### PR TITLE
fix(simulations): stop runs sitting on "running" until a manual refresh

### DIFF
--- a/platform/app/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
+++ b/platform/app/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
@@ -37,6 +37,8 @@ vi.mock("../usePageVisibility", () => ({
 
 const mockInvalidateBatchHistory = vi.fn();
 const mockInvalidateSuiteRunData = vi.fn();
+const mockInvalidateRunState = vi.fn().mockResolvedValue(undefined);
+const mockSetRunStateData = vi.fn();
 
 vi.mock("../../utils/api", () => ({
   api: {
@@ -47,6 +49,10 @@ vi.mock("../../utils/api", () => ({
         },
         getSuiteRunData: {
           invalidate: mockInvalidateSuiteRunData,
+        },
+        getRunState: {
+          invalidate: mockInvalidateRunState,
+          setData: mockSetRunStateData,
         },
       },
     }),
@@ -64,6 +70,8 @@ function simulateSSEEvent(payload: {
   event: string;
   scenarioSetId?: string;
   batchRunId?: string;
+  scenarioRunId?: string;
+  status?: string;
 }) {
   capturedOnData?.({ event: JSON.stringify(payload) });
 }
@@ -77,6 +85,7 @@ describe("useSimulationUpdateListener()", () => {
     mockIsVisible = true;
     capturedOnData = undefined;
     capturedInput = undefined;
+    mockInvalidateRunState.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -261,7 +270,7 @@ describe("useSimulationUpdateListener()", () => {
         }),
       );
 
-      // Event fires while hidden - scheduleUpdate runs but fireUpdate is suppressed
+      // Event fires while hidden — deferred, not run
       act(() => {
         simulateSSEEvent({ event: "simulation_updated" });
       });
@@ -272,16 +281,19 @@ describe("useSimulationUpdateListener()", () => {
         vi.advanceTimersByTime(600);
       });
 
-      // Tab becomes visible again
+      // Tab becomes visible again, which flushes what was deferred.
       mockIsVisible = true;
-      rerender();
+      act(() => {
+        rerender();
+      });
+      expect(refetchSpy).toHaveBeenCalledTimes(1);
 
-      // The next SSE event fires and refetch runs immediately
+      // And a later event still fires normally on top of that flush.
       act(() => {
         simulateSSEEvent({ event: "simulation_updated" });
       });
 
-      expect(refetchSpy).toHaveBeenCalledTimes(1);
+      expect(refetchSpy).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -528,6 +540,91 @@ describe("useSimulationUpdateListener()", () => {
 
       expect(onNewBatchRun).not.toHaveBeenCalled();
       expect(refetch).not.toHaveBeenCalled();
+    });
+  });
+  describe("when a run finishes", () => {
+    it("stamps the terminal status the event carried, after the refetch settles", async () => {
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch: refetchSpy,
+        }),
+      );
+
+      await act(async () => {
+        simulateSSEEvent({
+          event: "simulation_updated",
+          scenarioRunId: "run_1",
+          status: "SUCCESS",
+        });
+        await vi.runAllTimersAsync();
+      });
+
+      // The refetch alone can read back the pre-terminal row, and finished is
+      // the last event — nothing follows to correct it. The event's own status
+      // is what closes that race.
+      expect(mockInvalidateRunState).toHaveBeenCalledWith({
+        scenarioRunId: "run_1",
+      });
+      expect(mockSetRunStateData).toHaveBeenCalledTimes(1);
+
+      const updater = mockSetRunStateData.mock.calls[0]![1] as (
+        previous: { status: string } | undefined,
+      ) => { status: string } | undefined;
+
+      // Upgrades a stale read...
+      expect(updater({ status: "IN_PROGRESS" })).toEqual({ status: "SUCCESS" });
+      // ...but never downgrades a settled one.
+      expect(updater({ status: "CANCELLED" })).toEqual({ status: "CANCELLED" });
+      expect(updater(undefined)).toBeUndefined();
+    });
+
+    it("does not stamp anything for a non-terminal update", async () => {
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch: refetchSpy,
+        }),
+      );
+
+      await act(async () => {
+        simulateSSEEvent({
+          event: "simulation_updated",
+          scenarioRunId: "run_1",
+          status: "IN_PROGRESS",
+        });
+        await vi.runAllTimersAsync();
+      });
+
+      expect(mockSetRunStateData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an update arrives while the tab is hidden", () => {
+    it("defers it and flushes on return rather than dropping it", () => {
+      mockIsVisible = false;
+      const { rerender } = renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch: refetchSpy,
+        }),
+      );
+
+      act(() => {
+        simulateSSEEvent({ event: "simulation_updated" });
+      });
+
+      // Nothing yet — the tab is hidden.
+      expect(refetchSpy).not.toHaveBeenCalled();
+
+      mockIsVisible = true;
+      act(() => {
+        rerender();
+      });
+
+      // A dropped update is never retried: the broadcast has been and gone,
+      // so without this the run stays "running" until a manual reload.
+      expect(refetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/platform/app/src/hooks/useSimulationUpdateListener.ts
+++ b/platform/app/src/hooks/useSimulationUpdateListener.ts
@@ -5,6 +5,10 @@ import {
   type ScenarioTabNavigatePayload,
 } from "~/server/scenarios/browser-tab/scenario-tab-events";
 import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
+import {
+  isTerminalStatus,
+  type ScenarioRunStatus,
+} from "~/server/scenarios/scenario-event.enums";
 import { api } from "~/utils/api";
 import {
   type CompactStreamingEvent,
@@ -65,6 +69,8 @@ export function useSimulationUpdateListener({
 }: UseSimulationUpdateListenerOptions) {
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastFireRef = useRef<number>(0);
+  /** An update arrived while the tab was hidden; flush it on return. */
+  const missedWhileHiddenRef = useRef(false);
   const isVisible = usePageVisibility();
   const trpcUtils = api.useUtils();
   const knownBatchRunIdsRef = useRef<Set<string>>(new Set());
@@ -91,7 +97,14 @@ export function useSimulationUpdateListener({
   );
 
   const fireUpdate = useCallback(() => {
-    if (!isVisible) return;
+    // Hidden tabs defer rather than drop. A dropped update is never retried —
+    // the broadcast that would have refreshed this run has already been and
+    // gone — so a run that finished while you were on another tab stayed
+    // "running" until the page was reloaded by hand.
+    if (!isVisible) {
+      missedWhileHiddenRef.current = true;
+      return;
+    }
 
     void trpcUtils.scenarios.getScenarioSetBatchHistory.invalidate();
     // Invalidate suite run data queries so RunHistoryPanel refreshes
@@ -104,6 +117,36 @@ export function useSimulationUpdateListener({
       void refetch();
     }
   }, [isVisible, refetch, trpcUtils]);
+
+  /**
+   * Refetch the run, then apply the status the event carried.
+   *
+   * The refetch alone is not enough for a terminal event. The broadcast can
+   * beat the fold commit, so the refetch can read back the pre-terminal row —
+   * and `finished` is the last event, so no later broadcast arrives to correct
+   * it. That is what left cards sitting on "running" until a manual reload.
+   *
+   * The event is authoritative here: it carries the terminal status as
+   * event-carried state, which is exactly why the broadcast includes it. So
+   * the status is stamped AFTER the refetch settles, and only over a
+   * non-terminal cached value, so a settled read is never downgraded.
+   */
+  const applyRunUpdate = useCallback(
+    async (scenarioRunId: string, status: string | undefined) => {
+      await trpcUtils.scenarios.getRunState.invalidate({ scenarioRunId });
+
+      if (!status || !isTerminalStatus(status as ScenarioRunStatus)) return;
+
+      trpcUtils.scenarios.getRunState.setData(
+        { projectId, scenarioRunId },
+        (previous) =>
+          previous && !isTerminalStatus(previous.status)
+            ? { ...previous, status: status as ScenarioRunStatus }
+            : previous,
+      );
+    },
+    [projectId, trpcUtils],
+  );
 
   const scheduleUpdate = useCallback(() => {
     const now = Date.now();
@@ -132,6 +175,14 @@ export function useSimulationUpdateListener({
       }
     };
   }, []);
+
+  // Flush whatever arrived while the tab was hidden. Without this the deferral
+  // above would just be a slower drop.
+  useEffect(() => {
+    if (!isVisible || !missedWhileHiddenRef.current) return;
+    missedWhileHiddenRef.current = false;
+    fireUpdate();
+  }, [isVisible, fireUpdate]);
 
   const subscriptionInput = useMemo(
     () => (tabKey && tabId ? { projectId, tabKey, tabId } : { projectId }),
@@ -189,9 +240,7 @@ export function useSimulationUpdateListener({
             // Selective invalidation: only the affected card refetches,
             // not all N cards like the old blanket invalidation did.
             if (payload.scenarioRunId) {
-              void trpcUtils.scenarios.getRunState.invalidate({
-                scenarioRunId: payload.scenarioRunId,
-              });
+              void applyRunUpdate(payload.scenarioRunId, payload.status);
             }
 
             scheduleUpdate();

--- a/platform/app/src/server/scenarios/scenario-event.enums.ts
+++ b/platform/app/src/server/scenarios/scenario-event.enums.ts
@@ -59,3 +59,23 @@ export const CANCELLABLE_STATUSES = new Set<ScenarioRunStatus>([
 export function isCancellableStatus(status: ScenarioRunStatus): boolean {
   return CANCELLABLE_STATUSES.has(status);
 }
+
+/** Statuses a run cannot move out of. */
+export const TERMINAL_STATUSES = new Set<ScenarioRunStatus>([
+  ScenarioRunStatus.SUCCESS,
+  ScenarioRunStatus.FAILED,
+  ScenarioRunStatus.ERROR,
+  ScenarioRunStatus.CANCELLED,
+  ScenarioRunStatus.STALLED,
+]);
+
+/**
+ * Whether a run has reached a state it will never leave.
+ *
+ * Not the negation of `isCancellableStatus`: RUNNING is neither cancellable
+ * (it has no queued job to drop) nor terminal, so the two sets do not
+ * partition the enum between them.
+ */
+export function isTerminalStatus(status: ScenarioRunStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}


### PR DESCRIPTION
A finished simulation run keeps rendering as **running** until the page is reloaded by hand. Two independent causes, both landing on the same symptom — which is why it looked intermittent.

## 1. The server sends the terminal status; the client never read it

`snapshotUpdateBroadcast` deliberately puts `status` on the broadcast, and its own comment names that as the mitigation for the terminal race:

> `finished` carries `status`, so a client that refetches early still learns the terminal state from the message rather than from what it read back.

In `useSimulationUpdateListener`, `status` existed only as a field on the `SimulationBroadcastPayload` interface. Nothing read it. The handler invalidated and refetched, and that was all.

So the race was live:

```
finished broadcast → invalidate → refetch → fold has not committed yet
→ reads back the pre-terminal row
→ nothing follows, because finished is the last event
→ card stays "running"
```

The status is now applied from the event **after** the refetch settles, and only over a non-terminal cached value — so a stale read gets upgraded and a settled read is never downgraded.

## 2. Updates arriving while the tab was hidden were dropped, not deferred

```ts
const fireUpdate = useCallback(() => {
  if (!isVisible) return;   // dropped
```

`usePageVisibility` was used only in that guard, and nothing re-fired when the tab became visible again. A broadcast that arrived while you were on another tab was gone for good — independent of the race above, and enough on its own to leave a run stuck. It is now deferred and flushed on return.

This is the likelier cause of the "sometimes": it depends on whether you were looking at the tab when the run finished.

## Notes

- `isTerminalStatus` joins `isCancellableStatus` in the enums. They are **not** complements — `RUNNING` is neither cancellable nor terminal, so the two sets do not partition the enum, and the doc comment says so.
- One existing test changed. It asserted that only the *next* event after becoming visible triggers a refetch, which pinned the drop behaviour through an implementation comment ("fireUpdate is suppressed") rather than through its title. It now asserts the flush on return **and** that a later event still fires on top of it.

## Verification

- `useSimulationUpdateListener.unit.test.ts` — 22/22, including new coverage for the terminal stamp (upgrades a stale read, refuses to downgrade a settled one, ignores non-terminal updates) and for defer-and-flush.
- `typecheck` and `typecheck:tests` — 0 errors each, run separately.
- `biome check` over the CI paths — exits 0, same 3568-warning baseline as main, and no delta on the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulation update handling when the browser tab is hidden by deferring and processing updates when visibility returns.
  * Prevented stale run states by ensuring terminal statuses are reflected after updates complete.
  * Improved handling of non-terminal and terminal simulation status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->