### PR TITLE
feat(haven): revamp the hub — whole-machine RAM, worktrees, cleanup, reaping monitor

### DIFF
--- a/specs/setup/haven-hub-actions.feature
+++ b/specs/setup/haven-hub-actions.feature
@@ -6,12 +6,13 @@ Feature: The haven hub — one place to see and act on every stack
   view, shut it down, or destroy the worktree entirely.
 
   # Behavior lives in tools/thuishaven: `cmd/hub.go` + `app/hub.go`
-  # (DownStack, DestroyWorktree and their guards) and `adapters/hubtui/`
-  # (the TUI itself). Scenarios are bound by Go tests (`go test ./...` in
-  # tools/thuishaven): `adapters/hubtui/hubtui_test.go` (TestHubModel:
-  # enter/g opens git, d+confirm downs, x+type-the-name destroys) and
-  # `app/hub_test.go` (TestDownStack, TestDestroyWorktree with the
-  # primary-checkout and running-from refusals). The parity checker
+  # (DownStack, DestroyWorktree and their guards), `domain/footprint.go`
+  # (the memory partitioner) and `adapters/hubtui/` (the TUI itself).
+  # Scenarios are bound by Go tests (`go test ./...` in tools/thuishaven):
+  # `adapters/hubtui/hubtui_test.go` (TestHubModel: enter/g opens git,
+  # d+confirm downs, x+type-the-name destroys) and `app/hub_test.go`
+  # (TestDownStack, TestDestroyWorktree with the primary-checkout and
+  # running-from refusals). The parity checker
   # (`platform/app/scripts/check-feature-parity.ts`) scans tools/thuishaven's
   # Go tests: @unit scenarios are bound by `// @scenario` annotations above
   # those test funcs; the live-terminal flows remain `@unimplemented`.
@@ -76,3 +77,61 @@ Feature: The haven hub — one place to see and act on every stack
     Given the selected entry is the worktree I launched haven from
     When I try to destroy it
     Then the hub refuses and explains why
+
+  # --- The whole machine, not just the launchers ---
+  # The old footprint was each stack's launcher process group and nothing
+  # else, so the summary undercounted everything a dev machine actually
+  # spends: the shared database servers, the container VM, the coding agents
+  # and the dev tooling running beside the stacks. The partitioner reads ONE
+  # process listing and attributes every process exactly once: its group
+  # puts it in a stack, otherwise its command names a shared server, an
+  # agent, or dev tooling.
+
+  @unit
+  Scenario: The hub shows the machine's whole memory picture
+    Given stacks, shared database servers, coding agents and dev tooling are all running
+    When the hub computes the footprint
+    Then each stack is charged its whole process group
+    And the shared servers, agents and tooling are attributed by what they are
+    And no process is ever counted in two buckets
+
+  @unit
+  Scenario: A stack's own processes are never misfiled as tooling
+    Given a stack whose supervised services include node processes
+    When the hub computes the footprint
+    Then those processes count toward the stack, not toward tooling
+
+  # --- Every worktree, not just the running ones ---
+  @unit
+  Scenario: Worktrees without a running stack are listed too
+    Given a worktree with no registered stack
+    When the hub assembles its rows
+    Then the worktree appears with its branch, marked as having nothing running
+    And the primary checkout and the current worktree are marked protected
+
+  # --- Actions: cleanup, the web view, and the reaping monitor ---
+  @unit
+  Scenario: Cleanup is one key away
+    Given the hub is open in a terminal
+    When I press "c"
+    Then the hub hands the terminal to the interactive cleanup picker
+    And closing the picker returns me to the hub
+
+  @unit
+  Scenario: The machine dashboard is one key away
+    Given the hub is open in a terminal
+    When I press "w"
+    Then the machine's web dashboard opens in the browser
+
+  @unit
+  Scenario: The daemon's reaping is visible from the hub
+    Given the daemon has reaped stacks, containers or processes recently
+    When I press "m"
+    Then the hub shows the most recent reap events, newest first, with what was reaped and why
+
+  @unit
+  Scenario: Reaping is recorded as it happens
+    Given the daemon reaps a stack, a test container, or a governed process
+    When the reap happens
+    Then an event with the kind, target and reason is appended to the record
+    And the record keeps only the most recent events, dropping the oldest past its cap

--- a/specs/setup/haven-hub-actions.feature
+++ b/specs/setup/haven-hub-actions.feature
@@ -80,26 +80,33 @@ Feature: The haven hub — one place to see and act on every stack
 
   # --- The whole machine, not just the launchers ---
   # The old footprint was each stack's launcher process group and nothing
-  # else, so the summary undercounted everything a dev machine actually
-  # spends: the shared database servers, the container VM, the coding agents
-  # and the dev tooling running beside the stacks. The partitioner reads ONE
-  # process listing and attributes every process exactly once: its group
-  # puts it in a stack, otherwise its command names a shared server, an
-  # agent, or dev tooling.
+  # else — and supervised children lead their OWN groups so it saw only the
+  # ~20MB launcher, while the shared database servers, the container VM, the
+  # coding agents and the dev tooling never appeared at all. The partitioner
+  # reads ONE process listing and attributes every process exactly once:
+  # shared servers by what they are, then stack lineage (descendants of a
+  # launcher), then agents and tooling, and everything else as its own slice.
 
   @unit
   Scenario: The hub shows the machine's whole memory picture
     Given stacks, shared database servers, coding agents and dev tooling are all running
     When the hub computes the footprint
-    Then each stack is charged its whole process group
-    And the shared servers, agents and tooling are attributed by what they are
+    Then each stack is charged its whole process tree
+    And the shared servers, agents, tooling and everything else are attributed by what they are
     And no process is ever counted in two buckets
 
   @unit
-  Scenario: A stack's own processes are never misfiled as tooling
-    Given a stack whose supervised services include node processes
+  Scenario: A stack is charged its whole process tree, not just its launcher
+    Given a stack whose supervised services each lead their own process group
     When the hub computes the footprint
-    Then those processes count toward the stack, not toward tooling
+    Then the stack's number includes every descendant of its launcher
+    And its own processes are never misfiled as tooling or agents
+
+  @unit
+  Scenario: What is not dev work still shows on the chart
+    Given the machine also runs browsers and other non-dev processes
+    When the hub renders the memory chart
+    Then dev work and everything else appear as separate colours against the machine total
 
   # --- Every worktree, not just the running ones ---
   @unit
@@ -108,6 +115,20 @@ Feature: The haven hub — one place to see and act on every stack
     When the hub assembles its rows
     Then the worktree appears with its branch, marked as having nothing running
     And the primary checkout and the current worktree are marked protected
+
+  @unit
+  Scenario: Idle worktrees stay out of the way while stacks run
+    Given stacks are running and idle worktrees exist
+    When the hub opens
+    Then the worktree list stays hidden behind a one-key toggle
+    And with nothing running the worktrees show by default
+
+  @unit
+  Scenario: Refreshing the hub is silent
+    Given a worktree whose slug cache disagrees with the registry
+    When the hub refreshes its rows
+    Then nothing is logged over the terminal
+    And the destroy path still surfaces the disagreement
 
   # --- Actions: cleanup, the web view, and the reaping monitor ---
   @unit
@@ -135,3 +156,11 @@ Feature: The haven hub — one place to see and act on every stack
     When the reap happens
     Then an event with the kind, target and reason is appended to the record
     And the record keeps only the most recent events, dropping the oldest past its cap
