### PR TITLE
chore(release): restore the platform pin to 3.13.0

### DIFF
--- a/.release-please-shim
+++ b/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v6), next: 3.13.0
+release-please shadow marker (v7), next: 3.13.0


### PR DESCRIPTION
## Why

The platform is about to release `4.0.0` for a break that never happened to it.

#4998 pinned the platform to 3.13.0 the way `dev/docs/RELEASES.md` documents — `.release-please-shim` set to `next: 3.13.0`, with a matching release footer in a commit of its own. A squash merge dropped that pin, and the platform fell through to conventional-commit rules and took the Go SDK's two breaking footers as its own.

Release PR #6787 has carried that unwanted `4.0.0` since 2026-08-10, and nobody has wanted to merge it. Everything riding it has waited too — including #6842, the chart fix that stops the install notes reading cluster-scoped resources, which self-hosters need and which has been blocked since it merged this morning. The Helm chart ships from the app release train (`langwatch@vX` → `publish-docker-app` on `release: published` → `release-langwatch-chart`), so a parked release PR means a parked chart.

## What changed

One line of `.release-please-shim`, bumping its marker, on a commit carrying `Release-As: 3.13.0` as its final line.

After merge, release-please recomputes #6787 as `chore(main): release langwatch 3.13.0`. Merging that publishes chart `3.13.0` with the #6842 fix.

## How it works

Squash is this repository's only merge method (`allow_merge_commit: false`, `allow_rebase_merge: false`) and `squash_merge_commit_message` is `COMMIT_MESSAGES`. #4998's seventeen commits therefore became one commit — `893de7f` — touching every path and concatenating every body:

```
line 175  BREAKING CHANGE: the provider middlewares now capture input/output
line 182  BREAKING CHANGE: the REST client no longer retries non-idempotent
line 353  Release-As: 1.0.0      <- meant for sdks/go
line 372  Release-As: 3.13.0     <- meant for the platform
```

The platform pin did not apply — it released `4.0.0` rather than the `3.13.0` it asked for. One message cannot carry one pin per component, whatever the parser does with the collision. (`sdks/go` reaching 1.0.0, release PR #6828, is also what a plain major off 0.3.0 produces, so it is not evidence its pin applied either.)

Both breaks describe the **Go SDK** — provider middleware data capture, and REST client retry behaviour. Nothing in the platform or the Helm chart changed behaviour. The major is an artifact of the collapse, not a real one.

This PR touches one shim and carries one footer, so a squash cannot collapse it into anything else. That is precisely the failure it repairs.

## Test plan

The mechanism is release-please's, so verification is observational rather than a unit test:

- `#6787` title history shows the rename `chore(main): release langwatch 3.13.0` → `... 4.0.0` at `18:58:53`, 71 seconds after #4998 merged at `18:57:42`. That is the regression, timestamped.
- After merge, confirm #6787 regenerates as `chore(main): release langwatch 3.13.0`. **Do not assume it** — `RELEASES.md` step 5 exists because this is exactly where a pin silently does nothing.
- Then confirm `langwatch-3.13.0` appears in the published index after #6787 merges.

## Anything surprising?

**This fixes the version, not the changelog.** `Release-As:` overrides the version and nothing else, so once #6787 regenerates at 3.13.0 the Go SDK's `⚠ BREAKING CHANGES` section will still render under langwatch's changelog. The note comes from a commit already on `main` and cannot be removed by a pin. Dropping it needs a manual edit to #6787's `CHANGELOG.md` in the window just before merging, since release-please rewrites that branch on every push to `main`.

**The chart was never mis-wired.** `charts/langwatch` is not in the root package's `exclude-paths`, so a chart-only change already cuts a release and already bumps and publishes the chart. #6842 is line 33 of #6787's changelog right now. Nothing about chart releasing needs changing; the train was simply stopped.

**Follow-up:** #6919 stops this recurring, by making the scope guard refuse a breaking marker that spans release components regardless of pins.
