### PR TITLE
fix(aigateway): repoint controlPlaneRoot after ADR-076, and make the skip-guard unfakeable

### DIFF
--- a/services/aigateway/adapters/controlplane/guardrails_contract_test.go
+++ b/services/aigateway/adapters/controlplane/guardrails_contract_test.go
@@ -3,6 +3,9 @@ package controlplane
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -175,8 +178,16 @@ func TestContentForPacksEachDirectionUnderItsOwnKey(t *testing.T) {
 // <root>/langwatch to <root>/platform/app.
 var (
 	monorepoRoot     = filepath.Join("..", "..", "..", "..")
-	controlPlaneRoot = filepath.Join(monorepoRoot, "platform", "app")
+	controlPlaneRoot = controlPlaneRootFor(monorepoRoot)
 )
+
+// controlPlaneRootFor derives the control plane's location from a repo root.
+// Both the package-level controlPlaneRoot and controlPlaneVerdict resolve the
+// layout through here, so a future move cannot repoint one and leave the other
+// stale -- which is the drift ADR-076 already caused once.
+func controlPlaneRootFor(root string) string {
+	return filepath.Join(root, "platform", "app")
+}
 
 // The two witnesses that decide skip-versus-fail. Neither is a bare directory:
 // a directory is re-created by any stray file that lands under it, and one was.
@@ -203,43 +214,346 @@ func readControlPlaneSource(t *testing.T, parts ...string) string {
 	return string(source)
 }
 
-// requireControlPlane decides whether there is a control plane to compare
-// against. Skipping is reserved for a checkout that carries no TypeScript side
-// at all -- a vendored or split Go build -- and requires BOTH witnesses to be
-// absent: the pnpm workspace manifest at the repo root, and the control plane's
-// own package manifest at controlPlaneRoot. Either one alone is enough to run.
+// controlPlaneStatus is what controlPlaneVerdict decided. The zero value is
+// deliberately none of the three: an unset status is not a skip.
+type controlPlaneStatus string
+
+const (
+	controlPlaneOK    controlPlaneStatus = "ok"
+	controlPlaneSkip  controlPlaneStatus = "skip"
+	controlPlaneFatal controlPlaneStatus = "fatal"
+)
+
+// controlPlaneVerdict decides whether there is a control plane to compare
+// against under root. It is a pure decision -- it reads the filesystem and
+// returns, touching no *testing.T -- so every branch is driven by t.TempDir()
+// fixtures in TestControlPlaneVerdictDecidesEachWitnessCombination instead of by
+// whatever checkout CI happens to run in. Keep it that way: a guard whose
+// branches are only ever exercised by the ambient checkout is the trap this file
+// exists to close.
+//
+// Skipping is reserved for a checkout that carries no TypeScript side at all --
+// a vendored or split Go build -- and requires BOTH witnesses to be absent: the
+// pnpm workspace manifest at the repo root, and the control plane's own package
+// manifest under controlPlaneRootFor(root). Either one alone is enough to run.
 //
 // THE AMBIGUOUS CASE FAILS, IT DOES NOT SKIP. A workspace present without the
 // control plane under it -- exactly the shape of the ADR-076 rename -- is a hard
-// failure naming the stale constant. That direction is deliberate: a false red
-// costs one path edit, while a false green costs an unenforced cross-language
-// contract that nobody is watching, which is the failure this file exists to
-// make loud. Do not relax this into a skip.
+// failure naming the stale constant. So is a manifest that is present but
+// unreadable, malformed, or naming another package: something is there, so the
+// "no TypeScript side at all" premise for skipping is false, and the only honest
+// verdicts left are run or fail. That direction is deliberate: a false red costs
+// one path edit, while a false green costs an unenforced cross-language contract
+// that nobody is watching, which is the failure this file exists to make loud.
+// Do not relax any of this into a skip.
+func controlPlaneVerdict(root string) (controlPlaneStatus, string) {
+	cpRoot := controlPlaneRootFor(root)
+	manifestPath := filepath.Join(cpRoot, "package.json")
+
+	data, readErr := os.ReadFile(manifestPath)
+	switch {
+	case readErr == nil:
+		// Parsed rather than pattern-matched so that reformatting the
+		// manifest cannot read as a missing control plane.
+		var manifest struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return controlPlaneFatal, fmt.Sprintf(
+				"%s is present but is not valid JSON, so the control plane cannot be identified: %v. "+
+					"An unparseable manifest is drift, not a checkout without a TypeScript side.",
+				manifestPath, err)
+		}
+		if manifest.Name != controlPlanePackage {
+			return controlPlaneFatal, fmt.Sprintf(
+				"%s names package %q, want %q: controlPlaneRoot points at some other workspace package. Repoint controlPlaneRoot.",
+				manifestPath, manifest.Name, controlPlanePackage)
+		}
+		return controlPlaneOK, ""
+
+	case !errors.Is(readErr, fs.ErrNotExist):
+		// Something occupies the path but will not open. An unreadable
+		// witness is not an absent one.
+		return controlPlaneFatal, fmt.Sprintf(
+			"%s exists but could not be read, so the control plane cannot be identified: %v",
+			manifestPath, readErr)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, workspaceManifest)); err == nil {
+		return controlPlaneFatal, fmt.Sprintf(
+			"this checkout carries the monorepo (%s is at the repo root) but %s holds no %s package manifest: "+
+				"the control plane moved and controlPlaneRoot did not move with it. Repoint controlPlaneRoot.",
+			workspaceManifest, cpRoot, controlPlanePackage)
+	}
+
+	return controlPlaneSkip, fmt.Sprintf(
+		"no TypeScript control plane in this checkout: no %s at the repo root and no %s package manifest at %s",
+		workspaceManifest, controlPlanePackage, cpRoot)
+}
+
+// controlPlaneReporter is the slice of *testing.T the dispatch needs, so the
+// verdict-to-action mapping can be driven by a recorder. Mapping fatal onto Skip
+// would resurrect exactly the silent non-enforcement this file exists to
+// prevent, and nothing in a green CI run would show it.
+type controlPlaneReporter interface {
+	Helper()
+	Skip(args ...any)
+	Fatal(args ...any)
+}
+
+// requireControlPlane ends the calling test unless there is a control plane to
+// compare against.
 func requireControlPlane(t *testing.T) {
 	t.Helper()
+	dispatchControlPlaneVerdict(t, monorepoRoot)
+}
 
