### PR TITLE
fix(readme): repair nine dead links and check them in CI

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -129,7 +129,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/...
+      - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/...
 
   lint:
     needs: changes
@@ -173,6 +173,7 @@ jobs:
             --disable=funlen,gocognit,revive
             ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
             ./tools/migrationorder/... ./tools/herrgen/... ./tools/ciguard/...
+            ./tools/linkcheck/...
 
       # funlen / gocognit / revive encode house rules over a codebase that
       # predates them (331 pre-existing hits), so they are gated on new and
@@ -207,7 +208,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go vet ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/...
+      - run: go vet ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/...
 
   # packages/handled-error/src/codes.generated.ts mirrors the services' herr
   # codes; the TypeScript presentation registry is keyed off it, so a Go code

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -129,7 +129,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/...
+      - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/... ./cmd/linkcheck/...
 
   lint:
     needs: changes

--- a/.github/workflows/readme-links.yml
+++ b/.github/workflows/readme-links.yml
@@ -1,0 +1,71 @@
+name: readme-links
+
+# Resolves every link in the README, so a page renamed on the docs site fails
+# here rather than under the first person who clones the repository.
+#
+# Nine of the README's links were dead when this was written — seven docs pages
+# renamed under docs/integration/ and a hybrid-setup page that had moved out of
+# /self-hosting/ entirely. Nothing in this repository failed when they broke,
+# because none of the changes that broke them happened in this repository.
+#
+# That is why it runs on a schedule as well as on pull requests: this class of
+# rot needs no commit here to happen. The scheduled run is the one that catches
+# it; the pull-request run only stops us adding a new dead link.
+#
+# Only 404 and 410 fail the run. A bot block, a rate limit or a timeout is
+# reported as unverified and does not gate — npmjs.com answers 403 to CI egress
+# addresses, and a check that fails on that is a check people learn to ignore.
+#
+# No path filter: a filtered workflow in this repository needs a complementary
+# "-unmodified" stub so branch protection still resolves (specs/ci/path-filters.feature),
+# and this check is under a minute. Always running is the cheaper arrangement.
+#
+# Runs the checker from the PR head, so the trigger stays `pull_request` — never
+# `pull_request_target`. It needs no token.
+#
+# Spec: specs/ci/readme-link-check.feature
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Mondays, 07:00 UTC — a dead link found at the start of the week gets
+    # fixed that week.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: readme-links-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  readme-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+          # The job reads the README and builds the checker, so it takes a
+          # working tree — but never the marketing media, which is 165 MB of
+          # .gif and .mp4 it would fetch and not open.
+          # See specs/ci/lean-checkout.feature.
+          sparse-checkout: |
+            /*
+            !/docs/media/
+            !/docs/images/
+            !/assets/
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Check README links
+        run: go run ./cmd/linkcheck README.md

--- a/.github/workflows/readme-links.yml
+++ b/.github/workflows/readme-links.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Once running, LangWatch will be available at `http://localhost:5560`, where you 
 
 Run LangWatch on your own infrastructure:
 
-- [Docker Compose](https://docs.langwatch.ai/self-hosting/open-source#docker-compose) - Run LangWatch on your own machine.
-- [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/open-source#helm-chart-for-langwatch) - Run LangWatch on a Kubernetes cluster using Helm.
+- [Docker Compose](https://docs.langwatch.ai/self-hosting/deployment/docker-compose) - Run LangWatch on your own machine.
+- [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/deployment/kubernetes-helm) - Run LangWatch on a Kubernetes cluster using Helm.
 - [OnPrem](https://docs.langwatch.ai/self-hosting/onprem) - Cloud-specific setups for AWS, Google Cloud, and Azure.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built for teams that need regression testing, simulations, and production observ
   OpenTelemetry/OTLP-native. Framework- and LLM-provider agnostic by design.
 
 - [**AI Gateway for governance + cost control**](https://docs.langwatch.ai/ai-gateway/overview)
-  OpenAI/Anthropic-compatible proxy with virtual keys, hierarchical budgets, inline guardrails, automatic fallback across providers, and Anthropic `cache_control` passthrough. ~700 ns hot-path overhead. Ships as a separate Go binary (`services/gateway/`) + Helm sub-chart (`charts/gateway/`).
+  OpenAI/Anthropic-compatible proxy with virtual keys, hierarchical budgets, inline guardrails, automatic fallback across providers, and Anthropic `cache_control` passthrough. ~700 ns hot-path overhead. Ships as a separate Go binary (`services/aigateway/`) + Helm sub-chart (`charts/gateway/`).
 
 - [**Collaboration that doesn't slow shipping**](https://docs.langwatch.ai/features/annotations)
   Review runs, annotate failures, and ship fixes faster. Let domain experts label edge cases with [annotations & queues](https://docs.langwatch.ai/features/annotations), keep prompts in Git with the [GitHub integration](https://docs.langwatch.ai/prompt-management/features/essential/github-integration), and [link prompt versions to traces](https://docs.langwatch.ai/prompt-management/features/advanced/link-to-traces).
@@ -91,7 +91,7 @@ Run LangWatch on your own infrastructure:
 
 For companies that have strict data residency and control requirements, without needing to go fully on-prem.
 
-Read more about it on our [docs](https://docs.langwatch.ai/self-hosting/hybrid).
+Read more about it on our [docs](https://docs.langwatch.ai/hybrid-setup/overview).
 
 </details>
 
@@ -132,19 +132,19 @@ LangWatch builds and maintains several integrations listed below. Our tracing pl
 **Frameworks:**  
 [LangChain](https://langwatch.ai/docs/integration/python/integrations/langchain) ·
 [LangGraph](https://langwatch.ai/docs/integration/python/integrations/langgraph) ·
-[Vercel AI SDK](https://langwatch.ai/docs/integration/typescript/integrations/vercel-ai) ·
+[Vercel AI SDK](https://langwatch.ai/docs/integration/typescript/integrations/vercel-ai-sdk) ·
 [Mastra](https://langwatch.ai/docs/integration/typescript/integrations/mastra) ·
-[CrewAI](https://langwatch.ai/docs/integration/python/integrations/crewai) ·
+[CrewAI](https://langwatch.ai/docs/integration/python/integrations/crew-ai) ·
 [Google ADK](https://langwatch.ai/docs/integration/python/integrations/google-ai)
 
 **Model Providers:**  
-[OpenAI](https://langwatch.ai/docs/integration/python/integrations/openai) ·
+[OpenAI](https://langwatch.ai/docs/integration/python/integrations/open-ai) ·
 [Anthropic](https://langwatch.ai/docs/integration/python/integrations/anthropic) ·
-[Azure](https://langwatch.ai/docs/integration/python/integrations/azure) ·
-[Google Cloud](https://langwatch.ai/docs/integration/python/integrations/google-cloud) ·
-[AWS](https://langwatch.ai/docs/integration/python/integrations/aws) ·
-[Groq](https://langwatch.ai/docs/integration/python/integrations/groq) ·
-[Ollama](https://langwatch.ai/docs/integration/python/integrations/ollama)
+[Azure OpenAI](https://langwatch.ai/docs/integration/python/integrations/open-ai-azure) ·
+[Google Vertex AI](https://langwatch.ai/docs/integration/python/integrations/vertex-ai) ·
+[AWS Bedrock](https://langwatch.ai/docs/integration/python/integrations/aws-bedrock) ·
+[Groq](https://langwatch.ai/docs/integration/go/integrations/groq) ·
+[Ollama](https://langwatch.ai/docs/integration/go/integrations/ollama)
 
 ### Platforms
 

--- a/cmd/linkcheck/main.go
+++ b/cmd/linkcheck/main.go
@@ -1,0 +1,140 @@
+// Command linkcheck resolves the links in the repository's markdown, so a
+// page that gets renamed on the docs site fails here rather than under a
+// first-time reader.
+//
+// Only 404 and 410 fail the run. Everything else a host can answer — a bot
+// block, a rate limit, a timeout — is reported as unverified and does not
+// gate, because a check that fails on npmjs.com answering 403 to a datacenter
+// address is a check that gets ignored.
+//
+// Usage:
+//
+//	go run ./cmd/linkcheck                  # README.md
+//	go run ./cmd/linkcheck docs/README.md   # explicit files
+//	go run ./cmd/linkcheck -offline         # repository paths only, no network
+//
+// Spec: specs/ci/readme-link-check.feature
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/langwatch/langwatch/pkg/ciscan"
+	"github.com/langwatch/langwatch/tools/linkcheck"
+)
+
+func main() {
+	root := flag.String("root", "", "repository root (default: nearest ancestor holding go.work)")
+	offline := flag.Bool("offline", false, "check repository paths only, never the network")
+	timeout := flag.Duration("timeout", 20*time.Second, "per-request timeout")
+	flag.Parse()
+
+	repoRoot := *root
+	if repoRoot == "" {
+		found, err := ciscan.RepoRoot(".")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "linkcheck: %v\n", err)
+			os.Exit(2)
+		}
+		repoRoot = found
+	}
+
+	names := flag.Args()
+	if len(names) == 0 {
+		names = []string{"README.md"}
+	}
+
+	documents := make([]document, 0, len(names))
+	for _, name := range names {
+		path := name
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(repoRoot, name)
+		}
+		documents = append(documents, document{name: name, path: path})
+	}
+
+	checker := linkcheck.Checker{RepoRoot: repoRoot}
+	if !*offline {
+		checker.Fetch = linkcheck.HTTPFetcher(*timeout)
+	}
+
+	failed, err := run(context.Background(), checker, documents)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "linkcheck: %v\n", err)
+		os.Exit(2)
+	}
+	if failed {
+		fmt.Fprintln(os.Stderr, "\nSee specs/ci/readme-link-check.feature")
+		os.Exit(1)
+	}
+}
+
+// document is one file to check: the path to read, and the name to print,
+// which is what the caller typed.
+type document struct {
+	name string
+	path string
+}
+
+// run checks every document before reporting, so one run tells you every dead
+// link rather than the first one.
+func run(ctx context.Context, checker linkcheck.Checker, documents []document) (bool, error) {
+	failed := false
+
+	for _, doc := range documents {
+		content, err := os.ReadFile(doc.path)
+		if err != nil {
+			return false, err
+		}
+
+		if report(doc.name, checker.Run(ctx, doc.path, string(content))) {
+			failed = true
+		}
+	}
+	return failed, nil
+}
+
+// report prints one document's outcome and says whether it failed. Dead links
+// go to stderr; the unverified ones are a note, not a finding.
+func report(document string, results []linkcheck.Result) bool {
+	var dead, unverified []linkcheck.Result
+	for _, result := range results {
+		switch result.Verdict {
+		case linkcheck.Dead:
+			dead = append(dead, result)
+		case linkcheck.Unverified:
+			unverified = append(unverified, result)
+		case linkcheck.OK:
+		}
+	}
+
+	if len(dead) == 0 {
+		fmt.Printf("✓ %s\n", document)
+	} else {
+		fmt.Printf("✗ %s\n", document)
+	}
+	for _, result := range dead {
+		fmt.Fprintf(os.Stderr, "    %s:%d %s\n", document, result.Line, describe(result))
+	}
+	for _, result := range unverified {
+		fmt.Printf("    unverified: %s:%d %s\n", document, result.Line, describe(result))
+	}
+
+	return len(dead) > 0
+}
+
+func describe(result linkcheck.Result) string {
+	switch {
+	case result.Detail != "" && result.Status != 0:
+		return fmt.Sprintf("%s (%d, %s)", result.Target, result.Status, result.Detail)
+	case result.Detail != "":
+		return fmt.Sprintf("%s (%s)", result.Target, result.Detail)
+	default:
+		return fmt.Sprintf("%s (%d)", result.Target, result.Status)
+	}
+}

--- a/cmd/linkcheck/main.go
+++ b/cmd/linkcheck/main.go
@@ -31,7 +31,8 @@ import (
 func main() {
 	root := flag.String("root", "", "repository root (default: nearest ancestor holding go.work)")
 	offline := flag.Bool("offline", false, "check repository paths only, never the network")
-	timeout := flag.Duration("timeout", 20*time.Second, "per-request timeout")
+	timeout := flag.Duration("timeout", 20*time.Second, "per-attempt request timeout")
+	budget := flag.Duration("budget", 4*time.Minute, "overall deadline for the whole run")
 	flag.Parse()
 
 	repoRoot := *root
@@ -63,7 +64,15 @@ func main() {
 		checker.Fetch = linkcheck.HTTPFetcher(*timeout)
 	}
 
-	failed, err := run(context.Background(), checker, documents)
+	// The whole run is bounded, not just each request. Sequential fetches at
+	// the per-attempt timeout would otherwise outlast the job's own
+	// timeout-minutes and turn a slow third-party host into a red build —
+	// the opposite of treating an unanswered link as unverified. Past the
+	// budget the remaining fetches fail fast and report as unverified.
+	ctx, cancel := context.WithTimeout(context.Background(), *budget)
+	failed, err := run(ctx, checker, documents)
+	cancel()
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "linkcheck: %v\n", err)
 		os.Exit(2)

--- a/cmd/linkcheck/report_test.go
+++ b/cmd/linkcheck/report_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/langwatch/langwatch/tools/linkcheck"
+)
+
+// These cover the verdict-to-exit-code step, which is the only part of the
+// tool CI actually gates on. Everything below it is asserted in
+// tools/linkcheck; without these, gating on Unverified — or not gating at
+// all — would keep the whole suite green.
+
+// @scenario "A markdown link to a page that is gone fails the check"
+func TestReportFailsOnADeadLink(t *testing.T) {
+	failed := report("README.md", []linkcheck.Result{
+		{Link: linkcheck.Link{Target: "https://langwatch.ai/gone", Line: 3}, Status: http.StatusNotFound, Verdict: linkcheck.Dead},
+	})
+
+	if !failed {
+		t.Error("got failed=false for a dead link, want true")
+	}
+}
+
+// @scenario "A bot-blocked host does not fail the check"
+func TestReportPassesOnAnUnverifiedLink(t *testing.T) {
+	failed := report("README.md", []linkcheck.Result{
+		{Link: linkcheck.Link{Target: "https://www.npmjs.com/package/langwatch", Line: 11}, Status: http.StatusForbidden, Verdict: linkcheck.Unverified},
+	})
+
+	if failed {
+		t.Error("got failed=true for an unverified link, want false — a bot block must not gate")
+	}
+}
+
+func TestReportPassesWhenEveryLinkResolves(t *testing.T) {
+	failed := report("README.md", []linkcheck.Result{
+		{Link: linkcheck.Link{Target: "https://langwatch.ai", Line: 1}, Status: http.StatusOK, Verdict: linkcheck.OK},
+	})
+
+	if failed {
+		t.Error("got failed=true with no dead links, want false")
+	}
+}
+
+// A dead link alongside an unverified one still fails: the unverified result
+// must not mask the finding, nor rescue the run.
+func TestReportFailsWhenADeadLinkAccompaniesAnUnverifiedOne(t *testing.T) {
+	failed := report("README.md", []linkcheck.Result{
+		{Link: linkcheck.Link{Target: "https://www.npmjs.com/package/langwatch", Line: 11}, Status: http.StatusForbidden, Verdict: linkcheck.Unverified},
+		{Link: linkcheck.Link{Target: "https://langwatch.ai/gone", Line: 12}, Status: http.StatusNotFound, Verdict: linkcheck.Dead},
+	})
+
+	if !failed {
+		t.Error("got failed=false, want true — an unverified link must not rescue a dead one")
+	}
+}
+
+// @scenario "A relative link to a path that no longer exists fails the check"
+func TestRunFailsOnADocumentWithADeadRepositoryPath(t *testing.T) {
+	root := t.TempDir()
+	readme := filepath.Join(root, "README.md")
+	if err := os.WriteFile(readme, []byte("[gone](/does-not-exist.md)\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	failed, err := run(t.Context(), linkcheck.Checker{RepoRoot: root}, []document{{name: "README.md", path: readme}})
+
+	if err != nil {
+		t.Fatalf("got error %v, want none", err)
+	}
+	if !failed {
+		t.Error("got failed=false, want true")
+	}
+}
+
+func TestRunPassesOnADocumentWhoseRepositoryPathsResolve(t *testing.T) {
+	root := t.TempDir()
+	readme := filepath.Join(root, "README.md")
+	if err := os.WriteFile(readme, []byte("[license](/LICENSE.md)\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "LICENSE.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	failed, err := run(t.Context(), linkcheck.Checker{RepoRoot: root}, []document{{name: "README.md", path: readme}})
+
+	if err != nil {
+		t.Fatalf("got error %v, want none", err)
+	}
+	if failed {
+		t.Error("got failed=true, want false")
+	}
+}
+
+// An unreadable document is a run that could not happen, not a run that
+// found a dead link — main turns this into exit 2 rather than exit 1.
+func TestRunReturnsAnErrorForAnUnreadableDocument(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := run(context.Background(), linkcheck.Checker{RepoRoot: root},
+		[]document{{name: "missing.md", path: filepath.Join(root, "missing.md")}})
+
+	if err == nil {
+		t.Error("got no error for an unreadable document, want one")
+	}
+}

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -152,6 +152,9 @@ const DEFAULT_GO_TEST_ROOTS: string[] = [
   // asserts it, so scenarios under specs/ci/ can only bind from this root.
   // Without it those feature files report "all bound" while binding nothing.
   "tools/ciguard",
+  // The README link checker, for the same reason: specs/ci/readme-link-check.feature
+  // describes what CI asserts about the README, and only these Go tests assert it.
+  "tools/linkcheck",
 ];
 
 /**

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -155,6 +155,9 @@ const DEFAULT_GO_TEST_ROOTS: string[] = [
   // The README link checker, for the same reason: specs/ci/readme-link-check.feature
   // describes what CI asserts about the README, and only these Go tests assert it.
   "tools/linkcheck",
+  // The CLI half of the same tool: the verdict-to-exit-code step is the part
+  // CI gates on, so the "check fails" / "check passes" scenarios bind here.
+  "cmd/linkcheck",
 ];
 
 /**

--- a/specs/ci/readme-link-check.feature
+++ b/specs/ci/readme-link-check.feature
@@ -11,9 +11,12 @@ Feature: The README's links keep pointing at pages that exist
   # `vercel-ai-sdk`), and the hybrid-setup page, which had moved out of
   # /self-hosting/ entirely.
   #
-  # The check runs on pull requests that touch the README and on a schedule,
-  # because the second class of rot needs no commit here to happen: the link
-  # dies when the docs site changes, not when this repository does.
+  # The check runs on every pull request and on a schedule. It carries no path
+  # filter because a filtered workflow here needs a complementary "-unmodified"
+  # stub for branch protection to resolve (specs/ci/path-filters.feature), and
+  # the check is under a minute. The scheduled run is the one that matters:
+  # this rot needs no commit here to happen, because the link dies when the
+  # docs site changes, not when this repository does.
   #
   # Only 404 and 410 fail the run. A link check that fails on every non-2xx
   # answer fails on npmjs.com returning 403 to a datacentre IP and on any

--- a/specs/ci/readme-link-check.feature
+++ b/specs/ci/readme-link-check.feature
@@ -1,0 +1,86 @@
+Feature: The README's links keep pointing at pages that exist
+  As someone arriving at the repository for the first time
+  I want every link in the README to resolve
+  So that the first thing I click is not a 404
+
+  # The README is the one page every new user reads, and its links rot from the
+  # outside: a docs page gets renamed and nothing in this repository fails.
+  # Nine of its links were dead when this guard was written — seven integration
+  # pages that had been renamed under docs/ (`.../integrations/openai` became
+  # `.../integrations/open-ai`, `crewai` became `crew-ai`, `vercel-ai` became
+  # `vercel-ai-sdk`), and the hybrid-setup page, which had moved out of
+  # /self-hosting/ entirely.
+  #
+  # The check runs on pull requests that touch the README and on a schedule,
+  # because the second class of rot needs no commit here to happen: the link
+  # dies when the docs site changes, not when this repository does.
+  #
+  # Only 404 and 410 fail the run. A link check that fails on every non-2xx
+  # answer fails on npmjs.com returning 403 to a datacentre IP and on any
+  # transient timeout, and a check that cries wolf gets ignored or removed.
+  # Those answers are reported and do not gate.
+
+  Background:
+    Given the repository's README
+
+  @unit
+  Scenario: A markdown link to a page that is gone fails the check
+    Given a link whose target answers 404
+    Then the check reports that link with its status
+    And the check fails
+
+  @unit
+  Scenario: A link to a page that has been removed for good fails the check
+    Given a link whose target answers 410
+    Then the check fails
+
+  @unit
+  Scenario: A bot-blocked host does not fail the check
+    Given a link whose target answers 403
+    Then the check reports it as unverified
+    And the check passes
+    # npmjs.com answers 403 to CI egress addresses. The package page is fine;
+    # the checker is simply not a browser.
+
+  @unit
+  Scenario: A redirect to a live page passes
+    Given a link whose target answers 301 to a page that answers 200
+    Then the check passes
+
+  @unit
+  Scenario: A link that times out does not fail the check
+    Given a link whose target never answers
+    Then the check reports it as unverified
+    And the check passes
+
+  @unit
+  Scenario: A relative link is resolved against the repository, not the network
+    Given a link to "/LICENSE.md"
+    Then the check looks for that file in the repository
+    And the check passes when the file exists
+    # GitHub rewrites a root-relative README link onto the repository's own
+    # blob path, so "/LICENSE.md" is a repository path and never a URL.
+
+  @unit
+  Scenario: A relative link to a path that no longer exists fails the check
+    Given a link to a repository path that is absent from the working tree
+    Then the check reports that path
+    And the check fails
+
+  @unit
+  Scenario: Links inside HTML in the README are checked too
+    Given an HTML anchor and an image tag in the README
+    Then their targets are checked like markdown links
+    # The README's header badges and hero image are raw HTML, not markdown.
+
+  @unit
+  Scenario: Anchors, mailto and localhost are not fetched
+    Given links to "#section", "mailto:security@langwatch.ai" and "http://localhost:5560"
+    Then none of them are fetched
+    And the check passes
+
+  @unit
+  Scenario: Each distinct target is fetched once
+    Given the same URL appears in three places in the README
+    Then it is requested once
+    # The README links discord.gg and the docs root several times over.

--- a/tools/ciguard/leancheckout.go
+++ b/tools/ciguard/leancheckout.go
@@ -18,6 +18,9 @@ var LeanCheckoutWorkflows = []string{
 	// that timeout mid-clone, at 297-298s in checkout against a 22.8s average
 	// for the runs that finished.
 	".github/workflows/migration-order.yml",
+	// readme-links builds the checker from source, so it takes a working tree
+	// — and the media is the one part of it no link check ever opens.
+	".github/workflows/readme-links.yml",
 }
 
 // RequiredExclusions are the repository's marketing media: 165 MB of .gif and

--- a/tools/linkcheck/check.go
+++ b/tools/linkcheck/check.go
@@ -1,0 +1,155 @@
+package linkcheck
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Fetcher answers with the final status code for a URL, having followed any
+// redirects. Tests substitute one; the CLI uses HTTPFetcher.
+type Fetcher func(ctx context.Context, url string) (int, error)
+
+// Result is one distinct target's outcome.
+type Result struct {
+	Link
+	Kind    Kind
+	Status  int
+	Verdict Verdict
+	Detail  string
+}
+
+// Checker resolves a document's links.
+type Checker struct {
+	// RepoRoot anchors root-relative targets.
+	RepoRoot string
+	// Fetch resolves URLs. Nil checks repository paths only, which is what
+	// -offline gives you.
+	Fetch Fetcher
+}
+
+// Run checks every link in document, which was read from docPath. Each
+// distinct target is resolved once however many times the README links it,
+// and results come back in the order the targets first appear.
+func (c Checker) Run(ctx context.Context, docPath, document string) []Result {
+	seen := make(map[string]bool)
+	var results []Result
+
+	for _, link := range Extract(document) {
+		kind := Classify(link.Target)
+		if kind == Ignored || seen[link.Target] {
+			continue
+		}
+		seen[link.Target] = true
+
+		if result, checked := c.resolve(ctx, docPath, link); checked {
+			results = append(results, result)
+		}
+	}
+	return results
+}
+
+// resolve reports one link's outcome. The second return is false for a link
+// nothing looked at, which is a URL under -offline.
+func (c Checker) resolve(ctx context.Context, docPath string, link Link) (Result, bool) {
+	kind := Classify(link.Target)
+	result := Result{Link: link, Kind: kind}
+
+	if kind == RepoPath {
+		result.Verdict, result.Detail = c.checkPath(docPath, link.Target)
+		return result, true
+	}
+	if c.Fetch == nil {
+		return Result{}, false
+	}
+
+	status, err := c.Fetch(ctx, link.Target)
+	result.Status = status
+	result.Verdict = VerdictFor(status, err)
+	if err != nil {
+		result.Detail = err.Error()
+	}
+	return result, true
+}
+
+func (c Checker) checkPath(docPath, target string) (Verdict, string) {
+	clean := target
+	for _, sep := range []string{"#", "?"} {
+		clean, _, _ = strings.Cut(clean, sep)
+	}
+	if clean == "" {
+		return OK, ""
+	}
+
+	var resolved string
+	if fromRoot, isRootRelative := strings.CutPrefix(clean, "/"); isRootRelative {
+		resolved = filepath.Join(c.RepoRoot, filepath.FromSlash(fromRoot))
+	} else {
+		resolved = filepath.Join(filepath.Dir(docPath), filepath.FromSlash(clean))
+	}
+
+	if _, err := os.Stat(resolved); err != nil {
+		relative, relErr := filepath.Rel(c.RepoRoot, resolved)
+		if relErr != nil {
+			relative = resolved
+		}
+		return Dead, fmt.Sprintf("no such path in the repository: %s", relative)
+	}
+	return OK, ""
+}
+
+// HTTPFetcher issues a GET, follows redirects, and retries once on a
+// transport error so a single dropped connection does not read as a finding.
+//
+// It is a GET rather than a HEAD because enough hosts answer HEAD with 405 or
+// 404 while serving the page perfectly well, and a HEAD-only checker reports
+// those as broken links.
+func HTTPFetcher(timeout time.Duration) Fetcher {
+	client := &http.Client{Timeout: timeout}
+
+	return func(ctx context.Context, url string) (int, error) {
+		status, err := fetchOnce(ctx, client, url)
+		if err == nil {
+			return status, nil
+		}
+		if waitErr := pause(ctx, retryDelay); waitErr != nil {
+			return 0, err
+		}
+		return fetchOnce(ctx, client, url)
+	}
+}
+
+const retryDelay = time.Second
+
+func fetchOnce(ctx context.Context, client *http.Client, url string) (int, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	request.Header.Set("User-Agent", "langwatch-linkcheck (+https://github.com/langwatch/langwatch)")
+	request.Header.Set("Accept", "*/*")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return 0, err
+	}
+	response.Body.Close()
+
+	return response.StatusCode, nil
+}
+
+func pause(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/tools/linkcheck/check.go
+++ b/tools/linkcheck/check.go
@@ -92,11 +92,15 @@ func (c Checker) checkPath(docPath, target string) (Verdict, string) {
 		resolved = filepath.Join(filepath.Dir(docPath), filepath.FromSlash(clean))
 	}
 
+	// filepath.Join collapses "..", so a target can name a path outside the
+	// checkout. GitHub 404s those, and answering OK because the host happens
+	// to have the file would be the wrong answer to the question asked.
+	relative, err := filepath.Rel(c.RepoRoot, resolved)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return Dead, fmt.Sprintf("path resolves outside the repository: %s", clean)
+	}
+
 	if _, err := os.Stat(resolved); err != nil {
-		relative, relErr := filepath.Rel(c.RepoRoot, resolved)
-		if relErr != nil {
-			relative = resolved
-		}
 		return Dead, fmt.Sprintf("no such path in the repository: %s", relative)
 	}
 	return OK, ""

