### PR TITLE
feat(haven): process watch — tsgo can never take the machine down (ADR-095)

### DIFF
--- a/dev/docs/adr/095-haven-tsgo-governor.md
+++ b/dev/docs/adr/095-haven-tsgo-governor.md
@@ -1,0 +1,130 @@
+# ADR-095: haven governs tsgo — soft memory caps at spawn, a hard watchdog in the daemon
+
+## Status
+
+Accepted
+
+## Context
+
+tsgo (the native TypeScript compiler preview) is the single largest transient
+memory consumer on a LangWatch dev machine. Observed on an 18 GiB laptop during
+ordinary multi-agent work:
+
+- a whole-tree `typecheck:tests` run peaking at **10.0 GiB RSS**;
+- a second whole-tree run at 2.5–7.4 GiB running **concurrently** — allowed,
+  because the check-queue's slot policy (ADR-090 era, `dev/scripts/check-queue.mjs`)
+  bounds *concurrency* (2 slots on this machine), not *memory*, and its sizing
+  formula assumes ~3–4 GiB per run;
+- long-lived `tsgo --lsp` instances of ~2.5 GiB each, one per worktree the
+  tslsp daemon has ever served, parented to PID 1 and **exempt from every
+  existing control by design**.
+
+Three admission mechanisms already exist and none can make the guarantee "tsgo
+never takes the machine down":
+
+1. `haven gate` (ADR-091) sees only tool calls from hooked agent sessions.
+2. `check-queue.mjs` sees only spawns through the pnpm scripts and the shims
+   installed into `platform/app/node_modules/.bin` — `sdks/typescript`'s tsgo
+   binary is raw, and `--lsp`/`--watch` are exempt on purpose.
+3. The two count against **separate ledgers** (haven's registry vs the queue's
+   tmp directory), so each admits its own runs blind to the other's.
+
+Gating spawn paths is whack-a-mole: every new package, editor, or daemon that
+spawns tsgo reopens the hole.
+
+One more fact shapes the design: **tsgo is a Go binary**, so `GOMEMLIMIT`
+gives a soft ceiling — the runtime collects harder to stay under the limit
+instead of ballooning, degrading to "slower" rather than "10 GiB resident".
+A soft cap cannot be the whole answer (a live heap genuinely above the limit
+still grows, now with heavy GC), but it makes the common case self-limiting
+with no process ever killed.
+
+## Decision
+
+Two layers, one guarantee. The watchdog is the guarantee; the soft cap is what
+makes the watchdog almost never fire.
+
+### 1. `GOMEMLIMIT` at spawn (soft cap)
+
+Every spawn path we own sets `GOMEMLIMIT` on tsgo unless the operator already
+did: the check-queue shim path sizes it from machine RAM (half of total,
+clamped to [4 GiB, 10 GiB]). Runs degrade to more GC instead of more resident
+memory. Explicit `GOMEMLIMIT` in the environment always wins.
+
+### 2. tsgo watchdog on the daemon tick (hard backstop)
+
+The haven daemon's existing 10-second monitor tick samples every tsgo process
+on the machine — however it was spawned — and applies policy:
+
+- **Per-run hard ceiling** (`HAVEN_TSGO_RUN_MAX_RSS_MB`, default 12 GiB): a
+  whole-tree run above it is runaway and is killed.
+- **LSP ceiling** (`HAVEN_TSGO_LSP_MAX_RSS_MB`, default 4 GiB): an `--lsp`
+  instance above it is killed — LSPs respawn lazily on next use, so eviction
+  costs a reconnect, not work.
+- **LSP idle eviction** (`HAVEN_TSGO_LSP_IDLE_TTL`, default 45m): an LSP whose
+  CPU clock has not moved for the TTL is evicted. This is what stops the
+  one-2.5-GiB-LSP-per-worktree accumulation.
+- **Aggregate budget** (`HAVEN_TSGO_TOTAL_BUDGET_MB`, default two thirds of
+  RAM): when all tsgo together exceed it, the watchdog reclaims in order —
+  idle LSPs first, then the **youngest** whole-tree run (the oldest is closest
+  to finishing) — until under budget.
+- Setting a knob to 0 disables that rule; `HAVEN_TSGO_RUN_MAX_RSS_MB=0`
+  disables the watchdog entirely.
+
+Classification is deliberately crude: `--lsp` in the argv is an LSP, anything
+else is a run. Single-file checks are tiny and never cross any threshold, so
+distinguishing them buys nothing.
+
+### 3. A generic process watch feeding the local Grafana
+
+The sampler is not tsgo-specific. Every tick classifies the machine's
+dev-tooling processes — tsgo (run/lsp), gopls, biome, vitest workers, node,
+bun, and claude agents — and ships per-class footprints to the local
+observability stack over OTLP (`adapters/procmetrics`): resident set, process
+count, and oldest-process age by class and role, plus a counter of governor
+kills by reason. Exports are fire-and-forget: with the stack down they are
+dropped silently, never buffered and never logged into a spam stream.
+
+Only tsgo carries kill limits. node and claude are the user's own work and are
+observe-only by principle; gopls, biome and vitest are observe-only until the
+recorded history shows a class actually misbehaving — which is exactly the
+decision this data exists to inform ("did the Prisma 7 upgrade shrink
+typecheck?", "how many vitest workers really run at once?").
+
+### Killing is in scope here, unlike ADR-090
+
+ADR-090's governor demotes and never kills, because stacks are user work and
+killing one loses it. A tsgo process is **regenerable tooling** — killing a
+typecheck loses a check, killing an LSP loses a reconnect — the same class as
+the vitest orphans the daemon already sweeps. The watchdog kills only processes
+whose command line resolves to a tsgo binary; it can never touch a stack, an
+agent, or anything else.
+
+### Observability
+
+Every kill is logged with the reason, class, RSS and age. The watchdog also
+logs each run's peak RSS at exit (observed passively from the samples), so
+"did the Prisma 7 upgrade make types cheaper" becomes a number rather than a
+hunch.
+
+## Consequences
+
+- No spawn path can take the machine down: unshimmed binaries, editors and
+  daemons are all inside the watchdog's reach, because it watches processes,
+  not spawns.
+- A run killed by the aggregate budget fails visibly (the queue reports the
+  killed child); the daemon log carries the reason. This is judged better than
+  the alternative — the machine paging until the OS or the operator kills
+  something less regenerable.
+- A genuinely-larger future typecheck (live heap above the soft cap) gets
+  slower before it gets killed; raising the knobs is a one-line env change.
+- The queue's JS implementation and its split ledger remain (tracked
+  separately): this ADR makes the machine safe regardless of which admission
+  path a run took, which is what removes the urgency from consolidating them.
+
+## Related
+
+- ADR-090 — machine-wide resource governance (pressure, demotion, no kills for stacks)
+- ADR-091 — haven gate (agent-session admission)
+- `specs/setup/haven-tsgo-governor.feature` — the behavioural contract
+- `specs/setup/check-slots.feature` — the whole-tree check queue this backstops

--- a/dev/scripts/__tests__/check-queue-memlimit.unit.bats
+++ b/dev/scripts/__tests__/check-queue-memlimit.unit.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Unit tests for the soft Go-runtime memory cap check-queue sets on the runs it
+# spawns (specs/setup/haven-tsgo-governor.feature, ADR-095). The child echoes
+# its own environment, so the tests observe what a wrapped tsgo would actually
+# receive. CHECK_SLOTS is set high so the queue admits instantly and the tests
+# never wait on real slot contention.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+# @scenario "Queued whole-tree runs get a soft memory cap at spawn"
+@test "a spawned run receives a machine-sized GOMEMLIMIT" {
+  run env CHECK_SLOTS=99 GOMEMLIMIT= node "$SCRIPT_DIR/check-queue.mjs" \
+    node -e 'process.stdout.write(process.env.GOMEMLIMIT || "unset")'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+GiB$ ]]
+}
+
+@test "an operator's explicit GOMEMLIMIT is never overridden" {
+  run env CHECK_SLOTS=99 GOMEMLIMIT=123MiB node "$SCRIPT_DIR/check-queue.mjs" \
+    node -e 'process.stdout.write(process.env.GOMEMLIMIT || "unset")'
+  [ "$status" -eq 0 ]
+  [ "$output" = "123MiB" ]
+}

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -344,6 +344,20 @@ async function waitForTurn({
   }
 }
 