-	_, workspaceErr := os.Stat(filepath.Join(monorepoRoot, workspaceManifest))
-
-	// Parsed rather than pattern-matched so that reformatting the manifest
-	// cannot read as a missing control plane.
-	var manifest struct {
-		Name string `json:"name"`
-	}
-	data, readErr := os.ReadFile(filepath.Join(controlPlaneRoot, "package.json"))
-	controlPlanePresent := readErr == nil &&
-		json.Unmarshal(data, &manifest) == nil &&
-		manifest.Name == controlPlanePackage
-
-	switch {
-	case controlPlanePresent:
+// dispatchControlPlaneVerdict turns a verdict into an action. The one thing it
+// must never do is let an unrecognised verdict fall through to a skip, so the
+// default fails; it is unreachable while controlPlaneStatus has three values and
+// is here for the edit that adds a fourth.
+func dispatchControlPlaneVerdict(r controlPlaneReporter, root string) {
+	r.Helper()
+	switch status, reason := controlPlaneVerdict(root); status {
+	case controlPlaneOK:
 		return
-	case workspaceErr == nil:
-		t.Fatalf("this checkout carries the monorepo (%s is at the repo root) but %s holds no %s package manifest: "+
-			"the control plane moved and controlPlaneRoot did not move with it. Repoint controlPlaneRoot.",
-			workspaceManifest, controlPlaneRoot, controlPlanePackage)
+	case controlPlaneSkip:
+		r.Skip(reason)
+	case controlPlaneFatal:
+		r.Fatal(reason)
 	default:
-		t.Skipf("no TypeScript control plane in this checkout: no %s at the repo root and no %s package manifest at %s",
-			workspaceManifest, controlPlanePackage, controlPlaneRoot)
+		r.Fatal(fmt.Sprintf("unrecognised control plane verdict %q", status))
+	}
+}
+
+// The guard above is the same trap class as the bug this file documents: a
+// branch that skips where it should fail costs nothing visible in a green CI
+// run, and the last one survived eight days. Each case below builds a repo root
+// under t.TempDir() and pins one verdict, so a later edit that widens the skip
+// -- or that "simplifies" the switch, or repoints controlPlanePackage -- turns a
+// test red instead of turning enforcement off.
+func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
+	const (
+		validManifest   = `{"name":"` + controlPlanePackage + `","version":"0.0.0"}`
+		foreignManifest = `{"name":"@langwatch/some-other-package"}`
+		malformed       = `{"name": `
+	)
+
+	cases := []struct {
+		name               string
+		fixture            controlPlaneFixture
+		want               controlPlaneStatus
+		wantReasonContains string
+	}{
+		{
+			name:    "both witnesses present and valid",
+			fixture: controlPlaneFixture{workspace: true, controlPlaneDir: true, manifest: validManifest},
+			want:    controlPlaneOK,
+		},
+		{
+			// Either witness alone is enough to run: a split checkout that
+			// carries the app but not the workspace file still has a control
+			// plane to compare against.
+			name:    "the control plane is present without the workspace manifest",
+			fixture: controlPlaneFixture{controlPlaneDir: true, manifest: validManifest},
+			want:    controlPlaneOK,
+		},
+		{
+			// The literal shape of the ADR-076 rename.
+			name:               "the workspace is present and the control plane directory is gone",
+			fixture:            controlPlaneFixture{workspace: true},
+			want:               controlPlaneFatal,
+			wantReasonContains: "Repoint controlPlaneRoot",
+		},
+		{
+			// The old sentinel's exact defect: a bare directory, re-created by
+			// any stray file, used to read as a live control plane.
+			name:               "the workspace is present and the control plane path is an empty directory",
+			fixture:            controlPlaneFixture{workspace: true, controlPlaneDir: true},
+			want:               controlPlaneFatal,
+			wantReasonContains: "Repoint controlPlaneRoot",
+		},
+		{
+			// Same empty directory, no workspace: still must not be ok.
+			name:               "the control plane path is an empty directory and nothing else",
+			fixture:            controlPlaneFixture{controlPlaneDir: true},
+			want:               controlPlaneSkip,
+			wantReasonContains: "no TypeScript control plane",
+		},
+		{
+			name:               "the manifest names another package",
+			fixture:            controlPlaneFixture{workspace: true, controlPlaneDir: true, manifest: foreignManifest},
+			want:               controlPlaneFatal,
+			wantReasonContains: "@langwatch/some-other-package",
+		},
+		{
+			// A wrong-named manifest is a present witness, so the absent-both
+			// premise for skipping is false even without the workspace file.
+			name:               "the manifest names another package and there is no workspace",
+			fixture:            controlPlaneFixture{controlPlaneDir: true, manifest: foreignManifest},
+			want:               controlPlaneFatal,
+			wantReasonContains: "@langwatch/some-other-package",
+		},
+		{
+			name:               "the manifest is malformed JSON",
+			fixture:            controlPlaneFixture{workspace: true, controlPlaneDir: true, manifest: malformed},
+			want:               controlPlaneFatal,
+			wantReasonContains: "not valid JSON",
+		},
+		{
+			name:               "the manifest is malformed JSON and there is no workspace",
+			fixture:            controlPlaneFixture{controlPlaneDir: true, manifest: malformed},
+			want:               controlPlaneFatal,
+			wantReasonContains: "not valid JSON",
+		},
+		{
+			name:               "the manifest is present but will not open",
+			fixture:            controlPlaneFixture{controlPlaneDir: true, manifestIsDir: true},
+			want:               controlPlaneFatal,
+			wantReasonContains: "could not be read",
+		},
+		{
+			name:               "neither witness is present",
+			fixture:            controlPlaneFixture{},
+			want:               controlPlaneSkip,
+			wantReasonContains: "no TypeScript control plane",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := tc.fixture.build(t)
+
+			got, reason := controlPlaneVerdict(root)
+			if got != tc.want {
+				t.Fatalf("controlPlaneVerdict = %q (%s), want %q", got, reason, tc.want)
+			}
+			if tc.want == controlPlaneOK {
+				return
+			}
+			// A skip or a failure nobody can act on is how the stale
+			// constant went unnoticed, so the reason is part of the contract.
+			if reason == "" {
+				t.Fatalf("verdict %q carries no reason", got)
+			}
+			if !strings.Contains(reason, tc.wantReasonContains) {
+				t.Fatalf("reason %q does not mention %q", reason, tc.wantReasonContains)
+			}
+		})
+	}
+}
+
+// controlPlaneFixture describes which witnesses a temp repo root carries. The
+// zero value is a checkout with no TypeScript side at all.
+type controlPlaneFixture struct {
+	workspace       bool   // pnpm-workspace.yaml at the repo root
+	controlPlaneDir bool   // platform/app exists, possibly empty
+	manifest        string // written to platform/app/package.json when set
+	manifestIsDir   bool   // platform/app/package.json exists but will not open
+}
+
+// build materialises the fixture under t.TempDir() and returns the repo root.
+func (f controlPlaneFixture) build(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	if f.workspace {
+		writeControlPlaneFile(t, filepath.Join(root, workspaceManifest), "packages:\n  - platform/app\n")
+	}
+
+	cpRoot := controlPlaneRootFor(root)
+	if f.controlPlaneDir || f.manifest != "" || f.manifestIsDir {
+		if err := os.MkdirAll(cpRoot, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", cpRoot, err)
+		}
+	}
+
+	manifestPath := filepath.Join(cpRoot, "package.json")
+	switch {
+	case f.manifestIsDir:
+		// A directory opens but will not read, which is the cheapest
+		// deterministic stand-in for an unreadable manifest -- unlike a
+		// permission bit, it also holds when the suite runs as root.
+		if err := os.MkdirAll(manifestPath, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", manifestPath, err)
+		}
+	case f.manifest != "":
+		writeControlPlaneFile(t, manifestPath, f.manifest)
+	}
+	return root
+}
+
+func writeControlPlaneFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// controlPlaneRecorder captures what the dispatch did without ending a real
+// test. It does not reproduce t.Fatal's runtime.Goexit, which is harmless here:
+// every branch of the dispatch returns immediately after reporting.
+type controlPlaneRecorder struct {
+	skipped bool
+	failed  bool
+	message string
+}
+
+func (r *controlPlaneRecorder) Helper() {}
+
+func (r *controlPlaneRecorder) Skip(args ...any) {
+	r.skipped = true
+	r.message = fmt.Sprint(args...)
+}
+
+func (r *controlPlaneRecorder) Fatal(args ...any) {
+	r.failed = true
+	r.message = fmt.Sprint(args...)
+}
+
+// The verdict is only half the guard; the mapping from verdict to action is the
+// half that can silently turn a hard failure into a skip. A recorder pins it.
+func TestRequireControlPlaneDispatchesTheVerdictItWasGiven(t *testing.T) {
+	cases := []struct {
+		name        string
+		fixture     controlPlaneFixture
+		wantSkipped bool
+		wantFailed  bool
+	}{
+		{
+			name: "a present control plane lets the test run",
+			fixture: controlPlaneFixture{
+				workspace:       true,
+				controlPlaneDir: true,
+				manifest:        `{"name":"` + controlPlanePackage + `"}`,
+			},
+		},
+		{
+			name:       "an ambiguous checkout fails rather than skipping",
+			fixture:    controlPlaneFixture{workspace: true},
+			wantFailed: true,
+		},
+		{
+			name:        "a checkout with no TypeScript side skips",
+			fixture:     controlPlaneFixture{},
+			wantSkipped: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := tc.fixture.build(t)
+
+			var recorder controlPlaneRecorder
+			dispatchControlPlaneVerdict(&recorder, root)
+
+			if recorder.skipped != tc.wantSkipped {
+				t.Errorf("skipped = %v, want %v (message: %s)", recorder.skipped, tc.wantSkipped, recorder.message)
+			}
+			if recorder.failed != tc.wantFailed {
+				t.Errorf("failed = %v, want %v (message: %s)", recorder.failed, tc.wantFailed, recorder.message)
+			}
+		})
 	}
 }
 

