### PR TITLE
fix(simulations): record a duration for runs that actually ran

### DIFF
--- a/platform/app/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -503,6 +503,46 @@ describe("simulationRunStateFoldProjection", () => {
       expect(state.FinishedAt).toBe(3000);
     });
 
+    it("derives DurationMs from the run's own timestamps when the event omits it", () => {
+      // Every real run takes this path: the SDK ingest dispatches finishRun
+      // with results and status only, so an underived DurationMs was null for
+      // every run a customer executed and set only for seeded ones.
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createRunFinishedEvent({
+          results: { verdict: "success", metCriteria: [], unmetCriteria: [] },
+        }),
+      ]);
+
+      expect(state.StartedAt).toBe(1000);
+      expect(state.FinishedAt).toBe(3000);
+      expect(state.DurationMs).toBe(2000);
+    });
+
+    it("prefers a supplied duration over the derived one", () => {
+      // The runner knows its own elapsed time better than two projected
+      // timestamps do.
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createRunFinishedEvent({
+          results: { verdict: "success", metCriteria: [], unmetCriteria: [] },
+          durationMs: 42,
+        }),
+      ]);
+
+      expect(state.DurationMs).toBe(42);
+    });
+
+    it("leaves DurationMs null when the run never started", () => {
+      const state = foldEvents([
+        createRunFinishedEvent({
+          results: { verdict: "success", metCriteria: [], unmetCriteria: [] },
+        }),
+      ]);
+
+      expect(state.DurationMs).toBeNull();
+    });
+
     it("sets FAILURE status for failure verdict", () => {
       const state = foldEvents([
         createRunStartedEvent(),

--- a/platform/app/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -558,7 +558,19 @@ export class SimulationRunStateFoldProjection
       MetCriteria: results?.metCriteria ?? [],
       UnmetCriteria: results?.unmetCriteria ?? [],
       Error: results?.error ?? null,
-      DurationMs: event.data.durationMs ?? null,
+      // Derived when the event does not carry it, which is every real run:
+      // the SDK ingest path dispatches finishRun with results and status only.
+      // Left underived, DurationMs was null for every run a customer actually
+      // executed, and populated only for runs seeded with a synthetic event.
+      //
+      // The fold already holds both ends, so this needs no new field on the
+      // wire. A supplied value still wins — the runner knows its own elapsed
+      // time better than two projected timestamps do.
+      DurationMs:
+        event.data.durationMs ??
+        (state.StartedAt !== null && event.occurredAt >= state.StartedAt
+          ? event.occurredAt - state.StartedAt
+          : null),
       FinishedAt: event.occurredAt,
     };
   }


### PR DESCRIPTION
`DurationMs` was **null for every run a customer executed**, and populated only for seeded ones — so the UI showed no duration for real work while demo data looked fine.

Observed on a live stack: 9 real runs, all with `DurationMs` null and `FinishedAt` set; the 6 seeded runs all had it.

## Cause

The field is optional on the finished event, and the live path never supplies it. The SDK ingest dispatches `finishRun` with `results` and `status` only:

```ts
await getApp().simulations.finishRun({
  ...basePayload,
  results: ...,
  status: event.status,
});
```

Seeded runs have it because the seed constructs the event directly with `durationMs`. Nothing was broken — it was simply never set.

**This predates the process-manager migration.** The ingest path is identical on main.

## Fix

The fold already holds both ends of the run (`StartedAt`, and `FinishedAt` from the finishing event), so it derives the duration when the event omits it. No new field has to cross the wire, and it works for every producer rather than just the one that was patched.

A supplied value still wins — the runner knows its own elapsed time better than two projected timestamps do — and a run with no `StartedAt` stays null rather than inventing one.

## Verification

- 3 new fold tests: derives when omitted, prefers a supplied value, stays null with no start.
- simulation-processing projections — 8 files / 162 tests pass.
- `typecheck:tests` — 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Run durations are now automatically calculated from start and finish times when no duration is provided.
  - Explicitly supplied durations continue to take precedence.
  - Runs without valid timing information now correctly show no duration.

- **Tests**
  - Added coverage for calculated, explicit, and unavailable duration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->