### PR TITLE
fix(app): keep route URL and rendered view in sync

### DIFF
--- a/platform/app/src/main.test.tsx
+++ b/platform/app/src/main.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import type { ReactElement, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  rootRender: vi.fn(),
+  createRoot: vi.fn(),
+}));
+
+vi.mock("react-dom/client", () => ({
+  createRoot: mocks.createRoot,
+}));
+
+vi.mock("./AppProviders", () => ({
+  OuterProviders: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("./routes", () => ({
+  router: { id: "app-router" },
+}));
+
+vi.mock("./utils/chunkReload", () => ({
+  registerChunkReloadListener: vi.fn(),
+}));
+
+vi.mock("./utils/compat/next-router", () => ({
+  setRouterInstance: vi.fn(),
+}));
+
+describe("application router scheduling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.rootRender.mockReset();
+    mocks.createRoot.mockReset();
+    mocks.createRoot.mockReturnValue({ render: mocks.rootRender });
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it("commits route changes synchronously so the URL cannot outrun the page", async () => {
+    await import("./main");
+
+    const app = mocks.rootRender.mock.calls[0]?.[0] as ReactElement<{
+      children: ReactElement<{
+        children: ReactElement<{ useTransitions?: boolean }>;
+      }>;
+    }>;
+    const routerProvider = app.props.children.props.children;
+
+    expect(routerProvider.props.useTransitions).toBe(false);
+  });
+});

--- a/platform/app/src/main.tsx
+++ b/platform/app/src/main.tsx
@@ -23,7 +23,9 @@ if (!container) throw new Error("Root element not found");
 createRoot(container).render(
   <OuterProviders>
     <Suspense fallback={null}>
-      <RouterProvider router={router} />
+      {/* Lazy routes and drawers subscribe to external stores. Transition-wrapped
+          navigation can advance history while leaving the old tree committed. */}
+      <RouterProvider router={router} useTransitions={false} />
     </Suspense>
   </OuterProviders>,
 );

--- a/tools/thuishaven/app/plan.go
+++ b/tools/thuishaven/app/plan.go
@@ -61,23 +61,29 @@ func (o *Orchestrator) planChildren(st domain.Stack, opts PlanOptions, lwDir, la
 		Shell: "pnpm -s run dev:vite",
 		Env:   nodeEnv(),
 		// Hold the web (vite) until the API answers /api/health. The app proxies
-		// /api to the API (start:app), which is a bigger process and boots slower;
+		// /api to the API (start:app:dev), which is a bigger process and boots slower;
 		// a browser that loads the web before the API is up gets stuck in an auth
 		// redirect loop. Gating the lane means the hostname simply isn't served
 		// until the stack can actually handle a request.
 		ReadyProbeURL: fmt.Sprintf("http://127.0.0.1:%d/api/health", st.APIPort),
 	})
-	// In-process worker mode (the default): the app process (start:app ->
-	// start.ts) hosts the worker stack itself, so there is no separate
-	// `workers` lane below — one Node process instead of two, saving its RAM.
-	// `haven up +workers` selects the standalone lane instead.
+	// In-process worker mode (the default): the app process hosts the worker
+	// stack itself, so there is no separate `workers` lane below — one Node
+	// process instead of two, saving its RAM. `haven up +workers` selects the
+	// standalone lane instead.
 	apiEnv := nodeEnv()
 	if !opts.Selection.Workers {
 		apiEnv = append(apiEnv, "WORKERS_IN_PROCESS=1")
 	}
 	out = append(out, Child{
 		Name: "api", Dir: lwDir, Color: palette[3], LogPath: logPath("api"),
-		Shell: "pnpm -s run start:app",
+		// `:dev` runs the app from source through tsx. The bare `start:app` is the
+		// PRODUCTION entry (`node dist/server/server.cjs`) and nothing in a dev
+		// worktree builds that bundle, so it crash-loops on MODULE_NOT_FOUND and
+		// the app lane never passes its /api/health gate. scripts/start.sh makes
+		// the same split off NODE_ENV; these lanes bypass start.sh, so they pick
+		// the dev entry point themselves. Pinned by TestNodeLanesUseDevEntryPoints.
+		Shell: "pnpm -s run start:app:dev",
 		Env:   apiEnv,
 	})
 	if opts.Selection.Gateway {
@@ -106,7 +112,9 @@ func (o *Orchestrator) planChildren(st domain.Stack, opts PlanOptions, lwDir, la
 			// is reserved for genuine failures, so no lane label uses it —
 			// TestNoLaneIsRed pins that.
 			Name: "workers", Dir: lwDir, Color: palette[0], LogPath: logPath("workers"),
-			Shell: "pnpm -s run start:workers",
+			// `:dev` for the same reason as the api lane above — the bare
+			// `start:workers` is `node dist/server/workers.cjs`.
+			Shell: "pnpm -s run start:workers:dev",
 			Env:   append(nodeEnv(), "START_WORKERS=true"),
 		})
 	}

