### PR TITLE
fix(mcp): make /sse transport work across replicas and harden the OAuth path

### DIFF
--- a/docs/ai-governance/mcp.mdx
+++ b/docs/ai-governance/mcp.mdx
@@ -48,7 +48,7 @@ The pattern is `governance_<resource_with_underscores>_<verb_with_underscores>`,
 
 ## Authentication
 
-Governance MCP tools register inside LangWatch's existing MCP server (mounted at `/api/mcp/*` on the same host that serves the dashboard), there is **no separate `langwatch mcp serve` binary**. Clients connect over HTTP using either streamable-HTTP at `/mcp` or SSE at `/sse`, and authenticate with one of:
+Governance MCP tools register inside LangWatch's existing MCP server (served on the same host that serves the dashboard), there is **no separate `langwatch mcp serve` binary**. Clients connect over HTTP using either streamable-HTTP at `/mcp` or SSE at `/sse`, and authenticate with one of:
 
 - **Project API key as Bearer** (`Authorization: Bearer <projectApiKey>`), the plain read tools work immediately. Sufficient to call `governance_*_list` and `governance_*_get`. Admin reads (`governance_*_admin_list`, which expose `ottlRules`) and every write tool require a user-bound session and reject a project-key-only caller.
 - **OAuth (PKCE) flow** at `/api/mcp/authorize` → `/oauth/token`, required for write tools and admin reads. The OAuth flow captures the user's id at authorize time, threads it through the session token cache, and surfaces it to governance tools as `ctx.callerUserId`. Without it, a write tool returns an `AUTH_REQUIRED:` error pointing the client at the OAuth flow.
@@ -59,7 +59,9 @@ Governance MCP tools register inside LangWatch's existing MCP server (mounted at
 {
   "mcpServers": {
     "langwatch-governance": {
-      "url": "https://app.langwatch.ai/api/mcp"
+      "url": "https://app.langwatch.ai/mcp"
+      // Clients that speak the older SSE transport use
+      // https://app.langwatch.ai/sse instead.
       // Read-only access: add Authorization: Bearer <projectApiKey>.
       // Read+write access: complete the OAuth PKCE flow at /api/mcp/authorize.
     }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -17159,7 +17159,7 @@ The pattern is `governance_<resource_with_underscores>_<verb_with_underscores>`,
 
 ## Authentication
 
-Governance MCP tools register inside LangWatch's existing MCP server (mounted at `/api/mcp/*` on the same host that serves the dashboard), there is **no separate `langwatch mcp serve` binary**. Clients connect over HTTP using either streamable-HTTP at `/mcp` or SSE at `/sse`, and authenticate with one of:
+Governance MCP tools register inside LangWatch's existing MCP server (served on the same host that serves the dashboard), there is **no separate `langwatch mcp serve` binary**. Clients connect over HTTP using either streamable-HTTP at `/mcp` or SSE at `/sse`, and authenticate with one of:
 
 - **Project API key as Bearer** (`Authorization: Bearer <projectApiKey>`), the plain read tools work immediately. Sufficient to call `governance_*_list` and `governance_*_get`. Admin reads (`governance_*_admin_list`, which expose `ottlRules`) and every write tool require a user-bound session and reject a project-key-only caller.
 - **OAuth (PKCE) flow** at `/api/mcp/authorize` → `/oauth/token`, required for write tools and admin reads. The OAuth flow captures the user's id at authorize time, threads it through the session token cache, and surfaces it to governance tools as `ctx.callerUserId`. Without it, a write tool returns an `AUTH_REQUIRED:` error pointing the client at the OAuth flow.
@@ -17170,7 +17170,9 @@ Governance MCP tools register inside LangWatch's existing MCP server (mounted at
 {
   "mcpServers": {
     "langwatch-governance": {
-      "url": "https://app.langwatch.ai/api/mcp"
+      "url": "https://app.langwatch.ai/mcp"
+      // Clients that speak the older SSE transport use
+      // https://app.langwatch.ai/sse instead.
       // Read-only access: add Authorization: Bearer <projectApiKey>.
       // Read+write access: complete the OAuth PKCE flow at /api/mcp/authorize.
     }

--- a/platform/app/scripts/dogfood/mcp-sse-multipod-probe.ts
+++ b/platform/app/scripts/dogfood/mcp-sse-multipod-probe.ts
@@ -103,7 +103,9 @@ async function main(): Promise<number> {
   console.error(`[probe] round-robin proxy on :${proxyPort}`);
 
   const shutdown = async () => {
-    for (const handler of handlers) handler.closeAllSessions();
+    // Await the releases before the forced exit below: a record left
+    // behind still counts against the project's concurrent sessions.
+    await Promise.all(handlers.map((handler) => handler.closeAllSessions()));
     for (const server of [...replicas, proxy]) {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/platform/app/scripts/dogfood/mcp-sse-multipod-probe.ts
+++ b/platform/app/scripts/dogfood/mcp-sse-multipod-probe.ts
@@ -1,0 +1,155 @@
+/**
+ * mcp-sse-multipod-probe.ts — proves the MCP SSE transport survives a
+ * multi-replica deployment, which is what production actually is.
+ *
+ * Production runs several app replicas behind a load balancer with no session
+ * affinity. `GET /sse` opens a stream that lives only on the replica that
+ * answered it; every follow-up `POST /messages?sessionId=…` is a new
+ * connection the balancer may hand to any replica. This probe reproduces that
+ * with two in-process handler instances on two ports, sharing one local Redis,
+ * behind a round-robin proxy the real MCP SDK client talks to. Every request
+ * the client makes therefore lands on the "wrong" replica half the time.
+ *
+ * PASS means initialize and tools/list completed through that proxy and at
+ * least one tool came back. Before the relay landed this failed at the first
+ * message: a replica that did not hold the stream answered
+ * 400 "Invalid or missing session ID".
+ *
+ * OAuth is not exercised here — a project API key as Bearer reaches the same
+ * session machinery, and the OAuth legs are covered by the integration tests.
+ *
+ * Usage:
+ *   cd platform/app
+ *   LANGWATCH_API_KEY=<project apiKey> npx tsx scripts/dogfood/mcp-sse-multipod-probe.ts
+ *
+ * Requires REDIS_URL (read from platform/app/.env like the rest of the app)
+ * and a project whose apiKey is LANGWATCH_API_KEY.
+ */
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { createMcpHandler, type McpHandler } from "../../src/mcp/handler";
+
+const API_KEY = process.env.LANGWATCH_API_KEY;
+
+if (!API_KEY) {
+  console.error(
+    "LANGWATCH_API_KEY env var required (a project apiKey from your local database)",
+  );
+  process.exit(2);
+}
+
+const REPLICA_COUNT = 2;
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return typeof address === "object" && address ? address.port : 0;
+}
+
+/**
+ * A load balancer with no session affinity: each request goes to the next
+ * replica in turn, so a stream opened on one replica is guaranteed to receive
+ * messages through the other.
+ */
+function createRoundRobinProxy(replicaPorts: number[]): Server {
+  let next = 0;
+  return createServer((clientReq, clientRes) => {
+    const port = replicaPorts[next % replicaPorts.length]!;
+    next++;
+    console.error(
+      `[proxy] ${clientReq.method} ${clientReq.url} -> replica on :${port}`,
+    );
+    const upstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        method: clientReq.method,
+        path: clientReq.url,
+        headers: clientReq.headers,
+      },
+      (upstreamRes) => {
+        clientRes.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+        upstreamRes.pipe(clientRes);
+      },
+    );
+    upstream.on("error", (err) => {
+      console.error(`[proxy] upstream error: ${String(err)}`);
+      if (!clientRes.headersSent) clientRes.writeHead(502);
+      clientRes.end();
+    });
+    clientReq.pipe(upstream);
+  });
+}
+
+async function main(): Promise<number> {
+  const handlers: McpHandler[] = [];
+  const replicas: Server[] = [];
+  const replicaPorts: number[] = [];
+
+  for (let i = 0; i < REPLICA_COUNT; i++) {
+    const handler = createMcpHandler();
+    const server = createServer((req, res) => handler.handleRequest(req, res));
+    const port = await listen(server);
+    handlers.push(handler);
+    replicas.push(server);
+    replicaPorts.push(port);
+    console.error(`[probe] replica ${i + 1} listening on :${port}`);
+  }
+
+  const proxy = createRoundRobinProxy(replicaPorts);
+  const proxyPort = await listen(proxy);
+  const baseUrl = `http://127.0.0.1:${proxyPort}`;
+  console.error(`[probe] round-robin proxy on :${proxyPort}`);
+
+  const shutdown = async () => {
+    for (const handler of handlers) handler.closeAllSessions();
+    for (const server of [...replicas, proxy]) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  };
+
+  const client = new Client({
+    name: "mcp-sse-multipod-probe",
+    version: "0.0.0",
+  });
+  const transport = new SSEClientTransport(new URL(`${baseUrl}/sse`), {
+    requestInit: { headers: { Authorization: `Bearer ${API_KEY}` } },
+    eventSourceInit: {
+      fetch: (url, init) =>
+        fetch(url, {
+          ...init,
+          headers: { ...init?.headers, Authorization: `Bearer ${API_KEY}` },
+        }),
+    },
+  });
+
+  try {
+    console.error("[probe] connecting the SSE client through the proxy …");
+    await client.connect(transport);
+    console.error("[probe] connected (initialize completed)");
+
+    const { tools } = await client.listTools();
+    console.error(`[probe] tools/list returned ${tools.length} tools`);
+    if (tools.length === 0) {
+      console.log("FAIL: tools/list returned no tools");
+      return 1;
+    }
+
+    console.log(
+      `PASS: initialize and tools/list completed across ${REPLICA_COUNT} replicas ` +
+        `(${tools.length} tools listed)`,
+    );
+    return 0;
+  } catch (err) {
+    console.log(`FAIL: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  } finally {
+    await client.close().catch(() => undefined);
+    await shutdown();
+  }
+}
+
+void main().then((code) => {
+  process.exit(code);
+});

--- a/platform/app/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -169,6 +169,16 @@ function createPkceChallenge() {
 // Matches TEST_REDIRECT_URI / TEST_CLIENT_ID below — the values every
 // /oauth/token test request in this file sends, since the token endpoint now
 // requires them to match what /mcp/authorize bound to the code.
+/**
+ * Builds an `application/x-www-form-urlencoded` body. Interpolating the values
+ * into a template works only while none of them contains a `&`, `=`, `+` or
+ * `%`, and a redirect URI that grows a query string is exactly the case where
+ * the shape assertions keep passing against a truncated value.
+ */
+function formBody(fields: Record<string, string>): string {
+  return new URLSearchParams(fields).toString();
+}
+
 const TEST_REDIRECT_URI = "http://localhost/callback";
 const TEST_CLIENT_ID = "test_client";
 
@@ -313,7 +323,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   afterAll(async () => {
-    handler.closeAllSessions();
+    await handler.closeAllSessions();
     await new Promise<void>((resolve) => {
       server.close(() => resolve());
     });
@@ -434,7 +444,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
 
       expect(res.status).toBe(200);
@@ -460,7 +476,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=wrong-verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: "wrong-verifier",
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -477,7 +499,10 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: "grant_type=authorization_code&code_verifier=some-verifier",
+        body: formBody({
+          grant_type: "authorization_code",
+          code_verifier: "some-verifier",
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -494,7 +519,10 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${randomUUID()}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code: randomUUID(),
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -528,7 +556,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=invalid-code&code_verifier=some-verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code: "invalid-code",
+          code_verifier: "some-verifier",
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
 
       expect(res.status).toBe(400);
@@ -570,7 +604,12 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
         const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
           method: "POST",
           headers: { "content-type": "application/x-www-form-urlencoded" },
-          body: `grant_type=authorization_code&code=${randomUUID()}&code_verifier=some-verifier&client_id=${TEST_CLIENT_ID}`,
+          body: formBody({
+            grant_type: "authorization_code",
+            code: randomUUID(),
+            code_verifier: "some-verifier",
+            client_id: TEST_CLIENT_ID,
+          }),
         });
 
         expect(res.status).toBe(400);
@@ -588,7 +627,12 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
         const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
           method: "POST",
           headers: { "content-type": "application/x-www-form-urlencoded" },
-          body: `grant_type=authorization_code&code=${randomUUID()}&code_verifier=some-verifier&redirect_uri=${TEST_REDIRECT_URI}`,
+          body: formBody({
+            grant_type: "authorization_code",
+            code: randomUUID(),
+            code_verifier: "some-verifier",
+            redirect_uri: TEST_REDIRECT_URI,
+          }),
         });
 
         expect(res.status).toBe(400);
@@ -610,7 +654,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
         const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
           method: "POST",
           headers: { "content-type": "application/x-www-form-urlencoded" },
-          body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=https://attacker.invalid/callback&client_id=${TEST_CLIENT_ID}`,
+          body: formBody({
+            grant_type: "authorization_code",
+            code,
+            code_verifier: codeVerifier,
+            redirect_uri: "https://attacker.invalid/callback",
+            client_id: TEST_CLIENT_ID,
+          }),
         });
 
         expect(res.status).toBe(400);
@@ -633,7 +683,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
         const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
           method: "POST",
           headers: { "content-type": "application/x-www-form-urlencoded" },
-          body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=mcp_someone_elses_client`,
+          body: formBody({
+            grant_type: "authorization_code",
+            code,
+            code_verifier: codeVerifier,
+            redirect_uri: TEST_REDIRECT_URI,
+            client_id: "mcp_someone_elses_client",
+          }),
         });
 
         expect(res.status).toBe(400);
@@ -706,7 +762,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // single-page-app fallback and come back as 200 text/html, which the client
   // reports as a JSON parse failure rather than falling back to the bare form.
 
-  describe("OAuth discovery documents", () => {
+  describe("given the OAuth discovery documents are published", () => {
     async function getDiscovery(path: string) {
       const res = await sendRequest({ server, method: "GET", path });
       return {
@@ -718,34 +774,36 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
 
     describe("when the protected resource metadata is fetched at the resource path", () => {
       /** @scenario Protected resource metadata is served for the path-suffixed form */
-      it("describes the resource and its authorization server", async () => {
-        for (const resource of ["/sse", "/mcp"]) {
-          const res = await getDiscovery(
-            `/.well-known/oauth-protected-resource${resource}`,
-          );
+      it.each([
+        "/sse",
+        "/mcp",
+      ])("describes %s and its authorization server", async (resource) => {
+        const res = await getDiscovery(
+          `/.well-known/oauth-protected-resource${resource}`,
+        );
 
-          expect(res.status).toBe(200);
-          expect(res.contentType).toContain("application/json");
-          expect(res.body.resource).toContain(resource);
-          expect(res.body.authorization_servers.length).toBeGreaterThan(0);
-        }
+        expect(res.status).toBe(200);
+        expect(res.contentType).toContain("application/json");
+        expect(res.body.resource).toContain(resource);
+        expect(res.body.authorization_servers.length).toBeGreaterThan(0);
       });
     });
 
     describe("when the authorization server metadata is fetched at the resource path", () => {
       /** @scenario Authorization server metadata is served for the path-suffixed form */
-      it("advertises the authorization, token and registration endpoints", async () => {
-        for (const resource of ["/sse", "/mcp"]) {
-          const res = await getDiscovery(
-            `/.well-known/oauth-authorization-server${resource}`,
-          );
+      it.each([
+        "/sse",
+        "/mcp",
+      ])("advertises the authorization, token and registration endpoints for %s", async (resource) => {
+        const res = await getDiscovery(
+          `/.well-known/oauth-authorization-server${resource}`,
+        );
 
-          expect(res.status).toBe(200);
-          expect(res.contentType).toContain("application/json");
-          expect(res.body.authorization_endpoint).toContain("/mcp/authorize");
-          expect(res.body.token_endpoint).toContain("/oauth/token");
-          expect(res.body.registration_endpoint).toContain("/oauth/register");
-        }
+        expect(res.status).toBe(200);
+        expect(res.contentType).toContain("application/json");
+        expect(res.body.authorization_endpoint).toContain("/mcp/authorize");
+        expect(res.body.token_endpoint).toContain("/oauth/token");
+        expect(res.body.registration_endpoint).toContain("/oauth/register");
       });
     });
 
@@ -774,7 +832,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
 
   // --- OAuth token endpoint client authentication ---
 
-  describe("OAuth token endpoint client authentication", () => {
+  describe("given a client authenticates against the token endpoint", () => {
     beforeEach(() => {
       handler.clearRateLimiters();
     });
@@ -803,7 +861,12 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
             "content-type": "application/x-www-form-urlencoded",
             authorization: `Basic ${basic}`,
           },
-          body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}`,
+          body: formBody({
+            grant_type: "authorization_code",
+            code,
+            code_verifier: codeVerifier,
+            redirect_uri: TEST_REDIRECT_URI,
+          }),
         });
 
         expect(res.status).toBe(200);
@@ -822,7 +885,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
         const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
           method: "POST",
           headers: { "content-type": "application/x-www-form-urlencoded" },
-          body: `grant_type=authorization_code&code=${randomUUID()}&code_verifier=verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=mcp_registration_is_gone`,
+          body: formBody({
+            grant_type: "authorization_code",
+            code: randomUUID(),
+            code_verifier: "verifier",
+            redirect_uri: TEST_REDIRECT_URI,
+            client_id: "mcp_registration_is_gone",
+          }),
         });
 
         expect(res.status).toBe(401);
@@ -879,7 +948,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
       const tokenBody = await tokenRes.json();
       const accessToken = tokenBody.access_token;
@@ -921,7 +996,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
       const tokenBody = await tokenRes.json();
       const accessToken = tokenBody.access_token;
@@ -989,7 +1070,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
 
       // 2. Simulate pod switch: close all local sessions (as if this is a
       //    different pod) but keep the Redis entry.
-      handler.closeAllSessions();
+      await handler.closeAllSessions();
 
       // 3. Mock Redis returning the session metadata
       mockRedis.get.mockImplementation(async (key: string) => {
@@ -1004,7 +1085,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       mockRedis.expire.mockResolvedValue(1);
 
       // 4. Re-create the server+handler (simulating a different pod)
-      handler.closeAllSessions();
+      await handler.closeAllSessions();
 
       // 5. Send a tool list request with the old session ID — should recover
       const toolsRes = await sendRequest({
@@ -1190,7 +1271,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       return fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers,
-        body: `grant_type=authorization_code&code=${code}&code_verifier=verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: "verifier",
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
     }
 
@@ -1409,7 +1496,13 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
+        body: formBody({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+        }),
       });
       const tokenBody = (await tokenRes.json()) as { access_token: string };
       const accessToken = tokenBody.access_token;

--- a/platform/app/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -173,6 +173,28 @@ const TEST_REDIRECT_URI = "http://localhost/callback";
 const TEST_CLIENT_ID = "test_client";
 
 /**
+ * The registration /oauth/register would have persisted for TEST_CLIENT_ID.
+ * The token endpoint reads it to tell "your code is stale" apart from "your
+ * registration is gone", so every token test that is not about a missing
+ * registration needs it present.
+ */
+const REGISTERED_CLIENT = JSON.stringify({
+  redirectUris: [TEST_REDIRECT_URI],
+  clientName: "Test Client",
+});
+
+/** Redis GET backed by the registered test client plus any extra keys. */
+function redisGetWithRegisteredClient(
+  key: string,
+  extra: Record<string, string> = {},
+): Promise<string | null> {
+  if (key === `mcp:oauth:client:${TEST_CLIENT_ID}`) {
+    return Promise.resolve(REGISTERED_CLIENT);
+  }
+  return Promise.resolve(extra[key] ?? null);
+}
+
+/**
  * Stores a mock auth code in the Redis mock that the handler can retrieve.
  */
 function mockAuthCodeInRedis({
@@ -200,12 +222,9 @@ function mockAuthCodeInRedis({
     expiresAt: expiresAt ?? Date.now() + 600_000,
   });
 
-  mockRedis.get.mockImplementation((key: string) => {
-    if (key === `mcp:auth_code:${code}`) {
-      return Promise.resolve(entry);
-    }
-    return Promise.resolve(null);
-  });
+  mockRedis.get.mockImplementation((key: string) =>
+    redisGetWithRegisteredClient(key, { [`mcp:auth_code:${code}`]: entry }),
+  );
 }
 
 async function sendRequest({
@@ -302,7 +321,9 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRedis.get.mockResolvedValue(null);
+    mockRedis.get.mockImplementation((key: string) =>
+      redisGetWithRegisteredClient(key),
+    );
     mockRedis.set.mockResolvedValue("OK");
     mockRedis.del.mockResolvedValue(1);
     mockRedis.expire.mockResolvedValue(1);
@@ -677,6 +698,141 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
 
   // --- Bearer Token DB Validation ---
 
+  // --- OAuth discovery documents ---
+  //
+  // A client that only knows the resource URL asks for metadata at the
+  // resource's path under the well-known prefix (RFC 9728 §3.1), and current
+  // MCP clients try that form first. Unclaimed, those probes reach the
+  // single-page-app fallback and come back as 200 text/html, which the client
+  // reports as a JSON parse failure rather than falling back to the bare form.
+
+  describe("OAuth discovery documents", () => {
+    async function getDiscovery(path: string) {
+      const res = await sendRequest({ server, method: "GET", path });
+      return {
+        status: res.status,
+        contentType: res.headers["content-type"] ?? "",
+        body: JSON.parse(res.body),
+      };
+    }
+
+    describe("when the protected resource metadata is fetched at the resource path", () => {
+      /** @scenario Protected resource metadata is served for the path-suffixed form */
+      it("describes the resource and its authorization server", async () => {
+        for (const resource of ["/sse", "/mcp"]) {
+          const res = await getDiscovery(
+            `/.well-known/oauth-protected-resource${resource}`,
+          );
+
+          expect(res.status).toBe(200);
+          expect(res.contentType).toContain("application/json");
+          expect(res.body.resource).toContain(resource);
+          expect(res.body.authorization_servers.length).toBeGreaterThan(0);
+        }
+      });
+    });
+
+    describe("when the authorization server metadata is fetched at the resource path", () => {
+      /** @scenario Authorization server metadata is served for the path-suffixed form */
+      it("advertises the authorization, token and registration endpoints", async () => {
+        for (const resource of ["/sse", "/mcp"]) {
+          const res = await getDiscovery(
+            `/.well-known/oauth-authorization-server${resource}`,
+          );
+
+          expect(res.status).toBe(200);
+          expect(res.contentType).toContain("application/json");
+          expect(res.body.authorization_endpoint).toContain("/mcp/authorize");
+          expect(res.body.token_endpoint).toContain("/oauth/token");
+          expect(res.body.registration_endpoint).toContain("/oauth/register");
+        }
+      });
+    });
+
+    describe("when a discovery document that does not exist is fetched", () => {
+      /** @scenario An unknown OAuth discovery document answers with JSON rather than the web app */
+      it("answers 404 as JSON so the client can fall back", async () => {
+        const res = await getDiscovery(
+          "/.well-known/oauth-protected-resource/nothing-here",
+        );
+
+        expect(res.status).toBe(404);
+        expect(res.contentType).toContain("application/json");
+      });
+    });
+
+    describe("when the OpenID configuration is fetched", () => {
+      /** @scenario OpenID configuration is answered as absent rather than with the web app */
+      it("answers 404 as JSON", async () => {
+        const res = await getDiscovery("/.well-known/openid-configuration");
+
+        expect(res.status).toBe(404);
+        expect(res.contentType).toContain("application/json");
+      });
+    });
+  });
+
+  // --- OAuth token endpoint client authentication ---
+
+  describe("OAuth token endpoint client authentication", () => {
+    beforeEach(() => {
+      handler.clearRateLimiters();
+    });
+    afterEach(() => {
+      handler.clearRateLimiters();
+    });
+
+    describe("when the client presents its credentials as HTTP Basic", () => {
+      /** @scenario The token endpoint accepts client credentials presented as HTTP Basic */
+      it("issues an access token without client_id in the form body", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+        const code = randomUUID();
+        const { codeVerifier, codeChallenge } = createPkceChallenge();
+        mockAuthCodeInRedis({ code, codeChallenge });
+
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        // RFC 6749 §2.3.1: base64(client_id:client_secret), secret empty for
+        // a public client.
+        const basic = Buffer.from(`${TEST_CLIENT_ID}:`).toString("base64");
+
+        const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            authorization: `Basic ${basic}`,
+          },
+          body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}`,
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.access_token).toBeDefined();
+        expect(body.token_type).toBe("Bearer");
+      });
+    });
+
+    describe("when the presented client_id has no registration left", () => {
+      /** @scenario A token exchange from a client that is no longer registered is told to register again */
+      it("answers invalid_client and tells it to register again", async () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+
+        const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: `grant_type=authorization_code&code=${randomUUID()}&code_verifier=verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=mcp_registration_is_gone`,
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.error).toBe("invalid_client");
+        expect(body.error_description).toContain("register again");
+      });
+    });
+  });
+
   describe("when a direct API key is used as Bearer token", () => {
     it("validates against the database and accepts the connection", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
@@ -1007,30 +1163,96 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
 
   // --- Security: rate limiting ---
 
-  describe("when /oauth/token is called more than 10 times per minute", () => {
-    it("returns 429", async () => {
-      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+  describe("Security: per-caller rate limiting", () => {
+    const TOKEN_LIMIT_PER_MINUTE = 30;
 
+    beforeEach(() => {
+      handler.clearRateLimiters();
+    });
+    afterEach(() => {
+      handler.clearRateLimiters();
+    });
+
+    /** Posts a token request, optionally claiming a caller address. */
+    async function tokenRequest({
+      code,
+      callerIp,
+    }: {
+      code: string;
+      callerIp?: string;
+    }) {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
-
-      // Send 10 requests (allowed)
-      for (let i = 0; i < 10; i++) {
-        await fetch(`http://127.0.0.1:${port}/oauth/token`, {
-          method: "POST",
-          headers: { "content-type": "application/x-www-form-urlencoded" },
-          body: `grant_type=authorization_code&code=code-${i}&code_verifier=verifier`,
-        });
-      }
-
-      // 11th request should be rate limited
-      const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+      const headers: Record<string, string> = {
+        "content-type": "application/x-www-form-urlencoded",
+      };
+      if (callerIp) headers["cf-connecting-ip"] = callerIp;
+      return fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=code-11&code_verifier=verifier`,
+        headers,
+        body: `grant_type=authorization_code&code=${code}&code_verifier=verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
+    }
 
-      expect(res.status).toBe(429);
+    describe("when one caller exceeds the token endpoint budget", () => {
+      /** @scenario A rate limited OAuth request answers with an OAuth error and a retry hint */
+      it("answers with an OAuth error object and a retry hint", async () => {
+        for (let i = 0; i < TOKEN_LIMIT_PER_MINUTE; i++) {
+          await tokenRequest({ code: `code-${i}`, callerIp: "203.0.113.7" });
+        }
+
+        const res = await tokenRequest({
+          code: "code-over",
+          callerIp: "203.0.113.7",
+        });
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get("retry-after")).toBe("60");
+        const body = await res.json();
+        expect(body.error).toBe("temporarily_unavailable");
+        expect(body.error_description).toContain("Rate limit exceeded");
+      });
+    });
+
+    describe("when a different caller arrives through the same proxy", () => {
+      /** @scenario Rate limiting counts callers separately when a proxy reports the caller address */
+      it("does not charge it for the first caller's traffic", async () => {
+        for (let i = 0; i < TOKEN_LIMIT_PER_MINUTE + 5; i++) {
+          await tokenRequest({ code: `noisy-${i}`, callerIp: "203.0.113.7" });
+        }
+
+        const res = await tokenRequest({
+          code: "quiet-caller",
+          callerIp: "203.0.113.9",
+        });
+
+        expect(res.status).not.toBe(429);
+      });
+    });
+
+    describe("when a caller exhausted the client registration budget", () => {
+      /** @scenario Registering a client and exchanging a token do not share one rate limit budget */
+      it("still lets it exchange a token", async () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        for (let i = 0; i < 35; i++) {
+          await fetch(`http://127.0.0.1:${port}/oauth/register`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "cf-connecting-ip": "203.0.113.20",
+            },
+            body: JSON.stringify({ redirect_uris: ["https://a.example/cb"] }),
+          });
+        }
+
+        const res = await tokenRequest({
+          code: "after-registering",
+          callerIp: "203.0.113.20",
+        });
+
+        expect(res.status).not.toBe(429);
+      });
     });
   });
 

--- a/platform/app/src/mcp/__tests__/mcp-request-logging.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-request-logging.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment node
+ *
+ * The MCP routes are answered by a raw Node handler that returns before the
+ * app's Hono stack, so they never reached the access log, the metrics or the
+ * traces the rest of the app produces. A broken integration was invisible:
+ * nothing recorded that the request had happened at all.
+ */
+import { createServer, type Server } from "node:http";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const VALID_API_KEY = "lw_logging_key";
+
+const { mockPrisma, logLines, loggerStub } = vi.hoisted(() => {
+  const lines: { fields: Record<string, unknown>; message: string }[] = [];
+  const record = () => (fields: unknown, message?: unknown) => {
+    if (typeof fields === "object" && fields !== null) {
+      lines.push({
+        fields: fields as Record<string, unknown>,
+        message: String(message ?? ""),
+      });
+    }
+  };
+  const stub: Record<string, unknown> = {
+    info: record(),
+    debug: record(),
+    warn: record(),
+    error: record(),
+    fatal: record(),
+    trace: record(),
+  };
+  stub.child = () => stub;
+  return {
+    logLines: lines,
+    loggerStub: stub,
+    mockPrisma: {
+      project: {
+        findUnique: vi.fn(({ where }: { where: { apiKey: string } }) =>
+          Promise.resolve(
+            where.apiKey === "lw_logging_key"
+              ? {
+                  id: "logging-project",
+                  apiKey: where.apiKey,
+                  teamId: "team-1",
+                  archivedAt: null,
+                }
+              : null,
+          ),
+        ),
+      },
+    },
+  };
+});
+
+vi.mock("@langwatch/observability", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, createLogger: () => loggerStub };
+});
+
+vi.mock("~/server/db", () => ({ prisma: mockPrisma }));
+vi.mock("~/server/redis", () => ({ connection: undefined }));
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (text: string) => text,
+  decrypt: (text: string) => text,
+}));
+
+import { createMcpHandler, type McpHandler } from "../handler";
+
+describe("Feature: MCP request logging", () => {
+  let server: Server;
+  let handler: McpHandler;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    handler = createMcpHandler();
+    server = createServer((req, res) => handler.handleRequest(req, res));
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    handler.closeAllSessions();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    logLines.length = 0;
+  });
+
+  /** Waits for the access log line, which is written when the response closes. */
+  async function accessLogFor(path: string) {
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const line = logLines.find(
+        (l) => l.message === "MCP request" && l.fields.path === path,
+      );
+      if (line) return line;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    throw new Error(`no access log line was written for ${path}`);
+  }
+
+  describe("given a client sends a request to an MCP route", () => {
+    describe("when the response completes", () => {
+      /** @scenario Every MCP request is logged with its outcome */
+      it("records the method, path, status and duration without any credentials", async () => {
+        await fetch(`${baseUrl}/mcp/health`, {
+          headers: { authorization: `Bearer ${VALID_API_KEY}` },
+        });
+
+        const line = await accessLogFor("/mcp/health");
+
+        expect(line.fields.method).toBe("GET");
+        expect(line.fields.status).toBe(200);
+        expect(typeof line.fields.durationMs).toBe("number");
+
+        const serialized = JSON.stringify(line);
+        expect(serialized).not.toContain(VALID_API_KEY);
+        expect(serialized.toLowerCase()).not.toContain("authorization");
+      });
+    });
+
+    describe("when the request fails", () => {
+      it("records the failing status too", async () => {
+        await fetch(`${baseUrl}/sse`, { method: "GET" });
+
+        const line = await accessLogFor("/sse");
+
+        expect(line.fields.status).toBe(401);
+      });
+    });
+  });
+});

