### PR TITLE
fix(auth): make secondary storage degrade loud and pin with tests

### DIFF
--- a/platform/app/src/server/better-auth/__tests__/index.test.ts
+++ b/platform/app/src/server/better-auth/__tests__/index.test.ts
@@ -230,7 +230,7 @@ describe("better-auth config", () => {
   // ==========================================================================
 
   describe("when Redis is unavailable", () => {
-    /** @scenario Rate limiting falls back to in-memory when Redis is unavailable */
+    /** @scenario Rate limiting falls back to in-memory when Redis is not configured */
     it("sets secondaryStorage to undefined and rate limiting to memory", async () => {
       const { auth } = await import("../index");
       const options = (auth as any).options;
@@ -255,7 +255,7 @@ describe("better-auth config", () => {
   });
 
   describe("when Redis is available", () => {
-    /** @scenario Rate limiting uses Redis secondary storage when available */
+    /** @scenario Rate limiting uses Redis secondary storage when configured */
     it("builds secondaryStorage with get, set, and delete operations", async () => {
       const { buildSecondaryStorage } = await import("../index");
       const fakeRedis = {

--- a/platform/app/src/server/better-auth/__tests__/index.test.ts
+++ b/platform/app/src/server/better-auth/__tests__/index.test.ts
@@ -6,6 +6,14 @@ import { describe, expect, it, vi } from "vitest";
 // tests pass, causing shard 2 to hang until GitHub Actions cancels it.
 // Established pattern: see fallbackName.test.ts line 17-18.
 vi.mock("~/server/db", () => ({ prisma: {} }));
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
 
 describe("better-auth config", () => {
   describe("when imported", () => {
@@ -214,6 +222,132 @@ describe("better-auth config", () => {
       };
       expect(google.clientId).toBe("google-client-id");
       expect(google.clientSecret).toBe("google-client-secret");
+    });
+  });
+
+  // ==========================================================================
+  // Secondary storage degrade behavior (rate-limit safety) — issue #6950
+  // ==========================================================================
+
+  describe("when Redis is unavailable", () => {
+    /** @scenario Rate limiting falls back to in-memory when Redis is unavailable */
+    it("sets secondaryStorage to undefined and rate limiting to memory", async () => {
+      const { auth } = await import("../index");
+      const options = (auth as any).options;
+      expect(options?.secondaryStorage).toBeUndefined();
+      expect(options?.rateLimit?.storage).toBe("memory");
+    });
+
+    /** @scenario Secondary storage degrade is logged at startup */
+    it("logs a warning when secondary storage degrades to in-memory", async () => {
+      const { buildSecondaryStorage } = await import("../index");
+      const mockLogger = { warn: vi.fn() };
+      const result = buildSecondaryStorage({
+        isRedisConfigured: false,
+        connectionFactory: () => null,
+        logger: mockLogger,
+      });
+      expect(result).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("rate limiting"),
+      );
+    });
+  });
+
+  describe("when Redis is available", () => {
+    /** @scenario Rate limiting uses Redis secondary storage when available */
+    it("builds secondaryStorage with get, set, and delete operations", async () => {
+      const { buildSecondaryStorage } = await import("../index");
+      const fakeRedis = {
+        get: vi.fn().mockResolvedValue("value"),
+        set: vi.fn().mockResolvedValue("OK"),
+        del: vi.fn().mockResolvedValue(1),
+      };
+      const mockLogger = { warn: vi.fn() };
+      const result = buildSecondaryStorage({
+        isRedisConfigured: true,
+        connectionFactory: () => fakeRedis,
+        logger: mockLogger,
+      });
+
+      expect(result).toBeDefined();
+      expect(typeof result!.get).toBe("function");
+      expect(typeof result!.set).toBe("function");
+      expect(typeof result!.delete).toBe("function");
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("prefixes keys with better-auth:", async () => {
+      const { buildSecondaryStorage } = await import("../index");
+      const fakeRedis = {
+        get: vi.fn().mockResolvedValue("val"),
+        set: vi.fn().mockResolvedValue("OK"),
+        del: vi.fn().mockResolvedValue(1),
+      };
+      const storage = buildSecondaryStorage({
+        isRedisConfigured: true,
+        connectionFactory: () => fakeRedis,
+        logger: { warn: vi.fn() },
+      })!;
+
+      await storage.get("rate-limit:key");
+      expect(fakeRedis.get).toHaveBeenCalledWith("better-auth:rate-limit:key");
+
+      await storage.set("rate-limit:key", "1", 60);
+      expect(fakeRedis.set).toHaveBeenCalledWith(
+        "better-auth:rate-limit:key",
+        "1",
+        "EX",
+        60,
+      );
+
+      await storage.delete("rate-limit:key");
+      expect(fakeRedis.del).toHaveBeenCalledWith("better-auth:rate-limit:key");
+    });
+
+    it("sets value without TTL when ttl is not provided", async () => {
+      const { buildSecondaryStorage } = await import("../index");
+      const fakeRedis = {
+        get: vi.fn(),
+        set: vi.fn().mockResolvedValue("OK"),
+        del: vi.fn(),
+      };
+      const storage = buildSecondaryStorage({
+        isRedisConfigured: true,
+        connectionFactory: () => fakeRedis,
+        logger: { warn: vi.fn() },
+      })!;
+
+      await storage.set("key", "val", undefined);
+      expect(fakeRedis.set).toHaveBeenCalledWith("better-auth:key", "val");
+    });
+  });
+
+  describe("when Redis is configured but connection is unavailable (pre-init window)", () => {
+    /** @scenario Pre-init window drops are logged */
+    it("logs a warning on set/delete and returns null on get", async () => {
+      const { buildSecondaryStorage } = await import("../index");
+      const mockLogger = { warn: vi.fn() };
+      const storage = buildSecondaryStorage({
+        isRedisConfigured: true,
+        connectionFactory: () => null,
+        logger: mockLogger,
+      })!;
+
+      expect(storage).toBeDefined();
+      expect(await storage.get("key")).toBeNull();
+      // get does not warn — a cache miss is fine
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+
+      await storage.set("key", "val", 60);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("pre-init window"),
+      );
+
+      mockLogger.warn.mockClear();
+      await storage.delete("key");
+      // Second call should NOT warn again (deduped)
+      expect(mockLogger.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/server/better-auth/index.ts
+++ b/platform/app/src/server/better-auth/index.ts
@@ -73,18 +73,20 @@ const plugins =
     : [];
 
 /**
- * Wire BetterAuth's secondary storage to the App's Redis connection. Used by
- * rate limiting (below) so limits are enforced across pods.
+ * Build BetterAuth's secondary storage adapter.
+ * Used by rate limiting so limits are enforced across pods.
  *
- * WHETHER to configure it is decided here, at module load, because
- * `betterAuth()` below is itself constructed at module load and the choice
- * changes its session strategy — a deployment with no Redis must get `undefined`
- * and keep its sessions in the database. That decision is a pure question about
- * *configuration*, so it is answered from env rather than from a live client
- * (ADR-093); the client itself is resolved lazily, inside each callback.
+ * Two degrade paths, both now logged (#6950):
  *
- * `BUILD_TIME` joins `SKIP_REDIS` in the skip signal: a build or a test run has
- * env pointing at a Redis it must not adopt as a session store.
+ * 1. Redis not configured (no REDIS_URL, build time, SKIP_REDIS) → returns
+ *    `undefined`, rate limiting falls back to in-memory (per-process counters).
+ * 2. Redis configured but connection unavailable at call time (pre-init
+ *    window) → set/delete drop, get returns null (cache miss, DB fallback).
+ *    This is correct (throwing would fail the request outright) but must be
+ *    visible so operators notice.
+ *
+ * Exported for unit testing — lets us verify both degrade paths and the
+ * key-prefix contract without re-initializing the module.
  */
 const redisEnv = {
   url: env.REDIS_URL,
@@ -96,36 +98,74 @@ const redisEnv = {
  * The App's connection at the moment a storage callback runs.
  *
  * Null only where env advertises Redis but the App has none — a test app, or a
- * callback firing before boot completes. Degrading to a cache miss there is
- * right: better-auth re-reads from the database, whereas throwing would fail
- * the request outright.
+ * callback firing before boot completes.
  */
 const secondaryStorageConnection = () => tryGetApp()?.redis ?? null;
 
-const secondaryStorage: BetterAuthOptions["secondaryStorage"] =
-  new RedisConfigService().isConfigured(redisEnv)
-    ? {
-        get: async (key) => {
-          const redis = secondaryStorageConnection();
-          if (!redis) return null;
-          return await redis.get(`better-auth:${key}`);
-        },
-        set: async (key, value, ttl) => {
-          const redis = secondaryStorageConnection();
-          if (!redis) return;
-          if (ttl) {
-            await redis.set(`better-auth:${key}`, value, "EX", ttl);
-          } else {
-            await redis.set(`better-auth:${key}`, value);
-          }
-        },
-        delete: async (key) => {
-          const redis = secondaryStorageConnection();
-          if (!redis) return;
-          await redis.del(`better-auth:${key}`);
-        },
+export function buildSecondaryStorage({
+  isRedisConfigured,
+  connectionFactory,
+  logger: log,
+}: {
+  isRedisConfigured: boolean;
+  connectionFactory: () => {
+    get(key: string): Promise<string | null>;
+    set(key: string, value: string, ...args: unknown[]): Promise<unknown>;
+    del(key: string): Promise<unknown>;
+  } | null;
+  logger: Pick<typeof logger, "warn">;
+}): BetterAuthOptions["secondaryStorage"] {
+  if (!isRedisConfigured) {
+    log.warn(
+      "Redis unavailable — rate limiting will use in-memory storage (not distributed across pods)",
+    );
+    return undefined;
+  }
+
+  let runtimeDegradeWarned = false;
+  const warnRuntimeDegrade = () => {
+    if (!runtimeDegradeWarned) {
+      log.warn(
+        "Redis configured but unavailable at call time — rate-limit write dropped (pre-init window)",
+      );
+      runtimeDegradeWarned = true;
+    }
+  };
+
+  return {
+    get: async (key) => {
+      const redis = connectionFactory();
+      if (!redis) return null;
+      return await redis.get(`better-auth:${key}`);
+    },
+    set: async (key, value, ttl) => {
+      const redis = connectionFactory();
+      if (!redis) {
+        warnRuntimeDegrade();
+        return;
       }
-    : undefined;
+      if (ttl) {
+        await redis.set(`better-auth:${key}`, value, "EX", ttl);
+      } else {
+        await redis.set(`better-auth:${key}`, value);
+      }
+    },
+    delete: async (key) => {
+      const redis = connectionFactory();
+      if (!redis) {
+        warnRuntimeDegrade();
+        return;
+      }
+      await redis.del(`better-auth:${key}`);
+    },
+  };
+}
+
+const secondaryStorage = buildSecondaryStorage({
+  isRedisConfigured: new RedisConfigService().isConfigured(redisEnv),
+  connectionFactory: secondaryStorageConnection,
+  logger,
+});
 
 const isBuildTime = !!process.env.BUILD_TIME;
 

--- a/specs/auth/phase-1-better-auth-config.feature
+++ b/specs/auth/phase-1-better-auth-config.feature
@@ -176,28 +176,28 @@ Feature: BetterAuth config (unmounted)
   # ============================================================================
   # Secondary storage degrade behavior (rate-limit safety)
   #
-  # When Redis is unavailable (build time, tests, no REDIS_URL), rate-limit
-  # counters must NOT silently disappear — they must fall back to in-memory
-  # storage and the degrade must be logged so operators notice.
+  # When Redis is not configured (build time, no REDIS_URL, or SKIP_REDIS),
+  # rate-limit counters must NOT silently disappear — they must fall back to
+  # in-memory storage and the degrade must be logged so operators notice.
   # ============================================================================
 
   @unit
-  Scenario: Rate limiting falls back to in-memory when Redis is unavailable
-    Given the Redis connection is null (build time, tests, or no REDIS_URL)
+  Scenario: Rate limiting falls back to in-memory when Redis is not configured
+    Given Redis is not configured (build time, no REDIS_URL, or SKIP_REDIS)
     When the BetterAuth instance is initialized
     Then secondaryStorage is undefined
     And rate limiting uses "memory" storage instead of "secondary-storage"
 
   @unit
-  Scenario: Rate limiting uses Redis secondary storage when available
-    Given the Redis connection is available
+  Scenario: Rate limiting uses Redis secondary storage when configured
+    Given Redis is configured and the connection is available
     When the BetterAuth instance is initialized
     Then secondaryStorage is defined with get, set, and delete operations
     And rate limiting uses "secondary-storage"
 
   @unit
   Scenario: Secondary storage degrade is logged at startup
-    Given the Redis connection is null
+    Given Redis is not configured
     When the BetterAuth module loads
     Then a warning is logged indicating rate limiting will use in-memory storage
 

--- a/specs/auth/phase-1-better-auth-config.feature
+++ b/specs/auth/phase-1-better-auth-config.feature
@@ -172,3 +172,38 @@ Feature: BetterAuth config (unmounted)
     Then BetterAuth handles the request
     And no NextAuth handler is reachable on any `/api/auth/*` path
     And `pnpm typecheck` passes
+
+  # ============================================================================
+  # Secondary storage degrade behavior (rate-limit safety)
+  #
+  # When Redis is unavailable (build time, tests, no REDIS_URL), rate-limit
+  # counters must NOT silently disappear — they must fall back to in-memory
+  # storage and the degrade must be logged so operators notice.
+  # ============================================================================
+
+  @unit
+  Scenario: Rate limiting falls back to in-memory when Redis is unavailable
+    Given the Redis connection is null (build time, tests, or no REDIS_URL)
+    When the BetterAuth instance is initialized
+    Then secondaryStorage is undefined
+    And rate limiting uses "memory" storage instead of "secondary-storage"
+
+  @unit
+  Scenario: Rate limiting uses Redis secondary storage when available
+    Given the Redis connection is available
+    When the BetterAuth instance is initialized
+    Then secondaryStorage is defined with get, set, and delete operations
+    And rate limiting uses "secondary-storage"
+
+  @unit
+  Scenario: Secondary storage degrade is logged at startup
+    Given the Redis connection is null
+    When the BetterAuth module loads
+    Then a warning is logged indicating rate limiting will use in-memory storage
+
+  @unit
+  Scenario: Pre-init window drops are logged
+    Given Redis is configured but the connection is unavailable at call time
+    When a rate-limit set or delete is attempted
+    Then a warning is logged indicating the pre-init window drop
+    And get returns null (cache miss, database fallback)


### PR DESCRIPTION
## For humans

When Redis is unavailable, BetterAuth rate limiting silently falls back to in-memory counters — per-process, lost on restart, not shared across pods. This was invisible in production logs. Now both degrade paths are logged.

## What changed

- Extracted `buildSecondaryStorage()` from inline config so both degrade paths are testable
- Added `logger.warn()` for two cases:
  1. Redis not configured at startup → rate limiting uses in-memory
  2. Redis configured but connection unavailable at call time (pre-init window) → set/delete dropped, get returns null (cache miss, DB fallback)
- Added 5 unit tests pinning the degrade behavior:
  - `secondaryStorage` is `undefined` and rate limiting uses `"memory"` when Redis is not configured
  - Warning log fires when Redis is not configured
  - `get`/`set`/`delete` proxy correctly with `better-auth:` key prefix when Redis is available
  - `set` without TTL omits the `EX` argument
  - Pre-init window: set/delete warn (deduplicated), get returns null
- Added 4 feature scenarios to `specs/auth/phase-1-better-auth-config.feature`

## Pre-init window analysis

The pre-init window IS reachable. After the Redis rearchitecture (#6829), secondary storage uses `RedisConfigService` to decide at config time whether to create the adapter, then `tryGetApp()?.redis` to resolve the connection lazily at call time. When Redis is configured but the app hasn't booted yet, `set`/`delete` drop silently and `get` returns null (cache miss → DB fallback). This is correct behavior (throwing would fail the request), but the drop is now logged so operators can distinguish a cold-start blip from a persistent misconfiguration.

Closes #6950
