### PR TITLE
fix(automations): re-arm the close guard on the drawer's identity reset

### DIFF
--- a/packages/automations/src/providers/webhook.ts
+++ b/packages/automations/src/providers/webhook.ts
@@ -23,19 +23,19 @@ export type WebhookMethod = z.infer<typeof webhookMethodSchema>;
  * `x-langwatch-` prefix is reserved wholesale.
  */
 const RESERVED_HEADER_NAMES = new Set([
-  "host",
-  "content-length",
-  "content-type",
-  "transfer-encoding",
-  "connection",
+	"host",
+	"content-length",
+	"content-type",
+	"transfer-encoding",
+	"connection",
 ]);
 const RESERVED_HEADER_PREFIX = "x-langwatch-";
 
 export function isReservedWebhookHeader(name: string): boolean {
-  const lower = name.trim().toLowerCase();
-  return (
-    RESERVED_HEADER_NAMES.has(lower) || lower.startsWith(RESERVED_HEADER_PREFIX)
-  );
+	const lower = name.trim().toLowerCase();
+	return (
+		RESERVED_HEADER_NAMES.has(lower) || lower.startsWith(RESERVED_HEADER_PREFIX)
+	);
 }
 
 /** RFC 7230 header-name token: dropping a smuggling attempt beats mangling it
@@ -47,18 +47,18 @@ const HEADER_NAME_TOKEN_RX = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
  *  not valid header tokens. Values are stripped of CR/LF so a stored header
  *  can never smuggle a second one. */
 export function sanitizeWebhookHeaders(
-  headers: Record<string, string>,
+	headers: Record<string, string>,
 ): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [name, value] of Object.entries(headers)) {
-    const key = name.trim();
-    if (!key || !HEADER_NAME_TOKEN_RX.test(key)) continue;
-    if (isReservedWebhookHeader(key)) continue;
-    const clean = value.replace(/[\r\n\0]+/g, " ").trim();
-    if (!clean) continue;
-    out[key] = clean;
-  }
-  return out;
+	const out: Record<string, string> = {};
+	for (const [name, value] of Object.entries(headers)) {
+		const key = name.trim();
+		if (!key || !HEADER_NAME_TOKEN_RX.test(key)) continue;
+		if (isReservedWebhookHeader(key)) continue;
+		const clean = value.replace(/[\r\n\0]+/g, " ").trim();
+		if (!clean) continue;
+		out[key] = clean;
+	}
+	return out;
 }
 
 /** Which admission rule a URL fell foul of. Both webhook channels run this one
@@ -66,16 +66,16 @@ export function sanitizeWebhookHeaders(
  *  speaks to a trigger author, the endpoints REST API to an integrator — so the
  *  decision travels as a code and each surface maps it to its own sentence. */
 export type WebhookUrlProblemCode =
-  | "invalid_url"
-  | "scheme"
-  | "host"
-  | "port"
-  | "credentials";
+	| "invalid_url"
+	| "scheme"
+	| "host"
+	| "port"
+	| "credentials";
 
 export interface WebhookUrlProblem {
-  code: WebhookUrlProblemCode;
-  /** The automations channel's author-facing sentence. */
-  message: string;
+	code: WebhookUrlProblemCode;
+	/** The automations channel's author-facing sentence. */
+	message: string;
 }
 
 /**
@@ -90,82 +90,82 @@ export interface WebhookUrlProblem {
  * configuration, only a way to smuggle a host past a reader.
  */
 export function inspectWebhookUrlShape(
-  url: string,
-  { allowInsecureOrigin = false }: { allowInsecureOrigin?: boolean } = {},
+	url: string,
+	{ allowInsecureOrigin = false }: { allowInsecureOrigin?: boolean } = {},
 ): WebhookUrlProblem | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return { code: "invalid_url", message: "Enter a valid URL." };
