### PR TITLE
perf(scenarios): use the child bundle in dev while it is current

### DIFF
--- a/platform/app/src/server/scenarios/execution/__tests__/child-process-spawn.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/child-process-spawn.unit.test.ts
@@ -24,6 +24,8 @@ const mockLogger = vi.hoisted(() => ({
 vi.mock("fs", () => ({
   default: {
     existsSync: vi.fn(),
+    statSync: vi.fn(),
+    readdirSync: vi.fn(),
   },
 }));
 
@@ -39,6 +41,8 @@ const PACKAGE_ROOT = "/app/platform/app";
 describe("resolveChildProcessSpawn", () => {
   beforeEach(() => {
     vi.mocked(fs.existsSync).mockReset();
+    vi.mocked(fs.statSync).mockReset();
+    vi.mocked(fs.readdirSync).mockReset();
     mockLogger.info.mockReset();
     mockLogger.debug.mockReset();
     mockLogger.error.mockReset();
@@ -150,7 +154,63 @@ describe("resolveChildProcessSpawn", () => {
   });
 
   describe("when NODE_ENV is development", () => {
+    const BUNDLE = path.join(
+      PACKAGE_ROOT,
+      "dist",
+      "server",
+      "scenario-child-process.cjs",
+    );
+
+    /**
+     * Bundle at `bundleMtimeMs`, one child source at `sourceMtimeMs`. Omitting
+     * the bundle mtime makes statSync throw for it, standing in for "not built".
+     */
+    const givenMtimes = ({
+      bundleMtimeMs,
+      sourceMtimeMs,
+    }: {
+      bundleMtimeMs?: number;
+      sourceMtimeMs: number;
+    }) => {
+      vi.mocked(fs.statSync).mockImplementation(((target: string) => {
+        if (target === BUNDLE) {
+          if (bundleMtimeMs === undefined) throw new Error("ENOENT");
+          return { mtimeMs: bundleMtimeMs };
+        }
+        return { mtimeMs: sourceMtimeMs };
+      }) as unknown as typeof fs.statSync);
+      vi.mocked(fs.readdirSync).mockImplementation((() => [
+        { name: "scenario-child-process.ts", isDirectory: () => false },
+      ]) as unknown as typeof fs.readdirSync);
+    };
+
+    it("invokes node with the bundle when it is newer than every child source", () => {
+      givenMtimes({ bundleMtimeMs: 2000, sourceMtimeMs: 1000 });
+
+      const result = resolveChildProcessSpawn({
+        packageRoot: PACKAGE_ROOT,
+        nodeEnv: "development",
+      });
+
+      expect(result.command).toBe("node");
+      expect(result.args).toEqual([BUNDLE]);
+    });
+
+    it("falls back to tsx when a child source is newer than the bundle", () => {
+      // The point of the fallback: an edit takes effect on the next spawn and
+      // never silently runs the previously built code.
+      givenMtimes({ bundleMtimeMs: 1000, sourceMtimeMs: 2000 });
+
+      expect(
+        resolveChildProcessSpawn({
+          packageRoot: PACKAGE_ROOT,
+          nodeEnv: "development",
+        }).command,
+      ).toBe("pnpm");
+    });
+
     it("invokes pnpm exec tsx with the TypeScript source file", () => {
+      givenMtimes({ sourceMtimeMs: 1000 });
       const result = resolveChildProcessSpawn({
         packageRoot: PACKAGE_ROOT,
         nodeEnv: "development",

--- a/platform/app/src/server/scenarios/execution/child-process-spawn.ts
+++ b/platform/app/src/server/scenarios/execution/child-process-spawn.ts
@@ -7,7 +7,9 @@
  * dependencies are present: tsx is a devDependency, so the Docker image and the
  * published npx tree both prune it and the spawn fails there — a missing bundle
  * is a build fault to fix, not a degraded mode to live in.
- * In development, uses tsx to run the TypeScript source directly.
+ * Outside production the bundle is still used while it is current, because tsx
+ * costs seconds on every spawn. It is dropped the moment any child source is
+ * newer, so editing the child still takes effect without a rebuild.
  *
  * @see specs/scenarios/pre-compiled-child-process.feature
  */
@@ -26,8 +28,9 @@ export interface SpawnConfig {
 /**
  * Resolves the spawn command and args for the scenario child process.
  *
- * Only NODE_ENV === "production" uses the pre-compiled bundle.
- * All other values (development, test, staging, undefined) use tsx.
+ * Production always uses the pre-compiled bundle. Every other value
+ * (development, test, staging, undefined) uses it too while it is newer than
+ * the child's sources, and tsx otherwise.
  *
  * @param packageRoot - Absolute path to the langwatch package root
  * @param nodeEnv - Current NODE_ENV value
@@ -44,11 +47,78 @@ export function resolveChildProcessSpawn({
     return resolveProductionSpawn(packageRoot);
   }
 
+  // Outside production the bundle is an optimisation rather than a
+  // requirement, so it is used only while it is demonstrably current. tsx
+  // costs seconds on every spawn — measured at 4-6s alone and ~10s with the
+  // pool's three running at once — and a simulation pays that per run, which
+  // is the difference between a run starting promptly and a suite crawling.
+  //
+  // Currency is decided by mtime against the child's own sources: edit any of
+  // them and the next spawn returns to tsx by itself, so the fast path can
+  // never run code you did not build. Rebuild with `pnpm run build:server`.
+  const bundlePath = bundlePathFor(packageRoot);
+  if (isBundleCurrent({ packageRoot, bundlePath })) {
+    logger.debug({ bundlePath }, "Using pre-compiled bundle for child process");
+    return { command: "node", args: [bundlePath] };
+  }
+
   logger.debug(
     { nodeEnv: nodeEnv ?? "undefined" },
     "Using tsx for child process",
   );
   return resolveDevelopmentSpawn(packageRoot);
+}
+
+function bundlePathFor(packageRoot: string): string {
+  return path.join(packageRoot, "dist", "server", "scenario-child-process.cjs");
+}
+
+/**
+ * True when the bundle exists and nothing under the child's source tree is
+ * newer than it.
+ *
+ * The whole `scenarios/execution` tree is checked, not just the entry point:
+ * the child pulls in the adapters, the model factory and the serialized
+ * adapter registry, and a change to any of those is as much a reason to stop
+ * trusting the bundle. Anything unreadable counts as stale, so every failure
+ * direction lands on tsx rather than on stale code.
+ */
+function isBundleCurrent({
+  packageRoot,
+  bundlePath,
+}: {
+  packageRoot: string;
+  bundlePath: string;
+}): boolean {
+  let bundleMtimeMs: number;
+  try {
+    bundleMtimeMs = fs.statSync(bundlePath).mtimeMs;
+  } catch {
+    return false;
+  }
+
+  try {
+    return !hasFileNewerThan(
+      path.join(packageRoot, "src", "server", "scenarios", "execution"),
+      bundleMtimeMs,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Depth-first scan that stops at the first file newer than `thresholdMs`. */
+function hasFileNewerThan(dir: string, thresholdMs: number): boolean {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "__tests__") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (hasFileNewerThan(full, thresholdMs)) return true;
+      continue;
+    }
+    if (fs.statSync(full).mtimeMs > thresholdMs) return true;
+  }
+  return false;
 }
 
 function resolveProductionSpawn(packageRoot: string): SpawnConfig {


### PR DESCRIPTION
The pre-compiled child bundle was gated behind `NODE_ENV === "production"`, so every other environment shelled out to `pnpm exec tsx` and transpiled the child's whole import graph **at runtime, on every spawn**.

Measured on this machine:

| path | per child |
|---|---|
| `pnpm exec tsx` (what dev did), solo | 4,160–6,168 ms |
| `pnpm exec tsx`, 3 concurrent (pool concurrency) | **10,101 ms each** |
| `node dist/server/…cjs` | **686 ms** |

A simulation pays that per run, so a suite spends minutes before anything starts. This is why the earlier bundling work produced no visible improvement locally: it only ever applied to production.

## Keeping the fast path honest

Dev uses the bundle **only while it is demonstrably current**. Currency is mtime against everything under `scenarios/execution` — not just the entry point, since the child pulls in the adapters, the model factory and the serialized-adapter registry, and a change to any of those is as much a reason to distrust the bundle.

Edit any child source and the next spawn returns to tsx by itself, so the fast path can never run code you did not build. Every failure direction — missing bundle, unreadable directory — lands on tsx rather than on stale code.

Production behaviour is unchanged: it always uses the bundle and still logs loudly with remediation when it is missing.

## Verification

- `child-process-spawn.unit.test.ts` — 12/12, with new coverage for both directions (bundle newer → `node`; a source newer → `pnpm exec tsx`).
- `src/server/scenarios` — 42 files / 533 tests pass.
- `typecheck` and `typecheck:tests` — 0 errors each.

Note: the function docstring said "Only NODE_ENV === production uses the pre-compiled bundle", which this change makes false, so it is rewritten rather than left to mislead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved execution reliability when running in development environments.
  - The system now uses an up-to-date compiled bundle when available and automatically falls back to the source runner when the bundle is missing, outdated, or inaccessible.
  - Production execution continues to prioritize the compiled bundle while retaining a fallback option.

- **Tests**
  - Expanded coverage for fresh, stale, missing, and unreadable bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->