--- a/platform/app/src/mcp/__tests__/mcp-request-logging.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-request-logging.integration.test.ts
@@ -91,7 +91,7 @@ describe("Feature: MCP request logging", () => {
   });
 
   afterAll(async () => {
-    handler.closeAllSessions();
+    await handler.closeAllSessions();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 

--- a/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
@@ -1,0 +1,530 @@
+/**
+ * @vitest-environment node
+ *
+ * Cross-replica behaviour of the MCP SSE transport, against a real Redis.
+ *
+ * Production runs several app replicas behind a load balancer with no session
+ * affinity. `GET /sse` opens a stream that only lives on the replica that
+ * answered it, while every follow-up `POST /messages?sessionId=…` is a fresh
+ * connection the balancer may hand to any replica. Two handler instances in
+ * one process, sharing one Redis, reproduce that exactly: each has its own
+ * session map and its own relay subscriber, and only Redis is common.
+ */
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { connection as redis } from "~/server/redis";
+import { createMcpHandler, type McpHandler } from "../handler";
+
+const VALID_API_KEY = "lw_relay_key_a";
+const OTHER_API_KEY = "lw_relay_key_b";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    project: {
+      findUnique: vi.fn(({ where }: { where: { apiKey: string } }) =>
+        Promise.resolve(
+          where.apiKey === "lw_relay_key_a" || where.apiKey === "lw_relay_key_b"
+            ? {
+                id: `project-for-${where.apiKey}`,
+                apiKey: where.apiKey,
+                teamId: "team-1",
+                name: "Test Project",
+                archivedAt: null,
+              }
+            : null,
+        ),
+      ),
+    },
+  },
+}));
+
+vi.mock("~/server/db", () => ({ prisma: mockPrisma }));
+
+// Identity encryption so the test can write session records Redis-side and
+// read back what the handler stored without holding a key.
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (text: string) => `encrypted:${text}`,
+  decrypt: (text: string) =>
+    text.startsWith("encrypted:") ? text.slice(10) : text,
+}));
+
+const SSE_SESSION_PREFIX = "mcp:sse:session:";
+const SSE_SESSION_SET_PREFIX = "mcp:sse:sessions_by_key:";
+
+interface JsonRpcMessage {
+  id?: number | string;
+  result?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+  method?: string;
+}
+
+interface OpenSseStream {
+  status: number;
+  endpoint: string;
+  sessionId: string;
+  messages: JsonRpcMessage[];
+  waitFor: (match: (m: JsonRpcMessage) => boolean) => Promise<JsonRpcMessage>;
+  close: () => void;
+}
+
+/**
+ * Opens `GET /sse` and keeps consuming the stream in the background, so the
+ * test can assert on replies that arrive after the POST that triggered them
+ * has already been answered.
+ */
+async function openSseStream({
+  baseUrl,
+  apiKey,
+}: {
+  baseUrl: string;
+  apiKey: string;
+}): Promise<OpenSseStream> {
+  const abort = new AbortController();
+  const res = await fetch(`${baseUrl}/sse`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${apiKey}` },
+    signal: abort.signal,
+  });
+
+  const messages: JsonRpcMessage[] = [];
+  const waiters: {
+    match: (m: JsonRpcMessage) => boolean;
+    resolve: (m: JsonRpcMessage) => void;
+  }[] = [];
+  let resolveEndpoint!: (path: string) => void;
+  const endpointArrived = new Promise<string>((resolve) => {
+    resolveEndpoint = resolve;
+  });
+
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  void (async () => {
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let boundary = buffer.indexOf("\n\n");
+        while (boundary !== -1) {
+          const frame = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          boundary = buffer.indexOf("\n\n");
+
+          const data = /^data:\s*(.*)$/m.exec(frame)?.[1]?.trim();
+          if (data === undefined) continue;
+          const event =
+            /^event:\s*(.*)$/m.exec(frame)?.[1]?.trim() ?? "message";
+          if (event === "endpoint") {
+            resolveEndpoint(data);
+            continue;
+          }
+          try {
+            const parsed = JSON.parse(data) as JsonRpcMessage;
+            messages.push(parsed);
+            for (let i = waiters.length - 1; i >= 0; i--) {
+              const waiter = waiters[i]!;
+              if (waiter.match(parsed)) {
+                waiters.splice(i, 1);
+                waiter.resolve(parsed);
+              }
+            }
+          } catch {
+            // Not a JSON-RPC frame — keep reading.
+          }
+        }
+      }
+    } catch {
+      // The stream was aborted by close() — expected at the end of a test.
+    }
+  })();
+
+  const endpoint = await endpointArrived;
+  const sessionId =
+    new URL(endpoint, "http://localhost").searchParams.get("sessionId") ?? "";
+
+  return {
+    status: res.status,
+    endpoint,
+    sessionId,
+    messages,
+    waitFor: (match) =>
+      new Promise<JsonRpcMessage>((resolve, reject) => {
+        const already = messages.find(match);
+        if (already) {
+          resolve(already);
+          return;
+        }
+        const timer = setTimeout(
+          () => reject(new Error("timed out waiting for an SSE reply")),
+          20_000,
+        );
+        waiters.push({
+          match,
+          resolve: (m) => {
+            clearTimeout(timer);
+            resolve(m);
+          },
+        });
+      }),
+    close: () => abort.abort(),
+  };
+}
+
+async function postMessage({
+  baseUrl,
+  path,
+  apiKey,
+  body,
+}: {
+  baseUrl: string;
+  path: string;
+  apiKey?: string;
+  body: unknown;
+}) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+function initializeBody(id = 1) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "relay-test-client", version: "1.0.0" },
+    },
+  };
+}
+
+/** Drives an SSE session through the MCP handshake over the given base URL. */
+async function handshake({
+  stream,
+  baseUrl,
+  apiKey,
+}: {
+  stream: OpenSseStream;
+  baseUrl: string;
+  apiKey: string;
+}) {
+  const init = await postMessage({
+    baseUrl,
+    path: stream.endpoint,
+    apiKey,
+    body: initializeBody(1),
+  });
+  if (init.status !== 202) {
+    throw new Error(
+      `the handshake could not start: initialize answered ${init.status} ${init.body}`,
+    );
+  }
+  await stream.waitFor((m) => m.id === 1);
+  await postMessage({
+    baseUrl,
+    path: stream.endpoint,
+    apiKey,
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+  });
+}
+
+describe("Feature: MCP SSE transport across replicas", () => {
+  let replicaA: Server;
+  let replicaB: Server;
+  let handlerA: McpHandler;
+  let handlerB: McpHandler;
+  let urlA: string;
+  let urlB: string;
+
+  async function listen(handler: McpHandler): Promise<[Server, string]> {
+    const server = createServer((req, res) => handler.handleRequest(req, res));
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    return [server, `http://127.0.0.1:${port}`];
+  }
+
+  beforeAll(async () => {
+    if (!redis) {
+      throw new Error(
+        "These tests need a real Redis — set REDIS_URL / LANGWATCH_TEST_REDIS_URL",
+      );
+    }
+
+    handlerA = createMcpHandler();
+    handlerB = createMcpHandler();
+    [replicaA, urlA] = await listen(handlerA);
+    [replicaB, urlB] = await listen(handlerB);
+  });
+
+  afterAll(async () => {
+    handlerA.closeAllSessions();
+    handlerB.closeAllSessions();
+    await new Promise<void>((resolve) => replicaA.close(() => resolve()));
+    await new Promise<void>((resolve) => replicaB.close(() => resolve()));
+  });
+
+  describe("given a client opened an SSE connection against one replica", () => {
+    describe("when it posts a message to the other replica", () => {
+      /** @scenario A message posted to a replica that does not hold the stream still reaches the session */
+      it("relays the message to the replica holding the stream and answers on that stream", async () => {
+        const stream = await openSseStream({
+          baseUrl: urlA,
+          apiKey: VALID_API_KEY,
+        });
+        try {
+          expect(stream.status).toBe(200);
+          expect(stream.sessionId).not.toBe("");
+
+          // Every message goes to replica B, which never saw the stream open.
+          await handshake({ stream, baseUrl: urlB, apiKey: VALID_API_KEY });
+
+          const listed = await postMessage({
+            baseUrl: urlB,
+            path: stream.endpoint,
+            apiKey: VALID_API_KEY,
+            body: { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+          });
+          expect(listed.status).toBe(202);
+
+          const reply = await stream.waitFor((m) => m.id === 2);
+          const tools = (reply.result?.tools ?? []) as unknown[];
+          expect(reply.error).toBeUndefined();
+          expect(tools.length).toBeGreaterThan(0);
+        } finally {
+          stream.close();
+        }
+      });
+
+      /** @scenario Clients that append the message path to the connect path are still routed */
+      it("routes a message posted to the /sse/messages alias", async () => {
+        const stream = await openSseStream({
+          baseUrl: urlA,
+          apiKey: VALID_API_KEY,
+        });
+        try {
+          const aliased = `/sse${stream.endpoint}`;
+          const res = await postMessage({
+            baseUrl: urlB,
+            path: aliased,
+            apiKey: VALID_API_KEY,
+            body: initializeBody(11),
+          });
+
+          expect(res.status).toBe(202);
+          await stream.waitFor((m) => m.id === 11);
+        } finally {
+          stream.close();
+        }
+      });
+    });
+
+    describe("when it posts a message to the replica that holds the stream", () => {
+      /** @scenario A message posted to the replica holding the stream is answered directly */
+      it("answers it locally without going through the relay", async () => {
+        const stream = await openSseStream({
+          baseUrl: urlA,
+          apiKey: VALID_API_KEY,
+        });
+        try {
+          const res = await postMessage({
+            baseUrl: urlA,
+            path: stream.endpoint,
+            apiKey: VALID_API_KEY,
+            body: initializeBody(21),
+          });
+
+          expect(res.status).toBe(202);
+          const reply = await stream.waitFor((m) => m.id === 21);
+          expect(reply.error).toBeUndefined();
+        } finally {
+          stream.close();
+        }
+      });
+    });
+
+    describe("when a message presents credentials for a different project", () => {
+      /** @scenario A message carrying credentials for a different project is rejected */
+      it("rejects it as unauthorized and never delivers it", async () => {
+        const stream = await openSseStream({
+          baseUrl: urlA,
+          apiKey: VALID_API_KEY,
+        });
+        try {
+          const res = await postMessage({
+            baseUrl: urlB,
+            path: stream.endpoint,
+            apiKey: OTHER_API_KEY,
+            body: initializeBody(31),
+          });
+
+          expect(res.status).toBe(401);
+          expect(stream.messages.some((m) => m.id === 31)).toBe(false);
+        } finally {
+          stream.close();
+        }
+      });
+    });
+
+    describe("when a message carries no credentials at all", () => {
+      /** @scenario A message with no credentials is rejected as unauthorized rather than as a bad session */
+      it("answers 401 rather than reporting a bad session", async () => {
+        const stream = await openSseStream({
+          baseUrl: urlA,
+          apiKey: VALID_API_KEY,
+        });
+        try {
+          const res = await postMessage({
+            baseUrl: urlB,
+            path: stream.endpoint,
+            body: initializeBody(41),
+          });
+
+          expect(res.status).toBe(401);
+        } finally {
+          stream.close();
+        }
+      });
+    });
+  });
+
+  describe("given no session exists for the presented session id", () => {
+    describe("when a client posts a message for it", () => {
+      /** @scenario A message for an unknown session is rejected as a missing session */
+      it("answers 404 so the client reconnects", async () => {
+        const res = await postMessage({
+          baseUrl: urlB,
+          path: "/messages?sessionId=relay-session-that-never-existed",
+          apiKey: VALID_API_KEY,
+          body: initializeBody(51),
+        });
+
+        expect(res.status).toBe(404);
+        expect(JSON.parse(res.body).error).toContain("Session not found");
+      });
+    });
+  });
+
+  describe("given a session was recorded but the replica holding its stream is gone", () => {
+    describe("when a client posts a message for it", () => {
+      /** @scenario A message for a session whose replica is gone tells the client to reconnect */
+      it("answers 404 and forgets the recorded session", async () => {
+        const orphanId = "relay-orphan-session";
+        await redis!.set(
+          `${SSE_SESSION_PREFIX}${orphanId}`,
+          JSON.stringify({
+            encryptedApiKey: `encrypted:${VALID_API_KEY}`,
+            createdAt: Date.now(),
+          }),
+          "EX",
+          600,
+        );
+
+        const res = await postMessage({
+          baseUrl: urlB,
+          path: `/messages?sessionId=${orphanId}`,
+          apiKey: VALID_API_KEY,
+          body: initializeBody(61),
+        });
+
+        expect(res.status).toBe(404);
+        expect(await redis!.get(`${SSE_SESSION_PREFIX}${orphanId}`)).toBeNull();
+      });
+    });
+  });
+
+  describe("given a project already holds the maximum number of concurrent sessions", () => {
+    describe("when a client opens another SSE connection", () => {
+      /** @scenario SSE sessions count towards the per-project concurrent session limit */
+      it("refuses the connection as over the session limit", async () => {
+        const keyHash = createHash("sha256")
+          .update(VALID_API_KEY)
+          .digest("hex")
+          .slice(0, 16);
+        const setKey = `${SSE_SESSION_SET_PREFIX}${keyHash}`;
+        const seeded: string[] = [];
+        for (let i = 0; i < 20; i++) {
+          const id = `relay-seeded-${i}`;
+          seeded.push(id);
+          await redis!.set(
+            `${SSE_SESSION_PREFIX}${id}`,
+            JSON.stringify({
+              encryptedApiKey: `encrypted:${VALID_API_KEY}`,
+              createdAt: Date.now(),
+            }),
+            "EX",
+            600,
+          );
+          await redis!.sadd(setKey, id);
+        }
+
+        try {
+          const res = await fetch(`${urlA}/sse`, {
+            method: "GET",
+            headers: { authorization: `Bearer ${VALID_API_KEY}` },
+          });
+          const text = await res.text();
+
+          expect(res.status).toBe(429);
+          expect(text).toContain("Too many concurrent sessions");
+        } finally {
+          for (const id of seeded) {
+            await redis!.del(`${SSE_SESSION_PREFIX}${id}`);
+          }
+          await redis!.del(setKey);
+        }
+      });
+    });
+  });
+
+  describe("given a streamable session was created on one replica", () => {
+    describe("when the client reconnects the stream through the other replica", () => {
+      /** @scenario Reconnecting the streaming transport to another replica resumes the session */
+      it("serves the stream instead of reporting the session expired", async () => {
+        const created = await fetch(`${urlA}/mcp`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "text/event-stream, application/json",
+            authorization: `Bearer ${VALID_API_KEY}`,
+          },
+          body: JSON.stringify(initializeBody(71)),
+        });
+        expect(created.status).toBe(200);
+        const sessionId = created.headers.get("mcp-session-id");
+        expect(sessionId).toBeTruthy();
+        await created.text();
+
+        const abort = new AbortController();
+        try {
+          const resumed = await fetch(`${urlB}/mcp`, {
+            method: "GET",
+            headers: {
+              accept: "text/event-stream",
+              authorization: `Bearer ${VALID_API_KEY}`,
+              "mcp-session-id": sessionId!,
+            },
+            signal: abort.signal,
+          });
+
+          expect(resumed.status).toBe(200);
+        } finally {
+          abort.abort();
+        }
+      });
+    });
+  });
+});