-  }
-  const schemeAllowed = allowInsecureOrigin
-    ? parsed.protocol === "https:" || parsed.protocol === "http:"
-    : parsed.protocol === "https:";
-  if (!schemeAllowed) {
-    return { code: "scheme", message: "The webhook URL must use https." };
-  }
-  if (!parsed.hostname) {
-    return { code: "host", message: "The webhook URL needs a host." };
-  }
-  if (!allowInsecureOrigin && parsed.port !== "" && parsed.port !== "443") {
-    return {
-      code: "port",
-      message: "Only the default https port (443) is allowed.",
-    };
-  }
-  if (parsed.username || parsed.password) {
-    return {
-      code: "credentials",
-      message: "The webhook URL cannot carry credentials.",
-    };
-  }
-  return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return { code: "invalid_url", message: "Enter a valid URL." };
+	}
+	const schemeAllowed = allowInsecureOrigin
+		? parsed.protocol === "https:" || parsed.protocol === "http:"
+		: parsed.protocol === "https:";
+	if (!schemeAllowed) {
+		return { code: "scheme", message: "The webhook URL must use https." };
+	}
+	if (!parsed.hostname) {
+		return { code: "host", message: "The webhook URL needs a host." };
+	}
+	if (!allowInsecureOrigin && parsed.port !== "" && parsed.port !== "443") {
+		return {
+			code: "port",
+			message: "Only the default https port (443) is allowed.",
+		};
+	}
+	if (parsed.username || parsed.password) {
+		return {
+			code: "credentials",
+			message: "The webhook URL cannot carry credentials.",
+		};
+	}
+	return null;
 }
 
 /** The author-facing sentence for {@link inspectWebhookUrlShape}, or null when
  *  the URL is admissible. What the trigger drawer's form and its server-side
  *  schema both validate against. */
 export function validateWebhookUrlShape(url: string): string | null {
-  return inspectWebhookUrlShape(url)?.message ?? null;
+	return inspectWebhookUrlShape(url)?.message ?? null;
 }
 
 export const webhookActionParamsSchema = z.object({
-  url: z
-    .string()
-    .trim()
-    .min(1, "A webhook URL is required.")
-    .superRefine((url, ctx) => {
-      const problem = validateWebhookUrlShape(url);
-      if (problem) ctx.addIssue({ code: "custom", message: problem });
-    }),
-  method: webhookMethodSchema.default("POST"),
-  /** Static custom headers (ADR-040 §1). Reserved keys are stripped on save.
-   *  This is the WIRE shape: a value may be `WEBHOOK_HEADER_VALUE_KEPT`,
-   *  resolved server-side against the stored ciphertext. At rest the record
-   *  is encrypted into `headersEncrypted` (see `secret.ts`) — plaintext
-   *  header values never persist and never return to the client. */
-  headers: z
-    .record(z.string(), z.string())
-    .default({})
-    .transform(sanitizeWebhookHeaders),
-  /** Liquid JSON body source. NULL = the framework default envelope. Stored
-   *  inside `actionParams` (not a Trigger template column) — ADR-040 §1. */
-  bodyTemplate: z.string().nullable().default(null),
-  /**
-   * Optional HMAC signing secret (ADR-040 §3). NULL means unsigned, which is
-   * what every webhook automation was until this existed: one signing scheme
-   * shipped with the endpoints platform and this channel never passed a
-   * secret to it, so a receiver had no way to tell a LangWatch delivery from
-   * anyone who learned the URL.
-   *
-   * Set it and deliveries carry `X-LangWatch-Signature: t=<unix>,v1=<hmac>`,
-   * signed by the same implementation the endpoints platform uses. This is
-   * the WIRE shape: a value may be `WEBHOOK_HEADER_VALUE_KEPT`, resolved
-   * server-side against the stored ciphertext. At rest it is encrypted, like
-   * the header values, and never returns to the client.
-   */
-  signingSecret: z.string().trim().nullable().optional(),
+	url: z
+		.string()
+		.trim()
+		.min(1, "A webhook URL is required.")
+		.superRefine((url, ctx) => {
+			const problem = validateWebhookUrlShape(url);
+			if (problem) ctx.addIssue({ code: "custom", message: problem });
+		}),
+	method: webhookMethodSchema.default("POST"),
+	/** Static custom headers (ADR-040 §1). Reserved keys are stripped on save.
+	 *  This is the WIRE shape: a value may be `WEBHOOK_HEADER_VALUE_KEPT`,
+	 *  resolved server-side against the stored ciphertext. At rest the record
+	 *  is encrypted into `headersEncrypted` (see `secret.ts`) — plaintext
+	 *  header values never persist and never return to the client. */
+	headers: z
+		.record(z.string(), z.string())
+		.default({})
+		.transform(sanitizeWebhookHeaders),
+	/** Liquid JSON body source. NULL = the framework default envelope. Stored
+	 *  inside `actionParams` (not a Trigger template column) — ADR-040 §1. */
+	bodyTemplate: z.string().nullable().default(null),
+	/**
+	 * Optional HMAC signing secret (ADR-040 §3). NULL means unsigned, which is
+	 * what every webhook automation was until this existed: one signing scheme
+	 * shipped with the endpoints platform and this channel never passed a
+	 * secret to it, so a receiver had no way to tell a LangWatch delivery from
+	 * anyone who learned the URL.
+	 *
+	 * Set it and deliveries carry `X-LangWatch-Signature: t=<unix>,v1=<hmac>`,
+	 * signed by the same implementation the endpoints platform uses. This is
+	 * the WIRE shape: a value may be `WEBHOOK_HEADER_VALUE_KEPT`, resolved
+	 * server-side against the stored ciphertext. At rest it is encrypted, like
+	 * the header values, and never returns to the client.
+	 */
+	signingSecret: z.string().trim().nullable().optional(),
 });
 
 export type WebhookActionParams = z.infer<typeof webhookActionParamsSchema>;
