### PR TITLE
feat(haven): seed a play sandbox from the shared preset registry

### DIFF
--- a/dev/docs/adr/064-haven-cli-redesign.md
+++ b/dev/docs/adr/064-haven-cli-redesign.md
@@ -350,6 +350,19 @@ The rules it adds, and how they honour the constitution:
 - **A hard death is recoverable.** The sandbox is recorded before any
   resource exists; `haven clean` reaps any sandbox whose owning process is
   gone by finishing the same teardown.
+- **`--seed <preset>` reads the same registry as `db seed`.** A sandbox's
+  databases are born empty, so a PR about anything past onboarding opens on
+  the wrong screen. The presets are not duplicated for play and there is no
+  play-only variant — one list, one meaning, per the flag rule above. Where
+  each half lands differs by necessity: the preset's switches go to the
+  sandbox's own seed, before its services start, while data that travels
+  through the collector can only land once the sandbox is serving, so it runs
+  in a lane beside the supervised set that waits on the sandbox's own
+  `/api/health`. That lane is a warning path end to end — a failed ingest
+  names the step and the command that retries it and leaves the sandbox
+  running, because a PR that broke the collector is precisely one worth
+  watching — but teardown still waits for it to stop, rather than racing a
+  `docker volume rm` against a process still writing.
 
 Spec: `specs/setup/haven-play.feature`.
 

--- a/specs/setup/haven-play.feature
+++ b/specs/setup/haven-play.feature
@@ -221,19 +221,14 @@ Feature: haven play, a throwaway PR sandbox
     Then the sandbox runs no ingest step and waits for nothing
 
   # A sandbox whose app never answers is either being torn down or running a PR
-  # that does not boot. Either way the seeder has nowhere to send data.
+  # that does not boot. Its database still holds everything the base seed put
+  # there; only the data that needs the running sandbox is missing.
   @unit
-  Scenario: A sandbox that never serves is never seeded
+  Scenario: A sandbox that never serves keeps its base seed and nothing more
     Given a preset whose data goes through the collector
     And the sandbox's app never answers
-    Then the ingest gives up instead of sending to a stack that is not there
-
-  # The launcher is dispatchable by hand, and the parser caps positionals
-  # without ever requiring them.
-  @unit
-  Scenario: The launcher refuses an invocation with no PR number
-    When the sandbox launcher is run with no arguments
-    Then it says a PR number is required rather than failing on the missing argument
+    Then that data is never sent to a sandbox that is not there
+    And the identity the base seed wrote is still in place
 
   # The sandbox is the point; its sample data is not. A seeder that failed (or a
   # PR whose collector is the thing that is broken) must leave the PR running.

--- a/specs/setup/haven-play.feature
+++ b/specs/setup/haven-play.feature
@@ -220,6 +220,21 @@ Feature: haven play, a throwaway PR sandbox
     Given a preset that only switches the base seed
     Then the sandbox runs no ingest step and waits for nothing
 
+  # A sandbox whose app never answers is either being torn down or running a PR
+  # that does not boot. Either way the seeder has nowhere to send data.
+  @unit
+  Scenario: A sandbox that never serves is never seeded
+    Given a preset whose data goes through the collector
+    And the sandbox's app never answers
+    Then the ingest gives up instead of sending to a stack that is not there
+
+  # The launcher is dispatchable by hand, and the parser caps positionals
+  # without ever requiring them.
+  @unit
+  Scenario: The launcher refuses an invocation with no PR number
+    When the sandbox launcher is run with no arguments
+    Then it says a PR number is required rather than failing on the missing argument
+
   # The sandbox is the point; its sample data is not. A seeder that failed (or a
   # PR whose collector is the thing that is broken) must leave the PR running.
   @unit

--- a/specs/setup/haven-play.feature
+++ b/specs/setup/haven-play.feature
@@ -178,9 +178,66 @@ Feature: haven play, a throwaway PR sandbox
     And only sandboxes whose owner process is gone are offered for reaping
     And "haven clean" finishes the teardown
 
+  # --- Seeding the sandbox ---
+  # A sandbox's databases are born empty, so the PR opens on the onboarding
+  # "waiting for your first message" screen — the wrong starting point for
+  # reviewing anything that happens after onboarding. `--seed <preset>` takes
+  # exactly the presets `haven db seed` takes (see haven-seed-presets.feature);
+  # there is no second registry and no play-only preset. Without the flag the
+  # sandbox seeds the stable identity only, as it always has.
+  @unit
+  Scenario: A sandbox can be seeded with a data preset
+    When the developer runs "haven play 4913 --seed demo"
+    Then the sandbox's seed carries that preset
+    And the presets offered are the ones "haven db seed" takes
+
+  @unit
+  Scenario: An unknown preset is rejected before anything is created
+    When the developer runs "haven play 4913 --seed nosuch"
+    Then the command fails listing the presets it can pick from
+    And it fails before the PR is resolved, so nothing is checked out
+
+  # The sandbox is provisioned by a backgrounded launcher process, so a preset
+  # that only reached the parent would be silently dropped.
+  @unit
+  Scenario: The preset reaches the backgrounded launcher
+    Given a preset was asked for
+    When play backgrounds the sandbox launcher
+    Then the launcher is told which preset to seed
+
+  # A preset's data goes through the real collector and event-sourcing commands,
+  # which only exist once the sandbox is serving — and the sandbox's services are
+  # supervised until it is torn down, so the ingest cannot be a step before them.
+  @unit
+  Scenario: Preset data is ingested once the sandbox is serving
+    Given a preset whose data goes through the collector
+    When the sandbox's services start
+    Then the ingest waits for the sandbox's own app to answer before sending anything
+    And it targets the sandbox's app on loopback, never another stack's
+
+  @unit
+  Scenario: Presets with no ingest never wait for the app
+    Given a preset that only switches the base seed
+    Then the sandbox runs no ingest step and waits for nothing
+
+  # The sandbox is the point; its sample data is not. A seeder that failed (or a
+  # PR whose collector is the thing that is broken) must leave the PR running.
+  @unit
+  Scenario: A failed seed never takes the sandbox down
+    Given a preset ingest step fails
+    Then the sandbox keeps running and the failing step is named
+    And the retry command names this sandbox's own stack
+
   @e2e @unimplemented
   Scenario: A PR runs end to end in the sandbox
     Given a terminal
     When the developer runs "haven play 4913" and passes the trust gate
     Then the PR serves at its own play hostname with its own databases
     And quitting the view tears all of it down
+
+  @e2e @unimplemented
+  Scenario: A seeded sandbox lands end to end
+    Given a terminal
+    When the developer runs "haven play 4913 --seed demo"
+    Then the sandbox comes up past onboarding with its sample traces ingested
+    And quitting the view tears the seeded databases down with everything else

--- a/specs/setup/haven-seed-presets.feature
+++ b/specs/setup/haven-seed-presets.feature
@@ -5,7 +5,9 @@ Feature: Seed presets — a database that is ready to look at
   (an idempotent upsert, nothing dropped); `haven db reset [preset]` is the
   destructive sibling that starts from a fresh database. Presets are
   positional and shared by both: demo, traces, onboarding, post-onboarding,
-  bare (ADR-064).
+  bare (ADR-064). One registry serves the whole CLI — `haven play --seed
+  <preset>` seeds a throwaway PR sandbox from the same list
+  (haven-play.feature).
 
   # Behavior lives in tools/thuishaven `app/db.go` (the seedPresets registry,
   # DBSeed, DBReset, the live-stack ingest steps) plus the seed scripts they

--- a/specs/setup/haven-seed-presets.feature
+++ b/specs/setup/haven-seed-presets.feature
@@ -5,7 +5,7 @@ Feature: Seed presets — a database that is ready to look at
   (an idempotent upsert, nothing dropped); `haven db reset [preset]` is the
   destructive sibling that starts from a fresh database. Presets are
   positional and shared by both: demo, traces, onboarding, post-onboarding,