--- a/tools/thuishaven/app/plan_entrypoints_test.go
+++ b/tools/thuishaven/app/plan_entrypoints_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
+)
+
+// The Node lanes run pnpm scripts by name, and platform/app keeps two entry
+// points per process: `start:app` / `start:workers` are the PRODUCTION bundles
+// (`node dist/server/*.cjs`, built by `pnpm build:server`) and `start:app:dev` /
+// `start:workers:dev` run from source through tsx.
+//
+// Nothing in a dev worktree builds those bundles, so naming the production
+// script here is not a slower path — it is a crash loop on MODULE_NOT_FOUND,
+// and because the app lane is gated on the API's /api/health probe, the whole
+// stack silently never comes up. scripts/start.sh makes the same split off
+// NODE_ENV; these lanes bypass start.sh and so must choose for themselves.
+//
+// This resolves the lane's script name against the real package.json rather
+// than comparing the shell string to a literal, so it fails on the thing that
+// actually breaks — a lane pointed at a script that loads a build artifact —
+// however the scripts are later renamed or restructured.
+func TestNodeLanesUseDevEntryPoints(t *testing.T) {
+	scripts := appPackageScripts(t)
+
+	o := &Orchestrator{cfg: Config{Home: t.TempDir()}, proxy: stubProxy{}}
+	children := o.planChildren(
+		domain.Stack{Slug: "test"},
+		PlanOptions{Selection: domain.Selection{Workers: true}},
+		t.TempDir(),
+		"", // langyDockerHost — the langy lane is not a pnpm lane
+	)
+
+	pnpmRun := regexp.MustCompile(`pnpm(?:\s+-\w+)*\s+run\s+([\w:.-]+)`)
+	var checked int
+	for _, c := range children {
+		m := pnpmRun.FindStringSubmatch(c.Shell)
+		if m == nil {
+			continue // Go services and anything not driven by a pnpm script
+		}
+		name := m[1]
+		body, ok := scripts[name]
+		if !ok {
+			t.Errorf("lane %q runs pnpm script %q, which platform/app/package.json does not define", c.Name, name)
+			continue
+		}
+		checked++
+		if strings.Contains(body, "dist/") {
+			t.Errorf(
+				"lane %q runs %q (%q), which loads a build artifact; dev worktrees never build it, "+
+					"so the lane crash-loops on MODULE_NOT_FOUND. Use the :dev entry point.",
+				c.Name, name, body,
+			)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no pnpm-driven lane was checked; the plan or the shell format changed")
+	}
+}
+
+// appPackageScripts reads the "scripts" map out of platform/app/package.json,
+// found by walking up from this package to the repo root.
+func appPackageScripts(t *testing.T) map[string]string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cwd: %v", err)
+	}
+	var path string
+	for {
+		candidate := filepath.Join(dir, "platform", "app", "package.json")
+		if _, err := os.Stat(candidate); err == nil {
+			path = candidate
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find platform/app/package.json above the test's working directory")
+		}
+		dir = parent
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(raw, &pkg); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return pkg.Scripts
+}

--- a/tools/thuishaven/app/plan_entrypoints_test.go
+++ b/tools/thuishaven/app/plan_entrypoints_test.go
@@ -42,7 +42,16 @@ func TestNodeLanesUseDevEntryPoints(t *testing.T) {
 	for _, c := range children {
 		m := pnpmRun.FindStringSubmatch(c.Shell)
 		if m == nil {
-			continue // Go services and anything not driven by a pnpm script
+			// Skipping silently is how this check would rot: a lane rewritten
+			// into a pnpm form this regex cannot read (`pnpm --filter x run y`)
+			// would drop out of the loop while the other lane kept `checked`
+			// above zero, and the whole guard would go green on an unread lane.
+			// So a pnpm lane that cannot be parsed is a failure, not a skip;
+			// only genuinely non-pnpm lanes (the Go services, langy) pass here.
+			if strings.Contains(c.Shell, "pnpm") {
+				t.Errorf("lane %q runs pnpm (%q) in a form this test cannot parse, so its entry point went unchecked; widen pnpmRun", c.Name, c.Shell)
+			}
+			continue
 		}
 		name := m[1]
 		body, ok := scripts[name]


### PR DESCRIPTION
## For humans

Clicking Trace Explorer in the sidebar could change the address bar while the prompt playground stayed on screen — the URL said you had moved, the page said you had not. This makes the page always follow the URL. It also fixes the local development stack, which could not start the application server at all.

## Summary

- disable transition-wrapped React Router state updates at the application root
- keep the committed route tree synchronized with browser history for lazy routes and drawers that subscribe to external stores
- fix the local dev orchestrator (haven), whose app and workers lanes ran the production entry points
- add regression tests for both

## Root cause

**Route/URL desync.** React Router schedules route-state updates in a React transition by default. In this application, lazy route and drawer trees also subscribe to external stores. Under contention, browser history could advance while React kept the previous tree committed, producing a new URL with the old page still visible and making a closed drawer fail to reopen.

**Dev stack.** `tools/thuishaven/app/plan.go` ran `pnpm run start:app` and `pnpm run start:workers` for the Node lanes. Those are the production entry points (`node dist/server/*.cjs`) and nothing in a dev worktree builds those bundles, so the api lane crash-looped on `MODULE_NOT_FOUND`. Because the app lane is gated on the API's `/api/health` probe, the stack came up with no application served and no obvious cause in its own output. `scripts/start.sh` already makes this split off `NODE_ENV`; these lanes bypass `start.sh`, so they now pick the dev entry points themselves.

## Scope note

This closes the sidebar-navigation symptom in #6920. The other symptom reported there — `traces.getById` returning `NOT_FOUND` for a preallocated playground trace ID — is a separate ingestion-timing question and is **not** addressed here.

## Verification

- regression test failed before the fix and passes after it
- `TestNodeLanesUseDevEntryPoints` resolves each lane's pnpm script against the real `platform/app/package.json` and fails when a lane points at a script that loads a build artifact; verified failing against the pre-fix lane
- focused unit tests: 13 passed
- application typecheck passed
- Biome passed with no new violations
- `golangci-lint run ./tools/thuishaven/...` reports nothing new on the changed files
- `make haven up` now serves the app (HTTP 200) where it previously never came up
- verified in the local app that Prompt Playground → Trace Explorer commits the new view, and a trace drawer opens, closes, and reopens