+
+  # --- The web dashboard shows the same machine ---
+  @unit
+  Scenario: The web dashboard shows the same machine picture
+    Given the daemon serves the web dashboard
+    When the page renders
+    Then the memory chart, the idle worktrees and the recent reaping appear
+    And the shared servers are stated once instead of repeating on every stack card

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -56,8 +56,9 @@ One name per command, one meaning per flag, no aliases (ADR-064). The daily
 surface is six verbs; `db` and `clean` are the only destructive nouns.
 
 ```text
-haven            the hub: every stack + actions on the selected one (agents/pipes
-                 get the plain status report)
+haven            the hub: the whole machine — stacks, worktrees, RAM by owner,
+                 the daemon's reaping — with actions on the selected row
+                 (agents/pipes get the plain status report)
 haven up         start or reconcile this worktree's stack — in a terminal it
                  runs in the BACKGROUND under an attached log view: ←/→/tab/digits
                  switch between "all" and per-service logs, q detaches (the stack
@@ -133,13 +134,23 @@ size-capped files whether the stack runs attached or detached — so `haven
 logs` works from any terminal, filters by plain argument, and still reads
 after a crash or a `down`.
 
-**The hub.** Bare `haven` opens the interactive fleet view:
-every stack with its liveness, branch, service health, and RAM footprint.
-Actions run on the selected stack — enter/`g` opens its git view (and returns
-to the hub on quit), `d` shuts it down keeping its databases, and `x` destroys
-the worktree entirely: stack stopped, ClickHouse + Postgres databases dropped,
-directory deleted, confirmed by typing the stack's name. The primary checkout
-and the worktree haven runs from can never be destroyed.
+**The hub.** Bare `haven` opens the interactive machine view. The header is
+the machine's real memory picture from one process listing, every process
+attributed once: each stack charged its whole process group, plus the shared
+servers (ClickHouse, Postgres, Redis, the container VM), the coding agents and
+the dev tooling running beside them — with the daemon's pressure level when it
+is not green. Below it, every stack (liveness, branch, service health, RAM)
+and every worktree, including the ones with nothing running. Actions run on
+the selected row — enter/`g` opens its git view (and returns to the hub on
+quit), `o` opens the stack's app, `r` restarts it, `d` shuts it down keeping
+its databases, and `x` destroys the worktree entirely: stack stopped,
+ClickHouse + Postgres databases dropped, directory deleted, confirmed by
+typing the name. The primary checkout and the worktree haven runs from can
+never be destroyed. One-key handoffs: `c` opens the interactive cleanup picker
+and returns, `w` opens the machine's web dashboard, and `m` toggles the
+monitor panel — the shared servers' footprints plus the daemon's recent
+reaping (stacks, test containers, governed processes, idle databases), newest
+first, from the persisted event record.
 
 **Seeding.** `haven db seed` reseeds in place — an idempotent upsert that can
 only add or refresh, never discard — and `haven db reset` is the destructive

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -136,21 +136,26 @@ after a crash or a `down`.
 
 **The hub.** Bare `haven` opens the interactive machine view. The header is
 the machine's real memory picture from one process listing, every process
-attributed once: each stack charged its whole process group, plus the shared
-servers (ClickHouse, Postgres, Redis, the container VM), the coding agents and
-the dev tooling running beside them — with the daemon's pressure level when it
-is not green. Below it, every stack (liveness, branch, service health, RAM)
-and every worktree, including the ones with nothing running. Actions run on
-the selected row — enter/`g` opens its git view (and returns to the hub on
-quit), `o` opens the stack's app, `r` restarts it, `d` shuts it down keeping
-its databases, and `x` destroys the worktree entirely: stack stopped,
-ClickHouse + Postgres databases dropped, directory deleted, confirmed by
-typing the name. The primary checkout and the worktree haven runs from can
-never be destroyed. One-key handoffs: `c` opens the interactive cleanup picker
-and returns, `w` opens the machine's web dashboard, and `m` toggles the
-monitor panel — the shared servers' footprints plus the daemon's recent
-reaping (stacks, test containers, governed processes, idle databases), newest
-first, from the persisted event record.
+attributed once: each stack charged its whole process **tree** (supervised
+children lead their own process groups, so a group sum sees only the ~20MB
+launcher), the shared servers (ClickHouse, Postgres, Redis, the container VM),
+the coding agents and dev tooling beside them, and everything that is not dev
+work as its own colour in the chart — with the daemon's pressure level when it
+is not green. Below it, every stack (liveness, branch, service health, RAM);
+idle worktrees stay collapsed behind `t` while stacks run and show by default
+otherwise. Actions run on the selected row — enter/`g` opens its git view (and
+returns to the hub on quit), `o` opens the stack's app, `r` restarts it, `d`
+shuts it down keeping its databases, and `x` destroys the worktree entirely:
+stack stopped, ClickHouse + Postgres databases dropped, directory deleted,
+confirmed by typing the name. The primary checkout and the worktree haven runs
+from can never be destroyed. One-key handoffs: `c` opens the interactive
+cleanup picker and returns, `w` opens the machine's web dashboard, and `m`
+toggles the monitor panel — the shared servers' footprints plus the daemon's
+recent reaping (stacks, test containers, governed processes, idle databases),
+newest first, from the persisted event record. The web dashboard
+(`langwatch.localhost`) shows the same machine: the memory chart, the stack
+cards (their own services only — the shared servers are stated once), the idle
+worktrees, and the reaping feed.
 
 **Seeding.** `haven db seed` reseeds in place — an idempotent upsert that can
 only add or refresh, never discard — and `haven db reset` is the destructive

--- a/tools/thuishaven/adapters/dashboard/html.go
+++ b/tools/thuishaven/adapters/dashboard/html.go
@@ -103,8 +103,9 @@ type statView struct {
 }
 
 type barView struct {
-	DevPct, OtherPct int
-	Legend           string
+	DevPct, OtherPct     int
+	DevLabel, OtherLabel string
+	Breakdown            string
 }
 
 type wtRow struct {
@@ -317,10 +318,13 @@ func machineBar(s SummaryView) *barView {
 	if s.ToolingRSS > 0 {
 		parts = append(parts, "tooling ~"+humanBytesU(s.ToolingRSS))
 	}
-	if s.OtherRSS > 0 {
-		parts = append(parts, "other ~"+humanBytesU(s.OtherRSS))
+	return &barView{
+		DevPct:     devPct,
+		OtherPct:   otherPct,
+		DevLabel:   "dev work ~" + humanBytesU(s.DevRSS()),
+		OtherLabel: "everything else ~" + humanBytesU(s.OtherRSS),
+		Breakdown:  strings.Join(parts, " · "),
 	}
-	return &barView{DevPct: devPct, OtherPct: otherPct, Legend: strings.Join(parts, " · ")}
 }
 
 func sharedNote(servers map[string]uint64) string {
@@ -333,7 +337,7 @@ func sharedNote(servers map[string]uint64) string {
 	if len(parts) == 0 {
 		return ""
 	}
-	return "shared by every stack: " + strings.Join(parts, " · ")
+	return "Shared by every stack: " + strings.Join(parts, " · ")
 }
 
 func worktreeRows(worktrees []WorktreeView) []wtRow {
@@ -350,9 +354,9 @@ func worktreeRows(worktrees []WorktreeView) []wtRow {
 		note := ""
 		switch {
 		case w.IsPrimary:
-			note = "primary — protected"
+			note = "primary, protected"
 		case w.IsCurrent:
-			note = "current — protected"
+			note = "current, protected"
 		}
 		rows = append(rows, wtRow{Name: name, Branch: w.Branch, Dir: w.Dir, Note: note})
 	}
@@ -418,170 +422,3 @@ func hostFromURL(u string) string {
 }
 
 var pageTmpl = template.Must(template.New("page").Parse(pageTemplate))
-
-const pageTemplate = `<!doctype html><html lang="en"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>haven — LangWatch local stacks</title>
-<style>
-  :root { color-scheme: light dark;
-    --bg:#faf9f7; --fg:#1a1815; --dim:#6f6a62; --card:rgba(255,255,255,.72); --line:#e7e2da;
-    --accent:#ed8926; --accent-soft:rgba(237,137,38,.14); --violet:#7c3aed;
-    --live:#16a34a; --stale:#b45309; --down:#dc2626; }
-  @media (prefers-color-scheme: dark){ :root{
-    --bg:#0d0d10; --fg:#ece9e4; --dim:#98928a; --card:rgba(23,23,28,.66); --line:#26252c;
-    --accent:#f59e3f; --accent-soft:rgba(245,158,63,.16); --violet:#a78bfa; } }
-  * { box-sizing:border-box; }
-  body { margin:0; font:14px/1.5 ui-sans-serif,system-ui,-apple-system,sans-serif;
-    background:var(--bg); color:var(--fg); min-height:100vh; }
-  /* fluid gradient field behind everything */
-  body::before, body::after { content:""; position:fixed; z-index:-1; border-radius:50%;
-    filter:blur(90px); opacity:.35; pointer-events:none; }
-  body::before { width:52vw; height:52vw; background:radial-gradient(circle at center, var(--accent), transparent 65%);
-    top:-18vw; right:-12vw; animation:drift1 26s ease-in-out infinite alternate; }
-  body::after { width:44vw; height:44vw; background:radial-gradient(circle at center, var(--violet), transparent 65%);
-    bottom:-16vw; left:-10vw; opacity:.22; animation:drift2 32s ease-in-out infinite alternate; }
-  @keyframes drift1 { from{ transform:translate(0,0) scale(1);} to{ transform:translate(-6vw,5vh) scale(1.12);} }
-  @keyframes drift2 { from{ transform:translate(0,0) scale(1);} to{ transform:translate(5vw,-4vh) scale(1.08);} }
-  @media (prefers-reduced-motion: reduce){ body::before, body::after{ animation:none; } .dot.up::after{ animation:none; } }
-
-  header.top { position:sticky; top:0; z-index:10; padding:14px 30px; display:flex; align-items:center;
-    gap:14px; flex-wrap:wrap; background:color-mix(in oklab, var(--bg) 72%, transparent);
-    backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border-bottom:1px solid var(--line); }
-  header.top h1 { margin:0; font-size:19px; letter-spacing:.01em; font-weight:700; }
-  header.top h1 .mark { color:var(--accent); }
-  header.top .tag { color:var(--dim); font-size:13px; }
-  header.top .links { margin-left:auto; display:flex; gap:14px; align-items:center; font-size:12.5px; color:var(--dim); }
-  header.top .links a { color:var(--dim); border:1px solid var(--line); border-radius:999px; padding:3px 11px;
-    transition:color .15s ease, border-color .15s ease; }
-  header.top .links a:hover { color:var(--accent); border-color:color-mix(in oklab, var(--accent) 45%, var(--line)); text-decoration:none; }
-  #beat { width:7px; height:7px; border-radius:50%; background:var(--live); display:inline-block; }
-  #beat.off { background:var(--stale); }
-  .pressure { font-size:11px; padding:2px 10px; border-radius:999px; text-transform:uppercase; letter-spacing:.06em;
-    font-weight:700; background:color-mix(in oklab,var(--down) 16%,transparent); color:var(--down); }
-
-  .stats { display:flex; gap:12px; flex-wrap:wrap; padding:10px 30px 4px; }
-  .stat { background:var(--card); border:1px solid var(--line); border-radius:14px;
-    padding:12px 18px; min-width:132px; backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px); }
-  .stat .n { display:block; font-size:22px; font-weight:700; font-variant-numeric:tabular-nums; }
-  .stat .l { color:var(--dim); font-size:11.5px; text-transform:uppercase; letter-spacing:.08em; }
-  .of { color:var(--dim); font-weight:500; font-size:.72em; }
-
-  .machine { padding:8px 30px 0; }
-  .bar { display:flex; height:10px; border-radius:999px; overflow:hidden; border:1px solid var(--line);
-    background:color-mix(in oklab, var(--fg) 5%, transparent); }
-  .bar .dev { background:var(--accent); }
-  .bar .other { background:var(--violet); opacity:.55; }
-  .legend { color:var(--dim); font-size:12px; padding:6px 2px 0; }
-  .legend .key { display:inline-block; width:9px; height:9px; border-radius:2px; margin:0 4px 0 10px; vertical-align:middle; }
-  .legend .key.dev { background:var(--accent); } .legend .key.other { background:var(--violet); opacity:.55; }
-
-  main { padding:18px 30px 8px; display:grid; grid-template-columns:repeat(auto-fill,minmax(360px,1fr)); gap:16px; }
-  .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:16px 18px;
-    backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px);
-    transition:transform .22s ease, box-shadow .22s ease, border-color .22s ease; }
-  .card:hover { transform:translateY(-2px); box-shadow:0 12px 32px -16px color-mix(in oklab, var(--accent) 42%, transparent);
-    border-color:color-mix(in oklab, var(--accent) 36%, var(--line)); }
-  .card header { display:flex; align-items:center; gap:10px; margin-bottom:4px; }
-  .card header .spacer { flex:1; }
-  .slug { font-weight:700; font-size:15.5px; }
-  .branch { color:var(--dim); font-size:12px; margin-bottom:8px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-  .open { font-size:12px; font-weight:600; color:var(--accent); border:1px solid color-mix(in oklab, var(--accent) 38%, var(--line));
-    background:var(--accent-soft); border-radius:999px; padding:2px 11px; transition:background .15s ease; }
-  .open:hover { background:color-mix(in oklab, var(--accent) 26%, transparent); text-decoration:none; }
-  .pill { font-size:11px; padding:2px 9px; border-radius:999px; text-transform:uppercase; letter-spacing:.06em; font-weight:600; }
-  .pill.live { background:color-mix(in oklab,var(--live) 18%,transparent); color:var(--live); }
-  .pill.stale { background:color-mix(in oklab,var(--stale) 18%,transparent); color:var(--stale); }
-
-  .chips { display:flex; gap:6px; flex-wrap:wrap; margin-bottom:8px; }
-  .chip { color:var(--dim); font-size:11.5px; background:color-mix(in oklab, var(--fg) 4%, transparent);
-    border:1px solid var(--line); border-radius:999px; padding:2px 9px; }
-  .chip code { background:none; padding:0; color:var(--fg); font-size:11.5px; }
-  .chip.baseline { color:var(--accent); border-color:color-mix(in oklab, var(--accent) 42%, var(--line));
-    background:var(--accent-soft); font-weight:600; }
-  .dir { color:var(--dim); font-size:11.5px; word-break:break-all; margin-bottom:10px; }
-
-  table { width:100%; border-collapse:collapse; } td { padding:3.5px 0; }
-  .dot-cell { width:16px; }
-  .dot { display:inline-block; width:8px; height:8px; border-radius:50%; position:relative; }
-  .dot.up { background:var(--live); }
-  .dot.up::after { content:""; position:absolute; inset:-3px; border-radius:50%;
-    border:1.5px solid var(--live); opacity:.5; animation:ping 2.2s ease-out infinite; }
-  @keyframes ping { 0%{ transform:scale(.6); opacity:.6; } 80%,100%{ transform:scale(1.5); opacity:0; } }
-  .dot.down { background:var(--down); opacity:.75; }
-  .svc { width:88px; color:var(--dim); }
-  a { color:var(--accent); text-decoration:none; } a:hover { text-decoration:underline; }
-  .dim { color:var(--dim); font-size:12px; } .mono { font-variant-numeric:tabular-nums; }
-  code { background:color-mix(in oklab,var(--fg) 8%,transparent); padding:1px 5px; border-radius:5px; font-size:12px; }
-  .empty { grid-column:1/-1; color:var(--dim); text-align:center; padding:56px 0 64px; }
-  .empty .glyph { font-size:40px; color:var(--accent); opacity:.8; }
-  .empty h2 { margin:10px 0 6px; color:var(--fg); font-size:17px; }
-  .empty code { font-size:13px; padding:5px 12px; }
-
-  .strip { padding:0 30px; color:var(--dim); font-size:12.5px; }
-  section.wide { margin:14px 30px; background:var(--card); border:1px solid var(--line); border-radius:16px;
-    padding:14px 18px; backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px); }
-  section.wide h2 { margin:0 0 8px; font-size:12px; color:var(--dim); text-transform:uppercase; letter-spacing:.08em; }
-  section.wide td { padding:3px 14px 3px 0; vertical-align:top; }
-  .kind { color:var(--accent); font-weight:600; font-size:12px; }
-  footer { padding:16px 30px 30px; color:var(--dim); font-size:12px; display:flex; gap:8px; align-items:center; }
-</style></head><body>
-<header class="top">
-  <h1><span class="mark">●</span> haven</h1><span class="tag">LangWatch local stacks — hostname routing via portless</span>
-  {{if .Pressure}}<span class="pressure">pressure {{.Pressure}}</span>{{end}}
-  <span class="links">
-    <a href="{{.ObsURL}}">observability · {{.ObsHost}}</a>
-    <a href="{{.TelURL}}">telemetry · {{.TelHost}}</a>
-  </span>
-</header>
-<div id="live">
-<div class="stats">{{range .Stats}}
-    <div class="stat"><span class="n">{{.Value}}{{if .Of}}<span class="of"> / {{.Of}}</span>{{end}}</span><span class="l">{{.Label}}</span></div>{{end}}</div>
-{{with .Bar}}<div class="machine">
-  <div class="bar"><div class="dev" style="width:{{.DevPct}}%"></div><div class="other" style="width:{{.OtherPct}}%"></div></div>
-  <div class="legend"><span class="key dev"></span>dev work<span class="key other"></span>everything else — {{.Legend}}</div>
-</div>{{end}}
-<main>{{if .IsEmpty}}<div class="empty"><div class="glyph">⌂</div><h2>No stacks running</h2>
-      <p>Bring one up from any worktree and it appears here, on its own hostname.</p>
-      <code>haven up</code></div>{{end}}{{range .Cards}}
-      <section class="card">
-        <header><span class="slug">{{.Slug}}</span><span class="spacer"></span>{{if .OpenURL}}<a class="open" href="{{.OpenURL}}">open ↗</a>{{end}}<span class="pill {{.BadgeClass}}">{{.Badge}}</span></header>
-        <div class="branch">⎇ {{.Branch}}</div>
-        <div class="chips">{{range .Chips}}{{if .IsBaseline}}<span class="chip baseline">baseline</span>{{else}}<span class="chip">{{.Label}} <code>{{.Value}}</code></span>{{end}}{{end}}</div>
-        <div class="dir">{{.Dir}}</div>
-        <table>{{range .Rows}}{{if .IsSub}}<tr><td class="dot-cell"></td><td class="svc dim">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="dim mono">{{.Port}}</td></tr>{{else}}<tr><td class="dot-cell"><span class="dot {{.DotClass}}"></span></td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="dim mono">{{.Port}}</td></tr>{{end}}{{end}}</table>
-      </section>{{end}}</main>
-{{if .SharedNote}}<div class="strip">{{.SharedNote}}</div>{{end}}
-{{if .Worktrees}}<section class="wide"><h2>worktrees — nothing running</h2>
-  <table>{{range .Worktrees}}<tr><td><b>{{.Name}}</b></td><td class="dim">⎇ {{.Branch}}</td><td class="dim">{{.Dir}}</td><td class="dim">{{.Note}}</td></tr>{{end}}</table>
-</section>{{end}}
-{{if .Events}}<section class="wide"><h2>the daemon's recent reaping</h2>
-  <table>{{range .Events}}<tr><td class="dim mono">{{.Age}}</td><td class="kind">{{.Kind}}</td><td>{{.Target}}</td><td class="dim">{{.Reason}}</td></tr>{{end}}</table>
-</section>{{end}}
-</div>
-<footer><span id="beat"></span><span id="stamp">live — refreshes every 3s</span></footer>
-<script>
-(() => {
-  let failures = 0;
-  const beat = document.getElementById('beat'), stamp = document.getElementById('stamp');
-  async function refresh() {
-    const live = document.getElementById('live');
-    // Skip the swap while the user is tabbing through it — replacing the
-    // subtree would destroy the focused link every three seconds.
-    if (document.hidden || live.contains(document.activeElement)) return;
-    try {
-      const res = await fetch('/', {cache: 'no-store'});
-      const doc = new DOMParser().parseFromString(await res.text(), 'text/html');
-      const next = doc.getElementById('live');
-      if (next) live.replaceChildren(...next.children);
-      failures = 0;
-      beat.classList.remove('off');
-      stamp.textContent = 'live — updated ' + new Date().toLocaleTimeString();
-    } catch {
-      if (++failures >= 2) { beat.classList.add('off'); stamp.textContent = 'daemon unreachable — retrying'; }
-    }
-  }
-  setInterval(refresh, 3000);
-  document.addEventListener('visibilitychange', refresh);
-})();
-</script>
-</body></html>`

--- a/tools/thuishaven/adapters/dashboard/html.go
+++ b/tools/thuishaven/adapters/dashboard/html.go
@@ -9,12 +9,57 @@ import (
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
 
+// Extras is everything the page shows beyond the registry cards: the machine's
+// partitioned memory picture, the stackless worktrees, and the daemon's recent
+// reaping. It arrives through a callback so the adapter stays ignorant of the
+// app core; a zero Extras degrades to the registry-only page.
+type Extras struct {
+	Summary   SummaryView
+	Worktrees []WorktreeView
+	Events    []EventView
+	// StackRSS is each live stack's whole-tree resident set by launcher pid —
+	// the accurate per-card number (group RSS sees only the launcher itself).
+	StackRSS map[int]uint64
+}
+
+// SummaryView is the machine header: every process attributed once.
+type SummaryView struct {
+	TotalRAM   uint64
+	StacksRSS  uint64
+	ServerRSS  map[string]uint64
+	AgentRSS   uint64
+	AgentCount int
+	ToolingRSS uint64
+	OtherRSS   uint64
+	Pressure   string
+}
+
+// DevRSS is everything attributed to dev work, summed.
+func (s SummaryView) DevRSS() uint64 {
+	total := s.StacksRSS + s.AgentRSS + s.ToolingRSS
+	for _, rss := range s.ServerRSS {
+		total += rss
+	}
+	return total
+}
+
+// WorktreeView is a worktree with no registered stack.
+type WorktreeView struct {
+	Slug, Branch, Dir    string
+	IsPrimary, IsCurrent bool
+}
+
+// EventView is one daemon reclamation, newest first.
+type EventView struct {
+	At                   time.Time
+	Kind, Target, Reason string
+}
+
 // stackCard is renderCard's result: the card's view data plus the per-stack
 // numbers renderHTML aggregates into the page-level stats.
 type stackCard struct {
 	view          cardView
 	isLive        bool
-	rss           uint64
 	servicesUp    int
 	servicesTotal int
 }
@@ -45,25 +90,56 @@ type rowView struct {
 	Name     string
 	URL      string
 	Host     string
-	Port     int
+	Port     string // pre-rendered ":<n>", empty when the port is unknown
 	IsSub    bool
 }
 
+// statView renders as Value, then a dim "/ Of" when Of is set — plain fields,
+// so the template's auto-escaping stays in charge of every byte.
 type statView struct {
-	Value template.HTML
+	Value string
+	Of    string
 	Label string
+}
+
+type barView struct {
+	DevPct, OtherPct int
+	Legend           string
+}
+
+type wtRow struct {
+	Name, Branch, Dir, Note string
+}
+
+type eventRow struct {
+	Age, Kind, Target, Reason string
 }
 
 type pageView struct {
 	ObsURL, ObsHost string
 	TelURL, TelHost string
+	Pressure        string // shown as a header pill when not green/empty
 	Stats           []statView
+	Bar             *barView
+	SharedNote      string
 	Cards           []cardView
+	Worktrees       []wtRow
+	Events          []eventRow
 	IsEmpty         bool
 }
 
-// renderCard builds one stack's view data and per-stack aggregates.
-func renderCard(s domain.Stack, probes Probes) stackCard {
+// sharedServiceNames are the machine-wide servers every stack's routing table
+// carries. Their rows repeated identically on every card, so the cards keep
+// only the stack's own services and the shared set is stated once.
+var sharedServiceNames = map[string]bool{
+	domain.ClickHouseService: true,
+	domain.PostgresService:   true,
+	domain.RedisService:      true,
+}
+
+// renderCard builds one stack's view data and per-stack aggregates. treeRSS is
+// the stack's whole-tree footprint (0 hides the chip).
+func renderCard(s domain.Stack, probes Probes, treeRSS uint64) stackCard {
 	var c stackCard
 	c.isLive = s.LauncherPID != 0
 	if c.isLive && probes.ProcessAlive != nil {
@@ -74,33 +150,36 @@ func renderCard(s domain.Stack, probes Probes) stackCard {
 		badge = "live"
 	}
 
-	if c.isLive && probes.GroupRSS != nil {
-		c.rss = probes.GroupRSS(s.LauncherPID)
+	c.view = cardView{
+		Slug:       s.Slug,
+		Badge:      badge,
+		BadgeClass: badge,
+		Branch:     s.Branch,
+		Dir:        s.WorktreeDir,
+		OpenURL:    appURL(s),
+		Chips:      cardChips(s, c.isLive, treeRSS),
 	}
+	c.view.Rows, c.servicesUp, c.servicesTotal = cardRows(s, probes)
+	return c
+}
 
-	var rows []rowView
+func appURL(s domain.Stack) string {
 	for _, svc := range s.Services {
-		c.servicesTotal++
-		dotClass := "down"
-		if probes.PortInUse != nil && probes.PortInUse(svc.Port) {
-			dotClass = "up"
-			c.servicesUp++
-		}
-		rows = append(rows, rowView{DotClass: dotClass, Name: svc.Name, URL: svc.URL, Host: svc.Hostname, Port: svc.Port})
-		// The API shares app's origin — show it as a sub-row so the single URL
-		// is unmistakable (no separate api.<slug> hostname).
-		if svc.Name == "app" && s.APIPort != 0 {
-			rows = append(rows, rowView{IsSub: true, Name: "└ api", URL: svc.URL + "/api", Host: svc.Hostname + "/api", Port: s.APIPort})
+		if svc.Name == "app" && svc.URL != "" {
+			return svc.URL
 		}
 	}
+	return ""
+}
 
+func cardChips(s domain.Stack, isLive bool, treeRSS uint64) []chipView {
 	var chips []chipView
 	if s.ClickHouseDatabase != "" {
 		chips = append(chips, chipView{Label: "clickhouse", Value: s.ClickHouseDatabase})
 	}
 	chips = append(chips, chipView{Label: "redis db", Value: fmt.Sprintf("%d", s.RedisDB)})
-	if c.rss > 0 {
-		chips = append(chips, chipView{Label: "ram", Value: humanBytesU(c.rss)})
+	if isLive && treeRSS > 0 {
+		chips = append(chips, chipView{Label: "ram", Value: "~" + humanBytesU(treeRSS)})
 	}
 	if !s.UpdatedAt.IsZero() {
 		chips = append(chips, chipView{Label: "heartbeat", Value: shortAge(time.Since(s.UpdatedAt))})
@@ -108,83 +187,86 @@ func renderCard(s domain.Stack, probes Probes) stackCard {
 	if s.IsBaseline {
 		chips = append(chips, chipView{IsBaseline: true})
 	}
-
-	// The card's primary action: open the app. Present whenever the stack has a
-	// routed app URL, regardless of health — a booting stack is still one click.
-	var openURL string
-	for _, svc := range s.Services {
-		if svc.Name == "app" && svc.URL != "" {
-			openURL = svc.URL
-			break
-		}
-	}
-
-	c.view = cardView{
-		Slug:       s.Slug,
-		Badge:      badge,
-		BadgeClass: badge,
-		Branch:     s.Branch,
-		Dir:        s.WorktreeDir,
-		OpenURL:    openURL,
-		Chips:      chips,
-		Rows:       rows,
-	}
-	return c
+	return chips
 }
 
-// renderHTML draws the hub: aggregate health up top (stacks, services, RAM,
-// databases), then one card per stack — which worktree owns which slug, its
-// branch, databases, footprint, and every service hostname with a live dot.
-func renderHTML(stacks []domain.Stack, sharedURL func(string) string, probes Probes) string {
-	type agg struct {
-		live, servicesUp, servicesTotal, databases int
-		rss                                        uint64
+// cardRows lists the stack's OWN services — the shared servers are stated once
+// for the page, not repeated on every card.
+func cardRows(s domain.Stack, probes Probes) (rows []rowView, up, total int) {
+	for _, svc := range s.Services {
+		if sharedServiceNames[svc.Name] {
+			continue
+		}
+		total++
+		dotClass := "down"
+		if probes.PortInUse != nil && svc.Port != 0 && probes.PortInUse(svc.Port) {
+			dotClass = "up"
+			up++
+		}
+		rows = append(rows, rowView{DotClass: dotClass, Name: svc.Name, URL: svc.URL, Host: svc.Hostname, Port: portText(svc.Port)})
+		// The API shares app's origin — show it as a sub-row so the single URL
+		// is unmistakable (no separate api.<slug> hostname).
+		if svc.Name == "app" && s.APIPort != 0 {
+			rows = append(rows, rowView{IsSub: true, Name: "└ api", URL: svc.URL + "/api", Host: svc.Hostname + "/api", Port: portText(s.APIPort)})
+		}
 	}
-	var a agg
+	return rows, up, total
+}
 
+// portText renders a port for display; a zero port (not yet allocated) shows
+// nothing rather than a lying ":0".
+func portText(port int) string {
+	if port == 0 {
+		return ""
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+// pageAggregates are the card-derived counts the stats row shows.
+type pageAggregates struct {
+	total, live, servicesUp, servicesTotal, databases int
+}
+
+// renderInputs groups everything renderHTML needs beyond the registry itself.
+type renderInputs struct {
+	sharedURL func(string) string
+	probes    Probes
+	extras    Extras
+}
+
+// renderHTML draws the machine: the partitioned RAM picture up top, one card
+// per stack, the shared servers once, the stackless worktrees, and the
+// daemon's recent reaping.
+func renderHTML(stacks []domain.Stack, in renderInputs) string {
+	agg := pageAggregates{total: len(stacks)}
 	var cards []cardView
-	for _, s := range stacks {
-		c := renderCard(s, probes)
+	for i := range stacks {
+		c := renderCard(stacks[i], in.probes, in.extras.StackRSS[stacks[i].LauncherPID])
 		cards = append(cards, c.view)
 		if c.isLive {
-			a.live++
+			agg.live++
 		}
-		a.rss += c.rss
-		a.servicesUp += c.servicesUp
-		a.servicesTotal += c.servicesTotal
-		// Real database allocations: a ClickHouse database when the stack has
-		// one, plus the Redis DB every stack gets.
-		if s.ClickHouseDatabase != "" {
-			a.databases++
+		agg.servicesUp += c.servicesUp
+		agg.servicesTotal += c.servicesTotal
+		if stacks[i].ClickHouseDatabase != "" {
+			agg.databases++
 		}
-		a.databases++
-	}
-
-	ramStat := template.HTML("—")
-	if a.rss > 0 {
-		ram := template.HTML(template.HTMLEscapeString(humanBytesU(a.rss)))
-		if probes.TotalMemory != nil {
-			if total := probes.TotalMemory(); total > 0 {
-				ram += template.HTML(`<span class="of"> / ` + template.HTMLEscapeString(humanBytesU(total)) + `</span>`)
-			}
-		}
-		ramStat = ram
-	}
-	ofN := func(n, of int) template.HTML {
-		return template.HTML(fmt.Sprintf(`%d<span class="of"> / %d</span>`, n, of))
+		agg.databases++ // the Redis DB every stack gets
 	}
 
 	page := pageView{
-		ObsURL: sharedURL("observability"), ObsHost: hostFromURL(sharedURL("observability")),
-		TelURL: sharedURL("telemetry"), TelHost: hostFromURL(sharedURL("telemetry")),
-		Stats: []statView{
-			{Value: ofN(a.live, len(stacks)), Label: "stacks live"},
-			{Value: ofN(a.servicesUp, a.servicesTotal), Label: "services up"},
-			{Value: ramStat, Label: "stack ram"},
-			{Value: template.HTML(fmt.Sprintf("%d", a.databases)), Label: "databases"},
-		},
-		Cards:   cards,
-		IsEmpty: len(stacks) == 0,
+		ObsURL: in.sharedURL("observability"), ObsHost: hostFromURL(in.sharedURL("observability")),
+		TelURL: in.sharedURL("telemetry"), TelHost: hostFromURL(in.sharedURL("telemetry")),
+		Stats:      pageStats(agg, in.extras.Summary),
+		Bar:        machineBar(in.extras.Summary),
+		SharedNote: sharedNote(in.extras.Summary.ServerRSS),
+		Cards:      cards,
+		Worktrees:  worktreeRows(in.extras.Worktrees),
+		Events:     eventRows(in.extras.Events),
+		IsEmpty:    len(stacks) == 0,
+	}
+	if p := in.extras.Summary.Pressure; p != "" && p != "green" {
+		page.Pressure = p
 	}
 
 	var b strings.Builder
@@ -195,6 +277,110 @@ func renderHTML(stacks []domain.Stack, sharedURL func(string) string, probes Pro
 			template.HTMLEscapeString(err.Error())
 	}
 	return b.String()
+}
+
+func pageStats(agg pageAggregates, s SummaryView) []statView {
+	ram := statView{Value: "—", Label: "dev ram"}
+	if dev := s.DevRSS(); dev > 0 {
+		ram.Value = "~" + humanBytesU(dev)
+		if s.TotalRAM > 0 {
+			ram.Of = humanBytesU(s.TotalRAM)
+		}
+	}
+	return []statView{
+		{Value: fmt.Sprintf("%d", agg.live), Of: fmt.Sprintf("%d", agg.total), Label: "stacks live"},
+		{Value: fmt.Sprintf("%d", agg.servicesUp), Of: fmt.Sprintf("%d", agg.servicesTotal), Label: "services up"},
+		ram,
+		{Value: fmt.Sprintf("%d", s.AgentCount), Label: "agents"},
+		{Value: fmt.Sprintf("%d", agg.databases), Label: "databases"},
+	}
+}
+
+// machineBar sizes the two-color RAM bar: dev work, other work, free track.
+// Summed RSS double-counts shared pages, so segments are clamped to the bar.
+func machineBar(s SummaryView) *barView {
+	if s.TotalRAM == 0 || s.DevRSS() == 0 {
+		return nil
+	}
+	devPct := min(100, int(s.DevRSS()*100/s.TotalRAM))
+	otherPct := min(100-devPct, int(s.OtherRSS*100/s.TotalRAM))
+	var parts []string
+	if s.StacksRSS > 0 {
+		parts = append(parts, "stacks ~"+humanBytesU(s.StacksRSS))
+	}
+	if servers := sumRSS(s.ServerRSS); servers > 0 {
+		parts = append(parts, "servers ~"+humanBytesU(servers))
+	}
+	if s.AgentRSS > 0 {
+		parts = append(parts, fmt.Sprintf("agents ~%s (%d)", humanBytesU(s.AgentRSS), s.AgentCount))
+	}
+	if s.ToolingRSS > 0 {
+		parts = append(parts, "tooling ~"+humanBytesU(s.ToolingRSS))
+	}
+	if s.OtherRSS > 0 {
+		parts = append(parts, "other ~"+humanBytesU(s.OtherRSS))
+	}
+	return &barView{DevPct: devPct, OtherPct: otherPct, Legend: strings.Join(parts, " · ")}
+}
+
+func sharedNote(servers map[string]uint64) string {
+	var parts []string
+	for _, name := range []string{"clickhouse", "postgres", "redis", "containers"} {
+		if rss := servers[name]; rss > 0 {
+			parts = append(parts, fmt.Sprintf("%s ~%s", name, humanBytesU(rss)))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "shared by every stack: " + strings.Join(parts, " · ")
+}
+
+func worktreeRows(worktrees []WorktreeView) []wtRow {
+	var rows []wtRow
+	for _, w := range worktrees {
+		name := w.Slug
+		if name == "" {
+			if i := strings.LastIndexByte(w.Dir, '/'); i >= 0 {
+				name = w.Dir[i+1:]
+			} else {
+				name = w.Dir
+			}
+		}
+		note := ""
+		switch {
+		case w.IsPrimary:
+			note = "primary — protected"
+		case w.IsCurrent:
+			note = "current — protected"
+		}
+		rows = append(rows, wtRow{Name: name, Branch: w.Branch, Dir: w.Dir, Note: note})
+	}
+	return rows
+}
+
+func eventRows(events []EventView) []eventRow {
+	const maxEvents = 12
+	var rows []eventRow
+	for _, ev := range events {
+		if len(rows) == maxEvents {
+			break
+		}
+		age := "now"
+		if !ev.At.IsZero() {
+			age = shortAge(time.Since(ev.At))
+		}
+		rows = append(rows, eventRow{Age: age, Kind: ev.Kind, Target: ev.Target, Reason: ev.Reason})
+	}
+	return rows
+}
+
+func sumRSS(m map[string]uint64) uint64 {
+	var total uint64
+	for _, v := range m {
+		total += v
+	}
+	return total
 }
 
 func shortAge(d time.Duration) string {
@@ -270,6 +456,8 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
   header.top .links a:hover { color:var(--accent); border-color:color-mix(in oklab, var(--accent) 45%, var(--line)); text-decoration:none; }
   #beat { width:7px; height:7px; border-radius:50%; background:var(--live); display:inline-block; }
   #beat.off { background:var(--stale); }
+  .pressure { font-size:11px; padding:2px 10px; border-radius:999px; text-transform:uppercase; letter-spacing:.06em;
+    font-weight:700; background:color-mix(in oklab,var(--down) 16%,transparent); color:var(--down); }
 
   .stats { display:flex; gap:12px; flex-wrap:wrap; padding:10px 30px 4px; }
   .stat { background:var(--card); border:1px solid var(--line); border-radius:14px;
@@ -277,6 +465,15 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
   .stat .n { display:block; font-size:22px; font-weight:700; font-variant-numeric:tabular-nums; }
   .stat .l { color:var(--dim); font-size:11.5px; text-transform:uppercase; letter-spacing:.08em; }
   .of { color:var(--dim); font-weight:500; font-size:.72em; }
+
+  .machine { padding:8px 30px 0; }
+  .bar { display:flex; height:10px; border-radius:999px; overflow:hidden; border:1px solid var(--line);
+    background:color-mix(in oklab, var(--fg) 5%, transparent); }
+  .bar .dev { background:var(--accent); }
+  .bar .other { background:var(--violet); opacity:.55; }
+  .legend { color:var(--dim); font-size:12px; padding:6px 2px 0; }
+  .legend .key { display:inline-block; width:9px; height:9px; border-radius:2px; margin:0 4px 0 10px; vertical-align:middle; }
+  .legend .key.dev { background:var(--accent); } .legend .key.other { background:var(--violet); opacity:.55; }
 
   main { padding:18px 30px 8px; display:grid; grid-template-columns:repeat(auto-fill,minmax(360px,1fr)); gap:16px; }
   .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:16px 18px;
@@ -311,7 +508,7 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
     border:1.5px solid var(--live); opacity:.5; animation:ping 2.2s ease-out infinite; }
   @keyframes ping { 0%{ transform:scale(.6); opacity:.6; } 80%,100%{ transform:scale(1.5); opacity:0; } }
   .dot.down { background:var(--down); opacity:.75; }
-  .svc { width:78px; color:var(--dim); }
+  .svc { width:88px; color:var(--dim); }
   a { color:var(--accent); text-decoration:none; } a:hover { text-decoration:underline; }
   .dim { color:var(--dim); font-size:12px; } .mono { font-variant-numeric:tabular-nums; }
   code { background:color-mix(in oklab,var(--fg) 8%,transparent); padding:1px 5px; border-radius:5px; font-size:12px; }
@@ -319,10 +516,18 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
   .empty .glyph { font-size:40px; color:var(--accent); opacity:.8; }
   .empty h2 { margin:10px 0 6px; color:var(--fg); font-size:17px; }
   .empty code { font-size:13px; padding:5px 12px; }
+
+  .strip { padding:0 30px; color:var(--dim); font-size:12.5px; }
+  section.wide { margin:14px 30px; background:var(--card); border:1px solid var(--line); border-radius:16px;
+    padding:14px 18px; backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px); }
+  section.wide h2 { margin:0 0 8px; font-size:12px; color:var(--dim); text-transform:uppercase; letter-spacing:.08em; }
+  section.wide td { padding:3px 14px 3px 0; vertical-align:top; }
+  .kind { color:var(--accent); font-weight:600; font-size:12px; }
   footer { padding:16px 30px 30px; color:var(--dim); font-size:12px; display:flex; gap:8px; align-items:center; }
 </style></head><body>
 <header class="top">
   <h1><span class="mark">●</span> haven</h1><span class="tag">LangWatch local stacks — hostname routing via portless</span>
+  {{if .Pressure}}<span class="pressure">pressure {{.Pressure}}</span>{{end}}
   <span class="links">
     <a href="{{.ObsURL}}">observability · {{.ObsHost}}</a>
     <a href="{{.TelURL}}">telemetry · {{.TelHost}}</a>
@@ -330,7 +535,11 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
 </header>
 <div id="live">
 <div class="stats">{{range .Stats}}
-    <div class="stat"><span class="n">{{.Value}}</span><span class="l">{{.Label}}</span></div>{{end}}</div>
+    <div class="stat"><span class="n">{{.Value}}{{if .Of}}<span class="of"> / {{.Of}}</span>{{end}}</span><span class="l">{{.Label}}</span></div>{{end}}</div>
+{{with .Bar}}<div class="machine">
+  <div class="bar"><div class="dev" style="width:{{.DevPct}}%"></div><div class="other" style="width:{{.OtherPct}}%"></div></div>
+  <div class="legend"><span class="key dev"></span>dev work<span class="key other"></span>everything else — {{.Legend}}</div>
+</div>{{end}}
 <main>{{if .IsEmpty}}<div class="empty"><div class="glyph">⌂</div><h2>No stacks running</h2>
       <p>Bring one up from any worktree and it appears here, on its own hostname.</p>
       <code>haven up</code></div>{{end}}{{range .Cards}}
@@ -339,8 +548,15 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
         <div class="branch">⎇ {{.Branch}}</div>
         <div class="chips">{{range .Chips}}{{if .IsBaseline}}<span class="chip baseline">baseline</span>{{else}}<span class="chip">{{.Label}} <code>{{.Value}}</code></span>{{end}}{{end}}</div>
         <div class="dir">{{.Dir}}</div>
-        <table>{{range .Rows}}{{if .IsSub}}<tr><td class="dot-cell"></td><td class="svc dim">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="dim mono">:{{.Port}}</td></tr>{{else}}<tr><td class="dot-cell"><span class="dot {{.DotClass}}"></span></td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="dim mono">:{{.Port}}</td></tr>{{end}}{{end}}</table>
+        <table>{{range .Rows}}{{if .IsSub}}<tr><td class="dot-cell"></td><td class="svc dim">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="dim mono">{{.Port}}</td></tr>{{else}}<tr><td class="dot-cell"><span class="dot {{.DotClass}}"></span></td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="dim mono">{{.Port}}</td></tr>{{end}}{{end}}</table>
       </section>{{end}}</main>
+{{if .SharedNote}}<div class="strip">{{.SharedNote}}</div>{{end}}
+{{if .Worktrees}}<section class="wide"><h2>worktrees — nothing running</h2>
+  <table>{{range .Worktrees}}<tr><td><b>{{.Name}}</b></td><td class="dim">⎇ {{.Branch}}</td><td class="dim">{{.Dir}}</td><td class="dim">{{.Note}}</td></tr>{{end}}</table>
+</section>{{end}}
+{{if .Events}}<section class="wide"><h2>the daemon's recent reaping</h2>
+  <table>{{range .Events}}<tr><td class="dim mono">{{.Age}}</td><td class="kind">{{.Kind}}</td><td>{{.Target}}</td><td class="dim">{{.Reason}}</td></tr>{{end}}</table>
+</section>{{end}}
 </div>
 <footer><span id="beat"></span><span id="stamp">live — refreshes every 3s</span></footer>
 <script>

--- a/tools/thuishaven/adapters/dashboard/html.go
+++ b/tools/thuishaven/adapters/dashboard/html.go
@@ -71,7 +71,8 @@ type cardView struct {
 	Badge      string
 	BadgeClass string
 	Branch     string
-	Dir        string
+	Dir        string // shortened for display; DirFull carries the whole path
+	DirFull    string
 	OpenURL    string // the card's primary action; empty hides it
 	Chips      []chipView
 	Rows       []rowView
@@ -139,12 +140,13 @@ var sharedServiceNames = map[string]bool{
 }
 
 // renderCard builds one stack's view data and per-stack aggregates. treeRSS is
-// the stack's whole-tree footprint (0 hides the chip).
-func renderCard(s domain.Stack, probes Probes, treeRSS uint64) stackCard {
+// the stack's whole-tree footprint (0 hides the chip); in supplies the probes
+// and the base domain the hostnames are shortened against.
+func renderCard(s domain.Stack, in renderInputs, treeRSS uint64) stackCard {
 	var c stackCard
 	c.isLive = s.LauncherPID != 0
-	if c.isLive && probes.ProcessAlive != nil {
-		c.isLive = probes.ProcessAlive(s.LauncherPID)
+	if c.isLive && in.probes.ProcessAlive != nil {
+		c.isLive = in.probes.ProcessAlive(s.LauncherPID)
 	}
 	badge := "stale"
 	if c.isLive {
@@ -156,12 +158,23 @@ func renderCard(s domain.Stack, probes Probes, treeRSS uint64) stackCard {
 		Badge:      badge,
 		BadgeClass: badge,
 		Branch:     s.Branch,
-		Dir:        s.WorktreeDir,
+		Dir:        shortDir(s.WorktreeDir),
+		DirFull:    s.WorktreeDir,
 		OpenURL:    appURL(s),
 		Chips:      cardChips(s, c.isLive, treeRSS),
 	}
-	c.view.Rows, c.servicesUp, c.servicesTotal = cardRows(s, probes)
+	c.view.Rows, c.servicesUp, c.servicesTotal = cardRows(s, in)
 	return c
+}
+
+// shortDir keeps a path scannable on a card: the last two segments, the rest
+// elided (the full path stays available on hover).
+func shortDir(dir string) string {
+	parts := strings.Split(strings.TrimRight(dir, "/"), "/")
+	if len(parts) <= 3 {
+		return dir
+	}
+	return "…/" + strings.Join(parts[len(parts)-2:], "/")
 }
 
 func appURL(s domain.Stack) string {
@@ -192,23 +205,26 @@ func cardChips(s domain.Stack, isLive bool, treeRSS uint64) []chipView {
 }
 
 // cardRows lists the stack's OWN services — the shared servers are stated once
-// for the page, not repeated on every card.
-func cardRows(s domain.Stack, probes Probes) (rows []rowView, up, total int) {
+// for the page, not repeated on every card. Hostnames drop the base domain
+// every one of them shares, so a row stays one scannable line; the link and
+// its hover title still carry the full URL.
+func cardRows(s domain.Stack, in renderInputs) (rows []rowView, up, total int) {
+	base := "." + hostFromURL(in.sharedURL("langwatch"))
 	for _, svc := range s.Services {
 		if sharedServiceNames[svc.Name] {
 			continue
 		}
 		total++
 		dotClass := "down"
-		if probes.PortInUse != nil && svc.Port != 0 && probes.PortInUse(svc.Port) {
+		if in.probes.PortInUse != nil && svc.Port != 0 && in.probes.PortInUse(svc.Port) {
 			dotClass = "up"
 			up++
 		}
-		rows = append(rows, rowView{DotClass: dotClass, Name: svc.Name, URL: svc.URL, Host: svc.Hostname, Port: portText(svc.Port)})
+		rows = append(rows, rowView{DotClass: dotClass, Name: svc.Name, URL: svc.URL, Host: strings.TrimSuffix(svc.Hostname, base), Port: portText(svc.Port)})
 		// The API shares app's origin — show it as a sub-row so the single URL
 		// is unmistakable (no separate api.<slug> hostname).
 		if svc.Name == "app" && s.APIPort != 0 {
-			rows = append(rows, rowView{IsSub: true, Name: "└ api", URL: svc.URL + "/api", Host: svc.Hostname + "/api", Port: portText(s.APIPort)})
+			rows = append(rows, rowView{IsSub: true, Name: "└ api", URL: svc.URL + "/api", Host: strings.TrimSuffix(svc.Hostname, base) + "/api", Port: portText(s.APIPort)})
 		}
 	}
 	return rows, up, total
@@ -242,7 +258,7 @@ func renderHTML(stacks []domain.Stack, in renderInputs) string {
 	agg := pageAggregates{total: len(stacks)}
 	var cards []cardView
 	for i := range stacks {
-		c := renderCard(stacks[i], in.probes, in.extras.StackRSS[stacks[i].LauncherPID])
+		c := renderCard(stacks[i], in, in.extras.StackRSS[stacks[i].LauncherPID])
 		cards = append(cards, c.view)
 		if c.isLive {
 			agg.live++

--- a/tools/thuishaven/adapters/dashboard/html_test.go
+++ b/tools/thuishaven/adapters/dashboard/html_test.go
@@ -8,19 +8,20 @@ import (
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
 
+// @scenario "The web dashboard shows the same machine picture"
 func TestRenderHTML(t *testing.T) {
 	sharedURL := func(svc string) string { return "https://" + svc + ".langwatch.localhost" }
 
 	t.Run("given no stacks", func(t *testing.T) {
 		t.Run("when rendered, it explains how to start one", func(t *testing.T) {
-			page := renderHTML(nil, sharedURL, Probes{})
+			page := renderHTML(nil, renderInputs{sharedURL: sharedURL, probes: Probes{}, extras: Extras{}})
 			if !strings.Contains(page, "haven up") {
 				t.Error("empty state should tell the user how to start a stack")
 			}
 		})
 	})
 
-	t.Run("given a live stack with probes", func(t *testing.T) {
+	t.Run("given a live stack with probes and the machine picture", func(t *testing.T) {
 		stacks := []domain.Stack{{
 			Slug:               "portless",
 			Branch:             "feat/x <script>",
@@ -31,37 +32,90 @@ func TestRenderHTML(t *testing.T) {
 			UpdatedAt:          time.Now().Add(-20 * time.Second),
 			Services: []domain.Service{
 				{Name: "app", Hostname: "app.portless.langwatch.localhost", URL: "https://app.portless.langwatch.localhost", Port: 5560},
+				{Name: "langyagent", Hostname: "langyagent.portless.langwatch.localhost", URL: "https://langyagent.portless.langwatch.localhost", Port: 0},
+				{Name: "clickhouse", Hostname: "clickhouse.portless.langwatch.localhost", URL: "https://clickhouse.portless.langwatch.localhost", Port: 51748},
+				{Name: "postgres", Hostname: "postgres.portless.langwatch.localhost", URL: "https://postgres.portless.langwatch.localhost", Port: 5432},
+				{Name: "redis", Hostname: "redis.portless.langwatch.localhost", URL: "https://redis.portless.langwatch.localhost", Port: 6379},
 			},
 		}}
 		probes := Probes{
 			PortInUse:    func(int) bool { return true },
 			ProcessAlive: func(int) bool { return true },
-			GroupRSS:     func(int) uint64 { return 512 * 1024 * 1024 },
-			TotalMemory:  func() uint64 { return 32 * 1024 * 1024 * 1024 },
+		}
+		extras := Extras{
+			Summary: SummaryView{
+				TotalRAM:   32 << 30,
+				StacksRSS:  4 << 30,
+				ServerRSS:  map[string]uint64{"clickhouse": 1 << 30, "redis": 512 << 20},
+				AgentRSS:   3 << 30,
+				AgentCount: 2,
+				ToolingRSS: 2 << 30,
+				OtherRSS:   8 << 30,
+				Pressure:   "amber",
+			},
+			StackRSS: map[int]uint64{4242: 4 << 30},
+			Worktrees: []WorktreeView{
+				{Slug: "", Branch: "main", Dir: "/repos/langwatch", IsPrimary: true},
+				{Slug: "beta", Branch: "feat/beta", Dir: "/repos/worktrees/beta"},
+			},
+			Events: []EventView{
+				{At: time.Now().Add(-2 * time.Minute), Kind: "testcontainer", Target: "tc-ryuk", Reason: "left behind by an interrupted test run"},
+			},
 		}
 
-		page := renderHTML(stacks, sharedURL, probes)
+		page := renderHTML(stacks, renderInputs{sharedURL: sharedURL, probes: probes, extras: extras})
 
-		t.Run("when rendered, the stack shows live with its databases and footprint", func(t *testing.T) {
-			for _, want := range []string{"portless", `<span class="pill live">live</span>`, "lw_portless", "512.0MB", "32.0GB", "app.portless.langwatch.localhost"} {
+		t.Run("when rendered, the stack shows live with its databases and whole-tree footprint", func(t *testing.T) {
+			for _, want := range []string{"portless", `<span class="pill live">live</span>`, "lw_portless", "~4.0GB", "app.portless.langwatch.localhost"} {
 				if !strings.Contains(page, want) {
 					t.Errorf("page should contain %q", want)
 				}
 			}
 		})
 
-		t.Run("when rendered, the reachable service gets an up dot", func(t *testing.T) {
-			if !strings.Contains(page, `<span class="dot up">`) {
-				t.Error("service with its port in use should render an up dot")
+		t.Run("when rendered, the machine bar and its legend cover dev and other work", func(t *testing.T) {
+			for _, want := range []string{`class="bar"`, "dev work", "everything else", "agents ~3.0GB (2)", "other ~8.0GB", "pressure amber"} {
+				if !strings.Contains(page, want) {
+					t.Errorf("machine picture should contain %q", want)
+				}
 			}
 		})
 
-		t.Run("when rendered, the aggregate stats count the stack, its service, and its databases", func(t *testing.T) {
+		t.Run("when rendered, the shared servers appear once, not on every card", func(t *testing.T) {
+			if !strings.Contains(page, "shared by every stack: clickhouse ~1.0GB") {
+				t.Error("the shared strip should name the shared servers with their footprints")
+			}
+			if strings.Contains(page, "clickhouse.portless.langwatch.localhost") {
+				t.Error("shared service rows must not repeat on the stack card")
+			}
+			if strings.Contains(page, "postgres.portless.langwatch.localhost") || strings.Contains(page, "redis.portless.langwatch.localhost") {
+				t.Error("postgres/redis rows must not repeat on the stack card")
+			}
+		})
+
+		t.Run("when rendered, a portless service shows no lying :0", func(t *testing.T) {
+			if !strings.Contains(page, "langyagent.portless.langwatch.localhost") {
+				t.Fatal("the stack's own langyagent row should stay")
+			}
+			if strings.Contains(page, ":0<") {
+				t.Error("a zero port must render blank, not :0")
+			}
+		})
+
+		t.Run("when rendered, the stackless worktrees and the reaping are sections", func(t *testing.T) {
+			for _, want := range []string{"worktrees — nothing running", "beta", "primary — protected", "recent reaping", "tc-ryuk", "left behind by an interrupted test run"} {
+				if !strings.Contains(page, want) {
+					t.Errorf("page should contain %q", want)
+				}
+			}
+		})
+
+		t.Run("when rendered, the aggregate stats count the stack, its own services, and dev ram", func(t *testing.T) {
 			for _, want := range []string{
 				`<span class="n">1<span class="of"> / 1</span></span><span class="l">stacks live</span>`,
-				`<span class="n">1<span class="of"> / 1</span></span><span class="l">services up</span>`,
-				`<span class="n">512.0MB<span class="of"> / 32.0GB</span></span><span class="l">stack ram</span>`,
-				`<span class="n">2</span><span class="l">databases</span>`,
+				`<span class="l">services up</span>`,
+				`<span class="l">dev ram</span>`,
+				`<span class="n">2</span><span class="l">agents</span>`,
 			} {
 				if !strings.Contains(page, want) {
 					t.Errorf("stats should contain %q", want)
@@ -88,7 +142,7 @@ func TestRenderHTML(t *testing.T) {
 			PortInUse:    func(int) bool { return false },
 		}
 		t.Run("when rendered, the unreachable service gets a down dot", func(t *testing.T) {
-			if !strings.Contains(renderHTML(stacks, sharedURL, probes), `<span class="dot down">`) {
+			if !strings.Contains(renderHTML(stacks, renderInputs{sharedURL: sharedURL, probes: probes, extras: Extras{}}), `<span class="dot down">`) {
 				t.Error("service with a free port should render a down dot")
 			}
 		})
@@ -101,7 +155,7 @@ func TestRenderHTML(t *testing.T) {
 			PortInUse:    func(int) bool { return false },
 		}
 		t.Run("when rendered, it shows stale", func(t *testing.T) {
-			page := renderHTML(stacks, sharedURL, probes)
+			page := renderHTML(stacks, renderInputs{sharedURL: sharedURL, probes: probes, extras: Extras{}})
 			if !strings.Contains(page, `<span class="pill stale">stale</span>`) {
 				t.Error("dead launcher should render a stale pill")
 			}

--- a/tools/thuishaven/adapters/dashboard/html_test.go
+++ b/tools/thuishaven/adapters/dashboard/html_test.go
@@ -74,7 +74,7 @@ func TestRenderHTML(t *testing.T) {
 		})
 
 		t.Run("when rendered, the machine bar and its legend cover dev and other work", func(t *testing.T) {
-			for _, want := range []string{`class="bar"`, "dev work", "everything else", "agents ~3.0GB (2)", "other ~8.0GB", "pressure amber"} {
+			for _, want := range []string{`class="bar"`, "dev work ~10.5GB", "everything else ~8.0GB", "agents ~3.0GB (2)", "pressure amber"} {
 				if !strings.Contains(page, want) {
 					t.Errorf("machine picture should contain %q", want)
 				}
@@ -82,7 +82,7 @@ func TestRenderHTML(t *testing.T) {
 		})
 
 		t.Run("when rendered, the shared servers appear once, not on every card", func(t *testing.T) {
-			if !strings.Contains(page, "shared by every stack: clickhouse ~1.0GB") {
+			if !strings.Contains(page, "Shared by every stack: clickhouse ~1.0GB") {
 				t.Error("the shared strip should name the shared servers with their footprints")
 			}
 			if strings.Contains(page, "clickhouse.portless.langwatch.localhost") {
@@ -103,7 +103,7 @@ func TestRenderHTML(t *testing.T) {
 		})
 
 		t.Run("when rendered, the stackless worktrees and the reaping are sections", func(t *testing.T) {
-			for _, want := range []string{"worktrees — nothing running", "beta", "primary — protected", "recent reaping", "tc-ryuk", "left behind by an interrupted test run"} {
+			for _, want := range []string{"Worktrees", "nothing running from these", "beta", "primary, protected", "Recent reaping", "tc-ryuk", "left behind by an interrupted test run"} {
 				if !strings.Contains(page, want) {
 					t.Errorf("page should contain %q", want)
 				}

--- a/tools/thuishaven/adapters/dashboard/server.go
+++ b/tools/thuishaven/adapters/dashboard/server.go
@@ -23,27 +23,32 @@ import (
 // Server renders live state pulled through the callbacks it is built with, so it
 // never imports the app core.
 type Server struct {
-	stacks    func() []domain.Stack
-	sharedURL func(service string) string // builds langwatch/observability/telemetry URLs
-	probes    Probes
+	config Config
 }
 
-// Probes are the optional OS checks the page uses to show live health and
-// resource numbers. A nil PortInUse leaves every service dot in its default
-// "down" state (the page can't confirm the port is listening); a nil GroupRSS or
-// TotalMemory simply blanks the stat it feeds, and a nil ProcessAlive falls back
-// to treating a stack with a launcher PID as live.
+// Probes are the optional OS checks the page uses to show live health. A nil
+// PortInUse leaves every service dot in its default "down" state (the page
+// can't confirm the port is listening); a nil ProcessAlive falls back to
+// treating a stack with a launcher PID as live.
 type Probes struct {
 	PortInUse    func(port int) bool
 	ProcessAlive func(pid int) bool
-	GroupRSS     func(pid int) uint64
-	TotalMemory  func() uint64
 }
 
-// New builds a Server. stacks yields the live registry; sharedURL builds the
-// shared-surface URLs (dashboard root, observability, telemetry).
-func New(stacks func() []domain.Stack, sharedURL func(string) string, probes Probes) *Server {
-	return &Server{stacks: stacks, sharedURL: sharedURL, probes: probes}
+// Config wires the Server to the world. Stacks yields the live registry;
+// SharedURL builds the shared-surface URLs (dashboard root, observability,
+// telemetry); Extras yields the machine picture (may be nil — the page
+// degrades to registry-only).
+type Config struct {
+	Stacks    func() []domain.Stack
+	SharedURL func(service string) string
+	Probes    Probes
+	Extras    func() Extras
+}
+
+// New builds a Server.
+func New(config Config) *Server {
+	return &Server{config: config}
 }
 
 // Serve runs the HTTP surface until the context is cancelled.
@@ -98,7 +103,7 @@ func (s *Server) hostAllowed(host string) bool {
 	// shared-surface URL so it honours a custom LANGWATCH_LOCAL_TLD. The bare
 	// domain is the dashboard root; every stack host and the observability /
 	// telemetry surfaces are subdomains of it.
-	u, err := url.Parse(s.sharedURL("langwatch"))
+	u, err := url.Parse(s.config.SharedURL("langwatch"))
 	if err != nil {
 		return false
 	}
@@ -115,7 +120,13 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = io.WriteString(w, renderHTML(s.stacks(), s.sharedURL, s.probes))
+	var extras Extras
+	if s.config.Extras != nil {
+		extras = s.config.Extras()
+	}
+	_, _ = io.WriteString(w, renderHTML(s.config.Stacks(), renderInputs{
+		sharedURL: s.config.SharedURL, probes: s.config.Probes, extras: extras,
+	}))
 }
 
 // registryStack mirrors domain.Stack for the unauthenticated /api/registry
@@ -154,7 +165,7 @@ func toRegistryStack(st domain.Stack) registryStack {
 }
 
 func (s *Server) handleRegistry(w http.ResponseWriter, _ *http.Request) {
-	stacks := s.stacks()
+	stacks := s.config.Stacks()
 	out := make([]registryStack, len(stacks))
 	for i, st := range stacks {
 		out[i] = toRegistryStack(st)
@@ -162,9 +173,9 @@ func (s *Server) handleRegistry(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"stacks":        out,
-		"dashboard":     s.sharedURL("langwatch"),
-		"observability": s.sharedURL("observability"),
-		"telemetry":     s.sharedURL("telemetry"),
+		"dashboard":     s.config.SharedURL("langwatch"),
+		"observability": s.config.SharedURL("observability"),
+		"telemetry":     s.config.SharedURL("telemetry"),
 	})
 }
 
@@ -198,8 +209,9 @@ func (s *Server) handleTelemetry(w http.ResponseWriter, r *http.Request) {
 	}
 	ct := r.Header.Get("Content-Type")
 	fanned := 0
-	for _, st := range s.stacks() {
-		for _, svc := range st.Services {
+	stacks := s.config.Stacks()
+	for i := range stacks {
+		for _, svc := range stacks[i].Services {
 			if svc.Name != "app" {
 				continue
 			}

--- a/tools/thuishaven/adapters/dashboard/template.go
+++ b/tools/thuishaven/adapters/dashboard/template.go
@@ -79,7 +79,7 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
     text-transform:uppercase; color:var(--ink-400); }
   .kicker .count { color:var(--ink-300); font-weight:500; letter-spacing:.06em; margin-left:8px; }
 
-  main.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(340px,1fr)); gap:18px; }
+  main.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(310px,1fr)); gap:18px; }
   .card { background:var(--paper); border:1px solid var(--ink-100); border-radius:14px;
     padding:18px 20px 14px; box-shadow:var(--shadow); }
   @media (prefers-color-scheme: dark){ .card { background:var(--paper-soft); } }
@@ -115,7 +115,7 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
   @keyframes ping { 0%{ transform:scale(.6); opacity:.5; } 80%,100%{ transform:scale(1.5); opacity:0; } }
   @media (prefers-reduced-motion: reduce){ .dot.up::after { animation:none; } }
   .dot.down { background:var(--rust); opacity:.7; }
-  .svc { width:92px; color:var(--ink-500); font-size:13px; }
+  .subglyph { color:var(--ink-300); font-family:ui-monospace,"SF Mono",monospace; font-size:12px; }
   table.svcs a { color:var(--ink-600); font-size:12.5px; text-decoration:none;
     font-family:ui-monospace,"SF Mono","JetBrains Mono",monospace; transition:color .3s; }
   table.svcs a:hover { color:var(--brand-deep); }
@@ -180,7 +180,7 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
     <div class="branch">{{.Branch}}</div>
     <div class="chips">{{range .Chips}}{{if .IsBaseline}}<span class="chip baseline">baseline</span>{{else}}<span class="chip">{{.Label}} <code>{{.Value}}</code></span>{{end}}{{end}}</div>
     <div class="dir" title="{{.DirFull}}">{{.Dir}}</div>
-    <table class="svcs">{{range .Rows}}<tr><td class="dot-cell">{{if not .IsSub}}<span class="dot {{.DotClass}}"></span>{{end}}</td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}" title="{{.URL}}">{{.Host}}</a></td><td class="port">{{.Port}}</td></tr>{{end}}</table>
+    <table class="svcs">{{range .Rows}}<tr><td class="dot-cell">{{if not .IsSub}}<span class="dot {{.DotClass}}"></span>{{end}}</td><td class="host">{{if .IsSub}}<span class="subglyph">└</span> {{end}}<a href="{{.URL}}" title="{{.URL}}">{{.Host}}</a></td><td class="port">{{.Port}}</td></tr>{{end}}</table>
   </section>{{end}}</main>
 {{if .SharedNote}}<div class="strip">{{.SharedNote}}</div>{{end}}
 

--- a/tools/thuishaven/adapters/dashboard/template.go
+++ b/tools/thuishaven/adapters/dashboard/template.go
@@ -1,0 +1,223 @@
+package dashboard
+
+// The page follows the LangWatch design language: warm paper and a warm ink
+// scale (never blue-gray), one orange brand accent, semantic moss/amber/rust
+// used only as meaning, serif for the one statement, sans for interface, mono
+// for machine output, pill-shaped interactive chrome, hairline borders only on
+// true surfaces, whitespace instead of dividers, and a still page: nothing
+// animates except the live dots and the refresh heartbeat. Light is the
+// canonical scheme; dark inverts the same tokens. Copy avoids em-dashes by
+// house rule.
+const pageTemplate = `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>haven, this machine's stacks</title>
+<style>
+  :root { color-scheme: light dark;
+    --paper:#ffffff; --paper-soft:#efeee9; --paper-deep:#e3e2dc;
+    --ink-900:#141417; --ink-600:#36352f; --ink-500:#4d4d46; --ink-400:#6d6c64;
+    --ink-300:#99988f; --ink-100:#e3e2dd; --ink-50:#f0f0ee;
+    --brand:#f56b1a; --brand-deep:#d65209; --brand-soft:rgba(245,107,26,.09);
+    --moss:#5b7a4a; --amber:#c97b3a; --rust:#b85240;
+    --moss-soft:rgba(91,122,74,.13); --amber-soft:rgba(201,123,58,.14); --rust-soft:rgba(184,82,64,.12);
+    --shadow:0 30px 80px -30px rgba(30,20,40,.18), 0 10px 30px -15px rgba(30,20,40,.08);
+    --grain-opacity:.022; }
+  @media (prefers-color-scheme: dark){ :root{
+    --paper:#0a0a0c; --paper-soft:#17171a; --paper-deep:#1f1f23;
+    --ink-900:#f0f0ee; --ink-600:#c6c4bf; --ink-500:#99988f; --ink-400:#8a887f;
+    --ink-300:#6d6c64; --ink-100:#26261f; --ink-50:#1b1b15;
+    --brand:#ff8a3d; --brand-deep:#ffb380; --brand-soft:rgba(255,138,61,.12);
+    --moss:#8fb87a; --amber:#d99a5e; --rust:#cf8a7a;
+    --moss-soft:rgba(143,184,122,.14); --amber-soft:rgba(217,154,94,.15); --rust-soft:rgba(207,138,122,.14);
+    --shadow:0 30px 80px -30px rgba(0,0,0,.5), 0 10px 30px -15px rgba(0,0,0,.3);
+    --grain-opacity:.03; } }
+  * { box-sizing:border-box; }
+  html { background:var(--paper); }
+  body { margin:0; font:15px/1.6 ui-sans-serif,system-ui,-apple-system,"Geist",sans-serif;
+    background:var(--paper); color:var(--ink-600); min-height:100vh;
+    -webkit-font-smoothing:antialiased; }
+  /* paper grain: exists to kill sterile flatness, never consciously noticeable */
+  body::before { content:""; position:fixed; inset:0; z-index:9; pointer-events:none;
+    opacity:var(--grain-opacity); mix-blend-mode:multiply;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='240' height='240' filter='url(%23n)'/%3E%3C/svg%3E"); }
+  @media (prefers-color-scheme: dark){ body::before { mix-blend-mode:screen; } }
+
+  .shell { max-width:1120px; margin:0 auto; padding:0 24px; }
+
+  header.top { display:flex; align-items:center; gap:14px; flex-wrap:wrap; padding:26px 0 0; }
+  .wordmark { font-weight:650; font-size:16px; color:var(--ink-900); letter-spacing:-.01em; }
+  .wordmark .mark { color:var(--brand); margin-right:6px; }
+  header.top .links { margin-left:auto; display:flex; gap:8px; align-items:center; }
+  header.top .links a { color:var(--ink-500); font-size:13px; font-weight:500; text-decoration:none;
+    border:1px solid var(--ink-100); border-radius:999px; padding:5px 14px;
+    transition:color .3s, border-color .3s; }
+  header.top .links a:hover { color:var(--ink-900); border-color:var(--ink-300); }
+  .pressure { font-size:11.5px; font-weight:600; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--rust); background:var(--rust-soft); border-radius:999px; padding:4px 12px; }
+
+  .statement { margin:44px 0 0; font-family:"Sentient",ui-serif,Georgia,serif; font-weight:400;
+    font-size:clamp(28px,4vw,40px); line-height:1.05; letter-spacing:-.02em; color:var(--ink-900);
+    transform:scale(1,1.06); transform-origin:left top; }
+
+  .stats { display:flex; gap:44px; flex-wrap:wrap; margin:38px 0 0; }
+  .stat .n { display:block; font-size:26px; font-weight:650; color:var(--ink-900);
+    font-variant-numeric:tabular-nums; letter-spacing:-.01em; }
+  .stat .of { color:var(--ink-300); font-weight:450; font-size:.68em; }
+  .stat .l { display:block; margin-top:2px; color:var(--ink-400); font-size:11px; font-weight:550;
+    text-transform:uppercase; letter-spacing:.14em; }
+
+  .machine { margin:26px 0 0; max-width:720px; }
+  .bar { display:flex; height:8px; border-radius:999px; overflow:hidden; background:var(--paper-deep); }
+  .bar .dev { background:var(--brand); }
+  .bar .other { background:var(--ink-300); }
+  .legend { margin-top:10px; font-size:12.5px; color:var(--ink-400); display:flex; gap:18px; flex-wrap:wrap; }
+  .legend .key { display:inline-block; width:8px; height:8px; border-radius:2px; margin-right:7px; vertical-align:0; }
+  .legend .key.dev { background:var(--brand); }
+  .legend .key.other { background:var(--ink-300); }
+  .legend .breakdown { color:var(--ink-300); }
+
+  .kicker { margin:56px 0 16px; font-size:11.5px; font-weight:600; letter-spacing:.18em;
+    text-transform:uppercase; color:var(--ink-400); }
+  .kicker .count { color:var(--ink-300); font-weight:500; letter-spacing:.06em; margin-left:8px; }
+
+  main.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(340px,1fr)); gap:18px; }
+  .card { background:var(--paper); border:1px solid var(--ink-100); border-radius:14px;
+    padding:18px 20px 14px; box-shadow:var(--shadow); }
+  @media (prefers-color-scheme: dark){ .card { background:var(--paper-soft); } }
+  .card header { display:flex; align-items:center; gap:10px; }
+  .card header .spacer { flex:1; }
+  .slug { font-weight:650; font-size:15.5px; color:var(--ink-900); letter-spacing:-.01em; }
+  .pill { font-size:11px; font-weight:600; padding:3px 10px; border-radius:999px;
+    text-transform:uppercase; letter-spacing:.08em; }
+  .pill.live { background:var(--moss-soft); color:var(--moss); }
+  .pill.stale { background:var(--amber-soft); color:var(--amber); }
+  .open { font-size:12.5px; font-weight:550; color:var(--brand-deep); text-decoration:none;
+    background:var(--brand-soft); border-radius:999px; padding:3px 12px; transition:filter .3s; }
+  .open:hover { filter:brightness(.92); }
+  .branch { margin-top:3px; color:var(--ink-400); font-size:12.5px;
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .chips { display:flex; gap:6px; flex-wrap:wrap; margin:12px 0 4px; }
+  .chip { font-size:11.5px; color:var(--ink-500); background:var(--paper-soft);
+    border-radius:999px; padding:3px 10px; }
+  @media (prefers-color-scheme: dark){ .chip { background:var(--paper-deep); } }
+  .chip code { font-family:ui-monospace,"SF Mono","JetBrains Mono",monospace; font-size:11px; color:var(--ink-600); }
+  .chip.baseline { color:var(--brand-deep); background:var(--brand-soft); font-weight:600; }
+  .dir { color:var(--ink-300); font-size:11px; font-family:ui-monospace,"SF Mono",monospace;
+    word-break:break-all; margin:6px 0 10px; }
+  table.svcs { width:100%; border-collapse:collapse; }
+  table.svcs td { padding:5px 0; border-top:1px solid var(--ink-50); }
+  table.svcs tr:first-child td { border-top:0; }
+  .dot-cell { width:16px; }
+  .dot { display:inline-block; width:7px; height:7px; border-radius:50%; position:relative; }
+  .dot.up { background:var(--moss); }
+  .dot.up::after { content:""; position:absolute; inset:-3px; border-radius:50%;
+    border:1.5px solid var(--moss); opacity:.4; animation:ping 2.6s ease-out infinite; }
+  @keyframes ping { 0%{ transform:scale(.6); opacity:.5; } 80%,100%{ transform:scale(1.5); opacity:0; } }
+  @media (prefers-reduced-motion: reduce){ .dot.up::after { animation:none; } }
+  .dot.down { background:var(--rust); opacity:.7; }
+  .svc { width:86px; color:var(--ink-500); font-size:13px; }
+  table.svcs a { color:var(--ink-600); font-size:13px; text-decoration:none;
+    border-bottom:1px solid var(--ink-100); transition:color .3s, border-color .3s; }
+  table.svcs a:hover { color:var(--brand-deep); border-color:var(--brand); }
+  .port { color:var(--ink-300); font-size:12px; font-family:ui-monospace,"SF Mono",monospace; text-align:right; }
+
+  .empty { grid-column:1/-1; color:var(--ink-400); padding:40px 0 8px; }
+  .empty h2 { margin:0 0 6px; font-family:"Sentient",ui-serif,Georgia,serif; font-weight:400;
+    font-size:22px; color:var(--ink-900); }
+  .empty code { background:var(--paper-soft); padding:4px 12px; border-radius:8px;
+    font-family:ui-monospace,"SF Mono",monospace; font-size:13px; color:var(--ink-600); }
+
+  .strip { margin:18px 0 0; font-size:12.5px; color:var(--ink-400); }
+  .strip code { font-family:ui-monospace,"SF Mono",monospace; font-size:12px; color:var(--ink-500); }
+
+  .wt-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(320px,1fr)); gap:2px 32px; }
+  .wt { display:flex; align-items:baseline; gap:10px; padding:7px 0; border-top:1px solid var(--ink-50);
+    min-width:0; }
+  .wt b { color:var(--ink-900); font-weight:550; font-size:13.5px; white-space:nowrap; }
+  .wt .b { color:var(--ink-400); font-size:12.5px; overflow:hidden; text-overflow:ellipsis;
+    white-space:nowrap; min-width:0; }
+  .wt .note { margin-left:auto; font-size:10.5px; font-weight:600; letter-spacing:.06em;
+    text-transform:uppercase; color:var(--ink-300); white-space:nowrap; }
+
+  table.reap { border-collapse:collapse; max-width:860px; width:100%; }
+  table.reap td { padding:7px 18px 7px 0; border-top:1px solid var(--ink-50); vertical-align:baseline; }
+  table.reap tr:first-child td { border-top:0; }
+  .age { color:var(--ink-300); font-size:12px; font-family:ui-monospace,"SF Mono",monospace; white-space:nowrap; }
+  .kind { color:var(--brand-deep); font-size:12px; font-weight:600; letter-spacing:.04em; }
+  .target { color:var(--ink-600); font-size:13px; font-family:ui-monospace,"SF Mono",monospace; }
+  .why { color:var(--ink-400); font-size:12.5px; }
+
+  footer { margin:64px 0 40px; display:flex; gap:9px; align-items:center;
+    color:var(--ink-300); font-size:12px; }
+  #beat { width:6px; height:6px; border-radius:50%; background:var(--moss); }
+  #beat.off { background:var(--amber); }
+</style></head><body>
+<div class="shell">
+<header class="top">
+  <span class="wordmark"><span class="mark">●</span>haven</span>
+  {{if .Pressure}}<span class="pressure">pressure {{.Pressure}}</span>{{end}}
+  <span class="links">
+    <a href="{{.ObsURL}}">observability</a>
+    <a href="{{.TelURL}}">telemetry</a>
+  </span>
+</header>
+<div id="live">
+<h1 class="statement">What this machine is running</h1>
+<div class="stats">{{range .Stats}}
+  <div class="stat"><span class="n">{{.Value}}{{if .Of}}<span class="of"> / {{.Of}}</span>{{end}}</span><span class="l">{{.Label}}</span></div>{{end}}
+</div>
+{{with .Bar}}<div class="machine">
+  <div class="bar"><div class="dev" style="width:{{.DevPct}}%"></div><div class="other" style="width:{{.OtherPct}}%"></div></div>
+  <div class="legend"><span><span class="key dev"></span>{{.DevLabel}}</span><span><span class="key other"></span>{{.OtherLabel}}</span><span class="breakdown">{{.Breakdown}}</span></div>
+</div>{{end}}
+
+<div class="kicker">Stacks</div>
+<main class="cards">{{if .IsEmpty}}<div class="empty"><h2>Nothing running yet</h2>
+    <p>Bring a stack up from any worktree and it appears here, on its own hostname.</p>
+    <code>haven up</code></div>{{end}}{{range .Cards}}
+  <section class="card">
+    <header><span class="slug">{{.Slug}}</span><span class="spacer"></span>{{if .OpenURL}}<a class="open" href="{{.OpenURL}}">open</a>{{end}}<span class="pill {{.BadgeClass}}">{{.Badge}}</span></header>
+    <div class="branch">{{.Branch}}</div>
+    <div class="chips">{{range .Chips}}{{if .IsBaseline}}<span class="chip baseline">baseline</span>{{else}}<span class="chip">{{.Label}} <code>{{.Value}}</code></span>{{end}}{{end}}</div>
+    <div class="dir">{{.Dir}}</div>
+    <table class="svcs">{{range .Rows}}<tr><td class="dot-cell">{{if not .IsSub}}<span class="dot {{.DotClass}}"></span>{{end}}</td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="port">{{.Port}}</td></tr>{{end}}</table>
+  </section>{{end}}</main>
+{{if .SharedNote}}<div class="strip">{{.SharedNote}}</div>{{end}}
+
+{{if .Worktrees}}<div class="kicker">Worktrees<span class="count">nothing running from these</span></div>
+<div class="wt-grid">{{range .Worktrees}}
+  <div class="wt" title="{{.Dir}}"><b>{{.Name}}</b><span class="b">{{.Branch}}</span>{{if .Note}}<span class="note">{{.Note}}</span>{{end}}</div>{{end}}
+</div>{{end}}
+
+{{if .Events}}<div class="kicker">Recent reaping<span class="count">what the daemon reclaimed</span></div>
+<table class="reap">{{range .Events}}
+  <tr><td class="age">{{.Age}}</td><td class="kind">{{.Kind}}</td><td class="target">{{.Target}}</td><td class="why">{{.Reason}}</td></tr>{{end}}
+</table>{{end}}
+</div>
+<footer><span id="beat"></span><span id="stamp">live, refreshes every 3s</span></footer>
+</div>
+<script>
+(() => {
+  let failures = 0;
+  const beat = document.getElementById('beat'), stamp = document.getElementById('stamp');
+  async function refresh() {
+    const live = document.getElementById('live');
+    // Skip the swap while the user is tabbing through it: replacing the
+    // subtree would destroy the focused link every three seconds.
+    if (document.hidden || live.contains(document.activeElement)) return;
+    try {
+      const res = await fetch('/', {cache: 'no-store'});
+      const doc = new DOMParser().parseFromString(await res.text(), 'text/html');
+      const next = doc.getElementById('live');
+      if (next) live.replaceChildren(...next.children);
+      failures = 0;
+      beat.classList.remove('off');
+      stamp.textContent = 'live, updated ' + new Date().toLocaleTimeString();
+    } catch {
+      if (++failures >= 2) { beat.classList.add('off'); stamp.textContent = 'daemon unreachable, retrying'; }
+    }
+  }
+  setInterval(refresh, 3000);
+  document.addEventListener('visibilitychange', refresh);
+})();
+</script>
+</body></html>`

--- a/tools/thuishaven/adapters/dashboard/template.go
+++ b/tools/thuishaven/adapters/dashboard/template.go
@@ -103,10 +103,11 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
   .chip.baseline { color:var(--brand-deep); background:var(--brand-soft); font-weight:600; }
   .dir { color:var(--ink-300); font-size:11px; font-family:ui-monospace,"SF Mono",monospace;
     word-break:break-all; margin:6px 0 10px; }
-  table.svcs { width:100%; border-collapse:collapse; }
-  table.svcs td { padding:5px 0; border-top:1px solid var(--ink-50); }
+  table.svcs { width:100%; border-collapse:collapse; table-layout:fixed; }
+  table.svcs td { padding:6px 0; border-top:1px solid var(--ink-50); vertical-align:middle;
+    overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
   table.svcs tr:first-child td { border-top:0; }
-  .dot-cell { width:16px; }
+  .dot-cell { width:20px; }
   .dot { display:inline-block; width:7px; height:7px; border-radius:50%; position:relative; }
   .dot.up { background:var(--moss); }
   .dot.up::after { content:""; position:absolute; inset:-3px; border-radius:50%;
@@ -114,11 +115,11 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
   @keyframes ping { 0%{ transform:scale(.6); opacity:.5; } 80%,100%{ transform:scale(1.5); opacity:0; } }
   @media (prefers-reduced-motion: reduce){ .dot.up::after { animation:none; } }
   .dot.down { background:var(--rust); opacity:.7; }
-  .svc { width:86px; color:var(--ink-500); font-size:13px; }
-  table.svcs a { color:var(--ink-600); font-size:13px; text-decoration:none;
-    border-bottom:1px solid var(--ink-100); transition:color .3s, border-color .3s; }
-  table.svcs a:hover { color:var(--brand-deep); border-color:var(--brand); }
-  .port { color:var(--ink-300); font-size:12px; font-family:ui-monospace,"SF Mono",monospace; text-align:right; }
+  .svc { width:92px; color:var(--ink-500); font-size:13px; }
+  table.svcs a { color:var(--ink-600); font-size:12.5px; text-decoration:none;
+    font-family:ui-monospace,"SF Mono","JetBrains Mono",monospace; transition:color .3s; }
+  table.svcs a:hover { color:var(--brand-deep); }
+  .port { width:58px; color:var(--ink-300); font-size:12px; font-family:ui-monospace,"SF Mono",monospace; text-align:right; }
 
   .empty { grid-column:1/-1; color:var(--ink-400); padding:40px 0 8px; }
   .empty h2 { margin:0 0 6px; font-family:"Sentient",ui-serif,Georgia,serif; font-weight:400;
@@ -178,8 +179,8 @@ const pageTemplate = `<!doctype html><html lang="en"><head>
     <header><span class="slug">{{.Slug}}</span><span class="spacer"></span>{{if .OpenURL}}<a class="open" href="{{.OpenURL}}">open</a>{{end}}<span class="pill {{.BadgeClass}}">{{.Badge}}</span></header>
     <div class="branch">{{.Branch}}</div>
     <div class="chips">{{range .Chips}}{{if .IsBaseline}}<span class="chip baseline">baseline</span>{{else}}<span class="chip">{{.Label}} <code>{{.Value}}</code></span>{{end}}{{end}}</div>