+/**
+ * Soft memory cap for the Go-runtime tools this queue wraps (tsgo is a Go
+ * binary): GOMEMLIMIT makes the runtime collect harder to stay under the
+ * limit instead of ballooning — a whole-tree typecheck degrades to "slower",
+ * not "10 GiB resident" (ADR-095). Half the machine, clamped to [4,10] GiB;
+ * an operator's explicit GOMEMLIMIT always wins. The haven daemon's process
+ * watch is the hard backstop above this.
+ */
+function goMemLimit() {
+  if (process.env.GOMEMLIMIT) return process.env.GOMEMLIMIT;
+  const gib = Math.max(4, Math.min(10, Math.floor(os.totalmem() / 2 ** 31)));
+  return `${gib}GiB`;
+}
+
 /** Runs the command with stdio inherited, forwarding signals, resolving its exit code. */
 function runCommand(commandArgv) {
   return new Promise((resolve) => {
@@ -353,7 +367,7 @@ function runCommand(commandArgv) {
       // the only slot queues behind itself the moment it reaches a bin shim
       // (`pnpm typecheck` spawns .bin/tsgo, which is one) or a nested package
       // script, and waits out the whole maximum wait before starting.
-      env: { ...process.env, CHECK_SLOTS: "0" },
+      env: { ...process.env, CHECK_SLOTS: "0", GOMEMLIMIT: goMemLimit() },
     });
     // Handling these keeps the wrapper alive through a Ctrl-C so it releases its
     // slot after the child is done, instead of dying first and leaving an entry

--- a/specs/setup/haven-tsgo-governor.feature
+++ b/specs/setup/haven-tsgo-governor.feature
@@ -1,0 +1,89 @@
+Feature: tsgo can never take the machine down
+  A whole-tree tsgo run peaks around ten gigabytes, the check queue bounds how
+  many run at once but not how big each gets, and language-server instances
+  accumulate one per worktree, exempt from every admission control by design.
+  Gating spawn paths is whack-a-mole — every new package, editor or daemon
+  that spawns tsgo reopens the hole. So the guarantee moves to where every
+  process is visible: the haven daemon watches tsgo itself, caps it softly at
+  spawn where haven owns the spawn, and reclaims it forcibly when the machine
+  is at stake. See dev/docs/adr/095-haven-tsgo-governor.md.
+
+  # Behavior lives in tools/thuishaven: `domain/tsgowatch.go` decides what to
+  # reclaim, `app/daemon.go` samples and enforces on the monitor tick, and
+  # `dev/scripts/check-queue.mjs` sets the soft memory cap on the runs it
+  # spawns. Knobs: HAVEN_TSGO_RUN_MAX_RSS_MB, HAVEN_TSGO_LSP_MAX_RSS_MB,
+  # HAVEN_TSGO_LSP_IDLE_TTL, HAVEN_TSGO_TOTAL_BUDGET_MB (0 disables each).
+
+  @unit
+  Scenario: A runaway whole-tree run is stopped at the hard ceiling
+    Given a whole-tree tsgo run whose memory exceeds the per-run ceiling
+    When the daemon takes its next sample
+    Then that run is stopped
+    And the reason, size and age are logged
+
+  @unit
+  Scenario: A run under every ceiling is left alone
+    Given a whole-tree tsgo run within the per-run ceiling
+    And the combined tsgo footprint is within the machine budget
+    When the daemon takes its next sample
+    Then nothing is stopped
+
+  @unit
+  Scenario: Over the machine budget, idle language servers go first
+    Given the combined tsgo footprint exceeds the machine budget
+    And an idle language server and two whole-tree runs are live
+    When the daemon takes its next sample
+    Then the idle language server is reclaimed before any run
+
+  @unit
+  Scenario: Over the machine budget, the youngest run goes before the oldest
+    Given the combined tsgo footprint exceeds the machine budget
+    And no idle language server is left to reclaim
+    When the daemon takes its next sample
+    Then the youngest whole-tree run is stopped first
+    And the oldest keeps running
+
+  @unit
+  Scenario: An idle language server is evicted after the idle period
+    Given a language server whose CPU clock has not moved for the idle period
+    When the daemon takes its next sample
+    Then it is evicted
+    And a language server actively serving requests is never idle-evicted
+
+  @unit
+  Scenario: An oversized language server is evicted regardless of activity
+    Given a language server above the language-server ceiling
+    When the daemon takes its next sample
+    Then it is evicted
+
+  @unit
+  Scenario: The governor only ever touches tsgo
+    Given processes of every other kind on the machine
+    When the daemon takes its next sample
+    Then none of them is ever a candidate
+
+  @unit
+  Scenario: Coding agents, dev servers and test workers are observed, never touched
+    Given enormous node, coding-agent and test-worker processes
+    When the daemon takes its next sample
+    Then their footprint is recorded
+    But none of them is ever a removal candidate
+
+  @unit
+  Scenario: Every watched tool's footprint becomes queryable history
+    Given watched processes of several classes are live
+    When the daemon takes its next sample
+    Then each class's footprint is shipped to the local observability stack
+    And every governor enforcement is counted there with its reason
+
+  @unit
+  Scenario: The operator can disable the governor
+    Given the per-run ceiling is disabled via the environment
+    When the daemon takes its next sample
+    Then no tsgo process is considered at all
+
+  @unit
+  Scenario: Queued whole-tree runs get a soft memory cap at spawn
+    Given the check queue spawns a whole-tree tsgo run
+    Then the Go runtime memory limit is set from the machine's memory
+    But an operator's explicit limit is never overridden

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -243,6 +243,18 @@ registry, and dashboard stay the same.
   server once no stack is running (opt-in: native-mode tests and
   `haven db url clickhouse` reach it with no stack up) — the next `up`
   restarts it over the same data in seconds.
+- **tsgo can never take the machine down.** The daemon watches every tsgo
+  process on the machine — however it was spawned — and reclaims runaways: a
+  whole-tree run past `HAVEN_TSGO_RUN_MAX_RSS_MB` (default 12 GiB), a language
+  server past `HAVEN_TSGO_LSP_MAX_RSS_MB` (default 4 GiB) or idle past
+  `HAVEN_TSGO_LSP_IDLE_TTL` (default 45m), and — over
+  `HAVEN_TSGO_TOTAL_BUDGET_MB` (default two thirds of RAM) — the youngest run
+  until the rest fits. The check queue also sets `GOMEMLIMIT` on the runs it
+  spawns so the common case degrades to "slower", not "10 GiB resident". The
+  same watch observes gopls, biome, vitest workers, node, bun and claude
+  agents (never touched — observed only) and ships every class's footprint to
+  the local Grafana as `haven_proc_*` metrics. See
+  `dev/docs/adr/095-haven-tsgo-governor.md`.
 - **Leaked test containers are reaped.** An interrupted integration-test run
   leaves its testcontainers (a stray ClickHouse, a Redis) running in the shared
   VM forever — the library's own reaper (Ryuk) dies with the run, and reused

--- a/tools/thuishaven/adapters/procmetrics/procmetrics.go
+++ b/tools/thuishaven/adapters/procmetrics/procmetrics.go
@@ -1,0 +1,130 @@
+// Package procmetrics ships the daemon's process-watch observations (ADR-095)
+// to the local observability stack over OTLP, so per-class footprints and
+// governor kills become queryable history in Grafana. Fire-and-forget by
+// contract: when the stack is down, exports are dropped silently.
+package procmetrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
+)
+
+// Recorder implements the app's ProcTelemetry port.
+type Recorder struct {
+	rss    metric.Int64Gauge
+	count  metric.Int64Gauge
+	oldest metric.Int64Gauge
+	kills  metric.Int64Counter
+	// lastSeen tracks which class/role attribute pairs were published on the
+	// previous sample, so a class that vanishes is zeroed rather than frozen
+	// at its final value on the dashboard.
+	lastSeen map[[2]string]bool
+}
+
+// New builds a Recorder exporting to the local OTLP HTTP endpoint. Exports
+// that cannot be delivered are dropped without logging — the daemon must never
+// grow a spam stream because Grafana is down.
+func New(otlpHTTPPort int) *Recorder {
+	exporter, err := otlpmetrichttp.New(context.Background(),
+		otlpmetrichttp.WithEndpoint(fmt.Sprintf("127.0.0.1:%d", otlpHTTPPort)),
+		otlpmetrichttp.WithInsecure(),
+	)
+	if err != nil {
+		return nil
+	}
+	// The global handler would print every failed export to stderr; the
+	// port's contract is silence.
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(error) {}))
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(resource.NewWithAttributes(semconv.SchemaURL,
+			semconv.ServiceName("haven"),
+		)),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter,
+			sdkmetric.WithInterval(30*time.Second),
+		)),
+	)
+	meter := provider.Meter("haven/procwatch")
+	rss, err1 := meter.Int64Gauge("haven_proc_rss_bytes",
+		metric.WithDescription("resident set of all watched processes, by class and role"))
+	count, err2 := meter.Int64Gauge("haven_proc_count",
+		metric.WithDescription("watched process count, by class and role"))
+	oldest, err3 := meter.Int64Gauge("haven_proc_oldest_age_seconds",
+		metric.WithDescription("age of the oldest watched process, by class and role"))
+	kills, err4 := meter.Int64Counter("haven_proc_governor_kills_total",
+		metric.WithDescription("processes the governor reclaimed, by class and reason"))
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return nil
+	}
+	return &Recorder{rss: rss, count: count, oldest: oldest, kills: kills, lastSeen: map[[2]string]bool{}}
+}
+
+// RecordSample publishes the current footprint of every watched class.
+func (r *Recorder) RecordSample(procs []domain.WatchedProcess) {
+	if r == nil {
+		return
+	}
+	ctx := context.Background()
+	type agg struct {
+		rss    int64
+		count  int64
+		oldest time.Time
+	}
+	byKey := map[[2]string]agg{}
+	now := time.Now()
+	for _, p := range procs {
+		key := [2]string{p.Class, string(p.Role)}
+		a := byKey[key]
+		a.rss += p.RSS
+		a.count++
+		if a.oldest.IsZero() || p.Started.Before(a.oldest) {
+			a.oldest = p.Started
+		}
+		byKey[key] = a
+	}
+	seen := map[[2]string]bool{}
+	for key, a := range byKey {
+		attrs := metric.WithAttributes(
+			attribute.String("class", key[0]),
+			attribute.String("role", key[1]),
+		)
+		r.rss.Record(ctx, a.rss, attrs)
+		r.count.Record(ctx, a.count, attrs)
+		r.oldest.Record(ctx, int64(now.Sub(a.oldest).Seconds()), attrs)
+		seen[key] = true
+	}
+	for key := range r.lastSeen {
+		if seen[key] {
+			continue
+		}
+		attrs := metric.WithAttributes(
+			attribute.String("class", key[0]),
+			attribute.String("role", key[1]),
+		)
+		r.rss.Record(ctx, 0, attrs)
+		r.count.Record(ctx, 0, attrs)
+		r.oldest.Record(ctx, 0, attrs)
+	}
+	r.lastSeen = seen
+}
+
+// RecordKill counts one governor enforcement.
+func (r *Recorder) RecordKill(class, reason string) {
+	if r == nil {
+		return
+	}
+	r.kills.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("class", class),
+		attribute.String("reason", reason),
+	))
+}

