### PR TITLE
fix(experiments): a workflow agent target offers every result its workflow declares

### DIFF
--- a/platform/app/scripts/dogfood/qa-archive-workflow.ts
+++ b/platform/app/scripts/dogfood/qa-archive-workflow.ts
@@ -4,18 +4,28 @@
  *
  * Usage:
  *   WORKFLOW_ID=wf_x ARCHIVE=1 npx tsx scripts/dogfood/qa-archive-workflow.ts
+ *   WORKFLOW_ID=wf_x ARCHIVE=0 npx tsx scripts/dogfood/qa-archive-workflow.ts
  */
 import { prisma } from "../../src/server/db";
 
 async function main() {
   const id = process.env.WORKFLOW_ID;
   if (!id) throw new Error("WORKFLOW_ID is required");
-  const archive = process.env.ARCHIVE === "1";
+
+  // Spelled out rather than truthy-checked: ARCHIVE=true would otherwise
+  // restore the workflow the operator meant to archive, and the script would
+  // report success for it.
+  const archive = process.env.ARCHIVE;
+  if (archive !== "0" && archive !== "1") {
+    throw new Error('ARCHIVE must be "0" or "1"');
+  }
+  const shouldArchive = archive === "1";
+
   await prisma.workflow.update({
     where: { id },
-    data: { archivedAt: archive ? new Date() : null },
+    data: { archivedAt: shouldArchive ? new Date() : null },
   });
-  console.log(archive ? "archived" : "restored");
+  console.log(shouldArchive ? "archived" : "restored");
 }
 
 main()

