### PR TITLE
fix(security): raise the transitive security floors in the typescript SDK examples

### DIFF
--- a/sdks/typescript/examples/evaluation/package-lock.json
+++ b/sdks/typescript/examples/evaluation/package-lock.json
@@ -21,48 +21,52 @@
     },
     "../..": {
       "name": "langwatch",
-      "version": "0.33.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "^2.0.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.205.0",
-        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/instrumentation": "0.219.0",
         "@opentelemetry/resources": "^2.0.1",
         "@opentelemetry/sdk-logs": "0.205.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
+        "@opentelemetry/sdk-node": "^0.219.0",
         "@opentelemetry/sdk-trace-base": "^2.0.1",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@types/prompts": "^2.4.9",
-        "chalk": "^4.1.2",
-        "commander": "^12.0.0",
+        "chalk": "^5.6.2",
+        "commander": "^15.0.0",
         "dotenv": "^17.3.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^5.2.0",
+        "jsonc-parser": "^3.3.1",
         "liquidjs": "^10.27.0",
         "open": "^11.0.0",
-        "openapi-fetch": "^0.16.0",
+        "openapi-fetch": "^0.17.0",
         "ora": "^9.3.0",
         "prompts": "^2.4.2",
         "xksuid": "^0.0.4",
         "zod": "^4.0.14"
       },
       "bin": {
-        "langwatch": "dist/cli/index.js"
+        "langwatch": "dist/cli/index.js",
+        "lw": "dist/cli/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@langchain/core": ">=0.3.68 <0.4.0",
         "@langchain/langgraph": ">=0.4.0 <1.0.0",
         "@langchain/openai": ">=0.6.0 <1.0.0",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/sdk-node": "0.216.0",
+        "@langwatch/langy": "workspace:*",
+        "@opentelemetry/sdk-node": "0.219.0",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
         "@opentelemetry/sdk-trace-web": ">=2.0.1",
         "@types/debug": "^4.1.12",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.1.0",
-        "@typescript/native-preview": "7.0.0-dev.20260426.1",
+        "@types/prompts": "^2.4.9",
+        "@typescript/native-preview": "7.0.0-dev.20260705.1",
         "@vercel/otel": "^1.13.0",
         "@vitest/coverage-v8": "^4.1.0",
         "dotenv-cli": "^11.0.0",
@@ -74,11 +78,12 @@
         "msw": "^2.10.4",
         "nock": "^14.0.8",
         "openapi-msw": "^1.2.0",
+        "openapi-typescript": "7.13.0",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.38.0",
         "vitest": "^4.1.0",
-        "vitest-mock-extended": "^3.1.0",
+        "vitest-mock-extended": "^4.0.0",
         "yaml": "^2.8.1"
       },
       "engines": {
@@ -86,14 +91,12 @@
         "pnpm": ">=8"
       },
       "peerDependencies": {
-        "@ai-sdk/openai": ">=2.0.0 <4.0.0",
+        "@ai-sdk/openai": ">=2.0.0 <5.0.0",
         "@langchain/core": ">=0.3.0 <2.0.0",
         "@langchain/langgraph": ">=0.4.0 <2.0.0",
         "@langchain/openai": ">=0.6.0 <2.0.0",
-        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
         "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
-        "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
         "langchain": ">=0.3.0 <2.0.0"
       },
@@ -114,9 +117,6 @@
           "optional": true
         },
         "@opentelemetry/context-zone": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-node": {
           "optional": true
         },
         "@opentelemetry/sdk-trace-web": {
@@ -696,9 +696,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1014,12 +1014,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
-      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1"
+        "@opentelemetry/core": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1485,9 +1485,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
-      "integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -1628,6 +1628,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/sdks/typescript/examples/evaluation/package.json
+++ b/sdks/typescript/examples/evaluation/package.json
@@ -23,8 +23,10 @@
     "tsx": "^4.19.0"
   },
   "overrides": {
-    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.0",
     "@grpc/grpc-js": ">=1.14.4",
-    "esbuild": ">=0.28.1"
+    "@opentelemetry/core": ">=2.8.0 <3",
+    "@opentelemetry/propagator-jaeger": ">=2.9.0 <3",
+    "esbuild": ">=0.28.1",
+    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.6"
   }
 }