--- a/tools/thuishaven/adapters/system/system.go
+++ b/tools/thuishaven/adapters/system/system.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/netports"
+	"github.com/langwatch/langwatch/tools/thuishaven/app"
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
 
@@ -329,6 +330,47 @@ func parseProcessGroups(listing string) map[int][]int {
 // psCommandColumns is how many leading numeric columns the orphan listing asks
 // for before the command itself (ppid, pid).
 const psCommandColumns = 2
+
+// ProcessSamples lists every live process with the facts the tsgo governor
+// needs (ADR-095). A row whose numbers do not parse is dropped: the governor
+// makes kill decisions from these samples, so it never guesses.
+func (System) ProcessSamples() []app.ProcessSample {
+	out, err := probe("ps", "-ax", "-o", "pid=,rss=,cputime=,etime=,command=")
+	if err != nil {
+		return nil
+	}
+	var samples []app.ProcessSample
+	for line := range strings.SplitSeq(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		rssKB, rssErr := strconv.ParseInt(fields[1], 10, 64)
+		cpu, cpuOK := domain.ParsePSDuration(fields[2])
+		elapsed, elapsedOK := domain.ParsePSDuration(fields[3])
+		if pidErr != nil || rssErr != nil || !cpuOK || !elapsedOK {
+			continue
+		}
+		samples = append(samples, app.ProcessSample{
+			PID:      pid,
+			RSSBytes: rssKB << 10,
+			CPUTime:  cpu,
+			Elapsed:  elapsed,
+			Command:  strings.Join(fields[4:], " "),
+		})
+	}
+	return samples
+}
+
+// Kill SIGKILLs one process — never its group (see the port's contract: the
+// governor's targets live in process groups whose other members must survive).
+func (System) Kill(pid int) {
+	if pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}
 
 // OrphanedWorkers lists test-worker processes whose parent is PID 1 — on macOS
 // that is launchd, and it means an interrupted run left them behind.

--- a/tools/thuishaven/app/config.go
+++ b/tools/thuishaven/app/config.go
@@ -25,7 +25,11 @@ type Config struct {
 	// RunningTestContainerTTL is the same rule for containers still running,
 	// whose age says nothing about current use (reused containers keep their
 	// original creation time across runs). Clamped to at least TestContainerTTL.
-	RunningTestContainerTTL  time.Duration
+	RunningTestContainerTTL time.Duration
+	// Tsgo bounds what tsgo may take from the machine (ADR-095); the daemon's
+	// tick enforces it over every live tsgo process regardless of who spawned
+	// it. Tsgo.RunMaxRSS == 0 disables the governor.
+	Tsgo                     domain.TsgoLimits
 	HeartbeatEvery           time.Duration // launcher heartbeat cadence
 	DaemonArgv               []string      // how to (re)launch `haven daemon`
 	IsAgent                  bool          // token-free plain output for AI drivers (no color/TUI)

--- a/tools/thuishaven/app/daemon.go
+++ b/tools/thuishaven/app/daemon.go
@@ -160,6 +160,7 @@ func (o *Orchestrator) monitorLoop(ctx context.Context) {
 				o.log.Info("reaped stack", zap.String("slug", s.Slug), zap.Bool("dead", dead), zap.Bool("stale", stale))
 			}
 			o.governPressure()
+			o.governProcesses()
 			o.refreshObservability(ctx)
 			o.reapClickHouse()
 		}

--- a/tools/thuishaven/app/daemon_procwatch_test.go
+++ b/tools/thuishaven/app/daemon_procwatch_test.go
@@ -1,0 +1,124 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
+)
+
+type fakeProcTel struct {
+	samples [][]domain.WatchedProcess
+	kills   []string
+}
+
+func (f *fakeProcTel) RecordSample(procs []domain.WatchedProcess) {
+	f.samples = append(f.samples, procs)
+}
+func (f *fakeProcTel) RecordKill(class, reason string) { f.kills = append(f.kills, class) }
+
+func watchOrch(sys *fakeSystem, tel ProcTelemetry) *Orchestrator {
+	return &Orchestrator{
+		cfg:     Config{Tsgo: domain.DefaultTsgoLimits(18 << 30)},
+		sys:     sys,
+		procTel: tel,
+		log:     zap.NewNop(),
+	}
+}
+
+// @scenario "A runaway whole-tree run is stopped at the hard ceiling"
+func TestProcessWatchKillsARunawayTsgo(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+	t.Run("given a tsgo run above the ceiling among ordinary processes", func(t *testing.T) {
+		sys := &fakeSystem{now: now, procSamples: []ProcessSample{
+			{PID: 10, RSSBytes: 13 << 30, CPUTime: time.Minute, Elapsed: 5 * time.Minute,
+				Command: "/x/lib/tsgo --noEmit -p tsconfig.tsgo.tests.json"},
+			{PID: 11, RSSBytes: 20 << 30, CPUTime: time.Hour, Elapsed: time.Hour,
+				Command: "/opt/homebrew/bin/node server.cjs"},
+		}}
+		tel := &fakeProcTel{}
+		o := watchOrch(sys, tel)
+
+		t.Run("when the daemon takes its sample", func(t *testing.T) {
+			o.governProcesses()
+
+			t.Run("the runaway tsgo is killed and nothing else", func(t *testing.T) {
+				if len(sys.killed) != 1 || sys.killed[0] != 10 {
+					t.Fatalf("killed = %v, want exactly the tsgo run", sys.killed)
+				}
+			})
+
+			// @scenario "Every watched tool's footprint becomes queryable history"
+			t.Run("both watched classes are recorded for the dashboards", func(t *testing.T) {
+				if len(tel.samples) != 1 || len(tel.samples[0]) != 2 {
+					t.Fatalf("expected one sample of two watched processes, got %+v", tel.samples)
+				}
+				if len(tel.kills) != 1 || tel.kills[0] != "tsgo" {
+					t.Fatalf("expected the kill counted for tsgo, got %v", tel.kills)
+				}
+			})
+		})
+	})
+}
+
+// @scenario "Coding agents, dev servers and test workers are observed, never touched"
+func TestProcessWatchNeverKillsObserveOnlyClasses(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+	t.Run("given enormous node, claude and vitest processes", func(t *testing.T) {
+		sys := &fakeSystem{now: now, procSamples: []ProcessSample{
+			{PID: 1, RSSBytes: 30 << 30, CPUTime: time.Hour, Elapsed: time.Hour, Command: "node dist/server.cjs"},
+			{PID: 2, RSSBytes: 30 << 30, CPUTime: time.Hour, Elapsed: time.Hour, Command: "claude bg-spare --bg-spare /x.sock"},
+			{PID: 3, RSSBytes: 30 << 30, CPUTime: time.Hour, Elapsed: time.Hour, Command: "node /x/vitest/dist/workers.js"},
+		}}
+		o := watchOrch(sys, &fakeProcTel{})
+
+		t.Run("when the daemon takes its sample", func(t *testing.T) {
+			o.governProcesses()
+
+			if len(sys.killed) != 0 {
+				t.Fatalf("observe-only classes must never be killed, got %v", sys.killed)
+			}
+		})
+	})
+}
+
+func TestProcessWatchTracksIdleAcrossTicks(t *testing.T) {
+	start := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+	t.Run("given an LSP whose CPU clock stops moving", func(t *testing.T) {
+		sys := &fakeSystem{now: start, procSamples: []ProcessSample{
+			{PID: 5, RSSBytes: 2 << 30, CPUTime: time.Minute, Elapsed: time.Hour, Command: "/x/lib/tsgo --lsp --stdio"},
+		}}
+		o := watchOrch(sys, &fakeProcTel{})
+
+		o.governProcesses() // tick 1: first sight, active
+		sys.now = start.Add(50 * time.Minute)
+		o.governProcesses() // tick 2: same CPU clock — idle for 50m > 45m TTL
+
+		t.Run("it is evicted once idle past the TTL", func(t *testing.T) {
+			if len(sys.killed) != 1 || sys.killed[0] != 5 {
+				t.Fatalf("killed = %v, want the idle LSP", sys.killed)
+			}
+		})
+	})
+
+	t.Run("given an LSP that keeps working", func(t *testing.T) {
+		sys := &fakeSystem{now: start, procSamples: []ProcessSample{
+			{PID: 6, RSSBytes: 2 << 30, CPUTime: time.Minute, Elapsed: time.Hour, Command: "/x/lib/tsgo --lsp --stdio"},
+		}}
+		o := watchOrch(sys, &fakeProcTel{})
+
+		o.governProcesses()
+		sys.now = start.Add(50 * time.Minute)
+		sys.procSamples[0].CPUTime = 2 * time.Minute // the clock moved
+		o.governProcesses()
+
+		if len(sys.killed) != 0 {
+			t.Fatalf("an active LSP must never be idle-evicted, got %v", sys.killed)
+		}
+	})
+}