--- a/platform/app/scripts/dogfood/qa-archive-workflow.ts
+++ b/platform/app/scripts/dogfood/qa-archive-workflow.ts
@@ -1,0 +1,26 @@
+/**
+ * Archives (or restores) a workflow, to QA how a workflow agent target behaves
+ * when its linked Studio workflow can no longer be read.
+ *
+ * Usage:
+ *   WORKFLOW_ID=wf_x ARCHIVE=1 npx tsx scripts/dogfood/qa-archive-workflow.ts
+ */
+import { prisma } from "../../src/server/db";
+
+async function main() {
+  const id = process.env.WORKFLOW_ID;
+  if (!id) throw new Error("WORKFLOW_ID is required");
+  const archive = process.env.ARCHIVE === "1";
+  await prisma.workflow.update({
+    where: { id },
+    data: { archivedAt: archive ? new Date() : null },
+  });
+  console.log(archive ? "archived" : "restored");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/platform/app/scripts/dogfood/seed-workflow-agent-with-chunks.ts
+++ b/platform/app/scripts/dogfood/seed-workflow-agent-with-chunks.ts
@@ -18,11 +18,13 @@ const CODE = `class Code:
 `;
 
 async function main() {
+  // Named rather than guessed: the oldest project is rarely the one being
+  // dogfooded, and a workflow plus an agent seeded into the wrong one is
+  // invisible until someone goes looking for them in the right one.
   const slug = process.env.PROJECT_SLUG;
-  const project = slug
-    ? await prisma.project.findFirst({ where: { slug } })
-    : await prisma.project.findFirst({ orderBy: { createdAt: "asc" } });
-  if (!project) throw new Error("No project found");
+  if (!slug) throw new Error("PROJECT_SLUG is required");
+  const project = await prisma.project.findFirst({ where: { slug } });
+  if (!project) throw new Error(`No project with slug ${slug}`);
 
   const user = await prisma.user.findUnique({
     where: { email: "dogfood@langwatch.local" },
@@ -119,47 +121,53 @@ async function main() {
     state: {},
   };
 
-  await prisma.workflow.create({
-    data: {
-      id: workflowId,
-      projectId: project.id,
-      name: "wf agent",
-      icon: "🏁",
-      description: "Returns an answer plus the chunks it used",
-    },
-  });
+  // One transaction: the workflow has to exist before its version and the
+  // version before the workflow can point at it, so a failure part-way leaves
+  // a workflow with no current version, which reads in the product as a
+  // workflow agent whose graph cannot be found.
+  const agent = await prisma.$transaction(async (tx) => {
+    await tx.workflow.create({
+      data: {
+        id: workflowId,
+        projectId: project.id,
+        name: "wf agent",
+        icon: "🏁",
+        description: "Returns an answer plus the chunks it used",
+      },
+    });
 
-  const version = await prisma.workflowVersion.create({
-    data: {
-      id: `wfv_${nanoid(10)}`,
-      workflowId,
-      projectId: project.id,
-      version: "1",
-      commitMessage: "seed",
-      authorId: user.id,
-      dsl,
-    },
-  });
+    const version = await tx.workflowVersion.create({
+      data: {
+        id: `wfv_${nanoid(10)}`,
+        workflowId,
+        projectId: project.id,
+        version: "1",
+        commitMessage: "seed",
+        authorId: user.id,
+        dsl,
+      },
+    });
 
-  await prisma.workflow.update({
-    where: { id: workflowId },
-    data: {
-      currentVersionId: version.id,
-      latestVersionId: version.id,
-      publishedId: version.id,
-      publishedById: user.id,
-    },
-  });
+    await tx.workflow.update({
+      where: { id: workflowId },
+      data: {
+        currentVersionId: version.id,
+        latestVersionId: version.id,
+        publishedId: version.id,
+        publishedById: user.id,
+      },
+    });
 
-  const agent = await prisma.agent.create({
-    data: {
-      id: `agent_${nanoid(10)}`,
-      projectId: project.id,
-      name: "wf agent",
-      type: "workflow",
-      config: { name: "wf agent", isCustom: true, workflow_id: workflowId },
-      workflowId,
-    },
+    return tx.agent.create({
+      data: {
+        id: `agent_${nanoid(10)}`,
+        projectId: project.id,
+        name: "wf agent",
+        type: "workflow",
+        config: { name: "wf agent", isCustom: true, workflow_id: workflowId },
+        workflowId,
+      },
+    });
   });
 
   console.log(

--- a/platform/app/scripts/dogfood/seed-workflow-agent-with-chunks.ts
+++ b/platform/app/scripts/dogfood/seed-workflow-agent-with-chunks.ts
@@ -1,0 +1,184 @@
+/**
+ * Seeds the reported bug's shape: a Studio workflow whose End node declares two
+ * results ("output" as text and "chunks" as an object), saved as a workflow
+ * agent so it can be added as a target in the experiments workbench.
+ *
+ * Usage:
+ *   PROJECT_SLUG=<slug> npx tsx scripts/dogfood/seed-workflow-agent-with-chunks.ts
+ */
+import { nanoid } from "nanoid";
+import { prisma } from "../../src/server/db";
+
+const CODE = `class Code:
+    def __call__(self, question: str):
+        return {
+            "output": "yes",
+            "chunks": {"source": "kb-1", "text": question},
+        }
+`;
+
+async function main() {
+  const slug = process.env.PROJECT_SLUG;
+  const project = slug
+    ? await prisma.project.findFirst({ where: { slug } })
+    : await prisma.project.findFirst({ orderBy: { createdAt: "asc" } });
+  if (!project) throw new Error("No project found");
+
+  const user = await prisma.user.findUnique({
+    where: { email: "dogfood@langwatch.local" },
+  });
+  if (!user) throw new Error("Seed the dogfood user first");
+
+  const workflowId = `wf_${nanoid(10)}`;
+  const dsl = {
+    spec_version: "1.4",
+    workflow_id: workflowId,
+    name: "wf agent",
+    icon: "🏁",
+    description: "Returns an answer plus the chunks it used",
+    version: "1.0",
+    template_adapter: "default",
+    workflow_type: "workflow",
+    enable_tracing: true,
+    nodes: [
+      {
+        id: "entry",
+        type: "entry",
+        position: { x: 0, y: 0 },
+        deletable: false,
+        data: {
+          name: "Entry point",
+          outputs: [{ identifier: "question", type: "str" }],
+          entry_selection: "first",
+          train_size: 0.8,
+          test_size: 0.2,
+          seed: 42,
+          dataset: {
+            name: "Draft Dataset",
+            inline: {
+              records: { question: ["is a dog an animal?"] },
+              columnTypes: [{ name: "question", type: "string" }],
+            },
+          },
+        },
+      },
+      {
+        id: "retrieve",
+        type: "code",
+        position: { x: 300, y: 0 },
+        data: {
+          name: "Retrieve",
+          parameters: [{ identifier: "code", type: "code", value: CODE }],
+          inputs: [{ identifier: "question", type: "str" }],
+          outputs: [
+            { identifier: "output", type: "str" },
+            { identifier: "chunks", type: "dict" },
+          ],
+        },
+      },
+      {
+        id: "end",
+        type: "end",
+        position: { x: 600, y: 30 },
+        deletable: false,
+        data: {
+          name: "End",
+          inputs: [
+            { identifier: "output", type: "str" },
+            { identifier: "chunks", type: "dict" },
+          ],
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "e0-1",
+        source: "entry",
+        sourceHandle: "outputs.question",
+        target: "retrieve",
+        targetHandle: "inputs.question",
+        type: "default",
+      },
+      {
+        id: "e1-2",
+        source: "retrieve",
+        sourceHandle: "outputs.output",
+        target: "end",
+        targetHandle: "inputs.output",
+        type: "default",
+      },
+      {
+        id: "e1-3",
+        source: "retrieve",
+        sourceHandle: "outputs.chunks",
+        target: "end",
+        targetHandle: "inputs.chunks",
+        type: "default",
+      },
+    ],
+    state: {},
+  };
+
+  await prisma.workflow.create({
+    data: {
+      id: workflowId,
+      projectId: project.id,
+      name: "wf agent",
+      icon: "🏁",
+      description: "Returns an answer plus the chunks it used",
+    },
+  });
+
+  const version = await prisma.workflowVersion.create({
+    data: {
+      id: `wfv_${nanoid(10)}`,
+      workflowId,
+      projectId: project.id,
+      version: "1",
+      commitMessage: "seed",
+      authorId: user.id,
+      dsl,
+    },
+  });
+
+  await prisma.workflow.update({
+    where: { id: workflowId },
+    data: {
+      currentVersionId: version.id,
+      latestVersionId: version.id,
+      publishedId: version.id,
+      publishedById: user.id,
+    },
+  });
+
+  const agent = await prisma.agent.create({
+    data: {
+      id: `agent_${nanoid(10)}`,
+      projectId: project.id,
+      name: "wf agent",
+      type: "workflow",
+      config: { name: "wf agent", isCustom: true, workflow_id: workflowId },
+      workflowId,
+    },
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        projectSlug: project.slug,
+        workflowId,
+        agentId: agent.id,
+        studioUrl: `/${project.slug}/studio/${workflowId}`,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/platform/app/src/components/agents/AgentCodeEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentCodeEditorDrawer.tsx
@@ -47,8 +47,8 @@ import {
   DEFAULT_CODE,
   getCodeFromConfig,
 } from "~/optimization_studio/utils/codeAgentConfig";
-import type { AgentWithFields } from "~/server/agents/agent-fields";
 import type { AgentComponentConfig } from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
 import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 

--- a/platform/app/src/components/agents/AgentCodeEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentCodeEditorDrawer.tsx
@@ -47,10 +47,8 @@ import {
   DEFAULT_CODE,
   getCodeFromConfig,
 } from "~/optimization_studio/utils/codeAgentConfig";
-import type {
-  AgentComponentConfig,
-  TypedAgent,
-} from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
+import type { AgentComponentConfig } from "~/server/agents/agent.repository";
 import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 
@@ -76,7 +74,7 @@ const getOutputsFromConfig = (config: AgentComponentConfig): DSLField[] => {
 export type AgentCodeEditorDrawerProps = {
   open?: boolean;
   onClose?: () => void;
-  onSave?: (agent: TypedAgent) => void;
+  onSave?: (agent: AgentWithFields) => void;
   /** If provided, loads an existing agent for editing */
   agentId?: string;
   /** Available sources for variable mapping (from Evaluations V3) */

--- a/platform/app/src/components/agents/AgentHttpEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentHttpEditorDrawer.tsx
@@ -37,10 +37,8 @@ import type {
   HttpHeader,
   HttpMethod,
 } from "~/optimization_studio/types/dsl";
-import type {
-  AgentComponentConfig,
-  TypedAgent,
-} from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
+import type { AgentComponentConfig } from "~/server/agents/agent.repository";
 import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 import {
@@ -118,7 +116,7 @@ function buildHttpConfig(
 export type AgentHttpEditorDrawerProps = {
   open?: boolean;
   onClose?: () => void;
-  onSave?: (agent: TypedAgent) => void;
+  onSave?: (agent: AgentWithFields) => void;
   /** If provided, loads an existing agent for editing */
   agentId?: string;
   /** Available sources for variable mapping (from Evaluations V3) */

--- a/platform/app/src/components/agents/AgentHttpEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentHttpEditorDrawer.tsx
@@ -37,8 +37,8 @@ import type {
   HttpHeader,
   HttpMethod,
 } from "~/optimization_studio/types/dsl";
-import type { AgentWithFields } from "~/server/agents/agent-fields";
 import type { AgentComponentConfig } from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
 import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 import {

--- a/platform/app/src/components/agents/AgentListDrawer.tsx
+++ b/platform/app/src/components/agents/AgentListDrawer.tsx
@@ -31,14 +31,15 @@ import {
   useDrawer,
 } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
 import type { TypedAgent } from "~/server/agents/agent.repository";
 import { api } from "~/utils/api";
 
 export type AgentListDrawerProps = {
   open?: boolean;
   onClose?: () => void;
-  onSelect?: (agent: TypedAgent) => void;
-  onEdit?: (agent: TypedAgent) => void;
+  onSelect?: (agent: AgentWithFields) => void;
+  onEdit?: (agent: AgentWithFields) => void;
   onCreateNew?: () => void;
 };
 
@@ -115,12 +116,12 @@ export function AgentListDrawer(props: AgentListDrawerProps) {
     },
   });
 
-  const handleSelectAgent = (agent: TypedAgent) => {
+  const handleSelectAgent = (agent: AgentWithFields) => {
     onSelect?.(agent);
     onClose();
   };
 
-  const handleEditAgent = (agent: TypedAgent) => {
+  const handleEditAgent = (agent: AgentWithFields) => {
     if (onEdit) {
       onEdit(agent);
       return;

--- a/platform/app/src/components/agents/AgentListDrawer.tsx
+++ b/platform/app/src/components/agents/AgentListDrawer.tsx
@@ -31,8 +31,8 @@ import {
   useDrawer,
 } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import type { AgentWithFields } from "~/server/agents/agent-fields";
 import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
 import { api } from "~/utils/api";
 
 export type AgentListDrawerProps = {

--- a/platform/app/src/components/agents/AgentWorkflowEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentWorkflowEditorDrawer.tsx
@@ -29,11 +29,11 @@ import type {
   Workflow,
 } from "~/optimization_studio/types/dsl";
 import { getMappingSurfaceInputs } from "~/optimization_studio/utils/nodeUtils";
+import type { AgentComponentConfig } from "~/server/agents/agent.repository";
 import {
   type AgentWithFields,
   linkedWorkflowId,
 } from "~/server/agents/agent-fields";
-import type { AgentComponentConfig } from "~/server/agents/agent.repository";
 import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 

--- a/platform/app/src/components/agents/AgentWorkflowEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentWorkflowEditorDrawer.tsx
@@ -29,17 +29,18 @@ import type {
   Workflow,
 } from "~/optimization_studio/types/dsl";
 import { getMappingSurfaceInputs } from "~/optimization_studio/utils/nodeUtils";
-import type {
-  AgentComponentConfig,
-  TypedAgent,
-} from "~/server/agents/agent.repository";
+import {
+  type AgentWithFields,
+  linkedWorkflowId,
+} from "~/server/agents/agent-fields";
+import type { AgentComponentConfig } from "~/server/agents/agent.repository";
 import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 
 export type AgentWorkflowEditorDrawerProps = {
   open?: boolean;
   onClose?: () => void;
-  onSave?: (agent: TypedAgent) => void;
+  onSave?: (agent: AgentWithFields) => void;
   /** If provided, loads an existing workflow agent for editing. */
   agentId?: string;
 };
@@ -126,16 +127,10 @@ export function AgentWorkflowEditorDrawer(
     { enabled: !!agentId && !!project?.id && isOpen },
   );
 
-  // Derive linked workflowId from the agent (falling back to the DSL field).
-  const workflowId = useMemo(() => {
-    if (!agentQuery.data) return undefined;
-    const fromAgent = (
-      agentQuery.data as TypedAgent & { workflowId?: string | null }
-    ).workflowId;
-    if (fromAgent) return fromAgent;
-    const fromConfig = getWorkflowConfig(agentQuery.data.config).workflow_id;
-    return fromConfig;
-  }, [agentQuery.data]);
+  const workflowId = useMemo(
+    () => (agentQuery.data ? linkedWorkflowId(agentQuery.data) : undefined),
+    [agentQuery.data],
+  );
 
   // Fetch the linked workflow so we can derive its real inputs/outputs.
   const workflowQuery = api.workflow.getById.useQuery(

--- a/platform/app/src/components/agents/WorkflowSelectorDrawer.tsx
+++ b/platform/app/src/components/agents/WorkflowSelectorDrawer.tsx
@@ -29,7 +29,7 @@ import { EmojiPickerModal } from "~/optimization_studio/components/properties/mo
 import { getRandomWorkflowIcon } from "~/optimization_studio/components/workflow/NewWorkflowForm";
 import { blankTemplate } from "~/optimization_studio/templates/blank";
 import type { Workflow } from "~/optimization_studio/types/dsl";
-import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
 import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { trackEvent } from "~/utils/tracking";
@@ -37,7 +37,7 @@ import { trackEvent } from "~/utils/tracking";
 export type WorkflowSelectorDrawerProps = {
   open?: boolean;
   onClose?: () => void;
-  onSave?: (agent: TypedAgent) => void;
+  onSave?: (agent: AgentWithFields) => void;
   /** Name for the new agent (optional, prompts if not provided) */
   agentName?: string;
 };

--- a/platform/app/src/components/agents/useWorkflowTargetAgentData.ts
+++ b/platform/app/src/components/agents/useWorkflowTargetAgentData.ts
@@ -5,7 +5,7 @@ import type {
   Workflow,
 } from "~/optimization_studio/types/dsl";
 import { getMappingSurfaceInputs } from "~/optimization_studio/utils/nodeUtils";
-import type { TypedAgent } from "~/server/agents/agent.repository";
+import { linkedWorkflowId } from "~/server/agents/agent-fields";
 import { api } from "~/utils/api";
 
 /**
@@ -49,15 +49,10 @@ export function useWorkflowTargetAgentData({
     { enabled: !!agentId && !!projectId && isOpen },
   );
 
-  const workflowId = useMemo(() => {
-    if (!agentQuery.data) return undefined;
-    const agent = agentQuery.data as TypedAgent & {
-      workflowId?: string | null;
-    };
-    if (agent.workflowId) return agent.workflowId;
-    const config = agent.config as { workflow_id?: string };
-    return config.workflow_id;
-  }, [agentQuery.data]);
+  const workflowId = useMemo(
+    () => (agentQuery.data ? linkedWorkflowId(agentQuery.data) : undefined),
+    [agentQuery.data],
+  );
 
   const workflowQuery = api.workflow.getById.useQuery(
     { projectId: projectId ?? "", workflowId: workflowId ?? "" },

--- a/platform/app/src/experiments-v3/__tests__/WorkflowTargetFields.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/WorkflowTargetFields.integration.test.tsx
@@ -1,0 +1,340 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A workflow agent target's fields live on its Studio workflow, not on the
+ * agent, so the workbench reconciles them from the API on load. Before that,
+ * a workflow producing "output" and "chunks" reached the evaluator's variable
+ * picker as a single invented field called "output".
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/optimization_studio/hooks/useWorkflowStore", () => ({
+  store: vi.fn(() => ({})),
+  initialState: {},
+  useWorkflowStore: vi.fn(() => ({})),
+}));
+
+import type { AvailableSource } from "~/components/variables";
+import { EvaluationsV3Table } from "../components/EvaluationsV3Table";
+import { useEvaluationsV3Store } from "../hooks/useEvaluationsV3Store";
+import type { DatasetReference, EvaluatorConfig, TargetConfig } from "../types";
+
+let openedDrawerType: string | null = null;
+let openedDrawerParams: Record<string, any> = {};
+
+// What agents.getAll reports for this project, i.e. the fields the API derived
+// from each agent's linked workflow.
+const agentsOnServer = {
+  data: [] as Array<Record<string, unknown>>,
+};
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn((type: string, params: Record<string, unknown>) => {
+      openedDrawerType = type;
+      openedDrawerParams = params ?? {};
+    }),
+    closeDrawer: vi.fn(),
+    drawerOpen: () => false,
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+  setFlowCallbacks: vi.fn(),
+}));
+
+vi.mock("~/prompts/hooks/useLatestPromptVersion", () => ({
+  useLatestPromptVersion: () => ({
+    currentVersion: undefined,
+    latestVersion: undefined,
+    isOutdated: false,
+    isLoading: false,
+    nextVersion: undefined,
+  }),
+}));
+
+vi.mock("../hooks/useTargetName", () => {
+  const useTargetName = (_target: { id: string }) => "wf agent";
+  return {
+    useTargetName,
+    useTargetNames: (targets: ({ id: string } | undefined)[]) =>
+      targets.map((target) => (target ? useTargetName(target) : "")),
+  };
+});
+vi.mock("../hooks/useEvaluatorName", () => ({
+  useEvaluatorName: () => "Exact Match",
+  useEvaluatorNames: () => new Map(),
+  useCodeEvaluatorIds: () => new Set(),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      agents: { getById: { fetch: vi.fn() } },
+      prompts: { getByIdOrHandle: { fetch: vi.fn().mockResolvedValue(null) } },
+      evaluators: { getById: { fetch: vi.fn().mockResolvedValue(null) } },
+    }),
+    datasetRecord: {
+      getAll: { useQuery: () => ({ data: null, isLoading: false }) },
+      update: { useMutation: () => ({ mutate: vi.fn() }) },
+      deleteMany: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+    agents: {
+      getAll: {
+        useQuery: () => ({ data: agentsOnServer.data, isLoading: false }),
+      },
+    },
+    evaluators: {
+      getAll: { useQuery: () => ({ data: [], isLoading: false }) },
+    },
+    prompts: {
+      getAllPromptsForProject: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/AddOrEditDatasetDrawer", () => ({
+  AddOrEditDatasetDrawer: () => null,
+}));
+vi.mock("~/components/agents/AgentListDrawer", () => ({
+  AgentListDrawer: () => null,
+}));
+vi.mock("~/components/agents/AgentTypeSelectorDrawer", () => ({
+  AgentTypeSelectorDrawer: () => null,
+}));
+vi.mock("~/components/agents/AgentCodeEditorDrawer", () => ({
+  AgentCodeEditorDrawer: () => null,
+}));
+vi.mock("~/components/agents/WorkflowSelectorDrawer", () => ({
+  WorkflowSelectorDrawer: () => null,
+}));
+vi.mock("~/components/targets/TargetTypeSelectorDrawer", () => ({
+  TargetTypeSelectorDrawer: () => null,
+}));
+vi.mock("~/components/prompts/PromptListDrawer", () => ({
+  PromptListDrawer: () => null,
+}));
+vi.mock("~/components/evaluators/EvaluatorListDrawer", () => ({
+  EvaluatorListDrawer: () => null,
+}));
+vi.mock("~/components/evaluators/EvaluatorCategorySelectorDrawer", () => ({
+  EvaluatorCategorySelectorDrawer: () => null,
+}));
+vi.mock("~/components/evaluators/EvaluatorTypeSelectorDrawer", () => ({
+  EvaluatorTypeSelectorDrawer: () => null,
+}));
+vi.mock("~/components/evaluators/EvaluatorEditorDrawer", () => ({
+  EvaluatorEditorDrawer: () => null,
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const workflowTarget = (overrides?: Partial<TargetConfig>): TargetConfig => ({
+  id: "target-1",
+  type: "agent",
+  agentType: "workflow",
+  dbAgentId: "agent-1",
+  // What the workbench recorded when the column was added: the synthetic
+  // single field, because nothing read the workflow.
+  inputs: [{ identifier: "input", type: "str" }],
+  outputs: [{ identifier: "output", type: "str" }],
+  mappings: {},
+  ...overrides,
+});
+
+const dataset = (): DatasetReference => ({
+  id: "test-data",
+  name: "Test Data",
+  type: "inline",
+  columns: [
+    { id: "question", name: "question", type: "string" },
+    { id: "expected_output", name: "expected_output", type: "string" },
+  ],
+  inline: {
+    columns: [
+      { id: "question", name: "question", type: "string" },
+      { id: "expected_output", name: "expected_output", type: "string" },
+    ],
+    records: { question: ["is a dog an animal?"], expected_output: ["yes"] },
+  },
+});
+
+const evaluator = (): EvaluatorConfig => ({
+  id: "evaluator-1",
+  evaluatorType: "langevals/exact_match",
+  dbEvaluatorId: "db-eval-1",
+  inputs: [
+    { identifier: "output", type: "str" },
+    { identifier: "expected_output", type: "str" },
+  ],
+  mappings: {},
+});
+
+const seed = (target: TargetConfig) => {
+  useEvaluationsV3Store.setState({
+    targets: [target],
+    datasets: [dataset()],
+    activeDatasetId: "test-data",
+    evaluators: [evaluator()],
+  });
+};
+
+const targetInStore = () =>
+  useEvaluationsV3Store.getState().targets.find((t) => t.id === "target-1");
+
+describe("Workflow agent target fields", () => {
+  beforeEach(() => {
+    openedDrawerType = null;
+    openedDrawerParams = {};
+    agentsOnServer.data = [
+      {
+        id: "agent-1",
+        name: "wf agent",
+        type: "workflow",
+        config: { name: "wf agent", isCustom: true, workflow_id: "wf_1" },
+        inputFields: [{ identifier: "question", type: "str" }],
+        outputFields: [
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ],
+      },
+    ];
+    vi.clearAllMocks();
+    useEvaluationsV3Store.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given a saved workbench whose target records only one output", () => {
+    describe("when the workbench loads", () => {
+      /** @scenario "A target added before the fields were derived recovers on load" */
+      it("records every result the workflow declares", async () => {
+        seed(workflowTarget());
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(targetInStore()?.outputs).toEqual([
+            { identifier: "output", type: "str" },
+            { identifier: "chunks", type: "dict" },
+          ]);
+        });
+      });
+
+      it("records the workflow's own inputs rather than a synthetic one", async () => {
+        seed(workflowTarget());
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(targetInStore()?.inputs).toEqual([
+            { identifier: "question", type: "str" },
+          ]);
+        });
+      });
+
+      it("does not record the reconciliation as an undoable edit", async () => {
+        seed(workflowTarget());
+        useEvaluationsV3Store.temporal.getState().clear();
+
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(targetInStore()?.outputs).toHaveLength(2);
+        });
+        expect(
+          useEvaluationsV3Store.temporal.getState().pastStates,
+        ).toHaveLength(0);
+      });
+    });
+
+    describe("when an evaluator is opened against that target", () => {
+      /** @scenario "Adding a workflow agent as a target offers every result to an evaluator" */
+      it("offers every result as a mapping source, with its own type", async () => {
+        const user = userEvent.setup();
+        seed(workflowTarget());
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(targetInStore()?.outputs).toHaveLength(2);
+        });
+        await waitFor(() => {
+          expect(screen.getAllByText("Exact Match").length).toBeGreaterThan(0);
+        });
+
+        await user.click(screen.getAllByText("Exact Match")[0]!);
+        await waitFor(() => {
+          expect(screen.getByText("Edit Configuration")).toBeInTheDocument();
+        });
+        await user.click(screen.getByText("Edit Configuration"));
+
+        expect(openedDrawerType).toBe("evaluatorEditor");
+        const sources = openedDrawerParams.mappingsConfig
+          ?.availableSources as AvailableSource[];
+        expect(sources[0]?.name).toBe("wf agent");
+        expect(sources[0]?.fields).toEqual([
+          { name: "output", type: "str" },
+          { name: "chunks", type: "dict" },
+        ]);
+      });
+    });
+  });
+
+  describe("given the linked workflow cannot be read", () => {
+    describe("when the workbench loads", () => {
+      /** @scenario "A target does not lose its recorded fields when the workflow cannot be read" */
+      it("keeps the fields the target already recorded", async () => {
+        agentsOnServer.data = [
+          {
+            id: "agent-1",
+            name: "wf agent",
+            type: "workflow",
+            config: { name: "wf agent", isCustom: true, workflow_id: "wf_1" },
+            inputFields: [],
+            outputFields: [],
+          },
+        ];
+        seed(
+          workflowTarget({
+            outputs: [
+              { identifier: "output", type: "str" },
+              { identifier: "chunks", type: "dict" },
+            ],
+          }),
+        );
+
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(screen.getAllByText("wf agent").length).toBeGreaterThan(0);
+        });
+        expect(targetInStore()?.outputs).toEqual([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+      });
+    });
+  });
+});

--- a/platform/app/src/experiments-v3/__tests__/WorkflowTargetFields.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/WorkflowTargetFields.integration.test.tsx
@@ -209,6 +209,7 @@ describe("Workflow agent target fields", () => {
           { identifier: "output", type: "str" },
           { identifier: "chunks", type: "dict" },
         ],
+        fieldsResolved: true,
       },
     ];
     vi.clearAllMocks();
@@ -312,6 +313,7 @@ describe("Workflow agent target fields", () => {
             config: { name: "wf agent", isCustom: true, workflow_id: "wf_1" },
             inputFields: [],
             outputFields: [],
+            fieldsResolved: false,
           },
         ];
         seed(
@@ -334,6 +336,81 @@ describe("Workflow agent target fields", () => {
           { identifier: "output", type: "str" },
           { identifier: "chunks", type: "dict" },
         ]);
+      });
+    });
+  });
+
+  describe("given the workflow no longer declares any result", () => {
+    describe("when the workbench loads", () => {
+      /** @scenario "A target drops a result its workflow no longer declares" */
+      it("drops the results the target still recorded", async () => {
+        agentsOnServer.data = [
+          {
+            id: "agent-1",
+            name: "wf agent",
+            type: "workflow",
+            config: { name: "wf agent", isCustom: true, workflow_id: "wf_1" },
+            inputFields: [{ identifier: "question", type: "str" }],
+            outputFields: [],
+            fieldsResolved: true,
+          },
+        ];
+        seed(
+          workflowTarget({
+            outputs: [
+              { identifier: "output", type: "str" },
+              { identifier: "chunks", type: "dict" },
+            ],
+          }),
+        );
+
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(targetInStore()?.outputs).toEqual([]);
+        });
+      });
+
+      /** @scenario "A target drops a result its workflow no longer declares" */
+      it("stops offering the removed result to an evaluator", async () => {
+        const user = userEvent.setup();
+        agentsOnServer.data = [
+          {
+            id: "agent-1",
+            name: "wf agent",
+            type: "workflow",
+            config: { name: "wf agent", isCustom: true, workflow_id: "wf_1" },
+            inputFields: [{ identifier: "question", type: "str" }],
+            outputFields: [],
+            fieldsResolved: true,
+          },
+        ];
+        seed(
+          workflowTarget({ outputs: [{ identifier: "output", type: "str" }] }),
+        );
+
+        render(<EvaluationsV3Table disableVirtualization />, {
+          wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+          expect(targetInStore()?.outputs).toEqual([]);
+        });
+        await waitFor(() => {
+          expect(screen.getAllByText("Exact Match").length).toBeGreaterThan(0);
+        });
+
+        await user.click(screen.getAllByText("Exact Match")[0]!);
+        await waitFor(() => {
+          expect(screen.getByText("Edit Configuration")).toBeInTheDocument();
+        });
+        await user.click(screen.getByText("Edit Configuration"));
+
+        const sources = openedDrawerParams.mappingsConfig
+          ?.availableSources as AvailableSource[];
+        expect(sources[0]?.fields).toEqual([]);
       });
     });
   });

--- a/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -35,7 +35,7 @@ import type {
   Field,
   HttpComponentConfig,
 } from "~/optimization_studio/types/dsl";
-import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { AgentWithFields } from "~/server/agents/agent-fields";
 import type { DatasetColumnType } from "~/server/datasets/types";
 import type { EvaluatorTypes } from "~/server/evaluations/evaluators";
 import type { EvaluatorWithFields } from "~/server/evaluators/evaluator.service";
@@ -51,6 +51,7 @@ import {
   useOpenTargetEditor,
 } from "../hooks/useOpenTargetEditor";
 import { useDatasetSelectionLoader } from "../hooks/useSavedDatasetLoader";
