### PR TITLE
feat(traces): extract AWS Bedrock Converse payloads into trace I/O

### DIFF
--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -27,6 +27,14 @@
  * this pipeline does with each candidate Bedrock shape, so the observed
  * signature in production can be matched against a named shape.
  *
+ * OUTCOME (production data hydrated 2026-08-13, issue #1040): none of these
+ * rows describes Healify. Their empty Bedrock spans carry NO payload attribute
+ * under any key — mapped or unmapped — so there is nothing for stage 2 to read
+ * and no mapping change would populate them. The content is never emitted;
+ * AWS's botocore instrumentation omits message content unless
+ * OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true. This file therefore
+ * stands as a characterisation of the pipeline, NOT as a live bug report.
+ *
  * `describe` titles say which shapes are expected to work; the assertions are
  * the record of what the pipeline actually does today.
  */

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -204,6 +204,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
   });
 
   describe("when the assistant turn is a Converse toolUse block", () => {
+    /** @scenario Converse toolUse block survives extraction */
     it("extracts the tool call's input as the output text", () => {
       const { output } = computeTraceIO(
         makeSpan({
@@ -232,6 +233,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
   });
 
   describe("when the user turn is a Converse toolResult block", () => {
+    /** @scenario Converse toolResult block survives extraction */
     it("extracts the tool result's inner text as the input", () => {
       const { input } = computeTraceIO(
         makeSpan({
@@ -261,6 +263,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
 
 describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () => {
   describe("when the span carries the Converse request/response bodies verbatim", () => {
+    /** @scenario "aws.bedrock.* payload keys are mapped to canonical keys" */
     it("maps the payloads to canonical keys and extracts both sides", () => {
       const span = makeSpan({
         spanAttributes: {
@@ -299,6 +302,7 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
   });
 
   describe("when such a span is the root of an HTTP-instrumented trace", () => {
+    /** @scenario Mapped messages beat the HTTP fallback */
     it("prefers the mapped request messages over the HTTP fallback", () => {
       const { input, output } = computeTraceIO(
         makeSpan({

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Branch 1 of langwatch-saas#1040 — and the Healify-independent reproduction
+ * Branch 1 of langwatch-saas#1040 — and the customer-independent reproduction
  * (AC4). Does an AWS Bedrock **Converse** span survive the two-stage I/O
  * pipeline, or does it land in `trace_summaries` with empty ComputedInput /
  * ComputedOutput?
@@ -23,12 +23,12 @@
  *              carries a numeric `http.status_code`.
  *
  * These tests run the REAL canonicaliser and the REAL extraction service. They
- * make no assertion about what Healify actually emits — they establish what
+ * make no assertion about what the customer integration actually emits — they establish what
  * this pipeline does with each candidate Bedrock shape, so the observed
  * signature in production can be matched against a named shape.
  *
  * OUTCOME (production data hydrated 2026-08-13, issue #1040): none of these
- * rows describes Healify. Their empty Bedrock spans carry NO payload attribute
+ * rows describes the affected customer. Their empty Bedrock spans carry NO payload attribute
  * under any key — mapped or unmapped — so there is nothing for stage 2 to read
  * and no mapping change would populate them. The content is never emitted;
  * AWS's botocore instrumentation omits message content unless

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -54,6 +54,12 @@ import { TraceIOExtractionService } from "../trace-io-extraction.service";
 const canonicaliser = new CanonicalizeSpanAttributesService();
 const ioService = new TraceIOExtractionService();
 
+/**
+ * Only ever used to CONSTRUCT the span. The assertions below hardcode the
+ * literal instead of reusing this, so renaming the span turns them red — if
+ * both sides shared one constant the falsification would move together and
+ * prove nothing.
+ */
 const SPAN_NAME = "bedrock.converse";
 
 function makeSpan(
@@ -229,7 +235,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
         }),
       );
 
-      expect(input).toBe(SPAN_NAME);
+      expect(input).toBe("bedrock.converse");
     });
   });
 });
@@ -267,7 +273,7 @@ describe("given a Bedrock span whose messages sit under keys no extractor maps",
       // This pair IS the production signature. It is identifiable in stored
       // data with no access to the customer's account: input equal to the span
       // name, output empty, on a trace whose spans hold real content.
-      expect(input).toBe(SPAN_NAME);
+      expect(input).toBe("bedrock.converse");
       expect(output).toBe(null);
 
       // And the content is demonstrably still in the span — the trace is not

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -32,11 +32,14 @@
  * under any key — mapped or unmapped — so there is nothing for stage 2 to read
  * and no mapping change would populate them. The content is never emitted;
  * AWS's botocore instrumentation omits message content unless
- * OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true. This file therefore
- * stands as a characterisation of the pipeline, NOT as a live bug report.
+ * OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true.
  *
- * `describe` titles say which shapes are expected to work; the assertions are
- * the record of what the pipeline actually does today.
+ * The gaps this file originally characterised are now FIXED and these tests
+ * assert the fixed behaviour:
+ * - Converse's key-discriminated content blocks ({toolUse}, {toolResult})
+ *   are handled by extractTextsFromParts in extractors/_messages.ts.
+ * - aws.bedrock.* payload keys are mapped to canonical gen_ai.* keys by
+ *   BedrockExtractor (extractors/bedrock.ts).
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -193,7 +196,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
   });
 
   describe("when the assistant turn is a Converse toolUse block", () => {
-    it("records whether the tool call survives extraction", () => {
+    it("extracts the tool call's input as the output text", () => {
       const { output } = computeTraceIO(
         makeSpan({
           spanAttributes: {
@@ -216,12 +219,12 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
         }),
       );
 
-      expect(output).toBe(null);
+      expect(output).toContain('"patientId":"p-42"');
     });
   });
 
   describe("when the user turn is a Converse toolResult block", () => {
-    it("records whether the tool result survives extraction", () => {
+    it("extracts the tool result's inner text as the input", () => {
       const { input } = computeTraceIO(
         makeSpan({
           spanAttributes: {
@@ -243,19 +246,19 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
         }),
       );
 
-      expect(input).toBe("bedrock.converse");
+      expect(input).toBe("patient p-42 found");
     });
   });
 });
 
-describe("given a Bedrock span whose messages sit under keys no extractor maps", () => {
+describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () => {
   describe("when the span carries the Converse request/response bodies verbatim", () => {
-    it("degrades asymmetrically: input becomes the span name, output is lost", () => {
+    it("maps the payloads to canonical keys and extracts both sides", () => {
       const span = makeSpan({
         spanAttributes: {
           // A boto3/OTel AWS-SDK span: the operation is identified, and the
-          // Converse payloads ride along under aws.* keys. No registered
-          // extractor reads any of these — there is no AWS/Bedrock extractor.
+          // Converse payloads ride along under aws.* keys, which the
+          // BedrockExtractor maps onto the canonical gen_ai.* keys.
           "rpc.service": "BedrockRuntime",
           "rpc.method": "Converse",
           "aws.bedrock.model_id": "anthropic.claude-3-5-sonnet",
@@ -273,27 +276,19 @@ describe("given a Bedrock span whose messages sit under keys no extractor maps",
 
       const { input, output, canonicalAttributes } = computeTraceIO(span);
 
-      // Neither canonical I/O key was ever written: the payloads are present in
-      // the span and invisible to the extraction service.
-      expect(canonicalAttributes["langwatch.input"]).toBeUndefined();
-      expect(canonicalAttributes["gen_ai.input.messages"]).toBeUndefined();
+      // The canonical input key is now written from the aws.bedrock.* payload.
+      expect(canonicalAttributes["gen_ai.input.messages"]).toBeDefined();
 
-      // This pair IS the production signature. It is identifiable in stored
-      // data with no access to the customer's account: input equal to the span
-      // name, output empty, on a trace whose spans hold real content.
-      expect(input).toBe("bedrock.converse");
-      expect(output).toBe(null);
-
-      // And the content is demonstrably still in the span — the trace is not
-      // empty, only its summary is.
-      expect(span.spanAttributes["aws.bedrock.request.messages"]).toContain(
-        "summarise this consult note",
-      );
+      // Before the BedrockExtractor existed this pair degraded asymmetrically
+      // to {input: "bedrock.converse", output: null} — the span name and the
+      // HTTP-status fallback. The real content now reaches trace_summaries.
+      expect(input).toBe("summarise this consult note");
+      expect(output).toBe("The patient reports ...");
     });
   });
 
   describe("when such a span is the root of an HTTP-instrumented trace", () => {
-    it("substitutes the HTTP method, target and status for the real I/O", () => {
+    it("prefers the mapped request messages over the HTTP fallback", () => {
       const { input, output } = computeTraceIO(
         makeSpan({
           spanAttributes: {
@@ -308,9 +303,11 @@ describe("given a Bedrock span whose messages sit under keys no extractor maps",
         }),
       );
 
-      // Worth naming separately: here the trace does NOT read as empty. It
-      // reads as plausible-but-wrong, which is harder to notice than a blank.
-      expect(input).toBe("POST /model/anthropic.claude-3-5-sonnet/converse");
+      // Before the fix, the input read as plausible-but-wrong: the HTTP
+      // method + target. The mapped request messages now win; the output
+      // still falls back to the HTTP status because this span carries no
+      // aws.bedrock.response.output.
+      expect(input).toBe("summarise this consult note");
       expect(output).toBe("200");
     });
   });

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -147,7 +147,9 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
             "gen_ai.prompt": JSON.stringify([
               {
                 role: "user",
-                content: [{ type: "text", text: "summarise this consult note" }],
+                content: [
+                  { type: "text", text: "summarise this consult note" },
+                ],
               },
             ]),
             "gen_ai.completion": JSON.stringify([
@@ -179,10 +181,16 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
             // The AWS Converse API wire shape: content blocks are a union
             // discriminated by WHICH KEY IS PRESENT, not by a `type` field.
             "gen_ai.prompt": JSON.stringify([
-              { role: "user", content: [{ text: "summarise this consult note" }] },
+              {
+                role: "user",
+                content: [{ text: "summarise this consult note" }],
+              },
             ]),
             "gen_ai.completion": JSON.stringify([
-              { role: "assistant", content: [{ text: "The patient reports ..." }] },
+              {
+                role: "assistant",
+                content: [{ text: "The patient reports ..." }],
+              },
             ]),
           },
         }),
@@ -263,7 +271,10 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
           "rpc.method": "Converse",
           "aws.bedrock.model_id": "anthropic.claude-3-5-sonnet",
           "aws.bedrock.request.messages": JSON.stringify([
-            { role: "user", content: [{ text: "summarise this consult note" }] },
+            {
+              role: "user",
+              content: [{ text: "summarise this consult note" }],
+            },
           ]),
           "aws.bedrock.response.output": JSON.stringify({
             message: {
@@ -297,7 +308,10 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
             "http.target": "/model/anthropic.claude-3-5-sonnet/converse",
             "http.status_code": 200,
             "aws.bedrock.request.messages": JSON.stringify([
-              { role: "user", content: [{ text: "summarise this consult note" }] },
+              {
+                role: "user",
+                content: [{ text: "summarise this consult note" }],
+              },
             ]),
           },
         }),
@@ -308,6 +322,25 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
       // still falls back to the HTTP status because this span carries no
       // aws.bedrock.response.output.
       expect(input).toBe("summarise this consult note");
+      expect(output).toBe("200");
+    });
+  });
+
+  describe("when a non-Bedrock span carries none of the Bedrock signals", () => {
+    it("leaves the span alone (extractor does not fire)", () => {
+      const { input, output, appliedRules } = computeTraceIO(
+        makeSpan({
+          spanAttributes: {
+            "rpc.service": "DynamoDB",
+            "http.method": "POST",
+            "http.status_code": 200,
+          },
+        }),
+      );
+
+      expect(appliedRules.some((r) => r.startsWith("bedrock:"))).toBe(false);
+      // Ordinary fallback behaviour, untouched: span name in, status out.
+      expect(input).toBe("bedrock.converse");
       expect(output).toBe("200");
     });
   });

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -148,14 +148,14 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
               {
                 role: "user",
                 content: [
-                  { type: "text", text: "summarise this consult note" },
+                  { type: "text", text: "summarise this shipping manifest" },
                 ],
               },
             ]),
             "gen_ai.completion": JSON.stringify([
               {
                 role: "assistant",
-                content: [{ type: "text", text: "The patient reports ..." }],
+                content: [{ type: "text", text: "The shipment contains ..." }],
               },
             ]),
           },
@@ -166,8 +166,8 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
       // models, real content reaches trace_summaries. Without this passing,
       // an empty result elsewhere is equally well explained by a broken
       // fixture and the whole file proves nothing.
-      expect(input).toContain("summarise this consult note");
-      expect(output).toContain("The patient reports ...");
+      expect(input).toContain("summarise this shipping manifest");
+      expect(output).toContain("The shipment contains ...");
     });
   });
 
@@ -183,13 +183,13 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
             "gen_ai.prompt": JSON.stringify([
               {
                 role: "user",
-                content: [{ text: "summarise this consult note" }],
+                content: [{ text: "summarise this shipping manifest" }],
               },
             ]),
             "gen_ai.completion": JSON.stringify([
               {
                 role: "assistant",
-                content: [{ text: "The patient reports ..." }],
+                content: [{ text: "The shipment contains ..." }],
               },
             ]),
           },
@@ -197,8 +197,8 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
       );
 
       expect({ input, output }).toEqual({
-        input: "summarise this consult note",
-        output: "The patient reports ...",
+        input: "summarise this shipping manifest",
+        output: "The shipment contains ...",
       });
     });
   });
@@ -217,8 +217,8 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
                   {
                     toolUse: {
                       toolUseId: "tool-1",
-                      name: "lookup_patient",
-                      input: { patientId: "p-42" },
+                      name: "lookup_order",
+                      input: { orderId: "ord-42" },
                     },
                   },
                 ],
@@ -228,7 +228,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
         }),
       );
 
-      expect(output).toContain('"patientId":"p-42"');
+      expect(output).toContain('"orderId":"ord-42"');
     });
   });
 
@@ -246,7 +246,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
                   {
                     toolResult: {
                       toolUseId: "tool-1",
-                      content: [{ text: "patient p-42 found" }],
+                      content: [{ text: "order ord-42 found" }],
                     },
                   },
                 ],
@@ -256,7 +256,7 @@ describe("given a Bedrock span whose messages sit under canonical gen_ai keys", 
         }),
       );
 
-      expect(input).toBe("patient p-42 found");
+      expect(input).toBe("order ord-42 found");
     });
   });
 });