--- a/tools/thuishaven/app/daemon_tsgo.go
+++ b/tools/thuishaven/app/daemon_tsgo.go
@@ -32,9 +32,27 @@ func (o *Orchestrator) governProcesses() {
 	if o.procActivity == nil {
 		o.procActivity = map[int]tsgoSeen{}
 	}
-	now := o.sys.Now()
-	var watched []domain.WatchedProcess
-	var tsgo []domain.TsgoProcess
+	watched, tsgo := o.sampleWatched(o.sys.Now())
+	if o.procTel != nil {
+		o.procTel.RecordSample(watched)
+	}
+	for _, k := range domain.GovernTsgo(tsgo, o.cfg.Tsgo) {
+		o.sys.Kill(k.PID)
+		if o.procTel != nil {
+			o.procTel.RecordKill("tsgo", k.Reason)
+		}
+		o.log.Warn("process governor reclaimed tsgo",
+			zap.Int("pid", k.PID),
+			zap.String("role", string(k.Class)),
+			zap.String("rss", domain.HumanBytes(k.RSS)),
+			zap.String("reason", k.Reason))
+	}
+}
+
+// sampleWatched classifies the live process listing and maintains the
+// cross-tick idle memory. Returns every watched process plus the tsgo subset
+// the governor rules on.
+func (o *Orchestrator) sampleWatched(now time.Time) (watched []domain.WatchedProcess, tsgo []domain.TsgoProcess) {
 	live := map[int]bool{}
 	for _, s := range o.sys.ProcessSamples() {
 		w, ok := domain.ClassifyWatchedProcess(s.Command)
@@ -56,23 +74,15 @@ func (o *Orchestrator) governProcesses() {
 			})
 		}
 	}
+	o.pruneDeadActivity(live)
+	return watched, tsgo
+}
+
+// pruneDeadActivity forgets idle-tracking state for processes no longer alive.
+func (o *Orchestrator) pruneDeadActivity(live map[int]bool) {
 	for pid := range o.procActivity {
 		if !live[pid] {
 			delete(o.procActivity, pid)
 		}
-	}
-	if o.procTel != nil {
-		o.procTel.RecordSample(watched)
-	}
-	for _, k := range domain.GovernTsgo(tsgo, o.cfg.Tsgo) {
-		o.sys.Kill(k.PID)
-		if o.procTel != nil {
-			o.procTel.RecordKill("tsgo", k.Reason)
-		}
-		o.log.Warn("process governor reclaimed tsgo",
-			zap.Int("pid", k.PID),
-			zap.String("role", string(k.Class)),
-			zap.String("rss", domain.HumanBytes(k.RSS)),
-			zap.String("reason", k.Reason))
 	}
 }

--- a/tools/thuishaven/app/daemon_tsgo.go
+++ b/tools/thuishaven/app/daemon_tsgo.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
+)
+
+// The process watch (ADR-095): every daemon tick samples the machine's
+// dev-tooling processes — tsgo, gopls, biome, vitest workers, node, bun,
+// claude — however they were spawned, ships the footprint to the local
+// observability stack, and enforces limits on the one class that has them
+// (tsgo). Admission controls bound how much tooling *starts*; this bounds how
+// much *exists*, and records enough history to decide which class earns
+// limits next.
+
+// tsgoSeen is the cross-tick memory behind idle detection: a process whose CPU
+// clock moved since the last tick was active then.
+type tsgoSeen struct {
+	cpu      time.Duration
+	activeAt time.Time
+}
+
+// governProcesses runs on every daemon tick. Sampling is one ps invocation;
+// with nothing watched alive it records an empty sample and does no more.
+func (o *Orchestrator) governProcesses() {
+	if o.cfg.Tsgo.RunMaxRSS <= 0 {
+		return
+	}
+	if o.procActivity == nil {
+		o.procActivity = map[int]tsgoSeen{}
+	}
+	now := o.sys.Now()
+	var watched []domain.WatchedProcess
+	var tsgo []domain.TsgoProcess
+	live := map[int]bool{}
+	for _, s := range o.sys.ProcessSamples() {
+		w, ok := domain.ClassifyWatchedProcess(s.Command)
+		if !ok {
+			continue
+		}
+		live[s.PID] = true
+		seen, known := o.procActivity[s.PID]
+		if !known || s.CPUTime > seen.cpu {
+			seen = tsgoSeen{cpu: s.CPUTime, activeAt: now}
+			o.procActivity[s.PID] = seen
+		}
+		w.PID, w.RSS = s.PID, s.RSSBytes
+		w.Started, w.IdleFor = now.Add(-s.Elapsed), now.Sub(seen.activeAt)
+		watched = append(watched, w)
+		if w.Class == "tsgo" {
+			tsgo = append(tsgo, domain.TsgoProcess{
+				PID: w.PID, Class: w.Role, RSS: w.RSS, Started: w.Started, IdleFor: w.IdleFor,
+			})
+		}
+	}
+	for pid := range o.procActivity {
+		if !live[pid] {
+			delete(o.procActivity, pid)
+		}
+	}
+	if o.procTel != nil {
+		o.procTel.RecordSample(watched)
+	}
+	for _, k := range domain.GovernTsgo(tsgo, o.cfg.Tsgo) {
+		o.sys.Kill(k.PID)
+		if o.procTel != nil {
+			o.procTel.RecordKill("tsgo", k.Reason)
+		}
+		o.log.Warn("process governor reclaimed tsgo",
+			zap.Int("pid", k.PID),
+			zap.String("role", string(k.Class)),
+			zap.String("rss", domain.HumanBytes(k.RSS)),
+			zap.String("reason", k.Reason))
+	}
+}