--- a/sdks/typescript/examples/langchain/package-lock.json
+++ b/sdks/typescript/examples/langchain/package-lock.json
@@ -22,52 +22,56 @@
     },
     "../..": {
       "name": "langwatch",
-      "version": "0.33.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "^2.0.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.205.0",
-        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/instrumentation": "0.219.0",
         "@opentelemetry/resources": "^2.0.1",
         "@opentelemetry/sdk-logs": "0.205.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
+        "@opentelemetry/sdk-node": "^0.219.0",
         "@opentelemetry/sdk-trace-base": "^2.0.1",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@types/prompts": "^2.4.9",
-        "chalk": "^4.1.2",
-        "commander": "^12.0.0",
+        "chalk": "^5.6.2",
+        "commander": "^15.0.0",
         "dotenv": "^17.3.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^5.2.0",
+        "jsonc-parser": "^3.3.1",
         "liquidjs": "^10.27.0",
         "open": "^11.0.0",
-        "openapi-fetch": "^0.16.0",
+        "openapi-fetch": "^0.17.0",
         "ora": "^9.3.0",
         "prompts": "^2.4.2",
         "xksuid": "^0.0.4",
         "zod": "^4.0.14"
       },
       "bin": {
-        "langwatch": "dist/cli/index.js"
+        "langwatch": "dist/cli/index.js",
+        "lw": "dist/cli/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@langchain/core": ">=0.3.68 <0.4.0",
         "@langchain/langgraph": ">=0.4.0 <1.0.0",
         "@langchain/openai": ">=0.6.0 <1.0.0",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/sdk-node": "0.216.0",
+        "@langwatch/langy": "workspace:*",
+        "@opentelemetry/sdk-node": "0.219.0",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
         "@opentelemetry/sdk-trace-web": ">=2.0.1",
         "@types/debug": "^4.1.12",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.1.0",
-        "@typescript/native-preview": "7.0.0-dev.20260426.1",
+        "@types/prompts": "^2.4.9",
+        "@typescript/native-preview": "7.0.0-dev.20260705.1",
         "@vercel/otel": "^1.13.0",
         "@vitest/coverage-v8": "^4.1.0",
         "dotenv-cli": "^11.0.0",
-        "esbuild": "^0.27.3",
+        "esbuild": "^0.28.1",
         "eslint": "^9.32.0",
         "fets": "^0.8.5",
         "fishery": "^2.3.1",
@@ -75,11 +79,12 @@
         "msw": "^2.10.4",
         "nock": "^14.0.8",
         "openapi-msw": "^1.2.0",
+        "openapi-typescript": "7.13.0",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.38.0",
         "vitest": "^4.1.0",
-        "vitest-mock-extended": "^3.1.0",
+        "vitest-mock-extended": "^4.0.0",
         "yaml": "^2.8.1"
       },
       "engines": {
@@ -87,14 +92,12 @@
         "pnpm": ">=8"
       },
       "peerDependencies": {
-        "@ai-sdk/openai": ">=2.0.0 <4.0.0",
+        "@ai-sdk/openai": ">=2.0.0 <5.0.0",
         "@langchain/core": ">=0.3.0 <2.0.0",
         "@langchain/langgraph": ">=0.4.0 <2.0.0",
         "@langchain/openai": ">=0.6.0 <2.0.0",
-        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
         "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
-        "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
         "langchain": ">=0.3.0 <2.0.0"
       },
@@ -115,9 +118,6 @@
           "optional": true
         },
         "@opentelemetry/context-zone": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-node": {
           "optional": true
         },
         "@opentelemetry/sdk-trace-web": {
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -625,12 +625,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
-      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1"
+        "@opentelemetry/core": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1828,9 +1828,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -1997,9 +1997,9 @@
       "link": true
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -2335,9 +2335,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
-      "integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/sdks/typescript/examples/langchain/package.json
+++ b/sdks/typescript/examples/langchain/package.json
@@ -25,9 +25,13 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
+    "@grpc/grpc-js": ">=1.14.4",
+    "@opentelemetry/core": ">=2.8.0 <3",
+    "@opentelemetry/propagator-jaeger": ">=2.9.0 <3",
+    "js-yaml": ">=4.3.1 <5",
     "langsmith@<0.6.0": "0.6.0",
-    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.0",
-    "uuid": ">=11.1.1 <12",
-    "@grpc/grpc-js": ">=1.14.4"
+    "linkify-it": ">=5.0.2 <6",
+    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.6",
+    "uuid": ">=11.1.1 <12"
   }
 }

