### PR TITLE
fix(event-sourcing): confirm worker deaths before parking a group

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -393,7 +393,6 @@ const LEGACY_INERT: string[] = [
   "specs/event-sourcing/oversized-attribute-value-preview.feature",
   "specs/event-sourcing/payload-envelope.feature",
   "specs/event-sourcing/pipeline-model.feature",
-  "specs/event-sourcing/poison-group-park-guard.feature",
   "specs/event-sourcing/process-roles.feature",
   "specs/event-sourcing/reactors.feature",
   "specs/event-sourcing/redis-fold-cache.feature",

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -68,6 +68,11 @@ if wasBlocked > 0 then
   -- it did depended on how long the operator took to press the button (the
   -- chain expires on its own after GROUP_ATTEMPT_TTL_SECONDS).
   redis.call("DEL", strikesKey)
+-- The poison guard's per-group state is the claim marker; the legacy strikes
+-- counter above is cleared alongside it so a group blocked by the old guard
+-- still unblocks cleanly while both are in the fleet. Derived from strikesKey
+-- (":strikes" is 8 chars) so the key arity stays fixed.
+redis.call("DEL", string.sub(strikesKey, 1, #strikesKey - 8) .. ":claim")
   -- specs/event-sourcing/poison-group-park-guard.feature
   redis.call("DEL", attemptKey)
   redis.call("DEL", failStreakKey)
@@ -130,6 +135,11 @@ redis.call("DEL", errorKey)
 -- carried failure streak re-quarantines it (ADR-080,
 -- specs/event-sourcing/poison-group-park-guard.feature).
 redis.call("DEL", strikesKey)
+-- The poison guard's per-group state is the claim marker; the legacy strikes
+-- counter above is cleared alongside it so a group blocked by the old guard
+-- still unblocks cleanly while both are in the fleet. Derived from strikesKey
+-- (":strikes" is 8 chars) so the key arity stays fixed.
+redis.call("DEL", string.sub(strikesKey, 1, #strikesKey - 8) .. ":claim")
 redis.call("DEL", attemptKey)
 redis.call("DEL", failStreakKey)
 redis.call("ZREM", readyKey, groupId)
@@ -197,6 +207,11 @@ redis.call("DEL", srcErrorKey)
 -- get a fresh run, not inherit strikes, a spent retry chain, or a failure
 -- streak from the jobs that were carried off (ADR-080).
 redis.call("DEL", strikesKey)
+-- The poison guard's per-group state is the claim marker; the legacy strikes
+-- counter above is cleared alongside it so a group blocked by the old guard
+-- still unblocks cleanly while both are in the fleet. Derived from strikesKey
+-- (":strikes" is 8 chars) so the key arity stays fixed.
+redis.call("DEL", string.sub(strikesKey, 1, #strikesKey - 8) .. ":claim")
 redis.call("DEL", attemptKey)
 redis.call("DEL", failStreakKey)
 redis.call("ZREM", readyKey, groupId)

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -350,7 +350,7 @@ describe.skipIf(!hasTestcontainers)(
         // re-entered through the beacon write instead of the release. It sits
         // the guard out instead: a real death goes uncounted, which is the
         // cheap direction to be wrong in.
-        /** @scenario a worker that cannot publish its own beacon does not enforce the guard */
+        /** @scenario a worker that cannot report itself as running enforces nothing */
         it("records no claim and parks nothing", async () => {
           vi.spyOn(
             GroupStagingScripts.prototype,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -19,9 +19,15 @@ import type { EventSourcedQueueDefinition } from "../../queue.types";
 import { MAX_BLOB_BYTES } from "../blobConstants";
 import { GroupQueueProcessor } from "../groupQueue";
 import {
-  DEFAULT_CLAIM_STRIKE_THRESHOLD,
+  DEFAULT_CONFIRMED_DEATH_THRESHOLD,
   GroupStagingScripts,
 } from "../scripts";
+import {
+  beaconKey,
+  claimKey,
+  confirmedDeaths as sharedConfirmedDeaths,
+  seedDeadOwner as sharedSeedDeadOwner,
+} from "./poisonGuardFixtures";
 
 // Skip when running without testcontainers (unit-only test runs)
 const hasTestcontainers = !!(
@@ -65,6 +71,11 @@ describe.skipIf(!hasTestcontainers)(
     });
 
     afterEach(async () => {
+      // Before anything else: a suite that spies on GroupStagingScripts.prototype
+      // (the beacon and release paths both do) would otherwise leave every later
+      // queue in this file with a broken collaborator, and the failures land in
+      // whichever test happens to run next rather than the one that set it up.
+      vi.restoreAllMocks();
       await Promise.all(queues.map((q) => q.close().catch(() => {})));
       // Scoped to this suite's own namespace, never flushdb(). flushdb empties
       // the whole logical database, so it does not just reset this suite — it
@@ -91,33 +102,15 @@ describe.skipIf(!hasTestcontainers)(
       return { queue, name: definition.name };
     }
 
-    const claimKey = (name: string, groupId: string) =>
-      `${name}:gq:group:${groupId}:claim`;
-    const beaconKey = (name: string, workerId: string) =>
-      `${name}:gq:worker:${workerId}`;
-    const confirmedDeaths = async (name: string, groupId: string) =>
-      await redis.hget(claimKey(name, groupId), "deaths");
+    const confirmedDeaths = (name: string, groupId: string) =>
+      sharedConfirmedDeaths({ redis, queueName: name, groupId });
     const blockedMembers = (name: string) =>
       redis.smembers(`${name}:gq:blocked`);
     const storedError = (name: string, groupId: string) =>
       redis.hget(`${name}:gq:group:${groupId}:error`, "message");
 
-    /**
-     * Leave behind the marker of a worker that claimed this group and then
-     * died — no beacon, no retirement tombstone. `deaths` is seeded one short
-     * of the threshold so the claim under test observes the last one.
-     */
-    const seedDeadOwner = async (
-      name: string,
-      groupId: string,
-      deaths = DEFAULT_CLAIM_STRIKE_THRESHOLD - 1,
-    ) => {
-      await redis.hset(claimKey(name, groupId), {
-        owner: `dead-worker-${crypto.randomUUID().slice(0, 8)}`,
-        deaths: String(deaths),
-        stagedJobId: "staged-from-the-dead-claim",
-      });
-    };
+    const seedDeadOwner = (name: string, groupId: string, deaths?: number) =>
+      sharedSeedDeadOwner({ redis, queueName: name, groupId, deaths });
 
     describe("given a group at the confirmed-death threshold", () => {
       describe("when a worker claims the group again", () => {
@@ -193,7 +186,7 @@ describe.skipIf(!hasTestcontainers)(
             await seedDeadOwner(
               name,
               "poisoned",
-              DEFAULT_CLAIM_STRIKE_THRESHOLD + 5,
+              DEFAULT_CONFIRMED_DEATH_THRESHOLD + 5,
             );
 
             await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
@@ -212,7 +205,7 @@ describe.skipIf(!hasTestcontainers)(
             // the threshold is 0, so the pre-seeded count is left untouched
             // (never incremented past it, never released to a fresh value).
             expect(await confirmedDeaths(name, "poisoned")).toBe(
-              String(DEFAULT_CLAIM_STRIKE_THRESHOLD + 5),
+              String(DEFAULT_CONFIRMED_DEATH_THRESHOLD + 5),
             );
           } finally {
             if (previous === undefined) {
@@ -259,7 +252,7 @@ describe.skipIf(!hasTestcontainers)(
 
     describe("given a graceful shutdown with a job in flight", () => {
       describe("when close() begins while the handler is still running", () => {
-        /** @scenario graceful shutdown mid-job does not count as a poison strike */
+        /** @scenario graceful shutdown mid-job does not count as a confirmed death */
         it("publishes the retirement tombstone before the drain begins", async () => {
           let releaseHandler!: () => void;
           const handlerGate = new Promise<void>((resolve) => {
@@ -319,7 +312,7 @@ describe.skipIf(!hasTestcontainers)(
           // the very next claim would park the group.
           await redis.hset(claimKey(name, "inherited"), {
             owner: retiredWorkerId,
-            deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+            deaths: String(DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1),
             stagedJobId: "staged-before-the-retirement",
           });
 
@@ -345,6 +338,50 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 5000, interval: 50 },
           );
           expect(await blockedMembers(name)).not.toContain("inherited");
+        });
+      });
+    });
+
+    describe("given a worker whose own beacon write fails", () => {
+      describe("when it claims a group one death short of the threshold", () => {
+        // A worker that cannot publish its beacon cannot be vouched for. If it
+        // stamped markers anyway, every peer inheriting one would read this
+        // live worker as dead — the same false-park class this guard removes,
+        // re-entered through the beacon write instead of the release. It sits
+        // the guard out instead: a real death goes uncounted, which is the
+        // cheap direction to be wrong in.
+        /** @scenario a worker that cannot publish its own beacon does not enforce the guard */
+        it("records no claim and parks nothing", async () => {
+          vi.spyOn(
+            GroupStagingScripts.prototype,
+            "recordWorkerAlive",
+          ).mockRejectedValue(new Error("redis unavailable"));
+          const recordClaim = vi.spyOn(
+            GroupStagingScripts.prototype,
+            "recordClaim",
+          );
+
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
+          await queue.waitUntilReady();
+
+          await seedDeadOwner(name, "beaconless");
+          await queue.send({ id: "job-1", groupId: "beaconless", value: "x" });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          expect(await blockedMembers(name)).not.toContain("beaconless");
+          expect(recordClaim).not.toHaveBeenCalled();
+          // The seeded marker is untouched: the worker neither took ownership
+          // of it nor counted a death against it.
+          expect(await confirmedDeaths(name, "beaconless")).toBe(
+            String(DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1),
+          );
         });
       });
     });
@@ -376,7 +413,7 @@ describe.skipIf(!hasTestcontainers)(
           await seedDeadOwner(
             name,
             "dying",
-            DEFAULT_CLAIM_STRIKE_THRESHOLD - 1,
+            DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1,
           );
           await queue.send({ id: "job-2", groupId: "dying", value: "x" });
 
@@ -454,7 +491,7 @@ describe.skipIf(!hasTestcontainers)(
           await redis.set(beaconKey(name, livePeer), "alive", "EX", 90);
           await redis.hset(claimKey(name, "shared"), {
             owner: livePeer,
-            deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+            deaths: String(DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1),
             stagedJobId: "staged-by-the-live-peer",
           });
 
@@ -482,7 +519,7 @@ describe.skipIf(!hasTestcontainers)(
 
           await redis.hset(claimKey(name, "self"), {
             owner: workerIdOf(queue),
-            deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+            deaths: String(DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1),
             stagedJobId: "staged-under-the-lapsed-lease",
           });
 
@@ -520,7 +557,7 @@ describe.skipIf(!hasTestcontainers)(
             undefined,
           );
 
-          const jobs = DEFAULT_CLAIM_STRIKE_THRESHOLD * 3;
+          const jobs = DEFAULT_CONFIRMED_DEATH_THRESHOLD * 3;
           for (let i = 0; i < jobs; i++) {
             await queue.send({
               id: `job-${i}`,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -349,6 +349,95 @@ describe.skipIf(!hasTestcontainers)(
       });
     });
 
+    describe("given a claim marker whose owner vanished without retiring", () => {
+      describe("when another worker claims the same group", () => {
+        /** @scenario a claim left behind by a worker that vanished without retiring is a death */
+        it("books one death, and accumulates to the threshold", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
+          await queue.waitUntilReady();
+
+          // Well below the threshold, so this claim confirms a death but must
+          // still run the job: the guard counts, it does not park on the first.
+          await seedDeadOwner(name, "dying", 0);
+          await queue.send({ id: "job-1", groupId: "dying", value: "x" });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          expect(await blockedMembers(name)).not.toContain("dying");
+
+          // One more death on top of a count already at the threshold's edge
+          // tips it over — the accumulation the guard exists to detect.
+          await seedDeadOwner(
+            name,
+            "dying",
+            DEFAULT_CLAIM_STRIKE_THRESHOLD - 1,
+          );
+          await queue.send({ id: "job-2", groupId: "dying", value: "x" });
+
+          await vi.waitFor(
+            async () => {
+              expect(await blockedMembers(name)).toContain("dying");
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          expect(processed).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe("given a worker that retired while holding a claim", () => {
+      describe("when the claim marker is still within its own lifetime", () => {
+        /** @scenario the retirement tombstone outlives the claim markers it answers for */
+        it("keeps the tombstone alive longer than the marker it answers for", async () => {
+          // Hold the job in flight so its marker is still there to measure —
+          // a completed job releases the marker, which is the whole point of it.
+          let releaseHandler!: () => void;
+          const handlerGate = new Promise<void>((resolve) => {
+            releaseHandler = resolve;
+          });
+          let signalEntered!: () => void;
+          const handlerEntered = new Promise<void>((resolve) => {
+            signalEntered = resolve;
+          });
+          const { queue, name } = createQueue(async () => {
+            signalEntered();
+            await handlerGate;
+          });
+          await queue.waitUntilReady();
+          const workerId = workerIdOf(queue);
+
+          // A real claim marker, written by the real claim path.
+          await queue.send({ id: "job-1", groupId: "outlived", value: "x" });
+          await handlerEntered;
+          const markerTtl = await redis.ttl(claimKey(name, "outlived"));
+
+          const closing = queue.close();
+          await vi.waitFor(
+            async () => {
+              expect(await redis.get(beaconKey(name, workerId))).toBe(
+                "retired",
+              );
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          const tombstoneTtl = await redis.ttl(beaconKey(name, workerId));
+          releaseHandler();
+          await closing;
+
+          // If the tombstone expired first, a marker still naming this worker
+          // would decay from "retired" into "no beacon" — a false death.
+          expect(await redis.get(beaconKey(name, workerId))).toBe("retired");
+          expect(tombstoneTtl).toBeGreaterThan(markerTtl);
+        });
+      });
+    });
+
     describe("given a claim marker whose owner is still running", () => {
       describe("when another worker claims the same group", () => {
         /** @scenario a claim left behind by a worker that is still running is not a death */
@@ -412,15 +501,12 @@ describe.skipIf(!hasTestcontainers)(
 
     describe("given a worker whose claim release never reaches Redis", () => {
       describe("when it processes far more jobs for one group than the threshold", () => {
-        /**
-         * The regression that motivated the rewrite. Under the count-and-
-         * subtract guard every dropped release was indistinguishable from a
-         * worker death, so a healthy high-fan-out group parked itself after
-         * `threshold` of them. Here the releases are dropped outright and the
-         * group still has to survive, because the owner never stops being alive.
-         *
-         * @scenario a release that never reaches Redis does not park a healthy group
-         */
+        // The regression that motivated the rewrite. Under the count-and-
+        // subtract guard every dropped release was indistinguishable from a
+        // worker death, so a healthy high-fan-out group parked itself after
+        // `threshold` of them. Here the releases are dropped outright and the
+        // group still has to survive, because the owner never stops being alive.
+        /** @scenario a release that never reaches Redis does not park a healthy group */
         it("never parks the group", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockResolvedValue(undefined);

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -342,6 +342,86 @@ describe.skipIf(!hasTestcontainers)(
       });
     });
 
+    describe("given a claim that changed hands while the first worker ran on", () => {
+      describe("when the first worker finally releases", () => {
+        // Heartbeat failures are warn-and-continue, so a worker paused or
+        // partitioned past the active-key TTL keeps running while its group is
+        // redispatched. An unconditional release then deletes the NEW owner's
+        // marker, taking the group's accrued deaths with it — a poisoned group
+        // silently loses its progress toward the threshold.
+        /** @scenario a worker releases only a claim it still owns */
+        it("leaves the new owner's claim and death count intact", async () => {
+          const { queue, name } = createQueue(async () => {});
+          await queue.waitUntilReady();
+          const scripts = new GroupStagingScripts(redis, name);
+
+          const staleWorker = "worker-that-outlived-its-lease";
+          const currentWorker = "worker-that-took-over";
+
+          // The stale worker's claim, then the handover to the current one.
+          await redis.set(beaconKey(name, staleWorker), "alive", "EX", 90);
+          await redis.set(beaconKey(name, currentWorker), "alive", "EX", 90);
+          await scripts.recordClaim({
+            groupId: "handed-over",
+            workerId: staleWorker,
+            stagedJobId: "job-1",
+          });
+          await scripts.recordClaim({
+            groupId: "handed-over",
+            workerId: currentWorker,
+            stagedJobId: "job-2",
+          });
+          await redis.hset(
+            claimKey(name, "handed-over"),
+            "deaths",
+            String(DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1),
+          );
+
+          // The stale worker's job returns at last and releases.
+          await scripts.releaseClaim({
+            groupId: "handed-over",
+            workerId: staleWorker,
+          });
+
+          expect(await redis.hget(claimKey(name, "handed-over"), "owner")).toBe(
+            currentWorker,
+          );
+          expect(await confirmedDeaths(name, "handed-over")).toBe(
+            String(DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1),
+          );
+
+          // The count survived, so the current owner's death is still counted.
+          await redis.del(beaconKey(name, currentWorker));
+          const { deaths } = await scripts.recordClaim({
+            groupId: "handed-over",
+            workerId: "worker-after-the-death",
+            stagedJobId: "job-3",
+          });
+          expect(deaths).toBe(DEFAULT_CONFIRMED_DEATH_THRESHOLD);
+        });
+
+        /** @scenario a worker releases only a claim it still owns */
+        it("still releases the marker when the owner has not changed", async () => {
+          const { queue, name } = createQueue(async () => {});
+          await queue.waitUntilReady();
+          const scripts = new GroupStagingScripts(redis, name);
+
+          await redis.set(beaconKey(name, "sole-worker"), "alive", "EX", 90);
+          await scripts.recordClaim({
+            groupId: "sole-owner",
+            workerId: "sole-worker",
+            stagedJobId: "job-1",
+          });
+          await scripts.releaseClaim({
+            groupId: "sole-owner",
+            workerId: "sole-worker",
+          });
+
+          expect(await redis.exists(claimKey(name, "sole-owner"))).toBe(0);
+        });
+      });
+    });
+
     describe("given a worker whose own beacon write fails", () => {
       describe("when it claims a group one death short of the threshold", () => {
         // A worker that cannot publish its beacon cannot be vouched for. If it
@@ -551,9 +631,14 @@ describe.skipIf(!hasTestcontainers)(
           await queue.waitUntilReady();
 
           const internals = queue as unknown as {
-            scripts: { clearClaim: (groupId: string) => Promise<void> };
+            scripts: {
+              releaseClaim: (params: {
+                groupId: string;
+                workerId: string;
+              }) => Promise<void>;
+            };
           };
-          vi.spyOn(internals.scripts, "clearClaim").mockResolvedValue(
+          vi.spyOn(internals.scripts, "releaseClaim").mockResolvedValue(
             undefined,
           );
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -91,14 +91,35 @@ describe.skipIf(!hasTestcontainers)(
       return { queue, name: definition.name };
     }
 
-    const strikesKey = (name: string, groupId: string) =>
-      `${name}:gq:group:${groupId}:strikes`;
+    const claimKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:claim`;
+    const beaconKey = (name: string, workerId: string) =>
+      `${name}:gq:worker:${workerId}`;
+    const confirmedDeaths = async (name: string, groupId: string) =>
+      await redis.hget(claimKey(name, groupId), "deaths");
     const blockedMembers = (name: string) =>
       redis.smembers(`${name}:gq:blocked`);
     const storedError = (name: string, groupId: string) =>
       redis.hget(`${name}:gq:group:${groupId}:error`, "message");
 
-    describe("given a group at the claim-strike threshold", () => {
+    /**
+     * Leave behind the marker of a worker that claimed this group and then
+     * died — no beacon, no retirement tombstone. `deaths` is seeded one short
+     * of the threshold so the claim under test observes the last one.
+     */
+    const seedDeadOwner = async (
+      name: string,
+      groupId: string,
+      deaths = DEFAULT_CLAIM_STRIKE_THRESHOLD - 1,
+    ) => {
+      await redis.hset(claimKey(name, groupId), {
+        owner: `dead-worker-${crypto.randomUUID().slice(0, 8)}`,
+        deaths: String(deaths),
+        stagedJobId: "staged-from-the-dead-claim",
+      });
+    };
+
+    describe("given a group at the confirmed-death threshold", () => {
       describe("when a worker claims the group again", () => {
         /** @scenario a group whose jobs repeatedly kill the worker is parked at claim */
         it("parks the group into the blocked set before decoding", async () => {
@@ -107,12 +128,9 @@ describe.skipIf(!hasTestcontainers)(
           const { queue, name } = createQueue(processed);
           await queue.waitUntilReady();
 
-          // Strikes left behind by prior claims whose process died before the
-          // clear could run - the crash-loop signature this guard detects.
-          await redis.set(
-            strikesKey(name, "poisoned"),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          // A marker left by a claim whose process died before it could be
+          // released - the crash-loop signature this guard detects.
+          await seedDeadOwner(name, "poisoned");
 
           await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
 
@@ -126,7 +144,7 @@ describe.skipIf(!hasTestcontainers)(
           expect(processed).not.toHaveBeenCalled();
           const error = await storedError(name, "poisoned");
           expect(error).toContain("Poison guard");
-          expect(error).toContain("consecutive worker deaths");
+          expect(error).toContain("confirmed worker deaths");
           // The job is re-staged for inspection, not dropped.
           expect(
             await redis.zcard(`${name}:gq:group:poisoned:jobs`),
@@ -140,10 +158,7 @@ describe.skipIf(!hasTestcontainers)(
           const { queue, name } = createQueue(processed);
           await queue.waitUntilReady();
 
-          await redis.set(
-            strikesKey(name, "poisoned"),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          await seedDeadOwner(name, "poisoned");
 
           await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
           await queue.send({ id: "job-2", groupId: "healthy", value: "y" });
@@ -173,11 +188,12 @@ describe.skipIf(!hasTestcontainers)(
             const { queue, name } = createQueue(processed);
             await queue.waitUntilReady();
 
-            // Strikes at (and above) the old default threshold that WOULD park
-            // the group if the guard were enabled.
-            await redis.set(
-              strikesKey(name, "poisoned"),
-              String(DEFAULT_CLAIM_STRIKE_THRESHOLD + 5),
+            // A dead owner and a death count well past the old default
+            // threshold, which WOULD park the group if the guard were enabled.
+            await seedDeadOwner(
+              name,
+              "poisoned",
+              DEFAULT_CLAIM_STRIKE_THRESHOLD + 5,
             );
 
             await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
@@ -192,10 +208,10 @@ describe.skipIf(!hasTestcontainers)(
             expect(processed.mock.calls[0]![0].groupId).toBe("poisoned");
             // The group is never parked into the blocked set.
             expect(await blockedMembers(name)).not.toContain("poisoned");
-            // Strikes are not enforced: recordClaimStrike is skipped entirely
-            // when the threshold is 0, so the pre-seeded count is left untouched
-            // (never incremented past it, never cleared to a fresh value).
-            expect(await redis.get(strikesKey(name, "poisoned"))).toBe(
+            // The marker is not enforced: recordClaim is skipped entirely when
+            // the threshold is 0, so the pre-seeded count is left untouched
+            // (never incremented past it, never released to a fresh value).
+            expect(await confirmedDeaths(name, "poisoned")).toBe(
               String(DEFAULT_CLAIM_STRIKE_THRESHOLD + 5),
             );
           } finally {
@@ -211,8 +227,8 @@ describe.skipIf(!hasTestcontainers)(
 
     describe("given a healthy group", () => {
       describe("when its job completes", () => {
-        /** @scenario claim strikes are cleared when processing survives */
-        it("clears the claim strike", async () => {
+        /** @scenario claim markers are released when processing survives */
+        it("releases the claim marker", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockResolvedValue(undefined);
           const { queue, name } = createQueue(processed);
@@ -229,7 +245,7 @@ describe.skipIf(!hasTestcontainers)(
 
           await vi.waitFor(
             async () => {
-              expect(await redis.get(strikesKey(name, "group-a"))).toBeNull();
+              expect(await redis.exists(claimKey(name, "group-a"))).toBe(0);
             },
             { timeout: 5000, interval: 50 },
           );
@@ -237,10 +253,14 @@ describe.skipIf(!hasTestcontainers)(
       });
     });
 
+    /** The identity a queue stamps onto the claims it takes. */
+    const workerIdOf = (queue: GroupQueueProcessor<TestPayload>) =>
+      (queue as unknown as { workerId: string }).workerId;
+
     describe("given a graceful shutdown with a job in flight", () => {
       describe("when close() begins while the handler is still running", () => {
         /** @scenario graceful shutdown mid-job does not count as a poison strike */
-        it("sweeps the group's claim strike while the job is still in flight", async () => {
+        it("publishes the retirement tombstone before the drain begins", async () => {
           let releaseHandler!: () => void;
           const handlerGate = new Promise<void>((resolve) => {
             releaseHandler = resolve;
@@ -254,21 +274,27 @@ describe.skipIf(!hasTestcontainers)(
             await handlerGate;
           });
           await queue.waitUntilReady();
+          const workerId = workerIdOf(queue);
 
           await queue.send({ id: "job-1", groupId: "slow", value: "x" });
           await handlerEntered;
 
-          // The claim recorded its strike before the handler ran — this is
-          // the strike a hard death would leave behind.
-          expect(await redis.get(strikesKey(name, "slow"))).toBe("1");
+          // The claim stamped this worker onto the group, and the worker is
+          // vouching for itself. This is the marker a hard death leaves behind.
+          expect(await redis.hget(claimKey(name, "slow"), "owner")).toBe(
+            workerId,
+          );
+          expect(await redis.get(beaconKey(name, workerId))).toBe("alive");
 
           // Begin the graceful shutdown WITHOUT waiting for the drain: the
-          // sweep must clear the strike while the job is still in flight, so
-          // even a drain the budget abandons leaves nothing behind.
+          // tombstone must land while the job is still in flight, so even a
+          // drain the budget abandons answers for every marker left behind.
           const closing = queue.close();
           await vi.waitFor(
             async () => {
-              expect(await redis.get(strikesKey(name, "slow"))).toBeNull();
+              expect(await redis.get(beaconKey(name, workerId))).toBe(
+                "retired",
+              );
             },
             { timeout: 5000, interval: 50 },
           );
@@ -276,106 +302,187 @@ describe.skipIf(!hasTestcontainers)(
           releaseHandler();
           await closing;
 
-          // The group was never mistaken for poison.
           expect(await blockedMembers(name)).not.toContain("slow");
         });
       });
 
-      describe("when close() takes its sweep snapshot before the claim finishes recording", () => {
-        /** @scenario graceful shutdown mid-job does not count as a poison strike */
-        it("clears the strike via the post-claim recheck even though the sweep missed the group", async () => {
-          let releaseStrike!: () => void;
-          const strikeGate = new Promise<void>((resolve) => {
-            releaseStrike = resolve;
-          });
-          let signalStrikeRecorded!: () => void;
-          const strikeRecorded = new Promise<void>((resolve) => {
-            signalStrikeRecorded = resolve;
-          });
-          let releaseHandler!: () => void;
-          const handlerGate = new Promise<void>((resolve) => {
-            releaseHandler = resolve;
-          });
-          let signalHandlerEntered!: () => void;
-          const handlerEntered = new Promise<void>((resolve) => {
-            signalHandlerEntered = resolve;
+      describe("when a later worker inherits a retired worker's claim", () => {
+        /** @scenario a claim left behind by a gracefully retired worker is not a death */
+        it("reads the previous owner as retired rather than dead", async () => {
+          const { queue: retiring, name } = createQueue(async () => {});
+          await retiring.waitUntilReady();
+          const retiredWorkerId = workerIdOf(retiring);
+          await retiring.close();
+
+          // A claim the retired worker still owned when it exited, already one
+          // death short of the threshold: if retirement did not answer for it,
+          // the very next claim would park the group.
+          await redis.hset(claimKey(name, "inherited"), {
+            owner: retiredWorkerId,
+            deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+            stagedJobId: "staged-before-the-retirement",
           });
 
-          const { queue, name } = createQueue(async () => {
-            signalHandlerEntered();
-            await handlerGate;
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const successor = new GroupQueueProcessor<TestPayload>(
+            createQueueDefinition({ name, process: processed }),
+            redis,
+          );
+          queues.push(successor);
+          await successor.waitUntilReady();
+
+          await successor.send({
+            id: "job-1",
+            groupId: "inherited",
+            value: "x",
           });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          expect(await blockedMembers(name)).not.toContain("inherited");
+        });
+      });
+    });
+
+    describe("given a claim marker whose owner is still running", () => {
+      describe("when another worker claims the same group", () => {
+        /** @scenario a claim left behind by a worker that is still running is not a death */
+        it("does not book a death against the group", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
+          await queue.waitUntilReady();
+
+          // A peer that holds the marker and is provably alive — the shape a
+          // lost release leaves behind, and the one that used to park healthy
+          // groups roughly ten times a day in production.
+          const livePeer = "peer-worker-still-running";
+          await redis.set(beaconKey(name, livePeer), "alive", "EX", 90);
+          await redis.hset(claimKey(name, "shared"), {
+            owner: livePeer,
+            deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+            stagedJobId: "staged-by-the-live-peer",
+          });
+
+          await queue.send({ id: "job-1", groupId: "shared", value: "x" });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          expect(await blockedMembers(name)).not.toContain("shared");
+        });
+      });
+    });
+
+    describe("given a claim marker owned by the claiming worker itself", () => {
+      describe("when that worker re-claims the group after its lease lapsed", () => {
+        /** @scenario a worker re-claiming its own lapsed lease is not a death */
+        it("does not book a death against the group", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
+          await queue.waitUntilReady();
+
+          await redis.hset(claimKey(name, "self"), {
+            owner: workerIdOf(queue),
+            deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+            stagedJobId: "staged-under-the-lapsed-lease",
+          });
+
+          await queue.send({ id: "job-1", groupId: "self", value: "x" });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          expect(await blockedMembers(name)).not.toContain("self");
+        });
+      });
+    });
+
+    describe("given a worker whose claim release never reaches Redis", () => {
+      describe("when it processes far more jobs for one group than the threshold", () => {
+        /**
+         * The regression that motivated the rewrite. Under the count-and-
+         * subtract guard every dropped release was indistinguishable from a
+         * worker death, so a healthy high-fan-out group parked itself after
+         * `threshold` of them. Here the releases are dropped outright and the
+         * group still has to survive, because the owner never stops being alive.
+         *
+         * @scenario a release that never reaches Redis does not park a healthy group
+         */
+        it("never parks the group", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
           await queue.waitUntilReady();
 
           const internals = queue as unknown as {
-            scripts: {
-              recordClaimStrike: (groupId: string) => Promise<number>;
-            };
-            drainAndDisconnect: () => Promise<void>;
+            scripts: { clearClaim: (groupId: string) => Promise<void> };
           };
-
-          // Park the claim AFTER its strike lands in Redis but BEFORE
-          // processWithRetries adds the group to the in-flight set, so close()'s
-          // sweep snapshot runs against a set that does not yet hold the group.
-          const realRecordStrike = internals.scripts.recordClaimStrike.bind(
-            internals.scripts,
+          vi.spyOn(internals.scripts, "clearClaim").mockResolvedValue(
+            undefined,
           );
-          let gatedOnce = false;
-          vi.spyOn(internals.scripts, "recordClaimStrike").mockImplementation(
-            async (groupId: string) => {
-              const strikes = await realRecordStrike(groupId);
-              if (groupId === "raced" && !gatedOnce) {
-                gatedOnce = true;
-                signalStrikeRecorded();
-                await strikeGate;
-              }
-              return strikes;
+
+          const jobs = DEFAULT_CLAIM_STRIKE_THRESHOLD * 3;
+          for (let i = 0; i < jobs; i++) {
+            await queue.send({
+              id: `job-${i}`,
+              groupId: "leaky",
+              value: "x",
+            });
+          }
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(jobs);
             },
+            { timeout: 10000, interval: 50 },
           );
+          expect(await blockedMembers(name)).not.toContain("leaky");
+          // Every claim found the marker's owner alive, so nothing accrued.
+          expect(await confirmedDeaths(name, "leaky")).toBe("0");
+        });
+      });
+    });
 
-          // drainAndDisconnect() is invoked synchronously right after the sweep
-          // snapshot, so this fires only once close() has provably passed it -
-          // with the group still unswept.
-          let signalDrainReached!: () => void;
-          const drainReached = new Promise<void>((resolve) => {
-            signalDrainReached = resolve;
-          });
-          const realDrain = internals.drainAndDisconnect.bind(internals);
-          internals.drainAndDisconnect = () => {
-            signalDrainReached();
-            return realDrain();
-          };
+    describe("given a group being parked by the poison guard", () => {
+      describe("when the park completes", () => {
+        /** @scenario parking a group releases its claim marker */
+        it("releases the claim marker so an unblock gets a fresh run", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
+          await queue.waitUntilReady();
 
-          await queue.send({ id: "job-1", groupId: "raced", value: "x" });
-          await strikeRecorded;
-          // The strike a hard death would leave behind is present in Redis.
-          expect(await redis.get(strikesKey(name, "raced"))).toBe("1");
+          await seedDeadOwner(name, "parked");
+          await queue.send({ id: "job-1", groupId: "parked", value: "x" });
 
-          // Begin the shutdown: it flips shutdownRequested synchronously, then
-          // snapshots the still-group-less in-flight set before the drain.
-          const closing = queue.close();
-          await drainReached;
-
-          // Let the claim finish - it adds the group to the set now, after the
-          // sweep already ran, then runs the shutdown recheck.
-          releaseStrike();
-          await handlerEntered;
-
-          // The recheck cleared the strike while the handler is still in flight,
-          // so a drain the budget abandons leaves nothing behind. Without it the
-          // strike would survive until the finally the abandon path never runs.
           await vi.waitFor(
             async () => {
-              expect(await redis.get(strikesKey(name, "raced"))).toBeNull();
+              expect(await blockedMembers(name)).toContain("parked");
             },
             { timeout: 5000, interval: 50 },
           );
 
-          releaseHandler();
-          await closing;
-
-          // The group was never mistaken for poison.
-          expect(await blockedMembers(name)).not.toContain("raced");
+          // Left at the threshold, an operator unblocking inside the marker's
+          // hour would have the group re-park on its very next claim.
+          await vi.waitFor(
+            async () => {
+              expect(await redis.exists(claimKey(name, "parked"))).toBe(0);
+            },
+            { timeout: 5000, interval: 50 },
+          );
         });
       });
     });
@@ -502,8 +609,8 @@ describe.skipIf(!hasTestcontainers)(
 
     describe("given a group whose job always throws", () => {
       describe("when an attempt fails with the process alive", () => {
-        /** @scenario a failing-but-not-crashing job does not accumulate claim strikes */
-        it("clears the strike recorded for that claim", async () => {
+        /** @scenario a failing-but-not-crashing job does not accumulate confirmed deaths */
+        it("releases the marker recorded for that claim", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockRejectedValue(new Error("handler failure"));
           const { queue, name } = createQueue(processed);
@@ -518,12 +625,12 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 5000, interval: 50 },
           );
 
-          // The failure path survives the process, so the claim strike is
-          // cleared - retries are accounted by the retry budget, not by the
+          // The failure path survives the process, so the claim marker is
+          // released - retries are accounted by the retry budget, not by the
           // poison guard.
           await vi.waitFor(
             async () => {
-              expect(await redis.get(strikesKey(name, "group-a"))).toBeNull();
+              expect(await redis.exists(claimKey(name, "group-a"))).toBe(0);
             },
             { timeout: 5000, interval: 50 },
           );
@@ -659,16 +766,13 @@ describe.skipIf(!hasTestcontainers)(
     describe("given a parked poison group", () => {
       describe("when an operator unblocks it", () => {
         /** @scenario a parked poison group can be unblocked by an operator */
-        it("resets the strikes and returns the group to dispatch", async () => {
+        it("resets the death count and returns the group to dispatch", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockResolvedValue(undefined);
           const { queue, name } = createQueue(processed);
           await queue.waitUntilReady();
 
-          await redis.set(
-            strikesKey(name, "poisoned"),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          await seedDeadOwner(name, "poisoned");
           await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
 
           await vi.waitFor(
@@ -684,7 +788,7 @@ describe.skipIf(!hasTestcontainers)(
             groupId: "poisoned",
           });
           expect(wasBlocked).toBe(true);
-          expect(await redis.get(strikesKey(name, "poisoned"))).toBeNull();
+          expect(await redis.exists(claimKey(name, "poisoned"))).toBe(0);
 
           await vi.waitFor(
             () => {
@@ -697,17 +801,14 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when an operator drains it", () => {
-        /** @scenario draining a parked poison group resets its claim strikes */
+        /** @scenario draining a parked poison group resets its confirmed death count */
         it("resets the strikes so a re-created group dispatches normally", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockResolvedValue(undefined);
           const { queue, name } = createQueue(processed);
           await queue.waitUntilReady();
 
-          await redis.set(
-            strikesKey(name, "poisoned"),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          await seedDeadOwner(name, "poisoned");
           await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
 
           await vi.waitFor(
@@ -723,7 +824,7 @@ describe.skipIf(!hasTestcontainers)(
             groupId: "poisoned",
           });
           expect(jobsRemoved).toBeGreaterThan(0);
-          expect(await redis.get(strikesKey(name, "poisoned"))).toBeNull();
+          expect(await redis.exists(claimKey(name, "poisoned"))).toBe(0);
           expect(await blockedMembers(name)).not.toContain("poisoned");
 
           // A new job under the same group id gets a fresh run instead of
@@ -741,17 +842,14 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when an operator moves it to the dead-letter queue", () => {
-        /** @scenario moving a parked poison group to the dead-letter queue resets its claim strikes */
+        /** @scenario moving a parked poison group to the dead-letter queue resets its confirmed death count */
         it("resets the strikes so a re-created group dispatches normally", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockResolvedValue(undefined);
           const { queue, name } = createQueue(processed);
           await queue.waitUntilReady();
 
-          await redis.set(
-            strikesKey(name, "poisoned"),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          await seedDeadOwner(name, "poisoned");
           await queue.send({ id: "job-1", groupId: "poisoned", value: "x" });
 
           await vi.waitFor(
@@ -767,7 +865,7 @@ describe.skipIf(!hasTestcontainers)(
             groupId: "poisoned",
           });
           expect(jobsMoved).toBeGreaterThan(0);
-          expect(await redis.get(strikesKey(name, "poisoned"))).toBeNull();
+          expect(await redis.exists(claimKey(name, "poisoned"))).toBe(0);
           expect(await blockedMembers(name)).not.toContain("poisoned");
 
           await queue.send({ id: "job-2", groupId: "poisoned", value: "y" });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.workerLiveness.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.workerLiveness.unit.test.ts
@@ -11,8 +11,14 @@
 import { Redis as IORedis } from "ioredis";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
-import { GroupQueueProcessor } from "../groupQueue";
-import { GroupStagingScripts } from "../scripts";
+import { GROUP_QUEUE_CONFIG, GroupQueueProcessor } from "../groupQueue";
+import {
+  CLAIM_MARKER_TTL_SECONDS,
+  GroupStagingScripts,
+  WORKER_LIVENESS_REFRESH_MS,
+  WORKER_LIVENESS_TTL_SECONDS,
+  WORKER_RETIRED_TTL_SECONDS,
+} from "../scripts";
 
 vi.mock("../dispatcher", () => ({
   GroupQueueDispatcher: class {
@@ -38,6 +44,49 @@ function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
     groupKey: (p) => p.groupId,
   };
 }
+
+describe("poison-guard timing invariants", () => {
+  describe("given a dead worker whose group is waiting to be redispatched", () => {
+    describe("when the guard tries to observe the death", () => {
+      /**
+       * The guard can only see a death if the dead worker's beacon has already
+       * expired by the time someone else claims the group. The soonest that
+       * claim can happen is when the active key lapses, and the worst case is a
+       * worker dying immediately before a heartbeat that never lands — so the
+       * beacon has to expire within `activeTtlSec` minus one heartbeat
+       * interval. Nothing co-locates these constants: the beacon TTL is in
+       * scripts.ts and the lease is in groupQueue.ts, so a retune of either can
+       * invert this silently and turn every death into "still alive".
+       *
+       * @scenario a claim left behind by a worker that vanished without retiring is a death
+       */
+      it("expires the beacon before the group can be redispatched", () => {
+        const heartbeatIntervalSec = GROUP_QUEUE_CONFIG.activeTtlSec / 3;
+        const redispatchFloorSec =
+          GROUP_QUEUE_CONFIG.activeTtlSec - heartbeatIntervalSec;
+
+        expect(WORKER_LIVENESS_TTL_SECONDS).toBeLessThan(redispatchFloorSec);
+      });
+
+      it("refreshes the beacon often enough to survive a lost write or two", () => {
+        // A single failed refresh must not expire a live worker's beacon, or
+        // ordinary Redis noise starts booking deaths against healthy workers.
+        const refreshesPerTtl =
+          (WORKER_LIVENESS_TTL_SECONDS * 1000) / WORKER_LIVENESS_REFRESH_MS;
+
+        expect(refreshesPerTtl).toBeGreaterThanOrEqual(3);
+      });
+
+      it("keeps the retirement tombstone alive longer than the markers it answers for", () => {
+        // A marker outliving the tombstone that explains its owner would decay
+        // from "retired" into "no beacon" — a false death on a clean shutdown.
+        expect(WORKER_RETIRED_TTL_SECONDS).toBeGreaterThan(
+          CLAIM_MARKER_TTL_SECONDS,
+        );
+      });
+    });
+  });
+});
 
 describe("GroupQueueProcessor worker liveness beacon", () => {
   const connections: IORedis[] = [];

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.workerLiveness.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.workerLiveness.unit.test.ts
@@ -12,6 +12,7 @@ import { Redis as IORedis } from "ioredis";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
 import { GroupQueueProcessor } from "../groupQueue";
+import { GroupStagingScripts } from "../scripts";
 
 vi.mock("../dispatcher", () => ({
   GroupQueueDispatcher: class {
@@ -101,6 +102,59 @@ describe("GroupQueueProcessor worker liveness beacon", () => {
           internals.workerId,
         );
         expect(order.at(-1)).toBe("retired");
+      });
+    });
+  });
+
+  describe("given a shutdown that begins during the first beacon publish", () => {
+    describe("when the beacon publish finishes after the tombstone is written", () => {
+      /** @scenario the liveness beacon stops before the retirement tombstone is written */
+      it("arms no refresh timer, so nothing can overwrite the tombstone", async () => {
+        const conn = new IORedis({
+          lazyConnect: true,
+          maxRetriesPerRequest: 0,
+        });
+        connections.push(conn);
+        vi.spyOn(conn, "duplicate").mockReturnValue(conn as never);
+
+        // Hold the very first publish open so close() runs while the beacon is
+        // still starting: it finds no timer to clear, writes the tombstone, and
+        // the constructor's beacon setup resumes afterwards. The stub goes on
+        // the prototype because the publish is issued from the constructor.
+        let releasePublish!: () => void;
+        const publishGate = new Promise<void>((resolve) => {
+          releasePublish = resolve;
+        });
+        vi.spyOn(
+          GroupStagingScripts.prototype,
+          "recordWorkerAlive",
+        ).mockImplementation(async () => {
+          await publishGate;
+        });
+        vi.spyOn(
+          GroupStagingScripts.prototype,
+          "retireWorker",
+        ).mockResolvedValue(undefined);
+
+        const processor = new GroupQueueProcessor<TestPayload>(
+          makeDefinition(),
+          conn,
+          { consumerEnabled: true },
+        );
+        const internals = processor as unknown as {
+          livenessReady: Promise<void>;
+          livenessTimer: ReturnType<typeof setInterval> | undefined;
+          drainAndDisconnect: () => Promise<void>;
+        };
+        internals.drainAndDisconnect = async () => {};
+
+        await processor.close();
+        releasePublish();
+        await internals.livenessReady;
+
+        // Without the post-publish shutdown check, the constructor's setInterval
+        // lands here — after the tombstone — and refreshes `alive` over it.
+        expect(internals.livenessTimer).toBeUndefined();
       });
     });
   });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.workerLiveness.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.workerLiveness.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The poison guard books a worker death when a claim marker's owner has no
+ * liveness beacon (specs/event-sourcing/poison-group-park-guard.feature). That
+ * makes the ORDER of the two writes in `close()` load-bearing: the beacon
+ * refresh runs on an interval, so retiring first and stopping the timer second
+ * leaves a window where a refresh overwrites the `retired` tombstone with a
+ * 90-second `alive` — which then expires into exactly the false death the
+ * tombstone exists to prevent.
+ */
+
+import { Redis as IORedis } from "ioredis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+
+vi.mock("../dispatcher", () => ({
+  GroupQueueDispatcher: class {
+    start(): void {}
+    requestShutdown(): void {}
+    async waitUntilStopped(): Promise<void> {}
+  },
+}));
+
+vi.mock("../metricsCollector", () => ({
+  GroupQueueMetricsCollector: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+type TestPayload = { id: string; groupId: string };
+
+function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
+  return {
+    name: `{test/gq/live/${crypto.randomUUID().slice(0, 8)}}`,
+    process: async () => {},
+    groupKey: (p) => p.groupId,
+  };
+}
+
+describe("GroupQueueProcessor worker liveness beacon", () => {
+  const connections: IORedis[] = [];
+
+  afterEach(() => {
+    for (const conn of connections.splice(0)) conn.disconnect();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function createProcessor() {
+    const conn = new IORedis({ lazyConnect: true, maxRetriesPerRequest: 0 });
+    connections.push(conn);
+    vi.spyOn(conn, "duplicate").mockReturnValue(conn as never);
+
+    const processor = new GroupQueueProcessor<TestPayload>(
+      makeDefinition(),
+      conn,
+      { consumerEnabled: true },
+    );
+    const internals = processor as unknown as {
+      workerId: string;
+      livenessReady: Promise<void>;
+      livenessTimer: ReturnType<typeof setInterval> | undefined;
+      scripts: {
+        recordWorkerAlive: (workerId: string) => Promise<void>;
+        retireWorker: (workerId: string) => Promise<void>;
+      };
+      drainAndDisconnect: () => Promise<void>;
+    };
+    // The real drain talks to Redis; the beacon ordering is decided before it.
+    internals.drainAndDisconnect = async () => {};
+    return { processor, internals };
+  }
+
+  describe("given a consumer that has published its beacon", () => {
+    describe("when the worker retires", () => {
+      /** @scenario the liveness beacon stops before the retirement tombstone is written */
+      it("stops the refresh timer before writing the tombstone", async () => {
+        const { processor, internals } = createProcessor();
+
+        const order: string[] = [];
+        vi.spyOn(internals.scripts, "recordWorkerAlive").mockImplementation(
+          async () => {
+            order.push("alive");
+          },
+        );
+        vi.spyOn(internals.scripts, "retireWorker").mockImplementation(
+          async () => {
+            order.push("retired");
+          },
+        );
+
+        await internals.livenessReady;
+        expect(internals.livenessTimer).toBeDefined();
+
+        await processor.close();
+
+        // The timer is cleared, so no refresh can follow the tombstone.
+        expect(internals.livenessTimer).toBeUndefined();
+        expect(internals.scripts.retireWorker).toHaveBeenCalledWith(
+          internals.workerId,
+        );
+        expect(order.at(-1)).toBe("retired");
+      });
+    });
+  });
+
+  describe("given a producer-only queue", () => {
+    describe("when it is constructed", () => {
+      it("publishes no beacon, because it never claims", async () => {
+        const conn = new IORedis({
+          lazyConnect: true,
+          maxRetriesPerRequest: 0,
+        });
+        connections.push(conn);
+
+        const processor = new GroupQueueProcessor<TestPayload>(
+          makeDefinition(),
+          conn,
+          { consumerEnabled: false },
+        );
+        const internals = processor as unknown as {
+          livenessReady: Promise<void>;
+          livenessTimer: ReturnType<typeof setInterval> | undefined;
+        };
+
+        await internals.livenessReady;
+        expect(internals.livenessTimer).toBeUndefined();
+      });
+    });
+  });
+
+  describe("given two processors in the same process", () => {
+    describe("when each takes a claim", () => {
+      it("gives them distinct worker identities", () => {
+        const { internals: first } = createProcessor();
+        const { internals: second } = createProcessor();
+
+        // A shared identity would let one processor's death resolve as the
+        // other's liveness, and vice versa.
+        expect(first.workerId).not.toBe(second.workerId);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/poisonGuardFixtures.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/poisonGuardFixtures.ts
@@ -1,0 +1,64 @@
+import type { Cluster, Redis } from "ioredis";
+import {
+  CLAIM_MARKER_TTL_SECONDS,
+  DEFAULT_CONFIRMED_DEATH_THRESHOLD,
+} from "../scripts";
+
+/**
+ * Shared poison-guard fixtures.
+ *
+ * Both integration suites drive the guard through the same Redis keys, so the
+ * key layout and the seeded shape live here rather than being written twice.
+ * A fixture that drifts from `CLAIM_GUARD_LUA` stops testing the thing it names.
+ */
+
+export const claimKey = (queueName: string, groupId: string): string =>
+  `${queueName}:gq:group:${groupId}:claim`;
+
+export const beaconKey = (queueName: string, workerId: string): string =>
+  `${queueName}:gq:worker:${workerId}`;
+
+/**
+ * Leave behind the marker of a worker that claimed this group and then died —
+ * no liveness beacon, no retirement tombstone.
+ *
+ * Written with the same TTL the real claim path applies, so a seeded marker
+ * ages out of the test Redis exactly as production would rather than
+ * accumulating, and so a suite can never accidentally depend on a marker that
+ * only persists because the fixture forgot to expire it.
+ *
+ * `deaths` defaults to one short of the threshold, so the claim under test
+ * observes the last death and parks.
+ */
+export async function seedDeadOwner({
+  redis,
+  queueName,
+  groupId,
+  deaths = DEFAULT_CONFIRMED_DEATH_THRESHOLD - 1,
+}: {
+  redis: Redis | Cluster;
+  queueName: string;
+  groupId: string;
+  deaths?: number;
+}): Promise<void> {
+  const key = claimKey(queueName, groupId);
+  await redis.hset(key, {
+    owner: `dead-worker-${crypto.randomUUID().slice(0, 8)}`,
+    deaths: String(deaths),
+    stagedJobId: "staged-from-the-dead-claim",
+  });
+  await redis.expire(key, CLAIM_MARKER_TTL_SECONDS);
+}
+
+/** Confirmed worker deaths recorded against a group. */
+export async function confirmedDeaths({
+  redis,
+  queueName,
+  groupId,
+}: {
+  redis: Redis | Cluster;
+  queueName: string;
+  groupId: string;
+}): Promise<string | null> {
+  return await redis.hget(claimKey(queueName, groupId), "deaths");
+}

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
@@ -31,16 +31,14 @@ import {
   withJobAttempt,
 } from "../jobEnvelope";
 import { gqJobsDroppedTotal } from "../metrics";
-import {
-  DEFAULT_CLAIM_STRIKE_THRESHOLD,
-  GroupStagingScripts,
-} from "../scripts";
+import { GroupStagingScripts } from "../scripts";
 import { TieredBlobStore } from "../tieredBlobStore";
 import {
   InMemoryJobBlobStore,
   InMemoryObjectStore,
   incompressible,
 } from "./blobTestDoubles";
+import { seedDeadOwner as sharedSeedDeadOwner } from "./poisonGuardFixtures";
 
 // Skip outside testcontainers (e.g. plain unit runs) — mirrors the other
 // groupQueue integration suites (groupQueue.poisonGuard/decodeDrop).
@@ -153,20 +151,8 @@ describe.skipIf(!hasTestcontainers)(
       `${name}:gq:group:${groupId}:attempt`;
     const failStreakKey = (name: string, groupId: string) =>
       `${name}:gq:group:${groupId}:failstreak`;
-    const claimKey = (name: string, groupId: string) =>
-      `${name}:gq:group:${groupId}:claim`;
-    /**
-     * The marker of a worker that claimed this group and then died — no
-     * liveness beacon, no retirement tombstone — one death short of the
-     * threshold, so the next claim confirms the last one and parks.
-     */
-    const seedDeadOwner = async (name: string, groupId: string) => {
-      await redis.hset(claimKey(name, groupId), {
-        owner: `dead-worker-${crypto.randomUUID().slice(0, 8)}`,
-        deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
-        stagedJobId: "staged-from-the-dead-claim",
-      });
-    };
+    const seedDeadOwner = (name: string, groupId: string) =>
+      sharedSeedDeadOwner({ redis, queueName: name, groupId });
     const activeKey = (name: string, groupId: string) =>
       `${name}:gq:group:${groupId}:active`;
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/stagedJobIdIdentity.integration.test.ts
@@ -153,8 +153,20 @@ describe.skipIf(!hasTestcontainers)(
       `${name}:gq:group:${groupId}:attempt`;
     const failStreakKey = (name: string, groupId: string) =>
       `${name}:gq:group:${groupId}:failstreak`;
-    const strikesKey = (name: string, groupId: string) =>
-      `${name}:gq:group:${groupId}:strikes`;
+    const claimKey = (name: string, groupId: string) =>
+      `${name}:gq:group:${groupId}:claim`;
+    /**
+     * The marker of a worker that claimed this group and then died — no
+     * liveness beacon, no retirement tombstone — one death short of the
+     * threshold, so the next claim confirms the last one and parks.
+     */
+    const seedDeadOwner = async (name: string, groupId: string) => {
+      await redis.hset(claimKey(name, groupId), {
+        owner: `dead-worker-${crypto.randomUUID().slice(0, 8)}`,
+        deaths: String(DEFAULT_CLAIM_STRIKE_THRESHOLD - 1),
+        stagedJobId: "staged-from-the-dead-claim",
+      });
+    };
     const activeKey = (name: string, groupId: string) =>
       `${name}:gq:group:${groupId}:active`;
 
@@ -510,12 +522,9 @@ describe.skipIf(!hasTestcontainers)(
           });
           await queue.waitUntilReady();
 
-          // Strikes left by prior claims whose process died — the crash-loop
+          // The marker left by a prior claim whose process died — the crash-loop
           // signature the claim-side guard parks on.
-          await redis.set(
-            strikesKey(name, groupId),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          await seedDeadOwner(name, groupId);
 
           const payload: TestPayload = {
             id: "event_parked",
@@ -1530,15 +1539,12 @@ describe.skipIf(!hasTestcontainers)(
           );
           expect(await stagedIds(name, groupId)).toEqual([LEGACY_ID]);
 
-          // Step 3 — a poison park. Stop the consumer first so the strikes are
-          // in place before any claim can race them.
+          // Step 3 — a poison park. Stop the consumer first so the marker is
+          // in place before any claim can race it.
           await consumer.close();
           const ops = new QueueRedisRepository(redis);
           await ops.unblockGroup({ queueName: name, groupId });
-          await redis.set(
-            strikesKey(name, groupId),
-            String(DEFAULT_CLAIM_STRIKE_THRESHOLD),
-          );
+          await seedDeadOwner(name, groupId);
 
           const parker = newQueue({
             name,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1,6 +1,13 @@
 // biome-ignore-all lint/suspicious/noEmptyBlockStatements: the empty blocks in this file are deliberate no-ops.
 
+import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
 import { performance } from "node:perf_hooks";
+// Imported rather than read off the global: the constructor destructures a
+// `process` handler out of the queue definition, and a class field initializer
+// runs inside that same scope — so a bare `process.pid` here resolves to the
+// handler's binding and dies in its temporal dead zone.
+import { pid } from "node:process";
 import { generate } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
 import {
@@ -97,6 +104,7 @@ import {
   readBisectionSplitBudget,
   readClaimStrikeThreshold,
   readGroupQuarantineThreshold,
+  WORKER_LIVENESS_REFRESH_MS,
 } from "./scripts";
 import { type ObjectStore, TransientBlobStoreError } from "./tieredBlobStore";
 
@@ -332,12 +340,26 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private shutdownRequested = false;
   /** Tracks in-flight jobs for active count metrics. */
   private activeJobCount = 0;
+
   /**
-   * Groups whose claim strike is currently outstanding (recorded at claim,
-   * cleared in the processing finally). {@link close} sweeps these so a
-   * planned shutdown never leaves a strike behind as a fake worker death.
+   * Identity this process stamps onto every claim it takes, and the subject of
+   * the liveness beacon the poison guard reads. Unique per process INSTANCE —
+   * a restarted pod must never inherit the identity of the one it replaced, or
+   * its predecessor's death would resolve to "that's me, still running".
    */
-  private readonly inFlightStrikeGroups = new Set<string>();
+  private readonly workerId =
+    `${hostname()}-${pid}-${randomUUID().slice(0, 8)}`;
+
+  /** Beacon refresh timer; stopped before the retirement write in {@link close}. */
+  private livenessTimer: ReturnType<typeof setInterval> | undefined;
+
+  /**
+   * Resolves once this worker's beacon exists in Redis. Claims await it, so a
+   * worker can never own a claim marker before the beacon that vouches for it —
+   * the window in between is exactly the one where a peer would misread this
+   * live process as a dead one.
+   */
+  private readonly livenessReady: Promise<void>;
 
   constructor(
     definition: EventSourcedQueueDefinition<Payload>,
@@ -457,6 +479,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         "Processing queue saturated",
       );
     };
+
+    // Publish the liveness beacon before anything can claim. A consumer that
+    // never claims still needs no beacon, so producers skip it entirely.
+    this.livenessReady = this.consumerEnabled
+      ? this.startLivenessBeacon()
+      : Promise.resolve();
 
     // Start dispatcher and metrics collection in consumer mode
     if (this.consumerEnabled) {
@@ -858,74 +886,62 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   /**
    * fastq worker function: poison guard, then the real job processing.
    *
-   * The guard records a claim strike BEFORE any decode/parse work and clears
-   * it on every code path where the process survives (the finally below -
-   * success, retry, exhausted-park, drop-to-replay, graceful drain all pass
-   * through it). A job that seizes the event loop never reaches the finally:
-   * the liveness probe kills the process, the strike stays behind, and after
-   * enough consecutive deaths the next claim parks the group instead of
-   * re-running the killer (specs/event-sourcing/poison-group-park-guard.feature).
+   * The guard stamps this worker's identity onto the group's claim BEFORE any
+   * decode/parse work, and releases it on every path where the process survives
+   * (the finally below — success, retry, exhausted-park, drop-to-replay and
+   * graceful drain all pass through it). A job that seizes the event loop never
+   * reaches the finally: the liveness probe kills the process, its beacon stops,
+   * and the next worker to claim the group finds a marker whose owner is
+   * provably gone. Enough confirmed deaths and the claim parks the group instead
+   * of re-running the killer (specs/event-sourcing/poison-group-park-guard.feature).
    *
-   * A claim made after a graceful shutdown was requested records NO strike:
-   * the process is about to exit on purpose, and dying with that job in
-   * flight must not read as the job killing the worker. Pre-shutdown strikes
-   * are swept in {@link close} while the event loop is provably alive. A group
-   * already at the threshold is therefore parked at most one claim early: a
-   * claim that begins after the shutdown records no strike and parks on the next
-   * boot's claim instead, while a claim already awaiting its strike record when
-   * the shutdown flips can still cross the threshold and park during the drain —
-   * but only on its real prior-death strikes, never on a shutdown-born one.
+   * Nothing here has to special-case shutdown. A claim held by a process that
+   * exits gracefully resolves through that process's retirement tombstone, and
+   * a release that never reaches Redis resolves through its still-live beacon —
+   * so neither needs the strike to be withheld, swept, or re-checked the way the
+   * count-and-subtract guard did.
    */
   private async processWithRetries(dispatched: DispatchResult): Promise<void> {
     const { stagedJobId, groupId, jobDataJson, originalScore } = dispatched;
 
-    const strikeThreshold = readClaimStrikeThreshold();
-    const recordStrikes = strikeThreshold > 0 && !this.shutdownRequested;
-    if (recordStrikes) {
-      let strikes = 0;
+    const deathThreshold = readClaimStrikeThreshold();
+    const guardEnabled = deathThreshold > 0;
+    if (guardEnabled) {
+      let deaths = 0;
       try {
-        strikes = await this.scripts.recordClaimStrike(groupId);
+        // The beacon must exist before this worker owns a marker, or a peer
+        // would read our live claim as an abandoned one.
+        await this.livenessReady;
+        deaths = await this.scripts.recordClaim({
+          groupId,
+          workerId: this.workerId,
+          stagedJobId,
+        });
       } catch {
-        // Strike accounting is protective, never load-bearing: an unreadable
-        // counter must not stop the queue.
+        // Poison accounting is protective, never load-bearing: an unreadable
+        // marker must not stop the queue.
       }
-      if (strikes > strikeThreshold) {
+      if (deaths >= deathThreshold) {
         await this.parkPoisonGroup({
           groupId,
           stagedJobId,
           jobDataJson,
           originalScore,
           reason: "claim_strikes",
-          errorMessage: `Poison guard: ${strikes - 1} consecutive worker deaths while this group was in flight (threshold ${strikeThreshold}). Inspect the staged jobs, then unblock the group to retry.`,
+          errorMessage: `Poison guard: ${deaths} confirmed worker deaths while this group was in flight (threshold ${deathThreshold}). Each was a worker that claimed this group and then stopped heartbeating without shutting down. Inspect the staged jobs, then unblock the group to retry.`,
         });
         return;
-      }
-      this.inFlightStrikeGroups.add(groupId);
-
-      // close() may have flipped shutdownRequested and taken its sweep snapshot
-      // during the recordClaimStrike await above — before this group was in the
-      // set, so the sweep would miss it and an abandoned drain would leave the
-      // strike behind: exactly the false worker-death this guard must not book.
-      // Re-check on the synchronous heels of the add (no await between them, so
-      // close() cannot interleave here) and clear our own strike if the shutdown
-      // began mid-claim. The add and this check are jointly exhaustive: either
-      // close()'s snapshot already saw the group and swept it, or it did not and
-      // we clear it here.
-      if (this.shutdownRequested) {
-        this.inFlightStrikeGroups.delete(groupId);
-        await this.scripts.clearClaimStrikes(groupId).catch(() => {
-          // Protective accounting only; the strike key's TTL bounds a failed clear.
-        });
       }
     }
 
     try {
       await this.processClaimedJob(dispatched);
     } finally {
-      if (recordStrikes) {
-        this.inFlightStrikeGroups.delete(groupId);
-        this.scripts.clearClaimStrikes(groupId).catch(() => {
-          // The TTL on the strike key bounds the damage of a failed clear.
+      if (guardEnabled) {
+        this.scripts.clearClaim(groupId).catch(() => {
+          // Safe to lose: the marker it would have removed still names this
+          // worker, which is alive (and will retire rather than vanish), so the
+          // next claim reads it as ordinary rather than as a death.
         });
       }
     }
@@ -2092,6 +2108,39 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   /**
+   * Publishes this worker's liveness beacon and keeps refreshing it.
+   *
+   * The beacon is the poison guard's only evidence of a worker death: a claim
+   * marker whose owner has no beacon is a process that was working and is now
+   * gone. Refresh failures are logged and otherwise tolerated — the TTL is
+   * several refreshes wide precisely so a transient Redis error cannot make a
+   * live worker look dead.
+   */
+  private async startLivenessBeacon(): Promise<void> {
+    const publish = async () => {
+      try {
+        await this.scripts.recordWorkerAlive(this.workerId);
+      } catch (err) {
+        this.logger.warn(
+          {
+            queueName: this.queueName,
+            workerId: this.workerId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Failed to publish worker liveness beacon; the poison guard may read this worker as dead if this persists",
+        );
+      }
+    };
+
+    await publish();
+    this.livenessTimer = setInterval(() => {
+      void publish();
+    }, WORKER_LIVENESS_REFRESH_MS);
+    // Never hold the process open for a beacon refresh.
+    this.livenessTimer.unref?.();
+  }
+
+  /**
    * Starts a periodic heartbeat that refreshes the active key TTL during
    * processing. This prevents the safety-net TTL from expiring when a single
    * job attempt takes longer than activeTtlSec.
@@ -2401,6 +2450,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       jobDataJson,
       errorMessage,
     });
+    // Release the marker as the group is parked. Leaving it meant the death
+    // count survived the park, so an operator who unblocked inside the marker's
+    // TTL had the group re-park on its very next claim — and whether it did
+    // depended on how long they took to press the button.
+    await this.scripts.clearClaim(groupId).catch(() => {
+      // The marker's TTL bounds a failed clear; unblock clears it outright.
+    });
     gqGroupsPoisonParkedTotal.inc({
       queue_name: this.queueName,
       reason,
@@ -2599,23 +2655,33 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         // best-effort wake; a failed signal only delays dispatcher exit
       });
 
-    // A planned shutdown is not a worker death (poison-group-park-guard
-    // spec: "graceful shutdown mid-job does not count as a poison strike").
-    // Sweep the in-flight claim strikes NOW, before the drain below, while
-    // the event loop is provably alive — a worker whose loop a poison job
-    // seized can never reach this sweep, so real crash-loops keep their
-    // count. Jobs that complete during the drain re-clear harmlessly; jobs
-    // the drain budget (or the platform's SIGKILL) abandons leave no strike
-    // behind and re-dispatch cleanly on the next boot.
-    const inFlight = [...this.inFlightStrikeGroups];
-    if (inFlight.length > 0) {
-      await Promise.allSettled(
-        inFlight.map((groupId) => this.scripts.clearClaimStrikes(groupId)),
-      );
-      this.logger.info(
-        { queueName: this.queueName, groups: inFlight.length },
-        "Cleared in-flight claim strikes for graceful shutdown",
-      );
+    // A planned shutdown is not a worker death (poison-group-park-guard spec:
+    // "graceful shutdown mid-job does not count as a poison strike"). One
+    // tombstone answers for every claim this worker holds, however the drain
+    // ends: jobs it completes, jobs the shutdown budget abandons, and jobs the
+    // platform's SIGKILL cuts short all leave markers that resolve to "retired".
+    //
+    // Stop the beacon FIRST — a refresh landing after the tombstone would
+    // restore a short-lived `alive` that then expires into a false death. And
+    // do this while the event loop is provably alive: a worker whose loop a
+    // poison job seized never reaches here, so real crash-loops still count.
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = undefined;
+    }
+    if (this.consumerEnabled) {
+      try {
+        await this.scripts.retireWorker(this.workerId);
+      } catch (err) {
+        this.logger.warn(
+          {
+            queueName: this.queueName,
+            workerId: this.workerId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Failed to record worker retirement; groups this worker held may book a spurious death",
+        );
+      }
     }
 
     this.logger.debug(

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -144,8 +144,14 @@ function nonEmptyString(value: unknown): string | undefined {
 
 /**
  * Configuration for the group queue.
+ *
+ * Exported because `activeTtlSec` and the heartbeat interval derived from it
+ * set the floor on how soon a dead worker's group is redispatched, and the
+ * poison guard's beacon TTL has to stay under that floor to be able to observe
+ * the death at all. The two constants live in different modules, so the
+ * inequality between them is pinned by a test rather than by proximity.
  */
-const GROUP_QUEUE_CONFIG = {
+export const GROUP_QUEUE_CONFIG = {
   /** Default global concurrency (max parallel groups) */
   defaultGlobalConcurrency: Number(process.env.GLOBAL_QUEUE_CONCURRENCY) || 100,
   /** TTL for the active key (safety net for crashes), in seconds */
@@ -931,12 +937,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const guardEnabled = deathThreshold > 0 && this.beaconLive;
     if (guardEnabled) {
       let deaths = 0;
+      let lastOwnerState = "";
       try {
-        deaths = await this.scripts.recordClaim({
+        ({ deaths, lastOwnerState } = await this.scripts.recordClaim({
           groupId,
           workerId: this.workerId,
           stagedJobId,
-        });
+        }));
       } catch {
         // Poison accounting is protective, never load-bearing: an unreadable
         // marker must not stop the queue.
@@ -948,6 +955,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           jobDataJson,
           originalScore,
           reason: "claim_strikes",
+          lastOwnerState,
           errorMessage: `Poison guard: ${deaths} confirmed worker deaths while this group was in flight (threshold ${deathThreshold}). Each was a worker that claimed this group and then stopped heartbeating without shutting down. Inspect the staged jobs, then unblock the group to retry.`,
         });
         return;
@@ -958,11 +966,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       await this.processClaimedJob(dispatched);
     } finally {
       if (guardEnabled) {
-        this.scripts.clearClaim(groupId).catch(() => {
-          // Safe to lose: the marker it would have removed still names this
-          // worker, which is alive (and will retire rather than vanish), so the
-          // next claim reads it as ordinary rather than as a death.
-        });
+        // Compare-and-delete: this job may have outlived its own active lease
+        // (heartbeat failures are warn-and-continue), in which case the group
+        // was redispatched and the marker now belongs to someone else. Deleting
+        // it blind would erase their ownership AND the group's accrued deaths.
+        this.scripts
+          .releaseClaim({ groupId, workerId: this.workerId })
+          .catch(() => {
+            // Safe to lose: the marker it would have removed still names this
+            // worker, which is alive (and will retire rather than vanish), so
+            // the next claim reads it as ordinary rather than as a death.
+          });
       }
     }
   }
@@ -2460,6 +2474,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     originalScore,
     reason,
     errorMessage,
+    lastOwnerState,
   }: {
     groupId: string;
     stagedJobId: string;
@@ -2467,6 +2482,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     originalScore: number;
     reason: "claim_strikes" | "oversized_payload";
     errorMessage: string;
+    /**
+     * What the parking claim found the previous owner to be. A crash-loop and a
+     * Redis outage that expired healthy beacons both park with the same count
+     * and the same message; this is the field that tells them apart. Absent for
+     * the oversized-payload park, which consults no owner.
+     */
+    lastOwnerState?: string;
   }): Promise<void> {
     // Same reasoning as handleExhaustedRetries: keep the original score when it
     // is a real timestamp, otherwise the parked group reads as decades old.
@@ -2485,7 +2507,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // count survived the park, so an operator who unblocked inside the marker's
     // TTL had the group re-park on its very next claim — and whether it did
     // depended on how long they took to press the button.
-    await this.scripts.clearClaim(groupId).catch(() => {
+    // Unconditional, unlike the release on the healthy path: the group is
+    // leaving the dispatch path, and a marker left at the threshold would
+    // re-park it on the operator's very next unblock.
+    await this.scripts.discardClaim(groupId).catch(() => {
       // The marker's TTL bounds a failed clear; unblock clears it outright.
     });
     gqGroupsPoisonParkedTotal.inc({
@@ -2499,6 +2524,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         groupId,
         stagedJobId,
         reason,
+        // "gone" on every death is the crash-loop signature. A park whose
+        // observations were mostly "alive"/"retired" points at beacon weather
+        // (a Redis outage expiring healthy beacons), not at this group.
+        lastOwnerState,
       },
       "Poison guard parked group into the blocked set",
     );

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -102,7 +102,7 @@ import {
   type DrainedJob,
   GroupStagingScripts,
   readBisectionSplitBudget,
-  readClaimStrikeThreshold,
+  readConfirmedDeathThreshold,
   readGroupQuarantineThreshold,
   WORKER_LIVENESS_REFRESH_MS,
 } from "./scripts";
@@ -337,6 +337,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    */
   private readonly bisectionSplitBudget = readBisectionSplitBudget();
 
+  /**
+   * Confirmed worker deaths tolerated before a group is parked. Read once at
+   * construction, like the two thresholds above; 0 disables the poison guard.
+   * See {@link readConfirmedDeathThreshold}.
+   */
+  private readonly deathThreshold = readConfirmedDeathThreshold();
+
   private shutdownRequested = false;
   /** Tracks in-flight jobs for active count metrics. */
   private activeJobCount = 0;
@@ -352,6 +359,18 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
   /** Beacon refresh timer; stopped before the retirement write in {@link close}. */
   private livenessTimer: ReturnType<typeof setInterval> | undefined;
+
+  /**
+   * Whether this worker's beacon is known to have reached Redis.
+   *
+   * The guard reads a missing beacon as a death, so a worker that stamps claim
+   * markers it cannot vouch for hands every peer a false death — the exact
+   * failure this design removes, re-entered through the beacon write instead of
+   * the release. While the beacon is unconfirmed the guard sits out entirely:
+   * a real death then goes uncounted, which is the cheap direction to be wrong
+   * in. Parking a healthy group is the expensive one.
+   */
+  private beaconLive = false;
 
   /**
    * Resolves once this worker's beacon exists in Redis. Claims await it, so a
@@ -904,14 +923,15 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private async processWithRetries(dispatched: DispatchResult): Promise<void> {
     const { stagedJobId, groupId, jobDataJson, originalScore } = dispatched;
 
-    const deathThreshold = readClaimStrikeThreshold();
-    const guardEnabled = deathThreshold > 0;
+    // The beacon must exist before this worker owns a marker, or a peer would
+    // read our live claim as an abandoned one.
+    await this.livenessReady;
+
+    const { deathThreshold } = this;
+    const guardEnabled = deathThreshold > 0 && this.beaconLive;
     if (guardEnabled) {
       let deaths = 0;
       try {
-        // The beacon must exist before this worker owns a marker, or a peer
-        // would read our live claim as an abandoned one.
-        await this.livenessReady;
         deaths = await this.scripts.recordClaim({
           groupId,
           workerId: this.workerId,
@@ -2120,7 +2140,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const publish = async () => {
       try {
         await this.scripts.recordWorkerAlive(this.workerId);
+        this.beaconLive = true;
       } catch (err) {
+        // Stand the guard down until a refresh lands: claims made without a
+        // beacon behind them would be read as deaths by every peer.
+        this.beaconLive = false;
         this.logger.warn(
           {
             queueName: this.queueName,

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -2133,6 +2133,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     };
 
     await publish();
+
+    // close() may have run during that first publish, in which case it found no
+    // timer to stop and has already written the tombstone. Arming one now would
+    // put a refresh AFTER the retirement — restoring a short-lived `alive` that
+    // expires into exactly the false death the tombstone exists to prevent.
+    if (this.shutdownRequested) return;
+
     this.livenessTimer = setInterval(() => {
       void publish();
     }, WORKER_LIVENESS_REFRESH_MS);

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1498,8 +1498,34 @@ return 1
  *
  * A dropped clear, a torn-down connection and an abandoned drain all land in
  * the middle three branches, so none of them can park a healthy group; a pod
- * the job actually killed lands in the fourth, so a genuine poison group still
- * parks in exactly the same number of laps as before.
+ * the job actually killed lands in the fourth, and a crash-looping group parks
+ * in the same number of laps as before.
+ *
+ * Two honest limits on those two claims:
+ *
+ *  - "Nothing healthy parks" holds against every failure of OUR writes, not
+ *    against Redis itself being gone. An outage longer than
+ *    WORKER_LIVENESS_TTL_SECONDS expires every healthy beacon, and a handoff
+ *    claimed in the window after recovery but before the previous owner's next
+ *    refresh reads as a death. Reaching a park still needs the threshold met
+ *    with no completed job in between (a release resets the marker), so this is
+ *    strictly better than the guard it replaces rather than impossible. The
+ *    same shape applies if `retireWorker` times out during a shutdown. The park
+ *    log carries the observed state so an operator can tell the two apart.
+ *
+ *  - "The same number of laps" is about crash-loops specifically. A job that
+ *    hangs with the event loop free is NOT counted when a routine SIGTERM
+ *    overlaps it: the tombstone is written before the platform's SIGKILL, so
+ *    that kill reads as a planned exit. That is deliberate — hangs are the
+ *    exhausted-retries path's problem, not this guard's
+ *    (specs/event-sourcing/poison-group-park-guard.feature).
+ *
+ * Detection also rests on an inequality between constants that live apart:
+ * a dead worker's beacon must expire BEFORE its group is redispatched, i.e.
+ * WORKER_LIVENESS_TTL_SECONDS must stay under the redispatch floor
+ * (`activeTtlSec` minus one heartbeat interval). Pinned by
+ * groupQueue.workerLiveness.unit.test.ts so a future retune of either side
+ * cannot silently invert it.
  */
 const CLAIM_GUARD_LUA = `
 local claimKey = KEYS[1]
@@ -1513,11 +1539,20 @@ local previous  = redis.call("HMGET", claimKey, "owner", "deaths")
 local prevOwner = previous[1]
 local deaths    = tonumber(previous[2] or "0") or 0
 
-if prevOwner and prevOwner ~= workerId then
-  -- GET returns false for a missing key: no beacon at all is the death.
-  -- Either state ("alive" or "retired") is an ordinary outcome.
-  if not redis.call("GET", keyPrefix .. "worker:" .. prevOwner) then
-    deaths = deaths + 1
+local observed = "none"
+if prevOwner then
+  if prevOwner == workerId then
+    observed = "self"
+  else
+    -- GET returns false for a missing key: no beacon at all is the death.
+    -- Either state ("alive" or "retired") is an ordinary outcome.
+    local state = redis.call("GET", keyPrefix .. "worker:" .. prevOwner)
+    if state then
+      observed = state
+    else
+      observed = "gone"
+      deaths = deaths + 1
+    end
   end
 end
 
@@ -1529,7 +1564,33 @@ redis.call(
 )
 redis.call("EXPIRE", claimKey, ttlSec)
 
-return deaths
+-- The state is returned so the park log can say WHY a group was parked. A real
+-- crash-loop and a Redis outage that expired healthy beacons both arrive here
+-- as "gone"; only the run of observations tells an operator which one it was.
+return { deaths, observed }
+`;
+
+/**
+ * Release a claim marker, but only if this worker still owns it.
+ *
+ * The unconditional DEL this replaced assumed the releasing worker was still
+ * the owner. It is not always: heartbeat failures are warn-and-continue, so a
+ * worker paused or partitioned past the active-key TTL keeps running while its
+ * group is redispatched to someone else. When its job finally returned, its
+ * release deleted the NEW owner's marker — erasing both the owner and the
+ * accrued death count, so a genuinely poisoned group silently lost its
+ * progress toward the threshold and parked later than it should.
+ *
+ * Same shape as a Redlock release, and the same fix: compare-and-delete.
+ */
+const RELEASE_CLAIM_LUA = `
+local claimKey = KEYS[1]
+local workerId = ARGV[1]
+
+if redis.call("HGET", claimKey, "owner") == workerId then
+  return redis.call("DEL", claimKey)
+end
+return 0
 `;
 
 const RETRY_RESTAGE_LUA =
@@ -1893,6 +1954,7 @@ const refreshScript = new CachedLuaScript(REFRESH_LUA);
 const restageAndBlockScript = new CachedLuaScript(RESTAGE_AND_BLOCK_LUA);
 const retryRestageScript = new CachedLuaScript(RETRY_RESTAGE_LUA);
 const claimGuardScript = new CachedLuaScript(CLAIM_GUARD_LUA);
+const releaseClaimScript = new CachedLuaScript(RELEASE_CLAIM_LUA);
 
 export class GroupStagingScripts {
   private readonly keyPrefix: string;
@@ -2478,8 +2540,12 @@ export class GroupStagingScripts {
    * count is derived from the previous owner's beacon rather than from the
    * absence of a delete.
    *
-   * @returns the confirmed-death count for the group, including any death this
-   *   claim just observed
+   * @returns the confirmed-death count for the group including any death this
+   *   claim just observed, and what this claim found the previous owner to be —
+   *   `none` (no marker), `self`, `alive`, `retired`, or `gone` (the state that
+   *   books a death). The state is diagnostic only: it is what lets a park line
+   *   distinguish a real crash-loop from a Redis outage that expired healthy
+   *   beacons, which otherwise read identically.
    */
   async recordClaim({
     groupId,
@@ -2489,8 +2555,8 @@ export class GroupStagingScripts {
     groupId: string;
     workerId: string;
     stagedJobId: string;
-  }): Promise<number> {
-    const deaths = await claimGuardScript.run(
+  }): Promise<{ deaths: number; lastOwnerState: string }> {
+    const result = await claimGuardScript.run(
       this.redis,
       // Declared as a KEY, not derived in Lua: ioredis routes a cluster EVAL by
       // its KEYS, so a zero-key script lands on an arbitrary node and the
@@ -2503,16 +2569,50 @@ export class GroupStagingScripts {
       stagedJobId,
       String(CLAIM_MARKER_TTL_SECONDS),
     );
-    return typeof deaths === "number" ? deaths : 0;
+    const [deaths, lastOwnerState] = Array.isArray(result) ? result : [];
+    return {
+      deaths: typeof deaths === "number" ? deaths : 0,
+      lastOwnerState: typeof lastOwnerState === "string" ? lastOwnerState : "",
+    };
   }
 
   /**
-   * Release the claim marker. Unlike the strike delete this replaced, losing
-   * this write is harmless: the marker it would have removed still names a live
-   * (or cleanly retired) owner, so the next claim reads it as ordinary rather
-   * than as a death.
+   * Release this worker's claim marker, if it is still the owner.
+   *
+   * Losing this write is harmless: the marker it would have removed still names
+   * a live (or cleanly retired) owner, so the next claim reads it as ordinary
+   * rather than as a death.
+   *
+   * Deleting it when we are NOT the owner is not harmless, which is why this is
+   * a compare-and-delete — see {@link RELEASE_CLAIM_LUA}.
    */
-  async clearClaim(groupId: string): Promise<void> {
+  async releaseClaim({
+    groupId,
+    workerId,
+  }: {
+    groupId: string;
+    workerId: string;
+  }): Promise<void> {
+    await releaseClaimScript.run(
+      this.redis,
+      1,
+      this.claimMarkerKey(groupId),
+      workerId,
+    );
+  }
+
+  /**
+   * Drop the claim marker whoever owns it.
+   *
+   * Only for parking, where the group leaves the dispatch path entirely and the
+   * marker must not survive to re-park the group on the operator's next
+   * unblock. An ownership check here would reintroduce exactly that: the park
+   * can run on a claim this worker never recorded (the guard stands down when
+   * its beacon is unconfirmed, and the oversized-payload park does not consult
+   * the guard at all), and the marker would then be left sitting at the
+   * threshold.
+   */
+  async discardClaim(groupId: string): Promise<void> {
     await this.redis.del(this.claimMarkerKey(groupId));
   }
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1502,13 +1502,12 @@ return 1
  * parks in exactly the same number of laps as before.
  */
 const CLAIM_GUARD_LUA = `
-local keyPrefix   = ARGV[1]
-local groupId     = ARGV[2]
-local workerId    = ARGV[3]
-local stagedJobId = ARGV[4]
-local ttlSec      = tonumber(ARGV[5])
+local claimKey = KEYS[1]
 
-local claimKey = keyPrefix .. "group:" .. groupId .. ":claim"
+local keyPrefix   = ARGV[1]
+local workerId    = ARGV[2]
+local stagedJobId = ARGV[3]
+local ttlSec      = tonumber(ARGV[4])
 
 local previous  = redis.call("HMGET", claimKey, "owner", "deaths")
 local prevOwner = previous[1]
@@ -1737,7 +1736,7 @@ export function readTenantCap(): number {
  * graceful shutdown). A leftover marker is only booked as a death when its
  * owner is in neither state.
  */
-export const DEFAULT_CLAIM_STRIKE_THRESHOLD = 3;
+export const DEFAULT_CONFIRMED_DEATH_THRESHOLD = 3;
 
 /**
  * The claim marker self-expires so a group cannot be parked by evidence from
@@ -1769,14 +1768,14 @@ export const WORKER_RETIRED_TTL_SECONDS = CLAIM_MARKER_TTL_SECONDS * 2;
  * Read the poison-guard strike threshold from the environment.
  *
  * Semantics (mirrors readTenantCap):
- *   - env unset / empty / non-numeric / negative → DEFAULT_CLAIM_STRIKE_THRESHOLD
+ *   - env unset / empty / non-numeric / negative → DEFAULT_CONFIRMED_DEATH_THRESHOLD
  *   - env = "0" → 0 (explicit kill switch - guard disabled)
  *   - env = positive integer → that integer
  */
-export function readClaimStrikeThreshold(): number {
+export function readConfirmedDeathThreshold(): number {
   return readNonNegativeIntEnv({
     name: "LANGWATCH_GQ_POISON_STRIKE_THRESHOLD",
-    fallback: DEFAULT_CLAIM_STRIKE_THRESHOLD,
+    fallback: DEFAULT_CONFIRMED_DEATH_THRESHOLD,
   });
 }
 
@@ -1830,7 +1829,7 @@ export function readBisectionSplitBudget(): number {
 
 /**
  * Read the group-quarantine failure-streak threshold from the environment.
- * Mirrors {@link readClaimStrikeThreshold}:
+ * Mirrors {@link readConfirmedDeathThreshold}:
  *   - unset / empty / non-numeric / negative → DEFAULT_GROUP_QUARANTINE_THRESHOLD
  *   - "0" → 0 (explicit kill switch — the breaker is disabled)
  *   - positive integer → that integer
@@ -2493,9 +2492,13 @@ export class GroupStagingScripts {
   }): Promise<number> {
     const deaths = await claimGuardScript.run(
       this.redis,
-      0,
+      // Declared as a KEY, not derived in Lua: ioredis routes a cluster EVAL by
+      // its KEYS, so a zero-key script lands on an arbitrary node and the
+      // derived accesses can fall outside the slot that node owns. The beacon
+      // key stays derived from `keyPrefix`, which carries the same hash tag.
+      1,
+      this.claimMarkerKey(groupId),
       this.keyPrefix,
-      groupId,
       workerId,
       stagedJobId,
       String(CLAIM_MARKER_TTL_SECONDS),

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1470,6 +1470,69 @@ end
 return 1
 `;
 
+/**
+ * Poison guard, claim side (specs/event-sourcing/poison-group-park-guard.feature).
+ *
+ * Records this worker's ownership of a group's claim and returns the number of
+ * CONFIRMED worker deaths the group has caused.
+ *
+ * The guard this replaced counted claims and subtracted a delete: a strike was
+ * written before decode and deleted on every path where the process survived,
+ * so a surviving strike WAS the death signal. That inference is only sound if
+ * the delete is guaranteed, and it is not — it is issued fire-and-forget, and
+ * `process.exit(0)` discards whatever Redis has not yet read. Prod ran ~10
+ * groups a day into the blocked set that way, every one of them healthy: the
+ * park logs sat hours from the nearest deploy, on pods with zero restarts,
+ * for jobs whose p99 is 25ms and which had never once retried.
+ *
+ * So the evidence is positive here. The marker names the process that holds
+ * the claim; that process publishes `alive` on a heartbeat and overwrites it
+ * with `retired` when it shuts down gracefully. A leftover marker resolves to:
+ *
+ *   owner is this worker  -> our own lapsed lease under a slow job. Not a death.
+ *   owner is `alive`      -> still running; its clear is late or its lease
+ *                            lapsed while it works. Not a death.
+ *   owner is `retired`    -> shut down on purpose. Not a death.
+ *   owner has no beacon   -> was claiming, never retired, no longer heartbeats.
+ *                            THAT is a death, and the only thing counted.
+ *
+ * A dropped clear, a torn-down connection and an abandoned drain all land in
+ * the middle three branches, so none of them can park a healthy group; a pod
+ * the job actually killed lands in the fourth, so a genuine poison group still
+ * parks in exactly the same number of laps as before.
+ */
+const CLAIM_GUARD_LUA = `
+local keyPrefix   = ARGV[1]
+local groupId     = ARGV[2]
+local workerId    = ARGV[3]
+local stagedJobId = ARGV[4]
+local ttlSec      = tonumber(ARGV[5])
+
+local claimKey = keyPrefix .. "group:" .. groupId .. ":claim"
+
+local previous  = redis.call("HMGET", claimKey, "owner", "deaths")
+local prevOwner = previous[1]
+local deaths    = tonumber(previous[2] or "0") or 0
+
+if prevOwner and prevOwner ~= workerId then
+  -- GET returns false for a missing key: no beacon at all is the death.
+  -- Either state ("alive" or "retired") is an ordinary outcome.
+  if not redis.call("GET", keyPrefix .. "worker:" .. prevOwner) then
+    deaths = deaths + 1
+  end
+end
+
+redis.call(
+  "HSET", claimKey,
+  "owner", workerId,
+  "deaths", tostring(deaths),
+  "stagedJobId", stagedJobId
+)
+redis.call("EXPIRE", claimKey, ttlSec)
+
+return deaths
+`;
+
 const RETRY_RESTAGE_LUA =
   PENDING_INDEX_HELPER_LUA +
   BLOB_LEASE_HELPER_LUA +
@@ -1664,21 +1727,43 @@ export function readTenantCap(): number {
 
 /**
  * Poison guard (specs/event-sourcing/poison-group-park-guard.feature): a group
- * is parked once this many consecutive claims ended with the process dying
- * before the strike could be cleared. Deaths tolerated = threshold; the claim
- * after that parks. Kept small: every extra strike is another fleet-wide
- * worker crash. Interleaved victims of someone else's poison clear their
- * single strike on their next healthy claim, so only the group that keeps
- * killing workers ever reaches the threshold.
+ * is parked once this many claims found their predecessor's worker dead.
+ * Deaths tolerated = threshold; the claim that observes the last one parks.
+ * Kept small: every extra death is another fleet-wide worker crash.
+ *
+ * A death is CONFIRMED, never inferred. See {@link CLAIM_GUARD_LUA}: the claim
+ * marker names the process that owns it, and that process publishes its own
+ * liveness (`alive`, heartbeated) and its own exit (`retired`, written by the
+ * graceful shutdown). A leftover marker is only booked as a death when its
+ * owner is in neither state.
  */
 export const DEFAULT_CLAIM_STRIKE_THRESHOLD = 3;
 
 /**
- * Strikes self-expire so a burst of unrelated worker deaths (node eviction,
- * OOM of a neighbour) can't park a healthy group hours later. Refreshed on
- * every claim, so an actively-crash-looping group never loses its count.
+ * The claim marker self-expires so a group cannot be parked by evidence from
+ * an outage hours in the past. Refreshed on every claim, so an actively
+ * crash-looping group never loses its count.
  */
-export const CLAIM_STRIKE_TTL_SECONDS = 60 * 60;
+export const CLAIM_MARKER_TTL_SECONDS = 60 * 60;
+
+/**
+ * How long a worker's `alive` beacon survives without a refresh. Must exceed
+ * {@link WORKER_LIVENESS_REFRESH_MS} by enough that a couple of lost writes (a
+ * Redis blip, a GC pause) do not read as a death — an absent beacon is the one
+ * piece of evidence that CAN park a group, so it has to mean the process is
+ * genuinely gone rather than briefly unlucky.
+ */
+export const WORKER_LIVENESS_TTL_SECONDS = 90;
+
+/** Beacon refresh interval. Three refreshes fit inside the TTL above. */
+export const WORKER_LIVENESS_REFRESH_MS = 30_000;
+
+/**
+ * How long a graceful shutdown's `retired` tombstone survives. Must outlive the
+ * claim marker: a marker left by a pod that retired an hour ago must still
+ * resolve to "shut down cleanly" rather than decaying into "died".
+ */
+export const WORKER_RETIRED_TTL_SECONDS = CLAIM_MARKER_TTL_SECONDS * 2;
 
 /**
  * Read the poison-guard strike threshold from the environment.
@@ -1808,6 +1893,7 @@ const completeScript = new CachedLuaScript(COMPLETE_LUA);
 const refreshScript = new CachedLuaScript(REFRESH_LUA);
 const restageAndBlockScript = new CachedLuaScript(RESTAGE_AND_BLOCK_LUA);
 const retryRestageScript = new CachedLuaScript(RETRY_RESTAGE_LUA);
+const claimGuardScript = new CachedLuaScript(CLAIM_GUARD_LUA);
 
 export class GroupStagingScripts {
   private readonly keyPrefix: string;
@@ -2345,36 +2431,91 @@ export class GroupStagingScripts {
     await this.redis.srem(`${this.keyPrefix}paused-jobs`, key);
   }
 
-  private claimStrikesKey(groupId: string): string {
-    return `${this.keyPrefix}group:${groupId}:strikes`;
+  private claimMarkerKey(groupId: string): string {
+    return `${this.keyPrefix}group:${groupId}:claim`;
+  }
+
+  private workerBeaconKey(workerId: string): string {
+    return `${this.keyPrefix}worker:${workerId}`;
   }
 
   /**
-   * Poison-guard claim strike (specs/event-sourcing/poison-group-park-guard.feature).
-   * Recorded when a worker claims a group's job, cleared on every code path
-   * where the process survives - so only groups whose jobs kill the process
-   * (event-loop seizure → liveness kill) accumulate a count. The TTL keeps an
-   * old strike from parking a healthy group long after an unrelated death.
-   *
-   * @returns the strike count including this claim
+   * Publish this worker's liveness beacon. Called once before the worker takes
+   * its first claim and refreshed on {@link WORKER_LIVENESS_REFRESH_MS}: the
+   * beacon is what stops another worker booking this one's leftover claim
+   * markers as deaths, so it has to exist before the claims do.
    */
-  async recordClaimStrike(groupId: string): Promise<number> {
-    const key = this.claimStrikesKey(groupId);
-    const results = await this.redis
-      .multi()
-      .incr(key)
-      .expire(key, CLAIM_STRIKE_TTL_SECONDS)
-      .exec();
-    const count = results?.[0]?.[1];
-    return typeof count === "number" ? count : 0;
+  async recordWorkerAlive(workerId: string): Promise<void> {
+    await this.redis.set(
+      this.workerBeaconKey(workerId),
+      "alive",
+      "EX",
+      WORKER_LIVENESS_TTL_SECONDS,
+    );
   }
 
-  async clearClaimStrikes(groupId: string): Promise<void> {
-    await this.redis.del(this.claimStrikesKey(groupId));
+  /**
+   * Replace this worker's beacon with a retirement tombstone. A planned exit is
+   * not a worker death, and the tombstone is what says so to whoever inherits
+   * the claim markers this process leaves behind. Outlives the marker itself
+   * (see {@link WORKER_RETIRED_TTL_SECONDS}), so the answer cannot decay from
+   * "retired" into "died" while a marker still refers to it.
+   *
+   * The caller MUST stop the liveness heartbeat first, or a refresh landing
+   * after this write would restore a short-lived `alive` that then expires.
+   */
+  async retireWorker(workerId: string): Promise<void> {
+    await this.redis.set(
+      this.workerBeaconKey(workerId),
+      "retired",
+      "EX",
+      WORKER_RETIRED_TTL_SECONDS,
+    );
   }
 
-  async getClaimStrikes(groupId: string): Promise<number> {
-    const raw = await this.redis.get(this.claimStrikesKey(groupId));
+  /**
+   * Take ownership of a group's claim and report how many worker deaths this
+   * group has now confirmably caused. See {@link CLAIM_GUARD_LUA} for why the
+   * count is derived from the previous owner's beacon rather than from the
+   * absence of a delete.
+   *
+   * @returns the confirmed-death count for the group, including any death this
+   *   claim just observed
+   */
+  async recordClaim({
+    groupId,
+    workerId,
+    stagedJobId,
+  }: {
+    groupId: string;
+    workerId: string;
+    stagedJobId: string;
+  }): Promise<number> {
+    const deaths = await claimGuardScript.run(
+      this.redis,
+      0,
+      this.keyPrefix,
+      groupId,
+      workerId,
+      stagedJobId,
+      String(CLAIM_MARKER_TTL_SECONDS),
+    );
+    return typeof deaths === "number" ? deaths : 0;
+  }
+
+  /**
+   * Release the claim marker. Unlike the strike delete this replaced, losing
+   * this write is harmless: the marker it would have removed still names a live
+   * (or cleanly retired) owner, so the next claim reads it as ordinary rather
+   * than as a death.
+   */
+  async clearClaim(groupId: string): Promise<void> {
+    await this.redis.del(this.claimMarkerKey(groupId));
+  }
+
+  /** Confirmed worker deaths recorded against a group. */
+  async getConfirmedDeaths(groupId: string): Promise<number> {
+    const raw = await this.redis.hget(this.claimMarkerKey(groupId), "deaths");
     const n = raw === null ? 0 : Number.parseInt(raw, 10);
     return Number.isFinite(n) ? n : 0;
   }

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -110,6 +110,14 @@ Feature: GroupQueue poison-group park guard
     And the group is dispatched and processed instead of being parked
 
   @integration
+  Scenario: a worker that cannot publish its own beacon does not enforce the guard
+    Given a worker whose liveness beacon write to Redis fails
+    When it claims a group already one death short of the threshold
+    Then it records no claim and parks nothing
+    And the group is dispatched and processed normally
+    And the guard resumes for that worker once its beacon lands
+
+  @integration
   Scenario: a release that never reaches Redis does not park a healthy group
     Given a group whose job completed but whose claim release was lost
     When the group is claimed repeatedly beyond the poison threshold
@@ -147,7 +155,7 @@ Feature: GroupQueue poison-group park guard
     And the group is never parked into the blocked set by the failure-streak guard
 
   @integration
-  Scenario: graceful shutdown mid-job does not count as a poison strike
+  Scenario: graceful shutdown mid-job does not count as a confirmed death
     Given a group whose job is in flight when the worker begins a graceful shutdown
     When the shutdown drains or abandons the in-flight job with the event loop alive
     Then the worker has published a retirement tombstone before the drain begins

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -110,6 +110,14 @@ Feature: GroupQueue poison-group park guard
     And the group is dispatched and processed instead of being parked
 
   @integration
+  Scenario: a worker releases only a claim it still owns
+    Given a group whose claim was taken over by a second worker after the first
+      one outlived its lease
+    When the first worker finishes and releases
+    Then the second worker's claim survives, with the group's death count intact
+    And a later death is still counted against the group
+
+  @integration
   Scenario: a worker that cannot report itself as running enforces nothing
     Given a worker that is temporarily unable to report itself as running
     When it claims a group already one death short of the threshold

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -110,12 +110,13 @@ Feature: GroupQueue poison-group park guard
     And the group is dispatched and processed instead of being parked
 
   @integration
-  Scenario: a worker that cannot publish its own beacon does not enforce the guard
-    Given a worker whose liveness beacon write to Redis fails
+  Scenario: a worker that cannot report itself as running enforces nothing
+    Given a worker that is temporarily unable to report itself as running
     When it claims a group already one death short of the threshold
-    Then it records no claim and parks nothing
+    Then it counts no death and parks no group
     And the group is dispatched and processed normally
-    And the guard resumes for that worker once its beacon lands
+    And the group's death count is left exactly as it was
+    And the guard resumes for that worker once it can report itself again
 
   @integration
   Scenario: a release that never reaches Redis does not park a healthy group

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -16,13 +16,29 @@ Feature: GroupQueue poison-group park guard
   # never fires when the process dies mid-job.
   #
   # Design:
-  #   - Claim strikes: processWithRetries records a persistent per-group
-  #     strike in Redis BEFORE decoding, and clears it on every code path
-  #     where the process survives (success, retry, exhausted-park, transient
-  #     re-stage, graceful drain). A blocked event loop cannot run signal
-  #     handlers or clears, so only genuine loop-killers accumulate strikes.
-  #     At claim, strikes >= threshold parks the group via the existing
+  #   - Claim ownership: processWithRetries stamps the claiming worker's
+  #     identity onto a per-group claim marker in Redis BEFORE decoding, and
+  #     releases it on every code path where the process survives (success,
+  #     retry, exhausted-park, transient re-stage, graceful drain). At claim,
+  #     confirmed deaths >= threshold parks the group via the existing
   #     blocked-set mechanism with an explanatory stored error.
+  #   - Confirmed deaths: every consumer publishes an `alive` beacon on a
+  #     heartbeat and overwrites it with a `retired` tombstone when it shuts
+  #     down gracefully. A leftover marker is booked as a death ONLY when its
+  #     owner is in neither state. A live owner (slow job, or a release that
+  #     never reached Redis), a retired owner, and the same worker re-claiming
+  #     under a lapsed lease are all ordinary and count for nothing.
+  #
+  # Incident 2026-08-13: the guard above replaced one that counted claims and
+  # subtracted a delete - a surviving strike WAS the death signal. That
+  # inference is only sound if the delete is guaranteed, and it is not: it is
+  # issued fire-and-forget, and process.exit(0) discards whatever Redis has not
+  # yet read. Prod parked ~10 healthy groups a day that way, accelerating, each
+  # one hours from the nearest deploy, on pods with zero restarts, for a job
+  # whose p99 is 25ms and which had never once retried. Every operator unblock
+  # succeeded on the first try because nothing was ever wrong with the group.
+  # A death must therefore be evidenced by the absence of a live process, never
+  # by the absence of a write.
   #   - Decode size guard: staged values larger than the encode-side cap
   #     (legacy/bare payloads that predate or bypass envelope writes) are
   #     parked without being JSON.parsed; gunzip output is bounded so a
@@ -52,24 +68,59 @@ Feature: GroupQueue poison-group park guard
 
   Scenario: a group whose jobs repeatedly kill the worker is parked at claim
     Given a group whose staged job blocks the event loop until the process is killed
-    And the group has accumulated claim strikes at or above the poison threshold
+    And the group has accumulated confirmed worker deaths at or above the poison threshold
     When a worker claims the group again after a restart
     Then the group is moved to the blocked set before the job payload is decoded
-    And the stored group error explains the park with the accumulated strike count
+    And the stored group error explains the park with the confirmed death count
     And the staged job remains staged for operator inspection or replay
     And other groups continue to dispatch and process normally
 
-  Scenario: claim strikes are cleared when processing survives
+  Scenario: claim markers are released when processing survives
     Given a group whose job is claimed and processed to completion
     When the same group is claimed again later
-    Then its claim strike count starts from zero
+    Then its confirmed death count starts from zero
     And the group is not parked
 
-  Scenario: a failing-but-not-crashing job does not accumulate claim strikes
+  @integration
+  Scenario: a claim left behind by a worker that is still running is not a death
+    Given a group whose claim marker names a worker whose beacon is still live
+    When another worker claims the group
+    Then no death is recorded for the group
+    And the group is dispatched and processed instead of being parked
+
+  @integration
+  Scenario: a claim left behind by a gracefully retired worker is not a death
+    Given a group whose claim marker names a worker that published a retirement tombstone
+    When another worker claims the group
+    Then no death is recorded for the group
+    And the group is dispatched and processed instead of being parked
+
+  @integration
+  Scenario: a claim left behind by a worker that vanished without retiring is a death
+    Given a group whose claim marker names a worker with neither a beacon nor a tombstone
+    When another worker claims the group
+    Then one confirmed death is recorded for the group
+    And the count accumulates across successive deaths until the group is parked
+
+  @integration
+  Scenario: a worker re-claiming its own lapsed lease is not a death
+    Given a group whose claim marker names the same worker that is claiming it now
+    When that worker claims the group again after its active lease lapsed
+    Then no death is recorded for the group
+    And the group is dispatched and processed instead of being parked
+
+  @integration
+  Scenario: a release that never reaches Redis does not park a healthy group
+    Given a group whose job completed but whose claim release was lost
+    When the group is claimed repeatedly beyond the poison threshold
+    Then no death is recorded for any of those claims
+    And the group is never parked into the blocked set
+
+  Scenario: a failing-but-not-crashing job does not accumulate confirmed deaths
     Given a group whose job throws an error on every attempt
     When the job exhausts its retry budget
     Then the group is parked by the existing exhausted-retries path
-    And the claim strikes recorded for the group have been cleared on each surviving attempt
+    And the claim marker has been released on each surviving attempt
 
   Scenario: a group that fails on every attempt without draining is quarantined
     Given a group receiving a stream of fresh jobs that each fail on every attempt
@@ -95,17 +146,25 @@ Feature: GroupQueue poison-group park guard
     Then the group is retried under the normal per-job budget instead of being quarantined
     And the group is never parked into the blocked set by the failure-streak guard
 
+  @integration
   Scenario: graceful shutdown mid-job does not count as a poison strike
     Given a group whose job is in flight when the worker begins a graceful shutdown
     When the shutdown drains or abandons the in-flight job with the event loop alive
-    Then the group's claim strike is cleared
-    And the group is dispatched normally after the worker restarts
+    Then the worker has published a retirement tombstone before the drain begins
+    And the group records no death when it is claimed after the worker restarts
 
-  Scenario: a claim made during a graceful shutdown records no strike
-    Given a worker that has begun a graceful shutdown with jobs still queued
-    When the worker claims one of those jobs while draining
-    Then no claim strike is recorded for the job's group
-    And a group already at the strike threshold is parked by the next boot's claim, not during the drain
+  @integration
+  Scenario: the retirement tombstone outlives the claim markers it answers for
+    Given a worker that retired while holding claims on several groups
+    When one of those groups is claimed an hour later, within the claim marker's lifetime
+    Then the tombstone still resolves the previous owner as retired rather than dead
+    And no death is recorded for the group
+
+  @unit
+  Scenario: the liveness beacon stops before the retirement tombstone is written
+    Given a worker whose beacon refresh is due as it begins shutting down
+    When the worker retires
+    Then no later refresh can overwrite the tombstone with a short-lived beacon
 
   Scenario: an oversized staged value is parked without being parsed
     Given a staged value whose serialized size exceeds the decode-side cap
@@ -124,10 +183,10 @@ Feature: GroupQueue poison-group park guard
 
   Scenario: the poison guard is disabled by setting the strike threshold to 0
     Given the strike-threshold kill switch is set to 0
-    And a group has accumulated claim strikes at or above the former poison threshold
+    And a group has accumulated confirmed deaths at or above the former poison threshold
     When a worker claims the group
     Then the group is dispatched and processed instead of being parked
-    And no claim strike is recorded or enforced for the group
+    And no claim marker is recorded or enforced for the group
 
   Scenario: a compressed staged value that would decompress past the cap is parked
     Given a staged envelope whose gzip body would inflate beyond the decode-side cap
@@ -138,17 +197,25 @@ Feature: GroupQueue poison-group park guard
   Scenario: a parked poison group can be unblocked by an operator
     Given a group parked by the poison guard
     When an operator unblocks the group via the ops surface
-    Then its claim strikes are reset
+    Then its confirmed death count is reset
     And the group returns to normal dispatch
 
-  Scenario: draining a parked poison group resets its claim strikes
+  @integration
+  Scenario: parking a group releases its claim marker
+    Given a group being parked by the poison guard
+    When the park completes
+    Then the group's claim marker is released rather than left at the threshold
+    And an operator who unblocks within the marker's lifetime gets a fresh run
+      instead of the group re-parking on its very next claim
+
+  Scenario: draining a parked poison group resets its confirmed death count
     Given a group parked by the poison guard
     When an operator drains the group via the ops surface
-    Then its claim strikes are reset
+    Then its confirmed death count is reset
     And a new job arriving under the same group id is dispatched normally
 
-  Scenario: moving a parked poison group to the dead-letter queue resets its claim strikes
+  Scenario: moving a parked poison group to the dead-letter queue resets its confirmed death count
     Given a group parked by the poison guard
     When an operator moves the group to the dead-letter queue via the ops surface
-    Then its claim strikes are reset
+    Then its confirmed death count is reset
     And a new job arriving under the same group id is dispatched normally


### PR DESCRIPTION
## What

The GroupQueue poison guard parks a group after enough of its claims end in a
worker death. It inferred those deaths from the **absence of a Redis delete**:
`processWithRetries` INCR'd a per-group strike before decode and deleted it on
every path where the process survived, so a surviving strike *was* the death
signal.

That inference is only sound if the delete is guaranteed, and it is not. It is
issued fire-and-forget, and `process.exit(0)` discards whatever Redis has not
yet read.

This replaces the inference with positive evidence.

## Why

Production was parking roughly **ten healthy groups a day**, accelerating —
4 (08-11) → 6 (08-12) → 10 (08-13, half a day) — 81% of them on one
high-fan-out subscriber. None were poisoned:

| Signal | Reading |
|---|---|
| Container restarts, all 10 worker pods | **0** |
| Peak worker memory vs limit | 3454 MiB / 4096 MiB, never above 3800 |
| Pods reaching the SIGTERM handler in 72h | **120 of 120** |
| `Failed to heartbeat active key` warnings | **0** |
| Job p99 / p99.9 for the affected subscriber | **25 ms** / 148 ms |
| Retries for that subscriber in 24h | **0**, against 166k completions |

The parks landed one to five hours after the nearest deploy, and the strike TTL
is one hour — so the strikes accrued during ordinary steady-state operation,
with no deploy, no restart and no failed job anywhere near them. The full log
trail for a parked group is a single line: the park itself. The three "worker
deaths" it reported left no trace because they were not deaths.

Every operator unblock succeeded on the first try, because nothing was ever
wrong with the group. The guard was the only thing wrong.

## How

A claim marker names the process that holds it. Each consumer publishes an
`alive` beacon on a heartbeat and overwrites it with a `retired` tombstone on
graceful shutdown. A leftover marker is booked as a death only when its owner is
in **neither** state:

```
owner is this worker  -> our own lapsed lease under a slow job.  Not a death.
owner is `alive`      -> still running; release late or lease lapsed. Not a death.
owner is `retired`    -> shut down on purpose.                    Not a death.
owner has no beacon   -> was claiming, never retired, no longer
                         heartbeats.                              DEATH.
```

A dropped release, a torn-down connection and an abandoned drain all land in the
middle three branches, so none can park a healthy group. A pod the job actually
killed lands in the fourth, so a genuine poison group still parks in the same
number of laps. `LANGWATCH_GQ_POISON_STRIKE_THRESHOLD=0` still disables it.

The tombstone TTL deliberately outlives the claim marker, so a marker left by a
pod that retired an hour ago cannot decay from "retired" into "died".

**This removes machinery rather than adding it.** The in-flight strike set, the
shutdown sweep over it, and the post-claim recheck guarding the race between the
two existed only to keep the old negative signal honest. One tombstone now
answers for every claim a worker holds, however the drain ends.

### Also fixed

The park path left its own marker at the threshold, so an operator unblocking
inside the marker's hour had the group re-park on its very next claim — whether
the click worked depended on how long they took to press it.

## Testing

- Poison-guard integration: **19/19**, including five new scenarios. The
  headline one stubs the release write out entirely and pushes 3x the threshold
  of jobs through one group: under the old guard that parked it, and now it has
  to survive.
- `stagedJobIdIdentity` (two tests seeded the old strikes key) migrated — passes.
- New `groupQueue.workerLiveness.unit.test.ts` pins the beacon-before-tombstone
  ordering in `close()`, which is load-bearing: retiring first would let a
  pending refresh restore a short-lived `alive` that then expires into exactly
  the false death the tombstone prevents.
- 37 unit + 7 ops integration tests pass. `pnpm typecheck:all` clean. Biome
  clean with zero warning delta.

Writing the unit test caught a real bug: the constructor destructures a
`process` handler out of the queue definition, so a class-field initializer
reading `process.pid` resolved to that binding and died in its TDZ. It now
imports `pid` from `node:process`.

## Deployment impact

Safe to roll out with no coordination. During the rollout old pods use the
legacy `:strikes` counter and new pods use the `:claim` marker; they do not
interact, so the guard is briefly *weaker* rather than wrong — it fails open and
never parks spuriously. Legacy keys expire on their own after an hour, and
unblock / drain / DLQ clear both.

No migration, no config change, no new environment variable. Redis gains one
small key per consumer process (`{queue}:gq:worker:{workerId}`), refreshed every
30s, plus the per-group claim marker that replaces the per-group strike counter
one-for-one.

## Not in this PR

- **`sum(gq_blocked_groups)` overcounts by the pod count.** The gauge is
  exported per pod but reports one global Redis count, so any dashboard or alert
  using `sum()` reads 10x high — probably why this looked worse in Grafana than
  it was. Fixing it changes gauge semantics and deserves its own change.
- The spec file's pre-existing scenarios are untagged, so `check-feature-parity`
  binds nothing for them. New scenarios here carry `@integration` / `@unit`
  tags; retro-tagging the rest means tracing each to a test.

Spec: `specs/event-sourcing/poison-group-park-guard.feature`

---

### Follow-up in the second commit

Re-auditing the diff turned up one more instance of the same failure mode the
PR is about. `close()` can run while the constructor is still awaiting its
*first* beacon publish: it finds no timer to stop, writes the tombstone, and the
constructor then arms the refresh interval — putting an `alive` write *after*
the retirement, which expires into exactly the false death the tombstone
prevents. The beacon setup now returns without arming if a shutdown began while
it was publishing, and its test fails against the unguarded version.

CI's `feature-parity` gate also caught that three of the new scenarios were
tagged but bound nothing: a `@scenario` annotation only binds from a
**single-line** JSDoc directly above the `it(`, because the proximity scan stops
at the `*/` of a multi-line block. Two of those scenarios had no test at all and
now do. The spec is also out of `LEGACY_INERT`, so it enforces its own scenarios
from here on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved poison-job protection by distinguishing failed, active, gracefully shutting down, and self-reclaiming workers.
  - Prevented false quarantines caused by lost claim releases.
  - Ensured recovery actions clear stale worker claims.
  - Improved handling of oversized payloads and repeated processing attempts.

- **Reliability**
  - Added worker liveness tracking for more accurate queue recovery.
  - Preserved staged job identities through retries and poison-job parking.
  - Improved claim cleanup during parking, unblocking, draining, and dead-lettering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->