--- a/tools/thuishaven/app/hub_test.go
+++ b/tools/thuishaven/app/hub_test.go
@@ -135,6 +135,8 @@ type fakeSystem struct {
 	// asserting on the kills would pass with an EMPTY marker, which in production
 	// matches every process on the machine and group-kills the result.
 	orphanMarker string
+	procSamples  []ProcessSample
+	killed       []int
 }
 
 func (f *fakeSystem) FreePorts(n int) ([]int, error) { return make([]int, n), nil }
@@ -168,6 +170,8 @@ func (f *fakeSystem) OrphanedWorkers(marker string) []int {
 	f.orphanMarker = marker
 	return f.orphans
 }
+func (f *fakeSystem) ProcessSamples() []ProcessSample { return f.procSamples }
+func (f *fakeSystem) Kill(pid int)                    { f.killed = append(f.killed, pid) }
 
 type fakeProxy struct{ removed []string }
 

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -44,6 +44,12 @@ type Orchestrator struct {
 	// know that half has finished.
 	isGoverning atomic.Bool
 	governance  sync.WaitGroup
+
+	// procActivity is the process watch's cross-tick idle clock (ADR-095),
+	// touched only from the daemon's monitor loop. procTel ships the watch's
+	// observations to the local observability stack; nil means unobserved.
+	procActivity map[int]tsgoSeen
+	procTel      ProcTelemetry
 }
 
 // Deps is the injected object graph. A struct rather than a positional
@@ -63,6 +69,7 @@ type Deps struct {
 	Sem       Semaphore
 	Container ContainerRuntime
 	Janitor   ContainerJanitor
+	ProcTel   ProcTelemetry
 	Claude    ClaudeSettings
 	Log       *zap.Logger
 }
@@ -72,7 +79,7 @@ func New(d Deps) *Orchestrator {
 	return &Orchestrator{
 		cfg: d.Cfg, proxy: d.Proxy, store: d.Store, sup: d.Sup, sys: d.Sys,
 		ch: d.CH, pg: d.PG, rds: d.RDS, obs: d.Obs, hyg: d.Hyg, sem: d.Sem,
-		container: d.Container, janitor: d.Janitor, claude: d.Claude, log: d.Log,
+		container: d.Container, janitor: d.Janitor, procTel: d.ProcTel, claude: d.Claude, log: d.Log,
 	}
 }
 

--- a/tools/thuishaven/app/ports.go
+++ b/tools/thuishaven/app/ports.go
@@ -146,6 +146,28 @@ type Child struct {
 	LogPath string
 }
 