+import { useSyncWorkflowTargetFields } from "../hooks/useSyncWorkflowTargetFields";
 import type {
   ComparisonEvaluatorConfig,
   DatasetColumn,
@@ -213,6 +214,10 @@ export function EvaluationsV3Table({
 
   // Sync saved dataset changes to DB
   useDatasetSync();
+
+  // Re-read what each workflow agent target reads and produces from its
+  // workflow, which owns those fields and can change without the workbench.
+  useSyncWorkflowTargetFields();
 
   const {
     datasets,
@@ -416,7 +421,7 @@ export function EvaluationsV3Table({
 
   // Handler for when a saved agent is selected from the drawer
   const handleSelectSavedAgent = useCallback(
-    (savedAgent: TypedAgent) => {
+    (savedAgent: AgentWithFields) => {
       const config = savedAgent.config as Record<string, unknown>;
 
       // Check if this is an HTTP agent by looking at savedAgent.type or config structure
@@ -424,7 +429,7 @@ export function EvaluationsV3Table({
         savedAgent.type === "http" ||
         (config.url !== undefined && config.bodyTemplate !== undefined);
 
-      // Convert TypedAgent to TargetConfig format (agent type)
+      // Convert the saved agent to TargetConfig format (agent type)
       // For HTTP agents, extract inputs from bodyTemplate and store httpConfig
       // For code/workflow agents, use config.inputs directly
       let targetInputs: Field[];
@@ -449,6 +454,14 @@ export function EvaluationsV3Table({
         ];
       }
 
+      // A workflow agent keeps no inputs or outputs on its own config — its
+      // Studio graph does. The API derives them from that graph, so prefer
+      // them over the config read above and over the "one field called
+      // output" fallback, which is what used to hide every result but the
+      // first from the evaluator's variable picker.
+      const derivedInputs = savedAgent.inputFields;
+      const derivedOutputs = savedAgent.outputFields;
+
       const targetConfig: TargetConfig = {
         id: `target_${Date.now()}`, // Generate unique ID for the workbench
         type: "agent", // This is a target of type "agent" (code/workflow/http)
@@ -456,10 +469,16 @@ export function EvaluationsV3Table({
           ? "http"
           : (savedAgent.type as TargetConfig["agentType"]),
         dbAgentId: savedAgent.id, // Reference to the database agent
-        inputs: targetInputs,
-        outputs: (config.outputs as TargetConfig["outputs"]) ?? [
-          { identifier: "output", type: "str" },
-        ],
+        inputs:
+          derivedInputs && derivedInputs.length > 0
+            ? derivedInputs
+            : targetInputs,
+        outputs:
+          derivedOutputs && derivedOutputs.length > 0
+            ? derivedOutputs
+            : ((config.outputs as TargetConfig["outputs"]) ?? [
+                { identifier: "output", type: "str" },
+              ]),
         mappings: {},
         httpConfig, // Only set for HTTP agents
       };

--- a/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -454,13 +454,16 @@ export function EvaluationsV3Table({
         ];
       }
 
-      // A workflow agent keeps no inputs or outputs on its own config — its
-      // Studio graph does. The API derives them from that graph, so prefer
-      // them over the config read above and over the "one field called
-      // output" fallback, which is what used to hide every result but the
-      // first from the evaluator's variable picker.
-      const derivedInputs = savedAgent.inputFields;
-      const derivedOutputs = savedAgent.outputFields;
+      // A workflow agent keeps no inputs or outputs on its own config, its
+      // Studio graph does, and the API derives them from that graph. Once that
+      // derivation resolves it is the whole answer, empty lists included:
+      // falling back to the "one field called output" below is what used to
+      // hide every result but the first from the evaluator's variable picker.
+      // Every other kind keeps its fields on its own config, so an empty list
+      // there means nothing was saved and the fallbacks still apply.
+      const { inputFields, outputFields, fieldsResolved } = savedAgent;
+      const derivationIsFinal =
+        savedAgent.type === "workflow" && fieldsResolved;
 
       const targetConfig: TargetConfig = {
         id: `target_${Date.now()}`, // Generate unique ID for the workbench
@@ -470,12 +473,12 @@ export function EvaluationsV3Table({
           : (savedAgent.type as TargetConfig["agentType"]),
         dbAgentId: savedAgent.id, // Reference to the database agent
         inputs:
-          derivedInputs && derivedInputs.length > 0
-            ? derivedInputs
+          derivationIsFinal || inputFields.length > 0
+            ? inputFields
             : targetInputs,
         outputs:
-          derivedOutputs && derivedOutputs.length > 0
-            ? derivedOutputs
+          derivationIsFinal || outputFields.length > 0
+            ? outputFields
             : ((config.outputs as TargetConfig["outputs"]) ?? [
                 { identifier: "output", type: "str" },
               ]),

--- a/platform/app/src/experiments-v3/hooks/useSyncWorkflowTargetFields.ts
+++ b/platform/app/src/experiments-v3/hooks/useSyncWorkflowTargetFields.ts
@@ -10,6 +10,7 @@ type DerivedTargetFields = {
   targetId: string;
   inputFields: Field[];
   outputFields: Field[];
+  fieldsResolved: boolean;
 };
 
 const isWorkflowAgentTarget = (target: TargetConfig): boolean =>
@@ -17,7 +18,13 @@ const isWorkflowAgentTarget = (target: TargetConfig): boolean =>
   target.agentType === "workflow" &&
   !!target.dbAgentId;
 
-const sameFields = (recorded: Field[] | undefined, derived: Field[]): boolean =>
+const sameFields = ({
+  recorded,
+  derived,
+}: {
+  recorded: Field[] | undefined;
+  derived: Field[];
+}): boolean =>
   (recorded ?? []).length === derived.length &&
   (recorded ?? []).every(
     (field, index) =>
@@ -29,22 +36,28 @@ const sameFields = (recorded: Field[] | undefined, derived: Field[]): boolean =>
  * The fields a target records that its workflow no longer agrees with, or
  * undefined when the two already match.
  *
- * An empty derivation counts as agreement rather than as a change: the agent
- * reports no fields both for a workflow that genuinely declares none and for
- * one that could not be read, and clearing a column's fields on a failed
- * lookup would take the user's mappings with them.
+ * A derivation the agent could not resolve is not an answer, so nothing is
+ * applied from it: the workflow is archived, deleted, or in another project,
+ * and clearing the column would take the user's mappings with it. A workflow
+ * that resolved and declares nothing is an answer, and an emptied column is
+ * the honest reflection of it.
  */
-const staleFields = (
-  target: TargetConfig,
-  derived: DerivedTargetFields,
-): Partial<Pick<TargetConfig, "inputs" | "outputs">> | undefined => {
-  const updates: Partial<Pick<TargetConfig, "inputs" | "outputs">> = {};
-  const { inputFields, outputFields } = derived;
+const staleFields = ({
+  target,
+  derived,
+}: {
+  target: TargetConfig;
+  derived: DerivedTargetFields;
+}): Partial<Pick<TargetConfig, "inputs" | "outputs">> | undefined => {
+  const { inputFields, outputFields, fieldsResolved } = derived;
+  if (!fieldsResolved) return undefined;
 
-  if (inputFields.length > 0 && !sameFields(target.inputs, inputFields)) {
+  const updates: Partial<Pick<TargetConfig, "inputs" | "outputs">> = {};
+
+  if (!sameFields({ recorded: target.inputs, derived: inputFields })) {
     updates.inputs = inputFields;
   }
-  if (outputFields.length > 0 && !sameFields(target.outputs, outputFields)) {
+  if (!sameFields({ recorded: target.outputs, derived: outputFields })) {
     updates.outputs = outputFields;
   }
 
@@ -102,6 +115,9 @@ export const useSyncWorkflowTargetFields = () => {
         targetId: target.id,
         inputFields: agent?.inputFields ?? [],
         outputFields: agent?.outputFields ?? [],
+        // An agent that is not in the list yet has not answered, which reads
+        // the same as a workflow that could not be read: leave the column be.
+        fieldsResolved: agent?.fieldsResolved ?? false,
       };
     }),
   );
@@ -111,7 +127,9 @@ export const useSyncWorkflowTargetFields = () => {
     const pending = (JSON.parse(derived) as DerivedTargetFields[]).flatMap(
       (fields) => {
         const target = targets.find((t) => t.id === fields.targetId);
-        const updates = target ? staleFields(target, fields) : undefined;
+        const updates = target
+          ? staleFields({ target, derived: fields })
+          : undefined;
         return updates ? [{ targetId: fields.targetId, updates }] : [];
       },
     );

--- a/platform/app/src/experiments-v3/hooks/useSyncWorkflowTargetFields.ts
+++ b/platform/app/src/experiments-v3/hooks/useSyncWorkflowTargetFields.ts
@@ -26,6 +26,32 @@ const sameFields = (recorded: Field[] | undefined, derived: Field[]): boolean =>
   );
 
 /**
+ * The fields a target records that its workflow no longer agrees with, or
+ * undefined when the two already match.
+ *
+ * An empty derivation counts as agreement rather than as a change: the agent
+ * reports no fields both for a workflow that genuinely declares none and for
+ * one that could not be read, and clearing a column's fields on a failed
+ * lookup would take the user's mappings with them.
+ */
+const staleFields = (
+  target: TargetConfig,
+  derived: DerivedTargetFields,
+): Partial<Pick<TargetConfig, "inputs" | "outputs">> | undefined => {
+  const updates: Partial<Pick<TargetConfig, "inputs" | "outputs">> = {};
+  const { inputFields, outputFields } = derived;
+
+  if (inputFields.length > 0 && !sameFields(target.inputs, inputFields)) {
+    updates.inputs = inputFields;
+  }
+  if (outputFields.length > 0 && !sameFields(target.outputs, outputFields)) {
+    updates.outputs = outputFields;
+  }
+
+  return Object.keys(updates).length > 0 ? updates : undefined;
+};
+
+/**
  * Keeps a workflow agent target's recorded fields in step with its workflow.
  *
  * Every other target owns the fields it declares: a prompt, a code agent and
@@ -39,13 +65,6 @@ const sameFields = (recorded: Field[] | undefined, derived: Field[]): boolean =>
  *
  * Reconciling on load fixes both directions — columns added before these
  * fields were derived at all, and columns whose workflow has since changed.
- *
- * Two deliberate restraints:
- *
- * An empty derivation is never applied. The agent reports no fields both for a
- * workflow that genuinely declares none and for one that could not be read
- * (deleted, archived, or never committed), and clearing a column's fields on a
- * failed lookup would take the user's mappings with them.
  *
  * The reconciliation stays out of undo history. It is not an edit the user
  * made, so Ctrl+Z landing on it would either look like nothing happened or put
@@ -90,22 +109,10 @@ export const useSyncWorkflowTargetFields = () => {
   useEffect(() => {
     const targets = useEvaluationsV3Store.getState().targets;
     const pending = (JSON.parse(derived) as DerivedTargetFields[]).flatMap(
-      ({ targetId, inputFields, outputFields }) => {
-        const target = targets.find((t) => t.id === targetId);
-        if (!target) return [];
-
-        const updates: Partial<Pick<TargetConfig, "inputs" | "outputs">> = {};
-        if (inputFields.length > 0 && !sameFields(target.inputs, inputFields)) {
-          updates.inputs = inputFields;
-        }
-        if (
-          outputFields.length > 0 &&
-          !sameFields(target.outputs, outputFields)
-        ) {
-          updates.outputs = outputFields;
-        }
-
-        return Object.keys(updates).length > 0 ? [{ targetId, updates }] : [];
+      (fields) => {
+        const target = targets.find((t) => t.id === fields.targetId);
+        const updates = target ? staleFields(target, fields) : undefined;
+        return updates ? [{ targetId: fields.targetId, updates }] : [];
       },
     );
 

--- a/platform/app/src/experiments-v3/hooks/useSyncWorkflowTargetFields.ts
+++ b/platform/app/src/experiments-v3/hooks/useSyncWorkflowTargetFields.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import type { Field } from "~/optimization_studio/types/dsl";
+import { api } from "~/utils/api";
+import type { TargetConfig } from "../types";
+import { useEvaluationsV3Store } from "./useEvaluationsV3Store";
+
+type DerivedTargetFields = {
+  targetId: string;
+  inputFields: Field[];
+  outputFields: Field[];
+};
+
+const isWorkflowAgentTarget = (target: TargetConfig): boolean =>
+  target.type === "agent" &&
+  target.agentType === "workflow" &&
+  !!target.dbAgentId;
+
+const sameFields = (recorded: Field[] | undefined, derived: Field[]): boolean =>
+  (recorded ?? []).length === derived.length &&
+  (recorded ?? []).every(
+    (field, index) =>
+      field.identifier === derived[index]?.identifier &&
+      field.type === derived[index]?.type,
+  );
+
+/**
+ * Keeps a workflow agent target's recorded fields in step with its workflow.
+ *
+ * Every other target owns the fields it declares: a prompt, a code agent and
+ * an HTTP agent each save what they read and produce. A workflow agent owns
+ * nothing — it points at a Studio graph, and that graph's entry node and its
+ * RESULTS are the only record of its shape. A target column that copied those
+ * fields once, when it was added, therefore describes the workflow as it was
+ * at that moment. Add a result in the Studio and the workbench never hears
+ * about it: the evaluator's variable picker keeps offering the old list, and
+ * there is nothing in the UI to press to refresh it.
+ *
+ * Reconciling on load fixes both directions — columns added before these
+ * fields were derived at all, and columns whose workflow has since changed.
+ *
+ * Two deliberate restraints:
+ *
+ * An empty derivation is never applied. The agent reports no fields both for a
+ * workflow that genuinely declares none and for one that could not be read
+ * (deleted, archived, or never committed), and clearing a column's fields on a
+ * failed lookup would take the user's mappings with them.
+ *
+ * The reconciliation stays out of undo history. It is not an edit the user
+ * made, so Ctrl+Z landing on it would either look like nothing happened or put
+ * back a shape the workflow no longer has.
+ */
+export const useSyncWorkflowTargetFields = () => {
+  const { project } = useOrganizationTeamProject();
+  const projectId = project?.id ?? "";
+
+  const { targets, updateTarget } = useEvaluationsV3Store(
+    useShallow((state) => ({
+      targets: state.targets,
+      updateTarget: state.updateTarget,
+    })),
+  );
+
+  const workflowTargets = useMemo(
+    () => targets.filter(isWorkflowAgentTarget),
+    [targets],
+  );
+
+  // The project's agents, the same query the agent picker uses, so this
+  // usually costs nothing beyond a cache read.
+  const agentsQuery = api.agents.getAll.useQuery(
+    { projectId },
+    { enabled: !!projectId && workflowTargets.length > 0, staleTime: 60_000 },
+  );
+
+  // Serialized so the effect has one primitive dependency: only the resolved
+  // contents matter, and the query object is new on every render.
+  const derived = JSON.stringify(
+    workflowTargets.map((target): DerivedTargetFields => {
+      const agent = agentsQuery.data?.find((a) => a.id === target.dbAgentId);
+      return {
+        targetId: target.id,
+        inputFields: agent?.inputFields ?? [],
+        outputFields: agent?.outputFields ?? [],
+      };
+    }),
+  );
+
+  useEffect(() => {
+    const targets = useEvaluationsV3Store.getState().targets;
+    const pending = (JSON.parse(derived) as DerivedTargetFields[]).flatMap(
+      ({ targetId, inputFields, outputFields }) => {
+        const target = targets.find((t) => t.id === targetId);
+        if (!target) return [];
+
+        const updates: Partial<Pick<TargetConfig, "inputs" | "outputs">> = {};
+        if (inputFields.length > 0 && !sameFields(target.inputs, inputFields)) {
+          updates.inputs = inputFields;
+        }
+        if (
+          outputFields.length > 0 &&
+          !sameFields(target.outputs, outputFields)
+        ) {
+          updates.outputs = outputFields;
+        }
+
+        return Object.keys(updates).length > 0 ? [{ targetId, updates }] : [];
+      },
+    );
+
+    if (pending.length === 0) return;
+
+    const temporal = useEvaluationsV3Store.temporal.getState();
+    const wasTracking = temporal.isTracking;
+    if (wasTracking) temporal.pause();
+    try {
+      for (const { targetId, updates } of pending) {
+        updateTarget(targetId, updates);
+      }
+    } finally {
+      if (wasTracking) temporal.resume();
+    }
+  }, [derived, updateTarget]);
+};

--- a/platform/app/src/server/agents/__tests__/agent-fields.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent-fields.unit.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { Workflow } from "~/optimization_studio/types/dsl";
+import type { AgentComponentConfig } from "../agent.repository";
+import { linkedWorkflowId, resolveAgentFields } from "../agent-fields";
+
+const dsl = (
+  endInputs: Array<{ identifier: string; type: string }>,
+): Workflow =>
+  ({
+    nodes: [
+      {
+        id: "entry",
+        type: "entry",
+        data: { outputs: [{ identifier: "question", type: "str" }] },
+      },
+      { id: "code", type: "code", data: {} },
+      { id: "end", type: "end", data: { inputs: endInputs } },
+    ],
+    edges: [
+      { source: "entry", sourceHandle: "outputs.question", target: "code" },
+    ],
+  }) as unknown as Workflow;
+
+describe("resolveAgentFields", () => {
+  describe("given a workflow agent", () => {
+    describe("when the linked workflow declares several results", () => {
+      it("reports every result with its declared type", () => {
+        const fields = resolveAgentFields({
+          type: "workflow",
+          config: { name: "wf agent" },
+          dsl: dsl([
+            { identifier: "output", type: "str" },
+            { identifier: "chunks", type: "dict" },
+          ]),
+        });
+
+        expect(fields.outputFields).toEqual([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+      });
+
+      it("reports the entry node's fields as its inputs", () => {
+        const fields = resolveAgentFields({
+          type: "workflow",
+          config: { name: "wf agent" },
+          dsl: dsl([{ identifier: "output", type: "str" }]),
+        });
+
+        expect(fields.inputFields).toEqual([
+          { identifier: "question", type: "str" },
+        ]);
+      });
+    });
+
+    describe("when the linked workflow could not be read", () => {
+      it("reports no fields rather than inventing an output", () => {
+        const fields = resolveAgentFields({
+          type: "workflow",
+          config: { name: "wf agent" },
+          dsl: undefined,
+        });
+
+        expect(fields).toEqual({ inputFields: [], outputFields: [] });
+      });
+    });
+
+    describe("when the linked workflow declares no results", () => {
+      it("reports no output fields", () => {
+        const fields = resolveAgentFields({
+          type: "workflow",
+          config: { name: "wf agent" },
+          dsl: dsl([]),
+        });
+
+        expect(fields.outputFields).toEqual([]);
+      });
+    });
+  });
+
+  describe("given a code agent", () => {
+    describe("when its config declares its own fields", () => {
+      /** @scenario "A code agent keeps reporting the fields saved on its own config" */
+      it("reports the fields off the config", () => {
+        const config = {
+          name: "scorer",
+          inputs: [{ identifier: "text", type: "str" }],
+          outputs: [{ identifier: "answer", type: "str" }],
+          parameters: [{ identifier: "code", type: "code", value: "pass" }],
+        } as unknown as AgentComponentConfig;
+
+        expect(resolveAgentFields({ type: "code", config })).toEqual({
+          inputFields: [{ identifier: "text", type: "str" }],
+          outputFields: [{ identifier: "answer", type: "str" }],
+        });
+      });
+    });
+  });
+});
+
+describe("linkedWorkflowId", () => {
+  describe("when the agent row carries a workflowId", () => {
+    it("prefers the column over the config", () => {
+      expect(
+        linkedWorkflowId({
+          workflowId: "wf_column",
+          config: { name: "a", workflow_id: "wf_config" },
+        }),
+      ).toBe("wf_column");
+    });
+  });
+
+  describe("when only the config carries one", () => {
+    it("falls back to the config, as older agents have no column", () => {
+      expect(
+        linkedWorkflowId({
+          workflowId: null,
+          config: { name: "a", workflow_id: "wf_config" },
+        }),
+      ).toBe("wf_config");
+    });
+  });
+});

--- a/platform/app/src/server/agents/__tests__/agent-fields.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent-fields.unit.test.ts
@@ -61,7 +61,11 @@ describe("resolveAgentFields", () => {
           dsl: undefined,
         });
 
-        expect(fields).toEqual({ inputFields: [], outputFields: [] });
+        expect(fields).toEqual({
+          inputFields: [],
+          outputFields: [],
+          fieldsResolved: false,
+        });
       });
     });
 
@@ -92,7 +96,34 @@ describe("resolveAgentFields", () => {
         expect(resolveAgentFields({ type: "code", config })).toEqual({
           inputFields: [{ identifier: "text", type: "str" }],
           outputFields: [{ identifier: "answer", type: "str" }],
+          fieldsResolved: true,
         });
+      });
+    });
+  });
+
+  describe("given a workflow that declares no results", () => {
+    describe("when its graph was read", () => {
+      /** @scenario "A workflow agent whose workflow declares no results reports none" */
+      it("reports the empty list as an answer, not as a failed lookup", () => {
+        const fields = resolveAgentFields({
+          type: "workflow",
+          config: { name: "wf agent" },
+          dsl: {
+            nodes: [
+              {
+                id: "entry",
+                type: "entry",
+                data: { outputs: [{ identifier: "question", type: "str" }] },
+              },
+              { id: "end", type: "end", data: { inputs: [] } },
+            ],
+            edges: [],
+          } as unknown as Workflow,
+        });
+
+        expect(fields.outputFields).toEqual([]);
+        expect(fields.fieldsResolved).toBe(true);
       });
     });
   });

--- a/platform/app/src/server/agents/__tests__/agent.service.fields.integration.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.fields.integration.test.ts
@@ -1,0 +1,223 @@
+/**
+ * A workflow agent's fields come from its linked Studio workflow, not from its
+ * own config, so they are resolved against the real database on every read.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { getTestProject, getTestUser } from "~/utils/testUtils";
+import { AgentService } from "../agent.service";
+
+type EndResult = { identifier: string; type: string };
+
+describe("AgentService field derivation", () => {
+  let projectId: string;
+  let authorId: string;
+  const cleanupAgentIds: string[] = [];
+  const cleanupWorkflowIds: string[] = [];
+
+  beforeAll(async () => {
+    const project = await getTestProject("agent-fields");
+    projectId = project.id;
+    const user = await getTestUser();
+    authorId = user.id;
+  });
+
+  afterAll(async () => {
+    // Prisma enforces the version relations even with relationMode "prisma",
+    // so a workflow still pointing at its versions cannot be deleted.
+    if (cleanupWorkflowIds.length > 0 && projectId) {
+      await prisma.workflow.updateMany({
+        where: { id: { in: cleanupWorkflowIds }, projectId },
+        data: { currentVersionId: null, latestVersionId: null },
+      });
+    }
+
+    await cleanupTestRows(prisma, [
+      ["agent", { id: { in: cleanupAgentIds }, projectId }],
+      [
+        "workflowVersion",
+        { workflowId: { in: cleanupWorkflowIds }, projectId },
+      ],
+      ["workflow", { id: { in: cleanupWorkflowIds }, projectId }],
+    ]);
+  });
+
+  const dslWith = (endResults: EndResult[]) => ({
+    nodes: [
+      {
+        id: "entry",
+        type: "entry",
+        data: { outputs: [{ identifier: "question", type: "str" }] },
+      },
+      { id: "code", type: "code", data: {} },
+      { id: "end", type: "end", data: { inputs: endResults } },
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "entry",
+        sourceHandle: "outputs.question",
+        target: "code",
+        targetHandle: "inputs.input",
+      },
+    ],
+  });
+
+  const commitVersion = async (workflowId: string, endResults: EndResult[]) => {
+    const version = await prisma.workflowVersion.create({
+      data: {
+        id: `test_wfv_${nanoid(8)}`,
+        workflowId,
+        projectId,
+        version: `${Date.now()}`,
+        commitMessage: "test",
+        authorId,
+        dsl: dslWith(endResults),
+      },
+    });
+    await prisma.workflow.update({
+      where: { id: workflowId },
+      data: { currentVersionId: version.id, latestVersionId: version.id },
+    });
+    return version.id;
+  };
+
+  const createWorkflowAgent = async (endResults: EndResult[]) => {
+    const workflowId = `test_wf_${nanoid(8)}`;
+    await prisma.workflow.create({
+      data: {
+        id: workflowId,
+        projectId,
+        name: "wf agent workflow",
+        icon: "🤖",
+        description: "Test workflow",
+      },
+    });
+    cleanupWorkflowIds.push(workflowId);
+    await commitVersion(workflowId, endResults);
+
+    const service = AgentService.create(prisma);
+    const agent = await service.create({
+      id: `test_agent_${nanoid(8)}`,
+      projectId,
+      name: "wf agent",
+      type: "workflow",
+      config: { name: "wf agent", isCustom: true, workflow_id: workflowId },
+      workflowId,
+    });
+    cleanupAgentIds.push(agent.id);
+    return { agent, workflowId, service };
+  };
+
+  describe("given a workflow agent whose end node declares two results", () => {
+    describe("when the agent is read", () => {
+      /** @scenario "A workflow agent reports the end node's results as its output fields" */
+      it("reports both results, keeping the declared object type", async () => {
+        const { agent, service } = await createWorkflowAgent([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.outputFields).toEqual([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+      });
+
+      /** @scenario "A workflow agent reports the entry node's fields as its input fields" */
+      it("reports the entry node's fields as its inputs", async () => {
+        const { agent, service } = await createWorkflowAgent([
+          { identifier: "output", type: "str" },
+        ]);
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.inputFields).toEqual([
+          { identifier: "question", type: "str" },
+        ]);
+      });
+
+      it("reports the same fields when listing every agent in the project", async () => {
+        const { agent, service } = await createWorkflowAgent([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+
+        const all = await service.getAll({ projectId });
+        const listed = all.find((a) => a.id === agent.id);
+
+        expect(listed?.outputFields).toEqual([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+      });
+    });
+  });
+
+  describe("given the workflow gains a result after the agent was created", () => {
+    describe("when the agent is read again", () => {
+      /** @scenario "Editing the workflow changes the agent's fields without touching the agent" */
+      it("reports the new result without the agent row being touched", async () => {
+        const { agent, workflowId, service } = await createWorkflowAgent([
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+        ]);
+        const before = await service.getById({ id: agent.id, projectId });
+        expect(before?.outputFields).toHaveLength(2);
+        const updatedAtBefore = before?.updatedAt;
+
+        await commitVersion(workflowId, [
+          { identifier: "output", type: "str" },
+          { identifier: "chunks", type: "dict" },
+          { identifier: "citations", type: "list" },
+        ]);
+
+        const after = await service.getById({ id: agent.id, projectId });
+        expect(after?.outputFields.map((f) => f.identifier)).toEqual([
+          "output",
+          "chunks",
+          "citations",
+        ]);
+        expect(after?.updatedAt).toEqual(updatedAtBefore);
+      });
+    });
+  });
+
+  describe("given a workflow that declares no results", () => {
+    describe("when the agent is read", () => {
+      /** @scenario "A workflow agent whose workflow declares no results reports none" */
+      it("reports no output fields rather than inventing one named output", async () => {
+        const { agent, service } = await createWorkflowAgent([]);
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.outputFields).toEqual([]);
+      });
+    });
+  });
+
+  describe("given the linked workflow was archived", () => {
+    describe("when the agent is read", () => {
+      /** @scenario "A workflow agent whose workflow was deleted reports no fields" */
+      it("still returns the agent, with no fields", async () => {
+        const { agent, workflowId, service } = await createWorkflowAgent([
+          { identifier: "output", type: "str" },
+        ]);
+        await prisma.workflow.update({
+          where: { id: workflowId, projectId },
+          data: { archivedAt: new Date() },
+        });
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.id).toBe(agent.id);
+        expect(read?.outputFields).toEqual([]);
+        expect(read?.inputFields).toEqual([]);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/agents/__tests__/agent.service.fields.integration.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.fields.integration.test.ts
@@ -65,7 +65,13 @@ describe("AgentService field derivation", () => {
     ],
   });
 
-  const commitVersion = async (workflowId: string, endResults: EndResult[]) => {
+  const commitVersion = async ({
+    workflowId,
+    endResults,
+  }: {
+    workflowId: string;
+    endResults: EndResult[];
+  }) => {
     const version = await prisma.workflowVersion.create({
       data: {
         id: `test_wfv_${nanoid(8)}`,
@@ -96,7 +102,7 @@ describe("AgentService field derivation", () => {
       },
     });
     cleanupWorkflowIds.push(workflowId);
-    await commitVersion(workflowId, endResults);
+    await commitVersion({ workflowId, endResults });
 
     const service = AgentService.create(prisma);
     const agent = await service.create({
@@ -170,11 +176,14 @@ describe("AgentService field derivation", () => {
         expect(before?.outputFields).toHaveLength(2);
         const updatedAtBefore = before?.updatedAt;
 
-        await commitVersion(workflowId, [
-          { identifier: "output", type: "str" },
-          { identifier: "chunks", type: "dict" },
-          { identifier: "citations", type: "list" },
-        ]);
+        await commitVersion({
+          workflowId,
+          endResults: [
+            { identifier: "output", type: "str" },
+            { identifier: "chunks", type: "dict" },
+            { identifier: "citations", type: "list" },
+          ],
+        });
 
         const after = await service.getById({ id: agent.id, projectId });
         expect(after?.outputFields.map((f) => f.identifier)).toEqual([
@@ -197,6 +206,15 @@ describe("AgentService field derivation", () => {
 
         expect(read?.outputFields).toEqual([]);
       });
+
+      /** @scenario "A workflow agent whose workflow declares no results reports none" */
+      it("marks the fields resolved, so an empty list is an answer", async () => {
+        const { agent, service } = await createWorkflowAgent([]);
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.fieldsResolved).toBe(true);
+      });
     });
   });
 
@@ -217,6 +235,21 @@ describe("AgentService field derivation", () => {
         expect(read?.id).toBe(agent.id);
         expect(read?.outputFields).toEqual([]);
         expect(read?.inputFields).toEqual([]);
+      });
+
+      /** @scenario "A workflow agent whose workflow was deleted reports no fields" */
+      it("marks the fields unresolved, so no caller mistakes it for an empty workflow", async () => {
+        const { agent, workflowId, service } = await createWorkflowAgent([
+          { identifier: "output", type: "str" },
+        ]);
+        await prisma.workflow.update({
+          where: { id: workflowId, projectId },
+          data: { archivedAt: new Date() },
+        });
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.fieldsResolved).toBe(false);
       });
     });
   });

--- a/platform/app/src/server/agents/__tests__/agent.service.fields.integration.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.fields.integration.test.ts
@@ -218,7 +218,10 @@ describe("AgentService field derivation", () => {
     });
   });
 
-  describe("given the linked workflow was archived", () => {
+  // Deleting a workflow archives it: the delete endpoint sets archivedAt and
+  // the row stays, so this is the shape a deleted workflow really leaves
+  // behind. A workflow id matching no row at all is covered separately below.
+  describe("given the linked workflow was deleted", () => {
     describe("when the agent is read", () => {
       /** @scenario "A workflow agent whose workflow was deleted reports no fields" */
       it("still returns the agent, with no fields", async () => {
@@ -249,6 +252,34 @@ describe("AgentService field derivation", () => {
 
         const read = await service.getById({ id: agent.id, projectId });
 
+        expect(read?.fieldsResolved).toBe(false);
+      });
+    });
+  });
+
+  describe("given the agent points at a workflow that has no row", () => {
+    describe("when the agent is read", () => {
+      /** @scenario "A workflow agent pointing at no workflow at all reports no fields" */
+      it("reports no fields and says it could not resolve them", async () => {
+        const service = AgentService.create(prisma);
+        const agent = await service.create({
+          id: `test_agent_${nanoid(8)}`,
+          projectId,
+          name: "wf agent",
+          type: "workflow",
+          config: {
+            name: "wf agent",
+            isCustom: true,
+            workflow_id: "test_wf_missing",
+          },
+          workflowId: "test_wf_missing",
+        });
+        cleanupAgentIds.push(agent.id);
+
+        const read = await service.getById({ id: agent.id, projectId });
+
+        expect(read?.id).toBe(agent.id);
+        expect(read?.outputFields).toEqual([]);
         expect(read?.fieldsResolved).toBe(false);
       });
     });

--- a/platform/app/src/server/agents/agent-fields.ts
+++ b/platform/app/src/server/agents/agent-fields.ts
@@ -19,6 +19,16 @@ import type {
 export type AgentFields = {
   inputFields: Field[];
   outputFields: Field[];
+  /**
+   * Whether the two lists above are what the agent actually declares.
+   *
+   * `false` only for a workflow agent whose graph could not be read — archived,
+   * deleted, or in another project. That is not the same as a workflow that
+   * declares no results, and a caller that cannot tell the two apart has to
+   * pick one wrong behaviour for both: either wipe a column's mappings the
+   * first time a lookup fails, or keep offering a result that was removed.
+   */
+  fieldsResolved: boolean;
 };
 
 /**
@@ -55,7 +65,9 @@ export const linkedWorkflowId = (agent: {
 export const workflowAgentFields = (
   dsl: Workflow | undefined | null,
 ): AgentFields => {
-  if (!dsl?.nodes) return { inputFields: [], outputFields: [] };
+  if (!dsl?.nodes) {
+    return { inputFields: [], outputFields: [], fieldsResolved: false };
+  }
 
   const inputFields = getMappingSurfaceInputs(dsl.edges ?? [], dsl.nodes).map(
     (input) => ({
@@ -70,7 +82,7 @@ export const workflowAgentFields = (
     type: output.type as Field["type"],
   }));
 
-  return { inputFields, outputFields };
+  return { inputFields, outputFields, fieldsResolved: true };
 };
 
 /**
@@ -80,10 +92,11 @@ export const workflowAgentFields = (
  * (it lives on a different table), so it arrives as an argument rather than
  * being fetched here.
  *
- * A workflow agent whose graph could not be read reports no fields at all. The
- * alternative — inventing a single field named "output" — is what made a
- * two-result workflow look like it produced one text field, and a caller that
- * cannot tell "unknown" from "one output" has no way to avoid repeating that.
+ * A workflow agent whose graph could not be read reports no fields and
+ * `fieldsResolved: false`. The alternative, inventing a single field named
+ * "output", is what made a two-result workflow look like it produced one text
+ * field, and a caller that cannot tell "unknown" from "one output" has no way
+ * to avoid repeating that.
  */
 export const resolveAgentFields = ({
   type,
@@ -99,5 +112,6 @@ export const resolveAgentFields = ({
   return {
     inputFields: config.inputs ?? [],
     outputFields: config.outputs ?? [],
+    fieldsResolved: true,
   };
 };

--- a/platform/app/src/server/agents/agent-fields.ts
+++ b/platform/app/src/server/agents/agent-fields.ts
@@ -1,0 +1,103 @@
+import type { Field, Workflow } from "~/optimization_studio/types/dsl";
+import { getMappingSurfaceInputs } from "~/optimization_studio/utils/nodeUtils";
+import { getWorkflowEndInputs } from "~/optimization_studio/utils/workflowFields";
+import type {
+  AgentComponentConfig,
+  AgentType,
+  TypedAgent,
+} from "./agent.repository";
+
+/**
+ * The fields an agent reads and produces, whatever kind of agent it is.
+ *
+ * Code, signature and HTTP agents keep these on their own saved config. A
+ * workflow agent does not: it is a pointer to a Studio graph, so the only
+ * record of what it reads and produces is that graph's entry and end nodes.
+ * Consumers should not have to know which kind they are holding, so this is
+ * resolved for every agent at read time.
+ */
+export type AgentFields = {
+  inputFields: Field[];
+  outputFields: Field[];
+};
+
+/**
+ * What every read of an agent hands back: the row plus the fields it reads and
+ * produces. Callers pick an agent from a list and immediately need its shape,
+ * so the two always travel together.
+ */
+export type AgentWithFields = TypedAgent & AgentFields;
+
+/**
+ * The Studio workflow a workflow agent points at.
+ *
+ * The `workflowId` column is authoritative, but agents created before it
+ * existed only carry `workflow_id` inside their DSL config, and the two
+ * drawers that read this already disagreed about which to try first.
+ */
+export const linkedWorkflowId = (agent: {
+  workflowId?: string | null;
+  config: AgentComponentConfig;
+}): string | undefined => {
+  if (agent.workflowId) return agent.workflowId;
+  const config = agent.config as { workflow_id?: string };
+  return config.workflow_id;
+};
+
+/**
+ * A workflow's inputs are its entry node's mapping surface, and its outputs
+ * are its end node's inputs — what the Studio labels RESULTS.
+ *
+ * Derived on every read rather than copied onto the agent, because the graph
+ * is the source of truth and editing it must not leave the agent describing a
+ * shape the workflow no longer has.
+ */
+export const workflowAgentFields = (
+  dsl: Workflow | undefined | null,
+): AgentFields => {
+  if (!dsl?.nodes) return { inputFields: [], outputFields: [] };
+
+  const inputFields = getMappingSurfaceInputs(dsl.edges ?? [], dsl.nodes).map(
+    (input) => ({
+      identifier: input.identifier,
+      type: input.type,
+      ...(input.optional ? { optional: true } : {}),
+    }),
+  );
+
+  const outputFields = getWorkflowEndInputs(dsl).map((output) => ({
+    identifier: output.identifier,
+    type: output.type as Field["type"],
+  }));
+
+  return { inputFields, outputFields };
+};
+
+/**
+ * Resolve an agent's fields.
+ *
+ * `dsl` is only consulted for workflow agents, and only the caller can load it
+ * (it lives on a different table), so it arrives as an argument rather than
+ * being fetched here.
+ *
+ * A workflow agent whose graph could not be read reports no fields at all. The
+ * alternative — inventing a single field named "output" — is what made a
+ * two-result workflow look like it produced one text field, and a caller that
+ * cannot tell "unknown" from "one output" has no way to avoid repeating that.
+ */
+export const resolveAgentFields = ({
+  type,
+  config,
+  dsl,
+}: {
+  type: AgentType;
+  config: AgentComponentConfig;
+  dsl?: Workflow | null;
+}): AgentFields => {
+  if (type === "workflow") return workflowAgentFields(dsl);
+
+  return {
+    inputFields: config.inputs ?? [],
+    outputFields: config.outputs ?? [],
+  };
+};

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -3,11 +3,6 @@
 import type { PrismaClient } from "@prisma/client";
 import type { Workflow } from "~/optimization_studio/types/dsl";
 import {
-  type AgentWithFields,
-  linkedWorkflowId,
-  resolveAgentFields,
-} from "./agent-fields";
-import {
   type AgentComponentConfig,
   type AgentCopyRow,
   AgentRepository,
@@ -16,6 +11,11 @@ import {
   type TypedAgent,
   type UpdateAgentInput,
 } from "./agent.repository";
+import {
+  type AgentWithFields,
+  linkedWorkflowId,
+  resolveAgentFields,
+} from "./agent-fields";
 import { AgentNotFoundError } from "./errors";
 
 /**

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -47,7 +47,10 @@ export class AgentService {
   }): Promise<AgentWithFields | null> {
     const agent = await this.repository.findById(input);
     if (!agent) return null;
-    const [enriched] = await this.withFields([agent], input.projectId);
+    const [enriched] = await this.withFields({
+      agents: [agent],
+      projectId: input.projectId,
+    });
     return enriched ?? null;
   }
 
@@ -63,7 +66,7 @@ export class AgentService {
    */
   async getAll(input: { projectId: string }): Promise<AgentWithFields[]> {
     const agents = await this.repository.findAll(input);
-    return this.withFields(agents, input.projectId);
+    return this.withFields({ agents, projectId: input.projectId });
   }
 
   /**
@@ -74,10 +77,13 @@ export class AgentService {
    * once, and a project with fifty workflow agents would otherwise fan out
    * into fifty workflow lookups on every open.
    */
-  private async withFields(
-    agents: TypedAgent[],
-    projectId: string,
-  ): Promise<AgentWithFields[]> {
+  private async withFields({
+    agents,
+    projectId,
+  }: {
+    agents: TypedAgent[];
+    projectId: string;
+  }): Promise<AgentWithFields[]> {
     const workflowIds = agents.flatMap((agent) =>
       agent.type === "workflow" ? [linkedWorkflowId(agent)] : [],
     );
@@ -113,7 +119,10 @@ export class AgentService {
    */
   async create(input: CreateAgentInput): Promise<AgentWithFields> {
     const agent = await this.repository.create(input);
-    const [enriched] = await this.withFields([agent], input.projectId);
+    const [enriched] = await this.withFields({
+      agents: [agent],
+      projectId: input.projectId,
+    });
     return enriched!;
   }
 
@@ -122,7 +131,10 @@ export class AgentService {
    */
   async update(input: UpdateAgentInput): Promise<AgentWithFields> {
     const agent = await this.repository.update(input);
-    const [enriched] = await this.withFields([agent], input.projectId);
+    const [enriched] = await this.withFields({
+      agents: [agent],
+      projectId: input.projectId,
+    });
     return enriched!;
   }
 

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -1,11 +1,20 @@
 // biome-ignore-all lint/suspicious/noEmptyBlockStatements: the empty blocks in this file are deliberate no-ops.
 
 import type { PrismaClient } from "@prisma/client";
+import type { Workflow } from "~/optimization_studio/types/dsl";
+import {
+  type AgentWithFields,
+  linkedWorkflowId,
+  resolveAgentFields,
+} from "./agent-fields";
 import {
   type AgentComponentConfig,
   type AgentCopyRow,
   AgentRepository,
   type AgentType,
+  type CreateAgentInput,
+  type TypedAgent,
+  type UpdateAgentInput,
 } from "./agent.repository";
 import { AgentNotFoundError } from "./errors";
 
@@ -30,10 +39,16 @@ export class AgentService {
   }
 
   /**
-   * Gets an agent by ID and projectId.
+   * Gets an agent by ID and projectId, with the fields it reads and produces.
    */
-  get getById() {
-    return this.repository.findById.bind(this.repository);
+  async getById(input: {
+    id: string;
+    projectId: string;
+  }): Promise<AgentWithFields | null> {
+    const agent = await this.repository.findById(input);
+    if (!agent) return null;
+    const [enriched] = await this.withFields([agent], input.projectId);
+    return enriched ?? null;
   }
 
   /**
@@ -44,24 +59,71 @@ export class AgentService {
   }
 
   /**
-   * Gets all agents for a project.
+   * Gets all agents for a project, with the fields each reads and produces.
    */
-  get getAll() {
-    return this.repository.findAll.bind(this.repository);
+  async getAll(input: { projectId: string }): Promise<AgentWithFields[]> {
+    const agents = await this.repository.findAll(input);
+    return this.withFields(agents, input.projectId);
+  }
+
+  /**
+   * Attach each agent's input and output fields.
+   *
+   * Every workflow agent in the batch is resolved with one query rather than
+   * one per agent: the agent list drawer loads a whole project's agents at
+   * once, and a project with fifty workflow agents would otherwise fan out
+   * into fifty workflow lookups on every open.
+   */
+  private async withFields(
+    agents: TypedAgent[],
+    projectId: string,
+  ): Promise<AgentWithFields[]> {
+    const workflowIds = agents.flatMap((agent) =>
+      agent.type === "workflow" ? [linkedWorkflowId(agent)] : [],
+    );
+    const presentIds = workflowIds.filter((id): id is string => !!id);
+
+    const dslByWorkflowId = new Map<string, Workflow>();
+    if (presentIds.length > 0) {
+      const workflows = await this.prisma.workflow.findMany({
+        where: { id: { in: presentIds }, projectId, archivedAt: null },
+        include: { currentVersion: true },
+      });
+      for (const workflow of workflows) {
+        const dsl = workflow.currentVersion?.dsl;
+        if (dsl) dslByWorkflowId.set(workflow.id, dsl as unknown as Workflow);
+      }
+    }
+
+    return agents.map((agent) => {
+      const workflowId = linkedWorkflowId(agent);
+      return {
+        ...agent,
+        ...resolveAgentFields({
+          type: agent.type,
+          config: agent.config,
+          dsl: workflowId ? dslByWorkflowId.get(workflowId) : undefined,
+        }),
+      };
+    });
   }
 
   /**
    * Creates a new agent.
    */
-  get create() {
-    return this.repository.create.bind(this.repository);
+  async create(input: CreateAgentInput): Promise<AgentWithFields> {
+    const agent = await this.repository.create(input);
+    const [enriched] = await this.withFields([agent], input.projectId);
+    return enriched!;
   }
 
   /**
    * Updates an existing agent.
    */
-  get update() {
-    return this.repository.update.bind(this.repository);
+  async update(input: UpdateAgentInput): Promise<AgentWithFields> {
+    const agent = await this.repository.update(input);
+    const [enriched] = await this.withFields([agent], input.projectId);
+    return enriched!;
   }
 
   /**

--- a/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
@@ -277,9 +277,9 @@ describe("executeWorkflowCell", () => {
             e.type === "evaluator_result" && e.evaluatorId === "eval-grading",
         );
         expect(graded).toMatchObject({ rowIndex: 0, targetId: "wf-target" });
-        expect(graded?.type === "evaluator_result" && graded.result).toMatchObject(
-          { status: "processed", score: 1, passed: true },
-        );
+        expect(
+          graded?.type === "evaluator_result" && graded.result,
+        ).toMatchObject({ status: "processed", score: 1, passed: true });
       });
 
       /** @scenario "An evaluator can read a result other than the first one" */
@@ -359,15 +359,17 @@ describe("executeWorkflowCell", () => {
           output: "yes",
           chunks: { a: 1 },
         });
-        expect(target?.type === "target_result" && target.error).toBeUndefined();
+        expect(
+          target?.type === "target_result" && target.error,
+        ).toBeUndefined();
 
         const graded = events.find(
           (e) =>
             e.type === "evaluator_result" && e.evaluatorId === "eval-grading",
         );
-        expect(graded?.type === "evaluator_result" && graded.result).toMatchObject(
-          { status: "error", error_type: "EvaluatorError" },
-        );
+        expect(
+          graded?.type === "evaluator_result" && graded.result,
+        ).toMatchObject({ status: "error", error_type: "EvaluatorError" });
       });
     });
   });

--- a/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
@@ -4,7 +4,7 @@
  * dataset inlining) is mocked and fed a scripted set of server events, so this
  * runs the classification and mapping logic without a live NLP service.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EvaluatorConfig } from "~/experiments-v3/types";
 import type { Workflow } from "~/optimization_studio/types/dsl";
 import type { StudioServerEvent } from "~/optimization_studio/types/events";
@@ -192,19 +192,18 @@ const gradingSuccess: StudioServerEvent[] = [
   },
 ] as unknown as StudioServerEvent[];
 
-const resetScript = () => {
+beforeEach(() => {
   scripted.flow = [];
   scripted.component = [];
   scripted.componentThrows = undefined;
   scripted.dispatched = [];
-};
+});
 
 describe("executeWorkflowCell", () => {
   describe("given a workflow run that succeeds with an evaluator node", () => {
     describe("when the cell is executed", () => {
       /** @scenario "A workflow target produces one result per dataset row" */
       it("yields exactly one target_result from the workflow end-node result", async () => {
-        resetScript();
         scripted.flow = succeedingRun;
         const events = await run(makeCell());
 
@@ -220,7 +219,6 @@ describe("executeWorkflowCell", () => {
 
       /** @scenario "The workflow's own evaluator nodes surface as evaluator results" */
       it("surfaces each workflow evaluator node, coercing string score and passed", async () => {
-        resetScript();
         scripted.flow = succeedingRun;
         const events = await run(makeCell());
 
@@ -249,7 +247,6 @@ describe("executeWorkflowCell", () => {
 
       /** @scenario "Cost and duration from the workflow run are captured per row" */
       it("captures summed node cost and the run duration on the target result", async () => {
-        resetScript();
         scripted.flow = succeedingRun;
         const events = await run(makeCell());
 
@@ -264,7 +261,6 @@ describe("executeWorkflowCell", () => {
     describe("when the workflow run succeeds", () => {
       /** @scenario "An evaluator attached to a workflow target runs against its results" */
       it("dispatches the evaluator and yields its score", async () => {
-        resetScript();
         scripted.flow = twoResultRun;
         scripted.component = gradingSuccess;
 
@@ -284,7 +280,6 @@ describe("executeWorkflowCell", () => {
 
       /** @scenario "An evaluator can read a result other than the first one" */
       it("resolves a mapping onto a result other than output", async () => {
-        resetScript();
         scripted.flow = twoResultRun;
         scripted.component = gradingSuccess;
 
@@ -303,7 +298,6 @@ describe("executeWorkflowCell", () => {
 
       /** @scenario "An evaluator can read a result other than the first one" */
       it("runs the evaluator inside the same trace as the workflow", async () => {
-        resetScript();
         scripted.flow = twoResultRun;
         scripted.component = gradingSuccess;
 
@@ -319,7 +313,6 @@ describe("executeWorkflowCell", () => {
     describe("when the workflow run fails", () => {
       /** @scenario "A failing workflow row does not run its evaluators" */
       it("reports the workflow error and dispatches no evaluator", async () => {
-        resetScript();
         scripted.flow = failingRun;
         scripted.component = gradingSuccess;
 
@@ -347,7 +340,6 @@ describe("executeWorkflowCell", () => {
     describe("when the evaluator itself fails", () => {
       /** @scenario "An evaluator that fails does not lose the workflow's own result" */
       it("keeps the workflow result and reports the evaluator error", async () => {
-        resetScript();
         scripted.flow = twoResultRun;
         scripted.componentThrows = new Error("evaluator service unreachable");
 

--- a/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
@@ -5,17 +5,37 @@
  * runs the classification and mapping logic without a live NLP service.
  */
 import { describe, expect, it, vi } from "vitest";
+import type { EvaluatorConfig } from "~/experiments-v3/types";
 import type { Workflow } from "~/optimization_studio/types/dsl";
 import type { StudioServerEvent } from "~/optimization_studio/types/events";
 
 // vi.mock is hoisted above declarations, so the scripted events live in a
-// hoisted holder the mock factory can safely close over.
-const scripted = vi.hoisted(() => ({ events: [] as StudioServerEvent[] }));
+// hoisted holder the mock factory can safely close over. The workflow run and
+// the grading evaluators are two separate dispatches, so they are scripted
+// separately and the mock answers each by the message it was given.
+const scripted = vi.hoisted(() => ({
+  flow: [] as StudioServerEvent[],
+  component: [] as StudioServerEvent[],
+  componentThrows: undefined as Error | undefined,
+  dispatched: [] as Array<{ type: string; payload: Record<string, any> }>,
+}));
 
 vi.mock("~/app/api/workflows/post_event/post-event", () => ({
   studioBackendPostEvent: vi.fn(
-    async ({ onEvent }: { onEvent: (event: StudioServerEvent) => void }) => {
-      for (const event of scripted.events) onEvent(event);
+    async ({
+      message,
+      onEvent,
+    }: {
+      message: { type: string; payload: Record<string, any> };
+      onEvent: (event: StudioServerEvent) => void;
+    }) => {
+      scripted.dispatched.push(message);
+      if (message.type === "execute_component") {
+        if (scripted.componentThrows) throw scripted.componentThrows;
+        for (const event of scripted.component) onEvent(event);
+        return;
+      }
+      for (const event of scripted.flow) onEvent(event);
     },
   ),
 }));
@@ -55,57 +75,137 @@ const makeCell = (overrides?: Partial<ExecutionCell>): ExecutionCell => ({
   ...overrides,
 });
 
+/**
+ * A grading evaluator attached to the target column in the workbench, reading
+ * one of the workflow's results. This is not one of the workflow's own
+ * evaluator nodes — it exists only in the workbench.
+ */
+const gradingEvaluator = (sourceField: string): EvaluatorConfig => ({
+  id: "eval-grading",
+  evaluatorType: "langevals/exact_match",
+  dbEvaluatorId: "db-eval-1",
+  inputs: [{ identifier: "output", type: "str" }],
+  mappings: {
+    "dataset-1": {
+      "wf-target": {
+        output: {
+          type: "source",
+          source: "target",
+          sourceId: "wf-target",
+          sourceField,
+        },
+      },
+    },
+  },
+});
+
 const run = async (cell: ExecutionCell): Promise<EvaluationV3Event[]> => {
   const events: EvaluationV3Event[] = [];
-  for await (const event of executeWorkflowCell(cell, "p1", workflowDsl)) {
+  for await (const event of executeWorkflowCell({
+    cell,
+    projectId: "p1",
+    workflowDsl,
+    datasetColumns: [{ id: "col_1", name: "question", type: "string" }],
+  })) {
     events.push(event);
   }
   return events;
 };
 
+const succeedingRun: StudioServerEvent[] = [
+  {
+    type: "component_state_change",
+    payload: {
+      component_id: "llm",
+      execution_state: {
+        status: "success",
+        cost: 0.5,
+        outputs: { output: "yes" },
+      },
+    },
+  },
+  {
+    type: "component_state_change",
+    payload: {
+      component_id: "eval_1",
+      execution_state: {
+        status: "success",
+        cost: 0.25,
+        outputs: { score: "0.85", passed: "true", label: "match" },
+      },
+    },
+  },
+  {
+    type: "execution_state_change",
+    payload: {
+      execution_state: {
+        status: "success",
+        trace_id: "trace_wf_0",
+        result: { output: "yes" },
+        timestamps: { started_at: 1000, finished_at: 1500 },
+      },
+    },
+  },
+  { type: "done" },
+] as unknown as StudioServerEvent[];
+
+/** Two results on the end node, the shape that exposed the bug. */
+const twoResultRun: StudioServerEvent[] = [
+  {
+    type: "execution_state_change",
+    payload: {
+      execution_state: {
+        status: "success",
+        trace_id: "trace_wf_0",
+        result: { output: "yes", chunks: { a: 1 } },
+        timestamps: { started_at: 1000, finished_at: 1500 },
+      },
+    },
+  },
+  { type: "done" },
+] as unknown as StudioServerEvent[];
+
+const failingRun: StudioServerEvent[] = [
+  {
+    type: "execution_state_change",
+    payload: {
+      execution_state: {
+        status: "error",
+        trace_id: "trace_wf_0",
+        error: "the http call timed out",
+      },
+    },
+  },
+  { type: "done" },
+] as unknown as StudioServerEvent[];
+
+const gradingSuccess: StudioServerEvent[] = [
+  {
+    type: "component_state_change",
+    payload: {
+      component_id: "wf-target.eval-grading",
+      execution_state: {
+        status: "success",
+        outputs: { score: 1, passed: true },
+      },
+    },
+  },
+] as unknown as StudioServerEvent[];
+
+const resetScript = () => {
+  scripted.flow = [];
+  scripted.component = [];
+  scripted.componentThrows = undefined;
+  scripted.dispatched = [];
+};
+
 describe("executeWorkflowCell", () => {
   describe("given a workflow run that succeeds with an evaluator node", () => {
-    const succeedingRun: StudioServerEvent[] = [
-      {
-        type: "component_state_change",
-        payload: {
-          component_id: "llm",
-          execution_state: {
-            status: "success",
-            cost: 0.5,
-            outputs: { output: "yes" },
-          },
-        },
-      },
-      {
-        type: "component_state_change",
-        payload: {
-          component_id: "eval_1",
-          execution_state: {
-            status: "success",
-            cost: 0.25,
-            outputs: { score: "0.85", passed: "true", label: "match" },
-          },
-        },
-      },
-      {
-        type: "execution_state_change",
-        payload: {
-          execution_state: {
-            status: "success",
-            trace_id: "trace_wf_0",
-            result: { output: "yes" },
-            timestamps: { started_at: 1000, finished_at: 1500 },
-          },
-        },
-      },
-      { type: "done" },
-    ];
-
     describe("when the cell is executed", () => {
       /** @scenario "A workflow target produces one result per dataset row" */
       it("yields exactly one target_result from the workflow end-node result", async () => {
-        scripted.events = succeedingRun;
+        resetScript();
+        scripted.flow = succeedingRun;
         const events = await run(makeCell());
 
         const targets = events.filter((e) => e.type === "target_result");
@@ -120,7 +220,8 @@ describe("executeWorkflowCell", () => {
 
       /** @scenario "The workflow's own evaluator nodes surface as evaluator results" */
       it("surfaces each workflow evaluator node, coercing string score and passed", async () => {
-        scripted.events = succeedingRun;
+        resetScript();
+        scripted.flow = succeedingRun;
         const events = await run(makeCell());
 
         const evaluator = events.find((e) => e.type === "evaluator_result");
@@ -148,12 +249,125 @@ describe("executeWorkflowCell", () => {
 
       /** @scenario "Cost and duration from the workflow run are captured per row" */
       it("captures summed node cost and the run duration on the target result", async () => {
-        scripted.events = succeedingRun;
+        resetScript();
+        scripted.flow = succeedingRun;
         const events = await run(makeCell());
 
         const target = events.find((e) => e.type === "target_result");
         expect(target?.type === "target_result" && target.cost).toBe(0.75);
         expect(target?.type === "target_result" && target.duration).toBe(500);
+      });
+    });
+  });
+
+  describe("given a grading evaluator attached to the workflow target", () => {
+    describe("when the workflow run succeeds", () => {
+      /** @scenario "An evaluator attached to a workflow target runs against its results" */
+      it("dispatches the evaluator and yields its score", async () => {
+        resetScript();
+        scripted.flow = twoResultRun;
+        scripted.component = gradingSuccess;
+
+        const events = await run(
+          makeCell({ evaluatorConfigs: [gradingEvaluator("output")] }),
+        );
+
+        const graded = events.find(
+          (e) =>
+            e.type === "evaluator_result" && e.evaluatorId === "eval-grading",
+        );
+        expect(graded).toMatchObject({ rowIndex: 0, targetId: "wf-target" });
+        expect(graded?.type === "evaluator_result" && graded.result).toMatchObject(
+          { status: "processed", score: 1, passed: true },
+        );
+      });
+
+      /** @scenario "An evaluator can read a result other than the first one" */
+      it("resolves a mapping onto a result other than output", async () => {
+        resetScript();
+        scripted.flow = twoResultRun;
+        scripted.component = gradingSuccess;
+
+        await run(makeCell({ evaluatorConfigs: [gradingEvaluator("chunks")] }));
+
+        const componentDispatch = scripted.dispatched.find(
+          (m) => m.type === "execute_component",
+        );
+        expect(componentDispatch?.payload.node_id).toBe(
+          "wf-target.eval-grading",
+        );
+        expect(componentDispatch?.payload.inputs).toEqual({
+          output: { a: 1 },
+        });
+      });
+
+      /** @scenario "An evaluator can read a result other than the first one" */
+      it("runs the evaluator inside the same trace as the workflow", async () => {
+        resetScript();
+        scripted.flow = twoResultRun;
+        scripted.component = gradingSuccess;
+
+        await run(makeCell({ evaluatorConfigs: [gradingEvaluator("output")] }));
+
+        const componentDispatch = scripted.dispatched.find(
+          (m) => m.type === "execute_component",
+        );
+        expect(componentDispatch?.payload.trace_id).toBe("trace_wf_0");
+      });
+    });
+
+    describe("when the workflow run fails", () => {
+      /** @scenario "A failing workflow row does not run its evaluators" */
+      it("reports the workflow error and dispatches no evaluator", async () => {
+        resetScript();
+        scripted.flow = failingRun;
+        scripted.component = gradingSuccess;
+
+        const events = await run(
+          makeCell({ evaluatorConfigs: [gradingEvaluator("output")] }),
+        );
+
+        const target = events.find((e) => e.type === "target_result");
+        expect(target?.type === "target_result" && target.error).toBe(
+          "the http call timed out",
+        );
+        expect(
+          scripted.dispatched.some((m) => m.type === "execute_component"),
+        ).toBe(false);
+        expect(
+          events.some(
+            (e) =>
+              e.type === "evaluator_result" && e.evaluatorId === "eval-grading",
+          ),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the evaluator itself fails", () => {
+      /** @scenario "An evaluator that fails does not lose the workflow's own result" */
+      it("keeps the workflow result and reports the evaluator error", async () => {
+        resetScript();
+        scripted.flow = twoResultRun;
+        scripted.componentThrows = new Error("evaluator service unreachable");
+
+        const events = await run(
+          makeCell({ evaluatorConfigs: [gradingEvaluator("output")] }),
+        );
+
+        const target = events.find((e) => e.type === "target_result");
+        expect(target?.type === "target_result" && target.output).toEqual({
+          output: "yes",
+          chunks: { a: 1 },
+        });
+        expect(target?.type === "target_result" && target.error).toBeUndefined();
+
+        const graded = events.find(
+          (e) =>
+            e.type === "evaluator_result" && e.evaluatorId === "eval-grading",
+        );
+        expect(graded?.type === "evaluator_result" && graded.result).toMatchObject(
+          { status: "error", error_type: "EvaluatorError" },
+        );
       });
     });
   });

--- a/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/executeWorkflowCell.integration.test.ts
@@ -328,6 +328,7 @@ describe("executeWorkflowCell", () => {
         );
 
         const target = events.find((e) => e.type === "target_result");
+        expect(target).toBeDefined();
         expect(target?.type === "target_result" && target.error).toBe(
           "the http call timed out",
         );
@@ -355,6 +356,7 @@ describe("executeWorkflowCell", () => {
         );
 
         const target = events.find((e) => e.type === "target_result");
+        expect(target).toBeDefined();
         expect(target?.type === "target_result" && target.output).toEqual({
           output: "yes",
           chunks: { a: 1 },
@@ -367,6 +369,7 @@ describe("executeWorkflowCell", () => {
           (e) =>
             e.type === "evaluator_result" && e.evaluatorId === "eval-grading",
         );
+        expect(graded).toBeDefined();
         expect(
           graded?.type === "evaluator_result" && graded.result,
         ).toMatchObject({ status: "error", error_type: "EvaluatorError" });

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -1577,10 +1577,12 @@ export async function* executeWorkflowCell({
       targetOutputRecord &&
       cell.evaluatorConfigs.length > 0
     ) {
-      const { workflow, evaluatorNodeIds } = buildEvaluatorCellWorkflow(
-        { projectId, cell, datasetColumns },
+      const { workflow, evaluatorNodeIds } = buildEvaluatorCellWorkflow({
+        projectId,
+        cell,
+        datasetColumns,
         loadedEvaluators,
-      );
+      });
       yield* runCellEvaluators({
         cell,
         projectId,

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -69,7 +69,10 @@ import {
   type ExecutionSummary,
   UNNAMED_FAILURE,
 } from "./types";
-import { buildCellWorkflow } from "./workflowBuilder";
+import {
+  buildCellWorkflow,
+  buildEvaluatorCellWorkflow,
+} from "./workflowBuilder";
 
 const logger = createLogger("experiments-v3:orchestrator");
 
@@ -1025,6 +1028,133 @@ export const priceMetrics = async (
 };
 
 /**
+ * Dispatches a cell's grading evaluators against the target's output.
+ *
+ * Shared by both executors. A prompt or component target runs as one node of a
+ * mini-workflow; a workflow target runs its whole Studio graph. Either way the
+ * evaluators attached to the column are the same evaluators, dispatched one at
+ * a time with explicit inputs, so this is all the two have in common and all
+ * they need to share.
+ *
+ * One evaluator failing does not stop the rest: each reports its own error
+ * cell, and the target's own result is already yielded by the time this runs.
+ */
+async function* runCellEvaluators({
+  cell,
+  projectId,
+  workflow,
+  evaluatorNodeIds,
+  targetOutput,
+  traceId,
+  targetNodes,
+  config,
+  isAborted,
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  workflow: Workflow;
+  evaluatorNodeIds: Record<string, string>;
+  targetOutput: Record<string, unknown>;
+  traceId: string;
+  targetNodes: Set<string>;
+  config: ResultMapperConfig;
+  isAborted?: () => Promise<boolean>;
+}): AsyncGenerator<EvaluationV3Event> {
+  for (const [evaluatorId, evaluatorNodeId] of Object.entries(
+    evaluatorNodeIds,
+  )) {
+    // Check abort before each evaluator
+    if (isAborted && (await isAborted())) {
+      logger.debug(
+        { cell: cell.rowIndex, evaluatorId },
+        "Cell aborted before evaluator execution",
+      );
+      return;
+    }
+    try {
+      // Build evaluator inputs from target output and dataset
+      const evaluatorInputs = buildEvaluatorInputs(
+        cell,
+        evaluatorId,
+        targetOutput,
+      );
+
+      // Create execute_component event for evaluator
+      const evaluatorEvent = {
+        type: "execute_component" as const,
+        payload: {
+          trace_id: traceId,
+          workflow: {
+            ...workflow,
+            state: { execution: { status: "idle" as const } },
+          },
+          node_id: evaluatorNodeId,
+          inputs: evaluatorInputs,
+          origin: "evaluation",
+        },
+      };
+
+      // Add environment variables
+      const enrichedEvaluatorEvent = await addEnvs(evaluatorEvent, projectId);
+
+      // Execute evaluator
+      const evaluatorEvents: StudioServerEvent[] = [];
+      await studioBackendPostEvent({
+        projectId,
+        message: enrichedEvaluatorEvent,
+        isAborted,
+        onEvent: (serverEvent) => {
+          evaluatorEvents.push(serverEvent);
+        },
+      });
+
+      // Map and yield evaluator events
+      for (const event of evaluatorEvents) {
+        const mappedEvent = mapNlpEvent({
+          event,
+          rowIndex: cell.rowIndex,
+          targetNodes,
+          config,
+          evaluatorInputs,
+        });
+        if (mappedEvent) {
+          yield mappedEvent;
+        }
+      }
+    } catch (evalError) {
+      // Yield error for this evaluator but continue with others
+      logger.warn(
+        {
+          error: evalError,
+          evaluatorId,
+          rowIndex: cell.rowIndex,
+          targetId: cell.targetId,
+        },
+        "Evaluator execution failed",
+      );
+      yield {
+        type: "evaluator_result",
+        rowIndex: cell.rowIndex,
+        targetId: cell.targetId,
+        evaluatorId,
+        result: {
+          status: "error",
+          error_type: "EvaluatorError",
+          details:
+            evalError instanceof Error
+              ? evalError.message
+              : "Evaluator execution failed",
+          traceback: [],
+          ...(HandledError.isHandled(evalError)
+            ? { domainError: evalError.serialize() }
+            : {}),
+        },
+      };
+    }
+  }
+}
+
+/**
  * Executes a single cell and yields events.
  * @param isAborted - Optional function to check if execution should be aborted
  */
@@ -1188,101 +1318,17 @@ export async function* executeCell(
       targetOutput &&
       Object.keys(evaluatorNodeIds).length > 0
     ) {
-      for (const [evaluatorId, evaluatorNodeId] of Object.entries(
+      yield* runCellEvaluators({
+        cell,
+        projectId,
+        workflow,
         evaluatorNodeIds,
-      )) {
-        // Check abort before each evaluator
-        if (isAborted && (await isAborted())) {
-          logger.debug(
-            { cell: cell.rowIndex, evaluatorId },
-            "Cell aborted before evaluator execution",
-          );
-          return;
-        }
-        try {
-          // Build evaluator inputs from target output and dataset
-          const evaluatorInputs = buildEvaluatorInputs(
-            cell,
-            evaluatorId,
-            targetOutput,
-          );
-
-          // Create execute_component event for evaluator
-          const evaluatorEvent = {
-            type: "execute_component" as const,
-            payload: {
-              trace_id: traceId,
-              workflow: {
-                ...workflow,
-                state: { execution: { status: "idle" as const } },
-              },
-              node_id: evaluatorNodeId,
-              inputs: evaluatorInputs,
-              origin: "evaluation",
-            },
-          };
-
-          // Add environment variables
-          const enrichedEvaluatorEvent = await addEnvs(
-            evaluatorEvent,
-            projectId,
-          );
-
-          // Execute evaluator
-          const evaluatorEvents: StudioServerEvent[] = [];
-          await studioBackendPostEvent({
-            projectId,
-            message: enrichedEvaluatorEvent,
-            isAborted,
-            onEvent: (serverEvent) => {
-              evaluatorEvents.push(serverEvent);
-            },
-          });
-
-          // Map and yield evaluator events
-          for (const event of evaluatorEvents) {
-            const mappedEvent = mapNlpEvent({
-              event,
-              rowIndex: cell.rowIndex,
-              targetNodes,
-              config: cellConfig,
-              evaluatorInputs,
-            });
-            if (mappedEvent) {
-              yield mappedEvent;
-            }
-          }
-        } catch (evalError) {
-          // Yield error for this evaluator but continue with others
-          logger.warn(
-            {
-              error: evalError,
-              evaluatorId,
-              rowIndex: cell.rowIndex,
-              targetId: cell.targetId,
-            },
-            "Evaluator execution failed",
-          );
-          yield {
-            type: "evaluator_result",
-            rowIndex: cell.rowIndex,
-            targetId: cell.targetId,
-            evaluatorId,
-            result: {
-              status: "error",
-              error_type: "EvaluatorError",
-              details:
-                evalError instanceof Error
-                  ? evalError.message
-                  : "Evaluator execution failed",
-              traceback: [],
-              ...(HandledError.isHandled(evalError)
-                ? { domainError: evalError.serialize() }
-                : {}),
-            },
-          };
-        }
-      }
+        targetOutput,
+        traceId,
+        targetNodes,
+        config: cellConfig,
+        isAborted,
+      });
     }
   } catch (error) {
     logger.error(
@@ -1306,12 +1352,23 @@ export async function* executeCell(
  * evaluator result. This replaces the legacy nlpgo execute_evaluation loop,
  * keeping orchestration (parallelism, abort, storage) in TypeScript.
  */
-export async function* executeWorkflowCell(
-  cell: ExecutionCell,
-  projectId: string,
-  workflowDsl: Workflow,
-  isAborted?: () => Promise<boolean>,
-): AsyncGenerator<EvaluationV3Event> {
+export async function* executeWorkflowCell({
+  cell,
+  projectId,
+  workflowDsl,
+  datasetColumns = [],
+  loadedEvaluators,
+  resultMapperConfig,
+  isAborted,
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  workflowDsl: Workflow;
+  datasetColumns?: Array<{ id: string; name: string; type: string }>;
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+  resultMapperConfig?: ResultMapperConfig;
+  isAborted?: () => Promise<boolean>;
+}): AsyncGenerator<EvaluationV3Event> {
   yield {
     type: "cell_started",
     rowIndex: cell.rowIndex,
@@ -1363,6 +1420,12 @@ export async function* executeWorkflowCell(
     });
 
     let targetOutput: unknown;
+    /**
+     * The end node's results as a record, before extractTargetOutput unwraps a
+     * lone "output" into a bare value. This is what an evaluator maps against,
+     * so a mapping to any other result — "chunks", "citations" — still resolves.
+     */
+    let targetOutputRecord: Record<string, unknown> | undefined;
     let totalCost = 0;
     let sawCost = false;
     let targetFailed = false;
@@ -1387,6 +1450,7 @@ export async function* executeWorkflowCell(
         const ex = event.payload.execution_state;
         if (ex?.result !== undefined) {
           targetOutput = extractTargetOutput(ex.result);
+          targetOutputRecord = ex.result;
         }
         if (ex?.trace_id) finalTraceId = ex.trace_id;
         if (
@@ -1482,6 +1546,32 @@ export async function* executeWorkflowCell(
 
     for (const evaluatorEvent of evaluatorEvents) {
       yield evaluatorEvent;
+    }
+
+    // The evaluators attached to this column in the workbench, which are not
+    // part of the workflow and so did not run with it. Only reached when the
+    // workflow produced a result: grading a row that never produced one would
+    // score the absence of an answer rather than an answer.
+    if (
+      !targetFailed &&
+      targetOutputRecord &&
+      cell.evaluatorConfigs.length > 0
+    ) {
+      const { workflow, evaluatorNodeIds } = buildEvaluatorCellWorkflow(
+        { projectId, cell, datasetColumns },
+        loadedEvaluators,
+      );
+      yield* runCellEvaluators({
+        cell,
+        projectId,
+        workflow,
+        evaluatorNodeIds,
+        targetOutput: targetOutputRecord,
+        traceId: finalTraceId,
+        targetNodes: new Set([cell.targetId]),
+        config: resultMapperConfig ?? {},
+        isAborted,
+      });
     }
   } catch (error) {
     logger.error(
@@ -2329,12 +2419,15 @@ export async function* runOrchestrator(
               !!loadedData.workflow;
 
             const cellEvents = runsAsWorkflow
-              ? executeWorkflowCell(
+              ? executeWorkflowCell({
                   cell,
                   projectId,
-                  loadedData.workflow!.dsl,
-                  checkAbort,
-                )
+                  workflowDsl: loadedData.workflow!.dsl,
+                  datasetColumns,
+                  loadedEvaluators,
+                  resultMapperConfig,
+                  isAborted: checkAbort,
+                })
               : executeCell(
                   cell,
                   projectId,

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -1027,6 +1027,106 @@ export const priceMetrics = async (
   return estimateCost({ llmModelCost, inputTokens, outputTokens });
 };
 
+/** What every evaluator of a cell is dispatched against. */
+type CellEvaluatorContext = {
+  cell: ExecutionCell;
+  projectId: string;
+  workflow: Workflow;
+  targetOutput: Record<string, unknown>;
+  traceId: string;
+  targetNodes: Set<string>;
+  config: ResultMapperConfig;
+  isAborted?: () => Promise<boolean>;
+};
+
+/**
+ * Dispatches one evaluator and yields whatever the engine reports back.
+ *
+ * The engine's events are collected before any of them is yielded, so a
+ * dispatch that throws part-way through emits nothing and the caller reports a
+ * single error cell instead of a half-written result.
+ */
+async function* runOneCellEvaluator({
+  evaluatorId,
+  evaluatorNodeId,
+  cell,
+  projectId,
+  workflow,
+  targetOutput,
+  traceId,
+  targetNodes,
+  config,
+  isAborted,
+}: CellEvaluatorContext & {
+  evaluatorId: string;
+  evaluatorNodeId: string;
+}): AsyncGenerator<EvaluationV3Event> {
+  const evaluatorInputs = buildEvaluatorInputs(cell, evaluatorId, targetOutput);
+
+  const evaluatorEvent = {
+    type: "execute_component" as const,
+    payload: {
+      trace_id: traceId,
+      workflow: {
+        ...workflow,
+        state: { execution: { status: "idle" as const } },
+      },
+      node_id: evaluatorNodeId,
+      inputs: evaluatorInputs,
+      origin: "evaluation",
+    },
+  };
+
+  const evaluatorEvents: StudioServerEvent[] = [];
+  await studioBackendPostEvent({
+    projectId,
+    message: await addEnvs(evaluatorEvent, projectId),
+    isAborted,
+    onEvent: (serverEvent) => {
+      evaluatorEvents.push(serverEvent);
+    },
+  });
+
+  for (const event of evaluatorEvents) {
+    const mappedEvent = mapNlpEvent({
+      event,
+      rowIndex: cell.rowIndex,
+      targetNodes,
+      config,
+      evaluatorInputs,
+    });
+    if (mappedEvent) {
+      yield mappedEvent;
+    }
+  }
+}
+
+/** The error cell an evaluator that could not run reports for itself. */
+const evaluatorErrorResult = ({
+  cell,
+  evaluatorId,
+  error,
+}: {
+  cell: ExecutionCell;
+  evaluatorId: string;
+  error: unknown;
+}): EvaluationV3Event => ({
+  type: "evaluator_result",
+  rowIndex: cell.rowIndex,
+  targetId: cell.targetId,
+  evaluatorId,
+  result: {
+    status: "error",
+    error_type: "EvaluatorError",
+    details:
+      error instanceof Error ? error.message : "Evaluator execution failed",
+    traceback: [],
+    ...(HandledError.isHandled(error)
+      ? { domainError: error.serialize() }
+      : {}),
+  },
+});
+
 /**
  * Dispatches a cell's grading evaluators against the target's output.
  *
@@ -1040,30 +1140,16 @@ export const priceMetrics = async (
  * cell, and the target's own result is already yielded by the time this runs.
  */
 async function* runCellEvaluators({
-  cell,
-  projectId,
-  workflow,
   evaluatorNodeIds,
-  targetOutput,
-  traceId,
-  targetNodes,
-  config,
-  isAborted,
-}: {
-  cell: ExecutionCell;
-  projectId: string;
-  workflow: Workflow;
+  ...context
+}: CellEvaluatorContext & {
   evaluatorNodeIds: Record<string, string>;
-  targetOutput: Record<string, unknown>;
-  traceId: string;
-  targetNodes: Set<string>;
-  config: ResultMapperConfig;
-  isAborted?: () => Promise<boolean>;
 }): AsyncGenerator<EvaluationV3Event> {
+  const { cell, isAborted } = context;
+
   for (const [evaluatorId, evaluatorNodeId] of Object.entries(
     evaluatorNodeIds,
   )) {
-    // Check abort before each evaluator
     if (isAborted && (await isAborted())) {
       logger.debug(
         { cell: cell.rowIndex, evaluatorId },
@@ -1072,57 +1158,8 @@ async function* runCellEvaluators({
       return;
     }
     try {
-      // Build evaluator inputs from target output and dataset
-      const evaluatorInputs = buildEvaluatorInputs(
-        cell,
-        evaluatorId,
-        targetOutput,
-      );
-
-      // Create execute_component event for evaluator
-      const evaluatorEvent = {
-        type: "execute_component" as const,
-        payload: {
-          trace_id: traceId,
-          workflow: {
-            ...workflow,
-            state: { execution: { status: "idle" as const } },
-          },
-          node_id: evaluatorNodeId,
-          inputs: evaluatorInputs,
-          origin: "evaluation",
-        },
-      };
-
-      // Add environment variables
-      const enrichedEvaluatorEvent = await addEnvs(evaluatorEvent, projectId);
-
-      // Execute evaluator
-      const evaluatorEvents: StudioServerEvent[] = [];
-      await studioBackendPostEvent({
-        projectId,
-        message: enrichedEvaluatorEvent,
-        isAborted,
-        onEvent: (serverEvent) => {
-          evaluatorEvents.push(serverEvent);
-        },
-      });
-
-      // Map and yield evaluator events
-      for (const event of evaluatorEvents) {
-        const mappedEvent = mapNlpEvent({
-          event,
-          rowIndex: cell.rowIndex,
-          targetNodes,
-          config,
-          evaluatorInputs,
-        });
-        if (mappedEvent) {
-          yield mappedEvent;
-        }
-      }
+      yield* runOneCellEvaluator({ ...context, evaluatorId, evaluatorNodeId });
     } catch (evalError) {
-      // Yield error for this evaluator but continue with others
       logger.warn(
         {
           error: evalError,
@@ -1132,24 +1169,7 @@ async function* runCellEvaluators({
         },
         "Evaluator execution failed",
       );
-      yield {
-        type: "evaluator_result",
-        rowIndex: cell.rowIndex,
-        targetId: cell.targetId,
-        evaluatorId,
-        result: {
-          status: "error",
-          error_type: "EvaluatorError",
-          details:
-            evalError instanceof Error
-              ? evalError.message
-              : "Evaluator execution failed",
-          traceback: [],
-          ...(HandledError.isHandled(evalError)
-            ? { domainError: evalError.serialize() }
-            : {}),
-        },
-      };
+      yield evaluatorErrorResult({ cell, evaluatorId, error: evalError });
     }
   }
 }

--- a/platform/app/src/server/experiments-v3/execution/workflowBuilder.ts
+++ b/platform/app/src/server/experiments-v3/execution/workflowBuilder.ts
@@ -124,6 +124,75 @@ export const buildCellWorkflow = (
   };
 };
 
+/**
+ * Builds a mini-workflow holding only the cell's evaluators.
+ *
+ * A workflow target runs its whole Studio graph through execute_flow rather
+ * than as one component, so there is no single target node to hang the
+ * evaluators off. They are dispatched one at a time with explicit inputs, so
+ * what they need from a workflow is the entry row and their own nodes; the
+ * edges that would have carried the target's output stand for a node that is
+ * not in this graph and are left out.
+ */
+export const buildEvaluatorCellWorkflow = (
+  input: WorkflowBuilderInput,
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>,
+): Omit<WorkflowBuilderOutput, "targetNodeId"> => {
+  const { cell, datasetColumns } = input;
+  const { targetConfig, evaluatorConfigs, datasetEntry, rowIndex } = cell;
+
+  const entryNode = buildEntryNode(datasetColumns, datasetEntry);
+  const { evaluatorNodes, evaluatorNodeIds } = buildEvaluatorNodes(
+    evaluatorConfigs,
+    targetConfig.id,
+    cell,
+    loadedEvaluators,
+  );
+
+  const datasetId = cell.datasetEntry._datasetId as string | undefined;
+  const edges: Edge[] = evaluatorConfigs.flatMap((evaluator) => {
+    const evaluatorNodeId = evaluatorNodeIds[evaluator.id];
+    if (!evaluatorNodeId) return [];
+    const mappings = datasetId
+      ? (evaluator.mappings[datasetId]?.[targetConfig.id] ?? {})
+      : {};
+
+    return Object.entries(mappings).flatMap(([inputField, mapping]) => {
+      if (mapping.type !== "source" || mapping.source !== "dataset") return [];
+      const columnId =
+        datasetColumns.find((c) => c.name === mapping.sourceField)?.id ??
+        mapping.sourceField;
+      return [
+        {
+          id: `${entryNode.id}->${evaluatorNodeId}.${inputField}`,
+          source: entryNode.id,
+          sourceHandle: `outputs.${columnId}`,
+          target: evaluatorNodeId,
+          targetHandle: `inputs.${inputField}`,
+          type: "default",
+        },
+      ];
+    });
+  });
+
+  return {
+    workflow: {
+      spec_version: LATEST_SPEC_VERSION,
+      workflow_id: `eval_v3_${nanoid(8)}`,
+      name: `Evaluation V3 - Row ${rowIndex}`,
+      icon: "🧪",
+      description: `Evaluators for row ${rowIndex}`,
+      version: "1.0",
+      template_adapter: "default",
+      enable_tracing: true,
+      nodes: [entryNode, ...evaluatorNodes] as Workflow["nodes"],
+      edges,
+      state: {},
+    },
+    evaluatorNodeIds,
+  };
+};
+
 // ============================================================================
 // Entry Node Builder
 // ============================================================================

--- a/platform/app/src/server/experiments-v3/execution/workflowBuilder.ts
+++ b/platform/app/src/server/experiments-v3/execution/workflowBuilder.ts
@@ -125,6 +125,41 @@ export const buildCellWorkflow = (
 };
 
 /**
+ * The edge carrying one dataset column into a node's input.
+ *
+ * A mapping names the column the way the user sees it while the entry node
+ * exposes it by id, so the name is resolved here; a column that is no longer in
+ * the dataset keeps its name rather than dropping the edge. Both that
+ * resolution and the `outputs.` / `inputs.` handle naming the engine expects
+ * live in this one place, so the two workflow builders cannot drift apart.
+ */
+const datasetEdge = ({
+  entryNodeId,
+  nodeId,
+  inputField,
+  columnName,
+  datasetColumns,
+}: {
+  entryNodeId: string;
+  nodeId: string;
+  inputField: string;
+  columnName: string;
+  datasetColumns: Array<{ id: string; name: string; type: string }>;
+}): Edge => {
+  const columnId =
+    datasetColumns.find((column) => column.name === columnName)?.id ??
+    columnName;
+  return {
+    id: `${entryNodeId}->${nodeId}.${inputField}`,
+    source: entryNodeId,
+    sourceHandle: `outputs.${columnId}`,
+    target: nodeId,
+    targetHandle: `inputs.${inputField}`,
+    type: "default",
+  };
+};
+
+/**
  * Builds a mini-workflow holding only the cell's evaluators.
  *
  * A workflow target runs its whole Studio graph through execute_flow rather
@@ -134,11 +169,13 @@ export const buildCellWorkflow = (
  * edges that would have carried the target's output stand for a node that is
  * not in this graph and are left out.
  */
-export const buildEvaluatorCellWorkflow = (
-  input: WorkflowBuilderInput,
-  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>,
-): Omit<WorkflowBuilderOutput, "targetNodeId"> => {
-  const { cell, datasetColumns } = input;
+export const buildEvaluatorCellWorkflow = ({
+  cell,
+  datasetColumns,
+  loadedEvaluators,
+}: WorkflowBuilderInput & {
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+}): Omit<WorkflowBuilderOutput, "targetNodeId"> => {
   const { targetConfig, evaluatorConfigs, datasetEntry, rowIndex } = cell;
 
   const entryNode = buildEntryNode(datasetColumns, datasetEntry);
@@ -159,18 +196,14 @@ export const buildEvaluatorCellWorkflow = (
 
     return Object.entries(mappings).flatMap(([inputField, mapping]) => {
       if (mapping.type !== "source" || mapping.source !== "dataset") return [];
-      const columnId =
-        datasetColumns.find((c) => c.name === mapping.sourceField)?.id ??
-        mapping.sourceField;
       return [
-        {
-          id: `${entryNode.id}->${evaluatorNodeId}.${inputField}`,
-          source: entryNode.id,
-          sourceHandle: `outputs.${columnId}`,
-          target: evaluatorNodeId,
-          targetHandle: `inputs.${inputField}`,
-          type: "default",
-        },
+        datasetEdge({
+          entryNodeId: entryNode.id,
+          nodeId: evaluatorNodeId,
+          inputField,
+          columnName: mapping.sourceField,
+          datasetColumns,
+        }),
       ];
     });
   });
@@ -1106,30 +1139,22 @@ const buildEdges = (
   const edges: Edge[] = [];
   const datasetId = cell.datasetEntry._datasetId as string | undefined;
 
-  // Helper to resolve column name to column ID
-  // sourceField in mappings is the column name, but entry node uses column ID
-  const getColumnId = (columnName: string): string => {
-    const column = datasetColumns.find((c) => c.name === columnName);
-    return column?.id ?? columnName; // Fall back to columnName if not found
-  };
-
   // Build edges from entry to target based on target mappings
   const targetMappings = datasetId
     ? (targetConfig.mappings[datasetId] ?? {})
     : {};
 
-  // Python NLP expects handles in format "outputs.field" and "inputs.field"
   for (const [inputField, mapping] of Object.entries(targetMappings)) {
     if (mapping.type === "source" && mapping.source === "dataset") {
-      const columnId = getColumnId(mapping.sourceField);
-      edges.push({
-        id: `${entryNodeId}->${targetNodeId}.${inputField}`,
-        source: entryNodeId,
-        sourceHandle: `outputs.${columnId}`,
-        target: targetNodeId,
-        targetHandle: `inputs.${inputField}`,
-        type: "default",
-      });
+      edges.push(
+        datasetEdge({
+          entryNodeId,
+          nodeId: targetNodeId,
+          inputField,
+          columnName: mapping.sourceField,
+          datasetColumns,
+        }),
+      );
     }
   }
 
@@ -1145,16 +1170,15 @@ const buildEdges = (
     for (const [inputField, mapping] of Object.entries(evaluatorMappings)) {
       if (mapping.type === "source") {
         if (mapping.source === "dataset") {
-          // From dataset entry - use column ID, not name
-          const columnId = getColumnId(mapping.sourceField);
-          edges.push({
-            id: `${entryNodeId}->${evaluatorNodeId}.${inputField}`,
-            source: entryNodeId,
-            sourceHandle: `outputs.${columnId}`,
-            target: evaluatorNodeId,
-            targetHandle: `inputs.${inputField}`,
-            type: "default",
-          });
+          edges.push(
+            datasetEdge({
+              entryNodeId,
+              nodeId: evaluatorNodeId,
+              inputField,
+              columnName: mapping.sourceField,
+              datasetColumns,
+            }),
+          );
         } else if (
           mapping.source === "target" &&
           mapping.sourceId === targetConfig.id

--- a/specs/experiments-v3/workflow-agent-target-fields.feature
+++ b/specs/experiments-v3/workflow-agent-target-fields.feature
@@ -47,6 +47,7 @@ Feature: A workflow agent exposes its real fields as an evaluations target
     When I read the agent
     Then its output fields are empty
     And no field named "output" is invented for it
+    And the agent reports that it resolved those fields
 
   @integration
   Scenario: A workflow agent whose workflow was deleted reports no fields
@@ -54,6 +55,12 @@ Feature: A workflow agent exposes its real fields as an evaluations target
     When I read the agent
     Then its output fields are empty
     And reading the agent still succeeds
+    And the agent reports that it could not resolve them
+
+  # "Declares nothing" and "could not be read" are both an empty list, and a
+  # caller that cannot tell them apart has to pick one wrong behaviour for
+  # both: clear a column the first time a lookup fails, or keep offering a
+  # result the author removed. So the agent says which of the two it means.
 
   @unit
   Scenario: A code agent keeps reporting the fields saved on its own config
@@ -84,6 +91,14 @@ Feature: A workflow agent exposes its real fields as an evaluations target
     Given a saved workbench whose workflow agent target records "output" and "chunks"
     When I open that workbench and the linked workflow fails to load
     Then the target still records "output" and "chunks"
+
+  @integration
+  Scenario: A target drops a result its workflow no longer declares
+    Given a saved workbench whose workflow agent target records "output" and "chunks"
+    When the workflow's end node no longer declares any result
+    And I open that workbench
+    Then the target records no fields
+    And the evaluator no longer offers "output"
 
   # Auto-inference across several outputs is already specified in
   # mapping-auto-inference.feature; deriving the real results is what lets it

--- a/specs/experiments-v3/workflow-agent-target-fields.feature
+++ b/specs/experiments-v3/workflow-agent-target-fields.feature
@@ -1,0 +1,120 @@
+# A "workflow agent" is an Agent row of type "workflow": a name and an icon
+# pointing at a Studio workflow. Unlike a code or HTTP agent, its saved config
+# holds no inputs and no outputs, so the fields it really reads and produces
+# only exist in the linked workflow's DSL: the entry node's outputs are what it
+# reads, and the end node's inputs (labelled RESULTS in the Studio) are what it
+# produces.
+#
+# Bindings target platform/app/src/server/agents/__tests__/,
+# platform/app/src/experiments-v3/__tests__/ and
+# platform/app/src/server/experiments-v3/execution/__tests__/.
+Feature: A workflow agent exposes its real fields as an evaluations target
+  As an author evaluating a Studio workflow from the experiments workbench
+  I want the workflow's own inputs and results to be what I map against
+  So that an evaluator can grade any result the workflow produces, not just one
+  invented field named "output".
+
+  Background:
+    Given a project with a workflow whose entry node declares "question"
+    And whose end node declares the results "output" of type text and "chunks" of type object
+    And a workflow agent linked to that workflow
+
+  # ==========================================================================
+  # Deriving the fields from the linked workflow
+  # ==========================================================================
+
+  @integration
+  Scenario: A workflow agent reports the end node's results as its output fields
+    When I read the agent
+    Then its output fields are "output" and "chunks"
+    And "chunks" keeps its declared object type
+
+  @integration
+  Scenario: A workflow agent reports the entry node's fields as its input fields
+    When I read the agent
+    Then its input fields are "question"
+
+  @integration
+  Scenario: Editing the workflow changes the agent's fields without touching the agent
+    Given the agent already reports "output" and "chunks"
+    When a result named "citations" is added to the workflow's end node
+    And I read the agent again
+    Then its output fields are "output", "chunks" and "citations"
+
+  @integration
+  Scenario: A workflow agent whose workflow declares no results reports none
+    Given the linked workflow has no end node results
+    When I read the agent
+    Then its output fields are empty
+    And no field named "output" is invented for it
+
+  @integration
+  Scenario: A workflow agent whose workflow was deleted reports no fields
+    Given the linked workflow no longer exists
+    When I read the agent
+    Then its output fields are empty
+    And reading the agent still succeeds
+
+  @unit
+  Scenario: A code agent keeps reporting the fields saved on its own config
+    Given a code agent whose config declares the output "answer"
+    When I read the agent
+    Then its output fields are "answer"
+
+  # ==========================================================================
+  # The workbench target
+  # ==========================================================================
+
+  @integration
+  Scenario: Adding a workflow agent as a target offers every result to an evaluator
+    When I add the workflow agent as a target in the experiments workbench
+    And I open an evaluator and pick a source for one of its variables
+    Then the target offers both "output" and "chunks"
+    And "chunks" is badged as an object rather than as text
+
+  @integration
+  Scenario: A target added before the fields were derived recovers on load
+    Given a saved workbench whose workflow agent target records only "output"
+    When I open that workbench
+    Then the target records "output" and "chunks"
+    And an evaluator opened against it offers both
+
+  @integration
+  Scenario: A target does not lose its recorded fields when the workflow cannot be read
+    Given a saved workbench whose workflow agent target records "output" and "chunks"
+    When I open that workbench and the linked workflow fails to load
+    Then the target still records "output" and "chunks"
+
+  # Auto-inference across several outputs is already specified in
+  # mapping-auto-inference.feature; deriving the real results is what lets it
+  # apply here at all, since one invented output always looked unambiguous.
+
+  # ==========================================================================
+  # Grading a workflow target
+  # ==========================================================================
+
+  @integration
+  Scenario: An evaluator attached to a workflow target runs against its results
+    Given an evaluator on the workflow target reading "output"
+    When I run the evaluation
+    Then the evaluator produces a score for each row
+
+  @integration
+  Scenario: An evaluator can read a result other than the first one
+    Given an evaluator on the workflow target reading "chunks"
+    When I run the evaluation
+    Then the evaluator receives the workflow's "chunks" result
+
+  @integration
+  Scenario: A failing workflow row does not run its evaluators
+    Given the workflow fails on a row
+    When I run the evaluation
+    Then that row reports the workflow error
+    And no evaluator score is invented for it
+
+  @integration
+  Scenario: An evaluator that fails does not lose the workflow's own result
+    Given an evaluator on the workflow target that errors
+    When I run the evaluation
+    Then the row still shows the workflow's result
+    And the evaluator cell reports its error

--- a/specs/experiments-v3/workflow-agent-target-fields.feature
+++ b/specs/experiments-v3/workflow-agent-target-fields.feature
@@ -49,12 +49,22 @@ Feature: A workflow agent exposes its real fields as an evaluations target
     And no field named "output" is invented for it
     And the agent reports that it resolved those fields
 
+  # Deleting a workflow archives it: the delete endpoint sets archivedAt and
+  # the row stays. A workflow id matching no row at all is the rarer case, an
+  # agent copied into a project its workflow was never copied to.
   @integration
   Scenario: A workflow agent whose workflow was deleted reports no fields
-    Given the linked workflow no longer exists
+    Given the linked workflow was deleted, which archives it
     When I read the agent
     Then its output fields are empty
     And reading the agent still succeeds
+    And the agent reports that it could not resolve them
+
+  @integration
+  Scenario: A workflow agent pointing at no workflow at all reports no fields
+    Given the agent's workflow id matches no workflow in the project
+    When I read the agent
+    Then its output fields are empty
     And the agent reports that it could not resolve them
 
   # "Declares nothing" and "could not be read" are both an empty list, and a


### PR DESCRIPTION
## The bug

A workflow built in the Studio whose End node declares two results, `output` as text and `chunks` as an object, offered only `output` when it was added to the evaluations workbench and used as a target on an evaluator. `chunks` was nowhere in the variable picker.

It was not a type filter. A workflow agent is the one agent kind that keeps **no** inputs and outputs on its own config: it is a name and an icon pointing at a Studio graph, and that graph's entry node and RESULTS are the only record of its shape. The workbench read `config.outputs`, found nothing, and fell back to a hardcoded single field literally named `output`. Every workflow agent target in the product described itself as "one text field called output", whatever its workflow actually produced.

The same fallback hid the input side: the target claimed to read one field called `input`, so a workflow whose entry node declares `question` was mapped against a field that does not exist.

## Second bug found while fixing it

`executeWorkflowCell` never dispatched `cell.evaluatorConfigs`. Evaluators attached to a workflow target column in the workbench **never ran at all**, in a full run or a re-run. Fixing only the picker would have handed the customer a `chunks` option that scored nothing, so both are fixed here.

## The fix

**The agent reports what its workflow declares.** `AgentService` now resolves every agent's `inputFields` and `outputFields` on read, deriving a workflow agent's from the linked graph the way `EvaluatorService.enrichWithFields` already did for workflow evaluators. Entry node outputs are the inputs, End node inputs are the outputs. Derived per read rather than copied onto the agent, so editing the graph cannot leave the agent describing a shape the workflow no longer has. Workflow agents in one batch resolve with one query, not one each.

**The workbench reconciles on load.** A target column records a copy of these fields, so a column added before this change, or one whose workflow has since gained a result, is brought back in step when the workbench opens. The reconciliation stays out of undo history, since it is not an edit the user made.

**"Declares nothing" and "could not be read" are told apart.** Both derive to an empty list, and a caller that cannot distinguish them has to pick one wrong behaviour for both: clear a column the first time a lookup fails, or keep offering a result the author removed. So the agent reports which it means. A resolved derivation is applied verbatim, empty included, so a removed result leaves the column and the picker; an unresolved one is skipped entirely, so an archived workflow never takes the user's mappings with it.

**Grading evaluators run on workflow targets.** The evaluator dispatch loop is now shared by both executors instead of living inside `executeCell`. A workflow cell builds a target-less mini-workflow for its evaluators and dispatches them against the End node's results as a record, so a mapping onto any result resolves, not just `output`. A row whose workflow failed runs no evaluators, and an evaluator that fails does not take the workflow's own result down with it.

## Spec

`specs/experiments-v3/workflow-agent-target-fields.feature`, 15 scenarios, all bound.

## Proof

Reproduced the reported shape: a workflow whose End node declares `output` (text) and `chunks` (object).

![Studio](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/studio/end-node-two-results.png)

**Before** (from the report): only `output` is offered.

![Before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/before/picker-only-output.png)

**After**: both results are offered, and `chunks` keeps its Object badge rather than being flattened to Text.

![After](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/after/picker-light.png)

The input side too: the target reads the workflow's own `question`, not a synthetic `input`.

![Target inputs](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/after/target-inputs.png)

Mapped the evaluator onto `chunks` and ran it. The result panel shows the evaluator received the serialized chunks object, so the mapping resolves end to end, and the evaluator produced a verdict at all, which it never did before.

![Evaluator received chunks](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/after/evaluator-received-chunks.png)

Added a third result named `citations` in the Studio, reopened the workbench: it is offered without touching the column, with its own List type.

![Studio edit flows through](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/after/picker-three-results.png)

Then removed every result from the End node. The workflow resolved and declares nothing, so the target offers nothing: only the dataset is left in the picker, rather than the column keeping results the workflow no longer has.

![A workflow with no results](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/after/picker-workflow-with-no-results.png)

Dark mode.

![Dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6921/after/picker-dark.png)

Unhappy path: archived the linked workflow, reopened the workbench. The column keeps `output` and `chunks` and its `wf agent.chunks` mapping rather than being emptied.

## Tests

- `agent-fields.unit.test.ts`: derivation per agent kind, and the two empty cases apart, a workflow that declares nothing versus one that could not be read.
- `agent.service.fields.integration.test.ts`: against the real database, including a workflow that gains a result after the agent was created, an archived one, and the resolved flag each reports.
- `WorkflowTargetFields.integration.test.tsx`: renders the workbench, proves a stale column recovers, that the picker offers both with their types, that a failed lookup keeps the recorded fields, that a result removed in the Studio leaves the column and the picker, and that undo history stays clean.
- `executeWorkflowCell.integration.test.ts`: the grading evaluator runs, reads a result other than the first, is skipped on a failed row, and reports its own error without losing the workflow's result.

`pnpm typecheck:all` clean. The 12 failures in `httpAgentExecution`, `workflowExecution` and `orchestrator` integration suites are pre-existing on main (they need a live NLP service and an enabled model provider) and were verified identical at the base commit.