@@ -276,13 +276,13 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
           "aws.bedrock.request.messages": JSON.stringify([
             {
               role: "user",
-              content: [{ text: "summarise this consult note" }],
+              content: [{ text: "summarise this shipping manifest" }],
             },
           ]),
           "aws.bedrock.response.output": JSON.stringify({
             message: {
               role: "assistant",
-              content: [{ text: "The patient reports ..." }],
+              content: [{ text: "The shipment contains ..." }],
             },
           }),
         },
@@ -296,8 +296,8 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
       // Before the BedrockExtractor existed this pair degraded asymmetrically
       // to {input: "bedrock.converse", output: null} — the span name and the
       // HTTP-status fallback. The real content now reaches trace_summaries.
-      expect(input).toBe("summarise this consult note");
-      expect(output).toBe("The patient reports ...");
+      expect(input).toBe("summarise this shipping manifest");
+      expect(output).toBe("The shipment contains ...");
     });
   });
 
@@ -314,7 +314,7 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
             "aws.bedrock.request.messages": JSON.stringify([
               {
                 role: "user",
-                content: [{ text: "summarise this consult note" }],
+                content: [{ text: "summarise this shipping manifest" }],
               },
             ]),
           },
@@ -325,7 +325,7 @@ describe("given a Bedrock span whose messages sit under aws.bedrock.* keys", () 
       // method + target. The mapped request messages now win; the output
       // still falls back to the HTTP status because this span carries no
       // aws.bedrock.response.output.
-      expect(input).toBe("summarise this consult note");
+      expect(input).toBe("summarise this shipping manifest");
       expect(output).toBe("200");
     });
   });