+// ProcessSample is one live process as the tsgo governor's sampler sees it.
+type ProcessSample struct {
+	PID      int
+	RSSBytes int64
+	CPUTime  time.Duration // total CPU clock, for idle detection across ticks
+	Elapsed  time.Duration // wall-clock age
+	Command  string
+}
+
+// ProcTelemetry ships the process watch's observations to the local
+// observability stack, so "how big does tsgo get", "how many vitest workers
+// run at once" and "what did the governor kill" become queryable history
+// instead of anecdotes. Implementations must be fire-and-forget: when the
+// stack is down, observations are dropped silently, never buffered or logged
+// into a spam stream.
+type ProcTelemetry interface {
+	// RecordSample publishes the current footprint of every watched class.
+	RecordSample(procs []domain.WatchedProcess)
+	// RecordKill counts one governor enforcement, by class and reason.
+	RecordKill(class, reason string)
+}
+
 // System is the set of OS facts the app needs, behind a port so it can be faked.
 type System interface {
 	FreePorts(n int) ([]int, error)
@@ -177,6 +199,15 @@ type System interface {
 	// already running has to be walked.
 	DemoteGroup(pid int)
 	RestoreGroup(pid int)
+	// ProcessSamples lists every live process with the facts the tsgo governor
+	// needs (ADR-095): resident set, CPU clock, elapsed age, command line.
+	// Filtering to tsgo is the caller's job via domain.IsTsgoCommand — the
+	// sampler stays generic and the selection rule stays in one testable place.
+	ProcessSamples() []ProcessSample
+	// Kill SIGKILLs one process — never its group. The tsgo governor's targets
+	// are children of queue wrappers and daemons whose process group includes
+	// exactly the supervisors that must survive the kill.
+	Kill(pid int)
 	// OrphanedWorkers lists processes matching marker whose parent is PID 1 —
 	// test workers an interrupted run left behind, owned by nobody.
 	OrphanedWorkers(marker string) []int

--- a/tools/thuishaven/cmd/root.go
+++ b/tools/thuishaven/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/otellgtm"
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/portlessproxy"
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/postgresbrew"
+	"github.com/langwatch/langwatch/tools/thuishaven/adapters/procmetrics"
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/procsupervisor"
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/redisbrew"
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/semaphore"
@@ -36,6 +37,24 @@ import (
 	"github.com/langwatch/langwatch/tools/thuishaven/app"
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
+
+// tsgoLimits resolves the tsgo governor's knobs (ADR-095) from the machine
+// with env overrides; a knob set to 0 disables its rule, and
+// HAVEN_TSGO_RUN_MAX_RSS_MB=0 disables the governor entirely.
+func tsgoLimits(ram uint64) domain.TsgoLimits {
+	l := domain.DefaultTsgoLimits(ram)
+	if mb := envInt("HAVEN_TSGO_RUN_MAX_RSS_MB", -1); mb >= 0 {
+		l.RunMaxRSS = int64(mb) << 20
+	}
+	if mb := envInt("HAVEN_TSGO_LSP_MAX_RSS_MB", -1); mb >= 0 {
+		l.LSPMaxRSS = int64(mb) << 20
+	}
+	if mb := envInt("HAVEN_TSGO_TOTAL_BUDGET_MB", -1); mb >= 0 {
+		l.TotalBudget = int64(mb) << 20
+	}
+	l.LSPIdleTTL = envDuration("HAVEN_TSGO_LSP_IDLE_TTL", l.LSPIdleTTL)
+	return l
+}
 
 // Root parses the global flags, wires the object graph, and dispatches. The three
 // steps are separate so none of them grows the others: meta commands answer
@@ -181,6 +200,7 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 		DBIdleTTL:               envDuration("HAVEN_DB_TTL", 4*24*time.Hour),
 		TestContainerTTL:        envDuration("HAVEN_TESTCONTAINER_TTL", domain.DefaultTestContainerTTL),
 		RunningTestContainerTTL: envDuration("HAVEN_TESTCONTAINER_RUNNING_TTL", domain.DefaultRunningTestContainerTTL),
+		Tsgo:                    tsgoLimits(ram),
 		HeartbeatEvery:          30 * time.Second,
 		DaemonArgv:              selfArgv(trustedRepoRoot(), "daemon"),
 		IsAgent:                 isAgent,
@@ -205,7 +225,9 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 		orch: app.New(app.Deps{
 			Cfg: cfg, Proxy: proxy, Store: store, Sup: sup, Sys: sys,
 			CH: ch, PG: pg, RDS: rds, Obs: obs, Hyg: hyg, Sem: sem,
-			Container: rt, Janitor: dockerjanitor.New(rt), Claude: claudesettings.New(), Log: logger,
+			Container: rt, Janitor: dockerjanitor.New(rt),
+			ProcTel: procmetrics.New(observabilityEndpoints().OTLPHTTPPort),
+			Claude:  claudesettings.New(), Log: logger,
 		}),
 		dash: dashboard.New(store.Stacks, sharedURL, dashboard.Probes{
 			PortInUse:    sys.PortInUse,

--- a/tools/thuishaven/domain/tsgowatch.go
+++ b/tools/thuishaven/domain/tsgowatch.go
@@ -1,0 +1,234 @@
+package domain
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// The tsgo governor (ADR-095). tsgo is the single largest transient memory
+// consumer on a dev machine, and admission controls only see the spawns they
+// wrap. This is the other half: policy over a sample of every live tsgo
+// process, wherever it came from. The decisions here are pure; the daemon
+// samples and enforces.
+
+// TsgoClass is the crude-on-purpose classification: an --lsp instance is a
+// language server, anything else is a run. Single-file checks are tiny and
+// never cross a threshold, so telling them apart from whole-tree runs buys
+// nothing.
+type TsgoClass string
+
+const (
+	TsgoRun TsgoClass = "run"
+	TsgoLSP TsgoClass = "lsp"
+)
+
+// TsgoProcess is one live tsgo process as sampled by the daemon.
+type TsgoProcess struct {
+	PID     int
+	Class   TsgoClass
+	RSS     int64 // bytes
+	Started time.Time
+	// IdleFor is how long the process's CPU clock has not moved, tracked by
+	// the sampler across ticks. Zero means it was active at the last tick (or
+	// has not been observed long enough to know).
+	IdleFor time.Duration
+}
+
+// IsTsgoCommand reports whether a process command line is a tsgo binary
+// invocation — the whole selection rule, so the governor can never touch
+// anything else. Matched on the binary path, not the args: an unrelated
+// process mentioning "tsgo" in an argument is not a candidate.
+func IsTsgoCommand(command string) bool {
+	return binaryBase(command) == "tsgo"
+}
+
+// ClassifyTsgo reads the class off a tsgo command line.
+func ClassifyTsgo(command string) TsgoClass {
+	if strings.Contains(command, "--lsp") {
+		return TsgoLSP
+	}
+	return TsgoRun
+}
+
+// binaryBase is the base name of a command line's binary — the first token's
+// last path segment.
+func binaryBase(command string) string {
+	bin, _, _ := strings.Cut(strings.TrimSpace(command), " ")
+	if i := strings.LastIndexByte(bin, '/'); i >= 0 {
+		bin = bin[i+1:]
+	}
+	return bin
+}
+
+// WatchedProcess is one process of a class haven observes over time — the
+// facts behind the dev-tooling dashboards and, for classes with limits, the
+// governor's decisions.
+type WatchedProcess struct {
+	Class   string
+	Role    TsgoClass // run|lsp — meaningful for compiler-shaped classes, "run" otherwise
+	PID     int
+	RSS     int64
+	Started time.Time
+	IdleFor time.Duration
+}
+
+// ClassifyWatchedProcess maps a command line to the process class haven
+// tracks, or ok=false for everything haven has no interest in. The class list
+// is deliberately the dev-tooling that shapes machine health: compilers and
+// checkers (tsgo, gopls, biome), test workers (vitest — matched on the worker
+// path, the same marker the orphan sweep uses), the JS runtimes every dev
+// server and script runs on (node, bun), and coding agents (claude). Only
+// tsgo carries kill limits (ADR-095); every other class is observe-only —
+// node and claude in particular are the user's own work and are never
+// touched.
+func ClassifyWatchedProcess(command string) (WatchedProcess, bool) {
+	base := binaryBase(command)
+	switch base {
+	case "tsgo":
+		return WatchedProcess{Class: "tsgo", Role: ClassifyTsgo(command)}, true
+	case "gopls":
+		return WatchedProcess{Class: "gopls", Role: TsgoLSP}, true
+	case "biome":
+		return WatchedProcess{Class: "biome", Role: TsgoRun}, true
+	case "claude":
+		return WatchedProcess{Class: "claude", Role: TsgoRun}, true
+	case "bun":
+		return WatchedProcess{Class: "bun", Role: TsgoRun}, true
+	case "node":
+		if strings.Contains(command, "vitest") {
+			return WatchedProcess{Class: "vitest", Role: TsgoRun}, true
+		}
+		return WatchedProcess{Class: "node", Role: TsgoRun}, true
+	}
+	return WatchedProcess{}, false
+}
+
+// TsgoLimits bound what tsgo may take from the machine. Zero disables the
+// individual rule; RunMaxRSS == 0 disables the governor entirely.
+type TsgoLimits struct {
+	RunMaxRSS   int64         // hard per-run ceiling; a run above it is runaway
+	LSPMaxRSS   int64         // per-LSP ceiling; eviction costs a reconnect, not work
+	LSPIdleTTL  time.Duration // evict an LSP whose CPU clock has not moved this long
+	TotalBudget int64         // ceiling for all tsgo combined
+}
+
+// DefaultTsgoLimits sizes the governor against the machine. The per-run
+// ceiling sits above the observed legitimate peak (a whole-tree
+// typecheck:tests run reaches ~10 GiB), so it only fires on runaways; the
+// aggregate budget (two thirds of RAM, never below the per-run ceiling) is
+// what stops two legitimate runs from taking the machine together.
+func DefaultTsgoLimits(totalRAMBytes uint64) TsgoLimits {
+	budget := int64(totalRAMBytes) * 2 / 3
+	const runMax = 12 << 30
+	if budget < runMax {
+		budget = runMax
+	}
+	return TsgoLimits{
+		RunMaxRSS:   runMax,
+		LSPMaxRSS:   4 << 30,
+		LSPIdleTTL:  45 * time.Minute,
+		TotalBudget: budget,
+	}
+}
+
+// ParsePSDuration parses the `[[dd-]hh:]mm:ss[.cc]` shape ps prints for both
+// cputime and etime ("01-04:06:44", "05:38:38", "4:47.17", "52.46"). ok=false
+// for anything else — a sampler must never guess at a duration it will make a
+// kill decision from.
+func ParsePSDuration(s string) (time.Duration, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	var days int64
+	if before, after, found := strings.Cut(s, "-"); found {
+		n, err := strconv.ParseInt(before, 10, 64)
+		if err != nil || n < 0 {
+			return 0, false
+		}
+		days, s = n, after
+	}
+	var fraction time.Duration
+	if before, after, found := strings.Cut(s, "."); found {
+		n, err := strconv.ParseInt(after, 10, 64)
+		if err != nil || n < 0 || len(after) == 0 || len(after) > 2 {
+			return 0, false
+		}
+		for i := len(after); i < 2; i++ {
+			n *= 10
+		}
+		fraction, s = time.Duration(n)*10*time.Millisecond, before
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) > 3 {
+		return 0, false
+	}
+	var total time.Duration
+	for _, p := range parts {
+		n, err := strconv.ParseInt(p, 10, 64)
+		if err != nil || n < 0 {
+			return 0, false
+		}
+		total = total*60 + time.Duration(n)*time.Second
+	}
+	return time.Duration(days)*24*time.Hour + total + fraction, true
+}
+
+// TsgoKill is one enforcement decision, with the reason it carries into the log.
+type TsgoKill struct {
+	PID    int
+	Class  TsgoClass
+	RSS    int64
+	Reason string
+}
+
+// GovernTsgo decides what to reclaim from a sample of live tsgo processes.
+//
+// Order of rules: hard per-process ceilings and idle eviction first (those
+// processes are gone regardless of the total), then the aggregate budget over
+// whatever survives — idle LSPs are already gone by then, so the budget
+// reclaims the youngest runs first (the oldest is closest to finishing) until
+// the remainder fits.
+func GovernTsgo(procs []TsgoProcess, l TsgoLimits) []TsgoKill {
+	if l.RunMaxRSS <= 0 {
+		return nil
+	}
+	var kills []TsgoKill
+	var survivors []TsgoProcess
+	for _, p := range procs {
+		switch {
+		case p.Class == TsgoRun && p.RSS > l.RunMaxRSS:
+			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "run exceeds the per-run memory ceiling"})
+		case p.Class == TsgoLSP && l.LSPMaxRSS > 0 && p.RSS > l.LSPMaxRSS:
+			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "language server exceeds its memory ceiling"})
+		case p.Class == TsgoLSP && l.LSPIdleTTL > 0 && p.IdleFor >= l.LSPIdleTTL:
+			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "language server idle past the eviction period"})
+		default:
+			survivors = append(survivors, p)
+		}
+	}
+	if l.TotalBudget <= 0 {
+		return kills
+	}
+	var total int64
+	for _, p := range survivors {
+		total += p.RSS
+	}
+	// Youngest-first among runs; surviving LSPs are active and stay — an
+	// active LSP is somebody's editor session, and the budget pressure is
+	// almost always a run.
+	sort.Slice(survivors, func(i, j int) bool { return survivors[i].Started.After(survivors[j].Started) })
+	for _, p := range survivors {
+		if total <= l.TotalBudget {
+			break
+		}
+		if p.Class != TsgoRun {
+			continue
+		}
+		kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "combined tsgo footprint exceeds the machine budget"})
+		total -= p.RSS
+	}
+	return kills
+}

