### PR TITLE
fix(release): a pin no longer exempts a break from the scope guard

### DIFF
--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -683,10 +683,11 @@ describe("breaking-change scope guard", () => {
     // #4998. Two breaking footers, both describing the Go SDK, on a pull
     // request that also carried ~1,700 lines of ordinary platform code. It
     // pinned the platform to 3.13.0 the documented way and the guard passed it.
-    // Squash then merged seventeen commits into one carrying both footers, only
-    // the sdks/go pin applied, and the platform went to 4.0.0 with the Go SDK's
-    // breaks filed under its changelog. Release PR #6787 stalled on that major
-    // and took the #6842 Helm chart fix down with it.
+    // Squash then merged seventeen commits into one whose body is all of theirs
+    // concatenated, leaving two competing pins in a single 402-line message.
+    // The platform's did not apply: it went to 4.0.0 with the Go SDK's breaks
+    // filed under its changelog, release PR #6787 stalled on that major, and
+    // the #6842 Helm chart fix waited behind it.
     const files = [
       ".release-please-shim",
       "platform/app/src/server/app-layer/traces/canonicalisation/extractors/genAi.ts",

--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -358,7 +358,8 @@ describe("breaking-change scope guard", () => {
   });
 
   describe("when the pull request pins the components it must not major", () => {
-    it("passes once every bumped component is pinned", () => {
+    /** @scenario "A pin does not exempt a component from the scope check" */
+    it("refuses it even with every bumped component pinned", () => {
       const result = runGuard(
         checkout({
           files: [...threeComponents, rootShim, pythonShim, typescriptShim],
@@ -376,24 +377,14 @@ describe("breaking-change scope guard", () => {
         }),
       );
 
-      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.status, 1, result.stdout);
       assert.ok(
-        result.stdout.includes(
-          `typescript-sdk pinned to 1.5.0 by ${typescriptShim}`,
-        ),
-        result.stdout,
-      );
-      assert.ok(
-        result.stdout.includes(`python-sdk pinned to 1.2.1 by ${pythonShim}`),
-        result.stdout,
-      );
-      assert.ok(
-        result.stdout.includes(`langwatch pinned to 3.11.0 by ${rootShim}`),
-        result.stdout,
+        result.stderr.includes("A pin does not exempt a component"),
+        result.stderr,
       );
     });
 
-    it("passes with one component left unpinned, the one taking the major", () => {
+    it("says a pin leaves the break in the pinned component's changelog", () => {
       const result = runGuard(
         checkout({
           files: [...threeComponents, pythonShim, typescriptShim],
@@ -409,13 +400,24 @@ describe("breaking-change scope guard", () => {
         }),
       );
 
-      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.status, 1, result.stdout);
       assert.ok(
-        result.stdout.includes("breaking change scoped to langwatch"),
-        result.stdout,
+        result.stderr.includes("- typescript-sdk, pinned to 1.5.0"),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes("- python-sdk, pinned to 1.2.1"),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes(
+          "still take the break into their own changelog",
+        ),
+        result.stderr,
       );
     });
 
+    /** @scenario "A break spanning two components fails" */
     it("fails while more than one bumped component is still unpinned", () => {
       const result = runGuard(
         checkout({
@@ -511,6 +513,7 @@ describe("breaking-change scope guard", () => {
       );
     });
 
+    /** @scenario "A break confined to one component passes" */
     it("keeps a breaking change inside one component passing, pins or not", () => {
       const result = runGuard(
         checkout({
@@ -626,7 +629,12 @@ describe("breaking-change scope guard", () => {
     const title =
       "feat(spend): one filter vocabulary on both reads, and a grouping that refuses to lie";
 
-    it("accepts it, with all three components pinned and none going major", () => {
+    // Pin detection used to accept this. #4998 showed why that was wrong twice
+    // over: three pin commits squash into one commit carrying three footers, of
+    // which at most one can apply, and a pin that does apply still leaves the
+    // break in that component's changelog. Splitting is the only thing that
+    // scopes it, so this now fails and says so.
+    it("refuses it, naming the pins that do not exempt it", () => {
       const result = runGuard(
         checkout({
           files,
@@ -635,24 +643,22 @@ describe("breaking-change scope guard", () => {
         }),
       );
 
-      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.status, 1, result.stdout);
       assert.ok(
-        result.stdout.includes(
-          "typescript-sdk pinned to 1.5.0 by sdks/typescript/.release-please-shim",
-        ),
-        result.stdout,
+        result.stderr.includes("A pin does not exempt a component"),
+        result.stderr,
       );
       assert.ok(
-        result.stdout.includes(
-          "python-sdk pinned to 1.2.1 by sdks/python/.release-please-shim",
-        ),
-        result.stdout,
+        result.stderr.includes("- typescript-sdk, pinned to 1.5.0"),
+        result.stderr,
       );
       assert.ok(
-        result.stdout.includes(
-          "langwatch pinned to 3.11.0 by .release-please-shim",
-        ),
-        result.stdout,
+        result.stderr.includes("- python-sdk, pinned to 1.2.1"),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes("- langwatch, pinned to 3.11.0"),
+        result.stderr,
       );
     });
 
@@ -670,6 +676,99 @@ describe("breaking-change scope guard", () => {
           result.stderr,
         );
       }
+    });
+  });
+
+  describe("when replaying the Go SDK break that majored the platform", () => {
+    // #4998. Two breaking footers, both describing the Go SDK, on a pull
+    // request that also carried ~1,700 lines of ordinary platform code. It
+    // pinned the platform to 3.13.0 the documented way and the guard passed it.
+    // Squash then merged seventeen commits into one carrying both footers, only
+    // the sdks/go pin applied, and the platform went to 4.0.0 with the Go SDK's
+    // breaks filed under its changelog. Release PR #6787 stalled on that major
+    // and took the #6842 Helm chart fix down with it.
+    const files = [
+      ".release-please-shim",
+      "platform/app/src/server/app-layer/traces/canonicalisation/extractors/genAi.ts",
+      "platform/app/src/server/event-sourcing/pipelines/trace-processing/reactors/trackedEventSync.reactor.ts",
+      "sdks/go/instrumentation/openai/middleware.go",
+      "specs/go-sdk/span-attribute-parity.feature",
+    ];
+
+    const messages = [
+      "feat(sdk-go): native instrumentations, REST client, and gen_ai-first telemetry",
+      "BREAKING CHANGE: the provider middlewares now capture input and output content by default",
+      "chore(release): pin sdk-go at 1.0.0\n\nRelease-As: 1.0.0",
+      "chore(release): pin langwatch at 3.13.0\n\nRelease-As: 3.13.0",
+    ];
+
+    /** @scenario "A Go SDK break never reaches the platform release" */
+    it("refuses it, so the Go SDK break never reaches the platform release", () => {
+      const result = runGuard(
+        checkout({
+          files,
+          messages,
+          shims: { ".release-please-shim": shimSaying("3.13.0") },
+        }),
+      );
+
+      assert.equal(result.status, 1, result.stdout);
+      assert.ok(
+        result.stderr.includes("A pin does not exempt a component"),
+        result.stderr,
+      );
+      assert.ok(
+        result.stderr.includes("- langwatch, pinned to 3.13.0"),
+        result.stderr,
+      );
+    });
+
+    it("names both the platform and the Go SDK as reached by the break", () => {
+      const result = runGuard(
+        checkout({
+          files,
+          messages,
+          shims: { ".release-please-shim": shimSaying("3.13.0") },
+        }),
+      );
+
+      assert.ok(result.stderr.includes("- langwatch (.)"), result.stderr);
+      assert.ok(result.stderr.includes("- sdks/go (sdks/go)"), result.stderr);
+    });
+
+    it("passes once the break touches sdks/go alone", () => {
+      const result = runGuard(
+        checkout({
+          files: files.filter((file) => file.startsWith("sdks/go/")),
+          messages,
+        }),
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(
+        result.stdout.includes("breaking change scoped to sdks/go"),
+        result.stdout,
+      );
+    });
+
+    // specs/ is not among the root package's exclude-paths, so the feature file
+    // that documents the Go SDK's own behaviour is enough on its own to charge
+    // the platform and put it back in scope. Worth knowing before splitting:
+    // the spec has to travel in the non-breaking pull request.
+    /** @scenario "A spec file alone puts the platform back in scope" */
+    it("still refuses it when only the spec file rides along", () => {
+      const result = runGuard(
+        checkout({
+          files: files.filter(
+            (file) =>
+              file.startsWith("sdks/go/") || file.startsWith("specs/go-sdk/"),
+          ),
+          messages,
+        }),
+      );
+
+      assert.equal(result.status, 1, result.stdout);
+      assert.ok(result.stderr.includes("- langwatch (.)"), result.stderr);
     });
   });
 });

--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -685,7 +685,7 @@ describe("breaking-change scope guard", () => {
     // pinned the platform to 3.13.0 the documented way and the guard passed it.
     // Squash then merged seventeen commits into one whose body is all of theirs
     // concatenated, leaving two competing pins in a single 402-line message.
-    // The platform's did not apply: it went to 4.0.0 with the Go SDK's breaks
+    // The platform pin did not apply: it went to 4.0.0 with the Go SDK's breaks
     // filed under its changelog, release PR #6787 stalled on that major, and
     // the #6842 Helm chart fix waited behind it.
     const files = [
@@ -756,7 +756,7 @@ describe("breaking-change scope guard", () => {
     // that documents the Go SDK's own behaviour is enough on its own to charge
     // the platform and put it back in scope. Worth knowing before splitting:
     // the spec has to travel in the non-breaking pull request.
-    /** @scenario "A spec file alone puts the platform back in scope" */
+    /** @scenario "One incidental file is enough to widen the scope" */
     it("still refuses it when only the spec file rides along", () => {
       const result = runGuard(
         checkout({

--- a/.github/scripts/guard-breaking-change-scope.ts
+++ b/.github/scripts/guard-breaking-change-scope.ts
@@ -250,7 +250,7 @@ const reportHalfDonePins = ({
  * commits the old procedure asked for collapse into one commit whose body is
  * every branch commit's body concatenated. #4998 came out of that with two
  * competing `Release-As:` footers at lines 353 and 372 of a 402-line body, and
- * the platform's did not apply — it released 4.0.0, not the 3.13.0 it asked
+ * the platform pin did not apply — it released 4.0.0, not the 3.13.0 it asked
  * for. One message cannot carry one pin per component, however the parser
  * resolves the collision, so splitting is what actually scopes a break.
  */

--- a/.github/scripts/guard-breaking-change-scope.ts
+++ b/.github/scripts/guard-breaking-change-scope.ts
@@ -247,9 +247,12 @@ const reportHalfDonePins = ({
  * two breaks were still filed under the platform's release.
  *
  * Squash is this repository's only merge method, so the per-component pin
- * commits the old procedure asked for collapse into one commit carrying every
- * footer and touching every path — at which point at most one pin survives at
- * all. Splitting is what actually scopes a break.
+ * commits the old procedure asked for collapse into one commit whose body is
+ * every branch commit's body concatenated. #4998 came out of that with two
+ * competing `Release-As:` footers at lines 353 and 372 of a 402-line body, and
+ * the platform's did not apply — it released 4.0.0, not the 3.13.0 it asked
+ * for. One message cannot carry one pin per component, however the parser
+ * resolves the collision, so splitting is what actually scopes a break.
  */
 const reportPinsDoNotExempt = (pins: ComponentPin[]): void => {
   const pinned = pins.filter((pin) => pin.pinned !== undefined);

--- a/.github/scripts/guard-breaking-change-scope.ts
+++ b/.github/scripts/guard-breaking-change-scope.ts
@@ -189,19 +189,6 @@ const readShimFile = (path: string): string | undefined => {
 const unique = (values: string[]): string[] => [...new Set(values)];
 
 /**
- * Says which components the guard let past and at which version, so a passing
- * run still shows what it accepted.
- */
-const reportAcceptedPins = (pins: ComponentPin[]): void => {
-  for (const pin of pins) {
-    if (pin.pinned === undefined) continue;
-    console.log(
-      `${pin.component.name} pinned to ${pin.pinned} by ${pin.shim}`,
-    );
-  }
-};
-
-/**
  * Names the half of a pin that is missing. A shim edit without its footer is
  * the likeliest way to follow the procedure and still not pin anything, and a
  * footer whose version drifted from the shim looks identical from here.
@@ -252,6 +239,32 @@ const reportHalfDonePins = ({
   }
 };
 
+/**
+ * A pin used to exempt a component here. It no longer does, and #4998 is why:
+ * `Release-As:` overrides the version and nothing else, so a pinned component
+ * still takes the other component's `BREAKING CHANGE:` note into its own
+ * changelog. That pull request pinned the platform to 3.13.0 and the Go SDK's
+ * two breaks were still filed under the platform's release.
+ *
+ * Squash is this repository's only merge method, so the per-component pin
+ * commits the old procedure asked for collapse into one commit carrying every
+ * footer and touching every path — at which point at most one pin survives at
+ * all. Splitting is what actually scopes a break.
+ */
+const reportPinsDoNotExempt = (pins: ComponentPin[]): void => {
+  const pinned = pins.filter((pin) => pin.pinned !== undefined);
+  if (pinned.length === 0) return;
+
+  console.error("A pin does not exempt a component from this check.");
+  console.error("`Release-As:` fixes the version and nothing else, so these");
+  console.error("still take the break into their own changelog:");
+  console.error("");
+  for (const pin of pinned) {
+    console.error(`- ${pin.component.name}, pinned to ${pin.pinned}`);
+  }
+  console.error("");
+};
+
 const report = ({
   pins,
   versions,
@@ -267,8 +280,7 @@ const report = ({
   );
   console.error("one release component. release-please splits commits by path");
   console.error("but applies the whole commit message to every component the");
-  console.error("commit touched, so every one of these that is not pinned");
-  console.error("goes to a major:");
+  console.error("commit touched, so the break reaches every one of these:");
   console.error("");
   for (const pin of pins) {
     const current = versions[pin.component.path] ?? "unknown";
@@ -278,25 +290,15 @@ const report = ({
     );
   }
   console.error("");
+  reportPinsDoNotExempt(pins);
   reportHalfDonePins({ pins, footerVersions });
   console.error("If the break really does apply to all of them, add the");
   console.error(`\`${acknowledgementLabel}\` label and this check passes.`);
   console.error("");
-  console.error("Otherwise pick one:");
-  console.error("");
-  console.error("1. Split the change so the breaking commit touches one");
-  console.error("   component, which is the cheaper fix before merge.");
-  console.error("2. Keep it together and pin the components that must not go");
-  console.error("   major. Add a follow-up commit per component that edits");
-  console.error("   only that component's shim and carries one footer naming");
-  console.error("   the version that shim records. This check passes once at");
-  console.error("   most one bumped component is left unpinned:");
-  console.error("");
-  for (const pin of pins) {
-    if (pin.pinned !== undefined) continue;
-    const version = pin.recorded ?? "<x.y.z>";
-    console.error(`   ${pin.shim}   +   Release-As: ${version}`);
-  }
+  console.error("Otherwise split the change so the breaking commit touches");
+  console.error("one component. Land the incidental part as its own");
+  console.error("non-breaking pull request. That is the only thing that keeps");
+  console.error("one component's break out of another's release entirely.");
   console.error("");
   console.error("See dev/docs/RELEASES.md for the whole procedure.");
 };
@@ -338,22 +340,11 @@ const main = (): number => {
     footerVersions,
     readShim: (path) => readShimFile(resolve(repoRoot, path)),
   });
-  const unpinned = pins.filter((pin) => pin.pinned === undefined);
-  const halfDone = unpinned.filter((pin) => pin.shimChanged);
 
-  // A half-done pin fails even when the count alone would pass: the author meant
-  // to pin that component, and it is going major anyway.
-  if (halfDone.length === 0 && unpinned.length <= 1) {
-    reportAcceptedPins(pins);
-    const scope = unpinned[0]?.component.name;
-    console.log(
-      scope === undefined
-        ? "every bumped component is pinned, so none takes an implicit major"
-        : `breaking change scoped to ${scope}, every other component pinned`,
-    );
-    return 0;
-  }
-
+  // Pins are still read, but only to report them. They stopped being an
+  // exemption: see reportPinsDoNotExempt. More than one bumped component with a
+  // breaking marker fails, and the `multi-component-major` label — checked by
+  // the workflow before this script runs — is the only way past it.
   const versions = readJson<Record<string, string>>(
     resolve(repoRoot, manifestFile),
   );

--- a/dev/docs/RELEASES.md
+++ b/dev/docs/RELEASES.md
@@ -57,7 +57,7 @@ passed it. Two things went wrong at once:
 - Squash is this repository's only merge method, and `squash_merge_commit_message`
   is `COMMIT_MESSAGES`, so seventeen commits became one whose body is all of theirs
   concatenated — two competing `Release-As:` footers at lines 353 and 372 of a
-  402-line message. The platform's did not apply. It released 4.0.0 rather than
+  402-line message. The platform pin did not apply. It released 4.0.0 rather than
   the 3.13.0 it asked for, release PR #6787 stalled on a major nobody wanted, and
   the #6842 Helm chart fix waited behind it.
 
@@ -89,7 +89,7 @@ component a file to touch.
 **One pin per pull request.** Squash is the only merge method here, so several pin
 commits on one branch become a single commit whose body is all of theirs
 concatenated, and one message cannot carry one pin per component. #4998 came out
-of the squash with two competing footers and the platform's did not apply. To pin
+of the squash with two competing footers and the platform pin did not apply. To pin
 several components, open one PR per component. #3627 pinned six at once from a
 single branch and predates that being understood; do not copy it.
 

--- a/dev/docs/RELEASES.md
+++ b/dev/docs/RELEASES.md
@@ -54,11 +54,12 @@ passed it. Two things went wrong at once:
 - `Release-As:` overrides the **version and nothing else**. Even a pin that applies
   leaves the other component's `BREAKING CHANGE:` note in the pinned component's
   changelog. A Go SDK break was filed under the platform's release.
-- Squash is this repository's only merge method. The per-component pin commits the
-  old procedure asked for collapsed into one commit carrying every footer and
-  touching every path, so only the `sdks/go` pin applied at all. The platform went
-  to 4.0.0, release PR #6787 stalled on a major nobody wanted, and the #6842 Helm
-  chart fix waited behind it.
+- Squash is this repository's only merge method, and `squash_merge_commit_message`
+  is `COMMIT_MESSAGES`, so seventeen commits became one whose body is all of theirs
+  concatenated — two competing `Release-As:` footers at lines 353 and 372 of a
+  402-line message. The platform's did not apply. It released 4.0.0 rather than
+  the 3.13.0 it asked for, release PR #6787 stalled on a major nobody wanted, and
+  the #6842 Helm chart fix waited behind it.
 
 It reads the title and the commits because a squash merge builds the commit from
 exactly those two. It deliberately does not read the PR description, which never
@@ -86,10 +87,11 @@ component a file to touch.
 5. Confirm the release PR regenerated to the version you asked for. Do not assume it.
 
 **One pin per pull request.** Squash is the only merge method here, so several pin
-commits on one branch become a single commit carrying every footer and touching
-every shim, and at most one of them survives. To pin several components, open one
-PR per component. #3627 pinned six at once from a single branch and predates that
-being understood; do not copy it.
+commits on one branch become a single commit whose body is all of theirs
+concatenated, and one message cannot carry one pin per component. #4998 came out
+of the squash with two competing footers and the platform's did not apply. To pin
+several components, open one PR per component. #3627 pinned six at once from a
+single branch and predates that being understood; do not copy it.
 
 A pin fixes a version release-please got wrong. It does **not** scope a breaking
 change — see the previous section — so `release-scope-guard` reads pins only to

--- a/dev/docs/RELEASES.md
+++ b/dev/docs/RELEASES.md
@@ -37,16 +37,28 @@ That has happened repeatedly:
   product changelog.
 
 **So: keep a breaking change inside one component.** If the same work has to touch
-another component, land the incidental part in a separate non-breaking PR, or pin
-the components that should not go major, below.
+another component, land the incidental part in a separate non-breaking PR. That is
+the only thing that keeps one component's break out of another's release.
 
 `release-scope-guard` enforces this on every PR. It fails when the PR title or any
 of its commits carries a breaking marker and the changed files span more than one
-component, unless the extra components are pinned. It reads the pins described
-below and passes once at most one bumped component is left unpinned. If the break
-really does apply to all of them, add the **`multi-component-major`** label and the
-check passes. Reach for that label only when every one of those majors is wanted:
-it asserts intent, while a pin is what says a component is not going major.
+component. If the break really does apply to all of them, add the
+**`multi-component-major`** label and the check passes. Reach for that label only
+when every one of those majors is wanted.
+
+**A pin does not exempt a PR from this.** It used to, and #4998 is why it no longer
+does. That PR carried two Go SDK breaks alongside ordinary platform code, pinned
+the platform to 3.13.0 exactly as this document then described, and the guard
+passed it. Two things went wrong at once:
+
+- `Release-As:` overrides the **version and nothing else**. Even a pin that applies
+  leaves the other component's `BREAKING CHANGE:` note in the pinned component's
+  changelog. A Go SDK break was filed under the platform's release.
+- Squash is this repository's only merge method. The per-component pin commits the
+  old procedure asked for collapsed into one commit carrying every footer and
+  touching every path, so only the `sdks/go` pin applied at all. The platform went
+  to 4.0.0, release PR #6787 stalled on a major nobody wanted, and the #6842 Helm
+  chart fix waited behind it.
 
 It reads the title and the commits because a squash merge builds the commit from
 exactly those two. It deliberately does not read the PR description, which never
@@ -73,24 +85,24 @@ component a file to touch.
    the footer and the override silently does nothing.
 5. Confirm the release PR regenerated to the version you asked for. Do not assume it.
 
-To pin several components, use one commit per component, each touching only its own
-shim and carrying only its own footer. A commit with two footers, or one that
-touches two shims, is what caused the problem in the first place.
+**One pin per pull request.** Squash is the only merge method here, so several pin
+commits on one branch become a single commit carrying every footer and touching
+every shim, and at most one of them survives. To pin several components, open one
+PR per component. #3627 pinned six at once from a single branch and predates that
+being understood; do not copy it.
 
-`release-scope-guard` reads pins done this way, so a breaking PR that pins its
-extra components passes without the label. It requires both halves and binds them
-by version: the component's shim has to be among the changed files, and some
-commit has to carry a `Release-As:` footer naming the version that shim records
-after `next:`. A shim edit alone moves nothing, since release-please takes the
-version from the footer, and a footer alone reaches every component the PR
-touched, since only paths route it. The guard sees one file list per PR rather
-than one per commit, so the recorded version is what attributes a footer to a
-component. A changed shim with no footer naming its version fails the check by
-name, which catches a pin that would have done nothing before merge rather than
-after the release PR regenerates.
+A pin fixes a version release-please got wrong. It does **not** scope a breaking
+change — see the previous section — so `release-scope-guard` reads pins only to
+report them, and a breaking PR that spans components fails whether or not it pins
+anything. The guard still requires both halves of a pin and binds them by version:
+the component's shim has to be among the changed files, and some commit has to
+carry a `Release-As:` footer naming the version that shim records after `next:`. A
+changed shim with no footer naming its version fails by name, which catches a pin
+that would have done nothing before merge rather than after the release PR
+regenerates.
 
 Worked examples: #6704 pinned the root package to 3.10.0, #6734 pinned the
-typescript SDK to 1.3.0, and #3627 pinned six components at once.
+typescript SDK to 1.3.0, and #6918 pinned it back to 3.13.0 after #4998.
 
 ## Why not just configure it away
 

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -79,6 +79,10 @@ const DEFAULT_TEST_ROOTS: string[] = [
   // assistant's rules are tested here (and nowhere else), so scenarios about
   // what an instruction teaches can only bind from this root.
   "skills/_tests",
+  // CI guards run under `node --test` from the workflow that uses them, not
+  // vitest, and their tests live beside them. Without this root, a scenario
+  // describing what a guard refuses could only ever be @unimplemented.
+  ".github/scripts",
 ];
 
 /**

--- a/specs/ci/breaking-change-scope.feature
+++ b/specs/ci/breaking-change-scope.feature
@@ -54,7 +54,8 @@ Feature: A breaking change belongs to one release component
     Then the check fails naming both the platform and the Go SDK
 
   @unit
-  Scenario: A spec file alone puts the platform back in scope
-    Given the breaking commits touch the Go SDK and one file under specs
+  Scenario: One incidental file is enough to widen the scope
+    Given the breaking commits describe the Go SDK
+    And a single incidental file belongs to another release component
     When the scope guard runs
-    Then the check fails naming the platform
+    Then the check fails naming that other component

--- a/specs/ci/breaking-change-scope.feature
+++ b/specs/ci/breaking-change-scope.feature
@@ -1,0 +1,60 @@
+Feature: A breaking change belongs to one release component
+  As someone reading a LangWatch release
+  I want a major version to mean that LangWatch broke
+  So that a break in an SDK never stalls the platform and its Helm chart
+
+  # release-please decides which components a commit affects by path, then
+  # applies the WHOLE commit message to every one of them. It has no way to say
+  # "this break is only about the Go SDK". `release-scope-guard` is what keeps
+  # that from happening, by refusing a pull request whose breaking marker spans
+  # components.
+  #
+  # #4998 is why a pin no longer counts as an exemption. It carried two Go SDK
+  # breaks alongside ~1,700 lines of ordinary platform code, pinned the platform
+  # to 3.13.0 the way the procedure then described, and the guard passed it.
+  # Both halves of that failed:
+  #
+  #   - `Release-As:` overrides the version and NOTHING else, so the Go SDK's
+  #     breaks were still filed under the platform's changelog.
+  #   - Squash is the only merge method here, so seventeen commits became one
+  #     carrying both footers and touching every path. Only the sdks/go pin
+  #     applied. The platform went to 4.0.0.
+  #
+  # Release PR #6787 then stalled on a major nobody wanted, and the #6842 Helm
+  # chart fix waited behind it, because the chart ships from the app release
+  # train. See dev/docs/RELEASES.md.
+
+  Background:
+    Given a pull request whose title or commits carry a breaking-change marker
+
+  @unit
+  Scenario: A break confined to one component passes
+    Given every changed file belongs to the same release component
+    When the scope guard runs
+    Then the check passes naming the component the break is scoped to
+
+  @unit
+  Scenario: A break spanning two components fails
+    Given the changed files belong to two release components
+    When the scope guard runs
+    Then the check fails listing both components the break reaches
+
+  @unit
+  Scenario: A pin does not exempt a component from the scope check
+    Given the pull request pins every component it must not major
+    When the scope guard runs
+    Then the check still fails
+    And it says a pin fixes the version and leaves the break in the changelog
+
+  @unit
+  Scenario: A Go SDK break never reaches the platform release
+    Given the breaking commits describe the Go SDK
+    And the pull request also changes platform application code
+    When the scope guard runs
+    Then the check fails naming both the platform and the Go SDK
+
+  @unit
+  Scenario: A spec file alone puts the platform back in scope
+    Given the breaking commits touch the Go SDK and one file under specs
+    When the scope guard runs
+    Then the check fails naming the platform


### PR DESCRIPTION
## Why

A breaking change in the Go SDK must not make a breaking change in a LangWatch release. `release-scope-guard` was supposed to guarantee that, and did not.

#4998 carried two Go SDK breaks alongside ~1,700 lines of ordinary platform code. It pinned the platform to 3.13.0 exactly as `dev/docs/RELEASES.md` then described, and the guard passed it — because a pin counted as an exemption. The platform released `4.0.0` anyway, with the Go SDK's breaks filed under its changelog. Release PR #6787 has sat on that unwanted major since 2026-08-10, and #6842's Helm chart fix has waited behind it, because the chart ships from the app release train.

Pairs with #6918, which repairs that release.

## What changed

A breaking marker spanning more than one release component now fails the check, **pins or no pins**. `multi-component-major` remains the deliberate override.

Pins are still read and still reported — they remain the right tool for a version release-please got wrong — but they no longer exempt. The failure output says why:

```
A pin does not exempt a component from this check.
`Release-As:` fixes the version and nothing else, so these
still take the break into their own changelog:

- langwatch, pinned to 3.13.0
```

`dev/docs/RELEASES.md` is updated to match, including a new **one pin per pull request** rule.

## How it works

The exemption was unsound in two independent ways.

**A pin overrides the version and nothing else.** Even when it applies, the other component's `BREAKING CHANGE:` note still lands in the pinned component's changelog. Pinning never scoped a break; it only ever hid the version half.

**Squash is this repository's only merge method** (`allow_merge_commit: false`, `allow_rebase_merge: false`, `squash_merge_commit_message: COMMIT_MESSAGES`). Seventeen commits became one whose body is all of theirs concatenated, leaving two competing pins in a single 402-line message:

```
on the branch (what the guard modelled)   after squash (one 402-line body)
─────────────────────────────────────     ──────────────────────────────────────
commit A  sdks/go only                    ONE commit, every path
          Release-As: 1.0.0                 line 353  Release-As: 1.0.0
commit B  .release-please-shim only         line 372  Release-As: 3.13.0
          Release-As: 3.13.0                two pins, one message
```

Each pin commit even said so itself — *"One component, one path-routed file change, ONE footer."* The author followed the procedure exactly; squash undid it. The platform pin did not apply: it released `4.0.0` rather than the `3.13.0` it asked for.

The guard modelled the pre-squash branch. release-please only ever sees the post-squash commit. Splitting is the only thing that keeps one component's break out of another's release entirely, so that is what the guard now asks for.

## Test plan

`specs/ci/breaking-change-scope.feature` — 5 scenarios, all bound, including a replay of #4998 asserting the Go SDK break never reaches the platform release.

```
node --test --experimental-strip-types .github/scripts/guard-breaking-change-scope.test.ts
ℹ tests 32   ℹ pass 32   ℹ fail 0

check-feature-parity  →  specs/ci/breaking-change-scope.feature  5/5 scenarios bound  ✓ all bound
```

The #4998 replay fails without this change: the old pin exemption passed it, which is precisely the bug. Three previously-passing pin-exemption tests are updated to expect refusal, which is the behaviour change made visible.

Binding needed `.github/scripts` added as a feature-parity test root. CI guards run under `node --test` from the workflow that uses them, not vitest, and their tests live beside them — so scenarios describing what a guard refuses could otherwise only ever be `@unimplemented`, reported as bound while binding nothing.

## Anything surprising?

**This is stricter than what it replaces, and the cost is real.** A stacked branch that inherits a breaking marker from its base — the #6656 case that motivated pin detection in the first place — now has to split the incidental part into its own non-breaking PR, or take the label. Its replay test is updated to expect refusal rather than acceptance.

I think that trade is right, since splitting is the only thing that scopes a break *entirely*. If it lands wrong in practice, the narrower alternative is to keep the exemption but fail any PR carrying more than one `Release-As:` footer, since those cannot survive squash either.

**One incidental file is enough to widen scope.** `specs/` is not among the root package's `exclude-paths`, so a feature file documenting the Go SDK's own behaviour charges the platform on its own. When splitting, the spec travels in the non-breaking PR. There is a test for exactly this.

**What this does not fix.** Pinning corrects the version, not the changelog. Once #6918 lands and #6787 regenerates at 3.13.0, the Go SDK's `⚠ BREAKING CHANGES` section will still render under langwatch's changelog, because the note comes from a commit already on `main`. Removing it needs a manual edit to #6787's `CHANGELOG.md` just before merging.

**I did not verify how release-please resolves two competing `Release-As:` footers.** Both `BREAKING CHANGE:` footers also sit mid-message and release-please *did* read those, so a trailing-block-only rule cannot be the explanation. The comments and docs here assert only what is established: the platform pin did not apply. The one-pin-per-PR rule holds regardless of the resolution order.