--- a/sdks/typescript/examples/langgraph/package-lock.json
+++ b/sdks/typescript/examples/langgraph/package-lock.json
@@ -25,52 +25,56 @@
     },
     "../..": {
       "name": "langwatch",
-      "version": "0.33.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "^2.0.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.205.0",
-        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/instrumentation": "0.219.0",
         "@opentelemetry/resources": "^2.0.1",
         "@opentelemetry/sdk-logs": "0.205.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
+        "@opentelemetry/sdk-node": "^0.219.0",
         "@opentelemetry/sdk-trace-base": "^2.0.1",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@types/prompts": "^2.4.9",
-        "chalk": "^4.1.2",
-        "commander": "^12.0.0",
+        "chalk": "^5.6.2",
+        "commander": "^15.0.0",
         "dotenv": "^17.3.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^5.2.0",
+        "jsonc-parser": "^3.3.1",
         "liquidjs": "^10.27.0",
         "open": "^11.0.0",
-        "openapi-fetch": "^0.16.0",
+        "openapi-fetch": "^0.17.0",
         "ora": "^9.3.0",
         "prompts": "^2.4.2",
         "xksuid": "^0.0.4",
         "zod": "^4.0.14"
       },
       "bin": {
-        "langwatch": "dist/cli/index.js"
+        "langwatch": "dist/cli/index.js",
+        "lw": "dist/cli/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@langchain/core": ">=0.3.68 <0.4.0",
         "@langchain/langgraph": ">=0.4.0 <1.0.0",
         "@langchain/openai": ">=0.6.0 <1.0.0",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/sdk-node": "0.216.0",
+        "@langwatch/langy": "workspace:*",
+        "@opentelemetry/sdk-node": "0.219.0",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
         "@opentelemetry/sdk-trace-web": ">=2.0.1",
         "@types/debug": "^4.1.12",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.1.0",
-        "@typescript/native-preview": "7.0.0-dev.20260426.1",
+        "@types/prompts": "^2.4.9",
+        "@typescript/native-preview": "7.0.0-dev.20260705.1",
         "@vercel/otel": "^1.13.0",
         "@vitest/coverage-v8": "^4.1.0",
         "dotenv-cli": "^11.0.0",
-        "esbuild": "^0.27.3",
+        "esbuild": "^0.28.1",
         "eslint": "^9.32.0",
         "fets": "^0.8.5",
         "fishery": "^2.3.1",
@@ -78,11 +82,12 @@
         "msw": "^2.10.4",
         "nock": "^14.0.8",
         "openapi-msw": "^1.2.0",
+        "openapi-typescript": "7.13.0",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.38.0",
         "vitest": "^4.1.0",
-        "vitest-mock-extended": "^3.1.0",
+        "vitest-mock-extended": "^4.0.0",
         "yaml": "^2.8.1"
       },
       "engines": {
@@ -90,14 +95,12 @@
         "pnpm": ">=8"
       },
       "peerDependencies": {
-        "@ai-sdk/openai": ">=2.0.0 <4.0.0",
+        "@ai-sdk/openai": ">=2.0.0 <5.0.0",
         "@langchain/core": ">=0.3.0 <2.0.0",
         "@langchain/langgraph": ">=0.4.0 <2.0.0",
         "@langchain/openai": ">=0.6.0 <2.0.0",
-        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
         "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
-        "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
         "langchain": ">=0.3.0 <2.0.0"
       },
@@ -118,9 +121,6 @@
           "optional": true
         },
         "@opentelemetry/context-zone": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-node": {
           "optional": true
         },
         "@opentelemetry/sdk-trace-web": {
@@ -815,17 +815,16 @@
       }
     },
     "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph": {
@@ -868,17 +867,16 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
@@ -910,31 +908,29 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@langchain/openai": {
@@ -1036,9 +1032,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1354,12 +1350,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
-      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1"
+        "@opentelemetry/core": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2611,9 +2607,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -2752,17 +2748,16 @@
       }
     },
     "node_modules/langchain/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/langsmith": {
@@ -2809,9 +2804,9 @@
       "link": true
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -3160,9 +3155,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
-      "integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/sdks/typescript/examples/langgraph/package.json
+++ b/sdks/typescript/examples/langgraph/package.json
@@ -31,7 +31,7 @@
     "@grpc/grpc-js": ">=1.14.4",
     "@opentelemetry/core": ">=2.8.0 <3",
     "@opentelemetry/propagator-jaeger": ">=2.9.0 <3",
-    "axios": "^1.15.0",
+    "axios": ">=1.16.0 <2",
     "js-yaml": ">=4.3.1 <5",
     "langsmith@<0.6.0": "0.6.0",
     "linkify-it": ">=5.0.2 <6",

--- a/sdks/typescript/examples/langgraph/package.json
+++ b/sdks/typescript/examples/langgraph/package.json
@@ -28,9 +28,14 @@
     "dotenv-cli": "^10.0.0"
   },
   "overrides": {
+    "@grpc/grpc-js": ">=1.14.4",
+    "@opentelemetry/core": ">=2.8.0 <3",
+    "@opentelemetry/propagator-jaeger": ">=2.9.0 <3",
     "axios": "^1.15.0",
+    "js-yaml": ">=4.3.1 <5",
     "langsmith@<0.6.0": "0.6.0",
-    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.0",
-    "@grpc/grpc-js": ">=1.14.4"
+    "linkify-it": ">=5.0.2 <6",
+    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.6",
+    "uuid@<11.1.1": ">=11.1.1 <12"
   }
 }