--- a/services/aigateway/adapters/controlplane/guardrails_contract_test.go
+++ b/services/aigateway/adapters/controlplane/guardrails_contract_test.go
@@ -362,9 +362,8 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 			want:    controlPlaneOK,
 		},
 		{
-			// Either witness alone is enough to run: a split checkout that
-			// carries the app but not the workspace file still has a control
-			// plane to compare against.
+			// A valid package manifest is sufficient to run without the
+			// workspace manifest; a workspace-only checkout is fatal.
 			name:    "the control plane is present without the workspace manifest",
 			fixture: controlPlaneFixture{hasControlPlaneDir: true, manifest: validManifest},
 			want:    controlPlaneOK,
@@ -470,7 +469,7 @@ type controlPlaneFixture struct {
 	hasUnreadableWorkspaceManifest bool   // pnpm-workspace.yaml exists but will not stat
 	hasControlPlaneDir             bool   // platform/app exists, possibly empty
 	manifest                       string // written to platform/app/package.json when set
-	isManifestDirectory            bool   // platform/app/package.json exists but will not open
+	isManifestDirectory            bool   // platform/app/package.json exists but cannot be read
 }
 
 // build materializes the fixture under t.TempDir() and returns the repo root.

--- a/services/aigateway/adapters/controlplane/guardrails_contract_test.go
+++ b/services/aigateway/adapters/controlplane/guardrails_contract_test.go
@@ -170,24 +170,77 @@ func TestContentForPacksEachDirectionUnderItsOwnKey(t *testing.T) {
 	}
 }
 
