### PR TITLE
fix(traces): stop a deleted span reaching the dataset, and show removals where the reader can see them

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -376,7 +376,6 @@ const LEGACY_INERT: string[] = [
   "specs/data-retention/trace-pinning.feature",
   "specs/data-retention/ttl-activation.feature",
   "specs/data-retention/visibility-window-teaser-redaction.feature",
-  "specs/datasets/add-to-dataset-span-mapping.feature",
   "specs/dependencies/supply-chain-age-gates.feature",
   "specs/evaluations/evaluation-payload-offload.feature",
   "specs/evaluations/experiments-online-evaluations-separation.feature",

--- a/platform/app/src/components/datasets/DatasetMappingPreview.tsx
+++ b/platform/app/src/components/datasets/DatasetMappingPreview.tsx
@@ -175,12 +175,19 @@ export function DatasetMappingPreview({
   }, [selectedDataset.mapping]);
 
   return (
-    <Field.Root width="full" paddingY={4}>
+    // Each heading gets a field of its own, holding nothing but its words. A
+    // field describes one control and hands that control its id, so one wrapped
+    // around this whole panel gave the same id to every expansion switch and
+    // every preview checkbox under it, and a click on one went wherever the id
+    // resolved first.
+    <Box width="full" paddingY={4}>
       <HStack width="full" gap="64px" align="start">
         <VStack align="start" maxWidth="50%" gap={4}>
-          <HStack width="full" align="center" justify="space-between">
-            <Field.Label margin={0}>Mapping</Field.Label>
-          </HStack>
+          <Field.Root width="full">
+            <HStack width="full" align="center" justify="space-between">
+              <Field.Label margin={0}>Mapping</Field.Label>
+            </HStack>
+          </Field.Root>
           <HStack
             bg="gray.100"
             _dark={{ bg: "gray.800" }}
@@ -254,11 +261,13 @@ export function DatasetMappingPreview({
               </HStack>
             </Box>
           </HStack>
-          <Field.HelperText margin={0} fontSize="13px" marginBottom={2}>
-            {isThreadMapping
-              ? "Groups traces by thread and maps to dataset columns"
-              : "Maps each trace individually to dataset columns"}
-          </Field.HelperText>
+          <Field.Root width="full">
+            <Field.HelperText margin={0} fontSize="13px" marginBottom={2}>
+              {isThreadMapping
+                ? "Groups traces by thread and maps to dataset columns"
+                : "Maps each trace individually to dataset columns"}
+            </Field.HelperText>
+          </Field.Root>
 
           {isThreadMapping ? (
             <ThreadMapping
@@ -287,14 +296,16 @@ export function DatasetMappingPreview({
         </VStack>
         <VStack align="start" width="full" height="full">
           <HStack width="full" align="end">
-            <VStack align="start">
-              <Field.Label margin={0}>Preview</Field.Label>
-              <Field.HelperText margin={0} fontSize="13px">
-                {paragraph
-                  ? paragraph
-                  : "Those are the rows that are going to be added, double click a cell to edit it"}
-              </Field.HelperText>
-            </VStack>
+            <Field.Root width="auto">
+              <VStack align="start">
+                <Field.Label margin={0}>Preview</Field.Label>
+                <Field.HelperText margin={0} fontSize="13px">
+                  {paragraph
+                    ? paragraph
+                    : "Those are the rows that are going to be added, double click a cell to edit it"}
+                </Field.HelperText>
+              </VStack>
+            </Field.Root>
             <Spacer />
             <Button
               size="sm"
@@ -351,6 +362,6 @@ export function DatasetMappingPreview({
           </Box>
         </VStack>
       </HStack>
-    </Field.Root>
+    </Box>
   );
 }

--- a/platform/app/src/components/datasets/__tests__/DatasetMappingPreview.expansions.integration.test.tsx
+++ b/platform/app/src/components/datasets/__tests__/DatasetMappingPreview.expansions.integration.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Expansions switches as the Add to Dataset drawer actually composes them,
+ * beside the preview table. A field hands its own id to every control under it,
+ * so a field wrapped around both halves gave every switch and every preview
+ * checkbox the same id, and a click on a switch went wherever that id resolved
+ * first. Rendering the mapping on its own cannot see that.
+ * See specs/datasets/add-to-dataset-span-mapping.feature.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import type { Dataset } from "@prisma/client";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { DatasetColumns } from "~/server/datasets/types";
+import type { Trace } from "~/server/tracer/types";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-1", slug: "acme" },
+  }),
+}));
+
+vi.mock("~/hooks/useProjectSpanNames", () => ({
+  useProjectSpanNames: () => ({
+    spanNames: [],
+    metadataKeys: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("~/hooks/useProjectEventTypes", () => ({
+  useProjectEventTypes: () => ({ eventTypes: [], isLoading: false }),
+}));
+
+vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
+  useAnnotationsByTraceIds: () => ({ data: [] }),
+}));
+
+vi.mock("~/hooks/useFilterParams", () => ({
+  useFilterParams: () => ({ filterParams: {}, queryOpts: {} }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({ dataset: { getAll: { invalidate: vi.fn() } } }),
+    annotationScore: { getAllActive: { useQuery: () => ({ data: [] }) } },
+    dataset: { updateMapping: { useMutation: () => ({ mutate: vi.fn() }) } },
+    traces: {
+      getTracesWithSpansByThreadIds: { useQuery: () => ({ data: undefined }) },
+      getFormattedSpansDigest: { useQuery: () => ({ data: undefined }) },
+      getSampleTracesDataset: { useQuery: () => ({ data: [] }) },
+    },
+  },
+}));
+
+const { DatasetMappingPreview } = await import("../DatasetMappingPreview");
+
+const TRACE = {
+  trace_id: "trace-1",
+  project_id: "project-1",
+  metadata: {},
+  timestamps: { started_at: 1, inserted_at: 1, updated_at: 1 },
+  spans: [],
+} as unknown as Trace;
+
+const COLUMN_TYPES: DatasetColumns = [
+  { name: "spans_column", type: "json" },
+  { name: "annotations_column", type: "json" },
+];
+
+/** A dataset whose stored mapping offers both the span and the annotation expansion. */
+const DATASET = {
+  id: "dataset-1",
+  name: "runbook quality",
+  columnTypes: COLUMN_TYPES,
+  mapping: {
+    traceMapping: {
+      mapping: {
+        spans_column: { source: "spans" },
+        annotations_column: { source: "annotations" },
+      },
+      expansions: [],
+    },
+  },
+} as unknown as Dataset;
+
+/**
+ * One switch, by the name it announces. Chakra's Switch is a label wrapping a
+ * hidden checkbox, so it reaches the accessibility tree as a checkbox named
+ * after its own words. A switch that borrowed a field's id announces the
+ * field's label instead and cannot be found here at all.
+ */
+const switchNamed = (name: string) =>
+  screen.getByRole<HTMLInputElement>("checkbox", { name });
+
+function renderPreview() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <DatasetMappingPreview
+        traces={[TRACE]}
+        columnTypes={COLUMN_TYPES}
+        rowData={[{ id: "row-1", selected: true }]}
+        selectedDataset={DATASET}
+        onEditColumns={vi.fn()}
+        onRowDataChange={vi.fn()}
+      />
+    </ChakraProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("given the drawer's mapping and preview side by side", () => {
+  describe("when I click the words beside an expansion switch", () => {
+    /** @scenario "An expansion switch answers to its own label in the drawer" */
+    it("turns that expansion on", async () => {
+      const user = userEvent.setup();
+      renderPreview();
+
+      await user.click(screen.getByText("One row per span"));
+
+      expect(switchNamed("One row per span")).toBeChecked();
+    });
+
+    /** @scenario "An expansion switch answers to its own label in the drawer" */
+    it("leaves every other switch and the preview's own checkboxes alone", async () => {
+      const user = userEvent.setup();
+      renderPreview();
+
+      await user.click(screen.getByText("One row per span"));
+
+      expect(switchNamed("One row per annotation")).not.toBeChecked();
+      expect(switchNamed("Select all rows")).toBeChecked();
+    });
+  });
+
+  describe("when the switches are rendered", () => {
+    /** @scenario "An expansion switch answers to its own label in the drawer" */
+    it("gives each control its own id, so a click lands where it was aimed", () => {
+      renderPreview();
+
+      const ids = screen
+        .getAllByRole<HTMLInputElement>("checkbox")
+        .map((control) => control.id)
+        .filter(Boolean);
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+});

--- a/platform/app/src/components/traces/TracesMapping.tsx
+++ b/platform/app/src/components/traces/TracesMapping.tsx
@@ -144,12 +144,16 @@ const FIELD_NAME_ANY_LABEL: Record<string, string> = {
   events: "* (any event)",
 };
 
-/** Dedupe {key,label} options by key, preserving first-seen order. */
 /** Whether two expansion selections say the same thing. */
-const sameExpansions = (
-  a: Set<keyof typeof TRACE_EXPANSIONS>,
-  b: Set<keyof typeof TRACE_EXPANSIONS>,
-): boolean => a.size === b.size && Array.from(a).every((key) => b.has(key));
+const sameExpansions = ({
+  expansions,
+  other,
+}: {
+  expansions: Set<keyof typeof TRACE_EXPANSIONS>;
+  other: Set<keyof typeof TRACE_EXPANSIONS>;
+}): boolean =>
+  expansions.size === other.size &&
+  Array.from(expansions).every((key) => other.has(key));
 
 /**
  * The expansions after a column is mapped to a new source.
@@ -178,6 +182,7 @@ const expansionsAfterMapping = ({
   return new Set([...expansions, expandableBy]);
 };
 
+/** Dedupe {key,label} options by key, preserving first-seen order. */
 const dedupeKeyOptions = (options: KeyOption[]): KeyOption[] => {
   const seen = new Set<string>();
   const result: KeyOption[] = [];
@@ -492,10 +497,10 @@ export const TracesMapping = ({
     const mappingChanged =
       JSON.stringify(traceMappingState.mapping) !==
       JSON.stringify(traceMappingStateWithDefaults.mapping);
-    const expansionsChanged = !sameExpansions(
-      traceMappingState.expansions,
-      traceMappingStateWithDefaults.expansions,
-    );
+    const expansionsChanged = !sameExpansions({
+      expansions: traceMappingState.expansions,
+      other: traceMappingStateWithDefaults.expansions,
+    });
 
     if (
       !isInitializedRef.current ||
@@ -817,7 +822,7 @@ export const TracesMapping = ({
                                 : undefined;
 
                               const newExpansions = expansionsAfterMapping({
-                                expansions,
+                                expansions: prev.expansions,
                                 targetMapping,
                                 availableExpansions,
                               });

--- a/platform/app/src/components/traces/TracesMapping.tsx
+++ b/platform/app/src/components/traces/TracesMapping.tsx
@@ -145,6 +145,39 @@ const FIELD_NAME_ANY_LABEL: Record<string, string> = {
 };
 
 /** Dedupe {key,label} options by key, preserving first-seen order. */
+/** Whether two expansion selections say the same thing. */
+const sameExpansions = (
+  a: Set<keyof typeof TRACE_EXPANSIONS>,
+  b: Set<keyof typeof TRACE_EXPANSIONS>,
+): boolean => a.size === b.size && Array.from(a).every((key) => b.has(key));
+
+/**
+ * The expansions after a column is mapped to a new source.
+ *
+ * Mapping a source that can be expanded turns its expansion on for you, but
+ * only where expanding is what mapping it usually means: a dataset of traces
+ * stays a row per trace until the reader asks for the span expansion. A source
+ * whose expansion is already on offer changes nothing, since some other column
+ * already brought it.
+ */
+const expansionsAfterMapping = ({
+  expansions,
+  targetMapping,
+  availableExpansions,
+}: {
+  expansions: Set<keyof typeof TRACE_EXPANSIONS>;
+  targetMapping?: (typeof TRACE_MAPPINGS)[keyof typeof TRACE_MAPPINGS];
+  availableExpansions: Set<keyof typeof TRACE_EXPANSIONS>;
+}): Set<keyof typeof TRACE_EXPANSIONS> => {
+  const expandableBy =
+    targetMapping && "expandable_by" in targetMapping
+      ? targetMapping.expandable_by
+      : undefined;
+  if (!expandableBy || availableExpansions.has(expandableBy)) return expansions;
+  if (!TRACE_EXPANSIONS[expandableBy].enabledByDefault) return expansions;
+  return new Set([...expansions, expandableBy]);
+};
+
 const dedupeKeyOptions = (options: KeyOption[]): KeyOption[] => {
   const seen = new Set<string>();
   const result: KeyOption[] = [];
@@ -275,20 +308,28 @@ export const TracesMapping = ({
       mapping: {},
       expansions: new Set(),
     });
+  // The latest state, readable synchronously. Two updates in one tick (two
+  // switches clicked before React re-renders, or a click landing between the
+  // initialising effect and its re-render) would otherwise both build on the
+  // render's stale value, and the second would undo the first — which reads as
+  // one switch moving the other.
+  const traceMappingStateRef = React.useRef(traceMappingState);
+  traceMappingStateRef.current = traceMappingState;
   const setTraceMappingState = useCallback(
     (
       callback: (
         mappingState: LocalTraceMappingState,
       ) => LocalTraceMappingState,
     ) => {
-      const newMappingState = callback(traceMappingState);
+      const newMappingState = callback(traceMappingStateRef.current);
+      traceMappingStateRef.current = newMappingState;
       setTraceMappingState_(newMappingState);
       setTraceMapping?.({
         ...newMappingState,
         expansions: Array.from(newMappingState.expansions),
       });
     },
-    [traceMappingState, setTraceMapping],
+    [setTraceMapping],
   );
   const mapping = traceMappingState.mapping;
 
@@ -366,11 +407,14 @@ export const TracesMapping = ({
     [mapping],
   );
 
-  // Fetch formatted span digests from server when needed
+  // Fetch formatted span digests from server when needed, read the same way the
+  // traces being mapped were: this column quotes the whole trace, so reading it
+  // uncorrected would put back every span the other columns leave out.
   const formattedDigests = api.traces.getFormattedSpansDigest.useQuery(
     {
       projectId: project?.id ?? "",
       traceIds: traces.map((t) => t.trace_id),
+      withEditOverlay: shouldApplyCorrections,
     },
     {
       enabled: !!project?.id && needsFormattedDigest && traces.length > 0,
@@ -426,10 +470,13 @@ export const TracesMapping = ({
             inferredMappingFor(name),
         ]) ?? [],
       ),
-      expansions:
-        traceMappingState.expansions.size > 0
-          ? traceMappingState.expansions
-          : new Set(currentMapping.expansions),
+      // Only before the first pass do the stored expansions stand in. After it
+      // the state is the whole truth, including the empty set: turning the last
+      // expansion off is an answer, not an absence of one, and reading it as
+      // "nothing chosen yet" is what used to put the stored ones straight back.
+      expansions: isInitializedRef.current
+        ? traceMappingState.expansions
+        : new Set(currentMapping.expansions),
     };
 
     // Check if we need to update (new columns added, columns removed, or initial setup)
@@ -439,15 +486,26 @@ export const TracesMapping = ({
       currentFieldsSet.size !== targetFieldsSet.size ||
       !Array.from(targetFieldsSet).every((f) => currentFieldsSet.has(f));
 
+    // `JSON.stringify` writes a Set as `{}`, so comparing the whole state that
+    // way cannot see the expansions at all. Compare each half the way it can
+    // actually be compared.
+    const mappingChanged =
+      JSON.stringify(traceMappingState.mapping) !==
+      JSON.stringify(traceMappingStateWithDefaults.mapping);
+    const expansionsChanged = !sameExpansions(
+      traceMappingState.expansions,
+      traceMappingStateWithDefaults.expansions,
+    );
+
     if (
       !isInitializedRef.current ||
       fieldsChanged ||
-      JSON.stringify(traceMappingState) !==
-        JSON.stringify(traceMappingStateWithDefaults)
+      mappingChanged ||
+      expansionsChanged
     ) {
-      setTraceMappingState_(
-        traceMappingStateWithDefaults as LocalTraceMappingState,
-      );
+      const nextState = traceMappingStateWithDefaults as LocalTraceMappingState;
+      traceMappingStateRef.current = nextState;
+      setTraceMappingState_(nextState);
       setTraceMapping?.({
         ...traceMappingStateWithDefaults,
         expansions: Array.from(traceMappingStateWithDefaults.expansions),
@@ -758,20 +816,11 @@ export const TracesMapping = ({
                                   ]
                                 : undefined;
 
-                              let newExpansions = expansions;
-                              if (
-                                targetMapping &&
-                                "expandable_by" in targetMapping &&
-                                targetMapping.expandable_by &&
-                                !availableExpansions.has(
-                                  targetMapping.expandable_by,
-                                )
-                              ) {
-                                newExpansions = new Set([
-                                  ...new Set(Array.from(newExpansions)),
-                                  targetMapping.expandable_by,
-                                ]);
-                              }
+                              const newExpansions = expansionsAfterMapping({
+                                expansions,
+                                targetMapping,
+                                availableExpansions,
+                              });
 
                               return {
                                 ...prev,
@@ -1008,49 +1057,57 @@ export const TracesMapping = ({
       )}
 
       {!disableExpansions && availableExpansions.size > 0 && (
-        <Field.Root width="full" paddingY={4} marginTop={2}>
-          <VStack align="start">
-            <Field.Label margin={0}>Expansions</Field.Label>
-            <Field.HelperText
-              margin={0}
-              fontSize="13px"
-              marginBottom={2}
-              maxWidth="600px"
-            >
-              Normalize the dataset to duplicate the rows and have one entry per
-              line instead of an array for the following mappings:
-            </Field.HelperText>
-          </VStack>
+        // The switches sit outside the field on purpose. A field describes one
+        // control, so it hands the same id to every control inside it: each
+        // switch's label then pointed at the first switch's input, and clicking
+        // one moved another. Out here each switch owns its own id and label.
+        <VStack width="full" align="start" paddingY={4} marginTop={2} gap={0}>
+          <Field.Root width="full">
+            <VStack align="start">
+              <Field.Label margin={0}>Expansions</Field.Label>
+              <Field.HelperText
+                margin={0}
+                fontSize="13px"
+                marginBottom={2}
+                maxWidth="600px"
+              >
+                Normalize the dataset to duplicate the rows and have one entry
+                per line instead of an array for the following mappings:
+              </Field.HelperText>
+            </VStack>
+          </Field.Root>
           <VStack align="start" paddingTop={2} gap={2}>
             {Array.from(availableExpansions).map((expansion) => (
-              <HStack key={expansion}>
-                <Switch
-                  checked={expansions.has(expansion)}
-                  onCheckedChange={(event) => {
-                    const isChecked = event.checked;
+              // The name is the switch's own label, so clicking the words
+              // toggles it rather than only the switch itself.
+              <Switch
+                key={expansion}
+                checked={expansions.has(expansion)}
+                onCheckedChange={(event) => {
+                  const isChecked = event.checked;
 
-                    setTraceMappingState((prev) => {
-                      const newExpansions: Set<keyof typeof TRACE_EXPANSIONS> =
-                        isChecked
-                          ? new Set([...prev.expansions, expansion])
-                          : new Set(
-                              Array.from(prev.expansions).filter(
-                                (x) => x !== expansion,
-                              ),
-                            );
+                  setTraceMappingState((prev) => {
+                    const newExpansions: Set<keyof typeof TRACE_EXPANSIONS> =
+                      isChecked
+                        ? new Set([...prev.expansions, expansion])
+                        : new Set(
+                            Array.from(prev.expansions).filter(
+                              (x) => x !== expansion,
+                            ),
+                          );
 
-                      return {
-                        ...prev,
-                        expansions: newExpansions,
-                      };
-                    });
-                  }}
-                />
-                <Text>One row per {TRACE_EXPANSIONS[expansion].label}</Text>
-              </HStack>
+                    return {
+                      ...prev,
+                      expansions: newExpansions,
+                    };
+                  });
+                }}
+              >
+                One row per {TRACE_EXPANSIONS[expansion].label}
+              </Switch>
             ))}
           </VStack>
-        </Field.Root>
+        </VStack>
       )}
     </Grid>
   );

--- a/platform/app/src/components/traces/__tests__/TracesMapping.correctionReads.integration.test.tsx
+++ b/platform/app/src/components/traces/__tests__/TracesMapping.correctionReads.integration.test.tsx
@@ -19,6 +19,9 @@ const mocks = vi.hoisted(() => ({
   threadQuery: vi.fn((_input: { withEditOverlay?: boolean }) => ({
     data: undefined,
   })),
+  digestQuery: vi.fn((_input: { withEditOverlay?: boolean }) => ({
+    data: undefined,
+  })),
   sampleTraces: [] as unknown[],
 }));
 
@@ -54,7 +57,7 @@ vi.mock("~/utils/api", () => ({
     annotationScore: { getAllActive: { useQuery: () => ({ data: [] }) } },
     traces: {
       getTracesWithSpansByThreadIds: { useQuery: mocks.threadQuery },
-      getFormattedSpansDigest: { useQuery: () => ({ data: undefined }) },
+      getFormattedSpansDigest: { useQuery: mocks.digestQuery },
       getSampleTracesDataset: {
         useQuery: () => ({ data: mocks.sampleTraces }),
       },
@@ -79,6 +82,17 @@ const TRACE_IN_A_THREAD = {
 function threadReadInput(): { withEditOverlay?: boolean } {
   return mocks.threadQuery.mock.calls[0]?.[0] ?? {};
 }
+
+/** What the AI-readable column's own read asked for on its first call. */
+function digestReadInput(): { withEditOverlay?: boolean } {
+  return mocks.digestQuery.mock.calls[0]?.[0] ?? {};
+}
+
+/** A mapping that fills its one column from the AI-readable text. */
+const AI_READABLE_MAPPING = {
+  mapping: { input: { source: "formatted_trace" as const } },
+  expansions: [],
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -122,6 +136,43 @@ describe("given a mapping filled from the traces as they were captured", () => {
       );
 
       expect(threadReadInput().withEditOverlay).toBe(false);
+    });
+  });
+});
+
+describe("given a mapping whose column is the AI-readable trace", () => {
+  describe("when the traces it maps carry corrections", () => {
+    /** @scenario "The AI-readable column is read the way the rest of the mapping is" */
+    it("reads the trace behind that column with corrections", () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <TracesMapping
+            traces={[TRACE_IN_A_THREAD]}
+            traceMapping={AI_READABLE_MAPPING}
+            targetFields={["input"]}
+            shouldApplyCorrections
+          />
+        </ChakraProvider>,
+      );
+
+      expect(digestReadInput().withEditOverlay).toBe(true);
+    });
+  });
+
+  describe("when the traces it maps are the captured ones", () => {
+    /** @scenario "The AI-readable column is read the way the rest of the mapping is" */
+    it("reads the trace behind that column as captured", () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <TracesMapping
+            traces={[TRACE_IN_A_THREAD]}
+            traceMapping={AI_READABLE_MAPPING}
+            targetFields={["input"]}
+          />
+        </ChakraProvider>,
+      );
+
+      expect(digestReadInput().withEditOverlay).toBe(false);
     });
   });
 });

--- a/platform/app/src/components/traces/__tests__/TracesMapping.expansions.integration.test.tsx
+++ b/platform/app/src/components/traces/__tests__/TracesMapping.expansions.integration.test.tsx
@@ -148,7 +148,10 @@ function unmappedColumnSelect(): HTMLSelectElement {
   return unmapped;
 }
 
-/** The source dropdown reading the given source, of the only column there is. */
+/**
+ * Matched on what it reads rather than on where it sits: a mapped column also
+ * renders a key dropdown beside its source one, and both are comboboxes.
+ */
 function columnSourceSelect(source: string): HTMLSelectElement {
   const selects = screen.getAllByRole<HTMLSelectElement>("combobox");
   const mapped = selects.find((select) => select.value === source);

--- a/platform/app/src/components/traces/__tests__/TracesMapping.expansions.integration.test.tsx
+++ b/platform/app/src/components/traces/__tests__/TracesMapping.expansions.integration.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Expansions switches. Each one is a switch about its own expansion, and
+ * turning them all off is an answer the reader is allowed to give: a mapping
+ * with nothing expanded is the one that keeps a row per trace.
+ * See specs/datasets/add-to-dataset-span-mapping.feature.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { MappingState } from "~/server/tracer/tracesMapping";
+import type { Trace } from "~/server/tracer/types";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-1", slug: "acme" },
+  }),
+}));
+
+vi.mock("~/hooks/useProjectSpanNames", () => ({
+  useProjectSpanNames: () => ({
+    spanNames: [],
+    metadataKeys: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("~/hooks/useProjectEventTypes", () => ({
+  useProjectEventTypes: () => ({ eventTypes: [], isLoading: false }),
+}));
+
+vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
+  useAnnotationsByTraceIds: () => ({ data: [] }),
+}));
+
+vi.mock("~/hooks/useFilterParams", () => ({
+  useFilterParams: () => ({ filterParams: {}, queryOpts: {} }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    annotationScore: { getAllActive: { useQuery: () => ({ data: [] }) } },
+    traces: {
+      getTracesWithSpansByThreadIds: { useQuery: () => ({ data: undefined }) },
+      getFormattedSpansDigest: { useQuery: () => ({ data: undefined }) },
+      getSampleTracesDataset: { useQuery: () => ({ data: [] }) },
+    },
+  },
+}));
+
+const { TracesMapping } = await import("../TracesMapping");
+
+const TRACE = {
+  trace_id: "trace-1",
+  project_id: "project-1",
+  metadata: {},
+  timestamps: { started_at: 1, inserted_at: 1, updated_at: 1 },
+  spans: [],
+} as unknown as Trace;
+
+/** A mapping whose columns make both the span and the annotation expansion available. */
+const BOTH_EXPANDABLE = {
+  spans_column: { source: "spans" as const },
+  annotations_column: { source: "annotations" as const },
+};
+
+const setTraceMapping = vi.fn();
+
+/** Pushes a value down as if the host's re-read had just answered with it. */
+let handBackFromTheServer: ((mapping: MappingState) => void) | null = null;
+
+/** The expansions the mapping last reported, in the order it reported them. */
+function lastReportedExpansions(): string[] {
+  const calls = setTraceMapping.mock.calls;
+  return (calls[calls.length - 1]?.[0]?.expansions ?? []) as string[];
+}
+
+/**
+ * The mapping as its real hosts render it: they hold the mapping in state and
+ * hand it straight back down, so every change the mapping reports comes back to
+ * it as its own input. Rendering it uncontrolled hides anything that goes wrong
+ * on that round trip, which is where turning an expansion off used to be undone.
+ */
+function ControlledMapping({
+  mapping,
+  expansions,
+  targetFields,
+}: {
+  mapping: Record<string, { source: string }>;
+  expansions: string[];
+  targetFields: string[];
+}) {
+  const [traceMapping, setLocal] = React.useState<MappingState>({
+    mapping,
+    expansions,
+  } as MappingState);
+  // The host re-reads the mapping from the server, so a test can play that
+  // answer landing late, and landing stale.
+  handBackFromTheServer = setLocal;
+
+  return (
+    <TracesMapping
+      traces={[TRACE]}
+      traceMapping={traceMapping}
+      targetFields={targetFields}
+      setTraceMapping={(next) => {
+        setTraceMapping(next);
+        setLocal(next);
+      }}
+    />
+  );
+}
+
+function renderMapping({ expansions }: { expansions: string[] }) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <ControlledMapping
+        mapping={BOTH_EXPANDABLE}
+        expansions={expansions}
+        targetFields={["spans_column", "annotations_column"]}
+      />
+    </ChakraProvider>,
+  );
+}
+
+/**
+ * One switch, by the name it announces. Chakra's Switch is a label wrapping a
+ * hidden checkbox, so it reaches the accessibility tree as a checkbox named
+ * after its own words.
+ */
+const switchNamed = (name: string) =>
+  screen.getByRole<HTMLInputElement>("checkbox", { name });
+
+/** The words of one switch, which is what a reader actually clicks. */
+const labelOf = (label: string) => screen.getByText(label);
+
+/** The source dropdown of a column nothing has been mapped to yet. */
+function unmappedColumnSelect(): HTMLSelectElement {
+  const selects = screen.getAllByRole<HTMLSelectElement>("combobox");
+  const unmapped = selects.find((select) => select.value === "");
+  if (!unmapped) throw new Error("Every column is already mapped");
+  return unmapped;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("given a mapping that offers both the annotation and the span expansion", () => {
+  describe("when both are enabled and I turn off the span one", () => {
+    /** @scenario "Each expansion switch toggles only its own expansion" */
+    it("leaves the annotation expansion alone", async () => {
+      const user = userEvent.setup();
+      renderMapping({ expansions: ["spans.all.span_id", "annotations.id"] });
+
+      expect(switchNamed("One row per span")).toBeChecked();
+      expect(switchNamed("One row per annotation")).toBeChecked();
+
+      await user.click(labelOf("One row per span"));
+
+      expect(switchNamed("One row per span")).not.toBeChecked();
+      expect(switchNamed("One row per annotation")).toBeChecked();
+      expect(lastReportedExpansions()).toEqual(["annotations.id"]);
+    });
+  });
+
+  describe("when only the span expansion is enabled and I turn it off", () => {
+    /** @scenario "The last expansion can be turned off" */
+    it("stays off rather than coming back", async () => {
+      const user = userEvent.setup();
+      renderMapping({ expansions: ["spans.all.span_id"] });
+
+      await user.click(labelOf("One row per span"));
+
+      expect(switchNamed("One row per span")).not.toBeChecked();
+      expect(lastReportedExpansions()).toEqual([]);
+    });
+  });
+
+  // The host saves the mapping to the server and re-reads it, so the stored
+  // mapping arrives back late and can still be the one from before the click.
+  // Turning the last expansion off used to read as "nothing chosen yet", and
+  // that late answer put the stored expansions back — including the one the
+  // reader never touched.
+  describe("when the stored mapping arrives back stale after I turn the last one off", () => {
+    /** @scenario "The last expansion can be turned off" */
+    it("keeps them off rather than taking the stale answer", async () => {
+      const user = userEvent.setup();
+      const stored = ["spans.all.span_id", "annotations.id"];
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <ControlledMapping
+            mapping={BOTH_EXPANDABLE}
+            expansions={stored}
+            targetFields={["spans_column", "annotations_column"]}
+          />
+        </ChakraProvider>,
+      );
+
+      await user.click(labelOf("One row per span"));
+      await user.click(labelOf("One row per annotation"));
+
+      // The re-read lands, still carrying what was stored before the clicks.
+      act(() => {
+        handBackFromTheServer?.({
+          mapping: BOTH_EXPANDABLE,
+          expansions: stored,
+        } as MappingState);
+      });
+
+      expect(switchNamed("One row per span")).not.toBeChecked();
+      expect(switchNamed("One row per annotation")).not.toBeChecked();
+    });
+  });
+});
+
+describe("given a column that has not been mapped to anything yet", () => {
+  describe("when I map it to the spans source", () => {
+    /** @scenario "The span expansion starts off" */
+    it("offers the span expansion without turning it on", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <ControlledMapping
+            mapping={{ spans_column: { source: "" } }}
+            expansions={[]}
+            targetFields={["spans_column"]}
+          />
+        </ChakraProvider>,
+      );
+
+      await user.selectOptions(unmappedColumnSelect(), "spans");
+
+      expect(switchNamed("One row per span")).not.toBeChecked();
+      expect(lastReportedExpansions()).toEqual([]);
+    });
+  });
+
+  describe("when I map it to the annotations source", () => {
+    /** @scenario "The span expansion starts off" */
+    it("turns the annotation expansion on, which is what mapping them means", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <ControlledMapping
+            mapping={{ annotations_column: { source: "" } }}
+            expansions={[]}
+            targetFields={["annotations_column"]}
+          />
+        </ChakraProvider>,
+      );
+
+      await user.selectOptions(unmappedColumnSelect(), "annotations");
+
+      expect(switchNamed("One row per annotation")).toBeChecked();
+    });
+  });
+});

--- a/platform/app/src/components/traces/__tests__/TracesMapping.expansions.integration.test.tsx
+++ b/platform/app/src/components/traces/__tests__/TracesMapping.expansions.integration.test.tsx
@@ -148,6 +148,14 @@ function unmappedColumnSelect(): HTMLSelectElement {
   return unmapped;
 }
 
+/** The source dropdown reading the given source, of the only column there is. */
+function columnSourceSelect(source: string): HTMLSelectElement {
+  const selects = screen.getAllByRole<HTMLSelectElement>("combobox");
+  const mapped = selects.find((select) => select.value === source);
+  if (!mapped) throw new Error(`No column is mapped to ${source}`);
+  return mapped;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -245,7 +253,7 @@ describe("given a column that has not been mapped to anything yet", () => {
   });
 
   describe("when I map it to the annotations source", () => {
-    /** @scenario "The span expansion starts off" */
+    /** @scenario "Mapping annotations turns their expansion on" */
     it("turns the annotation expansion on, which is what mapping them means", async () => {
       const user = userEvent.setup();
       render(
@@ -261,6 +269,32 @@ describe("given a column that has not been mapped to anything yet", () => {
       await user.selectOptions(unmappedColumnSelect(), "annotations");
 
       expect(switchNamed("One row per annotation")).toBeChecked();
+    });
+  });
+});
+
+describe("given a mapping whose span expansion the reader turned on", () => {
+  describe("when its column is remapped to another source and back", () => {
+    /** @scenario "An expansion I turned on survives its column being remapped and mapped back" */
+    it("comes back on rather than starting the choice over", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <ControlledMapping
+            mapping={{ spans_column: { source: "spans" } }}
+            expansions={["spans.all.span_id"]}
+            targetFields={["spans_column"]}
+          />
+        </ChakraProvider>,
+      );
+      expect(switchNamed("One row per span")).toBeChecked();
+      const columnSource = columnSourceSelect("spans");
+
+      await user.selectOptions(columnSource, "trace_id");
+      await user.selectOptions(columnSource, "spans");
+
+      expect(switchNamed("One row per span")).toBeChecked();
+      expect(lastReportedExpansions()).toEqual(["spans.all.span_id"]);
     });
   });
 });

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -23,6 +23,7 @@ import {
 } from "./ApiKeyAttribute";
 import { AttributeValue } from "./AttributeValue";
 import { AnchorCommentButton } from "./anchoredComments/AnchorCommentButton";
+import { sameAttributeValue } from "./attributeValueEquality";
 import { PinnedAwareJsonView } from "./JsonHighlight";
 import { SegmentedToggle } from "./SegmentedToggle";
 
@@ -1248,18 +1249,18 @@ export function AttributeTable({
   );
 
   // A row is marked when the correction gave it a different value than the one
-  // captured, or added it outright. The comparison is per row, on the rendered
-  // value, which is what the reader is looking at: a correction may replace a
-  // whole attribute record and leave most of it saying exactly what it said.
+  // captured, or added it outright. The comparison is per row: a correction may
+  // replace a whole attribute record and leave most of it saying exactly what it
+  // said. It compares what the values mean rather than how they are written, so
+  // a row that came back re-serialised does not read as one someone edited.
   const correctionFor = useMemo(() => {
     if (!correctedFrom) return undefined;
     const capturedFlat = flattenAttributes(correctedFrom);
     return (key: string): AttributeCorrection | null => {
       if (key in capturedFlat) {
-        const captured = formatValue(capturedFlat[key]);
-        return captured === formatValue(flatAttrs[key])
+        return sameAttributeValue(capturedFlat[key], flatAttrs[key])
           ? null
-          : { original: captured };
+          : { original: formatValue(capturedFlat[key]) };
       }
       // A correction that turned a value the trace recorded as one string into
       // a structure gives every leaf under it a row the capture never had.

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -257,6 +257,12 @@ interface AttributeTableProps {
 interface AttributeCorrection {
   /** The captured value rendered for the tooltip, or null when it is new. */
   original: string | null;
+  /**
+   * The correction takes this attribute away. The row is still listed, struck
+   * through: a row that simply stopped existing reads as one the trace never
+   * carried, and the removal is the whole of what the correction did here.
+   */
+  removed?: boolean;
 }
 
 /**
@@ -264,6 +270,37 @@ interface AttributeCorrection {
  * Walks the dotted path from the longest prefix down, so the nearest captured
  * ancestor wins.
  */
+/**
+ * How one row differs from what the trace captured, or null when it says the
+ * same thing. A key the correction took away is marked removed rather than
+ * dropped; one the capture never had at all was added, unless it is a leaf of a
+ * value the capture held as one string.
+ */
+function correctionForKey({
+  key,
+  capturedFlat,
+  correctedFlat,
+  removedKeys,
+}: {
+  key: string;
+  capturedFlat: Record<string, unknown>;
+  correctedFlat: Record<string, unknown>;
+  removedKeys: Record<string, unknown>;
+}): AttributeCorrection | null {
+  if (key in removedKeys) {
+    return { original: formatValue(capturedFlat[key]), removed: true };
+  }
+  if (key in capturedFlat) {
+    return sameAttributeValue(capturedFlat[key], correctedFlat[key])
+      ? null
+      : { original: formatValue(capturedFlat[key]) };
+  }
+  const ancestor = capturedAncestorKey({ key, capturedFlat });
+  return ancestor === null
+    ? { original: null }
+    : { original: formatValue(capturedFlat[ancestor]) };
+}
+
 function capturedAncestorKey({
   key,
   capturedFlat,
@@ -489,10 +526,34 @@ function RestrictionMarker({ visibleTo, canSee }: AttributeRestriction) {
 function CorrectionMarker({
   attrKey,
   original,
+  removed,
 }: {
   attrKey: string;
   original: string | null;
+  removed?: boolean;
 }) {
+  if (removed) {
+    return (
+      <Tooltip content="Removed by an edit" positioning={{ placement: "top" }}>
+        <Text
+          as="span"
+          textStyle="2xs"
+          fontWeight="semibold"
+          color="red.fg"
+          bg="red.subtle"
+          borderWidth="1px"
+          borderColor="red.muted"
+          borderRadius="sm"
+          paddingX={1.5}
+          flexShrink={0}
+          cursor="help"
+          aria-label={`${attrKey}, removed by an edit`}
+        >
+          Removed
+        </Text>
+      </Tooltip>
+    );
+  }
   const label =
     original === null
       ? `${attrKey}, added by an edit`
@@ -745,12 +806,21 @@ function RowValueCell({
     <HStack flex={1} minWidth={0} gap={1.5}>
       {restriction ? <RestrictionMarker {...restriction} /> : null}
       {correction ? (
-        <CorrectionMarker attrKey={attrKey} original={correction.original} />
+        <CorrectionMarker
+          attrKey={attrKey}
+          original={correction.original}
+          removed={correction.removed}
+        />
       ) : null}
       {editing ? (
         <EditableValueCell attrKey={attrKey} value={value} editing={editing} />
       ) : (
-        <Box flex={1} minWidth={0}>
+        <Box
+          flex={1}
+          minWidth={0}
+          textDecoration={correction?.removed ? "line-through" : undefined}
+          color={correction?.removed ? "fg.subtle" : undefined}
+        >
           {isApiKeyIdRow(attrKey, value) ? (
             <ApiKeyAttributeValue apiKeyId={value} />
           ) : (
@@ -1229,8 +1299,21 @@ export function AttributeTable({
     [baselineFlat],
   );
 
+  // Keys the capture had that the correction does not. They keep their captured
+  // value so the struck-through row still shows what is being taken away.
+  const removedKeys = useMemo(() => {
+    if (!correctedFrom) return {};
+    const corrected = flattenAttributes(attributes);
+    const captured = flattenAttributes(correctedFrom);
+    return Object.fromEntries(
+      Object.entries(captured).filter(([key]) => !(key in corrected)),
+    );
+  }, [attributes, correctedFrom]);
+
   const flatAttrs = useMemo(() => {
-    const flat = flattenAttributes(attributes);
+    // The removed rows go in first so a correction that re-adds the key under a
+    // different value still reads as that value.
+    const flat = { ...removedKeys, ...flattenAttributes(attributes) };
     // Attributes the correction adds are rows in their own right; ones it
     // removes keep their captured value so the struck-through row still shows
     // what is being taken away.
@@ -1241,7 +1324,7 @@ export function AttributeTable({
     // Prepend the span id as a synthetic, copyable first row. A real
     // `span_id` attribute (vanishingly unlikely) still wins via the spread.
     return spanId ? { [SPAN_ID_KEY]: spanId, ...flat } : flat;
-  }, [attributes, spanId, editing?.edits]);
+  }, [attributes, spanId, editing?.edits, removedKeys]);
   const flatResAttrs = useMemo(
     () =>
       resourceAttributes ? flattenAttributes(resourceAttributes) : undefined,
@@ -1256,21 +1339,14 @@ export function AttributeTable({
   const correctionFor = useMemo(() => {
     if (!correctedFrom) return undefined;
     const capturedFlat = flattenAttributes(correctedFrom);
-    return (key: string): AttributeCorrection | null => {
-      if (key in capturedFlat) {
-        return sameAttributeValue(capturedFlat[key], flatAttrs[key])
-          ? null
-          : { original: formatValue(capturedFlat[key]) };
-      }
-      // A correction that turned a value the trace recorded as one string into
-      // a structure gives every leaf under it a row the capture never had.
-      // Those rows correct the value above them rather than adding anything.
-      const ancestor = capturedAncestorKey({ key, capturedFlat });
-      return ancestor === null
-        ? { original: null }
-        : { original: formatValue(capturedFlat[ancestor]) };
-    };
-  }, [correctedFrom, flatAttrs]);
+    return (key: string): AttributeCorrection | null =>
+      correctionForKey({
+        key,
+        capturedFlat,
+        correctedFlat: flatAttrs,
+        removedKeys,
+      });
+  }, [correctedFrom, flatAttrs, removedKeys]);
 
   const filterAttrs = useMemo(
     () => filterAttributesBySearch(flatAttrs, searchTerm),

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -266,11 +266,6 @@ interface AttributeCorrection {
 }
 
 /**
- * The captured key one flat key sits underneath, when the capture had one.
- * Walks the dotted path from the longest prefix down, so the nearest captured
- * ancestor wins.
- */
-/**
  * How one row differs from what the trace captured, or null when it says the
  * same thing. A key the correction took away is marked removed rather than
  * dropped; one the capture never had at all was added, unless it is a leaf of a
@@ -301,6 +296,11 @@ function correctionForKey({
     : { original: formatValue(capturedFlat[ancestor]) };
 }
 
+/**
+ * The captured key one flat key sits underneath, when the capture had one.
+ * Walks the dotted path from the longest prefix down, so the nearest captured
+ * ancestor wins.
+ */
 function capturedAncestorKey({
   key,
   capturedFlat,
@@ -1010,6 +1010,7 @@ function rowMarkersFor({
 function AttrSection({
   title,
   attributes,
+  jsonAttributes,
   viewMode,
   source,
   labelWidth,
@@ -1024,6 +1025,12 @@ function AttrSection({
 }: {
   title: string;
   attributes: Record<string, unknown>;
+  /**
+   * What the JSON view quotes, when that is not the rows listed. A removal is a
+   * row the flat view strikes through; JSON has nowhere to draw that, so it
+   * quotes the attributes as the correction left them.
+   */
+  jsonAttributes?: Record<string, unknown>;
   viewMode: AttrViewMode;
   source: PinnedAttributeSource;
   labelWidth: number;
@@ -1051,6 +1058,10 @@ function AttrSection({
   const { pins, isPinned, togglePin } = usePinnedAttributes(project?.id);
 
   const flat = useMemo(() => flattenAttributes(attributes), [attributes]);
+  const jsonFlat = useMemo(
+    () => (jsonAttributes ? flattenAttributes(jsonAttributes) : flat),
+    [jsonAttributes, flat],
+  );
   const leading = useMemo(() => new Set(leadingKeys ?? []), [leadingKeys]);
   const pinnedKeys = useMemo(
     () => new Set(pins.filter((p) => p.source === source).map((p) => p.key)),
@@ -1135,7 +1146,7 @@ function AttrSection({
           overflow="auto"
         >
           <PinnedAwareJsonView
-            content={JSON.stringify(buildNestedObject(flat), null, 2)}
+            content={JSON.stringify(buildNestedObject(jsonFlat), null, 2)}
             pinnedKeys={pinnedKeys}
           />
         </Box>
@@ -1310,13 +1321,12 @@ export function AttributeTable({
     );
   }, [attributes, correctedFrom]);
 
-  const flatAttrs = useMemo(() => {
-    // The removed rows go in first so a correction that re-adds the key under a
-    // different value still reads as that value.
-    const flat = { ...removedKeys, ...flattenAttributes(attributes) };
-    // Attributes the correction adds are rows in their own right; ones it
-    // removes keep their captured value so the struck-through row still shows
-    // what is being taken away.
+  // What the span carries once the correction is applied, which is what copying
+  // and the JSON view quote: an attribute the correction took away must not
+  // travel back out as one the span still has.
+  const correctedFlat = useMemo(() => {
+    const flat = flattenAttributes(attributes);
+    // Attributes the correction adds are rows in their own right.
     for (const [key, value] of Object.entries(editing?.edits ?? {})) {
       if (value === null) continue;
       flat[key] = value;
@@ -1324,7 +1334,20 @@ export function AttributeTable({
     // Prepend the span id as a synthetic, copyable first row. A real
     // `span_id` attribute (vanishingly unlikely) still wins via the spread.
     return spanId ? { [SPAN_ID_KEY]: spanId, ...flat } : flat;
-  }, [attributes, spanId, editing?.edits, removedKeys]);
+  }, [attributes, spanId, editing?.edits]);
+
+  // The rows the table lists: everything the corrected span carries, plus the
+  // keys it took away. Those keep their captured value so the struck-through
+  // row still shows what is being taken away, and a correction that re-adds one
+  // under a different value still reads as that value. Rows sort by key, so
+  // where a row goes in makes no difference to where it lands.
+  const flatAttrs = useMemo(() => {
+    const removedRows = Object.entries(removedKeys).filter(
+      ([key]) => !(key in correctedFlat),
+    );
+    if (removedRows.length === 0) return correctedFlat;
+    return { ...correctedFlat, ...Object.fromEntries(removedRows) };
+  }, [correctedFlat, removedKeys]);
   const flatResAttrs = useMemo(
     () =>
       resourceAttributes ? flattenAttributes(resourceAttributes) : undefined,
@@ -1352,6 +1375,13 @@ export function AttributeTable({
     () => filterAttributesBySearch(flatAttrs, searchTerm),
     [flatAttrs, searchTerm],
   );
+  const filterCorrectedAttrs = useMemo(
+    () =>
+      flatAttrs === correctedFlat
+        ? filterAttrs
+        : filterAttributesBySearch(correctedFlat, searchTerm),
+    [flatAttrs, correctedFlat, filterAttrs, searchTerm],
+  );
   const allAttributeKeys = useMemo(
     () => new Set(Object.keys(flatAttrs)),
     [flatAttrs],
@@ -1371,13 +1401,13 @@ export function AttributeTable({
 
   const copyPayload = useMemo(() => {
     const root: Record<string, unknown> = {
-      ...buildNestedObject(filterAttrs),
+      ...buildNestedObject(filterCorrectedAttrs),
     };
     if (filterResAttrs) {
       root.resource = buildNestedObject(filterResAttrs);
     }
     return JSON.stringify(root, null, 2);
-  }, [filterAttrs, filterResAttrs]);
+  }, [filterCorrectedAttrs, filterResAttrs]);
 
   return (
     <Box>
@@ -1405,6 +1435,7 @@ export function AttributeTable({
       <AttrSection
         title={spanAttrTitle}
         attributes={filterAttrs}
+        jsonAttributes={filterCorrectedAttrs}
         viewMode={effectiveViewMode}
         source="attribute"
         labelWidth={labelWidth}

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.editing.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.editing.integration.test.tsx
@@ -289,6 +289,67 @@ describe("AttributeTable editing", () => {
     });
   });
 
+  describe("given a stored correction that removed an attribute", () => {
+    describe("when the corrected trace renders", () => {
+      /** @scenario "An attribute the correction removes is listed struck through" */
+      it("still lists it, marked as removed and struck through", () => {
+        const { getByText, getByLabelText } = render(
+          <ChakraProvider value={defaultSystem}>
+            <AttributeTable
+              attributes={{ "gen_ai.request.model": "gpt-5" }}
+              correctedFrom={{
+                "gen_ai.request.model": "gpt-5",
+                "user.email": "someone@acme.test",
+              }}
+            />
+          </ChakraProvider>,
+        );
+
+        expect(getByText("user.email")).toBeInTheDocument();
+        expect(getByText("someone@acme.test")).toBeInTheDocument();
+        expect(
+          getByLabelText("user.email, removed by an edit"),
+        ).toBeInTheDocument();
+      });
+
+      /** @scenario "An attribute the correction removes is listed struck through" */
+      it("does not call the removal an edit", () => {
+        const { queryByText } = render(
+          <ChakraProvider value={defaultSystem}>
+            <AttributeTable
+              attributes={{ "gen_ai.request.model": "gpt-5" }}
+              correctedFrom={{
+                "gen_ai.request.model": "gpt-5",
+                "user.email": "someone@acme.test",
+              }}
+            />
+          </ChakraProvider>,
+        );
+
+        expect(queryByText("Edited")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when the captured trace renders", () => {
+      /** @scenario "An attribute the correction removes reads plainly in the captured trace" */
+      it("reads like any other row, with nothing said about the removal", () => {
+        const { getByText, queryByText } = render(
+          <ChakraProvider value={defaultSystem}>
+            <AttributeTable
+              attributes={{
+                "gen_ai.request.model": "gpt-5",
+                "user.email": "someone@acme.test",
+              }}
+            />
+          </ChakraProvider>,
+        );
+
+        expect(getByText("user.email")).toBeInTheDocument();
+        expect(queryByText("Removed")).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe("given a stored correction that added an attribute", () => {
     describe("when the span detail renders", () => {
       /** @scenario "An attribute the correction added is marked as added" */

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.editing.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.editing.integration.test.tsx
@@ -255,6 +255,37 @@ describe("AttributeTable editing", () => {
 
         expect(queryByLabelText(/edited\. Original/)).not.toBeInTheDocument();
       });
+
+      // A correction rewrites the whole attribute record, so an attribute
+      // holding JSON comes back re-serialised whether or not anyone touched it.
+      /** @scenario "JSON that only changed its formatting is not marked as edited" */
+      it("leaves an attribute the correction only re-serialised unmarked", () => {
+        const toolCalls = [
+          {
+            type: "tool-call",
+            toolName: "bash",
+            toolCallId: "call_VXJC9uzjpxa99ESxuMwQPEyF",
+            input: { command: "langwatch trace search", timeout: 120000 },
+          },
+        ];
+
+        const { queryByText } = renderCorrected(
+          { "ai.response.toolCalls": JSON.stringify(toolCalls, null, 2) },
+          { "ai.response.toolCalls": JSON.stringify(toolCalls) },
+        );
+
+        expect(queryByText("Edited")).not.toBeInTheDocument();
+      });
+
+      /** @scenario "JSON that only changed its formatting is not marked as edited" */
+      it("still marks one whose content the correction changed", () => {
+        const { getByText } = renderCorrected(
+          { "ai.response.toolCalls": '[{"toolName":"read"}]' },
+          { "ai.response.toolCalls": '[{"toolName":"bash"}]' },
+        );
+
+        expect(getByText("Edited")).toBeInTheDocument();
+      });
     });
   });
 

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.editing.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.editing.integration.test.tsx
@@ -330,6 +330,34 @@ describe("AttributeTable editing", () => {
       });
     });
 
+    describe("when the corrected span's attributes are copied", () => {
+      /** @scenario "Copying the attributes leaves out the ones the correction removed" */
+      it("hands on what the span carries, without the removed row", () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, "clipboard", {
+          configurable: true,
+          value: { writeText },
+        });
+        const { getByLabelText } = render(
+          <ChakraProvider value={defaultSystem}>
+            <AttributeTable
+              attributes={{ "gen_ai.request.model": "gpt-5" }}
+              correctedFrom={{
+                "gen_ai.request.model": "gpt-5",
+                "user.email": "someone@acme.test",
+              }}
+            />
+          </ChakraProvider>,
+        );
+
+        fireEvent.click(getByLabelText("Copy all attributes"));
+
+        expect(writeText).toHaveBeenCalledTimes(1);
+        const copied = JSON.parse(writeText.mock.calls[0]![0] as string);
+        expect(copied).toEqual({ gen_ai: { request: { model: "gpt-5" } } });
+      });
+    });
+
     describe("when the captured trace renders", () => {
       /** @scenario "An attribute the correction removes reads plainly in the captured trace" */
       it("reads like any other row, with nothing said about the removal", () => {

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/attributeValueEquality.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/attributeValueEquality.unit.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The attribute values in here are real ones off a corrected trace: the tool
+ * calls an assistant span recorded, and the conversation a span was given. They
+ * are what a correction re-serialises without changing, which is what used to
+ * light the "Edited" marker on rows nobody had edited.
+ *
+ * See specs/traces-v2/trace-edit-mode.feature.
+ */
+import { describe, expect, it } from "vitest";
+import { sameAttributeValue } from "../attributeValueEquality";
+
+/** `ai.response.toolCalls` as the trace recorded it. */
+const TOOL_CALLS = [
+  {
+    type: "tool-call",
+    input: {
+      command:
+        'langwatch trace search --query "off topic" --origin evaluation --limit 1 --format json',
+      timeout: 120000,
+      workdir: "/workspace/sessions/langyconv_0007F7chgdezG0kgTQDLy6Hqph7kf",
+    },
+    toolName: "bash",
+    toolCallId: "call_VXJC9uzjpxa99ESxuMwQPEyF",
+    providerMetadata: {
+      openai: {
+        itemId: "fc_0610d3aef2ce17a7016a79d1df6c108191985b164948aca4fb",
+      },
+    },
+  },
+];
+
+/** `gen_ai.input.messages` as the trace recorded it, trimmed to two turns. */
+const MESSAGES = [
+  { role: "system", content: "You are Langy, the LangWatch assistant." },
+  {
+    role: "user",
+    content: [
+      {
+        text: "I want to see all of the off topic evaluator traces",
+        type: "text",
+      },
+    ],
+  },
+];
+
+/** The same value written out the way a re-serialisation writes it. */
+const prettyPrinted = (value: unknown) => JSON.stringify(value, null, 2);
+
+/** The same object with its keys written in the opposite order. */
+function withReversedKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withReversedKeys);
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .reverse()
+        .map(([key, entry]) => [key, withReversedKeys(entry)]),
+    );
+  }
+  return value;
+}
+
+describe("sameAttributeValue", () => {
+  describe("given a value a correction only re-serialised", () => {
+    describe("when it is compared with what was captured", () => {
+      /** @scenario "JSON that only changed its formatting is not marked as edited" */
+      it("reads the tool calls as the same value", () => {
+        expect(
+          sameAttributeValue(
+            JSON.stringify(TOOL_CALLS),
+            prettyPrinted(TOOL_CALLS),
+          ),
+        ).toBe(true);
+      });
+
+      /** @scenario "JSON that only changed its formatting is not marked as edited" */
+      it("reads the conversation as the same value", () => {
+        expect(
+          sameAttributeValue(JSON.stringify(MESSAGES), prettyPrinted(MESSAGES)),
+        ).toBe(true);
+      });
+
+      it("reads text and the structure it spells out as the same value", () => {
+        expect(sameAttributeValue(JSON.stringify(TOOL_CALLS), TOOL_CALLS)).toBe(
+          true,
+        );
+      });
+    });
+  });
+
+  describe("given a value whose keys came back in another order", () => {
+    describe("when it is compared with what was captured", () => {
+      /** @scenario "Reordered JSON keys are not an edit" */
+      it("reads them as the same value", () => {
+        expect(
+          sameAttributeValue(TOOL_CALLS, withReversedKeys(TOOL_CALLS)),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe("given a value whose array entries came back in another order", () => {
+    describe("when it is compared with what was captured", () => {
+      /** @scenario "Reordered JSON array entries are an edit" */
+      it("reads them as different values", () => {
+        expect(sameAttributeValue(MESSAGES, [...MESSAGES].reverse())).toBe(
+          false,
+        );
+      });
+    });
+  });
+
+  describe("given a value the correction actually changed", () => {
+    describe("when it is compared with what was captured", () => {
+      it("reads a changed tool argument as a different value", () => {
+        const edited = structuredClone(TOOL_CALLS);
+        edited[0]!.input.command = "langwatch trace search --limit 5";
+
+        expect(sameAttributeValue(TOOL_CALLS, edited)).toBe(false);
+      });
+
+      it("reads a dropped key as a different value", () => {
+        const edited = structuredClone(TOOL_CALLS);
+        // biome-ignore lint/performance/noDelete: the point is the key going away
+        delete (edited[0] as Record<string, unknown>).providerMetadata;
+
+        expect(sameAttributeValue(TOOL_CALLS, edited)).toBe(false);
+      });
+
+      it("reads text that only looks like a number as the text it is", () => {
+        expect(sameAttributeValue("123", 123)).toBe(false);
+      });
+
+      it("reads text that never parsed as JSON by what it says", () => {
+        expect(sameAttributeValue("gpt-5-mini", "gpt-5-mini")).toBe(true);
+        expect(sameAttributeValue("gpt-5-mini", "gpt-5")).toBe(false);
+      });
+
+      it("reads text that opens like JSON but is not by what it says", () => {
+        expect(sameAttributeValue("{not json", "{not json")).toBe(true);
+        expect(sameAttributeValue("{not json", "{also not")).toBe(false);
+      });
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/attributeValueEquality.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/attributeValueEquality.unit.test.ts
@@ -119,11 +119,12 @@ describe("sameAttributeValue", () => {
       });
 
       it("reads a dropped key as a different value", () => {
-        const edited = structuredClone(TOOL_CALLS);
-        // biome-ignore lint/performance/noDelete: the point is the key going away
-        delete (edited[0] as Record<string, unknown>).providerMetadata;
+        const [first, ...rest] = structuredClone(TOOL_CALLS);
+        const { providerMetadata: _dropped, ...withoutMetadata } = first!;
 
-        expect(sameAttributeValue(TOOL_CALLS, edited)).toBe(false);
+        expect(sameAttributeValue(TOOL_CALLS, [withoutMetadata, ...rest])).toBe(
+          false,
+        );
       });
 
       it("reads text that only looks like a number as the text it is", () => {

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/traceDrawerClose.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/traceDrawerClose.integration.test.tsx
@@ -61,6 +61,7 @@ vi.mock("~/features/traces-v2/hooks/useSpanTree", () => ({
   useSpanTreeWithCaptured: () => ({
     captured: { data: [] },
     corrected: { data: [], isLoading: false },
+    display: { data: [], isLoading: false },
   }),
 }));
 

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/attributeValueEquality.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/attributeValueEquality.ts
@@ -1,0 +1,51 @@
+/**
+ * Whether a correction actually changed an attribute, or only re-typed it.
+ *
+ * A correction rewrites a whole attribute record, so an attribute holding JSON
+ * comes back re-serialised even when the reviewer never touched it: different
+ * spacing, different key order, sometimes text where the capture held the
+ * structure itself. Marking any of that as edited teaches the reader to
+ * distrust the marker, which costs more than the marker is worth.
+ *
+ * Key order is formatting, so it does not count. Array order is content, so it
+ * does.
+ */
+
+/**
+ * The structure a value spells out, when it spells one out. Only text that
+ * parses as an object or an array is read as JSON: "123" and 123 stay a string
+ * and a number, because a correction that changed one into the other changed
+ * the value.
+ */
+function structureOf(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return typeof parsed === "object" && parsed !== null ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
+/** One value written the one way, so that equal values write the same. */
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+/** Whether two attribute values say the same thing, however they are written. */
+export function sameAttributeValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  return canonicalJson(structureOf(a)) === canonicalJson(structureOf(b));
+}

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/useTraceDrawerScaffold.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/useTraceDrawerScaffold.ts
@@ -70,7 +70,11 @@ export function useTraceDrawerScaffold(): TraceDrawerScaffold {
   // own: how many of the trace's spans a correction removes, which is what
   // keeps the header's span count agreeing with the waterfall below it. Both
   // readings come from one read, so the live delta poll keeps a single observer.
-  const { captured: capturedSpanTree, corrected: spanTreeQuery } =
+  // The tree the drawer draws keeps the rows a correction removes, struck
+  // through, so the reader can see what went away rather than having to spot an
+  // absence. What the corrected trace actually contains is `corrected`, which is
+  // what the header counts.
+  const { captured: capturedSpanTree, display: spanTreeQuery } =
     useSpanTreeWithCaptured();
   const headerQuery = useTraceHeader({ spans: capturedSpanTree.data });
   // `useTraceHeader` uses React Query's `keepPreviousData`, so the

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/TreeRow.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/TreeRow.tsx
@@ -463,7 +463,11 @@ export const TreeRow = memo(function TreeRow({
               <Text
                 textStyle="xs"
                 color={isError ? "red.fg" : "fg"}
-                textDecoration={isDraftDeleted ? "line-through" : undefined}
+                textDecoration={
+                  isDraftDeleted || isDeletedByCorrection
+                    ? "line-through"
+                    : undefined
+                }
                 truncate
                 minWidth={0}
                 lineHeight={1.2}
@@ -566,6 +570,14 @@ export const TreeRow = memo(function TreeRow({
                   truncate
                   maxWidth="100%"
                   bg="bg.subtle"
+                  // The pill names the model or tool the row ran. On a row the
+                  // correction removes it goes with the row, so it is struck
+                  // through with the name rather than reading as a live one.
+                  textDecoration={
+                    isDraftDeleted || isDeletedByCorrection
+                      ? "line-through"
+                      : undefined
+                  }
                 >
                   {isLlm ? span.model! : span.toolName}
                 </Text>

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/__tests__/TreeRow.correction.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/__tests__/TreeRow.correction.integration.test.tsx
@@ -13,6 +13,8 @@ const span = {
   parentSpanId: null,
   name: "web_search",
   type: "tool",
+  // The pill under the name, which goes with the row when it is removed.
+  toolName: "search_the_web",
   startTimeMs: 0,
   endTimeMs: 10,
   durationMs: 10,
@@ -53,21 +55,47 @@ describe("TreeRow with a correction", () => {
   afterEach(cleanup);
 
   describe("given a span a correction removes", () => {
-    describe("when the reader is on the captured trace", () => {
-      /** @scenario "A deleted span is marked in the captured trace" */
+    describe("when the reader is on the corrected trace", () => {
+      /** @scenario "A deleted span is listed and struck through in the corrected trace" */
       it("lists the span and marks it as deleted", () => {
         const { getByText } = renderRow({ isDeletedByCorrection: true });
 
         expect(getByText("web_search")).toBeInTheDocument();
         expect(getByText("Deleted")).toBeInTheDocument();
       });
+
+      /** @scenario "A deleted span is listed and struck through in the corrected trace" */
+      it("strikes through its name and the tool it ran", () => {
+        const { getByText } = renderRow({ isDeletedByCorrection: true });
+
+        expect(getByText("web_search")).toHaveStyle({
+          textDecoration: "line-through",
+        });
+        expect(getByText("search_the_web")).toHaveStyle({
+          textDecoration: "line-through",
+        });
+      });
+
+      /** @scenario "A deleted span is not also coloured as changed" */
+      it("does not also read as edited", () => {
+        const { queryByText } = renderRow({
+          isDeletedByCorrection: true,
+          isCorrected: true,
+        });
+
+        expect(queryByText("Edited")).not.toBeInTheDocument();
+      });
     });
 
-    describe("when the reader is on the corrected trace", () => {
-      it("carries no marker, because the row is not there at all", () => {
-        const { queryByText } = renderRow();
+    describe("when the reader is on the captured trace", () => {
+      /** @scenario "A deleted span reads plainly in the captured trace" */
+      it("reads like any other row, with nothing said about the removal", () => {
+        const { getByText, queryByText } = renderRow();
 
         expect(queryByText("Deleted")).not.toBeInTheDocument();
+        expect(getByText("web_search")).not.toHaveStyle({
+          textDecoration: "line-through",
+        });
       });
     });
   });

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/__tests__/useCorrectionMarks.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/__tests__/useCorrectionMarks.integration.test.tsx
@@ -45,6 +45,12 @@ const PATCH = {
   spans: [{ spanId: "kept", name: "renamed" }],
 };
 
+/** The same correction, on a span it renames before removing it. */
+const RENAMED_THEN_REMOVED = {
+  deletedSpanIds: ["removed"],
+  spans: [{ spanId: "removed", name: "renamed" }],
+};
+
 beforeEach(() => {
   harness.overlayView = "edited";
   harness.isEditing = false;
@@ -72,6 +78,26 @@ describe("given a correction that removes a span", () => {
       const { result } = renderHook(() => useCorrectionMarks(SPANS));
 
       expect(result.current.deletedByCorrectionSpanIds.size).toBe(0);
+    });
+
+    /** @scenario "A deleted span reads plainly in the captured trace" */
+    it("does not colour the removed span as changed, since no value changed", () => {
+      harness.overlayView = "original";
+
+      const { result } = renderHook(() => useCorrectionMarks(SPANS));
+
+      expect(result.current.correctedSpanIds.has("removed")).toBe(false);
+      expect(result.current.correctedSpanIds.has("kept")).toBe(true);
+    });
+
+    /** @scenario "A span the correction both changes and deletes still reads as changed" */
+    it("colours a span it renamed before removing", () => {
+      harness.overlayView = "original";
+      harness.patch = RENAMED_THEN_REMOVED;
+
+      const { result } = renderHook(() => useCorrectionMarks(SPANS));
+
+      expect(result.current.correctedSpanIds.has("removed")).toBe(true);
     });
   });
 

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/__tests__/useCorrectionMarks.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/__tests__/useCorrectionMarks.integration.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Which view carries the marks a correction leaves. The corrected trace is where
+ * a reader goes to see what the correction did, so a removal is legible there;
+ * the captured trace is the trace as it arrived and says nothing about it.
+ *
+ * See specs/traces-v2/trace-edit-mode.feature.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  overlayView: "edited" as "edited" | "original",
+  isEditing: false,
+  patch: null as unknown,
+}));
+
+vi.mock("../../../../hooks/useTraceEditOverlay", () => ({
+  useTraceEditOverlay: () => ({ data: { patch: harness.patch } }),
+}));
+
+vi.mock("../../../../stores/drawerStore", () => ({
+  useDrawerStore: (selector: (s: unknown) => unknown) =>
+    selector({ isEditing: harness.isEditing }),
+}));
+
+vi.mock("../../../../stores/traceEditStore", () => ({
+  useTraceEditStore: (selector: (s: unknown) => unknown) =>
+    selector({ overlayView: harness.overlayView, basePatch: null }),
+}));
+
+import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
+import { useCorrectionMarks } from "../useCorrectionMarks";
+
+const SPANS = [
+  { spanId: "root", parentSpanId: null },
+  { spanId: "removed", parentSpanId: "root" },
+  { spanId: "kept", parentSpanId: "root" },
+] as unknown as SpanTreeNode[];
+
+/** A stored correction that removes one span and renames another. */
+const PATCH = {
+  deletedSpanIds: ["removed"],
+  spans: [{ spanId: "kept", name: "renamed" }],
+};
+
+beforeEach(() => {
+  harness.overlayView = "edited";
+  harness.isEditing = false;
+  harness.patch = PATCH;
+});
+
+describe("given a correction that removes a span", () => {
+  describe("when the reader is on the corrected trace", () => {
+    /** @scenario "A deleted span is listed and struck through in the corrected trace" */
+    it("marks the removed span so the row can say so", () => {
+      const { result } = renderHook(() => useCorrectionMarks(SPANS));
+
+      expect(result.current.deletedByCorrectionSpanIds.has("removed")).toBe(
+        true,
+      );
+      expect(result.current.deletedByCorrectionSpanIds.has("kept")).toBe(false);
+    });
+  });
+
+  describe("when the reader is on the captured trace", () => {
+    /** @scenario "A deleted span reads plainly in the captured trace" */
+    it("marks nothing, because the trace as it arrived says nothing about it", () => {
+      harness.overlayView = "original";
+
+      const { result } = renderHook(() => useCorrectionMarks(SPANS));
+
+      expect(result.current.deletedByCorrectionSpanIds.size).toBe(0);
+    });
+  });
+
+  describe("when the reviewer is writing the correction", () => {
+    it("marks nothing, because the editing marks already say what is going", () => {
+      harness.isEditing = true;
+
+      const { result } = renderHook(() => useCorrectionMarks(SPANS));
+
+      expect(result.current.deletedByCorrectionSpanIds.size).toBe(0);
+    });
+  });
+});
+
+describe("given a trace with no correction", () => {
+  describe("when the reader is on the corrected trace", () => {
+    it("marks nothing at all", () => {
+      harness.patch = null;
+
+      const { result } = renderHook(() => useCorrectionMarks(SPANS));
+
+      expect(result.current.deletedByCorrectionSpanIds.size).toBe(0);
+      expect(result.current.correctedSpanIds.size).toBe(0);
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/useCorrectionMarks.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/useCorrectionMarks.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 import { expandDeletedSpanIds } from "~/server/traces/edit-overlay/applyTraceEditOverlay";
-import { overlayTouchesSpan } from "~/server/traces/edit-overlay/applyTraceEditOverlayToViews";
+import { changedSpanFields } from "~/server/traces/edit-overlay/applyTraceEditOverlayToViews";
 import { useTraceEditOverlay } from "../../../hooks/useTraceEditOverlay";
 import { useDrawerStore } from "../../../stores/drawerStore";
 import { useTraceEditStore } from "../../../stores/traceEditStore";
@@ -21,6 +21,10 @@ const NO_MARKS = {
  * carries no marks about removal at all. While the correction is being written
  * the editing marks already say what is going away, so there is nothing left
  * to mark.
+ *
+ * The changed set is the rows whose values the correction replaces, and only
+ * those: it promises a captured value the reader can go and compare, which a
+ * removal has none of.
  */
 export function useCorrectionMarks(spans: SpanTreeNode[]): {
   correctedSpanIds: Set<string>;
@@ -43,7 +47,7 @@ export function useCorrectionMarks(spans: SpanTreeNode[]): {
     const correctedSpanIds = new Set(
       spans
         .map((span) => span.spanId)
-        .filter((spanId) => overlayTouchesSpan({ patch, spanId })),
+        .filter((spanId) => changedSpanFields({ patch, spanId }).length > 0),
     );
     const deletedByCorrectionSpanIds =
       !isEditing && overlayView === "edited"

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/useCorrectionMarks.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/waterfallView/useCorrectionMarks.ts
@@ -14,10 +14,13 @@ const NO_MARKS = {
 /**
  * Which rows a stored correction changed, and which ones it removed.
  *
- * The removed set is only populated while the reader is on the captured trace:
- * on the corrected one those rows are already gone, and while the correction is
- * being written the editing marks already say what is going away, so there is
- * nothing left to mark.
+ * The removed set belongs to the corrected trace, which is where a reader goes
+ * to see what the correction did: those rows are kept on screen and struck
+ * through rather than dropped, because a row that simply vanished reads as one
+ * that was never captured. The captured trace is the trace as it arrived and
+ * carries no marks about removal at all. While the correction is being written
+ * the editing marks already say what is going away, so there is nothing left
+ * to mark.
  */
 export function useCorrectionMarks(spans: SpanTreeNode[]): {
   correctedSpanIds: Set<string>;
@@ -43,7 +46,7 @@ export function useCorrectionMarks(spans: SpanTreeNode[]): {
         .filter((spanId) => overlayTouchesSpan({ patch, spanId })),
     );
     const deletedByCorrectionSpanIds =
-      !isEditing && overlayView === "original"
+      !isEditing && overlayView === "edited"
         ? expandDeletedSpanIds({
             links: spans.map((span) => ({
               id: span.spanId,

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useSpanTree.overlay.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useSpanTree.overlay.integration.test.tsx
@@ -116,11 +116,29 @@ describe("useSpanTree with a correction", () => {
 
       /** @scenario "A deleted span is listed and struck through in the corrected trace" */
       it("leaves a removed row saying what the trace had, not what the edit renamed", () => {
+        // The same correction renames the span it deletes. A row whose whole
+        // point is showing what the trace had must not be dressed up by it.
+        overlay.current = {
+          traceId: "trace-1",
+          patch: {
+            version: 1,
+            spans: [
+              { spanId: "root", name: "conversation turn" },
+              { spanId: "tool", name: "search the web" },
+            ],
+            deletedSpanIds: ["tool"],
+          },
+        };
+
         const { result } = renderHook(() => useSpanTreeWithCaptured());
+        const removed = result.current.display.data?.find(
+          (s) => s.spanId === "tool",
+        );
         const kept = result.current.display.data?.find(
           (s) => s.spanId === "root",
         );
 
+        expect(removed?.name).toBe("web_search");
         // The rename still lands on the rows the correction kept.
         expect(kept?.name).toBe("conversation turn");
       });

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useSpanTree.overlay.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useSpanTree.overlay.integration.test.tsx
@@ -57,7 +57,7 @@ vi.mock("../useTraceQueryArgs", () => ({
 
 import { useDrawerStore } from "../../stores/drawerStore";
 import { useTraceEditStore } from "../../stores/traceEditStore";
-import { useSpanTree } from "../useSpanTree";
+import { useSpanTree, useSpanTreeWithCaptured } from "../useSpanTree";
 
 function node(over: { spanId: string; parentSpanId?: string; name?: string }) {
   return {
@@ -96,11 +96,33 @@ describe("useSpanTree with a correction", () => {
 
   describe("given a correction that renames one span and deletes another", () => {
     describe("when the reader is on the corrected trace", () => {
-      /** @scenario "A deleted span is hidden in the corrected trace" */
+      /** @scenario "A deleted span is not part of the corrected trace" */
       it("drops the deleted span and its descendants", () => {
         const { result } = renderHook(() => useSpanTree());
 
         expect(result.current.data?.map((s) => s.spanId)).toEqual(["root"]);
+      });
+
+      /** @scenario "A deleted span is listed and struck through in the corrected trace" */
+      it("keeps them on the tree the drawer draws, for it to strike through", () => {
+        const { result } = renderHook(() => useSpanTreeWithCaptured());
+
+        expect(result.current.display.data?.map((s) => s.spanId)).toEqual([
+          "root",
+          "tool",
+          "child",
+        ]);
+      });
+
+      /** @scenario "A deleted span is listed and struck through in the corrected trace" */
+      it("leaves a removed row saying what the trace had, not what the edit renamed", () => {
+        const { result } = renderHook(() => useSpanTreeWithCaptured());
+        const kept = result.current.display.data?.find(
+          (s) => s.spanId === "root",
+        );
+
+        // The rename still lands on the rows the correction kept.
+        expect(kept?.name).toBe("conversation turn");
       });
 
       /** @scenario "The corrected trace is what the reader sees by default" */

--- a/platform/app/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/platform/app/src/features/traces-v2/hooks/useSpanTree.ts
@@ -159,7 +159,27 @@ export function useSpanTreeWithCaptured() {
     [captured, data, nodes],
   );
 
-  return useMemo(() => ({ captured, corrected }), [captured, corrected]);
+  // The same tree with the removed rows still on it, for the waterfall to show
+  // struck through. It is what the correction did, not what the trace now is,
+  // so it never stands in for `corrected`.
+  const displayData = useMemo(
+    () =>
+      nodes
+        ? applyOverlayToSpanTreeNodes({ nodes, patch, keepDeleted: true })
+        : nodes,
+    [nodes, patch],
+  );
+
+  const display = useMemo(
+    () =>
+      displayData === nodes ? captured : { ...captured, data: displayData },
+    [captured, displayData, nodes],
+  );
+
+  return useMemo(
+    () => ({ captured, corrected, display }),
+    [captured, corrected, display],
+  );
 }
 
 /**

--- a/platform/app/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/platform/app/src/features/traces-v2/hooks/useSpanTree.ts
@@ -165,7 +165,7 @@ export function useSpanTreeWithCaptured() {
   const displayData = useMemo(
     () =>
       nodes
-        ? applyOverlayToSpanTreeNodes({ nodes, patch, keepDeleted: true })
+        ? applyOverlayToSpanTreeNodes({ nodes, patch, shouldKeepDeleted: true })
         : nodes,
     [nodes, patch],
   );

--- a/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -325,10 +325,14 @@ describe("traces router — #4991 AC5 list grid stays preview", () => {
       });
       expect(mockBuildDeps).not.toHaveBeenCalled();
       // getTracesWithSpans called with NO { full: true } opts (preview only).
+      // It does carry the correction flag: applying a correction needs neither
+      // the blob-resolution deps nor full resolution.
       expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
         "project_123",
         ["t1"],
         expect.any(Object),
+        undefined,
+        expect.not.objectContaining({ full: true }),
       );
     });
   });

--- a/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -325,14 +325,31 @@ describe("traces router — #4991 AC5 list grid stays preview", () => {
       });
       expect(mockBuildDeps).not.toHaveBeenCalled();
       // getTracesWithSpans called with NO { full: true } opts (preview only).
-      // It does carry the correction flag: applying a correction needs neither
-      // the blob-resolution deps nor full resolution.
       expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
         "project_123",
         ["t1"],
         expect.any(Object),
         undefined,
-        expect.not.objectContaining({ full: true }),
+        { withEditOverlay: false },
+      );
+    });
+
+    it("stays on previews when it is asked for the corrected trace", async () => {
+      await caller.getFormattedSpansDigest({
+        projectId: "project_123",
+        traceIds: ["t1"],
+        withEditOverlay: true,
+      });
+      // Applying a correction needs neither the blob-resolution deps nor full
+      // resolution, so asking for one must not drag a whole page of offloaded
+      // values in behind it.
+      expect(mockBuildDeps).not.toHaveBeenCalled();
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+        "project_123",
+        ["t1"],
+        expect.any(Object),
+        undefined,
+        { withEditOverlay: true },
       );
     });
   });

--- a/platform/app/src/server/api/routers/traces.ts
+++ b/platform/app/src/server/api/routers/traces.ts
@@ -272,19 +272,20 @@ export const tracesRouter = createTRPCRouter({
       });
 
       // The digest is one more reading of the same spans the other columns are
-      // mapped from, so it is read the same way. Read without the correction it
-      // would spell out, in the one column that quotes the whole trace, the very
+      // mapped from, so the correction is read the same way. Read without it,
+      // the one column that quotes the whole trace would spell out the very
       // spans the reviewer deleted.
-      const traceService = TraceService.create(
-        ctx.prisma,
-        buildTraceBlobResolutionDeps(),
-      );
+      //
+      // It stays on previews all the same: this runs over a whole page of
+      // traces at once, and resolving every offloaded value on all of them is
+      // what #4991 kept off the grid. Applying a correction needs none of it.
+      const traceService = TraceService.create(ctx.prisma);
       const traces = await traceService.getTracesWithSpans(
         projectId,
         traceIds,
         protections,
         undefined,
-        { full: true, withEditOverlay: input.withEditOverlay },
+        { withEditOverlay: input.withEditOverlay },
       );
 
       return Object.fromEntries(

--- a/platform/app/src/server/api/routers/traces.ts
+++ b/platform/app/src/server/api/routers/traces.ts
@@ -257,7 +257,13 @@ export const tracesRouter = createTRPCRouter({
     }),
 
   getFormattedSpansDigest: protectedProcedure
-    .input(z.object({ projectId: z.string(), traceIds: z.array(z.string()) }))
+    .input(
+      z.object({
+        projectId: z.string(),
+        traceIds: z.array(z.string()),
+        withEditOverlay: withEditOverlayInput,
+      }),
+    )
     .use(checkProjectPermission("traces:view"))
     .query(async ({ input, ctx }) => {
       const { projectId, traceIds } = input;
@@ -265,11 +271,20 @@ export const tracesRouter = createTRPCRouter({
         projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      // The digest is one more reading of the same spans the other columns are
+      // mapped from, so it is read the same way. Read without the correction it
+      // would spell out, in the one column that quotes the whole trace, the very
+      // spans the reviewer deleted.
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       const traces = await traceService.getTracesWithSpans(
         projectId,
         traceIds,
         protections,
+        undefined,
+        { full: true, withEditOverlay: input.withEditOverlay },
       );
 
       return Object.fromEntries(

--- a/platform/app/src/server/tracer/tracesMapping.ts
+++ b/platform/app/src/server/tracer/tracesMapping.ts
@@ -830,9 +830,18 @@ export const TRACE_MAPPINGS = {
   }
 >;
 
+/**
+ * Whether mapping a source turns its expansion on for you.
+ *
+ * A trace has one annotation or a handful, so expanding them reads as the point
+ * of mapping them at all. It has as many spans as it has work, and a dataset
+ * built from them is a row per trace until someone says otherwise, so the span
+ * expansions are opt-in.
+ */
 export const TRACE_EXPANSIONS = {
   "spans.llm.span_id": {
     label: "LLM span",
+    enabledByDefault: false,
     expansion: (trace: TraceWithAnnotations) => {
       const spans = trace.spans?.filter((span) => span.type === "llm") ?? [];
       return spans.map((span) => ({
@@ -843,6 +852,7 @@ export const TRACE_EXPANSIONS = {
   },
   "spans.all.span_id": {
     label: "span",
+    enabledByDefault: false,
     expansion: (trace: TraceWithAnnotations) => {
       const spans = trace.spans ?? [];
       return spans.map((span) => ({
@@ -853,6 +863,7 @@ export const TRACE_EXPANSIONS = {
   },
   "annotations.id": {
     label: "annotation",
+    enabledByDefault: true,
     expansion: (trace: TraceWithAnnotations) => {
       const annotations = trace.annotations ?? [];
       return annotations.map((annotation) => ({
@@ -863,6 +874,7 @@ export const TRACE_EXPANSIONS = {
   },
   "events.event_id": {
     label: "event",
+    enabledByDefault: true,
     expansion: (trace: TraceWithAnnotations) => {
       const events = trace.events ?? [];
       return events.map((event) => ({
@@ -875,6 +887,7 @@ export const TRACE_EXPANSIONS = {
   string,
   {
     label: string;
+    enabledByDefault: boolean;
     expansion: (trace: TraceWithAnnotations) => TraceWithAnnotations[];
   }
 >;

--- a/platform/app/src/server/traces/edit-overlay/__tests__/applyTraceEditOverlay.unit.test.ts
+++ b/platform/app/src/server/traces/edit-overlay/__tests__/applyTraceEditOverlay.unit.test.ts
@@ -18,7 +18,6 @@ import {
   applyOverlayToTraceHeader,
   changedSpanFields,
   changedTraceMetadataKeys,
-  overlayTouchesSpan,
 } from "../applyTraceEditOverlayToViews";
 import type { TraceEditOverlayPatch } from "../traceEditOverlay.schemas";
 
@@ -468,8 +467,8 @@ describe("applying a correction to the drawer views", () => {
         "output",
       ]);
       expect(changedSpanFields({ patch, spanId: "span-3" })).toEqual([]);
-      expect(overlayTouchesSpan({ patch, spanId: "span-2" })).toBe(true);
-      expect(overlayTouchesSpan({ patch, spanId: "span-3" })).toBe(false);
+      // Removing a span replaces none of its fields, so it names none.
+      expect(changedSpanFields({ patch, spanId: "span-2" })).toEqual([]);
     });
   });
 });

--- a/platform/app/src/server/traces/edit-overlay/applyTraceEditOverlayToViews.ts
+++ b/platform/app/src/server/traces/edit-overlay/applyTraceEditOverlayToViews.ts
@@ -46,13 +46,21 @@ function correctedTreeNode({
  * Applies a correction to the v2 waterfall/flame nodes: deleted spans (and
  * their descendants) drop out, renames and type changes land. Node payloads
  * carry no content, so nothing here is privacy-sensitive.
+ *
+ * `keepDeleted` is for the tree the reader looks at rather than the trace the
+ * correction describes. A span that simply vanished reads as one that was never
+ * captured, so the waterfall keeps it on the row it had, for the caller to mark
+ * and strike through. Everything that asks what the corrected trace IS -- its
+ * span count, whether a comment still points at something -- leaves it off.
  */
 export function applyOverlayToSpanTreeNodes({
   nodes,
   patch,
+  keepDeleted = false,
 }: {
   nodes: SpanTreeNode[];
   patch: TraceEditOverlayPatch | null | undefined;
+  keepDeleted?: boolean;
 }): SpanTreeNode[] {
   if (!patch || !patchHasAnyEdit(patch)) return nodes;
 
@@ -65,18 +73,23 @@ export function applyOverlayToSpanTreeNodes({
   });
   const patchesBySpanId = indexSpanPatches(patch);
 
-  let changed = false;
-  const nextNodes: SpanTreeNode[] = [];
-  for (const node of nodes) {
-    if (deleted.has(node.spanId)) {
-      changed = true;
-      continue;
-    }
-    const spanPatch = patchesBySpanId.get(node.spanId);
-    const corrected = spanPatch ? correctedTreeNode({ node, spanPatch }) : node;
-    if (corrected !== node) changed = true;
-    nextNodes.push(corrected);
-  }
+  // A removed row that is kept is kept as captured: a rename the same
+  // correction made would dress up a row whose whole point is showing what the
+  // trace had.
+  const keptNodes = keepDeleted
+    ? nodes
+    : nodes.filter((node) => !deleted.has(node.spanId));
+
+  const nextNodes = keptNodes.map((node) => {
+    const spanPatch = deleted.has(node.spanId)
+      ? undefined
+      : patchesBySpanId.get(node.spanId);
+    return spanPatch ? correctedTreeNode({ node, spanPatch }) : node;
+  });
+
+  const changed =
+    keptNodes.length !== nodes.length ||
+    nextNodes.some((node, index) => node !== keptNodes[index]);
 
   return changed ? nextNodes : nodes;
 }

--- a/platform/app/src/server/traces/edit-overlay/applyTraceEditOverlayToViews.ts
+++ b/platform/app/src/server/traces/edit-overlay/applyTraceEditOverlayToViews.ts
@@ -271,20 +271,6 @@ export function applyOverlayToTraceHeader({
   return changed ? next : header;
 }
 
-/** True when the correction changes or removes this span. Drives the changed
- *  highlight on rows and fields. */
-export function overlayTouchesSpan({
-  patch,
-  spanId,
-}: {
-  patch: TraceEditOverlayPatch | null | undefined;
-  spanId: string;
-}): boolean {
-  if (!patch) return false;
-  if (patch.deletedSpanIds.includes(spanId)) return true;
-  return changedSpanFields({ patch, spanId }).length > 0;
-}
-
 /** The span fields this correction replaces, in presentation order. */
 export function changedSpanFields({
   patch,

--- a/platform/app/src/server/traces/edit-overlay/applyTraceEditOverlayToViews.ts
+++ b/platform/app/src/server/traces/edit-overlay/applyTraceEditOverlayToViews.ts
@@ -47,20 +47,20 @@ function correctedTreeNode({
  * their descendants) drop out, renames and type changes land. Node payloads
  * carry no content, so nothing here is privacy-sensitive.
  *
- * `keepDeleted` is for the tree the reader looks at rather than the trace the
- * correction describes. A span that simply vanished reads as one that was never
- * captured, so the waterfall keeps it on the row it had, for the caller to mark
- * and strike through. Everything that asks what the corrected trace IS -- its
- * span count, whether a comment still points at something -- leaves it off.
+ * `shouldKeepDeleted` is for the tree the reader looks at rather than the trace
+ * the correction describes. A span that simply vanished reads as one that was
+ * never captured, so the waterfall keeps it on the row it had, for the caller to
+ * mark and strike through. Everything that asks what the corrected trace IS --
+ * its span count, whether a comment still points at something -- leaves it off.
  */
 export function applyOverlayToSpanTreeNodes({
   nodes,
   patch,
-  keepDeleted = false,
+  shouldKeepDeleted = false,
 }: {
   nodes: SpanTreeNode[];
   patch: TraceEditOverlayPatch | null | undefined;
-  keepDeleted?: boolean;
+  shouldKeepDeleted?: boolean;
 }): SpanTreeNode[] {
   if (!patch || !patchHasAnyEdit(patch)) return nodes;
 
@@ -76,7 +76,7 @@ export function applyOverlayToSpanTreeNodes({
   // A removed row that is kept is kept as captured: a rename the same
   // correction made would dress up a row whose whole point is showing what the
   // trace had.
-  const keptNodes = keepDeleted
+  const keptNodes = shouldKeepDeleted
     ? nodes
     : nodes.filter((node) => !deleted.has(node.spanId));
 

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -155,6 +155,25 @@ Feature: Span field mapping when adding traces to a dataset
     When I open it without having chosen an expansion before
     Then the span expansion is off
 
+  # A trace carries one annotation or a handful, and asking for them is asking
+  # for each of them, so their expansion is the reading mapping them means. The
+  # spans are the opposite, which is why only some sources come with theirs on.
+  @integration
+  Scenario: Mapping annotations turns their expansion on
+    Given a column that has not been mapped to anything yet
+    When I map it to the annotations source
+    Then the annotation expansion is on
+
+  # An expansion is a choice the reader made, not a property of whichever column
+  # happens to be mapped right now. A source that stops being mapped takes its
+  # switch off the panel, and changing that column back has to bring the reader's
+  # answer back with it rather than start the question over.
+  @integration
+  Scenario: An expansion I turned on survives its column being remapped and mapped back
+    Given a mapping whose span expansion I turned on
+    When I change that column to another source and back to the spans source
+    Then the span expansion is still on
+
   # ============================================================================
   # The mapping preview renders with the SAME cells as the evaluations
   # workbench dataset table: same heights, JSON values formatted, double-click

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -135,6 +135,18 @@ Feature: Span field mapping when adding traces to a dataset
     Then no expansion is enabled
     And it stays off
 
+  # A switch is a control of its own, wherever the drawer places it. A field
+  # describes one control and hands that control its id, so a field wrapped
+  # around the mapping and the preview together gave every switch and every
+  # preview checkbox the same id, and a click on one went wherever that id
+  # resolved first, which was usually nowhere the reader aimed.
+  @integration
+  Scenario: An expansion switch answers to its own label in the drawer
+    Given the Add to Dataset drawer with the mapping and the preview side by side
+    When I click the words beside an expansion switch
+    Then that expansion is on
+    And no other switch and no preview checkbox moved
+
   # A dataset row per trace is what a reader asks for when they add traces to a
   # dataset; one row per span is a normalisation they opt into.
   @integration

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -114,6 +114,36 @@ Feature: Span field mapping when adding traces to a dataset
     Then it produces a single row whose spans field is the array of all spans
 
   # ============================================================================
+  # The Expansions switches. Each one is a switch about its own expansion, and
+  # turning them all off is a choice the reader is allowed to make: a mapping
+  # with nothing expanded is the one that keeps one row per trace.
+  # ============================================================================
+
+  @integration
+  Scenario: Each expansion switch toggles only its own expansion
+    Given a mapping that offers both the annotation and the span expansion
+    And both are enabled
+    When I turn off the span expansion
+    Then the span expansion is off
+    And the annotation expansion is still on
+
+  @integration
+  Scenario: The last expansion can be turned off
+    Given a mapping that offers both the annotation and the span expansion
+    And only the span expansion is enabled
+    When I turn off the span expansion
+    Then no expansion is enabled
+    And it stays off
+
+  # A dataset row per trace is what a reader asks for when they add traces to a
+  # dataset; one row per span is a normalisation they opt into.
+  @integration
+  Scenario: The span expansion starts off
+    Given a mapping that offers the span expansion
+    When I open it without having chosen an expansion before
+    Then the span expansion is off
+
+  # ============================================================================
   # The mapping preview renders with the SAME cells as the evaluations
   # workbench dataset table: same heights, JSON values formatted, double-click
   # opens the editor. Mapping a span-heavy trace into a column used to dump

--- a/specs/traces-v2/trace-edit-mode.feature
+++ b/specs/traces-v2/trace-edit-mode.feature
@@ -760,6 +760,17 @@ Feature: Editing a trace in the drawer
       Then that attribute is listed with no removed marker
       And its value is not struck through
 
+    # A struck-through row is a way of showing what is gone, and only the table
+    # can draw it. Copying the attributes, or reading them as JSON, hands them on
+    # somewhere with nowhere to strike anything through, so a removed attribute
+    # would arrive there looking like one the span still carries.
+    @integration
+    Scenario: Copying the attributes leaves out the ones the correction removed
+      Given the trace has a correction that removes a span attribute
+      When I copy the attributes of the corrected span
+      Then the copied attributes hold everything the corrected span carries
+      And the removed attribute is not among them
+
     # A correction rewrites a whole attribute record, so an attribute holding
     # JSON comes back re-serialised even when the reviewer never touched it:
     # different spacing, different key order, the same data. Marking that as

--- a/specs/traces-v2/trace-edit-mode.feature
+++ b/specs/traces-v2/trace-edit-mode.feature
@@ -684,14 +684,15 @@ Feature: Editing a trace in the drawer
       Then the header counts one span fewer than was captured
       And the captured trace still counts them all
 
-    # The captured trace is the trace as it arrived. Nothing the correction did
-    # belongs on it, so a span the correction removes reads there exactly like
-    # every span the correction never touched. The changed colour is not a
-    # milder way to say it: it promises a replaced value the reader can go and
-    # compare, and a removal replaces nothing.
+    # The captured trace is the trace as it arrived, so a span the correction
+    # does nothing to but remove reads there exactly like every span it never
+    # touched. The changed colour is not a milder way to say removed: it promises
+    # a replaced value the reader can go and compare, and a removal replaces
+    # nothing. A correction that renamed the span before removing it did replace
+    # one, which is the scenario after this.
     @integration
     Scenario: A deleted span reads plainly in the captured trace
-      Given the trace has a correction that deletes a span
+      Given the trace has a correction whose only change is deleting a span
       When I switch to the captured trace
       Then that span is listed with no deleted marker
       And its name is not struck through
@@ -703,11 +704,11 @@ Feature: Editing a trace in the drawer
       When I switch to the captured trace
       Then that span carries the changed colour
 
-    # Removal is the whole of the change, and the deleted marker says it. The
-    # changed colour on the same row argues with it.
+    # When removal is the whole of the change the deleted marker says it, and
+    # the changed colour on the same row argues with it.
     @integration
     Scenario: A deleted span is not also coloured as changed
-      Given the trace has a correction that deletes a span
+      Given the trace has a correction whose only change is deleting a span
       When I read the corrected trace
       Then that row does not carry the changed colour
 

--- a/specs/traces-v2/trace-edit-mode.feature
+++ b/specs/traces-v2/trace-edit-mode.feature
@@ -654,12 +654,21 @@ Feature: Editing a trace in the drawer
       When I open another trace
       Then it opens corrected
 
+    # The corrected trace is where a reader goes to see what the correction did,
+    # so a removal has to be visible there. A span that simply vanished would
+    # read as a span that was never captured, and the reader would have to hold
+    # both views in their head to notice anything went away at all. It stays on
+    # the row it had, struck through and marked, which is the one rendering that
+    # says "this was here and the correction takes it out".
     @integration
-    Scenario: A deleted span is hidden in the corrected trace
+    Scenario: A deleted span is listed and struck through in the corrected trace
       Given the trace has a correction that deletes a span
       When I read the corrected trace
-      Then that span is not listed
+      Then that span is listed and marked as deleted
+      And its name and its type are struck through
 
+    # The tombstone says what the correction removes; it is not part of what the
+    # corrected trace contains.
     @unit
     Scenario: The header counts the spans the corrected trace has
       Given the trace has a correction that deletes a span
@@ -667,18 +676,22 @@ Feature: Editing a trace in the drawer
       Then the header counts one span fewer than was captured
       And the captured trace still counts them all
 
+    # The captured trace is the trace as it arrived. Nothing the correction did
+    # belongs on it, so a span the correction removes reads there exactly like
+    # every span the correction never touched.
     @integration
-    Scenario: A deleted span is marked in the captured trace
+    Scenario: A deleted span reads plainly in the captured trace
       Given the trace has a correction that deletes a span
       When I switch to the captured trace
-      Then that span is listed and marked as deleted
+      Then that span is listed with no deleted marker
+      And its name is not struck through
 
     # Removal is the whole of the change, and the deleted marker says it. The
     # changed colour on the same row argues with it.
     @integration
     Scenario: A deleted span is not also coloured as changed
       Given the trace has a correction that deletes a span
-      When I switch to the captured trace
+      When I read the corrected trace
       Then that row does not carry the changed colour
 
     # The markers a correction adds sit beside the span name and take room from
@@ -712,6 +725,45 @@ Feature: Editing a trace in the drawer
     Scenario: An attribute the correction added is marked as added
       Given the trace has a correction that adds a span attribute
       Then that attribute is marked as added by an edit
+
+    # An attribute the correction takes away is the same case as a span it takes
+    # away: the corrected trace is where the removal has to be legible, and a row
+    # that simply stopped existing is not.
+    @integration
+    Scenario: An attribute the correction removes is listed struck through
+      Given the trace has a correction that removes a span attribute
+      When I read the corrected trace
+      Then that attribute is listed with its captured value struck through
+      And it is marked as removed
+
+    @integration
+    Scenario: An attribute the correction removes reads plainly in the captured trace
+      Given the trace has a correction that removes a span attribute
+      When I switch to the captured trace
+      Then that attribute is listed with no removed marker
+      And its value is not struck through
+
+    # A correction rewrites a whole attribute record, so an attribute holding
+    # JSON comes back re-serialised even when the reviewer never touched it:
+    # different spacing, different key order, the same data. Marking that as
+    # edited teaches the reader to distrust the marker, which costs more than
+    # the marker is worth.
+    @integration
+    Scenario: JSON that only changed its formatting is not marked as edited
+      Given the trace has a correction that reformats an attribute holding JSON
+      Then that attribute is not marked as edited
+
+    @unit
+    Scenario: Reordered JSON keys are not an edit
+      Given a captured attribute and a corrected one holding the same keys in a
+      different order
+      Then they read as the same value
+
+    @unit
+    Scenario: Reordered JSON array entries are an edit
+      Given a captured attribute and a corrected one holding the same array
+      entries in a different order
+      Then they read as different values
 
     @integration
     Scenario: A corrected span name names its captured name

--- a/specs/traces-v2/trace-edit-mode.feature
+++ b/specs/traces-v2/trace-edit-mode.feature
@@ -686,13 +686,22 @@ Feature: Editing a trace in the drawer
 
     # The captured trace is the trace as it arrived. Nothing the correction did
     # belongs on it, so a span the correction removes reads there exactly like
-    # every span the correction never touched.
+    # every span the correction never touched. The changed colour is not a
+    # milder way to say it: it promises a replaced value the reader can go and
+    # compare, and a removal replaces nothing.
     @integration
     Scenario: A deleted span reads plainly in the captured trace
       Given the trace has a correction that deletes a span
       When I switch to the captured trace
       Then that span is listed with no deleted marker
       And its name is not struck through
+      And it does not carry the changed colour either
+
+    @integration
+    Scenario: A span the correction both changes and deletes still reads as changed
+      Given the trace has a correction that renames a span and then deletes it
+      When I switch to the captured trace
+      Then that span carries the changed colour
 
     # Removal is the whole of the change, and the deleted marker says it. The
     # changed colour on the same row argues with it.

--- a/specs/traces-v2/trace-edit-mode.feature
+++ b/specs/traces-v2/trace-edit-mode.feature
@@ -667,8 +667,16 @@ Feature: Editing a trace in the drawer
       Then that span is listed and marked as deleted
       And its name and its type are struck through
 
-    # The tombstone says what the correction removes; it is not part of what the
-    # corrected trace contains.
+    # The tombstone is a row about what the correction did, not a span the
+    # corrected trace has. Everything that asks what the trace now contains
+    # leaves it out, which is what keeps the tombstone from reaching a dataset.
+    @integration
+    Scenario: A deleted span is not part of the corrected trace
+      Given the trace has a correction that deletes a span
+      When the corrected trace is read for what it contains
+      Then that span is not in it
+      And neither are its descendants
+
     @unit
     Scenario: The header counts the spans the corrected trace has
       Given the trace has a correction that deletes a span

--- a/specs/traces-v2/trace-edit-overlay.feature
+++ b/specs/traces-v2/trace-edit-overlay.feature
@@ -324,8 +324,10 @@ Feature: Correcting a trace without rewriting it
     Scenario: The AI-readable column is read the way the rest of the mapping is
       Given a corrected trace being mapped into a dataset
       When the mapping fills its AI-readable column
-      Then the trace behind that column is read with corrections
-      And an evaluator being set up on the same trace reads it as captured
+      Then the column spells out the corrected trace, without the spans the
+      correction deleted
+      And an evaluator being set up on the same trace still gets every span the
+      trace captured
 
     @unit
     Scenario: A page of traces fetches its corrections in one read

--- a/specs/traces-v2/trace-edit-overlay.feature
+++ b/specs/traces-v2/trace-edit-overlay.feature
@@ -317,6 +317,16 @@ Feature: Correcting a trace without rewriting it
       And an evaluator being set up on the same trace reads the conversation as
       it was captured
 
+    # The AI-readable column spells the whole trace out span by span, from a read
+    # of its own. Left uncorrected it is the one column that puts back what every
+    # other column leaves out, and a deleted span reaches the dataset through it.
+    @integration
+    Scenario: The AI-readable column is read the way the rest of the mapping is
+      Given a corrected trace being mapped into a dataset
+      When the mapping fills its AI-readable column
+      Then the trace behind that column is read with corrections
+      And an evaluator being set up on the same trace reads it as captured
+
     @unit
     Scenario: A page of traces fetches its corrections in one read
       Given several corrected traces read together


### PR DESCRIPTION
Four bugs found while dogfooding the trace edit overlay, all reported from the product.

## A deleted span reached the dataset through the AI-readable column

The "Full Trace (AI-Readable)" column is filled from a read of its own, and that read never asked for the reviewer's corrections. Every other column in the same mapping did, so a span the reviewer deleted was gone from `spans.*` and from the traces list, and still spelled out in full in the one column that quotes the whole trace.

`getFormattedSpansDigest` now takes `withEditOverlay` like its siblings, and the mapping passes it the same flag it already passes the thread read. I audited every other `getTracesWithSpans` caller: the evaluation paths read captured data on purpose, and the two dataset surfaces already opted in, so this was the only leak.

## Removals were shown on the wrong trace

A span a correction deletes used to vanish from the corrected trace and carry a "Deleted" badge on the captured one. That is backwards on both counts. The corrected trace is where a reader goes to see what the correction did, and a row that simply disappeared reads as a row that was never captured, so the removal was the one edit the reader could not see.

A removed span now stays on the row it had in the corrected trace, marked and struck through along with the model or tool pill under its name, and reads plainly in the captured one. Attributes a correction removes get the same treatment: still listed, struck through, marked Removed rather than Edited, since a removal is not an edit to the value.

The tombstones are a rendering of what the correction did, not spans the corrected trace has. The tree the drawer draws keeps them; everything that asks what the trace now contains, the header's span count, whether a comment still points at something, what a dataset row is built from, reads the tree that leaves them out.

## Re-serialised JSON read as an edited attribute

A correction rewrites a whole attribute record, so an attribute holding JSON comes back re-serialised whether or not the reviewer touched it: different spacing, different key order, sometimes text where the capture held the structure. The comparison behind the "Edited" marker was on the rendered string, so all of that counted and rows nobody had edited came back marked. A marker that fires on rows nobody edited is one readers learn to ignore.

Values are now compared by what they say. Key order is formatting and does not count; array order is content and does. Text is only read as JSON when it parses to an object or an array, so a correction that turned the string `"123"` into the number `123` still reads as the edit it is. The unit test uses the two payloads from the report, a tool-call array and a conversation.

## The Expansions switches could not be switched

Three separate faults on the add-to-dataset mapping:

The switches all sat inside one field. A field describes a single control, so it hands its id to every control under it, and the drawer wrapped the whole panel, the mapping and the preview table together, in one. Every switch and every preview checkbox came out with the same id, each switch's label pointed at whichever input that id found first, and the switches simply did not respond to a click. Both fields are now headings that hold nothing but their words, so each control owns its id and announces its own name instead of all announcing the field's.

Turning the last expansion off did not stick. An empty selection read as "nothing chosen yet", so when the host saved the mapping and re-read it, that answer put the stored expansions straight back, including one the reader never touched. After the first pass the selection is the whole truth, empty included.

Mapping a column to the spans source no longer turns "one row per span" on by itself. A dataset built from traces is a row per trace until someone asks otherwise. Annotations and events, where expanding is the point of mapping them, are unchanged.

Clicking the words beside a switch now toggles it, which it did not before.

## Screenshots

Dogfooded on a seven-span trace with one span deleted.

The corrected trace lists the removed span, struck through with its model pill, and counts six:

![corrected trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/trace-edit-overlay/6855-edited-view.png)

The captured trace reads exactly as it arrived, seven spans and no marks:

![captured trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/trace-edit-overlay/6855-original-view.png)

Attributes a correction removes, struck through and marked Removed. `gen_ai.output.messages` carries no marker: the stored correction holds it parsed while the capture holds the same JSON as a string, which is the false Edited the report was about:

![attributes](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/trace-edit-overlay/6855-attributes-removed.png)

The Expansions switches, each answering to its own click and staying where it was put:

![expansions](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/trace-edit-overlay/6855-expansions.png)

## Tests

Every fix has a test that fails without it, checked by reverting each one in turn:

- `TracesMapping.correctionReads` gains the AI-readable column, read with and without corrections.
- `TracesMapping.expansions` is new: each switch toggles only its own, the last one stays off through a stale re-read from the host, and the span expansion is not turned on by mapping the source. It renders the mapping the way its real hosts do, holding the value and handing it back, because an uncontrolled render hides the round trip the bug lived on.
- `attributeValueEquality` is new, 10 cases over the reported payloads.
- `useCorrectionMarks` is new: which view carries the marks, and that a span the correction only removes is not also coloured as changed.
- `DatasetMappingPreview.expansions` is new: the switches as the drawer composes them, beside the preview table. Rendering the mapping on its own cannot see a field wrapped around both halves.
- `TreeRow.correction`, `AttributeTable.editing` and `useSpanTree.overlay` cover the inverted display and the tombstone tree.

`specs/traces-v2/trace-edit-mode.feature`, `trace-edit-overlay.feature` and `specs/datasets/add-to-dataset-span-mapping.feature` carry the new scenarios. The dataset one was in `LEGACY_INERT` and is removed from it, since it now binds its scenarios for real.

Gates: `pnpm typecheck:all` clean, the traces, datasets and waterfall integration suites green, no new Biome violations, `check-feature-parity` exits 0 with all three feature files fully bound.


## After review

- The digest read stays on previews. Teaching `getFormattedSpansDigest` about corrections had also given it the blob-resolution deps and full resolution, which is the read #4991 kept off this path: it runs over a whole page of traces at once. Applying a correction needs neither, and `traces.4991-full-resolution` guards it.
- Copying a corrected span's attributes, and reading them as JSON, quoted the struck-through rows too, so an attribute a correction removed travelled back out as one the span still carries. The table now lists one map and hands on another.
- Mapping a column rebuilt the expansions from the render's filtered set rather than the latest state, so an expansion the reader had turned on was lost once its column was remapped away and back.
- Smaller ones: `keepDeleted` is `shouldKeepDeleted`, `sameExpansions` takes a named-parameter object, two doc comments are back on the functions they describe, and two tests that were bound to a scenario they did not prove now have the right one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace mapping supports independent expansion controls, sensible defaults, and preserved selections.
  * Corrected trace views retain deleted spans and attributes with strikethrough and removal labels.
  * AI-readable dataset mappings can reflect corrected trace data where applicable.
* **Bug Fixes**
  * Attribute comparisons ignore JSON formatting and object-key order while detecting meaningful edits.
  * Corrected and captured views distinguish edited and deleted content more reliably.
* **Tests**
  * Added coverage for expansion controls, correction overlays, deleted content, and attribute comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