--- a/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
@@ -257,12 +257,31 @@ describe("Feature: MCP SSE transport across replicas", () => {
     return [server, `http://127.0.0.1:${port}`];
   }
 
+  /**
+   * Session records outlive the process that wrote them, so an interrupted
+   * run can leave this key's session set full and make the next run's very
+   * first connection hit the per-project limit.
+   */
+  async function clearRecordedSessions(apiKey: string): Promise<void> {
+    const setKey = `${SSE_SESSION_SET_PREFIX}${createHash("sha256")
+      .update(apiKey)
+      .digest("hex")
+      .slice(0, 16)}`;
+    const members = await redis!.smembers(setKey);
+    for (const id of members) {
+      await redis!.del(`${SSE_SESSION_PREFIX}${id}`);
+    }
+    await redis!.del(setKey);
+  }
+
   beforeAll(async () => {
     if (!redis) {
       throw new Error(
         "These tests need a real Redis — set REDIS_URL / LANGWATCH_TEST_REDIS_URL",
       );
     }
+    await clearRecordedSessions(VALID_API_KEY);
+    await clearRecordedSessions(OTHER_API_KEY);
 
     handlerA = createMcpHandler();
     handlerB = createMcpHandler();
@@ -275,6 +294,8 @@ describe("Feature: MCP SSE transport across replicas", () => {
     handlerB.closeAllSessions();
     await new Promise<void>((resolve) => replicaA.close(() => resolve()));
     await new Promise<void>((resolve) => replicaB.close(() => resolve()));
+    await clearRecordedSessions(VALID_API_KEY);
+    await clearRecordedSessions(OTHER_API_KEY);
   });
 
   describe("given a client opened an SSE connection against one replica", () => {

--- a/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
@@ -73,7 +73,9 @@ describe("Feature: MCP SSE transport across replicas", () => {
   });
 
   afterAll(async () => {
-    await replicas.stop();
+    // beforeAll throws when Redis is missing, which leaves this unset;
+    // dereferencing it here would replace that message with a TypeError.
+    await replicas?.stop();
   });
 
   describe("given a client opened an SSE connection against one replica", () => {

--- a/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
@@ -6,22 +6,19 @@
  * Production runs several app replicas behind a load balancer with no session
  * affinity. `GET /sse` opens a stream that only lives on the replica that
  * answered it, while every follow-up `POST /messages?sessionId=…` is a fresh
- * connection the balancer may hand to any replica. Two handler instances in
- * one process, sharing one Redis, reproduce that exactly: each has its own
- * session map and its own relay subscriber, and only Redis is common.
+ * connection the balancer may hand to any replica.
  */
-import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { connection as redis } from "~/server/redis";
-import { createMcpHandler, type McpHandler } from "../handler";
 import {
-  clearRecordedSessions,
   handshake,
   initializeBody,
   openSseStream,
   postMessage,
+  type ReplicaPair,
   SSE_SESSION_PREFIX,
   sseSessionSetKey,
+  startReplicaPair,
 } from "./support/sseHarness";
 
 const VALID_API_KEY = "lw_relay_key_a";
@@ -58,25 +55,9 @@ vi.mock("~/utils/encryption", () => ({
 }));
 
 describe("Feature: MCP SSE transport across replicas", () => {
-  let replicaA: Server;
-  let replicaB: Server;
-  let handlerA: McpHandler;
-  let handlerB: McpHandler;
+  let replicas: ReplicaPair;
   let urlA: string;
   let urlB: string;
-
-  async function listen(handler: McpHandler): Promise<[Server, string]> {
-    const server = createServer((req, res) => handler.handleRequest(req, res));
-    await new Promise<void>((resolve) =>
-      server.listen(0, "127.0.0.1", resolve),
-    );
-    const address = server.address();
-    const port = typeof address === "object" && address ? address.port : 0;
-    return [server, `http://127.0.0.1:${port}`];
-  }
-
-  const clearSessions = (apiKey: string) =>
-    clearRecordedSessions({ redis: redis!, apiKey });
 
   beforeAll(async () => {
     if (!redis) {
@@ -84,22 +65,15 @@ describe("Feature: MCP SSE transport across replicas", () => {
         "These tests need a real Redis — set REDIS_URL / LANGWATCH_TEST_REDIS_URL",
       );
     }
-    await clearSessions(VALID_API_KEY);
-    await clearSessions(OTHER_API_KEY);
-
-    handlerA = createMcpHandler();
-    handlerB = createMcpHandler();
-    [replicaA, urlA] = await listen(handlerA);
-    [replicaB, urlB] = await listen(handlerB);
+    replicas = await startReplicaPair({
+      redis,
+      apiKeys: [VALID_API_KEY, OTHER_API_KEY],
+    });
+    ({ urlA, urlB } = replicas);
   });
 
   afterAll(async () => {
-    await handlerA.closeAllSessions();
-    await handlerB.closeAllSessions();
-    await new Promise<void>((resolve) => replicaA.close(() => resolve()));
-    await new Promise<void>((resolve) => replicaB.close(() => resolve()));
-    await clearSessions(VALID_API_KEY);
-    await clearSessions(OTHER_API_KEY);
+    await replicas.stop();
   });
 
   describe("given a client opened an SSE connection against one replica", () => {
@@ -309,127 +283,6 @@ describe("Feature: MCP SSE transport across replicas", () => {
           }
           await redis!.del(setKey);
         }
-      });
-    });
-  });
-
-  describe("given a streamable session was created on one replica", () => {
-    /** Opens a streamable session on replica A and returns its session id. */
-    async function createStreamableSession(id: number): Promise<string> {
-      const created = await fetch(`${urlA}/mcp`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "text/event-stream, application/json",
-          authorization: `Bearer ${VALID_API_KEY}`,
-        },
-        body: JSON.stringify(initializeBody(id)),
-      });
-      // biome-ignore-start lint/suspicious/noMisplacedAssertion: the arrangement fails loudly here rather than as a confusing assertion later
-      expect(created.status).toBe(200);
-      const sessionId = created.headers.get("mcp-session-id");
-      expect(sessionId).toBeTruthy();
-      // biome-ignore-end lint/suspicious/noMisplacedAssertion: end of the arrangement checks
-      await created.text();
-      return sessionId!;
-    }
-
-    /**
-     * Whether a replica built the session for itself. DELETE only consults
-     * the replica's own session map, so it answers 200 exactly when that
-     * replica holds the session and 404 when it never built one.
-     */
-    async function replicaHoldsSession(
-      baseUrl: string,
-      sessionId: string,
-    ): Promise<boolean> {
-      const res = await fetch(`${baseUrl}/mcp`, {
-        method: "DELETE",
-        headers: {
-          authorization: `Bearer ${VALID_API_KEY}`,
-          "mcp-session-id": sessionId,
-        },
-      });
-      await res.text();
-      return res.status === 200;
-    }
-
-    describe("when the client reconnects the stream through the other replica", () => {
-      /** @scenario Reconnecting the streaming transport to another replica resumes the session */
-      it("serves the stream instead of reporting the session expired", async () => {
-        const sessionId = await createStreamableSession(71);
-
-        const abort = new AbortController();
-        try {
-          const resumed = await fetch(`${urlB}/mcp`, {
-            method: "GET",
-            headers: {
-              accept: "text/event-stream",
-              authorization: `Bearer ${VALID_API_KEY}`,
-              "mcp-session-id": sessionId,
-            },
-            signal: abort.signal,
-          });
-
-          expect(resumed.status).toBe(200);
-        } finally {
-          abort.abort();
-        }
-      });
-    });
-
-    describe("when the reconnect carries no credentials", () => {
-      /** @scenario Reconnecting without credentials is refused and rebuilds nothing */
-      it("answers 401 and leaves the other replica holding no session", async () => {
-        const sessionId = await createStreamableSession(81);
-
-        const abort = new AbortController();
-        try {
-          const resumed = await fetch(`${urlB}/mcp`, {
-            method: "GET",
-            headers: {
-              accept: "text/event-stream",
-              "mcp-session-id": sessionId,
-            },
-            signal: abort.signal,
-          });
-          await resumed.text();
-
-          expect(resumed.status).toBe(401);
-        } finally {
-          abort.abort();
-        }
-
-        // Rebuilding decrypts the stored key and connects a server bound to
-        // it, so a refused caller must not have caused any of it.
-        expect(await replicaHoldsSession(urlB, sessionId)).toBe(false);
-      });
-    });
-
-    describe("when the reconnect carries credentials for a different project", () => {
-      /** @scenario Reconnecting with another project's credentials is refused and rebuilds nothing */
-      it("answers 401 and leaves the other replica holding no session", async () => {
-        const sessionId = await createStreamableSession(91);
-
-        const abort = new AbortController();
-        try {
-          const resumed = await fetch(`${urlB}/mcp`, {
-            method: "GET",
-            headers: {
-              accept: "text/event-stream",
-              authorization: `Bearer ${OTHER_API_KEY}`,
-              "mcp-session-id": sessionId,
-            },
-            signal: abort.signal,
-          });
-          await resumed.text();
-
-          expect(resumed.status).toBe(401);
-        } finally {
-          abort.abort();
-        }
-
-        expect(await replicaHoldsSession(urlB, sessionId)).toBe(false);
       });
     });
   });

--- a/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-sse-relay.integration.test.ts
@@ -10,11 +10,19 @@
  * one process, sharing one Redis, reproduce that exactly: each has its own
  * session map and its own relay subscriber, and only Redis is common.
  */
-import { createHash } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { connection as redis } from "~/server/redis";
 import { createMcpHandler, type McpHandler } from "../handler";
+import {
+  clearRecordedSessions,
+  handshake,
+  initializeBody,
+  openSseStream,
+  postMessage,
+  SSE_SESSION_PREFIX,
+  sseSessionSetKey,
+} from "./support/sseHarness";
 
 const VALID_API_KEY = "lw_relay_key_a";
 const OTHER_API_KEY = "lw_relay_key_b";
@@ -49,196 +57,6 @@ vi.mock("~/utils/encryption", () => ({
     text.startsWith("encrypted:") ? text.slice(10) : text,
 }));
 
-const SSE_SESSION_PREFIX = "mcp:sse:session:";
-const SSE_SESSION_SET_PREFIX = "mcp:sse:sessions_by_key:";
-
-interface JsonRpcMessage {
-  id?: number | string;
-  result?: Record<string, unknown>;
-  error?: Record<string, unknown>;
-  method?: string;
-}
-
-interface OpenSseStream {
-  status: number;
-  endpoint: string;
-  sessionId: string;
-  messages: JsonRpcMessage[];
-  waitFor: (match: (m: JsonRpcMessage) => boolean) => Promise<JsonRpcMessage>;
-  close: () => void;
-}
-
-/**
- * Opens `GET /sse` and keeps consuming the stream in the background, so the
- * test can assert on replies that arrive after the POST that triggered them
- * has already been answered.
- */
-async function openSseStream({
-  baseUrl,
-  apiKey,
-}: {
-  baseUrl: string;
-  apiKey: string;
-}): Promise<OpenSseStream> {
-  const abort = new AbortController();
-  const res = await fetch(`${baseUrl}/sse`, {
-    method: "GET",
-    headers: { authorization: `Bearer ${apiKey}` },
-    signal: abort.signal,
-  });
-
-  const messages: JsonRpcMessage[] = [];
-  const waiters: {
-    match: (m: JsonRpcMessage) => boolean;
-    resolve: (m: JsonRpcMessage) => void;
-  }[] = [];
-  let resolveEndpoint!: (path: string) => void;
-  const endpointArrived = new Promise<string>((resolve) => {
-    resolveEndpoint = resolve;
-  });
-
-  const reader = res.body!.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  void (async () => {
-    try {
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        let boundary = buffer.indexOf("\n\n");
-        while (boundary !== -1) {
-          const frame = buffer.slice(0, boundary);
-          buffer = buffer.slice(boundary + 2);
-          boundary = buffer.indexOf("\n\n");
-
-          const data = /^data:\s*(.*)$/m.exec(frame)?.[1]?.trim();
-          if (data === undefined) continue;
-          const event =
-            /^event:\s*(.*)$/m.exec(frame)?.[1]?.trim() ?? "message";
-          if (event === "endpoint") {
-            resolveEndpoint(data);
-            continue;
-          }
-          try {
-            const parsed = JSON.parse(data) as JsonRpcMessage;
-            messages.push(parsed);
-            for (let i = waiters.length - 1; i >= 0; i--) {
-              const waiter = waiters[i]!;
-              if (waiter.match(parsed)) {
-                waiters.splice(i, 1);
-                waiter.resolve(parsed);
-              }
-            }
-          } catch {
-            // Not a JSON-RPC frame — keep reading.
-          }
-        }
-      }
-    } catch {
-      // The stream was aborted by close() — expected at the end of a test.
-    }
-  })();
-
-  const endpoint = await endpointArrived;
-  const sessionId =
-    new URL(endpoint, "http://localhost").searchParams.get("sessionId") ?? "";
-
-  return {
-    status: res.status,
-    endpoint,
-    sessionId,
-    messages,
-    waitFor: (match) =>
-      new Promise<JsonRpcMessage>((resolve, reject) => {
-        const already = messages.find(match);
-        if (already) {
-          resolve(already);
-          return;
-        }
-        const timer = setTimeout(
-          () => reject(new Error("timed out waiting for an SSE reply")),
-          20_000,
-        );
-        waiters.push({
-          match,
-          resolve: (m) => {
-            clearTimeout(timer);
-            resolve(m);
-          },
-        });
-      }),
-    close: () => abort.abort(),
-  };
-}
-
-async function postMessage({
-  baseUrl,
-  path,
-  apiKey,
-  body,
-}: {
-  baseUrl: string;
-  path: string;
-  apiKey?: string;
-  body: unknown;
-}) {
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-  };
-  if (apiKey) headers.authorization = `Bearer ${apiKey}`;
-  const res = await fetch(`${baseUrl}${path}`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  });
-  return { status: res.status, body: await res.text() };
-}
-
-function initializeBody(id = 1) {
-  return {
-    jsonrpc: "2.0",
-    id,
-    method: "initialize",
-    params: {
-      protocolVersion: "2025-03-26",
-      capabilities: {},
-      clientInfo: { name: "relay-test-client", version: "1.0.0" },
-    },
-  };
-}
-
-/** Drives an SSE session through the MCP handshake over the given base URL. */
-async function handshake({
-  stream,
-  baseUrl,
-  apiKey,
-}: {
-  stream: OpenSseStream;
-  baseUrl: string;
-  apiKey: string;
-}) {
-  const init = await postMessage({
-    baseUrl,
-    path: stream.endpoint,
-    apiKey,
-    body: initializeBody(1),
-  });
-  if (init.status !== 202) {
-    throw new Error(
-      `the handshake could not start: initialize answered ${init.status} ${init.body}`,
-    );
-  }
-  await stream.waitFor((m) => m.id === 1);
-  await postMessage({
-    baseUrl,
-    path: stream.endpoint,
-    apiKey,
-    body: { jsonrpc: "2.0", method: "notifications/initialized" },
-  });
-}
-
 describe("Feature: MCP SSE transport across replicas", () => {
   let replicaA: Server;
   let replicaB: Server;
@@ -257,22 +75,8 @@ describe("Feature: MCP SSE transport across replicas", () => {
     return [server, `http://127.0.0.1:${port}`];
   }
 
-  /**
-   * Session records outlive the process that wrote them, so an interrupted
-   * run can leave this key's session set full and make the next run's very
-   * first connection hit the per-project limit.
-   */
-  async function clearRecordedSessions(apiKey: string): Promise<void> {
-    const setKey = `${SSE_SESSION_SET_PREFIX}${createHash("sha256")
-      .update(apiKey)
-      .digest("hex")
-      .slice(0, 16)}`;
-    const members = await redis!.smembers(setKey);
-    for (const id of members) {
-      await redis!.del(`${SSE_SESSION_PREFIX}${id}`);
-    }
-    await redis!.del(setKey);
-  }
+  const clearSessions = (apiKey: string) =>
+    clearRecordedSessions({ redis: redis!, apiKey });
 
   beforeAll(async () => {
     if (!redis) {
@@ -280,8 +84,8 @@ describe("Feature: MCP SSE transport across replicas", () => {
         "These tests need a real Redis — set REDIS_URL / LANGWATCH_TEST_REDIS_URL",
       );
     }
-    await clearRecordedSessions(VALID_API_KEY);
-    await clearRecordedSessions(OTHER_API_KEY);
+    await clearSessions(VALID_API_KEY);
+    await clearSessions(OTHER_API_KEY);
 
     handlerA = createMcpHandler();
     handlerB = createMcpHandler();
@@ -290,12 +94,12 @@ describe("Feature: MCP SSE transport across replicas", () => {
   });
 
   afterAll(async () => {
-    handlerA.closeAllSessions();
-    handlerB.closeAllSessions();
+    await handlerA.closeAllSessions();
+    await handlerB.closeAllSessions();
     await new Promise<void>((resolve) => replicaA.close(() => resolve()));
     await new Promise<void>((resolve) => replicaB.close(() => resolve()));
-    await clearRecordedSessions(VALID_API_KEY);
-    await clearRecordedSessions(OTHER_API_KEY);
+    await clearSessions(VALID_API_KEY);
+    await clearSessions(OTHER_API_KEY);
   });
 
   describe("given a client opened an SSE connection against one replica", () => {
@@ -462,6 +266,8 @@ describe("Feature: MCP SSE transport across replicas", () => {
         });
 
         expect(res.status).toBe(404);
+        expect(JSON.parse(res.body).error).toContain("Session not found");
+        // The stale record also stops counting against the project's limit.
         expect(await redis!.get(`${SSE_SESSION_PREFIX}${orphanId}`)).toBeNull();
       });
     });
@@ -471,11 +277,7 @@ describe("Feature: MCP SSE transport across replicas", () => {
     describe("when a client opens another SSE connection", () => {
       /** @scenario SSE sessions count towards the per-project concurrent session limit */
       it("refuses the connection as over the session limit", async () => {
-        const keyHash = createHash("sha256")
-          .update(VALID_API_KEY)
-          .digest("hex")
-          .slice(0, 16);
-        const setKey = `${SSE_SESSION_SET_PREFIX}${keyHash}`;
+        const setKey = sseSessionSetKey(VALID_API_KEY);
         const seeded: string[] = [];
         for (let i = 0; i < 20; i++) {
           const id = `relay-seeded-${i}`;
@@ -512,22 +314,50 @@ describe("Feature: MCP SSE transport across replicas", () => {
   });
 
   describe("given a streamable session was created on one replica", () => {
+    /** Opens a streamable session on replica A and returns its session id. */
+    async function createStreamableSession(id: number): Promise<string> {
+      const created = await fetch(`${urlA}/mcp`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "text/event-stream, application/json",
+          authorization: `Bearer ${VALID_API_KEY}`,
+        },
+        body: JSON.stringify(initializeBody(id)),
+      });
+      // biome-ignore-start lint/suspicious/noMisplacedAssertion: the arrangement fails loudly here rather than as a confusing assertion later
+      expect(created.status).toBe(200);
+      const sessionId = created.headers.get("mcp-session-id");
+      expect(sessionId).toBeTruthy();
+      // biome-ignore-end lint/suspicious/noMisplacedAssertion: end of the arrangement checks
+      await created.text();
+      return sessionId!;
+    }
+
+    /**
+     * Whether a replica built the session for itself. DELETE only consults
+     * the replica's own session map, so it answers 200 exactly when that
+     * replica holds the session and 404 when it never built one.
+     */
+    async function replicaHoldsSession(
+      baseUrl: string,
+      sessionId: string,
+    ): Promise<boolean> {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+      await res.text();
+      return res.status === 200;
+    }
+
     describe("when the client reconnects the stream through the other replica", () => {
       /** @scenario Reconnecting the streaming transport to another replica resumes the session */
       it("serves the stream instead of reporting the session expired", async () => {
-        const created = await fetch(`${urlA}/mcp`, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            accept: "text/event-stream, application/json",
-            authorization: `Bearer ${VALID_API_KEY}`,
-          },
-          body: JSON.stringify(initializeBody(71)),
-        });
-        expect(created.status).toBe(200);
-        const sessionId = created.headers.get("mcp-session-id");
-        expect(sessionId).toBeTruthy();
-        await created.text();
+        const sessionId = await createStreamableSession(71);
 
         const abort = new AbortController();
         try {
@@ -536,7 +366,7 @@ describe("Feature: MCP SSE transport across replicas", () => {
             headers: {
               accept: "text/event-stream",
               authorization: `Bearer ${VALID_API_KEY}`,
-              "mcp-session-id": sessionId!,
+              "mcp-session-id": sessionId,
             },
             signal: abort.signal,
           });
@@ -545,6 +375,61 @@ describe("Feature: MCP SSE transport across replicas", () => {
         } finally {
           abort.abort();
         }
+      });
+    });
+
+    describe("when the reconnect carries no credentials", () => {
+      /** @scenario Reconnecting without credentials is refused and rebuilds nothing */
+      it("answers 401 and leaves the other replica holding no session", async () => {
+        const sessionId = await createStreamableSession(81);
+
+        const abort = new AbortController();
+        try {
+          const resumed = await fetch(`${urlB}/mcp`, {
+            method: "GET",
+            headers: {
+              accept: "text/event-stream",
+              "mcp-session-id": sessionId,
+            },
+            signal: abort.signal,
+          });
+          await resumed.text();
+
+          expect(resumed.status).toBe(401);
+        } finally {
+          abort.abort();
+        }
+
+        // Rebuilding decrypts the stored key and connects a server bound to
+        // it, so a refused caller must not have caused any of it.
+        expect(await replicaHoldsSession(urlB, sessionId)).toBe(false);
+      });
+    });
+
+    describe("when the reconnect carries credentials for a different project", () => {
+      /** @scenario Reconnecting with another project's credentials is refused and rebuilds nothing */
+      it("answers 401 and leaves the other replica holding no session", async () => {
+        const sessionId = await createStreamableSession(91);
+
+        const abort = new AbortController();
+        try {
+          const resumed = await fetch(`${urlB}/mcp`, {
+            method: "GET",
+            headers: {
+              accept: "text/event-stream",
+              authorization: `Bearer ${OTHER_API_KEY}`,
+              "mcp-session-id": sessionId,
+            },
+            signal: abort.signal,
+          });
+          await resumed.text();
+
+          expect(resumed.status).toBe(401);
+        } finally {
+          abort.abort();
+        }
+
+        expect(await replicaHoldsSession(urlB, sessionId)).toBe(false);
       });
     });
   });

--- a/platform/app/src/mcp/__tests__/mcp-streamable-reconnect.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-streamable-reconnect.integration.test.ts
@@ -70,7 +70,9 @@ describe("Feature: MCP streamable transport across replicas", () => {
   });
 
   afterAll(async () => {
-    await replicas.stop();
+    // beforeAll throws when Redis is missing, which leaves this unset;
+    // dereferencing it here would replace that message with a TypeError.
+    await replicas?.stop();
   });
 
   describe("given a streamable session was created on one replica", () => {
@@ -131,6 +133,9 @@ describe("Feature: MCP streamable transport across replicas", () => {
             signal: abort.signal,
           });
 
+          // A served stream never ends on its own, so the body is deliberately
+          // left unread and torn down by the abort below. The refusal tests
+          // that follow do read theirs, because a refusal is a finite body.
           expect(resumed.status).toBe(200);
         } finally {
           abort.abort();

--- a/platform/app/src/mcp/__tests__/mcp-streamable-reconnect.integration.test.ts
+++ b/platform/app/src/mcp/__tests__/mcp-streamable-reconnect.integration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment node
+ *
+ * Cross-replica behaviour of the MCP Streamable HTTP transport, against a real
+ * Redis.
+ *
+ * A session is created on whichever replica answered the initialize, and the
+ * client's next request is a fresh connection the load balancer may hand to
+ * any of them. Rebuilding that session on the replica that receives it is what
+ * makes a reconnect work; doing it only for the project that owns the session
+ * is what keeps it safe.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { connection as redis } from "~/server/redis";
+import {
+  initializeBody,
+  type ReplicaPair,
+  startReplicaPair,
+} from "./support/sseHarness";
+
+const VALID_API_KEY = "lw_relay_key_a";
+const OTHER_API_KEY = "lw_relay_key_b";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    project: {
+      findUnique: vi.fn(({ where }: { where: { apiKey: string } }) =>
+        Promise.resolve(
+          where.apiKey === "lw_relay_key_a" || where.apiKey === "lw_relay_key_b"
+            ? {
+                id: `project-for-${where.apiKey}`,
+                apiKey: where.apiKey,
+                teamId: "team-1",
+                name: "Test Project",
+                archivedAt: null,
+              }
+            : null,
+        ),
+      ),
+    },
+  },
+}));
+
+vi.mock("~/server/db", () => ({ prisma: mockPrisma }));
+
+// Identity encryption so the test can write session records Redis-side and
+// read back what the handler stored without holding a key.
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (text: string) => `encrypted:${text}`,
+  decrypt: (text: string) =>
+    text.startsWith("encrypted:") ? text.slice(10) : text,
+}));
+
+describe("Feature: MCP streamable transport across replicas", () => {
+  let replicas: ReplicaPair;
+  let urlA: string;
+  let urlB: string;
+
+  beforeAll(async () => {
+    if (!redis) {
+      throw new Error(
+        "These tests need a real Redis — set REDIS_URL / LANGWATCH_TEST_REDIS_URL",
+      );
+    }
+    replicas = await startReplicaPair({
+      redis,
+      apiKeys: [VALID_API_KEY, OTHER_API_KEY],
+    });
+    ({ urlA, urlB } = replicas);
+  });
+
+  afterAll(async () => {
+    await replicas.stop();
+  });
+
+  describe("given a streamable session was created on one replica", () => {
+    /** Opens a streamable session on replica A and returns its session id. */
+    async function createStreamableSession(id: number): Promise<string> {
+      const created = await fetch(`${urlA}/mcp`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "text/event-stream, application/json",
+          authorization: `Bearer ${VALID_API_KEY}`,
+        },
+        body: JSON.stringify(initializeBody(id)),
+      });
+      // biome-ignore-start lint/suspicious/noMisplacedAssertion: the arrangement fails loudly here rather than as a confusing assertion later
+      expect(created.status).toBe(200);
+      const sessionId = created.headers.get("mcp-session-id");
+      expect(sessionId).toBeTruthy();
+      // biome-ignore-end lint/suspicious/noMisplacedAssertion: end of the arrangement checks
+      await created.text();
+      return sessionId!;
+    }
+
+    /**
+     * Whether a replica built the session for itself. DELETE only consults
+     * the replica's own session map, so it answers 200 exactly when that
+     * replica holds the session and 404 when it never built one.
+     */
+    async function replicaHoldsSession(
+      baseUrl: string,
+      sessionId: string,
+    ): Promise<boolean> {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+      await res.text();
+      return res.status === 200;
+    }
+
+    describe("when the client reconnects the stream through the other replica", () => {
+      /** @scenario Reconnecting the streaming transport to another replica resumes the session */
+      it("serves the stream instead of reporting the session expired", async () => {
+        const sessionId = await createStreamableSession(71);
+
+        const abort = new AbortController();
+        try {
+          const resumed = await fetch(`${urlB}/mcp`, {
+            method: "GET",
+            headers: {
+              accept: "text/event-stream",
+              authorization: `Bearer ${VALID_API_KEY}`,
+              "mcp-session-id": sessionId,
+            },
+            signal: abort.signal,
+          });
+
+          expect(resumed.status).toBe(200);
+        } finally {
+          abort.abort();
+        }
+      });
+    });
+
+    describe("when the reconnect carries no credentials", () => {
+      /** @scenario Reconnecting without credentials is refused and rebuilds nothing */
+      it("answers 401 and leaves the other replica holding no session", async () => {
+        const sessionId = await createStreamableSession(81);
+
+        const abort = new AbortController();
+        try {
+          const resumed = await fetch(`${urlB}/mcp`, {
+            method: "GET",
+            headers: {
+              accept: "text/event-stream",
+              "mcp-session-id": sessionId,
+            },
+            signal: abort.signal,
+          });
+          await resumed.text();
+
+          expect(resumed.status).toBe(401);
+        } finally {
+          abort.abort();
+        }
+
+        // Rebuilding decrypts the stored key and connects a server bound to
+        // it, so a refused caller must not have caused any of it.
+        expect(await replicaHoldsSession(urlB, sessionId)).toBe(false);
+      });
+    });
+
+    describe("when the reconnect carries credentials for a different project", () => {
+      /** @scenario Reconnecting with another project's credentials is refused and rebuilds nothing */
+      it("answers 401 and leaves the other replica holding no session", async () => {
+        const sessionId = await createStreamableSession(91);
+
+        const abort = new AbortController();
+        try {
+          const resumed = await fetch(`${urlB}/mcp`, {
+            method: "GET",
+            headers: {
+              accept: "text/event-stream",
+              authorization: `Bearer ${OTHER_API_KEY}`,
+              "mcp-session-id": sessionId,
+            },
+            signal: abort.signal,
+          });
+          await resumed.text();
+
+          expect(resumed.status).toBe(401);
+        } finally {
+          abort.abort();
+        }
+
+        expect(await replicaHoldsSession(urlB, sessionId)).toBe(false);
+      });
+    });
+  });
+});

--- a/platform/app/src/mcp/__tests__/support/sseHarness.ts
+++ b/platform/app/src/mcp/__tests__/support/sseHarness.ts
@@ -5,7 +5,9 @@
  * as transport plumbing.
  */
 import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
 import type { Cluster, Redis } from "ioredis";
+import { createMcpHandler, type McpHandler } from "../../handler";
 
 export const SSE_SESSION_PREFIX = "mcp:sse:session:";
 export const SSE_SESSION_SET_PREFIX = "mcp:sse:sessions_by_key:";
@@ -39,7 +41,13 @@ export interface OpenSseStream {
  * production side derives it the same way, and an equivalent alert on that
  * line is dismissed for the same reason.
  */
-function sessionSetKey(setPrefix: string, apiKey: string): string {
+function sessionSetKey({
+  setPrefix,
+  apiKey,
+}: {
+  setPrefix: string;
+  apiKey: string;
+}): string {
   // lgtm[js/insufficient-password-hash]
   const digest = createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
   return `${setPrefix}${digest}`;
@@ -65,7 +73,7 @@ export async function clearRecordedSessions({
     [SSE_SESSION_SET_PREFIX, SSE_SESSION_PREFIX],
     [SESSION_SET_PREFIX, SESSION_PREFIX],
   ] as const) {
-    const setKey = sessionSetKey(setPrefix, apiKey);
+    const setKey = sessionSetKey({ setPrefix, apiKey });
     for (const id of await redis.smembers(setKey)) {
       await redis.del(`${sessionPrefix}${id}`);
     }
@@ -75,13 +83,71 @@ export async function clearRecordedSessions({
 
 /** The Redis set of SSE session ids for a key, for suites that seed it. */
 export function sseSessionSetKey(apiKey: string): string {
-  return sessionSetKey(SSE_SESSION_SET_PREFIX, apiKey);
+  return sessionSetKey({ setPrefix: SSE_SESSION_SET_PREFIX, apiKey });
 }
 
 function rejectAfter(ms: number, message: string): Promise<never> {
-  return new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error(message)), ms),
-  );
+  return new Promise<never>((_, reject) => {
+    // Unreferenced so the loser of a race does not hold the event loop open
+    // for its full duration and stall the file's teardown.
+    setTimeout(() => reject(new Error(message)), ms).unref();
+  });
+}
+
+/**
+ * Two handlers, each on its own server, sharing one Redis.
+ *
+ * That is the shape of production: replicas behind a load balancer with no
+ * session affinity, each with its own session map and relay subscriber, with
+ * only Redis in common. A suite that wants to prove cross-replica behaviour
+ * cannot do it with one handler.
+ */
+export async function startReplicaPair({
+  redis,
+  apiKeys,
+}: {
+  redis: Redis | Cluster;
+  apiKeys: string[];
+}): Promise<ReplicaPair> {
+  for (const apiKey of apiKeys) {
+    await clearRecordedSessions({ redis, apiKey });
+  }
+
+  const handlers: McpHandler[] = [];
+  const servers: Server[] = [];
+  const urls: string[] = [];
+  for (let i = 0; i < 2; i++) {
+    const handler = createMcpHandler();
+    const server = createServer((req, res) => handler.handleRequest(req, res));
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    handlers.push(handler);
+    servers.push(server);
+    urls.push(`http://127.0.0.1:${port}`);
+  }
+
+  return {
+    urlA: urls[0]!,
+    urlB: urls[1]!,
+    async stop() {
+      for (const handler of handlers) await handler.closeAllSessions();
+      for (const server of servers) {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+      for (const apiKey of apiKeys) {
+        await clearRecordedSessions({ redis, apiKey });
+      }
+    },
+  };
+}
+
+export interface ReplicaPair {
+  urlA: string;
+  urlB: string;
+  stop: () => Promise<void>;
 }
 
 /**

--- a/platform/app/src/mcp/__tests__/support/sseHarness.ts
+++ b/platform/app/src/mcp/__tests__/support/sseHarness.ts
@@ -123,7 +123,10 @@ export async function startReplicaPair({
       server.listen(0, "127.0.0.1", resolve),
     );
     const address = server.address();
-    const port = typeof address === "object" && address ? address.port : 0;
+    if (typeof address !== "object" || !address) {
+      throw new Error("a replica reported no address after listening");
+    }
+    const port = address.port;
     handlers.push(handler);
     servers.push(server);
     urls.push(`http://127.0.0.1:${port}`);

--- a/platform/app/src/mcp/__tests__/support/sseHarness.ts
+++ b/platform/app/src/mcp/__tests__/support/sseHarness.ts
@@ -1,0 +1,277 @@
+/**
+ * A minimal MCP SSE client for tests: opens the stream, keeps consuming it in
+ * the background, and posts messages back over the endpoint the stream names.
+ * Kept apart from the scenarios so the suites read as behaviour rather than
+ * as transport plumbing.
+ */
+import { createHash } from "node:crypto";
+import type { Cluster, Redis } from "ioredis";
+
+export const SSE_SESSION_PREFIX = "mcp:sse:session:";
+export const SSE_SESSION_SET_PREFIX = "mcp:sse:sessions_by_key:";
+export const SESSION_PREFIX = "mcp:session:";
+export const SESSION_SET_PREFIX = "mcp:sessions_by_key:";
+
+/** How long a helper waits for the server before giving up with its own error. */
+const HARNESS_TIMEOUT_MS = 20_000;
+
+export interface JsonRpcMessage {
+  id?: number | string;
+  result?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+  method?: string;
+}
+
+export interface OpenSseStream {
+  status: number;
+  endpoint: string;
+  sessionId: string;
+  messages: JsonRpcMessage[];
+  waitFor: (match: (m: JsonRpcMessage) => boolean) => Promise<JsonRpcMessage>;
+  close: () => void;
+}
+
+/**
+ * Names the Redis set that holds one project's session ids for a transport.
+ *
+ * The digest namespaces a bucket of session ids, it does not protect the key:
+ * anything able to read it already holds the key it was derived from. The
+ * production side derives it the same way, and an equivalent alert on that
+ * line is dismissed for the same reason.
+ */
+function sessionSetKey(setPrefix: string, apiKey: string): string {
+  // lgtm[js/insufficient-password-hash]
+  const digest = createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+  return `${setPrefix}${digest}`;
+}
+
+/**
+ * Drops every session record a key owns, for both transports.
+ *
+ * Session records outlive the process that wrote them, and the streamable
+ * ones carry a 30-day TTL, so a suite that leaves them behind spends the
+ * project's concurrent-session budget on its own debris: the per-project
+ * limit counts both transports together, and after enough runs the first
+ * connection of a fresh run is the one that gets refused.
+ */
+export async function clearRecordedSessions({
+  redis,
+  apiKey,
+}: {
+  redis: Redis | Cluster;
+  apiKey: string;
+}): Promise<void> {
+  for (const [setPrefix, sessionPrefix] of [
+    [SSE_SESSION_SET_PREFIX, SSE_SESSION_PREFIX],
+    [SESSION_SET_PREFIX, SESSION_PREFIX],
+  ] as const) {
+    const setKey = sessionSetKey(setPrefix, apiKey);
+    for (const id of await redis.smembers(setKey)) {
+      await redis.del(`${sessionPrefix}${id}`);
+    }
+    await redis.del(setKey);
+  }
+}
+
+/** The Redis set of SSE session ids for a key, for suites that seed it. */
+export function sseSessionSetKey(apiKey: string): string {
+  return sessionSetKey(SSE_SESSION_SET_PREFIX, apiKey);
+}
+
+function rejectAfter(ms: number, message: string): Promise<never> {
+  return new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(message)), ms),
+  );
+}
+
+/**
+ * Opens `GET /sse` and keeps consuming the stream in the background, so the
+ * test can assert on replies that arrive after the POST that triggered them
+ * has already been answered.
+ */
+export async function openSseStream({
+  baseUrl,
+  apiKey,
+}: {
+  baseUrl: string;
+  apiKey: string;
+}): Promise<OpenSseStream> {
+  const abort = new AbortController();
+  const res = await fetch(`${baseUrl}/sse`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${apiKey}` },
+    signal: abort.signal,
+  });
+
+  // A refusal answers with a body that is not a stream, and waiting for an
+  // endpoint event on it would hang until the whole suite times out with no
+  // clue which call was stuck.
+  if (res.status !== 200 || !res.body) {
+    abort.abort();
+    throw new Error(
+      `GET /sse answered ${res.status}, no stream to read: ${await res
+        .text()
+        .catch(() => "")}`,
+    );
+  }
+
+  const messages: JsonRpcMessage[] = [];
+  const waiters: {
+    match: (m: JsonRpcMessage) => boolean;
+    resolve: (m: JsonRpcMessage) => void;
+  }[] = [];
+  let resolveEndpoint!: (path: string) => void;
+  const endpointArrived = new Promise<string>((resolve) => {
+    resolveEndpoint = resolve;
+  });
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  void (async () => {
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let boundary = buffer.indexOf("\n\n");
+        while (boundary !== -1) {
+          const frame = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          boundary = buffer.indexOf("\n\n");
+
+          const data = /^data:\s*(.*)$/m.exec(frame)?.[1]?.trim();
+          if (data === undefined) continue;
+          const event =
+            /^event:\s*(.*)$/m.exec(frame)?.[1]?.trim() ?? "message";
+          if (event === "endpoint") {
+            resolveEndpoint(data);
+            continue;
+          }
+          try {
+            const parsed = JSON.parse(data) as JsonRpcMessage;
+            messages.push(parsed);
+            for (let i = waiters.length - 1; i >= 0; i--) {
+              const waiter = waiters[i]!;
+              if (waiter.match(parsed)) {
+                waiters.splice(i, 1);
+                waiter.resolve(parsed);
+              }
+            }
+          } catch {
+            // Not a JSON-RPC frame — keep reading.
+          }
+        }
+      }
+    } catch {
+      // The stream was aborted by close() — expected at the end of a test.
+    }
+  })();
+
+  const endpoint = await Promise.race([
+    endpointArrived,
+    rejectAfter(
+      HARNESS_TIMEOUT_MS,
+      "the stream opened but never named its message endpoint",
+    ),
+  ]).catch((err: unknown) => {
+    abort.abort();
+    throw err;
+  });
+  const sessionId =
+    new URL(endpoint, "http://localhost").searchParams.get("sessionId") ?? "";
+
+  return {
+    status: res.status,
+    endpoint,
+    sessionId,
+    messages,
+    waitFor: (match) =>
+      new Promise<JsonRpcMessage>((resolve, reject) => {
+        const already = messages.find(match);
+        if (already) {
+          resolve(already);
+          return;
+        }
+        const timer = setTimeout(
+          () => reject(new Error("timed out waiting for an SSE reply")),
+          HARNESS_TIMEOUT_MS,
+        );
+        waiters.push({
+          match,
+          resolve: (m) => {
+            clearTimeout(timer);
+            resolve(m);
+          },
+        });
+      }),
+    close: () => abort.abort(),
+  };
+}
+
+export async function postMessage({
+  baseUrl,
+  path,
+  apiKey,
+  body,
+}: {
+  baseUrl: string;
+  path: string;
+  apiKey?: string;
+  body: unknown;
+}): Promise<{ status: number; body: string }> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+export function initializeBody(id = 1) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "relay-test-client", version: "1.0.0" },
+    },
+  };
+}
+
+/** Drives an SSE session through the MCP handshake over the given base URL. */
+export async function handshake({
+  stream,
+  baseUrl,
+  apiKey,
+}: {
+  stream: OpenSseStream;
+  baseUrl: string;
+  apiKey: string;
+}): Promise<void> {
+  const init = await postMessage({
+    baseUrl,
+    path: stream.endpoint,
+    apiKey,
+    body: initializeBody(1),
+  });
+  if (init.status !== 202) {
+    throw new Error(
+      `the handshake could not start: initialize answered ${init.status} ${init.body}`,
+    );
+  }
+  await stream.waitFor((m) => m.id === 1);
+  await postMessage({
+    baseUrl,
+    path: stream.endpoint,
+    apiKey,
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+  });
+}

--- a/platform/app/src/mcp/__tests__/support/sseHarness.ts
+++ b/platform/app/src/mcp/__tests__/support/sseHarness.ts
@@ -48,7 +48,6 @@ function sessionSetKey({
   setPrefix: string;
   apiKey: string;
 }): string {
-  // lgtm[js/insufficient-password-hash]
   const digest = createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
   return `${setPrefix}${digest}`;
 }

--- a/platform/app/src/mcp/handler.ts
+++ b/platform/app/src/mcp/handler.ts
@@ -10,7 +10,11 @@
  * - GET  /mcp          — Streamable HTTP polling
  * - DELETE /mcp        — Close session
  * - GET  /mcp/health   — Health check (no auth)
- * - GET  /.well-known/oauth-authorization-server — OAuth metadata
+ * - GET  /sse          — SSE transport stream
+ * - POST /messages, /sse/messages — SSE transport client messages
+ * - GET  /.well-known/oauth-protected-resource[/mcp|/sse] — RFC 9728 metadata
+ * - GET  /.well-known/oauth-authorization-server[/mcp|/sse] — OAuth metadata
+ * - POST /oauth/register — Dynamic client registration
  * - POST /oauth/token  — OAuth token endpoint
  */
 
@@ -28,11 +32,14 @@ import { createLogger } from "@langwatch/observability";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { Redis } from "ioredis";
 import { prisma } from "../server/db";
 import { connection as redis } from "../server/redis";
+import type { NextApiRequest } from "../types/next-stubs";
 import { decrypt, encrypt } from "../utils/encryption";
+import { getClientIp as clientIpFromRequest } from "../utils/getClientIp";
 import { registerGovernanceMcpTools } from "./governance-tools";
-import { registerOAuthClient } from "./oauthClientRegistry";
+import { getOAuthClient, registerOAuthClient } from "./oauthClientRegistry";
 
 const logger = createLogger("langwatch:mcp");
 
@@ -47,6 +54,20 @@ const REDIS_SESSION_PREFIX = "mcp:session:";
 
 /** Redis key for the set of session IDs belonging to an API key. */
 const REDIS_SESSION_SET_PREFIX = "mcp:sessions_by_key:";
+
+/** Redis key prefix for SSE transport sessions. */
+const REDIS_SSE_SESSION_PREFIX = "mcp:sse:session:";
+
+/** Redis key for the set of SSE session IDs belonging to an API key. */
+const REDIS_SSE_SESSION_SET_PREFIX = "mcp:sse:sessions_by_key:";
+
+/**
+ * Redis pub/sub channel prefix carrying a client message to whichever replica
+ * holds the SSE stream for that session. An SSE stream is bound to the socket
+ * that opened it, so a replica that receives a message for a session it does
+ * not hold cannot answer it and cannot recreate the stream either.
+ */
+const REDIS_SSE_RELAY_CHANNEL_PREFIX = "mcp:sse:relay:";
 
 /** OAuth token TTL in seconds (30 days — matches cookie-based login duration). */
 const TOKEN_TTL_SECONDS = 30 * 24 * 3600;
@@ -113,6 +134,31 @@ function createRateLimiter({
       entries.clear();
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Request logging
+// ---------------------------------------------------------------------------
+
+/**
+ * Fields a route handler learned mid-request that belong on its access log
+ * line. MCP requests return before the app's Hono stack, so this surface has
+ * no access log of its own and a failing integration is otherwise invisible.
+ *
+ * Only identifiers go in here. Bearer tokens, API keys and authorization codes
+ * never do: the log is the one place they would outlive the request.
+ */
+const requestLogFields = new WeakMap<ServerResponse, Record<string, string>>();
+
+function noteLogFields(
+  res: ServerResponse,
+  fields: Record<string, string | undefined>,
+): void {
+  const existing = requestLogFields.get(res) ?? {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value) existing[key] = value;
+  }
+  requestLogFields.set(res, existing);
 }
 
 // ---------------------------------------------------------------------------
@@ -185,10 +231,16 @@ export function createMcpHandler(): McpHandler {
   const sseSessions = new Map<string, SseSessionState>();
   const oauthTokens = new Map<string, OAuthTokenEntry>();
 
-  // Rate limiters
-  const oauthRateLimiter = createRateLimiter({
+  // Rate limiters. Registration and token exchange get a budget each: a
+  // client that just registered immediately exchanges a code, so one shared
+  // bucket makes the second call pay for the first.
+  const registerRateLimiter = createRateLimiter({
     windowMs: 60_000,
-    maxRequests: 10,
+    maxRequests: 30,
+  });
+  const tokenRateLimiter = createRateLimiter({
+    windowMs: 60_000,
+    maxRequests: 30,
   });
   const authFailRateLimiter = createRateLimiter({
     windowMs: 60_000,
@@ -216,11 +268,13 @@ export function createMcpHandler(): McpHandler {
       }
     }
 
-    // Sweep idle SSE sessions (SSE is connection-bound, no Redis needed)
+    // Sweep idle SSE sessions. The stream itself is connection-bound, but the
+    // Redis record and the relay subscription that let other replicas reach it
+    // have to go with it.
     for (const [id, session] of sseSessions) {
       if (now - session.lastActivityAt > SESSION_MAX_AGE_MS) {
         session.transport.close().catch(() => {});
-        sseSessions.delete(id);
+        releaseSseSession(id, session.apiKey).catch(() => {});
       }
     }
 
@@ -232,7 +286,8 @@ export function createMcpHandler(): McpHandler {
     }
 
     // Sweep expired rate limiter entries
-    oauthRateLimiter.sweep();
+    registerRateLimiter.sweep();
+    tokenRateLimiter.sweep();
     authFailRateLimiter.sweep();
   }, REAPER_INTERVAL_MS);
 
@@ -243,20 +298,47 @@ export function createMcpHandler(): McpHandler {
   // Route matching
   // -------------------------------------------------------------------------
 
+  const PROTECTED_RESOURCE_METADATA_PATH =
+    "/.well-known/oauth-protected-resource";
+  const AUTHORIZATION_SERVER_METADATA_PATH =
+    "/.well-known/oauth-authorization-server";
+
   const MCP_ROUTES = new Set([
     "/mcp",
     "/mcp/health",
     "/sse",
     "/messages",
-    "/.well-known/oauth-protected-resource",
-    "/.well-known/oauth-authorization-server",
+    // Some clients resolve the endpoint the SSE stream advertises by appending
+    // it to the path they connected on, so the same handler answers both.
+    "/sse/messages",
+    PROTECTED_RESOURCE_METADATA_PATH,
+    AUTHORIZATION_SERVER_METADATA_PATH,
+    "/.well-known/openid-configuration",
     "/oauth/token",
     "/oauth/register",
   ]);
 
+  /**
+   * RFC 9728 §3.1 lets a client that only knows the resource URL ask for
+   * metadata at the resource's path under the well-known prefix, and modern
+   * MCP clients try that form before the bare one. Claiming the whole subtree
+   * keeps those probes from reaching the single-page-app fallback, which
+   * answers 200 text/html and leaves the client parsing markup as JSON.
+   */
+  const OAUTH_METADATA_PREFIXES = [
+    `${PROTECTED_RESOURCE_METADATA_PATH}/`,
+    `${AUTHORIZATION_SERVER_METADATA_PATH}/`,
+  ];
+
   function isMcpRoute(pathname: string): boolean {
-    return MCP_ROUTES.has(pathname);
+    if (MCP_ROUTES.has(pathname)) return true;
+    return OAUTH_METADATA_PREFIXES.some((prefix) =>
+      pathname.startsWith(prefix),
+    );
   }
+
+  /** The resource paths whose metadata this server publishes. */
+  const METADATA_RESOURCE_SUFFIXES = new Set(["/mcp", "/sse"]);
 
   // -------------------------------------------------------------------------
   // CORS — Access-Control-Allow-Origin: * is intentional; the Bearer token
@@ -315,6 +397,33 @@ export function createMcpHandler(): McpHandler {
     });
   }
 
+  /**
+   * Reads and parses a JSON request body, answering the caller itself when the
+   * body is unusable. Returns `undefined` in that case — a response has
+   * already been sent and the caller must stop.
+   */
+  async function readJsonBody(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<unknown | undefined> {
+    let raw: string;
+    try {
+      raw = await readBody(req);
+    } catch (err) {
+      if (err instanceof Error && err.message === "Request body too large") {
+        sendJson(res, 413, { error: "Request body too large" });
+        return undefined;
+      }
+      throw err;
+    }
+    try {
+      return JSON.parse(raw);
+    } catch {
+      sendJson(res, 400, { error: "Invalid JSON body" });
+      return undefined;
+    }
+  }
+
   function parseFormBody(raw: string): Record<string, string> {
     const params = new URLSearchParams(raw);
     const result: Record<string, string> = {};
@@ -324,13 +433,32 @@ export function createMcpHandler(): McpHandler {
     return result;
   }
 
+  /**
+   * The rate-limit bucket for a caller.
+   *
+   * The socket address alone is the load balancer for every caller once the
+   * app runs behind Cloudflare and an NLB, which collapses every client in the
+   * world into one bucket and lets a single busy integration lock everyone
+   * else out. The proxy headers are the only per-client signal that survives
+   * that hop, so they are what we key on, with the socket address as the
+   * fallback for direct connections. Shares the header priority (and the
+   * address validation) with the rest of the app rather than re-deriving it.
+   */
   function getClientIp(req: IncomingMessage): string {
-    // Use socket address only — X-Forwarded-For is client-controlled and
-    // would let attackers bypass rate limits by spoofing different IPs.
-    // Behind a reverse proxy (K8s, Cloudflare), the socket address is the
-    // proxy's IP, which means rate limiting is per-proxy not per-client.
-    // This is acceptable: the proxy itself limits concurrent connections.
-    return req.socket.remoteAddress ?? "unknown";
+    return clientIpFromRequest(req as unknown as NextApiRequest) ?? "unknown";
+  }
+
+  /**
+   * RFC 6749 §5.2 shape for a throttled OAuth request. A bare
+   * `{"error":"Too many requests"}` is not an OAuth error object, so clients
+   * report it as a protocol failure instead of backing off.
+   */
+  function sendRateLimited(res: ServerResponse, retryAfterSeconds = 60): void {
+    res.setHeader("Retry-After", String(retryAfterSeconds));
+    sendJson(res, 429, {
+      error: "temporarily_unavailable",
+      error_description: "Rate limit exceeded, retry later",
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -615,6 +743,29 @@ export function createMcpHandler(): McpHandler {
     }
   }
 
+  /** Count live sessions of one transport for an API key across all pods. */
+  async function countLiveSessions({
+    setKey,
+    sessionPrefix,
+  }: {
+    setKey: string;
+    sessionPrefix: string;
+  }): Promise<number> {
+    if (!redis) return 0;
+    const members = await redis.smembers(setKey);
+    let liveCount = 0;
+    for (const id of members) {
+      const exists = await redis.exists(`${sessionPrefix}${id}`);
+      if (exists) {
+        liveCount++;
+      } else {
+        // Stale entry — session expired, clean it from the set
+        await redis.srem(setKey, id);
+      }
+    }
+    return liveCount;
+  }
+
   /** Count sessions for an API key across all pods via Redis. */
   async function sessionCountForKey(apiKey: string): Promise<number> {
     if (!redis) {
@@ -629,32 +780,151 @@ export function createMcpHandler(): McpHandler {
       return count;
     }
     try {
-      // Count Streamable HTTP sessions from Redis (cross-pod)
-      const members = await redis.smembers(
-        `${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
-      );
-      let liveCount = 0;
-      for (const id of members) {
-        const exists = await redis.exists(`${REDIS_SESSION_PREFIX}${id}`);
-        if (exists) {
-          liveCount++;
-        } else {
-          // Stale entry — session expired, clean it from the set
-          await redis.srem(
-            `${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
-            id,
-          );
-        }
-      }
-      // SSE sessions are connection-bound (not in Redis) — count local only
-      for (const session of sseSessions.values()) {
-        if (session.apiKey === apiKey) liveCount++;
-      }
-      return liveCount;
+      const keyHash = hashApiKey(apiKey);
+      const streamable = await countLiveSessions({
+        setKey: `${REDIS_SESSION_SET_PREFIX}${keyHash}`,
+        sessionPrefix: REDIS_SESSION_PREFIX,
+      });
+      const sse = await countLiveSessions({
+        setKey: `${REDIS_SSE_SESSION_SET_PREFIX}${keyHash}`,
+        sessionPrefix: REDIS_SSE_SESSION_PREFIX,
+      });
+      return streamable + sse;
     } catch (err) {
       logger.error({ error: err }, "Redis session count failed");
       return 0; // Fail open to avoid blocking users
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // SSE session records and the cross-replica message relay
+  // -------------------------------------------------------------------------
+
+  /**
+   * Lifetime of an SSE session record, matching the idle reap. A replica that
+   * dies without closing its streams leaves records behind, and this is what
+   * eventually clears them.
+   */
+  const SSE_SESSION_REDIS_TTL_SECONDS = SESSION_MAX_AGE_MS / 1000;
+
+  /**
+   * Dedicated subscriber connection. ioredis puts a connection into subscriber
+   * mode, where it can run no other command, so the relay cannot share the
+   * app's connection. One per handler covers every session it holds.
+   */
+  let relaySubscriber: Redis | null = null;
+  const relayListeners = new Map<string, (raw: string) => void>();
+
+  function getRelaySubscriber(): Redis | null {
+    if (relaySubscriber) return relaySubscriber;
+    if (!redis) return null;
+    try {
+      // Cluster.duplicate() takes optional overrides and returns a Cluster;
+      // both shapes answer subscribe/unsubscribe/on identically.
+      const subscriber = (redis.duplicate as () => Redis)();
+      subscriber.on("message", (channel: string, message: string) => {
+        relayListeners.get(channel)?.(message);
+      });
+      subscriber.on("error", (err: unknown) => {
+        logger.error({ error: err }, "MCP SSE relay subscriber error");
+      });
+      relaySubscriber = subscriber;
+      return subscriber;
+    } catch (err) {
+      logger.error({ error: err }, "Failed to open MCP SSE relay subscriber");
+      return null;
+    }
+  }
+
+  function relayChannel(sessionId: string): string {
+    return `${REDIS_SSE_RELAY_CHANNEL_PREFIX}${sessionId}`;
+  }
+
+  /** Record an SSE session so other replicas can find and reach it. */
+  async function storeSseSessionInRedis(
+    sessionId: string,
+    apiKey: string,
+  ): Promise<void> {
+    if (!redis) return;
+    const setKey = `${REDIS_SSE_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`;
+    await redis.set(
+      `${REDIS_SSE_SESSION_PREFIX}${sessionId}`,
+      JSON.stringify({
+        encryptedApiKey: encrypt(apiKey),
+        createdAt: Date.now(),
+      }),
+      "EX",
+      SSE_SESSION_REDIS_TTL_SECONDS,
+    );
+    await redis.sadd(setKey, sessionId);
+    await redis.expire(setKey, SSE_SESSION_REDIS_TTL_SECONDS);
+  }
+
+  /** Keep an active SSE session from being reaped, wherever it is driven from. */
+  async function touchSseSessionInRedis(
+    sessionId: string,
+    apiKey: string,
+  ): Promise<void> {
+    if (!redis) return;
+    try {
+      await redis.expire(
+        `${REDIS_SSE_SESSION_PREFIX}${sessionId}`,
+        SSE_SESSION_REDIS_TTL_SECONDS,
+      );
+      await redis.expire(
+        `${REDIS_SSE_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
+        SSE_SESSION_REDIS_TTL_SECONDS,
+      );
+    } catch {
+      // Non-critical — the session still works until the TTL expires
+    }
+  }
+
+  async function getSseSessionFromRedis(
+    sessionId: string,
+  ): Promise<string | null> {
+    if (!redis) return null;
+    try {
+      const data = await redis.get(`${REDIS_SSE_SESSION_PREFIX}${sessionId}`);
+      if (!data) return null;
+      const stored = JSON.parse(data) as { encryptedApiKey: string };
+      return decrypt(stored.encryptedApiKey);
+    } catch (err) {
+      logger.error({ error: err }, "Redis SSE session lookup failed");
+      return null;
+    }
+  }
+
+  async function removeSseSessionFromRedis(
+    sessionId: string,
+    apiKey?: string,
+  ): Promise<void> {
+    if (!redis) return;
+    try {
+      await redis.del(`${REDIS_SSE_SESSION_PREFIX}${sessionId}`);
+      if (apiKey) {
+        await redis.srem(
+          `${REDIS_SSE_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
+          sessionId,
+        );
+      }
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  /** Drop every trace of an SSE session: local map, relay subscription, Redis. */
+  async function releaseSseSession(
+    sessionId: string,
+    apiKey: string,
+  ): Promise<void> {
+    sseSessions.delete(sessionId);
+    const channel = relayChannel(sessionId);
+    relayListeners.delete(channel);
+    if (relaySubscriber) {
+      await relaySubscriber.unsubscribe(channel).catch(() => {});
+    }
+    await removeSseSessionFromRedis(sessionId, apiKey);
   }
 
   // -------------------------------------------------------------------------
@@ -665,17 +935,37 @@ export function createMcpHandler(): McpHandler {
     sendJson(res, 200, { status: "ok" });
   }
 
+  /**
+   * `resourceSuffix` is the resource path a client asked about when it used
+   * the RFC 9728 path-suffixed form. It is echoed back as the `resource`
+   * identifier so a client validating the document against the URL it is
+   * about to call finds them equal.
+   */
   function handleProtectedResourceMetadata(
     _req: IncomingMessage,
     res: ServerResponse,
+    resourceSuffix = "",
   ): void {
     const baseUrl = process.env.BASE_HOST ?? "https://app.langwatch.ai";
 
     sendJson(res, 200, {
-      resource: baseUrl,
+      resource: `${baseUrl}${resourceSuffix}`,
       authorization_servers: [baseUrl],
       bearer_methods_supported: ["header"],
       scopes_supported: ["mcp:tools"],
+    });
+  }
+
+  /**
+   * Answers the OAuth discovery subtree this server claims but does not
+   * publish a document for. Falling through to the single-page app would give
+   * the client 200 text/html; a JSON 404 is what lets it move on to the
+   * document that does exist.
+   */
+  function handleUnknownMetadata(res: ServerResponse): void {
+    sendJson(res, 404, {
+      error: "not_found",
+      error_description: "No metadata document is published at this path",
     });
   }
 
@@ -704,11 +994,11 @@ export function createMcpHandler(): McpHandler {
     res: ServerResponse,
   ): Promise<void> {
     const ip = getClientIp(req);
-    if (oauthRateLimiter.isBlocked(ip)) {
-      sendJson(res, 429, { error: "Too many requests" });
+    if (registerRateLimiter.isBlocked(ip)) {
+      sendRateLimited(res);
       return;
     }
-    oauthRateLimiter.track(ip);
+    registerRateLimiter.track(ip);
 
     let raw: string;
     try {
@@ -768,6 +1058,8 @@ export function createMcpHandler(): McpHandler {
       return;
     }
 
+    noteLogFields(res, { clientId });
+
     sendJson(res, 201, {
       client_id: clientId,
       client_name: clientName,
@@ -778,17 +1070,40 @@ export function createMcpHandler(): McpHandler {
     });
   }
 
+  /**
+   * RFC 6749 §2.3.1 client credentials carried in an `Authorization: Basic`
+   * header. Public clients registered here have no secret, so the password
+   * half is expected to be empty and is not checked; the header is only
+   * another place a client may put its `client_id`. Both halves are
+   * form-urlencoded per the same section.
+   */
+  function clientIdFromBasicAuth(req: IncomingMessage): string | null {
+    const header = req.headers.authorization;
+    if (!header?.toLowerCase().startsWith("basic ")) return null;
+    try {
+      const decoded = Buffer.from(header.slice(6).trim(), "base64").toString(
+        "utf-8",
+      );
+      const separator = decoded.indexOf(":");
+      const rawClientId =
+        separator === -1 ? decoded : decoded.slice(0, separator);
+      return decodeURIComponent(rawClientId) || null;
+    } catch {
+      return null;
+    }
+  }
+
   async function handleOAuthToken(
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
     // Rate limit token endpoint per IP
     const ip = getClientIp(req);
-    if (oauthRateLimiter.isBlocked(ip)) {
-      sendJson(res, 429, { error: "Too many requests" });
+    if (tokenRateLimiter.isBlocked(ip)) {
+      sendRateLimited(res);
       return;
     }
-    oauthRateLimiter.track(ip);
+    tokenRateLimiter.track(ip);
 
     let raw: string;
     try {
@@ -841,7 +1156,7 @@ export function createMcpHandler(): McpHandler {
       });
       return;
     }
-    const clientIdParam = params.client_id;
+    const clientIdParam = params.client_id ?? clientIdFromBasicAuth(req);
     if (!clientIdParam) {
       sendJson(res, 400, {
         error: "invalid_request",
@@ -849,6 +1164,7 @@ export function createMcpHandler(): McpHandler {
       });
       return;
     }
+    noteLogFields(res, { clientId: clientIdParam });
 
     // Look up auth code from Redis
     if (!redis) {
@@ -867,6 +1183,22 @@ export function createMcpHandler(): McpHandler {
     }
 
     if (!authCodeData) {
+      // A registration that fell out of Redis takes its outstanding codes with
+      // it, and both failures look the same from here. Telling a client whose
+      // registration is gone that its *code* was bad sends it round the
+      // authorize loop forever; `invalid_client` is the code that makes it
+      // register again (RFC 6749 §5.2).
+      const registeredClient = await getOAuthClient(clientIdParam).catch(
+        () => null,
+      );
+      if (!registeredClient) {
+        sendJson(res, 401, {
+          error: "invalid_client",
+          error_description:
+            "Unknown client_id — register again via dynamic client registration",
+        });
+        return;
+      }
       sendJson(res, 400, {
         error: "invalid_grant",
         error_description: "Invalid or expired authorization code",
@@ -955,6 +1287,79 @@ export function createMcpHandler(): McpHandler {
     });
   }
 
+  /**
+   * Rebuilds a Streamable HTTP session on this replica from its Redis record,
+   * for a session first created on another one. Returns null when no record
+   * exists, and throws when the SDK internals the rebuild depends on have
+   * moved.
+   */
+  async function recoverStreamableSession({
+    sessionId,
+    incomingToken,
+  }: {
+    sessionId: string;
+    incomingToken: string | null;
+  }): Promise<SessionState | null> {
+    const redisApiKey = await getSessionFromRedis(sessionId);
+    if (!redisApiKey) return null;
+
+    // WORKAROUND: The SDK transport starts uninitialized — we patch its
+    // inner state so it accepts non-init requests with the existing
+    // session ID. This accesses private fields of the SDK's
+    // StreamableHTTPServerTransport wrapper and the underlying
+    // WebStandardStreamableHTTPServerTransport.
+    // Tested against @modelcontextprotocol/sdk@1.29.0.
+    // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1658
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => sessionId,
+    });
+
+    // Runtime assertion: verify the internal structure hasn't changed
+    const transportAny = transport as unknown as Record<string, unknown>;
+    if (
+      !transportAny._webStandardTransport ||
+      typeof transportAny._webStandardTransport !== "object"
+    ) {
+      throw new Error(
+        "StreamableHTTPServerTransport internal structure changed — " +
+          "Redis session recovery unavailable. Update the SDK workaround.",
+      );
+    }
+
+    const inner = transportAny._webStandardTransport as Record<string, unknown>;
+    inner._initialized = true;
+    inner.sessionId = sessionId;
+
+    // Re-resolve to recover OAuth userId if the token still has one;
+    // graceful degradation to undefined for direct-apiKey sessions.
+    const recoveredCtx = incomingToken
+      ? await resolveSessionContext(incomingToken)
+      : null;
+    const session: SessionState = {
+      transport,
+      apiKey: redisApiKey,
+      userId: recoveredCtx?.userId,
+      lastActivityAt: Date.now(),
+    };
+    sessions.set(sessionId, session);
+
+    transport.onclose = () => {
+      sessions.delete(sessionId);
+    };
+
+    const sessionServer = createMcpServer();
+    registerGovernanceMcpTools(sessionServer, {
+      prisma,
+      apiKey: redisApiKey,
+      callerUserId: recoveredCtx?.userId,
+    });
+    await handleWithSessionConfig(redisApiKey, () =>
+      sessionServer.connect(transport),
+    );
+
+    return session;
+  }
+
   async function handleMcpPost(
     req: IncomingMessage,
     res: ServerResponse,
@@ -989,67 +1394,14 @@ export function createMcpHandler(): McpHandler {
 
       // L2: Redis lookup — session may live on another pod
       if (!session) {
-        const redisApiKey = await getSessionFromRedis(sessionId);
-        if (redisApiKey) {
-          // Recreate transport locally for this pod.
-          // WORKAROUND: The SDK transport starts uninitialized — we patch its
-          // inner state so it accepts non-init requests with the existing
-          // session ID. This accesses private fields of the SDK's
-          // StreamableHTTPServerTransport wrapper and the underlying
-          // WebStandardStreamableHTTPServerTransport.
-          // Tested against @modelcontextprotocol/sdk@1.26.0.
-          // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1658
-          const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: () => sessionId,
-          });
-
-          // Runtime assertion: verify the internal structure hasn't changed
-          const transportAny = transport as unknown as Record<string, unknown>;
-          if (
-            !transportAny._webStandardTransport ||
-            typeof transportAny._webStandardTransport !== "object"
-          ) {
-            logger.error(
-              "StreamableHTTPServerTransport internal structure changed — " +
-                "Redis session recovery unavailable. Update the SDK workaround.",
-            );
-            sendJson(res, 500, { error: "Internal server error" });
-            return;
-          }
-
-          const inner = transportAny._webStandardTransport as Record<
-            string,
-            unknown
-          >;
-          inner._initialized = true;
-          inner.sessionId = sessionId;
-
-          // Re-resolve to recover OAuth userId if the token still has one;
-          // graceful degradation to undefined for direct-apiKey sessions.
-          const recoveredCtx = incomingToken
-            ? await resolveSessionContext(incomingToken)
-            : null;
-          session = {
-            transport,
-            apiKey: redisApiKey,
-            userId: recoveredCtx?.userId,
-            lastActivityAt: Date.now(),
-          };
-          sessions.set(sessionId, session);
-
-          transport.onclose = () => {
-            sessions.delete(sessionId);
-          };
-
-          const sessionServer = createMcpServer();
-          registerGovernanceMcpTools(sessionServer, {
-            prisma,
-            apiKey: redisApiKey,
-            callerUserId: recoveredCtx?.userId,
-          });
-          await handleWithSessionConfig(redisApiKey, () =>
-            sessionServer.connect(transport),
-          );
+        try {
+          session =
+            (await recoverStreamableSession({ sessionId, incomingToken })) ??
+            undefined;
+        } catch (err) {
+          logger.error({ error: err }, "MCP session recovery failed");
+          sendJson(res, 500, { error: "Internal server error" });
+          return;
         }
       }
 
@@ -1156,30 +1508,50 @@ export function createMcpHandler(): McpHandler {
     res: ServerResponse,
   ): Promise<void> {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
-    const session = sessionId ? sessions.get(sessionId) : undefined;
-
-    if (sessionId && session) {
-      const token = extractBearerToken(req);
-      if (!token) {
-        send401(res, "Authorization header required");
-        return;
-      }
-      const apiKey = await resolveApiKey(token);
-      if (apiKey !== session.apiKey) {
-        send401(res, "Bearer token does not match session");
-        return;
-      }
-
-      session.lastActivityAt = Date.now();
-      touchSessionInRedis(sessionId, session.apiKey).catch(() => {});
-      await handleWithSessionConfig(session.apiKey, () =>
-        session.transport.handleRequest(req, res),
-      );
-    } else if (sessionId) {
-      send401(res, "Session expired or not found");
-    } else {
+    if (!sessionId) {
       sendJson(res, 400, { error: "Invalid request — no valid session ID" });
+      return;
     }
+
+    let session = sessions.get(sessionId);
+
+    // L2: Redis lookup — the session may have been created on another pod, and
+    // reopening the stream is exactly what a client does after a reconnect.
+    if (!session) {
+      try {
+        session =
+          (await recoverStreamableSession({
+            sessionId,
+            incomingToken: extractBearerToken(req),
+          })) ?? undefined;
+      } catch (err) {
+        logger.error({ error: err }, "MCP session recovery failed");
+        sendJson(res, 500, { error: "Internal server error" });
+        return;
+      }
+    }
+
+    if (!session) {
+      send401(res, "Session expired or not found");
+      return;
+    }
+
+    const token = extractBearerToken(req);
+    if (!token) {
+      send401(res, "Authorization header required");
+      return;
+    }
+    const apiKey = await resolveApiKey(token);
+    if (apiKey !== session.apiKey) {
+      send401(res, "Bearer token does not match session");
+      return;
+    }
+
+    session.lastActivityAt = Date.now();
+    touchSessionInRedis(sessionId, session.apiKey).catch(() => {});
+    await handleWithSessionConfig(session.apiKey, () =>
+      session.transport.handleRequest(req, res),
+    );
   }
 
   async function handleMcpDelete(
@@ -1215,6 +1587,60 @@ export function createMcpHandler(): McpHandler {
   // SSE transport handlers (ChatGPT, etc.)
   // -------------------------------------------------------------------------
 
+  /**
+   * Listens for messages other replicas hand to this session. The reply
+   * travels back down the stream this replica holds, which is why the message
+   * comes to the stream rather than the stream moving to the message.
+   */
+  async function subscribeSessionToRelay({
+    sessionId,
+    session,
+  }: {
+    sessionId: string;
+    session: SseSessionState;
+  }): Promise<void> {
+    const subscriber = getRelaySubscriber();
+    if (!subscriber) return;
+
+    const channel = relayChannel(sessionId);
+    relayListeners.set(channel, (rawMessage) => {
+      void deliverRelayedMessage({ sessionId, session, rawMessage });
+    });
+
+    try {
+      await subscriber.subscribe(channel);
+    } catch (err) {
+      relayListeners.delete(channel);
+      logger.error(
+        { error: err, sessionId },
+        "Failed to subscribe to the MCP SSE relay channel",
+      );
+    }
+  }
+
+  async function deliverRelayedMessage({
+    sessionId,
+    session,
+    rawMessage,
+  }: {
+    sessionId: string;
+    session: SseSessionState;
+    rawMessage: string;
+  }): Promise<void> {
+    try {
+      session.lastActivityAt = Date.now();
+      await handleWithSessionConfig(session.apiKey, () =>
+        session.transport.handleMessage(JSON.parse(rawMessage)),
+      );
+      await touchSseSessionInRedis(sessionId, session.apiKey);
+    } catch (err) {
+      logger.error(
+        { error: err, sessionId },
+        "Failed to handle relayed MCP SSE message",
+      );
+    }
+  }
+
   async function handleSseConnect(
     req: IncomingMessage,
     res: ServerResponse,
@@ -1234,12 +1660,26 @@ export function createMcpHandler(): McpHandler {
     }
 
     const transport = new SSEServerTransport("/messages", res);
-    sseSessions.set(transport.sessionId, {
+    const sessionId = transport.sessionId;
+    noteLogFields(res, { sessionId });
+
+    const session: SseSessionState = {
       transport,
       apiKey,
       userId: sseUserId,
       lastActivityAt: Date.now(),
-    });
+    };
+    sseSessions.set(sessionId, session);
+
+    // Published before the stream opens: a client can post its first message
+    // to another replica the instant it reads the endpoint event.
+    try {
+      await storeSseSessionInRedis(sessionId, apiKey);
+    } catch (err) {
+      logger.error({ error: err }, "Failed to record MCP SSE session in Redis");
+    }
+
+    await subscribeSessionToRelay({ sessionId, session });
 
     const sessionServer = createMcpServer();
     registerGovernanceMcpTools(sessionServer, {
@@ -1249,7 +1689,7 @@ export function createMcpHandler(): McpHandler {
     });
 
     res.on("close", () => {
-      sseSessions.delete(transport.sessionId);
+      releaseSseSession(sessionId, apiKey).catch(() => {});
     });
 
     await handleWithSessionConfig(apiKey, () =>
@@ -1264,58 +1704,179 @@ export function createMcpHandler(): McpHandler {
     const url = new URL(req.url ?? "", "http://localhost");
     const sessionId = url.searchParams.get("sessionId");
 
-    if (!sessionId || !sseSessions.has(sessionId)) {
+    if (!sessionId) {
       sendJson(res, 400, { error: "Invalid or missing session ID" });
       return;
     }
+    noteLogFields(res, { sessionId });
 
-    const session = sseSessions.get(sessionId)!;
-
-    // Re-authenticate: verify Bearer token matches the session
+    // Authenticate before looking the session up, so a caller with no
+    // credentials is told it is unauthorized rather than that its session is
+    // bad — the two need different fixes.
     const token = extractBearerToken(req);
     if (!token) {
       send401(res, "Authorization header required");
       return;
     }
     const apiKey = await resolveApiKey(token);
-    if (apiKey !== session.apiKey) {
+    if (!apiKey) {
+      authFailRateLimiter.track(getClientIp(req));
+      send401(res, "Invalid or expired token");
+      return;
+    }
+
+    const localSession = sseSessions.get(sessionId);
+    if (localSession) {
+      if (apiKey !== localSession.apiKey) {
+        send401(res, "Bearer token does not match session");
+        return;
+      }
+      localSession.lastActivityAt = Date.now();
+      touchSseSessionInRedis(sessionId, localSession.apiKey).catch(() => {});
+
+      const body = await readJsonBody(req, res);
+      if (body === undefined) return;
+
+      await handleWithSessionConfig(localSession.apiKey, () =>
+        localSession.transport.handlePostMessage(req, res, body),
+      );
+      return;
+    }
+
+    // The stream lives on another replica. Hand the message over rather than
+    // reject it: the load balancer has no session affinity, so most messages
+    // of a healthy session arrive on a replica that does not hold it.
+    const sessionApiKey = await getSseSessionFromRedis(sessionId);
+    if (!sessionApiKey) {
+      sendJson(res, 404, { error: "Session not found" });
+      return;
+    }
+    if (apiKey !== sessionApiKey) {
       send401(res, "Bearer token does not match session");
       return;
     }
 
-    session.lastActivityAt = Date.now();
+    const body = await readJsonBody(req, res);
+    if (body === undefined) return;
 
-    let raw: string;
-    try {
-      raw = await readBody(req);
-    } catch (err) {
-      if (err instanceof Error && err.message === "Request body too large") {
-        sendJson(res, 413, { error: "Request body too large" });
-        return;
-      }
-      throw err;
-    }
-    let body: unknown;
-    try {
-      body = JSON.parse(raw);
-    } catch {
-      sendJson(res, 400, { error: "Invalid JSON body" });
+    if (!redis) {
+      sendJson(res, 404, { error: "Session not found" });
       return;
     }
 
-    await handleWithSessionConfig(session.apiKey, () =>
-      session.transport.handlePostMessage(req, res, body),
+    const receivers = await redis.publish(
+      relayChannel(sessionId),
+      JSON.stringify(body),
     );
+    if (receivers === 0) {
+      // Nobody is listening: the replica that held the stream is gone, and the
+      // record outlived it. Clear it so the client reconnects instead of
+      // posting into a void.
+      await removeSseSessionFromRedis(sessionId, sessionApiKey);
+      sendJson(res, 404, { error: "Session not found" });
+      return;
+    }
+
+    await touchSseSessionInRedis(sessionId, sessionApiKey);
+    // The JSON-RPC reply travels down the SSE stream on the replica that holds
+    // it, so this response only acknowledges the handoff — the same 202 the
+    // SDK's own transport answers a local post with.
+    sendJson(res, 202, { status: "accepted" });
   }
 
   // -------------------------------------------------------------------------
   // Main request dispatcher
   // -------------------------------------------------------------------------
 
+  /**
+   * Serves the path-suffixed OAuth discovery documents. Returns true when the
+   * request belonged to one of those subtrees and has been answered.
+   */
+  function serveOAuthMetadataSubtree({
+    req,
+    res,
+    pathname,
+    method,
+  }: {
+    req: IncomingMessage;
+    res: ServerResponse;
+    pathname: string;
+    method: string;
+  }): boolean {
+    const prefix = OAUTH_METADATA_PREFIXES.find((candidate) =>
+      pathname.startsWith(candidate),
+    );
+    if (!prefix) return false;
+
+    if (method !== "GET") {
+      sendJson(res, 405, { error: "Method not allowed" });
+      return true;
+    }
+
+    // The trailing separator of the prefix starts the resource path.
+    const resourceSuffix = pathname.slice(prefix.length - 1);
+    if (!METADATA_RESOURCE_SUFFIXES.has(resourceSuffix)) {
+      handleUnknownMetadata(res);
+      return true;
+    }
+
+    if (prefix.startsWith(PROTECTED_RESOURCE_METADATA_PATH)) {
+      handleProtectedResourceMetadata(req, res, resourceSuffix);
+    } else {
+      handleOAuthMetadata(req, res);
+    }
+    return true;
+  }
+
+  /**
+   * Emits one access log line per MCP request once the response is done.
+   * Wrapped throughout: an observability failure must never take a request
+   * with it.
+   */
+  function logRequestOnCompletion({
+    req,
+    res,
+    pathname,
+    method,
+  }: {
+    req: IncomingMessage;
+    res: ServerResponse;
+    pathname: string;
+    method: string;
+  }): void {
+    try {
+      const startedAt = Date.now();
+      res.once("close", () => {
+        try {
+          logger.info(
+            {
+              method,
+              path: pathname,
+              status: res.statusCode,
+              durationMs: Date.now() - startedAt,
+              ...requestLogFields.get(res),
+            },
+            "MCP request",
+          );
+        } catch {
+          // Logging must not break request handling.
+        }
+      });
+      const headerSessionId = req.headers["mcp-session-id"];
+      if (typeof headerSessionId === "string") {
+        noteLogFields(res, { sessionId: headerSessionId });
+      }
+    } catch {
+      // Logging must not break request handling.
+    }
+  }
+
   function handleRequest(req: IncomingMessage, res: ServerResponse): void {
     const url = req.url ?? "";
     const pathname = url.split("?")[0] ?? "";
     const method = req.method ?? "GET";
+
+    logRequestOnCompletion({ req, res, pathname, method });
 
     // Set CORS headers on all MCP routes (including error responses)
     setCorsHeaders(res);
@@ -1329,23 +1890,32 @@ export function createMcpHandler(): McpHandler {
 
     // Dispatch to route handlers
     const handle = async () => {
+      // RFC 9728 path-suffixed discovery, tried before the bare form by every
+      // current MCP client.
+      if (serveOAuthMetadataSubtree({ req, res, pathname, method })) return;
+
       switch (pathname) {
         case "/mcp/health":
           handleHealthCheck(req, res);
           break;
-        case "/.well-known/oauth-protected-resource":
+        case PROTECTED_RESOURCE_METADATA_PATH:
           if (method === "GET") {
             handleProtectedResourceMetadata(req, res);
           } else {
             sendJson(res, 405, { error: "Method not allowed" });
           }
           break;
-        case "/.well-known/oauth-authorization-server":
+        case AUTHORIZATION_SERVER_METADATA_PATH:
           if (method === "GET") {
             handleOAuthMetadata(req, res);
           } else {
             sendJson(res, 405, { error: "Method not allowed" });
           }
+          break;
+        case "/.well-known/openid-configuration":
+          // Not an OpenID provider. Claimed anyway so the probe gets a JSON
+          // 404 rather than the single-page app.
+          handleUnknownMetadata(res);
           break;
         case "/oauth/register":
           if (method === "POST") {
@@ -1384,6 +1954,7 @@ export function createMcpHandler(): McpHandler {
           }
           break;
         case "/messages":
+        case "/sse/messages":
           if (method === "POST") {
             await handleSseMessage(req, res);
           } else {
@@ -1412,7 +1983,8 @@ export function createMcpHandler(): McpHandler {
   }
 
   function clearRateLimiters(): void {
-    oauthRateLimiter.clear();
+    registerRateLimiter.clear();
+    tokenRateLimiter.clear();
     authFailRateLimiter.clear();
   }
 
@@ -1424,7 +1996,12 @@ export function createMcpHandler(): McpHandler {
     }
     for (const [id, session] of sseSessions) {
       session.transport.close().catch(() => {});
-      sseSessions.delete(id);
+      releaseSseSession(id, session.apiKey).catch(() => {});
+    }
+    relayListeners.clear();
+    if (relaySubscriber) {
+      relaySubscriber.disconnect();
+      relaySubscriber = null;
     }
   }
 

--- a/platform/app/src/mcp/handler.ts
+++ b/platform/app/src/mcp/handler.ts
@@ -208,8 +208,8 @@ export interface McpHandler {
   clearTokenCache: () => void;
   /** Clear the in-memory OAuth/auth-failure rate limiter state (for testing). */
   clearRateLimiters: () => void;
-  /** Close all active sessions (for graceful shutdown). */
-  closeAllSessions: () => void;
+  /** Close all active sessions and release their records (graceful shutdown). */
+  closeAllSessions: () => Promise<void>;
 }
 
 /**
@@ -443,6 +443,14 @@ export function createMcpHandler(): McpHandler {
    * that hop, so they are what we key on, with the socket address as the
    * fallback for direct connections. Shares the header priority (and the
    * address validation) with the rest of the app rather than re-deriving it.
+   *
+   * That priority puts `cf-connecting-ip` first, which is the header the edge
+   * writes itself: Cloudflare replaces any caller-supplied value before the
+   * request reaches an origin, so what we bucket on is edge-authored rather
+   * than caller-authored wherever the deployment keeps that edge in front. A
+   * deployment that exposes the origin directly is trusting these headers to
+   * the same degree as every other rate limit in the app, which is why the
+   * resolution stays shared instead of being re-derived here.
    */
   function getClientIp(req: IncomingMessage): string {
     return clientIpFromRequest(req as unknown as NextApiRequest) ?? "unknown";
@@ -1290,18 +1298,26 @@ export function createMcpHandler(): McpHandler {
   /**
    * Rebuilds a Streamable HTTP session on this replica from its Redis record,
    * for a session first created on another one. Returns null when no record
-   * exists, and throws when the SDK internals the rebuild depends on have
-   * moved.
+   * exists or when the record belongs to a different project, and throws when
+   * the SDK internals the rebuild depends on have moved.
+   *
+   * Rebuilding is itself a side effect — it decrypts the stored key, connects
+   * a server bound to it and puts the session in this replica's map — so the
+   * caller's own key is checked against the record before any of that runs,
+   * rather than only checked on the response.
    */
   async function recoverStreamableSession({
     sessionId,
     incomingToken,
+    callerApiKey,
   }: {
     sessionId: string;
     incomingToken: string | null;
+    callerApiKey: string;
   }): Promise<SessionState | null> {
     const redisApiKey = await getSessionFromRedis(sessionId);
     if (!redisApiKey) return null;
+    if (redisApiKey !== callerApiKey) return null;
 
     // WORKAROUND: The SDK transport starts uninitialized — we patch its
     // inner state so it accepts non-init requests with the existing
@@ -1364,23 +1380,8 @@ export function createMcpHandler(): McpHandler {
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
-    let raw: string;
-    try {
-      raw = await readBody(req);
-    } catch (err) {
-      if (err instanceof Error && err.message === "Request body too large") {
-        sendJson(res, 413, { error: "Request body too large" });
-        return;
-      }
-      throw err;
-    }
-    let body: unknown;
-    try {
-      body = JSON.parse(raw);
-    } catch {
-      sendJson(res, 400, { error: "Invalid JSON body" });
-      return;
-    }
+    const body = await readJsonBody(req, res);
+    if (body === undefined) return;
 
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     // Extract once at the top — reused on session-recovery path to recover
@@ -1391,13 +1392,21 @@ export function createMcpHandler(): McpHandler {
     // Existing session — check local Map first, then Redis
     if (sessionId) {
       let session = sessions.get(sessionId);
+      const callerApiKey = incomingToken
+        ? await resolveApiKey(incomingToken)
+        : null;
 
-      // L2: Redis lookup — session may live on another pod
-      if (!session) {
+      // L2: Redis lookup — session may live on another pod. Only a caller
+      // that already proved it owns the session gets this far, so naming
+      // someone else's session id rebuilds nothing here.
+      if (!session && callerApiKey) {
         try {
           session =
-            (await recoverStreamableSession({ sessionId, incomingToken })) ??
-            undefined;
+            (await recoverStreamableSession({
+              sessionId,
+              incomingToken,
+              callerApiKey,
+            })) ?? undefined;
         } catch (err) {
           logger.error({ error: err }, "MCP session recovery failed");
           sendJson(res, 500, { error: "Internal server error" });
@@ -1406,13 +1415,11 @@ export function createMcpHandler(): McpHandler {
       }
 
       if (session) {
-        const token = extractBearerToken(req);
-        if (!token) {
+        if (!incomingToken) {
           send401(res, "Authorization header required");
           return;
         }
-        const apiKey = await resolveApiKey(token);
-        if (apiKey !== session.apiKey) {
+        if (callerApiKey !== session.apiKey) {
           send401(res, "Bearer token does not match session");
           return;
         }
@@ -1514,15 +1521,22 @@ export function createMcpHandler(): McpHandler {
     }
 
     let session = sessions.get(sessionId);
+    const incomingToken = extractBearerToken(req);
+    const callerApiKey = incomingToken
+      ? await resolveApiKey(incomingToken)
+      : null;
 
     // L2: Redis lookup — the session may have been created on another pod, and
     // reopening the stream is exactly what a client does after a reconnect.
-    if (!session) {
+    // The caller's key is resolved first so an unauthenticated reconnect
+    // cannot make this replica rebuild a session it was never given.
+    if (!session && callerApiKey) {
       try {
         session =
           (await recoverStreamableSession({
             sessionId,
-            incomingToken: extractBearerToken(req),
+            incomingToken,
+            callerApiKey,
           })) ?? undefined;
       } catch (err) {
         logger.error({ error: err }, "MCP session recovery failed");
@@ -1532,17 +1546,24 @@ export function createMcpHandler(): McpHandler {
     }
 
     if (!session) {
-      send401(res, "Session expired or not found");
+      // A caller that presented nothing is told that, rather than that the
+      // session vanished — the two need different things from the client.
+      // A caller whose token belongs elsewhere is told the session is gone,
+      // which is also the answer that confirms nothing about it.
+      send401(
+        res,
+        incomingToken
+          ? "Session expired or not found"
+          : "Authorization header required",
+      );
       return;
     }
 
-    const token = extractBearerToken(req);
-    if (!token) {
+    if (!incomingToken) {
       send401(res, "Authorization header required");
       return;
     }
-    const apiKey = await resolveApiKey(token);
-    if (apiKey !== session.apiKey) {
+    if (callerApiKey !== session.apiKey) {
       send401(res, "Bearer token does not match session");
       return;
     }
@@ -1988,16 +2009,24 @@ export function createMcpHandler(): McpHandler {
     authFailRateLimiter.clear();
   }
 
-  function closeAllSessions(): void {
+  /**
+   * Resolves once every session record this replica owns is gone from Redis.
+   * Shutdown waits on it: a released record frees a slot against the
+   * per-project concurrent-session limit, and a process that exits without
+   * waiting leaves those slots allocated until their TTL.
+   */
+  async function closeAllSessions(): Promise<void> {
     clearInterval(reaper);
     for (const [id, session] of sessions) {
       session.transport.close().catch(() => {});
       sessions.delete(id);
     }
+    const released: Promise<void>[] = [];
     for (const [id, session] of sseSessions) {
       session.transport.close().catch(() => {});
-      releaseSseSession(id, session.apiKey).catch(() => {});
+      released.push(releaseSseSession(id, session.apiKey).catch(() => {}));
     }
+    await Promise.all(released);
     relayListeners.clear();
     if (relaySubscriber) {
       relaySubscriber.disconnect();

--- a/platform/app/src/mcp/handler.ts
+++ b/platform/app/src/mcp/handler.ts
@@ -398,6 +398,27 @@ export function createMcpHandler(): McpHandler {
   }
 
   /**
+   * Reads a request body, answering the caller itself when it is too large.
+   * Returns `undefined` in that case — a response has already been sent and
+   * the caller must stop. Bodies that need their own parse failure (the form
+   * readers each answer with a different OAuth error) build on this.
+   */
+  async function readRawBody(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<string | undefined> {
+    try {
+      return await readBody(req);
+    } catch (err) {
+      if (err instanceof Error && err.message === "Request body too large") {
+        sendJson(res, 413, { error: "Request body too large" });
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Reads and parses a JSON request body, answering the caller itself when the
    * body is unusable. Returns `undefined` in that case — a response has
    * already been sent and the caller must stop.
@@ -406,16 +427,8 @@ export function createMcpHandler(): McpHandler {
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<unknown | undefined> {
-    let raw: string;
-    try {
-      raw = await readBody(req);
-    } catch (err) {
-      if (err instanceof Error && err.message === "Request body too large") {
-        sendJson(res, 413, { error: "Request body too large" });
-        return undefined;
-      }
-      throw err;
-    }
+    const raw = await readRawBody(req, res);
+    if (raw === undefined) return undefined;
     try {
       return JSON.parse(raw);
     } catch {
@@ -1008,16 +1021,8 @@ export function createMcpHandler(): McpHandler {
     }
     registerRateLimiter.track(ip);
 
-    let raw: string;
-    try {
-      raw = await readBody(req);
-    } catch (err) {
-      if (err instanceof Error && err.message === "Request body too large") {
-        sendJson(res, 413, { error: "Request body too large" });
-        return;
-      }
-      throw err;
-    }
+    const raw = await readRawBody(req, res);
+    if (raw === undefined) return;
 
     let body: {
       redirect_uris?: string[];
@@ -1113,16 +1118,8 @@ export function createMcpHandler(): McpHandler {
     }
     tokenRateLimiter.track(ip);
 
-    let raw: string;
-    try {
-      raw = await readBody(req);
-    } catch (err) {
-      if (err instanceof Error && err.message === "Request body too large") {
-        sendJson(res, 413, { error: "Request body too large" });
-        return;
-      }
-      throw err;
-    }
+    const raw = await readRawBody(req, res);
+    if (raw === undefined) return;
     const params = parseFormBody(raw);
 
     if (params.grant_type !== "authorization_code") {

--- a/platform/app/src/mcp/redirectSchemes.ts
+++ b/platform/app/src/mcp/redirectSchemes.ts
@@ -1,0 +1,33 @@
+/**
+ * Schemes an OAuth redirect_uri may never use, shared by the authorize route
+ * that verifies the URI and the consent page that navigates to it, so the two
+ * cannot drift apart.
+ *
+ * This is a deny-list rather than an `http:`/`https:` allow-list on purpose.
+ * Native MCP clients complete the OAuth flow through a custom-scheme callback
+ * they register with the operating system (an editor or desktop app answering
+ * its own `something://` URI), and RFC 8252 §7.1 names exactly that as the
+ * redirect for a native app. An allow-list would refuse every one of them and
+ * leave those clients unable to connect at all.
+ *
+ * So the list names what a browser executes or resolves against our own
+ * origin, which is the class that turns a redirect into script execution:
+ * `javascript:`, `vbscript:` and `data:` run, and `blob:`/`filesystem:` URLs
+ * are same-origin with the page that created them.
+ */
+export const DISALLOWED_REDIRECT_SCHEMES = [
+  "javascript:",
+  "vbscript:",
+  "data:",
+  "blob:",
+  "filesystem:",
+];
+
+/** Whether a redirect_uri is safe to navigate to. Unparseable means no. */
+export function isAllowedRedirectScheme(candidate: string): boolean {
+  try {
+    return !DISALLOWED_REDIRECT_SCHEMES.includes(new URL(candidate).protocol);
+  } catch {
+    return false;
+  }
+}

--- a/platform/app/src/mcp/redirectSchemes.ts
+++ b/platform/app/src/mcp/redirectSchemes.ts
@@ -21,12 +21,14 @@ export const DISALLOWED_REDIRECT_SCHEMES = [
   "data:",
   "blob:",
   "filesystem:",
-];
+] as const;
 
 /** Whether a redirect_uri is safe to navigate to. Unparseable means no. */
 export function isAllowedRedirectScheme(candidate: string): boolean {
   try {
-    return !DISALLOWED_REDIRECT_SCHEMES.includes(new URL(candidate).protocol);
+    return !(DISALLOWED_REDIRECT_SCHEMES as readonly string[]).includes(
+      new URL(candidate).protocol,
+    );
   } catch {
     return false;
   }

--- a/platform/app/src/pages/mcp/authorize.tsx
+++ b/platform/app/src/pages/mcp/authorize.tsx
@@ -18,6 +18,23 @@ import {
 import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 
+/** Schemes that execute rather than navigate, so they never reach `location`. */
+const EXECUTABLE_SCHEMES = ["javascript:", "data:", "vbscript:"];
+
+/**
+ * Whether a destination is safe to hand to `location`. Every redirect this
+ * page follows was verified against the client registry server-side first;
+ * this is the second lock, so that a regression on that side is a broken
+ * redirect rather than script running on our origin.
+ */
+function isNavigableRedirect(candidate: string): boolean {
+  try {
+    return !EXECUTABLE_SCHEMES.includes(new URL(candidate).protocol);
+  } catch {
+    return false;
+  }
+}
+
 export default function McpAuthorize() {
   const router = useRouter();
   const { data: session, status } = useSession();
@@ -88,11 +105,18 @@ export default function McpAuthorize() {
       // told what went wrong instead of hanging on a popup. Failures it could
       // not attribute have no safe destination and are shown here.
       if (data.redirect) {
+        if (!isNavigableRedirect(data.redirect)) {
+          showError("The application asked to return to an unusable address");
+          return;
+        }
         window.location.href = data.redirect;
         return;
       }
 
       if (!response.ok) {
+        // RFC 6749 §4.1.2.1 wire fields from our own authorize endpoint, not a
+        // mutation error: the copy is written for the customer at the point it
+        // is produced, so there is no error code to look up here.
         showError(data.error_description ?? data.error ?? "Unknown error");
         return;
       }
@@ -105,16 +129,11 @@ export default function McpAuthorize() {
 
   const handleDeny = () => {
     if (oauthParams.redirect_uri) {
-      const url = new URL(oauthParams.redirect_uri);
-      // Prevent XSS via executable schemes
-      if (
-        url.protocol === "javascript:" ||
-        url.protocol === "data:" ||
-        url.protocol === "vbscript:"
-      ) {
+      if (!isNavigableRedirect(oauthParams.redirect_uri)) {
         void router.push("/");
         return;
       }
+      const url = new URL(oauthParams.redirect_uri);
       url.searchParams.set("error", "access_denied");
       if (oauthParams.state) {
         url.searchParams.set("state", oauthParams.state);

--- a/platform/app/src/pages/mcp/authorize.tsx
+++ b/platform/app/src/pages/mcp/authorize.tsx
@@ -19,15 +19,6 @@ import {
 import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 
-/**
- * Whether a destination is safe to hand to `location`. Every redirect this
- * page follows was verified against the client registry server-side first;
- * this is the second lock, so that a regression on that side is a broken
- * redirect rather than script running on our origin. Shares its list with the
- * authorize route, which applies the same rule before it ever issues a code.
- */
-const isNavigableRedirect = isAllowedRedirectScheme;
-
 export default function McpAuthorize() {
   const router = useRouter();
   const { data: session, status } = useSession();
@@ -98,7 +89,10 @@ export default function McpAuthorize() {
       // told what went wrong instead of hanging on a popup. Failures it could
       // not attribute have no safe destination and are shown here.
       if (data.redirect) {
-        if (!isNavigableRedirect(data.redirect)) {
+        // The server verified this against the client registry before sending
+        // it, so this is the second lock: a regression there becomes a broken
+        // redirect rather than script running on our origin.
+        if (!isAllowedRedirectScheme(data.redirect)) {
           showError("The application asked to return to an unusable address");
           return;
         }
@@ -122,7 +116,7 @@ export default function McpAuthorize() {
 
   const handleDeny = () => {
     if (oauthParams.redirect_uri) {
-      if (!isNavigableRedirect(oauthParams.redirect_uri)) {
+      if (!isAllowedRedirectScheme(oauthParams.redirect_uri)) {
         void router.push("/");
         return;
       }

--- a/platform/app/src/pages/mcp/authorize.tsx
+++ b/platform/app/src/pages/mcp/authorize.tsx
@@ -9,6 +9,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { isAllowedRedirectScheme } from "~/mcp/redirectSchemes";
 import { useSession } from "~/utils/auth-client";
 import { useRouter } from "~/utils/compat/next-router";
 import {
@@ -18,22 +19,14 @@ import {
 import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 
-/** Schemes that execute rather than navigate, so they never reach `location`. */
-const EXECUTABLE_SCHEMES = ["javascript:", "data:", "vbscript:"];
-
 /**
  * Whether a destination is safe to hand to `location`. Every redirect this
  * page follows was verified against the client registry server-side first;
  * this is the second lock, so that a regression on that side is a broken
- * redirect rather than script running on our origin.
+ * redirect rather than script running on our origin. Shares its list with the
+ * authorize route, which applies the same rule before it ever issues a code.
  */
-function isNavigableRedirect(candidate: string): boolean {
-  try {
-    return !EXECUTABLE_SCHEMES.includes(new URL(candidate).protocol);
-  } catch {
-    return false;
-  }
-}
+const isNavigableRedirect = isAllowedRedirectScheme;
 
 export default function McpAuthorize() {
   const router = useRouter();

--- a/platform/app/src/pages/mcp/authorize.tsx
+++ b/platform/app/src/pages/mcp/authorize.tsx
@@ -83,16 +83,21 @@ export default function McpAuthorize() {
 
       const data = await response.json();
 
-      if (!response.ok) {
-        showError(data.error ?? "Unknown error");
+      // A failure the server could attribute to this client comes back with a
+      // redirect that carries the OAuth error, so the waiting application is
+      // told what went wrong instead of hanging on a popup. Failures it could
+      // not attribute have no safe destination and are shown here.
+      if (data.redirect) {
+        window.location.href = data.redirect;
         return;
       }
 
-      if (data.redirect) {
-        window.location.href = data.redirect;
-      } else {
-        showError("No redirect URL received from server");
+      if (!response.ok) {
+        showError(data.error_description ?? data.error ?? "Unknown error");
+        return;
       }
+
+      showError("No redirect URL received from server");
     } catch (err) {
       showError(err instanceof Error ? err.message : "Network error");
     }

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
@@ -97,11 +97,27 @@ async function authorize(overrides: Record<string, unknown> = {}) {
   });
 }
 
+/**
+ * `mockClear` does not drain a `mockResolvedValueOnce` queue, so a value a test
+ * queued but the route never read would answer the next test's call and make
+ * the outcome depend on execution order. Reset drains it, and also drops the
+ * declared default, so each default is restated here.
+ */
+function resetMocks() {
+  mockRedis.set.mockReset().mockResolvedValue("OK");
+  mockRedis.get.mockReset();
+  mockPrisma.roleBinding.findMany
+    .mockReset()
+    .mockResolvedValue([
+      { role: "ADMIN", customRoleId: null, scopeType: "TEAM" },
+    ]);
+  mockPrisma.organizationUser.findFirst
+    .mockReset()
+    .mockResolvedValue({ role: "MEMBER" });
+}
+
 describe("POST /api/mcp/authorize — redirect_uri binding", () => {
-  beforeEach(() => {
-    mockRedis.set.mockClear();
-    mockRedis.get.mockClear();
-  });
+  beforeEach(resetMocks);
 
   describe("when redirect_uri exactly matches a registered URI for client_id", () => {
     /** @scenario Authorization succeeds when redirect_uri exactly matches the registered client */
@@ -158,6 +174,8 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
       expect(json.error).toContain("disallowed scheme");
       expect(json.redirect).toBeUndefined();
       expect(mockRedis.set).not.toHaveBeenCalled();
+      // Proves the ordering the comment above relies on.
+      expect(mockRedis.get).not.toHaveBeenCalled();
     });
   });
 
@@ -196,10 +214,7 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
  * leaves the client's popup waiting forever with nothing to report.
  */
 describe("POST /api/mcp/authorize — where failures are reported", () => {
-  beforeEach(() => {
-    mockRedis.set.mockClear();
-    mockRedis.get.mockClear();
-  });
+  beforeEach(resetMocks);
 
   describe("when the client is verified but the request has no code challenge", () => {
     /** @scenario A consent failure a client can be told about is redirected back to the client */
@@ -221,6 +236,23 @@ describe("POST /api/mcp/authorize — where failures are reported", () => {
         "code_challenge",
       );
       expect(redirect.searchParams.get("state")).toBe("xyz");
+      expect(redirect.searchParams.get("code")).toBeNull();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the client is verified but asks for a PKCE method we do not support", () => {
+    /** @scenario A code challenge method other than S256 is refused at the authorization request */
+    it("refuses it rather than minting a code that can never be redeemed", async () => {
+      mockRedis.get.mockResolvedValueOnce(registeredClient());
+
+      const res = await authorize({ code_challenge_method: "plain" });
+      const json = (await res.json()) as { error?: string; redirect?: string };
+
+      expect(res.status).toBe(400);
+      expect(json.error).toBe("invalid_request");
+      const redirect = new URL(json.redirect ?? "");
+      expect(redirect.searchParams.get("error_description")).toContain("S256");
       expect(redirect.searchParams.get("code")).toBeNull();
       expect(mockRedis.set).not.toHaveBeenCalled();
     });

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
@@ -165,3 +165,74 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
     });
   });
 });
+
+/**
+ * RFC 6749 §4.1.2.1: once the client_id is known and the presented
+ * redirect_uri is one it registered, an authorization failure has to travel
+ * back to that redirect_uri as an OAuth error. The advertised authorize
+ * endpoint is a page in this app, so a failure rendered only as a toast here
+ * leaves the client's popup waiting forever with nothing to report.
+ */
+describe("POST /api/mcp/authorize — where failures are reported", () => {
+  beforeEach(() => {
+    mockRedis.set.mockClear();
+    mockRedis.get.mockClear();
+  });
+
+  describe("when the client is verified but the request has no code challenge", () => {
+    /** @scenario A consent failure a client can be told about is redirected back to the client */
+    it("sends the browser back to the registered redirect URI with the OAuth error", async () => {
+      mockRedis.get.mockResolvedValueOnce(registeredClient());
+
+      const res = await authorize({ code_challenge: undefined });
+      const json = (await res.json()) as {
+        error?: string;
+        redirect?: string;
+      };
+
+      expect(res.status).toBe(400);
+      expect(json.error).toBe("invalid_request");
+      const redirect = new URL(json.redirect ?? "");
+      expect(redirect.origin + redirect.pathname).toBe(REGISTERED_REDIRECT_URI);
+      expect(redirect.searchParams.get("error")).toBe("invalid_request");
+      expect(redirect.searchParams.get("error_description")).toContain(
+        "code_challenge",
+      );
+      expect(redirect.searchParams.get("state")).toBe("xyz");
+      expect(redirect.searchParams.get("code")).toBeNull();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the client is verified but the user cannot reach the project", () => {
+    /** @scenario A project the user cannot reach is reported to the client as access denied */
+    it("sends the browser back to the registered redirect URI as access denied", async () => {
+      mockRedis.get.mockResolvedValueOnce(registeredClient());
+      mockPrisma.roleBinding.findMany.mockResolvedValueOnce([]);
+      mockPrisma.organizationUser.findFirst.mockResolvedValueOnce(null);
+
+      const res = await authorize();
+      const json = (await res.json()) as { error?: string; redirect?: string };
+
+      expect(res.status).toBe(403);
+      expect(json.error).toBe("access_denied");
+      const redirect = new URL(json.redirect ?? "");
+      expect(redirect.searchParams.get("error")).toBe("access_denied");
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the failure cannot be attributed to a registered client", () => {
+    /** @scenario A consent failure that cannot be attributed to a client stays on the LangWatch page */
+    it("offers no redirect back to the caller", async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+
+      const res = await authorize({ client_id: "mcp_never_registered" });
+      const json = (await res.json()) as { error?: string; redirect?: string };
+
+      expect(res.status).toBe(400);
+      expect(json.redirect).toBeUndefined();
+      expect(json.error).toBe("Unknown or unregistered client_id");
+    });
+  });
+});

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
@@ -139,6 +139,28 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
     });
   });
 
+  describe.each([
+    "javascript:alert(1)",
+    "vbscript:msgbox(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "blob:https://app.langwatch.ai/00000000-0000-4000-8000-000000000000",
+    "filesystem:https://app.langwatch.ai/temporary/x",
+  ])("when redirect_uri is %s", (redirect_uri) => {
+    /** @scenario Authorization is rejected when redirect_uri uses a scheme the browser executes */
+    it("rejects with 400 and never mints an authorization code", async () => {
+      // No registration is queued on purpose: the scheme is refused before the
+      // client registry is ever consulted, which is what keeps a client that
+      // registered such a URI from being able to use it.
+      const res = await authorize({ redirect_uri });
+      const json = (await res.json()) as { redirect?: string; error?: string };
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain("disallowed scheme");
+      expect(json.redirect).toBeUndefined();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when client_id was never registered via /oauth/register", () => {
     /** @scenario Authorization is rejected for an unregistered client_id */
     it("rejects with 400 and never mints an authorization code", async () => {

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -121,6 +121,36 @@ async function authorize() {
   });
 }
 
+/**
+ * Every refusal here happens after the client_id and redirect_uri were
+ * verified against the registry, so the client is waiting on its redirect and
+ * has to be told there: a refusal that only renders on our page leaves it
+ * hanging. Asserting the destination as well as the body keeps a regression
+ * that drops or re-points the redirect from passing.
+ */
+async function expectAccessDenied(res: Response) {
+  const json = (await res.json()) as {
+    error?: string;
+    error_description?: string;
+    redirect?: string;
+  };
+
+  // biome-ignore-start lint/suspicious/noMisplacedAssertion: one refusal shape, asserted whole, for every case that produces it
+  expect(res.status).toBe(403);
+  expect(json.error).toBe(ERROR);
+  expect(json.error_description).toBe(ERROR_DESCRIPTION);
+
+  const redirect = new URL(json.redirect ?? "");
+  expect(`${redirect.origin}${redirect.pathname}`).toBe(validBody.redirect_uri);
+  expect(redirect.searchParams.get("error")).toBe(ERROR);
+  expect(redirect.searchParams.get("error_description")).toBe(
+    ERROR_DESCRIPTION,
+  );
+  expect(redirect.searchParams.get("state")).toBe(validBody.state);
+  expect(redirect.searchParams.get("code")).toBeNull();
+  // biome-ignore-end lint/suspicious/noMisplacedAssertion: end of the shared refusal assertions
+}
+
 describe("POST /mcp/authorize", () => {
   describe("when the user has project access via a TEAM-scoped RoleBinding but no legacy TeamUser row", () => {
     it("authorizes the connection instead of returning 403", async () => {
@@ -139,15 +169,7 @@ describe("POST /mcp/authorize", () => {
       // which is also absent → access denied.
       mockPrisma.roleBinding.findMany.mockResolvedValueOnce([]);
 
-      const res = await authorize();
-      const json = (await res.json()) as {
-        error?: string;
-        error_description?: string;
-      };
-
-      expect(res.status).toBe(403);
-      expect(json.error).toBe(ERROR);
-      expect(json.error_description).toBe(ERROR_DESCRIPTION);
+      await expectAccessDenied(await authorize());
     });
   });
 
@@ -161,15 +183,7 @@ describe("POST /mcp/authorize", () => {
         archivedAt: new Date("2026-01-01T00:00:00Z"),
       });
 
-      const res = await authorize();
-      const json = (await res.json()) as {
-        error?: string;
-        error_description?: string;
-      };
-
-      expect(res.status).toBe(403);
-      expect(json.error).toBe(ERROR);
-      expect(json.error_description).toBe(ERROR_DESCRIPTION);
+      await expectAccessDenied(await authorize());
     });
   });
 
@@ -180,15 +194,7 @@ describe("POST /mcp/authorize", () => {
       const previous = process.env.DEMO_PROJECT_ID;
       process.env.DEMO_PROJECT_ID = PROJECT_ID;
       try {
-        const res = await authorize();
-        const json = (await res.json()) as {
-          error?: string;
-          error_description?: string;
-        };
-
-        expect(res.status).toBe(403);
-        expect(json.error).toBe(ERROR);
-        expect(json.error_description).toBe(ERROR_DESCRIPTION);
+        await expectAccessDenied(await authorize());
       } finally {
         if (previous === undefined) delete process.env.DEMO_PROJECT_ID;
         else process.env.DEMO_PROJECT_ID = previous;

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -18,7 +18,10 @@ import { app } from "../misc";
 const PROJECT_ID = "project_1";
 const TEAM_ID = "team_1";
 const ORG_ID = "org_1";
-const ERROR = "Project not found or you don't have access";
+// The client is verified by this point, so the refusal travels back to it as
+// an OAuth error code; the prose is what the description carries.
+const ERROR = "access_denied";
+const ERROR_DESCRIPTION = "Project not found or you don't have access";
 
 // Hoisted so the mock objects exist before the mocked modules are evaluated
 // (the top-level `import { app } from "../misc"` triggers those factories).
@@ -137,10 +140,14 @@ describe("POST /mcp/authorize", () => {
       mockPrisma.roleBinding.findMany.mockResolvedValueOnce([]);
 
       const res = await authorize();
-      const json = (await res.json()) as { error?: string };
+      const json = (await res.json()) as {
+        error?: string;
+        error_description?: string;
+      };
 
       expect(res.status).toBe(403);
       expect(json.error).toBe(ERROR);
+      expect(json.error_description).toBe(ERROR_DESCRIPTION);
     });
   });
 
@@ -155,10 +162,14 @@ describe("POST /mcp/authorize", () => {
       });
 
       const res = await authorize();
-      const json = (await res.json()) as { error?: string };
+      const json = (await res.json()) as {
+        error?: string;
+        error_description?: string;
+      };
 
       expect(res.status).toBe(403);
       expect(json.error).toBe(ERROR);
+      expect(json.error_description).toBe(ERROR_DESCRIPTION);
     });
   });
 
@@ -170,10 +181,14 @@ describe("POST /mcp/authorize", () => {
       process.env.DEMO_PROJECT_ID = PROJECT_ID;
       try {
         const res = await authorize();
-        const json = (await res.json()) as { error?: string };
+        const json = (await res.json()) as {
+          error?: string;
+          error_description?: string;
+        };
 
         expect(res.status).toBe(403);
         expect(json.error).toBe(ERROR);
+        expect(json.error_description).toBe(ERROR_DESCRIPTION);
       } finally {
         if (previous === undefined) delete process.env.DEMO_PROJECT_ID;
         else process.env.DEMO_PROJECT_ID = previous;

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -871,6 +871,22 @@ secured
       );
     }
 
+    // S256 is the only method the discovery document advertises, and the token
+    // endpoint verifies every code as S256 regardless of what was requested.
+    // Accepting another method here would mint a code that can never be
+    // redeemed, so the client learns now rather than at the exchange.
+    if (code_challenge_method && code_challenge_method !== "S256") {
+      const description = "code_challenge_method must be S256";
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: description,
+          redirect: errorRedirect({ error: "invalid_request", description }),
+        },
+        400,
+      );
+    }
+
     // The demo project is a globally-readable showcase: isDemoProject grants
     // `project:view` to ANY caller, so it must never reach the RoleBinding check
     // below — otherwise any authenticated user could mint an MCP auth code

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -29,6 +29,7 @@ import { type ZodError, z } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { env } from "~/env.mjs";
 import { getOAuthClient } from "~/mcp/oauthClientRegistry";
+import { isAllowedRedirectScheme } from "~/mcp/redirectSchemes";
 import { findOrCreateExperiment } from "~/pages/api/experiment/init";
 import {
   type TimeseriesInputType,
@@ -797,16 +798,12 @@ secured
     }
 
     try {
-      const redirectUrl = new URL(redirect_uri);
-      if (
-        redirectUrl.protocol === "javascript:" ||
-        redirectUrl.protocol === "data:" ||
-        redirectUrl.protocol === "vbscript:"
-      ) {
-        return c.json({ error: "redirect_uri uses a disallowed scheme" }, 400);
-      }
+      new URL(redirect_uri);
     } catch {
       return c.json({ error: "Invalid redirect_uri" }, 400);
+    }
+    if (!isAllowedRedirectScheme(redirect_uri)) {
+      return c.json({ error: "redirect_uri uses a disallowed scheme" }, 400);
     }
 
     // RFC 6749 §10.6: an authorization server must only ever issue a code to

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -833,8 +833,38 @@ secured
       );
     }
 
+    // Past this point the client_id is registered and the redirect_uri is one
+    // of the URIs it registered, so RFC 6749 §4.1.2.1 says a failure belongs
+    // back at the client rather than on this page: the client is waiting on
+    // its redirect and an error rendered here leaves it hanging forever. The
+    // checks above deliberately stay local — an unverified redirect_uri is
+    // exactly what an attacker would supply, so nothing is ever sent to it.
+    const errorRedirect = ({
+      error,
+      description,
+    }: {
+      error: string;
+      description: string;
+    }) => {
+      const url = new URL(redirect_uri);
+      url.searchParams.set("error", error);
+      url.searchParams.set("error_description", description);
+      if (state) {
+        url.searchParams.set("state", state);
+      }
+      return url.toString();
+    };
+
     if (!code_challenge) {
-      return c.json({ error: "code_challenge is required (PKCE S256)" }, 400);
+      const description = "code_challenge is required (PKCE S256)";
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: description,
+          redirect: errorRedirect({ error: "invalid_request", description }),
+        },
+        400,
+      );
     }
 
     // The demo project is a globally-readable showcase: isDemoProject grants
@@ -842,11 +872,22 @@ secured
     // below — otherwise any authenticated user could mint an MCP auth code
     // embedding the demo project's API key. (The old `team.members.some` check
     // happened to block this; the RoleBinding-aware check does not.)
-    if (isDemoProject(projectId, "project:view")) {
-      return c.json(
-        { error: "Project not found or you don't have access" },
+    const noAccessDescription = "Project not found or you don't have access";
+    const noAccessResponse = () =>
+      c.json(
+        {
+          error: "access_denied",
+          error_description: noAccessDescription,
+          redirect: errorRedirect({
+            error: "access_denied",
+            description: noAccessDescription,
+          }),
+        },
         403,
       );
+
+    if (isDemoProject(projectId, "project:view")) {
+      return noAccessResponse();
     }
 
     // Authorize against RoleBindings (the authoritative source since migration
@@ -874,16 +915,21 @@ secured
     ) {
       // Single 403 whether the project is missing, archived, or simply
       // inaccessible — never disclose existence of a project the caller can't reach.
-      return c.json(
-        { error: "Project not found or you don't have access" },
-        403,
-      );
+      return noAccessResponse();
     }
 
     const code = randomUUID();
 
     if (!redis) {
-      return c.json({ error: "Redis is not available" }, 500);
+      const description = "Authorization is temporarily unavailable";
+      return c.json(
+        {
+          error: "server_error",
+          error_description: description,
+          redirect: errorRedirect({ error: "server_error", description }),
+        },
+        500,
+      );
     }
 
     const authCodeEntry = JSON.stringify({

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -839,6 +839,13 @@ secured
     // its redirect and an error rendered here leaves it hanging forever. The
     // checks above deliberately stay local — an unverified redirect_uri is
     // exactly what an attacker would supply, so nothing is ever sent to it.
+    //
+    // The refusals below answer with `c.json` rather than throwing a
+    // HandledError on purpose. OAuth clients parse `error` and
+    // `error_description` at the top level of the body (RFC 6749 §5.2), and
+    // the HandledError envelope nests its own shape, which those clients read
+    // as a malformed response. This endpoint speaks the OAuth wire format, so
+    // the shape below is the contract; do not "fix" it into the envelope.
     const errorRedirect = ({
       error,
       description,

--- a/platform/app/src/start.ts
+++ b/platform/app/src/start.ts
@@ -429,7 +429,7 @@ export const startApp = async (dir = resolveAppPackageRoot()) => {
             server.close(() => resolve()),
           );
           if ("closeIdleConnections" in server) server.closeIdleConnections();
-          mcpHandler.closeAllSessions();
+          await mcpHandler.closeAllSessions();
           try {
             await closed;
           } finally {

--- a/platform/app/vite.config.ts
+++ b/platform/app/vite.config.ts
@@ -369,6 +369,14 @@ export default defineConfig(async (): Promise<UserConfig> => {
         changeOrigin: true,
         secure: false,
       },
+      // Probed by MCP clients during discovery. The API answers a JSON 404;
+      // without this entry dev would answer the SPA's HTML instead, which is
+      // the failure mode this route exists to avoid.
+      "/.well-known/openid-configuration": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
   };

--- a/specs/mcp-server/mcp-in-app.feature
+++ b/specs/mcp-server/mcp-in-app.feature
@@ -194,6 +194,164 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
     Then the response status is 400 with error "invalid_grant"
     And no access token is issued
 
+  # --- SSE transport across replicas ---
+  #
+  # The SSE stream is connection-bound: it lives on the one replica that
+  # answered GET /sse. Every follow-up message is a separate POST that the
+  # load balancer may send to any replica, so a replica that does not hold
+  # the stream has to hand the message to the one that does.
+
+  @integration
+  Scenario: A message posted to a replica that does not hold the stream still reaches the session
+    Given a client opened an SSE connection and one replica holds the stream
+    When the client posts a tools/list message to a different replica
+    Then the response is accepted
+    And the tools/list reply arrives on the open SSE stream
+    And the reply lists at least one tool
+
+  @integration
+  Scenario: A message posted to the replica holding the stream is answered directly
+    Given a client opened an SSE connection to a replica
+    When the client posts a message to that same replica
+    Then the response is accepted
+    And the reply arrives on the open SSE stream
+
+  @integration
+  Scenario: Clients that append the message path to the connect path are still routed
+    Given a client opened an SSE connection
+    When the client posts its message to the /sse/messages path instead of /messages
+    Then the response is accepted
+
+  @integration
+  Scenario: A message for an unknown session is rejected as a missing session
+    Given no SSE session exists for the session id a client presents
+    When the client posts a message for that session id
+    Then the response status is 404
+    And the response says the session was not found
+
+  @integration
+  Scenario: A message carrying credentials for a different project is rejected
+    Given a client opened an SSE connection with one project's credentials
+    When a message for that session presents another project's credentials
+    Then the response status is 401
+    And the message is never delivered to the session
+
+  @integration
+  Scenario: A message with no credentials is rejected as unauthorized rather than as a bad session
+    Given an SSE session exists
+    When a message for that session arrives with no credentials
+    Then the response status is 401
+
+  @integration
+  Scenario: A message for a session whose replica is gone tells the client to reconnect
+    Given an SSE session was recorded but the replica holding its stream is gone
+    When a client posts a message for that session
+    Then the response status is 404
+    And the recorded session is forgotten so the client reconnects
+
+  @integration
+  Scenario: SSE sessions count towards the per-project concurrent session limit
+    Given a project already holds the maximum number of concurrent sessions
+    When a client opens another SSE connection for that project
+    Then the connection is refused as over the session limit
+
+  @integration
+  Scenario: Reconnecting the streaming transport to another replica resumes the session
+    Given a streamable session was created on one replica
+    When the client reconnects the stream through a different replica
+    Then the stream is served rather than reported as expired
+
+  # --- OAuth discovery documents ---
+
+  @integration
+  Scenario: Protected resource metadata is served for the path-suffixed form
+    When a client fetches the protected resource metadata for /sse or /mcp
+    Then the response is JSON describing the resource and its authorization server
+
+  @integration
+  Scenario: Authorization server metadata is served for the path-suffixed form
+    When a client fetches the authorization server metadata for /sse or /mcp
+    Then the response is JSON advertising the authorization, token and registration endpoints
+
+  @integration
+  Scenario: An unknown OAuth discovery document answers with JSON rather than the web app
+    When a client fetches an OAuth discovery document that does not exist
+    Then the response status is 404
+    And the response is JSON, so the client can fall back to the documents that do exist
+
+  @integration
+  Scenario: OpenID configuration is answered as absent rather than with the web app
+    When a client fetches the OpenID configuration document
+    Then the response status is 404
+    And the response is JSON
+
+  # --- OAuth token endpoint ---
+
+  @integration
+  Scenario: The token endpoint accepts client credentials presented as HTTP Basic
+    Given an authorization code was issued for a client
+    When the client exchanges it presenting its client id via HTTP Basic instead of the form body
+    Then an access token is issued
+
+  @integration
+  Scenario: A token exchange from a client that is no longer registered is told to register again
+    Given a client presents a client id that has no registration
+    When it exchanges an authorization code
+    Then the response error is "invalid_client"
+    And the response tells the client to register again
+
+  @integration
+  Scenario: Rate limiting counts callers separately when a proxy reports the caller address
+    Given many token requests arrive from one caller behind a proxy
+    When a different caller behind the same proxy sends a token request
+    Then that caller is not rate limited by the first caller's traffic
+
+  @integration
+  Scenario: A rate limited OAuth request answers with an OAuth error and a retry hint
+    Given a caller exceeded the token endpoint rate limit
+    When it sends another token request
+    Then the response status is 429
+    And the response error is "temporarily_unavailable"
+    And the response carries a retry hint
+
+  @integration
+  Scenario: Registering a client and exchanging a token do not share one rate limit budget
+    Given a caller exhausted the client registration rate limit
+    When it sends a token request
+    Then the token request is not rate limited
+
+  # --- Authorization consent errors ---
+
+  @integration
+  Scenario: A consent failure a client can be told about is redirected back to the client
+    Given a client is registered with a redirect URI and asks for authorization without a code challenge
+    When the user approves the request
+    Then the browser is sent back to the client's registered redirect URI
+    And the redirect carries error "invalid_request" and the request state
+
+  @integration
+  Scenario: A project the user cannot reach is reported to the client as access denied
+    Given a client is registered with a redirect URI and the user cannot access the requested project
+    When the user approves the request
+    Then the browser is sent back to the client's registered redirect URI
+    And the redirect carries error "access_denied"
+
+  @integration
+  Scenario: A consent failure that cannot be attributed to a client stays on the LangWatch page
+    Given the authorization request names a client that is not registered
+    When the user approves the request
+    Then no redirect back to the caller is offered
+    And the failure is shown on the LangWatch page instead
+
+  # --- Observability ---
+
+  @integration
+  Scenario: Every MCP request is logged with its outcome
+    Given a client sends a request to an MCP route
+    When the response completes
+    Then one log line records the method, path, status and duration
+    And no credentials appear in the log line
+
   # --- Tool Availability ---
 
   @integration @unimplemented

--- a/specs/mcp-server/mcp-in-app.feature
+++ b/specs/mcp-server/mcp-in-app.feature
@@ -164,6 +164,14 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
     And the response says the scheme is disallowed
     And no authorization code is issued
 
+  @integration
+  Scenario: A code challenge method other than S256 is refused at the authorization request
+    Given a verified client asks to authorize with a code challenge method we do not support
+    When the authorization request is made
+    Then the response status is 400
+    And the client is told the method must be S256
+    And no authorization code is issued
+
   @regression @integration
   Scenario: Authorization is rejected for an unregistered client_id
     Given no client is registered with client_id "mcp_never_registered"

--- a/specs/mcp-server/mcp-in-app.feature
+++ b/specs/mcp-server/mcp-in-app.feature
@@ -156,6 +156,14 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
     Then the response status is 400
     And no authorization code is issued
 
+  @integration
+  Scenario: Authorization is rejected when redirect_uri uses a scheme the browser executes
+    Given a client registered with a redirect_uri the browser would execute rather than navigate to
+    When an authorization request supplies that redirect_uri
+    Then the response status is 400
+    And the response says the scheme is disallowed
+    And no authorization code is issued
+
   @regression @integration
   Scenario: Authorization is rejected for an unregistered client_id
     Given no client is registered with client_id "mcp_never_registered"

--- a/specs/mcp-server/mcp-in-app.feature
+++ b/specs/mcp-server/mcp-in-app.feature
@@ -203,7 +203,7 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
 
   @integration
   Scenario: A message posted to a replica that does not hold the stream still reaches the session
-    Given a client opened an SSE connection and one replica holds the stream
+    Given a client opened an SSE connection against one replica
     When the client posts a tools/list message to a different replica
     Then the response is accepted
     And the tools/list reply arrives on the open SSE stream
@@ -244,10 +244,11 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
 
   @integration
   Scenario: A message for a session whose replica is gone tells the client to reconnect
-    Given an SSE session was recorded but the replica holding its stream is gone
+    Given an SSE session that no replica still holds
     When a client posts a message for that session
     Then the response status is 404
-    And the recorded session is forgotten so the client reconnects
+    And the response says the session was not found
+    And the session stops counting against the project's concurrent sessions
 
   @integration
   Scenario: SSE sessions count towards the per-project concurrent session limit
@@ -260,6 +261,20 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
     Given a streamable session was created on one replica
     When the client reconnects the stream through a different replica
     Then the stream is served rather than reported as expired
+
+  @integration
+  Scenario: Reconnecting without credentials is refused and rebuilds nothing
+    Given a streamable session was created on one replica
+    When a caller reconnects that session through a different replica with no credentials
+    Then the response status is 401
+    And the other replica serves no session for that session id
+
+  @integration
+  Scenario: Reconnecting with another project's credentials is refused and rebuilds nothing
+    Given a streamable session was created on one replica
+    When a caller reconnects that session through a different replica with another project's credentials
+    Then the response status is 401
+    And the other replica serves no session for that session id
 
   # --- OAuth discovery documents ---
 


### PR DESCRIPTION
## Root cause

The MCP server surface is a raw Node handler mounted before Hono in `start.ts`. Production runs 3 to 5 replicas behind an NLB and Cloudflare with `sessionAffinity: None`.

**1. The SSE transport was a pod lottery.** `GET /sse` opens a stream that lives only on the replica that answered it, and `handleSseConnect` recorded the session in a per-process `Map` and nowhere else. Every follow-up `POST /messages?sessionId=...` is a separate connection the balancer may hand to any replica, so with four replicas a message reached the right one about one time in four. Everything else got `400 {"error":"Invalid or missing session ID"}`. That is why Claude connectors reported no tools and ChatGPT connectors failed right after OAuth: both use the SSE transport when pointed at `/sse`. Reproducible against production today:

```
$ curl -s -X POST 'https://app.langwatch.ai/messages?sessionId=probe-does-not-exist'
{"error":"Invalid or missing session ID"}
```

The streamable transport at `/mcp` already had cross-replica recovery through Redis; SSE never got it.

**2. `POST /sse/messages` was unrouted.** The stream advertises `/messages` as its endpoint and some clients resolve that by appending it to the path they connected on. Unrouted, it fell through to the SPA fallback and answered `200 text/html`, so the client saw a successful POST that did nothing. The standalone npx server fixed exactly this in `7d7f46e450` and mounts both paths; the in-app handler never got the second mount.

**3. OAuth discovery answered HTML.** Route matching was an exact `Set`, so the RFC 9728 path-suffixed documents that modern MCP clients probe **first** were never claimed: `/.well-known/oauth-protected-resource/sse`, `/.well-known/oauth-protected-resource/mcp`, the two `oauth-authorization-server` equivalents and `/.well-known/openid-configuration` all reached the SPA and returned `200 text/html`. A client trying the path-suffixed form got a JSON parse error instead of the 404 that would have sent it to the root document.

**4. The token endpoint was brittle.** It required `client_id` in the form body and ignored HTTP Basic. `getClientIp` returned `req.socket.remoteAddress`, which behind Cloudflare and the NLB is the proxy for every caller on earth, and `/oauth/register` plus `/oauth/token` shared one 10 request/minute bucket answering a bare `429 {"error":"Too many requests"}`. One busy integration could lock out everyone.

**5. Authorization failures never reached the client.** The advertised authorize endpoint is a page in this app that XHRs to `POST /api/mcp/authorize`. Every validation failure rendered as a toast here and the client's popup waited forever with nothing to report.

**6. No observability.** The MCP branch returns before all access logging, metrics and tracing, so nothing recorded that these requests happened at all.

## What changed

An SSE stream cannot be recreated on another replica, so the message travels to the stream:

- The session is recorded in Redis, and the replica holding the stream subscribes to `mcp:sse:relay:<sessionId>` on a dedicated subscriber connection.
- A replica that receives a message for a session it does not hold authenticates it, checks the presented key against the session's binding, publishes it on that channel and answers `202`. The JSON-RPC reply flows back down the SSE stream on the owning replica, which is standard SSE-transport semantics.
- `PUBLISH` returning zero subscribers means the owning replica is gone, so the record is dropped and the client is told `404` to reconnect.
- Relayed messages refresh the record's TTL, so an active cross-replica session is not reaped.

Alongside that:

- `POST /sse/messages` routes to the same handler as `/messages`.
- The OAuth discovery subtree is claimed. The four path-suffixed documents are served, and anything else under it, plus `/.well-known/openid-configuration`, answers a JSON `404`. Other `/.well-known/*` paths are untouched. The path-suffixed protected-resource document echoes the concrete resource URL so a client validating it against the URL it is about to call finds them equal.
- `/oauth/token` accepts client credentials as HTTP Basic (RFC 6749 section 2.3.1), and answers `invalid_client` with "register again" when the presented `client_id` has no registration left, instead of blaming the code.
- Rate limiting keys on the caller address the proxy reports, reusing the app's existing `getClientIp` header priority (`cf-connecting-ip`, then the first hop of `x-forwarded-for`, then the socket). Registration and token exchange get 30/minute each, and a throttled request answers `{"error":"temporarily_unavailable","error_description":"Rate limit exceeded, retry later"}` with `Retry-After`.
- SSE sessions now count towards the per-project concurrent session limit, which they silently never did.
- `GET /mcp` gained the same Redis session recovery the POST path had, so reopening a stream through another replica resumes rather than reporting the session expired.
- Auth on `/messages` now runs **before** the session lookup, so a request with no credentials answers `401` rather than a misleading `400` about the session.
- Every MCP request writes one structured line through `createLogger("langwatch:mcp")`: method, path, status, duration, and `sessionId` / `client_id` when known. No tokens, keys, codes or `Authorization` headers, asserted by a test. The whole thing is wrapped so logging can never break a request.
- Authorization failures the server can attribute to a verified client now return a redirect carrying `error`, `error_description` and the request `state`, and the page follows it. Failures it cannot attribute (unknown `client_id`, unregistered `redirect_uri`) have no safe destination and keep showing on the page, which is the RFC 6749 section 4.1.2.1 split.
- The docs advertised `https://app.langwatch.ai/api/mcp`, which is not a route. Corrected to `/mcp` and `/sse`.

## How it was verified

A committed probe reproduces production: two in-process handler instances on two ports sharing one local Redis, behind a round-robin proxy that guarantees every request lands on the "wrong" replica half the time, driven by the real MCP SDK SSE client.

```
cd platform/app
LANGWATCH_API_KEY=<a project apiKey> npx tsx scripts/dogfood/mcp-sse-multipod-probe.ts
```

On `origin/main`'s handler it fails at the first message with the exact production symptom:

```
[proxy] GET /sse -> replica on :50059
[proxy] POST /messages?sessionId=6bc06f41... -> replica on :50060
FAIL: Error POSTing to endpoint (HTTP 400): {"error":"Invalid or missing session ID"}
```

On this branch it completes the handshake and lists tools:

```
[proxy] GET /sse -> replica on :50138
[proxy] POST /messages?sessionId=6be861b0... -> replica on :50139
[proxy] POST /messages?sessionId=6be861b0... -> replica on :50138
[proxy] POST /messages?sessionId=6be861b0... -> replica on :50139
PASS: initialize and tools/list completed across 2 replicas (99 tools listed)
```

Test results, all local:

- `src/mcp/__tests__/` (5 files, 62 tests) pass, including a new `mcp-sse-relay.integration.test.ts` that runs two handler instances against a real Redis and asserts a `tools/list` posted to replica B is answered on replica A's stream with more than zero tools, plus the `/sse/messages` alias, wrong credentials to `401`, unknown session to `404`, an orphaned record to `404` with the record cleared, the session limit, and streamable recovery through the other replica.
- `src/server/routes/__tests__/mcp-authorize.*` (7 + 4 tests) pass.
- `src/server/routes/__tests__/track-usage-security.integration.test.ts` (9 tests) passes, it shares the `misc.ts` router.
- `src/server/__tests__/frontend-boundary.unit.test.ts` passes, no browser-only import reached server code.
- `pnpm typecheck:all` passes.
- Biome: no new violations. Diagnostic counts per (file, rule) are identical to the merge base for every touched file.
- `check-feature-parity.ts`: `specs/mcp-server/mcp-in-app.feature` reports 32/32 scenarios bound.

## Verify after deploy

```bash
# 1. Path-suffixed discovery answers JSON, not HTML
curl -si https://app.langwatch.ai/.well-known/oauth-protected-resource/sse | head -20
curl -si https://app.langwatch.ai/.well-known/oauth-authorization-server/mcp | head -20
#    expect: 200, content-type: application/json

# 2. Unknown discovery documents answer a JSON 404, not the app
curl -si https://app.langwatch.ai/.well-known/openid-configuration | head -5
#    expect: 404, content-type: application/json

# 3. A bogus session answers a JSON 404, not the old 400
curl -si -X POST 'https://app.langwatch.ai/messages?sessionId=probe-does-not-exist' \
  -H 'Authorization: Bearer <a project apiKey>' \
  -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
#    expect: 404 {"error":"Session not found"}

# 4. The message alias is routed rather than answering the app's HTML
curl -si -X POST 'https://app.langwatch.ai/sse/messages?sessionId=probe-does-not-exist' \
  -H 'Authorization: Bearer <a project apiKey>' \
  -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
#    expect: 404 JSON, NOT 200 text/html
```

Then, with several replicas running, connect a Claude connector and a ChatGPT connector to `https://app.langwatch.ai/sse` and confirm both list tools and can call one. Repeat the connection a few times, since the old failure was probabilistic and a single lucky attempt used to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP now supports reliable SSE and streamable HTTP sessions across multiple server instances, including reconnection and message delivery.
  * Added OAuth discovery, client authentication, registration, rate limiting, and clearer authorization error redirects.
  * Added request logging that records activity without exposing credentials.
* **Bug Fixes**
  * Updated MCP documentation and client examples to use `/mcp`, while retaining `/sse` for legacy transport.
  * Improved handling of invalid sessions, unauthorized requests, unsafe redirects, and cross-instance connections.
* **Tests**
  * Expanded coverage for MCP transport, OAuth, authorization, rate limits, logging, and multi-instance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->