### PR TITLE
perf(scenarios): inline the scenario SDK into the child bundle

### DIFF
--- a/platform/app/scripts/build-server.mjs
+++ b/platform/app/scripts/build-server.mjs
@@ -72,12 +72,35 @@ const basePackage = (id) => {
   return id.startsWith("@") ? parts.slice(0, 2).join("/") : (parts[0] ?? id);
 };
 
-// Kept external even by an inlineAll entry. @opentelemetry/* is a correctness
-// requirement, not an optimisation: the scenario child flushes spans at exit
-// through the globally registered provider, so a second inlined copy of the
-// API would split registration and flush across two registries and drop every
-// span. Prisma carries native engines that cannot be inlined at all.
-const NEVER_INLINED = [/^@opentelemetry\//, /^@prisma\//, /^\.prisma(\/|$)/];
+// Kept external even by an inlineAll entry, each for a reason that inlining
+// would break:
+//
+//   @opentelemetry/*  The child flushes spans at exit through the GLOBALLY
+//                     registered provider. A second inlined copy of the API
+//                     splits registration and flush across two registries, so
+//                     every span is dropped while the process still exits 0.
+//   @prisma/*         Native engines; cannot be inlined at all.
+//   pino / thread-stream
+//                     They start their log transport on a worker thread whose
+//                     script they locate with `join(__dirname, "worker.js")`.
+//                     Inlined, __dirname becomes dist/server and the lookup
+//                     misses, and thread-stream reports it by rethrowing on
+//                     nextTick — an UNCAUGHT exception that kills the child,
+//                     not something the transport's try/catch can swallow.
+//                     Every realistic configuration hits it: pretty console
+//                     logs (the dev default) and the OTel log transport both
+//                     create a transport.
+//
+// The rule of thumb for adding to this list: a package that resolves a FILE at
+// runtime relative to its own location cannot be inlined, because inlining is
+// exactly what moves that location.
+const NEVER_INLINED = [
+  /^@opentelemetry\//,
+  /^@prisma\//,
+  /^\.prisma(\/|$)/,
+  /^pino(-|$)/,
+  /^thread-stream$/,
+];
 
 /**
  * Whether a specifier gets inlined into the bundle. First-party source always

--- a/platform/app/scripts/build-server.mjs
+++ b/platform/app/scripts/build-server.mjs
@@ -24,6 +24,7 @@ import { builtinModules } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
+import { OPTIONAL_EXTERNALS } from "./bundle-optional-externals.mjs";
 
 const APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const OUT_DIR = path.join(APP, "dist", "server");
@@ -71,20 +72,45 @@ const basePackage = (id) => {
   return id.startsWith("@") ? parts.slice(0, 2).join("/") : (parts[0] ?? id);
 };
 
-/** @type {import("esbuild").Plugin} */
-const externalize = {
+// Kept external even by an inlineAll entry. @opentelemetry/* is a correctness
+// requirement, not an optimisation: the scenario child flushes spans at exit
+// through the globally registered provider, so a second inlined copy of the
+// API would split registration and flush across two registries and drop every
+// span. Prisma carries native engines that cannot be inlined at all.
+const NEVER_INLINED = [/^@opentelemetry\//, /^@prisma\//, /^\.prisma(\/|$)/];
+
+/**
+ * Whether a specifier gets inlined into the bundle. First-party source always
+ * is; an `inlineAll` entry takes everything else with it except NEVER_INLINED.
+ *
+ * @param {string} id @param {boolean} inlineAll @returns {boolean}
+ */
+const isInlined = (id, inlineAll) => {
+  // Relative (./ ../), absolute (/) and tsconfig-alias (~/, @app/, @ee/)
+  // specifiers are first-party source. `.prisma/…` looks relative but is a
+  // bare specifier, so it falls through and stays external like the rest. A
+  // future tsconfig alias missing here fails the build loudly (the dependency
+  // check below names it as an undeclared package).
+  if (/^(\.\.?\/|\/|~\/|@app\/|@ee\/)/.test(id)) return true;
+  // Workspace packages ship raw TypeScript, so only bundling can resolve them.
+  // One inlined copy per process is the correct instance count anyway.
+  if (workspaceBundled.has(basePackage(id))) return true;
+  return inlineAll && !NEVER_INLINED.some((re) => re.test(id));
+};
+
+/**
+ * Entries default to bundling first-party code only. `inlineAll` flips that to
+ * bundling everything except NEVER_INLINED — used by the scenario child, which
+ * is a fresh process per run and so pays its whole module graph every time.
+ *
+ * @param {boolean} inlineAll
+ * @returns {import("esbuild").Plugin}
+ */
+const createExternalize = (inlineAll) => ({
   name: "externalize",
   setup(b) {
     b.onResolve({ filter: /.*/ }, (a) => {
-      // Relative (./ ../), absolute (/) and tsconfig-alias (~/, @app/, @ee/)
-      // specifiers are first-party source: bundle. `.prisma/…` looks relative
-      // but is a bare specifier, so it falls through and stays external like
-      // the rest. A future tsconfig alias missing here fails the build loudly
-      // (the dependency check below names it as an undeclared package).
-      if (/^(\.\.?\/|\/|~\/|@app\/|@ee\/)/.test(a.path)) return;
-      // Workspace packages ship raw TypeScript: bundle. One inlined copy per
-      // process is the correct instance count anyway.
-      if (workspaceBundled.has(basePackage(a.path))) return;
+      if (isInlined(a.path, inlineAll)) return;
       // Side-effect-only imports keep their side effects (no waiver), or the
       // import statement itself would be dropped.
       if (sideEffectImports.has(a.path)) {
@@ -101,7 +127,7 @@ const externalize = {
       return { path: a.path, external: true, sideEffects: false };
     });
   },
-};
+});
 
 // CommonJS output (like the scenario child-process bundle). CJS is deliberate:
 // `__dirname`/`__filename`/`require` are native (goose.ts's
@@ -134,11 +160,21 @@ const ENTRIES = [
   { name: "task", entry: "src/task.ts" },
   {
     // Spawned per scenario run (src/server/scenarios/execution/
-    // child-process-spawn.ts). Externals stay requires, so the shared
-    // singletons (@opentelemetry/api, @langwatch/scenario) resolve to the same
-    // instances as the parent. @see specs/scenarios/pre-compiled-child-process.feature
+    // child-process-spawn.ts), as a FRESH process every time, so whatever this
+    // entry resolves from disk at boot is paid once per simulation.
+    //
+    // That is why the scenario SDK is inlined here and nowhere else: left
+    // external it is the single largest startup cost, because requiring it
+    // walks its whole dependency graph across the pnpm symlink tree.
+    //
+    // @opentelemetry/* deliberately stays external. The child flushes spans at
+    // exit by reaching for the globally registered provider, so a second
+    // inlined copy of the OTEL API would split registration and flush across
+    // two registries and drop every span while still exiting 0.
+    // @see specs/scenarios/pre-compiled-child-process.feature
     name: "scenario-child-process",
     entry: "src/server/scenarios/execution/scenario-child-process.ts",
+    inlineAll: true,
   },
 ];
 
@@ -153,6 +189,7 @@ const builtins = new Set(builtinModules);
 // tokenizer's lazy `import("node-fetch-cache")` runs in production, and
 // leaving it undeclared would silently kill token counting.
 const devOnlyDynamicImports = new Set(["selfsigned"]);
+const optionalExternals = new Set(OPTIONAL_EXTERNALS);
 /** @type {Map<string, Set<string>>} package -> entry names that require it */
 const undeclared = new Map();
 const scannedSources = new Set();
@@ -161,7 +198,7 @@ const unlistedSideEffectImports = new Map();
 /** @type {Map<string, Set<string>>} specifier -> files importing JSON with no attribute */
 const jsonImportsWithoutAttribute = new Map();
 
-for (const { name, entry } of ENTRIES) {
+for (const { name, entry, inlineAll } of ENTRIES) {
   const result = await build({
     entryPoints: [path.join(APP, entry)],
     outfile: path.join(OUT_DIR, `${name}.cjs`),
@@ -178,7 +215,13 @@ for (const { name, entry } of ENTRIES) {
     banner,
     define,
     loader: { ".css": "empty", ".scss": "empty", ".sass": "empty" },
-    plugins: [externalize],
+    // Inlined packages are tree-shaken only if esbuild can see ESM: a CJS
+    // entry is opaque, so every branch of it (the voice stack included) would
+    // be kept. Entries that inline nothing keep the node default.
+    ...(inlineAll
+      ? { mainFields: ["module", "main"], conditions: ["import"] }
+      : {}),
+    plugins: [createExternalize(inlineAll ?? false)],
     metafile: true,
     // Linked source maps so production stack traces name real files/lines
     // instead of bundle offsets (the entrypoints run with --enable-source-maps).
@@ -196,6 +239,7 @@ for (const { name, entry } of ENTRIES) {
       if (id === ".prisma" || id.startsWith(".prisma/")) continue;
       const base = basePackage(id);
       if (declared.has(base)) continue;
+      if (optionalExternals.has(base)) continue;
       if (imp.kind === "dynamic-import" && devOnlyDynamicImports.has(base))
         continue;
       let entriesFor = undeclared.get(base);

--- a/platform/app/scripts/bundle-optional-externals.mjs
+++ b/platform/app/scripts/bundle-optional-externals.mjs
@@ -1,0 +1,20 @@
+/**
+ * Externals whose absence at runtime is handled by the code that requires
+ * them, so they are deliberately NOT declared in `dependencies`.
+ *
+ * Shared by the build's dependency check (scripts/build-server.mjs) and the
+ * bundle's resolution guard (child-process-bundle.integration.test.ts) so the
+ * two cannot disagree about what is allowed to be missing.
+ *
+ * Only add an entry after reading the guard that protects it — an unguarded
+ * package listed here becomes a MODULE_NOT_FOUND at boot in production, which
+ * is exactly what that dependency check exists to prevent (#5855).
+ */
+export const OPTIONAL_EXTERNALS = Object.freeze([
+  // ws requires it inside a try/catch and falls back to its own JS validator.
+  // It is a native addon, so it could not be inlined regardless.
+  "utf-8-validate",
+  // Lazily imported by the scenario SDK's Gemini Live voice adapter, which
+  // throws a "not installed" error naming the package when it is missing.
+  "@google/genai",
+]);

--- a/platform/app/src/server/scenarios/__tests__/child-process-env.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/child-process-env.unit.test.ts
@@ -10,7 +10,7 @@ import { buildChildProcessEnv } from "../scenario.processor";
 
 describe("buildChildProcessEnv", () => {
   describe("given the scenario processor builds the child environment", () => {
-    /** @scenario 'The spawned child is given a compile cache directory' */
+    /** @scenario 'Repeat simulations do not repeat the same startup work' */
     it("names a compile cache directory, and keeps one the caller already set", () => {
       // The child is a fresh process per scenario run, so without a compile
       // cache it re-compiles the same bundle on every single run.

--- a/platform/app/src/server/scenarios/__tests__/child-process-env.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/child-process-env.unit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node
+ *
+ * The environment handed to the scenario child process.
+ * @see specs/scenarios/pre-compiled-child-process.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildChildProcessEnv } from "../scenario.processor";
+
+describe("buildChildProcessEnv", () => {
+  describe("given the scenario processor builds the child environment", () => {
+    /** @scenario 'The spawned child is given a compile cache directory' */
+    it("names a compile cache directory, and keeps one the caller already set", () => {
+      // The child is a fresh process per scenario run, so without a compile
+      // cache it re-compiles the same bundle on every single run.
+      const fresh = buildChildProcessEnv({});
+      expect(fresh.NODE_COMPILE_CACHE).toBeTruthy();
+
+      const previous = process.env.NODE_COMPILE_CACHE;
+      process.env.NODE_COMPILE_CACHE = "/somewhere/else";
+      try {
+        expect(buildChildProcessEnv({}).NODE_COMPILE_CACHE).toBe(
+          "/somewhere/else",
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env.NODE_COMPILE_CACHE;
+        } else {
+          process.env.NODE_COMPILE_CACHE = previous;
+        }
+      }
+    });
+
+    /** @scenario 'Child process environment variables are preserved' */
+    it("passes scenario variables through to the child", () => {
+      const env = buildChildProcessEnv({
+        LANGWATCH_API_KEY: "key-1",
+        LANGWATCH_ENDPOINT: "http://localhost:9999",
+      });
+
+      expect(env.LANGWATCH_API_KEY).toBe("key-1");
+      expect(env.LANGWATCH_ENDPOINT).toBe("http://localhost:9999");
+    });
+
+    it("drops variables with no value rather than passing them as undefined", () => {
+      const env = buildChildProcessEnv({ SOME_UNSET_VAR: undefined });
+
+      expect("SOME_UNSET_VAR" in env).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/__tests__/scenario.processor.spawning.integration.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenario.processor.spawning.integration.test.ts
@@ -42,6 +42,7 @@ describe.skipIf(process.env.CI)("Scenario Processor - Worker Spawning", () => {
     expect(exitCode).toBeDefined();
   }, 60000);
 
+  /** @scenario 'Child process receives job data via stdin' */
   it("receives serialized scenario data and returns result object", async () => {
     const jobData = createTestJobData();
     const env = {

--- a/platform/app/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
@@ -10,6 +10,7 @@ import fs from "fs";
 import { isBuiltin } from "module";
 import path from "path";
 import { beforeAll, describe, expect, it } from "vitest";
+import { OPTIONAL_EXTERNALS } from "../../../../../scripts/bundle-optional-externals.mjs";
 
 const PACKAGE_ROOT = path.resolve(__dirname, "../../../../..");
 const BUNDLE_PATH = path.join(
@@ -36,6 +37,7 @@ describe("Pre-compiled Scenario Child Process", () => {
     // points rebuilt, the scenario bundle gone — which is the state that sends
     // production scenario spawns down the tsx fallback.
 
+    /** @scenario 'Build step produces a runnable JavaScript bundle' */
     it("produces a single JavaScript file at dist/server/scenario-child-process.cjs", () => {
       expect(fs.existsSync(BUNDLE_PATH)).toBe(true);
 
@@ -64,14 +66,32 @@ describe("Pre-compiled Scenario Child Process", () => {
       expect(stderr).not.toContain("Cannot find module");
     });
 
-    it("excludes shared singleton dependencies from the bundle", () => {
+    /** @scenario 'OpenTelemetry stays external so the child holds one tracer provider' */
+    it("keeps OpenTelemetry external so exactly one API instance exists", () => {
       const content = fs.readFileSync(BUNDLE_PATH, "utf8");
 
-      // External deps should appear as require() calls, not inlined code
+      // The child flushes spans at exit through the globally registered
+      // provider. A second, inlined copy of the API would take registration
+      // and flush to different registries and silently drop every span, so
+      // this must stay a require and no copy may be inlined alongside it.
       expect(content).toContain('require("@opentelemetry/api")');
-      expect(content).toContain('require("@langwatch/scenario")');
+
+      // `createNoopMeter` is defined only inside @opentelemetry/api's own
+      // source, so its presence would mean a copy got inlined.
+      expect(content).not.toContain("createNoopMeter");
     });
 
+    /** @scenario 'The scenario SDK is inlined rather than required at runtime' */
+    it("inlines the scenario SDK instead of resolving it from node_modules", () => {
+      const content = fs.readFileSync(BUNDLE_PATH, "utf8");
+
+      // Left external, requiring it walked the SDK's whole dependency graph
+      // across the pnpm tree on every spawn — and the child is a fresh process
+      // per scenario run, so that cost was paid every time.
+      expect(content).not.toContain('require("@langwatch/scenario")');
+    });
+
+    /** @scenario 'Pre-compiled child process is ready for job data promptly' */
     it("starts and reads from stdin within 5 seconds", async () => {
       const startTime = Date.now();
 
@@ -116,14 +136,18 @@ describe("Pre-compiled Scenario Child Process", () => {
       expect(result.exitCode).toBe(1);
     }, 8000);
 
-    // Regression guard for #5855: the bundle keeps every dependency external
-    // (scripts/build-server.mjs bundles first-party code only), so it emits
-    // runtime require("x") calls that MUST resolve from the bundle's own
-    // directory — the exact resolution root prod uses. An external that is only
-    // a transitive dep of a workspace package (e.g. pino via
+    // Regression guard for #5855. Whatever this entry does NOT inline is
+    // emitted as a runtime require("x") that MUST resolve from the bundle's
+    // own directory — the exact resolution root prod uses. A package that is
+    // only a transitive dep of a workspace package (e.g. pino via
     // @langwatch/observability) is NOT top-linked into platform/app/node_modules by
     // pnpm, so its require throws MODULE_NOT_FOUND at prod boot. #2404 caused
     // exactly this by moving the pino family out of the app manifest.
+    //
+    // This entry now inlines its graph, which shrinks the exposure to the
+    // OpenTelemetry packages held out on purpose — but it does not remove it,
+    // and the check stays as the thing that proves it.
+    /** @scenario 'Every externalized require resolves from the bundle directory' */
     it("boots without MODULE_NOT_FOUND — every externalized require() resolves in a prod-shaped layout", () => {
       const content = fs.readFileSync(BUNDLE_PATH, "utf8");
       const distDir = path.dirname(BUNDLE_PATH);
@@ -142,9 +166,12 @@ describe("Pre-compiled Scenario Child Process", () => {
         (name) => !name.startsWith(".") && !isBuiltin(name),
       );
 
-      // Sanity: the logger dep whose absence broke prod must be one of them —
-      // if it ever stops being emitted, this guard would silently pass empty.
-      expect(externalPkgs).toContain("pino");
+      // Sanity: if nothing is emitted the filters below pass vacuously, so pin
+      // a package that is external BY DESIGN. This entry inlines its graph, so
+      // OpenTelemetry — held out deliberately to keep one API instance in the
+      // child — is the dependable sentinel. (pino filled this role while the
+      // entry externalized everything; it is inlined now.)
+      expect(externalPkgs).toContain("@opentelemetry/api");
 
       // PRIMARY — EXECUTE the affected code path (coding guideline: runtime
       // regression tests must run the code and observe the crash, not just assert
@@ -173,7 +200,12 @@ describe("Pre-compiled Scenario Child Process", () => {
       // SUPPLEMENTARY — resolve each external from the prod-shaped root so a
       // failure NAMES the exact unresolved module (the runtime check above only
       // reports that *something* failed). Execute-the-path + precise attribution.
+      // Optional peers are require'd behind a runtime guard, so being
+      // unresolvable is their designed state, not a regression. Same list the
+      // build's dependency check uses, so the two cannot drift apart.
+      const optional = new Set<string>(OPTIONAL_EXTERNALS);
       const unresolved = externalPkgs.filter((name) => {
+        if (optional.has(name)) return false;
         try {
           require.resolve(name, { paths: [distDir] });
           return false;

--- a/platform/app/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
@@ -66,7 +66,7 @@ describe("Pre-compiled Scenario Child Process", () => {
       expect(stderr).not.toContain("Cannot find module");
     });
 
-    /** @scenario 'OpenTelemetry stays external so the child holds one tracer provider' */
+    /** @scenario 'A simulation still reports its spans' */
     it("keeps OpenTelemetry external so exactly one API instance exists", () => {
       const content = fs.readFileSync(BUNDLE_PATH, "utf8");
 
@@ -81,7 +81,7 @@ describe("Pre-compiled Scenario Child Process", () => {
       expect(content).not.toContain("createNoopMeter");
     });
 
-    /** @scenario 'The scenario SDK is inlined rather than required at runtime' */
+    /** @scenario 'Starting a simulation does not re-read its dependencies from disk' */
     it("inlines the scenario SDK instead of resolving it from node_modules", () => {
       const content = fs.readFileSync(BUNDLE_PATH, "utf8");
 
@@ -91,7 +91,7 @@ describe("Pre-compiled Scenario Child Process", () => {
       expect(content).not.toContain('require("@langwatch/scenario")');
     });
 
-    /** @scenario 'The child starts its log transport when logging is configured' */
+    /** @scenario 'Configuring log output does not stop a simulation starting' */
     it.each([
       ["pretty console logs", { LOG_FORMAT: "pretty" }],
       ["the telemetry log transport", { PINO_OTEL_ENABLED: "true" }],
@@ -182,7 +182,7 @@ describe("Pre-compiled Scenario Child Process", () => {
     // This entry now inlines its graph, which shrinks the exposure to the
     // OpenTelemetry packages held out on purpose — but it does not remove it,
     // and the check stays as the thing that proves it.
-    /** @scenario 'Every externalized require resolves from the bundle directory' */
+    /** @scenario 'The child starts with every dependency it needs' */
     it("boots without MODULE_NOT_FOUND — every externalized require() resolves in a prod-shaped layout", () => {
       const content = fs.readFileSync(BUNDLE_PATH, "utf8");
       const distDir = path.dirname(BUNDLE_PATH);

--- a/platform/app/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
@@ -91,6 +91,41 @@ describe("Pre-compiled Scenario Child Process", () => {
       expect(content).not.toContain('require("@langwatch/scenario")');
     });
 
+    /** @scenario 'The child starts its log transport when logging is configured' */
+    it.each([
+      ["pretty console logs", { LOG_FORMAT: "pretty" }],
+      ["the telemetry log transport", { PINO_OTEL_ENABLED: "true" }],
+    ])(
+      "starts with %s configured, without losing its transport worker",
+      (_label, logEnv) => {
+        // EXECUTES the path rather than asserting on the bundle text: the logger
+        // resolves its worker script next to its own package, so inlining it
+        // moved the lookup and the worker rethrew on nextTick — uncaught, past
+        // the transport's try/catch, killing the child. Only running it shows
+        // that. Empty stdin makes the child fail on job parsing AFTERWARDS, so
+        // any transport error here is the real thing.
+        const boot = spawnSync("node", [BUNDLE_PATH], {
+          cwd: path.dirname(BUNDLE_PATH),
+          input: "",
+          stdio: "pipe",
+          env: {
+            ...process.env,
+            NODE_ENV: "production",
+            SKIP_ENV_VALIDATION: "1",
+            LANGWATCH_API_KEY: "test-key",
+            LANGWATCH_ENDPOINT: "http://localhost:9999",
+            ...logEnv,
+          },
+          timeout: 30000,
+        });
+
+        const stderr = boot.stderr?.toString() ?? "";
+        expect(stderr).not.toContain("worker.js");
+        expect(stderr).not.toContain("Cannot find module");
+      },
+      35000,
+    );
+
     /** @scenario 'Pre-compiled child process is ready for job data promptly' */
     it("starts and reads from stdin within 5 seconds", async () => {
       const startTime = Date.now();
@@ -167,10 +202,11 @@ describe("Pre-compiled Scenario Child Process", () => {
       );
 
       // Sanity: if nothing is emitted the filters below pass vacuously, so pin
-      // a package that is external BY DESIGN. This entry inlines its graph, so
-      // OpenTelemetry — held out deliberately to keep one API instance in the
-      // child — is the dependable sentinel. (pino filled this role while the
-      // entry externalized everything; it is inlined now.)
+      // packages that are external BY DESIGN. Both are in NEVER_INLINED — the
+      // logger because it loads its worker script by directory, OpenTelemetry
+      // to keep one API instance in the child — so neither can quietly stop
+      // being emitted while this entry inlines the rest of its graph.
+      expect(externalPkgs).toContain("pino");
       expect(externalPkgs).toContain("@opentelemetry/api");
 
       // PRIMARY — EXECUTE the affected code path (coding guideline: runtime

--- a/platform/app/src/server/scenarios/execution/__tests__/child-process-spawn.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/child-process-spawn.unit.test.ts
@@ -54,6 +54,7 @@ describe("resolveChildProcessSpawn", () => {
         vi.mocked(fs.existsSync).mockReturnValue(true);
       });
 
+      /** @scenario 'Processor spawns child process using the pre-compiled bundle in production' */
       it("invokes node with the path to the compiled bundle", () => {
         const result = resolveChildProcessSpawn({
           packageRoot: PACKAGE_ROOT,
@@ -103,6 +104,7 @@ describe("resolveChildProcessSpawn", () => {
         vi.mocked(fs.existsSync).mockReturnValue(false);
       });
 
+      /** @scenario 'Processor falls back to tsx with loud logging when bundle is missing in production' */
       it("falls back to tsx instead of crashing", () => {
         const result = resolveChildProcessSpawn({
           packageRoot: PACKAGE_ROOT,
@@ -150,6 +152,7 @@ describe("resolveChildProcessSpawn", () => {
   });
 
   describe("when NODE_ENV is development", () => {
+    /** @scenario 'Processor spawns child process using tsx in development' */
     it("invokes pnpm exec tsx with the TypeScript source file", () => {
       const result = resolveChildProcessSpawn({
         packageRoot: PACKAGE_ROOT,

--- a/platform/app/src/server/scenarios/scenario.processor.ts
+++ b/platform/app/src/server/scenarios/scenario.processor.ts
@@ -15,6 +15,8 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { createLogger } from "@langwatch/observability";
 import { type ChildProcess, spawn } from "child_process";
+import os from "os";
+import path from "path";
 import { env } from "~/env.mjs";
 import { getApp, tryGetApp } from "../app-layer/app";
 import { resolveAppPackageRoot } from "../appPackageRoot";
@@ -270,6 +272,16 @@ export function buildOtelResourceAttributes(labels: string[]): string {
  * Build minimal env for child process - whitelist only what's needed.
  * @internal Exported for testing
  */
+/**
+ * Where the scenario child keeps its V8 compile cache. Under the OS temp dir
+ * because that is writable in every deployment shape we ship, including a
+ * read-only application root.
+ */
+const SCENARIO_CHILD_COMPILE_CACHE_DIR = path.join(
+  os.tmpdir(),
+  "langwatch-scenario-compile-cache",
+);
+
 export function buildChildProcessEnv(
   scenarioVars: Record<string, string | undefined>,
 ): NodeJS.ProcessEnv {
@@ -284,6 +296,13 @@ export function buildChildProcessEnv(
     NODE_ENV: process.env.NODE_ENV,
     NODE_OPTIONS: process.env.NODE_OPTIONS,
     SKIP_ENV_VALIDATION: "1",
+    // The child is a fresh process per run, so without this it re-compiles the
+    // same bundle every time. Node keys each entry by a hash of the source, so
+    // a rebuilt bundle can never be served a stale compilation — the entries
+    // for the old one are simply never read again. An unwritable directory
+    // degrades to no caching rather than failing the spawn.
+    NODE_COMPILE_CACHE:
+      process.env.NODE_COMPILE_CACHE ?? SCENARIO_CHILD_COMPILE_CACHE_DIR,
     COREPACK_ENABLE_DOWNLOAD_PROMPT:
       process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT,
     ...scenarioVars,

--- a/specs/scenarios/pre-compiled-child-process.feature
+++ b/specs/scenarios/pre-compiled-child-process.feature
@@ -40,13 +40,13 @@ Feature: Pre-compiled Scenario Child Process
     Then it produces a single JavaScript file at dist/server/scenario-child-process.cjs
 
   @integration
-  Scenario: The scenario SDK is inlined rather than required at runtime
+  Scenario: Starting a simulation does not re-read its dependencies from disk
     When the child process build step runs
     Then the bundle does not require the scenario SDK from node_modules
     And the SDK's own module graph is not resolved from disk at child startup
 
   @integration
-  Scenario: OpenTelemetry stays external so the child holds one tracer provider
+  Scenario: A simulation still reports its spans
     A second copy of the OTEL API inside the bundle would take the provider
     registration and the span flush to different global registries, and the
     child would report no spans at all while still exiting successfully.
@@ -56,7 +56,7 @@ Feature: Pre-compiled Scenario Child Process
     And no copy of the OpenTelemetry API is inlined into the bundle
 
   @regression
-  Scenario: The child starts its log transport when logging is configured
+  Scenario: Configuring log output does not stop a simulation starting
     A package that locates a FILE relative to its own directory cannot be
     inlined, because inlining is what moves that directory. The logger is one:
     it runs its transport on a worker thread whose script it finds next to
@@ -71,7 +71,7 @@ Feature: Pre-compiled Scenario Child Process
     Then it does not die failing to load its log transport worker
 
   @integration
-  Scenario: Every externalized require resolves from the bundle directory
+  Scenario: The child starts with every dependency it needs
     Given a pre-compiled child process bundle
     When the bundle is loaded from a production-shaped directory layout
     Then no module fails to resolve
@@ -118,7 +118,7 @@ Feature: Pre-compiled Scenario Child Process
     Then it is ready to receive job data well inside the startup budget
 
   @unit
-  Scenario: The spawned child is given a compile cache directory
+  Scenario: Repeat simulations do not repeat the same startup work
     Re-compiling the bundle's JavaScript on every spawn is wasted work, since
     the bundle only changes when the app is rebuilt.
 

--- a/specs/scenarios/pre-compiled-child-process.feature
+++ b/specs/scenarios/pre-compiled-child-process.feature
@@ -1,17 +1,26 @@
 Feature: Pre-compiled Scenario Child Process
 
-  Scenario child processes are spawned via `pnpm exec tsx`, which compiles
-  TypeScript at runtime on every invocation. Cold starts take ~4.5 minutes and
-  warm starts ~53 seconds, nearly exhausting the 5-minute timeout before actual
-  scenario execution begins.
+  Scenario child processes are spawned fresh per run, so whatever the child
+  loads at module scope is paid on every simulation. Spawning via
+  `pnpm exec tsx` compiled TypeScript at runtime on every invocation; the
+  pre-compiled bundle removed that.
 
-  Pre-compiling the child process entry point into a single bundled JavaScript
-  file eliminates tsx compilation, pnpm resolution, and corepack overhead,
-  reducing startup to low single-digit seconds.
+  Pre-compiling alone did not remove the dominant cost. The bundle kept the
+  scenario SDK external, so the child still resolved that package's entire
+  dependency graph from disk at boot — thousands of file reads before it could
+  read a single byte of job data. Inlining the SDK into the bundle turns that
+  graph into one file read.
 
   Key design decisions:
-  - Shared singleton dependencies (OTEL, scenario SDK) are kept external
-    to preserve runtime semantics and avoid double-bundling
+  - The scenario SDK is INLINED into the bundle. It is the single largest
+    startup cost when left external, and the child is a fresh process per run
+    so it pays that cost every time.
+  - OpenTelemetry stays EXTERNAL, and this is load-bearing rather than
+    incidental. The child reaches for the globally registered tracer provider
+    to flush spans before exit. Inlining the OTEL API would give the child two
+    copies of it — the SDK registering its provider into one, the flush code
+    reading the other and finding a no-op proxy — and every span would be
+    dropped silently.
   - In development, tsx is used for fast iteration; in production, the
     pre-compiled bundle is required — packaged deployments carry no tsx
   - Bundle output lives at dist/server/scenario-child-process.cjs relative to
@@ -29,7 +38,28 @@ Feature: Pre-compiled Scenario Child Process
   Scenario: Build step produces a runnable JavaScript bundle
     When the child process build step runs
     Then it produces a single JavaScript file at dist/server/scenario-child-process.cjs
-    And shared singleton dependencies are excluded from the bundle
+
+  @integration
+  Scenario: The scenario SDK is inlined rather than required at runtime
+    When the child process build step runs
+    Then the bundle does not require the scenario SDK from node_modules
+    And the SDK's own module graph is not resolved from disk at child startup
+
+  @integration
+  Scenario: OpenTelemetry stays external so the child holds one tracer provider
+    A second copy of the OTEL API inside the bundle would take the provider
+    registration and the span flush to different global registries, and the
+    child would report no spans at all while still exiting successfully.
+
+    When the child process build step runs
+    Then the bundle requires "@opentelemetry/api" from node_modules
+    And no copy of the OpenTelemetry API is inlined into the bundle
+
+  @integration
+  Scenario: Every externalized require resolves from the bundle directory
+    Given a pre-compiled child process bundle
+    When the bundle is loaded from a production-shaped directory layout
+    Then no module fails to resolve
 
   # ---------------------------------------------------------------------------
   # Spawning — processor uses the compiled bundle
@@ -49,7 +79,7 @@ Feature: Pre-compiled Scenario Child Process
     When the scenario processor spawns a child process
     Then it invokes "pnpm exec tsx" with the TypeScript source file
 
-  @unit
+  @integration
   Scenario: Child process receives job data via stdin
     Given a child process spawned from the pre-compiled bundle
     When the processor writes job data to stdin
@@ -67,10 +97,19 @@ Feature: Pre-compiled Scenario Child Process
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: Pre-compiled child process starts within seconds
+  Scenario: Pre-compiled child process is ready for job data promptly
     Given a pre-compiled child process bundle
     When a child process is spawned and begins reading from stdin
-    Then it is ready to receive job data in under 5 seconds
+    Then it is ready to receive job data well inside the startup budget
+
+  @unit
+  Scenario: The spawned child is given a compile cache directory
+    Re-compiling the bundle's JavaScript on every spawn is wasted work, since
+    the bundle only changes when the app is rebuilt.
+
+    Given the scenario processor builds the child environment
+    Then the child environment names a compile cache directory
+    And a caller-provided cache directory is preserved
 
   # ---------------------------------------------------------------------------
   # Error Handling

--- a/specs/scenarios/pre-compiled-child-process.feature
+++ b/specs/scenarios/pre-compiled-child-process.feature
@@ -55,6 +55,21 @@ Feature: Pre-compiled Scenario Child Process
     Then the bundle requires "@opentelemetry/api" from node_modules
     And no copy of the OpenTelemetry API is inlined into the bundle
 
+  @regression
+  Scenario: The child starts its log transport when logging is configured
+    A package that locates a FILE relative to its own directory cannot be
+    inlined, because inlining is what moves that directory. The logger is one:
+    it runs its transport on a worker thread whose script it finds next to
+    itself. Inlined, that lookup missed and the worker rethrew on nextTick —
+    an uncaught error, so the transport's own try/catch never saw it and the
+    child died instead of degrading. Both ordinary configurations reach it:
+    pretty console logs and the telemetry log transport.
+
+    Given a pre-compiled child process bundle
+    And the child is configured to write pretty console logs
+    When the child process starts
+    Then it does not die failing to load its log transport worker
+
   @integration
   Scenario: Every externalized require resolves from the bundle directory
     Given a pre-compiled child process bundle


### PR DESCRIPTION
The scenario child is a fresh Node process per simulation run, so every module it resolves at boot is paid again on every single run. The pre-compiled bundle removed tsx transpilation but kept the scenario SDK **external**, so each spawn still walked that package's whole dependency graph across the pnpm symlink tree before the child could read a byte of job data.

This inlines the SDK — and the rest of that graph with it — turning thousands of file reads into one.

## Measured

Interleaved A/B, six runs each, same machine, quiet, production-shaped layout (bundle run from `dist/server/` so externals resolve exactly as they do in the image):

```
A (today):      1087 1068 1103 1128 1090 1047   median 1090ms
B (this PR):     552  557  565  621  576  558   median  565ms
                                     -> 1.93x, 525ms saved per spawn
```

The variance also collapses, which is the same finding from the other side: what was being measured before was disk, not compute.

**Cost:** the bundle grows 815KB -> 15.8MB. That is the honest trade — ~525ms per run against ~15MB of image.

## The rule this PR establishes

`NEVER_INLINED` holds packages out of the inlined graph, and every entry is there for one reason:

> A package that resolves a **file** at runtime relative to its own location cannot be inlined, because inlining is exactly what moves that location.

Three entries, two of which are silent-failure traps:

**`pino` / `thread-stream`** — they run the log transport on a worker thread found via `join(__dirname, "worker.js")`. Inlined, `__dirname` becomes `dist/server`, the lookup misses, and thread-stream reports it by **rethrowing on `nextTick`** — an uncaught error, so the transport's own `try/catch` never sees it and the child **dies** instead of degrading to stdout. Every ordinary configuration reaches it: pretty console logs (the dev default) and the telemetry log transport both create a transport. Caught by the audit pass on this PR, verified against the pre-change bundle in all three configurations, and now guarded by a test that spawns the real bundle under both.

**`@opentelemetry/*`** — the child flushes spans at exit through the **globally registered** provider. A naive inline pulls in a second copy of `@opentelemetry/api` (493 of its files) — the SDK registers into one copy, the flush code reads the other, finds a no-op proxy, and **drops every span while still exiting 0**. Silent trace loss, green build. Pinned by two assertions: the bundle must still `require("@opentelemetry/api")`, and must not contain `createNoopMeter` (a symbol only present inside that package's own source).

**`@prisma/*`** — native engines, cannot be inlined at all.

## Also here

- **`NODE_COMPILE_CACHE` for the child.** It was recompiling the same bundle on every spawn. Node keys entries by a hash of the source, so a rebuilt bundle can never be served stale compiled code. An unwritable cache directory degrades to no caching rather than failing the spawn.
- **Optional-peer allowlist.** Inlining surfaces the SDK's guarded optional peers as bundle-level externals. Both are genuinely optional and the guard was read before listing either: `ws` requires `utf-8-validate` inside a `try/catch` with a JS fallback (and it is a native addon, so it could not be inlined anyway), and the SDK lazily imports `@google/genai` from its Gemini Live voice adapter, throwing a "not installed" error when absent. The list lives in one module shared by the build's dependency check and the bundle's resolution guard, so they cannot drift apart.
- **The `#5855` guard still works.** It now pins both `pino` and `@opentelemetry/api` as sentinels — packages external *by design* for this entry — so it cannot pass vacuously as the entry inlines the rest of its graph.

## Known limitation

Two voice-only packages resolve assets by directory and are now inlined, so their paths are wrong: `ffmpeg-static` (`join(__dirname, "ffmpeg")`) and the scenario SDK's background-noise assets. **Not reachable from this child** — it uses only `run`, `judgeAgent` and `userSimulatorAgent`, never the voice path — so this is latent rather than live. Flagging it explicitly rather than leaving it to be discovered: if voice execution ever moves into this child, both need adding to `NEVER_INLINED` (and `ffmpeg-static` then needs declaring in the app manifest, which pulls an ffmpeg binary into the image).

`bufferutil`'s native binding is in the same class but degrades safely — it is loaded inside a `try/catch` with a pure-JS fallback.

## Spec parity

`pre-compiled-child-process.feature` lived under `platform/app/specs/`, which is **not a parity root** — so all 8 of its scenarios enforced nothing and the file read as green while binding zero tests. Moved to `specs/scenarios/` and every scenario is now bound, including the four new ones.

The old header also claimed shared singletons "(OTEL, scenario SDK)" were both kept external to avoid double-bundling. That is the reasoning this PR changes, so the prose is rewritten to say which packages are held out and why.

## Verification

- `child-process-bundle.integration.test.ts` — 8/8 pass, builds the bundle for real and boots it
- `src/server/scenarios` unit suite — 43 files / 534 tests pass
- `check-feature-parity.ts` — `OK: 6373 enforced scenario(s) bound across 1021 file(s)`
- biome — no delta against baseline (5 pre-existing warnings before and after)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scenario child-process startup by bundling required components while preserving telemetry support.
  * Added automatic compile-cache configuration to speed up repeated scenario execution.
  * Added support for optional runtime packages that may be unavailable in some environments.
  * Added reliable production bundle selection with a clear development fallback.

* **Bug Fixes**
  * Improved dependency resolution and startup behavior for scenario processes.

* **Tests**
  * Expanded coverage for environment handling, bundling, logging, external dependencies, and startup readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->