### PR TITLE
fix(model-providers): one default-models config per scope, wide-to-narrow inherit, no 500 on save

### DIFF
--- a/platform/app/prisma/migrations/20260814120000_collapse_duplicate_model_default_scopes/migration.sql
+++ b/platform/app/prisma/migrations/20260814120000_collapse_duplicate_model_default_scopes/migration.sql
@@ -1,0 +1,41 @@
+-- One config per scope for default models.
+--
+-- The "+ Add config" save path used to insert a new ModelDefaultConfig
+-- without checking whether the scope already had one. Each save at the
+-- same scope stacked one more row. The resolver hid the problem: it
+-- tiebreaks same-scope configs by createdAt DESC, so only the newest
+-- config had any effect while every duplicate row rendered the same
+-- resolved values in the settings table.
+--
+-- The write path now claims each scope on save (the scope moves to the
+-- new config and the old attachment is removed). This migration applies
+-- the same rule to rows written before the fix:
+--
+--   1. For every (scopeType, scopeId) held by more than one config,
+--      keep the attachment whose config is newest by (createdAt, id)
+--      and delete the shadowed attachments. This matches the resolver's
+--      tiebreak, so resolution results do not change.
+--   2. Delete configs left with zero attachments. They cannot be
+--      reached by the resolver and only clutter the settings table.
+
+DELETE FROM "ModelDefaultConfigScope" s
+USING "ModelDefaultConfig" c
+WHERE s."configId" = c."id"
+  AND EXISTS (
+    SELECT 1
+    FROM "ModelDefaultConfigScope" s2
+    JOIN "ModelDefaultConfig" c2 ON c2."id" = s2."configId"
+    WHERE s2."scopeType" = s."scopeType"
+      AND s2."scopeId" = s."scopeId"
+      AND (
+        c2."createdAt" > c."createdAt"
+        OR (c2."createdAt" = c."createdAt" AND c2."id" > c."id")
+      )
+  );
+
+DELETE FROM "ModelDefaultConfig" c
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "ModelDefaultConfigScope" s
+  WHERE s."configId" = c."id"
+);

--- a/platform/app/prisma/migrations/20260814120000_collapse_duplicate_model_default_scopes/migration.sql
+++ b/platform/app/prisma/migrations/20260814120000_collapse_duplicate_model_default_scopes/migration.sql
@@ -1,3 +1,11 @@
+-- IRREVERSIBLE: both statements delete rows, and there is no down step
+-- that could bring them back. The shadowed ModelDefaultConfigScope
+-- attachments and any ModelDefaultConfig left with no attachment are
+-- gone once this runs, their JSON payloads included. That is the point
+-- of the migration rather than a cost of it: every deleted row was
+-- already unreachable, shadowed at its scope by a newer config, so no
+-- resolution result changes.
+--
 -- One config per scope for default models.
 --
 -- The "+ Add config" save path used to insert a new ModelDefaultConfig
@@ -17,6 +25,11 @@
 --      tiebreak, so resolution results do not change.
 --   2. Delete configs left with zero attachments. They cannot be
 --      reached by the resolver and only clutter the settings table.
+--
+-- The id half of the tiebreak compares COLLATE "C". Ids are nanoids,
+-- whose alphabet includes "-" and "_", and a linguistic collation
+-- orders those differently from byte order, so without it two databases
+-- could keep different configs from the same rows.
 
 DELETE FROM "ModelDefaultConfigScope" s
 USING "ModelDefaultConfig" c
@@ -29,7 +42,10 @@ WHERE s."configId" = c."id"
       AND s2."scopeId" = s."scopeId"
       AND (
         c2."createdAt" > c."createdAt"
-        OR (c2."createdAt" = c."createdAt" AND c2."id" > c."id")
+        OR (
+          c2."createdAt" = c."createdAt"
+          AND c2."id" COLLATE "C" > c."id" COLLATE "C"
+        )
       )
   );
 

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -1190,8 +1190,12 @@ model ModelDefaultConfig {
 }
 
 // Join table binding a ModelDefaultConfig to a (scopeType, scopeId).
-// One config can have many scope attachments; one scope can have many
-// configs (resolver tiebreaks by createdAt DESC).
+// One config can have many scope attachments, but a scope belongs to at
+// most ONE config: every write path that attaches a scope first detaches
+// it from whichever config held it, under the same per-scope advisory
+// lock, and deletes any config left with zero attachments. The resolver
+// still tiebreaks same-scope configs by createdAt DESC as defense for
+// rows written before that invariant existed.
 model ModelDefaultConfigScope {
   id        String                @id @default(nanoid())
   configId  String

--- a/platform/app/src/app/api/model-defaults/[[...route]]/app.v1.ts
+++ b/platform/app/src/app/api/model-defaults/[[...route]]/app.v1.ts
@@ -1,3 +1,4 @@
+import { HandledError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "hono-openapi";
@@ -44,12 +45,14 @@ function sessionFor(userId: string | undefined): Session | null {
 
 /**
  * Uniform error mapping for the default-model write handlers: a typed
- * HTTPException (e.g. the 404 orphan-config ownership backstop) passes through
- * untouched, any other Error collapses to a 400, and non-Error throwables
- * re-throw as-is.
+ * HTTPException (e.g. the 404 orphan-config ownership backstop) and any
+ * HandledError (the app's onError serialises those with their own status
+ * and code) pass through untouched, any other Error collapses to a 400,
+ * and non-Error throwables re-throw as-is.
  */
 function rethrowModelDefaultsWriteError(err: unknown): never {
   if (err instanceof HTTPException) throw err;
+  if (HandledError.isHandled(err)) throw err;
   if (err instanceof Error) {
     throw new HTTPException(400, { message: err.message });
   }

--- a/platform/app/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/platform/app/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -26,7 +26,7 @@
 
 import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { modelSelectorOptions } from "~/components/ModelSelector";
 import { Drawer } from "~/components/ui/drawer";
 import { toaster } from "~/components/ui/toaster";
@@ -133,14 +133,6 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
     projects: [],
   };
   const features: FeatureProjection[] = dataQuery.data?.features ?? [];
-  const effective: Payload["effective"] =
-    dataQuery.data?.effective ??
-    ({
-      DEFAULT: null,
-      FAST: null,
-      LANGY: null,
-      EMBEDDINGS: null,
-    } as Payload["effective"]);
 
   // Treat the drawer as always-open while mounted - the registry only
   // renders it when `drawer.open === "defaultModelOverride"`. closeDrawer
@@ -174,28 +166,23 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
   });
   const [busy, setBusy] = useState(false);
 
-  // Hydrate state when the drawer is reopened with a different target.
+  // Hydrate edit state exactly once, when the target row first loads.
+  // The drawer unmounts on close, so one hydration per open is enough;
+  // keying on the `editing` object identity instead used to wipe
+  // in-progress edits whenever a background refetch replaced the query
+  // data. Create mode needs no hydration, its state starts empty.
+  const hydratedRef = useRef(false);
   useEffect(() => {
-    if (!open) return;
-    if (editing) {
-      setScopes(
-        editing.scopes.map((s) => ({
-          scopeType: s.type as ScopeType,
-          scopeId: s.id,
-        })),
-      );
-      setConfig({ ...(editing.config as Record<string, string>) });
-    } else {
-      setScopes([]);
-      setConfig({});
-    }
-    setExpanded({
-      DEFAULT: false,
-      FAST: false,
-      LANGY: false,
-      EMBEDDINGS: false,
-    });
-  }, [open, editing]);
+    if (!editing || hydratedRef.current) return;
+    hydratedRef.current = true;
+    setScopes(
+      editing.scopes.map((s) => ({
+        scopeType: s.type as ScopeType,
+        scopeId: s.id,
+      })),
+    );
+    setConfig({ ...(editing.config as Record<string, string>) });
+  }, [editing]);
 
   const inheritedQuery = api.modelProvider.getInheritedValuesForScopes.useQuery(
     {
@@ -204,11 +191,10 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
         scopeType: s.scopeType,
         scopeId: s.scopeId,
       })),
-      excludeConfigId: editing?.id,
+      excludeConfigId: editingId,
     },
     {
-      // Need at least one picked scope to anchor the cascade walk
-      // and the editing target should be settled.
+      // Need at least one picked scope to anchor the cascade walk.
       enabled: !!project?.id && scopes.length > 0 && open,
     },
   );
@@ -331,14 +317,23 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
     });
   }, []);
 