-    <div class="dir">{{.Dir}}</div>
-    <table class="svcs">{{range .Rows}}<tr><td class="dot-cell">{{if not .IsSub}}<span class="dot {{.DotClass}}"></span>{{end}}</td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}">{{.Host}}</a></td><td class="port">{{.Port}}</td></tr>{{end}}</table>
+    <div class="dir" title="{{.DirFull}}">{{.Dir}}</div>
+    <table class="svcs">{{range .Rows}}<tr><td class="dot-cell">{{if not .IsSub}}<span class="dot {{.DotClass}}"></span>{{end}}</td><td class="svc">{{.Name}}</td><td><a href="{{.URL}}" title="{{.URL}}">{{.Host}}</a></td><td class="port">{{.Port}}</td></tr>{{end}}</table>
   </section>{{end}}</main>
 {{if .SharedNote}}<div class="strip">{{.SharedNote}}</div>{{end}}
 

--- a/tools/thuishaven/adapters/fileregistry/store.go
+++ b/tools/thuishaven/adapters/fileregistry/store.go
@@ -500,3 +500,34 @@ func (s *Store) ReadPressure() (domain.PressureRecord, bool) {
 	}
 	return rec, true
 }
+
+func (s *Store) reapEventsPath() string { return filepath.Join(s.home, "reap-events.json") }
+
+// AppendReapEvent appends one daemon reclamation to the bounded record. The
+// daemon is the only writer (its monitor goroutine), so read-modify-write with
+// an atomic replace is race-free in practice; the hub only ever reads.
+func (s *Store) AppendReapEvent(ev domain.ReapEvent) error {
+	events := domain.AppendReapEvent(s.ReapEvents(), ev)
+	b, err := json.Marshal(events)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.home, 0o750); err != nil {
+		return err
+	}
+	return writeFileAtomic(s.reapEventsPath(), b, 0o644)
+}
+
+// ReapEvents reads the record newest-last. Absent or unreadable is an empty
+// record — the hub shows "nothing reaped", never an error.
+func (s *Store) ReapEvents() []domain.ReapEvent {
+	b, err := os.ReadFile(s.reapEventsPath())
+	if err != nil {
+		return nil
+	}
+	var events []domain.ReapEvent
+	if json.Unmarshal(b, &events) != nil {
+		return nil
+	}
+	return events
+}