--- a/tools/linkcheck/links.go
+++ b/tools/linkcheck/links.go
@@ -62,20 +62,67 @@ var (
 // build.
 func Extract(document string) []Link {
 	var links []Link
-	inFence := false
+	var fence fences
 
 	for index, line := range strings.Split(document, "\n") {
-		if isFenceDelimiter(line) {
-			inFence = !inFence
+		if fence.crossed(line) || fence.inside() {
 			continue
 		}
-		if inFence {
-			continue
-		}
-
 		links = append(links, linksInLine(line, index+1)...)
 	}
 	return links
+}
+
+// fences tracks whether Extract is inside a fenced code block. A block closes
+// only on its own marker, at least as long as the one that opened it, so a
+// ``` line inside a ```` block does not end it early and leave the rest of the
+// sample being checked as prose.
+type fences struct {
+	marker byte
+	length int
+}
+
+func (f *fences) inside() bool { return f.length > 0 }
+
+// crossed reports whether the line opens or closes a block, and records the
+// new state if it does.
+func (f *fences) crossed(line string) bool {
+	marker, length, ok := fenceDelimiter(line)
+	if !ok {
+		return false
+	}
+
+	switch {
+	case !f.inside():
+		f.marker, f.length = marker, length
+		return true
+	case marker == f.marker && length >= f.length:
+		f.marker, f.length = 0, 0
+		return true
+	default:
+		return false
+	}
+}
+
+// fenceDelimiter reports a line's fence marker and run length. CommonMark
+// allows up to three spaces of indentation before one; a deeper indent is an
+// indented code block, not a fence.
+func fenceDelimiter(line string) (byte, int, bool) {
+	trimmed := strings.TrimLeft(line, " ")
+	if len(line)-len(trimmed) > 3 {
+		return 0, 0, false
+	}
+
+	for _, marker := range []byte{'`', '~'} {
+		length := 0
+		for length < len(trimmed) && trimmed[length] == marker {
+			length++
+		}
+		if length >= 3 {
+			return marker, length, true
+		}
+	}
+	return 0, 0, false
 }
 
 // linksInLine returns a line's links, markdown first then HTML — pattern
@@ -101,11 +148,6 @@ func firstCapture(match []string) string {
 		}
 	}
 	return ""
-}
-
-func isFenceDelimiter(line string) bool {
-	trimmed := strings.TrimSpace(line)
-	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
 }
 
 // Classify says how a target should be resolved.