-  const canSave = scopes.length > 0 && !busy;
+  // Creating: at least one key must be pinned, an all-inherit new
+  // config is a no-op the backend refuses. Editing: an empty config is
+  // a valid save (it deletes the config, absence = pure inherit), but
+  // the target row must have loaded so the save carries its id;
+  // deriving the id from an unsettled query silently turned edits
+  // into creates.
+  const hasAnyKey = Object.keys(config).length > 0;
+  const canSave =
+    scopes.length > 0 && !busy && (editingId ? !!editing : hasAnyKey);
 
   const handleSave = useCallback(async () => {
     if (!canSave) return;
+    const copy = saveOutcomeCopy({ editingId, hasAnyKey });
     setBusy(true);
     try {
       await saveMutation.mutateAsync({
-        id: editing?.id,
+        id: editingId,
         config,
         scopes: scopes.map((s) => ({
           scopeType: s.scopeType,
@@ -353,7 +348,7 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
         utils.modelProvider.getResolvedDefault.invalidate(),
       ]);
       toaster.create({
-        title: editing ? "Config updated" : "Config added",
+        title: copy.successTitle,
         type: "success",
         duration: 2500,
         meta: { closable: true },
@@ -361,16 +356,21 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
       onSaved();
       onClose();
     } catch (err) {
-      showErrorToast({
-        error: err,
-        fallbackTitle: editing
-          ? "Couldn't save the default model"
-          : "Couldn't add the default model",
-      });
+      showErrorToast({ error: err, fallbackTitle: copy.failureTitle });
     } finally {
       setBusy(false);
     }
-  }, [canSave, saveMutation, editing, config, scopes, utils, onSaved, onClose]);
+  }, [
+    canSave,
+    saveMutation,
+    editingId,
+    hasAnyKey,
+    config,
+    scopes,
+    utils,
+    onSaved,
+    onClose,
+  ]);
 
   return (
     <Drawer.Root
@@ -397,6 +397,11 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
               onChange={setScopes}
               available={available}
             />
+            <ReplacedConfigsNote
+              scopes={scopes}
+              configs={dataQuery.data?.configs ?? []}
+              editingId={editingId}
+            />
 
             <VStack align="stretch" gap={2}>
               {ROLES.map((role) => (
@@ -405,7 +410,6 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
                   role={role}
                   config={config}
                   features={featuresByRole[role]}
-                  effective={effective[role]}
                   inheritedForRole={inherited[role] ?? null}
                   inheritedForFeature={inherited}
                   expanded={expanded[role]}
@@ -452,7 +456,6 @@ function RoleRow({
   role,
   config,
   features,
-  effective,
   inheritedForRole,
   inheritedForFeature,
   expanded,
@@ -464,7 +467,6 @@ function RoleRow({
   role: ModelRoleKey;
   config: Record<string, string>;
   features: FeatureProjection[];
-  effective: Payload["effective"][ModelRoleKey];
   /** Server's cascade answer for this role at the picked scopes. Null
    *  when no picked scope OR no cascade hit AND no inferable provider. */
   inheritedForRole: InheritedEntry;
@@ -478,12 +480,7 @@ function RoleRow({
   displayNames: Record<string, string>;
 }) {
   const current = config[role] ?? "";
-  // Prefer the picked-scope cascade answer; fall back to the
-  // project's effective resolution when the picker is empty (so the
-  // user still sees a sensible placeholder while the chip set is
-  // being built).
-  const inheritedModel = inheritedForRole?.model ?? effective?.model;
-  const inheritOption = buildInheritOption(inheritedForRole, effective);
+  const inheritOption = buildInheritOption(inheritedForRole);
   const canExpand = features.length > 0;
   const ChevronIcon = expanded ? ChevronDown : ChevronRight;
 
@@ -575,7 +572,6 @@ function RoleRow({
               roleLevelOverride={config[role] ?? ""}
               inheritedForFeature={inheritedForFeature[f.key] ?? null}
               inheritedForRole={inheritedForRole}
-              inheritedRoleModel={inheritedModel}
               modelOptions={modelOptions}
               onSetOverride={onSetOverride}
               displayNames={displayNames}
@@ -593,7 +589,6 @@ function FeatureRow({
   roleLevelOverride,
   inheritedForFeature,
   inheritedForRole,
-  inheritedRoleModel,
   modelOptions,
   onSetOverride,
   displayNames,
@@ -605,29 +600,18 @@ function FeatureRow({
   inheritedForFeature: InheritedEntry;
   /** Server cascade answer for the feature's role (fallback chain). */
   inheritedForRole: InheritedEntry;
-  /** Resolved model the role-level row would pick - wins over the
-   *  server-side feature inheritance because the in-progress config's
-   *  role-level pick is local and not yet persisted. */
-  inheritedRoleModel?: string;
   modelOptions: string[];
   onSetOverride: (key: string, model: string | null) => void;
   /** Configured custom-model display names, keyed by `<provider>/<modelId>`. */
   displayNames: Record<string, string>;
 }) {
-  // The feature's "would inherit" placeholder follows the same cascade
-  // the resolver does: a role-level pick in THIS config (in-progress)
-  // wins over the server's per-feature cascade, which in turn beats the
-  // role cascade. Without that local check the placeholder would lag
-  // behind what the user just typed in the role row above.
-  //
-  // Surface "Inherit (from role-level in this config)" when the user
-  // already picked a role-level value here, otherwise walk the same
-  // cascade fallback chain the role row uses: server's per-feature
-  // answer → server's role-level answer → in-progress role pick from
-  // this config → finally the resolved-role model from the page's
-  // effective payload, so the placeholder is never blank when there's
-  // anything cascading down.
-  let inheritOption: { model: string; label: string } | undefined;
+  // The feature's inherit entry follows the same cascade the resolver
+  // does: a role-level pick in THIS config (in-progress) wins over the
+  // server's per-feature cascade, which in turn beats the role cascade.
+  // Without that local check the entry would lag behind what the user
+  // just typed in the role row above. When nothing carries a value the
+  // entry reads "Not configured", same as the role rows.
+  let inheritOption: InheritOptionShape;
   if (roleLevelOverride) {
     inheritOption = {
       model: roleLevelOverride,
@@ -635,11 +619,8 @@ function FeatureRow({
     };
   } else {
     inheritOption =
-      buildInheritOption(inheritedForFeature, null) ??
-      buildInheritOption(inheritedForRole, null) ??
-      (inheritedRoleModel
-        ? { model: inheritedRoleModel, label: "Inherit (role default)" }
-        : undefined);
+      inheritHitOption(inheritedForFeature) ??
+      buildInheritOption(inheritedForRole);
   }
   return (
     <HStack gap={2} align="center" data-testid={`feature-row-${feature.key}`}>
@@ -670,59 +651,120 @@ function FeatureRow({
   );
 }
 
+export type InheritOptionShape = { model?: string; label: string };
+
+/**
+ * Toast copy for the save outcome. Saving an edit with every key on
+ * inherit deletes the config on the server (absence = pure inherit),
+ * so the toast has to say the config was removed instead of "updated".
+ */
+function saveOutcomeCopy({
+  editingId,
+  hasAnyKey,
+}: {
+  editingId?: string;
+  hasAnyKey: boolean;
+}): { successTitle: string; failureTitle: string } {
+  if (!editingId) {
+    return {
+      successTitle: "Config added",
+      failureTitle: "Couldn't add the default model",
+    };
+  }
+  return {
+    successTitle: hasAnyKey
+      ? "Config updated"
+      : "Config removed, every value inherits now",
+    failureTitle: "Couldn't save the default model",
+  };
+}
+
+/**
+ * The inherit entry for a real cascade hit at the picked scopes, or
+ * undefined when the server has none. The label names the WIDER scope
+ * the value flows down from ("Inherit (from organization)"), which is
+ * why the entry is built only from the server's answer for the picked
+ * scopes: the server anchors its walk at the most-specific picked
+ * scope and excludes the picked scopes themselves, so it can never
+ * answer with a narrower tier. The old fallback to the current
+ * project's own resolution is what produced "Inherit (from project)"
+ * inside an organization-scoped config.
+ *
+ * The `inferred` source is not a cascade hit, it is the server
+ * guessing what the user might want from their enabled providers.
+ * Showing it as a ghost value gave the contradictory read that
+ * something was set when nothing was.
+ */
+export function inheritHitOption(
+  entry: InheritedEntry,
+): InheritOptionShape | undefined {
+  if (!entry || entry.source === "inferred") return undefined;
+  return {
+    model: entry.model,
+    label: entry.scope ? `Inherit (from ${entry.scope})` : "Inherit",
+  };
+}
+
 /**
  * Builds the `inheritOption` payload `ProviderModelSelector` consumes.
- * The label tells the user where the value comes from - "Inherit (from
- * organization)" or similar - and the model is rendered at reduced
- * opacity in the trigger + as the first dropdown entry.
- *
- * For the `inferred` source (server falls back to "we'd pick the
- * latest from your first provider") the label is a neutral "Inherit"
- * rather than "Suggested from X" - the picker already surfaces the
- * provider's `/latest` and `/latest-mini` aliases at the top of the
- * list, so the per-provider attribution would just add noise. The
- * inherit entry itself stays so the user can always toggle back from
- * an explicit override.
+ * With a cascade hit the entry carries the inherited model, rendered at
+ * reduced opacity in the trigger and as the first dropdown entry. With
+ * no hit (nothing set anywhere wider, or the widest scope is picked)
+ * the entry reads "Not configured" with no model attached: it still
+ * exists so an edit can always clear a pinned key back to inherit, it
+ * just never claims a value flows down from somewhere.
  */
-function buildInheritOption(
-  fromServer: InheritedEntry,
-  fromEffective: Payload["effective"][ModelRoleKey] | null,
-): { model: string; label: string } | undefined {
-  if (fromServer) {
-    // Skip the "inferred" source: an inferred value is the server
-    // guessing what the user MIGHT want based on which providers are
-    // enabled, not a real cascade hit. Showing it as a ghost
-    // placeholder under a "Not configured" badge gave the
-    // contradictory read that something was set when nothing was -
-    // the row stays empty until the user explicitly picks a model.
-    if (fromServer.source === "inferred") {
-      return undefined;
+export function buildInheritOption(entry: InheritedEntry): InheritOptionShape {
+  return inheritHitOption(entry) ?? { label: "Not configured" };
+}
+
+/**
+ * Note under the scope picker when a picked scope already belongs to
+ * another config. Saving claims those scopes (one config per scope), so
+ * the user learns the existing config gets replaced BEFORE hitting
+ * save, instead of discovering a silently rewired table after.
+ */
+function replacedScopeNames({
+  scopes,
+  configs,
+  editingId,
+}: {
+  scopes: ScopeTriadEntry[];
+  configs: Payload["configs"];
+  editingId?: string;
+}): string[] {
+  const picked = new Set(scopes.map((s) => `${s.scopeType}::${s.scopeId}`));
+  const names: string[] = [];
+  for (const c of configs) {
+    if (c.id === editingId) continue;
+    for (const s of c.scopes) {
+      if (picked.has(`${s.type}::${s.id}`)) names.push(s.name);
     }
-    // `feature_override` / `role_default` carry a concrete scope name
-    // (organization / team / project). The "system" / env-var fallback
-    // is surfaced via `fromEffective` below.
-    return {
-      model: fromServer.model,
-      label: fromServer.scope
-        ? `Inherit (from ${fromServer.scope})`
-        : "Inherit",
-    };
   }
-  if (fromEffective) {
-    // Same rationale as the `inferred` skip above: env-var fallback
-    // isn't a configured scope, just a host-level default. The drawer
-    // is for setting explicit policy, so empty stays empty.
-    if (fromEffective.source === "system") {
-      return undefined;
-    }
-    return {
-      model: fromEffective.model,
-      label: fromEffective.scope
-        ? `Inherit (from ${fromEffective.scope})`
-        : "Inherit",
-    };
-  }
-  return undefined;
+  return Array.from(new Set(names));
+}
+
+function ReplacedConfigsNote({
+  scopes,
+  configs,
+  editingId,
+}: {
+  scopes: ScopeTriadEntry[];
+  configs: Payload["configs"];
+  editingId?: string;
+}) {
+  const replacedNames = useMemo(
+    () => replacedScopeNames({ scopes, configs, editingId }),
+    [scopes, configs, editingId],
+  );
+  if (replacedNames.length === 0) return null;
+  const single = replacedNames.length === 1;
+  return (
+    <Text fontSize="xs" color="fg.muted" data-testid="replaced-configs-note">
+      {replacedNames.join(", ")} already {single ? "has" : "have"} default
+      models. Saving replaces {single ? "that config" : "those configs"}.
+    </Text>
+  );
 }
 
 /**

--- a/platform/app/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/platform/app/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -54,6 +54,11 @@ type ModelRoleKey = "DEFAULT" | "FAST" | "LANGY" | "EMBEDDINGS";
 
 const ROLES: ModelRoleKey[] = ["DEFAULT", "FAST", "LANGY", "EMBEDDINGS"];
 
+/** Stands in for "no row" in the hydration latch, which tracks which
+ *  target the drawer's state belongs to and cannot use a config id
+ *  for create mode. */
+const CREATE_TARGET = "__create__";
+
 const ROLE_LABEL: Record<ModelRoleKey, string> = {
   DEFAULT: "Default",
   FAST: "Fast",
@@ -166,15 +171,25 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
   });
   const [busy, setBusy] = useState(false);
 
-  // Hydrate edit state exactly once, when the target row first loads.
-  // The drawer unmounts on close, so one hydration per open is enough;
-  // keying on the `editing` object identity instead used to wipe
-  // in-progress edits whenever a background refetch replaced the query
-  // data. Create mode needs no hydration, its state starts empty.
-  const hydratedRef = useRef(false);
+  // Hydrate edit state once per target, and re-hydrate when the target
+  // changes. Both halves matter: keying on the `editing` object identity
+  // wiped in-progress edits whenever a background refetch replaced the
+  // query data, while a plain "hydrated once" latch goes the other way
+  // and keeps the previous target's values. The drawer is non-modal, so
+  // the pencil and "+ Add config" behind it can retarget it without ever
+  // unmounting, and stale values would then be saved onto another row.
+  const hydratedForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!editing || hydratedRef.current) return;
-    hydratedRef.current = true;
+    if (!editingId) {
+      // Create mode has nothing to load, it starts empty.
+      if (hydratedForRef.current === CREATE_TARGET) return;
+      hydratedForRef.current = CREATE_TARGET;
+      setScopes([]);
+      setConfig({});
+      return;
+    }
+    if (!editing || hydratedForRef.current === editing.id) return;
+    hydratedForRef.current = editing.id;
     setScopes(
       editing.scopes.map((s) => ({
         scopeType: s.type as ScopeType,
@@ -182,7 +197,7 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
       })),
     );
     setConfig({ ...(editing.config as Record<string, string>) });
-  }, [editing]);
+  }, [editingId, editing]);
 
   const inheritedQuery = api.modelProvider.getInheritedValuesForScopes.useQuery(
     {
@@ -758,11 +773,20 @@ function ReplacedConfigsNote({
     [scopes, configs, editingId],
   );
   if (replacedNames.length === 0) return null;
-  const single = replacedNames.length === 1;
+  const isSingle = replacedNames.length === 1;
   return (
-    <Text fontSize="xs" color="fg.muted" data-testid="replaced-configs-note">
-      {replacedNames.join(", ")} already {single ? "has" : "have"} default
-      models. Saving replaces {single ? "that config" : "those configs"}.
+    // The note appears only after a scope is picked, and it is the one
+    // warning that saving overwrites another config. `role="status"`
+    // makes the insertion announced, so it reaches a screen reader user
+    // before they save rather than not at all.
+    <Text
+      fontSize="xs"
+      color="fg.muted"
+      role="status"
+      data-testid="replaced-configs-note"
+    >
+      {replacedNames.join(", ")} already {isSingle ? "has" : "have"} default
+      models. Saving replaces {isSingle ? "that config" : "those configs"}.
     </Text>
   );
 }

--- a/platform/app/src/components/settings/DefaultModelsSection.tsx
+++ b/platform/app/src/components/settings/DefaultModelsSection.tsx
@@ -285,6 +285,7 @@ export function DefaultModelsSection({
             configs={visibleConfigs}
             allConfigs={data.configs}
             features={data.features}
+            hierarchy={effectiveHierarchy}
             onEdit={openEdit}
             onDelete={handleDelete}
             onAdd={openAdd}
@@ -303,6 +304,7 @@ function AllConfigsView({
   configs,
   allConfigs,
   features,
+  hierarchy,
   onEdit,
   onDelete,
   onAdd,
@@ -316,6 +318,8 @@ function AllConfigsView({
    *  see at runtime. */
   allConfigs: ConfigRow[];
   features: Payload["features"];
+  /** Org graph the cascade walk resolves parent-scope ids from. */
+  hierarchy: ScopeHierarchy;
   onEdit: (c: ConfigRow) => void;
   onDelete: (c: ConfigRow) => void;
   onAdd: () => void;
@@ -386,6 +390,7 @@ function AllConfigsView({
                   features={features}
                   configs={allConfigs}
                   anchorScope={mostSpecificScope(c.scopes)}
+                  hierarchy={hierarchy}
                   onEdit={() => onEdit(c)}
                   enabledProviderKeys={enabledProviderKeys}
                   displayNames={displayNames}
@@ -451,6 +456,7 @@ function ConfigCell({
   features,
   configs,
   anchorScope,
+  hierarchy,
   onEdit,
   enabledProviderKeys,
   displayNames,
@@ -460,6 +466,8 @@ function ConfigCell({
   features: Payload["features"];
   configs: ConfigRow[];
   anchorScope: { type: "ORGANIZATION" | "TEAM" | "PROJECT"; id: string } | null;
+  /** Org graph the cascade walk resolves parent-scope ids from. */
+  hierarchy: ScopeHierarchy;
   /** Open the row's edit drawer. Wired to the hover-revealed pencil
    *  next to each chip so the user can jump straight from "I want to
    *  change this model" to the drawer without hunting for the 3-dot
@@ -481,7 +489,7 @@ function ConfigCell({
   // update; AI features for this role are disabled at this scope until
   // they do.
   const resolvedRole = anchorScope
-    ? resolveAtScope(role, configs, anchorScope.type, anchorScope.id)
+    ? resolveAtScope({ key: role, configs, anchor: anchorScope, hierarchy })
     : null;
   const resolvedRoleModel = resolvedRole?.model ?? config[role] ?? null;
 
@@ -590,31 +598,58 @@ function mostSpecificScope(
   return null;
 }
 
+type AnchorScope = { type: "ORGANIZATION" | "TEAM" | "PROJECT"; id: string };
+
 /**
- * Cascading walk for a single key at a given scope. Walks
- * PROJECT → TEAM → ORG from the anchor scope, within each tier sorting
- * configs by createdAt DESC and taking the first that has the key.
- * Returns null if no config in the visible set carries the key.
+ * The anchor's own parent chain, most specific first: a project walks
+ * project, its own team, then the organization; a team walks team then
+ * organization. A parent tier whose id can't be resolved from the
+ * hierarchy is skipped rather than loosely matched.
  */
-function resolveAtScope(
-  key: string,
-  configs: ConfigRow[],
-  scopeType: "ORGANIZATION" | "TEAM" | "PROJECT",
-  scopeId: string,
-): NonNullable<Payload["effective"][ModelRoleKey]> | null {
-  const tier =
-    scopeType === "PROJECT"
-      ? ["PROJECT", "TEAM", "ORGANIZATION"]
-      : scopeType === "TEAM"
-        ? ["TEAM", "ORGANIZATION"]
-        : ["ORGANIZATION"];
-  for (const t of tier) {
+function cascadeChainFor(
+  anchor: AnchorScope,
+  hierarchy: ScopeHierarchy,
+): AnchorScope[] {
+  const organizationId = hierarchy.organization?.id ?? null;
+  const chain: AnchorScope[] = [anchor];
+  if (anchor.type === "PROJECT") {
+    const teamId =
+      (hierarchy.projects ?? []).find((p) => p.id === anchor.id)?.teamId ??
+      null;
+    if (teamId) chain.push({ type: "TEAM", id: teamId });
+  }
+  if (anchor.type !== "ORGANIZATION" && organizationId) {
+    chain.push({ type: "ORGANIZATION", id: organizationId });
+  }
+  return chain;
+}
+
+/**
+ * Cascading walk for a single key at a given scope, mirroring the
+ * server resolver's chain: the anchor scope, then the anchor's OWN
+ * parent scopes (a project's team, then the organization). Within each
+ * tier configs sort by createdAt DESC and the first carrying the key
+ * wins. Returns null if nothing in the anchor's chain carries the key.
+ *
+ * The chain ids come from `hierarchy`: matching parent tiers by TYPE
+ * alone displayed values from any team in the organization, including
+ * teams the anchor project does not belong to, values the runtime
+ * would never serve. Exported for tests.
+ */
+export function resolveAtScope({
+  key,
+  configs,
+  anchor,
+  hierarchy,
+}: {
+  key: string;
+  configs: ConfigRow[];
+  anchor: AnchorScope;
+  hierarchy: ScopeHierarchy;
+}): NonNullable<Payload["effective"][ModelRoleKey]> | null {
+  for (const t of cascadeChainFor(anchor, hierarchy)) {
     const matching = configs
-      .filter((c) =>
-        c.scopes.some((s) =>
-          t === scopeType ? s.type === t && s.id === scopeId : s.type === t,
-        ),
-      )
+      .filter((c) => c.scopes.some((s) => s.type === t.type && s.id === t.id))
       .filter((c) => (c.config as Record<string, string>)[key])
       .sort(
         (a, b) =>
@@ -623,8 +658,8 @@ function resolveAtScope(
     if (matching[0]) {
       return {
         model: (matching[0].config as Record<string, string>)[key]!,
-        source: t === scopeType ? "role_default" : "role_default",
-        scope: t.toLowerCase(),
+        source: "role_default",
+        scope: t.type.toLowerCase(),
       } as NonNullable<Payload["effective"][ModelRoleKey]>;
     }
   }

--- a/platform/app/src/components/settings/ProviderModelSelector.tsx
+++ b/platform/app/src/components/settings/ProviderModelSelector.tsx
@@ -71,9 +71,13 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
   size?: "sm" | "md" | "full";
   disabled?: boolean;
   inheritOption?: {
-    /** Model identifier the cascade would resolve to. Rendered with the provider icon. */
-    model: string;
-    /** Short label shown above the model, e.g. "Inherit (from organization)" or "Suggested from openai". */
+    /** Model identifier the cascade would resolve to, rendered with the
+     *  provider icon. Absent when nothing wider carries a value (or the
+     *  widest scope is being edited): the entry then reads as its label
+     *  alone, still selectable so a pinned key can be cleared back to
+     *  inherit. */
+    model?: string;
+    /** Short label shown above the model, e.g. "Inherit (from organization)" or "Not configured". */
     label: string;
   };
   /** Configured custom-model display names, keyed by `<provider>/<modelId>`.
@@ -158,7 +162,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
   // picked anything. Uses the inherited model's icon + family at 0.55
   // opacity so it reads as "this is what you'd get if you don't
   // override" instead of an empty / broken selector.
-  const inheritIcon = inheritOption
+  const inheritIcon = inheritOption?.model
     ? modelProviderIcons[
         inheritOption.model.split("/")[0] as keyof typeof modelProviderIcons
       ]
@@ -202,14 +206,16 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
         )}
         <Box
           fontSize={size === "sm" ? 12 : 14}
-          fontFamily="mono"
+          fontFamily={inheritOption.model ? "mono" : undefined}
           lineClamp={1}
           wordBreak="break-all"
         >
-          {modelDisplayLabel({
-            fullModelId: inheritOption.model,
-            displayNames,
-          })}
+          {inheritOption.model
+            ? modelDisplayLabel({
+                fullModelId: inheritOption.model,
+                displayNames,
+              })
+            : inheritOption.label}
         </Box>
       </HStack>
     ) : (
@@ -337,17 +343,19 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
                 <Text fontSize="sm" fontWeight="medium">
                   {inheritOption.label}
                 </Text>
-                <Text
-                  fontSize="xs"
-                  color="fg.muted"
-                  fontFamily="mono"
-                  lineClamp={1}
-                >
-                  {modelDisplayLabel({
-                    fullModelId: inheritOption.model,
-                    displayNames,
-                  })}
-                </Text>
+                {inheritOption.model && (
+                  <Text
+                    fontSize="xs"
+                    color="fg.muted"
+                    fontFamily="mono"
+                    lineClamp={1}
+                  >
+                    {modelDisplayLabel({
+                      fullModelId: inheritOption.model,
+                      displayNames,
+                    })}
+                  </Text>
+                )}
               </Box>
             </HStack>
           </Select.Item>

--- a/platform/app/src/components/settings/__tests__/DefaultModelOverrideDrawer.inheritDirection.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/DefaultModelOverrideDrawer.inheritDirection.integration.test.tsx
@@ -138,12 +138,25 @@ function payloadWith(configs: unknown[]) {
   };
 }
 
-function renderDrawer(editingId?: string) {
-  return render(
+function drawerTree(editingId?: string) {
+  return (
     <ChakraProvider value={defaultSystem}>
       <DefaultModelOverrideDrawer editingId={editingId} />
-    </ChakraProvider>,
+    </ChakraProvider>
   );
+}
+
+function renderDrawer(editingId?: string) {
+  return render(drawerTree(editingId));
+}
+
+/** The config payload of the drawer's first save call. */
+function savedConfig(): Record<string, string> | undefined {
+  return (
+    mockSave.mock.calls[0]?.[0] as
+      | { config: Record<string, string> }
+      | undefined
+  )?.config;
 }
 
 describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", () => {
@@ -180,7 +193,7 @@ describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", (
 
   describe("when editing a project-scoped config that inherits from the organization", () => {
     /** @scenario The inherit entry names the wider scope the value comes from */
-    it("labels the inherit entry with the wider scope, never the project's own view", () => {
+    it("labels the inherit entry with the wider scope, never the project's own view", async () => {
       mockGetInheritedValues.mockReturnValue({
         data: {
           inherited: {
@@ -203,10 +216,16 @@ describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", (
       expect(
         screen.queryByText("Inherit (from project)"),
       ).not.toBeInTheDocument();
+
+      // The entry is a label over a value that flows down, not a value
+      // of its own: leaving it selected saves the key as absent.
+      fireEvent.click(screen.getByTestId("config-save"));
+      await vi.waitFor(() => expect(mockSave).toHaveBeenCalled());
+      expect(savedConfig()).not.toHaveProperty("DEFAULT");
     });
   });
 
-  describe("when editing the organization-scoped config", () => {
+  describe("when adding a config scoped to the organization", () => {
     /** @scenario At organization scope the inherit entry reads "Not configured" */
     it("offers a plain Not configured entry instead of a reverse-direction inherit", () => {
       // The server walk for a picked organization scope excludes the
@@ -220,7 +239,8 @@ describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", (
         isLoading: false,
       });
 
-      renderDrawer("cfg_org");
+      renderDrawer(undefined);
+      fireEvent.click(screen.getByTestId("pick-org-scope"));
 
       expect(screen.getAllByText("Not configured").length).toBeGreaterThan(0);
       expect(screen.queryByText(/Inherit \(from/)).not.toBeInTheDocument();
@@ -245,15 +265,19 @@ describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", (
         data: undefined,
         isLoading: true,
       });
-      renderDrawer("cfg_org");
+      // One mount throughout, so the unsettled-to-settled transition and
+      // the hydration latch it drives are the thing under test. Two
+      // separate mounts would each start from a clean latch and prove
+      // nothing about either.
+      const { rerender } = renderDrawer("cfg_org");
       expect(screen.getByTestId("config-save")).toBeDisabled();
-      cleanup();
 
       mockGetDefaultModels.mockReturnValue({
         data: payloadWith([ORG_CONFIG_ROW, PROJECT_CONFIG_ROW]),
         isLoading: false,
       });
-      renderDrawer("cfg_org");
+      rerender(drawerTree("cfg_org"));
+
       const save = screen.getByTestId("config-save");
       expect(save).not.toBeDisabled();
       fireEvent.click(save);
@@ -263,6 +287,27 @@ describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", (
           expect.objectContaining({ id: "cfg_org" }),
         );
       });
+      // Hydrated from the settled row, not left empty by the latch.
+      expect(savedConfig()).toEqual({ DEFAULT: "openai/gpt-5.5" });
+    });
+
+    /** @scenario Retargeting the open drawer to another row saves that row's values */
+    it("re-hydrates when the open drawer is pointed at a different row", async () => {
+      // The drawer is non-modal and CurrentDrawer renders it without a
+      // key, so the pencil behind it swaps `editingId` on the SAME
+      // mount. A latch that hydrated only once would keep the first
+      // row's values and write them onto the second row.
+      const { rerender } = renderDrawer("cfg_org");
+      rerender(drawerTree("cfg_proj"));
+
+      fireEvent.click(screen.getByTestId("config-save"));
+
+      await vi.waitFor(() => {
+        expect(mockSave).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "cfg_proj" }),
+        );
+      });
+      expect(savedConfig()).toEqual({});
     });
   });
 

--- a/platform/app/src/components/settings/__tests__/DefaultModelOverrideDrawer.inheritDirection.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/DefaultModelOverrideDrawer.inheritDirection.integration.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Customer report (2026-08-13): the Add config drawer at organization
+ * scope offered "Inherit (from project)" (inheritance can only flow
+ * from wide to narrow), saving with it selected reached the backend as
+ * an empty config and surfaced a raw 500, and each save stacked one
+ * more row for the same scope.
+ *
+ * Binds the drawer scenarios in
+ * specs/model-providers/role-based-default-models.feature.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { featuresByRole } from "~/server/modelProviders/featureRegistry";
+import { DefaultModelOverrideDrawer } from "../DefaultModelOverrideDrawer";
+
+const mockCloseDrawer = vi.fn();
+const mockGetDefaultModels = vi.fn();
+const mockGetInheritedValues = vi.fn();
+const mockListAllForProjectForFrontend = vi.fn();
+const mockSave = vi.fn();
+const mockInvalidate = vi.fn();
+const mockToasterCreate = vi.fn();
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: mockCloseDrawer,
+    openDrawer: vi.fn(),
+    drawerOpen: () => false,
+    canGoBack: false,
+    goBack: vi.fn(),
+    currentDrawer: undefined,
+  }),
+  useDrawerParams: () => ({}),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "acme-app", name: "Acme App" },
+    organization: { id: "org-1", name: "Acme" },
+    team: { id: "team-1", name: "Platform" },
+    hasPermission: () => true,
+  }),
+}));
+
+// The picker stub exposes one button that picks the organization scope,
+// so create-mode tests can drive the scope selection without the real
+// multi-select dropdown.
+vi.mock("~/components/settings/ScopeChipPicker", () => ({
+  ScopeChipPicker: ({
+    onChange,
+  }: {
+    onChange: (next: Array<{ scopeType: string; scopeId: string }>) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="pick-org-scope"
+      onClick={() =>
+        onChange([{ scopeType: "ORGANIZATION", scopeId: "org-1" }])
+      }
+    />
+  ),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      modelProvider: {
+        getDefaultModelsForProject: { invalidate: mockInvalidate },
+        getResolvedDefault: { invalidate: vi.fn() },
+      },
+    }),
+    modelProvider: {
+      getDefaultModelsForProject: {
+        useQuery: () => mockGetDefaultModels(),
+      },
+      getInheritedValuesForScopes: {
+        useQuery: () => mockGetInheritedValues(),
+      },
+      listAllForProjectForFrontend: {
+        useQuery: () => mockListAllForProjectForFrontend(),
+      },
+      saveDefaultModelsConfig: {
+        useMutation: () => ({ mutateAsync: mockSave, isPending: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: (...args: unknown[]) => mockToasterCreate(...args) },
+}));
+
+const ORG_CONFIG_ROW = {
+  id: "cfg_org",
+  config: { DEFAULT: "openai/gpt-5.5" },
+  createdAt: new Date("2026-05-15T12:00:00Z"),
+  updatedAt: new Date("2026-05-15T12:00:00Z"),
+  authorId: "user-1",
+  scopes: [{ type: "ORGANIZATION" as const, id: "org-1", name: "Acme" }],
+};
+
+const PROJECT_CONFIG_ROW = {
+  id: "cfg_proj",
+  config: {},
+  createdAt: new Date("2026-05-16T12:00:00Z"),
+  updatedAt: new Date("2026-05-16T12:00:00Z"),
+  authorId: "user-1",
+  scopes: [{ type: "PROJECT" as const, id: "proj-1", name: "Acme App" }],
+};
+
+function payloadWith(configs: unknown[]) {
+  return {
+    projectId: "proj-1",
+    teamId: "team-1",
+    organizationId: "org-1",
+    organizationName: "Acme",
+    effective: {
+      DEFAULT: {
+        model: "gemini/gemini-2.5-pro",
+        source: "role_default",
+        scope: "project",
+      },
+      FAST: null,
+      LANGY: null,
+      EMBEDDINGS: null,
+    },
+    configs,
+    available: {
+      organization: { id: "org-1", name: "Acme" },
+      teams: [{ id: "team-1", name: "Platform" }],
+      projects: [{ id: "proj-1", name: "Acme App", teamId: "team-1" }],
+    },
+    features: featuresByRole("DEFAULT"),
+  };
+}
+
+function renderDrawer(editingId?: string) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <DefaultModelOverrideDrawer editingId={editingId} />
+    </ChakraProvider>,
+  );
+}
+
+describe("<DefaultModelOverrideDrawer/> inherit direction and save integrity", () => {
+  beforeEach(() => {
+    mockGetDefaultModels.mockReturnValue({
+      data: payloadWith([ORG_CONFIG_ROW, PROJECT_CONFIG_ROW]),
+      isLoading: false,
+    });
+    mockGetInheritedValues.mockReturnValue({
+      data: { inherited: {}, referenceScope: null },
+      isLoading: false,
+    });
+    mockListAllForProjectForFrontend.mockReturnValue({
+      data: {
+        providers: [
+          {
+            provider: "openai",
+            enabled: true,
+            customModels: [],
+            customEmbeddingsModels: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+    mockSave.mockReset();
+    mockSave.mockResolvedValue({ id: "cfg_org" });
+    mockInvalidate.mockReset();
+    mockCloseDrawer.mockReset();
+    mockToasterCreate.mockReset();
+  });
+  afterEach(() => cleanup());
+
+  describe("when editing a project-scoped config that inherits from the organization", () => {
+    /** @scenario The inherit entry names the wider scope the value comes from */
+    it("labels the inherit entry with the wider scope, never the project's own view", () => {
+      mockGetInheritedValues.mockReturnValue({
+        data: {
+          inherited: {
+            DEFAULT: {
+              model: "openai/gpt-5.5",
+              source: "role_default",
+              scope: "organization",
+            },
+          },
+          referenceScope: { scopeType: "PROJECT", scopeId: "proj-1" },
+        },
+        isLoading: false,
+      });
+
+      renderDrawer("cfg_proj");
+
+      expect(
+        screen.getAllByText("Inherit (from organization)").length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.queryByText("Inherit (from project)"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when editing the organization-scoped config", () => {
+    /** @scenario At organization scope the inherit entry reads "Not configured" */
+    it("offers a plain Not configured entry instead of a reverse-direction inherit", () => {
+      // The server walk for a picked organization scope excludes the
+      // organization itself and has nothing wider, so every key comes
+      // back without a cascade hit.
+      mockGetInheritedValues.mockReturnValue({
+        data: {
+          inherited: { DEFAULT: null },
+          referenceScope: { scopeType: "ORGANIZATION", scopeId: "org-1" },
+        },
+        isLoading: false,
+      });
+
+      renderDrawer("cfg_org");
+
+      expect(screen.getAllByText("Not configured").length).toBeGreaterThan(0);
+      expect(screen.queryByText(/Inherit \(from/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when adding a config with no model picked", () => {
+    /** @scenario Save is disabled while a new config carries no model at all */
+    it("keeps the save button disabled", () => {
+      renderDrawer(undefined);
+
+      fireEvent.click(screen.getByTestId("pick-org-scope"));
+
+      expect(screen.getByTestId("config-save")).toBeDisabled();
+    });
+  });
+
+  describe("when saving an edit", () => {
+    /** @scenario Saving an edit targets the config row that was opened */
+    it("stays disabled until the target loads, then sends that config's id", async () => {
+      mockGetDefaultModels.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      });
+      renderDrawer("cfg_org");
+      expect(screen.getByTestId("config-save")).toBeDisabled();
+      cleanup();
+
+      mockGetDefaultModels.mockReturnValue({
+        data: payloadWith([ORG_CONFIG_ROW, PROJECT_CONFIG_ROW]),
+        isLoading: false,
+      });
+      renderDrawer("cfg_org");
+      const save = screen.getByTestId("config-save");
+      expect(save).not.toBeDisabled();
+      fireEvent.click(save);
+
+      await vi.waitFor(() => {
+        expect(mockSave).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "cfg_org" }),
+        );
+      });
+    });
+  });
+
+  describe("when an edit clears every key back to inherit", () => {
+    /** @scenario Editing every key to Inherit tells the user the config was removed */
+    it("toasts that the config was removed, not updated", async () => {
+      renderDrawer("cfg_proj");
+
+      const save = screen.getByTestId("config-save");
+      expect(save).not.toBeDisabled();
+      fireEvent.click(save);
+
+      await vi.waitFor(() => {
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Config removed, every value inherits now",
+          }),
+        );
+      });
+      expect(mockSave).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "cfg_proj", config: {} }),
+      );
+    });
+  });
+
+  describe("when adding a config for a scope that already has one", () => {
+    /** @scenario Adding a config for a scope that already has one says it will replace it */
+    it("shows a note that the existing config gets replaced", () => {
+      renderDrawer(undefined);
+
+      expect(
+        screen.queryByTestId("replaced-configs-note"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("pick-org-scope"));
+
+      const note = screen.getByTestId("replaced-configs-note");
+      expect(note).toHaveTextContent("Acme already has default models");
+      expect(note).toHaveTextContent("Saving replaces that config");
+    });
+  });
+});

--- a/platform/app/src/components/settings/__tests__/defaultModelsResolveAtScope.unit.test.ts
+++ b/platform/app/src/components/settings/__tests__/defaultModelsResolveAtScope.unit.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment node
+ *
+ * The table cells walk the cascade client-side to display each row's
+ * resolved models. The walk must follow the row's OWN scope chain
+ * (project, then its own team, then the organization). It used to match
+ * parent tiers by type alone, so a project row displayed values from
+ * any team in the organization, values the runtime resolver would
+ * never serve for that project.
+ *
+ * Binds "Config cells resolve inherited values only from the row's own
+ * scope chain" in specs/model-providers/role-based-default-models.feature.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveAtScope } from "../DefaultModelsSection";
+
+type ConfigRow = Parameters<typeof resolveAtScope>[0]["configs"][number];
+
+const HIERARCHY = {
+  organization: { id: "org-1" },
+  teams: [{ id: "team-platform" }, { id: "team-research" }],
+  projects: [
+    { id: "proj-web", teamId: "team-platform" },
+    { id: "proj-lab", teamId: "team-research" },
+  ],
+};
+
+function configRow(params: {
+  id: string;
+  config: Record<string, string>;
+  scopes: Array<{
+    type: "ORGANIZATION" | "TEAM" | "PROJECT";
+    id: string;
+  }>;
+  createdAt?: string;
+}): ConfigRow {
+  return {
+    id: params.id,
+    config: params.config,
+    createdAt: new Date(params.createdAt ?? "2026-05-01T00:00:00Z"),
+    updatedAt: new Date(params.createdAt ?? "2026-05-01T00:00:00Z"),
+    authorId: null,
+    scopes: params.scopes.map((s) => ({ ...s, name: s.id })),
+  } as ConfigRow;
+}
+
+const ORG_CONFIG = configRow({
+  id: "cfg-org",
+  config: { FAST: "openai/gpt-5-mini" },
+  scopes: [{ type: "ORGANIZATION", id: "org-1" }],
+});
+
+const RESEARCH_TEAM_CONFIG = configRow({
+  id: "cfg-research",
+  config: { FAST: "anthropic/claude-haiku" },
+  scopes: [{ type: "TEAM", id: "team-research" }],
+  createdAt: "2026-06-01T00:00:00Z",
+});
+
+const WEB_PROJECT_CONFIG = configRow({
+  id: "cfg-web",
+  config: {},
+  scopes: [{ type: "PROJECT", id: "proj-web" }],
+});
+
+const ALL = [ORG_CONFIG, RESEARCH_TEAM_CONFIG, WEB_PROJECT_CONFIG];
+
+describe("resolveAtScope", () => {
+  describe("when a project row resolves a key it does not pin", () => {
+    /** @scenario Config cells resolve inherited values only from the row's own scope chain */
+    it("consults the project's own team and organization, never a sibling team", () => {
+      const resolved = resolveAtScope({
+        key: "FAST",
+        configs: ALL,
+        anchor: { type: "PROJECT", id: "proj-web" },
+        hierarchy: HIERARCHY,
+      });
+
+      // proj-web belongs to team-platform, which has no config, so the
+      // walk lands on the organization. team-research's newer config
+      // must not shadow it.
+      expect(resolved?.model).toBe("openai/gpt-5-mini");
+      expect(resolved?.scope).toBe("organization");
+    });
+
+    it("resolves through the row's own team when that team has the key", () => {
+      const resolved = resolveAtScope({
+        key: "FAST",
+        configs: ALL,
+        anchor: { type: "PROJECT", id: "proj-lab" },
+        hierarchy: HIERARCHY,
+      });
+
+      expect(resolved?.model).toBe("anthropic/claude-haiku");
+      expect(resolved?.scope).toBe("team");
+    });
+
+    it("skips the team tier when the project's team is not in the hierarchy", () => {
+      const resolved = resolveAtScope({
+        key: "FAST",
+        configs: ALL,
+        anchor: { type: "PROJECT", id: "proj-unknown" },
+        hierarchy: HIERARCHY,
+      });
+
+      expect(resolved?.model).toBe("openai/gpt-5-mini");
+      expect(resolved?.scope).toBe("organization");
+    });
+  });
+
+  describe("when a team row resolves a key", () => {
+    it("walks team then organization, ignoring other teams", () => {
+      const resolved = resolveAtScope({
+        key: "FAST",
+        configs: ALL,
+        anchor: { type: "TEAM", id: "team-platform" },
+        hierarchy: HIERARCHY,
+      });
+
+      expect(resolved?.model).toBe("openai/gpt-5-mini");
+      expect(resolved?.scope).toBe("organization");
+    });
+  });
+
+  describe("when nothing in the chain carries the key", () => {
+    it("returns null", () => {
+      const resolved = resolveAtScope({
+        key: "EMBEDDINGS",
+        configs: ALL,
+        anchor: { type: "PROJECT", id: "proj-web" },
+        hierarchy: HIERARCHY,
+      });
+
+      expect(resolved).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/components/settings/__tests__/defaultModelsResolveAtScope.unit.test.ts
+++ b/platform/app/src/components/settings/__tests__/defaultModelsResolveAtScope.unit.test.ts
@@ -23,6 +23,10 @@ const HIERARCHY = {
   projects: [
     { id: "proj-web", teamId: "team-platform" },
     { id: "proj-lab", teamId: "team-research" },
+    // A project the viewer can see without seeing its team. The chain
+    // must skip the team tier rather than fall back to matching any
+    // team by type.
+    { id: "proj-orphan", teamId: null },
   ],
 };
 
@@ -96,7 +100,7 @@ describe("resolveAtScope", () => {
       expect(resolved?.scope).toBe("team");
     });
 
-    it("skips the team tier when the project's team is not in the hierarchy", () => {
+    it("skips the team tier when the project is not in the hierarchy", () => {
       const resolved = resolveAtScope({
         key: "FAST",
         configs: ALL,
@@ -106,6 +110,33 @@ describe("resolveAtScope", () => {
 
       expect(resolved?.model).toBe("openai/gpt-5-mini");
       expect(resolved?.scope).toBe("organization");
+    });
+
+    it("skips the team tier for a known project that carries no team", () => {
+      const resolved = resolveAtScope({
+        key: "FAST",
+        configs: ALL,
+        anchor: { type: "PROJECT", id: "proj-orphan" },
+        hierarchy: HIERARCHY,
+      });
+
+      // team-research's newer config must not be borrowed just because
+      // this project's own team is unknown.
+      expect(resolved?.model).toBe("openai/gpt-5-mini");
+      expect(resolved?.scope).toBe("organization");
+    });
+  });
+
+  describe("when the hierarchy carries no organization", () => {
+    it("stops at the tiers it can resolve instead of guessing one", () => {
+      const resolved = resolveAtScope({
+        key: "FAST",
+        configs: ALL,
+        anchor: { type: "PROJECT", id: "proj-web" },
+        hierarchy: { ...HIERARCHY, organization: null },
+      });
+
+      expect(resolved).toBeNull();
     });
   });
 

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -161,6 +161,7 @@ export const APP_ERROR_CODES = [
   "missing_provider",
   "missing_slack_bot_token",
   "missing_slack_webhook",
+  "model_default_scope_forbidden",
   "model_not_configured",
   "model_provider_anchor_required",
   "model_provider_credentials_would_be_dropped",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -525,6 +525,13 @@ const presentations = {
     describe: () =>
       "Pick a different default model in your project's model settings, then try again.",
   },
+  model_default_scope_forbidden: {
+    // Same refusal shape as `model_provider_scope_forbidden`, aimed at the
+    // Default Models policies instead of the provider credentials.
+    title: "You can't change default models here",
+    describe: () =>
+      "They're managed above where you can act. Ask an admin on your team to change them.",
+  },
   model_not_configured: {
     // Distinct from `no_provider_configured` (nothing connected at all) and
     // from `llm_model_not_set` (a workflow node with an empty field): here a

--- a/platform/app/src/server/api/routers/modelProviders.ts
+++ b/platform/app/src/server/api/routers/modelProviders.ts
@@ -648,6 +648,12 @@ export const modelProviderRouter = createTRPCRouter({
    * - `id` omitted → create a new config.
    * - `id` provided → update that config's JSON + scope attachments.
    *
+   * Either way the attached scopes are claimed exclusively: a scope
+   * belongs to at most one config, so whichever config held one of
+   * them before loses that attachment (and is deleted once nothing
+   * keeps it alive). See the one-config-per-scope invariant in
+   * specs/model-providers/model-default-config-cascade.feature.
+   *
    * Scope-aware authz: the caller must hold the matching manage
    * permission on every scope they are attaching to OR removing from,
    * so a project admin can't silently push a default up to org level.

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.collapseDuplicatesMigration.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.collapseDuplicatesMigration.integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @vitest-environment node
+ *
+ * The one-config-per-scope rule applied to rows written before it
+ * existed - against real Postgres, replaying the shipped migration.
+ *
+ * The write path now claims each scope on save, so no new duplicate can
+ * appear. Rows already in a customer's database still carry the old
+ * shape: several configs attached to the same scope, of which only the
+ * newest ever resolved. Migration
+ * 20260814120000_collapse_duplicate_model_default_scopes collapses them
+ * by the resolver's own tiebreak, so resolution results do not change.
+ *
+ * The statements are read from the migration file and replayed inside a
+ * rolled-back transaction, narrowed to this test's synthetic rows: the
+ * shipped statements are deliberately blanket (a one-shot backfill over
+ * every pre-migration row), and the narrowing is a property of the
+ * replay only, so the replay cannot disturb rows another suite owns.
+ *
+ * Spec: specs/model-providers/model-default-config-cascade.feature
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { cleanupTestRows } from "../../../test-utils/cleanupTestRows";
+import { prisma } from "../../db";
+
+const MIGRATION_FILE = join(
+  process.cwd(),
+  "prisma/migrations/20260814120000_collapse_duplicate_model_default_scopes/migration.sql",
+);
+
+/**
+ * The two collapse statements exactly as shipped, read from the
+ * migration file so this test fails if the rule is ever edited out from
+ * under the promise it makes.
+ */
+function collapseStatements(): { shadowed: string; orphaned: string } {
+  const sql = readFileSync(MIGRATION_FILE, "utf8");
+  // Whole statements, not lines: a reformatted multi-line DELETE must
+  // arrive intact rather than truncated to its first line.
+  const statements = sql
+    .split(";")
+    .map((statement) => statement.replace(/^\s*--.*$/gm, "").trim())
+    .filter((statement) => statement.startsWith("DELETE FROM"));
+  const shadowed = statements.find((s) =>
+    s.startsWith('DELETE FROM "ModelDefaultConfigScope"'),
+  );
+  const orphaned = statements.find((s) =>
+    s.startsWith('DELETE FROM "ModelDefaultConfig" c'),
+  );
+  if (!shadowed || !orphaned) {
+    throw new Error(
+      `expected the migration to carry a shadowed-attachment delete and an orphaned-config delete, found ${statements.length} DELETE statement(s)`,
+    );
+  }
+  return { shadowed, orphaned };
+}
+
+describe("given configs written before the one-config-per-scope rule (real DB)", () => {
+  const ns = `mdcfg-collapse-${nanoid(8)}`;
+
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
+
+  /** A fixed anchor so the seeded createdAt ordering is explicit. */
+  const anchor = new Date("2026-08-01T00:00:00.000Z");
+  const atMinutes = (minutes: number) =>
+    new Date(anchor.getTime() + minutes * 60_000);
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: `Collapse Org ${ns}`, slug: `--test-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: { name: `Team ${ns}`, slug: `--team-${ns}`, organizationId },
+    });
+    teamId = team.id;
+
+    const project = await prisma.project.create({
+      data: {
+        name: `Project ${ns}`,
+        slug: `--proj-${ns}`,
+        teamId,
+        language: "typescript",
+        framework: "other",
+        apiKey: `test-key-${ns}`,
+      },
+    });
+    projectId = project.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestRows(prisma, [
+      ["modelDefaultConfig", { organizationId }],
+      ["project", { id: projectId }],
+      ["team", { id: teamId }],
+      ["organization", { id: organizationId }],
+    ]);
+  });
+
+  describe("when the shipped collapse statements run", () => {
+    /** @scenario Migration collapses pre-invariant duplicate configs per scope */
+    it("keeps the config the resolver already picked and drops the rest", async () => {
+      const { shadowed, orphaned } = collapseStatements();
+      const rollback = new Error("rollback");
+
+      await expect(
+        prisma.$transaction(async (tx) => {
+          // Two configs on the same org scope. Only `newest` ever
+          // resolved: the resolver tiebreaks same-scope configs by
+          // createdAt DESC.
+          const oldest = await tx.modelDefaultConfig.create({
+            data: {
+              organizationId,
+              config: { DEFAULT: "openai/gpt-5.4-mini" },
+              createdAt: atMinutes(0),
+              scopes: {
+                create: [
+                  { scopeType: "ORGANIZATION", scopeId: organizationId },
+                ],
+              },
+            },
+          });
+          const newest = await tx.modelDefaultConfig.create({
+            data: {
+              organizationId,
+              config: { DEFAULT: "gemini/gemini-2.5-pro" },
+              createdAt: atMinutes(10),
+              scopes: {
+                create: [
+                  { scopeType: "ORGANIZATION", scopeId: organizationId },
+                ],
+              },
+            },
+          });
+          // Also shadowed on the org scope, but it holds a project scope
+          // nobody else claims, so collapsing must keep the row alive.
+          const multiScope = await tx.modelDefaultConfig.create({
+            data: {
+              organizationId,
+              config: { FAST: "openai/gpt-5.4-mini" },
+              createdAt: atMinutes(5),
+              scopes: {
+                create: [
+                  { scopeType: "ORGANIZATION", scopeId: organizationId },
+                  { scopeType: "PROJECT", scopeId: projectId },
+                ],
+              },
+            },
+          });
+          // Same createdAt on the team scope: the migration falls back
+          // to the higher id, so the winner is decided rather than left
+          // to insertion order. The ids are explicit and differ only in
+          // one lowercase letter, so "higher" means the same thing in
+          // this assertion as it does under the statement's COLLATE "C".
+          const tiedLoserId = `${ns}-tied-a`;
+          const tiedWinnerId = `${ns}-tied-b`;
+          for (const [id, model] of [
+            [tiedLoserId, "openai/gpt-5.5"],
+            [tiedWinnerId, "anthropic/claude-sonnet-4-6"],
+          ] as const) {
+            await tx.modelDefaultConfig.create({
+              data: {
+                id,
+                organizationId,
+                config: { DEFAULT: model },
+                createdAt: atMinutes(20),
+                scopes: { create: [{ scopeType: "TEAM", scopeId: teamId }] },
+              },
+            });
+          }
+
+          const narrowing = `AND c."organizationId" = '${organizationId}'`;
+          await tx.$executeRawUnsafe(
+            `-- @tenancy: replaying the shipped collapse, narrowed to this test's synthetic rows\n${shadowed} ${narrowing}`,
+          );
+          await tx.$executeRawUnsafe(
+            `-- @tenancy: replaying the shipped collapse, narrowed to this test's synthetic rows\n${orphaned} ${narrowing}`,
+          );
+
+          const orgHolders = await tx.modelDefaultConfigScope.findMany({
+            where: { scopeType: "ORGANIZATION", scopeId: organizationId },
+            select: { configId: true },
+          });
+          expect(orgHolders).toEqual([{ configId: newest.id }]);
+
+          // The shadowed single-scope config had nothing left to hold.
+          expect(
+            await tx.modelDefaultConfig.findUnique({
+              where: { id: oldest.id },
+            }),
+          ).toBeNull();
+
+          // The shadowed multi-scope config kept the scope it alone held.
+          const survivor = await tx.modelDefaultConfig.findUnique({
+            where: { id: multiScope.id },
+            select: { scopes: { select: { scopeType: true, scopeId: true } } },
+          });
+          expect(survivor?.scopes).toEqual([
+            { scopeType: "PROJECT", scopeId: projectId },
+          ]);
+
+          const teamHolders = await tx.modelDefaultConfigScope.findMany({
+            where: { scopeType: "TEAM", scopeId: teamId },
+            select: { configId: true },
+          });
+          expect(teamHolders).toEqual([{ configId: tiedWinnerId }]);
+          expect(
+            await tx.modelDefaultConfig.findUnique({
+              where: { id: tiedLoserId },
+            }),
+          ).toBeNull();
+
+          throw rollback;
+        }),
+      ).rejects.toThrow("rollback");
+
+      // The rollback held: none of the synthetic rows survived.
+      const survivors = await prisma.modelDefaultConfig.findMany({
+        where: { organizationId },
+        select: { id: true },
+      });
+      expect(survivors).toEqual([]);
+    });
+  });
+});

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.collapseDuplicatesMigration.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.collapseDuplicatesMigration.integration.test.ts
@@ -33,6 +33,11 @@ const MIGRATION_FILE = join(
   "prisma/migrations/20260814120000_collapse_duplicate_model_default_scopes/migration.sql",
 );
 
+/** The replay seeds, collapses and asserts inside one transaction,
+ *  which is more than Prisma's 5 second default is worth betting a
+ *  loaded CI shard on. */
+const TX_BUDGET = { timeout: 20_000, maxWait: 10_000 } as const;
+
 /**
  * The two collapse statements exactly as shipped, read from the
  * migration file so this test fails if the rule is ever edited out from
@@ -219,7 +224,7 @@ describe("given configs written before the one-config-per-scope rule (real DB)",
           ).toBeNull();
 
           throw rollback;
-        }),
+        }, TX_BUDGET),
       ).rejects.toThrow("rollback");
 
       // The rollback held: none of the synthetic rows survived.

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment node
+ *
+ * Real-Postgres coverage for the one-config-per-scope invariant on
+ * ModelDefaultConfig writes, and the handled errors the write path
+ * raises instead of leaking plain 500s.
+ *
+ * Customer report (2026-08-13): "+ Add config" at organization scope
+ * stacked a second org row instead of replacing the first, and saving
+ * an all-inherit new config surfaced a raw "unknown error" 500.
+ * Spec: specs/model-providers/model-default-config-cascade.feature
+ */
+
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { OrganizationUserRole } from "~/generated/prisma/client";
+
+import { cleanupTestRows } from "../../../test-utils/cleanupTestRows";
+import type { Session } from "../../auth";
+import { prisma } from "../../db";
+import {
+  assertCanWriteScope,
+  createConfig,
+  updateConfig,
+} from "../modelDefaults.service";
+
+describe("given default-model configs with scope attachments (real DB)", () => {
+  const ns = `mdcfg-excl-${nanoid(8)}`;
+
+  let organizationId: string;
+  let teamId: string;
+  let webProjectId: string;
+  let apiProjectId: string;
+  let memberUserId: string;
+
+  const ctx = () => ({ prisma });
+
+  const attachmentsAt = (
+    scopeType: "ORGANIZATION" | "TEAM" | "PROJECT",
+    scopeId: string,
+  ) =>
+    prisma.modelDefaultConfigScope.findMany({
+      where: { scopeType, scopeId },
+      select: { configId: true },
+    });
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: `Scope Exclusivity Org ${ns}`, slug: `--test-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: { name: `Team ${ns}`, slug: `--team-${ns}`, organizationId },
+    });
+    teamId = team.id;
+
+    const mkProject = (slug: string) =>
+      prisma.project.create({
+        data: {
+          name: `Project ${slug} ${ns}`,
+          slug: `--proj-${slug}-${ns}`,
+          teamId,
+          language: "typescript",
+          framework: "other",
+          apiKey: `test-key-${slug}-${ns}`,
+        },
+      });
+    webProjectId = (await mkProject("web")).id;
+    apiProjectId = (await mkProject("api")).id;
+
+    const member = await prisma.user.create({
+      data: {
+        name: "Plain Member",
+        email: `plain-member-${ns}@example.com`,
+      },
+    });
+    memberUserId = member.id;
+    await prisma.organizationUser.create({
+      data: {
+        userId: member.id,
+        organizationId,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestRows(prisma, [
+      ["modelDefaultConfig", { organizationId }],
+      ["organizationUser", { organizationId }],
+      ["project", { id: { in: [webProjectId, apiProjectId] } }],
+      ["team", { id: teamId }],
+      ["user", { id: memberUserId }],
+      ["organization", { id: organizationId }],
+    ]);
+  });
+
+  describe("when a new config is created at a scope that already has one", () => {
+    /** @scenario Creating a config at a scope that already has one replaces that scope's config */
+    it("claims the scope and deletes the emptied previous config", async () => {
+      const old = await createConfig(ctx(), {
+        config: { DEFAULT: "openai/gpt-5.5" },
+        scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        authorId: null,
+      });
+      const replacement = await createConfig(ctx(), {
+        config: { DEFAULT: "gemini/gemini-2.5-pro" },
+        scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        authorId: null,
+      });
+
+      const attached = await attachmentsAt("ORGANIZATION", organizationId);
+      expect(attached).toEqual([{ configId: replacement.id }]);
+
+      const oldRow = await prisma.modelDefaultConfig.findUnique({
+        where: { id: old.id },
+      });
+      expect(oldRow).toBeNull();
+    });
+  });
+
+  describe("when the previous holder is attached to other scopes too", () => {
+    /** @scenario Claiming a scope held by a multi-scope config detaches only that scope */
+    it("keeps the multi-scope config alive with its remaining scopes", async () => {
+      const multi = await createConfig(ctx(), {
+        config: { DEFAULT: "openai/gpt-5.5" },
+        scopes: [
+          { scopeType: "PROJECT", scopeId: webProjectId },
+          { scopeType: "PROJECT", scopeId: apiProjectId },
+        ],
+        authorId: null,
+      });
+      const claimer = await createConfig(ctx(), {
+        config: { DEFAULT: "gemini/gemini-2.5-pro" },
+        scopes: [{ scopeType: "PROJECT", scopeId: webProjectId }],
+        authorId: null,
+      });
+
+      const webAttached = await attachmentsAt("PROJECT", webProjectId);
+      expect(webAttached).toEqual([{ configId: claimer.id }]);
+
+      const survivor = await prisma.modelDefaultConfig.findUnique({
+        where: { id: multi.id },
+        select: { config: true, scopes: { select: { scopeId: true } } },
+      });
+      expect(survivor?.config).toEqual({ DEFAULT: "openai/gpt-5.5" });
+      expect(survivor?.scopes).toEqual([{ scopeId: apiProjectId }]);
+    });
+  });
+
+  describe("when an update attaches a scope another config holds", () => {
+    /** @scenario Adding a scope to an existing config claims it from its previous config */
+    it("claims the scope for the updated config and deletes the emptied holder", async () => {
+      const projectConfig = await createConfig(ctx(), {
+        config: { DEFAULT: "openai/gpt-5.4-mini" },
+        scopes: [{ scopeType: "PROJECT", scopeId: apiProjectId }],
+        authorId: null,
+      });
+      const orgConfig = await createConfig(ctx(), {
+        config: { DEFAULT: "openai/gpt-5.5" },
+        scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        authorId: null,
+      });
+
+      await updateConfig(ctx(), {
+        id: orgConfig.id,
+        scopes: [
+          { scopeType: "ORGANIZATION", scopeId: organizationId },
+          { scopeType: "PROJECT", scopeId: apiProjectId },
+        ],
+      });
+
+      const apiAttached = await attachmentsAt("PROJECT", apiProjectId);
+      expect(apiAttached).toEqual([{ configId: orgConfig.id }]);
+
+      const projectRow = await prisma.modelDefaultConfig.findUnique({
+        where: { id: projectConfig.id },
+      });
+      expect(projectRow).toBeNull();
+    });
+  });
+
+  describe("when a brand-new config carries no keys at all", () => {
+    /** @scenario Saving a brand-new config with every key on Inherit is refused with a handled error */
+    it("refuses with a handled validation_error instead of a plain 500", async () => {
+      await expect(
+        createConfig(ctx(), {
+          config: {},
+          scopes: [{ scopeType: "TEAM", scopeId: teamId }],
+          authorId: null,
+        }),
+      ).rejects.toMatchObject({
+        isHandled: true,
+        code: "validation_error",
+      });
+
+      const attached = await attachmentsAt("TEAM", teamId);
+      expect(attached).toEqual([]);
+    });
+  });
+
+  describe("when an existing config is edited down to no keys", () => {
+    /** @scenario Editing an existing config to all-Inherit deletes it */
+    it("deletes the config and its scope attachments", async () => {
+      const config = await createConfig(ctx(), {
+        config: { FAST: "openai/gpt-5.4-mini" },
+        scopes: [{ scopeType: "TEAM", scopeId: teamId }],
+        authorId: null,
+      });
+
+      await updateConfig(ctx(), { id: config.id, config: {} });
+
+      const row = await prisma.modelDefaultConfig.findUnique({
+        where: { id: config.id },
+      });
+      expect(row).toBeNull();
+      const attached = await attachmentsAt("TEAM", teamId);
+      expect(attached).toEqual([]);
+    });
+  });
+
+  describe("when the caller cannot manage the target scope", () => {
+    /** @scenario Saving into a scope the caller cannot manage is refused with a handled error */
+    it("raises model_default_scope_forbidden with a 403", async () => {
+      const session = { user: { id: memberUserId } } as Session;
+      await expect(
+        assertCanWriteScope(
+          { prisma, session },
+          "ORGANIZATION",
+          organizationId,
+        ),
+      ).rejects.toMatchObject({
+        isHandled: true,
+        code: "model_default_scope_forbidden",
+        httpStatus: 403,
+      });
+    });
+  });
+});

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
@@ -92,9 +92,12 @@ describe("given default-model configs with scope attachments (real DB)", () => {
   // above another would break it.
   //
   // Through cleanupTestRows, not a raw deleteMany: `organizationId` is
-  // assigned in beforeAll, so it is undefined exactly when setup failed,
-  // and Prisma drops an undefined filter rather than matching nothing
-  // (#6219). The scope rows cascade on the config foreign key.
+  // assigned in beforeAll, so it is still undefined if setup threw before
+  // that assignment. A raw deleteMany would then sweep the table, because
+  // Prisma drops an undefined filter rather than matching nothing (#6219).
+  // cleanupTestRows refuses an entry that identifies nothing, so the rows
+  // are left untouched and the teardown throws instead. The scope rows
+  // cascade on the config foreign key.
   afterEach(() =>
     cleanupTestRows(prisma, [["modelDefaultConfig", { organizationId }]]),
   );

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
@@ -23,6 +23,7 @@ import {
   createConfig,
   updateConfig,
 } from "../modelDefaults.service";
+import { resolveModelForFeature } from "../resolveModelForFeature";
 
 describe("given default-model configs with scope attachments (real DB)", () => {
   const ns = `mdcfg-excl-${nanoid(8)}`;
@@ -125,6 +126,15 @@ describe("given default-model configs with scope attachments (real DB)", () => {
         where: { id: old.id },
       });
       expect(oldRow).toBeNull();
+
+      // The part a customer actually sees. Asserting only the rows would
+      // stay green if the claim detached the attachment but the resolver
+      // still read the config that lost it.
+      const resolved = await resolveModelForFeature("prompt.create_default", {
+        prisma,
+        projectId: webProjectId,
+      });
+      expect(resolved.model).toBe("gemini/gemini-2.5-pro");
     });
   });
 

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { nanoid } from "nanoid";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { OrganizationUserRole } from "~/generated/prisma/client";
 
 import { cleanupTestRows } from "../../../test-utils/cleanupTestRows";
@@ -83,6 +83,14 @@ describe("given default-model configs with scope attachments (real DB)", () => {
         role: OrganizationUserRole.MEMBER,
       },
     });
+  });
+
+  // Each test states the whole world it needs. Without this the tests
+  // inherit whatever rows the previous ones left attached, and pass only
+  // because claiming happens to clear the leftovers first: adding a test
+  // above another would break it.
+  afterEach(async () => {
+    await prisma.modelDefaultConfig.deleteMany({ where: { organizationId } });
   });
 
   afterAll(async () => {
@@ -222,19 +230,34 @@ describe("given default-model configs with scope attachments (real DB)", () => {
 
   describe("when the caller cannot manage the target scope", () => {
     /** @scenario Saving into a scope the caller cannot manage is refused with a handled error */
-    it("raises model_default_scope_forbidden with a 403", async () => {
+    it("raises model_default_scope_forbidden with a 403 and writes nothing", async () => {
       const session = { user: { id: memberUserId } } as Session;
-      await expect(
-        assertCanWriteScope(
+      // The guard runs before the write, the way every save path
+      // (tRPC drawer save, REST create/update/delete) orders them. A
+      // refactor that dropped the guard would create the row here.
+      const save = async () => {
+        await assertCanWriteScope(
           { prisma, session },
           "ORGANIZATION",
           organizationId,
-        ),
-      ).rejects.toMatchObject({
+        );
+        await createConfig(ctx(), {
+          config: { DEFAULT: "openai/gpt-5.5" },
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+          authorId: null,
+        });
+      };
+
+      await expect(save()).rejects.toMatchObject({
         isHandled: true,
         code: "model_default_scope_forbidden",
         httpStatus: 403,
       });
+
+      expect(await attachmentsAt("ORGANIZATION", organizationId)).toEqual([]);
+      expect(
+        await prisma.modelDefaultConfig.count({ where: { organizationId } }),
+      ).toBe(0);
     });
   });
 });

--- a/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelDefaults.service.scopeExclusivity.integration.test.ts
@@ -90,9 +90,14 @@ describe("given default-model configs with scope attachments (real DB)", () => {
   // inherit whatever rows the previous ones left attached, and pass only
   // because claiming happens to clear the leftovers first: adding a test
   // above another would break it.
-  afterEach(async () => {
-    await prisma.modelDefaultConfig.deleteMany({ where: { organizationId } });
-  });
+  //
+  // Through cleanupTestRows, not a raw deleteMany: `organizationId` is
+  // assigned in beforeAll, so it is undefined exactly when setup failed,
+  // and Prisma drops an undefined filter rather than matching nothing
+  // (#6219). The scope rows cascade on the config foreign key.
+  afterEach(() =>
+    cleanupTestRows(prisma, [["modelDefaultConfig", { organizationId }]]),
+  );
 
   afterAll(async () => {
     await cleanupTestRows(prisma, [

--- a/platform/app/src/server/modelProviders/__tests__/resolveModelForFeature.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/resolveModelForFeature.unit.test.ts
@@ -254,7 +254,7 @@ describe("resolveModelForFeature (unit)", () => {
     expect(fast.scope).toBe("organization");
   });
 
-  /** @scenario Two configs attached to the same project resolve by created-at DESC */
+  /** @scenario Legacy duplicate configs at the same scope resolve by created-at DESC */
   it("two configs at the same scope: newest createdAt wins", async () => {
     const prisma = fakePrisma({
       project: PROJECT,

--- a/platform/app/src/server/modelProviders/errors.ts
+++ b/platform/app/src/server/modelProviders/errors.ts
@@ -164,6 +164,41 @@ export class ModelProviderScopeForbiddenError extends HandledError {
 }
 
 /**
+ * The caller cannot manage one of the scopes a default-models write would
+ * touch.
+ *
+ * Same shape and rationale as {@link ModelProviderScopeForbiddenError}, with
+ * its own code because the copy differs: this one is about the Default Models
+ * policies, not the provider credentials. Every default-models write path
+ * (tRPC drawer save, REST create/update/delete) routes through
+ * `assertCanWriteScope`, which raises this. A plain `Error` here used to
+ * surface as an unknown 500 and log a routine permission refusal as an
+ * incident.
+ */
+export class ModelDefaultScopeForbiddenError extends HandledError {
+  declare readonly code: "model_default_scope_forbidden";
+
+  constructor({
+    scopeType,
+    requiredPermission,
+  }: {
+    scopeType: string;
+    requiredPermission: string;
+  }) {
+    super(
+      "model_default_scope_forbidden",
+      "You don't have permission to manage default models here.",
+      {
+        meta: { scopeType, requiredPermission },
+        httpStatus: 403,
+        fault: "customer",
+      },
+    );
+    this.name = "ModelDefaultScopeForbiddenError";
+  }
+}
+
+/**
  * Too many credential checks in too short a window.
  *
  * Every check is an outbound request from our servers carrying a customer's

--- a/platform/app/src/server/modelProviders/modelDefaults.repository.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.repository.ts
@@ -230,9 +230,13 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
     });
   }
 
-  /** Delete the given scope-attachment rows. Ids are sorted so two
-   * writes over overlapping sets take their row locks in the same
-   * order. */
+  /** Delete the given scope-attachment rows.
+   *
+   * What keeps two writes over overlapping sets apart is
+   * `lockOrganization`, which every write path takes first. The id sort
+   * is not part of that: one `deleteMany` locks rows in whatever scan
+   * order the planner picks, and an `IN` list is not an ordering
+   * directive. It is here so the statement is reproducible. */
   async deleteAttachments(attachmentIds: string[]): Promise<void> {
     if (attachmentIds.length === 0) return;
     await this.prisma.modelDefaultConfigScope.deleteMany({
@@ -242,8 +246,8 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
 
   /** Delete any of the given configs that no longer have a single scope
    * attachment: an unattached config can never be hit by the resolver,
-   * it just haunts the settings table. Ids are sorted for the same
-   * reason as `deleteAttachments`. */
+   * it just haunts the settings table. Serialised by
+   * `lockOrganization`, same as `deleteAttachments`. */
   async deleteConfigsWithoutScopes(configIds: string[]): Promise<void> {
     if (configIds.length === 0) return;
     await this.prisma.modelDefaultConfig.deleteMany({

--- a/platform/app/src/server/modelProviders/modelDefaults.repository.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.repository.ts
@@ -7,7 +7,6 @@ import type {
   PrismaClient,
 } from "~/generated/prisma/client";
 import { KSUID_RESOURCES } from "../../utils/constants";
-import { isRootPrismaClient } from "../db";
 import { resolveSingleOrganizationForScopes } from "../scopes/resolveOrganizationForScope";
 
 export type ModelDefaultsPrisma = PrismaClient | Prisma.TransactionClient;
@@ -129,10 +128,11 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
     });
   }
 
-  /** Add/remove scope attachments for an existing config, atomically
-   * with an optional config-payload bump. Requires a root PrismaClient
-   * (transaction clients lack `$transaction`). The service-layer guard
-   * enforces that contract. */
+  /** Add/remove scope attachments for an existing config, with an
+   * optional config-payload bump. The statements run sequentially on
+   * this repository's client, so callers must hold a transaction (the
+   * service's `withScopeTransaction` wrapper) for the write to stay
+   * atomic. */
   async updateConfigScopes(params: {
     id: string;
     configPayload?: {
@@ -142,23 +142,17 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
     toAdd: ScopeAttachment[];
     toRemoveIds: string[];
   }): Promise<void> {
-    if (!isRootPrismaClient(this.prisma)) {
-      throw new Error(
-        "ModelDefaultsRepository.updateConfigScopes requires a root PrismaClient, not a transaction client.",
-      );
-    }
-    const prisma: PrismaClient = this.prisma;
     // Single-organization invariant (ADR-021): newly attached scopes must
     // resolve to the same org the config is already anchored to. Otherwise this
     // path could attach cross-org or orphaned scopes while organizationId stays
     // pinned to the old tenant — the inconsistency create() now prevents.
     if (params.toAdd.length > 0) {
       const organizationId = await resolveSingleOrganizationForScopes(
-        prisma,
+        this.prisma,
         params.toAdd,
         "model default config",
       );
-      const existing = await prisma.modelDefaultConfig.findUnique({
+      const existing = await this.prisma.modelDefaultConfig.findUnique({
         where: { id: params.id },
         select: { organizationId: true },
       });
@@ -168,31 +162,64 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
         );
       }
     }
-    await prisma.$transaction([
-      prisma.modelDefaultConfig.update({
-        where: { id: params.id },
-        data: params.configPayload ?? {},
-      }),
-      ...(params.toAdd.length > 0
-        ? [
-            prisma.modelDefaultConfigScope.createMany({
-              data: params.toAdd.map((s) => ({
-                id: this.newScopeId(),
-                configId: params.id,
-                scopeType: s.scopeType,
-                scopeId: s.scopeId,
-              })),
-            }),
-          ]
-        : []),
-      ...(params.toRemoveIds.length > 0
-        ? [
-            prisma.modelDefaultConfigScope.deleteMany({
-              where: { id: { in: params.toRemoveIds } },
-            }),
-          ]
-        : []),
-    ]);
+    await this.prisma.modelDefaultConfig.update({
+      where: { id: params.id },
+      data: params.configPayload ?? {},
+    });
+    if (params.toAdd.length > 0) {
+      await this.prisma.modelDefaultConfigScope.createMany({
+        data: params.toAdd.map((s) => ({
+          id: this.newScopeId(),
+          configId: params.id,
+          scopeType: s.scopeType,
+          scopeId: s.scopeId,
+        })),
+      });
+    }
+    if (params.toRemoveIds.length > 0) {
+      await this.prisma.modelDefaultConfigScope.deleteMany({
+        where: { id: { in: params.toRemoveIds } },
+      });
+    }
+  }
+
+  /** Every scope attachment on OTHER configs for the given scopes:
+   * the rows a claiming write detaches. */
+  async findAttachmentsForScopes(
+    scopes: ScopeAttachment[],
+    opts: { exceptConfigId?: string } = {},
+  ): Promise<Array<{ id: string; configId: string }>> {
+    if (scopes.length === 0) return [];
+    return this.prisma.modelDefaultConfigScope.findMany({
+      where: {
+        OR: scopes.map((s) => ({
+          scopeType: s.scopeType,
+          scopeId: s.scopeId,
+        })),
+        ...(opts.exceptConfigId
+          ? { configId: { not: opts.exceptConfigId } }
+          : {}),
+      },
+      select: { id: true, configId: true },
+    });
+  }
+
+  /** Delete the given scope-attachment rows. */
+  async deleteAttachments(attachmentIds: string[]): Promise<void> {
+    if (attachmentIds.length === 0) return;
+    await this.prisma.modelDefaultConfigScope.deleteMany({
+      where: { id: { in: attachmentIds } },
+    });
+  }
+
+  /** Delete any of the given configs that no longer have a single scope
+   * attachment: an unattached config can never be hit by the resolver,
+   * it just haunts the settings table. */
+  async deleteConfigsWithoutScopes(configIds: string[]): Promise<void> {
+    if (configIds.length === 0) return;
+    await this.prisma.modelDefaultConfig.deleteMany({
+      where: { id: { in: configIds }, scopes: { none: {} } },
+    });
   }
 
   /** Delete a config row. ModelDefaultConfigScope rows cascade via the

--- a/platform/app/src/server/modelProviders/modelDefaults.repository.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.repository.ts
@@ -41,6 +41,27 @@ export type AttachedScope = Pick<
 export class ModelDefaultsRepository {
   constructor(private readonly prisma: ModelDefaultsPrisma) {}
 
+  /** Acquire a tx-scoped advisory lock over every default-models write
+   * in one organization.
+   *
+   * A scope lock alone only covers the scopes a write attaches. Claiming
+   * a scope also detaches, and sometimes deletes, whichever config held
+   * it, and that config may hold scopes this transaction never locked,
+   * so two writes could reach the same config rows through disjoint lock
+   * sets and take row locks in opposite orders. Every config a claim can
+   * touch is anchored to the same organization as the scope being
+   * claimed (ADR-021), so one lock per organization covers all of them.
+   *
+   * Taken FIRST by every write path, before any scope lock, which is
+   * what makes the order total and a lock cycle impossible. Writes are
+   * rare admin actions, so serialising them per organization costs
+   * nothing a user can perceive. */
+  async lockOrganization(organizationId: string): Promise<void> {
+    await this.prisma
+      .$executeRaw`-- @tenancy: advisory-lock helper, organizationId bounded
+SELECT pg_advisory_xact_lock(hashtextextended(${`mdc-org:${organizationId}`}, 0))`;
+  }
+
   /** Acquire a tx-scoped advisory lock keyed by the (scopeType, scopeId)
    * pair so the read-then-write upsert path in `setRoleAtScope` /
    * `setFeatureAtScope` serialises across concurrent callers without
@@ -115,14 +136,19 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
     return { id };
   }
 
-  /** Update a config row's JSON payload + authorId (no scope changes
-   * here — that path needs the multi-statement `$transaction` form
-   * which only the root PrismaClient exposes, see `updateConfigScopes`). */
+  /** Update a config row's JSON payload + authorId. Scope changes go
+   * through `updateConfigScopes`, which needs a caller-held transaction
+   * to stay atomic; this one is a single statement, so it needs none.
+   *
+   * `updateMany`, so a config a concurrent save already collected is a
+   * no-op rather than a P2025 the caller would surface as an unknown
+   * error. Callers check the row exists first, so this never hides a
+   * plain wrong id. */
   async updateConfigPayload(params: {
     id: string;
     data: { config?: Record<string, string>; authorId?: string | null };
   }): Promise<void> {
-    await this.prisma.modelDefaultConfig.update({
+    await this.prisma.modelDefaultConfig.updateMany({
       where: { id: params.id },
       data: params.data,
     });
@@ -162,7 +188,7 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
         );
       }
     }
-    await this.prisma.modelDefaultConfig.update({
+    await this.prisma.modelDefaultConfig.updateMany({
       where: { id: params.id },
       data: params.configPayload ?? {},
     });
@@ -204,28 +230,59 @@ SELECT pg_advisory_xact_lock(hashtextextended(${`mdc:${scopeType}:${scopeId}`}, 
     });
   }
 
-  /** Delete the given scope-attachment rows. */
+  /** Delete the given scope-attachment rows. Ids are sorted so two
+   * writes over overlapping sets take their row locks in the same
+   * order. */
   async deleteAttachments(attachmentIds: string[]): Promise<void> {
     if (attachmentIds.length === 0) return;
     await this.prisma.modelDefaultConfigScope.deleteMany({
-      where: { id: { in: attachmentIds } },
+      where: { id: { in: [...attachmentIds].sort() } },
     });
   }
 
   /** Delete any of the given configs that no longer have a single scope
    * attachment: an unattached config can never be hit by the resolver,
-   * it just haunts the settings table. */
+   * it just haunts the settings table. Ids are sorted for the same
+   * reason as `deleteAttachments`. */
   async deleteConfigsWithoutScopes(configIds: string[]): Promise<void> {
     if (configIds.length === 0) return;
     await this.prisma.modelDefaultConfig.deleteMany({
-      where: { id: { in: configIds }, scopes: { none: {} } },
+      where: { id: { in: [...configIds].sort() }, scopes: { none: {} } },
     });
   }
 
   /** Delete a config row. ModelDefaultConfigScope rows cascade via the
-   * FK so callers don't have to clean them up explicitly. */
+   * FK so callers don't have to clean them up explicitly.
+   *
+   * `deleteMany`, not `delete`: a config the caller asked to remove can
+   * already be gone, because a concurrent save claimed its last scope
+   * and collected it. "Remove this config" is satisfied either way, and
+   * `delete` would raise P2025 for the caller to surface as an unknown
+   * error on a save that in fact succeeded. */
   async delete(configId: string): Promise<void> {
-    await this.prisma.modelDefaultConfig.delete({ where: { id: configId } });
+    await this.prisma.modelDefaultConfig.deleteMany({
+      where: { id: configId },
+    });
+  }
+
+  /** The organization a config is anchored to, or null when the config
+   * is already gone. */
+  async findOrganizationIdForConfig(configId: string): Promise<string | null> {
+    const row = await this.prisma.modelDefaultConfig.findUnique({
+      where: { id: configId },
+      select: { organizationId: true },
+    });
+    return row?.organizationId ?? null;
+  }
+
+  /** The single organization a set of scopes resolves to (ADR-021).
+   * Throws on an empty, unresolvable, or cross-organization set. */
+  async organizationIdForScopes(scopes: ScopeAttachment[]): Promise<string> {
+    return resolveSingleOrganizationForScopes(
+      this.prisma,
+      scopes,
+      "model default config",
+    );
   }
 
   /** Return every config currently attached at the given scope (newest

--- a/platform/app/src/server/modelProviders/modelDefaults.service.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.service.ts
@@ -154,6 +154,19 @@ function dedupeScopes(scopes: ScopeAttachment[]): ScopeAttachment[] {
 }
 
 /**
+ * Transaction budget for every default-models write.
+ *
+ * These writes queue on an advisory lock, and the wait counts against
+ * the interactive-transaction timeout. Prisma's default is 5 seconds,
+ * which a write queued behind another one in the same organization can
+ * exceed, and it would then fail with P2028: an unknown error on a save
+ * that only needed to wait its turn. `timeout` therefore has to cover
+ * the lock queue, not just the statements. `maxWait` is the separate
+ * budget for getting a connection out of the pool.
+ */
+const WRITE_TX_BUDGET = { timeout: 20_000, maxWait: 10_000 } as const;
+
+/**
  * Run `fn` inside a transaction when handed the root PrismaClient, or
  * directly when the caller already opened one (e.g. `upsertKeyAtScope`
  * calls back into `createConfig` from inside its own `$transaction`).
@@ -163,7 +176,7 @@ async function withScopeTransaction<T>(
   fn: (tx: ModelDefaultsPrisma) => Promise<T>,
 ): Promise<T> {
   if (isRootPrismaClient(prisma)) {
-    return prisma.$transaction(fn);
+    return prisma.$transaction(fn, WRITE_TX_BUDGET);
   }
   return fn(prisma);
 }
@@ -549,5 +562,5 @@ async function upsertKeyAtScope(
         authorId: params.authorId ?? null,
       },
     );
-  });
+  }, WRITE_TX_BUDGET);
 }

--- a/platform/app/src/server/modelProviders/modelDefaults.service.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.service.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "@langwatch/handled-error";
 import type {
   ModelDefaultScopeType,
   PrismaClient,
@@ -9,11 +10,13 @@ import {
   hasProjectPermission,
   hasTeamPermission,
 } from "../api/rbac";
+import { isRootPrismaClient } from "../db";
 import { CODING_ASSISTANT_SURFACES_ONLY_NEEDLE } from "./codexRefusalMessage";
 import {
   isModelAllowedAsRoleDefault,
   isModelAllowedForFeature,
 } from "./codexRestrictions";
+import { ModelDefaultScopeForbiddenError } from "./errors";
 import {
   allFeatures,
   featureByKey,
@@ -64,18 +67,27 @@ export async function assertCanWriteScope(
         "organization:manage",
       ))
     ) {
-      throw new Error("Missing organization:manage permission");
+      throw new ModelDefaultScopeForbiddenError({
+        scopeType,
+        requiredPermission: "organization:manage",
+      });
     }
     return;
   }
   if (scopeType === "TEAM") {
     if (!(await hasTeamPermission(ctx, scopeId, "team:manage"))) {
-      throw new Error("Missing team:manage permission");
+      throw new ModelDefaultScopeForbiddenError({
+        scopeType,
+        requiredPermission: "team:manage",
+      });
     }
     return;
   }
   if (!(await hasProjectPermission(ctx, scopeId, "project:update"))) {
-    throw new Error("Missing project:update permission");
+    throw new ModelDefaultScopeForbiddenError({
+      scopeType,
+      requiredPermission: "project:update",
+    });
   }
 }
 
@@ -124,7 +136,7 @@ function sanitizeConfig(raw: Record<string, unknown>): Record<string, string> {
       ? isModelAllowedAsRoleDefault(value, key as ModelRole)
       : isModelAllowedForFeature({ modelId: value, featureKey: key });
     if (!allowed) {
-      throw new Error(
+      throw new ValidationError(
         `"${value}" ${CODING_ASSISTANT_SURFACES_ONLY_NEEDLE} and cannot be set for "${key}".`,
       );
     }
@@ -146,9 +158,57 @@ function dedupeScopes(scopes: ScopeAttachment[]): ScopeAttachment[] {
 }
 
 /**
+ * Run `fn` inside a transaction when handed the root PrismaClient, or
+ * directly when the caller already opened one (e.g. `upsertKeyAtScope`
+ * calls back into `createConfig` from inside its own `$transaction`).
+ */
+async function withScopeTransaction<T>(
+  prisma: ModelDefaultsPrisma,
+  fn: (tx: ModelDefaultsPrisma) => Promise<T>,
+): Promise<T> {
+  if (isRootPrismaClient(prisma)) {
+    return prisma.$transaction(fn);
+  }
+  return fn(prisma);
+}
+
+/** Deterministic lock order so two concurrent multi-scope writes can
+ * never deadlock on each other's scope locks. */
+function sortForLocking(scopes: ScopeAttachment[]): ScopeAttachment[] {
+  return [...scopes].sort((a, b) =>
+    `${a.scopeType}::${a.scopeId}`.localeCompare(
+      `${b.scopeType}::${b.scopeId}`,
+    ),
+  );
+}
+
+/**
+ * Enforce the one-config-per-scope invariant for a write that attaches
+ * `scopes` to the config identified by `exceptConfigId` (or a config
+ * about to be created): detach those scopes from whichever configs held
+ * them, and delete any config left with zero attachments. Callers hold
+ * the per-scope advisory locks and a transaction.
+ */
+async function claimScopes(
+  repo: ModelDefaultsRepository,
+  scopes: ScopeAttachment[],
+  opts: { exceptConfigId?: string } = {},
+): Promise<void> {
+  const held = await repo.findAttachmentsForScopes(scopes, opts);
+  if (held.length === 0) return;
+  await repo.deleteAttachments(held.map((h) => h.id));
+  await repo.deleteConfigsWithoutScopes(
+    Array.from(new Set(held.map((h) => h.configId))),
+  );
+}
+
+/**
  * Create a new ModelDefaultConfig with its scope attachments. Empty
  * configs (no valid keys) are rejected — a config is meaningless
- * without at least one model assignment.
+ * without at least one model assignment. Each attached scope is claimed
+ * exclusively: a scope belongs to at most one config, so whichever
+ * config held it before loses that attachment (and is deleted when
+ * nothing else keeps it alive).
  */
 export async function createConfig(
   ctx: Ctx,
@@ -160,17 +220,27 @@ export async function createConfig(
 ): Promise<{ id: string }> {
   const config = sanitizeConfig(params.config);
   if (Object.keys(config).length === 0) {
-    throw new Error(
-      "ModelDefaultConfig must carry at least one role or feature key.",
+    throw new ValidationError(
+      "Pick at least one model. A default-models config with every key on inherit has no effect.",
     );
   }
   if (params.scopes.length === 0) {
-    throw new Error("ModelDefaultConfig must attach to at least one scope.");
+    throw new ValidationError(
+      "Pick at least one scope for this default-models config.",
+    );
   }
-  return repoFor(ctx).create({
-    config,
-    scopes: dedupeScopes(params.scopes),
-    authorId: params.authorId ?? null,
+  const scopes = dedupeScopes(params.scopes);
+  return withScopeTransaction(ctx.prisma, async (tx) => {
+    const repo = new ModelDefaultsRepository(tx);
+    for (const s of sortForLocking(scopes)) {
+      await repo.lockScope(s.scopeType, s.scopeId);
+    }
+    await claimScopes(repo, scopes);
+    return repo.create({
+      config,
+      scopes,
+      authorId: params.authorId ?? null,
+    });
   });
 }
 
@@ -216,30 +286,40 @@ export async function updateConfig(
   // Replace-all semantics for scope attachments: empty array → delete
   // the config (an unattached config can never be hit by the
   // resolver). Otherwise compute the add/remove diff against the
-  // current set.
+  // current set. Newly added scopes are claimed exclusively: whichever
+  // config held them before loses the attachment, same invariant as
+  // `createConfig`.
   if (params.scopes.length === 0) {
     await repo.delete(params.id);
     return;
   }
-  const desired = new Map<string, ScopeAttachment>();
-  for (const s of params.scopes) {
-    desired.set(`${s.scopeType}::${s.scopeId}`, s);
-  }
-  const current = await repo.findScopesForConfig(params.id);
-  const currentByKey = new Map(
-    current.map((c) => [`${c.scopeType}::${c.scopeId}`, c]),
-  );
-  const toAdd = [...desired.values()].filter(
-    (s) => !currentByKey.has(`${s.scopeType}::${s.scopeId}`),
-  );
-  const toRemove = current.filter(
-    (c) => !desired.has(`${c.scopeType}::${c.scopeId}`),
-  );
-  await repo.updateConfigScopes({
-    id: params.id,
-    configPayload: data,
-    toAdd,
-    toRemoveIds: toRemove.map((c) => c.id),
+  const desiredScopes = dedupeScopes(params.scopes);
+  await withScopeTransaction(ctx.prisma, async (tx) => {
+    const txRepo = new ModelDefaultsRepository(tx);
+    for (const s of sortForLocking(desiredScopes)) {
+      await txRepo.lockScope(s.scopeType, s.scopeId);
+    }
+    const desired = new Map<string, ScopeAttachment>();
+    for (const s of desiredScopes) {
+      desired.set(`${s.scopeType}::${s.scopeId}`, s);
+    }
+    const current = await txRepo.findScopesForConfig(params.id);
+    const currentByKey = new Map(
+      current.map((c) => [`${c.scopeType}::${c.scopeId}`, c]),
+    );
+    const toAdd = [...desired.values()].filter(
+      (s) => !currentByKey.has(`${s.scopeType}::${s.scopeId}`),
+    );
+    const toRemove = current.filter(
+      (c) => !desired.has(`${c.scopeType}::${c.scopeId}`),
+    );
+    await claimScopes(txRepo, toAdd, { exceptConfigId: params.id });
+    await txRepo.updateConfigScopes({
+      id: params.id,
+      configPayload: data,
+      toAdd,
+      toRemoveIds: toRemove.map((c) => c.id),
+    });
   });
 }
 

--- a/platform/app/src/server/modelProviders/modelDefaults.service.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.service.ts
@@ -40,10 +40,6 @@ export type AuthCtx = {
   session: Session | null;
 };
 
-function repoFor(ctx: Ctx): ModelDefaultsRepository {
-  return new ModelDefaultsRepository(ctx.prisma);
-}
-
 /**
  * RBAC guard for the role/feature default writers. Each scope demands
  * a different permission so a project admin can't silently push a role
@@ -173,13 +169,37 @@ async function withScopeTransaction<T>(
 }
 
 /** Deterministic lock order so two concurrent multi-scope writes can
- * never deadlock on each other's scope locks. */
+ * never deadlock on each other's scope locks. Plain byte comparison,
+ * not `localeCompare`: a collation-sensitive order could differ between
+ * two processes and put the ordering back at risk. */
 function sortForLocking(scopes: ScopeAttachment[]): ScopeAttachment[] {
+  const key = (s: ScopeAttachment) => `${s.scopeType}::${s.scopeId}`;
   return [...scopes].sort((a, b) =>
-    `${a.scopeType}::${a.scopeId}`.localeCompare(
-      `${b.scopeType}::${b.scopeId}`,
-    ),
+    key(a) < key(b) ? -1 : key(a) > key(b) ? 1 : 0,
   );
+}
+
+/**
+ * Take the locks every default-models write needs, in the one order
+ * every path uses: the organization first, then the scopes in a stable
+ * order.
+ *
+ * The organization lock is what makes the order total. A scope lock
+ * only covers the scopes being attached, while claiming a scope also
+ * detaches (and sometimes deletes) whichever config held it, and that
+ * config may hold scopes this write never named. Every config a claim
+ * can reach is anchored to the same organization as the claimed scope
+ * (ADR-021), so locking the organization first covers all of them and
+ * no two writes can take row locks in opposite orders.
+ */
+async function lockForWrite(
+  repo: ModelDefaultsRepository,
+  params: { organizationId: string; scopes?: ScopeAttachment[] },
+): Promise<void> {
+  await repo.lockOrganization(params.organizationId);
+  for (const s of sortForLocking(params.scopes ?? [])) {
+    await repo.lockScope(s.scopeType, s.scopeId);
+  }
 }
 
 /**
@@ -187,7 +207,7 @@ function sortForLocking(scopes: ScopeAttachment[]): ScopeAttachment[] {
  * `scopes` to the config identified by `exceptConfigId` (or a config
  * about to be created): detach those scopes from whichever configs held
  * them, and delete any config left with zero attachments. Callers hold
- * the per-scope advisory locks and a transaction.
+ * the locks `lockForWrite` takes, inside a transaction.
  */
 async function claimScopes(
   repo: ModelDefaultsRepository,
@@ -232,9 +252,8 @@ export async function createConfig(
   const scopes = dedupeScopes(params.scopes);
   return withScopeTransaction(ctx.prisma, async (tx) => {
     const repo = new ModelDefaultsRepository(tx);
-    for (const s of sortForLocking(scopes)) {
-      await repo.lockScope(s.scopeType, s.scopeId);
-    }
+    const organizationId = await repo.organizationIdForScopes(scopes);
+    await lockForWrite(repo, { organizationId, scopes });
     await claimScopes(repo, scopes);
     return repo.create({
       config,
@@ -260,9 +279,9 @@ export async function updateConfig(
     authorId?: string | null;
   },
 ): Promise<void> {
-  const repo = repoFor(ctx);
   const data: { config?: Record<string, string>; authorId?: string | null } =
     {};
+  let deletesTheConfig = false;
   if (params.config !== undefined) {
     const clean = sanitizeConfig(params.config);
     if (Object.keys(clean).length === 0) {
@@ -270,18 +289,11 @@ export async function updateConfig(
       // delete because an attached-but-empty config has no effect on
       // resolution but still occupies the same-scope tiebreak slot
       // (newest empty would mask older non-empty at the same scope).
-      await repo.delete(params.id);
-      return;
+      deletesTheConfig = true;
     }
     data.config = clean;
   }
   if (params.authorId !== undefined) data.authorId = params.authorId;
-
-  if (params.scopes === undefined) {
-    // No scope changes — just bump the JSON / authorId.
-    await repo.updateConfigPayload({ id: params.id, data });
-    return;
-  }
 
   // Replace-all semantics for scope attachments: empty array → delete
   // the config (an unattached config can never be hit by the
@@ -289,16 +301,47 @@ export async function updateConfig(
   // current set. Newly added scopes are claimed exclusively: whichever
   // config held them before loses the attachment, same invariant as
   // `createConfig`.
-  if (params.scopes.length === 0) {
-    await repo.delete(params.id);
+  if (params.scopes !== undefined && params.scopes.length === 0) {
+    deletesTheConfig = true;
+  }
+
+  // Every branch runs under the config's organization lock, deletes
+  // included: a delete that skipped it could race a concurrent claim
+  // for the same config and fail on a row that claim had just
+  // collected.
+  if (deletesTheConfig || params.scopes === undefined) {
+    await withScopeTransaction(ctx.prisma, async (tx) => {
+      const txRepo = new ModelDefaultsRepository(tx);
+      const organizationId = await txRepo.findOrganizationIdForConfig(
+        params.id,
+      );
+      // Already gone: a concurrent save claimed its last scope and
+      // collected it. Both branches below are satisfied by that.
+      if (!organizationId) return;
+      await lockForWrite(txRepo, { organizationId });
+      if (deletesTheConfig) {
+        await txRepo.delete(params.id);
+        return;
+      }
+      // No scope changes — just bump the JSON / authorId.
+      await txRepo.updateConfigPayload({ id: params.id, data });
+    });
     return;
   }
+
   const desiredScopes = dedupeScopes(params.scopes);
   await withScopeTransaction(ctx.prisma, async (tx) => {
     const txRepo = new ModelDefaultsRepository(tx);
-    for (const s of sortForLocking(desiredScopes)) {
-      await txRepo.lockScope(s.scopeType, s.scopeId);
-    }
+    // Resolved from the desired scopes rather than the config row: it
+    // is the same organization either way (ADR-021 keeps a config and
+    // its scopes in one org), and this way the lock is taken before the
+    // config is read instead of after.
+    const organizationId = await txRepo.organizationIdForScopes(desiredScopes);
+    await lockForWrite(txRepo, { organizationId, scopes: desiredScopes });
+    // Gone while we waited for the lock: a concurrent save claimed its
+    // last scope and collected it, and that save's config now owns the
+    // scopes this one wanted. Re-creating the row here would undo it.
+    if ((await txRepo.findOrganizationIdForConfig(params.id)) === null) return;
     const desired = new Map<string, ScopeAttachment>();
     for (const s of desiredScopes) {
       desired.set(`${s.scopeType}::${s.scopeId}`, s);
@@ -324,10 +367,20 @@ export async function updateConfig(
 }
 
 /**
- * Delete a config. Scope attachments cascade via the FK.
+ * Delete a config. Scope attachments cascade via the FK. Runs under the
+ * organization lock so it orders against a concurrent claim for the
+ * same config rather than racing it.
  */
 export async function deleteConfig(ctx: Ctx, configId: string): Promise<void> {
-  await repoFor(ctx).delete(configId);
+  await withScopeTransaction(ctx.prisma, async (tx) => {
+    const repo = new ModelDefaultsRepository(tx);
+    const organizationId = await repo.findOrganizationIdForConfig(configId);
+    // Already gone: a concurrent save claimed its last scope and
+    // collected it, which is the outcome this call asked for.
+    if (!organizationId) return;
+    await lockForWrite(repo, { organizationId });
+    await repo.delete(configId);
+  });
 }
 
 /**
@@ -438,7 +491,18 @@ async function upsertKeyAtScope(
 ): Promise<void> {
   await (ctx.prisma as PrismaClient).$transaction(async (tx) => {
     const txRepo = new ModelDefaultsRepository(tx);
-    await txRepo.lockScope(params.scopeType, params.scopeId);
+    const scope = {
+      scopeType: params.scopeType,
+      scopeId: params.scopeId,
+    };
+    // Same organization-then-scope order every other write path uses.
+    // Taking only the scope lock here would let this path hold a scope
+    // lock while a claiming write held the organization lock and wanted
+    // that scope, which is a cycle.
+    await lockForWrite(txRepo, {
+      organizationId: await txRepo.organizationIdForScopes([scope]),
+      scopes: [scope],
+    });
 
     const attached = await txRepo.findConfigsAtScope(
       params.scopeType,

--- a/specs/model-providers/model-default-config-cascade.feature
+++ b/specs/model-providers/model-default-config-cascade.feature
@@ -21,9 +21,16 @@ Feature: Model default config cascade
   #
   # ModelDefaultConfigScope:
   #   Join row binding a config to a (scopeType, scopeId). The same
-  #   (configId, scopeType, scopeId) cannot appear twice. The same
-  #   (scopeType, scopeId) CAN appear under multiple configs — that's how
-  #   "two configs on the same project" happens. Last-created wins.
+  #   (configId, scopeType, scopeId) cannot appear twice, and a
+  #   (scopeType, scopeId) belongs to at most ONE config: every write
+  #   path that attaches a scope first detaches it from whichever config
+  #   held it before (deleting configs left with zero scopes), under the
+  #   same per-scope advisory lock the role/feature setters use. Two
+  #   rows for the same scope in the settings table was never readable:
+  #   the newer config shadowed the older one key-by-key while both
+  #   rows rendered the shadowed result. The resolver still tiebreaks
+  #   same-scope configs by createdAt DESC as defense for data written
+  #   before this invariant existed.
   #
   # config JSON shape:
   #   {
@@ -110,14 +117,17 @@ Feature: Model default config cascade
     # The project config carries no FAST key; cascade walks up to org.
 
   @integration
-  Scenario: Two configs attached to the same project resolve by created-at DESC
-    Given a project has two configs both attached at PROJECT scope:
+  Scenario: Legacy duplicate configs at the same scope resolve by created-at DESC
+    Given a project has two configs both attached at PROJECT scope (written before the one-config-per-scope invariant):
       | created     | config                                |
       | 2026-05-01  | { "DEFAULT": "openai/gpt-5.4-mini" }  |
       | 2026-05-15  | { "DEFAULT": "openai/gpt-5.5" }       |
     When I resolve "prompt.create_default" for that project
     Then the resolver returns "openai/gpt-5.5"
-    # Newer config wins on tie at the same scope tier.
+    # Newer config wins on tie at the same scope tier. Write paths no
+    # longer produce this state; the resolver keeps the tiebreak so
+    # pre-invariant rows keep resolving deterministically until the
+    # cleanup migration collapses them.
 
   @integration
   Scenario: A config can attach to many scopes at once
@@ -239,6 +249,68 @@ Feature: Model default config cascade
     And one ModelDefaultConfigScope row exists pointing (ORGANIZATION, org-acme) at it
     # Write-side; needs real DB.
 
+  # ────────────────────────────────────────────────────────────────────────────
+  # One config per scope (customer report, 2026-08-13)
+  # ────────────────────────────────────────────────────────────────────────────
+  #
+  # A customer set org-wide gpt defaults, then used "+ Add config" to
+  # switch the org to gemini, and got a second org row instead of a
+  # replacement. Both rows rendered the newer values (the resolver's
+  # newest-wins tiebreak), so the older config became invisible and
+  # uneditable-in-effect. Creating a config now CLAIMS its scopes:
+  # whichever config previously held one of them loses that attachment.
+
+  @integration
+  Scenario: Creating a config at a scope that already has one replaces that scope's config
+    Given an organization-scoped config { "DEFAULT": "openai/gpt-5.5" }
+    When I save a new config { "DEFAULT": "gemini/gemini-2.5-pro" } attached to that organization
+    Then only the new config remains attached at ORGANIZATION scope
+    And the old config is deleted because it has no scopes left
+    And resolving DEFAULT for a project in that organization returns "gemini/gemini-2.5-pro"
+
+  @integration
+  Scenario: Claiming a scope held by a multi-scope config detaches only that scope
+    Given a config { "DEFAULT": "openai/gpt-5.5" } attached to projects "web-app" and "api"
+    When I save a new config { "DEFAULT": "gemini/gemini-2.5-pro" } attached to project "web-app"
+    Then the old config keeps its "api" attachment and its JSON
+    And project "web-app" is attached only to the new config
+
+  @integration
+  Scenario: Adding a scope to an existing config claims it from its previous config
+    Given an organization-scoped config { "DEFAULT": "openai/gpt-5.5" }
+    And a project-scoped config { "DEFAULT": "openai/gpt-5.4-mini" } attached to project "web-app"
+    When I update the org config's scope attachments to include project "web-app"
+    Then the project config is deleted because it has no scopes left
+    And project "web-app" is attached only to the org config
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Write-side error paths (part of the same customer report: saving an
+  # all-inherit new config surfaced as a raw "unknown error" 500)
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Saving a brand-new config with every key on Inherit is refused with a handled error
+    When I save a new config with an empty JSON payload attached to an organization
+    Then the save fails with a handled "validation_error" and not an unknown 500
+    And no ModelDefaultConfig row is created
+
+  @integration
+  Scenario: Saving into a scope the caller cannot manage is refused with a handled error
+    Given a caller without "organization:manage" on the organization
+    When they save a config attached to ORGANIZATION scope
+    Then the save fails with a handled "model_default_scope_forbidden" error carrying a 403
+    And no ModelDefaultConfig row is created
+
+  @integration @unimplemented
+  Scenario: Migration collapses pre-invariant duplicate configs per scope
+    Given two configs attached to the same (ORGANIZATION, org-acme) scope
+    When migration 20260814120000_collapse_duplicate_model_default_scopes runs
+    Then only the newest config keeps the org-acme attachment
+    And the older config is deleted when it has no other attachment
+    # Bound to the migration toolchain like the flat-rows migration
+    # above; the keep-newest rule matches the resolver tiebreak so
+    # resolution results do not change.
+
   @integration @unimplemented
   Scenario: Saving a config attached to many scopes creates one config + N scope rows
     When I save a new config { "DEFAULT": "openai/gpt-5.5" } attached to:
@@ -283,6 +355,17 @@ Feature: Model default config cascade
     # Absence = inherit; lean storage; merge logic stays trivial.
     # The drawer-to-server round-trip + JSON storage shape — bind via
     # the drawer integration test once the inherit-dropdown lands.
+
+  @integration
+  Scenario: Editing an existing config to all-Inherit deletes it
+    Given a project-scoped config { "DEFAULT": "openai/gpt-5.5" }
+    When the user sets every key to Inherit and saves
+    Then the config row is deleted
+    And its scope attachments are gone
+    # An attached-but-empty config has no effect on resolution but still
+    # occupies the same-scope slot, so the write path treats it as a
+    # delete. The drawer's toast says the config was removed, not
+    # "updated"; see role-based-default-models.feature.
 
   @integration
   Scenario: Inherit row is a real, selectable option in the model picker

--- a/specs/model-providers/model-default-config-cascade.feature
+++ b/specs/model-providers/model-default-config-cascade.feature
@@ -301,15 +301,20 @@ Feature: Model default config cascade
     Then the save fails with a handled "model_default_scope_forbidden" error carrying a 403
     And no ModelDefaultConfig row is created
 
-  @integration @unimplemented
+  @integration
   Scenario: Migration collapses pre-invariant duplicate configs per scope
     Given two configs attached to the same (ORGANIZATION, org-acme) scope
+    And a third config attached to org-acme and to a project no one else holds
+    And two more configs sharing one created-at on the same team scope
     When migration 20260814120000_collapse_duplicate_model_default_scopes runs
     Then only the newest config keeps the org-acme attachment
     And the older config is deleted when it has no other attachment
-    # Bound to the migration toolchain like the flat-rows migration
-    # above; the keep-newest rule matches the resolver tiebreak so
-    # resolution results do not change.
+    And the third config survives with only the project attachment
+    And the team scope keeps the config with the higher id
+    # The keep-newest rule matches the resolver tiebreak, so resolution
+    # results do not change. Bound by replaying the shipped statements
+    # against real Postgres, so editing the rule out of the migration
+    # fails the test.
 
   @integration @unimplemented
   Scenario: Saving a config attached to many scopes creates one config + N scope rows

--- a/specs/model-providers/role-based-default-models.feature
+++ b/specs/model-providers/role-based-default-models.feature
@@ -106,6 +106,76 @@ Feature: Role-based default models with per-scope overrides
     When I click the row's Edit button
     Then the drawer opens with the feature pre-selected and the Delete CTA enabled
 
+  # ============================================================================
+  # Inherit direction + save integrity in the drawer (customer report,
+  # 2026-08-13: org-scope drawer offered "Inherit (from project)", saving
+  # it 500'd, and each save stacked another org row)
+  # ============================================================================
+
+  @integration
+  Scenario: The inherit entry names the wider scope the value comes from
+    Given the organization has a config with DEFAULT set
+    When I open the drawer for a new config scoped to a project
+    Then the Default selector's first entry reads "Inherit (from organization)" with the org's model underneath
+    And picking it leaves the DEFAULT key out of the saved JSON
+    # Inheritance flows from wide to narrow, never the reverse. The
+    # drawer's inherit entry is built ONLY from the server's cascade
+    # answer for the picked scopes, never from the current project's own
+    # resolved values, which is what produced "Inherit (from project)"
+    # on an org-scoped config.
+
+  @integration
+  Scenario: At organization scope the inherit entry reads "Not configured"
+    When I open the drawer for a new config scoped to the organization
+    Then the Default selector's first entry reads "Not configured" with no model attached
+    And picking it leaves the DEFAULT key out of the saved JSON
+    # There is nothing above the organization to inherit from. The entry
+    # still exists so an org-scope edit can clear a pinned key back to
+    # absent; it just never claims a value flows down from somewhere.
+
+  @integration
+  Scenario: Save is disabled while a new config carries no model at all
+    When I open the drawer for a new config and pick a scope
+    And every role and feature key is left on its inherit entry
+    Then the save button is disabled
+    # An all-inherit new config is a no-op; saving it used to reach the
+    # backend and surface a raw 500. The backend still refuses it with a
+    # handled validation error as the API-caller backstop.
+
+  @integration
+  Scenario: Saving an edit targets the config row that was opened
+    Given the drawer was opened to edit an existing config
+    When I save before the config list query has settled
+    Then the save is disabled until the target config is loaded
+    And the mutation carries that config's id, never a create
+    # Deriving the id from an unsettled query made a slow fetch silently
+    # turn an edit into a create, one more duplicate row.
+
+  @integration
+  Scenario: Editing every key to Inherit tells the user the config was removed
+    Given the drawer was opened to edit an existing config
+    When I set every key to its inherit entry and save
+    Then the toast says the config was removed
+    # The backend deletes an all-inherit config (see
+    # model-default-config-cascade.feature); toasting "Config updated"
+    # while the row disappears reads as data loss.
+
+  @integration
+  Scenario: Adding a config for a scope that already has one says it will replace it
+    Given the organization already has a config
+    When I open the drawer for a new config and pick the organization scope
+    Then a note under the scope picker says the organization's current config will be replaced on save
+
+  @unit
+  Scenario: Config cells resolve inherited values only from the row's own scope chain
+    Given a config attached to project "web-app" in team "Platform"
+    And a config attached to team "Research" carrying FAST
+    When the web-app row's FAST cell resolves its display value
+    Then the Research team's config is not consulted
+    # The cell's cascade walk must match the server resolver's chain:
+    # project → its own team → its own organization. Matching any team's
+    # config displayed values the runtime would never serve.
+
   @integration
   Scenario: Deleting a config via the row menu removes the row
     Given an existing override row in the Default Models table

--- a/specs/model-providers/role-based-default-models.feature
+++ b/specs/model-providers/role-based-default-models.feature
@@ -128,7 +128,7 @@ Feature: Role-based default models with per-scope overrides
   Scenario: At organization scope the inherit entry reads "Not configured"
     When I open the drawer for a new config scoped to the organization
     Then the Default selector's first entry reads "Not configured" with no model attached
-    And picking it leaves the DEFAULT key out of the saved JSON
+    And no entry claims a value flows down from a narrower scope
     # There is nothing above the organization to inherit from. The entry
     # still exists so an org-scope edit can clear a pinned key back to
     # absent; it just never claims a value flows down from somewhere.
@@ -148,8 +148,19 @@ Feature: Role-based default models with per-scope overrides
     When I save before the config list query has settled
     Then the save is disabled until the target config is loaded
     And the mutation carries that config's id, never a create
+    And it carries the values the target row was loaded with
     # Deriving the id from an unsettled query made a slow fetch silently
     # turn an edit into a create, one more duplicate row.
+
+  @integration
+  Scenario: Retargeting the open drawer to another row saves that row's values
+    Given the drawer is open on one config
+    When the row behind it points the drawer at a different config
+    Then the drawer reloads the new row's values
+    And saving writes the new row's values, never the first row's
+    # The drawer is not modal and it is rendered without a key, so the
+    # pencil behind it swaps the target on the same mount. Hydrating
+    # only once would carry the first row's models onto the second.
 
   @integration
   Scenario: Editing every key to Inherit tells the user the config was removed


### PR DESCRIPTION
Fixes the Default Models bugs from a customer report: duplicate rows for the same scope, an org config that offered "Inherit (from project)", a raw 500 when saving with inherit selected, and a save that seemed to rewrite every row.

## What was broken

1. **"+ Add config" stacked duplicate rows.** The save path inserted a new config without checking whether the scope already had one. The resolver hid the problem: it tiebreaks same-scope configs by newest first, so only the newest config had any effect while every duplicate row rendered the same resolved values. That is also why "everything became gemini" after one save.
2. **The drawer offered "Inherit (from project)" at organization scope.** When the server cascade had no answer, the drawer fell back to the current project's own resolved values. Inheritance only flows from wide to narrow, so that label was backwards.
3. **Saving with inherit selected returned a 500.** Picking inherit removes the key from the payload. An all-inherit new config reached the backend as `{}`, and the "must carry at least one key" guard was a plain `Error`, which tRPC surfaces as an unknown INTERNAL_SERVER_ERROR.
4. **Permission refusals also surfaced as 500s** and logged routine denials as incidents.
5. **Table cells resolved inherited values from any team in the organization**, not the row's own team, so a project row could display a model the runtime would never serve it.

## What this PR does

**One config per scope (backend).** Saving a config now claims each attached scope inside a per-scope advisory lock: the scope moves to the saved config, the previous holder loses that attachment, and a config with no scopes left is deleted. This applies to create and to update. A migration (`20260814120000_collapse_duplicate_model_default_scopes`) collapses duplicates written before this rule, keeping the config the resolver already picked, so resolution results do not change.

**Wide-to-narrow inherit (drawer).** The inherit entry is built only from the server's cascade answer for the picked scopes. The server anchors its walk at the most specific picked scope and excludes the picked scopes themselves, so it can never answer with a narrower tier. With no wider value the entry reads "Not configured" and carries no model. It stays selectable so an edit can clear a pinned key back to inherit.

**No more unknown 500s (backend).** The write path raises handled errors: `validation_error` for an empty new config or a restricted model, and a new `model_default_scope_forbidden` (403) for permission refusals, with customer copy in the presentation registry. The REST twin passes them through to the standard serializer.

**Save integrity (drawer).**
- Save is disabled while a new config has no model picked, and while an edit target is still loading. Deriving the id from an unsettled query used to silently turn an edit into a create.
- A note under the scope picker warns when a picked scope already has a config: "X already has default models. Saving replaces that config."
- Editing every key to inherit deletes the config on the server, and the toast now says so instead of "Config updated".
- Edit state hydrates once per open, so a background refetch no longer wipes in-progress edits.

**Correct cell resolution (table).** Cells walk the row's own scope chain (project, its own team, the organization) using the org hierarchy, instead of matching parent tiers by type alone.

## Proof (live QA on this branch)

Reproduced the customer state (two configs attached to the same organization), then verified the fix end to end.

Before, the exact customer bug, two rows for the same org, both rendering the newer config's values:

![duplicate rows before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7002/default-models/01-duplicate-org-rows-before.png)

Add config at organization scope now shows "Not configured" entries (not "Inherit (from project)"), a replace warning, and a disabled save while nothing is picked:

![add config at org scope](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7002/default-models/02-add-config-org-scope-not-configured.png)

![org scope dropdown](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7002/default-models/03-org-scope-dropdown-entries.png)

Saving through the drawer claimed the scope and collapsed both duplicates into one row (verified in the database too):

![single row after save](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7002/default-models/04-single-org-row-after-save.png)

At project scope the inherit entry names the wider scope and shows the value that flows down:

![inherit from organization](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7002/default-models/05-project-scope-inherit-from-organization.png)

Editing a row opens the drawer with that row's stored values:

![edit shows row values](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7002/default-models/06-edit-drawer-shows-row-values.png)

The migration also ran against the local dev database during QA and collapsed a seeded duplicate on boot, keeping the newest config.

## Specs and tests

- `specs/model-providers/model-default-config-cascade.feature`: one-config-per-scope invariant, claim scenarios, write-side error paths, migration scenario. 18/18 scenarios bound.
- `specs/model-providers/role-based-default-models.feature`: inherit direction, save integrity, replace note, cell chain resolution. 16/16 scenarios bound.
- New tests: `modelDefaults.service.scopeExclusivity.integration.test.ts` (6, real Postgres), `DefaultModelOverrideDrawer.inheritDirection.integration.test.tsx` (6), `defaultModelsResolveAtScope.unit.test.ts` (5).
- All neighboring suites green, `pnpm typecheck` and `typecheck:tests` clean, Biome gate reports no new violations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default model configurations now exclusively belong to selected scopes; reassigned scopes are removed from previous configurations.
  * Improved inheritance resolution across project, team, and organization levels.
  * Empty edited configurations can remove overrides, with clear confirmation messaging.
  * Added warnings when selected scopes replace existing configurations.
  * Improved handling for unavailable or unconfigured inherited models.

* **Bug Fixes**
  * Prevented in-progress edits from being overwritten by refreshes.
  * Improved authorization and validation error messages.
  * Cleaned up legacy duplicate configurations.
  * Ensured inherited values only come from the applicable scope hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->