### PR TITLE
refactor(scenarios): give the child's execution contract no outside importers

### DIFF
--- a/platform/app/src/optimization_studio/types/dsl.ts
+++ b/platform/app/src/optimization_studio/types/dsl.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import type { LocalPromptConfig } from "~/experiments-v3/types";
 import type { EvaluatorTypes } from "~/server/evaluations/evaluators";
-import { FieldMappingSchema } from "~/server/scenarios/execution/types";
+import { FieldMappingSchema } from "~/server/scenarios/field-mapping";
 import type { LlmConfigInputType, LlmConfigOutputType } from "~/types";
 
 import { datasetColumnTypeSchema } from "../../server/datasets/types";

--- a/platform/app/src/server/scenarios/__tests__/child-execution-contract.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/child-execution-contract.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards the boundary that lets the scenario child's execution contract move to
+ * its own package: `execution/types.ts` may only be imported from inside the
+ * child's own tree.
+ *
+ * This is an architectural guard, not a snapshot. It reads the real source
+ * files, so a new import anywhere in the app fails it — which is the point. The
+ * one thing outside the child that needed a piece of that file,
+ * `FieldMappingSchema`, now lives in `../field-mapping`; anything else that
+ * finds itself reaching in should move there too rather than widening this.
+ *
+ * @see specs/scenarios/child-execution-contract.feature
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+import { suiteTargetSchema } from "../../suites/types";
+import { PromptConfigDataSchema } from "../execution/types";
+import { FieldMappingSchema } from "../field-mapping";
+
+const SELF = fileURLToPath(import.meta.url);
+const SRC = path.resolve(path.dirname(SELF), "../../..");
+
+/** The child's own tree, relative to `src/`. Imports from here are expected. */
+const EXECUTION_TREE = "server/scenarios/execution/";
+
+/** Every way a file can name the contract module, alias or relative. */
+const CONTRACT_SPECIFIERS = [
+  "~/server/scenarios/execution/types",
+  "server/scenarios/execution/types",
+];
+
+const isSource = (file: string) =>
+  /\.(?:mts|cts|tsx?)$/.test(file) && !/\.d\.(?:mts|cts|ts)$/.test(file);
+
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (isSource(full)) out.push(full);
+  }
+  return out;
+};
+
+const rel = (file: string) =>
+  path.relative(SRC, file).split(path.sep).join("/");
+
+describe("scenario child execution contract", () => {
+  describe("when the whole application source tree is scanned", () => {
+    /** @scenario Nothing outside the child's own tree imports the execution contract */
+    it("finds importers of the contract only inside the execution tree", () => {
+      const outsiders = walk(SRC)
+        // This file names the specifiers in order to search for them.
+        .filter((file) => file !== SELF)
+        .filter((file) => {
+          const source = fs.readFileSync(file, "utf8");
+          return CONTRACT_SPECIFIERS.some((specifier) =>
+            source.includes(`"${specifier}"`),
+          );
+        })
+        .map(rel)
+        .filter((file) => !file.startsWith(EXECUTION_TREE));
+
+      expect(outsiders).toEqual([]);
+    });
+
+    /** @scenario The shared field mapping schema carries no framework dependency */
+    it("keeps the shared field mapping module on zod alone", () => {
+      const source = fs.readFileSync(
+        path.join(SRC, "server", "scenarios", "field-mapping.ts"),
+        "utf8",
+      );
+
+      const specifiers = [...source.matchAll(/from\s+"([^"]+)"/g)].map(
+        (match) => match[1],
+      );
+
+      expect(specifiers).toEqual(["zod"]);
+    });
+  });
+
+  describe("when a suite target and the child parse the same mappings", () => {
+    /** @scenario A mapping accepted by the suite target schema is accepted by the child */
+    it("accepts the same source and literal mappings on both sides", () => {
+      const scenarioMappings = {
+        query: { type: "source", sourceId: "scenario", path: ["input"] },
+        context: { type: "value", value: "Use the knowledge base" },
+      };
+
+      // Prompt targets are the ones that carry mappings: an agent stores its
+      // own on the agent record, and the suite schema rejects them there.
+      const onSuite = suiteTargetSchema.safeParse({
+        type: "prompt",
+        referenceId: "prompt_1",
+        scenarioMappings,
+      });
+
+      const onChild = PromptConfigDataSchema.safeParse({
+        type: "prompt",
+        promptId: "prompt_1",
+        systemPrompt: "You answer questions.",
+        messages: [{ role: "user", content: "{{query}}" }],
+        scenarioMappings,
+      });
+
+      expect(onSuite.success).toBe(true);
+      expect(onChild.success).toBe(true);
+      expect(
+        Object.values(scenarioMappings).every(
+          (mapping) => FieldMappingSchema.safeParse(mapping).success,
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
@@ -13,11 +13,11 @@
 
 import { type AgentInput, AgentRole } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
+import type { FieldMapping } from "../../field-mapping";
 import {
   buildTemplateContext,
   renderBodyTemplate,
 } from "../http-template-engine";
-import type { FieldMapping } from "../types";
 
 function inputWith(content: string | unknown[]): AgentInput {
   return {

--- a/platform/app/src/server/scenarios/execution/__tests__/resolve-field-mappings.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/resolve-field-mappings.unit.test.ts
@@ -4,11 +4,11 @@
 
 import { type AgentInput, AgentRole } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
+import type { FieldMapping } from "../../field-mapping";
 import {
   computeBestMatchMappings,
   resolveFieldMappings,
 } from "../resolve-field-mappings";
-import type { FieldMapping } from "../types";
 
 const makeAgentInput = (overrides: Partial<AgentInput> = {}): AgentInput => ({
   threadId: "thread-1",

--- a/platform/app/src/server/scenarios/execution/data-prefetcher.ts
+++ b/platform/app/src/server/scenarios/execution/data-prefetcher.ts
@@ -38,14 +38,13 @@ import {
   PromptService,
   type VersionedPrompt,
 } from "../../prompt-config/prompt.service";
+import { type FieldMapping, FieldMappingSchema } from "../field-mapping";
 import { ScenarioService } from "../scenario.service";
 import {
   AuthConfigSchema,
   type ChildProcessJobData,
   type CodeAgentData,
   type ExecutionContext,
-  type FieldMapping,
-  FieldMappingSchema,
   type HttpAgentData,
   type LiteLLMParams,
   type PromptConfigData,

--- a/platform/app/src/server/scenarios/execution/http-template-engine.ts
+++ b/platform/app/src/server/scenarios/execution/http-template-engine.ts
@@ -14,8 +14,8 @@
 
 import type { AgentInput } from "@langwatch/scenario";
 import { Liquid } from "liquidjs";
+import type { FieldMapping } from "../field-mapping";
 import { resolveFieldMappings, sourceFieldOf } from "./resolve-field-mappings";
-import type { FieldMapping } from "./types";
 
 /**
  * Marks a context value as already-serialized JSON that must be interpolated

--- a/platform/app/src/server/scenarios/execution/prompt-template-context.ts
+++ b/platform/app/src/server/scenarios/execution/prompt-template-context.ts
@@ -17,12 +17,12 @@
  */
 
 import type { AgentInput } from "@langwatch/scenario";
+import type { FieldMapping } from "../field-mapping";
 import {
   computeBestMatchMappings,
   resolveFieldMappings,
   sourceFieldOf,
 } from "./resolve-field-mappings";
-import type { FieldMapping } from "./types";
 
 /** An input variable declared on the prompt. */
 export interface PromptInputDeclaration {

--- a/platform/app/src/server/scenarios/execution/resolve-field-mappings.ts
+++ b/platform/app/src/server/scenarios/execution/resolve-field-mappings.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentInput } from "@langwatch/scenario";
-import type { FieldMapping } from "./types";
+import type { FieldMapping } from "../field-mapping";
 
 /** Maps pre-rename field names to current names for backwards compatibility. */
 const LEGACY_FIELD_NAMES: Record<string, string> = {

--- a/platform/app/src/server/scenarios/execution/types.ts
+++ b/platform/app/src/server/scenarios/execution/types.ts
@@ -8,22 +8,16 @@
 
 import { z } from "zod";
 import type { Span } from "../../tracer/types";
+import { FieldMappingSchema } from "../field-mapping";
 
 // ============================================================================
 // Field Mapping Types
 // (defined first so adapter schemas can reference them)
 // ============================================================================
 
-/** Field mapping for agent inputs — maps to a scenario source or a static value */
-export const FieldMappingSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("source"),
-    sourceId: z.string(),
-    path: z.array(z.string()),
-  }),
-  z.object({ type: z.literal("value"), value: z.string() }),
-]);
-export type FieldMapping = z.infer<typeof FieldMappingSchema>;
+// FieldMappingSchema lives in ../field-mapping: it is the one thing here that
+// the suite schema and the studio DSL also need, and keeping it out means this
+// module has no importers outside the child's own code.
 
 // ============================================================================
 // Adapter Data Types (Zod schemas for data contracts)

--- a/platform/app/src/server/scenarios/field-mapping.ts
+++ b/platform/app/src/server/scenarios/field-mapping.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+/**
+ * How one agent input is filled: from a scenario source, or from a literal.
+ *
+ * This lives on its own because it is the ONLY thing outside the scenario
+ * child's own code that reaches into `execution/types.ts` — the suite target
+ * schema and the optimization-studio DSL both need it, and the latter is
+ * frontend-reachable.
+ *
+ * Keeping it here means `execution/types.ts` describes only the parent/child
+ * execution contract, with no external importers, which is what allows that
+ * contract to move to the child's own package later. It is deliberately
+ * framework-free (zod and nothing else) so either side can import it without
+ * dragging a dependency across the boundary.
+ */
+export const FieldMappingSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("source"),
+    sourceId: z.string(),
+    path: z.array(z.string()),
+  }),
+  z.object({ type: z.literal("value"), value: z.string() }),
+]);
+
+export type FieldMapping = z.infer<typeof FieldMappingSchema>;

--- a/platform/app/src/server/suites/types.ts
+++ b/platform/app/src/server/suites/types.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from "zod";
-import { FieldMappingSchema } from "../scenarios/execution/types";
+import { FieldMappingSchema } from "../scenarios/field-mapping";
 
 const suiteTargetFields = z.object({
   type: z.enum(["prompt", "http", "code", "workflow"]),

--- a/specs/scenarios/child-execution-contract.feature
+++ b/specs/scenarios/child-execution-contract.feature
@@ -1,0 +1,47 @@
+Feature: Scenario child execution contract stays private to the child
+
+  `server/scenarios/execution/types.ts` describes the wire contract between the
+  scenario worker and the child process it spawns: the job data written to the
+  child's stdin, the adapter payloads inside it, and the execution context it
+  runs under. It is meant to move to the child's own package, so that the app
+  can stop depending on the scenario runner and the production image can stop
+  shipping it.
+
+  One thing stopped that move. `FieldMappingSchema` — how a single agent input
+  is filled, from a scenario source or from a literal — lived in that same file,
+  and two callers outside the child needed it: the suite target schema, and the
+  optimization-studio DSL. The DSL is frontend-reachable, so the browser bundle
+  reached into the child's execution contract to read one small schema.
+
+  Splitting the schema into `server/scenarios/field-mapping.ts` gives each side
+  what it actually needs: a zod-only module both can import, and an execution
+  contract with no importers outside the child's own tree.
+
+  # ---------------------------------------------------------------------------
+  # The boundary
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Nothing outside the child's own tree imports the execution contract
+    Given the application source tree
+    When every import of the scenario execution contract is collected
+    Then all of them come from files inside the scenario execution tree
+
+  @unit
+  Scenario: The shared field mapping schema carries no framework dependency
+    Given the shared field mapping module
+    When its imports are inspected
+    Then it imports zod and nothing else
+
+  # ---------------------------------------------------------------------------
+  # Both sides still agree on the shape
+  # ---------------------------------------------------------------------------
+
+  # A split that let the two definitions drift would be worse than the coupling
+  # it removed: a suite would save a mapping the child then refused to parse.
+
+  @unit
+  Scenario: A mapping accepted by the suite target schema is accepted by the child
+    Given a suite target carrying a source mapping and a literal mapping
+    When the child's job data schema parses the same mappings
+    Then both schemas accept them


### PR DESCRIPTION
`server/scenarios/execution/types.ts` is the wire contract between the scenario worker and the child process it spawns: the job data written to the child's stdin, the adapter payloads inside it, the execution context it runs under. It is meant to move to the child's own package, so the app can stop depending on the scenario runner and the production image can stop shipping it.

One thing stopped that move.

`FieldMappingSchema` — how a single agent input is filled, from a scenario source or from a literal — lived in that same file, and two callers outside the child needed it:

- `server/suites/types.ts`, for the suite target schema
- `optimization_studio/types/dsl.ts`, which is **frontend-reachable**

So the browser bundle reached into the child's execution contract to read one small schema.

## What changed

`FieldMappingSchema` moves to `server/scenarios/field-mapping.ts` — zod and nothing else, so either side imports it without dragging a dependency across the boundary. Everything else in `execution/types.ts` stays exactly where it is.

After this, `grep -rln 'scenarios/execution/types' src` returns only files inside `server/scenarios/execution/`.

## The guard

A boundary nobody checks is a boundary that lasts one PR, so `scenarios/__tests__/child-execution-contract.unit.test.ts` walks the real source tree and fails on a new outside importer. It is an architectural guard, not a snapshot — it reads the files rather than asserting a list back at itself. (It caught its own file on the first run, before I excluded it, which is the evidence that the detection works.)

A second scenario pins both schemas to the same mappings. A split that let the two definitions drift would be **worse** than the coupling it removed: a suite would save a mapping the child then refused to parse. That test parses one source mapping and one literal through `suiteTargetSchema` and through the child's `PromptConfigDataSchema`, and prompt targets are used deliberately — the suite schema rejects `scenarioMappings` on agent targets, since an agent's mappings belong on the agent record.

## Why this is the whole change

Nothing here alters behaviour. Every schema keeps its shape, and the same values parse the same way; the only difference is which file a symbol is declared in. The value is entirely in what it unblocks: extracting the child into its own package no longer has to move a schema the frontend depends on.

## Verification

- `src/server/scenarios` + `src/server/suites` + `src/components/suites` — **824/824 pass**
- `src/optimization_studio` — **435/435 pass** (the DSL's import moved)
- `pnpm typecheck` and `pnpm typecheck:tests` — 0 errors on both. Both, because `tsconfig.tsgo.json` excludes test files and the source project alone would not have looked at the guard test.
- `check-feature-parity.ts` — all 3 scenarios bound, `OK: 6465 enforced scenario(s) bound`
- biome — 0 errors on touched files; the 10 remaining warnings are pre-existing complexity warnings on functions this PR does not touch

One note on the spec's location: it lives in the repo-root `specs/`, not `platform/app/specs/`. The parity checker only reads the root, so a feature file under `platform/app/specs/` binds nothing and reads green while doing it.
