### PR TITLE
fix(ci): widen redis ownership guard to scan all of platform/app and JS files

### DIFF
--- a/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
+++ b/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
@@ -27,7 +27,15 @@ const APP_ROOT = path.resolve(HERE, "../../../..");
 /** Repo root — where the `packages/*` workspace tree lives (ADR-076). */
 const REPO_ROOT = path.resolve(APP_ROOT, "../..");
 
-const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".mjs",
+  ".cjs",
+]);
 
 /**
  * Every way an ioredis client gets constructed.
@@ -52,12 +60,32 @@ const IOREDIS_CONSTRUCTION =
  */
 const RETIRED_REDIS_MODULE =
   /["'][^"']*(?:~\/server\/redis|\.\.\/redis|\.\/redis)["']/;
+
+/**
+ * Standalone operational scripts that run their own process and legitimately
+ * own their Redis connection. Each entry is relative to the repo root.
+ *
+ * Adding a path here is an explicit decision — the reviewer sees it in the
+ * diff and can ask whether the script really needs a standalone client.
+ */
+const STANDALONE_SCRIPT_ALLOWLIST = new Set([
+  "platform/app/scripts/_dogfood_cli_mint_demo.ts",
+  "platform/app/scripts/dogfood/governance/sergey-relogin-as.ts",
+]);
+/**
+ * Directories under `platform/app` that are never source code.
+ *
+ * This is an ALLOWLIST of exclusions — anything NOT listed here IS scanned.
+ * Adding a directory to dodge the guard requires updating the snapshot
+ * assertion below, which is the point.
+ */
 const SKIP_DIRECTORIES = new Set([
   "node_modules",
   "dist",
   ".next",
   ".next-saas",
   "coverage",
+  "public",
 ]);
 
 function shouldDescend(entry: fs.Dirent): boolean {
@@ -88,8 +116,7 @@ function* walkSourceFiles(root: string): Generator<string> {
 /** Every source file in the app tree plus the workspace packages. */
 function allSourceFiles(): string[] {
   return [
-    ...walkSourceFiles(path.join(APP_ROOT, "src")),
-    ...walkSourceFiles(path.join(APP_ROOT, "ee")),
+    ...walkSourceFiles(APP_ROOT),
     ...walkSourceFiles(path.join(REPO_ROOT, "packages")),
   ];
 }
@@ -257,6 +284,7 @@ describe("Redis ownership", () => {
       const offenders = allSourceFiles()
         .filter((file) => !file.startsWith(clientPackage))
         .filter((file) => !isTestFile(file))
+        .filter((file) => !STANDALONE_SCRIPT_ALLOWLIST.has(relative(file)))
         .filter((file) =>
           IOREDIS_CONSTRUCTION.test(fs.readFileSync(file, "utf8")),
         );
@@ -291,6 +319,58 @@ describe("Redis ownership", () => {
         "new RedisReadinessService({ logger })",
       ]) {
         expect(IOREDIS_CONSTRUCTION.test(innocent)).toBe(false);
+      }
+    });
+
+    /** @scenario The source guard scans every directory under platform/app */
+    it("walks all of platform/app, not just src and ee", () => {
+      const files = allSourceFiles();
+      const relFiles = files.map(relative);
+
+      // Files from directories that the old walker missed must now appear.
+      expect(relFiles.some((f) => f.startsWith("platform/app/scripts/"))).toBe(
+        true,
+      );
+      // The specs directory is also scanned (feature files are not source, but
+      // .ts helpers inside specs/ are).
+      const hasSpecsOrE2eOrVendor = relFiles.some(
+        (f) =>
+          f.startsWith("platform/app/e2e/") ||
+          f.startsWith("platform/app/vendor/") ||
+          f.startsWith("platform/app/specs/"),
+      );
+      expect(hasSpecsOrE2eOrVendor).toBe(true);
+    });
+
+    /** @scenario The allowlist contains exactly the expected directories */
+    it("excludes only the pinned allowlist of directories", () => {
+      expect([...SKIP_DIRECTORIES].sort()).toEqual([
+        ".next",
+        ".next-saas",
+        "coverage",
+        "dist",
+        "node_modules",
+        "public",
+      ]);
+    });
+
+    /** @scenario The source guard scans JavaScript files alongside TypeScript */
+    it("includes .js, .mjs, and .cjs files in the scan", () => {
+      const files = allSourceFiles().map(relative);
+
+      // These three files exist under src/ and were previously invisible.
+      expect(files).toContain("platform/app/src/env.mjs");
+      expect(files).toContain("platform/app/src/env-create.mjs");
+      expect(files).toContain("platform/app/src/noop-css.cjs");
+    });
+
+    /** @scenario Standalone operational scripts that own their process are allowlisted */
+    it("allowlists standalone scripts that all exist on disk", () => {
+      for (const rel of STANDALONE_SCRIPT_ALLOWLIST) {
+        expect(
+          fs.existsSync(path.join(REPO_ROOT, rel)),
+          `allowlisted script missing: ${rel}`,
+        ).toBe(true);
       }
     });
 

--- a/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
+++ b/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
@@ -358,9 +358,14 @@ describe("Redis ownership", () => {
 
     /** @scenario The source guard scans JavaScript files alongside TypeScript */
     it("includes .js, .mjs, and .cjs files in the scan", () => {
-      const files = allSourceFiles().map(relative);
+      // Assert the mechanism — SOURCE_EXTENSIONS contains all three JS variants.
+      // (No .js files exist in the tree today, so we can only observe .mjs/.cjs.)
+      expect(SOURCE_EXTENSIONS.has(".js")).toBe(true);
+      expect(SOURCE_EXTENSIONS.has(".mjs")).toBe(true);
+      expect(SOURCE_EXTENSIONS.has(".cjs")).toBe(true);
 
-      // These three files exist under src/ and were previously invisible.
+      // These files exist under src/ and prove the walker picks them up.
+      const files = allSourceFiles().map(relative);
       expect(files).toContain("platform/app/src/env.mjs");
       expect(files).toContain("platform/app/src/env-create.mjs");
       expect(files).toContain("platform/app/src/noop-css.cjs");

--- a/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
+++ b/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
@@ -75,9 +75,10 @@ const STANDALONE_SCRIPT_ALLOWLIST = new Set([
 /**
  * Directories under `platform/app` that are never source code.
  *
- * This is an ALLOWLIST of exclusions — anything NOT listed here IS scanned.
- * Adding a directory to dodge the guard requires updating the snapshot
- * assertion below, which is the point.
+ * This is an ALLOWLIST of exclusions — anything NOT listed here and not
+ * dot-prefixed (`.git`, `.next`, etc.) IS scanned. Adding a directory to
+ * dodge the guard requires updating the snapshot assertion below, which is
+ * the point.
  */
 const SKIP_DIRECTORIES = new Set([
   "node_modules",
@@ -327,22 +328,23 @@ describe("Redis ownership", () => {
       const files = allSourceFiles();
       const relFiles = files.map(relative);
 
-      // Files from directories that the old walker missed must now appear.
-      expect(relFiles.some((f) => f.startsWith("platform/app/scripts/"))).toBe(
-        true,
-      );
-      // The specs directory is also scanned (feature files are not source, but
-      // .ts helpers inside specs/ are).
-      const hasSpecsOrE2eOrVendor = relFiles.some(
-        (f) =>
-          f.startsWith("platform/app/e2e/") ||
-          f.startsWith("platform/app/vendor/") ||
-          f.startsWith("platform/app/specs/"),
-      );
-      expect(hasSpecsOrE2eOrVendor).toBe(true);
+      // Directories that the old walker missed and that contain source files
+      // must now appear. (vendor/ and specs/ are also walked but contain no
+      // files matching SOURCE_EXTENSIONS, so they produce no results.)
+      for (const directory of ["scripts", "e2e"]) {
+        expect(
+          relFiles.some((f) => f.startsWith(`platform/app/${directory}/`)),
+          `expected files from platform/app/${directory}/`,
+        ).toBe(true);
+      }
+
+      // vendor/ and specs/ are NOT in SKIP_DIRECTORIES — the walker enters
+      // them — but they contain no source files today.
+      expect(SKIP_DIRECTORIES.has("vendor")).toBe(false);
+      expect(SKIP_DIRECTORIES.has("specs")).toBe(false);
     });
 
-    /** @scenario The allowlist contains exactly the expected directories */
+    /** Part of @scenario The source guard scans every directory under platform/app */
     it("excludes only the pinned allowlist of directories", () => {
       expect([...SKIP_DIRECTORIES].sort()).toEqual([
         ".next",

--- a/specs/server/redis-client-ownership.feature
+++ b/specs/server/redis-client-ownership.feature
@@ -181,8 +181,9 @@ Feature: Redis is an owned client, never a module singleton
     Scenario: The source guard scans every directory under platform/app
       Given the platform source tree
       When the ownership guard walks source files
-      Then it includes files from scripts, e2e, vendor, and specs
-      And only an explicit allowlist of directories is excluded
+      Then it includes files from scripts and e2e
+      And vendor and specs are not excluded from the walk
+      And only an explicit allowlist of directories and dot-prefixed directories are excluded
       And the allowlist contains exactly node_modules, dist, .next, .next-saas, coverage, and public
 
     @unit

--- a/specs/server/redis-client-ownership.feature
+++ b/specs/server/redis-client-ownership.feature
@@ -177,6 +177,26 @@ Feature: Redis is an owned client, never a module singleton
       When every construction of an ioredis client is located
       Then each one is inside the Redis client package or a test fixture
 
+    @unit
+    Scenario: The source guard scans every directory under platform/app
+      Given the platform source tree
+      When the ownership guard walks source files
+      Then it includes files from scripts, e2e, vendor, and specs
+      And only an explicit allowlist of directories is excluded
+      And the allowlist contains exactly node_modules, dist, .next, .next-saas, coverage, and public
+
+    @unit
+    Scenario: The source guard scans JavaScript files alongside TypeScript
+      Given the platform source tree
+      When the ownership guard walks source files
+      Then it includes .js, .mjs, and .cjs files
+
+    @unit
+    Scenario: Standalone operational scripts that own their process are allowlisted
+      Given the platform source tree
+      When every construction of an ioredis client is located
+      Then scripts on the operational allowlist are excluded from the violation check
+
   Rule: Consumers reach Redis by injection or from the application
 
     @unit


### PR DESCRIPTION
## For humans

The Redis ownership guard test was only scanning `src/`, `ee/`, and `packages/` — scripts that build their own Redis connection in `scripts/`, `e2e/`, or `vendor/` passed CI clean. It also only checked `.ts` files, missing `.js`/`.mjs`/`.cjs` entirely.

Now it walks **all of `platform/app`** with an explicit skip-list (snapshot-asserted so silently widening it requires updating the test), and scans JS files too. Two dogfood scripts that legitimately own their own Redis connection are on an explicit allowlist.

## What changed

- **`allSourceFiles()`** now walks `APP_ROOT` (all of `platform/app`) instead of three hardcoded subdirectories
- **`SOURCE_EXTENSIONS`** includes `.js`, `.mjs`, `.cjs` alongside TypeScript extensions
- **`SKIP_DIRECTORIES`** is an explicit allowlist (`node_modules`, `dist`, `.next`, `.next-saas`, `coverage`, `public`) — snapshot-asserted
- **`STANDALONE_SCRIPT_ALLOWLIST`** exempts two dogfood scripts that run standalone processes and legitimately construct their own Redis client
- 4 new test cases: directory coverage, allowlist snapshot, JS extension scan, allowlist existence check
- 3 new feature scenarios in `specs/server/redis-client-ownership.feature`

Closes #6948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Redis ownership checks across the full application source tree.
  * Added coverage for JavaScript, MJS, and CJS files.
  * Verified approved standalone operational scripts are excluded from violation checks.
  * Confirmed directory exclusions, including the public assets directory, remain enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->