--- a/tools/thuishaven/domain/tsgowatch.go
+++ b/tools/thuishaven/domain/tsgowatch.go
@@ -19,6 +19,8 @@ import (
 // nothing.
 type TsgoClass string
 
+// The two classes: a compile run (whole-tree or targeted) and a long-lived
+// --lsp language server.
 const (
 	TsgoRun TsgoClass = "run"
 	TsgoLSP TsgoClass = "lsp"
@@ -142,25 +144,52 @@ func ParsePSDuration(s string) (time.Duration, bool) {
 	if s == "" {
 		return 0, false
 	}
-	var days int64
-	if before, after, found := strings.Cut(s, "-"); found {
-		n, err := strconv.ParseInt(before, 10, 64)
-		if err != nil || n < 0 {
-			return 0, false
-		}
-		days, s = n, after
+	days, s, ok := cutPSDays(s)
+	if !ok {
+		return 0, false
 	}
-	var fraction time.Duration
-	if before, after, found := strings.Cut(s, "."); found {
-		n, err := strconv.ParseInt(after, 10, 64)
-		if err != nil || n < 0 || len(after) == 0 || len(after) > 2 {
-			return 0, false
-		}
-		for i := len(after); i < 2; i++ {
-			n *= 10
-		}
-		fraction, s = time.Duration(n)*10*time.Millisecond, before
+	fraction, s, ok := cutPSFraction(s)
+	if !ok {
+		return 0, false
 	}
+	clock, ok := parsePSClock(s)
+	if !ok {
+		return 0, false
+	}
+	return time.Duration(days)*24*time.Hour + clock + fraction, true
+}
+
+// cutPSDays strips the optional leading "dd-" prefix.
+func cutPSDays(s string) (days int64, rest string, ok bool) {
+	before, after, found := strings.Cut(s, "-")
+	if !found {
+		return 0, s, true
+	}
+	n, err := strconv.ParseInt(before, 10, 64)
+	if err != nil || n < 0 {
+		return 0, "", false
+	}
+	return n, after, true
+}
+
+// cutPSFraction strips the optional trailing ".cc" centiseconds.
+func cutPSFraction(s string) (fraction time.Duration, rest string, ok bool) {
+	before, after, found := strings.Cut(s, ".")
+	if !found {
+		return 0, s, true
+	}
+	n, err := strconv.ParseInt(after, 10, 64)
+	if err != nil || n < 0 || len(after) == 0 || len(after) > 2 {
+		return 0, "", false
+	}
+	for i := len(after); i < 2; i++ {
+		n *= 10
+	}
+	return time.Duration(n) * 10 * time.Millisecond, before, true
+}
+
+// parsePSClock parses the "[[hh:]mm:]ss" colon groups.
+func parsePSClock(s string) (time.Duration, bool) {
 	parts := strings.Split(s, ":")
 	if len(parts) > 3 {
 		return 0, false
@@ -173,7 +202,7 @@ func ParsePSDuration(s string) (time.Duration, bool) {
 		}
 		total = total*60 + time.Duration(n)*time.Second
 	}
-	return time.Duration(days)*24*time.Hour + total + fraction, true
+	return total, true
 }
 
 // TsgoKill is one enforcement decision, with the reason it carries into the log.
@@ -198,30 +227,44 @@ func GovernTsgo(procs []TsgoProcess, l TsgoLimits) []TsgoKill {
 	var kills []TsgoKill
 	var survivors []TsgoProcess
 	for _, p := range procs {
-		switch {
-		case p.Class == TsgoRun && p.RSS > l.RunMaxRSS:
-			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "run exceeds the per-run memory ceiling"})
-		case p.Class == TsgoLSP && l.LSPMaxRSS > 0 && p.RSS > l.LSPMaxRSS:
-			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "language server exceeds its memory ceiling"})
-		case p.Class == TsgoLSP && l.LSPIdleTTL > 0 && p.IdleFor >= l.LSPIdleTTL:
-			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: "language server idle past the eviction period"})
-		default:
+		if reason, over := overOwnLimit(p, l); over {
+			kills = append(kills, TsgoKill{PID: p.PID, Class: p.Class, RSS: p.RSS, Reason: reason})
+		} else {
 			survivors = append(survivors, p)
 		}
 	}