@@ -173,21 +173,22 @@ export type WebhookActionParams = z.infer<typeof webhookActionParamsSchema>;
 /** The render-time preview shape this provider's ConfigForm consumes: the
  *  request the dispatch would make, with the rendered JSON body. */
 export interface WebhookPreview extends PreviewEnvelope {
-  channel: "webhook";
-  payload: {
-    method: WebhookMethod;
-    url: string;
-    body: string;
-  };
+	channel: "webhook";
+	payload: {
+		method: WebhookMethod;
+		url: string;
+		body: string;
+	};
 }
 
 const def: SharedDef = {
-  action: TriggerAction.SEND_WEBHOOK,
-  category: "notify",
-  label: "Webhook",
-  description: "Send a JSON payload to your own endpoint when a trace matches.",
-  alertDescription: "Send a JSON payload to your own endpoint when it fires.",
-  actionParamsSchema: webhookActionParamsSchema,
+	action: TriggerAction.SEND_WEBHOOK,
+	category: "notify",
+	label: "Webhook",
+	description: "Send a JSON payload to your own endpoint when a trace matches.",
+	alertDescription:
+		"Send a JSON payload to your own endpoint when it fires.",
+	actionParamsSchema: webhookActionParamsSchema,
 };
 
 export default def;

--- a/platform/app/src/features/automations/AutomationDrawer.tsx
+++ b/platform/app/src/features/automations/AutomationDrawer.tsx
@@ -423,6 +423,54 @@ export function AutomationDrawer({
   // re-fire this effect mid-session and overwrite unsaved edits with the
   // last-saved row.
   const hydratedFromServerFor = useRef<string | null>(null);
+  /** Latched once the name has been seeded from the watched graph's own name;
+   *  declared here so the identity-reset effect below can unlatch it. */
+  const seededNameFromGraph = useRef(false);
+
+  /**
+   * Reopening this drawer for a DIFFERENT automation does not remount it.
+   *
+   * `openDrawer` replaces the URL params in place when the drawer type is
+   * already open (`useDrawer`), and the drawer host renders the component
+   * without a key — so the instance, the singleton store, and every latch in
+   * this file survive the transition. The unmount `reset()` and the mount-time
+   * "editing opens on Review" effect are both dead in that path.
+   *
+   * Left alone, "New automation" from a saved automation's locked Watch step
+   * carried the whole edited draft into the create: the heading flipped, the
+   * store still held the saved name, query and action, and Save wrote a second
+   * row from it (or hit the one-automation-per-graph constraint, wearing an
+   * error that named nothing the author had done). The close-guard was equally
+   * blind, diffing against the previous automation's baseline.
+   *
+   * So the identity change does by hand exactly what unmounting would have
+   * done. Keyed on the id rather than only on set→absent, because edit-A →
+   * edit-B is the same transition with the same consequence.
+   *
+   * It is declared ABOVE the hydration effect on purpose: effects run in
+   * declaration order, and hydration reading a draft this one has not blanked
+   * yet takes its "the author already started editing" branch, latches, and
+   * never runs again — which would open the next automation on an empty Review.
+   *
+   * The baseline is re-armed rather than cleared, because the effect that
+   * captures a create's baseline runs on mount only. Left null, `isDirty`
+   * would be false forever and closing a fully configured new automation would
+   * discard it without a word.
+   */
+  const openedForRef = useRef<string | undefined>(automationId);
+  useEffect(() => {
+    if (openedForRef.current === automationId) return;
+    openedForRef.current = automationId;
+    reset();
+    hydratedFromServerFor.current = null;
+    baselineRef.current = JSON.stringify(useAutomationStore.getState().draft);
+    prefilledFromTraces.current = false;
+    prefilledFromGraph.current = false;
+    prefilledFromParams.current = false;
+    seededNameFromGraph.current = false;
+    setStep(automationId ? "review" : "watch");
+  }, [automationId, reset, setStep]);
+
   useEffect(() => {
     if (!automationId) return;
     const row = triggerQuery.data;
@@ -588,7 +636,6 @@ export function AutomationDrawer({
   // Seed the name from the watched graph once its row loads — "Latency
   // p95 alert" beats an empty field on the golden Add-alert path. Only
   // when the author hasn't typed anything, and only once.
-  const seededNameFromGraph = useRef(false);
   useEffect(() => {
     if (automationId || seededNameFromGraph.current) return;
     if (!prefilledGraphId || !graphName) return;
@@ -1043,40 +1090,6 @@ export function AutomationDrawer({
       testHistory,
     ],
   );
-
-  /**
-   * Reopening this drawer for a DIFFERENT automation does not remount it.
-   *
-   * `openDrawer` replaces the URL params in place when the drawer type is
-   * already open (`useDrawer`), and the drawer host renders the component
-   * without a key — so the instance, the singleton store, and every latch in
-   * this file survive the transition. The unmount `reset()` and the mount-time
-   * "editing opens on Review" effect are both dead in that path.
-   *
-   * Left alone, "New automation" from a saved automation's locked Watch step
-   * carried the whole edited draft into the create: the heading flipped, the
-   * store still held the saved name, query and action, and Save wrote a second
-   * row from it (or hit the one-automation-per-graph constraint, wearing an
-   * error that named nothing the author had done). The close-guard was equally
-   * blind, diffing against the previous automation's baseline.
-   *
-   * So the identity change does by hand exactly what unmounting would have
-   * done. Keyed on the id rather than only on set→absent, because edit-A →
-   * edit-B is the same transition with the same consequence.
-   */
-  const openedForRef = useRef<string | undefined>(automationId);
-  useEffect(() => {
-    if (openedForRef.current === automationId) return;
-    openedForRef.current = automationId;
-    reset();
-    hydratedFromServerFor.current = null;
-    baselineRef.current = null;
-    prefilledFromTraces.current = false;
-    prefilledFromGraph.current = false;
-    prefilledFromParams.current = false;
-    seededNameFromGraph.current = false;
-    setStep(automationId ? "review" : "watch");
-  }, [automationId, reset, setStep]);
 
   // Dirty when the live draft no longer matches the baseline captured at
   // hydrate/create time. Guards an accidental close from silently dropping an

--- a/platform/app/src/features/automations/__tests__/AutomationDrawer.integration.test.tsx
+++ b/platform/app/src/features/automations/__tests__/AutomationDrawer.integration.test.tsx
@@ -549,7 +549,7 @@ describe("AutomationDrawer", () => {
         expect(screen.getByText("Add automation")).toBeInTheDocument();
       });
 
-      it("re-arms the close guard against the fresh draft, not the edited one", async () => {
+      it("re-arms the close guard, so work done in the new one is not dropped silently", async () => {
         const user = userEvent.setup();
         mockTriggerRow = savedRow();
         const opened = renderDrawer({ automationId: "trigger-1" });
@@ -565,14 +565,52 @@ describe("AutomationDrawer", () => {
           expect(useAutomationStore.getState().draft).toEqual(INITIAL_DRAFT);
         });
 
-        // A pristine create has nothing to discard, so closing it goes
-        // straight through instead of prompting about the previous draft.
+        // The baseline the guard diffs against is captured on mount, and this
+        // transition is not a mount. Left unarmed, the new automation reads as
+        // clean however much of it the author fills in, and closing throws it
+        // away without a word.
+        fireEvent.change(
+          await screen.findByPlaceholderText("Flag failing traces"),
+          { target: { value: "A new automation" } },
+        );
         await user.click(await screen.findByRole("button", { name: /close/i }));
 
-        expect(mockCloseDrawer).toHaveBeenCalled();
         expect(
-          screen.queryByText("Discard unsaved changes?"),
-        ).not.toBeInTheDocument();
+          await screen.findByText("Discard unsaved changes?"),
+        ).toBeInTheDocument();
+        expect(mockCloseDrawer).not.toHaveBeenCalled();
+
+        // And discarding still closes it, so the guard is a prompt, not a trap.
+        await user.click(screen.getByRole("button", { name: "Discard" }));
+        expect(mockCloseDrawer).toHaveBeenCalled();
+      });
+
+      it("hydrates the next automation when the drawer moves straight from one to another", async () => {
+        mockTriggerRow = savedRow({ name: "First automation" });
+        const opened = renderDrawer({ automationId: "trigger-1" });
+        await waitFor(() => {
+          expect(useAutomationStore.getState().draft.name).toBe(
+            "First automation",
+          );
+        });
+
+        // The row for the next one is already cached, so hydration runs in the
+        // same commit as the reset. Whichever effect is declared first wins:
+        // with hydration first it sees a draft still holding the previous
+        // automation, takes its "already editing" branch, latches, and never
+        // runs again — leaving the second automation blank on Review.
+        mockTriggerRow = savedRow({
+          id: "trigger-2",
+          name: "Second automation",
+        });
+        opened.rerender(<AutomationDrawer automationId="trigger-2" />);
+
+        await waitFor(() => {
+          expect(useAutomationStore.getState().draft.name).toBe(
+            "Second automation",
+          );
+        });
+        expect(useAutomationStore.getState().step).toBe("review");
       });
     });
 


### PR DESCRIPTION
Follow-up to #6907, which merged at `0601a90263` — one commit before this one. Everything here is the validator's fix-needed round, so the integration branch currently carries the defect it names.

## What is wrong on the branch right now

**The close guard is disarmed after edit→create.** #6907's identity reset cleared `baselineRef`, but the only writer for a create's baseline is an effect that runs on mount — and that transition is not a mount. The baseline stays null, `isDirty` is false forever, and closing a fully configured new automation discards it without a prompt. Repro: edit an automation → "New automation" → fill in Watch, Delivery and a name → Esc → the whole draft is gone silently.

The reset now re-arms the baseline against the blank draft it just installed, which is exactly what the mount effect would have captured.

**The reset also ran after hydration.** Effects run in declaration order, so hydration reading a draft the reset had not blanked yet took its "the author already started editing" branch, latched, and never ran again — moving straight from one automation to another opened the second one blank on Review. The reset is now declared above it.

## Tests

Both new tests were verified red against the exact defect before being restored:

- the close-guard test now closes a **dirty** create and expects "Discard unsaved changes?" — the previous shape closed a pristine one and passed under both the fix and the bug;
- the ordering test hands the second automation's row over already cached, and reproduces the blank Review exactly (`expected '' to be 'Second automation'`) when the effect is moved back below hydration.

## Also

`packages/automations/src/providers/webhook.ts` had picked up a tabs→spaces reformat of ~200 lines around one copy string, putting the branch on blame for the SSRF-admission code next to it. Reverted to its original whitespace with only the one string changed.

## Evidence

33 integration files / 302 tests, 18 unit files / 307 tests, tslsp clean. `AutomationDrawer.tsx` warning counts are identical rule-for-rule to the merge base (8 cognitive-complexity + 3 lines-per-function), so no lint delta from this change.

## Deployment Impact

No operator impact. Three frontend files and one shared copy string: no environment variables, no Helm values, no chart or service touched, no Prisma migration, no API surface. A vanilla `helm install` with no overrides behaves exactly as before — the change is confined to when the automation composer resets its draft and whether it prompts before discarding one. BYOC dataplanes are unaffected: nothing here touches the gateway, the workers, or any data-plane contract.