-// controlPlaneRoot is the langwatch/ directory of the monorepo, relative to
-// this package. A checkout that does not carry the TypeScript side (a vendored
-// or split Go build) has no control plane to compare against and the test is
-// skipped. When the directory IS there, a missing or unreadable file is drift,
-// which is precisely what this test exists to catch, so it fails instead.
-var controlPlaneRoot = filepath.Join("..", "..", "..", "..", "langwatch")
+// monorepoRoot and controlPlaneRoot locate the TypeScript side relative to this
+// package. The control plane is the @langwatch/web app, which ADR-076 moved from
+// <root>/langwatch to <root>/platform/app.
+var (
+	monorepoRoot     = filepath.Join("..", "..", "..", "..")
+	controlPlaneRoot = filepath.Join(monorepoRoot, "platform", "app")
+)
 
+// The two witnesses that decide skip-versus-fail. Neither is a bare directory:
+// a directory is re-created by any stray file that lands under it, and one was.
+// A misplaced test restored langwatch/src/server, which re-satisfied the old
+// os.Stat(controlPlaneRoot, "src", "server") guard and turned a constant that
+// had been stale and silently skipping since the ADR-076 move into five red
+// tests on main. A witness has to be something only the real control plane can
+// produce, so these are a named repo-root manifest and a package identity.
+const (
+	workspaceManifest   = "pnpm-workspace.yaml"
+	controlPlanePackage = "@langwatch/web"
+)
+
+// readControlPlaneSource reads one control plane source file, or ends the test.
 func readControlPlaneSource(t *testing.T, parts ...string) string {
 	t.Helper()
-	if _, err := os.Stat(filepath.Join(controlPlaneRoot, "src", "server")); err != nil {
-		t.Skipf("control plane is not part of this checkout: %v", err)
-	}
+	requireControlPlane(t)
+
 	path := filepath.Join(append([]string{controlPlaneRoot}, parts...)...)
 	source, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("control plane source %s is missing or unreadable, which means the two sides have drifted: %v", path, err)
 	}
 	return string(source)
+}
+
+// requireControlPlane decides whether there is a control plane to compare
+// against. Skipping is reserved for a checkout that carries no TypeScript side
+// at all -- a vendored or split Go build -- and requires BOTH witnesses to be
+// absent: the pnpm workspace manifest at the repo root, and the control plane's
+// own package manifest at controlPlaneRoot. Either one alone is enough to run.
+//
+// THE AMBIGUOUS CASE FAILS, IT DOES NOT SKIP. A workspace present without the
+// control plane under it -- exactly the shape of the ADR-076 rename -- is a hard
+// failure naming the stale constant. That direction is deliberate: a false red
+// costs one path edit, while a false green costs an unenforced cross-language
+// contract that nobody is watching, which is the failure this file exists to
+// make loud. Do not relax this into a skip.
+func requireControlPlane(t *testing.T) {
+	t.Helper()
+
+	_, workspaceErr := os.Stat(filepath.Join(monorepoRoot, workspaceManifest))
+
+	// Parsed rather than pattern-matched so that reformatting the manifest
+	// cannot read as a missing control plane.
+	var manifest struct {
+		Name string `json:"name"`
+	}
+	data, readErr := os.ReadFile(filepath.Join(controlPlaneRoot, "package.json"))
+	controlPlanePresent := readErr == nil &&
+		json.Unmarshal(data, &manifest) == nil &&
+		manifest.Name == controlPlanePackage
+
+	switch {
+	case controlPlanePresent:
+		return
+	case workspaceErr == nil:
+		t.Fatalf("this checkout carries the monorepo (%s is at the repo root) but %s holds no %s package manifest: "+
+			"the control plane moved and controlPlaneRoot did not move with it. Repoint controlPlaneRoot.",
+			workspaceManifest, controlPlaneRoot, controlPlanePackage)
+	default:
+		t.Skipf("no TypeScript control plane in this checkout: no %s at the repo root and no %s package manifest at %s",
+			workspaceManifest, controlPlanePackage, controlPlaneRoot)
+	}
 }
 
 // The control plane's Zod schema is the other half of the contract. Reading it

--- a/services/aigateway/adapters/controlplane/guardrails_contract_test.go
+++ b/services/aigateway/adapters/controlplane/guardrails_contract_test.go
@@ -279,11 +279,22 @@ func controlPlaneVerdict(root string) (controlPlaneStatus, string) {
 			manifestPath, readErr)
 	}
 