--- a/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/bedrock-converse-io-extraction.unit.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Branch 1 of langwatch-saas#1040 — and the Healify-independent reproduction
+ * (AC4). Does an AWS Bedrock **Converse** span survive the two-stage I/O
+ * pipeline, or does it land in `trace_summaries` with empty ComputedInput /
+ * ComputedOutput?
+ *
+ * The pipeline has two stages, and the second one only ever reads what the
+ * first one wrote:
+ *
+ *   1. `CanonicalizeSpanAttributesService` maps a vendor's attribute keys onto
+ *      the canonical `gen_ai.*` / `langwatch.*` keys.
+ *   2. `TraceIOExtractionService` reads ONLY `gen_ai.input.messages`,
+ *      `gen_ai.output.messages`, `langwatch.input`, `langwatch.output`
+ *      (`IO_ATTR_KEYS`), and falls back to the span name / HTTP status.
+ *
+ * So an unmapped instrumentation does not fail loudly — it degrades, and the
+ * degradation is ASYMMETRIC, which is what makes it identifiable in production
+ * data without access to the customer's account:
+ *
+ *   - input  → `getHttpFallback` ends `return topSpan.name ?? null`, so a named
+ *              root span ALWAYS yields a non-empty input: the span's own name.
+ *   - output → `getHttpStatusFallback` ends `return null` unless the root span
+ *              carries a numeric `http.status_code`.
+ *
+ * These tests run the REAL canonicaliser and the REAL extraction service. They
+ * make no assertion about what Healify actually emits — they establish what
+ * this pipeline does with each candidate Bedrock shape, so the observed
+ * signature in production can be matched against a named shape.
+ *
+ * `describe` titles say which shapes are expected to work; the assertions are
+ * the record of what the pipeline actually does today.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// TraceIOExtractionService wraps its methods in getLangWatchTracer spans.
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (
+      _name: string,
+      _opts: unknown,
+      fn: (span: { setAttributes: () => void }) => unknown,
+    ) => fn({ setAttributes: () => undefined }),
+  }),
+}));
+
+import {
+  type NormalizedSpan,
+  NormalizedSpanKind,
+  NormalizedStatusCode,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import { CanonicalizeSpanAttributesService } from "../canonicalisation/canonicalizeSpanAttributesService";
+import { TraceIOExtractionService } from "../trace-io-extraction.service";
+
+const canonicaliser = new CanonicalizeSpanAttributesService();
+const ioService = new TraceIOExtractionService();
+
+const SPAN_NAME = "bedrock.converse";
+
+function makeSpan(
+  overrides: Partial<NormalizedSpan> & {
+    spanAttributes?: Record<string, unknown>;
+  } = {},
+): NormalizedSpan {
+  return {
+    id: "span-1",
+    traceId: "trace-1",
+    spanId: "span-1",
+    tenantId: "proj-1",
+    parentSpanId: null,
+    parentTraceId: null,
+    parentIsRemote: null,
+    sampled: true,
+    startTimeUnixMs: 0,
+    endTimeUnixMs: 1000,
+    durationMs: 1000,
+    name: SPAN_NAME,
+    kind: NormalizedSpanKind.CLIENT,
+    resourceAttributes: {},
+    spanAttributes: {},
+    events: [],
+    links: [],
+    statusMessage: null,
+    statusCode: NormalizedStatusCode.OK,
+    instrumentationScope: { name: "test", version: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    cost: null,
+    nonBilledCost: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Runs the real production pair: canonicalise the span's attributes, then
+ * extract trace-level I/O from the canonicalised span — which is the order the
+ * ingestion pipeline uses. Returns the two `ComputedInput` / `ComputedOutput`
+ * texts as they would be written to `trace_summaries`.
+ */
+function computeTraceIO(span: NormalizedSpan) {
+  const canonicalised = canonicaliser.canonicalize(
+    span.spanAttributes,
+    span.events,
+    span,
+  );
+  const spans: NormalizedSpan[] = [
+    {
+      ...span,
+      spanAttributes: canonicalised.attributes,
+      events: canonicalised.events,
+    },
+  ];
+
+  return {
+    input: ioService.extractFirstInput(spans)?.text ?? null,
+    output: ioService.extractLastOutput(spans)?.text ?? null,
+    appliedRules: canonicalised.appliedRules,
+    canonicalAttributes: canonicalised.attributes,
+  };
+}
+
+describe("given a Bedrock span whose messages sit under canonical gen_ai keys", () => {
+  describe("when the content blocks are InvokeModel-typed ({type:'text'})", () => {
+    it("extracts both the prompt and the completion", () => {
+      const { input, output } = computeTraceIO(
+        makeSpan({
+          spanAttributes: {
+            "gen_ai.system": "aws.bedrock",
+            "gen_ai.request.model": "anthropic.claude-3-5-sonnet",
+            "gen_ai.prompt": JSON.stringify([
+              {
+                role: "user",
+                content: [{ type: "text", text: "summarise this consult note" }],
+              },
+            ]),
+            "gen_ai.completion": JSON.stringify([
+              {
+                role: "assistant",
+                content: [{ type: "text", text: "The patient reports ..." }],
+              },
+            ]),
+          },
+        }),
+      );
+
+      // The control for every other case below: with a shape the pipeline
+      // models, real content reaches trace_summaries. Without this passing,
+      // an empty result elsewhere is equally well explained by a broken
+      // fixture and the whole file proves nothing.
+      expect(input).toContain("summarise this consult note");
+      expect(output).toContain("The patient reports ...");
+    });
+  });
+
+  describe("when the content blocks are Converse-shaped (typeless {'text': ...})", () => {
+    it("records whether the typeless block survives extraction", () => {
+      const { input, output } = computeTraceIO(
+        makeSpan({
+          spanAttributes: {
+            "gen_ai.system": "aws.bedrock",
+            "gen_ai.request.model": "anthropic.claude-3-5-sonnet",
+            // The AWS Converse API wire shape: content blocks are a union
+            // discriminated by WHICH KEY IS PRESENT, not by a `type` field.
+            "gen_ai.prompt": JSON.stringify([
+              { role: "user", content: [{ text: "summarise this consult note" }] },
+            ]),
+            "gen_ai.completion": JSON.stringify([
+              { role: "assistant", content: [{ text: "The patient reports ..." }] },
+            ]),
+          },
+        }),
+      );
+
+      expect({ input, output }).toEqual({
+        input: "summarise this consult note",
+        output: "The patient reports ...",
+      });
+    });
+  });
+
+  describe("when the assistant turn is a Converse toolUse block", () => {
+    it("records whether the tool call survives extraction", () => {
+      const { output } = computeTraceIO(
+        makeSpan({
+          spanAttributes: {
+            "gen_ai.system": "aws.bedrock",
+            "gen_ai.completion": JSON.stringify([
+              {
+                role: "assistant",
+                content: [
+                  {
+                    toolUse: {
+                      toolUseId: "tool-1",
+                      name: "lookup_patient",
+                      input: { patientId: "p-42" },
+                    },
+                  },
+                ],
+              },
+            ]),
+          },
+        }),
+      );
+
+      expect(output).toBe(null);
+    });
+  });
+
+  describe("when the user turn is a Converse toolResult block", () => {
+    it("records whether the tool result survives extraction", () => {
+      const { input } = computeTraceIO(
+        makeSpan({
+          spanAttributes: {
+            "gen_ai.system": "aws.bedrock",
+            "gen_ai.prompt": JSON.stringify([
+              {
+                role: "user",
+                content: [
+                  {
+                    toolResult: {
+                      toolUseId: "tool-1",
+                      content: [{ text: "patient p-42 found" }],
+                    },
+                  },
+                ],
+              },
+            ]),
+          },
+        }),
+      );
+
+      expect(input).toBe(SPAN_NAME);
+    });
+  });
+});
+
+describe("given a Bedrock span whose messages sit under keys no extractor maps", () => {
+  describe("when the span carries the Converse request/response bodies verbatim", () => {
+    it("degrades asymmetrically: input becomes the span name, output is lost", () => {
+      const span = makeSpan({
+        spanAttributes: {
+          // A boto3/OTel AWS-SDK span: the operation is identified, and the
+          // Converse payloads ride along under aws.* keys. No registered
+          // extractor reads any of these — there is no AWS/Bedrock extractor.
+          "rpc.service": "BedrockRuntime",
+          "rpc.method": "Converse",
+          "aws.bedrock.model_id": "anthropic.claude-3-5-sonnet",
+          "aws.bedrock.request.messages": JSON.stringify([
+            { role: "user", content: [{ text: "summarise this consult note" }] },
+          ]),
+          "aws.bedrock.response.output": JSON.stringify({
+            message: {
+              role: "assistant",
+              content: [{ text: "The patient reports ..." }],
+            },
+          }),
+        },
+      });
+
+      const { input, output, canonicalAttributes } = computeTraceIO(span);
+
+      // Neither canonical I/O key was ever written: the payloads are present in
+      // the span and invisible to the extraction service.
+      expect(canonicalAttributes["langwatch.input"]).toBeUndefined();
+      expect(canonicalAttributes["gen_ai.input.messages"]).toBeUndefined();
+
+      // This pair IS the production signature. It is identifiable in stored
+      // data with no access to the customer's account: input equal to the span
+      // name, output empty, on a trace whose spans hold real content.
+      expect(input).toBe(SPAN_NAME);
+      expect(output).toBe(null);
+
+      // And the content is demonstrably still in the span — the trace is not
+      // empty, only its summary is.
+      expect(span.spanAttributes["aws.bedrock.request.messages"]).toContain(
+        "summarise this consult note",
+      );
+    });
+  });
+
+  describe("when such a span is the root of an HTTP-instrumented trace", () => {
+    it("substitutes the HTTP method, target and status for the real I/O", () => {
+      const { input, output } = computeTraceIO(
+        makeSpan({
+          spanAttributes: {
+            "rpc.method": "Converse",
+            "http.method": "POST",
+            "http.target": "/model/anthropic.claude-3-5-sonnet/converse",
+            "http.status_code": 200,
+            "aws.bedrock.request.messages": JSON.stringify([
+              { role: "user", content: [{ text: "summarise this consult note" }] },
+            ]),
+          },
+        }),
+      );
+
+      // Worth naming separately: here the trace does NOT read as empty. It
+      // reads as plausible-but-wrong, which is harder to notice than a blank.
+      expect(input).toBe("POST /model/anthropic.claude-3-5-sonnet/converse");
+      expect(output).toBe("200");
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/canonicalisation/canonicalizeSpanAttributesService.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/canonicalizeSpanAttributesService.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../event-sourcing/pipelines/trace-processing/schemas/spans";
 import { parseJsonStringValues } from "../../../event-sourcing/pipelines/trace-processing/utils/traceRequest.utils";
 import {
+  BedrockExtractor,
   ClaudeCodeExtractor,
   CodexExtractor,
   CopilotExtractor,
@@ -38,6 +39,10 @@ export class CanonicalizeSpanAttributesService {
     // Priority is determined by the order of registration.
     new LangWatchExtractor(),
     new GenAIExtractor(),
+    // Bedrock: after GenAIExtractor — canonical/legacy gen_ai.* keys are
+    // GenAI's job; BedrockExtractor lifts only the aws.bedrock.* payload
+    // keys the AWS SDK instrumentation ships (langwatch-saas#1040 Branch 1).
+    new BedrockExtractor(),
     new VertexAdkExtractor(),
     new MastraExtractor(),
     new OpenInferenceExtractor(),

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/_messages.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/_messages.ts
@@ -55,7 +55,9 @@ export const extractMessageContentText = (message: unknown): string | null => {
  * Handles plain strings, {type:"text", text:...}, {text:...}, {content:...},
  * {type:"thinking", thinking:...}, {type:"tool_use", input:...}, and
  * {type:"tool_result", content:...} so unwrapped Anthropic typed blocks
- * still surface as a meaningful raw match.
+ * still surface as a meaningful raw match. Also handles the AWS Bedrock
+ * Converse block union, which is discriminated by which key is present
+ * rather than a `type` field: {toolUse:{...}} and {toolResult:{content:[...]}}.
  */
 const extractTextsFromParts = (parts: unknown[]): string[] => {
   const texts: string[] = [];
@@ -81,6 +83,21 @@ const extractTextsFromParts = (parts: unknown[]): string[] => {
         }
       } else if (p.type === "tool_result" && Array.isArray(p.content)) {
         const inner = extractTextsFromParts(p.content);
+        if (inner.length > 0) texts.push(inner.join("\n"));
+      } else if (isRecord(p.toolUse)) {
+        const input = (p.toolUse as Record<string, unknown>).input;
+        try {
+          texts.push(JSON.stringify(input ?? p.toolUse));
+        } catch {
+          // ignore unstringifiable inputs
+        }
+      } else if (
+        isRecord(p.toolResult) &&
+        Array.isArray((p.toolResult as Record<string, unknown>).content)
+      ) {
+        const inner = extractTextsFromParts(
+          (p.toolResult as Record<string, unknown>).content as unknown[],
+        );
         if (inner.length > 0) texts.push(inner.join("\n"));
       }
     }

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/bedrock.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/bedrock.ts
@@ -1,0 +1,106 @@
+/**
+ * AWS Bedrock Extractor
+ *
+ * Handles: spans from AWS SDK / boto3 instrumentation that carry Bedrock
+ * Converse request/response payloads under `aws.bedrock.*` attribute keys
+ * instead of the canonical `gen_ai.*` keys.
+ * Reference: langwatch-saas#1040 (Branch 1 — no extractor read these keys,
+ * so trace summaries degraded to span-name input / empty output while the
+ * real content sat in the span).
+ *
+ * Detection: `rpc.service` = "BedrockRuntime", `gen_ai.system` /
+ * `gen_ai.provider.name` = "aws.bedrock", or any `aws.bedrock.*` payload key.
+ *
+ * Canonical attributes produced:
+ * - gen_ai.input.messages (from aws.bedrock.request.messages)
+ * - gen_ai.output.messages (from aws.bedrock.response.output — the Converse
+ *   API wraps the assistant turn as `{ output: { message: {...} } }`; the
+ *   attribute may carry either the wrapper or the inner `{ message: {...} }`)
+ * - gen_ai.request.model / gen_ai.response.model (from aws.bedrock.model_id)
+ */
+
+import { ATTR_KEYS } from "./_constants";
+import {
+  extractInputMessages,
+  extractModelToBoth,
+  recordValueType,
+} from "./_extraction";
+import { isRecord, safeJsonParse } from "./_guards";
+import type { CanonicalAttributesExtractor, ExtractorContext } from "./_types";
+
+const BEDROCK_ATTR_KEYS = {
+  RPC_SERVICE: "rpc.service",
+  MODEL_ID: "aws.bedrock.model_id",
+  REQUEST_MESSAGES: "aws.bedrock.request.messages",
+  RESPONSE_OUTPUT: "aws.bedrock.response.output",
+} as const;
+
+export class BedrockExtractor implements CanonicalAttributesExtractor {
+  readonly id = "bedrock";
+
+  apply(ctx: ExtractorContext): void {
+    const { attrs } = ctx.bag;
+
+    const isBedrock =
+      attrs.get(BEDROCK_ATTR_KEYS.RPC_SERVICE) === "BedrockRuntime" ||
+      attrs.get(ATTR_KEYS.GEN_AI_SYSTEM) === "aws.bedrock" ||
+      attrs.get(ATTR_KEYS.GEN_AI_PROVIDER_NAME) === "aws.bedrock" ||
+      attrs.has(BEDROCK_ATTR_KEYS.REQUEST_MESSAGES) ||
+      attrs.has(BEDROCK_ATTR_KEYS.RESPONSE_OUTPUT) ||
+      attrs.has(BEDROCK_ATTR_KEYS.MODEL_ID);
+
+    if (!isBedrock) return;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Model
+    // ─────────────────────────────────────────────────────────────────────────
+    extractModelToBoth(
+      ctx,
+      BEDROCK_ATTR_KEYS.MODEL_ID,
+      (raw) => (typeof raw === "string" ? raw : null),
+      `${this.id}:model(aws.bedrock.model_id)`,
+    );
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Input Messages
+    // Converse request messages ride verbatim: [{role, content:[{text}|...]}]
+    // ─────────────────────────────────────────────────────────────────────────
+    const inputExtracted = extractInputMessages(
+      ctx,
+      [{ type: "attr", keys: [BEDROCK_ATTR_KEYS.REQUEST_MESSAGES] }],
+      `${this.id}:aws.bedrock.request.messages->gen_ai.input.messages`,
+    );
+    if (inputExtracted) {
+      recordValueType(ctx, ATTR_KEYS.GEN_AI_INPUT_MESSAGES, "chat_messages");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Output Messages
+    // The Converse response nests the assistant turn: unwrap `output` and/or
+    // `message` wrappers down to the message object itself.
+    // ─────────────────────────────────────────────────────────────────────────
+    if (
+      !attrs.has(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES) &&
+      ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES] === undefined
+    ) {
+      const raw = attrs.take(BEDROCK_ATTR_KEYS.RESPONSE_OUTPUT);
+      if (raw !== undefined) {
+        let parsed = safeJsonParse(raw);
+        if (isRecord(parsed) && isRecord(parsed.output)) parsed = parsed.output;
+        if (isRecord(parsed) && isRecord(parsed.message)) parsed = parsed.message;
+        if (isRecord(parsed) || Array.isArray(parsed)) {
+          const messages = Array.isArray(parsed) ? parsed : [parsed];
+          ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, messages);
+          ctx.recordRule(
+            `${this.id}:aws.bedrock.response.output->gen_ai.output.messages`,
+          );
+          recordValueType(
+            ctx,
+            ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES,
+            "chat_messages",
+          );
+        }
+      }
+    }
+  }
+}

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/bedrock.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/bedrock.ts
@@ -87,7 +87,8 @@ export class BedrockExtractor implements CanonicalAttributesExtractor {
       if (raw !== undefined) {
         let parsed = safeJsonParse(raw);
         if (isRecord(parsed) && isRecord(parsed.output)) parsed = parsed.output;
-        if (isRecord(parsed) && isRecord(parsed.message)) parsed = parsed.message;
+        if (isRecord(parsed) && isRecord(parsed.message))
+          parsed = parsed.message;
         if (isRecord(parsed) || Array.isArray(parsed)) {
           const messages = Array.isArray(parsed) ? parsed : [parsed];
           ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, messages);

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/bedrock.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/bedrock.ts
@@ -39,17 +39,7 @@ export class BedrockExtractor implements CanonicalAttributesExtractor {
   readonly id = "bedrock";
 
   apply(ctx: ExtractorContext): void {
-    const { attrs } = ctx.bag;
-
-    const isBedrock =
-      attrs.get(BEDROCK_ATTR_KEYS.RPC_SERVICE) === "BedrockRuntime" ||
-      attrs.get(ATTR_KEYS.GEN_AI_SYSTEM) === "aws.bedrock" ||
-      attrs.get(ATTR_KEYS.GEN_AI_PROVIDER_NAME) === "aws.bedrock" ||
-      attrs.has(BEDROCK_ATTR_KEYS.REQUEST_MESSAGES) ||
-      attrs.has(BEDROCK_ATTR_KEYS.RESPONSE_OUTPUT) ||
-      attrs.has(BEDROCK_ATTR_KEYS.MODEL_ID);
-
-    if (!isBedrock) return;
+    if (!this.isBedrockSpan(ctx)) return;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Model
@@ -79,29 +69,54 @@ export class BedrockExtractor implements CanonicalAttributesExtractor {
     // The Converse response nests the assistant turn: unwrap `output` and/or
     // `message` wrappers down to the message object itself.
     // ─────────────────────────────────────────────────────────────────────────
-    if (
-      !attrs.has(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES) &&
-      ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES] === undefined
-    ) {
-      const raw = attrs.take(BEDROCK_ATTR_KEYS.RESPONSE_OUTPUT);
-      if (raw !== undefined) {
-        let parsed = safeJsonParse(raw);
-        if (isRecord(parsed) && isRecord(parsed.output)) parsed = parsed.output;
-        if (isRecord(parsed) && isRecord(parsed.message))
-          parsed = parsed.message;
-        if (isRecord(parsed) || Array.isArray(parsed)) {
-          const messages = Array.isArray(parsed) ? parsed : [parsed];
-          ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, messages);
-          ctx.recordRule(
-            `${this.id}:aws.bedrock.response.output->gen_ai.output.messages`,
-          );
-          recordValueType(
-            ctx,
-            ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES,
-            "chat_messages",
-          );
-        }
-      }
-    }
+    this.extractOutputMessages(ctx);
   }
+
+  private isBedrockSpan(ctx: ExtractorContext): boolean {
+    const { attrs } = ctx.bag;
+    return (
+      attrs.get(BEDROCK_ATTR_KEYS.RPC_SERVICE) === "BedrockRuntime" ||
+      attrs.get(ATTR_KEYS.GEN_AI_SYSTEM) === "aws.bedrock" ||
+      attrs.get(ATTR_KEYS.GEN_AI_PROVIDER_NAME) === "aws.bedrock" ||
+      attrs.has(BEDROCK_ATTR_KEYS.REQUEST_MESSAGES) ||
+      attrs.has(BEDROCK_ATTR_KEYS.RESPONSE_OUTPUT) ||
+      attrs.has(BEDROCK_ATTR_KEYS.MODEL_ID)
+    );
+  }
+
+  private extractOutputMessages(ctx: ExtractorContext): void {
+    const { attrs } = ctx.bag;
+    if (
+      attrs.has(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES) ||
+      ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES] !== undefined
+    ) {
+      return;
+    }
+
+    const raw = attrs.take(BEDROCK_ATTR_KEYS.RESPONSE_OUTPUT);
+    if (raw === undefined) return;
+
+    const messages = unwrapConverseOutput(safeJsonParse(raw));
+    if (messages === null) return;
+
+    ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, messages);
+    ctx.recordRule(
+      `${this.id}:aws.bedrock.response.output->gen_ai.output.messages`,
+    );
+    recordValueType(ctx, ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, "chat_messages");
+  }
+}
+
+/**
+ * The Converse API nests the assistant turn as `{ output: { message: {...} } }`;
+ * the attribute may carry the wrapper, the inner `{ message: {...} }`, the
+ * message itself, or already-listed messages. Unwrap down to a message array.
+ */
+function unwrapConverseOutput(parsed: unknown): unknown[] | null {
+  let value = parsed;
+  if (isRecord(value) && isRecord(value.output)) value = value.output;
+  if (isRecord(value) && isRecord(value.message)) value = value.message;
+  if (Array.isArray(value)) return value;
+  if (isRecord(value)) return [value];
+  return null;
 }

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/index.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/index.ts
@@ -1,4 +1,5 @@
 export * from "./_constants";
+export { BedrockExtractor } from "./bedrock";
 export { ClaudeCodeExtractor } from "./claudeCode";
 export { CodexExtractor } from "./codex";
 export { CopilotExtractor } from "./copilot";

--- a/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
@@ -158,8 +158,10 @@ async function readPage(options: Record<string, unknown>) {
     openProtections,
     options,
   );
-  expect(results).not.toBeNull();
-  return results!.groups.flat();
+  if (results === null) {
+    throw new Error("getAllTracesForProject returned null for a page read");
+  }
+  return results.groups.flat();
 }
 
 beforeAll(async () => {

--- a/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
@@ -42,11 +42,11 @@ const now = Date.now();
  */
 const BEDROCK_INPUT = JSON.stringify({
   type: "text",
-  value: 'Bedrock Converse input: [{"text":"summarise this consult note"}]',
+  value: 'Bedrock Converse input: [{"text":"summarise this shipping manifest"}]',
 });
 const BEDROCK_OUTPUT = JSON.stringify({
   type: "text",
-  value: 'Bedrock Converse output: [{"text":"The patient reports ..."}]',
+  value: 'Bedrock Converse output: [{"text":"The shipment contains ..."}]',
 });
 
 function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
@@ -223,8 +223,8 @@ describe("given a trace whose spans carry real Bedrock content", () => {
 
       // Emptiness measured on THESE fields would be real. Emptiness measured on
       // `spans` would not — that is the whole distinction branch 2 turns on.
-      expect(trace!.input?.value).toContain("summarise this consult note");
-      expect(trace!.output?.value).toContain("The patient reports");
+      expect(trace!.input?.value).toContain("summarise this shipping manifest");
+      expect(trace!.output?.value).toContain("The shipment contains");
     });
   });
 

--- a/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
@@ -42,7 +42,8 @@ const now = Date.now();
  */
 const BEDROCK_INPUT = JSON.stringify({
   type: "text",
-  value: 'Bedrock Converse input: [{"text":"summarise this shipping manifest"}]',
+  value:
+    'Bedrock Converse input: [{"text":"summarise this shipping manifest"}]',
 });
 const BEDROCK_OUTPUT = JSON.stringify({
   type: "text",

--- a/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Branch 2 of langwatch-saas#1040: is "N empty traces" counted through
+ * `POST /api/trace/search` a MEASUREMENT ARTIFACT rather than missing content?
+ *
+ * The route (`src/server/routes/traces-legacy.ts`, `POST /trace/search`) calls
+ * `getAllTracesForProject` with `{ downloadMode: true, scrollId }` and never
+ * sets `includeSpans`. `ClickHouseTraceService.getAllTracesForProject` gates the
+ * span read on `options.includeSpans === true`, so the search page is served
+ * from `trace_summaries` alone and carries no span tree — however much content
+ * the spans actually hold.
+ *
+ * The control is the point: the SAME seeded trace, read with `includeSpans:
+ * true`, must come back with its spans. Without it, "spans are empty" is
+ * equally well explained by a seed that never landed, and the test proves
+ * nothing.
+ *
+ * Trace-level `input`/`output` are asserted present on the search path too:
+ * they come from `trace_summaries.Computed*`, so a trace that reads empty in
+ * THOSE fields is empty for a different and real reason. That distinction is
+ * what decides branch 2 against branch 1.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { prisma } from "~/server/db";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import { openProtections } from "./open-protections";
+
+const tenantId = `test-1040-${nanoid()}`;
+const traceId = `trace-1040-${nanoid()}`;
+const now = Date.now();
+
+/**
+ * Content deliberately shaped like an AWS Bedrock Converse span: typeless
+ * `{"text": ...}` content blocks, which is the shape the repo models nowhere.
+ */
+const BEDROCK_INPUT = JSON.stringify({
+  type: "text",
+  value: 'Bedrock Converse input: [{"text":"summarise this consult note"}]',
+});
+const BEDROCK_OUTPUT = JSON.stringify({
+  type: "text",
+  value: 'Bedrock Converse output: [{"text":"The patient reports ..."}]',
+});
+
+function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: BEDROCK_INPUT,
+    ComputedOutput: BEDROCK_OUTPUT,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 2,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: ["anthropic.claude-3-5-sonnet"],
+    TotalCost: 0.0031,
+    TokensEstimated: false,
+    TotalPromptTokenCount: 120,
+    TotalCompletionTokenCount: 80,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+    ...overrides,
+  };
+}
+
+function makeSpanRow({
+  spanName,
+  spanAttributes,
+}: {
+  spanName: string;
+  spanAttributes: Record<string, string>;
+}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    SpanId: `span-${nanoid()}`,
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(now),
+    EndTime: new Date(now + 5),
+    DurationMs: 5,
+    SpanName: spanName,
+    SpanKind: 1,
+    ServiceName: "healify-repro",
+    ResourceAttributes: {},
+    SpanAttributes: spanAttributes,
+    StatusCode: 1,
+    StatusMessage: null,
+    ScopeName: "test",
+    ScopeVersion: null,
+    "Events.Timestamp": [],
+    "Events.Name": [],
+    "Events.Attributes": [],
+    "Links.TraceId": [],
+    "Links.SpanId": [],
+    "Links.Attributes": [],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+  };
+}
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: { findUnique: vi.fn().mockResolvedValue({}) },
+    annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    annotationScore: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+/** The exact options `POST /api/trace/search` passes for a default JSON read. */
+const SEARCH_ROUTE_OPTIONS = { downloadMode: true, scrollId: undefined };
+
+async function readPage(options: Record<string, unknown>) {
+  const results = await service.getAllTracesForProject(
+    {
+      projectId: tenantId,
+      startDate: now - 60_000,
+      endDate: now + 60_000,
+      filters: {},
+      pageSize: 100,
+    },
+    openProtections,
+    options,
+  );
+  expect(results).not.toBeNull();
+  return results!.groups.flat();
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+
+  await ch.insert({
+    table: "trace_summaries",
+    values: [makeTraceSummaryRow()],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+  await ch.insert({
+    table: "stored_spans",
+    values: [
+      makeSpanRow({
+        spanName: "bedrock.converse",
+        spanAttributes: {
+          "gen_ai.system": "aws.bedrock",
+          "gen_ai.request.model": "anthropic.claude-3-5-sonnet",
+          "langwatch.input": BEDROCK_INPUT,
+          "langwatch.output": BEDROCK_OUTPUT,
+        },
+      }),
+      makeSpanRow({
+        spanName: "healify.pipeline",
+        spanAttributes: { "langwatch.span.type": "chain" },
+      }),
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}, 120_000);
+
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+describe("given a trace whose spans carry real Bedrock content", () => {
+  describe("when it is read the way POST /api/trace/search reads it", () => {
+    it("returns no span tree even though the spans exist", async () => {
+      const [trace] = await readPage(SEARCH_ROUTE_OPTIONS);
+
+      expect(trace).toBeDefined();
+      expect(trace!.trace_id).toBe(traceId);
+      // Pinned deliberately: the route serialises whatever the service returns,
+      // so whether the caller sees `"spans": []` or no `spans` key at all is
+      // the difference between "the count saw an empty array" and "the count
+      // saw undefined". Both read as empty; a reader must know which.
+      expect(trace!.spans).toEqual([]);
+    });
+
+    it("still returns the trace-level input and output", async () => {
+      const [trace] = await readPage(SEARCH_ROUTE_OPTIONS);
+
+      // Emptiness measured on THESE fields would be real. Emptiness measured on
+      // `spans` would not — that is the whole distinction branch 2 turns on.
+      expect(trace!.input?.value).toContain("summarise this consult note");
+      expect(trace!.output?.value).toContain("The patient reports");
+    });
+  });
+
+  describe("when the same trace is read with includeSpans", () => {
+    it("returns the spans, proving the seed landed and the emptiness is the read option", async () => {
+      const [trace] = await readPage({
+        ...SEARCH_ROUTE_OPTIONS,
+        includeSpans: true,
+      });
+
+      expect(trace!.spans).toHaveLength(2);
+      expect(trace!.spans!.map((s) => s.name).sort()).toEqual([
+        "bedrock.converse",
+        "healify.pipeline",
+      ]);
+    });
+  });
+});

--- a/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
@@ -108,7 +108,7 @@ function makeSpanRow({
     DurationMs: 5,
     SpanName: spanName,
     SpanKind: 1,
-    ServiceName: "healify-repro",
+    ServiceName: "converse-repro",
     ResourceAttributes: {},
     SpanAttributes: spanAttributes,
     StatusCode: 1,
@@ -192,7 +192,7 @@ beforeAll(async () => {
         },
       }),
       makeSpanRow({
-        spanName: "healify.pipeline",
+        spanName: "converse.pipeline",
         spanAttributes: { "langwatch.span.type": "chain" },
       }),
     ],
@@ -239,7 +239,7 @@ describe("given a trace whose spans carry real Bedrock content", () => {
       expect(trace!.spans).toHaveLength(2);
       expect(trace!.spans!.map((s) => s.name).sort()).toEqual([
         "bedrock.converse",
-        "healify.pipeline",
+        "converse.pipeline",
       ]);
     });
   });

--- a/specs/trace-processing/bedrock-converse-io-extraction.feature
+++ b/specs/trace-processing/bedrock-converse-io-extraction.feature
@@ -1,0 +1,46 @@
+Feature: Bedrock Converse span I/O extraction
+  As an operator viewing traces from AWS Bedrock instrumentation
+  I want Converse-shaped payloads to reach the trace summary input/output
+  So that Bedrock traces don't read as empty (or as span-name/HTTP noise)
+  while the real content sits unread in span attributes.
+
+  # Why this exists — langwatch-saas#1040 (Branch 1)
+  #
+  # None of the registered canonicalisation extractors read AWS Bedrock
+  # payload keys, and the Converse API's content-block union is
+  # discriminated by WHICH KEY IS PRESENT ({text}, {toolUse}, {toolResult})
+  # rather than a `type` field, so tool turns were dropped even when the
+  # messages sat under canonical gen_ai.* keys. The degradation was
+  # asymmetric and easy to miss: input fell back to the root span's name,
+  # output to the HTTP status or nothing.
+  #
+  # Note: this gap did NOT cause the Healify empty traces in #1040 — those
+  # spans carry no payload attributes at all (producer-side omission).
+
+  Background:
+    Given the canonicalisation pipeline runs before trace I/O extraction
+
+  @unit @canonicalisation
+  Scenario: Converse toolUse block survives extraction
+    Given a gen_ai.completion message whose content is [{toolUse: {name, input}}]
+    When trace I/O is extracted
+    Then the output text contains the JSON of the tool call's input
+
+  @unit @canonicalisation
+  Scenario: Converse toolResult block survives extraction
+    Given a gen_ai.prompt message whose content is [{toolResult: {content: [{text}]}}]
+    When trace I/O is extracted
+    Then the input text is the tool result's inner text
+
+  @unit @canonicalisation
+  Scenario: aws.bedrock.* payload keys are mapped to canonical keys
+    Given a span with aws.bedrock.request.messages and aws.bedrock.response.output
+    When the BedrockExtractor canonicalises the span
+    Then gen_ai.input.messages and gen_ai.output.messages are written
+    And the trace summary shows the real prompt and completion
+
+  @unit @canonicalisation
+  Scenario: Mapped messages beat the HTTP fallback
+    Given an HTTP-instrumented Bedrock span with aws.bedrock.request.messages
+    When trace I/O is extracted
+    Then the input is the request message text, not "POST /model/.../converse"

--- a/specs/trace-processing/bedrock-converse-io-extraction.feature
+++ b/specs/trace-processing/bedrock-converse-io-extraction.feature
@@ -14,7 +14,7 @@ Feature: Bedrock Converse span I/O extraction
   # asymmetric and easy to miss: input fell back to the root span's name,
   # output to the HTTP status or nothing.
   #
-  # Note: this gap did NOT cause the Healify empty traces in #1040 — those
+  # Note: this gap did NOT cause the customer empty traces in #1040 — those
   # spans carry no payload attributes at all (producer-side omission).
 
   Background:


### PR DESCRIPTION
# Related Issue

- Resolves #1040

## Why

Investigating langwatch-saas#1040 (private customer report; empty Bedrock traces) surfaced a real, customer-independent gap: no canonicalisation extractor reads AWS Bedrock payload keys, and the Converse API's content-block union (`{text}` / `{toolUse}` / `{toolResult}`, discriminated by key presence rather than a `type` field) loses its tool turns even under canonical `gen_ai.*` keys. The degradation is asymmetric and easy to miss: input falls back to the root span's **name**, output to the HTTP status or nothing — while the real content sits unread in span attributes.

**This gap did not cause the #1040 empties** — those spans carry no payload attributes at all (producer-side omission, confirmed against production data). But any tenant shipping real Converse payloads hits it.

## What changed

- `extractors/_messages.ts` — `extractTextsFromParts` now handles Converse `{toolUse: {input}}` (stringified) and `{toolResult: {content: [...]}}` (recursed), mirroring the existing Anthropic `tool_use`/`tool_result` branches.
- `extractors/bedrock.ts` (new) — `BedrockExtractor` maps `aws.bedrock.request.messages` → `gen_ai.input.messages`, `aws.bedrock.response.output` (unwrapping the `output`/`message` nesting) → `gen_ai.output.messages`, `aws.bedrock.model_id` → model keys. Detection: `rpc.service=BedrockRuntime`, `gen_ai.system|provider.name=aws.bedrock`, or any `aws.bedrock.*` payload key. Registered after `GenAIExtractor`, before the fallback.
- `specs/trace-processing/bedrock-converse-io-extraction.feature` (new) — the requirement.
- The #1040 characterisation test now asserts the fixed behaviour.

## How it works

Canonicalisation runs once at ingestion, upstream of both the fold-time accumulator and the read-time `TraceIOExtractionService`, so both consumers see the mapped keys — no duplicated logic across call sites.

## How I can prove I was successful

Red→green split on purpose:
- `ce1344b4da` (test) — the four Converse-shape assertions fail against the old code: `output = null` for toolUse, `input = "bedrock.converse"` (span name) for toolResult and the aws.* payload span, `input = "POST /model/.../converse"` for the HTTP-instrumented span.
- `459e1d0288` (feat) — same tests pass.

Verified locally: `npx vitest run src/server/app-layer/traces` → **86 files, 1725 tests passed** (no regression in the other 15 extractors' suites); `pnpm typecheck:all` clean; biome clean on the changed files. A negative-case test (`222d600b8b`) proves the extractor applies no rule on a non-Bedrock rpc span.

**Residual risk:** the Converse shapes here are derived from the AWS Converse API wire format, not from a captured production payload — the #1040 spans carry no payloads at all, so no real-world fixture exists. A capture from a tenant that ships content should be checked against these fixtures before relying on the `aws.bedrock.*` mapping.

## Human verification

Send a span with `aws.bedrock.request.messages` / `aws.bedrock.response.output` (or a `gen_ai.prompt` containing a `toolResult` block) and confirm the trace summary shows the message text instead of the span name / blank.

## Anything surprising

The first three commits on the branch are the #1040 investigation artifacts (characterisation test, search-vs-hydration integration test, docs commit) — kept, since they document why the fix is shaped this way.

## UI surface

Backend-only change — no UI surface. The diff touches server-side span canonicalisation and tests only; nothing renders differently except data already displayed by existing trace views.
<!-- no-ui-surface -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added extraction of AWS Bedrock Converse request and response content into standardized trace input and output fields.
  - Preserved text, tool-use, and tool-result content for improved trace visibility.
  - Added Bedrock model identification and support for canonical and legacy payload formats.
  - Ensured mapped message content takes precedence over HTTP fallback data.

- **Bug Fixes**
  - Improved trace search behavior when spans are not requested, while retaining trace-level input and output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
