### PR TITLE
fix(clickhouse): name the cluster on every ClickHouse failure

### DIFF
--- a/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -160,11 +160,13 @@ function logFailure({
   error,
   durationMs,
   params,
+  cluster,
 }: {
   operation: "query" | "insert";
   error: unknown;
   durationMs: number;
   params: unknown;
+  cluster: string;
 }): void {
   try {
     const meta = safeQueryMeta(params);
@@ -172,6 +174,14 @@ function logFailure({
     queryLogger.warn(
       {
         source: "clickhouse",
+        // Which ClickHouse refused it. Not every deployment has one cluster:
+        // an organization can be routed to its own, so without this field a
+        // rejection from a customer's dedicated instance is indistinguishable
+        // from one on the shared cluster. On 2026-08-13 that ambiguity is what
+        // made a three-hour saturation take an afternoon to attribute — the
+        // answer had to be inferred from a concurrency limit quoted in the
+        // vendor's error text and matched against terraform.
+        cluster,
         operation,
         durationMs: Math.round(durationMs),
         queryId: meta.queryId,
@@ -315,10 +325,12 @@ function guardInbandException<
   result,
   startMs,
   params,
+  cluster,
 }: {
   result: T;
   startMs: number;
   params: unknown;
+  cluster: string;
 }): T {
   if (typeof result?.json !== "function") return result;
   const queryType = extractQueryType(params);
@@ -330,7 +342,7 @@ function guardInbandException<
       if (exception !== undefined) {
         const durationMs = performance.now() - startMs;
         const error = inbandExceptionError({ message: exception, durationMs });
-        logFailure({ operation: "query", error, durationMs, params });
+        logFailure({ operation: "query", error, durationMs, params, cluster });
         // Dedicated outcome, and no second duration sample: the transport
         // outcome (success + one histogram observation) was already
         // recorded when the query resolved. Counting this as "error" too
@@ -375,11 +387,17 @@ function guardInbandException<
  */
 export function createResilientClickHouseClient({
   client,
+  cluster = "shared",
   maxRetries = 3,
   baseDelayMs = 500,
   maxDelayMs = 10_000,
 }: {
   client: ClickHouseClient;
+  /**
+   * Which ClickHouse this client talks to, stamped on every failure line.
+   * Defaults to "shared" because that is what a caller naming nothing has.
+   */
+  cluster?: string;
   maxRetries?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
@@ -399,10 +417,10 @@ export function createResilientClickHouseClient({
       logSuccess({ operation: "query", durationMs, params });
       observeClickHouseQueryDuration(queryType, table, durationMs / 1000);
       incrementClickHouseQueryCount(queryType, "success");
-      return guardInbandException({ result, startMs: start, params });
+      return guardInbandException({ result, startMs: start, params, cluster });
     } catch (error) {
       const durationMs = performance.now() - start;
-      logFailure({ operation: "query", error, durationMs, params });
+      logFailure({ operation: "query", error, durationMs, params, cluster });
       observeClickHouseQueryDuration(queryType, table, durationMs / 1000);
       incrementClickHouseQueryCount(queryType, "error");
       // Retries are exhausted at this point: translate known ClickHouse
@@ -429,7 +447,7 @@ export function createResilientClickHouseClient({
       return result;
     } catch (error) {
       const durationMs = performance.now() - start;
-      logFailure({ operation: "insert", error, durationMs, params });
+      logFailure({ operation: "insert", error, durationMs, params, cluster });
       observeClickHouseQueryDuration("INSERT", insertTable, durationMs / 1000);
       incrementClickHouseQueryCount("INSERT", "error");
       throw error;

--- a/platform/app/src/server/clickhouse/__tests__/parseRouteKey.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/parseRouteKey.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { parseRouteKey } from "../privateRouteKey";
+
+/**
+ * Reading a cluster's name out of `CLICKHOUSE_URL__<label>__<orgId>`.
+ *
+ * The label was parsed and discarded for as long as private instances have
+ * existed, documented as "ignored by code". It is the only human-readable name
+ * the platform has for a customer's dedicated ClickHouse, and its absence had a
+ * cost: a private instance rejected ~5.6k statements in three hours on
+ * 2026-08-13 and no log line said which cluster refused them.
+ */
+
+const prefix = "CLICKHOUSE_URL__";
+
+describe("parseRouteKey", () => {
+  describe("given a labelled env var", () => {
+    it("routes on the org id and names the cluster after the label", () => {
+      expect(
+        parseRouteKey({ key: `${prefix}acme__org_abc123`, prefix }),
+      ).toEqual({ orgId: "org_abc123", cluster: "acme" });
+    });
+  });
+
+  describe("given a label that itself contains the separator", () => {
+    /**
+     * The org id is taken from the LAST separator, not the first. A label is
+     * free text a person wrote; splitting on the first "__" would route
+     * "acme__eu" to org "eu" and send a customer's traffic to the wrong
+     * cluster — or, more likely, to none.
+     */
+    it("keeps the whole label and still routes on the trailing org id", () => {
+      expect(
+        parseRouteKey({ key: `${prefix}acme__eu__org_abc123`, prefix }),
+      ).toEqual({ orgId: "org_abc123", cluster: "acme__eu" });
+    });
+  });
+
+  describe("given no label at all", () => {
+    it("falls back to the org id, so the field is never empty", () => {
+      expect(parseRouteKey({ key: `${prefix}org_abc123`, prefix })).toEqual({
+        orgId: "org_abc123",
+        cluster: "org_abc123",
+      });
+    });
+
+    it("treats a leading separator as unlabelled rather than as an empty name", () => {
+      expect(parseRouteKey({ key: `${prefix}__org_abc123`, prefix })).toEqual({
+        orgId: "org_abc123",
+        cluster: "org_abc123",
+      });
+    });
+  });
+
+  describe("given nothing to route", () => {
+    it("returns null for a bare prefix", () => {
+      expect(parseRouteKey({ key: prefix, prefix })).toBeNull();
+    });
+
+    it("returns null when the org id segment is empty", () => {
+      expect(parseRouteKey({ key: `${prefix}acme__`, prefix })).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/server/clickhouse/clickhouseClient.ts
+++ b/platform/app/src/server/clickhouse/clickhouseClient.ts
@@ -4,6 +4,11 @@ import { prisma } from "../db";
 import { _getSharedClickHouseClient } from "./client";
 import { createManagedClickHouseClient } from "./managedClient";
 import { unregisterClickHouseLimiter } from "./metrics";
+import {
+  PRIVATE_CH_ENV_PREFIX,
+  type PrivateRoute,
+  parseRouteKey,
+} from "./privateRouteKey";
 
 const logger = createLogger("langwatch:clickhouse:routing");
 
@@ -23,18 +28,9 @@ export type ClickHouseClientResolver = (
 ) => Promise<ClickHouseClient>;
 
 /**
- * Env var format: CLICKHOUSE_URL__<label>__<orgId>=<connectionUrl>
+ * Map of orgId → route, parsed from env vars at module load. The format and its
+ * parsing live in `./privateRouteKey`.
  *
- * The <label> is a human-readable customer name (e.g., "acme"), ignored by code.
- * The <orgId> is the organization ID used for routing.
- *
- * Example:
- *   CLICKHOUSE_URL__acme__dv0uZFgPfenFvzg2qKNQa=http://default:pass@acme-ch:8123/langwatch
- */
-const PRIVATE_CH_ENV_PREFIX = "CLICKHOUSE_URL__";
-
-/**
- * Map of orgId → connectionUrl, parsed from env vars at module load.
  * Zero runtime overhead — no DB queries, no decryption.
  */
 const privateClickHouseUrls = parsePrivateEnvVars(
@@ -45,8 +41,8 @@ const privateClickHouseUrls = parsePrivateEnvVars(
 function parsePrivateEnvVars(
   prefix: string,
   label: string,
-): Map<string, string> {
-  const map = new Map<string, string>();
+): Map<string, PrivateRoute & { url: string }> {
+  const map = new Map<string, PrivateRoute & { url: string }>();
   for (const [key, value] of Object.entries(process.env)) {
     if (!key.startsWith(prefix)) continue;
 
@@ -58,13 +54,9 @@ function parsePrivateEnvVars(
       continue;
     }
 
-    // Format: <PREFIX><label>__<orgId>
-    // Strip prefix, then take the last segment after "__" as orgId
-    const suffix = key.slice(prefix.length);
-    const lastSep = suffix.lastIndexOf("__");
-    const orgId = lastSep >= 0 ? suffix.slice(lastSep + 2) : suffix;
-
-    if (!orgId) continue;
+    const parsed = parseRouteKey({ key, prefix });
+    if (!parsed) continue;
+    const { orgId, cluster } = parsed;
 
     if (map.has(orgId)) {
       throw new Error(
@@ -72,9 +64,9 @@ function parsePrivateEnvVars(
       );
     }
 
-    map.set(orgId, value);
+    map.set(orgId, { cluster, url: value });
     logger.info(
-      { orgId, envVar: key },
+      { orgId, cluster, envVar: key },
       `Loaded private ${label} URL from env var`,
     );
   }
@@ -127,8 +119,8 @@ export async function getClickHouseClientForProject(
 export async function getClickHouseClientForOrganization(
   organizationId: string,
 ): Promise<ClickHouseClient> {
-  const privateUrl = privateClickHouseUrls.get(organizationId);
-  if (!privateUrl) {
+  const route = privateClickHouseUrls.get(organizationId);
+  if (!route) {
     const shared = _getSharedClickHouseClient();
     if (!shared) {
       throw new Error(
@@ -139,7 +131,7 @@ export async function getClickHouseClientForOrganization(
     return shared;
   }
 
-  return getOrCreateCustomClient(organizationId, privateUrl);
+  return getOrCreateCustomClient(organizationId, route);
 }
 
 /**
@@ -163,18 +155,20 @@ export async function getAllClickHouseInstances(): Promise<
   }
 
   const seenUrls = new Set<string>();
-  for (const [orgId, url] of privateClickHouseUrls) {
-    if (seenUrls.has(url)) {
+  for (const [orgId, route] of privateClickHouseUrls) {
+    if (seenUrls.has(route.url)) {
+      // The cluster name, never the URL: a private ClickHouse URL embeds
+      // `user:password@host`, and this line put it in the log sink verbatim.
       logger.info(
-        { orgId, url },
+        { orgId, cluster: route.cluster },
         "Skipping duplicate private ClickHouse URL (already included for another org)",
       );
       continue;
     }
-    seenUrls.add(url);
+    seenUrls.add(route.url);
     instances.push({
       target: orgId,
-      client: getOrCreateCustomClient(orgId, url),
+      client: getOrCreateCustomClient(orgId, route),
     });
   }
 
@@ -200,7 +194,7 @@ export { _getSharedClickHouseClient as getSharedClickHouseClient } from "./clien
  */
 function getOrCreateCustomClient(
   organizationId: string,
-  url: string,
+  route: PrivateRoute & { url: string },
 ): ClickHouseClient {
   const cached = customClientCache.get(organizationId);
   if (cached) {
@@ -213,8 +207,9 @@ function getOrCreateCustomClient(
   // server than the shared one, so it is the last place that should have had
   // the weaker limits.
   const client = createManagedClickHouseClient({
-    url,
+    url: route.url,
     instance: organizationId,
+    cluster: route.cluster,
   });
   customClientCache.set(organizationId, client);
   return client;

--- a/platform/app/src/server/clickhouse/managedClient.ts
+++ b/platform/app/src/server/clickhouse/managedClient.ts
@@ -58,6 +58,7 @@ export const CLICKHOUSE_REQUEST_TIMEOUT_MS = 30_000;
 export function createManagedClickHouseClient({
   url,
   instance,
+  cluster = instance,
 }: {
   /** Connection URL. Passed through as a string if it will not parse. */
   url: string;
@@ -66,6 +67,17 @@ export function createManagedClickHouseClient({
    * private instance. Not the URL - that carries credentials.
    */
   instance: string;
+  /**
+   * Human name of the cluster this client talks to, for the LOGS: "shared", or
+   * the label from `CLICKHOUSE_URL__<label>__<orgId>`.
+   *
+   * Deliberately separate from `instance` rather than replacing it. `instance`
+   * is a metrics label, and repointing it would move every existing series and
+   * break the dashboards built on them; this only has to be readable by a
+   * person looking at one error line. Defaults to `instance` so a caller with
+   * no better name still gets a populated field rather than an absent one.
+   */
+  cluster?: string;
 }): ResilientClickHouseClient {
   let parsedUrl: URL | string = url;
   try {
@@ -106,7 +118,7 @@ export function createManagedClickHouseClient({
 
   return wrapWithDefaultSettings(
     withStatementLimit({
-      client: createResilientClickHouseClient({ client: raw }),
+      client: createResilientClickHouseClient({ client: raw, cluster }),
       // The pool size, so this bounds where the pool used to and capacity is
       // unchanged. The difference is that the queue in front of it is finite,
       // timed and counted.

--- a/platform/app/src/server/clickhouse/privateRouteKey.ts
+++ b/platform/app/src/server/clickhouse/privateRouteKey.ts
@@ -1,0 +1,55 @@
+/**
+ * Reading a private ClickHouse route out of its environment variable name.
+ *
+ * Its own module, and not a helper inside `clickhouseClient.ts`, because that
+ * module imports Prisma: splitting a string should not need a database client
+ * to test, and a test that has to generate the Prisma client first is a test
+ * nobody runs.
+ */
+
+/** Env var format: `CLICKHOUSE_URL__<label>__<orgId>=<connectionUrl>`. */
+export const PRIVATE_CH_ENV_PREFIX = "CLICKHOUSE_URL__";
+
+export interface PrivateRoute {
+  /** The organization whose traffic goes to this cluster. */
+  orgId: string;
+  /**
+   * The name a human calls this cluster, from the `<label>` segment.
+   *
+   * This used to be parsed and thrown away — the format was documented as
+   * "<label> is a human-readable customer name, ignored by code". It is the
+   * only human-readable name the platform has for a customer's dedicated
+   * ClickHouse, and discarding it had a cost: when a private instance rejected
+   * ~5.6k statements in three hours on 2026-08-13, no log line said which
+   * cluster had refused them, and identifying it meant reading a concurrency
+   * limit out of the vendor's error text and matching it against terraform.
+   */
+  cluster: string;
+}
+
+/**
+ * Split the variable name into the org it routes and the cluster's name.
+ * Returns null when there is no org id, which is the only part that must exist.
+ */
+export function parseRouteKey({
+  key,
+  prefix = PRIVATE_CH_ENV_PREFIX,
+}: {
+  key: string;
+  prefix?: string;
+}): PrivateRoute | null {
+  // The org id is the LAST "__"-separated segment, not the first. A label is
+  // free text somebody wrote and may itself contain the separator, while an org
+  // id never does — splitting on the first would route "acme__eu" to org "eu".
+  const suffix = key.slice(prefix.length);
+  const lastSep = suffix.lastIndexOf("__");
+  const orgId = lastSep >= 0 ? suffix.slice(lastSep + 2) : suffix;
+  if (!orgId) return null;
+
+  // Falls back to the org id so the field is never empty: an operator reading
+  // an error needs *a* name, and an unlabelled variable still describes a
+  // different cluster from the shared one. `> 0` rather than `>= 0` so a
+  // leading separator reads as unlabelled instead of as an empty name.
+  const cluster = (lastSep > 0 ? suffix.slice(0, lastSep) : "") || orgId;
+  return { orgId, cluster };
+}

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -242,25 +242,27 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z.array(z.object({ description: z.string() })).default([
-        { description: "The response is incorrect, irrelevant." },
-        {
-          description:
-            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-        },
-      ]),
+      rubrics: z
+        .array(z.object({ description: z.string() }))
+        .default([
+          { description: "The response is incorrect, irrelevant." },
+          {
+            description:
+              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+          },
+        ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -891,13 +893,7 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    | "quality"
-    | "rag"
-    | "safety"
-    | "policy"
-    | "other"
-    | "custom"
-    | "similarity";
+    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/platform/app/src/shared/langy/langySkills.generated.json
+++ b/platform/app/src/shared/langy/langySkills.generated.json
@@ -1,132 +1,132 @@
 [
-	{
-		"id": "agent-best-practices",
-		"label": "Agent best practices",
-		"description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
-		"category": "recipe",
-		"userPrompt": "Where can I improve our agent development best practices?"
-	},
-	{
-		"id": "agent-improve",
-		"label": "Agent improve",
-		"description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
-		"category": "skill",
-		"userPrompt": "What should I do next to improve my agent?"
-	},
-	{
-		"id": "agent-performance",
-		"label": "Agent performance",
-		"description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
-		"category": "skill",
-		"userPrompt": "How is my agent performing?"
-	},
-	{
-		"id": "datasets",
-		"label": "Datasets",
-		"description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
-		"category": "skill"
-	},
-	{
-		"id": "debug-instrumentation",
-		"label": "Debug instrumentation",
-		"description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
-		"category": "recipe"
-	},
-	{
-		"id": "debug-with-langwatch",
-		"label": "Debug with langwatch",
-		"description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production — errors, bad answers, latency spikes.",
-		"category": "recipe"
-	},
-	{
-		"id": "eval-triage",
-		"label": "Eval triage",
-		"description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluate-multimodal",
-		"label": "Evaluate multimodal",
-		"description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
-		"category": "recipe"
-	},
-	{
-		"id": "evaluations",
-		"label": "Evaluations",
-		"description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
-		"category": "skill",
-		"userPrompt": "Help me evaluate my agent"
-	},
-	{
-		"id": "experiments",
-		"label": "Experiments",
-		"description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
-		"category": "skill",
-		"userPrompt": "Set up experiments for my agent"
-	},
-	{
-		"id": "generate-rag-dataset",
-		"label": "Generate RAG dataset",
-		"description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
-		"category": "recipe"
-	},
-	{
-		"id": "github",
-		"label": "GitHub",
-		"description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
-		"category": "skill"
-	},
-	{
-		"id": "level-up",
-		"label": "Level up",
-		"description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
-		"category": "skill",
-		"userPrompt": "Take my agent to the next level"
-	},
-	{
-		"id": "online-evaluations",
-		"label": "Online evaluations",
-		"description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
-		"category": "skill",
-		"userPrompt": "Set up online evaluations for my agent"
-	},
-	{
-		"id": "prompts",
-		"label": "Prompts",
-		"description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
-		"category": "skill",
-		"userPrompt": "Version my prompts with LangWatch"
-	},
-	{
-		"id": "scenarios",
-		"label": "Scenarios",
-		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
-		"category": "skill",
-		"userPrompt": "Add scenario tests for my agent"
-	},
-	{
-		"id": "setup-lw",
-		"label": "Setup lw",
-		"description": "Set up and troubleshoot the LangWatch CLI — login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-cli-usability",
-		"label": "Test CLI usability",
-		"description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
-		"category": "recipe"
-	},
-	{
-		"id": "test-compliance",
-		"label": "Test compliance",
-		"description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
-		"category": "recipe"
-	},
-	{
-		"id": "tracing",
-		"label": "Tracing",
-		"description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
-		"category": "skill",
-		"userPrompt": "Instrument my code with LangWatch"
-	}
+  {
+    "id": "agent-best-practices",
+    "label": "Agent best practices",
+    "description": "Expert AI engineering consultant for your agent development practices. Audits your codebase, traces, evaluations, and scenarios against best practices, then guides you to close the gaps, starting from low-hanging fruit and going deeper. Use when you want to level up your agent's engineering quality.",
+    "category": "recipe",
+    "userPrompt": "Where can I improve our agent development best practices?"
+  },
+  {
+    "id": "agent-improve",
+    "label": "Agent improve",
+    "description": "Turns production evidence into tested improvements for your AI agent. Forms hypotheses from real traces and analytics, explains the reasoning behind each one, then executes with the user: scenario tests that reproduce production failures, prompt and code changes as reviewable PRs, new evaluators and monitors that capture production signals, and experiments that settle open questions. Use when you want to know what to do next to improve your agent.",
+    "category": "skill",
+    "userPrompt": "What should I do next to improve my agent?"
+  },
+  {
+    "id": "agent-performance",
+    "label": "Agent performance",
+    "description": "Deep-dive diagnosis of how your AI agent behaves in production. Explores LangWatch analytics and traces end to end to map failure patterns, dissatisfied users, token cost hotspots, edge cases, behavior changes, and outliers, then delivers an HTML report where every finding links to real example traces. Use when you want to truly understand what your agent is doing in production.",
+    "category": "skill",
+    "userPrompt": "How is my agent performing?"
+  },
+  {
+    "id": "datasets",
+    "label": "Datasets",
+    "description": "Generate realistic synthetic evaluation datasets by analyzing the user's codebase, prompts, production traces, and reference materials. Interactive, consultant-style — asks clarifying questions, proposes a plan, generates a preview for approval, then delivers a complete dataset uploaded to LangWatch. Use when user asks to generate, create, or build a dataset for evaluation, testing, or benchmarking.",
+    "category": "skill"
+  },
+  {
+    "id": "debug-instrumentation",
+    "label": "Debug instrumentation",
+    "description": "Debug and improve your LangWatch traces. Inspects production traces for missing input/output, disconnected spans, unlabeled traces, and missing metadata. Use when traces look broken or incomplete.",
+    "category": "recipe"
+  },
+  {
+    "id": "debug-with-langwatch",
+    "label": "Debug with langwatch",
+    "description": "Root-cause production errors and misbehaving agent runs with LangWatch. Finds errored traces, inspects spans, checks monitor and evaluator scores, then narrows to a root cause. Use when something is failing or misbehaving in production (errors, bad answers, latency spikes).",
+    "category": "recipe"
+  },
+  {
+    "id": "eval-triage",
+    "label": "Eval triage",
+    "description": "Investigate failing experiments and evaluations with LangWatch. Triage a failing experiment run to the exact rows and evaluator scores that regressed, then to a root cause. Use when an experiment fails, scores drop, or evaluations regress.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluate-multimodal",
+    "label": "Evaluate multimodal",
+    "description": "Evaluate multimodal AI agents that process images, audio, PDFs, or other files. Sets up evaluations using LangWatch's LLM-as-judge with image inputs, Scenario's multimodal testing, and document parsing evaluation patterns. Use when your agent handles non-text inputs.",
+    "category": "recipe"
+  },
+  {
+    "id": "evaluations",
+    "label": "Evaluations",
+    "description": "Compatibility router for LangWatch evaluation requests. Use only when the user asks for evaluations without making it clear whether they mean pre-deployment experiments or production online evaluations. Routes the request to the focused companion skill and does not implement either workflow itself.",
+    "category": "skill",
+    "userPrompt": "Help me evaluate my agent"
+  },
+  {
+    "id": "experiments",
+    "label": "Experiments",
+    "description": "Create and run LangWatch experiments for pre-deployment batch testing. Use when the user wants to test an agent against a dataset, compare prompts or models, benchmark quality, detect regressions, or add a CI quality gate. Do not use for production monitoring or guardrails.",
+    "category": "skill",
+    "userPrompt": "Set up experiments for my agent"
+  },
+  {
+    "id": "generate-rag-dataset",
+    "label": "Generate RAG dataset",
+    "description": "Generate a synthetic evaluation dataset from your RAG knowledge base. Creates diverse Q&A pairs with expected answers and relevant context, ready for LangWatch experiments and platform import. Use when you need test data for your RAG pipeline.",
+    "category": "recipe"
+  },
+  {
+    "id": "github",
+    "label": "GitHub",
+    "description": "Open a real pull request — clone a repo, branch, commit, push, and open a PR authored by the LangWatch app on behalf of the requesting user. Use when the user asks to open a PR, fix something in a repo and submit it, send a patch, raise a pull request, or otherwise land a code change on GitHub.",
+    "category": "skill"
+  },
+  {
+    "id": "level-up",
+    "label": "Level up",
+    "description": "Take your AI agent to the next level with full LangWatch integration. Adds tracing, prompt versioning, evaluation experiments, and simulation tests in one go. Use when the user wants comprehensive observability, testing, and prompt management for their agent.",
+    "category": "skill",
+    "userPrompt": "Take my agent to the next level"
+  },
+  {
+    "id": "online-evaluations",
+    "label": "Online evaluations",
+    "description": "Configure LangWatch online evaluations and guardrails for production traffic. Use when the user wants to score live traces or threads, monitor production quality, sample incoming traffic, or synchronously block unsafe requests and responses. Do not use for batch experiments.",
+    "category": "skill",
+    "userPrompt": "Set up online evaluations for my agent"
+  },
+  {
+    "id": "prompts",
+    "label": "Prompts",
+    "description": "Version and manage your agent's prompts with LangWatch Prompts CLI. Use for both onboarding (set up prompt versioning for an entire codebase) and targeted operations (version a specific prompt, create a new prompt version). Supports Python and TypeScript.",
+    "category": "skill",
+    "userPrompt": "Version my prompts with LangWatch"
+  },
+  {
+    "id": "scenarios",
+    "label": "Scenarios",
+    "description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+    "category": "skill",
+    "userPrompt": "Add scenario tests for my agent"
+  },
+  {
+    "id": "setup-lw",
+    "label": "Setup lw",
+    "description": "Set up and troubleshoot the LangWatch CLI, covering login (cloud and self-hosted), endpoint configuration, project selection, and connection problems. Use when the CLI isn't authenticated, can't reach LangWatch, or talks to the wrong project.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-cli-usability",
+    "label": "Test CLI usability",
+    "description": "Write scenario tests that verify your CLI tool is usable by AI agents. Ensures commands work non-interactively, provide clear output, and don't hang on prompts. Use when you want to prove your CLI is agent-friendly.",
+    "category": "recipe"
+  },
+  {
+    "id": "test-compliance",
+    "label": "Test compliance",
+    "description": "Test that your AI agent stays observational and doesn't give prescriptive advice in regulated domains (healthcare, finance, legal). Creates scenario tests for boundary enforcement and red team tests for adversarial probing. Use when your agent advises but must not prescribe.",
+    "category": "recipe"
+  },
+  {
+    "id": "tracing",
+    "label": "Tracing",
+    "description": "Add LangWatch tracing and observability to your code. Use for both onboarding (instrument an entire codebase) and targeted operations (add tracing to a specific function or module). Supports Python and TypeScript with all major frameworks.",
+    "category": "skill",
+    "userPrompt": "Instrument my code with LangWatch"
+  }
 ]


### PR DESCRIPTION
## Problem

A ClickHouse error says what failed and never *which server refused it*.

An organization can be routed to its own private instance, so a rejection from a customer's dedicated cluster and one from the shared cluster produce the same log line. During the 2026-08-13 saturation that ambiguity is the whole reason attribution took an afternoon: ~5.6k `TOO_MANY_SIMULTANEOUS_QUERIES` in three hours had to be pinned to a cluster by reading the limit out of the **vendor's error text** — `Maximum: 25` — and matching it against terraform, because 25 is the `private-instance` module default while the shared cluster runs 300.

That is not a diagnosis, it is a coincidence that the two numbers happened to differ.

## Fix

The name already existed and was being thrown away. `CLICKHOUSE_URL__<label>__<orgId>` carries a human label, documented in the code as *"a human-readable customer name (e.g. `acme`), **ignored by code**"*. Keep it, and stamp it on every failure line as `cluster`.

```
ClickHouse query failed   cluster=acme  operation=query  queryId=…
ClickHouse query failed   cluster=shared operation=insert queryId=…
```

**Kept separate from the existing `instance` field rather than replacing it.** `instance` is a *metrics* label; repointing it would move every existing series and break the dashboards built on them. `cluster` only has to be readable by a person looking at one error, so it is additive and defaults to `instance` when a caller has no better name — no field ever becomes absent.

## Parsing moved to its own module

It is a string split, and it lived in a file that imports Prisma. Testing it meant generating a Prisma client first, which is why its edge cases had no tests at all. Now pinned by `parseRouteKey.unit.test.ts`:

- a label containing the separator still routes on the **trailing** org id — splitting on the first `__` would send `acme__eu` to org `eu`, i.e. route a customer's traffic to a cluster that does not exist
- an unlabelled variable falls back to the org id, so the field is never empty
- a bare prefix or an empty org segment returns null rather than registering an unroutable entry

## Incidental: stops logging a ClickHouse URL verbatim

`getAllClickHouseInstances` logged `{ orgId, url }` on the duplicate-URL branch. A private ClickHouse URL embeds `user:password@host`, so that line put a database password into the log sink — and therefore into Loki. It now logs the cluster name.

Narrow (one branch, fires only on duplicate config) but it is a credential in a log, so it is fixed here rather than filed.

## Verification

- `parseRouteKey.unit.test.ts` — 6 cases, all passing
- 257 tests across the 23 affected suites pass (`src/server/clickhouse`, `src/server/app-layer/clients/clickhouse`)
- `biome check` clean on every touched file; the one complexity warning on `parsePrivateEnvVars` is pre-existing on `main` and unchanged by this PR — verified by running biome against the stashed tree

## Not covered by a test

The log *emission* itself. The logger here is a module-level singleton, so asserting on it would mean mocking `@langwatch/observability`, and this codebase has no precedent for that — no test in the app mocks the logger. The pure parsing is tested; the field's presence on the record is not. This is one of the concrete reasons to make these collaborators injectable, which is the subject of the follow-up refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse failure logging with cluster-specific context.
  * Prevented private ClickHouse URLs from appearing in duplicate-instance logs.
  * Improved handling of private ClickHouse route labels, including labels containing separators and missing labels.

* **Tests**
  * Added coverage for private route parsing across common and edge-case formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->