-	if _, err := os.Stat(filepath.Join(root, workspaceManifest)); err == nil {
+	workspacePath := filepath.Join(root, workspaceManifest)
+	_, statErr := os.Stat(workspacePath)
+	switch {
+	case statErr == nil:
 		return controlPlaneFatal, fmt.Sprintf(
 			"this checkout carries the monorepo (%s is at the repo root) but %s holds no %s package manifest: "+
 				"the control plane moved and controlPlaneRoot did not move with it. Repoint controlPlaneRoot.",
 			workspaceManifest, cpRoot, controlPlanePackage)
+
+	case !errors.Is(statErr, fs.ErrNotExist):
+		// Exactly as strict as the manifest witness above. Anything other
+		// than "not there" leaves the no-TypeScript-side premise unproven.
+		return controlPlaneFatal, fmt.Sprintf(
+			"%s exists but could not be read, so this checkout cannot be shown to carry no TypeScript side: %v. "+
+				"An unreadable witness is not an absent one.",
+			workspacePath, statErr)
 	}
 
 	return controlPlaneSkip, fmt.Sprintf(
@@ -309,7 +320,7 @@ func requireControlPlane(t *testing.T) {
 }
 
 // dispatchControlPlaneVerdict turns a verdict into an action. The one thing it
-// must never do is let an unrecognised verdict fall through to a skip, so the
+// must never do is let an unrecognized verdict fall through to a skip, so the
 // default fails; it is unreachable while controlPlaneStatus has three values and
 // is here for the edit that adds a fourth.
 func dispatchControlPlaneVerdict(r controlPlaneReporter, root string) {
@@ -322,7 +333,7 @@ func dispatchControlPlaneVerdict(r controlPlaneReporter, root string) {
 	case controlPlaneFatal:
 		r.Fatal(reason)
 	default:
-		r.Fatal(fmt.Sprintf("unrecognised control plane verdict %q", status))
+		r.Fatal(fmt.Sprintf("unrecognized control plane verdict %q", status))
 	}
 }
 
@@ -413,6 +424,15 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 			wantReasonContains: "could not be read",
 		},
 		{
+			// The workspace witness has to be exactly as strict as the
+			// manifest witness above: a witness that will not stat is present,
+			// not absent, so the both-absent premise for skipping is false.
+			name:               "the workspace manifest is present but will not stat",
+			fixture:            controlPlaneFixture{workspaceUnreadable: true},
+			want:               controlPlaneFatal,
+			wantReasonContains: "An unreadable witness is not an absent one",
+		},
+		{
 			name:               "neither witness is present",
 			fixture:            controlPlaneFixture{},
 			want:               controlPlaneSkip,
@@ -446,13 +466,14 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 // controlPlaneFixture describes which witnesses a temp repo root carries. The
 // zero value is a checkout with no TypeScript side at all.
 type controlPlaneFixture struct {
-	workspace       bool   // pnpm-workspace.yaml at the repo root
-	controlPlaneDir bool   // platform/app exists, possibly empty
-	manifest        string // written to platform/app/package.json when set
-	manifestIsDir   bool   // platform/app/package.json exists but will not open
+	workspace           bool   // pnpm-workspace.yaml at the repo root
+	workspaceUnreadable bool   // pnpm-workspace.yaml exists but will not stat
+	controlPlaneDir     bool   // platform/app exists, possibly empty
+	manifest            string // written to platform/app/package.json when set
+	manifestIsDir       bool   // platform/app/package.json exists but will not open
 }
 
-// build materialises the fixture under t.TempDir() and returns the repo root.
+// build materializes the fixture under t.TempDir() and returns the repo root.
 func (f controlPlaneFixture) build(t *testing.T) string {
 	t.Helper()
 
@@ -460,10 +481,19 @@ func (f controlPlaneFixture) build(t *testing.T) string {
 	if f.workspace {
 		writeControlPlaneFile(t, filepath.Join(root, workspaceManifest), "packages:\n  - platform/app\n")
 	}
+	if f.workspaceUnreadable {
+		// A symlink pointing at itself stats as ELOOP rather than ENOENT,
+		// which is the cheapest deterministic unreadable witness -- and like
+		// the directory below, it holds when the suite runs as root.
+		loop := filepath.Join(root, workspaceManifest)
+		if err := os.Symlink(loop, loop); err != nil {
+			t.Fatalf("symlink loop %s: %v", loop, err)
+		}
+	}
 
 	cpRoot := controlPlaneRootFor(root)
 	if f.controlPlaneDir || f.manifest != "" || f.manifestIsDir {
-		if err := os.MkdirAll(cpRoot, 0o755); err != nil {
+		if err := os.MkdirAll(cpRoot, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", cpRoot, err)
 		}
 	}
@@ -474,7 +504,7 @@ func (f controlPlaneFixture) build(t *testing.T) string {
 		// A directory opens but will not read, which is the cheapest
 		// deterministic stand-in for an unreadable manifest -- unlike a
 		// permission bit, it also holds when the suite runs as root.
-		if err := os.MkdirAll(manifestPath, 0o755); err != nil {
+		if err := os.MkdirAll(manifestPath, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", manifestPath, err)
 		}
 	case f.manifest != "":
@@ -485,7 +515,7 @@ func (f controlPlaneFixture) build(t *testing.T) string {
 
 func writeControlPlaneFile(t *testing.T, path, contents string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/services/aigateway/adapters/controlplane/guardrails_contract_test.go
+++ b/services/aigateway/adapters/controlplane/guardrails_contract_test.go
@@ -358,7 +358,7 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 	}{
 		{
 			name:    "both witnesses present and valid",
-			fixture: controlPlaneFixture{workspace: true, controlPlaneDir: true, manifest: validManifest},
+			fixture: controlPlaneFixture{hasWorkspaceManifest: true, hasControlPlaneDir: true, manifest: validManifest},
 			want:    controlPlaneOK,
 		},
 		{
@@ -366,13 +366,13 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 			// carries the app but not the workspace file still has a control
 			// plane to compare against.
 			name:    "the control plane is present without the workspace manifest",
-			fixture: controlPlaneFixture{controlPlaneDir: true, manifest: validManifest},
+			fixture: controlPlaneFixture{hasControlPlaneDir: true, manifest: validManifest},
 			want:    controlPlaneOK,
 		},
 		{
 			// The literal shape of the ADR-076 rename.
 			name:               "the workspace is present and the control plane directory is gone",
-			fixture:            controlPlaneFixture{workspace: true},
+			fixture:            controlPlaneFixture{hasWorkspaceManifest: true},
 			want:               controlPlaneFatal,
 			wantReasonContains: "Repoint controlPlaneRoot",
 		},
@@ -380,20 +380,20 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 			// The old sentinel's exact defect: a bare directory, re-created by
 			// any stray file, used to read as a live control plane.
 			name:               "the workspace is present and the control plane path is an empty directory",
-			fixture:            controlPlaneFixture{workspace: true, controlPlaneDir: true},
+			fixture:            controlPlaneFixture{hasWorkspaceManifest: true, hasControlPlaneDir: true},
 			want:               controlPlaneFatal,
 			wantReasonContains: "Repoint controlPlaneRoot",
 		},
 		{
 			// Same empty directory, no workspace: still must not be ok.
 			name:               "the control plane path is an empty directory and nothing else",
-			fixture:            controlPlaneFixture{controlPlaneDir: true},
+			fixture:            controlPlaneFixture{hasControlPlaneDir: true},
 			want:               controlPlaneSkip,
 			wantReasonContains: "no TypeScript control plane",
 		},
 		{
 			name:               "the manifest names another package",
-			fixture:            controlPlaneFixture{workspace: true, controlPlaneDir: true, manifest: foreignManifest},
+			fixture:            controlPlaneFixture{hasWorkspaceManifest: true, hasControlPlaneDir: true, manifest: foreignManifest},
 			want:               controlPlaneFatal,
 			wantReasonContains: "@langwatch/some-other-package",
 		},
@@ -401,25 +401,25 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 			// A wrong-named manifest is a present witness, so the absent-both
 			// premise for skipping is false even without the workspace file.
 			name:               "the manifest names another package and there is no workspace",
-			fixture:            controlPlaneFixture{controlPlaneDir: true, manifest: foreignManifest},
+			fixture:            controlPlaneFixture{hasControlPlaneDir: true, manifest: foreignManifest},
 			want:               controlPlaneFatal,
 			wantReasonContains: "@langwatch/some-other-package",
 		},
 		{
 			name:               "the manifest is malformed JSON",
-			fixture:            controlPlaneFixture{workspace: true, controlPlaneDir: true, manifest: malformed},
+			fixture:            controlPlaneFixture{hasWorkspaceManifest: true, hasControlPlaneDir: true, manifest: malformed},
 			want:               controlPlaneFatal,
 			wantReasonContains: "not valid JSON",
 		},
 		{
 			name:               "the manifest is malformed JSON and there is no workspace",
-			fixture:            controlPlaneFixture{controlPlaneDir: true, manifest: malformed},
+			fixture:            controlPlaneFixture{hasControlPlaneDir: true, manifest: malformed},
 			want:               controlPlaneFatal,
 			wantReasonContains: "not valid JSON",
 		},
 		{
 			name:               "the manifest is present but will not open",
-			fixture:            controlPlaneFixture{controlPlaneDir: true, manifestIsDir: true},
+			fixture:            controlPlaneFixture{hasControlPlaneDir: true, isManifestDirectory: true},
 			want:               controlPlaneFatal,
 			wantReasonContains: "could not be read",
 		},
@@ -428,7 +428,7 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 			// manifest witness above: a witness that will not stat is present,
 			// not absent, so the both-absent premise for skipping is false.
 			name:               "the workspace manifest is present but will not stat",
-			fixture:            controlPlaneFixture{workspaceUnreadable: true},
+			fixture:            controlPlaneFixture{hasUnreadableWorkspaceManifest: true},
 			want:               controlPlaneFatal,
 			wantReasonContains: "An unreadable witness is not an absent one",
 		},
@@ -466,11 +466,11 @@ func TestControlPlaneVerdictDecidesEachWitnessCombination(t *testing.T) {
 // controlPlaneFixture describes which witnesses a temp repo root carries. The
 // zero value is a checkout with no TypeScript side at all.
 type controlPlaneFixture struct {
-	workspace           bool   // pnpm-workspace.yaml at the repo root
-	workspaceUnreadable bool   // pnpm-workspace.yaml exists but will not stat
-	controlPlaneDir     bool   // platform/app exists, possibly empty
-	manifest            string // written to platform/app/package.json when set
-	manifestIsDir       bool   // platform/app/package.json exists but will not open
+	hasWorkspaceManifest           bool   // pnpm-workspace.yaml at the repo root
+	hasUnreadableWorkspaceManifest bool   // pnpm-workspace.yaml exists but will not stat
+	hasControlPlaneDir             bool   // platform/app exists, possibly empty
+	manifest                       string // written to platform/app/package.json when set
+	isManifestDirectory            bool   // platform/app/package.json exists but will not open
 }
 
 // build materializes the fixture under t.TempDir() and returns the repo root.
@@ -478,10 +478,10 @@ func (f controlPlaneFixture) build(t *testing.T) string {
 	t.Helper()
 
 	root := t.TempDir()
-	if f.workspace {
+	if f.hasWorkspaceManifest {
 		writeControlPlaneFile(t, filepath.Join(root, workspaceManifest), "packages:\n  - platform/app\n")
 	}
-	if f.workspaceUnreadable {
+	if f.hasUnreadableWorkspaceManifest {
 		// A symlink pointing at itself stats as ELOOP rather than ENOENT,
 		// which is the cheapest deterministic unreadable witness -- and like
 		// the directory below, it holds when the suite runs as root.
@@ -492,7 +492,7 @@ func (f controlPlaneFixture) build(t *testing.T) string {
 	}
 
 	cpRoot := controlPlaneRootFor(root)
-	if f.controlPlaneDir || f.manifest != "" || f.manifestIsDir {
+	if f.hasControlPlaneDir || f.manifest != "" || f.isManifestDirectory {
 		if err := os.MkdirAll(cpRoot, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", cpRoot, err)
 		}
@@ -500,7 +500,7 @@ func (f controlPlaneFixture) build(t *testing.T) string {
 
 	manifestPath := filepath.Join(cpRoot, "package.json")
 	switch {
-	case f.manifestIsDir:
+	case f.isManifestDirectory:
 		// A directory opens but will not read, which is the cheapest
 		// deterministic stand-in for an unreadable manifest -- unlike a
 		// permission bit, it also holds when the suite runs as root.
@@ -553,14 +553,14 @@ func TestRequireControlPlaneDispatchesTheVerdictItWasGiven(t *testing.T) {
 		{
 			name: "a present control plane lets the test run",
 			fixture: controlPlaneFixture{
-				workspace:       true,
-				controlPlaneDir: true,
-				manifest:        `{"name":"` + controlPlanePackage + `"}`,
+				hasWorkspaceManifest: true,
+				hasControlPlaneDir:   true,
+				manifest:             `{"name":"` + controlPlanePackage + `"}`,
 			},
 		},
 		{
 			name:       "an ambiguous checkout fails rather than skipping",
-			fixture:    controlPlaneFixture{workspace: true},
+			fixture:    controlPlaneFixture{hasWorkspaceManifest: true},
 			wantFailed: true,
 		},
 		{


### PR DESCRIPTION
Fixes #6895. `main` is red at tip with five controlplane contract failures. This PR is not a symptom patch — it repoints the stale constant *and* removes the class of trap that hid it for eight days.

## What broke

Three steps, not one cause:

1. #6405 (`2bbeb7dd2`, ADR-076) renamed `langwatch/` → `platform/app/`. `controlPlaneRoot` was not moved with it.
2. `readControlPlaneSource` **skipped** rather than failed when the directory was absent. Every run for eight days skipped silently, so the stale constant was invisible.
3. #5748 (`a5784bedb`) added one misplaced test file under the old path, re-creating `langwatch/src/server`. The `os.Stat` sentinel flipped to "found", the tests stopped skipping, and the dormant breakage went live as five hard failures.

Not caused by any PR merged today. The stale line has been on `main` since ADR-076:

```
$ git show origin/main:services/aigateway/adapters/controlplane/guardrails_contract_test.go | grep -n "controlPlaneRoot ="
178:var controlPlaneRoot = filepath.Join("..", "..", "..", "..", "langwatch")
```

## The fix

Repointing the constant alone restores green and leaves the same trap armed for the next rename. So the guard is rebuilt too.

**Both witnesses are now identities, not directories.** A directory is re-created by any stray file — which is exactly what happened. Skip now requires **both** to be absent: the pnpm workspace manifest at the repo root, and a `package.json` at `controlPlaneRoot` whose *parsed* `name` is `@langwatch/web`. Either one alone runs the tests.

**The ambiguous case fails, it does not skip.** A workspace present without the control plane under it — the precise shape of the ADR-076 rename — is now a hard failure naming the stale constant. A false red costs one path edit; a false green costs an unenforced cross-language contract nobody is watching.

## Deliberately not in this PR

The misplaced file from step 3 is left where it is. It is dead code — `langwatch/` is not in `pnpm-workspace.yaml`'s `packages:` list, so it runs nowhere. Moving it to `platform/app/` would **activate a ClickHouse integration test that has never executed anywhere**, which is a real risk that does not belong in a main-is-red fix. The new guard is unaffected by the stray tree, verified below. Left tracked on #6895.

## Verification

Run with the stray tree **present** — the state this actually lands in.

All five RUN and PASS, no `--- SKIP`:

```
=== RUN   TestControlPlaneMaterialiserEmitsTheBudgetContract
--- PASS: TestControlPlaneMaterialiserEmitsTheBudgetContract (0.00s)
=== RUN   TestControlPlaneBucketSeparatorsAreStable
--- PASS: TestControlPlaneBucketSeparatorsAreStable (0.00s)
=== RUN   TestSpanAttributeContractForProviderAttribution
--- PASS: TestSpanAttributeContractForProviderAttribution (0.00s)
=== RUN   TestProvidersAllowedEmptyListNormalization
--- PASS: TestProvidersAllowedEmptyListNormalization (0.00s)
=== RUN   TestControlPlaneSchemaAgreesOnTheWireShape
--- PASS: TestControlPlaneSchemaAgreesOnTheWireShape (0.00s)
ok      github.com/langwatch/langwatch/services/aigateway/adapters/controlplane
```

**Mutation** — constant reverted to `langwatch/`, nothing else changed. Fails hard, and names itself:

```
--- FAIL: TestControlPlaneSchemaAgreesOnTheWireShape (0.00s)
    guardrails_contract_test.go:250: this checkout carries the monorepo (pnpm-workspace.yaml is at the
    repo root) but ../../../../langwatch holds no @langwatch/web package manifest: the control plane
    moved and controlPlaneRoot did not move with it. Repoint controlPlaneRoot.
```

Restored → green again.

Further mutation cases. **Provenance is marked per row and is not uniform** — I ran two of these myself; the rest are the implementing agent's self-report, reproduced here because they are useful, not because I re-ran them. Weigh them accordingly.

| Case | Result | Source |
|---|---|---|
| New guard + stray tree (the landing state) | all 5 PASS — the stray tree is inert | **verified here** |
| Constant reverted, nothing else | hard FAIL naming the constant, not SKIP | **verified here** |
| Old guard, `langwatch/src/server` present as an **empty dir** | passes the old sentinel — proves a bare directory was never a witness | agent self-report |
| Old guard, `langwatch/` fully absent | SKIP — confirms the dormant week | agent self-report |
| Corrupt a Go needle expectation | RED at `budgets_contract_test.go:160` | agent self-report |
| Rename `provider_key:` in the **live TypeScript** source | RED — proves it reads the real file, not a stale copy | agent self-report |
| `package.json` present but wrong `name` | FAIL — identity, not mere existence | agent self-report |
| Both witnesses absent | SKIP — split/vendored Go build still works | agent self-report |

Same split applies to the suite run: I ran `./services/aigateway/adapters/controlplane/...` only. The full six-package-tree CI invocation from `.github/workflows/go-ci.yaml:132` is the agent's self-report, not mine. CI on this PR is the real check on that.

`gofmt -l` clean, `go vet` clean.

## How I can prove I was successful

| Claim | Evidence | Where |
|---|---|---|
| The guard now fails instead of silently skipping when the control plane moves | Mutation: constant reverted to `langwatch/` → hard FAIL naming the constant (quoted above), not `--- SKIP` | ## Verification |
| The decision is exhaustively covered, not spot-checked | `go test -run ControlPlane -count=1 -v` → **15 subtests PASS** over a 12-row witness-combination table plus the dispatch table | this branch, head `a00309d9` |
| An unreadable witness is treated as present, never as absent | Table row "the workspace manifest is present but will not stat" (ELOOP symlink fixture) → `controlPlaneFatal` | `guardrails_contract_test.go` |
| Nothing outside the test file changed | `git diff --stat main...HEAD` → one `_test.go` file | ## Blast radius |
| CI is green on the landing SHA | All checks at `a00309d9`: **0 failures**, 58 success, 39 skipped; the 3 earlier `cancelled` metadata checks each have a later `success` run at 08:42Z | Checks tab |

## Human verification

Backend-only change — no UI surface. <!-- no-ui-surface -->

To reproduce locally:

```bash
git checkout fix/6895-controlplane-root-adr076
go test ./services/aigateway/adapters/controlplane/ -count=1 -v   # expect all PASS, zero SKIP
```

Then break it on purpose and confirm it shouts:

```bash
# in guardrails_contract_test.go, repoint the constant back to the pre-ADR-076 path
#   controlPlaneRoot = filepath.Join(monorepoRoot, "langwatch")
go test ./services/aigateway/adapters/controlplane/ -count=1
# expect: FAIL, with a message naming controlPlaneRoot — NOT "--- SKIP"
```

The second step is the one worth doing by hand: the whole point of this PR is that the old code skipped there.

## Blast radius

One `_test.go` file. No production code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved control-plane source validation by checking repository-root workspace and package manifests.
  - Missing, malformed, unreadable, or incorrectly named manifests now produce explicit failures.
  - Source checkouts are skipped only when both required validation indicators are absent.
  - Improved handling of incomplete or stale source paths, reducing incorrect skips and providing more reliable diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact

No deployment impact — this PR changes exactly one file, `services/aigateway/adapters/controlplane/guardrails_contract_test.go`, and ships zero production code.

The CI gate here checks only that this heading is **present**, so a filled-in section proves nothing on its own. Each answer below is therefore backed by a disconfirming command — one that would have shown something if the answer were wrong.

- **Env vars added/changed:** none. `grep -cE 'os\.Getenv|os\.LookupEnv' services/aigateway/adapters/controlplane/guardrails_contract_test.go` → `0`. Every path is derived from the repo layout (`monorepoRoot`, `platform/app`).
- **Helm values added/changed:** none. `git diff --stat origin/main...HEAD -- 'charts/**' '**/values*.yaml' '**/*.env*' 'dev/docs/adr/**' 'dev/docs/best_practices/**'` → empty.
- **Default behaviour on a vanilla `helm install` with no overrides:** unchanged, because the changed file is not part of any shipped build. `go list -f 'GoFiles={{.GoFiles}}' ./services/aigateway/adapters/controlplane/` → `[client.go config_wire.go guardrails.go signer.go]` — `guardrails_contract_test.go` is absent from `GoFiles` and present only in `TestGoFiles` (7). No deployed artefact differs by a byte.
- **BYOC dataplane impact:** none. `git diff --name-only origin/main...HEAD | grep -v '_test\.go$'` → empty, so the change is test-only; full diff is `1 file changed, 406 insertions(+), 9 deletions(-)`.

The only behaviour that changes is CI's own: the aigateway control-plane contract tests now fail loudly on a checkout whose control-plane witness is missing or wrong, instead of silently skipping. That is the defect this PR exists to close (#6895).

