### PR TITLE
fix(codex-extractor): recognize codex-app-server scope from codex 0.144+

### DIFF
--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
@@ -157,6 +157,38 @@ describe("CodexExtractor.applyLog", () => {
       expect(ctx.recordRule).toHaveBeenCalledWith("codex/session_task.turn");
     });
 
+    it("lifts codex.turn.token_usage.* + model + turn.id off the codex-app-server session_task.turn span (codex 0.144+)", () => {
+      const ctx = createExtractorContext(
+        {
+          model: "gpt-5.6-luna",
+          "codex.turn.token_usage.input_tokens": "14365",
+          "codex.turn.token_usage.output_tokens": "6",
+          "codex.turn.token_usage.cached_input_tokens": "10112",
+          "codex.turn.token_usage.total_tokens": "14371",
+          "codex.turn.reasoning_effort": "high",
+          "turn.id": "019e939c-48a1-7021-a71d-714f74d6ad64",
+        },
+        {
+          name: "session_task.turn",
+          instrumentationScope: { name: "codex-app-server", version: null },
+        },
+      );
+
+      new CodexExtractor().apply(ctx);
+
+      expect(ctx.out).toEqual({
+        "langwatch.span.type": "agent",
+        "gen_ai.request.model": "gpt-5.6-luna",
+        "gen_ai.response.model": "gpt-5.6-luna",
+        "gen_ai.usage.input_tokens": 14365,
+        "gen_ai.usage.output_tokens": 6,
+        "gen_ai.usage.cache_read.input_tokens": 10112,
+        "gen_ai.request.reasoning_effort": "high",
+        "gen_ai.conversation.id": "019e939c-48a1-7021-a71d-714f74d6ad64",
+      });
+      expect(ctx.recordRule).toHaveBeenCalledWith("codex/session_task.turn");
+    });
+
     /** @scenario "Codex reasoning effort is canonicalised from the turn span" */
     it("canonicalises codex.turn.reasoning_effort to gen_ai.request.reasoning_effort", () => {
       const ctx = createExtractorContext(

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
@@ -26,7 +26,8 @@
  * codex.user_prompt branch in extractIOFromLogRecord this class replaces).
  *
  * On the SPAN side, codex 0.137+ emits native spans under scope
- * `codex_cli_rs` to /v1/traces (Path B with `[otel.trace_exporter.otlp-http]`).
+ * `codex_cli_rs` (codex < 0.144) or `codex-app-server` (codex 0.144+) to
+ * /v1/traces (Path B with `[otel.trace_exporter.otlp-http]`).
  * The `session_task.turn` span carries the full per-turn metadata as
  * codex-namespaced attributes:
  *   - model
@@ -74,9 +75,19 @@ const CODEX_RUST_SCOPE_NAME = "codex_cli_rs";
  * usage record, so the redundant-usage skip below must never fire for it.
  */
 const CODEX_EXEC_SCOPE_NAME = "codex_exec";
+/**
+ * Codex 0.144+ renamed its instrumentation scope from `codex_cli_rs` to
+ * `codex-app-server` (the interactive TUI and the app server now share one
+ * scope name). Without this entry the CodexExtractor's scope gate bails
+ * before lifting `session_task.turn` attributes, so the model name, token
+ * counts, and reasoning effort never reach the canonical gen_ai.* keys
+ * and the trace summary shows no model.
+ */
+const CODEX_APP_SERVER_SCOPE_NAME = "codex-app-server";
 const CODEX_SCOPE_NAMES: ReadonlySet<string> = new Set([
   CODEX_RUST_SCOPE_NAME,
   CODEX_EXEC_SCOPE_NAME,
+  CODEX_APP_SERVER_SCOPE_NAME,
 ]);
 export const CODEX_TURN_SPAN_NAME = "session_task.turn";
 

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
@@ -143,7 +143,8 @@ export class CodexExtractor implements CanonicalAttributesExtractor {
     // Path A codex traffic flows through the gateway as gen_ai.*
     // spans; GenAIExtractor handles that side and emits canonical
     // attributes. This branch covers Path B native spans from the
-    // Rust CLI (scope `codex_cli_rs`), where the per-turn
+    // Rust CLI (scope `codex_cli_rs` / `codex_exec` / `codex-app-server`
+    // — see CODEX_SCOPE_NAMES), where the per-turn
     // `session_task.turn` span carries codex-namespaced attributes
     // that won't match GenAIExtractor's gen_ai.* gates.
     //


### PR DESCRIPTION
## Summary

Codex 0.144+ renamed its OpenTelemetry instrumentation scope from `codex_cli_rs` to `codex-app-server`. The `CodexExtractor` scope gate bailed before processing `session_task.turn` spans, so model name, token counts, and reasoning effort never reached the canonical `gen_ai.*` keys — the trace summary showed no model for all Codex 0.144+ users.

This adds `codex-app-server` to `CODEX_SCOPE_NAMES` and updates the JSDoc to document both scope names.

## Evidence

Self-hosted LangWatch 3.12.0 + Codex 0.144.1 (Path B / direct OTLP):

```sql
-- All spans carry the new scope name
SELECT DISTINCT ScopeName FROM langwatch.stored_spans WHERE ServiceName = 'codex-app-server';
-- codex-app-server

-- session_task.turn has model + token usage
SELECT SpanAttributes['model'] FROM langwatch.stored_spans
WHERE SpanName = 'session_task.turn' AND ServiceName = 'codex-app-server';
-- gpt-5.6-luna

-- But zero spans have gen_ai.request.model (extractor never ran)
SELECT count() FROM langwatch.stored_spans
WHERE ServiceName = 'codex-app-server'
  AND has(mapKeys(SpanAttributes), 'gen_ai.request.model');
-- 0
```

After applying the patch and restarting, new traces correctly show the model in the UI.

## Changes

- Add `CODEX_APP_SERVER_SCOPE_NAME = "codex-app-server"` constant
- Add it to the `CODEX_SCOPE_NAMES` set
- Update the class-level JSDoc to mention both scope names with version context

Closes #6864

## Test Plan

- [ ] Run Codex 0.144+ with LangWatch OTLP ingestion (Path B)
- [ ] Verify `session_task.turn` span gets `gen_ai.request.model` set
- [ ] Verify model name appears in the LangWatch trace list and detail drawer
- [ ] Verify token counts (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, etc.) are populated
- [ ] Verify older Codex versions (< 0.144, scope `codex_cli_rs`) still work (no regression)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for processing Codex app-server spans.
  * Canonical model, token usage, reasoning metadata, conversation IDs, and span details can now be extracted from app-server activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->