### PR TITLE
fix(automations): decode middle-dot in metadata filter keys for in-memory matching

### DIFF
--- a/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
+++ b/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
@@ -163,7 +163,7 @@ describe("matchesTriggerFilters", () => {
     it("decodes middle-dot encoded keys from the UI (metadata·env)", () => {
       const data = makeTraceData({ customMetadata: { env: "production" } });
       const filters: TriggerFilters = {
-        "metadata.value": { "metadata·env": ["production"] },
+        "metadata.value": { metadata·env: ["production"] },
       };
       expect(matchesTriggerFilters(data, filters)).toBe(true);
     });
@@ -171,7 +171,7 @@ describe("matchesTriggerFilters", () => {
     it("decodes middle-dot keys with langwatch.metadata prefix", () => {
       const data = makeTraceData({ customMetadata: { env: "production" } });
       const filters: TriggerFilters = {
-        "metadata.value": { "langwatch·metadata·env": ["production"] },
+        "metadata.value": { langwatch·metadata·env: ["production"] },
       };
       expect(matchesTriggerFilters(data, filters)).toBe(true);
     });
@@ -179,7 +179,7 @@ describe("matchesTriggerFilters", () => {
     it("does not match middle-dot encoded key when value differs", () => {
       const data = makeTraceData({ customMetadata: { env: "staging" } });
       const filters: TriggerFilters = {
-        "metadata.value": { "metadata·env": ["production"] },
+        "metadata.value": { metadata·env: ["production"] },
       };
       expect(matchesTriggerFilters(data, filters)).toBe(false);
     });

--- a/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
+++ b/platform/app/src/server/filters/__tests__/triggerFilter.matcher.unit.test.ts
@@ -159,6 +159,30 @@ describe("matchesTriggerFilters", () => {
       };
       expect(matchesTriggerFilters(data, filters)).toBe(false);
     });
+
+    it("decodes middle-dot encoded keys from the UI (metadata·env)", () => {
+      const data = makeTraceData({ customMetadata: { env: "production" } });
+      const filters: TriggerFilters = {
+        "metadata.value": { "metadata·env": ["production"] },
+      };
+      expect(matchesTriggerFilters(data, filters)).toBe(true);
+    });
+
+    it("decodes middle-dot keys with langwatch.metadata prefix", () => {
+      const data = makeTraceData({ customMetadata: { env: "production" } });
+      const filters: TriggerFilters = {
+        "metadata.value": { "langwatch·metadata·env": ["production"] },
+      };
+      expect(matchesTriggerFilters(data, filters)).toBe(true);
+    });
+
+    it("does not match middle-dot encoded key when value differs", () => {
+      const data = makeTraceData({ customMetadata: { env: "staging" } });
+      const filters: TriggerFilters = {
+        "metadata.value": { "metadata·env": ["production"] },
+      };
+      expect(matchesTriggerFilters(data, filters)).toBe(false);
+    });
   });
 
   describe("when filtering by topics.topics", () => {

--- a/platform/app/src/server/filters/precondition-matchers.ts
+++ b/platform/app/src/server/filters/precondition-matchers.ts
@@ -91,8 +91,16 @@ export const PRECONDITION_FIELD_MATCHERS: Record<
   "metadata.labels": (data) => data.labels,
   "metadata.prompt_ids": (data) => data.promptIds,
   "metadata.key": null, // key selector — not matchable
-  "metadata.value": (data, _value, key) =>
-    key ? (data.customMetadata?.[key] ?? null) : null,
+  "metadata.value": (data, _value, key) => {
+    if (!key) return null;
+    const decoded = key.replaceAll("·", ".");
+    const resolved = decoded.startsWith("metadata.")
+      ? decoded.slice("metadata.".length)
+      : decoded.startsWith("langwatch.metadata.")
+        ? decoded.slice("langwatch.metadata.".length)
+        : decoded;
+    return resolved ? (data.customMetadata?.[resolved] ?? null) : null;
+  },
 
   // Span fields
   "spans.type": (data) => data.spanTypes,


### PR DESCRIPTION
## Summary

- Fix in-memory precondition matcher to decode middle-dot encoded filter keys before `customMetadata` lookup
- The UI encodes `.` as `·` in filter keys; the ClickHouse path decoded them but the in-memory path did not
- This caused all automations filtering on custom metadata to silently stop firing platform-wide

Closes #6869

## Changes

- `precondition-matchers.ts:94`: decode `·` → `.` and strip `metadata.` / `langwatch.metadata.` prefix before lookup
- 3 new unit tests for middle-dot encoded keys

## Test plan

- [x] Existing 61 precondition-matchers tests pass
- [x] Existing 86 + 3 new triggerFilter.matcher tests pass
- [x] New tests cover: `metadata·env`, `langwatch·metadata·env`, and non-match case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata-based filtering when keys use middle-dot encoding.
  - Added support for metadata keys with optional `metadata.` or `langwatch.metadata.` prefixes.
  - Ensured filters safely fail when decoded metadata values do not match.
  - Preserved expected behavior for empty metadata keys.

- **Tests**
  - Added coverage for encoded metadata keys, prefixed formats, successful matches, and mismatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->