--- a/sdks/typescript/examples/mastra/package-lock.json
+++ b/sdks/typescript/examples/mastra/package-lock.json
@@ -1148,12 +1148,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1868,22 +1868,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
@@ -1902,22 +1886,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
@@ -1940,22 +1908,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
@@ -2015,22 +1967,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
@@ -2086,22 +2022,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
@@ -2155,22 +2075,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
@@ -2244,22 +2148,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz",
@@ -2277,22 +2165,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
@@ -2314,22 +2186,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
@@ -2401,21 +2257,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
@@ -2447,22 +2288,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
@@ -3762,9 +3587,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5100,9 +4925,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.0.0.tgz",
-      "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -5505,9 +5330,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5614,9 +5439,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5873,9 +5698,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7610,9 +7435,9 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
-      "integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -8223,9 +8048,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8370,9 +8195,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/sdks/typescript/examples/mastra/package.json
+++ b/sdks/typescript/examples/mastra/package.json
@@ -32,12 +32,18 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "fast-uri": ">=3.1.2",
-    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.0",
-    "uuid": ">=11.1.1 <12",
-    "shell-quote": ">=1.8.4",
     "@grpc/grpc-js": ">=1.14.4",
+    "@hono/node-server": ">=2.0.10 <3",
+    "@opentelemetry/core": ">=2.8.0 <3",
+    "brace-expansion@<1.1.18": ">=1.1.18 <2",
+    "brace-expansion@>=2.0.0 <2.1.4": ">=2.1.4 <3",
     "esbuild": ">=0.28.1",
-    "js-yaml": ">=3.15.0 <4"
+    "fast-uri": ">=4.1.2 <5",
+    "hono": ">=4.12.34 <5",
+    "ip-address": ">=10.3.1 <11",
+    "js-yaml": ">=3.15.1 <4",
+    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.6",
+    "shell-quote": ">=1.9.0 <2",
+    "uuid": ">=11.1.1 <12"
   }
 }

--- a/sdks/typescript/examples/vercel-ai/package-lock.json
+++ b/sdks/typescript/examples/vercel-ai/package-lock.json
@@ -25,52 +25,56 @@
     },
     "../..": {
       "name": "langwatch",
-      "version": "0.33.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "^2.0.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.205.0",
-        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/instrumentation": "0.219.0",
         "@opentelemetry/resources": "^2.0.1",
         "@opentelemetry/sdk-logs": "0.205.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
+        "@opentelemetry/sdk-node": "^0.219.0",
         "@opentelemetry/sdk-trace-base": "^2.0.1",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@types/prompts": "^2.4.9",
-        "chalk": "^4.1.2",
-        "commander": "^12.0.0",
+        "chalk": "^5.6.2",
+        "commander": "^15.0.0",
         "dotenv": "^17.3.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^5.2.0",
+        "jsonc-parser": "^3.3.1",
         "liquidjs": "^10.27.0",
         "open": "^11.0.0",
-        "openapi-fetch": "^0.16.0",
+        "openapi-fetch": "^0.17.0",
         "ora": "^9.3.0",
         "prompts": "^2.4.2",
         "xksuid": "^0.0.4",
         "zod": "^4.0.14"
       },
       "bin": {
-        "langwatch": "dist/cli/index.js"
+        "langwatch": "dist/cli/index.js",
+        "lw": "dist/cli/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@langchain/core": ">=0.3.68 <0.4.0",
         "@langchain/langgraph": ">=0.4.0 <1.0.0",
         "@langchain/openai": ">=0.6.0 <1.0.0",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/sdk-node": "0.216.0",
+        "@langwatch/langy": "workspace:*",
+        "@opentelemetry/sdk-node": "0.219.0",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
         "@opentelemetry/sdk-trace-web": ">=2.0.1",
         "@types/debug": "^4.1.12",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.1.0",
-        "@typescript/native-preview": "7.0.0-dev.20260426.1",
+        "@types/prompts": "^2.4.9",
+        "@typescript/native-preview": "7.0.0-dev.20260705.1",
         "@vercel/otel": "^1.13.0",
         "@vitest/coverage-v8": "^4.1.0",
         "dotenv-cli": "^11.0.0",
-        "esbuild": "^0.27.3",
+        "esbuild": "^0.28.1",
         "eslint": "^9.32.0",
         "fets": "^0.8.5",
         "fishery": "^2.3.1",
@@ -78,11 +82,12 @@
         "msw": "^2.10.4",
         "nock": "^14.0.8",
         "openapi-msw": "^1.2.0",
+        "openapi-typescript": "7.13.0",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.38.0",
         "vitest": "^4.1.0",
-        "vitest-mock-extended": "^3.1.0",
+        "vitest-mock-extended": "^4.0.0",
         "yaml": "^2.8.1"
       },
       "engines": {
@@ -90,14 +95,12 @@
         "pnpm": ">=8"
       },
       "peerDependencies": {
-        "@ai-sdk/openai": ">=2.0.0 <4.0.0",
+        "@ai-sdk/openai": ">=2.0.0 <5.0.0",
         "@langchain/core": ">=0.3.0 <2.0.0",
         "@langchain/langgraph": ">=0.4.0 <2.0.0",
         "@langchain/openai": ">=0.6.0 <2.0.0",
-        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.1.0",
         "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
-        "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
         "langchain": ">=0.3.0 <2.0.0"
       },
