### PR TITLE
fix(simulations): stop losing run metrics silently

### DIFF
--- a/platform/app/src/server/event-sourcing/pipelines/simulation-processing/commands/computeRunMetrics.command.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/simulation-processing/commands/computeRunMetrics.command.ts
@@ -112,9 +112,21 @@ export class ComputeRunMetricsCommand
             occurredAt: Date.now(),
           });
         } else {
-          logger.warn(
-            { tenantId, scenarioRunId, traceId },
-            "Max retries reached for trace metrics computation, giving up",
+          // Error, not warn: giving up here means this run's cost and
+          // latency never exist. No later event repairs it — the retry was
+          // the only path — so a run silently carries no metrics forever.
+          // Logged with everything needed to find it, and with the window
+          // that was actually waited, because "the trace was slower than the
+          // budget" and "the trace never arrived" need different responses.
+          logger.error(
+            {
+              tenantId,
+              scenarioRunId,
+              traceId,
+              attempts: MAX_RETRIES,
+              waitedMs: MAX_RETRIES * COMPUTE_METRICS_RETRY_DELAY_MS,
+            },
+            "Gave up computing trace metrics: the trace summary never arrived, so this run has no cost or latency",
           );
         }
 
@@ -155,9 +167,15 @@ export class ComputeRunMetricsCommand
             occurredAt: Date.now(),
           });
         } else {
-          logger.warn(
-            { tenantId, scenarioRunId, traceId },
-            "Max retries reached for trace metrics (summary empty), giving up",
+          logger.error(
+            {
+              tenantId,
+              scenarioRunId,
+              traceId,
+              attempts: MAX_RETRIES,
+              waitedMs: MAX_RETRIES * COMPUTE_METRICS_RETRY_DELAY_MS,
+            },
+            "Gave up computing trace metrics: the trace summary stayed empty, so this run has no cost or latency",
           );
         }
 


### PR DESCRIPTION
When `computeRunMetrics` exhausts its retries it returns no events, so the run's **cost and latency never exist**. Nothing repairs that afterwards — the retry *was* the repair path — and it was logged at `warn`, so a run permanently carrying no metrics looked like routine noise.

Now an `error`, carrying the trace and run ids and the window actually waited.

The window is the part worth having: *"the trace was slower than 30s"* and *"the trace never arrived"* want completely different responses, and the previous log could not tell them apart.

## What I did not do, and why

The finding that prompted this was to invert the trigger — have trace-processing **emit** summary completion and let simulation-processing subscribe, instead of the command reading another aggregate's projection and rescheduling itself up to 3 times at 10s intervals.

That is the right shape, and I am not doing it here. The trace pipeline emits `span_received`, `topic_assigned`, `log_contributed` and friends — there is **no trace-settled event**, and there cannot trivially be one: traces are open-ended, spans keep arriving, and deciding when a trace is "complete" is precisely the question the pull-and-retry design exists to avoid answering.

So the inversion is not wiring, it is a new domain event plus a completeness rule. That wants an ADR and a deliberate decision, not a refactor smuggled into a logging fix.

What is left in the meantime is a bounded, honest failure: the gap is now visible and attributable instead of silent.

## Verification

- computeRunMetrics command tests — 5/5 pass.
- `typecheck` — 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when run metrics cannot be computed after all retry attempts.
  * Error logs now include retry details, total wait time, and clearer information about whether trace data is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->