--- a/tools/thuishaven/adapters/fileregistry/store_test.go
+++ b/tools/thuishaven/adapters/fileregistry/store_test.go
@@ -196,3 +196,29 @@ func TestObserveDurationKeepsEveryKeyWhenRunsFinishTogether(t *testing.T) {
 		})
 	})
 }
+
+// @scenario "Reaping is recorded as it happens"
+func TestReapEventsPersistBoundedNewestLast(t *testing.T) {
+	s := New(t.TempDir())
+
+	if got := s.ReapEvents(); len(got) != 0 {
+		t.Fatalf("an absent record must read empty, got %d events", len(got))
+	}
+	for i := range domain.ReapEventCap + 5 {
+		ev := domain.ReapEvent{At: time.Unix(int64(i), 0), Kind: "testcontainer", Target: "tc-ryuk", Reason: "leaked"}
+		if err := s.AppendReapEvent(ev); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+
+	events := s.ReapEvents()
+	if len(events) != domain.ReapEventCap {
+		t.Fatalf("record must cap at %d, got %d", domain.ReapEventCap, len(events))
+	}
+	if !events[len(events)-1].At.Equal(time.Unix(int64(domain.ReapEventCap+4), 0)) {
+		t.Fatal("the newest event must survive the cap, oldest dropped")
+	}
+	if events[0].At.Equal(time.Unix(0, 0)) {
+		t.Fatal("the oldest event past the cap must be dropped")
+	}
+}

--- a/tools/thuishaven/adapters/hubtui/hubtui.go
+++ b/tools/thuishaven/adapters/hubtui/hubtui.go
@@ -1,14 +1,17 @@
-// Package hubtui is the interactive hub: one screen showing every stack with
-// its health and footprint, and actions on the selected one — open its git
-// view, shut it down, or destroy the worktree entirely. Like the dashboard
-// adapter it never imports the app core: it reads state and performs actions
-// through the callbacks it is constructed with, so the composition root stays
-// the only place that knows both sides.
+// Package hubtui is the interactive hub: one screen showing the whole machine
+// — every stack with its health and footprint, every worktree (running or
+// not), the shared servers, agents and tooling beside them, and the daemon's
+// recent reaping — with actions on the selected row and one-key handoffs to
+// cleanup and the web dashboard. Like the dashboard adapter it never imports
+// the app core: it reads state and performs actions through the callbacks it
+// is constructed with, so the composition root stays the only place that knows
+// both sides.
 package hubtui
 
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,32 +39,101 @@ type Row struct {
 	Services          []ServiceRow
 }
 
-// Actions wires the hub to the world. Rows is re-read on every refresh tick;
-// Down and Destroy run against the selected row when the user confirms.
-// Restart bounces the selected stack's supervised services in place; OpenURL
-// opens the stack's app URL in the browser. Either may be nil (action hidden).
+// WorktreeRow is a worktree with nothing running from it — visible so the hub
+// answers "what is on this machine", not just "what is up".
+type WorktreeRow struct {
+	Slug, Branch, Dir    string
+	IsPrimary, IsCurrent bool
+}
+
+// Name is what the worktree is called on screen and what a destroy
+// confirmation must type: the haven slug when one is known, the directory's
+// base name otherwise.
+func (w WorktreeRow) Name() string {
+	if w.Slug != "" {
+		return w.Slug
+	}
+	return filepath.Base(w.Dir)
+}
+
+// Protected reports whether the row may never be destroyed (the primary
+// checkout and the worktree haven runs from — the same guards the app layer
+// enforces again).
+func (w WorktreeRow) Protected() bool { return w.IsPrimary || w.IsCurrent }
+
+// Summary is the machine header: the RAM picture with every dev-work process
+// attributed once, plus the daemon's pressure reading.
+type Summary struct {
+	TotalRAM   uint64
+	StacksRSS  uint64
+	ServerRSS  map[string]uint64
+	AgentRSS   uint64
+	AgentCount int
+	ToolingRSS uint64
+	Pressure   string // the daemon's pressure level ("green" hidden, others shown)
+}
+
+// DevRSS is everything attributed to dev work, summed.
+func (s Summary) DevRSS() uint64 {
+	total := s.StacksRSS + s.AgentRSS + s.ToolingRSS
+	for _, rss := range s.ServerRSS {
+		total += rss
+	}
+	return total
+}
+
+// Event is one daemon reclamation, newest first, as the monitor panel shows it.
+type Event struct {
+	At                   time.Time
+	Kind, Target, Reason string
+}
+
+// View is everything one refresh shows.
+type View struct {
+	Stacks    []Row
+	Worktrees []WorktreeRow
+	Summary   Summary
+	Events    []Event
+}
+
+// Actions wires the hub to the world. Refresh is re-read on every tick; Down
+// and Destroy run against the selected row when the user confirms. Restart
+// bounces the selected stack's supervised services in place; OpenURL opens a
+// URL in the browser (the stack's app, or WebURL for the machine dashboard).
+// Any action may be nil (hidden).
 type Actions struct {
-	Rows    func() []Row
+	Refresh func() View
 	Down    func(ctx context.Context, slug string) error
 	Destroy func(ctx context.Context, dir string) error
 	Restart func(ctx context.Context, slug string) error
 	OpenURL func(url string) error
+	// WebURL is the machine dashboard ("w" opens it via OpenURL).
+	WebURL string
+	// HasCleanup advertises the cleanup handoff ("c"): the hub quits with
+	// Outcome.RunCleanup set and the caller runs the picker in the terminal.
+	HasCleanup bool
 }
 
-// Run blocks in the hub TUI. It returns a non-empty directory when the user
-// chose to open the git view for a stack — the caller runs that and re-enters
-// the hub — and "" when the user quit.
-func Run(ctx context.Context, a Actions) (openDir string, err error) {
+// Outcome is what the hub wants the caller to do after it closed: open a git
+// view, hand the terminal to cleanup, or nothing (a plain quit). The caller
+// re-enters the hub after either handoff.
+type Outcome struct {
+	OpenGitDir string
+	RunCleanup bool
+}
+
+// Run blocks in the hub TUI and returns what to do next.
+func Run(ctx context.Context, a Actions) (Outcome, error) {
 	p := tea.NewProgram(newModel(ctx, a), tea.WithAltScreen(), tea.WithContext(ctx))
 	out, err := p.Run()
 	if err != nil {
-		if ctx.Err() != nil { // Ctrl-C via signal context is a clean quit
-			return "", nil
+		if ctx.Err() != nil {
+			return Outcome{}, nil //nolint:nilerr // Ctrl-C via signal context is a clean quit, not an error
 		}
-		return "", err
+		return Outcome{}, err
 	}
 	m := out.(model)
-	return m.openDir, nil
+	return m.outcome, nil
 }
 
 type mode int
@@ -72,9 +144,29 @@ const (
 	modeConfirmDestroy
 )
 
+// item is one selectable line: a stack or a worktree.
+type item struct {
+	stack *Row
+	wt    *WorktreeRow
+}
+
+func (it item) dir() string {
+	if it.stack != nil {
+		return it.stack.Dir
+	}
+	return it.wt.Dir
+}
+
+func (it item) name() string {
+	if it.stack != nil {
+		return it.stack.Slug
+	}
+	return it.wt.Name()
+}
+
 type tickMsg struct{}
 
-// actionDoneMsg reports a Down/Destroy result back to the update loop.
+// actionDoneMsg reports a Down/Destroy/Restart result back to the update loop.
 type actionDoneMsg struct {
 	verb string
 	slug string
@@ -84,21 +176,39 @@ type actionDoneMsg struct {
 type model struct {
 	ctx     context.Context
 	actions Actions
-	rows    []Row
+	view    View
+	items   []item
 	cursor  int
 	mode    mode
-	pending *Row   // the row a confirmation prompt is acting on, frozen at open time
+	pending *item  // the row a confirmation prompt is acting on, frozen at open time
 	typed   string // the name typed to confirm a destroy
 	flash   string // last action's outcome, shown until the next keypress
 	// isQuitting means quit was requested while an action was in flight: the hub
 	// exits when the action completes (a second ctrl+c force-quits).
-	isQuitting bool
-	openDir    string
-	busy       bool
+	isQuitting  bool
+	outcome     Outcome
+	busy        bool
+	showMonitor bool
 }
 
 func newModel(ctx context.Context, a Actions) model {
-	return model{ctx: ctx, actions: a, rows: a.Rows()}
+	m := model{ctx: ctx, actions: a}
+	m.refresh()
+	return m
+}
+
+func (m *model) refresh() {
+	m.view = m.actions.Refresh()
+	m.items = m.items[:0]
+	for i := range m.view.Stacks {
+		m.items = append(m.items, item{stack: &m.view.Stacks[i]})
+	}
+	for i := range m.view.Worktrees {
+		m.items = append(m.items, item{wt: &m.view.Worktrees[i]})
+	}
+	if m.cursor >= len(m.items) {
+		m.cursor = max(0, len(m.items)-1)
+	}
 }
 
 func (m model) Init() tea.Cmd { return tick() }
@@ -110,10 +220,7 @@ func tick() tea.Cmd {
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tickMsg:
-		m.rows = m.actions.Rows()
-		if m.cursor >= len(m.rows) {
-			m.cursor = max(0, len(m.rows)-1)
-		}
+		m.refresh()
 		return m, tick()
 	case actionDoneMsg:
 		m.busy = false
@@ -122,10 +229,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.flash = fmt.Sprintf("%s %s — done", msg.verb, msg.slug)
 		}
-		m.rows = m.actions.Rows()
-		if m.cursor >= len(m.rows) {
-			m.cursor = max(0, len(m.rows)-1)
-		}
+		m.refresh()
 		if m.isQuitting {
 			return m, tea.Quit
 		}
@@ -170,71 +274,90 @@ func (m model) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cursor--
 		}
 	case "down", "j":
-		if m.cursor < len(m.rows)-1 {
+		if m.cursor < len(m.items)-1 {
 			m.cursor++
 		}
 	case "enter", "g":
-		if r, ok := m.selected(); ok {
-			m.openDir = r.Dir
+		if it, ok := m.selected(); ok {
+			m.outcome.OpenGitDir = it.dir()
 			return m, tea.Quit
 		}
 	case "d":
-		if r, ok := m.selected(); ok {
+		if it, ok := m.selected(); ok && it.stack != nil {
 			m.mode = modeConfirmDown
-			m.pending = &r
+			m.pending = &it
 		}
 	case "r":
-		if r, ok := m.selected(); ok && m.actions.Restart != nil && r.IsLive {
+		if it, ok := m.selected(); ok && it.stack != nil && m.actions.Restart != nil && it.stack.IsLive {
 			m.busy = true
-			slug := r.Slug
+			slug := it.stack.Slug
 			return m, func() tea.Msg {
 				return actionDoneMsg{verb: "restart", slug: slug, err: m.actions.Restart(m.ctx, slug)}
 			}
 		}
 	case "o":
-		if r, ok := m.selected(); ok && m.actions.OpenURL != nil && r.AppURL != "" {
-			if err := m.actions.OpenURL(r.AppURL); err != nil {
-				m.flash = fmt.Sprintf("open %s failed: %v", r.AppURL, err)
-			} else {
-				m.flash = "opened " + r.AppURL
-			}
+		if it, ok := m.selected(); ok && it.stack != nil && m.actions.OpenURL != nil && it.stack.AppURL != "" {
+			m.open(it.stack.AppURL)
 		}
+	case "w":
+		if m.actions.OpenURL != nil && m.actions.WebURL != "" {
+			m.open(m.actions.WebURL)
+		}
+	case "c":
+		if m.actions.HasCleanup {
+			m.outcome.RunCleanup = true
+			return m, tea.Quit
+		}
+	case "m":
+		m.showMonitor = !m.showMonitor
 	case "x":
-		if r, ok := m.selected(); ok {
+		if it, ok := m.selected(); ok {
+			if it.wt != nil && it.wt.Protected() {
+				m.flash = fmt.Sprintf("%s is protected — the primary checkout and the current worktree are never destroyed", it.name())
+				return m, nil
+			}
 			m.mode = modeConfirmDestroy
-			m.pending = &r
+			m.pending = &it
 			m.typed = ""
 		}
 	}
 	return m, nil
 }
 
+func (m *model) open(url string) {
+	if err := m.actions.OpenURL(url); err != nil {
+		m.flash = fmt.Sprintf("open %s failed: %v", url, err)
+	} else {
+		m.flash = "opened " + url
+	}
+}
+
 func (m model) updateConfirmDown(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y":
-		r := m.pending
+		it := m.pending
 		m.mode = modeBrowse
 		m.pending = nil
-		if r == nil || !m.rowStillPresent(*r) {
-			m.flash = "down cancelled — stack changed"
+		if it == nil || it.stack == nil || !m.itemStillPresent(*it) {
+			m.flash = "down canceled — stack changed"
 			return m, nil
 		}
 		m.busy = true
-		slug := r.Slug
+		slug := it.stack.Slug
 		return m, func() tea.Msg {
 			return actionDoneMsg{verb: "down", slug: slug, err: m.actions.Down(m.ctx, slug)}
 		}
 	default:
 		m.mode = modeBrowse
 		m.pending = nil
-		m.flash = "down cancelled"
+		m.flash = "down canceled"
 	}
 	return m, nil
 }
 
 func (m model) updateConfirmDestroy(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	r := m.pending
-	if r == nil {
+	it := m.pending
+	if it == nil {
 		m.mode = modeBrowse
 		return m, nil
 	}
@@ -242,7 +365,7 @@ func (m model) updateConfirmDestroy(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc", "ctrl+c":
 		m.mode = modeBrowse
 		m.pending = nil
-		m.flash = "destroy cancelled"
+		m.flash = "destroy canceled"
 	case "backspace":
 		if len(m.typed) > 0 {
 			m.typed = m.typed[:len(m.typed)-1]
@@ -250,20 +373,20 @@ func (m model) updateConfirmDestroy(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.mode = modeBrowse
 		m.pending = nil
-		if m.typed != r.Slug {
+		if m.typed != it.name() {
 			m.flash = "name did not match — nothing destroyed"
 			m.typed = ""
 			return m, nil
 		}
 		m.typed = ""
-		if !m.rowStillPresent(*r) {
-			m.flash = "destroy cancelled — stack changed"
+		if !m.itemStillPresent(*it) {
+			m.flash = "destroy canceled — the row changed"
 			return m, nil
 		}
 		m.busy = true
-		dir, slug := r.Dir, r.Slug
+		dir, name := it.dir(), it.name()
 		return m, func() tea.Msg {
-			return actionDoneMsg{verb: "destroy", slug: slug, err: m.actions.Destroy(m.ctx, dir)}
+			return actionDoneMsg{verb: "destroy", slug: name, err: m.actions.Destroy(m.ctx, dir)}
 		}
 	default:
 		if msg.Type == tea.KeyRunes {
@@ -273,92 +396,207 @@ func (m model) updateConfirmDestroy(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// rowStillPresent reports whether the frozen confirmation row is still in the
-// freshly-read row set — a refresh tick may have removed it while the prompt
-// was open, in which case the destructive action must not fire.
-func (m model) rowStillPresent(r Row) bool {
-	for _, x := range m.rows {
-		if x.Slug == r.Slug && x.Dir == r.Dir {
+// itemStillPresent reports whether the frozen confirmation row is still in the
+// freshly-read view — a refresh tick may have removed it while the prompt was
+// open, in which case the destructive action must not fire.
+func (m model) itemStillPresent(it item) bool {
+	for _, x := range m.items {
+		if x.dir() == it.dir() && x.name() == it.name() && (x.stack != nil) == (it.stack != nil) {
 			return true
 		}
 	}
 	return false
 }
 
-func (m model) selected() (Row, bool) {
-	if m.cursor < 0 || m.cursor >= len(m.rows) {
-		return Row{}, false
+func (m model) selected() (item, bool) {
+	if m.cursor < 0 || m.cursor >= len(m.items) {
+		return item{}, false
 	}
-	return m.rows[m.cursor], true
+	return m.items[m.cursor], true
 }
 
 // --- view --------------------------------------------------------------------
 
 var (
-	accent     = lipgloss.AdaptiveColor{Light: "#ed8926", Dark: "#f59e3f"}
-	styleTitle = lipgloss.NewStyle().Bold(true).Foreground(accent)
-	styleDim   = lipgloss.NewStyle().Faint(true)
-	styleSel   = lipgloss.NewStyle().Foreground(accent).Bold(true)
-	styleLive  = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	styleStale = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	styleWarn  = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Bold(true)
+	accent       = lipgloss.AdaptiveColor{Light: "#ed8926", Dark: "#f59e3f"}
+	styleTitle   = lipgloss.NewStyle().Bold(true).Foreground(accent)
+	styleDim     = lipgloss.NewStyle().Faint(true)
+	styleSel     = lipgloss.NewStyle().Foreground(accent).Bold(true)
+	styleLive    = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	styleStale   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	styleWarn    = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Bold(true)
+	styleSection = lipgloss.NewStyle().Bold(true).Faint(true)
+	styleBarOn   = lipgloss.NewStyle().Foreground(accent)
 )
+
+const hubWidth = 72
 
 func (m model) View() string {
 	var b strings.Builder
+	m.viewHeader(&b)
+	m.viewStacks(&b)
+	m.viewWorktrees(&b)
+	if m.showMonitor {
+		m.viewMonitor(&b)
+	}
+	m.viewFooter(&b)
+	return b.String()
+}
 
+func (m model) viewHeader(b *strings.Builder) {
 	live := 0
-	var totalRSS uint64
-	for _, r := range m.rows {
-		if r.IsLive {
+	for i := range m.view.Stacks {
+		if m.view.Stacks[i].IsLive {
 			live++
 		}
-		totalRSS += r.RSS
 	}
-	summary := fmt.Sprintf("%d stack(s) · %d live", len(m.rows), live)
-	if totalRSS > 0 {
-		summary += " · " + humanBytes(totalRSS)
+	title := " ⌂ haven "
+	right := fmt.Sprintf("%d stack(s) · %d live", len(m.view.Stacks), live)
+	if p := m.view.Summary.Pressure; p != "" && p != "green" {
+		right += " · pressure " + styleWarn.Render(p)
 	}
-	b.WriteString(styleTitle.Render(" ⌂ thuishaven hub "))
-	b.WriteString(styleDim.Render("  " + summary))
-	b.WriteString("\n" + styleDim.Render(" "+strings.Repeat("─", 66)) + "\n\n")
+	pad := max(1, hubWidth-lipgloss.Width(title)-lipgloss.Width(right))
+	b.WriteString(styleTitle.Render(title) + strings.Repeat(" ", pad) + styleDim.Render(right) + "\n")
+	b.WriteString(styleDim.Render(" "+strings.Repeat("─", hubWidth)) + "\n")
 
-	if len(m.rows) == 0 {
-		b.WriteString(styleDim.Render("  no stacks running — run `haven up` in a worktree\n"))
+	s := m.view.Summary
+	if s.TotalRAM > 0 && s.DevRSS() > 0 {
+		bar := memBar(s.DevRSS(), s.TotalRAM, 24)
+		fmt.Fprintf(b, " %s %s  dev work ~%s of %s\n",
+			styleSection.Render("machine"), bar, humanBytes(s.DevRSS()), humanBytes(s.TotalRAM))
+		b.WriteString(styleDim.Render("         "+strings.Join(summaryParts(s), " · ")) + "\n")
 	}
-	for i, r := range m.rows {
-		isSelected := i == m.cursor
-		marker, style := "  ", lipgloss.NewStyle()
-		if isSelected {
-			marker, style = "▸ ", styleSel
-		}
-		dot := styleLive.Render("●")
-		if !r.IsLive {
-			dot = styleStale.Render("○")
-		}
-		facts := fmt.Sprintf("%-28s %d/%d up", truncate(r.Branch, 28), r.ServicesUp, r.ServicesTotal)
-		if r.RSS > 0 {
-			facts += fmt.Sprintf("  %7s", humanBytes(r.RSS))
-		}
-		b.WriteString(fmt.Sprintf("%s%s %s  %s\n", marker, dot, style.Render(fmt.Sprintf("%-20s", truncate(r.Slug, 20))), styleDim.Render(facts)))
+	b.WriteString("\n")
+}
+
+// summaryParts is the machine breakdown: only the buckets that hold anything.
+func summaryParts(s Summary) []string {
+	var parts []string
+	if s.StacksRSS > 0 {
+		parts = append(parts, "stacks ~"+humanBytes(s.StacksRSS))
+	}
+	if servers := sumValues(s.ServerRSS); servers > 0 {
+		parts = append(parts, "servers ~"+humanBytes(servers))
+	}
+	if s.AgentRSS > 0 {
+		parts = append(parts, fmt.Sprintf("agents ~%s (%d)", humanBytes(s.AgentRSS), s.AgentCount))
+	}
+	if s.ToolingRSS > 0 {
+		parts = append(parts, "tooling ~"+humanBytes(s.ToolingRSS))
+	}
+	return parts
+}
+
+func (m model) viewStacks(b *strings.Builder) {
+	b.WriteString(styleSection.Render(" stacks") + "\n")
+	if len(m.view.Stacks) == 0 {
+		b.WriteString(styleDim.Render("   none running — `haven up` in a worktree starts one") + "\n")
+	}
+	for i := range m.view.Stacks {
+		r := &m.view.Stacks[i]
+		isSelected := m.itemSelected(item{stack: r})
+		renderStackRow(b, r, isSelected)
 		// The selected stack unfolds: where it lives, and each service's health +
 		// hostname — the detail you'd otherwise dig out of `haven list`.
 		if isSelected {
-			b.WriteString(styleDim.Render("       "+r.Dir) + "\n")
-			for _, svc := range r.Services {
-				sdot := styleLive.Render("●")
-				if !svc.IsUp {
-					sdot = styleStale.Render("○")
-				}
-				note := svc.URL
-				if svc.IsFallback {
-					note += styleDim.Render("  (baseline)")
-				}
-				b.WriteString(fmt.Sprintf("       %s %-12s %s\n", sdot, svc.Name, styleDim.Render(note)))
-			}
+			renderStackDetail(b, r)
 		}
 	}
+}
 
+func renderStackRow(b *strings.Builder, r *Row, isSelected bool) {
+	marker, style := "  ", lipgloss.NewStyle()
+	if isSelected {
+		marker, style = " ▸", styleSel
+	}
+	dot := styleLive.Render("●")
+	if !r.IsLive {
+		dot = styleStale.Render("○")
+	}
+	facts := fmt.Sprintf("%-26s %d/%d up", truncate(r.Branch, 26), r.ServicesUp, r.ServicesTotal)
+	if r.RSS > 0 {
+		facts += fmt.Sprintf("  %7s", humanBytes(r.RSS))
+	}
+	fmt.Fprintf(b, "%s %s %s  %s\n", marker, dot, style.Render(fmt.Sprintf("%-18s", truncate(r.Slug, 18))), styleDim.Render(facts))
+}
+
+func renderStackDetail(b *strings.Builder, r *Row) {
+	b.WriteString(styleDim.Render("       "+r.Dir) + "\n")
+	for _, svc := range r.Services {
+		sdot := styleLive.Render("●")
+		if !svc.IsUp {
+			sdot = styleStale.Render("○")
+		}
+		note := svc.URL
+		if svc.IsFallback {
+			note += styleDim.Render("  (baseline)")
+		}
+		fmt.Fprintf(b, "       %s %-12s %s\n", sdot, svc.Name, styleDim.Render(note))
+	}
+}
+
+func (m model) viewWorktrees(b *strings.Builder) {
+	if len(m.view.Worktrees) == 0 {
+		return
+	}
+	b.WriteString("\n" + styleSection.Render(" worktrees — nothing running") + "\n")
+	for i := range m.view.Worktrees {
+		w := &m.view.Worktrees[i]
+		isSelected := m.itemSelected(item{wt: w})
+		marker, style := "  ", styleDim
+		if isSelected {
+			marker, style = " ▸", styleSel
+		}
+		note := truncate(w.Branch, 30)
+		switch {
+		case w.IsPrimary:
+			note += "  (primary — protected)"
+		case w.IsCurrent:
+			note += "  (current — protected)"
+		}
+		fmt.Fprintf(b, "%s ○ %s  %s\n", marker, style.Render(fmt.Sprintf("%-18s", truncate(w.Name(), 18))), styleDim.Render(note))
+		if isSelected {
+			b.WriteString(styleDim.Render("       "+w.Dir) + "\n")
+		}
+	}
+}
+
+func (m model) viewMonitor(b *strings.Builder) {
+	b.WriteString("\n" + styleSection.Render(" monitor — the daemon's recent reaping") + "\n")
+	if parts := serverParts(m.view.Summary.ServerRSS); len(parts) > 0 {
+		b.WriteString(styleDim.Render("   shared servers: "+strings.Join(parts, " · ")) + "\n")
+	}
+	if len(m.view.Events) == 0 {
+		b.WriteString(styleDim.Render("   nothing reaped yet") + "\n")
+		return
+	}
+	shown := m.view.Events
+	const maxEvents = 8
+	if len(shown) > maxEvents {
+		shown = shown[:maxEvents]
+	}
+	for _, ev := range shown {
+		age := "now"
+		if !ev.At.IsZero() {
+			age = humanAge(time.Since(ev.At))
+		}
+		fmt.Fprintf(b, "   %s  %-13s %-22s %s\n",
+			styleDim.Render(fmt.Sprintf("%6s", age)), ev.Kind, truncate(ev.Target, 22), styleDim.Render(ev.Reason))
+	}
+}
+
+// serverParts names each shared server that holds memory, in a stable order.
+func serverParts(servers map[string]uint64) []string {
+	var parts []string
+	for _, name := range []string{"clickhouse", "postgres", "redis", "containers"} {
+		if rss := servers[name]; rss > 0 {
+			parts = append(parts, fmt.Sprintf("%s ~%s", name, humanBytes(rss)))
+		}
+	}
+	return parts
+}
+
+func (m model) viewFooter(b *strings.Builder) {
 	b.WriteString("\n")
 	switch {
 	case m.busy && m.isQuitting:
@@ -366,26 +604,71 @@ func (m model) View() string {
 	case m.busy:
 		b.WriteString(styleWarn.Render("  working…") + "\n")
 	case m.mode == modeConfirmDown && m.pending != nil:
-		b.WriteString(styleWarn.Render(fmt.Sprintf("  shut %q down? Its databases are kept. y/n", m.pending.Slug)) + "\n")
+		b.WriteString(styleWarn.Render(fmt.Sprintf("  shut %q down? Its databases are kept. y/n", m.pending.name())) + "\n")
 	case m.mode == modeConfirmDestroy && m.pending != nil:
-		b.WriteString(styleWarn.Render(fmt.Sprintf("  DESTROY %q — stops the stack, drops its databases, deletes the worktree.", m.pending.Slug)) + "\n")
+		b.WriteString(styleWarn.Render(fmt.Sprintf("  DESTROY %q — stops anything running, drops its databases, deletes the worktree.", m.pending.name())) + "\n")
 		b.WriteString(styleWarn.Render(fmt.Sprintf("  type the name to confirm: %s▏", m.typed)) + "\n")
 	case m.flash != "":
 		b.WriteString("  " + m.flash + "\n")
 	default:
-		keys := "  ↑↓ select · enter/g git"
-		if r, ok := m.selected(); ok {
-			if m.actions.OpenURL != nil && r.AppURL != "" {
-				keys += " · o open"
-			}
-			if m.actions.Restart != nil && r.IsLive {
-				keys += " · r restart"
-			}
-		}
-		keys += " · d down · x destroy · q quit"
-		b.WriteString(styleDim.Render(keys) + "\n")
+		b.WriteString(styleDim.Render("  "+strings.Join(m.keyHints(), " · ")) + "\n")
 	}
-	return b.String()
+}
+
+func (m model) keyHints() []string {
+	keys := append([]string{"↑↓ select", "enter git"}, m.stackKeys()...)
+	keys = append(keys, "x destroy")
+	if m.actions.HasCleanup {
+		keys = append(keys, "c cleanup")
+	}
+	if m.actions.OpenURL != nil && m.actions.WebURL != "" {
+		keys = append(keys, "w web")
+	}
+	return append(keys, "m monitor", "q quit")
+}
+
+// stackKeys are the hints that only apply with a stack row selected.
+func (m model) stackKeys() []string {
+	it, ok := m.selected()
+	if !ok || it.stack == nil {
+		return nil
+	}
+	var keys []string
+	if m.actions.OpenURL != nil && it.stack.AppURL != "" {
+		keys = append(keys, "o open")
+	}
+	if m.actions.Restart != nil && it.stack.IsLive {
+		keys = append(keys, "r restart")
+	}
+	return append(keys, "d down")
+}
+
+func (m model) itemSelected(it item) bool {
+	sel, ok := m.selected()
+	if !ok {
+		return false
+	}
+	if it.stack != nil {
+		return sel.stack == it.stack
+	}
+	return sel.wt == it.wt
+}
+
+// memBar renders dev work's share of machine RAM as a fixed-width bar.
+func memBar(used, total uint64, width int) string {
+	if total == 0 {
+		return ""
+	}
+	on := int(min(uint64(width), used*uint64(width)/total))
+	return styleBarOn.Render(strings.Repeat("█", on)) + styleDim.Render(strings.Repeat("░", width-on))
+}
+
+func sumValues(m map[string]uint64) uint64 {
+	var total uint64
+	for _, v := range m {
+		total += v
+	}
+	return total
 }
 
 // truncate bounds a cell to n runes so one long branch name can't shear the
@@ -409,4 +692,18 @@ func humanBytes(b uint64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f%cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+// humanAge is a compact "how long ago" for the monitor panel.
+func humanAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }

--- a/tools/thuishaven/adapters/hubtui/hubtui.go
+++ b/tools/thuishaven/adapters/hubtui/hubtui.go
@@ -61,8 +61,9 @@ func (w WorktreeRow) Name() string {
 // enforces again).
 func (w WorktreeRow) Protected() bool { return w.IsPrimary || w.IsCurrent }
 
-// Summary is the machine header: the RAM picture with every dev-work process
-// attributed once, plus the daemon's pressure reading.
+// Summary is the machine header: the RAM picture with every process attributed
+// once — the dev buckets by name, everything else as Other — plus the daemon's
+// pressure reading.
 type Summary struct {
 	TotalRAM   uint64
 	StacksRSS  uint64
@@ -70,6 +71,7 @@ type Summary struct {
 	AgentRSS   uint64
 	AgentCount int
 	ToolingRSS uint64
+	OtherRSS   uint64 // not dev work — its own color in the chart
 	Pressure   string // the daemon's pressure level ("green" hidden, others shown)
 }
 
@@ -189,6 +191,10 @@ type model struct {
 	outcome     Outcome
 	busy        bool
 	showMonitor bool
+	// wtOverride is the user's explicit worktree-section toggle ("t"); nil means
+	// automatic — visible only while no stacks are running, so the running work
+	// owns the screen and the idle trees stay out of the way.
+	wtOverride *bool
 }
 
 func newModel(ctx context.Context, a Actions) model {
@@ -203,12 +209,21 @@ func (m *model) refresh() {
 	for i := range m.view.Stacks {
 		m.items = append(m.items, item{stack: &m.view.Stacks[i]})
 	}
-	for i := range m.view.Worktrees {
-		m.items = append(m.items, item{wt: &m.view.Worktrees[i]})
+	if m.worktreesVisible() {
+		for i := range m.view.Worktrees {
+			m.items = append(m.items, item{wt: &m.view.Worktrees[i]})
+		}
 	}
 	if m.cursor >= len(m.items) {
 		m.cursor = max(0, len(m.items)-1)
 	}
+}
+
+func (m model) worktreesVisible() bool {
+	if m.wtOverride != nil {
+		return *m.wtOverride
+	}
+	return len(m.view.Stacks) == 0
 }
 
 func (m model) Init() tea.Cmd { return tick() }
@@ -310,6 +325,10 @@ func (m model) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "m":
 		m.showMonitor = !m.showMonitor
+	case "t":
+		visible := !m.worktreesVisible()
+		m.wtOverride = &visible
+		m.refresh()
 	case "x":
 		if it, ok := m.selected(); ok {
 			if it.wt != nil && it.wt.Protected() {
@@ -427,6 +446,9 @@ var (
 	styleWarn    = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Bold(true)
 	styleSection = lipgloss.NewStyle().Bold(true).Faint(true)
 	styleBarOn   = lipgloss.NewStyle().Foreground(accent)
+	// styleBarOther colors the non-dev slice of the RAM bar: a muted violet so
+	// it reads as "occupied, not ours" next to the accent's "ours".
+	styleBarOther = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#7c3aed", Dark: "#a78bfa"})
 )
 
 const hubWidth = 72
@@ -461,9 +483,9 @@ func (m model) viewHeader(b *strings.Builder) {
 
 	s := m.view.Summary
 	if s.TotalRAM > 0 && s.DevRSS() > 0 {
-		bar := memBar(s.DevRSS(), s.TotalRAM, 24)
-		fmt.Fprintf(b, " %s %s  dev work ~%s of %s\n",
-			styleSection.Render("machine"), bar, humanBytes(s.DevRSS()), humanBytes(s.TotalRAM))
+		bar := s.memBar(24)
+		fmt.Fprintf(b, " %s %s  dev ~%s · other ~%s · %s RAM\n",
+			styleSection.Render("machine"), bar, humanBytes(s.DevRSS()), humanBytes(s.OtherRSS), humanBytes(s.TotalRAM))
 		b.WriteString(styleDim.Render("         "+strings.Join(summaryParts(s), " · ")) + "\n")
 	}
 	b.WriteString("\n")
@@ -537,6 +559,10 @@ func renderStackDetail(b *strings.Builder, r *Row) {
 
 func (m model) viewWorktrees(b *strings.Builder) {
 	if len(m.view.Worktrees) == 0 {
+		return
+	}
+	if !m.worktreesVisible() {
+		b.WriteString("\n" + styleDim.Render(fmt.Sprintf(" %d idle worktree(s) hidden — t shows them", len(m.view.Worktrees))) + "\n")
 		return
 	}
 	b.WriteString("\n" + styleSection.Render(" worktrees — nothing running") + "\n")
@@ -618,6 +644,9 @@ func (m model) viewFooter(b *strings.Builder) {
 func (m model) keyHints() []string {
 	keys := append([]string{"↑↓ select", "enter git"}, m.stackKeys()...)
 	keys = append(keys, "x destroy")
+	if len(m.view.Worktrees) > 0 {
+		keys = append(keys, "t worktrees")
+	}
 	if m.actions.HasCleanup {
 		keys = append(keys, "c cleanup")
 	}
@@ -654,13 +683,20 @@ func (m model) itemSelected(it item) bool {
 	return sel.wt == it.wt
 }
 
-// memBar renders dev work's share of machine RAM as a fixed-width bar.
-func memBar(used, total uint64, width int) string {
-	if total == 0 {
+// memBar renders the machine's RAM as a fixed-width bar: dev work in the
+// accent color, everything else in its own color, free space dim. Summed RSS
+// double-counts shared pages, so the segments are clamped to the bar.
+func (s Summary) memBar(width int) string {
+	if s.TotalRAM == 0 {
 		return ""
 	}
-	on := int(min(uint64(width), used*uint64(width)/total))
-	return styleBarOn.Render(strings.Repeat("█", on)) + styleDim.Render(strings.Repeat("░", width-on))
+	w := uint64(width)
+	devW := min(w, s.DevRSS()*w/s.TotalRAM)
+	otherW := min(w-devW, s.OtherRSS*w/s.TotalRAM)
+	free := width - int(devW) - int(otherW)
+	return styleBarOn.Render(strings.Repeat("█", int(devW))) +
+		styleBarOther.Render(strings.Repeat("█", int(otherW))) +
+		styleDim.Render(strings.Repeat("░", free))
 }
 
 func sumValues(m map[string]uint64) uint64 {

--- a/tools/thuishaven/adapters/hubtui/hubtui_test.go
+++ b/tools/thuishaven/adapters/hubtui/hubtui_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -42,11 +43,11 @@ func press(t *testing.T, m model, s string) model {
 
 func testActions(downed, destroyed *[]string) Actions {
 	return Actions{
-		Rows: func() []Row {
-			return []Row{
+		Refresh: func() View {
+			return View{Stacks: []Row{
 				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
 				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-			}
+			}}
 		},
 		Down: func(_ context.Context, slug string) error {
 			*downed = append(*downed, slug)
@@ -59,11 +60,11 @@ func testActions(downed, destroyed *[]string) Actions {
 	}
 }
 
-// mutableActions reads rows through a caller-owned slice pointer so a test can
+// mutableActions reads the view through a caller-owned pointer so a test can
 // reorder or shrink the row set between keypresses, mimicking a refresh tick.
-func mutableActions(rows *[]Row, downed, destroyed *[]string) Actions {
+func mutableActions(view *View, downed, destroyed *[]string) Actions {
 	return Actions{
-		Rows: func() []Row { return *rows },
+		Refresh: func() View { return *view },
 		Down: func(_ context.Context, slug string) error {
 			*downed = append(*downed, slug)
 			return nil
@@ -74,6 +75,8 @@ func mutableActions(rows *[]Row, downed, destroyed *[]string) Actions {
 		},
 	}
 }
+
+func stacksView(rows ...Row) View { return View{Stacks: rows} }
 
 // @scenario "Jumping into a stack's git view from the hub"
 // @scenario "Destruction requires typing the name"
@@ -85,8 +88,8 @@ func TestHubModel(t *testing.T) {
 			m = press(t, m, "j")
 			next, cmd := m.Update(key("enter"))
 			m = next.(model)
-			if m.openDir != "/wt/beta" {
-				t.Errorf("openDir = %q, want /wt/beta", m.openDir)
+			if m.outcome.OpenGitDir != "/wt/beta" {
+				t.Errorf("OpenGitDir = %q, want /wt/beta", m.outcome.OpenGitDir)
 			}
 			if cmd == nil {
 				t.Fatal("enter should quit the hub so the git view can take the terminal")
@@ -158,7 +161,7 @@ func TestHubModel(t *testing.T) {
 	})
 
 	t.Run("given no stacks", func(t *testing.T) {
-		empty := Actions{Rows: func() []Row { return nil }}
+		empty := Actions{Refresh: func() View { return View{} }}
 
 		t.Run("when rendered, it explains how to start one", func(t *testing.T) {
 			m := newModel(context.Background(), empty)
@@ -172,28 +175,169 @@ func TestHubModel(t *testing.T) {
 			for _, k := range []string{"enter", "g", "d", "x", "j", "k"} {
 				m = press(t, m, k)
 			}
-			if m.openDir != "" {
-				t.Errorf("openDir = %q, want empty", m.openDir)
+			if m.outcome.OpenGitDir != "" {
+				t.Errorf("OpenGitDir = %q, want empty", m.outcome.OpenGitDir)
 			}
 		})
 	})
 }
 
+// @scenario "Worktrees without a running stack are listed too"
+func TestHubWorktreeRows(t *testing.T) {
+	view := View{
+		Stacks: []Row{{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true}},
+		Worktrees: []WorktreeRow{
+			{Slug: "", Branch: "main", Dir: "/repo", IsPrimary: true},
+			{Slug: "beta", Branch: "feat/b", Dir: "/wt/beta"},
+		},
+	}
+	var downed, destroyed []string
+
+	t.Run("when rendered, the stackless worktrees appear with their protection", func(t *testing.T) {
+		m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
+		out := m.View()
+		if !strings.Contains(out, "worktrees") || !strings.Contains(out, "beta") {
+			t.Error("stackless worktrees should be listed")
+		}
+		if !strings.Contains(out, "primary — protected") {
+			t.Error("the primary checkout should be marked protected")
+		}
+	})
+
+	t.Run("when x is typed on a stackless worktree, it destroys by directory", func(t *testing.T) {
+		downed, destroyed = nil, nil
+		m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
+		m = press(t, m, "j") // primary (protected)
+		m = press(t, m, "j") // beta
+		m = press(t, m, "x")
+		for _, ch := range "beta" {
+			m = press(t, m, string(ch))
+		}
+		_ = press(t, m, "enter")
+		if len(destroyed) != 1 || destroyed[0] != "/wt/beta" {
+			t.Errorf("destroyed = %v, want [/wt/beta]", destroyed)
+		}
+	})
+
+	t.Run("when x is pressed on a protected worktree, the hub refuses", func(t *testing.T) {
+		downed, destroyed = nil, nil
+		m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
+		m = press(t, m, "j") // primary
+		m = press(t, m, "x")
+		if m.mode != modeBrowse {
+			t.Fatal("a protected worktree must not open the destroy prompt")
+		}
+		if !strings.Contains(m.View(), "protected") {
+			t.Error("the refusal should be explained")
+		}
+		if len(destroyed) != 0 {
+			t.Errorf("destroyed = %v, want none", destroyed)
+		}
+	})
+}
+
+// @scenario "Cleanup is one key away"
+// @scenario "The machine dashboard is one key away"
+// @scenario "The daemon's reaping is visible from the hub"
+func TestHubActionsKeys(t *testing.T) {
+	t.Run("when c is pressed with cleanup wired, the hub quits asking for the cleanup handoff", func(t *testing.T) {
+		a := Actions{Refresh: func() View { return View{} }, HasCleanup: true}
+		m := newModel(context.Background(), a)
+		next, cmd := m.Update(key("c"))
+		m = next.(model)
+		if !m.outcome.RunCleanup {
+			t.Fatal("c should ask the caller to run cleanup")
+		}
+		if cmd == nil {
+			t.Fatal("c should quit the hub so cleanup can take the terminal")
+		}
+	})
+
+	t.Run("when c is pressed without cleanup wired, nothing happens", func(t *testing.T) {
+		m := newModel(context.Background(), Actions{Refresh: func() View { return View{} }})
+		m = press(t, m, "c")
+		if m.outcome.RunCleanup {
+			t.Error("cleanup must stay hidden when not wired")
+		}
+	})
+
+	t.Run("when w is pressed, the machine dashboard opens in the browser", func(t *testing.T) {
+		var opened []string
+		a := Actions{
+			Refresh: func() View { return View{} },
+			OpenURL: func(url string) error { opened = append(opened, url); return nil },
+			WebURL:  "https://langwatch.localhost",
+		}
+		m := newModel(context.Background(), a)
+		_ = press(t, m, "w")
+		if len(opened) != 1 || opened[0] != "https://langwatch.localhost" {
+			t.Errorf("opened = %v, want the dashboard", opened)
+		}
+	})
+
+	t.Run("when m is pressed, the monitor panel shows the reaping newest first", func(t *testing.T) {
+		a := Actions{Refresh: func() View {
+			return View{Events: []Event{
+				{At: time.Now().Add(-2 * time.Minute), Kind: "testcontainer", Target: "tc-ryuk", Reason: "leaked by an interrupted test run"},
+				{At: time.Now().Add(-3 * time.Hour), Kind: "stack", Target: "old", Reason: "launcher died"},
+			}}
+		}}
+		m := newModel(context.Background(), a)
+		if strings.Contains(m.View(), "tc-ryuk") {
+			t.Fatal("the monitor panel should start hidden")
+		}
+		m = press(t, m, "m")
+		out := m.View()
+		if !strings.Contains(out, "tc-ryuk") || !strings.Contains(out, "leaked by an interrupted test run") {
+			t.Error("the monitor panel should show what was reaped and why")
+		}
+		if strings.Index(out, "tc-ryuk") > strings.Index(out, "launcher died") {
+			t.Error("events should render newest first")
+		}
+		m = press(t, m, "m")
+		if strings.Contains(m.View(), "tc-ryuk") {
+			t.Error("m again should hide the panel")
+		}
+	})
+}
+
+// @scenario "The hub shows the machine's whole memory picture"
+func TestHubHeaderShowsTheMachine(t *testing.T) {
+	a := Actions{Refresh: func() View {
+		return View{Summary: Summary{
+			TotalRAM:   16 << 30,
+			StacksRSS:  3 << 30,
+			ServerRSS:  map[string]uint64{"redis": 1 << 30, "clickhouse": 2 << 30},
+			AgentRSS:   4 << 30,
+			AgentCount: 2,
+			ToolingRSS: 1 << 30,
+			Pressure:   "amber",
+		}}
+	}}
+	m := newModel(context.Background(), a)
+	out := m.View()
+	for _, want := range []string{"stacks ~3.0GB", "servers ~3.0GB", "agents ~4.0GB (2)", "tooling ~1.0GB", "amber"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("header should contain %q\n%s", want, out)
+		}
+	}
+}
+
 func TestHubConfirmationFreezesSelectedRow(t *testing.T) {
 	t.Run("given a down prompt open for the top stack", func(t *testing.T) {
 		t.Run("when a refresh reorders the rows before y is pressed, the originally-selected stack is downed", func(t *testing.T) {
-			rows := []Row{
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-			}
+			view := stacksView(
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+			)
 			var downed, destroyed []string
-			m := newModel(context.Background(), mutableActions(&rows, &downed, &destroyed))
+			m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
 			m = press(t, m, "d") // confirm-down for alpha (cursor 0)
 			// a refresh reorders rows so the cursor now points at beta
-			rows = []Row{
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-			}
+			view = stacksView(
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+			)
 			next, _ := m.Update(tickMsg{})
 			m = next.(model)
 			m = press(t, m, "y")
@@ -203,14 +347,14 @@ func TestHubConfirmationFreezesSelectedRow(t *testing.T) {
 		})
 
 		t.Run("when the selected stack disappears before y is pressed, nothing is downed", func(t *testing.T) {
-			rows := []Row{
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-			}
+			view := stacksView(
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+			)
 			var downed, destroyed []string
-			m := newModel(context.Background(), mutableActions(&rows, &downed, &destroyed))
+			m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
 			m = press(t, m, "d")
-			rows = []Row{{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"}}
+			view = stacksView(Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"})
 			next, _ := m.Update(tickMsg{})
 			m = next.(model)
 			m = press(t, m, "y")
@@ -225,18 +369,18 @@ func TestHubConfirmationFreezesSelectedRow(t *testing.T) {
 
 	t.Run("given a destroy prompt open for the top stack", func(t *testing.T) {
 		t.Run("when a refresh reorders the rows before the name is confirmed, the originally-selected worktree is destroyed", func(t *testing.T) {
-			rows := []Row{
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-			}
+			view := stacksView(
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+			)
 			var downed, destroyed []string
-			m := newModel(context.Background(), mutableActions(&rows, &downed, &destroyed))
+			m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
 			m = press(t, m, "x") // confirm-destroy for alpha (cursor 0)
 			// a refresh reorders rows so the cursor now points at beta
-			rows = []Row{
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-			}
+			view = stacksView(
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+			)
 			next, _ := m.Update(tickMsg{})
 			m = next.(model)
 			for _, ch := range "alpha" { // the name shown when the prompt opened
@@ -256,12 +400,12 @@ func TestHubBusyGate(t *testing.T) {
 		// command, so the action stays in flight and busy remains set.
 		setup := func(t *testing.T) (model, *[]string) {
 			t.Helper()
-			rows := []Row{
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-			}
+			view := stacksView(
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+			)
 			var downed, destroyed []string
-			m := newModel(context.Background(), mutableActions(&rows, &downed, &destroyed))
+			m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
 			m = press(t, m, "d")
 			next, cmd := m.Update(key("y"))
 			m = next.(model)
@@ -336,21 +480,21 @@ func TestHubBusyGate(t *testing.T) {
 func TestHubTickRefresh(t *testing.T) {
 	t.Run("given the cursor is on the last of two stacks", func(t *testing.T) {
 		t.Run("when a refresh tick drops a stack, the cursor clamps and View does not panic", func(t *testing.T) {
-			rows := []Row{
-				{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
-				{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
-			}
+			view := stacksView(
+				Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true},
+				Row{Slug: "beta", Dir: "/wt/beta", Branch: "feat/b"},
+			)
 			var downed, destroyed []string
-			m := newModel(context.Background(), mutableActions(&rows, &downed, &destroyed))
+			m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
 			m = press(t, m, "j") // cursor -> 1 (beta, last row)
 			if m.cursor != 1 {
 				t.Fatalf("cursor = %d, want 1", m.cursor)
 			}
-			rows = []Row{{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true}}
+			view = stacksView(Row{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true})
 			next, _ := m.Update(tickMsg{})
 			m = next.(model)
-			if len(m.rows) != 1 {
-				t.Errorf("rows = %d, want 1 after refresh", len(m.rows))
+			if len(m.view.Stacks) != 1 {
+				t.Errorf("stacks = %d, want 1 after refresh", len(m.view.Stacks))
 			}
 			if m.cursor != 0 {
 				t.Errorf("cursor = %d, want clamped to 0", m.cursor)

--- a/tools/thuishaven/adapters/hubtui/hubtui_test.go
+++ b/tools/thuishaven/adapters/hubtui/hubtui_test.go
@@ -183,6 +183,7 @@ func TestHubModel(t *testing.T) {
 }
 
 // @scenario "Worktrees without a running stack are listed too"
+// @scenario "Idle worktrees stay out of the way while stacks run"
 func TestHubWorktreeRows(t *testing.T) {
 	view := View{
 		Stacks: []Row{{Slug: "alpha", Dir: "/wt/alpha", Branch: "feat/a", IsLive: true}},
@@ -193,20 +194,34 @@ func TestHubWorktreeRows(t *testing.T) {
 	}
 	var downed, destroyed []string
 
-	t.Run("when rendered, the stackless worktrees appear with their protection", func(t *testing.T) {
+	t.Run("when stacks are running, the worktrees stay hidden until t", func(t *testing.T) {
 		m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
 		out := m.View()
-		if !strings.Contains(out, "worktrees") || !strings.Contains(out, "beta") {
-			t.Error("stackless worktrees should be listed")
+		if strings.Contains(out, "feat/b") {
+			t.Fatal("idle worktrees should stay out of the way while stacks run")
 		}
-		if !strings.Contains(out, "primary — protected") {
-			t.Error("the primary checkout should be marked protected")
+		if !strings.Contains(out, "hidden") {
+			t.Error("the hub should say the worktrees are hidden and how to show them")
+		}
+		m = press(t, m, "t")
+		out = m.View()
+		if !strings.Contains(out, "beta") || !strings.Contains(out, "primary — protected") {
+			t.Error("t should reveal the worktrees with their protection")
+		}
+	})
+
+	t.Run("when no stacks run, the worktrees show by default", func(t *testing.T) {
+		stackless := View{Worktrees: view.Worktrees}
+		m := newModel(context.Background(), mutableActions(&stackless, &downed, &destroyed))
+		if !strings.Contains(m.View(), "beta") {
+			t.Error("with nothing running, the worktrees are the content")
 		}
 	})
 
 	t.Run("when x is typed on a stackless worktree, it destroys by directory", func(t *testing.T) {
 		downed, destroyed = nil, nil
 		m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
+		m = press(t, m, "t") // reveal worktrees
 		m = press(t, m, "j") // primary (protected)
 		m = press(t, m, "j") // beta
 		m = press(t, m, "x")
@@ -222,6 +237,7 @@ func TestHubWorktreeRows(t *testing.T) {
 	t.Run("when x is pressed on a protected worktree, the hub refuses", func(t *testing.T) {
 		downed, destroyed = nil, nil
 		m := newModel(context.Background(), mutableActions(&view, &downed, &destroyed))
+		m = press(t, m, "t")
 		m = press(t, m, "j") // primary
 		m = press(t, m, "x")
 		if m.mode != modeBrowse {
@@ -302,6 +318,7 @@ func TestHubActionsKeys(t *testing.T) {
 }
 
 // @scenario "The hub shows the machine's whole memory picture"
+// @scenario "What is not dev work still shows on the chart"
 func TestHubHeaderShowsTheMachine(t *testing.T) {
 	a := Actions{Refresh: func() View {
 		return View{Summary: Summary{
@@ -311,15 +328,21 @@ func TestHubHeaderShowsTheMachine(t *testing.T) {
 			AgentRSS:   4 << 30,
 			AgentCount: 2,
 			ToolingRSS: 1 << 30,
+			OtherRSS:   5 << 30,
 			Pressure:   "amber",
 		}}
 	}}
 	m := newModel(context.Background(), a)
 	out := m.View()
-	for _, want := range []string{"stacks ~3.0GB", "servers ~3.0GB", "agents ~4.0GB (2)", "tooling ~1.0GB", "amber"} {
+	for _, want := range []string{"stacks ~3.0GB", "servers ~3.0GB", "agents ~4.0GB (2)", "tooling ~1.0GB", "other ~5.0GB", "amber"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("header should contain %q\n%s", want, out)
 		}
+	}
+	// The chart carries both occupied colors: dev (11/16 of the bar's 24
+	// cells = 16) and other (5/16 = 7), against the dim free track.
+	if !strings.Contains(out, strings.Repeat("█", 16)) {
+		t.Error("the dev slice should fill its share of the bar")
 	}
 }
 

--- a/tools/thuishaven/adapters/system/system.go
+++ b/tools/thuishaven/adapters/system/system.go
@@ -335,31 +335,33 @@ const psCommandColumns = 2
 // needs (ADR-095). A row whose numbers do not parse is dropped: the governor
 // makes kill decisions from these samples, so it never guesses.
 func (System) ProcessSamples() []app.ProcessSample {
-	out, err := probe("ps", "-ax", "-o", "pid=,pgid=,rss=,cputime=,etime=,command=")
+	out, err := probe("ps", "-ax", "-o", "pid=,ppid=,pgid=,rss=,cputime=,etime=,command=")
 	if err != nil {
 		return nil
 	}
 	var samples []app.ProcessSample
 	for line := range strings.SplitSeq(string(out), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 6 {
+		if len(fields) < 7 {
 			continue
 		}
 		pid, pidErr := strconv.Atoi(fields[0])
-		pgid, pgidErr := strconv.Atoi(fields[1])
-		rssKB, rssErr := strconv.ParseInt(fields[2], 10, 64)
-		cpu, cpuOK := domain.ParsePSDuration(fields[3])
-		elapsed, elapsedOK := domain.ParsePSDuration(fields[4])
-		if pidErr != nil || pgidErr != nil || rssErr != nil || !cpuOK || !elapsedOK {
+		ppid, ppidErr := strconv.Atoi(fields[1])
+		pgid, pgidErr := strconv.Atoi(fields[2])
+		rssKB, rssErr := strconv.ParseInt(fields[3], 10, 64)
+		cpu, cpuOK := domain.ParsePSDuration(fields[4])
+		elapsed, elapsedOK := domain.ParsePSDuration(fields[5])
+		if pidErr != nil || ppidErr != nil || pgidErr != nil || rssErr != nil || !cpuOK || !elapsedOK {
 			continue
 		}
 		samples = append(samples, app.ProcessSample{
 			PID:      pid,
+			PPID:     ppid,
 			PGID:     pgid,
 			RSSBytes: rssKB << 10,
 			CPUTime:  cpu,
 			Elapsed:  elapsed,
-			Command:  strings.Join(fields[5:], " "),
+			Command:  strings.Join(fields[6:], " "),
 		})
 	}
 	return samples

--- a/tools/thuishaven/adapters/system/system.go
+++ b/tools/thuishaven/adapters/system/system.go
@@ -335,29 +335,31 @@ const psCommandColumns = 2
 // needs (ADR-095). A row whose numbers do not parse is dropped: the governor
 // makes kill decisions from these samples, so it never guesses.
 func (System) ProcessSamples() []app.ProcessSample {
-	out, err := probe("ps", "-ax", "-o", "pid=,rss=,cputime=,etime=,command=")
+	out, err := probe("ps", "-ax", "-o", "pid=,pgid=,rss=,cputime=,etime=,command=")
 	if err != nil {
 		return nil
 	}
 	var samples []app.ProcessSample
 	for line := range strings.SplitSeq(string(out), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 5 {
+		if len(fields) < 6 {
 			continue
 		}
 		pid, pidErr := strconv.Atoi(fields[0])
-		rssKB, rssErr := strconv.ParseInt(fields[1], 10, 64)
-		cpu, cpuOK := domain.ParsePSDuration(fields[2])
-		elapsed, elapsedOK := domain.ParsePSDuration(fields[3])
-		if pidErr != nil || rssErr != nil || !cpuOK || !elapsedOK {
+		pgid, pgidErr := strconv.Atoi(fields[1])
+		rssKB, rssErr := strconv.ParseInt(fields[2], 10, 64)
+		cpu, cpuOK := domain.ParsePSDuration(fields[3])
+		elapsed, elapsedOK := domain.ParsePSDuration(fields[4])
+		if pidErr != nil || pgidErr != nil || rssErr != nil || !cpuOK || !elapsedOK {
 			continue
 		}
 		samples = append(samples, app.ProcessSample{
 			PID:      pid,
+			PGID:     pgid,
 			RSSBytes: rssKB << 10,
 			CPUTime:  cpu,
 			Elapsed:  elapsed,
-			Command:  strings.Join(fields[4:], " "),
+			Command:  strings.Join(fields[5:], " "),
 		})
 	}
 	return samples

--- a/tools/thuishaven/app/daemon.go
+++ b/tools/thuishaven/app/daemon.go
@@ -162,6 +162,11 @@ func (o *Orchestrator) monitorLoop(ctx context.Context) {
 					o.proxy.Remove(svc.Name, s.Slug)
 				}
 				o.store.RemoveStack(s.Slug)
+				reason := "launcher died"
+				if stale && !dead {
+					reason = "heartbeat stale past the idle TTL"
+				}
+				o.recordReap("stack", s.Slug, reason)
 				o.log.Info("reaped stack", zap.String("slug", s.Slug), zap.Bool("dead", dead), zap.Bool("stale", stale))
 			}
 			o.governPressure()
@@ -307,7 +312,17 @@ func (o *Orchestrator) sweepOrphanedWorkers() {
 		o.sys.KillGroup(pid)
 	}
 	if len(orphans) > 0 {
+		o.recordReap("orphans", fmt.Sprintf("%d test worker(s)", len(orphans)), "parented to PID 1 by an interrupted run")
 		o.log.Info("reclaimed orphaned test workers", zap.Int("count", len(orphans)))
+	}
+}
+
+// recordReap appends one reclamation to the store's bounded record — the hub's
+// "what has the reaper been doing" feed. Losing an event never stops a reap.
+func (o *Orchestrator) recordReap(kind, target, reason string) {
+	ev := domain.ReapEvent{At: o.sys.Now(), Kind: kind, Target: target, Reason: reason}
+	if err := o.store.AppendReapEvent(ev); err != nil {
+		o.log.Warn("could not record reap event", zap.String("kind", kind), zap.Error(err))
 	}
 }
 
@@ -387,6 +402,7 @@ func (o *Orchestrator) pruneIdleDatabases(ctx context.Context) {
 		}
 		o.store.RemoveDBActivity(slug)
 		if existsSomewhere {
+			o.recordReap("database", db, "worktree idle past the database TTL")
 			o.log.Info("pruned idle databases", zap.String("slug", slug), zap.String("db", db), zap.Duration("idle", now.Sub(lastSeen)))
 		}
 	}
@@ -414,6 +430,9 @@ func (o *Orchestrator) reapTestContainers(ctx context.Context) {
 		return
 	}
 	if len(names) > 0 {
+		for _, name := range names {
+			o.recordReap("testcontainer", name, "left behind by an interrupted test run")
+		}
 		o.log.Info("reaped leaked test containers", zap.Strings("containers", names))
 	}
 }
@@ -427,6 +446,7 @@ func (o *Orchestrator) reapClickHouse() {
 	}
 	if len(o.store.Stacks()) == 0 && o.ch.Running() {
 		o.ch.Stop()
+		o.recordReap("clickhouse", "clickhouse-server", "no stacks running")
 		o.log.Info("stopped idle managed clickhouse-server (no stacks running)")
 	}
 }

--- a/tools/thuishaven/app/daemon.go
+++ b/tools/thuishaven/app/daemon.go
@@ -326,16 +326,17 @@ func (o *Orchestrator) recordReap(kind, target, reason string) {
 	}
 }
 
-// fattestStack names the live stack with the largest process-group footprint.
-// Approximate by construction — GroupRSS double-counts shared pages — which is
-// fine for "which one should I look at first" and is why it is never a control
-// input.
+// fattestStack names the live stack with the largest whole-tree footprint.
+// Approximate by construction — summed RSS double-counts shared pages — which
+// is fine for "which one should I look at first" and is why it is never a
+// control input.
 func (o *Orchestrator) fattestStack() (slug string, rss uint64) {
+	stackRSS := o.StackRSSByLauncher()
 	for _, s := range o.store.Stacks() {
 		if !o.sys.ProcessAlive(s.LauncherPID) {
 			continue
 		}
-		if got := o.sys.GroupRSS(s.LauncherPID); got > rss {
+		if got := stackRSS[s.LauncherPID]; got > rss {
 			slug, rss = s.Slug, got
 		}
 	}

--- a/tools/thuishaven/app/daemon_procwatch_test.go
+++ b/tools/thuishaven/app/daemon_procwatch_test.go
@@ -27,6 +27,7 @@ func watchOrch(sys *fakeSystem, tel ProcTelemetry) *Orchestrator {
 		cfg:     Config{Tsgo: domain.DefaultTsgoLimits(18 << 30)},
 		sys:     sys,
 		procTel: tel,
+		store:   &fakeStore{},
 		log:     zap.NewNop(),
 	}
 }

--- a/tools/thuishaven/app/daemon_reaper_test.go
+++ b/tools/thuishaven/app/daemon_reaper_test.go
@@ -27,6 +27,7 @@ func reaperOrch(janitor ContainerJanitor, ttl, runningTTL time.Duration, now tim
 		cfg:     Config{TestContainerTTL: ttl, RunningTestContainerTTL: runningTTL},
 		sys:     &fakeSystem{now: now},
 		janitor: janitor,
+		store:   &fakeStore{},
 		log:     zap.NewNop(),
 	}
 }
@@ -50,6 +51,16 @@ func TestDaemonSweepsWithTheConfiguredGracePeriod(t *testing.T) {
 				}
 				if got, want := janitor.runningCutoffs[0], now.Add(-4*time.Hour); !got.Equal(want) {
 					t.Fatalf("running cutoff = %v, want %v", got, want)
+				}
+			})
+
+			t.Run("the reap lands in the record the hub reads", func(t *testing.T) {
+				events := o.store.ReapEvents()
+				if len(events) != 1 {
+					t.Fatalf("expected one recorded reap, got %d", len(events))
+				}
+				if events[0].Kind != "testcontainer" || events[0].Target != "lucid_goodall" {
+					t.Errorf("recorded event should name what was reaped, got %+v", events[0])
 				}
 			})
 		})

--- a/tools/thuishaven/app/daemon_tsgo.go
+++ b/tools/thuishaven/app/daemon_tsgo.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -42,6 +43,7 @@ func (o *Orchestrator) governProcesses() {
 		if o.procTel != nil {
 			o.procTel.RecordKill("tsgo", k.Reason)
 		}
+		o.recordReap("tsgo", fmt.Sprintf("pid %d (%s, %s)", k.PID, k.Class, domain.HumanBytes(k.RSS)), k.Reason)
 		o.log.Warn("process governor reclaimed tsgo",
 			zap.Int("pid", k.PID),
 			zap.String("role", string(k.Class)),

--- a/tools/thuishaven/app/hub.go
+++ b/tools/thuishaven/app/hub.go
@@ -232,24 +232,152 @@ type HubStack struct {
 	ServiceUp map[string]bool
 }
 
-// HubStacks assembles the hub rows from the registry + live probes.
-func (o *Orchestrator) HubStacks() []HubStack {
-	var rows []HubStack
-	for _, st := range o.store.Stacks() {
-		row := HubStack{Stack: st, IsLive: o.sys.ProcessAlive(st.LauncherPID), ServiceUp: map[string]bool{}}
-		if row.IsLive {
-			row.RSS = o.sys.GroupRSS(st.LauncherPID)
-		}
-		for _, svc := range st.Services {
-			up := svc.Port != 0 && o.sys.PortInUse(svc.Port)
-			row.ServiceUp[svc.Name] = up
-			if up {
-				row.PortsUp++
-			}
-		}
-		rows = append(rows, row)
+// HubWorktree is a worktree with no registered stack — visible in the hub so
+// "what is on this machine" includes the trees nothing is running from.
+type HubWorktree struct {
+	Dir, Branch, Slug    string
+	IsPrimary, IsCurrent bool
+}
+
+// HubFootprint is the machine's memory picture as the hub header shows it:
+// every dev-work process attributed once (domain.PartitionFootprint), plus the
+// machine total and the daemon's pressure reading for context.
+type HubFootprint struct {
+	TotalRAM   uint64
+	StacksRSS  uint64
+	ServerRSS  map[string]uint64 // clickhouse | postgres | redis | containers
+	AgentRSS   uint64
+	AgentCount int
+	ToolingRSS uint64
+	Pressure   domain.Pressure
+}
+
+// DevRSS is everything the partitioner attributed to dev work, summed.
+func (f HubFootprint) DevRSS() uint64 {
+	total := f.StacksRSS + f.AgentRSS + f.ToolingRSS
+	for _, rss := range f.ServerRSS {
+		total += rss
 	}
-	return rows
+	return total
+}
+
+// HubView is everything one hub refresh shows: the stacks, the stackless
+// worktrees, the machine footprint, and the daemon's recent reap events
+// (newest first).
+type HubView struct {
+	Stacks    []HubStack
+	Worktrees []HubWorktree
+	Footprint HubFootprint
+	Events    []domain.ReapEvent
+}
+
+// HubView assembles one refresh of the hub from a single process listing plus
+// the registry, the worktree list, and the daemon's records. gitDir is the
+// repository the worktree list comes from and selfDir the worktree haven runs
+// from (its row is marked protected); either may be "" to skip the listing.
+func (o *Orchestrator) HubView(gitDir, selfDir string) HubView {
+	stacks := o.store.Stacks()
+	part := o.partitionMachine(stacks)
+	view := HubView{Footprint: o.hubFootprint(part)}
+	for i := range stacks {
+		view.Stacks = append(view.Stacks, o.hubStackRow(&stacks[i], part))
+	}
+	view.Worktrees = o.hubWorktrees(gitDir, selfDir, stacks)
+	view.Events = newestFirst(o.store.ReapEvents())
+	return view
+}
+
+// partitionMachine attributes one process listing across the live stacks'
+// launcher groups and everything else the footprint names.
+func (o *Orchestrator) partitionMachine(stacks []domain.Stack) domain.Footprint {
+	var launchers []int
+	for i := range stacks {
+		if o.sys.ProcessAlive(stacks[i].LauncherPID) {
+			launchers = append(launchers, stacks[i].LauncherPID)
+		}
+	}
+	samples := o.sys.ProcessSamples()
+	fpSamples := make([]domain.FootprintSample, 0, len(samples))
+	for _, s := range samples {
+		fpSamples = append(fpSamples, domain.FootprintSample{PID: s.PID, PGID: s.PGID, RSS: s.RSSBytes, Command: s.Command})
+	}
+	return domain.PartitionFootprint(fpSamples, launchers)
+}
+
+func (o *Orchestrator) hubStackRow(st *domain.Stack, part domain.Footprint) HubStack {
+	row := HubStack{Stack: *st, IsLive: o.sys.ProcessAlive(st.LauncherPID), ServiceUp: map[string]bool{}}
+	if row.IsLive {
+		row.RSS = uint64(max(part.StackRSS[st.LauncherPID], 0))
+	}
+	for _, svc := range st.Services {
+		up := svc.Port != 0 && o.sys.PortInUse(svc.Port)
+		row.ServiceUp[svc.Name] = up
+		if up {
+			row.PortsUp++
+		}
+	}
+	return row
+}
+
+func (o *Orchestrator) hubFootprint(part domain.Footprint) HubFootprint {
+	f := HubFootprint{
+		TotalRAM:   o.sys.TotalMemory(),
+		StacksRSS:  uint64(max(part.StacksRSS(), 0)),
+		ServerRSS:  map[string]uint64{},
+		AgentRSS:   uint64(max(part.AgentRSS, 0)),
+		AgentCount: part.AgentCount,
+		ToolingRSS: uint64(max(part.ToolingRSS, 0)),
+	}
+	for name, rss := range part.ServerRSS {
+		f.ServerRSS[name] = uint64(max(rss, 0))
+	}
+	rec, ok := o.store.ReadPressure()
+	f.Pressure = domain.ReadPressure(rec, ok, o.sys.Now())
+	return f
+}
+
+// hubWorktrees lists the repository's worktrees that have no registered stack,
+// via the same scan (and the same primary/current protection flags) the prune
+// picker uses. A repo that cannot be listed degrades to no rows, never an error
+// — the hub must open even when git is momentarily unhappy.
+func (o *Orchestrator) hubWorktrees(gitDir, selfDir string, stacks []domain.Stack) []HubWorktree {
+	if gitDir == "" || o.hyg == nil {
+		return nil
+	}
+	rows, err := o.PlanPrune(gitDir, selfDir)
+	if err != nil {
+		return nil
+	}
+	hasStack := map[string]bool{}
+	for i := range stacks {
+		hasStack[canonicalPath(stacks[i].WorktreeDir)] = true
+	}
+	var worktrees []HubWorktree
+	for _, r := range rows {
+		if hasStack[canonicalPath(r.Dir)] {
+			continue
+		}
+		worktrees = append(worktrees, HubWorktree{
+			Dir: r.Dir, Branch: r.Branch, Slug: r.Slug,
+			IsPrimary: r.IsPrimary, IsCurrent: r.IsCurrent,
+		})
+	}
+	return worktrees
+}
+
+// DashboardURL is the machine's cross-worktree web dashboard — what the hub's
+// "w" opens.
+func (o *Orchestrator) DashboardURL() string {
+	scheme, port := o.proxy.Endpoint()
+	return o.cfg.Naming.URL(domain.HubService, "", scheme, port)
+}
+
+func newestFirst(events []domain.ReapEvent) []domain.ReapEvent {
+	out := make([]domain.ReapEvent, 0, len(events))
+	for _, ev := range slices.Backward(events) {
+		out = append(out, ev)
+	}
+	return out
 }
 
 func (o *Orchestrator) stackBySlug(slug string) (domain.Stack, bool) {

--- a/tools/thuishaven/app/hub.go
+++ b/tools/thuishaven/app/hub.go
@@ -3,11 +3,13 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
@@ -111,37 +113,70 @@ func (o *Orchestrator) stopAndDropForDir(ctx context.Context, canonDir string) {
 	o.dropWorktreeDatabases(ctx, dbSlug)
 }
 
-// resolveDestroySlug picks the slug whose databases DestroyWorktree may drop.
-// The registry is authoritative: a stack registered for dir carries the slug
-// haven itself assigned, so it wins over the worktree-local slug cache
-// (.langwatch-slug), which a hostile branch checked out via `haven pr` can forge
-// to name another worktree's slug. The cache is consulted only as a fallback
-// when no stack is registered for dir, and even then a cached slug that collides
-// with a *different* registered worktree's slug is refused. Returns "" when no
-// safe slug can be established (nothing is dropped).
+// resolveDestroySlug picks the slug whose databases DestroyWorktree may drop,
+// logging any slug-cache disagreement — the destroy path is where that
+// tampering signal matters.
 func (o *Orchestrator) resolveDestroySlug(dir string) string {
+	slug, warns := o.slugForDir(dir)
+	for _, w := range warns {
+		o.log.Warn("destroy: "+w.message, w.fields...)
+	}
+	return slug
+}
+
+type slugWarning struct {
+	message string
+	fields  []zap.Field
+}
+
+// slugForDir picks the slug that owns dir's databases, silently. The registry
+// is authoritative: a stack registered for dir carries the slug haven itself
+// assigned, so it wins over the worktree-local slug cache (.langwatch-slug),
+// which a hostile branch checked out via `haven pr` can forge to name another
+// worktree's slug. The cache is consulted only as a fallback when no stack is
+// registered for dir, and even then a cached slug that collides with a
+// *different* registered worktree's slug is refused. Returns "" when no safe
+// slug can be established (nothing is dropped). Read-only surfaces (the hub's
+// worktree list, the prune plan) call this on every refresh, so it returns its
+// warnings instead of logging them — only the destroy path speaks.
+func (o *Orchestrator) slugForDir(dir string) (string, []slugWarning) {
+	if slug, warns, ok := o.registrySlugForDir(dir); ok {
+		return slug, warns
+	}
+	return o.cachedSlugForDir(dir)
+}
+
+// registrySlugForDir answers from the registry (ok=false when no stack is
+// registered for dir), warning when the worktree-local cache disagrees.
+func (o *Orchestrator) registrySlugForDir(dir string) (string, []slugWarning, bool) {
 	for _, st := range o.store.Stacks() {
 		if canonicalPath(st.WorktreeDir) != dir {
 			continue
 		}
+		var warns []slugWarning
 		if cached, ok := o.store.ReadSlugCache(dir); ok && cached != "" && cached != st.Slug {
-			o.log.Warn("destroy: ignoring worktree slug cache that disagrees with the registry",
-				zap.String("dir", dir), zap.String("cached", cached), zap.String("registry", st.Slug))
+			warns = append(warns, slugWarning{"ignoring worktree slug cache that disagrees with the registry",
+				[]zap.Field{zap.String("dir", dir), zap.String("cached", cached), zap.String("registry", st.Slug)}})
 		}
-		return st.Slug
+		return st.Slug, warns, true
 	}
+	return "", nil, false
+}
+
+// cachedSlugForDir is the fallback: the worktree-local cache, refused when the
+// cached slug collides with a different registered worktree's slug.
+func (o *Orchestrator) cachedSlugForDir(dir string) (string, []slugWarning) {
 	cached, ok := o.store.ReadSlugCache(dir)
 	if !ok || cached == "" {
-		return ""
+		return "", nil
 	}
 	for _, st := range o.store.Stacks() {
 		if st.Slug == cached && canonicalPath(st.WorktreeDir) != dir {
-			o.log.Warn("destroy: refusing to drop databases — cached slug belongs to another registered worktree",
-				zap.String("dir", dir), zap.String("cached", cached), zap.String("owner", st.WorktreeDir))
-			return ""
+			return "", []slugWarning{{"refusing to drop databases — cached slug belongs to another registered worktree",
+				[]zap.Field{zap.String("dir", dir), zap.String("cached", cached), zap.String("owner", st.WorktreeDir)}}}
 		}
 	}
-	return cached
+	return cached, nil
 }
 
 // dropWorktreeDatabases drops the ClickHouse + Postgres databases for slug — a
@@ -249,7 +284,10 @@ type HubFootprint struct {
 	AgentRSS   uint64
 	AgentCount int
 	ToolingRSS uint64
-	Pressure   domain.Pressure
+	// OtherRSS is everything alive that is not dev work — shown in its own
+	// color so the chart reflects the whole machine.
+	OtherRSS uint64
+	Pressure domain.Pressure
 }
 
 // DevRSS is everything the partitioner attributed to dev work, summed.
@@ -299,9 +337,23 @@ func (o *Orchestrator) partitionMachine(stacks []domain.Stack) domain.Footprint 
 	samples := o.sys.ProcessSamples()
 	fpSamples := make([]domain.FootprintSample, 0, len(samples))
 	for _, s := range samples {
-		fpSamples = append(fpSamples, domain.FootprintSample{PID: s.PID, PGID: s.PGID, RSS: s.RSSBytes, Command: s.Command})
+		fpSamples = append(fpSamples, domain.FootprintSample{PID: s.PID, PPID: s.PPID, PGID: s.PGID, RSS: s.RSSBytes, Command: s.Command})
 	}
 	return domain.PartitionFootprint(fpSamples, launchers)
+}
+
+// StackRSSByLauncher is each live stack's whole-tree resident set, keyed by
+// launcher pid — the one number every reporting surface (hub, status, session,
+// the daemon's pressure hint) should agree on. Group RSS is wrong for this:
+// supervised children lead their own process groups, so a group sum sees only
+// the launcher itself.
+func (o *Orchestrator) StackRSSByLauncher() map[int]uint64 {
+	part := o.partitionMachine(o.store.Stacks())
+	out := make(map[int]uint64, len(part.StackRSS))
+	for pid, rss := range part.StackRSS {
+		out[pid] = uint64(max(rss, 0))
+	}
+	return out
 }
 
 func (o *Orchestrator) hubStackRow(st *domain.Stack, part domain.Footprint) HubStack {
@@ -327,6 +379,7 @@ func (o *Orchestrator) hubFootprint(part domain.Footprint) HubFootprint {
 		AgentRSS:   uint64(max(part.AgentRSS, 0)),
 		AgentCount: part.AgentCount,
 		ToolingRSS: uint64(max(part.ToolingRSS, 0)),
+		OtherRSS:   uint64(max(part.OtherRSS, 0)),
 	}
 	for name, rss := range part.ServerRSS {
 		f.ServerRSS[name] = uint64(max(rss, 0))
@@ -370,6 +423,21 @@ func (o *Orchestrator) hubWorktrees(gitDir, selfDir string, stacks []domain.Stac
 func (o *Orchestrator) DashboardURL() string {
 	scheme, port := o.proxy.Endpoint()
 	return o.cfg.Naming.URL(domain.HubService, "", scheme, port)
+}
+
+// RedirectLogsToFile sends this orchestrator's logs to a file under the haven
+// home instead of stderr — for commands that own the terminal with a
+// full-screen TUI, where a stray log line scribbles over the interface. If the
+// file cannot be opened the logs are dropped: a corrupted TUI is worse than a
+// lost warning.
+func (o *Orchestrator) RedirectLogsToFile(name string) {
+	f, err := os.OpenFile(filepath.Join(o.cfg.Home, name), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		o.log = zap.NewNop()
+		return
+	}
+	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	o.log = zap.New(zapcore.NewCore(enc, zapcore.AddSync(f), zap.InfoLevel))
 }
 
 func newestFirst(events []domain.ReapEvent) []domain.ReapEvent {

--- a/tools/thuishaven/app/hub_test.go
+++ b/tools/thuishaven/app/hub_test.go
@@ -27,6 +27,7 @@ type fakeStore struct {
 	hasWrittenPressure bool
 	heavyRuns          int
 	observed           map[string]time.Duration
+	reapEvents         []domain.ReapEvent
 }
 
 func (f *fakeStore) SaveStack(domain.Stack) error { return nil }
@@ -108,6 +109,11 @@ func (f *fakeStore) ObserveDuration(key string, took time.Duration) {
 	}
 	f.observed[key] = took
 }
+func (f *fakeStore) AppendReapEvent(ev domain.ReapEvent) error {
+	f.reapEvents = domain.AppendReapEvent(f.reapEvents, ev)
+	return nil
+}
+func (f *fakeStore) ReapEvents() []domain.ReapEvent { return f.reapEvents }
 
 // fakeClaudeSettings records what `haven setup` asked to install.
 type fakeClaudeSettings struct {
@@ -137,10 +143,12 @@ type fakeSystem struct {
 	orphanMarker string
 	procSamples  []ProcessSample
 	killed       []int
+	totalMemory  uint64
+	portsInUse   map[int]bool
 }
 
 func (f *fakeSystem) FreePorts(n int) ([]int, error) { return make([]int, n), nil }
-func (f *fakeSystem) PortInUse(int) bool             { return false }
+func (f *fakeSystem) PortInUse(port int) bool        { return f.portsInUse[port] }
 func (f *fakeSystem) ProcessAlive(pid int) bool      { return f.alive[pid] }
 func (f *fakeSystem) Terminate(pid int) {
 	f.terminated = append(f.terminated, pid)
@@ -161,7 +169,7 @@ func (f *fakeSystem) PIDsOnPort(port int) []int                    { return f.pi
 func (f *fakeSystem) SpawnDetached([]string, string, string) error { return nil }
 func (f *fakeSystem) Now() time.Time                               { return f.now }
 func (f *fakeSystem) Getpid() int                                  { return 1 }
-func (f *fakeSystem) TotalMemory() uint64                          { return 0 }
+func (f *fakeSystem) TotalMemory() uint64                          { return f.totalMemory }
 func (f *fakeSystem) GroupRSS(int) uint64                          { return 0 }
 func (f *fakeSystem) MemStat() domain.MemStat                      { return f.memStat }
 func (f *fakeSystem) DemoteGroup(pid int)                          { f.demoted = append(f.demoted, pid) }
@@ -456,5 +464,83 @@ func TestDestroyWorktree(t *testing.T) {
 				t.Errorf("must not drop another worktree's database, got %v", pg.dropped)
 			}
 		})
+	})
+}
+
+// --- HubView ------------------------------------------------------------------
+
+// @scenario "Worktrees without a running stack are listed too"
+func TestHubViewAssemblesTheWholeMachine(t *testing.T) {
+	const primary = "/repos/langwatch"
+	const stackDir = "/repos/worktrees/alpha"
+	const idleDir = "/repos/worktrees/beta"
+
+	store := &fakeStore{stacks: []domain.Stack{{
+		Slug: "alpha", WorktreeDir: stackDir, LauncherPID: 100,
+		Services: []domain.Service{{Name: "app", Port: 5560, URL: "https://app.alpha.langwatch.localhost"}},
+	}}}
+	store.reapEvents = []domain.ReapEvent{
+		{Kind: "stack", Target: "old", Reason: "launcher died"},
+		{Kind: "testcontainer", Target: "tc-ryuk", Reason: "leaked"},
+	}
+	sys := &fakeSystem{
+		alive:       map[int]bool{100: true},
+		totalMemory: 16 << 30,
+		portsInUse:  map[int]bool{5560: true},
+		procSamples: []ProcessSample{
+			{PID: 100, PGID: 100, RSSBytes: 1 << 30, Command: "node scripts/dev.mjs"},
+			{PID: 101, PGID: 100, RSSBytes: 2 << 30, Command: "node vite dev"},
+			{PID: 200, PGID: 200, RSSBytes: 1 << 30, Command: "redis-server *:6379"},
+			{PID: 300, PGID: 300, RSSBytes: 3 << 30, Command: "claude --continue"},
+		},
+	}
+	hyg := &fakeHygiene{worktrees: []Worktree{
+		{Dir: primary, Branch: "main"},
+		{Dir: stackDir, Branch: "feat/alpha"},
+		{Dir: idleDir, Branch: "feat/beta"},
+	}}
+	o := hubOrchestrator(store, sys, &fakeProxy{}, &fakeDBServer{}, &fakeDBServer{}, hyg)
+
+	view := o.HubView(primary, idleDir)
+
+	t.Run("charges the stack its whole process group and probes its services", func(t *testing.T) {
+		if len(view.Stacks) != 1 {
+			t.Fatalf("expected 1 stack row, got %d", len(view.Stacks))
+		}
+		row := view.Stacks[0]
+		if row.RSS != 3<<30 {
+			t.Errorf("stack RSS should be its whole group (3GiB), got %d", row.RSS)
+		}
+		if row.PortsUp != 1 || !row.ServiceUp["app"] {
+			t.Errorf("the app service's port probe should be up, got %+v", row)
+		}
+	})
+
+	t.Run("lists only the worktrees with no running stack, protection marked", func(t *testing.T) {
+		if len(view.Worktrees) != 2 {
+			t.Fatalf("expected the primary and the idle worktree, got %+v", view.Worktrees)
+		}
+		if view.Worktrees[0].Dir != primary || !view.Worktrees[0].IsPrimary {
+			t.Errorf("the primary checkout must be listed and marked, got %+v", view.Worktrees[0])
+		}
+		if view.Worktrees[1].Dir != idleDir || !view.Worktrees[1].IsCurrent {
+			t.Errorf("the current worktree must be listed and marked, got %+v", view.Worktrees[1])
+		}
+	})
+
+	t.Run("attributes servers and agents beside the stacks", func(t *testing.T) {
+		f := view.Footprint
+		if f.TotalRAM != 16<<30 {
+			t.Errorf("machine total, got %d", f.TotalRAM)
+		}
+		if f.StacksRSS != 3<<30 || f.ServerRSS["redis"] != 1<<30 || f.AgentRSS != 3<<30 || f.AgentCount != 1 {
+			t.Errorf("footprint misattributed: %+v", f)
+		}
+	})
+
+	t.Run("hands the reap events over newest first", func(t *testing.T) {
+		if len(view.Events) != 2 || view.Events[0].Kind != "testcontainer" {
+			t.Errorf("events must be newest first, got %+v", view.Events)
+		}
 	})
 }

--- a/tools/thuishaven/app/hub_test.go
+++ b/tools/thuishaven/app/hub_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
@@ -465,6 +466,39 @@ func TestDestroyWorktree(t *testing.T) {
 			}
 		})
 	})
+}
+
+// @scenario "Refreshing the hub is silent"
+func TestSlugResolutionIsSilentOnReadPaths(t *testing.T) {
+	// The regression this pins: the hub refreshes its worktree list every two
+	// seconds through the prune plan, and the slug resolver used to WARN on a
+	// cache/registry disagreement on every pass — scribbling a log line over
+	// the TUI (and flooding the daemon log) forever. Reads are silent; only the
+	// destroy path, where the signal matters, speaks.
+	const dir = "/repos/worktrees/scenario-child-startup"
+	store := &fakeStore{
+		stacks:    []domain.Stack{{Slug: "pr-6946", WorktreeDir: dir, LauncherPID: 100}},
+		slugCache: map[string]string{dir: "scenario-child-startup"},
+	}
+	sys := &fakeSystem{alive: map[int]bool{100: true}}
+	hyg := &fakeHygiene{worktrees: []Worktree{{Dir: "/repos/langwatch", Branch: "main"}, {Dir: dir, Branch: "pr"}}}
+	core, logs := observer.New(zap.WarnLevel)
+	o := hubOrchestrator(store, sys, &fakeProxy{}, &fakeDBServer{}, &fakeDBServer{}, hyg)
+	o.log = zap.New(core)
+
+	if _, err := o.PlanPrune("/repos/langwatch", "/repos/langwatch"); err != nil {
+		t.Fatalf("PlanPrune: %v", err)
+	}
+	if got := logs.Len(); got != 0 {
+		t.Fatalf("a read-path refresh must log nothing, got %d entries: %v", got, logs.All())
+	}
+
+	if slug := o.resolveDestroySlug(dir); slug != "pr-6946" {
+		t.Fatalf("registry slug must win, got %q", slug)
+	}
+	if logs.Len() != 1 {
+		t.Fatalf("the destroy path must still surface the disagreement, got %d entries", logs.Len())
+	}
 }
 
 // --- HubView ------------------------------------------------------------------

--- a/tools/thuishaven/app/ports.go
+++ b/tools/thuishaven/app/ports.go
@@ -92,6 +92,12 @@ type Store interface {
 	// ObserveDuration records how long a run actually took, so the next one can
 	// be decided on evidence rather than a default.
 	ObserveDuration(command string, took time.Duration)
+	// AppendReapEvent records one daemon reclamation (bounded ring, oldest
+	// dropped) and ReapEvents reads the record newest-last — the hub's "what
+	// has the reaper been doing" feed. Append failures are the daemon's to
+	// log; losing an event must never stop a reap.
+	AppendReapEvent(ev domain.ReapEvent) error
+	ReapEvents() []domain.ReapEvent
 }
 
 // ClaudeSettings writes another tool's configuration, which is why it is not on
@@ -149,6 +155,7 @@ type Child struct {
 // ProcessSample is one live process as the tsgo governor's sampler sees it.
 type ProcessSample struct {
 	PID      int
+	PGID     int // process group, for attributing a process to a stack's launcher group
 	RSSBytes int64
 	CPUTime  time.Duration // total CPU clock, for idle detection across ticks
 	Elapsed  time.Duration // wall-clock age

--- a/tools/thuishaven/app/ports.go
+++ b/tools/thuishaven/app/ports.go
@@ -155,7 +155,8 @@ type Child struct {
 // ProcessSample is one live process as the tsgo governor's sampler sees it.
 type ProcessSample struct {
 	PID      int
-	PGID     int // process group, for attributing a process to a stack's launcher group
+	PPID     int // parent, for attributing a process to a stack launcher's tree
+	PGID     int // process group, the fallback stack-membership signal
 	RSSBytes int64
 	CPUTime  time.Duration // total CPU clock, for idle detection across ticks
 	Elapsed  time.Duration // wall-clock age

--- a/tools/thuishaven/app/prune_scan.go
+++ b/tools/thuishaven/app/prune_scan.go
@@ -98,12 +98,15 @@ func (o *Orchestrator) PlanPrune(repoRoot, selfDir string) ([]PruneRow, error) {
 	rows := make([]PruneRow, 0, len(worktrees))
 	for i, wt := range worktrees {
 		canon := canonicalPath(wt.Dir)
+		// slugForDir expects an already-canonicalised dir (DestroyWorktree
+		// canonicalises before calling it) — pass the same here. Its warnings are
+		// deliberately dropped: this plan re-runs on every hub refresh, and a
+		// slug-cache disagreement only matters when a destroy acts on it.
+		slug, _ := o.slugForDir(canon)
 		rows = append(rows, PruneRow{
 			Dir:    wt.Dir,
 			Branch: wt.Branch,
-			// resolveDestroySlug expects an already-canonicalised dir (DestroyWorktree
-			// canonicalises before calling it) — pass the same here.
-			Slug: o.resolveDestroySlug(canon),
+			Slug:   slug,
 			// worktrees[0] is git's primary checkout: `git worktree list` always emits
 			// it first. The same ordering DestroyWorktree's primary-guard relies on.
 			IsPrimary: i == 0,

--- a/tools/thuishaven/app/report.go
+++ b/tools/thuishaven/app/report.go
@@ -45,7 +45,8 @@ func (o *Orchestrator) Status(asJSON bool, worktreeDir string) error {
 		ok, detail := o.rds.Health(ctx)
 		servers["redis"] = health{OK: ok, Detail: detail}
 	}
-	live, rss := o.stackFootprint()
+	stackRSS := o.StackRSSByLauncher()
+	live, rss := o.stackFootprint(stackRSS)
 	selection, haveSelection := o.store.ReadSelection(worktreeDir)
 	if !haveSelection && worktreeDir != "" {
 		selection = domain.DefaultSelection()
@@ -77,8 +78,8 @@ func (o *Orchestrator) Status(asJSON bool, worktreeDir string) error {
 	for _, s := range stacks {
 		ram := ""
 		if o.sys.ProcessAlive(s.LauncherPID) {
-			if groupRSS := o.sys.GroupRSS(s.LauncherPID); groupRSS > 0 {
-				ram = "  ~" + domain.HumanBytes(int64(groupRSS))
+			if treeRSS := stackRSS[s.LauncherPID]; treeRSS > 0 {
+				ram = "  ~" + domain.HumanBytes(int64(treeRSS))
 			}
 		}
 		fmt.Printf("%-18s %-6s %s  (%s)%s\n", s.Slug, o.liveness(s), s.Branch, s.WorktreeDir, ram)
@@ -119,13 +120,13 @@ func (o *Orchestrator) liveness(s domain.Stack) string {
 	return "stale"
 }
 
-// stackFootprint sums the live stacks' process-group RSS — the "what are my
+// stackFootprint sums the live stacks' whole-tree RSS — the "what are my
 // dev stacks actually costing this machine" number.
-func (o *Orchestrator) stackFootprint() (live int, rss uint64) {
+func (o *Orchestrator) stackFootprint(stackRSS map[int]uint64) (live int, rss uint64) {
 	for _, s := range o.store.Stacks() {
 		if o.sys.ProcessAlive(s.LauncherPID) {
 			live++
-			rss += o.sys.GroupRSS(s.LauncherPID)
+			rss += stackRSS[s.LauncherPID]
 		}
 	}
 	return live, rss

--- a/tools/thuishaven/app/session.go
+++ b/tools/thuishaven/app/session.go
@@ -63,7 +63,7 @@ func (o *Orchestrator) SessionSnapshot(slug string) SessionReport {
 	r.Branch = st.Branch
 	r.Live = o.sys.ProcessAlive(st.LauncherPID)
 	if r.Live {
-		r.RSS = o.sys.GroupRSS(st.LauncherPID)
+		r.RSS = o.StackRSSByLauncher()[st.LauncherPID]
 	}
 
 	// Only the routed children this stack actually runs are bounceable — the

--- a/tools/thuishaven/cmd/clean.go
+++ b/tools/thuishaven/cmd/clean.go
@@ -48,12 +48,23 @@ func runClean(ctx context.Context, d deps, inv invocation) error {
 		return nil
 	}
 	threshold := pruneStaleThreshold(inv)
+	if d.isAgent {
+		rows, err := d.orch.PlanPrune(d.worktree, d.worktree)
+		if err != nil {
+			return err
+		}
+		return printPruneReport(ctx, d, rows, threshold)
+	}
+	return runInteractiveClean(ctx, d, threshold)
+}
+
+// runInteractiveClean is the terminal cleanup flow — the picker plus the
+// always-safe orphan reaping — shared by `haven clean` and the hub's "c"
+// handoff.
+func runInteractiveClean(ctx context.Context, d deps, threshold time.Duration) error {
 	rows, err := d.orch.PlanPrune(d.worktree, d.worktree)
 	if err != nil {
 		return err
-	}
-	if d.isAgent {
-		return printPruneReport(ctx, d, rows, threshold)
 	}
 	if err := prunetui.Run(ctx, d.pruneActions(rows, threshold)); err != nil {
 		return err

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -30,7 +30,7 @@ COMMANDS
 EXAMPLES
     haven up                     # stack up in the background + attached log view
     haven up +langy              # add a service here, now and from now on
-    haven                        # the hub: every stack + actions (git/down/destroy)
+    haven                        # the hub: the whole machine + actions (git/cleanup/down/destroy)
     haven status                 # every stack + shared-server health, one shot
     haven logs nlp -t            # tail one service live
     haven db seed demo           # reseed in place, dropping nothing

--- a/tools/thuishaven/cmd/hub.go
+++ b/tools/thuishaven/cmd/hub.go
@@ -10,25 +10,36 @@ import (
 	"github.com/0xdeafcafe/moron/tui"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/hubtui"
+	"github.com/langwatch/langwatch/tools/thuishaven/app"
 )
 
 // runHub is bare `haven` in a terminal: the interactive hub. Opening a stack's
-// git view quits the hub, runs the moron TUI, and re-enters the hub when it
-// closes — two full-screen programs take turns rather than nesting. Agents get
-// the plain list; a TUI is useless to them.
+// git view — or handing off to the cleanup picker — quits the hub, runs the
+// other full-screen program, and re-enters the hub when it closes: two
+// full-screen programs take turns rather than nesting. Agents get the plain
+// list; a TUI is useless to them.
 func runHub(ctx context.Context, d deps) error {
 	if d.isAgent {
 		return d.orch.Status(false, d.worktree)
 	}
 	for {
-		dir, err := hubtui.Run(ctx, d.hubActions())
-		if err != nil || dir == "" {
+		out, err := hubtui.Run(ctx, d.hubActions())
+		if err != nil {
 			return err
 		}
-		if err := tui.Run(dir); err != nil {
-			// A stale row (e.g. the worktree dir was deleted underneath us)
-			// shouldn't end the session — surface the error and re-enter the hub.
-			fmt.Fprintf(os.Stderr, "haven: git view for %s failed: %v\n", dir, err)
+		switch {
+		case out.RunCleanup:
+			if err := runInteractiveClean(ctx, d, pruneStaleThreshold(invocation{})); err != nil {
+				fmt.Fprintf(os.Stderr, "haven: cleanup failed: %v\n", err)
+			}
+		case out.OpenGitDir != "":
+			if err := tui.Run(out.OpenGitDir); err != nil {
+				// A stale row (e.g. the worktree dir was deleted underneath us)
+				// shouldn't end the session — surface the error and re-enter the hub.
+				fmt.Fprintf(os.Stderr, "haven: git view for %s failed: %v\n", out.OpenGitDir, err)
+			}
+		default:
+			return nil
 		}
 		if ctx.Err() != nil {
 			return nil
@@ -42,32 +53,8 @@ func runHub(ctx context.Context, d deps) error {
 // TUI asks for.
 func (d deps) hubActions() hubtui.Actions {
 	return hubtui.Actions{
-		Rows: func() []hubtui.Row {
-			var rows []hubtui.Row
-			for _, hs := range d.orch.HubStacks() {
-				row := hubtui.Row{
-					Slug:          hs.Stack.Slug,
-					Branch:        hs.Stack.Branch,
-					Dir:           hs.Stack.WorktreeDir,
-					IsLive:        hs.IsLive,
-					RSS:           hs.RSS,
-					ServicesUp:    hs.PortsUp,
-					ServicesTotal: len(hs.Stack.Services),
-				}
-				for _, svc := range hs.Stack.Services {
-					if svc.Name == "app" {
-						row.AppURL = svc.URL
-					}
-					row.Services = append(row.Services, hubtui.ServiceRow{
-						Name: svc.Name, Port: svc.Port, URL: svc.URL,
-						IsUp: hs.ServiceUp[svc.Name], IsFallback: svc.IsFallback,
-					})
-				}
-				rows = append(rows, row)
-			}
-			return rows
-		},
-		Down: d.orch.DownStack,
+		Refresh: func() hubtui.View { return hubView(d.orch.HubView(d.worktree, d.worktree)) },
+		Down:    d.orch.DownStack,
 		Restart: func(ctx context.Context, slug string) error {
 			return d.orch.RestartStack(ctx, slug, "")
 		},
@@ -75,7 +62,57 @@ func (d deps) hubActions() hubtui.Actions {
 		Destroy: func(ctx context.Context, dir string) error {
 			return d.orch.DestroyWorktree(ctx, d.worktree, dir, d.worktree)
 		},
+		WebURL:     d.orch.DashboardURL(),
+		HasCleanup: true,
 	}
+}
+
+// hubView maps the app view onto the TUI's own types — the adapter never
+// imports the app core, so the translation lives here in the composition root.
+func hubView(v app.HubView) hubtui.View {
+	out := hubtui.View{Summary: hubtui.Summary{
+		TotalRAM:   v.Footprint.TotalRAM,
+		StacksRSS:  v.Footprint.StacksRSS,
+		ServerRSS:  v.Footprint.ServerRSS,
+		AgentRSS:   v.Footprint.AgentRSS,
+		AgentCount: v.Footprint.AgentCount,
+		ToolingRSS: v.Footprint.ToolingRSS,
+		Pressure:   v.Footprint.Pressure.String(),
+	}}
+	for i := range v.Stacks {
+		hs := &v.Stacks[i]
+		row := hubtui.Row{
+			Slug:          hs.Stack.Slug,
+			Branch:        hs.Stack.Branch,
+			Dir:           hs.Stack.WorktreeDir,
+			IsLive:        hs.IsLive,
+			RSS:           hs.RSS,
+			ServicesUp:    hs.PortsUp,
+			ServicesTotal: len(hs.Stack.Services),
+		}
+		for _, svc := range hs.Stack.Services {
+			if svc.Name == "app" {
+				row.AppURL = svc.URL
+			}
+			row.Services = append(row.Services, hubtui.ServiceRow{
+				Name: svc.Name, Port: svc.Port, URL: svc.URL,
+				IsUp: hs.ServiceUp[svc.Name], IsFallback: svc.IsFallback,
+			})
+		}
+		out.Stacks = append(out.Stacks, row)
+	}
+	for _, wt := range v.Worktrees {
+		out.Worktrees = append(out.Worktrees, hubtui.WorktreeRow{
+			Slug: wt.Slug, Branch: wt.Branch, Dir: wt.Dir,
+			IsPrimary: wt.IsPrimary, IsCurrent: wt.IsCurrent,
+		})
+	}
+	for _, ev := range v.Events {
+		out.Events = append(out.Events, hubtui.Event{
+			At: ev.At, Kind: ev.Kind, Target: ev.Target, Reason: ev.Reason,
+		})
+	}
+	return out
 }
 
 func openInBrowser(url string) error {

--- a/tools/thuishaven/cmd/hub.go
+++ b/tools/thuishaven/cmd/hub.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/0xdeafcafe/moron/tui"
 
+	"github.com/langwatch/langwatch/tools/thuishaven/adapters/dashboard"
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/hubtui"
 	"github.com/langwatch/langwatch/tools/thuishaven/app"
 )
@@ -22,6 +23,9 @@ func runHub(ctx context.Context, d deps) error {
 	if d.isAgent {
 		return d.orch.Status(false, d.worktree)
 	}
+	// The TUI owns the terminal: a stray zap line would scribble over the
+	// interface, so the orchestrator's logs go to a file for this command.
+	d.orch.RedirectLogsToFile("hub.log")
 	for {
 		out, err := hubtui.Run(ctx, d.hubActions())
 		if err != nil {
@@ -77,6 +81,7 @@ func hubView(v app.HubView) hubtui.View {
 		AgentRSS:   v.Footprint.AgentRSS,
 		AgentCount: v.Footprint.AgentCount,
 		ToolingRSS: v.Footprint.ToolingRSS,
+		OtherRSS:   v.Footprint.OtherRSS,
 		Pressure:   v.Footprint.Pressure.String(),
 	}}
 	for i := range v.Stacks {
@@ -109,6 +114,40 @@ func hubView(v app.HubView) hubtui.View {
 	}
 	for _, ev := range v.Events {
 		out.Events = append(out.Events, hubtui.Event{
+			At: ev.At, Kind: ev.Kind, Target: ev.Target, Reason: ev.Reason,
+		})
+	}
+	return out
+}
+
+// dashboardExtras maps the app view onto the web dashboard's own types — same
+// composition-root translation the TUI gets, for the same reason: the adapter
+// never imports the app core.
+func dashboardExtras(v app.HubView) dashboard.Extras {
+	out := dashboard.Extras{
+		Summary: dashboard.SummaryView{
+			TotalRAM:   v.Footprint.TotalRAM,
+			StacksRSS:  v.Footprint.StacksRSS,
+			ServerRSS:  v.Footprint.ServerRSS,
+			AgentRSS:   v.Footprint.AgentRSS,
+			AgentCount: v.Footprint.AgentCount,
+			ToolingRSS: v.Footprint.ToolingRSS,
+			OtherRSS:   v.Footprint.OtherRSS,
+			Pressure:   v.Footprint.Pressure.String(),
+		},
+		StackRSS: map[int]uint64{},
+	}
+	for i := range v.Stacks {
+		out.StackRSS[v.Stacks[i].Stack.LauncherPID] = v.Stacks[i].RSS
+	}
+	for _, wt := range v.Worktrees {
+		out.Worktrees = append(out.Worktrees, dashboard.WorktreeView{
+			Slug: wt.Slug, Branch: wt.Branch, Dir: wt.Dir,
+			IsPrimary: wt.IsPrimary, IsCurrent: wt.IsCurrent,
+		})
+	}
+	for _, ev := range v.Events {
+		out.Events = append(out.Events, dashboard.EventView{
 			At: ev.At, Kind: ev.Kind, Target: ev.Target, Reason: ev.Reason,
 		})
 	}

--- a/tools/thuishaven/cmd/root.go
+++ b/tools/thuishaven/cmd/root.go
@@ -221,19 +221,23 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 		ShouldDisableGoogleDLP:    shouldDisableGoogleDLP(disableDLP, disableDLPSet),
 	}
 
+	orch := app.New(app.Deps{
+		Cfg: cfg, Proxy: proxy, Store: store, Sup: sup, Sys: sys,
+		CH: ch, PG: pg, RDS: rds, Obs: obs, Hyg: hyg, Sem: sem,
+		Container: rt, Janitor: dockerjanitor.New(rt),
+		ProcTel: procmetrics.New(observabilityEndpoints().OTLPHTTPPort),
+		Claude:  claudesettings.New(), Log: logger,
+	})
 	return deps{
-		orch: app.New(app.Deps{
-			Cfg: cfg, Proxy: proxy, Store: store, Sup: sup, Sys: sys,
-			CH: ch, PG: pg, RDS: rds, Obs: obs, Hyg: hyg, Sem: sem,
-			Container: rt, Janitor: dockerjanitor.New(rt),
-			ProcTel: procmetrics.New(observabilityEndpoints().OTLPHTTPPort),
-			Claude:  claudesettings.New(), Log: logger,
-		}),
-		dash: dashboard.New(store.Stacks, sharedURL, dashboard.Probes{
-			PortInUse:    sys.PortInUse,
-			ProcessAlive: sys.ProcessAlive,
-			GroupRSS:     sys.GroupRSS,
-			TotalMemory:  sys.TotalMemory,
+		orch: orch,
+		dash: dashboard.New(dashboard.Config{
+			Stacks:    store.Stacks,
+			SharedURL: sharedURL,
+			Probes: dashboard.Probes{
+				PortInUse:    sys.PortInUse,
+				ProcessAlive: sys.ProcessAlive,
+			},
+			Extras: func() dashboard.Extras { return dashboardExtras(orch.HubView(worktree, worktree)) },
 		}),
 		params:   app.UpParams{WorktreeDir: worktree, LwDir: lwDir, Branch: gitBranch(worktree), ExplicitSlug: os.Getenv("LANGWATCH_SLUG"), IsBaseline: os.Getenv("HAVEN_BASELINE") == "1", IsLinkedWorktree: gitIsLinkedWorktree(worktree), UntrustedCheckout: os.Getenv("HAVEN_UNTRUSTED_CHECKOUT") == "1"},
 		opts:     optionsFromEnv(worktree),

--- a/tools/thuishaven/domain/footprint.go
+++ b/tools/thuishaven/domain/footprint.go
@@ -1,0 +1,115 @@
+package domain
+
+import "strings"
+
+// FootprintSample is one live process as the memory partitioner needs it: its
+// group (to attribute it to a stack) and its command line (to attribute it to
+// anything else).
+type FootprintSample struct {
+	PID     int
+	PGID    int
+	RSS     int64
+	Command string
+}
+
+// Footprint is the machine's dev-work memory picture, every process attributed
+// exactly once. RSS sums double-count shared pages, so these are honest
+// approximations, not accounting — the point is that the shared database
+// servers, the container VM, the coding agents and the dev tooling appear at
+// all, where the old launcher-group-only number silently omitted them.
+type Footprint struct {
+	// StackRSS is each stack's whole process group, keyed by launcher pid —
+	// haven spawns launchers as group leaders, so the pid is the group id.
+	StackRSS map[int]int64
+	// ServerRSS is the shared machine-wide servers by name: "clickhouse",
+	// "postgres", "redis", and "containers" for the container VM (which is
+	// where managed ClickHouse and the observability stack live when they run
+	// as containers).
+	ServerRSS map[string]int64
+	// Agents are coding-agent processes (claude) outside any stack group.
+	AgentRSS   int64
+	AgentCount int
+	// Tooling is the dev tooling outside any stack group: compilers, checkers,
+	// test workers and the JS runtimes they spawn.
+	ToolingRSS   int64
+	ToolingCount int
+}
+
+// StacksRSS is every stack group summed.
+func (f Footprint) StacksRSS() int64 {
+	var total int64
+	for _, rss := range f.StackRSS {
+		total += rss
+	}
+	return total
+}
+
+// ServersRSS is every shared server summed.
+func (f Footprint) ServersRSS() int64 {
+	var total int64
+	for _, rss := range f.ServerRSS {
+		total += rss
+	}
+	return total
+}
+
+// TotalRSS is everything the partitioner attributed, summed.
+func (f Footprint) TotalRSS() int64 {
+	return f.StacksRSS() + f.ServersRSS() + f.AgentRSS + f.ToolingRSS
+}
+
+// PartitionFootprint attributes every sample to exactly one bucket. Group
+// membership wins: a process inside a stack's group belongs to that stack no
+// matter what its command says, so a stack's node servers are never misfiled
+// as tooling. Everything else is attributed by command — a shared server, a
+// coding agent, dev tooling — or dropped as not dev work.
+func PartitionFootprint(samples []FootprintSample, launcherPIDs []int) Footprint {
+	launchers := make(map[int]bool, len(launcherPIDs))
+	f := Footprint{StackRSS: map[int]int64{}, ServerRSS: map[string]int64{}}
+	for _, pid := range launcherPIDs {
+		launchers[pid] = true
+		f.StackRSS[pid] = 0
+	}
+	for _, s := range samples {
+		if launchers[s.PGID] {
+			f.StackRSS[s.PGID] += s.RSS
+			continue
+		}
+		if server, ok := classifyServer(s.Command); ok {
+			f.ServerRSS[server] += s.RSS
+			continue
+		}
+		w, ok := ClassifyWatchedProcess(s.Command)
+		if !ok {
+			continue
+		}
+		if w.Class == "claude" {
+			f.AgentRSS += s.RSS
+			f.AgentCount++
+			continue
+		}
+		f.ToolingRSS += s.RSS
+		f.ToolingCount++
+	}
+	return f
+}
+
+// classifyServer names the shared machine-wide servers the footprint reports:
+// the database servers however they run (brew, native binary, LaunchAgent) and
+// the container VM as a whole. Postgres helper processes show up as
+// "postgres: checkpointer" on macOS, so the binary base is trimmed of the
+// colon before matching.
+func classifyServer(command string) (string, bool) {
+	base := strings.TrimSuffix(binaryBase(command), ":")
+	switch {
+	case strings.HasPrefix(base, "clickhouse"):
+		return "clickhouse", true
+	case base == "postgres" || base == "postmaster":
+		return "postgres", true
+	case base == "redis-server":
+		return "redis", true
+	case strings.Contains(command, "Virtualization.VirtualMachine") || strings.HasPrefix(base, "qemu-system"):
+		return "containers", true
+	}
+	return "", false
+}

--- a/tools/thuishaven/domain/footprint.go
+++ b/tools/thuishaven/domain/footprint.go
@@ -3,39 +3,47 @@ package domain
 import "strings"
 
 // FootprintSample is one live process as the memory partitioner needs it: its
-// group (to attribute it to a stack) and its command line (to attribute it to
-// anything else).
+// lineage (to attribute it to a stack), and its command line (to attribute it
+// to anything else).
 type FootprintSample struct {
 	PID     int
+	PPID    int
 	PGID    int
 	RSS     int64
 	Command string
 }
 
-// Footprint is the machine's dev-work memory picture, every process attributed
-// exactly once. RSS sums double-count shared pages, so these are honest
-// approximations, not accounting — the point is that the shared database
-// servers, the container VM, the coding agents and the dev tooling appear at
-// all, where the old launcher-group-only number silently omitted them.
+// Footprint is the machine's memory picture, every process attributed exactly
+// once. RSS sums double-count shared pages, so these are honest approximations,
+// not accounting — the point is that the shared database servers, the container
+// VM, the coding agents, the dev tooling and everything else on the machine
+// appear at all, where the old launcher-group-only number silently omitted them.
 type Footprint struct {
-	// StackRSS is each stack's whole process group, keyed by launcher pid —
-	// haven spawns launchers as group leaders, so the pid is the group id.
+	// StackRSS is each stack's whole process TREE, keyed by launcher pid.
+	// Supervised children lead their own process groups on purpose (that is how
+	// one child is bounced without killing its siblings), so group membership
+	// alone sees only the launcher itself — descendants are what a stack costs.
 	StackRSS map[int]int64
 	// ServerRSS is the shared machine-wide servers by name: "clickhouse",
 	// "postgres", "redis", and "containers" for the container VM (which is
 	// where managed ClickHouse and the observability stack live when they run
 	// as containers).
 	ServerRSS map[string]int64
-	// Agents are coding-agent processes (claude) outside any stack group.
+	// Agents are coding-agent processes (claude) outside any stack tree.
 	AgentRSS   int64
 	AgentCount int
-	// Tooling is the dev tooling outside any stack group: compilers, checkers,
+	// Tooling is the dev tooling outside any stack tree: compilers, checkers,
 	// test workers and the JS runtimes they spawn.
 	ToolingRSS   int64
 	ToolingCount int
+	// Other is everything else alive on the machine — browsers, the OS, the
+	// user's non-dev work. Shown in its own color so the RAM chart reflects
+	// the whole machine, not just the dev slice.
+	OtherRSS   int64
+	OtherCount int
 }
 
-// StacksRSS is every stack group summed.
+// StacksRSS is every stack tree summed.
 func (f Footprint) StacksRSS() int64 {
 	var total int64
 	for _, rss := range f.StackRSS {
@@ -53,45 +61,111 @@ func (f Footprint) ServersRSS() int64 {
 	return total
 }
 
-// TotalRSS is everything the partitioner attributed, summed.
-func (f Footprint) TotalRSS() int64 {
+// DevRSS is everything attributed to dev work, summed.
+func (f Footprint) DevRSS() int64 {
 	return f.StacksRSS() + f.ServersRSS() + f.AgentRSS + f.ToolingRSS
 }
 
-// PartitionFootprint attributes every sample to exactly one bucket. Group
-// membership wins: a process inside a stack's group belongs to that stack no
-// matter what its command says, so a stack's node servers are never misfiled
-// as tooling. Everything else is attributed by command — a shared server, a
-// coding agent, dev tooling — or dropped as not dev work.
+// TotalRSS is everything the partitioner saw, summed — dev and other alike.
+func (f Footprint) TotalRSS() int64 {
+	return f.DevRSS() + f.OtherRSS
+}
+
+// PartitionFootprint attributes every sample to exactly one bucket. Shared
+// servers are claimed first — a database server is machine-wide even when a
+// stack's launcher happened to spawn it. Then stack lineage wins: a process
+// descended from (or grouped with) a launcher belongs to that stack no matter
+// what its command says, so a stack's node servers are never misfiled as
+// tooling. What remains is attributed by command — a coding agent, dev
+// tooling — and everything else lands in Other.
 func PartitionFootprint(samples []FootprintSample, launcherPIDs []int) Footprint {
-	launchers := make(map[int]bool, len(launcherPIDs))
 	f := Footprint{StackRSS: map[int]int64{}, ServerRSS: map[string]int64{}}
 	for _, pid := range launcherPIDs {
-		launchers[pid] = true
 		f.StackRSS[pid] = 0
 	}
+	stackOf := stackMembership(samples, launcherPIDs)
 	for _, s := range samples {
-		if launchers[s.PGID] {
-			f.StackRSS[s.PGID] += s.RSS
-			continue
+		switch {
+		case attributeServer(&f, s):
+		case attributeStack(&f, s, stackOf):
+		case attributeDev(&f, s):
+		default:
+			f.OtherRSS += s.RSS
+			f.OtherCount++
 		}
-		if server, ok := classifyServer(s.Command); ok {
-			f.ServerRSS[server] += s.RSS
-			continue
-		}
-		w, ok := ClassifyWatchedProcess(s.Command)
-		if !ok {
-			continue
-		}
-		if w.Class == "claude" {
-			f.AgentRSS += s.RSS
-			f.AgentCount++
-			continue
-		}
+	}
+	return f
+}
+
+func attributeServer(f *Footprint, s FootprintSample) bool {
+	server, ok := classifyServer(s.Command)
+	if ok {
+		f.ServerRSS[server] += s.RSS
+	}
+	return ok
+}
+
+func attributeStack(f *Footprint, s FootprintSample, stackOf map[int]int) bool {
+	root, ok := stackOf[s.PID]
+	if ok {
+		f.StackRSS[root] += s.RSS
+	}
+	return ok
+}
+
+func attributeDev(f *Footprint, s FootprintSample) bool {
+	w, ok := ClassifyWatchedProcess(s.Command)
+	if !ok {
+		return false
+	}
+	if w.Class == "claude" {
+		f.AgentRSS += s.RSS
+		f.AgentCount++
+	} else {
 		f.ToolingRSS += s.RSS
 		f.ToolingCount++
 	}
-	return f
+	return true
+}
+
+// stackMembership maps every pid that belongs to a stack to its launcher pid:
+// the launcher itself, every descendant by parentage, and anything sharing the
+// launcher's process group.
+func stackMembership(samples []FootprintSample, launcherPIDs []int) map[int]int {
+	children := map[int][]int{}
+	for _, s := range samples {
+		children[s.PPID] = append(children[s.PPID], s.PID)
+	}
+	stackOf := map[int]int{}
+	for _, root := range launcherPIDs {
+		claimDescendants(stackOf, children, root)
+	}
+	launchers := map[int]bool{}
+	for _, pid := range launcherPIDs {
+		launchers[pid] = true
+	}
+	for _, s := range samples {
+		if _, seen := stackOf[s.PID]; !seen && launchers[s.PGID] {
+			stackOf[s.PID] = s.PGID
+		}
+	}
+	return stackOf
+}
+
+// claimDescendants walks root's subtree breadth-first, claiming every pid not
+// already claimed (a pid can only have one parent, but pid reuse in one sample
+// could otherwise loop).
+func claimDescendants(stackOf map[int]int, children map[int][]int, root int) {
+	queue := []int{root}
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		if _, seen := stackOf[pid]; seen {
+			continue
+		}
+		stackOf[pid] = root
+		queue = append(queue, children[pid]...)
+	}
 }
 
 // classifyServer names the shared machine-wide servers the footprint reports:

--- a/tools/thuishaven/domain/footprint_test.go
+++ b/tools/thuishaven/domain/footprint_test.go
@@ -1,0 +1,65 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// @scenario "The hub shows the machine's whole memory picture"
+func TestPartitionFootprintAttributesEveryProcessOnce(t *testing.T) {
+	samples := []FootprintSample{
+		// Stack 100: launcher + two supervised services in its group.
+		{PID: 100, PGID: 100, RSS: 50, Command: "node scripts/dev.mjs"},
+		{PID: 101, PGID: 100, RSS: 700, Command: "node vite dev"},
+		{PID: 102, PGID: 100, RSS: 300, Command: "/usr/local/bin/service nlpgo"},
+		// Shared servers, each running its own way.
+		{PID: 200, PGID: 200, RSS: 900, Command: "/opt/clickhouse-macos-aarch64 server --config x.yml"},
+		{PID: 201, PGID: 201, RSS: 400, Command: "/opt/homebrew/bin/postgres -D /opt/homebrew/var/postgresql@16"},
+		{PID: 202, PGID: 201, RSS: 60, Command: "postgres: checkpointer"},
+		{PID: 203, PGID: 203, RSS: 30, Command: "redis-server *:6379"},
+		{PID: 204, PGID: 204, RSS: 2400, Command: "/Library/Frameworks/com.apple.Virtualization.VirtualMachine"},
+		// Agents and tooling outside any stack group.
+		{PID: 300, PGID: 300, RSS: 800, Command: "claude --continue"},
+		{PID: 301, PGID: 301, RSS: 2500, Command: "tsgo --lsp"},
+		{PID: 302, PGID: 302, RSS: 150, Command: "node /x/node_modules/vitest/dist/workers/forks.js"},
+		// Not dev work: never attributed anywhere.
+		{PID: 400, PGID: 400, RSS: 9999, Command: "/System/Library/CoreServices/Finder.app"},
+	}
+
+	f := PartitionFootprint(samples, []int{100})
+
+	assert.Equal(t, int64(1050), f.StackRSS[100])
+	assert.Equal(t, int64(900), f.ServerRSS["clickhouse"])
+	assert.Equal(t, int64(460), f.ServerRSS["postgres"])
+	assert.Equal(t, int64(30), f.ServerRSS["redis"])
+	assert.Equal(t, int64(2400), f.ServerRSS["containers"])
+	assert.Equal(t, int64(800), f.AgentRSS)
+	assert.Equal(t, 1, f.AgentCount)
+	assert.Equal(t, int64(2650), f.ToolingRSS)
+	assert.Equal(t, 2, f.ToolingCount)
+	// Every attributed byte lands in exactly one bucket, and Finder in none.
+	assert.Equal(t, int64(1050+900+460+30+2400+800+2650), f.TotalRSS())
+}
+
+// @scenario "A stack's own processes are never misfiled as tooling"
+func TestPartitionFootprintGroupMembershipWins(t *testing.T) {
+	samples := []FootprintSample{
+		// A claude agent AND a node process inside the stack's group: both are
+		// the stack's own work, even though their commands match other buckets.
+		{PID: 101, PGID: 100, RSS: 500, Command: "node vite dev"},
+		{PID: 102, PGID: 100, RSS: 200, Command: "claude -p something"},
+	}
+
+	f := PartitionFootprint(samples, []int{100})
+
+	assert.Equal(t, int64(700), f.StackRSS[100])
+	assert.Zero(t, f.AgentRSS)
+	assert.Zero(t, f.ToolingRSS)
+}
+
+func TestPartitionFootprintListsEveryLauncherEvenWhenIdle(t *testing.T) {
+	f := PartitionFootprint(nil, []int{100, 200})
+	assert.Len(t, f.StackRSS, 2)
+	assert.Zero(t, f.StacksRSS())
+}

--- a/tools/thuishaven/domain/footprint_test.go
+++ b/tools/thuishaven/domain/footprint_test.go
@@ -9,22 +9,24 @@ import (
 // @scenario "The hub shows the machine's whole memory picture"
 func TestPartitionFootprintAttributesEveryProcessOnce(t *testing.T) {
 	samples := []FootprintSample{
-		// Stack 100: launcher + two supervised services in its group.
-		{PID: 100, PGID: 100, RSS: 50, Command: "node scripts/dev.mjs"},
-		{PID: 101, PGID: 100, RSS: 700, Command: "node vite dev"},
-		{PID: 102, PGID: 100, RSS: 300, Command: "/usr/local/bin/service nlpgo"},
+		// Stack 100: the launcher plus a supervised child tree. Each child leads
+		// its OWN process group (that is how one child is bounced without killing
+		// its siblings), so only parentage ties them to the stack.
+		{PID: 100, PGID: 100, PPID: 1, RSS: 50, Command: "haven up"},
+		{PID: 101, PGID: 101, PPID: 100, RSS: 700, Command: "node vite dev"},
+		{PID: 102, PGID: 101, PPID: 101, RSS: 300, Command: "node /x/tsx watch src/server"},
 		// Shared servers, each running its own way.
-		{PID: 200, PGID: 200, RSS: 900, Command: "/opt/clickhouse-macos-aarch64 server --config x.yml"},
-		{PID: 201, PGID: 201, RSS: 400, Command: "/opt/homebrew/bin/postgres -D /opt/homebrew/var/postgresql@16"},
-		{PID: 202, PGID: 201, RSS: 60, Command: "postgres: checkpointer"},
-		{PID: 203, PGID: 203, RSS: 30, Command: "redis-server *:6379"},
-		{PID: 204, PGID: 204, RSS: 2400, Command: "/Library/Frameworks/com.apple.Virtualization.VirtualMachine"},
-		// Agents and tooling outside any stack group.
-		{PID: 300, PGID: 300, RSS: 800, Command: "claude --continue"},
-		{PID: 301, PGID: 301, RSS: 2500, Command: "tsgo --lsp"},
-		{PID: 302, PGID: 302, RSS: 150, Command: "node /x/node_modules/vitest/dist/workers/forks.js"},
-		// Not dev work: never attributed anywhere.
-		{PID: 400, PGID: 400, RSS: 9999, Command: "/System/Library/CoreServices/Finder.app"},
+		{PID: 200, PGID: 200, PPID: 1, RSS: 900, Command: "/opt/clickhouse-macos-aarch64 server --config x.yml"},
+		{PID: 201, PGID: 201, PPID: 1, RSS: 400, Command: "/opt/homebrew/bin/postgres -D /opt/homebrew/var/postgresql@16"},
+		{PID: 202, PGID: 201, PPID: 201, RSS: 60, Command: "postgres: checkpointer"},
+		{PID: 203, PGID: 203, PPID: 1, RSS: 30, Command: "redis-server *:6379"},
+		{PID: 204, PGID: 204, PPID: 1, RSS: 2400, Command: "/Library/Frameworks/com.apple.Virtualization.VirtualMachine"},
+		// Agents and tooling outside any stack tree.
+		{PID: 300, PGID: 300, PPID: 1, RSS: 800, Command: "claude --continue"},
+		{PID: 301, PGID: 301, PPID: 1, RSS: 2500, Command: "tsgo --lsp"},
+		{PID: 302, PGID: 302, PPID: 1, RSS: 150, Command: "node /x/node_modules/vitest/dist/workers/forks.js"},
+		// Not dev work: the machine's own slice, in its own bucket.
+		{PID: 400, PGID: 400, PPID: 1, RSS: 9999, Command: "/System/Library/CoreServices/Finder.app"},
 	}
 
 	f := PartitionFootprint(samples, []int{100})
@@ -38,24 +40,47 @@ func TestPartitionFootprintAttributesEveryProcessOnce(t *testing.T) {
 	assert.Equal(t, 1, f.AgentCount)
 	assert.Equal(t, int64(2650), f.ToolingRSS)
 	assert.Equal(t, 2, f.ToolingCount)
-	// Every attributed byte lands in exactly one bucket, and Finder in none.
-	assert.Equal(t, int64(1050+900+460+30+2400+800+2650), f.TotalRSS())
+	assert.Equal(t, int64(9999), f.OtherRSS)
+	assert.Equal(t, 1, f.OtherCount)
+	// Every byte lands in exactly one bucket.
+	assert.Equal(t, int64(1050+900+460+30+2400+800+2650), f.DevRSS())
+	assert.Equal(t, f.DevRSS()+9999, f.TotalRSS())
 }
 
-// @scenario "A stack's own processes are never misfiled as tooling"
-func TestPartitionFootprintGroupMembershipWins(t *testing.T) {
+// @scenario "A stack is charged its whole process tree, not just its launcher"
+func TestPartitionFootprintChargesTheWholeTree(t *testing.T) {
+	// The regression this pins: supervised children lead their own process
+	// groups, so a group-based sum saw only the ~20MB launcher and reported a
+	// multi-GB stack as costing nothing.
 	samples := []FootprintSample{
-		// A claude agent AND a node process inside the stack's group: both are
-		// the stack's own work, even though their commands match other buckets.
-		{PID: 101, PGID: 100, RSS: 500, Command: "node vite dev"},
-		{PID: 102, PGID: 100, RSS: 200, Command: "claude -p something"},
+		{PID: 100, PGID: 100, PPID: 1, RSS: 20, Command: "haven up"},
+		{PID: 101, PGID: 101, PPID: 100, RSS: 4000, Command: "node vite dev"},
+		{PID: 102, PGID: 102, PPID: 100, RSS: 1500, Command: "/usr/local/bin/service nlpgo"},
+		{PID: 103, PGID: 101, PPID: 101, RSS: 800, Command: "node worker"},
+		// A claude agent inside the tree is the stack's own work, even though
+		// its command matches the agent bucket.
+		{PID: 104, PGID: 104, PPID: 100, RSS: 200, Command: "claude -p something"},
 	}
 
 	f := PartitionFootprint(samples, []int{100})
 
-	assert.Equal(t, int64(700), f.StackRSS[100])
+	assert.Equal(t, int64(20+4000+1500+800+200), f.StackRSS[100])
 	assert.Zero(t, f.AgentRSS)
 	assert.Zero(t, f.ToolingRSS)
+}
+
+func TestPartitionFootprintServersAreNeverChargedToAStack(t *testing.T) {
+	// haven spawns the native ClickHouse detached from a launcher, so it can sit
+	// inside a stack's tree — but it serves every worktree, so it stays a server.
+	samples := []FootprintSample{
+		{PID: 100, PGID: 100, PPID: 1, RSS: 20, Command: "haven up"},
+		{PID: 105, PGID: 105, PPID: 100, RSS: 3000, Command: "/opt/clickhouse server"},
+	}
+
+	f := PartitionFootprint(samples, []int{100})
+
+	assert.Equal(t, int64(3000), f.ServerRSS["clickhouse"])
+	assert.Equal(t, int64(20), f.StackRSS[100])
 }
 
 func TestPartitionFootprintListsEveryLauncherEvenWhenIdle(t *testing.T) {

--- a/tools/thuishaven/domain/observability.go
+++ b/tools/thuishaven/domain/observability.go
@@ -96,11 +96,14 @@ type ObservabilityLimits struct {
 // at all and the ceiling is what keeps it from competing with the dev stack it
 // exists to observe.
 func DefaultObservabilityLimits(totalRAMBytes uint64, numCPU int) ObservabilityLimits {
-	// A seventh of the machine rather than the old eighth, and half a core more
-	// at the top: with two stacks feeding it the bundle sat pinned at its 2-CPU
-	// cap, which shows up as laggy dashboards exactly when you are debugging.
-	memMB := clampInt(int(totalRAMBytes/(1<<20))/7, 1536, 3072)
-	cpus := clampFloat(float64(numCPU)/4, 1, 2.5)
+	// A sixth of the machine and up to three cores. The previous seventh/2.5
+	// was sized for logs, traces and metrics; Pyroscope now also ingests
+	// continuous CPU and heap profiles from every worktree's app process, and
+	// profile heads plus flame-graph queries are exactly the load that pinned
+	// the old caps — a starved bundle shows up as laggy dashboards at the
+	// moment you are debugging.
+	memMB := clampInt(int(totalRAMBytes/(1<<20))/6, 2048, 4096)
+	cpus := clampFloat(float64(numCPU)/3, 1, 3)
 	return ObservabilityLimits{
 		MemoryMB:        memMB,
 		CPUs:            cpus,

--- a/tools/thuishaven/domain/observability_test.go
+++ b/tools/thuishaven/domain/observability_test.go
@@ -98,10 +98,11 @@ func TestObservabilityEnvPublishesTheGrafanaLink(t *testing.T) {
 func TestDefaultObservabilityLimitsStayWithinTheirBounds(t *testing.T) {
 	gib := uint64(1) << 30
 
-	// A small machine still gets enough to start the six-process bundle at all.
+	// A small machine still gets enough to start the six-process bundle at all
+	// — the floor covers the ~1.5 GiB idle plus profile ingest headroom.
 	small := DefaultObservabilityLimits(4*gib, 2)
-	if small.MemoryMB != 1536 {
-		t.Errorf("4 GiB machine: MemoryMB = %d, want the 1536 floor", small.MemoryMB)
+	if small.MemoryMB != 2048 {
+		t.Errorf("4 GiB machine: MemoryMB = %d, want the 2048 floor", small.MemoryMB)
 	}
 	if small.CPUs != 1 {
 		t.Errorf("2-core machine: CPUs = %v, want the floor of 1", small.CPUs)
@@ -109,21 +110,21 @@ func TestDefaultObservabilityLimitsStayWithinTheirBounds(t *testing.T) {
 
 	// A big one does not get to hand the stack an unbounded slice of it.
 	big := DefaultObservabilityLimits(128*gib, 32)
-	if big.MemoryMB != 3072 {
-		t.Errorf("128 GiB machine: MemoryMB = %d, want the 3072 ceiling", big.MemoryMB)
+	if big.MemoryMB != 4096 {
+		t.Errorf("128 GiB machine: MemoryMB = %d, want the 4096 ceiling", big.MemoryMB)
 	}
-	if big.CPUs != 2.5 {
-		t.Errorf("32-core machine: CPUs = %v, want the ceiling of 2.5", big.CPUs)
+	if big.CPUs != 3 {
+		t.Errorf("32-core machine: CPUs = %v, want the ceiling of 3", big.CPUs)
 	}
 
-	// A seventh of the machine in between, with the CPU divisor between its
+	// A sixth of the machine in between, with the CPU divisor between its
 	// floor and ceiling.
 	mid := DefaultObservabilityLimits(16*gib, 8)
-	if want := 16 * 1024 / 7; mid.MemoryMB != want {
-		t.Errorf("16 GiB machine: MemoryMB = %d, want %d (a seventh)", mid.MemoryMB, want)
+	if want := 16 * 1024 / 6; mid.MemoryMB != want {
+		t.Errorf("16 GiB machine: MemoryMB = %d, want %d (a sixth)", mid.MemoryMB, want)
 	}
-	if mid.CPUs != 2 {
-		t.Errorf("8-core machine: CPUs = %v, want 2 (a quarter)", mid.CPUs)
+	if want := float64(8) / 3; mid.CPUs != want {
+		t.Errorf("8-core machine: CPUs = %v, want %v (a third)", mid.CPUs, want)
 	}
 }
 

--- a/tools/thuishaven/domain/reapevents.go
+++ b/tools/thuishaven/domain/reapevents.go
@@ -1,0 +1,27 @@
+package domain
+
+import "time"
+
+// ReapEvent is one thing the daemon reclaimed: a dead or stale stack, a leaked
+// test container, a governed tsgo process, an orphaned test worker, an idle
+// database. The record exists so the hub can answer "what has the reaper been
+// doing" without grepping the daemon log.
+type ReapEvent struct {
+	At     time.Time `json:"at"`
+	Kind   string    `json:"kind"`   // stack | testcontainer | tsgo | orphans | database | clickhouse
+	Target string    `json:"target"` // slug, container name, "pid 123 (run)", database name
+	Reason string    `json:"reason"`
+}
+
+// ReapEventCap bounds the persisted record: enough to see what the last few
+// days of reaping did, small enough to read and rewrite on every append.
+const ReapEventCap = 100
+
+// AppendReapEvent appends newest-last and drops the oldest past the cap.
+func AppendReapEvent(events []ReapEvent, ev ReapEvent) []ReapEvent {
+	events = append(events, ev)
+	if len(events) > ReapEventCap {
+		events = events[len(events)-ReapEventCap:]
+	}
+	return events
+}


### PR DESCRIPTION
## What

Bare `haven` (and the web dashboard at `langwatch.localhost`) now show the whole machine, accurately, in both the terminal and the browser.

### Accurate RAM: stacks are charged their whole process tree

The old footprint was each stack's launcher process group — and supervised children lead their **own** process groups (that is how one child is bounced without killing its siblings), so the number only ever counted the ~20MB launcher and a multi-GB stack reported as costing nothing. Process samples now carry `ppid`, and `domain.PartitionFootprint` attributes by launcher descent (group membership kept as the fallback): shared servers are claimed first (a database server a launcher spawned still serves every worktree), then stack lineage, then coding agents (claude), dev tooling (tsgo/gopls/biome/vitest/node/bun), and everything else on the machine as its own `Other` bucket. Every reporting surface — hub, `haven status`, session, the daemon's pressure hint — reads the same tree number.

### The hub TUI

- Header renders the machine gauge: dev work and everything-else as separate colours against total RAM, with the per-bucket breakdown and the daemon's pressure level when not green.
- Idle worktrees are listed (same scan and primary/current protection as the prune picker) but stay collapsed behind `t` while stacks run; shown by default when nothing runs. `x` destroys stackless worktrees with the typed-name confirmation; protected rows refuse with an explanation.
- One-key actions: `c` hands the terminal to the interactive cleanup picker and returns (same take-turns pattern as the git view), `w` opens the web dashboard, `m` toggles the monitor panel — shared-server footprints plus the daemon's recent reaping, newest first.
- The daemon records every reclamation (stack reaps, leaked testcontainers, tsgo governor kills, orphaned test workers, idle databases, the idle ClickHouse stop) into a bounded ring (`reap-events.json`, cap 100) in the registry.
- The slug resolver no longer warns on read paths — it used to scribble a log line over the TUI on every 2-second refresh; reads are silent, the destroy path still speaks. The hub's remaining logs go to a file while the TUI owns the terminal.

### The web dashboard

Rebuilt on the LangWatch design language (from the website-concept design system): warm paper + warm ink scale, light canonical and dark inverted from the same tokens, one orange brand accent, moss/amber/rust strictly as meaning, serif statement / sans interface / mono machine output, pill chrome, hairline borders only on true surfaces, paper-grain overlay, and a still page (only the live dots and heartbeat move; `prefers-reduced-motion` collapses those). Iterated against real screenshots in both schemes:

- machine memory bar (dev + other + free) with keyed legend and pressure badge
- stack cards list only their own services — each row is the mono hostname itself (base domain trimmed, full URL on the link) with a status dot and right-aligned port; zero ports render blank instead of `:0`
- the shared servers are stated once with their footprints instead of repeating on every card
- idle worktrees as a compact grid (full path on hover), the reaping feed as a quiet table

## Spec

`specs/setup/haven-hub-actions.feature` gained ten scenarios (whole-machine footprint, tree attribution, non-dev slice, stackless worktrees + collapse, silent refresh, cleanup/dashboard/monitor keys, the recorded reap ring, the web dashboard) — 17/17 bound, verified by `check-feature-parity`.

## Test plan

- `go test -count=1 -race ./tools/thuishaven/...` — green
- `make go-lint-changed` — 0 issues
- `check:feature-parity` — haven-hub-actions 17/17 bound
- Verified live on this machine: hub TUI, `haven status`, and the dashboard screenshotted headless in light and dark

## Deployment Impact

None — developer tooling only (`tools/thuishaven`); nothing ships to production.