@@ -118,9 +121,6 @@
           "optional": true
         },
         "@opentelemetry/context-zone": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-node": {
           "optional": true
         },
         "@opentelemetry/sdk-trace-web": {
@@ -352,9 +352,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -670,12 +670,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
-      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1"
+        "@opentelemetry/core": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1961,9 +1961,9 @@
       "link": true
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -2220,9 +2220,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
-      "integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/sdks/typescript/examples/vercel-ai/package.json
+++ b/sdks/typescript/examples/vercel-ai/package.json
@@ -28,7 +28,10 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
-    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.0",
-    "@grpc/grpc-js": ">=1.14.4"
+    "@grpc/grpc-js": ">=1.14.4",
+    "@opentelemetry/core": ">=2.8.0 <3",
+    "@opentelemetry/propagator-jaeger": ">=2.9.0 <3",
+    "linkify-it": ">=5.0.2 <6",
+    "protobufjs": ">=7.5.6 <8.0.0 || >=8.6.6"
   }
 }


### PR DESCRIPTION
Re-homes #6449 onto the post-restructure paths. The five example apps under `sdks/typescript/examples/` keep their own standalone npm lockfiles, so the workspace-wide pnpm overrides in `pnpm-workspace.yaml` never reach them and their transitive dependencies drifted behind. Each example already had an `overrides` block; this extends it and regenerates the lockfile.

## What it closes

**45 of the 50 open alerts** on these manifests: 19 HIGH, 25 MODERATE, 1 LOW.

| example | alerts closed | packages raised |
|---|---|---|
| `mastra` | 22 | `@hono/node-server` 1.19.14 to 2.1.0, `hono` 4.12.25 to 4.13.1, `ip-address` 10.2.0 to 10.5.0, `fast-uri` 4.0.0 to 4.1.2, `shell-quote` 1.8.4 to 1.10.0, `brace-expansion` 1.1.15/2.1.1 to 1.1.18/2.1.4, `js-yaml` 3.15.0 to 3.15.1, `@opentelemetry/core` 2.7.1+2.8.0 to 2.10.0, `protobufjs` 8.6.3 to 8.7.2 |
| `langgraph` | 8 | `js-yaml` 4.2.0 to 4.3.1, `linkify-it` 5.0.1 to 5.0.2, `uuid` 9.0.1+10.0.0 to 11.1.1, `@opentelemetry/core` and `propagator-jaeger` 2.7.1 to 2.10.0, `protobufjs` 8.6.3 to 8.7.2 |
| `langchain` | 7 | same set as langgraph, minus uuid |
| `vercel-ai` | 5 | `linkify-it`, `@opentelemetry/core`, `propagator-jaeger`, `protobufjs` |
| `evaluation` | 3 | `@opentelemetry/core`, `propagator-jaeger`, `protobufjs` |

