### PR TITLE
docs(mcp): lead with Claude Desktop and use /sse for remote setup

### DIFF
--- a/docs/integration/mcp.mdx
+++ b/docs/integration/mcp.mdx
@@ -30,6 +30,17 @@ See the [API Keys guide](/platform/api-keys#creating-a-personal-api-key) for ste
 <Step title="Configure your MCP">
 
 <Tabs>
+<Tab title="Claude Desktop">
+1. Go to **Settings → Connectors**
+2. Click **Add custom connector**
+3. Enter the server URL: `https://app.langwatch.ai/sse`
+4. Click **Connect**: you'll be redirected to sign in and authorize access to your project
+
+The same steps work in Claude Cowork and in Claude chat on the web.
+
+*Requires a paid Claude plan.*
+</Tab>
+
 <Tab title="Claude Code">
 Run this command to add the MCP server:
 
@@ -79,24 +90,15 @@ Under the `servers` object, add an entry named `langwatch` with these fields:
 *Requires a Plus or Team plan.*
 </Tab>
 
-<Tab title="Claude Chat">
-1. Go to **Settings → Connectors**
-2. Click **Add custom connector**
-3. Enter the server URL: `https://app.langwatch.ai/mcp`
-4. Click **Connect**: you'll be redirected to sign in and authorize access to your project
-
-*Requires a Pro or Max plan.*
-</Tab>
-
 <Tab title="BoltAI, Other MCP Clients">
 For any MCP client that supports remote servers with OAuth:
 
 1. Add a new remote MCP server
-2. Enter the endpoint URL: `https://app.langwatch.ai/mcp`
+2. Enter the endpoint URL: `https://app.langwatch.ai/sse`
 3. Select **OAuth (browser)** authentication
 4. Click **Connect**: you'll be redirected to sign in and authorize access to your project
 
-The server supports OAuth Authorization Code + PKCE with Dynamic Client Registration, so any standards-compliant MCP client should work automatically.
+The server supports OAuth Authorization Code + PKCE with Dynamic Client Registration, so any standards-compliant MCP client should work automatically. Clients that speak the Streamable HTTP transport can point at `https://app.langwatch.ai/mcp` instead.
 </Tab>
 
 <Tab title="Other">
@@ -129,7 +131,7 @@ Open your AI assistant chat (e.g., `Cmd/Ctrl + I` in Cursor, or `Cmd/Ctrl + Shif
 The MCP server runs in two modes:
 
 - **Local (stdio)**: Default. Runs as a subprocess of your coding assistant (Claude Code, Copilot, Cursor). API key set via `--apiKey` flag or `LANGWATCH_API_KEY` env var.
-- **Remote (HTTP/SSE)**: For web-based assistants (ChatGPT, Claude Chat, BoltAI, etc.). Hosted at `https://app.langwatch.ai`. Uses OAuth Authorization Code + PKCE, click Connect and sign in via your browser to authorize access to your project. Supports both Streamable HTTP (`/mcp`) and SSE (`/sse`) transports.
+- **Remote (HTTP/SSE)**: For chat assistants (Claude Desktop, ChatGPT, BoltAI, etc.). Hosted at `https://app.langwatch.ai`. Uses OAuth Authorization Code + PKCE, click Connect and sign in via your browser to authorize access to your project. Supports both SSE (`/sse`) and Streamable HTTP (`/mcp`) transports.
 
 ## Usage Examples
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -30302,6 +30302,18 @@ See the [API Keys guide](/platform/api-keys#creating-a-personal-api-key) for ste
 <Step title="Configure your MCP">
 
 
+### Claude Desktop
+
+1. Go to **Settings → Connectors**
+2. Click **Add custom connector**
+3. Enter the server URL: `https://app.langwatch.ai/sse`
+4. Click **Connect**: you'll be redirected to sign in and authorize access to your project
+
+The same steps work in Claude Cowork and in Claude chat on the web.
+
+*Requires a paid Claude plan.*
+
+
 ### Claude Code
 
 Run this command to add the MCP server:
@@ -30355,26 +30367,16 @@ Under the `servers` object, add an entry named `langwatch` with these fields:
 *Requires a Plus or Team plan.*
 
 
-### Claude Chat
-
-1. Go to **Settings → Connectors**
-2. Click **Add custom connector**
-3. Enter the server URL: `https://app.langwatch.ai/mcp`
-4. Click **Connect**: you'll be redirected to sign in and authorize access to your project
-
-*Requires a Pro or Max plan.*
-
-
 ### BoltAI, Other MCP Clients
 
 For any MCP client that supports remote servers with OAuth:
 
 1. Add a new remote MCP server
-2. Enter the endpoint URL: `https://app.langwatch.ai/mcp`
+2. Enter the endpoint URL: `https://app.langwatch.ai/sse`
 3. Select **OAuth (browser)** authentication
 4. Click **Connect**: you'll be redirected to sign in and authorize access to your project
 
-The server supports OAuth Authorization Code + PKCE with Dynamic Client Registration, so any standards-compliant MCP client should work automatically.
+The server supports OAuth Authorization Code + PKCE with Dynamic Client Registration, so any standards-compliant MCP client should work automatically. Clients that speak the Streamable HTTP transport can point at `https://app.langwatch.ai/mcp` instead.
 
 
 ### Other
@@ -30406,7 +30408,7 @@ Open your AI assistant chat (e.g., `Cmd/Ctrl + I` in Cursor, or `Cmd/Ctrl + Shif
 The MCP server runs in two modes:
 
 - **Local (stdio)**: Default. Runs as a subprocess of your coding assistant (Claude Code, Copilot, Cursor). API key set via `--apiKey` flag or `LANGWATCH_API_KEY` env var.
-- **Remote (HTTP/SSE)**: For web-based assistants (ChatGPT, Claude Chat, BoltAI, etc.). Hosted at `https://app.langwatch.ai`. Uses OAuth Authorization Code + PKCE, click Connect and sign in via your browser to authorize access to your project. Supports both Streamable HTTP (`/mcp`) and SSE (`/sse`) transports.
+- **Remote (HTTP/SSE)**: For chat assistants (Claude Desktop, ChatGPT, BoltAI, etc.). Hosted at `https://app.langwatch.ai`. Uses OAuth Authorization Code + PKCE, click Connect and sign in via your browser to authorize access to your project. Supports both SSE (`/sse`) and Streamable HTTP (`/mcp`) transports.
 
 ## Usage Examples
 


### PR DESCRIPTION
## What

Updates the MCP setup docs now that the remote SSE transport is fixed and deployed (#6860).

- **Claude Desktop leads the client tabs.** It was fifth, behind the editor integrations, even though it is where most people connect first. The tab also covers Claude Cowork and Claude chat on the web, which use the same connector flow.
- **The remote setup steps use `https://app.langwatch.ai/sse`.** They pointed at `/mcp` before. `/sse` is what the connector UIs default to and what ChatGPT requires, and it now works across replicas. The generic MCP client tab notes `/mcp` for clients that speak Streamable HTTP.

## Why

`/sse` was not multi-pod safe until #6860: sessions lived in a per-process map while production runs four replicas with no affinity, so the first message after connecting reached the right pod about one time in four. The docs steered people to `/mcp` to route around that. With the transport fixed there is no reason to send people down the less compatible path, and the connector UIs that default to `/sse` no longer fail.

## Verification

The deployed fix was confirmed against production before changing the docs:

```
GET /.well-known/oauth-protected-resource/sse
  200 application/json  {"resource":"https://app.langwatch.ai/sse", ...}

GET /.well-known/oauth-authorization-server/sse
  200 application/json  {"issuer":"https://app.langwatch.ai", ...,
                         "code_challenge_methods_supported":["S256"]}

POST /sse/messages?sessionId=<bogus>
  401 application/json  {"error":"Authorization header required"}
```

All three used to return the SPA's HTML with a 200. Connecting a real client to `/sse` now lists tools, which is what prompted this change.

## Notes

The plan line on the Claude tab now reads "Requires a paid Claude plan" instead of naming Pro or Max. The tab covers three surfaces whose plan requirements differ and move, and the previous wording already omitted Team and Enterprise.

Docs only, no code paths touched. `docs/llms-full.txt` carries the same edits so the two stay in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for Claude Desktop, Claude Cowork, and Claude web.
  * Clarified authentication and connection options for MCP clients, including OAuth, SSE, and Streamable HTTP.
  * Updated remote-mode documentation to cover chat assistants and supported transport methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->