-  bare (ADR-064). One registry serves the whole CLI — `haven play --seed
+  bare, mass (ADR-064). One registry serves the whole CLI — `haven play --seed
   <preset>` seeds a throwaway PR sandbox from the same list
   (haven-play.feature).
 

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -89,6 +89,8 @@ haven play [pr]  run a PR in a throwaway sandbox: own checkout, own
                  Postgres/ClickHouse/Redis containers, own play-<n> hostname.
                  Quitting the view DESTROYS everything it created, every time.
                  No argument opens a picker of open PRs (terminal only).
+                 --seed <preset> opens it on data instead of the onboarding
+                 screen (the same presets `db seed` takes).
                  Trust-gated: every commit author must have write access, or a
                  two-step confirmation — y/N, then the PR number typed back
                  after it discloses that the code runs as you, from this
@@ -164,6 +166,16 @@ access; anyone without it (including commits with no GitHub account) stops
 play for an explicit default-no confirmation, and in agent mode only
 `--allow-untrusted` proceeds. If a play dies hard, `haven clean` finds its
 record and finishes the teardown.
+
+A sandbox's databases start empty, so the PR opens on the onboarding screen —
+the wrong place to be standing if the change is about anything afterwards.
+`haven play 4913 --seed demo` takes the same presets as `haven db seed` (one
+registry, no play-only variants) and applies them where each belongs: the
+preset's switches go to the sandbox's own seed, and any data that has to travel
+through the collector is ingested once the sandbox's app answers, in a lane
+beside the services. A failed ingest never takes the sandbox down — it names
+the step and the command that retries it, since a PR that broke the collector
+is exactly the PR you want to keep watching.
 
 **Git across worktrees.** `haven git` opens [moron](https://github.com/0xdeafcafe/moron)
 in-process (a Go module dependency — nothing extra to install) for the current

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -89,8 +89,10 @@ haven play [pr]  run a PR in a throwaway sandbox: own checkout, own
                  Postgres/ClickHouse/Redis containers, own play-<n> hostname.
                  Quitting the view DESTROYS everything it created, every time.
                  No argument opens a picker of open PRs (terminal only).
-                 --seed <preset> opens it on data instead of the onboarding
-                 screen (the same presets `db seed` takes).
+                 --seed <preset> seeds it from the same registry `db seed`
+                 reads, so it can open on data rather than the onboarding
+                 screen (demo/traces/mass load data; onboarding, post-
+                 onboarding and bare only move the flags)
                  Trust-gated: every commit author must have write access, or a
                  two-step confirmation — y/N, then the PR number typed back
                  after it discloses that the code runs as you, from this

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -91,8 +91,9 @@ haven play [pr]  run a PR in a throwaway sandbox: own checkout, own
                  No argument opens a picker of open PRs (terminal only).
                  --seed <preset> seeds it from the same registry `db seed`
                  reads, so it can open on data rather than the onboarding
-                 screen (demo/traces/mass load data; onboarding, post-
-                 onboarding and bare only move the flags)
+                 screen: demo, traces and mass load data, onboarding and
+                 post-onboarding move the onboarding flag, bare is the
+                 identity alone
                  Trust-gated: every commit author must have write access, or a
                  two-step confirmation — y/N, then the PR number typed back
                  after it discloses that the code runs as you, from this

--- a/tools/thuishaven/adapters/procsupervisor/supervisor.go
+++ b/tools/thuishaven/adapters/procsupervisor/supervisor.go
@@ -51,6 +51,16 @@ func (s Supervisor) RunOnce(ctx context.Context, name, dir, shell string, env []
 	return err
 }
 
+// WaitReady blocks until url answers non-5xx, logging under name so the wait is
+// visible in the same stream as the lanes. It is the same probe that gates a
+// child on its dependency, exposed for callers that are not a child themselves:
+// the play sandbox's seed ingest, which has to reach the stack it just started.
+func (s Supervisor) WaitReady(ctx context.Context, name, url string) bool {
+	c := proc{name: name, color: "90", isPlain: s.isPlain}
+	waitForReady(ctx, url, c.logln)
+	return ctx.Err() == nil
+}
+
 // RunOnceBounded is RunOnce plus a reaper: a background poll kills the whole
 // process group (the child owns its own group via Setpgid, same as every other
 // supervised child) if its total RSS or wall-clock time crosses limits. Reaping

--- a/tools/thuishaven/app/db.go
+++ b/tools/thuishaven/app/db.go
@@ -73,6 +73,15 @@ func SeedPresetNames() []string {
 	return names
 }
 
+// ValidateSeedPreset reports whether a preset name is one this registry knows
+// ("" is the plain identity seed). It exists for the surfaces that must reject
+// a bad preset before they start doing expensive or destructive work — `haven
+// play --seed` checks it before it resolves the PR, so a typo costs nothing.
+func ValidateSeedPreset(name string) error {
+	_, err := resolveSeedPreset(name)
+	return err
+}
+
 // resolveSeedPreset validates a preset name ("" is the plain identity seed).
 func resolveSeedPreset(name string) (seedPreset, error) {
 	if name == "" {

--- a/tools/thuishaven/app/db_test.go
+++ b/tools/thuishaven/app/db_test.go
@@ -19,6 +19,10 @@ type fakeSupervisor struct {
 	// errOn, when non-empty, fails only the shell containing this substring —
 	// so a test can break the seed while letting the prepare pass.
 	errOn string
+	// waited records every URL WaitReady was asked about; notReady makes it
+	// report "gave up" instead, the way a canceled context does.
+	waited   []string
+	notReady bool
 }
 
 func (f *fakeSupervisor) RunOnce(_ context.Context, _, dir, shell string, env []string) error {
@@ -37,6 +41,10 @@ func (f *fakeSupervisor) RunOnceBounded(_ context.Context, _, _, shell string, e
 	return f.RunOnce(context.Background(), "", "", shell, env)
 }
 func (f *fakeSupervisor) Supervise(context.Context, []Child) {}
+func (f *fakeSupervisor) WaitReady(_ context.Context, _, url string) bool {
+	f.waited = append(f.waited, url)
+	return !f.notReady
+}
 
 type portSystem struct {
 	fakeSystem

--- a/tools/thuishaven/app/play.go
+++ b/tools/thuishaven/app/play.go
@@ -1139,7 +1139,7 @@ func (o *Orchestrator) preparePlaySandbox(ctx context.Context, pl PlaySandbox, s
 	}
 	env := append(st.OverlayEnv(), "DOTENV_CONFIG_QUIET=true")
 	if err := o.sup.RunOnce(ctx, "codegen", pl.LwDir, "pnpm -s run start:prepare:files", env); err != nil {
-		o.log.Warn("play codegen failed (continuing)")
+		o.log.Warn("play codegen failed (continuing)", zap.Error(err))
 	}
 	if err := o.sup.RunOnce(ctx, "prepare", pl.LwDir, "pnpm -s run start:prepare:db", env); err != nil {
 		return fmt.Errorf("play migrations failed: %w", err)
@@ -1148,7 +1148,7 @@ func (o *Orchestrator) preparePlaySandbox(ctx context.Context, pl PlaySandbox, s
 	// are the same run whatever data was asked for.
 	seedEnv := append(append([]string{}, env...), pl.pre.env...)
 	if err := o.sup.RunOnce(ctx, "seed", pl.LwDir, seedShell("pnpm -s run prisma:seed", seedEnv), seedEnv); err != nil {
-		o.log.Warn("play seed failed (continuing)")
+		o.log.Warn("play seed failed (continuing)", zap.Error(err))
 	}
 	return nil
 }

--- a/tools/thuishaven/app/play.go
+++ b/tools/thuishaven/app/play.go
@@ -11,7 +11,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
@@ -922,115 +925,291 @@ func PlayDisclosure(number int) string {
 // migrations, seed, then the supervised service set until ctx is cancelled.
 // It never cleans up - the owning `haven play` process (or `haven clean`)
 // owns the teardown, so a hard death here can never skip it.
-func (o *Orchestrator) PlayLaunch(ctx context.Context, number int, checkout, lwDir string) error {
-	slug := PlaySlug(number)
-	database := domain.DatabaseForSlug(slug)
-	fmt.Print(PlayDisclosure(number))
-
-	if !o.proxy.Installed() {
-		fmt.Println("portless is not installed: installing it (one time)…")
-		if err := o.proxy.Install(); err != nil {
-			return fmt.Errorf("could not install portless automatically (%w)", err)
-		}
-	}
-	if err := o.proxy.EnsureReady(); err != nil {
-		return fmt.Errorf("could not start the portless proxy: %w", err)
-	}
-	if o.container == nil {
-		return fmt.Errorf("haven play needs the container runtime (colima) for its dedicated databases")
-	}
-	dockerHost, err := o.container.Ensure(ctx)
-	if err != nil {
-		return fmt.Errorf("colima (%s): %w", o.container.Profile(), err)
-	}
-
-	nSvc := len(domain.PerWorktreeServices)
-	ports, err := o.sys.FreePorts(nSvc + 5)
+//
+// preset ("" = the plain identity seed) picks a variant from the same registry
+// `haven db seed` reads, so a sandbox can open on data instead of the
+// onboarding screen. A preset that loads data through the collector is ingested
+// once the sandbox is serving, alongside the supervised set.
+func (o *Orchestrator) PlayLaunch(ctx context.Context, pl PlaySandbox) error {
+	pre, err := resolveSeedPreset(pl.Preset)
 	if err != nil {
 		return err
 	}
-	pgPort, chPort, redisPort := ports[nSvc+2], ports[nSvc+3], ports[nSvc+4]
-
-	// Dedicated infra first: the overlay needs the ports, migrations need the
-	// databases. Each engine is its own lane so its output reads distinctly.
-	dockerEnv := []string{"DOCKER_HOST=" + dockerHost}
-	fmt.Printf("  play: starting dedicated postgres/clickhouse/redis (volumes %s…)\n", PlayVolumeName(number, "postgres"))
-	if err := o.sup.RunOnce(ctx, "play-postgres", checkout, playPostgresShell(number, pgPort, database), dockerEnv); err != nil {
-		return fmt.Errorf("play postgres: %w", err)
-	}
-	if err := o.sup.RunOnce(ctx, "play-clickhouse", checkout, playClickHouseShell(number, chPort, database), dockerEnv); err != nil {
-		return fmt.Errorf("play clickhouse: %w", err)
-	}
-	if err := o.sup.RunOnce(ctx, "play-redis", checkout, playRedisShell(number, redisPort), dockerEnv); err != nil {
-		return fmt.Errorf("play redis: %w", err)
+	pl.pre = pre
+	pl.slug = PlaySlug(pl.Number)
+	pl.database = domain.DatabaseForSlug(pl.slug)
+	fmt.Print(PlayDisclosure(pl.Number))
+	if pl.Preset != "" {
+		fmt.Printf("  Seeding it with the %q preset: %s.\n", pl.Preset, pre.summary)
 	}
 
+	if pl.dockerHost, err = o.ensurePlayRuntime(ctx); err != nil {
+		return err
+	}
+	free, err := o.sys.FreePorts(len(domain.PerWorktreeServices) + 5)
+	if err != nil {
+		return err
+	}
+	ports := newPlayPorts(free)
+	if err := o.startPlayDatabases(ctx, pl, ports); err != nil {
+		return err
+	}
+	st, err := o.registerPlayStack(pl, ports)
+	if err != nil {
+		return err
+	}
+	if err := o.preparePlaySandbox(ctx, pl, st); err != nil {
+		return err
+	}
+
+	// A preset's data goes through the real collector and event-sourcing
+	// commands, so it can only land once the sandbox is serving — and Supervise
+	// below runs until teardown. Hence a lane of its own beside the services,
+	// which waits for the app itself rather than guessing at a delay.
+	var ingesting sync.WaitGroup
+	if len(pre.ingest) > 0 {
+		ingesting.Add(1)
+		go func() {
+			defer ingesting.Done()
+			o.ingestPlaySeed(ctx, st, pl)
+		}()
+	}
+	opts := PlanOptions{Selection: playSelection(), RepoRoot: pl.Checkout}
+	o.sup.Supervise(ctx, o.planChildren(st, opts, pl.LwDir, ""))
+	// Both stop on the same canceled context, but the seeder writes to the
+	// databases teardown is about to delete — so hand back only once it has
+	// actually stopped, rather than racing a `docker volume rm` against it.
+	ingesting.Wait()
+	return nil
+}
+
+// PlaySandbox is one sandbox launch: which PR, where its code lives, and what
+// it was asked to seed. The steps below take it whole rather than passing the
+// same values down in different orders; the unexported fields are what
+// PlayLaunch derives from the rest on the way in.
+type PlaySandbox struct {
+	Number   int
+	Checkout string // the PR's own tree, under the haven home's play area
+	LwDir    string // the app directory inside that tree
+	// Preset names a variant from the seed registry `haven db seed` reads; empty
+	// is the plain identity seed.
+	Preset string
+
+	slug       string
+	database   string
+	pre        seedPreset
+	dockerHost string
+}
+
+// playSelection is the service set a sandbox runs: lean, and never langy — an
+// unreviewed branch has no business driving an agent runtime.
+func playSelection() domain.Selection { return domain.Selection{Gateway: true, NLP: true} }
+
+// playPorts is one sandbox's port allocation, named rather than indexed: the
+// slice arithmetic that assigned these was the kind of thing that goes wrong
+// silently when a service is added.
+type playPorts struct {
+	services      []int // one per domain.PerWorktreeServices, in order
+	api           int
+	workerMetrics int
+	postgres      int
+	clickHouse    int
+	redis         int
+}
+
+func newPlayPorts(free []int) playPorts {
+	n := len(domain.PerWorktreeServices)
+	return playPorts{
+		services: free[:n], api: free[n], workerMetrics: free[n+1],
+		postgres: free[n+2], clickHouse: free[n+3], redis: free[n+4],
+	}
+}
+
+// ensurePlayRuntime brings up what a sandbox needs before it can exist: the
+// proxy that serves its hostnames and the container runtime that holds its
+// dedicated databases. It returns the DOCKER_HOST addressing that runtime.
+func (o *Orchestrator) ensurePlayRuntime(ctx context.Context) (string, error) {
+	if !o.proxy.Installed() {
+		fmt.Println("portless is not installed: installing it (one time)…")
+		if err := o.proxy.Install(); err != nil {
+			return "", fmt.Errorf("could not install portless automatically (%w)", err)
+		}
+	}
+	if err := o.proxy.EnsureReady(); err != nil {
+		return "", fmt.Errorf("could not start the portless proxy: %w", err)
+	}
+	if o.container == nil {
+		return "", fmt.Errorf("haven play needs the container runtime (colima) for its dedicated databases")
+	}
+	dockerHost, err := o.container.Ensure(ctx)
+	if err != nil {
+		return "", fmt.Errorf("colima (%s): %w", o.container.Profile(), err)
+	}
+	return dockerHost, nil
+}
+
+// startPlayDatabases starts the sandbox's dedicated engines. They come first:
+// the overlay needs their ports and the migrations need the databases. Each
+// engine is its own lane so its output reads distinctly.
+func (o *Orchestrator) startPlayDatabases(ctx context.Context, pl PlaySandbox, ports playPorts) error {
+	dockerEnv := []string{"DOCKER_HOST=" + pl.dockerHost}
+	fmt.Printf("  play: starting dedicated postgres/clickhouse/redis (volumes %s…)\n", PlayVolumeName(pl.Number, "postgres"))
+	engines := []struct {
+		lane  string
+		shell string
+	}{
+		{"play-postgres", playPostgresShell(pl.Number, ports.postgres, pl.database)},
+		{"play-clickhouse", playClickHouseShell(pl.Number, ports.clickHouse, pl.database)},
+		{"play-redis", playRedisShell(pl.Number, ports.redis)},
+	}
+	for _, engine := range engines {
+		if err := o.sup.RunOnce(ctx, engine.lane, pl.Checkout, engine.shell, dockerEnv); err != nil {
+			return fmt.Errorf("%s: %w", engine.lane, err)
+		}
+	}
+	return nil
+}
+
+// registerPlayStack builds the sandbox's stack record, routes its hostnames,
+// and publishes it — the overlay its own processes read and the registry every
+// other haven command (status, logs, clean, teardown) discovers it through.
+func (o *Orchestrator) registerPlayStack(pl PlaySandbox, ports playPorts) (domain.Stack, error) {
 	scheme, pport := o.proxy.Endpoint()
-	sel := domain.Selection{Gateway: true, NLP: true} // lean default; langy never runs in a sandbox
 	st := domain.Stack{
-		Slug: slug, WorktreeDir: checkout, Branch: PlayBranch(number),
+		Slug: pl.slug, WorktreeDir: pl.Checkout, Branch: PlayBranch(pl.Number),
 		LauncherPID: o.sys.Getpid(),
 		// The sandbox's Redis is dedicated, so index 0 is always free.
 		RedisDB:            0,
-		APIPort:            ports[nSvc],
-		WorkerMetricsPort:  ports[nSvc+1],
+		APIPort:            ports.api,
+		WorkerMetricsPort:  ports.workerMetrics,
 		LocalAPIKey:        o.cfg.LocalAPIKey,
-		ClickHouseHTTPPort: chPort, ClickHouseDatabase: database,
-		PostgresPort: pgPort, PostgresDatabase: database,
-		RedisPort: redisPort,
+		ClickHouseHTTPPort: ports.clickHouse, ClickHouseDatabase: pl.database,
+		PostgresPort: ports.postgres, PostgresDatabase: pl.database,
+		RedisPort: ports.redis,
 		// Sandboxes run unreviewed branches, so this is the last place that
 		// should be shipping trace text to Google on someone's real credentials.
 		DisableGoogleDLP: o.cfg.ShouldDisableGoogleDLP,
 	}
 	for i, r := range domain.PerWorktreeServices {
 		svc := domain.Service{
-			Name: r.Name, Role: r.Role, Port: ports[i],
-			Hostname: o.cfg.Naming.Hostname(r.Name, slug),
-			URL:      o.cfg.Naming.URL(r.Name, slug, scheme, pport),
+			Name: r.Name, Role: r.Role, Port: ports.services[i],
+			Hostname: o.cfg.Naming.Hostname(r.Name, pl.slug),
+			URL:      o.cfg.Naming.URL(r.Name, pl.slug, scheme, pport),
 		}
 		// The sandbox is hermetic: a service it does not run (langy) gets no
 		// baseline fallback - its port is simply absent.
-		if !runsLocally(r.Name, PlanOptions{Selection: sel}) {
+		if !runsLocally(r.Name, PlanOptions{Selection: playSelection()}) {
 			svc.Port = 0
 		}
 		st.Services = append(st.Services, svc)
-		if svc.Port != 0 {
-			if err := o.proxy.Register(svc.Name, slug, svc.Port); err != nil {
-				return fmt.Errorf("registering %s.%s: %w", svc.Name, slug, err)
-			}
+		if svc.Port == 0 {
+			continue
+		}
+		if err := o.proxy.Register(svc.Name, pl.slug, svc.Port); err != nil {
+			return st, fmt.Errorf("registering %s.%s: %w", svc.Name, pl.slug, err)
 		}
 	}
-	if err := o.proxy.Register(domain.ClickHouseService, slug, chPort); err != nil {
+	if err := o.proxy.Register(domain.ClickHouseService, pl.slug, ports.clickHouse); err != nil {
 		o.log.Warn("play clickhouse alias registration failed")
 	}
 	st.UpdatedAt = o.sys.Now()
-	if err := o.store.WriteOverlay(lwDir, st); err != nil {
-		return err
+	if err := o.store.WriteOverlay(pl.LwDir, st); err != nil {
+		return st, err
 	}
 	if err := o.store.SaveStack(st); err != nil {
-		return err
+		return st, err
 	}
 	o.printStack(st)
+	return st, nil
+}
 
+// preparePlaySandbox gets the checkout ready to run: dependencies, codegen,
+// migrations, seed. Codegen and the seed warn and continue — a sandbox that
+// serves a PR with stale generated files or an unseeded database is still worth
+// looking at — while a failed migration is fatal, because everything after it
+// would be running against a schema nobody has.
+func (o *Orchestrator) preparePlaySandbox(ctx context.Context, pl PlaySandbox, st domain.Stack) error {
 	// A sandbox exists to run somebody else's PR, so its package scripts are
 	// never trusted — install without lifecycle scripts unconditionally rather
 	// than re-deriving fork status inside this detached child. Nothing is lost:
 	// the repo's postinstall is codegen, and the very next step runs it
 	// explicitly through start:prepare:files.
-	if err := o.ensureDeps(ctx, checkout, false); err != nil {
+	if err := o.ensureDeps(ctx, pl.Checkout, false); err != nil {
 		return err
 	}
 	env := append(st.OverlayEnv(), "DOTENV_CONFIG_QUIET=true")
-	if err := o.sup.RunOnce(ctx, "codegen", lwDir, "pnpm -s run start:prepare:files", env); err != nil {
+	if err := o.sup.RunOnce(ctx, "codegen", pl.LwDir, "pnpm -s run start:prepare:files", env); err != nil {
 		o.log.Warn("play codegen failed (continuing)")
 	}
-	if err := o.sup.RunOnce(ctx, "prepare", lwDir, "pnpm -s run start:prepare:db", env); err != nil {
+	if err := o.sup.RunOnce(ctx, "prepare", pl.LwDir, "pnpm -s run start:prepare:db", env); err != nil {
 		return fmt.Errorf("play migrations failed: %w", err)
 	}
-	if err := o.sup.RunOnce(ctx, "seed", lwDir, seedShell("pnpm -s run prisma:seed", env), env); err != nil {
+	// The preset's switches belong to the seed alone — codegen and migrations
+	// are the same run whatever data was asked for.
+	seedEnv := append(append([]string{}, env...), pl.pre.env...)
+	if err := o.sup.RunOnce(ctx, "seed", pl.LwDir, seedShell("pnpm -s run prisma:seed", seedEnv), seedEnv); err != nil {
 		o.log.Warn("play seed failed (continuing)")
 	}
-	opts := PlanOptions{Selection: sel, RepoRoot: checkout}
-	o.sup.Supervise(ctx, o.planChildren(st, opts, lwDir, ""))
 	return nil
+}
+
+// ingestPlaySeed loads a preset's sample data into a sandbox that is starting:
+// wait for its own app to answer, then run the preset's ingest scripts in order.
+//
+// Every failure is a warning, never a stop. The sandbox exists to run the PR;
+// its sample data is a convenience, and a PR that broke the collector is
+// precisely a PR someone wants to look at running. The retry line names this
+// sandbox's stack explicitly because the play checkout's directory is not its
+// slug — `haven db seed` run in there would resolve to a different stack.
+func (o *Orchestrator) ingestPlaySeed(ctx context.Context, st domain.Stack, pl PlaySandbox) {
+	appPort := playAppPort(st)
+	if appPort == 0 {
+		o.log.Warn("play seed ingest skipped: the sandbox has no app port")
+		return
+	}
+	if !o.sup.WaitReady(ctx, "seed", fmt.Sprintf("http://127.0.0.1:%d/api/health", appPort)) {
+		return // the sandbox is being torn down; nothing to say about it
+	}
+	env := append(append([]string{}, st.OverlayEnv()...),
+		fmt.Sprintf("HAVEN_SEED_ENDPOINT=http://127.0.0.1:%d", appPort),
+		"HAVEN_SEED_LANGWATCH_API_KEY="+o.cfg.LocalAPIKey,
+		"DOTENV_CONFIG_QUIET=true",
+	)
+	env = devNodeEnv(env)
+	for _, script := range pl.pre.ingest {
+		if err := o.sup.RunOnce(ctx, script, pl.LwDir, "pnpm run "+script, env); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			o.log.Warn("play seed ingest failed (the sandbox keeps running)",
+				zap.String("step", script), zap.Error(err))
+			fmt.Print(PlaySeedFailure(st.Slug, pl.Preset, script))
+			return
+		}
+	}
+	fmt.Printf("haven: sandbox seeded (%s)\n", pl.Preset)
+}
+
+// PlaySeedFailure is what a sandbox says when its sample data did not land: the
+// step that failed, that the sandbox is unaffected, and the one command that
+// retries it. That command carries the slug explicitly — the play checkout's
+// directory name is pr-<n> while its stack is play-<n>, so a bare `haven db
+// seed` run in there would seed a different stack entirely.
+func PlaySeedFailure(slug, preset, script string) string {
+	return fmt.Sprintf(
+		"haven: seeding %q failed at %s — the sandbox is still running.\n"+
+			"  Retry it with: LANGWATCH_SLUG=%s haven db seed %s\n",
+		preset, script, slug, preset)
+}
+
+// playAppPort is the sandbox's own app port — the loopback endpoint its seed
+// ingest sends to. A sandbox always runs its own app, so a zero here means the
+// stack was built wrong rather than that the service lives elsewhere.
+func playAppPort(st domain.Stack) int {
+	for _, svc := range st.Services {
+		if svc.Name == "app" {
+			return svc.Port
+		}
+	}
+	return 0
 }

--- a/tools/thuishaven/app/play_seed_test.go
+++ b/tools/thuishaven/app/play_seed_test.go
@@ -211,7 +211,7 @@ func TestPlaySeedWithoutIngestNeverWaits(t *testing.T) {
 // A sandbox whose app never answers is one being torn down (or one whose PR
 // does not boot). Either way the ingest has nowhere to send data, so it must
 // give up rather than run the scripts against a stack that is not there.
-// @scenario "Preset data is ingested once the sandbox is serving"
+// @scenario "A sandbox that never serves is never seeded"
 func TestPlaySeedIngestGivesUpWhenTheAppNeverAnswers(t *testing.T) {
 	sup := &fakeSupervisor{notReady: true}
 	launchPlay(t, sup, "demo")

--- a/tools/thuishaven/app/play_seed_test.go
+++ b/tools/thuishaven/app/play_seed_test.go
@@ -1,0 +1,233 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
+)
+
+// playPortSystem hands out distinct ports, unlike fakeSystem's zeros: a sandbox
+// that seeds has to address its own app, so the ports have to be real values.
+type playPortSystem struct {
+	fakeSystem
+	next int
+}
+
+func (p *playPortSystem) FreePorts(n int) ([]int, error) {
+	ports := make([]int, n)
+	for i := range ports {
+		p.next++
+		ports[i] = 6000 + p.next
+	}
+	return ports, nil
+}
+
+type fakeContainer struct{}
+
+func (fakeContainer) Ensure(context.Context) (string, error) { return "unix:///fake.sock", nil }
+func (fakeContainer) Profile() string                        { return "fake" }
+
+// playCheckout is a complete-enough checkout for the launcher: a lockfile (so
+// the dependency install resolves a workspace root) and the app directory.
+func playCheckout(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "platform", "app"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// playStore records what the launcher registers, so a test can read back the
+// sandbox's own ports the way the seed ingest does.
+type playStore struct{ fakeStore }
+
+func (s *playStore) SaveStack(st domain.Stack) error {
+	s.stacks = append(s.stacks, st)
+	return nil
+}
+
+func playOrchestrator(sup *fakeSupervisor) *Orchestrator {
+	return &Orchestrator{
+		cfg: Config{
+			Naming:      domain.DefaultNaming(""),
+			LocalAPIKey: "sk-lw-local-development-key",
+		},
+		sup: sup, store: &playStore{}, sys: &playPortSystem{}, proxy: &fakeProxy{},
+		container: fakeContainer{}, log: zap.NewNop(),
+	}
+}
+
+// launchPlay runs the sandbox launcher to completion. Supervise is a no-op in
+// the fake, so this returns once provisioning is done and the seed ingest lane
+// has finished — PlayLaunch waits for it rather than leaving it running into
+// teardown.
+func launchPlay(t *testing.T, sup *fakeSupervisor, preset string) *Orchestrator {
+	t.Helper()
+	o := playOrchestrator(sup)
+	checkout := playCheckout(t)
+	sandbox := PlaySandbox{
+		Number: 4913, Checkout: checkout,
+		LwDir: filepath.Join(checkout, "platform", "app"), Preset: preset,
+	}
+	if err := o.PlayLaunch(context.Background(), sandbox); err != nil {
+		t.Fatalf("PlayLaunch(%q): %v", preset, err)
+	}
+	return o
+}
+
+// shellsMatching are the run-once lanes whose command contains want, in order.
+func shellsMatching(sup *fakeSupervisor, want string) []string {
+	var out []string
+	for _, shell := range sup.shells {
+		if strings.Contains(shell, want) {
+			out = append(out, shell)
+		}
+	}
+	return out
+}
+
+// envForShell is the environment the lane running want was given.
+func envForShell(t *testing.T, sup *fakeSupervisor, want string) string {
+	t.Helper()
+	for i, shell := range sup.shells {
+		if strings.Contains(shell, want) {
+			return strings.Join(sup.envs[i], " ")
+		}
+	}
+	t.Fatalf("no lane ran %q — shells were %v", want, sup.shells)
+	return ""
+}
+
+// @scenario "A sandbox can be seeded with a data preset"
+func TestPlaySeedsFromTheSharedPresetRegistry(t *testing.T) {
+	t.Run("given a preset", func(t *testing.T) {
+		t.Run("when the sandbox launches, the seed carries the preset's switches", func(t *testing.T) {
+			sup := &fakeSupervisor{}
+			launchPlay(t, sup, "demo")
+			if env := envForShell(t, sup, "prisma:seed"); !strings.Contains(env, "HAVEN_SEED_PRESET=demo") {
+				t.Errorf("seed env = %q, want the demo preset's switches", env)
+			}
+		})
+	})
+
+	t.Run("given no preset", func(t *testing.T) {
+		t.Run("when the sandbox launches, the identity seed is unchanged", func(t *testing.T) {
+			sup := &fakeSupervisor{}
+			launchPlay(t, sup, "")
+			if env := envForShell(t, sup, "prisma:seed"); strings.Contains(env, "HAVEN_SEED_PRESET") {
+				t.Errorf("seed env = %q, want no preset switches without --seed", env)
+			}
+		})
+	})
+
+	t.Run("given a name that is not in the registry", func(t *testing.T) {
+		t.Run("when the sandbox launches, it fails naming the presets", func(t *testing.T) {
+			err := ValidateSeedPreset("nosuch")
+			if err == nil {
+				t.Fatal("ValidateSeedPreset accepted a preset that does not exist")
+			}
+			for _, name := range SeedPresetNames() {
+				if !strings.Contains(err.Error(), name) {
+					t.Errorf("error %q does not offer %q", err, name)
+				}
+				if err := ValidateSeedPreset(name); err != nil {
+					t.Errorf("ValidateSeedPreset(%q) = %v, want the shared registry to accept it", name, err)
+				}
+			}
+			if err := ValidateSeedPreset(""); err != nil {
+				t.Errorf("ValidateSeedPreset(\"\") = %v, want the plain identity seed", err)
+			}
+		})
+	})
+}
+
+// @scenario "Preset data is ingested once the sandbox is serving"
+func TestPlaySeedIngestWaitsForTheSandboxsOwnApp(t *testing.T) {
+	sup := &fakeSupervisor{}
+	o := launchPlay(t, sup, "demo")
+
+	stack, ok := o.stackBySlug(PlaySlug(4913))
+	if !ok {
+		t.Fatal("the sandbox registered no stack")
+	}
+	appPort := playAppPort(stack)
+	if appPort == 0 {
+		t.Fatal("the sandbox stack has no app port")
+	}
+
+	t.Run("when the ingest runs, it waits for that app's health endpoint first", func(t *testing.T) {
+		want := "http://127.0.0.1:" + strconv.Itoa(appPort) + "/api/health"
+		if len(sup.waited) != 1 || sup.waited[0] != want {
+			t.Fatalf("waited on %v, want exactly %q", sup.waited, want)
+		}
+	})
+
+	t.Run("when the ingest runs, every step targets the sandbox on loopback", func(t *testing.T) {
+		steps := shellsMatching(sup, "pnpm run seed:")
+		if len(steps) != len(seedPresets["demo"].ingest) {
+			t.Fatalf("ingest steps = %v, want the demo preset's %v", steps, seedPresets["demo"].ingest)
+		}
+		for i, script := range seedPresets["demo"].ingest {
+			if !strings.Contains(steps[i], script) {
+				t.Errorf("ingest step %d = %q, want %q — order is the registry's", i, steps[i], script)
+			}
+		}
+		env := envForShell(t, sup, "seed:sample-traces")
+		if !strings.Contains(env, "HAVEN_SEED_ENDPOINT=http://127.0.0.1:"+strconv.Itoa(appPort)) {
+			t.Errorf("ingest env = %q, want the sandbox's own loopback app", env)
+		}
+		if !strings.Contains(env, "HAVEN_SEED_LANGWATCH_API_KEY=sk-lw-local-development-key") {
+			t.Errorf("ingest env = %q, want the local ingestion key", env)
+		}
+	})
+}
+
+// @scenario "Presets with no ingest never wait for the app"
+func TestPlaySeedWithoutIngestNeverWaits(t *testing.T) {
+	for _, preset := range []string{"", "post-onboarding"} {
+		sup := &fakeSupervisor{}
+		launchPlay(t, sup, preset)
+		if len(sup.waited) != 0 {
+			t.Errorf("preset %q waited on %v, want no wait — it loads no data", preset, sup.waited)
+		}
+		if steps := shellsMatching(sup, "pnpm run seed:"); len(steps) != 0 {
+			t.Errorf("preset %q ran %v, want no ingest step", preset, steps)
+		}
+	}
+}
+
+// The sandbox is the point; its sample data is a convenience. A PR that breaks
+// the collector is exactly a PR someone wants to watch running.
+// @scenario "A failed seed never takes the sandbox down"
+func TestPlaySeedFailureLeavesTheSandboxRunning(t *testing.T) {
+	sup := &fakeSupervisor{errOn: "seed:sample-traces", err: errors.New("collector said no")}
+	launchPlay(t, sup, "demo") // launchPlay fails the test if the launch returns an error
+
+	t.Run("when a step fails, the steps after it are abandoned", func(t *testing.T) {
+		steps := shellsMatching(sup, "pnpm run seed:")
+		if len(steps) != 2 {
+			t.Fatalf("ingest steps = %v, want the retention pin then the failing traces step", steps)
+		}
+	})
+
+	t.Run("when a step fails, the retry names this sandbox's own stack", func(t *testing.T) {
+		msg := PlaySeedFailure(PlaySlug(4913), "demo", "seed:sample-traces")
+		for _, want := range []string{"seed:sample-traces", "still running", "LANGWATCH_SLUG=play-4913", "haven db seed demo"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("failure message %q is missing %q", msg, want)
+			}
+		}
+	})
+}

--- a/tools/thuishaven/app/play_seed_test.go
+++ b/tools/thuishaven/app/play_seed_test.go
@@ -208,6 +208,21 @@ func TestPlaySeedWithoutIngestNeverWaits(t *testing.T) {
 	}
 }
 
+// A sandbox whose app never answers is one being torn down (or one whose PR
+// does not boot). Either way the ingest has nowhere to send data, so it must
+// give up rather than run the scripts against a stack that is not there.
+// @scenario "Preset data is ingested once the sandbox is serving"
+func TestPlaySeedIngestGivesUpWhenTheAppNeverAnswers(t *testing.T) {
+	sup := &fakeSupervisor{notReady: true}
+	launchPlay(t, sup, "demo")
+	if len(sup.waited) != 1 {
+		t.Fatalf("waited on %v, want one attempt at the app", sup.waited)
+	}
+	if steps := shellsMatching(sup, "pnpm run seed:"); len(steps) != 0 {
+		t.Errorf("ran %v against a stack that never came up, want nothing", steps)
+	}
+}
+
 // The sandbox is the point; its sample data is a convenience. A PR that breaks
 // the collector is exactly a PR someone wants to watch running.
 // @scenario "A failed seed never takes the sandbox down"

--- a/tools/thuishaven/app/play_seed_test.go
+++ b/tools/thuishaven/app/play_seed_test.go
@@ -211,7 +211,7 @@ func TestPlaySeedWithoutIngestNeverWaits(t *testing.T) {
 // A sandbox whose app never answers is one being torn down (or one whose PR
 // does not boot). Either way the ingest has nowhere to send data, so it must
 // give up rather than run the scripts against a stack that is not there.
-// @scenario "A sandbox that never serves is never seeded"
+// @scenario "A sandbox that never serves keeps its base seed and nothing more"
 func TestPlaySeedIngestGivesUpWhenTheAppNeverAnswers(t *testing.T) {
 	sup := &fakeSupervisor{notReady: true}
 	launchPlay(t, sup, "demo")
@@ -220,6 +220,11 @@ func TestPlaySeedIngestGivesUpWhenTheAppNeverAnswers(t *testing.T) {
 	}
 	if steps := shellsMatching(sup, "pnpm run seed:"); len(steps) != 0 {
 		t.Errorf("ran %v against a stack that never came up, want nothing", steps)
+	}
+	// The base seed runs before the services and is unaffected: what the app
+	// never answering costs is the collector-borne data, not the identity.
+	if env := envForShell(t, sup, "prisma:seed"); !strings.Contains(env, "HAVEN_SEED_PRESET=demo") {
+		t.Errorf("seed env = %q, want the base seed to have run regardless", env)
 	}
 }
 

--- a/tools/thuishaven/app/ports.go
+++ b/tools/thuishaven/app/ports.go
@@ -80,6 +80,11 @@ type Supervisor interface {
 	// runaway one-shot (tsgo) sit on a slot forever.
 	RunOnceBounded(ctx context.Context, name, dir, shell string, env []string, limits ReapLimits) error
 	Supervise(ctx context.Context, children []Child)
+	// WaitReady blocks until an HTTP GET to url gets a non-5xx response, the same
+	// probe Child.ReadyProbeURL gates a lane on. It reports false when the context
+	// ended first, so a caller that must not act on a stack that never came up
+	// (the play sandbox's seed ingest) can tell "ready" from "gave up".
+	WaitReady(ctx context.Context, name, url string) bool
 }
 
 // ReapLimits bounds a RunOnceBounded call. Either field left at 0 disables that

--- a/tools/thuishaven/cmd/play.go
+++ b/tools/thuishaven/cmd/play.go
@@ -260,6 +260,12 @@ func playLaunchArgs(number int, preset string) []string {
 // to the play checkout. Internal - it is dispatchable but absent from help,
 // like `daemon`.
 func runPlayLaunchCmd(ctx context.Context, d deps, inv invocation) error {
+	// The parser enforces a maximum number of positionals, never a minimum, and
+	// this command is dispatchable by hand — so a bare `haven play-launch` would
+	// index into an empty slice.
+	if len(inv.args) == 0 {
+		return fmt.Errorf("haven play-launch: a PR number is required")
+	}
 	number, err := strconv.Atoi(inv.args[0])
 	if err != nil || number <= 0 {
 		return fmt.Errorf("haven play-launch: %q is not a PR number", inv.args[0])

--- a/tools/thuishaven/cmd/play.go
+++ b/tools/thuishaven/cmd/play.go
@@ -28,6 +28,12 @@ func runPlay(ctx context.Context, d deps, inv invocation) error {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return fmt.Errorf("the GitHub CLI `gh` is required - install it (https://cli.github.com) and run `gh auth login`")
 	}
+	// The preset is checked before the PR is even resolved: a typo should cost a
+	// line of output, not a checkout, a container set, and a trust prompt.
+	preset := inv.value("--seed")
+	if err := app.ValidateSeedPreset(preset); err != nil {
+		return err
+	}
 	ref := ""
 	if len(inv.args) > 0 {
 		ref = inv.args[0]
@@ -123,12 +129,16 @@ func runPlay(ctx context.Context, d deps, inv invocation) error {
 	// plain streaming; Ctrl-C (or the driver killing us) ends it and the
 	// deferred teardown still destroys everything.
 	if d.isAgent || !stdoutIsTTY() {
-		if err := d.orch.PlayLaunch(ctx, pr.Number, checkout, filepath.Join(checkout, "platform", "app")); err != nil && ctx.Err() == nil {
+		sandbox := app.PlaySandbox{
+			Number: pr.Number, Checkout: checkout,
+			LwDir: filepath.Join(checkout, "platform", "app"), Preset: preset,
+		}
+		if err := d.orch.PlayLaunch(ctx, sandbox); err != nil && ctx.Err() == nil {
 			return err
 		}
 		return teardown()
 	}
-	child, err := startPlayLaunch(pr.Number, checkout, rec.Slug)
+	child, err := startPlayLaunch(rec, preset)
 	if err != nil {
 		return err
 	}
@@ -196,22 +206,23 @@ type playChild struct {
 	pid int
 }
 
-// startPlayLaunch backgrounds the hidden `haven play-launch <n>` in the play
-// checkout, streaming its combined output to the slug's log file - the same
-// launcher shape as `haven up`'s detached mode, so the attached viewer and
-// `haven logs` read it identically.
-func startPlayLaunch(number int, checkout, slug string) (playChild, error) {
-	logPath := stackLogPath(slug)
+// startPlayLaunch backgrounds the hidden `haven play-launch <n> [preset]` in
+// the play checkout, streaming its combined output to the slug's log file - the
+// same launcher shape as `haven up`'s detached mode, so the attached viewer and
+// `haven logs` read it identically. It takes the sandbox record rather than its
+// fields so the child can never be pointed at a different sandbox than the one
+// teardown will destroy.
+func startPlayLaunch(rec app.PlayRecord, preset string) (playChild, error) {
+	logPath := stackLogPath(rec.Slug)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return playChild{}, err
 	}
-	// haven's own source comes from the trusted checkout, never from `checkout`:
-	// that is the PR's tree, and it contains a cmd/haven of its own.
+	// haven's own source comes from the trusted checkout, never from the
+	// sandbox's: that is the PR's tree, and it contains a cmd/haven of its own.
 	root := trustedRepoRoot()
-	argv := selfArgv(root, "play-launch")
-	argv = append(argv, strconv.Itoa(number))
+	argv := append(selfArgv(root, "play-launch"), playLaunchArgs(rec.Number, preset)...)
 	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Dir = checkout
+	cmd.Dir = rec.Checkout
 	cmd.Env = childEnvWithTrustedRoot(root)
 	// Owner-only: the combined log captures seed output (admin password, tokens).
 	f, ferr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
@@ -233,14 +244,31 @@ func startPlayLaunch(number int, checkout, slug string) (playChild, error) {
 	return playChild{pid: cmd.Process.Pid}, nil
 }
 
-// runPlayLaunchCmd is the hidden `haven play-launch <n>`: the sandbox's
-// backgrounded launcher process, spawned by `haven play` with cwd set to the
-// play checkout. Internal - it is dispatchable but absent from help, like
-// `daemon`.
+// playLaunchArgs is the launcher's argument list. An empty preset is left off
+// entirely rather than passed as "", so the launcher's own parse sees exactly
+// what `haven play` was given.
+func playLaunchArgs(number int, preset string) []string {
+	argv := []string{strconv.Itoa(number)}
+	if preset != "" {
+		argv = append(argv, preset)
+	}
+	return argv
+}
+
+// runPlayLaunchCmd is the hidden `haven play-launch <n> [preset]`: the
+// sandbox's backgrounded launcher process, spawned by `haven play` with cwd set
+// to the play checkout. Internal - it is dispatchable but absent from help,
+// like `daemon`.
 func runPlayLaunchCmd(ctx context.Context, d deps, inv invocation) error {
 	number, err := strconv.Atoi(inv.args[0])
 	if err != nil || number <= 0 {
 		return fmt.Errorf("haven play-launch: %q is not a PR number", inv.args[0])
 	}
-	return d.orch.PlayLaunch(ctx, number, d.worktree, d.lwDir)
+	preset := ""
+	if len(inv.args) > 1 {
+		preset = inv.args[1]
+	}
+	return d.orch.PlayLaunch(ctx, app.PlaySandbox{
+		Number: number, Checkout: d.worktree, LwDir: d.lwDir, Preset: preset,
+	})
 }

--- a/tools/thuishaven/cmd/play_seed_test.go
+++ b/tools/thuishaven/cmd/play_seed_test.go
@@ -52,7 +52,7 @@ func TestPlaySeedFlagTakesTheSharedPresets(t *testing.T) {
 // itself. Calling it with no orchestrator proves the guard returns before
 // anything downstream is touched; without the guard this indexes an empty
 // slice and panics.
-// @scenario "The preset reaches the backgrounded launcher"
+// @scenario "The launcher refuses an invocation with no PR number"
 func TestPlayLaunchWithoutANumberFailsInsteadOfPanicking(t *testing.T) {
 	inv, err := parse(specByName(t, "play-launch"), nil)
 	if err != nil {

--- a/tools/thuishaven/cmd/play_seed_test.go
+++ b/tools/thuishaven/cmd/play_seed_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/app"
+)
+
+// The sandbox seeds from the same registry as `haven db seed` — one list, one
+// meaning, whichever command asks for it (ADR-064).
+// @scenario "An unknown preset is rejected before anything is created"
+func TestPlaySeedFlagTakesTheSharedPresets(t *testing.T) {
+	spec := specByName(t, "play")
+	var seed *flagSpec
+	for i := range spec.flags {
+		if spec.flags[i].long == "--seed" {
+			seed = &spec.flags[i]
+		}
+	}
+	if seed == nil {
+		t.Fatal("play does not declare --seed — a sandbox would always open on the onboarding screen")
+	}
+	if !seed.takesValue {
+		t.Error("--seed takes a preset name; a valueless flag would have to pick one for the developer")
+	}
+	for _, name := range app.SeedPresetNames() {
+		if !strings.Contains(seed.summary, name) {
+			t.Errorf("--seed's help %q does not offer %q", seed.summary, name)
+		}
+	}
+
+	t.Run("given a preset that is not in the registry", func(t *testing.T) {
+		t.Run("when play parses it, the value is rejected rather than passed on", func(t *testing.T) {
+			inv, err := parse(spec, []string{"4913", "--seed", "nosuch"})
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			// runPlay validates this before it looks the PR up, so a typo costs a
+			// line of output rather than a checkout and a container set.
+			if app.ValidateSeedPreset(inv.value("--seed")) == nil {
+				t.Error("a preset outside the registry was accepted")
+			}
+		})
+	})
+}
+
+// The launcher is a separate process, so a preset the parent parsed and did not
+// pass on would be silently dropped — the sandbox would come up empty with no
+// sign anything was asked for.
+// @scenario "The preset reaches the backgrounded launcher"
+func TestPresetTravelsToTheBackgroundedLauncher(t *testing.T) {
+	t.Run("given a preset", func(t *testing.T) {
+		argv := playLaunchArgs(4913, "demo")
+		if !slices.Equal(argv, []string{"4913", "demo"}) {
+			t.Fatalf("launcher argv = %v, want the number then the preset", argv)
+		}
+		inv, err := parse(specByName(t, "play-launch"), argv)
+		if err != nil {
+			t.Fatalf("the launcher rejects what play sends it: %v", err)
+		}
+		if len(inv.args) != 2 || inv.args[1] != "demo" {
+			t.Errorf("launcher args = %v, want the preset as the second positional", inv.args)
+		}
+	})
+
+	t.Run("given no preset", func(t *testing.T) {
+		argv := playLaunchArgs(4913, "")
+		if !slices.Equal(argv, []string{"4913"}) {
+			t.Fatalf("launcher argv = %v, want the number alone — never an empty preset", argv)
+		}
+		if _, err := parse(specByName(t, "play-launch"), argv); err != nil {
+			t.Fatalf("the launcher rejects a plain sandbox: %v", err)
+		}
+	})
+}

--- a/tools/thuishaven/cmd/play_seed_test.go
+++ b/tools/thuishaven/cmd/play_seed_test.go
@@ -52,7 +52,9 @@ func TestPlaySeedFlagTakesTheSharedPresets(t *testing.T) {
 // itself. Calling it with no orchestrator proves the guard returns before
 // anything downstream is touched; without the guard this indexes an empty
 // slice and panics.
-// @scenario "The launcher refuses an invocation with no PR number"
+//
+// No @scenario: play-launch is internal (hidden from help, spawned by `haven
+// play`), so its argument handling is not behavior the feature file describes.
 func TestPlayLaunchWithoutANumberFailsInsteadOfPanicking(t *testing.T) {
 	inv, err := parse(specByName(t, "play-launch"), nil)
 	if err != nil {

--- a/tools/thuishaven/cmd/play_seed_test.go
+++ b/tools/thuishaven/cmd/play_seed_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -44,6 +45,23 @@ func TestPlaySeedFlagTakesTheSharedPresets(t *testing.T) {
 			}
 		})
 	})
+}
+
+// The parser caps positionals but never requires them, and play-launch is
+// dispatchable by hand, so the launcher has to reject an empty argument list
+// itself. Calling it with no orchestrator proves the guard returns before
+// anything downstream is touched; without the guard this indexes an empty
+// slice and panics.
+// @scenario "The preset reaches the backgrounded launcher"
+func TestPlayLaunchWithoutANumberFailsInsteadOfPanicking(t *testing.T) {
+	inv, err := parse(specByName(t, "play-launch"), nil)
+	if err != nil {
+		t.Fatalf("parse accepted no arguments but errored: %v", err)
+	}
+	err = runPlayLaunchCmd(context.Background(), deps{}, inv)
+	if err == nil || !strings.Contains(err.Error(), "PR number") {
+		t.Errorf("err = %v, want a complaint about the missing PR number", err)
+	}
 }
 
 // The launcher is a separate process, so a preset the parent parsed and did not

--- a/tools/thuishaven/cmd/table.go
+++ b/tools/thuishaven/cmd/table.go
@@ -321,15 +321,18 @@ var table = []commandSpec{
 		maxArgs: 1,
 		flags: []flagSpec{
 			{long: "--allow-untrusted", summary: "proceed although not every PR author has write access (the only way in agent mode)"},
+			{long: "--seed", takesValue: true, value: "<preset>", summary: "seed the sandbox's database: " + strings.Join(app.SeedPresetNames(), ", ")},
 		},
 		run: runPlay,
 	},
 	{
 		// The backgrounded sandbox launcher `haven play` spawns in the play
-		// checkout - internal, like daemon: dispatchable, absent from help.
+		// checkout - internal, like daemon: dispatchable, absent from help. The
+		// preset travels as a positional because the launcher is a separate
+		// process: anything the parent parsed and did not pass on is lost.
 		name:    "play-launch",
-		args:    "<number>",
-		maxArgs: 1,
+		args:    "<number> [preset]",
+		maxArgs: 2,
 		hidden:  true,
 		run:     runPlayLaunchCmd,
 	},


### PR DESCRIPTION
## Why

A `haven play` sandbox gets its databases fresh and empty, so the PR under review opens on the onboarding "waiting for your first message" screen with nothing in the project. That is the wrong place to be standing whenever the change is about anything *after* onboarding, which is most of them.

Filling it by hand was worse than it looks. `haven db seed demo` resolves the slug from the checkout's directory name, and a play checkout is `pr-<n>` while its stack is `play-<n>` — so the obvious command seeds a different stack, quietly. You had to know that and pass `LANGWATCH_SLUG=play-<n>` yourself.

## What changed

`haven play <pr> --seed <preset>` takes the same presets `haven db seed` takes, from the same registry (`demo`, `traces`, `onboarding`, `post-onboarding`, `bare`, `mass`). No second list and no play-only variants — one registry, one meaning, per ADR-064's flag rule. Without the flag nothing changes: the sandbox seeds the stable identity exactly as before.

The two halves of a preset land where each belongs:

- **The preset's switches** go to the sandbox's own `prisma:seed`, before its services start.
- **Data that travels through the collector** (`seed:retention`, `seed:sample-traces`, `seed:realistic-platform`, `seed:mass`) can only land once the sandbox is serving, so it runs in a lane beside the supervised set, waiting on the sandbox's own `/api/health` rather than guessing at a delay.

`--seed` is validated before the PR is resolved, so a typo costs a line of output instead of a checkout, a container set and a trust prompt.

Review also turned up a latent crash next door: `haven play-launch` with no argument indexed an empty slice and panicked, because the parser caps positionals but never requires them. Guarded, with a test that panics without the guard.

## How it works

The sandbox is provisioned by a backgrounded `play-launch` process, so the preset travels to it as a positional argument. A preset the parent parsed and dropped would have left the sandbox silently empty, which is the failure mode worth designing against.

The ingest lane needs a readiness probe that is not a child process, so `Supervisor` gains `WaitReady` — the same probe `Child.ReadyProbeURL` already gates a lane on, exposed for a caller that is not itself a lane.

Failure handling is deliberate. A failed ingest step is a warning, never a stop: it names the step and prints the command that retries it (with the slug spelled out, for the reason in "Why"), and the sandbox keeps running. A PR that broke the collector is precisely one you want to watch run. Teardown does wait for the seeder to finish, though, rather than racing a `docker volume rm` against a process still writing to the volume.

`PlayLaunch` is split into named steps along the way — runtime, databases, stack registration, checkout preparation. It was already over the cognitive-complexity and argument limits `go-ci` gates on changed lines the moment its signature was touched, and the seams were there to be taken.

## Test plan

- [ ] `go test ./...` in `tools/thuishaven` — green, including eight new tests that drive `PlayLaunch` and the launcher command through fakes
- [ ] `golangci-lint run --new-from-merge-base=origin/main ./tools/thuishaven/...` — 0 issues with the house rules enabled
- [ ] `check-feature-parity.ts` — `specs/setup/haven-play.feature` 27/27 scenarios bound
- [ ] `haven help` renders `--seed <preset>` with the registry's names
- [ ] `haven play 4913 --seed nosuch` fails with `unknown seed preset "nosuch" — available: bare, demo, mass, onboarding, post-onboarding, traces`, before resolving the PR
- [ ] Bare `haven play --seed` fails asking for a value
- [ ] End to end on a real PR (`haven play <n> --seed demo` lands past onboarding with its traces, and teardown still destroys everything) — the `@e2e` scenarios stay `@unimplemented`, same as the rest of play's live paths

## Deployment Impact

No deployment impact. The change is confined to `tools/thuishaven` — the local development CLI — plus its spec and the ADR that documents its constitution. No chart, service, image, or product code path is touched. No environment variables are added or changed; no Helm values are added or changed; a vanilla `helm install` with no overrides behaves exactly as it does today; there is no BYOC dataplane impact. The ADR edit that pulled this PR into the gate records a CLI flag, not an operator-facing decision.

## Anything surprising?

`haven pr` and `haven up` still seed identity-only. `pr` hands off to `up`, so a flag there is a wider question than this change: `up` is the daily driver and re-seeding on every up is exactly what the environment section warns against. Worth doing, separately.

The `mass` preset works here but is a slow thing to ask of a sandbox you are about to throw away; `demo` is the one to reach for.