--- a/tools/linkcheck/links.go
+++ b/tools/linkcheck/links.go
@@ -50,22 +50,49 @@ var (
 	htmlAttr     = regexp.MustCompile(`(?:href|src)\s*=\s*"([^"]+)"`)
 )
 
-// Extract returns every link in the document, in the order they appear. The
-// README's badges and hero image are raw HTML rather than markdown, so href
-// and src attributes count as links too.
+// Extract returns every link in the document, line by line. The README's
+// badges and hero image are raw HTML rather than markdown, so href and src
+// attributes count as links too.
+//
+// Fenced code blocks are skipped: a link inside a ```bash sample is
+// illustration, and checking it turns a documentation example into a red
+// build.
 func Extract(document string) []Link {
 	var links []Link
+	inFence := false
+
 	for index, line := range strings.Split(document, "\n") {
-		for _, pattern := range []*regexp.Regexp{markdownLink, htmlAttr} {
-			for _, match := range pattern.FindAllStringSubmatch(line, -1) {
-				target := strings.TrimSpace(match[1])
-				if target != "" {
-					links = append(links, Link{Target: target, Line: index + 1})
-				}
+		if isFenceDelimiter(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		links = append(links, linksInLine(line, index+1)...)
+	}
+	return links
+}
+
+// linksInLine returns a line's links, markdown first then HTML — pattern
+// order, not the order they sit in the text.
+func linksInLine(line string, number int) []Link {
+	var links []Link
+	for _, pattern := range []*regexp.Regexp{markdownLink, htmlAttr} {
+		for _, match := range pattern.FindAllStringSubmatch(line, -1) {
+			target := strings.TrimSpace(match[1])
+			if target != "" {
+				links = append(links, Link{Target: target, Line: number})
 			}
 		}
 	}
 	return links
+}
+
+func isFenceDelimiter(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
 }
 
 // Classify says how a target should be resolved.

--- a/tools/linkcheck/links.go
+++ b/tools/linkcheck/links.go
@@ -1,0 +1,108 @@
+// Package linkcheck resolves the links in a markdown document: repository
+// paths against the working tree, URLs against the network.
+//
+// Spec: specs/ci/readme-link-check.feature
+package linkcheck
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Link is one link occurrence in a document.
+type Link struct {
+	Target string
+	Line   int
+}
+
+// Kind says where a link's target has to be resolved, if anywhere.
+type Kind int
+
+const (
+	// Ignored covers anchors, mail addresses, localhost and any other scheme:
+	// targets that no checker can resolve and none should try to.
+	Ignored Kind = iota
+	// RepoPath is a path in this repository. GitHub rewrites a root-relative
+	// README link onto the repository's own blob path, so "/LICENSE.md" is a
+	// repository path and never a URL.
+	RepoPath
+	// URL is an absolute http(s) target.
+	URL
+)
+
+// Verdict is what a check concluded about a link.
+type Verdict int
+
+const (
+	// OK means the target resolved.
+	OK Verdict = iota
+	// Dead means the target is gone. Only this verdict fails a run.
+	Dead
+	// Unverified means the answer says nothing about the target: a bot block,
+	// a rate limit, a timeout. Reported, never gating — a check that fails on
+	// npmjs.com answering 403 to a datacenter address gets ignored or removed.
+	Unverified
+)
+
+var (
+	markdownLink = regexp.MustCompile(`\[[^\]]*\]\(\s*<?([^)\s>]+)`)
+	htmlAttr     = regexp.MustCompile(`(?:href|src)\s*=\s*"([^"]+)"`)
+)
+
+// Extract returns every link in the document, in the order they appear. The
+// README's badges and hero image are raw HTML rather than markdown, so href
+// and src attributes count as links too.
+func Extract(document string) []Link {
+	var links []Link
+	for index, line := range strings.Split(document, "\n") {
+		for _, pattern := range []*regexp.Regexp{markdownLink, htmlAttr} {
+			for _, match := range pattern.FindAllStringSubmatch(line, -1) {
+				target := strings.TrimSpace(match[1])
+				if target != "" {
+					links = append(links, Link{Target: target, Line: index + 1})
+				}
+			}
+		}
+	}
+	return links
+}
+
+// Classify says how a target should be resolved.
+func Classify(target string) Kind {
+	lower := strings.ToLower(target)
+	switch {
+	case target == "", strings.HasPrefix(target, "#"):
+		return Ignored
+	case strings.HasPrefix(lower, "http://localhost"), strings.HasPrefix(lower, "https://localhost"),
+		strings.HasPrefix(lower, "http://127.0.0.1"), strings.HasPrefix(lower, "https://127.0.0.1"):
+		return Ignored
+	case strings.HasPrefix(lower, "http://"), strings.HasPrefix(lower, "https://"):
+		return URL
+	case strings.Contains(target, ":"):
+		// mailto:, tel:, and any other scheme we have no business fetching.
+		// A bare path never contains a colon before its first slash.
+		if scheme, _, found := strings.Cut(target, ":"); found && !strings.Contains(scheme, "/") {
+			return Ignored
+		}
+		return RepoPath
+	default:
+		return RepoPath
+	}
+}
+
+// VerdictFor grades one answer. A transport error is never fatal: it says the
+// network was unhappy, not that the page is gone.
+func VerdictFor(status int, err error) Verdict {
+	if err != nil {
+		return Unverified
+	}
+	switch {
+	case status == http.StatusNotFound, status == http.StatusGone:
+		return Dead
+	case status >= 200 && status < 400:
+		return OK
+	default:
+		return Unverified
+	}
+}

--- a/tools/linkcheck/links.go
+++ b/tools/linkcheck/links.go
@@ -96,12 +96,20 @@ func (f *fences) crossed(line string) bool {
 	case !f.inside():
 		f.marker, f.length = marker, length
 		return true
-	case marker == f.marker && length >= f.length:
+	case marker == f.marker && length >= f.length && closesBlock(line, length):
 		f.marker, f.length = 0, 0
 		return true
 	default:
 		return false
 	}
+}
+
+// closesBlock reports whether nothing but whitespace follows the marker run.
+// An info string makes the line an opening fence, so "```bash" inside a block
+// is content and must not end it.
+func closesBlock(line string, length int) bool {
+	trimmed := strings.TrimLeft(line, " ")
+	return strings.Trim(trimmed[length:], " \t") == ""
 }
 
 // fenceDelimiter reports a line's fence marker and run length. CommonMark

--- a/tools/linkcheck/links.go
+++ b/tools/linkcheck/links.go
@@ -65,6 +65,11 @@ func Extract(document string) []Link {
 	var fence fences
 
 	for index, line := range strings.Split(document, "\n") {
+		// A CRLF document leaves a carriage return on every line. Dropping it
+		// here rather than in one helper keeps fence detection and link
+		// matching agreeing about where a line ends.
+		line = strings.TrimSuffix(line, "\r")
+
 		if fence.crossed(line) || fence.inside() {
 			continue
 		}

--- a/tools/linkcheck/links.go
+++ b/tools/linkcheck/links.go
@@ -47,7 +47,10 @@ const (
 
 var (
 	markdownLink = regexp.MustCompile(`\[[^\]]*\]\(\s*<?([^)\s>]+)`)
-	htmlAttr     = regexp.MustCompile(`(?:href|src)\s*=\s*"([^"]+)"`)
+	// Case-insensitive and either quote style: HREF= and href='...' are valid
+	// HTML, and a badge written that way would otherwise go unchecked while
+	// the run still printed a tick.
+	htmlAttr = regexp.MustCompile(`(?i)(?:href|src)\s*=\s*(?:"([^"]+)"|'([^']+)')`)
 )
 
 // Extract returns every link in the document, line by line. The README's
@@ -81,13 +84,23 @@ func linksInLine(line string, number int) []Link {
 	var links []Link
 	for _, pattern := range []*regexp.Regexp{markdownLink, htmlAttr} {
 		for _, match := range pattern.FindAllStringSubmatch(line, -1) {
-			target := strings.TrimSpace(match[1])
-			if target != "" {
+			if target := firstCapture(match); target != "" {
 				links = append(links, Link{Target: target, Line: number})
 			}
 		}
 	}
 	return links
+}
+
+// firstCapture returns the first non-empty capture group, since the HTML
+// pattern has one group per quote style and only one of them can match.
+func firstCapture(match []string) string {
+	for _, group := range match[1:] {
+		if trimmed := strings.TrimSpace(group); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func isFenceDelimiter(line string) bool {

--- a/tools/linkcheck/links_test.go
+++ b/tools/linkcheck/links_test.go
@@ -1,0 +1,313 @@
+package linkcheck_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/langwatch/langwatch/tools/linkcheck"
+)
+
+func targets(results []linkcheck.Result) []string {
+	found := make([]string, 0, len(results))
+	for _, result := range results {
+		found = append(found, result.Target)
+	}
+	return found
+}
+
+func verdictOf(t *testing.T, results []linkcheck.Result, target string) linkcheck.Result {
+	t.Helper()
+	for _, result := range results {
+		if result.Target == target {
+			return result
+		}
+	}
+	t.Fatalf("no result for %q, got %v", target, targets(results))
+	return linkcheck.Result{}
+}
+
+// @scenario "Links inside HTML in the README are checked too"
+func TestExtractFindsMarkdownAndHTMLLinks(t *testing.T) {
+	document := "" +
+		"[docs](https://docs.langwatch.ai)\n" +
+		"<a href=\"https://langwatch.ai\">site</a>\n" +
+		"<img src=\"https://img.shields.io/badge\" alt=\"badge\" />\n"
+
+	links := linkcheck.Extract(document)
+
+	want := []string{"https://docs.langwatch.ai", "https://langwatch.ai", "https://img.shields.io/badge"}
+	if len(links) != len(want) {
+		t.Fatalf("got %d links, want %d: %+v", len(links), len(want), links)
+	}
+	for index, expected := range want {
+		if links[index].Target != expected {
+			t.Errorf("link %d: got %q, want %q", index, links[index].Target, expected)
+		}
+		if links[index].Line != index+1 {
+			t.Errorf("link %d: got line %d, want %d", index, links[index].Line, index+1)
+		}
+	}
+}
+
+func TestClassifyIgnoresWhatCannotBeResolved(t *testing.T) {
+	for target, want := range map[string]linkcheck.Kind{
+		"#section":                       linkcheck.Ignored,
+		"mailto:security@langwatch.ai":   linkcheck.Ignored,
+		"http://localhost:5560":          linkcheck.Ignored,
+		"https://docs.langwatch.ai/x":    linkcheck.URL,
+		"/LICENSE.md":                    linkcheck.RepoPath,
+		"platform/app/ee/LICENSE.md":     linkcheck.RepoPath,
+		"/platform/app/ee/":              linkcheck.RepoPath,
+		"tel:+310000000":                 linkcheck.Ignored,
+		"https://langwatch.ai/pricing#x": linkcheck.URL,
+	} {
+		if got := linkcheck.Classify(target); got != want {
+			t.Errorf("Classify(%q) = %v, want %v", target, got, want)
+		}
+	}
+}
+
+func TestVerdictForGradesAnswers(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		status int
+		err    error
+		want   linkcheck.Verdict
+	}{
+		{name: "a rate limit does not fail", status: http.StatusTooManyRequests, want: linkcheck.Unverified},
+		{name: "a server error does not fail", status: http.StatusBadGateway, want: linkcheck.Unverified},
+		{name: "a live page passes", status: http.StatusOK, want: linkcheck.OK},
+		{name: "a transport error does not fail", err: errors.New("timeout"), want: linkcheck.Unverified},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := linkcheck.VerdictFor(testCase.status, testCase.err); got != testCase.want {
+				t.Errorf("got %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// @scenario "A relative link is resolved against the repository, not the network"
+func TestRunResolvesARelativeLinkAgainstTheRepository(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "LICENSE.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fetched := false
+	checker := linkcheck.Checker{
+		RepoRoot: root,
+		Fetch: func(context.Context, string) (int, error) {
+			fetched = true
+			return http.StatusNotFound, nil
+		},
+	}
+
+	results := checker.Run(t.Context(), filepath.Join(root, "README.md"), "[license](/LICENSE.md)")
+
+	if fetched {
+		t.Error("a repository path was fetched over the network")
+	}
+	if got := verdictOf(t, results, "/LICENSE.md").Verdict; got != linkcheck.OK {
+		t.Errorf("got %v, want OK", got)
+	}
+}
+
+// @scenario "A relative link to a path that no longer exists fails the check"
+func TestRunFailsOnARelativeLinkToAnAbsentPath(t *testing.T) {
+	checker := linkcheck.Checker{RepoRoot: t.TempDir()}
+	document := "[gone](/platform/app/ee/LICENSE.md)"
+
+	results := checker.Run(t.Context(), "README.md", document)
+
+	missing := verdictOf(t, results, "/platform/app/ee/LICENSE.md")
+	if missing.Verdict != linkcheck.Dead {
+		t.Errorf("got %v, want Dead", missing.Verdict)
+	}
+	if !strings.Contains(missing.Detail, "platform/app/ee/LICENSE.md") {
+		t.Errorf("want the offending path reported, got %q", missing.Detail)
+	}
+}
+
+// The fetcher is exercised against a real server; Run's grading is exercised
+// with a stub, because a loopback test server is exactly what Classify
+// declines to fetch.
+//
+// @scenario "A redirect to a live page passes"
+func TestHTTPFetcherFollowsRedirectsToALivePage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/moved" {
+			http.Redirect(writer, request, "/live", http.StatusMovedPermanently)
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	status, err := linkcheck.HTTPFetcher(5*time.Second)(t.Context(), server.URL+"/moved")
+
+	if err != nil {
+		t.Fatalf("got error %v, want none", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("got status %d, want 200", status)
+	}
+	if got := linkcheck.VerdictFor(status, err); got != linkcheck.OK {
+		t.Errorf("got %v, want OK", got)
+	}
+}
+
+func TestHTTPFetcherReportsTheStatusOfADeadPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	status, err := linkcheck.HTTPFetcher(5*time.Second)(t.Context(), server.URL+"/x")
+
+	if err != nil {
+		t.Fatalf("got error %v, want none", err)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("got status %d, want 404", status)
+	}
+}
+
+// @scenario "A link that times out does not fail the check"
+func TestHTTPFetcherSurvivesAHostThatNeverAnswers(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	// Accepted and then left hanging: the request times out rather than being
+	// refused, which is the case that must not read as a dead link.
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			defer connection.Close()
+			<-t.Context().Done()
+		}
+	}()
+
+	status, err := linkcheck.HTTPFetcher(200*time.Millisecond)(t.Context(), "http://"+listener.Addr().String())
+
+	if err == nil {
+		t.Fatalf("got status %d and no error, want a transport error", status)
+	}
+	if got := linkcheck.VerdictFor(status, err); got != linkcheck.Unverified {
+		t.Errorf("got %v, want Unverified", got)
+	}
+}
+
+// answering is a Fetch stub that gives every URL the same status.
+func answering(status int) linkcheck.Fetcher {
+	return func(context.Context, string) (int, error) { return status, nil }
+}
+
+// @scenario "A markdown link to a page that is gone fails the check"
+func TestRunReportsADeadPageWithItsStatus(t *testing.T) {
+	checker := linkcheck.Checker{RepoRoot: t.TempDir(), Fetch: answering(http.StatusNotFound)}
+
+	results := checker.Run(t.Context(), "README.md", "[gone](https://docs.langwatch.ai/self-hosting/hybrid)")
+
+	result := verdictOf(t, results, "https://docs.langwatch.ai/self-hosting/hybrid")
+	if result.Verdict != linkcheck.Dead {
+		t.Errorf("got %v, want Dead", result.Verdict)
+	}
+	if result.Status != http.StatusNotFound {
+		t.Errorf("got status %d, want 404", result.Status)
+	}
+}
+
+// @scenario "A link to a page that has been removed for good fails the check"
+func TestRunTreatsAGoneStatusAsDead(t *testing.T) {
+	checker := linkcheck.Checker{RepoRoot: t.TempDir(), Fetch: answering(http.StatusGone)}
+
+	results := checker.Run(t.Context(), "README.md", "[removed](https://langwatch.ai/removed)")
+
+	if got := verdictOf(t, results, "https://langwatch.ai/removed").Verdict; got != linkcheck.Dead {
+		t.Errorf("got %v, want Dead", got)
+	}
+}
+
+// npmjs.com answers 403 to CI egress addresses. The package page is fine; the
+// checker is simply not a browser.
+//
+// @scenario "A bot-blocked host does not fail the check"
+func TestRunTreatsABotBlockAsUnverified(t *testing.T) {
+	checker := linkcheck.Checker{RepoRoot: t.TempDir(), Fetch: answering(http.StatusForbidden)}
+
+	results := checker.Run(t.Context(), "README.md", "[npm](https://www.npmjs.com/package/langwatch)")
+
+	if got := verdictOf(t, results, "https://www.npmjs.com/package/langwatch").Verdict; got != linkcheck.Unverified {
+		t.Errorf("got %v, want Unverified", got)
+	}
+}
+
+// @scenario "Each distinct target is fetched once"
+func TestRunFetchesEachDistinctTargetOnce(t *testing.T) {
+	var requests int
+	checker := linkcheck.Checker{
+		RepoRoot: t.TempDir(),
+		Fetch: func(context.Context, string) (int, error) {
+			requests++
+			return http.StatusOK, nil
+		},
+	}
+
+	document := "[a](https://langwatch.ai) [b](https://langwatch.ai) [c](https://langwatch.ai)"
+	results := checker.Run(t.Context(), "README.md", document)
+
+	if requests != 1 {
+		t.Errorf("got %d requests, want 1", requests)
+	}
+	if len(results) != 1 {
+		t.Errorf("got %d results, want 1: %v", len(results), targets(results))
+	}
+}
+
+// @scenario "Anchors, mailto and localhost are not fetched"
+func TestRunDoesNotFetchIgnoredTargets(t *testing.T) {
+	fetched := false
+	checker := linkcheck.Checker{
+		RepoRoot: t.TempDir(),
+		Fetch: func(context.Context, string) (int, error) {
+			fetched = true
+			return http.StatusOK, nil
+		},
+	}
+
+	document := "[a](#section) [b](mailto:security@langwatch.ai) [c](http://localhost:5560)"
+	results := checker.Run(t.Context(), "README.md", document)
+
+	if fetched {
+		t.Error("an ignored target was fetched")
+	}
+	if len(results) != 0 {
+		t.Errorf("got %v, want no results", targets(results))
+	}
+}
+
+func TestRunSkipsURLsWhenOffline(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "NOTICE"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := linkcheck.Checker{RepoRoot: root}
+	results := checker.Run(t.Context(), filepath.Join(root, "README.md"), "[n](/NOTICE) [d](https://docs.langwatch.ai)")
+
+	if len(results) != 1 || results[0].Target != "/NOTICE" {
+		t.Errorf("got %v, want only the repository path", targets(results))
+	}
+}

--- a/tools/linkcheck/links_test.go
+++ b/tools/linkcheck/links_test.go
@@ -121,6 +121,64 @@ func TestRunResolvesARelativeLinkAgainstTheRepository(t *testing.T) {
 	}
 }
 
+func TestRunFailsOnARelativeLinkThatEscapesTheRepository(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Exists on disk, but outside the repository — GitHub 404s it, so
+	// answering OK would be the wrong answer to the question asked.
+	if err := os.WriteFile(filepath.Join(root, "..", "outside.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := linkcheck.Checker{RepoRoot: root}
+	results := checker.Run(t.Context(), filepath.Join(root, "README.md"), "[escape](/../outside.md)")
+
+	escaped := verdictOf(t, results, "/../outside.md")
+	if escaped.Verdict != linkcheck.Dead {
+		t.Errorf("got %v, want Dead", escaped.Verdict)
+	}
+	if !strings.Contains(escaped.Detail, "outside the repository") {
+		t.Errorf("want the reason reported, got %q", escaped.Detail)
+	}
+}
+
+func TestExtractReadsBothQuoteStylesAndAnyCase(t *testing.T) {
+	document := `<a HREF="https://langwatch.ai/upper">a</a> <img src='https://langwatch.ai/single'/>`
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 2 {
+		t.Fatalf("got %d links, want 2: %+v", len(links), links)
+	}
+	for index, want := range []string{"https://langwatch.ai/upper", "https://langwatch.ai/single"} {
+		if links[index].Target != want {
+			t.Errorf("link %d: got %q, want %q", index, links[index].Target, want)
+		}
+	}
+}
+
+func TestExtractSkipsLinksInsideFencedCodeBlocks(t *testing.T) {
+	document := "" +
+		"[real](https://langwatch.ai/real)\n" +
+		"```bash\n" +
+		"# [sample](https://langwatch.ai/not-a-real-link)\n" +
+		"```\n" +
+		"[also-real](https://langwatch.ai/also-real)\n"
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 2 {
+		t.Fatalf("got %d links, want 2 (the fenced one must be skipped): %+v", len(links), links)
+	}
+	for _, link := range links {
+		if strings.Contains(link.Target, "not-a-real-link") {
+			t.Errorf("a link inside a code fence was extracted: %q", link.Target)
+		}
+	}
+}
+
 // @scenario "A relative link to a path that no longer exists fails the check"
 func TestRunFailsOnARelativeLinkToAnAbsentPath(t *testing.T) {
 	checker := linkcheck.Checker{RepoRoot: t.TempDir()}

--- a/tools/linkcheck/links_test.go
+++ b/tools/linkcheck/links_test.go
@@ -179,6 +179,62 @@ func TestExtractSkipsLinksInsideFencedCodeBlocks(t *testing.T) {
 	}
 }
 
+// A shorter fence inside a longer one is content, not a terminator — closing
+// on it would leave the rest of the sample being checked as prose.
+func TestExtractKeepsALongerFenceOpenAcrossAShorterOne(t *testing.T) {
+	document := "" +
+		"````markdown\n" +
+		"```bash\n" +
+		"[inner](https://langwatch.ai/inner)\n" +
+		"```\n" +
+		"[still-inside](https://langwatch.ai/still-inside)\n" +
+		"````\n" +
+		"[outside](https://langwatch.ai/outside)\n"
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 1 || links[0].Target != "https://langwatch.ai/outside" {
+		t.Fatalf("got %v, want only the link after the closing fence", targetsOf(links))
+	}
+}
+
+func TestExtractClosesAFenceOnlyOnItsOwnMarker(t *testing.T) {
+	document := "" +
+		"~~~\n" +
+		"```\n" +
+		"[inside](https://langwatch.ai/inside)\n" +
+		"~~~\n" +
+		"[outside](https://langwatch.ai/outside)\n"
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 1 || links[0].Target != "https://langwatch.ai/outside" {
+		t.Fatalf("got %v, want only the link after the tilde fence closed", targetsOf(links))
+	}
+}
+
+// Four or more spaces make an indented code block, not a fence, so a line
+// like that must not be mistaken for one and swallow the rest of the file.
+func TestExtractDoesNotTreatADeeplyIndentedRunAsAFence(t *testing.T) {
+	document := "" +
+		"    ```\n" +
+		"[after](https://langwatch.ai/after)\n"
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 1 || links[0].Target != "https://langwatch.ai/after" {
+		t.Fatalf("got %v, want the link after an indented run", targetsOf(links))
+	}
+}
+
+func targetsOf(links []linkcheck.Link) []string {
+	found := make([]string, 0, len(links))
+	for _, link := range links {
+		found = append(found, link.Target)
+	}
+	return found
+}
+
 // @scenario "A relative link to a path that no longer exists fails the check"
 func TestRunFailsOnARelativeLinkToAnAbsentPath(t *testing.T) {
 	checker := linkcheck.Checker{RepoRoot: t.TempDir()}

--- a/tools/linkcheck/links_test.go
+++ b/tools/linkcheck/links_test.go
@@ -227,6 +227,23 @@ func TestExtractDoesNotTreatADeeplyIndentedRunAsAFence(t *testing.T) {
 	}
 }
 
+// An info string makes a line an opening fence, so it cannot also close the
+// block it sits inside.
+func TestExtractDoesNotCloseAFenceOnALineCarryingAnInfoString(t *testing.T) {
+	document := "" +
+		"```\n" +
+		"```bash\n" +
+		"[inside](https://langwatch.ai/inside)\n" +
+		"```\n" +
+		"[outside](https://langwatch.ai/outside)\n"
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 1 || links[0].Target != "https://langwatch.ai/outside" {
+		t.Fatalf("got %v, want only the link after the real closing fence", targetsOf(links))
+	}
+}
+
 func targetsOf(links []linkcheck.Link) []string {
 	found := make([]string, 0, len(links))
 	for _, link := range links {

--- a/tools/linkcheck/links_test.go
+++ b/tools/linkcheck/links_test.go
@@ -244,6 +244,23 @@ func TestExtractDoesNotCloseAFenceOnALineCarryingAnInfoString(t *testing.T) {
 	}
 }
 
+// A CRLF document must behave like an LF one. The failure mode is silent:
+// an unrecognized closing fence swallows the rest of the file, and the run
+// still prints a tick.
+func TestExtractHandlesCarriageReturns(t *testing.T) {
+	document := "" +
+		"```bash\r\n" +
+		"# [sample](https://langwatch.ai/sample)\r\n" +
+		"```\r\n" +
+		"[after](https://langwatch.ai/after)\r\n"
+
+	links := linkcheck.Extract(document)
+
+	if len(links) != 1 || links[0].Target != "https://langwatch.ai/after" {
+		t.Fatalf("got %v, want the link after the CRLF closing fence", targetsOf(links))
+	}
+}
+
 func targetsOf(links []linkcheck.Link) []string {
 	found := make([]string, 0, len(links))
 	for _, link := range links {


### PR DESCRIPTION
## What

Eleven links in the root README went somewhere wrong. This fixes them and adds a check so the next one fails here rather than under a first-time reader.

### The dead links

Nine returned a hard 404 — seven docs pages renamed under `docs/integration/`, plus two that only ever had Go pages:

| Link | Was | Now |
|---|---|---|
| OpenAI | `.../python/integrations/openai` | `.../python/integrations/open-ai` |
| Azure | `.../python/integrations/azure` | `.../python/integrations/open-ai-azure` |
| Google Cloud | `.../python/integrations/google-cloud` | `.../python/integrations/vertex-ai` |
| AWS | `.../python/integrations/aws` | `.../python/integrations/aws-bedrock` |
| CrewAI | `.../python/integrations/crewai` | `.../python/integrations/crew-ai` |
| Vercel AI SDK | `.../typescript/integrations/vercel-ai` | `.../typescript/integrations/vercel-ai-sdk` |
| Groq | `.../python/integrations/groq` | `.../go/integrations/groq` |
| Ollama | `.../python/integrations/ollama` | `.../go/integrations/ollama` |
| Hybrid | `docs.langwatch.ai/self-hosting/hybrid` | `docs.langwatch.ai/hybrid-setup/overview` |

Groq and Ollama have no Python page, so the labels now say what they link to (`Azure OpenAI`, `Google Vertex AI`, `AWS Bedrock`).

Two more answered 200 and still sent readers to the wrong page. Both deployment links pointed at `/self-hosting/open-source`, which `docs.json` redirects to the Docker Compose page — so the link labelled **Kubernetes (Helm)** landed on Docker Compose, and neither `#docker-compose` nor `#helm-chart-for-langwatch` matches a heading there. Both now point at their canonical pages under `/self-hosting/deployment/`.

Also corrects the gateway's source path in the AI Gateway bullet: it is `services/aigateway/`, not `services/gateway/`.

## The check

Nothing in this repository failed when those links broke, because none of the changes that broke them happened in this repository. So the checker runs on a schedule as well as on pull requests — the scheduled run is the one that catches this class of rot.

- `tools/linkcheck` + `cmd/linkcheck` — resolves repository paths against the working tree and URLs over the network. Root-relative targets like `/LICENSE.md` are repository paths, because that is what GitHub rewrites them to. Links inside fenced code blocks are skipped, so a URL in a `bash` sample stays illustration — a block closes only on its own marker at least as long as the one that opened it, carrying nothing but whitespace after it, and CRLF documents are handled.
- `.github/workflows/readme-links.yml` — pull requests, Mondays 07:00 UTC, and `workflow_dispatch`.

**Only 404 and 410 fail the run.** A bot block, a rate limit or a timeout is reported as unverified and does not gate: npmjs.com answers 403 to CI egress addresses, and a check that fails on that is one people learn to ignore. The whole run is bounded by a deadline well under the job timeout, so a slow host reports unverified instead of killing the job.

## Test plan

- `go test ./tools/linkcheck/... ./cmd/linkcheck/...` — 33 tests. `cmd/linkcheck` covers the verdict-to-exit-code step, which is the part CI actually gates on.
- `specs/ci/readme-link-check.feature` — 10 scenarios, 10 bound (`check-feature-parity.ts` exit 0).
- `golangci-lint` both tiers at the pinned v2.11.4, `go vet`, `gofmt` — clean.
- `go run ./cmd/ciguard` — lean-checkout and go-version both pass with the new workflow in the guarded set.
- `go run ./cmd/linkcheck` against the live README — clean, npmjs's 403 reported as unverified rather than failing.
- The `readme-links` job passed on this PR in 39s.

Wired into `go-ci` (test, lint, vet lists) and added to `LeanCheckoutWorkflows` so the new workflow's checkout stays lean.

## Not doing

- **Private-network blocking in the checker.** A fork PR's job gets a read-only token and no secrets, so DNS resolution plus an IP allowlist plus a redirect policy buys very little and costs false failures whenever a docs host moves behind an unexpected CDN. The `localhost` skip is a convenience, not a security boundary.
- **Anchor verification.** The checker grades on HTTP status, so a dead `#fragment` is invisible to it — which is how the two deployment links above survived. Fixed by hand here; catching it automatically means parsing heading ids and is its own change.

## Known-broken, left alone

The Docker Compose quickstart in the README (`cd platform/app`, then `cp platform/app/.env.example`) cannot work: the clone lands in `langwatch/`, and the only compose file is `infra/compose.yml`. `docs/self-hosting/deployment/docker-compose.mdx` carries the same snippet verbatim. It is not a link, and fixing it properly means correcting the docs page too — worth its own PR.

Spec: `specs/ci/readme-link-check.feature`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated README link checking for pull requests, scheduled runs, and manual checks.
  * Added a link-checking command with offline support and clear results for valid, broken, ignored, and unverifiable links.
  * Added support for redirects, timeouts, repository-relative paths, duplicate links, and HTML links.

* **Documentation**
  * Updated AI Gateway, deployment, and integration/provider links in the README.

* **Tests**
  * Expanded CI and automated coverage for link-checking behavior and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
