### PR TITLE
feat(governance): let admins create the Anthropic Admin source from the UI

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
@@ -83,6 +83,52 @@ describe("buildAnthropicAdminPullConfig", () => {
     ).toBeNull();
   });
 
+  it("given a bucket width on a cost report, refuses to build", () => {
+    // The puller sends COST_REPORT_BUCKET_WIDTH and ignores config.bucketWidth,
+    // so saving one on a cost source records a setting that never applies —
+    // which is the opposite of what the field's own hint promises.
+    expect(
+      buildAnthropicAdminPullConfig(
+        composer({
+          credentialsToken: "sk-ant-admin-test",
+          report: "cost",
+          bucketWidth: "1h",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("given a start date that is impossible or timezone-less, refuses to build", () => {
+    const base = { credentialsToken: "sk-ant-admin-test", report: "usage" };
+    // Date.parse rolls this forward to March 2 rather than failing, which would
+    // backfill from a date nobody chose.
+    expect(
+      buildAnthropicAdminPullConfig(
+        composer({ ...base, startingAt: "2026-02-30" }),
+      ),
+    ).toBeNull();
+    // Spec'd as local time, so the same typed value means a different instant
+    // for an admin in Amsterdam than one in Tokyo.
+    expect(
+      buildAnthropicAdminPullConfig(
+        composer({ ...base, startingAt: "2026-08-01T00:00" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("given an instant carrying a timezone, keeps it as the same moment", () => {
+    const config = buildAnthropicAdminPullConfig(
+      composer({
+        credentialsToken: "sk-ant-admin-test",
+        report: "usage",
+        startingAt: "2026-08-01T02:00:00+02:00",
+      }),
+    );
+
+    const parsed = anthropicAdminPullConfigSchema.parse(config);
+    expect(parsed.startingAt).toBe("2026-08-01T00:00:00.000Z");
+  });
+
   it("given the same form state, keeps the secret and adapter-owned fields out of parserConfig", () => {
     const state = composer({
       credentialsToken: "sk-ant-admin-test",

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
@@ -70,8 +70,13 @@ describe("buildAnthropicAdminPullConfig", () => {
     expect(
       buildAnthropicAdminPullConfig(composer({ ...base, report: "both" })),
     ).toBeNull();
+    // Deliberately `usage`, not the `cost` of `base`: on a cost report the
+    // usage-only gate rejects any width first, so this assertion would pass
+    // with the value check deleted and prove nothing about "2h".
     expect(
-      buildAnthropicAdminPullConfig(composer({ ...base, bucketWidth: "2h" })),
+      buildAnthropicAdminPullConfig(
+        composer({ ...base, report: "usage", bucketWidth: "2h" }),
+      ),
     ).toBeNull();
     expect(
       buildAnthropicAdminPullConfig(

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The contract between the Anthropic Admin composer form and the adapter:
+ * whatever `buildAnthropicAdminPullConfig` saves must parse under
+ * `anthropicAdminPullConfigSchema`, because nothing validates the pullConfig
+ * at save time — the first thing that reads it is the puller worker, and a
+ * shape mismatch there is a source that looked fine when it was created and
+ * fails on every run. This is exactly how Genie's `spaceIds` broke once, so
+ * the new source type gets the guard from day one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { anthropicAdminPullConfigSchema } from "../../../services/pullers/anthropicAdmin.puller";
+import {
+  buildAnthropicAdminPullConfig,
+  buildParserConfig,
+  type ComposerState,
+} from "../ingestion-sources";
+
+function composer(
+  parserConfig: Record<string, string>,
+  pullSchedule = "",
+): ComposerState {
+  return {
+    sourceType: "anthropic_admin",
+    name: "Anthropic org spend",
+    description: "",
+    parserConfig,
+    ottlStatements: [],
+    pullSchedule,
+  };
+}
+
+describe("buildAnthropicAdminPullConfig", () => {
+  it("given the minimal valid form, produces a config the adapter schema accepts", () => {
+    const config = buildAnthropicAdminPullConfig(
+      composer({ credentialsToken: "sk-ant-admin-test", report: "cost" }),
+    );
+
+    expect(config).not.toBeNull();
+    // z.object strips unknown keys (`credentials` rides along for the
+    // worker) — the parse throwing is the failure this test exists for.
+    const parsed = anthropicAdminPullConfigSchema.parse(config);
+    expect(parsed.report).toBe("cost");
+    expect(parsed.schedule).toBe("0 * * * *");
+    expect((config as Record<string, unknown>).credentials).toEqual({
+      token: "sk-ant-admin-test",
+    });
+  });
+
+  it("given a bare date for startingAt, normalizes it to the ISO instant the schema demands", () => {
+    const config = buildAnthropicAdminPullConfig(
+      composer({
+        credentialsToken: "sk-ant-admin-test",
+        report: "usage",
+        bucketWidth: "1h",
+        startingAt: "2026-08-01",
+      }),
+    );
+
+    const parsed = anthropicAdminPullConfigSchema.parse(config);
+    expect(parsed.startingAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(parsed.bucketWidth).toBe("1h");
+  });
+
+  it("given an invalid report, bucket width, or start date, refuses to build", () => {
+    const base = { credentialsToken: "sk-ant-admin-test", report: "cost" };
+    expect(
+      buildAnthropicAdminPullConfig(composer({ ...base, report: "both" })),
+    ).toBeNull();
+    expect(
+      buildAnthropicAdminPullConfig(composer({ ...base, bucketWidth: "2h" })),
+    ).toBeNull();
+    expect(
+      buildAnthropicAdminPullConfig(
+        composer({ ...base, startingAt: "not-a-date" }),
+      ),
+    ).toBeNull();
+    expect(
+      buildAnthropicAdminPullConfig(composer({ report: "cost" })),
+    ).toBeNull();
+  });
+
+  it("given the same form state, keeps the secret and adapter-owned fields out of parserConfig", () => {
+    const state = composer({
+      credentialsToken: "sk-ant-admin-test",
+      report: "cost",
+      bucketWidth: "1d",
+      startingAt: "2026-08-01",
+    });
+
+    const parser = buildParserConfig(state);
+    // The token must only travel inside pullConfig.credentials (the encrypted
+    // subtree), and the owned fields must not clobber the typed pullConfig on
+    // the server-side merge where parserConfig wins.
+    expect(parser).not.toHaveProperty("credentialsToken");
+    expect(parser).not.toHaveProperty("report");
+    expect(parser).not.toHaveProperty("bucketWidth");
+    expect(parser).not.toHaveProperty("startingAt");
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -1346,22 +1346,16 @@ export function buildAnthropicAdminPullConfig(
   c: ComposerState,
 ): Record<string, unknown> | null {
   const p = c.parserConfig;
-  const token = (p.credentialsToken ?? "").trim();
-  const report = (p.report ?? "").trim().toLowerCase();
-  if (!token || (report !== "usage" && report !== "cost")) return null;
+  const token = trimmedField(p, "credentialsToken");
+  const report = trimmedField(p, "report").toLowerCase();
+  if (!token) return null;
+  if (report !== "usage" && report !== "cost") return null;
 
-  const bucketWidth = (p.bucketWidth ?? "").trim();
+  const bucketWidth = trimmedField(p, "bucketWidth");
   if (bucketWidth && !["1m", "1h", "1d"].includes(bucketWidth)) return null;
 
-  // The adapter schema wants a full ISO instant (`z.string().datetime()`);
-  // admins type dates. Normalize, and reject anything Date can't parse.
-  const startingAtRaw = (p.startingAt ?? "").trim();
-  let startingAt: string | undefined;
-  if (startingAtRaw) {
-    const parsed = Date.parse(startingAtRaw);
-    if (Number.isNaN(parsed)) return null;
-    startingAt = new Date(parsed).toISOString();
-  }
+  const startingAt = normalizeStartingAt(trimmedField(p, "startingAt"));
+  if (startingAt === null) return null;
 
   return {
     adapter: "anthropic_admin",
@@ -1369,9 +1363,28 @@ export function buildAnthropicAdminPullConfig(
     ...(bucketWidth ? { bucketWidth } : {}),
     ...(startingAt ? { startingAt } : {}),
     schedule:
-      c.pullSchedule.trim() || PULL_SCHEDULE_DEFAULTS.anthropic_admin || "0 * * * *",
+      c.pullSchedule.trim() ||
+      PULL_SCHEDULE_DEFAULTS.anthropic_admin ||
+      "0 * * * *",
     credentials: { token },
   };
+}
+
+/** One composer field, trimmed, with an absent key reading as empty. */
+function trimmedField(p: Record<string, string>, key: string): string {
+  return (p[key] ?? "").trim();
+}
+
+/**
+ * ISO-normalizes an admin-typed date for the adapter's `z.string().datetime()`.
+ *
+ * Empty is not an error — the field is optional — so it yields undefined, while
+ * text Date cannot parse yields null for the caller to reject.
+ */
+function normalizeStartingAt(raw: string): string | null | undefined {
+  if (!raw) return undefined;
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? null : new Date(parsed).toISOString();
 }
 
 /**

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -67,6 +67,7 @@ type SourceType =
   | "copilot_studio"
   | "openai_compliance"
   | "claude_compliance"
+  | "anthropic_admin"
   | "databricks_genie"
   | "s3_custom"
   | "http_custom";
@@ -124,6 +125,13 @@ const SOURCE_TYPE_OPTIONS: Array<{
     label: "Anthropic Claude Enterprise Compliance",
     mode: "pull",
     blurb: "Polls Anthropic's compliance API with a workspace API key.",
+  },
+  {
+    value: "anthropic_admin",
+    label: "Anthropic Admin API (usage & cost)",
+    mode: "pull",
+    blurb:
+      "Polls Anthropic's organization usage/cost reports with an Admin API key (sk-ant-admin-...). Pick ONE report per source: usage (token counts, we price them) or cost (invoice amounts, carried verbatim). Never create both for the same org — the same spend would be counted twice.",
   },
   {
     value: "databricks_genie",
@@ -198,6 +206,7 @@ const PULL_ADAPTER_FOR_SOURCE: Partial<Record<SourceType, string>> = {
   copilot_studio: "copilot_studio",
   openai_compliance: "openai_compliance",
   claude_compliance: "claude_compliance",
+  anthropic_admin: "anthropic_admin",
   databricks_genie: "databricks_genie",
   http_custom: "http_polling",
 };
@@ -212,6 +221,7 @@ const PULL_SCHEDULE_DEFAULTS: Record<string, string> = {
   copilot_studio: "*/15 * * * *",
   openai_compliance: "*/15 * * * *",
   claude_compliance: "*/15 * * * *",
+  anthropic_admin: "0 * * * *",
   databricks_genie: "*/15 * * * *",
   http_polling: "*/15 * * * *",
 };
@@ -331,9 +341,11 @@ function IngestionSourcesPage() {
         ? buildHttpCustomPullConfig(composer)
         : composer.sourceType === "databricks_genie"
           ? buildDatabricksGeniePullConfig(composer)
-          : pullAdapter
-            ? { adapter: pullAdapter }
-            : null;
+          : composer.sourceType === "anthropic_admin"
+            ? buildAnthropicAdminPullConfig(composer)
+            : pullAdapter
+              ? { adapter: pullAdapter }
+              : null;
     if (composer.sourceType === "http_custom" && !pullConfig) {
       // buildHttpCustomPullConfig returns null when required fields are
       // empty - keep the drawer open so the user can fix the form.
@@ -341,6 +353,15 @@ function IngestionSourcesPage() {
         title: "Missing required HTTP source fields",
         description:
           "URL, auth header value, token, events JSONPath, cursor JSONPath, and event mapping are all required.",
+        type: "error",
+      });
+      return;
+    }
+    if (composer.sourceType === "anthropic_admin" && !pullConfig) {
+      toaster.create({
+        title: "Missing or invalid Anthropic fields",
+        description:
+          "Admin API key is required, report must be `usage` or `cost`, bucket width (if set) must be 1m/1h/1d, and the backfill start must be a parseable date.",
         type: "error",
       });
       return;
@@ -1069,6 +1090,37 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       placeholder: "300",
     },
   ],
+  anthropic_admin: [
+    {
+      // `credentials*` prefix routes this into the encrypted `credentials`
+      // subtree — same rule as the Genie token below.
+      key: "credentialsToken",
+      label: "Admin API key",
+      placeholder: "sk-ant-admin-...",
+      hint: "Generate under Anthropic Admin Console → API Keys → Admin Keys. A regular workspace key returns 401 on the organization reports. We encrypt this server-side.",
+      required: true,
+      secret: true,
+    },
+    {
+      key: "report",
+      label: "Report (usage or cost)",
+      placeholder: "cost",
+      hint: "Exactly one per source. `cost` carries Anthropic's invoice amounts verbatim; `usage` pulls token counts that we price ourselves. Never create both reports for the same organization — the same spend would be counted twice.",
+      required: true,
+    },
+    {
+      key: "bucketWidth",
+      label: "Bucket width (optional, usage report only)",
+      placeholder: "1d",
+      hint: "1m, 1h or 1d. Only affects the usage report; cost is always daily. Default 1d.",
+    },
+    {
+      key: "startingAt",
+      label: "Backfill start (optional)",
+      placeholder: "2026-08-01",
+      hint: "Date or ISO instant the first run reads from. Empty = 24 hours back.",
+    },
+  ],
   databricks_genie: [
     {
       key: "workspaceUrl",
@@ -1284,6 +1336,45 @@ function buildHttpCustomPullConfig(
 }
 
 /**
+ * The Anthropic Admin adapter config, or null when a required field is empty
+ * or `report` is not one of the two values the adapter accepts. Nothing
+ * validates pullConfig against the adapter schema at save time — a bad value
+ * here would sit in the row looking fine and fail on every pull — so the
+ * builder is the last checkpoint before the database.
+ */
+export function buildAnthropicAdminPullConfig(
+  c: ComposerState,
+): Record<string, unknown> | null {
+  const p = c.parserConfig;
+  const token = (p.credentialsToken ?? "").trim();
+  const report = (p.report ?? "").trim().toLowerCase();
+  if (!token || (report !== "usage" && report !== "cost")) return null;
+
+  const bucketWidth = (p.bucketWidth ?? "").trim();
+  if (bucketWidth && !["1m", "1h", "1d"].includes(bucketWidth)) return null;
+
+  // The adapter schema wants a full ISO instant (`z.string().datetime()`);
+  // admins type dates. Normalize, and reject anything Date can't parse.
+  const startingAtRaw = (p.startingAt ?? "").trim();
+  let startingAt: string | undefined;
+  if (startingAtRaw) {
+    const parsed = Date.parse(startingAtRaw);
+    if (Number.isNaN(parsed)) return null;
+    startingAt = new Date(parsed).toISOString();
+  }
+
+  return {
+    adapter: "anthropic_admin",
+    report,
+    ...(bucketWidth ? { bucketWidth } : {}),
+    ...(startingAt ? { startingAt } : {}),
+    schedule:
+      c.pullSchedule.trim() || PULL_SCHEDULE_DEFAULTS.anthropic_admin || "0 * * * *",
+    credentials: { token },
+  };
+}
+
+/**
  * The Databricks Genie adapter config, or null when a required field is empty.
  *
  * Genie needs a real builder rather than the bare `{ adapter }` the other
@@ -1421,6 +1512,11 @@ function PullScheduleField({
  */
 const PULL_CONFIG_OWNED_FIELDS: Partial<Record<SourceType, readonly string[]>> =
   {
+    // `report`/`bucketWidth` pass through unchanged, but `startingAt` is
+    // normalized to an ISO instant by the builder — the raw form value
+    // winning the merge would fail the adapter's `.datetime()` check at
+    // pull time.
+    anthropic_admin: ["report", "bucketWidth", "startingAt"],
     databricks_genie: ["workspaceUrl", "spaceIds"],
   };
 

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -361,7 +361,7 @@ function IngestionSourcesPage() {
       toaster.create({
         title: "Missing or invalid Anthropic fields",
         description:
-          "Admin API key is required, report must be `usage` or `cost`, bucket width (if set) must be 1m/1h/1d, and the backfill start must be a parseable date.",
+          "Admin API key is required, report must be `usage` or `cost`, bucket width is usage-only and must be 1m/1h/1d, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z).",
         type: "error",
       });
       return;
@@ -1118,7 +1118,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       key: "startingAt",
       label: "Backfill start (optional)",
       placeholder: "2026-08-01",
-      hint: "Date or ISO instant the first run reads from. Empty = 24 hours back.",
+      hint: "The date the first run reads from: `2026-08-01`, or an instant carrying a timezone (`2026-08-01T00:00:00Z`). A time without a timezone is rejected rather than read as yours. Empty = 24 hours back.",
     },
   ],
   databricks_genie: [
@@ -1351,8 +1351,8 @@ export function buildAnthropicAdminPullConfig(
   if (!token) return null;
   if (report !== "usage" && report !== "cost") return null;
 
-  const bucketWidth = trimmedField(p, "bucketWidth");
-  if (bucketWidth && !["1m", "1h", "1d"].includes(bucketWidth)) return null;
+  const bucketWidth = validBucketWidth(trimmedField(p, "bucketWidth"), report);
+  if (bucketWidth === null) return null;
 
   const startingAt = normalizeStartingAt(trimmedField(p, "startingAt"));
   if (startingAt === null) return null;
@@ -1376,13 +1376,66 @@ function trimmedField(p: Record<string, string>, key: string): string {
 }
 
 /**
- * ISO-normalizes an admin-typed date for the adapter's `z.string().datetime()`.
+ * The bucket width to store, or null when it is one the adapter will not honour.
+ *
+ * Only the usage report reads this. The cost report pins `1d` — the puller sends
+ * `COST_REPORT_BUCKET_WIDTH` and deliberately ignores `config.bucketWidth` — so
+ * saving `1m` on a cost source writes a setting that silently never applies, and
+ * the form's own hint already promises the opposite.
+ *
+ * Empty yields undefined (the field is optional); rejected yields null.
+ */
+function validBucketWidth(
+  raw: string,
+  report: string,
+): string | null | undefined {
+  if (!raw) return undefined;
+  if (report !== "usage") return null;
+  return ["1m", "1h", "1d"].includes(raw) ? raw : null;
+}
+
+/** Whether y-m-d is a date that exists, rather than one Date would roll forward. */
+function isRealCalendarDate(year: number, month: number, day: number): boolean {
+  const probe = new Date(Date.UTC(year, month - 1, day));
+  return (
+    probe.getUTCFullYear() === year &&
+    probe.getUTCMonth() === month - 1 &&
+    probe.getUTCDate() === day
+  );
+}
+
+/**
+ * A bare `YYYY-MM-DD`, or a timestamp carrying an explicit offset. Anything else
+ * is rejected rather than guessed.
+ *
+ * The two shapes are the ones `Date.parse` reads unambiguously. An offset-less
+ * `2026-08-01T00:00` is spec'd as *local* time, so the same typed value would
+ * mean a different instant for an admin in Amsterdam than one in Tokyo.
+ */
+const STARTING_AT =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2}))?$/;
+
+/**
+ * ISO-normalizes an admin-typed backfill start for the adapter's
+ * `z.string().datetime()`.
+ *
+ * Strict on purpose: `Date.parse` rolls `2026-02-30` forward to March 2 instead
+ * of failing, which would silently backfill from a date nobody chose.
  *
  * Empty is not an error — the field is optional — so it yields undefined, while
- * text Date cannot parse yields null for the caller to reject.
+ * anything rejected yields null for the caller to turn into a toast.
  */
 function normalizeStartingAt(raw: string): string | null | undefined {
   if (!raw) return undefined;
+
+  const match = STARTING_AT.exec(raw);
+  if (!match) return null;
+  if (
+    !isRealCalendarDate(Number(match[1]), Number(match[2]), Number(match[3]))
+  ) {
+    return null;
+  }
+
   const parsed = Date.parse(raw);
   return Number.isNaN(parsed) ? null : new Date(parsed).toISOString();
 }

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -50,6 +50,7 @@ export type SourceType =
   | "copilot_studio"
   | "openai_compliance"
   | "claude_compliance"
+  | "anthropic_admin"
   | "databricks_genie"
   | "s3_custom"
   | "http_custom";
@@ -62,6 +63,7 @@ export const SUPPORTED_SOURCE_TYPES: readonly SourceType[] = [
   "copilot_studio",
   "openai_compliance",
   "claude_compliance",
+  "anthropic_admin",
   "databricks_genie",
   "s3_custom",
   "http_custom",


### PR DESCRIPTION
Stacked on #6649. (#6670 merged on 13 Aug, so this now sits directly on `feat/adr-088-pulled-usage-reporting`.)

## For humans

LangWatch can already read how much your organization spends on Anthropic, and who is spending it — but until now there was no way to switch that on. Anthropic simply wasn't in the list of things you could connect, so turning it on meant someone editing the database by hand and restarting the app.

This adds it to the list. An admin picks "Anthropic Admin API" the same way they'd pick any other source, pastes an admin key, chooses whether they want usage or spend, and it starts collecting on its own schedule.

One deliberate restriction: a source reports either usage or cost, never both. They describe the same activity, so collecting both would count everything twice. Connect Anthropic twice if you want both.

## Why

The `anthropic_admin` puller (shipped in #6649) had no UI path: the composer never listed it and `SUPPORTED_SOURCE_TYPES` rejected it, so the only way to create a source was a hand-inserted Prisma row plus an app restart for boot reconciliation. UI-created sources schedule immediately.

## What

- `anthropic_admin` added to the source-type union, `SUPPORTED_SOURCE_TYPES`, the composer picker, `PULL_ADAPTER_FOR_SOURCE`, and `PULL_SCHEDULE_DEFAULTS` (hourly, the adapter default).
- Form fields: Admin API key (`credentialsToken`, routed into the encrypted `credentials` subtree), report (`usage`|`cost`, exactly one per source — the blurb and hint spell out why both would double-count), optional bucket width, optional backfill start.
- `buildAnthropicAdminPullConfig`: last checkpoint before the database since nothing validates pullConfig at save time. Rejects bad report/bucketWidth values and normalizes `startingAt` to the full ISO instant `z.string().datetime()` demands (admins type `2026-08-01`).
- `PULL_CONFIG_OWNED_FIELDS` covers `report`/`bucketWidth`/`startingAt` so the server-side merge (parserConfig wins) can't clobber the typed config with raw form strings — the same failure mode Genie's `spaceIds` had.

## Testing

- New unit test pins the builder's output to `anthropicAdminPullConfigSchema` and asserts the secret + owned fields stay out of parserConfig (9/9 page tests green).
- Verified live: picker renders the new type on an Enterprise-licensed local stack, tsc clean.
- Biome run the way CI runs it, including `.github/scripts/biome-new-violations.sh` against the merge base: no new violations. The builder's field read and date normalization are extracted as helpers to stay under the cognitive-complexity ceiling (it scored 13 against a max of 10 inline).

## Not in scope

- The edit drawer still only edits name/description/OTTL for every pull source; changing report/key means archive + recreate (pre-existing).
- `assertPullDestinationAllowed` is a deliberate no-op here: the adapter's API base is hardcoded, there is no user-supplied destination to pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic Admin as a supported ingestion source.
  * Added configuration for usage and cost reports, polling frequency, optional backfill dates, and bucket width.
  * Added credential handling and validation for Anthropic Admin connections.

* **Bug Fixes**
  * Improved validation and error reporting for incomplete or invalid ingestion settings.
  * Ensured sensitive credentials and adapter-managed settings are handled securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
