### PR TITLE
fix(analytics): apply per-series filters and percentage mode in the ClickHouse builder

### DIFF
--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -23,6 +23,7 @@ export const APP_ERROR_CODES = [
   "ai_call_failed",
   "ai_query_provider_error",
   "already_organization_member",
+  "analytics_series_percentage_unsupported",
   "anomaly_rule_not_found",
   "api_key_already_revoked",
   "api_key_not_found",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1157,6 +1157,17 @@ const presentations = {
       "This is a self-hosted deployment, so plans are managed outside the app.",
   },
 
+  // ---- analytics ----
+  analytics_series_percentage_unsupported: {
+    // A percentage is the series divided by the same measurement without the
+    // series' own filters. A per-entity measurement (average per user, sum per
+    // thread) also changes which entities exist once filtered, so the two
+    // halves stop being comparable — the author has to drop one of the two.
+    title: "This series can't be shown as a percentage",
+    describe: () =>
+      "Turn the percentage toggle off for this series, or remove its per user, per thread or per customer breakdown.",
+  },
+
   // ---- governance ----
   anomaly_rule_not_found: {
     title: "Anomaly rule not found",

--- a/platform/app/src/pages/[project]/analytics/reports.tsx
+++ b/platform/app/src/pages/[project]/analytics/reports.tsx
@@ -59,6 +59,7 @@ function ReportsContent() {
     { enabled: !!projectId && !!activeDashboardId },
   );
 
+  const queryClient = api.useContext();
   const deleteGraph = api.graphs.delete.useMutation();
   const updateLayout = api.graphs.updateLayout.useMutation();
   const batchUpdateLayouts = api.graphs.batchUpdateLayouts.useMutation();
@@ -90,7 +91,11 @@ function ReportsContent() {
       { projectId, id: graphId },
       {
         onSuccess: () => {
-          void graphsQuery.refetch();
+          // Invalidate EVERY graphs.getAll key, not just this dashboard's.
+          // The alert composer reads the list keyed by {projectId} alone, so
+          // refetching only the {projectId, dashboardId} query left a deleted
+          // graph on offer there until a full page reload.
+          void queryClient.graphs.getAll.invalidate();
         },
         onError: () => {
           toaster.create({

--- a/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -950,6 +950,41 @@ describe("aggregation-builder", () => {
         expect(result.sql).toContain("AND ((ts.ContainsErrorStatus = 1))");
       });
 
+      // ClickHouse's `-If` combinators do NOT return NULL for an empty match
+      // set when the source column is non-nullable — `minIf` returns 0. A
+      // filtered latency floor would then draw a real-looking 0ms line for
+      // every bucket the filter excluded, where the row parser and ES both
+      // leave a non-additive series absent.
+      describe("when the aggregation is not additive", () => {
+        it("reports no value instead of zero for a bucket nothing matched", () => {
+          const result = buildTimeseriesQuery({
+            ...baseInput,
+            series: [
+              {
+                metric:
+                  "performance.completion_time" as FlattenAnalyticsMetricsEnum,
+                aggregation: "min" as const,
+                filters: { "traces.error": ["true"] },
+              },
+            ],
+          });
+
+          expect(result.sql).toContain(
+            "if(countIf((ts.ContainsErrorStatus = 1)) > 0, min",
+          );
+          expect(result.sql).toContain(", NULL) AS 0__");
+        });
+
+        it("leaves an additive aggregation unguarded, because zero is the truth there", () => {
+          const result = buildTimeseriesQuery({
+            ...baseInput,
+            series: [errorSeries(["true"])],
+          });
+
+          expect(result.sql).not.toContain("NULL) AS 0__");
+        });
+      });
+
       describe("when the series is also shown as a percentage", () => {
         // @scenario "Percentage mode on an unfiltered series leaves the series unchanged"
         it("leaves an unfiltered series exactly as it was", () => {

--- a/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -834,6 +834,207 @@ describe("aggregation-builder", () => {
       });
     });
 
+    // @regression issue #6718: two series differing only by their `filters`
+    // compiled to byte-identical SQL, because the per-series loop passed only
+    // metric/aggregation/key/subkey on and the only filter translation was the
+    // graph-wide one. An "errors" series and a "no errors" series therefore
+    // drew the same line, and every alert on a filtered series watched the
+    // wrong number.
+    describe("when a series carries its own filters", () => {
+      const errorSeries = (
+        values: string[],
+        extra: { asPercent?: boolean } = {},
+      ) => ({
+        metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+        aggregation: "cardinality" as const,
+        filters: { "traces.error": values },
+        ...extra,
+      });
+
+      // @scenario "Two series that differ only by their filters produce different queries"
+      it("compiles opposite error filters to different aggregate expressions", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          series: [errorSeries(["true"]), errorSeries(["false"])],
+        });
+
+        expect(result.sql).toContain(
+          "uniqIf(ts.TraceId, ((ts.ContainsErrorStatus = 1)))",
+        );
+        expect(result.sql).toContain(
+          "uniqIf(ts.TraceId, (((ts.ContainsErrorStatus = 0 OR ts.ContainsErrorStatus IS NULL))))",
+        );
+      });
+
+      it("keeps the graph-wide WHERE free of the per-series predicate", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          series: [errorSeries(["true"])],
+        });
+
+        // The predicate belongs to one series; putting it in the WHERE would
+        // narrow every other series in the same graph.
+        expect(result.sql).not.toMatch(
+          /WHERE[\s\S]*?AND \(ts\.ContainsErrorStatus = 1\)[\s\S]*?GROUP BY/,
+        );
+      });
+
+      it("keeps the column the predicate reads in the deduped trace subquery", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          series: [errorSeries(["true"])],
+        });
+
+        expect(result.sql).toMatch(
+          /SELECT [^\n]*ContainsErrorStatus[^\n]*FROM trace_summaries/,
+        );
+      });
+
+      it("parameterizes a span filter and scopes it to its own series", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          series: [
+            {
+              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+              filters: { "spans.type": ["llm"] },
+            },
+            {
+              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        });
+
+        expect(result.sql).toMatch(
+          /uniqIf\(ts\.TraceId, \(\(ts\.TraceId IN \(\s*SELECT TraceId FROM stored_spans/,
+        );
+        expect(result.sql).toContain("uniq(ts.TraceId) AS 1__");
+        expect(Object.keys(result.params)).toContain("spanTypes_0");
+      });
+
+      it("hoists the predicate into the CTE on the grouped path", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          groupBy: "metadata.labels" as const,
+          series: [errorSeries(["true"])],
+        });
+
+        expect(result.sql).toContain(
+          "ts.ContainsErrorStatus = 1) AS series_filter_0",
+        );
+        expect(result.sql).toContain(
+          "uniqExactIf(trace_id, (series_filter_0))",
+        );
+      });
+
+      it("narrows a per-entity series inside its own subquery instead", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          timeScale: "full" as const,
+          series: [
+            {
+              metric: "performance.total_cost" as FlattenAnalyticsMetricsEnum,
+              aggregation: "sum" as const,
+              pipeline: {
+                field: "user_id" as const,
+                aggregation: "avg" as const,
+              },
+              filters: { "traces.error": ["true"] },
+            },
+          ],
+        });
+
+        // A per-entity average has to lose the non-matching entities entirely,
+        // not keep them as zeros — so the filter goes in that metric's own scan.
+        expect(result.sql).toContain("AND ((ts.ContainsErrorStatus = 1))");
+      });
+
+      describe("when the series is also shown as a percentage", () => {
+        // @scenario "Percentage mode on an unfiltered series leaves the series unchanged"
+        it("leaves an unfiltered series exactly as it was", () => {
+          const withPercent = buildTimeseriesQuery({
+            ...baseInput,
+            series: [
+              {
+                metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+                aggregation: "cardinality" as const,
+                asPercent: true,
+              },
+            ],
+          });
+          resetParamCounter();
+          const without = buildTimeseriesQuery(baseInput);
+
+          expect(withPercent.sql).toBe(without.sql);
+        });
+
+        it("divides the filtered aggregate by the unfiltered one", () => {
+          const result = buildTimeseriesQuery({
+            ...baseInput,
+            series: [errorSeries(["true"], { asPercent: true })],
+          });
+
+          expect(result.sql).toContain(
+            "if(uniq(ts.TraceId) > 0, (uniqIf(ts.TraceId, ((ts.ContainsErrorStatus = 1)))) / (uniq(ts.TraceId)) * 100, 0)",
+          );
+        });
+
+        // @scenario "A percentage on a per-entity average is refused rather than answered wrongly"
+        it("refuses a percentage on a per-entity series", () => {
+          expect(() =>
+            buildTimeseriesQuery({
+              ...baseInput,
+              series: [
+                {
+                  metric:
+                    "performance.total_cost" as FlattenAnalyticsMetricsEnum,
+                  aggregation: "sum" as const,
+                  pipeline: {
+                    field: "user_id" as const,
+                    aggregation: "avg" as const,
+                  },
+                  filters: { "traces.error": ["true"] },
+                  asPercent: true,
+                },
+              ],
+            }),
+          ).toThrowError(
+            expect.objectContaining({
+              code: "analytics_series_percentage_unsupported",
+            }),
+          );
+        });
+      });
+    });
+
+    // @regression issue #6718: grouping by error status read the SPAN-level
+    // StatusCode through a stored_spans JOIN, so a trace with one failing span
+    // and several healthy ones landed in BOTH buckets and the buckets could not
+    // add up to the total. Error status is a trace-level fact.
+    describe("when grouping by error status", () => {
+      it("groups on the trace-level error column", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          groupBy: "error.has_error" as const,
+        });
+
+        expect(result.sql).toContain(
+          "if(ifNull(ts.ContainsErrorStatus, 0) = 1, 'with error', 'without error')",
+        );
+        expect(result.sql).not.toContain("StatusCode");
+      });
+
+      it("stops joining stored_spans for a column the trace already carries", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          groupBy: "error.has_error" as const,
+        });
+
+        expect(result.sql).not.toContain("FROM stored_spans");
+      });
+    });
+
     describe("when timeScale is full with groupBy", () => {
       // @regression issue #2644: Summary charts with groupBy render blank because
       // buildSubqueryTimeseriesQuery never includes group_key in SELECT, GROUP BY,

--- a/platform/app/src/server/analytics/clickhouse/__tests__/error-series.integration.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/error-series.integration.test.ts
@@ -62,6 +62,37 @@ const traceCount = (index: number) => ({
   alias: `${index}__metadata_trace_id__cardinality`,
 });
 
+/** Traces the evaluation-run fixtures cover, and the score each one carries. */
+const EVALUATED = [
+  { id: "err-0", score: 0.2 },
+  { id: "err-1", score: 0.4 },
+  { id: "ok-0", score: 0.9 },
+] as const;
+
+const EVALUATED_WITH_ERROR = EVALUATED.filter((evaluated) =>
+  TRACES.some((trace) => trace.id === evaluated.id && trace.hasError),
+).length;
+
+const EVALUATOR_ID = `${TENANT_ID}-evaluator`;
+
+function evaluationRunRow(evaluated: (typeof EVALUATED)[number]) {
+  return {
+    ProjectionId: `proj-eval-${TENANT_ID}-${evaluated.id}`,
+    TenantId: TENANT_ID,
+    EvaluationId: `eval-${TENANT_ID}-${evaluated.id}`,
+    Version: "1",
+    EvaluatorId: EVALUATOR_ID,
+    EvaluatorType: "custom",
+    TraceId: `${TENANT_ID}-${evaluated.id}`,
+    Status: "processed",
+    Score: evaluated.score,
+    Passed: 1,
+    Label: "PASS",
+    LastProcessedEventId: `evt-${TENANT_ID}-${evaluated.id}`,
+    UpdatedAt: new Date(T0).toISOString(),
+  };
+}
+
 function traceSummaryRow(trace: (typeof TRACES)[number]) {
   return {
     ProjectionId: `proj-${TENANT_ID}-${trace.id}`,
@@ -163,12 +194,7 @@ describe("per-series filters and percentage mode", () => {
 
     // Pre-clean: an aborted earlier run leaves its rows behind (afterAll never
     // ran) and a second fixture copy doubles every count assertion.
-    for (const table of ["trace_summaries", "stored_spans"] as const) {
-      await ch.exec({
-        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
-        query_params: { tenantId: TENANT_ID },
-      });
-    }
+    await deleteTenantRows();
 
     await ch.insert({
       table: "trace_summaries",
@@ -182,16 +208,30 @@ describe("per-series filters and percentage mode", () => {
       format: "JSONEachRow",
       clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
     });
+    await ch.insert({
+      table: "evaluation_runs",
+      values: EVALUATED.map(evaluationRunRow),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
   }, 60_000);
 
   afterAll(async () => {
-    for (const table of ["trace_summaries", "stored_spans"] as const) {
+    await deleteTenantRows();
+  });
+
+  async function deleteTenantRows(): Promise<void> {
+    for (const table of [
+      "trace_summaries",
+      "stored_spans",
+      "evaluation_runs",
+    ] as const) {
       await ch.exec({
         query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
         query_params: { tenantId: TENANT_ID },
       });
     }
-  });
+  }
 
   describe("given a graph with an errors series and a no-errors series", () => {
     describe("when the graph is queried over a window", () => {
@@ -290,6 +330,130 @@ describe("per-series filters and percentage mode", () => {
 
         expect(rows.length).toBeGreaterThan(0);
         expect(numberAt(rows[0], series.alias)).toBe(0);
+      });
+    });
+  });
+
+  // The grouped path aggregates OUTSIDE the scan, over a CTE where the `ts`
+  // alias no longer exists, so the predicate rides as a hoisted per-trace
+  // boolean column. Executing it is the only way to prove that hoist lands on
+  // the right trace.
+  describe("given a grouped graph with one filtered and one unfiltered series", () => {
+    describe("when the graph is queried over a window", () => {
+      // @scenario "A per-series filter narrows its series on a grouped graph"
+      it("narrows only the filtered series within every group", async () => {
+        const [filtered, unfiltered] = [traceCount(0), traceCount(1)];
+        const rows = await runCurrent({
+          ...WINDOW,
+          timeScale: 1440,
+          groupBy: "metadata.span_type",
+          series: [
+            { ...filtered, filters: { "traces.error": ["true"] } },
+            unfiltered,
+          ],
+        });
+
+        const totals = new Map<string, { filtered: number; all: number }>();
+        for (const row of rows) {
+          const key = String(row.group_key);
+          const running = totals.get(key) ?? { filtered: 0, all: 0 };
+          running.filtered += numberAt(row, filtered.alias);
+          running.all += numberAt(row, unfiltered.alias);
+          totals.set(key, running);
+        }
+
+        const expected = (spanType: string, hasError?: boolean) =>
+          TRACES.filter(
+            (trace) =>
+              trace.spanType === spanType &&
+              (hasError === undefined || trace.hasError === hasError),
+          ).length;
+
+        expect(totals.get("llm")).toEqual({
+          filtered: expected("llm", true),
+          all: expected("llm"),
+        });
+        expect(totals.get("agent")).toEqual({
+          filtered: expected("agent", true),
+          all: expected("agent"),
+        });
+      });
+    });
+  });
+
+  // Mixing an evaluation metric with a trace metric routes through a different
+  // CTE again — one that pre-aggregates per trace to undo the evaluation-run
+  // fan-out. It carries the same hoisted boolean, and it is the path most
+  // likely to attribute a filter to the wrong row.
+  describe("given a graph pairing an evaluation score with a filtered trace count", () => {
+    describe("when the graph is queried over a window", () => {
+      // @scenario "A per-series filter narrows its series alongside an evaluation measurement"
+      it("counts only traces with an error and leaves the score alone", async () => {
+        const [filtered, unfiltered] = [traceCount(1), traceCount(2)];
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [
+            {
+              metric:
+                "evaluations.evaluation_score" as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg" as const,
+            },
+            { ...filtered, filters: { "traces.error": ["true"] } },
+            unfiltered,
+          ],
+        });
+
+        const averageScore =
+          EVALUATED.reduce((total, evaluated) => total + evaluated.score, 0) /
+          EVALUATED.length;
+
+        expect(numberAt(rows[0], filtered.alias)).toBe(EVALUATED_WITH_ERROR);
+        expect(numberAt(rows[0], unfiltered.alias)).toBe(EVALUATED.length);
+        expect(
+          numberAt(rows[0], "0__evaluations_evaluation_score__avg"),
+        ).toBeCloseTo(averageScore, 6);
+      });
+    });
+  });
+
+  describe("given a filtered series whose aggregation is not additive", () => {
+    describe("when the window holds traces but the filter matches none", () => {
+      // @scenario "A filtered average or extremum reports no value when nothing matched"
+      it("reports no value rather than a duration of zero", async () => {
+        const alias = "0__performance_completion_time__min";
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [
+            {
+              metric:
+                "performance.completion_time" as FlattenAnalyticsMetricsEnum,
+              aggregation: "min" as const,
+              filters: { "spans.type": ["no-span-type-matches-this"] },
+            },
+          ],
+        });
+
+        expect(rows.length).toBeGreaterThan(0);
+        expect(rows[0]?.[alias] ?? null).toBeNull();
+      });
+    });
+
+    describe("when the filter does match traces", () => {
+      it("still reports the real measurement", async () => {
+        const alias = "0__performance_completion_time__min";
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [
+            {
+              metric:
+                "performance.completion_time" as FlattenAnalyticsMetricsEnum,
+              aggregation: "min" as const,
+              filters: { "traces.error": ["true"] },
+            },
+          ],
+        });
+
+        expect(numberAt(rows[0], alias)).toBe(200);
       });
     });
   });

--- a/platform/app/src/server/analytics/clickhouse/__tests__/error-series.integration.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/error-series.integration.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Integration tests for per-series filters and percentage mode (#6718).
+ *
+ * The ClickHouse timeseries builder dropped a series' own `filters` entirely,
+ * so a "traces with errors" series and a "traces without errors" series drew
+ * the identical line and the "show in percentages" toggle changed nothing.
+ * SQL-shape assertions live in `aggregation-builder.test.ts`; these execute the
+ * built query against seeded data, because the shape being different is not the
+ * same claim as the numbers being right.
+ *
+ * @see specs/analytics/error-series.feature
+ * @see https://github.com/langwatch/langwatch/issues/6718
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import { getTestClickHouseClient } from "../../../event-sourcing/__tests__/integration/testContainers";
+import type { FlattenAnalyticsMetricsEnum } from "../../registry";
+import { buildTimeseriesQuery } from "../aggregation-builder";
+import { resetParamCounter } from "../filter-translator";
+
+const TENANT_ID = "test-error-series-6718";
+
+/** Anchor an hour back so every seeded row sits inside the current window. */
+const T0 = Date.now() - 60 * 60 * 1000;
+
+const WINDOW = {
+  projectId: TENANT_ID,
+  startDate: new Date(T0 - 24 * 60 * 60 * 1000),
+  endDate: new Date(T0 + 24 * 60 * 60 * 1000),
+  previousPeriodStartDate: new Date(T0 - 48 * 60 * 60 * 1000),
+  timeScale: "full" as const,
+};
+
+/** A window that deliberately contains none of the seeded traces. */
+const EMPTY_WINDOW = {
+  ...WINDOW,
+  startDate: new Date(T0 - 400 * 24 * 60 * 60 * 1000),
+  endDate: new Date(T0 - 399 * 24 * 60 * 60 * 1000),
+  previousPeriodStartDate: new Date(T0 - 401 * 24 * 60 * 60 * 1000),
+};
+
+/**
+ * Two traces carry an error, three do not. Two carry an `llm` span (one of each
+ * error status) so a span-facet filter can be told apart from the error one.
+ */
+const TRACES = [
+  { id: "err-0", hasError: true, spanType: "llm" },
+  { id: "err-1", hasError: true, spanType: "agent" },
+  { id: "ok-0", hasError: false, spanType: "llm" },
+  { id: "ok-1", hasError: false, spanType: "agent" },
+  { id: "ok-2", hasError: false, spanType: "agent" },
+] as const;
+
+const TRACES_WITH_ERROR = TRACES.filter((t) => t.hasError).length;
+const TRACES_TOTAL = TRACES.length;
+
+const traceCount = (index: number) => ({
+  metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+  aggregation: "cardinality" as const,
+  alias: `${index}__metadata_trace_id__cardinality`,
+});
+
+function traceSummaryRow(trace: (typeof TRACES)[number]) {
+  return {
+    ProjectionId: `proj-${TENANT_ID}-${trace.id}`,
+    TenantId: TENANT_ID,
+    TraceId: `${TENANT_ID}-${trace.id}`,
+    Version: "v1",
+    Attributes: { "metadata.env": "test" },
+    OccurredAt: new Date(T0),
+    CreatedAt: new Date(T0),
+    UpdatedAt: new Date(T0),
+    ComputedIOSchemaVersion: "",
+    ComputedInput: "in",
+    ComputedOutput: "out",
+    TimeToFirstTokenMs: 50,
+    TimeToLastTokenMs: 200,
+    TotalDurationMs: 200,
+    TokensPerSecond: 100,
+    SpanCount: 1,
+    ContainsErrorStatus: trace.hasError ? 1 : 0,
+    ContainsOKStatus: trace.hasError ? 0 : 1,
+    ErrorMessage: trace.hasError ? "boom" : null,
+    Models: ["gpt-5-mini"],
+    TotalCost: 1,
+    TokensEstimated: false,
+    TotalPromptTokenCount: 100,
+    TotalCompletionTokenCount: 10,
+    OutputFromRootSpan: 0,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: 0,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+}
+
+function storedSpanRow(trace: (typeof TRACES)[number]) {
+  return {
+    ProjectionId: `proj-span-${TENANT_ID}-${trace.id}`,
+    TenantId: TENANT_ID,
+    TraceId: `${TENANT_ID}-${trace.id}`,
+    SpanId: `${TENANT_ID}-${trace.id}-span`,
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(T0),
+    EndTime: new Date(T0 + 200),
+    DurationMs: 200,
+    SpanName: trace.id,
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: { "langwatch.span.type": trace.spanType },
+    StatusCode: trace.hasError ? 2 : 1,
+    StatusMessage: "",
+    ScopeName: "",
+    ScopeVersion: null,
+    "Events.Timestamp": [],
+    "Events.Name": [],
+    "Events.Attributes": [],
+    "Links.TraceId": [],
+    "Links.SpanId": [],
+    "Links.Attributes": [],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    Cost: null,
+    NonBilledCost: null,
+  };
+}
+
+describe("per-series filters and percentage mode", () => {
+  let ch: ClickHouseClient;
+
+  /** Run a built query and return the row tagged as the current period. */
+  const runCurrent = async (
+    input: Parameters<typeof buildTimeseriesQuery>[0],
+  ): Promise<Record<string, number | string>[]> => {
+    resetParamCounter();
+    const { sql, params } = buildTimeseriesQuery(input);
+    const result = await ch.query({
+      query: sql,
+      query_params: params,
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Record<string, number | string>[];
+    return rows.filter((row) => row.period === "current");
+  };
+
+  const numberAt = (
+    row: Record<string, number | string> | undefined,
+    alias: string,
+  ): number => Number(row?.[alias] ?? 0);
+
+  beforeAll(async () => {
+    const rawClient = getTestClickHouseClient();
+    if (!rawClient) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(rawClient);
+
+    // Pre-clean: an aborted earlier run leaves its rows behind (afterAll never
+    // ran) and a second fixture copy doubles every count assertion.
+    for (const table of ["trace_summaries", "stored_spans"] as const) {
+      await ch.exec({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
+        query_params: { tenantId: TENANT_ID },
+      });
+    }
+
+    await ch.insert({
+      table: "trace_summaries",
+      values: TRACES.map(traceSummaryRow),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+    await ch.insert({
+      table: "stored_spans",
+      values: TRACES.map(storedSpanRow),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    for (const table of ["trace_summaries", "stored_spans"] as const) {
+      await ch.exec({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
+        query_params: { tenantId: TENANT_ID },
+      });
+    }
+  });
+
+  describe("given a graph with an errors series and a no-errors series", () => {
+    describe("when the graph is queried over a window", () => {
+      // @scenario "The with-errors and without-errors series partition the window"
+      it("reports different counts that add up to every trace in the window", async () => {
+        const [withErrors, withoutErrors] = [traceCount(0), traceCount(1)];
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [
+            { ...withErrors, filters: { "traces.error": ["true"] } },
+            { ...withoutErrors, filters: { "traces.error": ["false"] } },
+          ],
+        });
+
+        const errors = numberAt(rows[0], withErrors.alias);
+        const nonErrors = numberAt(rows[0], withoutErrors.alias);
+
+        expect(errors).toBe(TRACES_WITH_ERROR);
+        expect(nonErrors).toBe(TRACES_TOTAL - TRACES_WITH_ERROR);
+        expect(errors).not.toBe(nonErrors);
+        expect(errors + nonErrors).toBe(TRACES_TOTAL);
+      });
+
+      // @scenario "An alert on the error series counts only traces with errors"
+      it("counts only the traces that contain an error", async () => {
+        const series = traceCount(0);
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [{ ...series, filters: { "traces.error": ["true"] } }],
+        });
+
+        expect(numberAt(rows[0], series.alias)).toBe(TRACES_WITH_ERROR);
+      });
+    });
+  });
+
+  describe("given a graph with one series filtered by span type", () => {
+    describe("when the graph is queried over a window", () => {
+      // @scenario "A filter that reads span data still applies to its own series only"
+      it("narrows only the filtered series", async () => {
+        const [filtered, unfiltered] = [traceCount(0), traceCount(1)];
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [
+            { ...filtered, filters: { "spans.type": ["llm"] } },
+            unfiltered,
+          ],
+        });
+
+        const tracesWithLlmSpan = TRACES.filter(
+          (trace) => trace.spanType === "llm",
+        ).length;
+        expect(numberAt(rows[0], filtered.alias)).toBe(tracesWithLlmSpan);
+        expect(numberAt(rows[0], unfiltered.alias)).toBe(TRACES_TOTAL);
+      });
+    });
+  });
+
+  describe("given a filtered series shown as a percentage", () => {
+    describe("when the graph is queried over a window", () => {
+      // @scenario "Percentage mode divides the filtered series by the unfiltered series"
+      it("reports the share of traces in the window that contain an error", async () => {
+        const series = traceCount(0);
+        const rows = await runCurrent({
+          ...WINDOW,
+          series: [
+            {
+              ...series,
+              filters: { "traces.error": ["true"] },
+              asPercent: true,
+            },
+          ],
+        });
+
+        expect(numberAt(rows[0], series.alias)).toBeCloseTo(
+          (TRACES_WITH_ERROR / TRACES_TOTAL) * 100,
+          6,
+        );
+      });
+    });
+
+    describe("when the window holds no traces", () => {
+      // @scenario "Percentage mode reports zero when the window holds no traces"
+      it("reports zero rather than no value at all", async () => {
+        const series = traceCount(0);
+        const rows = await runCurrent({
+          ...EMPTY_WINDOW,
+          series: [
+            {
+              ...series,
+              filters: { "traces.error": ["true"] },
+              asPercent: true,
+            },
+          ],
+        });
+
+        expect(rows.length).toBeGreaterThan(0);
+        expect(numberAt(rows[0], series.alias)).toBe(0);
+      });
+    });
+  });
+
+  describe("given a graph grouped by whether the trace contains an error", () => {
+    describe("when the graph is queried over a window", () => {
+      // @scenario "Grouping by error status puts each trace in exactly one bucket"
+      it("puts each trace in exactly one bucket", async () => {
+        const series = traceCount(0);
+        const rows = await runCurrent({
+          ...WINDOW,
+          timeScale: 1440,
+          groupBy: "error.has_error",
+          series: [series],
+        });
+
+        const buckets = new Map<string, number>();
+        for (const row of rows) {
+          const key = String(row.group_key);
+          buckets.set(
+            key,
+            (buckets.get(key) ?? 0) + numberAt(row, series.alias),
+          );
+        }
+
+        expect(buckets.get("with error")).toBe(TRACES_WITH_ERROR);
+        expect(buckets.get("without error")).toBe(
+          TRACES_TOTAL - TRACES_WITH_ERROR,
+        );
+        expect([...buckets.values()].reduce((a, b) => a + b, 0)).toBe(
+          TRACES_TOTAL,
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -7,8 +7,8 @@
 
 import { MAX_PROCESSED_SPANS } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection";
 import { snakeCase } from "../../../utils/stringCasing";
-import { SeriesPercentageUnsupportedError } from "../errors";
 import type { FilterField } from "../../filters/types";
+import { SeriesPercentageUnsupportedError } from "../errors";
 import { isZeroWhenAbsentSeries, type SeriesInputType } from "../registry";
 import {
   buildJoinClause,
@@ -254,6 +254,16 @@ interface SeriesMetric extends MetricTranslation {
    * was a no-op.
    */
   asPercent: boolean;
+  /**
+   * Whether an absent value for this series genuinely means zero
+   * ({@link isZeroWhenAbsentSeries}). Counts and sums are additive: no matching
+   * rows IS zero. Averages, extrema and percentiles are not — and ClickHouse's
+   * `-If` combinators do NOT return NULL for an empty match set when the source
+   * column is non-nullable, they return 0. Left alone, a filtered `min` over a
+   * bucket nothing matched would report a real-looking 0 where the row parser
+   * and Elasticsearch both leave the series absent.
+   */
+  zeroWhenAbsent: boolean;
 }
 
 /**
@@ -323,51 +333,51 @@ interface AggregateCall {
  * Parametric aggregates (`quantileTDigest(0.5)(col)`) have two paren groups;
  * the SECOND is the argument list and the one a condition is appended to.
  */
-function findOutermostAggregate(expression: string): AggregateCall | null {
-  let index = 0;
-  while (index < expression.length) {
-    const char = expression[index]!;
-    if (char === "'" || char === '"' || char === "`") {
-      index = skipQuoted(expression, index);
-      continue;
-    }
-    if (!/[A-Za-z_]/.test(char)) {
-      index += 1;
-      continue;
-    }
-    const nameStart = index;
-    while (
-      index < expression.length &&
-      /[A-Za-z0-9_]/.test(expression[index]!)
-    ) {
-      index += 1;
-    }
-    const name = expression.slice(nameStart, index);
-    let cursor = index;
-    while (cursor < expression.length && /\s/.test(expression[cursor]!)) {
-      cursor += 1;
-    }
-    if (expression[cursor] !== "(") continue;
-    if (!AGGREGATE_FUNCTION_NAMES.has(name)) continue;
+const FUNCTION_CALL_PATTERN = /([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
 
-    let argsOpen = cursor;
-    let argsClose = matchClosingParen(expression, argsOpen);
-    // Parametric aggregate: the first group holds the level, the second the
-    // arguments the condition belongs in.
-    let afterFirst = argsClose + 1;
-    while (
-      afterFirst < expression.length &&
-      /\s/.test(expression[afterFirst]!)
-    ) {
-      afterFirst += 1;
-    }
-    if (expression[afterFirst] === "(") {
-      argsOpen = afterFirst;
-      argsClose = matchClosingParen(expression, argsOpen);
-    }
-    return { nameStart, name, argsOpen, argsClose };
+function findOutermostAggregate(expression: string): AggregateCall | null {
+  for (const match of expression.matchAll(FUNCTION_CALL_PATTERN)) {
+    const name = match[1]!;
+    if (!AGGREGATE_FUNCTION_NAMES.has(name)) continue;
+    if (isInsideStringLiteral(expression, match.index)) continue;
+    const firstOpen = match.index + match[0].length - 1;
+    return {
+      nameStart: match.index,
+      name,
+      ...resolveArgumentGroup(expression, firstOpen),
+    };
   }
   return null;
+}
+
+/**
+ * Which paren group of a call holds its arguments.
+ *
+ * A parametric aggregate (`quantileTDigest(0.5)(col)`) has two: the first
+ * carries the level, the second the arguments a condition is appended to.
+ */
+function resolveArgumentGroup(
+  expression: string,
+  firstOpen: number,
+): { argsOpen: number; argsClose: number } {
+  const firstClose = matchClosingParen(expression, firstOpen);
+  const afterFirst = skipWhitespace(expression, firstClose + 1);
+  if (expression[afterFirst] !== "(") {
+    return { argsOpen: firstOpen, argsClose: firstClose };
+  }
+  return {
+    argsOpen: afterFirst,
+    argsClose: matchClosingParen(expression, afterFirst),
+  };
+}
+
+/** Index of the first non-whitespace character at or after `from`. */
+function skipWhitespace(expression: string, from: number): number {
+  let index = from;
+  while (index < expression.length && /\s/.test(expression[index]!)) {
+    index += 1;
+  }
+  return index;
 }
 
 /** Index just past the string literal opened at `start`. */
@@ -385,22 +395,62 @@ function skipQuoted(expression: string, start: number): number {
   return expression.length;
 }
 
-/** Index of the `)` matching the `(` at `open`, quote- and nesting-aware. */
+/**
+ * Does `position` fall inside a string literal?
+ *
+ * Metric expressions carry attribute keys (`ts.Attributes['langwatch.user_id']`)
+ * and quoted nested columns (`ss."Events.Name"`), so a name that looks like a
+ * function call inside one must not be read as an identifier.
+ */
+function isInsideStringLiteral(expression: string, position: number): boolean {
+  let index = 0;
+  while (index < position) {
+    if (!isQuote(expression[index])) {
+      index += 1;
+      continue;
+    }
+    const end = skipQuoted(expression, index);
+    if (end > position) return true;
+    index = end;
+  }
+  return false;
+}
+
+function isQuote(char: string | undefined): boolean {
+  return char === "'" || char === '"' || char === "`";
+}
+
+/**
+ * One step of a quote-aware left-to-right scan: where the next character
+ * begins, and how this one moves the bracket depth. Shared so the two scanners
+ * below hold the depth rule in one place instead of two.
+ */
+function scanStep(
+  expression: string,
+  index: number,
+): { next: number; delta: number } {
+  const char = expression[index]!;
+  if (isQuote(char)) return { next: skipQuoted(expression, index), delta: 0 };
+  if (char === "(" || char === "[") return { next: index + 1, delta: 1 };
+  if (char === ")" || char === "]") return { next: index + 1, delta: -1 };
+  return { next: index + 1, delta: 0 };
+}
+
+/**
+ * Index of the `)` matching the `(` at `open`, quote- and nesting-aware.
+ *
+ * Square brackets count toward the same depth. They are always balanced within
+ * the parens (they only ever appear as map access), so a `]` can never bring
+ * the depth to zero ahead of the matching `)`.
+ */
 function matchClosingParen(expression: string, open: number): number {
   let depth = 0;
   let index = open;
   while (index < expression.length) {
-    const char = expression[index]!;
-    if (char === "'" || char === '"' || char === "`") {
-      index = skipQuoted(expression, index);
-      continue;
-    }
-    if (char === "(") depth += 1;
-    if (char === ")") {
-      depth -= 1;
-      if (depth === 0) return index;
-    }
-    index += 1;
+    const { next, delta } = scanStep(expression, index);
+    depth += delta;
+    if (depth === 0 && delta < 0) return index;
+    index = next;
   }
   throw new Error(`Unbalanced parentheses in metric expression: ${expression}`);
 }
@@ -412,18 +462,13 @@ function splitTopLevelArguments(argumentList: string): string[] {
   let start = 0;
   let index = 0;
   while (index < argumentList.length) {
-    const char = argumentList[index]!;
-    if (char === "'" || char === '"' || char === "`") {
-      index = skipQuoted(argumentList, index);
-      continue;
-    }
-    if (char === "(" || char === "[") depth += 1;
-    if (char === ")" || char === "]") depth -= 1;
-    if (char === "," && depth === 0) {
+    const { next, delta } = scanStep(argumentList, index);
+    depth += delta;
+    if (depth === 0 && argumentList[index] === ",") {
       args.push(argumentList.slice(start, index));
       start = index + 1;
     }
-    index += 1;
+    index = next;
   }
   args.push(argumentList.slice(start));
   return args;
@@ -480,17 +525,28 @@ function withAggregateCondition(expression: string, condition: string): string {
  * of no value at all, and the result is a percentage rather than a fraction.
  * It is only ever reached with a condition — an unfiltered series has nothing
  * to be a percentage OF, and ES treated that combination as a no-op too.
+ *
+ * A NON-additive series (average, extremum, percentile) additionally gets an
+ * emptiness guard. `minIf(x, cond)` over a bucket nothing matched returns 0,
+ * not NULL, whenever `x` is a non-nullable column — so without the guard a
+ * filtered latency floor would draw a 0ms line for every bucket the filter
+ * excluded. `countIf(cond) > 0` is the only reliable "did anything match"
+ * signal, and NULL is what the row parser
+ * (`_timeseries-row-parser.ts` → `isZeroWhenAbsentSeries`) and Elasticsearch
+ * both treat as "no data here".
  */
 function shapeSeriesExpression({
   selectExpression,
   alias,
   condition,
   asPercent,
+  zeroWhenAbsent,
 }: {
   selectExpression: string;
   alias: string;
   condition: string | null;
   asPercent: boolean;
+  zeroWhenAbsent: boolean;
 }): string {
   if (!condition) return selectExpression;
   const base = stripSelectExpressionAlias(selectExpression, alias);
@@ -498,8 +554,12 @@ function shapeSeriesExpression({
   // NULL; there is no aggregate to condition and no number to divide.
   if (base === "NULL") return selectExpression;
   const filtered = withAggregateCondition(base, condition);
-  if (!asPercent) return `${filtered} AS ${alias}`;
-  return `if(${base} > 0, (${filtered}) / (${base}) * 100, 0) AS ${alias}`;
+  // Percentage mode already answers the empty bucket, with ES's own 0.
+  if (asPercent) {
+    return `if(${base} > 0, (${filtered}) / (${base}) * 100, 0) AS ${alias}`;
+  }
+  if (zeroWhenAbsent) return `${filtered} AS ${alias}`;
+  return `if(countIf(${condition}) > 0, ${filtered}, NULL) AS ${alias}`;
 }
 
 /**
@@ -1112,7 +1172,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
     // entities, which is a second scan rather than a second aggregate. Refuse
     // it by name instead of answering with a number that looks right.
     if (series.asPercent && seriesCondition && translation.requiresSubquery) {
-      throw new SeriesPercentageUnsupportedError(series.metric);
+      throw new SeriesPercentageUnsupportedError();
     }
     metricTranslations.push({
       ...translation,
@@ -1121,6 +1181,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
         ? seriesConditionColumnName(i)
         : null,
       asPercent: series.asPercent === true && seriesCondition !== null,
+      zeroWhenAbsent: isZeroWhenAbsentSeries(series),
     });
     for (const join of translation.requiredJoins) {
       allJoins.add(join);
@@ -1364,6 +1425,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
         alias: metric.alias,
         condition: metric.seriesCondition,
         asPercent: metric.asPercent,
+        zeroWhenAbsent: metric.zeroWhenAbsent,
       }),
     );
   }
@@ -1523,6 +1585,7 @@ function buildMixedEvalTimeseriesQuery({
         alias: quoteIdentifier(metric.alias),
         condition: metric.seriesConditionColumn,
         asPercent: metric.asPercent,
+        zeroWhenAbsent: metric.zeroWhenAbsent,
       }),
     );
   };
@@ -1899,6 +1962,7 @@ function buildArrayJoinTimeseriesQuery({
         seriesCondition: translation.seriesCondition,
         seriesConditionColumn: translation.seriesConditionColumn,
         asPercent: translation.asPercent,
+        zeroWhenAbsent: translation.zeroWhenAbsent,
       });
     }
   }
@@ -2112,6 +2176,7 @@ function buildArrayJoinTimeseriesQuery({
           alias: quoteIdentifier(metric.alias),
           condition: metric.seriesConditionColumn,
           asPercent: metric.asPercent,
+          zeroWhenAbsent: metric.zeroWhenAbsent,
         }),
       );
       continue;
@@ -2129,6 +2194,7 @@ function buildArrayJoinTimeseriesQuery({
         alias: metric.alias,
         condition: metric.seriesConditionColumn,
         asPercent: metric.asPercent,
+        zeroWhenAbsent: metric.zeroWhenAbsent,
       }),
     );
   }
@@ -2513,6 +2579,7 @@ function buildSubqueryTimeseriesQuery(
       alias: metric.alias,
       condition: metric.seriesCondition,
       asPercent: metric.asPercent,
+      zeroWhenAbsent: metric.zeroWhenAbsent,
     });
     simpleSelectExprs.push(
       shaped.replace(` AS ${metric.alias}`, ` AS ${quotedAlias}`),
@@ -2750,6 +2817,7 @@ function buildDateBucketedPipelineQuery({
           alias: m.alias,
           condition: m.seriesCondition,
           asPercent: m.asPercent,
+          zeroWhenAbsent: m.zeroWhenAbsent,
         });
         return shaped.replace(` AS ${m.alias}`, ` AS ${quotedAlias}`);
       }),

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -7,6 +7,7 @@
 
 import { MAX_PROCESSED_SPANS } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection";
 import { snakeCase } from "../../../utils/stringCasing";
+import { SeriesPercentageUnsupportedError } from "../errors";
 import type { FilterField } from "../../filters/types";
 import { isZeroWhenAbsentSeries, type SeriesInputType } from "../registry";
 import {
@@ -211,6 +212,331 @@ function referencedTraceColumns(
       ...extraExpressions,
     ]),
   ];
+}
+
+/**
+ * A translated metric plus the per-series shaping the graph author asked for.
+ *
+ * A series can carry its own `filters` — the canonical case being one series
+ * filtered to traces WITH an error and a second filtered to traces WITHOUT
+ * one — and can ask to be shown as a percentage of the same measurement taken
+ * without those filters. Neither reached the executed SQL before #6718: the
+ * per-series loop passed only metric/aggregation/key/subkey on, so two series
+ * differing only by their filters compiled to byte-identical expressions and
+ * every alert built on a filtered series watched the wrong number.
+ *
+ * Both are applied by rewriting the metric's aggregate into its `-If` form
+ * (see {@link shapeSeriesExpression}) rather than by touching the query's
+ * WHERE, because the WHERE is shared by every series in the graph.
+ */
+interface SeriesMetric extends MetricTranslation {
+  /**
+   * The series' own filter predicate as SQL over the `ts` scan, or `null` when
+   * the series has no filters of its own. Every filter handler resolves to a
+   * predicate on `trace_summaries` — span, event and evaluation facets as
+   * `ts.TraceId IN (SELECT … )` subqueries — so no filter class needs a JOIN
+   * to be expressed per series. {@link translateSeriesCondition} refuses one
+   * that ever does, rather than silently applying it to the whole graph.
+   */
+  seriesCondition: string | null;
+  /**
+   * Name of the CTE column carrying {@link seriesCondition} on the paths that
+   * aggregate outside the scan (the arrayJoin / group-by CTE and the mixed
+   * evaluation CTE). The raw predicate references `ts`, which is out of scope
+   * in those outer SELECTs.
+   */
+  seriesConditionColumn: string | null;
+  /**
+   * Divide this series by the same measurement without {@link seriesCondition}.
+   * Only ever true when the series has a condition — matching the Elasticsearch
+   * behaviour this replaces, where the percentage wrapper only existed inside
+   * the per-series filter wrapper, so percentage mode on an unfiltered series
+   * was a no-op.
+   */
+  asPercent: boolean;
+}
+
+/**
+ * Aggregate functions the metric translators can emit as the outermost
+ * aggregation of a series expression, including the combinator forms.
+ *
+ * Used to find the one call {@link shapeSeriesExpression} must rewrite. Listing
+ * them beats pattern-matching function shapes: a new metric that compiles to an
+ * aggregate nobody added here fails loudly at build time instead of quietly
+ * dropping the series' filter.
+ */
+const AGGREGATE_FUNCTION_NAMES: ReadonlySet<string> = new Set([
+  "avg",
+  "avgArray",
+  "avgArrayIf",
+  "avgIf",
+  "count",
+  "countIf",
+  "max",
+  "maxArray",
+  "maxArrayIf",
+  "maxIf",
+  "min",
+  "minArray",
+  "minArrayIf",
+  "minIf",
+  "quantileExact",
+  "quantileExactArray",
+  "quantileExactArrayIf",
+  "quantileExactIf",
+  "quantileTDigest",
+  "quantileTDigestArray",
+  "quantileTDigestArrayIf",
+  "quantileTDigestIf",
+  "sum",
+  "sumArray",
+  "sumArrayIf",
+  "sumIf",
+  "uniq",
+  "uniqArray",
+  "uniqArrayIf",
+  "uniqExact",
+  "uniqExactIf",
+  "uniqIf",
+]);
+
+/** A located aggregate call inside a SELECT expression. */
+interface AggregateCall {
+  /** Index of the first character of the function name. */
+  nameStart: number;
+  name: string;
+  /** Index of the `(` opening the ARGUMENT list (after any parameter list). */
+  argsOpen: number;
+  /** Index of the `)` closing the argument list. */
+  argsClose: number;
+}
+
+/**
+ * Find the outermost aggregate call in a metric expression.
+ *
+ * Scans left to right, so a wrapper that is not itself an aggregate
+ * (`coalesce(sum(x), 0)`) is stepped over and the aggregate inside it is the
+ * one returned. String literals are skipped, because metric expressions carry
+ * attribute keys (`ts.Attributes['langwatch.user_id']`) and quoted nested
+ * columns (`ss."Events.Name"`) that must not be read as identifiers.
+ *
+ * Parametric aggregates (`quantileTDigest(0.5)(col)`) have two paren groups;
+ * the SECOND is the argument list and the one a condition is appended to.
+ */
+function findOutermostAggregate(expression: string): AggregateCall | null {
+  let index = 0;
+  while (index < expression.length) {
+    const char = expression[index]!;
+    if (char === "'" || char === '"' || char === "`") {
+      index = skipQuoted(expression, index);
+      continue;
+    }
+    if (!/[A-Za-z_]/.test(char)) {
+      index += 1;
+      continue;
+    }
+    const nameStart = index;
+    while (
+      index < expression.length &&
+      /[A-Za-z0-9_]/.test(expression[index]!)
+    ) {
+      index += 1;
+    }
+    const name = expression.slice(nameStart, index);
+    let cursor = index;
+    while (cursor < expression.length && /\s/.test(expression[cursor]!)) {
+      cursor += 1;
+    }
+    if (expression[cursor] !== "(") continue;
+    if (!AGGREGATE_FUNCTION_NAMES.has(name)) continue;
+
+    let argsOpen = cursor;
+    let argsClose = matchClosingParen(expression, argsOpen);
+    // Parametric aggregate: the first group holds the level, the second the
+    // arguments the condition belongs in.
+    let afterFirst = argsClose + 1;
+    while (
+      afterFirst < expression.length &&
+      /\s/.test(expression[afterFirst]!)
+    ) {
+      afterFirst += 1;
+    }
+    if (expression[afterFirst] === "(") {
+      argsOpen = afterFirst;
+      argsClose = matchClosingParen(expression, argsOpen);
+    }
+    return { nameStart, name, argsOpen, argsClose };
+  }
+  return null;
+}
+
+/** Index just past the string literal opened at `start`. */
+function skipQuoted(expression: string, start: number): number {
+  const quote = expression[start];
+  let index = start + 1;
+  while (index < expression.length) {
+    if (expression[index] === "\\") {
+      index += 2;
+      continue;
+    }
+    if (expression[index] === quote) return index + 1;
+    index += 1;
+  }
+  return expression.length;
+}
+
+/** Index of the `)` matching the `(` at `open`, quote- and nesting-aware. */
+function matchClosingParen(expression: string, open: number): number {
+  let depth = 0;
+  let index = open;
+  while (index < expression.length) {
+    const char = expression[index]!;
+    if (char === "'" || char === '"' || char === "`") {
+      index = skipQuoted(expression, index);
+      continue;
+    }
+    if (char === "(") depth += 1;
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+    index += 1;
+  }
+  throw new Error(`Unbalanced parentheses in metric expression: ${expression}`);
+}
+
+/** Split an argument list on its top-level commas. */
+function splitTopLevelArguments(argumentList: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let start = 0;
+  let index = 0;
+  while (index < argumentList.length) {
+    const char = argumentList[index]!;
+    if (char === "'" || char === '"' || char === "`") {
+      index = skipQuoted(argumentList, index);
+      continue;
+    }
+    if (char === "(" || char === "[") depth += 1;
+    if (char === ")" || char === "]") depth -= 1;
+    if (char === "," && depth === 0) {
+      args.push(argumentList.slice(start, index));
+      start = index + 1;
+    }
+    index += 1;
+  }
+  args.push(argumentList.slice(start));
+  return args;
+}
+
+/**
+ * Rewrite a metric expression so its aggregate only sees rows matching
+ * `condition` — `sum(x)` becomes `sumIf(x, (condition))`, `count()` becomes
+ * `countIf((condition))`, and an aggregate that is ALREADY conditional
+ * (evaluation metrics compile to `avgIf(es.Score, …)`) has the condition ANDed
+ * into the condition it already carries rather than gaining a second `If`.
+ */
+function withAggregateCondition(expression: string, condition: string): string {
+  const call = findOutermostAggregate(expression);
+  if (!call) {
+    throw new Error(
+      `Cannot apply a per-series filter to "${expression}": no known aggregate function found. ` +
+        `Add the aggregate metric-translator.ts emits to AGGREGATE_FUNCTION_NAMES in aggregation-builder.ts.`,
+    );
+  }
+  const head = expression.slice(0, call.nameStart);
+  const parameters = expression.slice(
+    call.nameStart + call.name.length,
+    call.argsOpen,
+  );
+  const argumentList = expression.slice(call.argsOpen + 1, call.argsClose);
+  const tail = expression.slice(call.argsClose + 1);
+
+  if (call.name.endsWith("If")) {
+    const args = splitTopLevelArguments(argumentList);
+    const existing = args.pop() ?? "";
+    const merged = [...args, `(${existing.trim()}) AND (${condition})`].join(
+      ", ",
+    );
+    return `${head}${call.name}${parameters}(${merged})${tail}`;
+  }
+
+  const merged =
+    argumentList.trim().length > 0
+      ? `${argumentList}, (${condition})`
+      : `(${condition})`;
+  return `${head}${call.name}If${parameters}(${merged})${tail}`;
+}
+
+/**
+ * Apply a series' own filter and percentage mode to its SELECT expression.
+ *
+ * `condition` is the SQL the caller has in scope: the raw `ts` predicate on the
+ * paths that aggregate over the scan, and the hoisted CTE column on the paths
+ * that aggregate over a CTE.
+ *
+ * Percentage mode reproduces the Elasticsearch `bucket_script` this replaces:
+ * `all > 0 ? filtered / all * 100 : 0`, so an empty bucket reads as 0% instead
+ * of no value at all, and the result is a percentage rather than a fraction.
+ * It is only ever reached with a condition — an unfiltered series has nothing
+ * to be a percentage OF, and ES treated that combination as a no-op too.
+ */
+function shapeSeriesExpression({
+  selectExpression,
+  alias,
+  condition,
+  asPercent,
+}: {
+  selectExpression: string;
+  alias: string;
+  condition: string | null;
+  asPercent: boolean;
+}): string {
+  if (!condition) return selectExpression;
+  const base = stripSelectExpressionAlias(selectExpression, alias);
+  // The pipeline fallback for a metric that cannot be nested emits a literal
+  // NULL; there is no aggregate to condition and no number to divide.
+  if (base === "NULL") return selectExpression;
+  const filtered = withAggregateCondition(base, condition);
+  if (!asPercent) return `${filtered} AS ${alias}`;
+  return `if(${base} > 0, (${filtered}) / (${base}) * 100, 0) AS ${alias}`;
+}
+
+/**
+ * Translate one series' own filters into a predicate over the `ts` scan.
+ *
+ * Returns `null` when the series carries no filters, or only empty ones (the
+ * composer keeps empty entries around while the author is picking values).
+ */
+function translateSeriesCondition(
+  series: SeriesInputType,
+  params: Record<string, unknown>,
+): string | null {
+  const filters = series.filters;
+  if (!filters || Object.keys(filters).length === 0) return null;
+
+  const translation = translateAllFilters(
+    filters,
+    SPAN_TIME_FILTER_BOTH_PERIODS,
+  );
+  if (translation.whereClause === "1=1") return null;
+  if (translation.requiredJoins.length > 0) {
+    // A per-series filter has to be a predicate: a JOIN it needed would be
+    // added to the whole query and would narrow every OTHER series too. No
+    // handler needs one today; failing here keeps a future one from shipping
+    // silently wrong numbers for the rest of the graph.
+    throw new Error(
+      `Per-series filter for metric "${series.metric}" requires a JOIN (${translation.requiredJoins.join(", ")}), ` +
+        `which cannot be scoped to a single series. Express the filter as a predicate in filter-translator.ts.`,
+    );
+  }
+  Object.assign(params, translation.params);
+  return translation.whereClause;
+}
+
+/** The CTE column a series' filter predicate is hoisted to. */
+function seriesConditionColumnName(index: number): string {
+  return `series_filter_${index}`;
 }
 
 /** Maximum number of filter options returned by filter queries */
@@ -583,9 +909,19 @@ const groupByExpressions: Partial<
     usesArrayJoin: true,
   }),
 
+  // Error status is a TRACE-level fact: the fold rolls span statuses, error
+  // attributes and exception events into ts.ContainsErrorStatus, which is what
+  // `field-mappings.ts` maps `error.has_error` to and what the `traces.error`
+  // filter reads. Grouping on the SPAN-level StatusCode instead put a trace in
+  // BOTH buckets (the stored_spans JOIN fans a trace out into one row per span,
+  // and a trace with an error almost always has non-error spans too), so the
+  // two buckets overlapped and could not add up to the total. It also joined
+  // stored_spans for a column trace_summaries already carries. `ifNull` keeps
+  // the grouping total on deployments whose column still admits NULL.
   "error.has_error": () => ({
-    column: `if(${tableAliases.stored_spans}.StatusCode = 2, 'with error', 'without error')`,
-    requiredJoins: ["stored_spans"],
+    column: `if(ifNull(${tableAliases.trace_summaries}.ContainsErrorStatus, 0) = 1, 'with error', 'without error')`,
+    requiredJoins: [],
+    handlesUnknown: true,
   }),
 };
 
@@ -739,7 +1075,8 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
 
   // Collect all required JOINs and metric expressions
   const allJoins = new Set<CHTable>();
-  const metricTranslations: MetricTranslation[] = [];
+  const metricTranslations: SeriesMetric[] = [];
+  const seriesFilterParams: Record<string, unknown> = {};
 
   // Translate each series metric
   for (let i = 0; i < input.series.length; i++) {
@@ -766,11 +1103,36 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
       );
     }
 
-    metricTranslations.push(translation);
+    const seriesCondition = translateSeriesCondition(
+      series,
+      seriesFilterParams,
+    );
+    // A per-entity measurement (pipeline) filtered AND shown as a percentage
+    // would need the unfiltered denominator computed over a DIFFERENT set of
+    // entities, which is a second scan rather than a second aggregate. Refuse
+    // it by name instead of answering with a number that looks right.
+    if (series.asPercent && seriesCondition && translation.requiresSubquery) {
+      throw new SeriesPercentageUnsupportedError(series.metric);
+    }
+    metricTranslations.push({
+      ...translation,
+      seriesCondition,
+      seriesConditionColumn: seriesCondition
+        ? seriesConditionColumnName(i)
+        : null,
+      asPercent: series.asPercent === true && seriesCondition !== null,
+    });
     for (const join of translation.requiredJoins) {
       allJoins.add(join);
     }
   }
+
+  // Every expression a per-series filter contributes, so the deduped trace
+  // subquery keeps the columns those predicates read (e.g. ContainsErrorStatus)
+  // instead of pruning them away.
+  const seriesConditionExpressions = metricTranslations
+    .map((metric) => metric.seriesCondition)
+    .filter((condition): condition is string => condition !== null);
 
   // Translate filters. Span/event facet filters resolve to stored_spans
   // subqueries; pass the StartTime envelope so they prune partitions instead of
@@ -790,6 +1152,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   );
   const allTranslationParams = {
     ...filterTranslation.params,
+    ...seriesFilterParams,
     ...metricParams,
   };
 
@@ -816,6 +1179,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   // so we only SELECT the columns actually needed in each JOIN subquery.
   const allExpressions = [
     ...metricTranslations.map((m) => m.selectExpression),
+    ...seriesConditionExpressions,
     filterTranslation.whereClause,
     groupByColumn ?? "",
   ];
@@ -991,9 +1355,17 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
     }
   }
 
-  // Add metric expressions
+  // Add metric expressions. The scan is in scope here, so a series' own filter
+  // goes straight into its aggregate as the raw `ts` predicate.
   for (const metric of simpleMetrics) {
-    selectExprs.push(metric.selectExpression);
+    selectExprs.push(
+      shapeSeriesExpression({
+        selectExpression: metric.selectExpression,
+        alias: metric.alias,
+        condition: metric.seriesCondition,
+        asPercent: metric.asPercent,
+      }),
+    );
   }
 
   // Build GROUP BY
@@ -1013,6 +1385,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   });
 
   const traceColumns = referencedTraceColumns(metricTranslations, [
+    ...seriesConditionExpressions,
     filterWhere,
     groupByColumn ?? "",
     joinClauses,
@@ -1073,7 +1446,7 @@ function buildMixedEvalTimeseriesQuery({
 }: {
   input: TimeseriesQueryInput;
   ts: string;
-  simpleMetrics: MetricTranslation[];
+  simpleMetrics: SeriesMetric[];
   groupByColumn: string | null;
   groupByHandlesUnknown: boolean;
   joinClauses: string;
@@ -1083,6 +1456,7 @@ function buildMixedEvalTimeseriesQuery({
   timeZone: string;
 }): BuiltQuery {
   const traceColumns = referencedTraceColumns(simpleMetrics, [
+    ...simpleMetrics.map((metric) => metric.seriesCondition ?? ""),
     filterWhere,
     groupByColumn ?? "",
     joinClauses,
@@ -1128,7 +1502,30 @@ function buildMixedEvalTimeseriesQuery({
   //
   // Per-trace aliases start with the metric index digit (e.g. `0__…`), so we
   // wrap them in `quoteIdentifier` to satisfy ClickHouse's identifier rules.
+  //
+  // A series' own filter is applied in the OUTER query, against the per-trace
+  // predicate hoisted into the CTE below: the raw predicate reads `ts`, which
+  // only exists inside the CTE, and every filter is a trace-level fact, so
+  // "did this trace match" is decided once per trace and then decides whether
+  // that trace's contribution is counted.
   const outerMetricExprs: string[] = [];
+  const hoistSeriesCondition = (metric: SeriesMetric): void => {
+    if (!metric.seriesCondition || !metric.seriesConditionColumn) return;
+    innerSelectExprs.push(
+      `any(${metric.seriesCondition}) AS ${metric.seriesConditionColumn}`,
+    );
+  };
+  const pushOuterMetric = (metric: SeriesMetric, outerExpr: string): void => {
+    hoistSeriesCondition(metric);
+    outerMetricExprs.push(
+      shapeSeriesExpression({
+        selectExpression: outerExpr,
+        alias: quoteIdentifier(metric.alias),
+        condition: metric.seriesConditionColumn,
+        asPercent: metric.asPercent,
+      }),
+    );
+  };
   for (const metric of simpleMetrics) {
     const perTraceAlias = quoteIdentifier(`${metric.alias}__per_trace`);
     const quotedAlias = quoteIdentifier(metric.alias);
@@ -1147,7 +1544,10 @@ function buildMixedEvalTimeseriesQuery({
             `Update AGGREGATION_PATTERNS in mapEvalAggregationToOuter to add the new mapping.`,
         );
       }
-      outerMetricExprs.push(`${outerAgg}(${perTraceAlias}) AS ${quotedAlias}`);
+      pushOuterMetric(
+        metric,
+        `${outerAgg}(${perTraceAlias}) AS ${quotedAlias}`,
+      );
       continue;
     }
 
@@ -1155,7 +1555,7 @@ function buildMixedEvalTimeseriesQuery({
     // count() / count(*) becomes sum(1) across traces = count(distinct traces).
     if (/\bcount\s*\(\s*\*?\s*\)/.test(exprWithoutAlias)) {
       innerSelectExprs.push(`1 AS ${perTraceAlias}`);
-      outerMetricExprs.push(`sum(${perTraceAlias}) AS ${quotedAlias}`);
+      pushOuterMetric(metric, `sum(${perTraceAlias}) AS ${quotedAlias}`);
       continue;
     }
 
@@ -1166,7 +1566,7 @@ function buildMixedEvalTimeseriesQuery({
       exprWithoutAlias.includes("TraceId")
     ) {
       innerSelectExprs.push(`1 AS ${perTraceAlias}`);
-      outerMetricExprs.push(`sum(${perTraceAlias}) AS ${quotedAlias}`);
+      pushOuterMetric(metric, `sum(${perTraceAlias}) AS ${quotedAlias}`);
       continue;
     }
 
@@ -1191,7 +1591,7 @@ function buildMixedEvalTimeseriesQuery({
       column,
       perTraceAlias,
     );
-    outerMetricExprs.push(`${outerExpr} AS ${quotedAlias}`);
+    pushOuterMetric(metric, `${outerExpr} AS ${quotedAlias}`);
   }
 
   const innerGroupBy: string[] = ["trace_id", "period"];
@@ -1405,7 +1805,7 @@ function buildArrayJoinTimeseriesQuery({
   input: TimeseriesQueryInput;
   groupByColumn: string;
   groupByHandlesUnknown: boolean;
-  metricTranslations: MetricTranslation[];
+  metricTranslations: SeriesMetric[];
   joinClauses: string;
   baseWhere: string;
   filterWhere: string;
@@ -1492,6 +1892,13 @@ function buildArrayJoinTimeseriesQuery({
           new RegExp(` AS ${escapedAlias}$`),
           ` AS ${translation.alias}`,
         ),
+        // The series' own filter and percentage mode travel with the metric
+        // when a trace_id pipeline is re-translated as a simple aggregation;
+        // dropping them here is how a filtered pie-chart series lost its
+        // filter while every other path kept it.
+        seriesCondition: translation.seriesCondition,
+        seriesConditionColumn: translation.seriesConditionColumn,
+        asPercent: translation.asPercent,
       });
     }
   }
@@ -1666,6 +2073,18 @@ function buildArrayJoinTimeseriesQuery({
     );
   }
 
+  // Hoist each filtered series' predicate into the CTE as a per-trace boolean.
+  // The predicate reads `ts`, which is out of scope in the outer SELECT that
+  // does the aggregating; every filter is a trace-level fact, so deciding it
+  // once per trace here and conditioning the outer aggregate on it below is
+  // the same answer with the alias in scope.
+  for (const metric of simpleMetrics) {
+    if (!metric.seriesCondition || !metric.seriesConditionColumn) continue;
+    cteSelectExprs.push(
+      `${traceColumnWrapper(metric.seriesCondition)} AS ${metric.seriesConditionColumn}`,
+    );
+  }
+
   // Build outer SELECT expressions
   const outerSelectExprs: string[] = ["period"];
   if (dateTrunc) {
@@ -1688,16 +2107,30 @@ function buildArrayJoinTimeseriesQuery({
         );
       }
       outerSelectExprs.push(
-        `${outerAgg}(${perTraceAlias}) AS ${quoteIdentifier(metric.alias)}`,
+        shapeSeriesExpression({
+          selectExpression: `${outerAgg}(${perTraceAlias}) AS ${quoteIdentifier(metric.alias)}`,
+          alias: quoteIdentifier(metric.alias),
+          condition: metric.seriesConditionColumn,
+          asPercent: metric.asPercent,
+        }),
       );
       continue;
     }
-    // Transform the metric expression for the deduplicated context
+    // Transform the metric expression for the deduplicated context, THEN apply
+    // the series' own filter: the rewrite maps count() onto uniqExact(trace_id),
+    // and conditioning the rewritten aggregate keeps that mapping intact.
     const transformedExpr = transformMetricForDedup(
       metric.selectExpression,
       metric.alias,
     );
-    outerSelectExprs.push(transformedExpr);
+    outerSelectExprs.push(
+      shapeSeriesExpression({
+        selectExpression: transformedExpr,
+        alias: metric.alias,
+        condition: metric.seriesConditionColumn,
+        asPercent: metric.asPercent,
+      }),
+    );
   }
 
   // Build GROUP BY for outer query
@@ -1923,8 +2356,8 @@ function buildGroupByUnionAllQuery({
  */
 function buildSubqueryTimeseriesQuery(
   input: TimeseriesQueryInput,
-  simpleMetrics: MetricTranslation[],
-  subqueryMetrics: MetricTranslation[],
+  simpleMetrics: SeriesMetric[],
+  subqueryMetrics: SeriesMetric[],
   joinClauses: string,
   baseWhere: string,
   filterWhere: string,
@@ -1933,10 +2366,13 @@ function buildSubqueryTimeseriesQuery(
   groupByHandlesUnknown = false,
 ): BuiltQuery {
   const ts = tableAliases.trace_summaries;
-  const traceColumns = referencedTraceColumns(
-    [...simpleMetrics, ...subqueryMetrics],
-    [filterWhere, groupByColumn ?? "", joinClauses],
-  );
+  const allMetrics = [...simpleMetrics, ...subqueryMetrics];
+  const traceColumns = referencedTraceColumns(allMetrics, [
+    ...allMetrics.map((metric) => metric.seriesCondition ?? ""),
+    filterWhere,
+    groupByColumn ?? "",
+    joinClauses,
+  ]);
   const ctes: string[] = [];
 
   // Build group_key expression when groupBy is active, matching the pattern used in
@@ -1953,6 +2389,15 @@ function buildSubqueryTimeseriesQuery(
     if (!metric.subquery) continue;
     const subquery = metric.subquery;
     const cteName = `cte_${metric.alias}`;
+
+    // A per-entity metric gets its series filter in its OWN CTE's WHERE rather
+    // than as a conditional aggregate. The filter decides which entities exist
+    // at all — an entity with no matching traces must not survive as a zero and
+    // drag the cross-entity average down — and each such metric already owns a
+    // private CTE, so narrowing the scan there touches no other series.
+    const seriesWhere = metric.seriesCondition
+      ? `AND (${metric.seriesCondition})`
+      : "";
 
     // When groupByColumn is set, propagate group_key into the CTE so the outer query
     // can group results by it. The group_key is added to both the inner SELECT and
@@ -1979,6 +2424,7 @@ function buildSubqueryTimeseriesQuery(
               AND ${ts}.OccurredAt >= {currentStart:DateTime64(3)}
               AND ${ts}.OccurredAt < {currentEnd:DateTime64(3)}
               ${filterWhere}
+              ${seriesWhere}
             GROUP BY ${nested.groupBy}
             ${havingClause}
           ) thread_data
@@ -2002,6 +2448,7 @@ function buildSubqueryTimeseriesQuery(
               AND ${ts}.OccurredAt >= {previousStart:DateTime64(3)}
               AND ${ts}.OccurredAt < {previousEnd:DateTime64(3)}
               ${filterWhere}
+              ${seriesWhere}
             GROUP BY ${nested.groupBy}
             ${havingClause}
           ) thread_data
@@ -2024,6 +2471,7 @@ function buildSubqueryTimeseriesQuery(
             AND ${ts}.OccurredAt >= {currentStart:DateTime64(3)}
             AND ${ts}.OccurredAt < {currentEnd:DateTime64(3)}
             ${filterWhere}
+            ${seriesWhere}
           GROUP BY ${subquery.innerGroupBy}${groupKeyInnerGroupBy}
           HAVING ${subquery.innerGroupBy} IS NOT NULL AND toString(${subquery.innerGroupBy}) != ''
         ) sub
@@ -2042,6 +2490,7 @@ function buildSubqueryTimeseriesQuery(
             AND ${ts}.OccurredAt >= {previousStart:DateTime64(3)}
             AND ${ts}.OccurredAt < {previousEnd:DateTime64(3)}
             ${filterWhere}
+            ${seriesWhere}
           GROUP BY ${subquery.innerGroupBy}${groupKeyInnerGroupBy}
           HAVING ${subquery.innerGroupBy} IS NOT NULL AND toString(${subquery.innerGroupBy}) != ''
         ) sub
@@ -2059,11 +2508,15 @@ function buildSubqueryTimeseriesQuery(
   for (const metric of simpleMetrics) {
     // Replace unquoted alias with quoted alias in the selectExpression
     const quotedAlias = quoteIdentifier(metric.alias);
-    const quotedExpression = metric.selectExpression.replace(
-      ` AS ${metric.alias}`,
-      ` AS ${quotedAlias}`,
+    const shaped = shapeSeriesExpression({
+      selectExpression: metric.selectExpression,
+      alias: metric.alias,
+      condition: metric.seriesCondition,
+      asPercent: metric.asPercent,
+    });
+    simpleSelectExprs.push(
+      shaped.replace(` AS ${metric.alias}`, ` AS ${quotedAlias}`),
     );
-    simpleSelectExprs.push(quotedExpression);
   }
 
   // CTE for simple metrics current period
@@ -2230,8 +2683,8 @@ function buildDateBucketedPipelineQuery({
   timeZone,
 }: {
   input: TimeseriesQueryInput;
-  simpleMetrics?: MetricTranslation[];
-  pipelineMetrics: MetricTranslation[];
+  simpleMetrics?: SeriesMetric[];
+  pipelineMetrics: SeriesMetric[];
   groupByColumn: string | null;
   groupByHandlesUnknown: boolean;
   joinClauses: string;
@@ -2292,10 +2745,13 @@ function buildDateBucketedPipelineQuery({
       ...(groupKeyExpr ? [groupKeyExpr] : []),
       ...simpleMetrics.map((m) => {
         const quotedAlias = quoteIdentifier(m.alias);
-        return m.selectExpression.replace(
-          ` AS ${m.alias}`,
-          ` AS ${quotedAlias}`,
-        );
+        const shaped = shapeSeriesExpression({
+          selectExpression: m.selectExpression,
+          alias: m.alias,
+          condition: m.seriesCondition,
+          asPercent: m.asPercent,
+        });
+        return shaped.replace(` AS ${m.alias}`, ` AS ${quotedAlias}`);
       }),
     ];
     const simpleGroupByCols = ["period", "date"];
@@ -2319,6 +2775,7 @@ function buildDateBucketedPipelineQuery({
     }
     const allSimpleExprs = [
       ...simpleMetrics.map((m) => m.selectExpression),
+      ...simpleMetrics.map((m) => m.seriesCondition ?? ""),
       fullFilterWhere,
       groupByColumn ?? "",
     ];
@@ -2436,7 +2893,7 @@ interface PipelineCTEContext {
  * Handles both standard 2-level and nested 3-level aggregations.
  */
 function buildPipelineMetricCTE(
-  metric: MetricTranslation,
+  metric: SeriesMetric,
   ctx: PipelineCTEContext,
 ): string {
   if (!metric.subquery) {
@@ -2445,7 +2902,12 @@ function buildPipelineMetricCTE(
   const subquery = metric.subquery;
   const traceColumns = referencedTraceColumns(
     [metric],
-    [ctx.fullFilterWhere, ctx.groupKeyExpr ?? "", ctx.joinClauses],
+    [
+      metric.seriesCondition ?? "",
+      ctx.fullFilterWhere,
+      ctx.groupKeyExpr ?? "",
+      ctx.joinClauses,
+    ],
   );
   const cteName = `cte_${metric.alias}`;
   const hasGroup = !!ctx.groupByColumn;
@@ -2470,11 +2932,19 @@ function buildPipelineMetricCTE(
     ...(ctx.groupKeyExpr ? [ctx.groupKeyExpr] : []),
   ];
 
+  // Same reasoning as the timeScale-"full" pipeline CTEs: a per-entity metric
+  // takes its series filter in its own CTE's scan, because the filter changes
+  // which entities exist and not just how much each one contributes.
+  const seriesWhere = metric.seriesCondition
+    ? `AND (${metric.seriesCondition})`
+    : "";
+
   const baseFrom = `
           FROM ${dedupedTraceSummaries(ctx.ts, traceColumns, DATE_FILTER_BOTH_PERIODS)}
           ${ctx.joinClauses}
           WHERE ${ctx.baseWhere}
-            ${ctx.fullFilterWhere}`;
+            ${ctx.fullFilterWhere}
+            ${seriesWhere}`;
 
   if (subquery.nestedSubquery) {
     // 3-level aggregation (e.g., threads per user)

--- a/platform/app/src/server/analytics/errors.ts
+++ b/platform/app/src/server/analytics/errors.ts
@@ -1,0 +1,31 @@
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * Raised when a graph series asks for percentage mode on a measurement the
+ * query builder cannot express as "filtered over unfiltered" in one pass.
+ *
+ * Percentage mode divides a series by the same measurement taken without that
+ * series' own filters. For a plain aggregation both halves are two aggregates
+ * over one scan. For a per-entity measurement (average per user, sum per
+ * thread) the filter also decides which entities exist at all, so the two
+ * halves are two different scans and cannot be divided bucket by bucket
+ * without changing what the number means.
+ *
+ * The author can act on it — drop the percentage toggle, or drop the per-entity
+ * breakdown — so it is handled rather than a silent wrong number. `fault`
+ * stays the default (`customer`): the combination came from the graph the
+ * author saved. The metric rides in `meta` so the composer can name the series
+ * that has to change.
+ */
+export class SeriesPercentageUnsupportedError extends HandledError {
+  declare readonly code: "analytics_series_percentage_unsupported";
+
+  constructor(metric: string) {
+    super(
+      "analytics_series_percentage_unsupported",
+      "This series cannot be shown as a percentage.",
+      { httpStatus: 400, meta: { metric } },
+    );
+    this.name = "SeriesPercentageUnsupportedError";
+  }
+}

--- a/platform/app/src/server/analytics/errors.ts
+++ b/platform/app/src/server/analytics/errors.ts
@@ -14,18 +14,38 @@ import { HandledError } from "@langwatch/handled-error";
  * The author can act on it — drop the percentage toggle, or drop the per-entity
  * breakdown — so it is handled rather than a silent wrong number. `fault`
  * stays the default (`customer`): the combination came from the graph the
- * author saved. The metric rides in `meta` so the composer can name the series
- * that has to change.
+ * author saved.
+ *
+ * It carries no `meta`. The metric that triggered it used to ride along, but
+ * nothing read it: the presentation copy cannot name an internal metric key at
+ * a customer, and the one caller that genuinely needs to know which series is
+ * at fault — the graph-trigger evaluator — already has the series in its own
+ * scope and logs it there.
  */
 export class SeriesPercentageUnsupportedError extends HandledError {
   declare readonly code: "analytics_series_percentage_unsupported";
 
-  constructor(metric: string) {
+  constructor() {
     super(
       "analytics_series_percentage_unsupported",
       "This series cannot be shown as a percentage.",
-      { httpStatus: 400, meta: { metric } },
+      { httpStatus: 400 },
     );
     this.name = "SeriesPercentageUnsupportedError";
   }
+}
+
+/**
+ * Is this the "percentage on a per-entity series" refusal, after it may have
+ * crossed a worker or serialisation boundary?
+ *
+ * Matched on `code`, not `instanceof`: a background evaluator can receive this
+ * error re-hydrated from a payload, where the prototype is gone but the code
+ * survives.
+ */
+export function isSeriesPercentageUnsupported(error: unknown): boolean {
+  return (
+    (error as { code?: unknown } | null)?.code ===
+    "analytics_series_percentage_unsupported"
+  );
 }

--- a/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-evaluation.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-evaluation.service.unit.test.ts
@@ -326,6 +326,59 @@ describe("evaluateGraphTrigger", () => {
     });
   });
 
+  describe("given a series the query builder refuses to express as a percentage", () => {
+    // #6718 added a handled refusal for "percentage of a per-entity
+    // measurement", which the composer still lets an author save. The builder
+    // raises it on EVERY evaluation of such a trigger, and a rethrow here is a
+    // redelivery — the same poison-pill shape the row ceiling above documents.
+    function percentageUnsupported() {
+      const error = new Error("analytics_series_percentage_unsupported");
+      (error as Error & { code?: string }).code =
+        "analytics_series_percentage_unsupported";
+      return error;
+    }
+
+    // @scenario "An alert on a series the query refuses is skipped, not retried forever"
+    it("skips that trigger instead of failing the evaluation", async () => {
+      harness.getTimeseries.mockRejectedValue(percentageUnsupported());
+
+      const result = await evaluateGraphTrigger({
+        deps: harness.deps,
+        triggerId: TRIGGER_ID,
+        projectId: PROJECT_ID,
+        reason: "real-time",
+      });
+
+      expect(result.status).toBe("skipped");
+    });
+
+    it("does not throw, so one bad series cannot quarantine the tenant's lane", async () => {
+      harness.getTimeseries.mockRejectedValue(percentageUnsupported());
+
+      await expect(
+        evaluateGraphTrigger({
+          deps: harness.deps,
+          triggerId: TRIGGER_ID,
+          projectId: PROJECT_ID,
+          reason: "real-time",
+        }),
+      ).resolves.toMatchObject({ status: "skipped" });
+    });
+
+    it("never fires an alert on a result it could not read", async () => {
+      harness.getTimeseries.mockRejectedValue(percentageUnsupported());
+
+      await evaluateGraphTrigger({
+        deps: harness.deps,
+        triggerId: TRIGGER_ID,
+        projectId: PROJECT_ID,
+        reason: "real-time",
+      });
+
+      expect(harness.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
   describe("given the timeseries read fails for any other reason", () => {
     // Only the row ceiling is a configuration fault. A real outage must still
     // reach the queue's retry, or a transient ClickHouse blip would silently

--- a/platform/app/src/server/app-layer/automations/graph-trigger-evaluation.service.ts
+++ b/platform/app/src/server/app-layer/automations/graph-trigger-evaluation.service.ts
@@ -31,6 +31,7 @@ import { buildGraphAlertTemplateContext } from "@langwatch/automations/templatin
 import { createLogger } from "@langwatch/observability";
 import type { CustomGraph, Project, Trigger } from "@prisma/client";
 import type { CustomGraphInput } from "~/components/analytics/CustomGraph";
+import { isSeriesPercentageUnsupported } from "~/server/analytics/errors";
 import type {
   SeriesInputType,
   TimeseriesInputType,
@@ -323,31 +324,59 @@ export async function evaluateGraphTrigger({
       maxResultRows: GRAPH_TRIGGER_MAX_RESULT_ROWS,
     });
   } catch (error) {
-    if (!isResultTooLarge(error)) throw error;
-    // A configuration fault, not an outage: this graph's `groupBy` has more
-    // distinct values than a threshold read can carry. Retrying re-asks the
-    // identical question, so this must NOT reach the caller's failure count —
-    // an evaluation that throws is redelivered, and a permanently oversized
-    // trigger would then re-fail on every delivery until it quarantined its
-    // tenant's whole lane, taking every OTHER trigger in that project down
-    // with it. Skipping isolates the damage to the one misconfigured trigger.
-    logger.error(
-      {
-        projectId,
+    if (isResultTooLarge(error)) {
+      // A configuration fault, not an outage: this graph's `groupBy` has more
+      // distinct values than a threshold read can carry. Retrying re-asks the
+      // identical question, so this must NOT reach the caller's failure count —
+      // an evaluation that throws is redelivered, and a permanently oversized
+      // trigger would then re-fail on every delivery until it quarantined its
+      // tenant's whole lane, taking every OTHER trigger in that project down
+      // with it. Skipping isolates the damage to the one misconfigured trigger.
+      logger.error(
+        {
+          projectId,
+          triggerId,
+          reason,
+          groupBy: graphData.groupBy,
+          timePeriodMinutes: timePeriod,
+          maxResultRows: GRAPH_TRIGGER_MAX_RESULT_ROWS,
+        },
+        "graph trigger evaluation skipped: timeseries result exceeds the row ceiling",
+      );
+      return skipped({
         triggerId,
+        projectId,
         reason,
-        groupBy: graphData.groupBy,
-        timePeriodMinutes: timePeriod,
-        maxResultRows: GRAPH_TRIGGER_MAX_RESULT_ROWS,
-      },
-      "graph trigger evaluation skipped: timeseries result exceeds the row ceiling",
-    );
-    return skipped({
-      triggerId,
-      projectId,
-      reason,
-      detail: "timeseries result exceeds the row ceiling",
-    });
+        detail: "timeseries result exceeds the row ceiling",
+      });
+    }
+    if (isSeriesPercentageUnsupported(error)) {
+      // Same class, same treatment: the saved series asks for a percentage of a
+      // per-entity measurement, which the query builder refuses because the
+      // unfiltered denominator would be taken over a different set of entities.
+      // Re-asking cannot change the answer, so rethrowing would redeliver this
+      // trigger forever and quarantine its tenant's lane. The series' metric
+      // rides in the log line rather than on the error, since this is the one
+      // caller that needs to know WHICH series has to be edited.
+      logger.error(
+        {
+          projectId,
+          triggerId,
+          reason,
+          seriesIndex,
+          seriesMetric: series.metric,
+          seriesAggregation: series.aggregation,
+        },
+        "graph trigger evaluation skipped: series cannot be shown as a percentage",
+      );
+      return skipped({
+        triggerId,
+        projectId,
+        reason,
+        detail: "series cannot be shown as a percentage",
+      });
+    }
+    throw error;
   }
   // The stored `seriesName` identifies WHICH series the trigger watches
   // (`{index}/{key|metric}/{aggregation}` — parsed above via

--- a/specs/analytics/error-series.feature
+++ b/specs/analytics/error-series.feature
@@ -48,6 +48,30 @@ Feature: Per-series filters and percentage mode on analytics graphs
     Then only the filtered series is narrowed to traces holding a matching span
 
   @integration
+  Scenario: A per-series filter narrows its series on a grouped graph
+    Given a graph counting traces grouped by span type, with one filtered series and one unfiltered
+    When the graph is queried over a window
+    Then every group reports the filtered count for one series and the whole count for the other
+
+  @integration
+  Scenario: A per-series filter narrows its series alongside an evaluation measurement
+    Given a graph pairing an evaluation score with a trace count filtered to traces with an error
+    When the graph is queried over a window
+    Then the trace count covers only traces with an error and the score is unaffected
+
+  @integration
+  Scenario: A filtered average or extremum reports no value when nothing matched
+    Given a graph reporting the shortest trace duration, filtered to something no trace matches
+    When the graph is queried over a window that does hold traces
+    Then the series reports no value rather than a duration of zero
+
+  @unit
+  Scenario: An alert on a series the query refuses is skipped, not retried forever
+    Given an alert watching a series that cannot be shown as a percentage
+    When the alert is evaluated
+    Then the evaluation is skipped instead of failing, so other alerts keep running
+
+  @integration
   Scenario: Grouping by error status puts each trace in exactly one bucket
     Given a graph counting traces grouped by whether the trace contains an error
     When the graph is queried over a window

--- a/specs/analytics/error-series.feature
+++ b/specs/analytics/error-series.feature
@@ -1,0 +1,73 @@
+Feature: Per-series filters and percentage mode on analytics graphs
+  As a platform user
+  I want each series of a graph to honour its own filters
+  So that a "with errors" series and a "without errors" series show different data
+
+  A custom graph can give every series its own filter set — the canonical case
+  being one series filtered to traces with an error and a second filtered to
+  traces without one. Each series can additionally be shown as a percentage of
+  the same measurement taken without that series' own filters.
+
+  Until this change the per-series filters never reached the executed query, so
+  both series returned the identical unfiltered number and the percentage
+  toggle changed nothing. Every alert built on a filtered series therefore
+  watched the wrong measurement.
+
+  Background:
+    Given a project with traces, some of which contain an error
+
+  @integration
+  Scenario: The with-errors and without-errors series partition the window
+    Given a graph counting traces, with one series filtered to traces with an error and one to traces without
+    When the graph is queried over a window
+    Then the two series report different counts
+    And their counts add up to the count of every trace in the window
+
+  @integration
+  Scenario: Percentage mode divides the filtered series by the unfiltered series
+    Given a graph counting traces, with one series filtered to traces with an error
+    When the series is shown as a percentage
+    Then the series reports the share of traces in the window that contain an error
+
+  @integration
+  Scenario: Percentage mode reports zero when the window holds no traces
+    Given a graph counting traces, with one series filtered to traces with an error and shown as a percentage
+    When the graph is queried over a window with no traces
+    Then the series reports zero rather than no value at all
+
+  @integration
+  Scenario: An alert on the error series counts only traces with errors
+    Given a graph whose only series is filtered to traces with an error
+    When the graph is queried over a window
+    Then the reported value counts only the traces that contain an error
+
+  @integration
+  Scenario: A filter that reads span data still applies to its own series only
+    Given a graph with one series filtered by span type and one series unfiltered
+    When the graph is queried over a window
+    Then only the filtered series is narrowed to traces holding a matching span
+
+  @integration
+  Scenario: Grouping by error status puts each trace in exactly one bucket
+    Given a graph counting traces grouped by whether the trace contains an error
+    When the graph is queried over a window
+    Then each trace appears in exactly one of the two buckets
+    And the buckets add up to the count of every trace in the window
+
+  @unit
+  Scenario: Two series that differ only by their filters produce different queries
+    Given a graph with the same measurement twice, filtered to traces with and without an error
+    When the query is built
+    Then the two series compile to different expressions
+
+  @unit
+  Scenario: Percentage mode on an unfiltered series leaves the series unchanged
+    Given a graph with a single unfiltered series shown as a percentage
+    When the query is built
+    Then the series is measured exactly as it would be without percentage mode
+
+  @unit
+  Scenario: A percentage on a per-entity average is refused rather than answered wrongly
+    Given a graph whose series averages per user and is both filtered and shown as a percentage
+    When the query is built
+    Then building the query fails and names the unsupported combination


### PR DESCRIPTION
Closes #6718. Part of the #6716 follow-up (WS-7 of the Automations & Alerts bug-bash plan).

## The bug

Two series that differ only by `filters: {"traces.error": ["true"|"false"]}` compiled to **byte-identical SQL**. The per-series loop in `aggregation-builder.ts` passed only `metric/aggregation/index/key/subkey` on, and the only filter translation was the graph-wide one — so the "with errors" and "without errors" lines were the same line, and every alert built on a filtered series watched the wrong number.

The filter definitions and the ClickHouse predicates were already right (`server/filters/registry.ts`, `filter-translator.ts` — `ContainsErrorStatus = 1` vs `= 0 OR IS NULL`), the UI already sent per-series filters, and the schema already accepted them. Only the builder ignored them. This is an Elasticsearch → ClickHouse regression: the deleted ES builder implemented it as a `__filters` wrapper aggregation, and nothing covered it.

Two more defects sat on the same feature:

- **`asPercent` ("Show in percentage (%)") was read by nothing.** It flowed form → input → `registry.ts` → no consumer at all.
- **Grouping by `error.has_error` used the span-level `StatusCode`** through a `stored_spans` JOIN. The JOIN fans a trace out into one row per span, and a trace with an error almost always has healthy spans too, so a trace landed in **both** buckets and the buckets could not add up to the total. It also contradicted `field-mappings.ts`, which maps the field to the trace-level `ContainsErrorStatus`.

## The fix

**Per-series filters as conditional aggregation.** Each series' filters translate to a predicate that is folded into that series' own aggregate through the `-If` combinator, leaving the graph-wide `WHERE` shared:

| before | after |
|---|---|
| `sum(ts.TotalCost)` | `sumIf(ts.TotalCost, (pred))` |
| `count()` | `countIf((pred))` |
| `uniq(ts.TraceId)` | `uniqIf(ts.TraceId, (pred))` |
| `quantileTDigest(0.5)(x)` | `quantileTDigestIf(0.5)(x, (pred))` |
| `avgIf(es.Score, cond)` (already conditional) | `avgIf(es.Score, (cond) AND (pred))` |

**Which filter classes are supported.** All of them. Every handler in `filter-translator.ts` returns `requiredJoins: []` — span, event and evaluation facets are expressed as `ts.TraceId IN (SELECT … )` subqueries, not JOINs — so no filter class needs a JOIN to be scoped to a single series, and each compiles cleanly into an `-If` condition. A per-series filter that ever *did* need a JOIN now throws by name (a JOIN added for one series would narrow every other series in the graph), instead of shipping silently wrong numbers for the rest of the graph.

**All five builder paths carry it.** The three that aggregate directly over the scan (standard, `timeScale: "full"`, date-bucketed) take the raw `ts` predicate. The two that aggregate over a CTE (the arrayJoin / group-by path and the mixed evaluation path) hoist the predicate into the CTE as a per-trace boolean first, because the raw predicate reads an alias those outer `SELECT`s do not have — and the condition is applied *after* the dedup rewrite, so `count() → uniqExact(trace_id)` becomes `uniqExactIf(trace_id, …)` with the mapping intact.

**Per-entity (pipeline) series** take their filter in their own subquery's `WHERE` rather than as a conditional aggregate, because the filter decides which entities exist at all — an entity with no matching traces must disappear, not survive as a zero and drag the cross-entity average down. Each such metric already owns a private CTE, so this touches no other series.

**Non-additive aggregates no longer fabricate zeros.** ClickHouse's `-If` combinators do **not** return NULL for an empty match set when the source column is non-nullable — `minIf` returns `0` (verified: `SELECT minIf(x, 0) FROM (SELECT toUInt32(200) AS x)` → `0`, type `UInt32`). Left alone, a filtered latency floor would draw a real-looking 0ms line for every bucket the filter excluded, where `_timeseries-row-parser.ts` and Elasticsearch both leave a non-additive series absent. Series that are non-additive per `isZeroWhenAbsentSeries` now carry an emptiness guard — `if(countIf(<cond>) > 0, minIf(x, <cond>), NULL)` — while additive series stay unguarded, because no matching rows genuinely *is* zero there.

**`asPercent`** matches ES semantics for non-pipeline series: `all > 0 ? filtered / all * 100 : 0`.

- Result is a **percentage (0–100)**, not a fraction — matching the toggle's label.
- An **empty bucket reads as 0**, not as "no value".
- Percentage mode on an **unfiltered** series is a **no-op** — matching ES, where the percentage wrapper only ever existed inside the per-series filter wrapper. There is nothing for an unfiltered series to be a percentage *of*. Pinned by a test asserting byte-identical SQL with and without the flag.
- Nothing on the render side needed changing: the series value simply becomes the percentage.
- **Pipeline percentages are refused rather than answered with a wrong number** — the one deliberate divergence from ES, which did support them (`c6e63df26f`). The unfiltered denominator would have to be computed over a *different* set of entities (a second scan, not a second aggregate), so the two halves stop being comparable. The refusal is the handled error `analytics_series_percentage_unsupported`, with customer copy in the presentation registry telling the author which toggle to drop.

**That refusal is not allowed to poison the alert lane.** `graph-trigger-evaluation.service.ts` rethrows anything it does not recognise, and a rethrow there is a redelivery — so a saved per-entity percentage series would re-fail on every delivery until it quarantined its tenant's whole graph-trigger lane, taking every *other* alert in the project down with it (the same failure mode the file's row-ceiling comment documents from the 2026-08-09 incident). It is now classified alongside `resultTooLarge`: skipped and logged with the trigger id, the series index and the series metric, never rethrown. The composer's save-time gate and the report path's per-panel catch are **coordinated with the streams that own those files** and are not in this PR.

**`error.has_error` group-by** now groups on `if(ifNull(ts.ContainsErrorStatus, 0) = 1, 'with error', 'without error')` and drops the `stored_spans` JOIN it never needed.

**Folded finding (validator sweep):** deleting a graph from a dashboard refetched only the page's own `{projectId, dashboardId}` query, so the alert composer — which reads `graphs.getAll` keyed by `{projectId}` alone — kept offering the deleted graph until a full reload. Now invalidates every `graphs.getAll` key.

## Spec

`specs/analytics/error-series.feature`, 13 scenarios, all tagged and bound (`pnpm check:feature-parity` → `13/13 scenarios bound ✓ all bound`), each with a `@scenario` annotation on its covering test.

## Test evidence

SQL-shape unit tests were extended into the existing `aggregation-builder.test.ts` (no parallel suite). The headline one: two series with opposite error filters must **not** compile to the same expression.

```
$ pnpm test:unit run src/server/analytics/clickhouse/__tests__/
 Test Files  13 passed (13)
      Tests  360 passed (360)

$ pnpm test:unit run src/server/analytics src/features/errors \
                    src/server/app-layer/analytics src/server/app-layer/automations
 Test Files  65 passed (65)
      Tests  1132 passed (1132)
```

Integration tests execute the built query against seeded ClickHouse data, because "the SQL is different" is not the same claim as "the numbers are right":

```
$ pnpm test:integration run src/server/analytics/clickhouse/__tests__/error-series.integration.test.ts --watch=false
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ pnpm test:integration run src/server/analytics/clickhouse/__tests__/ \
                            src/server/app-layer/analytics/__tests__/ --watch=false
 Test Files  13 passed (13)
      Tests  122 passed | 3 skipped (125)
```

The integration suite seeds five traces (two with an error, three without; two carrying an `llm` span, one of each error status) plus three evaluation runs, and asserts at the query-result level that:

- the two error series report different counts summing to the window total;
- a span-facet filter narrows only its own series;
- a per-series filter narrows only its own series **on the grouped/arrayJoin CTE path** (checked per span-type group);
- a per-series filter narrows only its own series **on the mixed-evaluation CTE path**, leaving the evaluation score untouched — those two are the paths carrying the hoisted per-trace boolean;
- percentage mode returns the real share, and an empty window returns 0;
- a filtered `min` over a window that holds traces but matches none reports **no value**, not 0 — with a control asserting the same series still reports the real duration when the filter does match;
- the error group-by buckets partition the window exactly.

Lint delta was measured against `main` by restoring the baseline files and re-running the identical command: **3593 warnings on both**, zero new diagnostics, zero errors. `tslsp diagnostics` clean on every touched file; `pnpm format` clean.

## Query rules

`TenantId` stays the first predicate everywhere; the partition-key time range is unchanged; no `LIMIT 1 BY`; dedup still uses the IN-tuple form. Per-series predicates go through the same parameterized placeholders as the graph-wide ones (a test asserts the span filter's `spanTypes_0` param), and the columns those predicates read are threaded into `referencedTraceColumns` so the deduped trace subquery does not prune them away.

## Not in this PR

- **"Add alert" on the Analytics reports page** (WS-7 scope item 4) turned out to be **already shipped**: `components/analytics/reports/GraphCardHeader.tsx` renders an `Add alert` button (and an `Edit alert` bell when a trigger exists) on every saved graph card, opening the automation composer with `prefilledGraphId` + `prefilledSeriesName`. `reports.tsx → ReportGrid → DraggableGraphCard → GraphCardHeader` is the chain. Nothing to add.
- **The composer save-time gate** for "percentage on a per-entity series", and **the report path's per-panel catch** for the same refusal — coordinated with the streams that own those files.
- **The `graphs.getAll` invalidation fix has no test.** The reports page has no test harness (only `GraphCardHeader` does), and standing one up is a separate lift.
