### PR TITLE
fix(haven): stop two stacks sharing a Redis database

### DIFF
--- a/tools/thuishaven/app/db.go
+++ b/tools/thuishaven/app/db.go
@@ -165,7 +165,7 @@ func (o *Orchestrator) runSeedIngest(ctx context.Context, p UpParams, pre seedPr
 // ensures, an unavailable managed server is a hard error here: there is no
 // .env fallback that could make "reset the managed database" mean anything.
 func (o *Orchestrator) managedStackEnv(ctx context.Context, slug string) ([]string, error) {
-	st := domain.Stack{Slug: slug, RedisDB: domain.RedisDBForSlug(slug), LocalAPIKey: o.cfg.LocalAPIKey}
+	st := domain.Stack{Slug: slug, RedisDB: o.redisDBFor(slug), LocalAPIKey: o.cfg.LocalAPIKey}
 	o.ensureClickHouse(ctx, &st)
 	o.ensurePostgres(ctx, &st)
 	o.ensureRedis(ctx, &st)
@@ -301,7 +301,7 @@ func (o *Orchestrator) DBURL(ctx context.Context, p UpParams, engine string) err
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%sredis://127.0.0.1:%d/%d\n", label("redis"), port, domain.RedisDBForSlug(slug))
+		fmt.Printf("%sredis://127.0.0.1:%d/%d\n", label("redis"), port, o.redisDBFor(slug))
 		return nil
 	}
 	switch engine {

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -54,7 +54,7 @@ type Orchestrator struct {
 
 // Deps is the injected object graph. A struct rather than a positional
 // parameter list, because thirteen positional dependencies is a call nobody can
-// read and one whose neighbours can be transposed without the compiler noticing.
+// read and one whose neighbors can be transposed without the compiler noticing.
 type Deps struct {
 	Cfg       Config
 	Proxy     Proxy
@@ -150,9 +150,19 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 	// ports[0..nSvc-1] back the routed services (app/gateway/nlp/langyagent, in
 	// PerWorktreeServices order); ports[nSvc] is the API backend behind app's /api,
 	// ports[nSvc+1] the worker metrics endpoint.
+	redisDB, exclusive := o.allocateRedisDB(slug)
+	if !exclusive {
+		fmt.Printf(
+			"  warning: all %d Redis databases are in use, so %q shares db %d with another stack.\n"+
+				"  They will share a job queue while writing to separate ClickHouse databases,\n"+
+				"  which lands work in the wrong stack. Take a stack down before continuing.\n",
+			domain.RedisDBCount, slug, redisDB,
+		)
+	}
+
 	st := domain.Stack{
 		Slug: slug, WorktreeDir: p.WorktreeDir, Branch: p.Branch,
-		LauncherPID: o.sys.Getpid(), RedisDB: domain.RedisDBForSlug(slug),
+		LauncherPID: o.sys.Getpid(), RedisDB: redisDB,
 		APIPort: ports[nSvc], WorkerMetricsPort: ports[nSvc+1], LocalAPIKey: o.cfg.LocalAPIKey, IsBaseline: p.IsBaseline,
 		// Mirror planChildren: a separate `workers` lane exists only when workers
 		// are requested AND not hosted in-process. Persist it so restart targets
@@ -727,4 +737,39 @@ func (o *Orchestrator) printStack(st domain.Stack) {
 	}
 	scheme, port := o.proxy.Endpoint()
 	fmt.Printf("    %-10s %s\n\n", "hub", o.cfg.Naming.URL(domain.HubService, "", scheme, port))
+}
+
+// allocateRedisDB picks this stack's Redis database, keeping the one it already
+// holds when it has one and otherwise avoiding every database a live stack is
+// using.
+//
+// Reusing the registered value is what makes the assignment stable across
+// restarts: the slug's hash is only a starting point, so a stack that had to
+// probe away from it once must not drift back on the next `up`.
+func (o *Orchestrator) allocateRedisDB(slug string) (int, bool) {
+	taken := map[int]bool{}
+	stacks := o.store.Stacks()
+	for i := range stacks {
+		if stacks[i].Slug == slug {
+			return stacks[i].RedisDB, true
+		}
+		taken[stacks[i].RedisDB] = true
+	}
+	return domain.AllocateRedisDB(slug, taken)
+}
+
+// redisDBFor reports the Redis database a slug's stack uses, preferring the
+// value recorded when it was provisioned.
+//
+// Recomputing the hash here instead would report a different database than the
+// stack actually runs on, for any stack that had to probe away from its
+// preferred index — which is precisely the stacks a collision affected.
+func (o *Orchestrator) redisDBFor(slug string) int {
+	stacks := o.store.Stacks()
+	for i := range stacks {
+		if stacks[i].Slug == slug {
+			return stacks[i].RedisDB
+		}
+	}
+	return domain.RedisDBForSlug(slug)
 }

--- a/tools/thuishaven/app/prune_scan.go
+++ b/tools/thuishaven/app/prune_scan.go
@@ -210,7 +210,7 @@ func (o *Orchestrator) scanMeta(row PruneRow, chDBs, pgDBs []string, now time.Ti
 		if !domain.IsProtectedDatabase(db) {
 			meta.HasCHDB = o.cfg.ShouldManageClickHouse && slices.Contains(chDBs, db)
 			meta.HasPGDB = o.cfg.ShouldManagePostgres && slices.Contains(pgDBs, db)
-			meta.RedisDB = domain.RedisDBForSlug(row.Slug)
+			meta.RedisDB = o.redisDBFor(row.Slug)
 		}
 	}
 	return meta

--- a/tools/thuishaven/domain/redis_db_test.go
+++ b/tools/thuishaven/domain/redis_db_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import "testing"
+
+// The collision that motivated AllocateRedisDB: three concurrently-live
+// worktrees whose slugs all hash to the same database. Redis carries the
+// GroupQueue, so sharing one means sharing a job queue while writing to
+// separate ClickHouse databases — work lands in the wrong stack silently.
+func TestRedisDBForSlugCollidesInPractice(t *testing.T) {
+	slugs := []string{
+		"scenario-child-startup",
+		"shared-ops-snapshot-plan",
+		"bugbash-integration",
+	}
+	first := RedisDBForSlug(slugs[0])
+	for _, slug := range slugs[1:] {
+		if got := RedisDBForSlug(slug); got != first {
+			t.Fatalf("expected the observed collision on db %d, %q got %d", first, slug, got)
+		}
+	}
+}
+
+func TestAllocateRedisDBPrefersTheHashWhenFree(t *testing.T) {
+	slug := "scenario-child-startup"
+	db, exclusive := AllocateRedisDB(slug, map[int]bool{})
+	if !exclusive {
+		t.Fatal("expected an exclusive database when none are taken")
+	}
+	if db != RedisDBForSlug(slug) {
+		t.Fatalf("want the preferred db %d, got %d", RedisDBForSlug(slug), db)
+	}
+}
+
+func TestAllocateRedisDBProbesPastTakenDatabases(t *testing.T) {
+	slugs := []string{
+		"scenario-child-startup",
+		"shared-ops-snapshot-plan",
+		"bugbash-integration",
+	}
+
+	taken := map[int]bool{}
+	seen := map[int]string{}
+	for _, slug := range slugs {
+		db, exclusive := AllocateRedisDB(slug, taken)
+		if !exclusive {
+			t.Fatalf("%q: expected an exclusive database, 16 were free", slug)
+		}
+		if other, clash := seen[db]; clash {
+			t.Fatalf("%q got db %d, already held by %q", slug, db, other)
+		}
+		seen[db] = slug
+		taken[db] = true
+	}
+}
+
+func TestAllocateRedisDBReportsWhenNoneAreFree(t *testing.T) {
+	taken := map[int]bool{}
+	for db := range RedisDBCount {
+		taken[db] = true
+	}
+
+	db, exclusive := AllocateRedisDB("scenario-child-startup", taken)
+	if exclusive {
+		t.Fatal("expected exclusive=false when every database is held")
+	}
+	// Still returns a usable index rather than a sentinel: the caller warns
+	// and carries on, it does not refuse to start.
+	if db < 0 || db >= RedisDBCount {
+		t.Fatalf("db %d out of range", db)
+	}
+}

--- a/tools/thuishaven/domain/slug.go
+++ b/tools/thuishaven/domain/slug.go
@@ -76,15 +76,47 @@ func SlugOrBase(slug, dir string) string {
 	return filepath.Base(dir)
 }
 
-// RedisDBForSlug maps a slug to a stable Redis DB (0-15) so BullMQ queues,
-// GroupQueue streams, and fold caches stay isolated across concurrent worktrees —
-// the job the old PORT-slot derivation did, now keyed on the slug.
+// RedisDBCount is how many databases a stock Redis serves (0-15).
+const RedisDBCount = 16
+
+// RedisDBForSlug maps a slug to a PREFERRED Redis DB (0-15). It is only a
+// starting point: with 16 databases and a plain hash, distinct slugs collide
+// often — three concurrent worktrees landing on the same index is ordinary,
+// not unlucky. Use AllocateRedisDB, which probes from here for a free one.
 func RedisDBForSlug(slug string) int {
 	var h uint32
 	for _, c := range slug {
 		h = h*31 + uint32(c)
 	}
-	return int(h % 16)
+	return int(h % RedisDBCount)
+}
+
+// AllocateRedisDB picks the Redis DB a stack should use, given the databases
+// other live stacks already hold.
+//
+// Sharing one is not a mild inconvenience: Redis is where the GroupQueue
+// lives, so two stacks on the same index share a job queue while writing to
+// SEPARATE ClickHouse databases. Whichever worker claims a job projects it
+// into its own database, and because every stack seeds the same fixed local
+// identity the tenant ids match perfectly — so the work lands in the wrong
+// stack and nothing looks wrong.
+//
+// Probing starts at the slug's preferred index so a stack keeps the same
+// database whenever it can, and the caller persists the result so it survives
+// restarts even if the neighbors change.
+//
+// With all 16 held it returns the preferred index and reports false: a
+// collision is then unavoidable, and the caller should say so rather than
+// pretend the stack is isolated.
+func AllocateRedisDB(slug string, taken map[int]bool) (db int, exclusive bool) {
+	preferred := RedisDBForSlug(slug)
+	for offset := range RedisDBCount {
+		candidate := (preferred + offset) % RedisDBCount
+		if !taken[candidate] {
+			return candidate, true
+		}
+	}
+	return preferred, false
 }
 
 // ErrInvalidSlug is returned when an explicit LANGWATCH_SLUG is malformed.


### PR DESCRIPTION
`RedisDBForSlug` hashed the slug into 16 databases with **no collision check**. With a handful of live worktrees that is ordinary rather than unlucky — three concurrent stacks were observed all holding db 15:

```
15  scenario-child-startup
15  shared-ops-snapshot-plan
15  bugbash-integration
```

## Why it matters more than it looks

Redis carries the GroupQueue, so colliding stacks **share one job queue while writing to separate ClickHouse databases**. Whichever worker claims a job projects it into its own database.

And because every stack seeds the same fixed local identity (`local-dev-project`), the tenant ids match perfectly — so the misplaced work looks entirely legitimate wherever it lands. This was found by chasing simulation runs that never appeared: the events were in one stack's `event_log`, and ClickHouse's `query_log` showed the inserts had gone to *another stack's* database.

## The fix

`AllocateRedisDB` probes from the slug's preferred index for a free database, and the result is **persisted on the stack**. The hash stays as the starting point so a stack keeps the same database whenever it can.

The read sites (`haven db url`, the prune scan, the db-ops stack) now read that persisted value instead of recomputing the hash — recomputing would report a different database than the stack actually runs on, for precisely the stacks a collision affected.

With all 16 held it warns and carries on rather than refusing to start, naming the consequence so a genuine collision is visible instead of silent.

## Verification

- 4 new domain tests, including one that pins the real-world three-way collision so a future hash change cannot quietly reintroduce it.
- `go build`, `go test ./...` across thuishaven — all packages pass.
- `golangci-lint` — no findings on the new code (including `misspell`, which rejects the British spellings this repo's prose otherwise uses).
- `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis database allocation now preserves existing assignments and selects an available database when provisioning stacks.
  * Allocation avoids databases already in use and falls back to shared access with a warning when none are available.

* **Bug Fixes**
  * Redis connections, URLs, and scans now consistently use the assigned database, honoring configured allocation choices.

* **Tests**
  * Added coverage for collisions, occupied databases, preferred allocations, and full-database fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->