Closure was computed by interval-testing each resolved version against the advisory's `vulnerableVersionRange`, not against `firstPatchedVersion`, so parallel major lines are not miscounted.

## What stays open, and why

Five alerts have no published fix, so no override can close them:

- `image-size` #2092, #2093 (HIGH). The advisory range is `<= 2.0.2` and 2.0.2 is the newest version on npm. Reached transitively through `mastra`.
- `@ai-sdk/provider-utils` #1963, #1981, #2003 (LOW). The advisory range is `<= 3.0.97`; the 3.x line tops out at 3.0.32. The 4.x subtree in `mastra` is already out of range.

These need either an upstream release or a dismissal decision. Nothing to do in this repo today.

## Scoped selectors where majors run in parallel

A blanket floor would have dragged already-patched majors backwards, so two entries are selector-scoped:

- `"uuid@<11.1.1": ">=11.1.1 <12"` in `langgraph`, replacing a bare `"uuid"` override. This lifts 9.0.1 and 10.0.0 and leaves the 14.0.0 subtree untouched.
- `"brace-expansion@<1.1.18"` and `"brace-expansion@>=2.0.0 <2.1.4"` in `mastra`, kept as separate 1.x and 2.x entries.

`@opentelemetry/core` is floored bluntly at `>=2.8.0 <3` here, which is safe in these five trees specifically: none of them carries a 1.x otel subtree, unlike the platform workspace.

## Version-set audit

Every lockfile was diffed as a set of resolved versions before and after:

```
evaluation   4 up, 0 down, 1 added (zod hoist), 0 removed
langchain    6 up, 0 down, 0 added, 0 removed
langgraph    6 up, 0 down, 0 added, 0 removed
vercel-ai    5 up, 0 down, 0 added, 0 removed
mastra       9 up, 0 down, 0 added, 0 removed
```

No downgrades and no dropped packages anywhere. The `langwatch` entry moving 0.33.1 to 1.4.0 in four of them is the local `file:../../` SDK picking up its current version.

## What was tested

No CI workflow builds these examples, so local verification is the only signal and it was done per example.

- `npm ci` from the regenerated lockfile in all five. All exit 0, which also proves each lockfile is consistent with its `package.json`.
- **`mastra` full build and boot**, since it takes the only major bump (`@hono/node-server` 1.x to 2.x). `npm run build` succeeds, then `node .mastra/output/index.mjs` serves: `GET /api/agents` returns 200 with the agent JSON, and `GET /api/logs` returns a correctly validated 400. Routing, middleware and the validator layer all work on `@hono/node-server` 2.1.0 with `hono` 4.13.1.
- Functional smoke of every raised package in the example that carries it, not just an import: `js-yaml` parses a document, `linkify-it` matches a URL, `uuid.v4()` returns a well-formed id, `JaegerPropagator().fields()` returns `["uber-trace-id"]`, `Address4.startAddress()` computes, `fast-uri.parse()` extracts a host, `shell-quote.parse()` tokenises, and a `Hono` app answers a routed request with 200.
- `@opentelemetry/core` 2.10.0, `@opentelemetry/sdk-node` 0.217.0 and `protobufjs` 8.7.2 load in every example that declares them.

## Two pre-existing problems this PR does not introduce

Both reproduce with main's own `package.json`, verified by reverting the file and re-running:

1. `langgraph` and `vercel-ai` cannot resolve without `--legacy-peer-deps`. In `vercel-ai`, `@vercel/otel` 1.14.1 peers `@opentelemetry/instrumentation >=0.46.0 <0.200.0` while the root pulls `sdk-node` 0.217.0. In `langgraph`, `@langchain/community` 1.1.29 wants `@langchain/core` 1.x while the root pins `^0.3.80`. Their lockfiles were regenerated with `--legacy-peer-deps`, which is how the checked-in versions were evidently produced.
2. `langchain`'s `npm run build` fails with `TS2688: Cannot find type definition file for 'node'` and the same for `'yauzl'`. Identical output and exit code on main with this branch's changes fully reverted. The example declares `typescript` but no `@types/node`.

Worth fixing, but both are separate from a dependency floor bump and neither should hold this up.

Supersedes #6449, which targeted the pre-restructure `typescript-sdk/examples/*` paths and has been unrebaseable since those paths moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency version constraints across TypeScript examples to improve compatibility and consistency.
  - Refined package version ranges for telemetry, protobuf, YAML, linking, networking, and related tooling.
  - Raised the minimum supported `protobufjs` version in applicable examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->