### PR TITLE
fix(redis): close the ownership guard's blind spots and stop silent auth writes

### DIFF
--- a/dev/docs/adr/093-redis-is-an-owned-client.md
+++ b/dev/docs/adr/093-redis-is-an-owned-client.md
@@ -203,6 +203,39 @@ future consumer must now decide where it sits — injected dependency, or
 is the pragmatic option for route modules that have no constructor, and
 injection remains the default everywhere a seam exists.
 
+### Where "`redis === null`" is the same answer the singleton gave, and where it is not
+
+The migration's equivalence claim — `getApp().redis` is `null` exactly where the
+old `connection` was `undefined` — holds **for the web and worker processes,
+after boot**. Both build an App before they serve anything, so every consumer
+reached through a request or a job sees the connection the composition root
+made. It does not hold universally, and the difference is worth stating rather
+than leaving to be rediscovered (#6951):
+
+- **A process that never builds an App now has no Redis.** The old module
+  connected at import in any process that imported it, `pnpm run task` and a
+  bare `tsx scripts/*.ts` included; its skip guards only fired at build or test
+  time. `task.ts` deliberately boots no App for most tasks, so in one of those
+  `tryGetApp()?.redis ?? null` answers `null` permanently — not for a moment,
+  but for the life of the process.
+- **A callback firing before boot completes sees `null` too.** The window is
+  narrow and `start.ts` closes it for the web entrypoint by booting the App
+  before it listens, but it is a real state and consumers are written for it.
+
+Neither is a bug on its own, because every consumer of `getApp().redis` already
+branches on absence: Redis has always been optional here. What changes is which
+branch an App-less process takes, so a task or script that genuinely needs Redis
+must now say so — by building an App, or by owning a connection through
+`RedisConnectionService`, the way `migrateObjectStorage` and the dogfood login
+scripts do. The tasks and scripts in the tree were audited against this on
+2026-08-13 and none was silently relying on the old import-time connection.
+
+The two source guards in `redis-ownership.unit.test.ts` are what keep the second
+option honest: they scan the whole of `platform/app` — scripts, end-to-end specs
+and build tooling included, in JavaScript as well as TypeScript — so a script
+that reaches for ioredis directly instead of the client package is a failing
+test rather than a discovery.
+
 ## References
 
 - Spec: `specs/server/redis-client-ownership.feature`

--- a/platform/app/scripts/_dogfood_cli_mint_demo.ts
+++ b/platform/app/scripts/_dogfood_cli_mint_demo.ts
@@ -14,6 +14,7 @@ import {
   PersonalVirtualKeyAlreadyExistsError,
   PersonalVirtualKeyService,
 } from "@ee/governance/services/personalVirtualKey.service";
+import { RedisConnectionService } from "@langwatch/redis-client";
 import { prisma } from "~/server/db";
 import { approveDeviceCode } from "~/server/routes/auth-cli";
 
@@ -89,11 +90,20 @@ async function main() {
   // that lookup by hitting Redis directly via the server's auth-cli
   // helpers — easier than re-implementing the magic-link auth + CSRF
   // dance the browser approve UI requires.
-  const { default: Redis } = await import("ioredis");
-  const redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";
-  const redis = new Redis(redisUrl);
-  // Mirror userCodeKey() in src/server/routes/auth-cli.ts (line 213).
-  const deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
+  // This script boots no App, so it owns the connection it needs — built
+  // through the sanctioned service rather than by constructing ioredis here
+  // (ADR-093), and closed as soon as the lookup is done.
+  const redis = new RedisConnectionService().connectStandalone({
+    url: process.env.REDIS_URL ?? "redis://localhost:6379",
+  });
+  if (!redis) throw new Error("REDIS_URL did not resolve to a connection");
+  let deviceCode: string | null = null;
+  try {
+    // Mirror userCodeKey() in src/server/routes/auth-cli.ts (line 213).
+    deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
+  } finally {
+    redis.disconnect();
+  }
   if (!deviceCode) {
     child.kill("SIGTERM");
     throw new Error(`no device_code mapped for user_code ${userCode}`);

--- a/platform/app/scripts/_dogfood_cli_mint_demo.ts
+++ b/platform/app/scripts/_dogfood_cli_mint_demo.ts
@@ -92,18 +92,14 @@ async function main() {
   // dance the browser approve UI requires.
   // This script boots no App, so it owns the connection it needs — built
   // through the sanctioned service rather than by constructing ioredis here
-  // (ADR-093), and closed as soon as the lookup is done.
+  // (ADR-093). It is closed by the `redis.quit()` at the end of main(),
+  // which is also what keeps the process from hanging on an open socket.
   const redis = new RedisConnectionService().connectStandalone({
     url: process.env.REDIS_URL ?? "redis://localhost:6379",
   });
   if (!redis) throw new Error("REDIS_URL did not resolve to a connection");
-  let deviceCode: string | null = null;
-  try {
-    // Mirror userCodeKey() in src/server/routes/auth-cli.ts (line 213).
-    deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
-  } finally {
-    redis.disconnect();
-  }
+  // Mirror userCodeKey() in src/server/routes/auth-cli.ts (line 213).
+  const deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
   if (!deviceCode) {
     child.kill("SIGTERM");
     throw new Error(`no device_code mapped for user_code ${userCode}`);

--- a/platform/app/scripts/dogfood/governance/sergey-relogin-as.ts
+++ b/platform/app/scripts/dogfood/governance/sergey-relogin-as.ts
@@ -14,6 +14,7 @@
 import { spawn } from "node:child_process";
 import { setTimeout as wait } from "node:timers/promises";
 import { PersonalVirtualKeyService } from "@ee/governance/services/personalVirtualKey.service";
+import { RedisConnectionService } from "@langwatch/redis-client";
 import { approveDeviceCode } from "~/server/routes/auth-cli";
 import { PrismaClient } from "../../../src/generated/prisma/client";
 import { createPrismaPgAdapter } from "../../../src/server/prismaPgAdapter";
@@ -124,9 +125,19 @@ async function main() {
   }
   console.error(`[relogin] user_code=${userCode}`);
 
-  const Redis = (await import("ioredis")).default;
-  const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379");
-  const deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
+  // This script boots no App, so it owns the connection it needs — built
+  // through the sanctioned service rather than by constructing ioredis here
+  // (ADR-093), and closed as soon as the lookup is done.
+  const redis = new RedisConnectionService().connectStandalone({
+    url: process.env.REDIS_URL ?? "redis://localhost:6379",
+  });
+  if (!redis) throw new Error("REDIS_URL did not resolve to a connection");
+  let deviceCode: string | null = null;
+  try {
+    deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
+  } finally {
+    redis.disconnect();
+  }
   if (!deviceCode) {
     child.kill();
     throw new Error(`no device_code for user_code ${userCode}`);

--- a/platform/app/scripts/dogfood/governance/sergey-relogin-as.ts
+++ b/platform/app/scripts/dogfood/governance/sergey-relogin-as.ts
@@ -127,17 +127,13 @@ async function main() {
 
   // This script boots no App, so it owns the connection it needs — built
   // through the sanctioned service rather than by constructing ioredis here
-  // (ADR-093), and closed as soon as the lookup is done.
+  // (ADR-093). It is closed by the `redis.quit()` at the end of main(),
+  // which is also what keeps the process from hanging on an open socket.
   const redis = new RedisConnectionService().connectStandalone({
     url: process.env.REDIS_URL ?? "redis://localhost:6379",
   });
   if (!redis) throw new Error("REDIS_URL did not resolve to a connection");
-  let deviceCode: string | null = null;
-  try {
-    deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
-  } finally {
-    redis.disconnect();
-  }
+  const deviceCode = await redis.get(`lwcli:device:usercode:${userCode}`);
   if (!deviceCode) {
     child.kill();
     throw new Error(`no device_code for user_code ${userCode}`);

--- a/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
+++ b/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
@@ -86,23 +86,30 @@ const SKIP_DIRECTORIES = new Set([
   "dist",
   ".next",
   ".next-saas",
+  ".turbo",
+  ".vite",
+  ".cache",
+  ".git",
   "coverage",
 ]);
 
+/**
+ * This list is the ONLY thing that keeps a directory out of the scan.
+ *
+ * There is deliberately no `name.startsWith(".")` rule here. One used to be,
+ * and it was a second exclusion nobody had to write down — a hidden directory
+ * holding real source would have been skipped in silence, which is the same
+ * class of hole as the named-trees walk this test exists to close. The dot
+ * directories above are named because they are build artifacts and a VCS
+ * store; anything else hidden gets scanned like any other directory.
+ */
 function shouldDescend(entry: fs.Dirent): boolean {
-  return (
-    entry.isDirectory() &&
-    !entry.name.startsWith(".") &&
-    !SKIP_DIRECTORIES.has(entry.name)
-  );
+  return entry.isDirectory() && !SKIP_DIRECTORIES.has(entry.name);
 }
 
+/** Extension alone decides, for the same reason `shouldDescend` names its skips. */
 function isSourceFile(entry: fs.Dirent): boolean {
-  return (
-    entry.isFile() &&
-    !entry.name.startsWith(".") &&
-    SOURCE_EXTENSIONS.has(path.extname(entry.name))
-  );
+  return entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name));
 }
 
 function* walkSourceFiles(root: string): Generator<string> {
@@ -324,9 +331,13 @@ describe("Redis ownership", () => {
         );
       }
 
-      // A concrete non-TypeScript module, so the extension set cannot quietly
-      // shrink back to the TypeScript four.
+      // Concrete non-TypeScript modules, so the extension set cannot quietly
+      // shrink back to the TypeScript four. Both spellings that actually occur
+      // in the tree are anchored; `.js` and `.jsx` have no instance to point
+      // at today, and asserting them against `SOURCE_EXTENSIONS` itself would
+      // only check the constant against a copy of itself.
       expect(scanned.has("platform/app/src/env.mjs")).toBe(true);
+      expect(scanned.has("platform/app/src/noop-css.cjs")).toBe(true);
 
       // And the exclusions still hold, or the scan is reading dependencies.
       for (const file of scanned) {

--- a/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
+++ b/platform/app/src/server/app-layer/__tests__/redis-ownership.unit.test.ts
@@ -27,7 +27,24 @@ const APP_ROOT = path.resolve(HERE, "../../../..");
 /** Repo root — where the `packages/*` workspace tree lives (ADR-076). */
 const REPO_ROOT = path.resolve(APP_ROOT, "../..");
 
-const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+/**
+ * Every extension a module can be written in, not just the TypeScript ones.
+ *
+ * The JS spellings are here because leaving them out made the guard's answer
+ * depend on a file's extension rather than on what it does (#6948): `src/`
+ * holds `env.mjs`, `env-create.mjs` and `noop-css.cjs` today, and a
+ * `new IORedis(...)` in any of them scanned clean.
+ */
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
 
 /**
  * Every way an ioredis client gets constructed.
@@ -52,6 +69,18 @@ const IOREDIS_CONSTRUCTION =
  */
 const RETIRED_REDIS_MODULE =
   /["'][^"']*(?:~\/server\/redis|\.\.\/redis|\.\/redis)["']/;
+/**
+ * The only directories the scan is allowed not to see.
+ *
+ * Every entry is something this repository did not write — a dependency tree or
+ * a build artifact. The list is deliberately an exclusion allowlist rather than
+ * an inclusion one: the first version of this guard named the three trees to
+ * walk (`src`, `ee`, `packages`) and therefore never looked at `scripts/`,
+ * `e2e/`, `vite/` or `vendor/`, where two scripts were constructing ioredis
+ * directly with CI green (#6948). Naming what to skip fails safe — a new
+ * top-level directory is scanned by default, and dropping one out of the scan
+ * takes an edit here that a reviewer can see.
+ */
 const SKIP_DIRECTORIES = new Set([
   "node_modules",
   "dist",
@@ -85,11 +114,18 @@ function* walkSourceFiles(root: string): Generator<string> {
   }
 }
 
-/** Every source file in the app tree plus the workspace packages. */
+/**
+ * Every source file in the app, plus the workspace packages.
+ *
+ * The whole of `platform/app` — not `src` and `ee` alone. A script, an E2E
+ * spec, a vite plugin and a Prisma seed run in the same processes and against
+ * the same Redis as everything else, so a connection opened in one of them is
+ * the very thing ADR-093 retired; that they used to be invisible here was an
+ * accident of which trees got named (#6948).
+ */
 function allSourceFiles(): string[] {
   return [
-    ...walkSourceFiles(path.join(APP_ROOT, "src")),
-    ...walkSourceFiles(path.join(APP_ROOT, "ee")),
+    ...walkSourceFiles(APP_ROOT),
     ...walkSourceFiles(path.join(REPO_ROOT, "packages")),
   ];
 }
@@ -262,6 +298,40 @@ describe("Redis ownership", () => {
         );
 
       expect(offenders.map(relative)).toEqual([]);
+    });
+
+    /** @scenario The scan covers every tree and every module extension */
+    it("reaches every tree and every extension the platform is written in", () => {
+      // The two scans above are only as good as the file list they run over,
+      // and a shortfall there is silent in exactly the same way a gap in the
+      // patterns is: fewer files, nothing found, green. This is what noticed
+      // that `scripts/` was never walked and that `.mjs` was never read.
+      const scanned = new Set(allSourceFiles().map(relative));
+
+      const reached = (directory: string) =>
+        [...scanned].some((file) => file.startsWith(directory));
+
+      for (const directory of [
+        "platform/app/src/",
+        "platform/app/ee/",
+        "platform/app/scripts/",
+        "platform/app/e2e/",
+        "platform/app/vite/",
+        "packages/",
+      ]) {
+        expect(reached(directory), `nothing scanned under ${directory}`).toBe(
+          true,
+        );
+      }
+
+      // A concrete non-TypeScript module, so the extension set cannot quietly
+      // shrink back to the TypeScript four.
+      expect(scanned.has("platform/app/src/env.mjs")).toBe(true);
+
+      // And the exclusions still hold, or the scan is reading dependencies.
+      for (const file of scanned) {
+        expect(file).not.toContain("/node_modules/");
+      }
     });
 
     it("recognises every spelling of an ioredis construction", () => {

--- a/platform/app/src/server/better-auth/__tests__/secondaryStorage.test.ts
+++ b/platform/app/src/server/better-auth/__tests__/secondaryStorage.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/server/redis-client-ownership.feature
+ * @see dev/docs/adr/093-redis-is-an-owned-client.md
+ *
+ * better-auth's secondary storage after ADR-093.
+ *
+ * WHY THIS FILE EXISTS (#6950)
+ *
+ * On main, `secondaryStorage` closed over an eagerly-created singleton: once
+ * configured, the connection object always existed, and a command issued while
+ * Redis was unreachable sat in ioredis's offline queue until it wasn't.
+ * ADR-093 replaced that with `tryGetApp()?.redis ?? null`, resolved per call —
+ * which answers `null` before the App boots, and permanently in a process that
+ * never builds one.
+ *
+ * A dropped READ is a cache miss and better-auth recovers it from the database.
+ * A dropped WRITE has no recovery, and the credential sign-in rate-limit
+ * counters live only in secondary storage: dropping their `set` is a rate limit
+ * that fails OPEN. So the degrade is allowed, but it is not allowed to be
+ * quiet, and neither half of that was covered by a test.
+ */
+import type { BetterAuthOptions } from "better-auth";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { createTestApp } from "../../app-layer/presets";
+
+const { warn } = vi.hoisted(() => ({ warn: vi.fn() }));
+
+// Both create persistent handles (Prisma pool, Redis socket) that keep vitest
+// from closing after the suite passes — the same reason index.test.ts mocks it.
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+// The module under test decides WHETHER to configure secondary storage from
+// env, at import. Forcing a Redis URL is what makes the callbacks exist at all;
+// without it this suite would assert against `undefined` and pass vacuously.
+vi.mock("~/env.mjs", async () => {
+  const actual = await vi.importActual<typeof import("~/env.mjs")>("~/env.mjs");
+  return {
+    ...actual,
+    env: {
+      ...actual.env,
+      REDIS_URL: "redis://localhost:6379",
+      REDIS_CLUSTER_ENDPOINTS: undefined,
+      SKIP_REDIS: false,
+    },
+  };
+});
+
+/**
+ * Only better-auth's own logger feeds the spy.
+ *
+ * Booting a test App warms other modules that legitimately warn about a missing
+ * Redis — the SSE broadcast service is one — and a spy shared across every
+ * logger would count those as dropped writes. The name is spelled inline
+ * because a `vi.mock` factory is hoisted above any const it might reference.
+ */
+vi.mock("@langwatch/observability", async () => {
+  const actual = await vi.importActual<
+    typeof import("@langwatch/observability")
+  >("@langwatch/observability");
+  return {
+    ...actual,
+    createLogger: (name: string) => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: name === "langwatch:better-auth" ? warn : vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+/**
+ * The configured store, imported once under an environment that actually asks
+ * for secondary storage.
+ *
+ * `vitest.config.ts` sets `BUILD_TIME=1` for every unit run, and better-auth
+ * reads that as "do not adopt this Redis as a session store" — so in a stock
+ * unit test `secondaryStorage` is `undefined` and every assertion about it
+ * passes vacuously. Clearing it here is what gives this suite something to
+ * assert against, and is a large part of why the degrade path went uncovered.
+ */
+let store: NonNullable<BetterAuthOptions["secondaryStorage"]>;
+
+beforeAll(async () => {
+  vi.stubEnv("BUILD_TIME", "");
+  // The env stub only reaches a module that has not been evaluated yet, and
+  // this suite shares its module registry with the rest of the run.
+  vi.resetModules();
+
+  const { secondaryStorage } = await import("../index");
+  if (!secondaryStorage) {
+    throw new Error(
+      "secondaryStorage was not configured — the env setup above stopped working, and every assertion below would be vacuous.",
+    );
+  }
+  store = secondaryStorage;
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+/**
+ * Runs `body` with `globalForApp.__langwatch_app` set to `app`, restoring
+ * whatever was there before. `undefined` is the App-less process — the state
+ * `tryGetApp()` answers `null` for.
+ */
+async function withApp(app: unknown, body: () => Promise<void>): Promise<void> {
+  const { globalForApp } = await import("../../app-layer/app");
+  const previous = globalForApp.__langwatch_app;
+  globalForApp.__langwatch_app = app as never;
+  try {
+    await body();
+  } finally {
+    globalForApp.__langwatch_app = previous;
+  }
+}
+
+function fakeRedis() {
+  return {
+    get: vi.fn().mockResolvedValue("stored"),
+    set: vi.fn().mockResolvedValue("OK"),
+    del: vi.fn().mockResolvedValue(1),
+  };
+}
+
+describe("better-auth secondary storage", () => {
+  beforeEach(() => {
+    warn.mockClear();
+  });
+
+  describe("given an application holding a Redis connection", () => {
+    /** @scenario Secondary storage reads and writes the application's connection */
+    it("namespaces every operation and reaches that connection", async () => {
+      const redis = fakeRedis();
+
+      await withApp(createTestApp({ redis: redis as never }), async () => {
+        expect(await store.get("session-key")).toBe("stored");
+        await store.set("session-key", "value", 60);
+        await store.set("no-ttl", "value");
+        await store.delete("session-key");
+      });
+
+      expect(redis.get).toHaveBeenCalledWith("better-auth:session-key");
+      expect(redis.set).toHaveBeenCalledWith(
+        "better-auth:session-key",
+        "value",
+        "EX",
+        60,
+      );
+      expect(redis.set).toHaveBeenCalledWith("better-auth:no-ttl", "value");
+      expect(redis.del).toHaveBeenCalledWith("better-auth:session-key");
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a process with no application", () => {
+    /** @scenario A read with no connection degrades to a cache miss */
+    it("answers a read with a miss instead of throwing", async () => {
+      await withApp(undefined, async () => {
+        expect(await store.get("session-key")).toBeNull();
+      });
+
+      // A miss is a complete answer here: better-auth re-reads the session from
+      // the database. Nothing was lost, so nothing is reported.
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    /** @scenario A dropped write is reported rather than silently discarded */
+    it("drops a write loudly, naming the operation but never the key", async () => {
+      await withApp(undefined, async () => {
+        await store.set("rate-limit:count", "3", 60);
+        await store.delete("rate-limit:count");
+      });
+
+      expect(warn).toHaveBeenCalledTimes(2);
+
+      const operations = warn.mock.calls.map(([fields]) => fields.operation);
+      expect(operations).toEqual(["set", "delete"]);
+
+      // The count separates "one request raced boot" from "this process has been
+      // serving auth with no secondary storage all along". Asserted as a rise
+      // rather than as literal 1 and 2: the counter is module state, so pinning
+      // absolute values would make this test depend on the order of the ones
+      // around it.
+      const [first, second] = warn.mock.calls.map(
+        ([fields]) => fields.droppedSecondaryWrites as number,
+      );
+      expect(first).toBeGreaterThan(0);
+      expect(second).toBe((first ?? 0) + 1);
+
+      // better-auth keys secondary storage BY SESSION TOKEN, so the key is a
+      // credential. It must not reach the logs, in a field or in the message.
+      for (const [fields, message] of warn.mock.calls) {
+        expect(JSON.stringify(fields)).not.toContain("rate-limit:count");
+        expect(message).not.toContain("rate-limit:count");
+      }
+    });
+
+    /** @scenario A dropped write does not fail the request that caused it */
+    it("resolves rather than rejecting, so the caller degrades open", async () => {
+      await withApp(undefined, async () => {
+        await expect(store.set("k", "v")).resolves.toBeUndefined();
+        await expect(store.delete("k")).resolves.toBeUndefined();
+      });
+    });
+  });
+
+  describe("given an application configured without Redis", () => {
+    /** @scenario A deployment with no Redis drops writes the same way */
+    it("degrades identically to having no application at all", async () => {
+      await withApp(createTestApp(), async () => {
+        expect(await store.get("k")).toBeNull();
+        await store.set("k", "v");
+      });
+
+      expect(warn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/platform/app/src/server/better-auth/__tests__/secondaryStorage.unit.test.ts
+++ b/platform/app/src/server/better-auth/__tests__/secondaryStorage.unit.test.ts
@@ -36,8 +36,10 @@ import { createTestApp } from "../../app-layer/presets";
 
 const { warn } = vi.hoisted(() => ({ warn: vi.fn() }));
 
-// Both create persistent handles (Prisma pool, Redis socket) that keep vitest
-// from closing after the suite passes — the same reason index.test.ts mocks it.
+// A real Prisma client opens a connection pool that keeps vitest from closing
+// after the suite passes — the same reason index.test.ts mocks it. No Redis
+// mock is needed alongside it: `secondaryStorage` never constructs a client,
+// it reads whatever the App is holding.
 vi.mock("~/server/db", () => ({ prisma: {} }));
 
 // The module under test decides WHETHER to configure secondary storage from

--- a/platform/app/src/server/better-auth/index.ts
+++ b/platform/app/src/server/better-auth/index.ts
@@ -95,24 +95,70 @@ const redisEnv = {
 /**
  * The App's connection at the moment a storage callback runs.
  *
- * Null only where env advertises Redis but the App has none — a test app, or a
- * callback firing before boot completes. Degrading to a cache miss there is
- * right: better-auth re-reads from the database, whereas throwing would fail
- * the request outright.
+ * Null wherever env advertises Redis but the App has none, which is three
+ * states, not one: a test app, a callback firing before boot completes, and —
+ * for the whole life of the process — anything that never builds an App at all
+ * (a task, a bare `tsx scripts/*.ts`). `start.ts` boots before it listens, so
+ * the web entrypoint only ever sees the first two.
+ *
+ * Resolving per call rather than once at import is what makes this possible,
+ * and it is deliberate: the alternative needs a live client at module load.
+ * See the ADR's note on where the old singleton's behaviour is and is not
+ * reproduced.
  */
 const secondaryStorageConnection = () => tryGetApp()?.redis ?? null;
 
-const secondaryStorage: BetterAuthOptions["secondaryStorage"] =
+/**
+ * How many writes this process has dropped for want of a connection.
+ *
+ * Carried in the log line because the *first* drop and the ten-thousandth mean
+ * different things: one is a request that raced boot, a climbing count is a
+ * process serving auth with no secondary storage at all.
+ */
+let droppedSecondaryWrites = 0;
+
+/**
+ * Reports a write that went nowhere.
+ *
+ * A dropped read is a cache miss and better-auth recovers it from the database.
+ * A dropped WRITE has no such recovery, and one of its tenants is the
+ * credential sign-in rate-limit counter, which lives only in secondary storage:
+ * dropping the `set` is a rate limit that fails OPEN. That is a security-
+ * relevant degradation, so it does not get to be silent (#6950).
+ *
+ * The key is deliberately not logged. Better-auth keys secondary storage by
+ * session token, so the key IS a credential.
+ */
+const reportDroppedSecondaryWrite = (operation: "set" | "delete"): void => {
+  droppedSecondaryWrites += 1;
+  logger.warn(
+    { operation, droppedSecondaryWrites },
+    "better-auth secondary storage write dropped: Redis is configured but the application has no connection. Rate limiting and session revocation degrade to fail-open until it does.",
+  );
+};
+
+/**
+ * The storage better-auth is configured with — `undefined` when this deployment
+ * has no Redis, in which case sessions stay in the database.
+ *
+ * Exported for unit testing, the same way `isEmailPasswordEnabled` is: ADR-093
+ * moved this from "decided once against a live singleton" to "resolved per
+ * call", which opened a window where the callbacks run with no connection.
+ * That window is the contract now, so it is asserted rather than merely
+ * commented (#6950).
+ */
+export const secondaryStorage: BetterAuthOptions["secondaryStorage"] =
   new RedisConfigService().isConfigured(redisEnv)
     ? {
         get: async (key) => {
           const redis = secondaryStorageConnection();
+          // A miss, not a failure: better-auth falls through to the database.
           if (!redis) return null;
           return await redis.get(`better-auth:${key}`);
         },
         set: async (key, value, ttl) => {
           const redis = secondaryStorageConnection();
-          if (!redis) return;
+          if (!redis) return reportDroppedSecondaryWrite("set");
           if (ttl) {
             await redis.set(`better-auth:${key}`, value, "EX", ttl);
           } else {
@@ -121,7 +167,7 @@ const secondaryStorage: BetterAuthOptions["secondaryStorage"] =
         },
         delete: async (key) => {
           const redis = secondaryStorageConnection();
-          if (!redis) return;
+          if (!redis) return reportDroppedSecondaryWrite("delete");
           await redis.del(`better-auth:${key}`);
         },
       }

--- a/specs/server/redis-client-ownership.feature
+++ b/specs/server/redis-client-ownership.feature
@@ -177,6 +177,20 @@ Feature: Redis is an owned client, never a module singleton
       When every construction of an ioredis client is located
       Then each one is inside the Redis client package or a test fixture
 
+    # The guard is only as good as the file list it runs over, and a shortfall
+    # there is silent: fewer files scanned, nothing found, green. Naming three
+    # trees to walk left scripts, end-to-end specs and build tooling unscanned,
+    # and reading only the TypeScript extensions left the JavaScript modules in
+    # the scanned trees unread — two scripts constructed ioredis directly with
+    # CI passing. Scanning is therefore a claim the suite makes about itself.
+    @unit
+    Scenario: The scan covers every tree and every module extension
+      Given the platform source tree
+      When the set of files the guard scans is inspected
+      Then it includes the scripts, end-to-end and build-tooling trees
+      And it includes modules written in JavaScript as well as TypeScript
+      And it excludes installed dependencies
+
   Rule: Consumers reach Redis by injection or from the application
 
     @unit
@@ -198,3 +212,52 @@ Feature: Redis is an owned client, never a module singleton
       Given an application configured without Redis
       When a consumer that needs Redis runs
       Then it takes its documented fallback path rather than throwing
+
+  Rule: A degraded write is allowed, but it is never silent
+
+    # Resolving the connection per call rather than once at import introduced a
+    # state the old singleton did not have: a callback running with no
+    # connection, before the application boots or in a process that never
+    # builds one. Sign-in rate-limit counters live only in this storage, so a
+    # write dropped there is a rate limit that fails OPEN. The degrade is the
+    # right behaviour — failing the request outright would be worse — but a
+    # security control quietly turning itself off is not something an operator
+    # should have to infer.
+
+    @unit
+    Scenario: A read with no connection degrades to a cache miss
+      Given a session store backed by the application's Redis
+      And a process with no application
+      When the store reads a key
+      Then it answers with a miss rather than raising
+      And nothing is reported, because the caller recovers from the database
+
+    @unit
+    Scenario: A dropped write is reported rather than silently discarded
+      Given a session store backed by the application's Redis
+      And a process with no application
+      When the store writes or deletes a key
+      Then the drop is logged with the operation and a running count of drops
+      And the key is absent from the report, because it is a credential
+
+    @unit
+    Scenario: A dropped write does not fail the request that caused it
+      Given a session store backed by the application's Redis
+      And a process with no application
+      When the store writes a key
+      Then the write completes rather than raising
+
+    @unit
+    Scenario: A deployment with no Redis drops writes the same way
+      Given a session store backed by the application's Redis
+      And an application configured without Redis
+      When the store writes a key
+      Then the drop is reported exactly as it is for a missing application
+
+    @unit
+    Scenario: Secondary storage reads and writes the application's connection
+      Given a session store backed by the application's Redis
+      And an application holding a Redis connection
+      When the store reads, writes and deletes a key
+      Then every operation reaches that connection under the store's namespace
+      And no drop is reported


### PR DESCRIPTION
Three follow-ups from the adversarial review of #6829.

## #6948 — the ownership guard had blind spots it could not report

`redis-ownership.unit.test.ts` walked three named trees (`platform/app/src`, `platform/app/ee`, `packages/`) and read only `.ts/.tsx/.mts/.cts`. So:

- a `new IORedis(...)` in `scripts/`, `e2e/`, `vite/` or `vendor/` passed `pnpm test:unit` clean — and two scripts were doing exactly that on main;
- a `.js`, `.mjs` or `.cjs` file was invisible even inside the trees it *did* walk (`src/env.mjs`, `src/env-create.mjs`, `src/noop-css.cjs` live there today).

The scan now walks all of `platform/app` minus an explicit skip allowlist, and reads the JavaScript extensions. An exclusion list rather than an inclusion list is the point: a new top-level directory is scanned by default, and removing one takes an edit a reviewer can see.

It also asserts its own coverage now. A shortfall in the file list was previously as silent as a gap in the regexes — fewer files, nothing found, green — so `The scan covers every tree and every module extension` pins that the scripts, end-to-end and build-tooling trees are reached, that a non-TypeScript module is read, and that dependencies are not.

The two offenders (`scripts/_dogfood_cli_mint_demo.ts`, `scripts/dogfood/governance/sergey-relogin-as.ts`) now build their connection through `RedisConnectionService` instead of constructing ioredis inline. Only construction changes — each script already closed its connection with `redis.quit()` at the end of `main()`, and that stays exactly where it was.

## #6950 — better-auth dropped secondary-storage writes silently

Since ADR-093, `secondaryStorage` resolves `tryGetApp()?.redis ?? null` per call rather than closing over an eagerly-created singleton, so the callbacks can run with no connection.

A dropped **read** is fine and stays silent: better-auth re-reads the session from the database. A dropped **write** has no such recovery, and credential sign-in rate-limit counters live only in secondary storage — so the drop was a rate limit failing **open**, with nothing in the logs to say so.

`set` and `delete` now report the drop with the operation and a running per-process count. The count matters: one drop is a request that raced boot, a climbing count is a process serving auth with no secondary storage at all. The key is deliberately never logged — better-auth keys this store *by session token*, so the key is a credential.

The degrade path is now covered end to end. Getting there needed one discovery worth flagging to reviewers: `vitest.config.ts` sets `BUILD_TIME=1` for every unit run, and better-auth reads that as a skip signal, so in a stock unit test `secondaryStorage` is `undefined` and any assertion about it passes vacuously. That is a large part of why this path had no coverage. The new suite clears it and re-imports the module.

## #6951 — closed as no-action, but half-done

The closing audit checked all 13 tasks and 20 scripts and found no live regression. That holds, and this PR makes it mechanical rather than a point-in-time audit: the widened guard now fails CI if a script reaches for ioredis directly.

Its second fix option was not actually done, though. ADR-093 documented the accessor design but never stated the consequence, so the ADR now says where the migration's equivalence claim holds — web and worker, after boot — and where it does not: a process that never builds an App gets `null` for the life of the process, where the old module connected at import.

No code change for this one.

## Deployment Impact

None. No migrations, no configuration, no infrastructure, no rollout ordering.

The only runtime behaviour change is additive logging: a `WARN` from `langwatch:better-auth` when a secondary-storage write is dropped. In the web and worker processes — which boot an App before serving — this should never fire, and if it does it is reporting a real fail-open that was previously invisible. Everything else is a test, a script, a spec or a doc.

## Verification

- `pnpm test:unit run src/server/better-auth/__tests__/secondaryStorage.test.ts src/server/app-layer/__tests__/redis-ownership.unit.test.ts` — 16 passed
- `pnpm test:unit run src/server/better-auth` — 9 files, 110 passed
- `pnpm check:feature-parity` — `specs/server/redis-client-ownership.feature` 30/30 scenarios bound
- `biome check` over the touched directories — zero diagnostics from the changed files
- Guard proven non-vacuous by hand: a probe `new IORedis(...)` dropped into `platform/app/scripts/` (a previously unwalked tree) and into `platform/app/src/*.mjs` (a previously unread extension) both fail the scan; probes removed.

Closes #6948
Closes #6950

## Notes for reviewers

One behavioural consequence of routing the two scripts through `RedisConnectionService`: it sets `maxRetriesPerRequest: null`, where a bare `new Redis(url)` uses ioredis's default of 20. Against a dead Redis the old code would eventually reject; the new code retries indefinitely. Left as is deliberately — by the time either script reaches this lookup the CLI has already completed a device-flow request whose device code the *server* stored in Redis, so a dead Redis is not reachable at that point, and matching the rest of the platform's connection options is worth more here than a bespoke retry budget.

## Review round 1 (6c009b9c52)

Five comments from CodeRabbit, all acted on. The first was a bug in this PR, not a nit:

- **Both scripts already closed their connection.** The first draft added an early `redis.disconnect()` in a `finally`, on top of the `await redis.quit()` that was already at the end of `main()`. `disconnect()` closes immediately, so the later `quit()` would reject and skip the `$disconnect()` database cleanup after it. The `try/finally` is gone; construction is the only thing this PR changes about those scripts now.
- **The skip list was not actually explicit.** `shouldDescend()` also skipped every directory starting with `.` — an exclusion nobody had to write down, which is the same class of hole as the named-trees walk this PR exists to close. Skipping is now `SKIP_DIRECTORIES` and nothing else, with the build-artifact and VCS dot directories named. Same for the dot-file rule in `isSourceFile()`. No dot directories exist in either tree today, so this changes what happens when someone adds one, not the current result.
- **Extension coverage** now anchors `noop-css.cjs` alongside `env.mjs`. Not extended to `.js`/`.jsx`: neither has an instance in the tree, so the only way to cover them is to assert `SOURCE_EXTENSIONS` against a copy of itself, which proves nothing about the scan.
- **A comment that described behaviour the code doesn't have** — the mock rationale claimed a Redis socket, but `secondaryStorage` never constructs a client. Trimmed to the Prisma pool.
- **Renamed** `secondaryStorage.test.ts` → `secondaryStorage.unit.test.ts`.