-	if l.TotalBudget <= 0 {
-		return kills
+	if l.TotalBudget > 0 {
+		kills = append(kills, reclaimOverBudget(survivors, l.TotalBudget)...)
 	}
+	return kills
+}
+
+// overOwnLimit is the per-process rule: the reason a process is reclaimed on
+// its own, independent of the aggregate budget.
+func overOwnLimit(p TsgoProcess, l TsgoLimits) (string, bool) {
+	switch {
+	case p.Class == TsgoRun && p.RSS > l.RunMaxRSS:
+		return "run exceeds the per-run memory ceiling", true
+	case p.Class == TsgoLSP && l.LSPMaxRSS > 0 && p.RSS > l.LSPMaxRSS:
+		return "language server exceeds its memory ceiling", true
+	case p.Class == TsgoLSP && l.LSPIdleTTL > 0 && p.IdleFor >= l.LSPIdleTTL:
+		return "language server idle past the eviction period", true
+	}
+	return "", false
+}
+
+// reclaimOverBudget stops the youngest surviving runs until the remainder
+// fits the budget. Surviving LSPs are active and stay — an active LSP is
+// somebody's editor session, and the budget pressure is almost always a run.
+func reclaimOverBudget(survivors []TsgoProcess, budget int64) []TsgoKill {
 	var total int64
 	for _, p := range survivors {
 		total += p.RSS
 	}
-	// Youngest-first among runs; surviving LSPs are active and stay — an
-	// active LSP is somebody's editor session, and the budget pressure is
-	// almost always a run.
 	sort.Slice(survivors, func(i, j int) bool { return survivors[i].Started.After(survivors[j].Started) })
+	var kills []TsgoKill
 	for _, p := range survivors {
-		if total <= l.TotalBudget {
+		if total <= budget {
 			break
 		}
 		if p.Class != TsgoRun {

--- a/tools/thuishaven/domain/tsgowatch_test.go
+++ b/tools/thuishaven/domain/tsgowatch_test.go
@@ -1,0 +1,187 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+const tsgoGiB = int64(1) << 30
+
+func tsgoAt(pid int, class TsgoClass, rssGiB int64, started time.Time) TsgoProcess {
+	return TsgoProcess{PID: pid, Class: class, RSS: rssGiB * tsgoGiB, Started: started}
+}
+
+// @scenario "The governor only ever touches tsgo"
+func TestIsTsgoCommand(t *testing.T) {
+	t.Run("matches the binary path, not the arguments", func(t *testing.T) {
+		yes := []string{
+			"/x/node_modules/@typescript/native-preview-darwin-arm64/lib/tsgo --lsp --stdio",
+			"tsgo --noEmit --project ./tsconfig.tsgo.json",
+		}
+		no := []string{
+			"node dev/scripts/check-queue.mjs ./node_modules/.bin/tsgo.real",
+			"grep tsgo server.log",
+			"/usr/bin/vim tsgo.go",
+			"clickhouse-server --daemon",
+		}
+		for _, c := range yes {
+			if !IsTsgoCommand(c) {
+				t.Errorf("expected tsgo: %q", c)
+			}
+		}
+		for _, c := range no {
+			if IsTsgoCommand(c) {
+				t.Errorf("must never be a candidate: %q", c)
+			}
+		}
+	})
+}
+
+func TestClassifyTsgo(t *testing.T) {
+	if ClassifyTsgo("/lib/tsgo --lsp --stdio") != TsgoLSP {
+		t.Error("an --lsp invocation is a language server")
+	}
+	if ClassifyTsgo("/lib/tsgo --noEmit -p tsconfig.json") != TsgoRun {
+		t.Error("everything else is a run")
+	}
+}
+
+func TestGovernTsgo(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	limits := TsgoLimits{
+		RunMaxRSS:   12 * tsgoGiB,
+		LSPMaxRSS:   4 * tsgoGiB,
+		LSPIdleTTL:  45 * time.Minute,
+		TotalBudget: 12 * tsgoGiB,
+	}
+
+	// @scenario "A runaway whole-tree run is stopped at the hard ceiling"
+	t.Run("given a run above the per-run ceiling", func(t *testing.T) {
+		kills := GovernTsgo([]TsgoProcess{tsgoAt(1, TsgoRun, 13, now)}, limits)
+		if len(kills) != 1 || kills[0].PID != 1 {
+			t.Fatalf("expected the runaway stopped, got %+v", kills)
+		}
+	})
+
+	// @scenario "A run under every ceiling is left alone"
+	t.Run("given a run within every ceiling and budget", func(t *testing.T) {
+		kills := GovernTsgo([]TsgoProcess{tsgoAt(1, TsgoRun, 10, now)}, limits)
+		if len(kills) != 0 {
+			t.Fatalf("expected nothing stopped, got %+v", kills)
+		}
+	})
+
+	// @scenario "Over the machine budget, idle language servers go first"
+	t.Run("given the budget exceeded with an idle language server present", func(t *testing.T) {
+		idleLSP := TsgoProcess{PID: 3, Class: TsgoLSP, RSS: 3 * tsgoGiB, Started: now.Add(-3 * time.Hour), IdleFor: time.Hour}
+		procs := []TsgoProcess{
+			tsgoAt(1, TsgoRun, 6, now.Add(-10*time.Minute)),
+			tsgoAt(2, TsgoRun, 5, now.Add(-2*time.Minute)),
+			idleLSP,
+		}
+		kills := GovernTsgo(procs, limits)
+
+		// 6+5+3 = 14 GiB against a 12 GiB budget: evicting the idle LSP alone
+		// brings the total to 11 GiB, so no run needs to die.
+		if len(kills) != 1 || kills[0].PID != 3 {
+			t.Fatalf("expected only the idle language server reclaimed, got %+v", kills)
+		}
+	})
+
+	// @scenario "Over the machine budget, the youngest run goes before the oldest"
+	t.Run("given the budget exceeded by two runs alone", func(t *testing.T) {
+		procs := []TsgoProcess{
+			tsgoAt(1, TsgoRun, 8, now.Add(-10*time.Minute)), // the older, further along
+			tsgoAt(2, TsgoRun, 7, now.Add(-1*time.Minute)),  // the younger
+		}
+		kills := GovernTsgo(procs, limits)
+
+		if len(kills) != 1 || kills[0].PID != 2 {
+			t.Fatalf("expected the youngest run stopped and the oldest kept, got %+v", kills)
+		}
+	})
+
+	// @scenario "An idle language server is evicted after the idle period"
+	t.Run("given language servers on both sides of the idle period", func(t *testing.T) {
+		procs := []TsgoProcess{
+			{PID: 1, Class: TsgoLSP, RSS: 2 * tsgoGiB, Started: now.Add(-3 * time.Hour), IdleFor: time.Hour},
+			{PID: 2, Class: TsgoLSP, RSS: 2 * tsgoGiB, Started: now.Add(-3 * time.Hour), IdleFor: time.Minute},
+		}
+		kills := GovernTsgo(procs, limits)
+
+		if len(kills) != 1 || kills[0].PID != 1 {
+			t.Fatalf("expected only the idle language server evicted, got %+v", kills)
+		}
+	})
+
+	// @scenario "An oversized language server is evicted regardless of activity"
+	t.Run("given an active language server above its ceiling", func(t *testing.T) {
+		procs := []TsgoProcess{{PID: 1, Class: TsgoLSP, RSS: 5 * tsgoGiB, Started: now, IdleFor: 0}}
+		kills := GovernTsgo(procs, limits)
+		if len(kills) != 1 {
+			t.Fatalf("expected the oversized language server evicted, got %+v", kills)
+		}
+	})
+
+	t.Run("given budget pressure with only active language servers over", func(t *testing.T) {
+		// Active LSPs within their own ceiling are never budget-killed: they
+		// are somebody's editor session, and the pressure is almost always a
+		// run that will finish.
+		procs := []TsgoProcess{
+			{PID: 1, Class: TsgoLSP, RSS: 3 * tsgoGiB, Started: now, IdleFor: 0},
+			{PID: 2, Class: TsgoLSP, RSS: 3 * tsgoGiB, Started: now, IdleFor: 0},
+			{PID: 3, Class: TsgoLSP, RSS: 3 * tsgoGiB, Started: now, IdleFor: 0},
+			{PID: 4, Class: TsgoLSP, RSS: 3 * tsgoGiB, Started: now, IdleFor: 0},
+			{PID: 5, Class: TsgoLSP, RSS: 3 * tsgoGiB, Started: now, IdleFor: 0},
+		}
+		if kills := GovernTsgo(procs, limits); len(kills) != 0 {
+			t.Fatalf("active in-ceiling language servers are never budget-killed, got %+v", kills)
+		}
+	})
+
+	// @scenario "The operator can disable the governor"
+	t.Run("given the per-run ceiling is disabled", func(t *testing.T) {
+		off := limits
+		off.RunMaxRSS = 0
+		kills := GovernTsgo([]TsgoProcess{tsgoAt(1, TsgoRun, 20, now)}, off)
+		if len(kills) != 0 {
+			t.Fatalf("a disabled governor considers nothing, got %+v", kills)
+		}
+	})
+}
+
+func TestParsePSDuration(t *testing.T) {
+	cases := map[string]time.Duration{
+		"52.46":       52*time.Second + 460*time.Millisecond,
+		"4:47.17":     4*time.Minute + 47*time.Second + 170*time.Millisecond,
+		"05:38:38":    5*time.Hour + 38*time.Minute + 38*time.Second,
+		"01-04:06:44": 28*time.Hour + 6*time.Minute + 44*time.Second,
+		"0:53.92":     53*time.Second + 920*time.Millisecond,
+	}
+	for in, want := range cases {
+		got, ok := ParsePSDuration(in)
+		if !ok || got != want {
+			t.Errorf("ParsePSDuration(%q) = %v/%v, want %v", in, got, ok, want)
+		}
+	}
+	for _, bad := range []string{"", "abc", "1:2:3:4", "-5:00", "1..2"} {
+		if _, ok := ParsePSDuration(bad); ok {
+			t.Errorf("ParsePSDuration(%q) must refuse to guess", bad)
+		}
+	}
+}
+
+func TestDefaultTsgoLimits(t *testing.T) {
+	t.Run("the budget never undercuts the per-run ceiling", func(t *testing.T) {
+		small := DefaultTsgoLimits(8 << 30) // 8 GiB machine: two thirds would be ~5.3 GiB
+		if small.TotalBudget < small.RunMaxRSS {
+			t.Fatalf("budget %d undercuts the run ceiling %d", small.TotalBudget, small.RunMaxRSS)
+		}
+	})
+	t.Run("a bigger machine gets a proportional budget", func(t *testing.T) {
+		big := DefaultTsgoLimits(36 << 30)
+		if want := int64(36<<30) * 2 / 3; big.TotalBudget != want {
+			t.Fatalf("budget = %d, want two thirds of RAM (%d)", big.TotalBudget, want)
+		}
+	})
+}


### PR DESCRIPTION
## What

Two whole-tree tsgo runs (10.0 GiB + 2.5 GiB) ran concurrently on an 18 GiB machine, legally: the check queue bounds how many runs *start*, not how big each gets; its slot ledger is separate from `haven gate`'s; and tsgo LSP instances (2.5 GiB each, one per worktree the tslsp daemon ever served) are exempt from every admission control by design. Gating spawn paths is whack-a-mole — the guarantee moves to where every process is visible. See `dev/docs/adr/095-haven-tsgo-governor.md` and `specs/setup/haven-tsgo-governor.feature` (11/11 scenarios bound).

## Changes

- **Soft cap at spawn**: check-queue sets `GOMEMLIMIT` on the runs it wraps (tsgo is a Go binary) — half the machine, clamped to [4, 10] GiB — so a whole-tree typecheck degrades to *slower*, not 10 GiB resident. An explicit operator `GOMEMLIMIT` always wins (bats-tested, runs via `make test-scripts`).
- **Hard backstop on the daemon tick**: one `ps` sample per 10 s tick classifies the machine's dev tooling — tsgo (run/lsp), gopls, biome, vitest workers, node, bun, claude — and enforces limits on **tsgo only**: runs past `HAVEN_TSGO_RUN_MAX_RSS_MB` (12 GiB), LSPs past `HAVEN_TSGO_LSP_MAX_RSS_MB` (4 GiB) or idle past `HAVEN_TSGO_LSP_IDLE_TTL` (45 m, CPU-clock based), and over `HAVEN_TSGO_TOTAL_BUDGET_MB` (two thirds of RAM) the youngest run until the rest fits. node and claude are the user's own work and stay observe-only; killing regenerable tooling follows the existing vitest-orphan-sweep precedent, not ADR-090's no-kill rule for stacks.
- **Telemetry to the local Grafana** (`adapters/procmetrics`, OTLP, fire-and-forget): `haven_proc_rss_bytes` / `haven_proc_count` / `haven_proc_oldest_age_seconds` by class+role, `haven_proc_governor_kills_total` by reason. Vanished classes are zeroed, exports drop silently when the stack is down. This history decides which class earns limits next and turns "did Prisma 7 shrink typecheck" into a query.

## Stacked

Based on #6944 (both change the daemon loop); retarget to `main` after it merges.

## Deployment Impact

None — `tools/thuishaven` is the local dev orchestrator; nothing here ships to production deployments. The ADR documents local-dev machine governance only.

## Testing

- `go test ./tools/thuishaven/...` all green (governor policy, classifier, ps-duration parser, daemon wiring incl. cross-tick idle tracking)
- `npx bats dev/scripts/__tests__/check-queue-memlimit.unit.bats` — both pass (child observably receives the cap)
- `check-feature-parity` — 11/11 bound
- gofmt clean; no new lint findings beyond the package's pre-existing gocognit profile