### PR TITLE
feat: sync wait mode for langy turns + gateway provider routing fixes

### DIFF
--- a/packages/handled-error/src/codes.generated.ts
+++ b/packages/handled-error/src/codes.generated.ts
@@ -243,6 +243,16 @@ export const goErrorCodes = {
    */
   model_not_allowed: { service: "aigateway", httpStatus: 400 },
   /**
+   * ErrProviderNotBound — means the request names a provider (explicit
+   * "provider/model" prefix or alias) that has no credential slot on this VK.
+   * Dispatching anyway would hand a mismatched credential to the provider
+   * selected by the model prefix, which surfaces as opaque provider-config
+   * errors ("deployments not set", HTML error pages).
+   *
+   * @source services/aigateway/domain/errors.go
+   */
+  model_provider_not_bound: { service: "aigateway", httpStatus: 400 },
+  /**
    * ErrNoFreeUID — signals every UID slot in the per-worker range is in use.
    * With 60_000 slots and a default MAX_WORKERS of 20 this cannot happen in
    * practice; surfaced rather than silently colliding when an operator raises

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -310,8 +310,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-gateway/guardrails.feature",
   "specs/ai-gateway/health-checks.feature",
   "specs/ai-gateway/license-gate-governance.feature",
-  "specs/ai-gateway/model-disambiguation.feature",
-  "specs/ai-gateway/model-provider-scoping.feature",
   "specs/ai-gateway/payload-capture.feature",
   "specs/ai-gateway/policy-rules.feature",
   "specs/ai-gateway/prometheus-metrics.feature",

--- a/platform/app/src/components/gateway/eligibleModelProviders.ts
+++ b/platform/app/src/components/gateway/eligibleModelProviders.ts
@@ -1,4 +1,5 @@
 import { modelProviderRegistry } from "~/features/onboarding/regions/model-providers/registry";
+import { isDispatchableProvider } from "~/server/modelProviders/registry";
 
 /**
  * A scope a VirtualKey is reachable from: the org/team/project triad the
@@ -103,14 +104,22 @@ export function buildScopeHierarchy(
 
 /**
  * A provider is only offered to a key when the gateway would actually
- * dispatch to it: `enabled: true, disabledAt: null`, the same predicate
- * `scopeResolver.eligibleModelProvidersForVk` runs against Postgres.
- * Fails closed — a row that arrives without the flag is not advertised,
- * because listing a credential an admin has withdrawn overstates the
- * key's reach and is a governance problem, not a cosmetic one.
+ * dispatch to it: `enabled: true, disabledAt: null` AND registry-dispatchable
+ * (shared `isDispatchableProvider` — the predicate
+ * `scopeResolver.eligibleModelProvidersForVk` also applies), so the picker
+ * never advertises a provider the dispatch chain would drop.
+ * The enabled/disabledAt dimension fails closed — a row that arrives without
+ * the flag is not advertised, because listing a credential an admin has
+ * withdrawn overstates the key's reach and is a governance problem, not a
+ * cosmetic one. The registry dimension's failure direction is stated on
+ * `isDispatchableProvider` itself.
  */
 function isRoutable(provider: OrgModelProvider): boolean {
-  return provider.enabled === true && !provider.disabledAt;
+  return (
+    provider.enabled === true &&
+    !provider.disabledAt &&
+    isDispatchableProvider(provider.provider)
+  );
 }
 
 /**

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1711,6 +1711,11 @@ const presentations = {
     title: "No model provider configured",
     describe: () => "Add a provider in settings to continue.",
   },
+  model_provider_not_bound: {
+    title: "That provider isn't bound to this key",
+    describe: () =>
+      "The model name asks for a provider this virtual key has no slot for. Bind that provider to the key, or drop the prefix from the model name.",
+  },
   guardrail_blocked: {
     title: "Blocked by a guardrail",
     describe: () => "This request didn't pass one of your configured policies.",

--- a/platform/app/src/server/api/routers/langy.ts
+++ b/platform/app/src/server/api/routers/langy.ts
@@ -22,6 +22,7 @@ import {
   type LangyTurnContext,
   langyTurnContextSchema,
 } from "~/server/app-layer/langy/langyTurnContext.schema";
+import { abortableDelay } from "~/server/app-layer/langy/streaming/awaitTurnSettlement";
 import {
   createLangyTokenBuffer,
   type LangyStreamEntry,
@@ -216,25 +217,6 @@ async function canWatchTurn({
     userId,
   });
   return !!conv;
-}
-
-/**
- * Sleep for `ms`, resolving early to `false` when the signal aborts — so a
- * watcher loop unblocks promptly the moment its follow() ends — otherwise `true`.
- */
-function abortableDelay(ms: number, signal: AbortSignal): Promise<boolean> {
-  if (signal.aborted) return Promise.resolve(false);
-  return new Promise<boolean>((resolve) => {
-    const onAbort = () => {
-      clearTimeout(timer);
-      resolve(false);
-    };
-    const timer = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve(true);
-    }, ms);
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
 }
 
 /** How often the settlement watcher consults the durable fold + heartbeat. */

--- a/platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.ts
+++ b/platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.ts
@@ -1,0 +1,280 @@
+/**
+ * Await a turn's settlement — the shared primitive behind every "hold until
+ * this turn finishes" surface (today: the public API's `Prefer: wait` mode).
+ *
+ * Two sources compose here, each doing the one job it is good at:
+ *
+ *  - The Redis token buffer (`LangyTokenBuffer.readTail`/`follow`) is the
+ *    PROMPTNESS source: `follow` blocks on `XREAD BLOCK` keyed on
+ *    `(conversationId, turnId)` and returns the moment the worker writes the
+ *    terminal frame — no polling. It is best-effort (may be absent entirely
+ *    when Redis is not configured) and its terminal frame carries no reply
+ *    text, so it can only say "settled", never what settled to.
+ *  - The durable fold (`getEventsAfter`) is the TRUTH source: `AGENT_RESPONDED`
+ *    / `AGENT_RESPONSE_FAILED` carry the `turnId`, the outcome and the reply
+ *    parts — what `finalizeTurn` calls "the real backend confirmation". It is
+ *    the only thing this function ever returns from.
+ *
+ * So the loop polls the fold slowly while the buffer's follow() is armed, and
+ * snaps to a fast confirm cadence the moment a terminal frame is seen —
+ * buffer-first promptness, fold-only authority. Without Redis it degrades to a
+ * plain fold poll at the fallback cadence.
+ *
+ * The signal is honored everywhere (the follow() block, the delays, the fold
+ * loop), so an abandoned caller — client disconnect or deadline — stops
+ * costing reads immediately.
+ */
+
+import type { LangyEventCursor } from "@langwatch/langy";
+import { LANGY_CONVERSATION_EVENT_TYPES } from "@langwatch/langy";
+import { getApp, tryGetApp } from "~/server/app-layer/app";
+import { LangyConversationNotFoundError } from "~/server/app-layer/langy/errors";
+import { extractTextFromParts } from "~/server/app-layer/langy/langy-message.service";
+import { createLangyTokenBuffer } from "./langyTokenBuffer";
+
+/**
+ * Settled state of one turn, decided ONCE from the fold event that carries it.
+ * `succeeded` is the discriminant consumers branch on; `outcome` is the event's
+ * own enum (`AGENT_RESPONDED.data.outcome`, plus `"failed"` for
+ * `AGENT_RESPONSE_FAILED`), preserved for the wire.
+ */
+export type TurnSettlement =
+  | {
+      succeeded: true;
+      outcome: "completed" | "stopped";
+      text: string;
+      error: null;
+    }
+  | { succeeded: false; outcome: "failed"; text: null; error: string };
+
+/** Fold poll cadence while follow() is armed — the buffer owns promptness. */
+const BUFFERED_POLL_MS = 5_000;
+/** Fold poll cadence with no Redis — polling is all we have. */
+const FALLBACK_POLL_MS = 750;
+/** Fold poll cadence after the buffer saw a terminal — projection catch-up. */
+const CONFIRM_POLL_MS = 250;
+
+/**
+ * Sleep for `ms`, resolving early to `false` when the signal aborts — so a
+ * waiter unblocks promptly on disconnect/deadline — otherwise `true`.
+ */
+export function abortableDelay(
+  ms: number,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (signal.aborted) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(false);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+type ConversationTurnEvents = Awaited<
+  ReturnType<
+    ReturnType<typeof getApp>["langy"]["conversations"]["getEventsAfter"]
+  >
+>;
+
+/**
+ * The settlement decision, made at the only place with the evidence: the fold
+ * events themselves. `AGENT_RESPONDED` with `outcome: "failed"` and
+ * `AGENT_RESPONSE_FAILED` both collapse to the failed arm, so no consumer ever
+ * re-derives "did it fail" from a string.
+ */
+export function settlementFromEvents(
+  events: ConversationTurnEvents["events"],
+  turnId: string,
+): TurnSettlement | null {
+  for (const event of events) {
+    if (
+      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED &&
+      event.data.turnId === turnId
+    ) {
+      if (event.data.outcome === "failed") {
+        return {
+          succeeded: false,
+          outcome: "failed",
+          text: null,
+          error: event.data.error ?? "Turn failed",
+        };
+      }
+      return {
+        succeeded: true,
+        outcome: event.data.outcome,
+        text: extractTextFromParts(event.data.parts),
+        error: null,
+      };
+    }
+    if (
+      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONSE_FAILED &&
+      event.data.turnId === turnId
+    ) {
+      return {
+        succeeded: false,
+        outcome: "failed",
+        text: null,
+        error: event.data.error,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * One full pass over the fold from the zero cursor. Truncated pages are read
+ * through within the pass (the cursor advances every page, so this terminates);
+ * `LangyConversationNotFoundError` is projection lag — the accepted turn's row
+ * has not landed yet — so it means "not settled yet", not "gone". Every other
+ * error propagates.
+ */
+async function readSettlementFromFold({
+  projectId,
+  conversationId,
+  turnId,
+  userId,
+  signal,
+}: {
+  projectId: string;
+  conversationId: string;
+  turnId: string;
+  userId: string;
+  signal: AbortSignal;
+}): Promise<TurnSettlement | null> {
+  let cursor: LangyEventCursor = { acceptedAt: 0, eventId: "" };
+  while (!signal.aborted) {
+    const events = await getApp()
+      .langy.conversations.getEventsAfter({
+        projectId,
+        conversationId,
+        userId,
+        after: cursor,
+      })
+      .catch((error: unknown) => {
+        if (error instanceof LangyConversationNotFoundError) return null;
+        throw error;
+      });
+    if (!events) return null;
+    const settlement = settlementFromEvents(events.events, turnId);
+    if (settlement) return settlement;
+    if (!events.truncated) return null;
+    cursor = events.cursor;
+  }
+  return null;
+}
+
+/**
+ * Hold until THIS turn settles on the fold, the signal aborts, or — nothing
+ * else: there is no internal deadline. Callers own the deadline by composing it
+ * into the signal (`AbortSignal.any([clientSignal, AbortSignal.timeout(...)])`).
+ * Returns null when the signal aborted before settlement.
+ *
+ * `pollIntervalMs` overrides the no-Redis fallback cadence — a test seam, so
+ * suites never sleep real wall-clock time.
+ */
+/**
+ * A promise that never settles — used so an aborted/ended buffer follow can
+ * never win the settlement race below.
+ */
+function neverSettles(): Promise<never> {
+  return new Promise<never>(() => {
+    // Intentionally never resolved.
+  });
+}
+
+export async function awaitTurnSettlement({
+  projectId,
+  conversationId,
+  turnId,
+  userId,
+  signal,
+  pollIntervalMs = FALLBACK_POLL_MS,
+}: {
+  projectId: string;
+  conversationId: string;
+  turnId: string;
+  userId: string;
+  signal: AbortSignal;
+  pollIntervalMs?: number;
+}): Promise<TurnSettlement | null> {
+  const redis = tryGetApp()?.redis ?? null;
+
+  let terminalSeen: Promise<void> | null = null;
+  let releaseBuffer = () => {
+    // No buffered connection to release until one is opened below.
+  };
+  if (redis) {
+    const blocking = (redis as { duplicate(): unknown }).duplicate();
+    const buffer = createLangyTokenBuffer({ redis, blockingRedis: blocking });
+    releaseBuffer = () => {
+      (blocking as { disconnect(): void }).disconnect();
+    };
+    // Resolves when the buffer delivers a terminal frame (or never — abort and
+    // buffer absence both leave it pending; the fold loop below is the
+    // authority either way).
+    terminalSeen = (async () => {
+      const { reads, lastId } = await buffer.readTail({
+        conversationId,
+        turnId,
+      });
+      if (
+        reads.some(
+          ({ entry }) => entry.type === "end" || entry.type === "error",
+        )
+      ) {
+        return;
+      }
+      for await (const { entry } of buffer.follow({
+        conversationId,
+        turnId,
+        fromId: lastId,
+        signal,
+      })) {
+        if (entry.type === "end" || entry.type === "error") return;
+      }
+      // follow() ended without a terminal: aborted. Stay pending forever so
+      // the race below never mistakes an abort for a settlement signal.
+      await neverSettles();
+    })().catch(() => neverSettles());
+  }
+
+  let pollMs = terminalSeen !== null ? BUFFERED_POLL_MS : pollIntervalMs;
+  try {
+    while (!signal.aborted) {
+      const settlement = await readSettlementFromFold({
+        projectId,
+        conversationId,
+        turnId,
+        userId,
+        signal,
+      });
+      if (settlement) return settlement;
+
+      if (terminalSeen !== null) {
+        const raced = await Promise.race([
+          terminalSeen.then(() => "terminal" as const),
+          abortableDelay(pollMs, signal).then((completed) =>
+            completed ? ("tick" as const) : ("abort" as const),
+          ),
+        ]);
+        if (raced === "abort") return null;
+        if (raced === "terminal") {
+          // The turn IS settled; only the projection may lag. Confirm fast.
+          terminalSeen = null;
+          pollMs = CONFIRM_POLL_MS;
+        }
+      } else if (!(await abortableDelay(pollMs, signal))) {
+        return null;
+      }
+    }
+    return null;
+  } finally {
+    releaseBuffer();
+  }
+}

--- a/platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.ts
+++ b/platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.ts
@@ -88,41 +88,50 @@ type ConversationTurnEvents = Awaited<
  * `AGENT_RESPONSE_FAILED` both collapse to the failed arm, so no consumer ever
  * re-derives "did it fail" from a string.
  */
+function settlementFromEvent(
+  event: ConversationTurnEvents["events"][number],
+  turnId: string,
+): TurnSettlement | null {
+  if (
+    event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED &&
+    event.data.turnId === turnId
+  ) {
+    if (event.data.outcome === "failed") {
+      return {
+        succeeded: false,
+        outcome: "failed",
+        text: null,
+        error: event.data.error ?? "Turn failed",
+      };
+    }
+    return {
+      succeeded: true,
+      outcome: event.data.outcome,
+      text: extractTextFromParts(event.data.parts),
+      error: null,
+    };
+  }
+  if (
+    event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONSE_FAILED &&
+    event.data.turnId === turnId
+  ) {
+    return {
+      succeeded: false,
+      outcome: "failed",
+      text: null,
+      error: event.data.error,
+    };
+  }
+  return null;
+}
+
 export function settlementFromEvents(
   events: ConversationTurnEvents["events"],
   turnId: string,
 ): TurnSettlement | null {
   for (const event of events) {
-    if (
-      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED &&
-      event.data.turnId === turnId
-    ) {
-      if (event.data.outcome === "failed") {
-        return {
-          succeeded: false,
-          outcome: "failed",
-          text: null,
-          error: event.data.error ?? "Turn failed",
-        };
-      }
-      return {
-        succeeded: true,
-        outcome: event.data.outcome,
-        text: extractTextFromParts(event.data.parts),
-        error: null,
-      };
-    }
-    if (
-      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONSE_FAILED &&
-      event.data.turnId === turnId
-    ) {
-      return {
-        succeeded: false,
-        outcome: "failed",
-        text: null,
-        error: event.data.error,
-      };
-    }
+    const settlement = settlementFromEvent(event, turnId);
+    if (settlement) return settlement;
   }
   return null;
 }
@@ -188,6 +197,95 @@ function neverSettles(): Promise<never> {
   });
 }
 
+function isTerminalFrame(entry: { type: string }): boolean {
+  return entry.type === "end" || entry.type === "error";
+}
+
+/**
+ * Resolves when the buffer delivers a terminal frame (or never — abort and
+ * buffer absence both leave it pending; the fold loop is the authority either
+ * way).
+ */
+async function watchBufferForTerminal(
+  buffer: ReturnType<typeof createLangyTokenBuffer>,
+  {
+    conversationId,
+    turnId,
+    signal,
+  }: { conversationId: string; turnId: string; signal: AbortSignal },
+): Promise<void> {
+  const { reads, lastId } = await buffer.readTail({ conversationId, turnId });
+  if (reads.some(({ entry }) => isTerminalFrame(entry))) return;
+  for await (const { entry } of buffer.follow({
+    conversationId,
+    turnId,
+    fromId: lastId,
+    signal,
+  })) {
+    if (isTerminalFrame(entry)) return;
+  }
+  // follow() ended without a terminal: aborted. Stay pending forever so the
+  // settlement race never mistakes an abort for a settlement signal.
+  await neverSettles();
+}
+
+/**
+ * Arm the buffer-side terminal watch when Redis is available. `terminalSeen`
+ * is null when there is no Redis to watch.
+ */
+function armBufferWatch({
+  conversationId,
+  turnId,
+  signal,
+}: {
+  conversationId: string;
+  turnId: string;
+  signal: AbortSignal;
+}): { terminalSeen: Promise<void> | null; releaseBuffer: () => void } {
+  const redis = tryGetApp()?.redis ?? null;
+  if (!redis) {
+    return {
+      terminalSeen: null,
+      releaseBuffer: () => {
+        // No buffered connection was opened, so nothing to release.
+      },
+    };
+  }
+  const blocking = (redis as { duplicate(): unknown }).duplicate();
+  const buffer = createLangyTokenBuffer({ redis, blockingRedis: blocking });
+  return {
+    terminalSeen: watchBufferForTerminal(buffer, {
+      conversationId,
+      turnId,
+      signal,
+    }).catch(() => neverSettles()),
+    releaseBuffer: () => {
+      (blocking as { disconnect(): void }).disconnect();
+    },
+  };
+}
+
+type PollWaitOutcome = "tick" | "terminal" | "abort";
+
+/**
+ * Wait out one poll interval, unblocking early on the buffer's terminal frame
+ * or on abort.
+ */
+async function waitForNextPoll(
+  terminalSeen: Promise<void> | null,
+  pollMs: number,
+  signal: AbortSignal,
+): Promise<PollWaitOutcome> {
+  const delay = abortableDelay(pollMs, signal).then(
+    (completed): PollWaitOutcome => (completed ? "tick" : "abort"),
+  );
+  if (terminalSeen === null) return delay;
+  return Promise.race([
+    terminalSeen.then((): PollWaitOutcome => "terminal"),
+    delay,
+  ]);
+}
+
 export async function awaitTurnSettlement({
   projectId,
   conversationId,
@@ -203,46 +301,8 @@ export async function awaitTurnSettlement({
   signal: AbortSignal;
   pollIntervalMs?: number;
 }): Promise<TurnSettlement | null> {
-  const redis = tryGetApp()?.redis ?? null;
-
-  let terminalSeen: Promise<void> | null = null;
-  let releaseBuffer = () => {
-    // No buffered connection to release until one is opened below.
-  };
-  if (redis) {
-    const blocking = (redis as { duplicate(): unknown }).duplicate();
-    const buffer = createLangyTokenBuffer({ redis, blockingRedis: blocking });
-    releaseBuffer = () => {
-      (blocking as { disconnect(): void }).disconnect();
-    };
-    // Resolves when the buffer delivers a terminal frame (or never — abort and
-    // buffer absence both leave it pending; the fold loop below is the
-    // authority either way).
-    terminalSeen = (async () => {
-      const { reads, lastId } = await buffer.readTail({
-        conversationId,
-        turnId,
-      });
-      if (
-        reads.some(
-          ({ entry }) => entry.type === "end" || entry.type === "error",
-        )
-      ) {
-        return;
-      }
-      for await (const { entry } of buffer.follow({
-        conversationId,
-        turnId,
-        fromId: lastId,
-        signal,
-      })) {
-        if (entry.type === "end" || entry.type === "error") return;
-      }
-      // follow() ended without a terminal: aborted. Stay pending forever so
-      // the race below never mistakes an abort for a settlement signal.
-      await neverSettles();
-    })().catch(() => neverSettles());
-  }
+  const armed = armBufferWatch({ conversationId, turnId, signal });
+  let terminalSeen = armed.terminalSeen;
 
   let pollMs = terminalSeen !== null ? BUFFERED_POLL_MS : pollIntervalMs;
   try {
@@ -256,25 +316,16 @@ export async function awaitTurnSettlement({
       });
       if (settlement) return settlement;
 
-      if (terminalSeen !== null) {
-        const raced = await Promise.race([
-          terminalSeen.then(() => "terminal" as const),
-          abortableDelay(pollMs, signal).then((completed) =>
-            completed ? ("tick" as const) : ("abort" as const),
-          ),
-        ]);
-        if (raced === "abort") return null;
-        if (raced === "terminal") {
-          // The turn IS settled; only the projection may lag. Confirm fast.
-          terminalSeen = null;
-          pollMs = CONFIRM_POLL_MS;
-        }
-      } else if (!(await abortableDelay(pollMs, signal))) {
-        return null;
+      const waited = await waitForNextPoll(terminalSeen, pollMs, signal);
+      if (waited === "abort") return null;
+      if (waited === "terminal") {
+        // The turn IS settled; only the projection may lag. Confirm fast.
+        terminalSeen = null;
+        pollMs = CONFIRM_POLL_MS;
       }
     }
     return null;
   } finally {
-    releaseBuffer();
+    armed.releaseBuffer();
   }
 }

--- a/platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.unit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment node
+ *
+ * The buffered path of `awaitTurnSettlement`: with Redis present, the token
+ * buffer's follow() is the promptness source and the durable fold stays the
+ * only settlement authority. Pinned here:
+ *
+ *   - A terminal frame from the buffer accelerates settlement, but the answer
+ *     always comes from the fold (buffer says "settled", fold says what to).
+ *   - The signal aborting mid-wait returns null and releases the blocking
+ *     Redis connection.
+ *   - An aborted follow() is never mistaken for a settlement signal.
+ */
+import { LANGY_CONVERSATION_EVENT_TYPES } from "@langwatch/langy";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetEventsAfter = vi.fn();
+const mockDuplicate = vi.fn();
+const mockDisconnect = vi.fn();
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(() => ({
+    langy: { conversations: { getEventsAfter: mockGetEventsAfter } },
+  })),
+  tryGetApp: vi.fn(() => ({ redis: { duplicate: mockDuplicate } })),
+}));
+
+const mockReadTail = vi.fn();
+const mockFollow = vi.fn();
+
+vi.mock("./langyTokenBuffer", () => ({
+  createLangyTokenBuffer: vi.fn(() => ({
+    readTail: mockReadTail,
+    follow: mockFollow,
+  })),
+}));
+
+const { awaitTurnSettlement } = await import("./awaitTurnSettlement");
+
+const emptyTail = {
+  events: [],
+  cursor: { acceptedAt: 0, eventId: "" },
+  truncated: false,
+};
+
+const settledFold = {
+  events: [
+    {
+      id: "evt-1",
+      createdAt: 1,
+      occurredAt: 1,
+      type: LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED,
+      data: {
+        conversationId: "conv-1",
+        turnId: "turn-1",
+        messageId: "msg-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "from the fold" }],
+        outcome: "completed",
+        error: null,
+      },
+    },
+  ],
+  cursor: { acceptedAt: 1, eventId: "evt-1" },
+  truncated: false,
+};
+
+const ARGS = {
+  projectId: "project-1",
+  conversationId: "conv-1",
+  turnId: "turn-1",
+  userId: "user-1",
+};
+
+describe("awaitTurnSettlement (buffered path)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDuplicate.mockReturnValue({ disconnect: mockDisconnect });
+    mockReadTail.mockResolvedValue({ reads: [], lastId: "0" });
+  });
+
+  it("settles fast when follow() delivers the terminal frame, answer from the fold", async () => {
+    // Fold is behind on the first read, settled on the confirm re-read.
+    mockGetEventsAfter
+      .mockResolvedValueOnce(emptyTail)
+      .mockResolvedValue(settledFold);
+    // follow() yields the terminal immediately — no fold-poll tick is needed.
+    mockFollow.mockImplementation(async function* () {
+      yield { id: "1-1", entry: { type: "end" } };
+    });
+
+    const settlement = await awaitTurnSettlement({
+      ...ARGS,
+      signal: AbortSignal.timeout(5_000),
+      pollIntervalMs: 5,
+    });
+
+    expect(settlement).toEqual({
+      succeeded: true,
+      outcome: "completed",
+      text: "from the fold",
+      error: null,
+    });
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("settles from the tail alone when the terminal was already buffered", async () => {
+    mockReadTail.mockResolvedValue({
+      reads: [{ id: "1-1", entry: { type: "end" } }],
+      lastId: "1-1",
+    });
+    mockFollow.mockImplementation(async function* () {
+      throw new Error("follow must not run when the tail holds the terminal");
+    });
+    mockGetEventsAfter.mockResolvedValue(settledFold);
+
+    const settlement = await awaitTurnSettlement({
+      ...ARGS,
+      signal: AbortSignal.timeout(5_000),
+      pollIntervalMs: 5,
+    });
+
+    expect(settlement).toMatchObject({ succeeded: true });
+  });
+
+  it("returns null on abort without treating the ended follow() as settlement", async () => {
+    mockGetEventsAfter.mockResolvedValue(emptyTail);
+    // follow() honors the signal: it ends (without terminal) when aborted.
+    mockFollow.mockImplementation(async function* (opts: {
+      signal: AbortSignal;
+    }) {
+      await new Promise((resolve) =>
+        opts.signal.addEventListener("abort", resolve, { once: true }),
+      );
+    });
+
+    const settlement = await awaitTurnSettlement({
+      ...ARGS,
+      signal: AbortSignal.timeout(50),
+      pollIntervalMs: 5,
+    });
+
+    expect(settlement).toBeNull();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+});

--- a/platform/app/src/server/evaluations/getEvaluator.ts
+++ b/platform/app/src/server/evaluations/getEvaluator.ts
@@ -24,13 +24,19 @@ export const getEvaluatorDefinitions = (evaluator: string) => {
  * nothing to say (e.g. server-side callers without project context).
  */
 export const getEvaluatorDefaultSettings = <T extends EvaluatorTypes>(
-  evaluator: EvaluatorDefinition<T> | undefined,
+  evaluator:
+    | EvaluatorDefinition<T>
+    | { name: string; requiredFields: string[] }
+    | undefined,
   resolved?: {
     defaultModel?: string | null;
     embeddingsModel?: string | null;
   },
 ) => {
-  if (!evaluator) return {};
+  // Custom (non-workflow) evaluator definitions built by
+  // getEvaluatorIncludingCustom carry no `settings` — treat them the same
+  // as an unknown evaluator rather than crashing on Object.entries.
+  if (!evaluator || !("settings" in evaluator)) return {};
   return Object.fromEntries(
     Object.entries(evaluator.settings).map(([key, setting]) => {
       if (key === "model") {

--- a/platform/app/src/server/evaluations/getEvaluator.ts
+++ b/platform/app/src/server/evaluations/getEvaluator.ts
@@ -6,6 +6,18 @@ import {
   type EvaluatorTypes,
 } from "./evaluators";
 
+/**
+ * The shape `getEvaluatorIncludingCustom` builds for a project's custom
+ * (workflow-derived) evaluators: contract only — a name and the input fields
+ * the caller must supply. Unlike a built-in `EvaluatorDefinition` it carries
+ * no `settings`, which is why `getEvaluatorDefaultSettings` accepts the union
+ * and answers `{}` for this arm.
+ */
+export type CustomEvaluatorDefinition = {
+  name: string;
+  requiredFields: string[];
+};
+
 export const getEvaluatorDefinitions = (evaluator: string) => {
   for (const [key, val] of Object.entries(AVAILABLE_EVALUATORS)) {
     if (key === evaluator) return val;
@@ -24,10 +36,7 @@ export const getEvaluatorDefinitions = (evaluator: string) => {
  * nothing to say (e.g. server-side callers without project context).
  */
 export const getEvaluatorDefaultSettings = <T extends EvaluatorTypes>(
-  evaluator:
-    | EvaluatorDefinition<T>
-    | { name: string; requiredFields: string[] }
-    | undefined,
+  evaluator: EvaluatorDefinition<T> | CustomEvaluatorDefinition | undefined,
   resolved?: {
     defaultModel?: string | null;
     embeddingsModel?: string | null;

--- a/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -630,6 +630,7 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
   });
 
   describe("when materialising a VK with no linked RoutingPolicy", () => {
+    /** @scenario Safety-type providers are excluded from gateway dispatch chains */
     it("excludes safety-type providers (azure_safety) from the dispatch chain", async () => {
       const repo = new VirtualKeyRepository(prisma);
       const vk = await repo.findById(VK_NO_RP_ID, ORG_ID);

--- a/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -59,6 +59,7 @@ const MP_ANTHROPIC_BASE_ID = `mp-mat-anthropic-base-${suffix}`;
 const ANTHROPIC_BASE_URL_OVERRIDE = "http://vllm-anthropic:8000";
 const MP_ANTHROPIC_PLAIN_ID = `mp-mat-anthropic-plain-${suffix}`;
 const MP_ANTHROPIC_KEYLESS_ID = `mp-mat-anthropic-keyless-${suffix}`;
+const MP_SAFETY_ID = `mp-mat-safety-${suffix}`;
 const RP_ID = `rp-mat-${suffix}`;
 const GUARDRAIL_ID = `gr-mat-${suffix}`;
 const VK_ID = `vk-mat-${suffix}`;
@@ -253,6 +254,25 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         },
       },
     });
+    // Safety-type provider (azure_safety): holds evaluator credentials,
+    // not chat-dispatchable — must never appear in a gateway bundle's
+    // providers[] (the Go router has no Bifrost adapter for it).
+    await prisma.modelProvider.create({
+      data: {
+        id: MP_SAFETY_ID,
+        name: "azure-safety",
+        provider: "azure_safety",
+        enabled: true,
+        organizationId: ORG_ID,
+        customKeys: {
+          AZURE_CONTENT_SAFETY_ENDPOINT: "https://safety.example.com",
+          AZURE_CONTENT_SAFETY_KEY: "safety-key",
+        },
+        scopes: {
+          create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+        },
+      },
+    });
     await prisma.routingPolicy.create({
       data: {
         id: RP_ID,
@@ -417,6 +437,7 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       MP_ANTHROPIC_BASE_ID,
       MP_ANTHROPIC_PLAIN_ID,
       MP_ANTHROPIC_KEYLESS_ID,
+      MP_SAFETY_ID,
     ];
     await prisma.modelProviderScope.deleteMany({
       where: {
@@ -609,6 +630,16 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
   });
 
   describe("when materialising a VK with no linked RoutingPolicy", () => {
+    it("excludes safety-type providers (azure_safety) from the dispatch chain", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_NO_RP_ID, ORG_ID);
+      const mat = new GatewayConfigMaterialiser(prisma, null);
+      const bundle = await mat.materialise(vk!);
+      expect(bundle.providers.length).toBeGreaterThan(0);
+      expect(bundle.providers.map((p) => p.id)).not.toContain(MP_SAFETY_ID);
+      expect(bundle.fallback.chain).not.toContain(MP_SAFETY_ID);
+    });
+
     it("returns empty model_aliases + normalized empty policy_rules", async () => {
       const repo = new VirtualKeyRepository(prisma);
       const vk = await repo.findById(VK_NO_RP_ID, ORG_ID);

--- a/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -635,8 +635,12 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       const vk = await repo.findById(VK_NO_RP_ID, ORG_ID);
       const mat = new GatewayConfigMaterialiser(prisma, null);
       const bundle = await mat.materialise(vk!);
-      expect(bundle.providers.length).toBeGreaterThan(0);
+      // Naming the LLM provider that must survive, rather than just
+      // asserting a non-empty list, keeps this from passing vacuously if
+      // the filter ever drops dispatchable providers too.
+      expect(bundle.providers.map((p) => p.id)).toContain(MP_ID);
       expect(bundle.providers.map((p) => p.id)).not.toContain(MP_SAFETY_ID);
+      expect(bundle.fallback.chain).toContain(MP_ID);
       expect(bundle.fallback.chain).not.toContain(MP_SAFETY_ID);
     });
 

--- a/platform/app/src/server/gateway/scopeResolver.ts
+++ b/platform/app/src/server/gateway/scopeResolver.ts
@@ -34,7 +34,7 @@ import type {
   Prisma,
   PrismaClient,
 } from "~/generated/prisma/client";
-import { modelProviders } from "../modelProviders/registry";
+import { isDispatchableProvider } from "~/server/modelProviders/registry";
 import type { ScopeInput, VirtualKeyWithScopes } from "./virtualKey.repository";
 
 export type EligibleModelProvider = ModelProvider;
@@ -57,7 +57,7 @@ export async function eligibleModelProvidersForVk(
         scopes: { some: { OR: scopePredicates } },
       },
     })
-  ).filter(isDispatchableProvider);
+  ).filter((mp) => isDispatchableProvider(mp.provider));
 
   if (vk.routingPolicyId) {
     const policy = await client.routingPolicy.findUnique({
@@ -74,18 +74,6 @@ export async function eligibleModelProvidersForVk(
   }
 
   return candidates.sort(deterministicMpOrder);
-}
-
-// Non-LLM providers (registry type "safety", e.g. azure_safety) hold
-// credentials for evaluators, not chat dispatch. The Go gateway's Bifrost
-// router has no adapter for them, so letting one into the VK chain makes
-// fallback attempts fail with "unsupported provider: azure_safety".
-// Providers absent from the registry pass through: they may be newer than
-// this build's registry snapshot, and the materialiser's default branch
-// still knows how to shape their credentials.
-function isDispatchableProvider(mp: ModelProvider): boolean {
-  const entry = modelProviders[mp.provider as keyof typeof modelProviders];
-  return !entry || entry.type === "llm";
 }
 
 function deterministicMpOrder(a: ModelProvider, b: ModelProvider): number {

--- a/platform/app/src/server/gateway/scopeResolver.ts
+++ b/platform/app/src/server/gateway/scopeResolver.ts
@@ -37,6 +37,8 @@ import type {
 
 import type { ScopeInput, VirtualKeyWithScopes } from "./virtualKey.repository";
 
+import { modelProviders } from "../modelProviders/registry";
+
 export type EligibleModelProvider = ModelProvider;
 
 export async function eligibleModelProvidersForVk(
@@ -49,13 +51,15 @@ export async function eligibleModelProvidersForVk(
   const scopePredicates = await buildScopePredicates(client, vk);
   if (scopePredicates.length === 0) return [];
 
-  const candidates = await client.modelProvider.findMany({
-    where: {
-      enabled: true,
-      disabledAt: null,
-      scopes: { some: { OR: scopePredicates } },
-    },
-  });
+  const candidates = (
+    await client.modelProvider.findMany({
+      where: {
+        enabled: true,
+        disabledAt: null,
+        scopes: { some: { OR: scopePredicates } },
+      },
+    })
+  ).filter(isDispatchableProvider);
 
   if (vk.routingPolicyId) {
     const policy = await client.routingPolicy.findUnique({
@@ -72,6 +76,18 @@ export async function eligibleModelProvidersForVk(
   }
 
   return candidates.sort(deterministicMpOrder);
+}
+
+// Non-LLM providers (registry type "safety", e.g. azure_safety) hold
+// credentials for evaluators, not chat dispatch. The Go gateway's Bifrost
+// router has no adapter for them, so letting one into the VK chain makes
+// fallback attempts fail with "unsupported provider: azure_safety".
+// Providers absent from the registry pass through: they may be newer than
+// this build's registry snapshot, and the materialiser's default branch
+// still knows how to shape their credentials.
+function isDispatchableProvider(mp: ModelProvider): boolean {
+  const entry = modelProviders[mp.provider as keyof typeof modelProviders];
+  return !entry || entry.type === "llm";
 }
 
 function deterministicMpOrder(a: ModelProvider, b: ModelProvider): number {

--- a/platform/app/src/server/gateway/scopeResolver.ts
+++ b/platform/app/src/server/gateway/scopeResolver.ts
@@ -34,10 +34,8 @@ import type {
   Prisma,
   PrismaClient,
 } from "~/generated/prisma/client";
-
-import type { ScopeInput, VirtualKeyWithScopes } from "./virtualKey.repository";
-
 import { modelProviders } from "../modelProviders/registry";
+import type { ScopeInput, VirtualKeyWithScopes } from "./virtualKey.repository";
 
 export type EligibleModelProvider = ModelProvider;
 

--- a/platform/app/src/server/modelProviders/registry.ts
+++ b/platform/app/src/server/modelProviders/registry.ts
@@ -564,6 +564,28 @@ export const modelProviders = {
 } satisfies Record<string, ModelProviderDefinition>;
 
 /**
+ * Whether the gateway's chat dispatcher can route to this provider — the ONE
+ * predicate behind both the server-side eligibility walk
+ * (`gateway/scopeResolver.eligibleModelProvidersForVk`) and the client-side
+ * mirror (`components/gateway/eligibleModelProviders.isRoutable`), so the
+ * binding picker never offers a provider the dispatch chain would drop.
+ *
+ * Non-LLM providers (registry type "safety", e.g. azure_safety) hold
+ * credentials for evaluators, not chat dispatch; the Go gateway's Bifrost
+ * router has no adapter for them, so letting one into a VK chain makes
+ * fallback attempts fail with "unsupported provider: azure_safety".
+ *
+ * This dimension deliberately fails OPEN for ids absent from the registry:
+ * they may be newer than this build's registry snapshot, and the
+ * materialiser's default branch still knows how to shape their credentials.
+ * (The enabled/disabledAt dimension, checked elsewhere, fails closed.)
+ */
+export function isDispatchableProvider(providerId: string): boolean {
+  const entry = modelProviders[providerId as keyof typeof modelProviders];
+  return !entry || entry.type === "llm";
+}
+
+/**
  * The deprecation on a provider, or undefined when it still accepts new
  * rows.
  *

--- a/platform/app/src/server/routes/__tests__/evaluations-legacy-model-cascade.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/evaluations-legacy-model-cascade.unit.test.ts
@@ -53,7 +53,7 @@ describe("resolveEvaluatorSettingsDefaults", () => {
         async (_ctx: unknown, params: { featureKey: string }) => {
           if (params.featureKey === "evaluator.create_default") {
             return {
-              model: "openai/gpt-4o",
+              model: "openai/gpt-5-mini",
               source: "feature_override",
               scope: "project",
             };
@@ -69,14 +69,24 @@ describe("resolveEvaluatorSettingsDefaults", () => {
       const resolved = await resolveEvaluatorSettingsDefaults("proj-1");
 
       expect(resolved).toEqual({
-        defaultModel: "openai/gpt-4o",
+        defaultModel: "openai/gpt-5-mini",
         embeddingsModel: "openai/text-embedding-3-large",
       });
+      // The embeddings model must come from its own feature key — a typo'd
+      // key would fall into the mock's catch-all and still return the right
+      // value, so pin the exact second call.
+      expect(getResolvedDefaultForFeature).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          projectId: "proj-1",
+          featureKey: "analytics.topic_clustering_embeddings",
+        },
+      );
     });
 
     it("resolves for the given project id and the evaluator.create_default feature key (AC#3/#4)", async () => {
       getResolvedDefaultForFeature.mockResolvedValue({
-        model: "anthropic/claude-3-5-sonnet",
+        model: "openai/gpt-5-mini",
         source: "role_default",
         scope: "team",
       });
@@ -95,7 +105,7 @@ describe("resolveEvaluatorSettingsDefaults", () => {
 
     it("feeds getEvaluatorDefaultSettings the custom model, not DEFAULT_MODEL (AC#6)", async () => {
       getResolvedDefaultForFeature.mockResolvedValue({
-        model: "openai/gpt-4o",
+        model: "openai/gpt-5-mini",
         source: "feature_override",
         scope: "project",
       });
@@ -106,8 +116,23 @@ describe("resolveEvaluatorSettingsDefaults", () => {
         resolved,
       );
 
-      expect((settings as any).model).toBe("openai/gpt-4o");
+      expect((settings as any).model).toBe("openai/gpt-5-mini");
       expect((settings as any).model).not.toBe(DEFAULT_MODEL);
+    });
+  });
+
+  describe("when the evaluator definition carries no settings (custom evaluator)", () => {
+    it("getEvaluatorDefaultSettings returns {} instead of throwing (regression)", () => {
+      // getEvaluatorIncludingCustom builds custom (non-workflow) definitions
+      // as { name, requiredFields } with NO `settings`; the legacy dispatch
+      // route used to hand those straight to getEvaluatorDefaultSettings,
+      // which crashed on Object.entries(undefined).
+      const customDefinition = {
+        name: "Custom evaluator",
+        requiredFields: ["input"],
+      } as any;
+
+      expect(getEvaluatorDefaultSettings(customDefinition)).toEqual({});
     });
   });
 

--- a/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
@@ -9,7 +9,8 @@
  *
  *   - No preference means the async contract is untouched: 202, ids only, and
  *     the durable fold is never even consulted.
- *   - A settled turn comes back 200 with `Preference-Applied: wait` and the
+ *   - A settled turn comes back 200 with `Preference-Applied: wait=<applied>`
+ *     (the value echoed per RFC 7240 §3, so a capped caller can tell) and the
  *     assistant's text, keyed on the turnId THIS request started — a terminal
  *     event for some other turn on the same conversation must not satisfy the
  *     wait.
@@ -82,6 +83,9 @@ vi.mock("~/server/app-layer/app", () => ({
       conversations: { getEventsAfter: mockGetEventsAfter },
     },
   })),
+  // No Redis in this suite: awaitTurnSettlement exercises its fold-poll
+  // fallback, which is the deterministic path a unit suite can pin.
+  tryGetApp: vi.fn(() => null),
 }));
 
 // Imported AFTER every mock, same as the sibling suite.
@@ -201,7 +205,7 @@ describe("/api/langy wait mode (Prefer: wait)", () => {
     const res = await postTurn({ Prefer: "wait=30" });
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("preference-applied")).toBe("wait");
+    expect(res.headers.get("preference-applied")).toBe("wait=30");
     expect(await res.json()).toEqual({
       conversationId: "conv-1",
       turnId: "turn-1",
@@ -234,12 +238,18 @@ describe("/api/langy wait mode (Prefer: wait)", () => {
         truncated: false,
       });
 
-    const res = await postTurn({ Prefer: "wait=30" });
-    const body = (await res.json()) as { reply: { text: string } };
+    vi.useFakeTimers();
+    try {
+      const pending = postTurn({ Prefer: "wait=30" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      const res = await pending;
+      const body = (await res.json()) as { reply: { text: string } };
 
-    expect(res.status).toBe(200);
-    expect(body.reply.text).toBe("yours");
-    expect(mockGetEventsAfter.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(res.status).toBe(200);
+      expect(body.reply.text).toBe("yours");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /** @scenario "A failed turn settles the wait as a domain outcome, not a transport refusal" */
@@ -286,11 +296,18 @@ describe("/api/langy wait mode (Prefer: wait)", () => {
         truncated: false,
       });
 
-    const res = await postTurn({ Prefer: "wait=30" });
-    const body = (await res.json()) as { reply: { text: string } };
+    vi.useFakeTimers();
+    try {
+      const pending = postTurn({ Prefer: "wait=30" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      const res = await pending;
+      const body = (await res.json()) as { reply: { text: string } };
 
-    expect(res.status).toBe(200);
-    expect(body.reply.text).toBe("late but here");
+      expect(res.status).toBe(200);
+      expect(body.reply.text).toBe("late but here");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /** @scenario "A plain-text message is accepted without the parts structure" */
@@ -341,5 +358,83 @@ describe("/api/langy wait mode (Prefer: wait)", () => {
       conversationId: "conv-1",
       turnId: "turn-1",
     });
+  });
+
+  it("caps the wait at MAX_WAIT_SECONDS and echoes the applied value", async () => {
+    mockGetEventsAfter.mockResolvedValue({
+      events: [respondedEvent({ turnId: "turn-1", text: "capped" })],
+      cursor: { acceptedAt: 1, eventId: "evt-turn-1" },
+      truncated: false,
+    });
+
+    const res = await postTurn({ Prefer: "wait=99999" });
+
+    expect(res.status).toBe(200);
+    // RFC 7240 §3: the echoed value is how the caller learns the cap.
+    expect(res.headers.get("preference-applied")).toBe("wait=120");
+  });
+
+  it("treats wait=0 as no preference: 202 without consulting the fold", async () => {
+    const res = await postTurn({ Prefer: "wait=0" });
+
+    expect(res.status).toBe(202);
+    expect(res.headers.get("preference-applied")).toBeNull();
+    expect(mockGetEventsAfter).not.toHaveBeenCalled();
+  });
+
+  it("ignores a negative wait and answers 202", async () => {
+    const res = await postTurn({ Prefer: "wait=-5" });
+
+    expect(res.status).toBe(202);
+    expect(mockGetEventsAfter).not.toHaveBeenCalled();
+  });
+
+  it("parses wait when it is not the first preference in the header", async () => {
+    mockGetEventsAfter.mockResolvedValue({
+      events: [respondedEvent({ turnId: "turn-1", text: "mid-header" })],
+      cursor: { acceptedAt: 1, eventId: "evt-turn-1" },
+      truncated: false,
+    });
+
+    const res = await postTurn({ Prefer: "respond-async, wait=30" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("preference-applied")).toBe("wait=30");
+  });
+
+  it('parses the RFC 7240 quoted-string form wait="30"', async () => {
+    mockGetEventsAfter.mockResolvedValue({
+      events: [respondedEvent({ turnId: "turn-1", text: "quoted" })],
+      cursor: { acceptedAt: 1, eventId: "evt-turn-1" },
+      truncated: false,
+    });
+
+    const res = await postTurn({ Prefer: 'wait="30"' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("preference-applied")).toBe("wait=30");
+  });
+
+  it("stops waiting and degrades to 202 when the client disconnects", async () => {
+    mockGetEventsAfter.mockResolvedValue(emptyTail);
+    const client = new AbortController();
+
+    const pending = testApp.request(TURN_URL, {
+      method: "POST",
+      headers: {
+        "X-Auth-Token": "test-token",
+        "Content-Type": "application/json",
+        Prefer: "wait=30",
+      },
+      body: JSON.stringify(VALID_TURN_BODY),
+      signal: client.signal,
+    });
+    // Let the turn start and the wait enter its first poll delay, then walk away.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    client.abort();
+    const res = await pending;
+
+    expect(res.status).toBe(202);
+    expect(res.headers.get("preference-applied")).toBeNull();
   });
 });

--- a/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
@@ -293,6 +293,42 @@ describe("/api/langy wait mode (Prefer: wait)", () => {
     expect(body.reply.text).toBe("late but here");
   });
 
+  /** @scenario "A plain-text message is accepted without the parts structure" */
+  it("normalizes a `content` string message into a single text part", async () => {
+    const res = await testApp.request(TURN_URL, {
+      method: "POST",
+      headers: {
+        "X-Auth-Token": "test-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem-2",
+        messages: [
+          { role: "user", content: "hello from a plain client" },
+          // parts wins over content when both are present
+          {
+            role: "assistant",
+            content: "ignored",
+            parts: [{ type: "text", text: "kept" }],
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(mockStartConversationTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          {
+            role: "user",
+            parts: [{ type: "text", text: "hello from a plain client" }],
+          },
+          { role: "assistant", parts: [{ type: "text", text: "kept" }] },
+        ],
+      }),
+    );
+  });
+
   /** @scenario "An expired wait degrades to the asynchronous acceptance" */
   it("degrades to the exact async 202 when the wait expires unsettled", async () => {
     mockGetEventsAfter.mockResolvedValue(emptyTail);

--- a/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @vitest-environment node
+ *
+ * The synchronous wait mode of `/api/langy` (`Prefer: wait=<seconds>`,
+ * RFC 7240), driven through the real Hono app exactly like the refusal-chain
+ * suite next door.
+ *
+ * The properties pinned here:
+ *
+ *   - No preference means the async contract is untouched: 202, ids only, and
+ *     the durable fold is never even consulted.
+ *   - A settled turn comes back 200 with `Preference-Applied: wait` and the
+ *     assistant's text, keyed on the turnId THIS request started — a terminal
+ *     event for some other turn on the same conversation must not satisfy the
+ *     wait.
+ *   - A failed turn is still a 200: the REQUEST succeeded, and the failure is
+ *     the turn's own outcome, carried in `status`/`error`.
+ *   - Expiry degrades to the exact 202 the async path returns, with no
+ *     `Preference-Applied` — a caller cannot tell it from never having asked.
+ *   - Projection lag (`LangyConversationNotFoundError` from the fold read)
+ *     means "keep waiting", not "gone".
+ */
+import { LANGY_CONVERSATION_EVENT_TYPES } from "@langwatch/langy";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Auth mocks (same seam as langy-api-refusal-chain.unit.test.ts) ───────────
+const mockResolve = vi.fn();
+const mockMarkUsed = vi.fn();
+
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: vi.fn(() => ({ resolve: mockResolve, markUsed: mockMarkUsed })),
+  },
+}));
+
+const mockExtractCredentials = vi.fn();
+const mockEnforceApiKeyCeiling = vi.fn();
+
+vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    extractCredentials: (...args: unknown[]) => mockExtractCredentials(...args),
+    enforceApiKeyCeiling: (...args: unknown[]) =>
+      mockEnforceApiKeyCeiling(...args),
+  };
+});
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+const mockIsEnabled = vi.fn();
+
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: {
+    isEnabled: (...args: unknown[]) => mockIsEnabled(...args),
+  },
+}));
+
+const mockResolveLangyKeyIdentity = vi.fn();
+const mockResolveLangyActorSession = vi.fn();
+
+vi.mock("~/server/app-layer/langy/langyApiKeyIdentity", () => ({
+  resolveLangyKeyIdentity: (...args: unknown[]) =>
+    mockResolveLangyKeyIdentity(...args),
+}));
+
+vi.mock("~/server/app-layer/langy/langyApiKeyActorSession", () => ({
+  resolveLangyActorSession: (...args: unknown[]) =>
+    mockResolveLangyActorSession(...args),
+}));
+
+// ─── App layer ────────────────────────────────────────────────────────────────
+const mockStartConversationTurn = vi.fn();
+const mockGetEventsAfter = vi.fn();
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(() => ({
+    langy: {
+      turns: { startConversationTurn: mockStartConversationTurn },
+      conversations: { getEventsAfter: mockGetEventsAfter },
+    },
+  })),
+}));
+
+// Imported AFTER every mock, same as the sibling suite.
+const { app: langyApp } = await import("../langy-api");
+
+const testApp = new Hono();
+testApp.route("/", langyApp);
+
+const TURN_URL = "http://localhost/api/langy/conversations";
+
+const VALID_TURN_BODY = {
+  idempotencyKey: "idem-1",
+  messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+};
+
+function postTurn(headers: Record<string, string> = {}) {
+  return testApp.request(TURN_URL, {
+    method: "POST",
+    headers: {
+      "X-Auth-Token": "test-token",
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(VALID_TURN_BODY),
+  });
+}
+
+function respondedEvent({
+  turnId,
+  text,
+  outcome = "completed",
+  error = null,
+}: {
+  turnId: string;
+  text: string;
+  outcome?: string;
+  error?: string | null;
+}) {
+  return {
+    id: `evt-${turnId}`,
+    createdAt: 1,
+    occurredAt: 1,
+    type: LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED,
+    data: {
+      conversationId: "conv-1",
+      turnId,
+      messageId: `msg-${turnId}`,
+      role: "assistant",
+      parts: [{ type: "text", text }],
+      outcome,
+      error,
+    },
+  };
+}
+
+const emptyTail = {
+  events: [],
+  cursor: { acceptedAt: 0, eventId: "" },
+  truncated: false,
+};
+
+describe("/api/langy wait mode (Prefer: wait)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtractCredentials.mockReturnValue({
+      token: "test-token",
+      projectId: "project-123",
+    });
+    mockResolve.mockResolvedValue({
+      type: "apiKey" as const,
+      apiKeyId: "key-1",
+      project: { id: "project-123", team: { organizationId: "org-1" } },
+    });
+    mockIsEnabled.mockResolvedValue(true);
+    mockEnforceApiKeyCeiling.mockResolvedValue(undefined);
+    mockResolveLangyKeyIdentity.mockResolvedValue({
+      ok: true,
+      userId: "user-1",
+    });
+    mockResolveLangyActorSession.mockResolvedValue({
+      ok: true,
+      session: { user: { id: "user-1" } },
+    });
+    mockStartConversationTurn.mockResolvedValue({
+      conversationId: "conv-1",
+      turnId: "turn-1",
+    });
+  });
+
+  it("keeps the async 202 contract untouched when no preference is sent", async () => {
+    const res = await postTurn();
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({
+      conversationId: "conv-1",
+      turnId: "turn-1",
+    });
+    expect(res.headers.get("preference-applied")).toBeNull();
+    expect(mockGetEventsAfter).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unparseable wait preference and answers 202", async () => {
+    const res = await postTurn({ Prefer: "wait=soon, respond-async" });
+
+    expect(res.status).toBe(202);
+    expect(mockGetEventsAfter).not.toHaveBeenCalled();
+  });
+
+  /** @scenario "A caller preferring to wait receives the assistant's output synchronously" */
+  it("returns the assistant reply with 200 and Preference-Applied when the turn settles", async () => {
+    mockGetEventsAfter.mockResolvedValue({
+      events: [respondedEvent({ turnId: "turn-1", text: "hello back" })],
+      cursor: { acceptedAt: 1, eventId: "evt-turn-1" },
+      truncated: false,
+    });
+
+    const res = await postTurn({ Prefer: "wait=30" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("preference-applied")).toBe("wait");
+    expect(await res.json()).toEqual({
+      conversationId: "conv-1",
+      turnId: "turn-1",
+      status: "completed",
+      error: null,
+      reply: { role: "assistant", text: "hello back" },
+    });
+    // The wait authorizes the fold read as the same user the credential
+    // bridged to — not some ambient identity.
+    expect(mockGetEventsAfter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-123",
+        conversationId: "conv-1",
+        userId: "user-1",
+      }),
+    );
+  });
+
+  /** @scenario "A wait is satisfied only by the turn this request started" */
+  it("is keyed on THIS request's turnId, not any terminal event", async () => {
+    mockGetEventsAfter
+      .mockResolvedValueOnce({
+        events: [respondedEvent({ turnId: "turn-OTHER", text: "not yours" })],
+        cursor: { acceptedAt: 1, eventId: "evt-turn-OTHER" },
+        truncated: false,
+      })
+      .mockResolvedValue({
+        events: [respondedEvent({ turnId: "turn-1", text: "yours" })],
+        cursor: { acceptedAt: 2, eventId: "evt-turn-1" },
+        truncated: false,
+      });
+
+    const res = await postTurn({ Prefer: "wait=30" });
+    const body = (await res.json()) as { reply: { text: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.reply.text).toBe("yours");
+    expect(mockGetEventsAfter.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  /** @scenario "A failed turn settles the wait as a domain outcome, not a transport refusal" */
+  it("reports a failed turn as a 200 with the turn's own error, reply null", async () => {
+    mockGetEventsAfter.mockResolvedValue({
+      events: [
+        {
+          id: "evt-fail",
+          createdAt: 1,
+          occurredAt: 1,
+          type: LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONSE_FAILED,
+          data: {
+            conversationId: "conv-1",
+            turnId: "turn-1",
+            error: "model exploded",
+          },
+        },
+      ],
+      cursor: { acceptedAt: 1, eventId: "evt-fail" },
+      truncated: false,
+    });
+
+    const res = await postTurn({ Prefer: "wait=30" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      conversationId: "conv-1",
+      turnId: "turn-1",
+      status: "failed",
+      error: "model exploded",
+      reply: null,
+    });
+  });
+
+  it("treats projection lag as keep-waiting, not gone", async () => {
+    const { LangyConversationNotFoundError } = await import(
+      "~/server/app-layer/langy/errors"
+    );
+    mockGetEventsAfter
+      .mockRejectedValueOnce(new LangyConversationNotFoundError("conv-1"))
+      .mockResolvedValue({
+        events: [respondedEvent({ turnId: "turn-1", text: "late but here" })],
+        cursor: { acceptedAt: 1, eventId: "evt-turn-1" },
+        truncated: false,
+      });
+
+    const res = await postTurn({ Prefer: "wait=30" });
+    const body = (await res.json()) as { reply: { text: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.reply.text).toBe("late but here");
+  });
+
+  /** @scenario "An expired wait degrades to the asynchronous acceptance" */
+  it("degrades to the exact async 202 when the wait expires unsettled", async () => {
+    mockGetEventsAfter.mockResolvedValue(emptyTail);
+
+    const res = await postTurn({ Prefer: "wait=1" });
+
+    expect(res.status).toBe(202);
+    expect(res.headers.get("preference-applied")).toBeNull();
+    expect(await res.json()).toEqual({
+      conversationId: "conv-1",
+      turnId: "turn-1",
+    });
+  });
+});

--- a/platform/app/src/server/routes/evaluations-legacy.ts
+++ b/platform/app/src/server/routes/evaluations-legacy.ts
@@ -60,7 +60,10 @@ import {
   evaluatorsSchema,
   type SingleEvaluationResult,
 } from "~/server/evaluations/evaluators";
-import { getEvaluatorDefaultSettings } from "~/server/evaluations/getEvaluator";
+import {
+  type CustomEvaluatorDefinition,
+  getEvaluatorDefaultSettings,
+} from "~/server/evaluations/getEvaluator";
 import {
   type DataForEvaluation,
   runEvaluation,
@@ -989,14 +992,15 @@ export const getEvaluatorIncludingCustom = async (
   projectId: string,
   checkType: EvaluatorTypes,
 ): Promise<
-  EvaluatorDefinition<keyof typeof AVAILABLE_EVALUATORS> | undefined
+  | EvaluatorDefinition<keyof typeof AVAILABLE_EVALUATORS>
+  | CustomEvaluatorDefinition
+  | undefined
 > => {
   const availableCustomEvaluators = await getCustomEvaluators({
     projectId,
   });
 
-  const customEntries: [string, { name: string; requiredFields: string[] }][] =
-    [];
+  const customEntries: [string, CustomEvaluatorDefinition][] = [];
   for (const evaluator of availableCustomEvaluators ?? []) {
     const dsl = evaluator.versions[0]?.dsl;
     if (!dsl) {
@@ -1280,9 +1284,9 @@ async function handleEvaluatorCall(
     // flips silently on reroute. Narrow enough (and low-impact enough) to
     // document rather than special-case.
     const mergedSettings = {
-      // Workflow and custom evaluator definitions have no `settings` to
-      // derive defaults from — getEvaluatorDefaultSettings returns {} for
-      // those instead of crashing.
+      // Custom evaluator definitions have no `settings` to derive defaults
+      // from — getEvaluatorDefaultSettings returns {} for that arm instead of
+      // crashing. (Workflow evaluators never reach it: this branch.)
       ...(!workflowEvaluatorDef
         ? getEvaluatorDefaultSettings(
             evaluatorDefinition,

--- a/platform/app/src/server/routes/evaluations-legacy.ts
+++ b/platform/app/src/server/routes/evaluations-legacy.ts
@@ -1280,9 +1280,12 @@ async function handleEvaluatorCall(
     // flips silently on reroute. Narrow enough (and low-impact enough) to
     // document rather than special-case.
     const mergedSettings = {
+      // Workflow and custom evaluator definitions have no `settings` to
+      // derive defaults from — getEvaluatorDefaultSettings returns {} for
+      // those instead of crashing.
       ...(!workflowEvaluatorDef
         ? getEvaluatorDefaultSettings(
-            evaluatorDefinition as any,
+            evaluatorDefinition,
             await resolveEvaluatorSettingsDefaults(project.id),
           )
         : {}),

--- a/platform/app/src/server/routes/langy-api.ts
+++ b/platform/app/src/server/routes/langy-api.ts
@@ -81,10 +81,6 @@
  * HandledError that is re-thrown untouched.
  */
 
-import {
-  LANGY_CONVERSATION_EVENT_TYPES,
-  type LangyEventCursor,
-} from "@langwatch/langy";
 import type { Context } from "hono";
 import { z } from "zod";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
@@ -99,12 +95,11 @@ import {
   LangyApiCredentialMissingError,
   LangyApiIdentityDeniedError,
   LangyApiRequestInvalidError,
-  LangyConversationNotFoundError,
 } from "~/server/app-layer/langy/errors";
-import { extractTextFromParts } from "~/server/app-layer/langy/langy-message.service";
 import type { LangyChatMessageInput } from "~/server/app-layer/langy/langy-turn.service";
 import { resolveLangyActorSession } from "~/server/app-layer/langy/langyApiKeyActorSession";
 import { resolveLangyKeyIdentity } from "~/server/app-layer/langy/langyApiKeyIdentity";
+import { awaitTurnSettlement } from "~/server/app-layer/langy/streaming/awaitTurnSettlement";
 import { prisma } from "~/server/db";
 import { featureFlagService } from "~/server/featureFlag";
 import { bodyLimit } from "./_lib/body-limit";
@@ -255,108 +250,14 @@ async function authorizeTurn(c: Context) {
  * response degrades to the exact 202 the async path returns.
  */
 const MAX_WAIT_SECONDS = 120;
-const WAIT_POLL_INTERVAL_MS = 750;
 
 function requestedWaitSeconds(c: Context): number | null {
   const prefer = c.req.header("prefer");
   if (!prefer) return null;
-  const match = /(?:^|[,;\s])wait=(\d{1,4})/i.exec(prefer);
+  // RFC 7240 §2: the value may be a token or a quoted-string (`wait="30"`).
+  const match = /(?:^|[,;\s])wait="?(\d{1,4})"?/i.exec(prefer);
   if (!match?.[1]) return null;
   return Math.min(Number(match[1]), MAX_WAIT_SECONDS);
-}
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Watch the conversation's durable TURN events until THIS turn settles.
- *
- * The durable fold, not the Redis token buffer, is the source of truth here:
- * `AGENT_RESPONDED` / `AGENT_RESPONSE_FAILED` both carry the `turnId`, so the
- * wait can key on exactly the turn this request started — a concurrent or
- * replayed turn on the same conversation cannot satisfy it. The buffer is
- * best-effort live delivery and may be absent entirely (no Redis); the fold is
- * what `finalizeTurn` calls "the real backend confirmation".
- *
- * `LangyConversationNotFoundError` inside the loop is projection lag — the
- * accepted turn's row has not landed yet — so it means "keep waiting", not
- * "gone". Every other error propagates.
- */
-type TurnSettlement = {
-  outcome: string;
-  error: string | null;
-  text: string;
-};
-
-type ConversationTurnEvents = Awaited<
-  ReturnType<
-    ReturnType<typeof getApp>["langy"]["conversations"]["getEventsAfter"]
-  >
->;
-
-function settlementFromEvents(
-  events: ConversationTurnEvents["events"],
-  turnId: string,
-): TurnSettlement | null {
-  for (const event of events) {
-    if (
-      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED &&
-      event.data.turnId === turnId
-    ) {
-      return {
-        outcome: event.data.outcome,
-        error: event.data.error ?? null,
-        text: extractTextFromParts(event.data.parts),
-      };
-    }
-    if (
-      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONSE_FAILED &&
-      event.data.turnId === turnId
-    ) {
-      return { outcome: "failed", error: event.data.error, text: "" };
-    }
-  }
-  return null;
-}
-
-async function waitForTurnSettlement({
-  projectId,
-  conversationId,
-  turnId,
-  userId,
-  deadlineMs,
-}: {
-  projectId: string;
-  conversationId: string;
-  turnId: string;
-  userId: string;
-  deadlineMs: number;
-}): Promise<TurnSettlement | null> {
-  let cursor: LangyEventCursor = { acceptedAt: 0, eventId: "" };
-  while (Date.now() < deadlineMs) {
-    const events = await getApp()
-      .langy.conversations.getEventsAfter({
-        projectId,
-        conversationId,
-        userId,
-        after: cursor,
-      })
-      .catch((error: unknown) => {
-        if (error instanceof LangyConversationNotFoundError) return null;
-        throw error;
-      });
-    if (!events) {
-      await sleep(WAIT_POLL_INTERVAL_MS);
-      continue;
-    }
-
-    const settlement = settlementFromEvents(events.events, turnId);
-    if (settlement) return settlement;
-
-    cursor = events.cursor;
-    if (events.truncated) continue;
-    await sleep(WAIT_POLL_INTERVAL_MS);
-  }
-  return null;
 }
 
 /**
@@ -403,15 +304,22 @@ async function startTurn({
   // the 202 below, indistinguishable from never having asked.
   const waitSeconds = requestedWaitSeconds(c);
   if (waitSeconds && waitSeconds > 0) {
-    const settlement = await waitForTurnSettlement({
+    // Client disconnect and the wait deadline are one signal: an abandoned
+    // hold stops consuming fold reads (and its blocking Redis read) at once.
+    const settlement = await awaitTurnSettlement({
       projectId: auth.projectId,
       conversationId: result.conversationId,
       turnId: result.turnId,
       userId: auth.session.user.id,
-      deadlineMs: Date.now() + waitSeconds * 1000,
+      signal: AbortSignal.any([
+        c.req.raw.signal,
+        AbortSignal.timeout(waitSeconds * 1000),
+      ]),
     });
     if (settlement) {
-      c.header("Preference-Applied", "wait");
+      // RFC 7240 §3: echo the applied value — it is how a caller asking for
+      // more than MAX_WAIT_SECONDS learns what they actually got.
+      c.header("Preference-Applied", `wait=${waitSeconds}`);
       // 200 even when the turn itself failed: the REQUEST succeeded — it was
       // authorized, accepted and settled — and `status`/`error` carry the
       // turn's own outcome. Failure here is a domain result, not a transport
@@ -421,10 +329,9 @@ async function startTurn({
           ...result,
           status: settlement.outcome,
           error: settlement.error,
-          reply:
-            settlement.outcome === "failed"
-              ? null
-              : { role: "assistant" as const, text: settlement.text },
+          reply: settlement.succeeded
+            ? { role: "assistant" as const, text: settlement.text }
+            : null,
         },
         200,
       );

--- a/platform/app/src/server/routes/langy-api.ts
+++ b/platform/app/src/server/routes/langy-api.ts
@@ -15,7 +15,9 @@
  *   3. `langy:create` ceiling         → else 403
  *   4. key owns an actor + has Langy  → else 403
  *   5. actor row still exists         → else 403
- *   6. shared `startConversationTurn` → 202
+ *   6. shared `startConversationTurn` → 202 — or, with `Prefer: wait=<seconds>`
+ *      (RFC 7240), a 200 carrying the assistant's reply once the turn settles
+ *      on the durable fold, degrading to the same 202 when the wait expires.
  *
  * The flag is checked AFTER authentication as a deliberate choice, NOT because
  * it is impossible to check earlier. Rollback is staged per project, so the
@@ -79,6 +81,10 @@
  * HandledError that is re-thrown untouched.
  */
 
+import {
+  LANGY_CONVERSATION_EVENT_TYPES,
+  type LangyEventCursor,
+} from "@langwatch/langy";
 import type { Context } from "hono";
 import { z } from "zod";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
@@ -93,7 +99,9 @@ import {
   LangyApiCredentialMissingError,
   LangyApiIdentityDeniedError,
   LangyApiRequestInvalidError,
+  LangyConversationNotFoundError,
 } from "~/server/app-layer/langy/errors";
+import { extractTextFromParts } from "~/server/app-layer/langy/langy-message.service";
 import type { LangyChatMessageInput } from "~/server/app-layer/langy/langy-turn.service";
 import { resolveLangyActorSession } from "~/server/app-layer/langy/langyApiKeyActorSession";
 import { resolveLangyKeyIdentity } from "~/server/app-layer/langy/langyApiKeyIdentity";
@@ -225,6 +233,119 @@ async function authorizeTurn(c: Context) {
 }
 
 /**
+ * `Prefer: wait=<seconds>` (RFC 7240) opts a caller into synchronous delivery:
+ * the request is held until the turn settles and the assistant's reply comes
+ * back in the body. The ceiling exists because this connection crosses an
+ * ingress with its own idle timeout; a caller asking for more simply gets the
+ * ceiling (RFC 7240 §3: a preference is not a contract), and on expiry the
+ * response degrades to the exact 202 the async path returns.
+ */
+const MAX_WAIT_SECONDS = 120;
+const WAIT_POLL_INTERVAL_MS = 750;
+
+function requestedWaitSeconds(c: Context): number | null {
+  const prefer = c.req.header("prefer");
+  if (!prefer) return null;
+  const match = /(?:^|[,;\s])wait=(\d{1,4})/i.exec(prefer);
+  if (!match?.[1]) return null;
+  return Math.min(Number(match[1]), MAX_WAIT_SECONDS);
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Watch the conversation's durable TURN events until THIS turn settles.
+ *
+ * The durable fold, not the Redis token buffer, is the source of truth here:
+ * `AGENT_RESPONDED` / `AGENT_RESPONSE_FAILED` both carry the `turnId`, so the
+ * wait can key on exactly the turn this request started — a concurrent or
+ * replayed turn on the same conversation cannot satisfy it. The buffer is
+ * best-effort live delivery and may be absent entirely (no Redis); the fold is
+ * what `finalizeTurn` calls "the real backend confirmation".
+ *
+ * `LangyConversationNotFoundError` inside the loop is projection lag — the
+ * accepted turn's row has not landed yet — so it means "keep waiting", not
+ * "gone". Every other error propagates.
+ */
+type TurnSettlement = {
+  outcome: string;
+  error: string | null;
+  text: string;
+};
+
+type ConversationTurnEvents = Awaited<
+  ReturnType<
+    ReturnType<typeof getApp>["langy"]["conversations"]["getEventsAfter"]
+  >
+>;
+
+function settlementFromEvents(
+  events: ConversationTurnEvents["events"],
+  turnId: string,
+): TurnSettlement | null {
+  for (const event of events) {
+    if (
+      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONDED &&
+      event.data.turnId === turnId
+    ) {
+      return {
+        outcome: event.data.outcome,
+        error: event.data.error ?? null,
+        text: extractTextFromParts(event.data.parts),
+      };
+    }
+    if (
+      event.type === LANGY_CONVERSATION_EVENT_TYPES.AGENT_RESPONSE_FAILED &&
+      event.data.turnId === turnId
+    ) {
+      return { outcome: "failed", error: event.data.error, text: "" };
+    }
+  }
+  return null;
+}
+
+async function waitForTurnSettlement({
+  projectId,
+  conversationId,
+  turnId,
+  userId,
+  deadlineMs,
+}: {
+  projectId: string;
+  conversationId: string;
+  turnId: string;
+  userId: string;
+  deadlineMs: number;
+}): Promise<TurnSettlement | null> {
+  let cursor: LangyEventCursor = { acceptedAt: 0, eventId: "" };
+  while (Date.now() < deadlineMs) {
+    const events = await getApp()
+      .langy.conversations.getEventsAfter({
+        projectId,
+        conversationId,
+        userId,
+        after: cursor,
+      })
+      .catch((error: unknown) => {
+        if (error instanceof LangyConversationNotFoundError) return null;
+        throw error;
+      });
+    if (!events) {
+      await sleep(WAIT_POLL_INTERVAL_MS);
+      continue;
+    }
+
+    const settlement = settlementFromEvents(events.events, turnId);
+    if (settlement) return settlement;
+
+    cursor = events.cursor;
+    if (events.truncated) continue;
+    await sleep(WAIT_POLL_INTERVAL_MS);
+  }
+  return null;
+}
+
+/**
  * Start or continue a turn.
  *
  * Nothing is caught. A domain `HandledError` already carries the status, code
@@ -260,6 +381,42 @@ async function startTurn({
     turnContext: {},
   });
   auth.markUsed();
+
+  // `Prefer: wait=<seconds>` holds the connection until the turn settles and
+  // returns the assistant's reply in the body — the synchronous mode a plain
+  // HTTP client (or a scenario HTTP agent) needs, since this surface has no
+  // public poll or stream endpoint yet. On timeout the response degrades to
+  // the 202 below, indistinguishable from never having asked.
+  const waitSeconds = requestedWaitSeconds(c);
+  if (waitSeconds && waitSeconds > 0) {
+    const settlement = await waitForTurnSettlement({
+      projectId: auth.projectId,
+      conversationId: result.conversationId,
+      turnId: result.turnId,
+      userId: auth.session.user.id,
+      deadlineMs: Date.now() + waitSeconds * 1000,
+    });
+    if (settlement) {
+      c.header("Preference-Applied", "wait");
+      // 200 even when the turn itself failed: the REQUEST succeeded — it was
+      // authorized, accepted and settled — and `status`/`error` carry the
+      // turn's own outcome. Failure here is a domain result, not a transport
+      // refusal.
+      return c.json(
+        {
+          ...result,
+          status: settlement.outcome,
+          error: settlement.error,
+          reply:
+            settlement.outcome === "failed"
+              ? null
+              : { role: "assistant" as const, text: settlement.text },
+        },
+        200,
+      );
+    }
+  }
+
   // 202, not 200: the turn is accepted and dispatched, and the assistant's
   // answer does not exist yet. The caller polls or streams for it.
   return c.json(result, 202);

--- a/platform/app/src/server/routes/langy-api.ts
+++ b/platform/app/src/server/routes/langy-api.ts
@@ -138,11 +138,25 @@ const secured = createServiceApp({
   errorEnvelope: "canonical",
 });
 
-/** One user turn on the wire. Parts stay opaque; the app layer bounds them. */
-const messageSchema = z.object({
-  role: z.enum(["user", "assistant", "system"]),
-  parts: z.array(z.record(z.string(), z.unknown())).default([]),
-});
+/**
+ * One user turn on the wire. Parts stay opaque; the app layer bounds them.
+ *
+ * `content` is the plain-text shorthand a generic HTTP client (a script, a
+ * scenario HTTP agent's body template) can produce without restructuring its
+ * own message shape; it normalizes to a single text part. When both are sent,
+ * `parts` wins — it is the richer form.
+ */
+const messageSchema = z
+  .object({
+    role: z.enum(["user", "assistant", "system"]),
+    parts: z.array(z.record(z.string(), z.unknown())).optional(),
+    content: z.string().optional(),
+  })
+  .transform(({ role, parts, content }) => ({
+    role,
+    parts:
+      parts ?? (content === undefined ? [] : [{ type: "text", text: content }]),
+  }));
 
 const turnBodySchema = z.object({
   messages: z.array(messageSchema).min(1),

--- a/services/aigateway/adapters/controlplane/config_wire.go
+++ b/services/aigateway/adapters/controlplane/config_wire.go
@@ -464,22 +464,5 @@ func providerSlotToCredential(p providerSlotWire) domain.Credential {
 }
 
 func normalizeProviderType(t string) domain.ProviderID {
-	switch t {
-	case "azure":
-		return domain.ProviderAzure
-	case "bedrock", "aws_bedrock":
-		return domain.ProviderBedrock
-	case "vertex", "vertex_ai", "google_vertex":
-		return domain.ProviderVertex
-	case "gemini", "google_gemini":
-		return domain.ProviderGemini
-	case "anthropic":
-		return domain.ProviderAnthropic
-	case "openai":
-		return domain.ProviderOpenAI
-	case "openai_codex":
-		return domain.ProviderOpenAICodex
-	default:
-		return domain.ProviderID(t)
-	}
+	return domain.NormalizeProviderID(t)
 }

--- a/services/aigateway/adapters/controlplane/config_wire.go
+++ b/services/aigateway/adapters/controlplane/config_wire.go
@@ -303,7 +303,7 @@ func buildModelAlias(target string) domain.ModelAlias {
 	if !found || provider == "" || model == "" {
 		return domain.ModelAlias{Model: target}
 	}
-	return domain.ModelAlias{ProviderID: normalizeProviderType(provider), Model: model}
+	return domain.ModelAlias{ProviderID: domain.NormalizeProviderID(provider), Model: model}
 }
 
 func buildPolicyRules(pr policyRulesWire) []domain.PolicyRule {
@@ -385,7 +385,7 @@ func buildCacheRules(wires []cacheRuleWire) []domain.CacheRule {
 func providerSlotToCredential(p providerSlotWire) domain.Credential {
 	cred := domain.Credential{
 		ID:         p.ID,
-		ProviderID: normalizeProviderType(p.Type),
+		ProviderID: domain.NormalizeProviderID(p.Type),
 	}
 
 	getString := func(key string) string {
@@ -461,8 +461,4 @@ func providerSlotToCredential(p providerSlotWire) domain.Credential {
 	}
 
 	return cred
-}
-
-func normalizeProviderType(t string) domain.ProviderID {
-	return domain.NormalizeProviderID(t)
 }

--- a/services/aigateway/adapters/httpapi/audio_test.go
+++ b/services/aigateway/adapters/httpapi/audio_test.go
@@ -26,10 +26,17 @@ import (
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
 
-func audioRouter(capture *domain.Request) http.Handler {
+// audioRouter builds an audio-capable router. Extra credentials are
+// appended to the default bundle so a test asking for a non-OpenAI
+// provider prefix has the matching slot bound — without one the
+// dispatcher rejects the request as model_provider_not_bound before
+// the provider is ever reached.
+func audioRouter(capture *domain.Request, extraCreds ...domain.Credential) http.Handler {
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
+			b := testBundle()
+			b.Credentials = append(b.Credentials, extraCreds...)
+			return b, nil
 		},
 	}
 	provider := &mockProvider{
@@ -107,7 +114,9 @@ func TestAudioSpeech_ReturnsBinaryAudioWithContentType(t *testing.T) {
 
 func TestAudioSpeech_ElevenLabsModelResolvesToElevenLabsProvider(t *testing.T) {
 	var captured domain.Request
-	router := audioRouter(&captured)
+	router := audioRouter(&captured, domain.Credential{
+		ID: "cred-11labs", ProviderID: domain.ProviderElevenLabs, APIKey: "sk-11labs-test",
+	})
 
 	body := `{"model":"elevenlabs/eleven_flash_v2","voice":"cjVigY5qzO86Huf0OWal","input":"Hola."}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
@@ -416,7 +425,11 @@ func TestAudioSpeech_UpstreamProviderErrorPassesThrough(t *testing.T) {
 	}
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
+			b := testBundle()
+			b.Credentials = append(b.Credentials, domain.Credential{
+				ID: "cred-11labs", ProviderID: domain.ProviderElevenLabs, APIKey: "sk-11labs-test",
+			})
+			return b, nil
 		},
 	}
 	router := buildRouter(

--- a/services/aigateway/adapters/httpapi/audio_test.go
+++ b/services/aigateway/adapters/httpapi/audio_test.go
@@ -32,13 +32,6 @@ import (
 // dispatcher rejects the request as model_provider_not_bound before
 // the provider is ever reached.
 func audioRouter(capture *domain.Request, extraCreds ...domain.Credential) http.Handler {
-	auth := &mockAuth{
-		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			b := testBundle()
-			b.Credentials = append(b.Credentials, extraCreds...)
-			return b, nil
-		},
-	}
 	provider := &mockProvider{
 		dispatchFn: func(_ context.Context, req *domain.Request, _ domain.Credential) (*domain.Response, error) {
 			if capture != nil {
@@ -64,11 +57,22 @@ func audioRouter(capture *domain.Request, extraCreds ...domain.Credential) http.
 		},
 	}
 	return buildRouter(
-		app.WithAuth(auth),
+		app.WithAuth(audioAuth(extraCreds...)),
 		app.WithProviders(provider),
 		app.WithModels(modelresolver.New()),
 		app.WithLogger(zap.NewNop()),
 	)
+}
+
+// audioAuth resolves every key to the default bundle plus extraCreds.
+func audioAuth(extraCreds ...domain.Credential) *mockAuth {
+	return &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			b := testBundle()
+			b.Credentials = append(b.Credentials, extraCreds...)
+			return b, nil
+		},
+	}
 }
 
 func multipartBody(t *testing.T, fields map[string]string, fileField, filename string, fileBytes []byte) (*bytes.Buffer, string) {

--- a/services/aigateway/adapters/httpapi/audio_test.go
+++ b/services/aigateway/adapters/httpapi/audio_test.go
@@ -427,15 +427,9 @@ func TestAudioSpeech_UpstreamProviderErrorPassesThrough(t *testing.T) {
 			}, nil
 		},
 	}
-	auth := &mockAuth{
-		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			b := testBundle()
-			b.Credentials = append(b.Credentials, domain.Credential{
-				ID: "cred-11labs", ProviderID: domain.ProviderElevenLabs, APIKey: "sk-11labs-test",
-			})
-			return b, nil
-		},
-	}
+	auth := audioAuth(domain.Credential{
+		ID: "cred-11labs", ProviderID: domain.ProviderElevenLabs, APIKey: "sk-11labs-test",
+	})
 	router := buildRouter(
 		app.WithAuth(auth),
 		app.WithProviders(provider),

--- a/services/aigateway/adapters/httpapi/faults.go
+++ b/services/aigateway/adapters/httpapi/faults.go
@@ -69,6 +69,7 @@ func faultForCode(code herr.Code) Fault {
 	switch code {
 	case domain.ErrInvalidAPIKey, domain.ErrBudgetExceeded, domain.ErrRateLimited,
 		domain.ErrGuardrailBlocked, domain.ErrPolicyViolation, domain.ErrModelNotAllowed,
+		domain.ErrProviderNotBound,
 		domain.ErrPayloadTooLarge, domain.ErrBadRequest, domain.ErrMissingModel, domain.ErrNotFound,
 		domain.ErrKeyRevoked, domain.ErrKeyDisabled, domain.ErrNoProviderConfigured,
 		domain.ErrEndUserRequired,

--- a/services/aigateway/adapters/httpapi/provider_not_bound_test.go
+++ b/services/aigateway/adapters/httpapi/provider_not_bound_test.go
@@ -1,0 +1,73 @@
+package httpapi
+
+// Binds specs/ai-gateway/model-disambiguation.feature: the scenario for a
+// model prefix naming a provider the virtual key has no slot for. The
+// envelope is the whole point of the scenario — a 400 whose body names the
+// provider and says how to bind it — so it is asserted here at the HTTP
+// boundary rather than at the dispatcher, where the wire shape is invisible.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/services/aigateway/adapters/modelresolver"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// @scenario "Unknown provider prefix on VK returns 400 with clear envelope"
+func TestChat_UnknownProviderPrefixReturnsNotBoundEnvelope(t *testing.T) {
+	dispatched := false
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			dispatched = true
+			return successResponse(), nil
+		},
+	}
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			// An OpenAI slot and nothing else: the key works, it just has
+			// no bedrock binding. This is the shape that used to reach
+			// Bifrost and come back as an opaque provider-config error.
+			return testBundle(), nil
+		},
+	}
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	body := `{"model":"bedrock/claude-3-haiku","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.False(t, dispatched, "a request naming an unbound provider must not reach any provider")
+
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Hint    string `json:"hint"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), "body: %s", rec.Body.String())
+	assert.Equal(t, string(domain.ErrProviderNotBound), env.Error.Code)
+	// Naming the provider is what separates this from the opaque errors it
+	// replaces; a hint that does not say which slot is missing would leave
+	// the caller exactly where they started.
+	assert.Contains(t, rec.Body.String(), "bedrock")
+	assert.Contains(t, rec.Body.String(), "virtual key")
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -1214,6 +1214,7 @@ func registerErrorStatuses() {
 	herr.RegisterStatus(domain.ErrGuardrailUpstreamUnavailable, http.StatusServiceUnavailable)
 	herr.RegisterStatus(domain.ErrPolicyViolation, http.StatusForbidden)
 	herr.RegisterStatus(domain.ErrModelNotAllowed, http.StatusBadRequest)
+	herr.RegisterStatus(domain.ErrProviderNotBound, http.StatusBadRequest)
 	herr.RegisterStatus(domain.ErrProviderError, http.StatusBadGateway)
 	herr.RegisterStatus(domain.ErrProviderTimeout, http.StatusGatewayTimeout)
 	herr.RegisterStatus(domain.ErrBadRequest, http.StatusBadRequest)

--- a/services/aigateway/adapters/modelresolver/resolver.go
+++ b/services/aigateway/adapters/modelresolver/resolver.go
@@ -107,7 +107,7 @@ func (r *Resolver) Resolve(ctx context.Context, req *domain.Request, config doma
 	if strings.Contains(target, "/") {
 		source = domain.ModelSourceExplicit
 		parts := strings.SplitN(target, "/", 2)
-		providerID := normalizeProvider(parts[0])
+		providerID := domain.NormalizeProviderID(parts[0])
 		modelID := parts[1]
 
 		if !modelAllowed(config, modelID) {
@@ -131,10 +131,6 @@ func (r *Resolver) Resolve(ctx context.Context, req *domain.Request, config doma
 		ProviderID: "", // will be filled by credential selection
 		Source:     source,
 	}, nil
-}
-
-func normalizeProvider(raw string) domain.ProviderID {
-	return domain.NormalizeProviderID(raw)
 }
 
 func modelAllowed(config domain.BundleConfig, model string) bool {

--- a/services/aigateway/adapters/modelresolver/resolver.go
+++ b/services/aigateway/adapters/modelresolver/resolver.go
@@ -134,22 +134,7 @@ func (r *Resolver) Resolve(ctx context.Context, req *domain.Request, config doma
 }
 
 func normalizeProvider(raw string) domain.ProviderID {
-	switch raw {
-	case "azure_openai", "azure":
-		return domain.ProviderAzure
-	case "google_vertex", "vertex":
-		return domain.ProviderVertex
-	case "aws_bedrock", "bedrock":
-		return domain.ProviderBedrock
-	case "google_gemini", "gemini":
-		return domain.ProviderGemini
-	case "anthropic":
-		return domain.ProviderAnthropic
-	case "openai":
-		return domain.ProviderOpenAI
-	default:
-		return domain.ProviderID(raw)
-	}
+	return domain.NormalizeProviderID(raw)
 }
 
 func modelAllowed(config domain.BundleConfig, model string) bool {

--- a/services/aigateway/adapters/modelresolver/resolver_test.go
+++ b/services/aigateway/adapters/modelresolver/resolver_test.go
@@ -48,6 +48,15 @@ func TestResolve_ExplicitFormat_NormalizedProviders(t *testing.T) {
 		{"google_vertex", "google_vertex/m", domain.ProviderVertex, "m"},
 		{"aws_bedrock", "aws_bedrock/m", domain.ProviderBedrock, "m"},
 		{"google_gemini", "google_gemini/m", domain.ProviderGemini, "m"},
+		// LiteLLM's spelling, and the one most SDKs emit. The credential
+		// side has always normalized it; this side had not, so a caller
+		// with a working Vertex credential resolved to a provider that
+		// matched none of their credentials.
+		{"vertex_ai", "vertex_ai/gemini-2.5-flash", domain.ProviderVertex, "gemini-2.5-flash"},
+		{"azure", "azure/m", domain.ProviderAzure, "m"},
+		{"bedrock", "bedrock/m", domain.ProviderBedrock, "m"},
+		{"vertex", "vertex/m", domain.ProviderVertex, "m"},
+		{"openai_codex", "openai_codex/m", domain.ProviderOpenAICodex, "m"},
 	}
 
 	r := New()

--- a/services/aigateway/app/dispatch.go
+++ b/services/aigateway/app/dispatch.go
@@ -133,7 +133,10 @@ func translateWalkError(ctx context.Context, err error) error {
 //     iterated; with several simultaneous exclusions any of them is an
 //     accurate answer to "why was nothing dispatchable").
 func (a *App) candidateChain(ctx context.Context, call *pipeline.Call) ([]domain.Credential, error) {
-	creds := eligibleCredentials(call.Bundle.Credentials, call.Request.Resolved)
+	creds, err := eligibleCredentials(ctx, call.Bundle.Credentials, call.Request.Resolved)
+	if err != nil {
+		return nil, err
+	}
 	if len(creds) == 0 {
 		return nil, errNoProviderConfigured(ctx)
 	}

--- a/services/aigateway/app/eligible.go
+++ b/services/aigateway/app/eligible.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
+	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
 
@@ -28,22 +31,32 @@ import (
 //     no provider knows the prefix, leave the chain untouched (fall
 //     back to existing behavior).
 //
-// Safety net: if the filter empties the chain entirely, return the
-// original creds. We never want this helper to convert "the user has
-// a usable provider somewhere" into a hard-fail; a wrong-provider
-// dispatch surfaces a clear error from Bifrost, but no-providers
-// surfaces an opaque internal error to the caller.
-func eligibleCredentials(creds []domain.Credential, resolved *domain.ResolvedModel) []domain.Credential {
+// Safety net (implicit names only): if inferring a provider from a bare
+// model name empties the chain, return the original creds — a bare model
+// name carries no provider prefix, so each attempt dispatches with the
+// credential's own provider and fails with that provider's real error.
+//
+// Explicitly-named providers (a "provider/model" prefix or an alias) get
+// the opposite treatment: an empty filter is a hard fail with
+// ErrProviderNotBound. Dispatching anyway would forward the prefixed
+// model string with a mismatched credential, and Bifrost's model-prefix
+// provider override then reads that credential through the wrong
+// provider's key-config shape — surfacing as opaque errors like
+// "deployments not set" (Azure), "no keys found that support model"
+// (Gemini), or raw HTML error pages (Vertex) instead of telling the
+// caller the provider isn't configured.
+func eligibleCredentials(ctx context.Context, creds []domain.Credential, resolved *domain.ResolvedModel) ([]domain.Credential, error) {
 	if len(creds) == 0 || resolved == nil {
-		return creds
+		return creds, nil
 	}
 
 	target := resolved.ProviderID
+	explicit := target != ""
 	if target == "" {
 		target = inferProviderFromModel(resolved.ModelID)
 	}
 	if target == "" {
-		return creds
+		return creds, nil
 	}
 
 	out := make([]domain.Credential, 0, len(creds))
@@ -53,9 +66,15 @@ func eligibleCredentials(creds []domain.Credential, resolved *domain.ResolvedMod
 		}
 	}
 	if len(out) == 0 {
-		return creds
+		if explicit {
+			return nil, herr.New(ctx, domain.ErrProviderNotBound, herr.M{
+				"message": fmt.Sprintf("no %q provider is configured for this key", target),
+				"hint":    fmt.Sprintf("bind a %q provider slot to this virtual key, or drop the %q model prefix", target, target),
+			})
+		}
+		return creds, nil
 	}
-	return out
+	return out, nil
 }
 
 // inferProviderFromModel maps a bare model name to the provider that

--- a/services/aigateway/app/eligible_test.go
+++ b/services/aigateway/app/eligible_test.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"context"
 	"testing"
 
+	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
 
@@ -22,6 +24,7 @@ func TestEligibleCredentials(t *testing.T) {
 		name     string
 		resolved *domain.ResolvedModel
 		wantIDs  []string
+		wantErr  herr.Code
 	}{
 		{
 			name:     "explicit anthropic provider keeps both anthropic creds in order",
@@ -69,9 +72,9 @@ func TestEligibleCredentials(t *testing.T) {
 			wantIDs:  []string{"anthropic_1", "openai_1", "gemini_1", "anthropic_2"},
 		},
 		{
-			name:     "no matching provider falls back to original chain (defensive)",
+			name:     "explicit provider with no matching cred hard-fails as not bound",
 			resolved: &domain.ResolvedModel{ProviderID: domain.ProviderBedrock, ModelID: "bedrock-only"},
-			wantIDs:  []string{"anthropic_1", "openai_1", "gemini_1", "anthropic_2"},
+			wantErr:  domain.ErrProviderNotBound,
 		},
 		{
 			name:     "nil resolved leaves chain untouched",
@@ -87,7 +90,16 @@ func TestEligibleCredentials(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := eligibleCredentials(mkCreds(), tc.resolved)
+			got, err := eligibleCredentials(context.Background(), mkCreds(), tc.resolved)
+			if tc.wantErr != "" {
+				if !herr.IsCode(err, tc.wantErr) {
+					t.Fatalf("got err %v, want code %s", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			gotIDs := make([]string, len(got))
 			for i, c := range got {
 				gotIDs[i] = c.ID
@@ -100,7 +112,10 @@ func TestEligibleCredentials(t *testing.T) {
 }
 
 func TestEligibleCredentialsEmptyChain(t *testing.T) {
-	got := eligibleCredentials(nil, &domain.ResolvedModel{ModelID: "gpt-4o"})
+	got, err := eligibleCredentials(context.Background(), nil, &domain.ResolvedModel{ModelID: "gpt-4o"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got != nil {
 		t.Errorf("expected nil slice, got %v", got)
 	}
@@ -114,7 +129,10 @@ func TestEligibleCredentialsPreservesPriority(t *testing.T) {
 		{ID: "openai_first", ProviderID: domain.ProviderOpenAI},
 		{ID: "secondary_anthropic", ProviderID: domain.ProviderAnthropic},
 	}
-	got := eligibleCredentials(creds, &domain.ResolvedModel{ProviderID: domain.ProviderAnthropic})
+	got, err := eligibleCredentials(context.Background(), creds, &domain.ResolvedModel{ProviderID: domain.ProviderAnthropic})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(got) != 2 {
 		t.Fatalf("got %d creds, want 2", len(got))
 	}
@@ -133,4 +151,21 @@ func equalSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestEligibleCredentialsImplicitNoMatchKeepsSafetyNet(t *testing.T) {
+	// A bare model name (no provider prefix) whose inferred provider has
+	// no credential must NOT hard-fail: without a prefix on the model
+	// string, each attempt dispatches with the credential's own provider
+	// and surfaces that provider's real error.
+	creds := []domain.Credential{
+		{ID: "openai_1", ProviderID: domain.ProviderOpenAI},
+	}
+	got, err := eligibleCredentials(context.Background(), creds, &domain.ResolvedModel{ProviderID: "", ModelID: "gemini-2.5-pro"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "openai_1" {
+		t.Errorf("safety net not applied: got %v", got)
+	}
 }

--- a/services/aigateway/app/eligible_test.go
+++ b/services/aigateway/app/eligible_test.go
@@ -169,3 +169,20 @@ func TestEligibleCredentialsImplicitNoMatchKeepsSafetyNet(t *testing.T) {
 		t.Errorf("safety net not applied: got %v", got)
 	}
 }
+
+func TestEligibleCredentialsEmptyChainDefersToNoProviderConfigured(t *testing.T) {
+	// A VK with zero credentials is a different customer problem than a
+	// VK missing one provider: the org has configured nothing at all, so
+	// "bind a bedrock slot" is the wrong advice. This helper stays silent
+	// and lets candidateChain raise no_provider_configured, which names
+	// the actual next step. Both are 400s, so the status contract holds.
+	got, err := eligibleCredentials(context.Background(), nil, &domain.ResolvedModel{
+		ProviderID: domain.ProviderBedrock, ModelID: "anthropic.claude-3-5-sonnet",
+	})
+	if err != nil {
+		t.Fatalf("empty chain must not hard-fail here: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty chain to pass through, got %v", got)
+	}
+}

--- a/services/aigateway/domain/errors.go
+++ b/services/aigateway/domain/errors.go
@@ -63,7 +63,7 @@ const (
 	ErrGuardrailUpstreamUnavailable = herr.Code("guardrail_upstream_unavailable")
 	ErrPolicyViolation              = herr.Code("policy_violation")
 	ErrModelNotAllowed              = herr.Code("model_not_allowed")
-	// ErrProviderNotBound: the request names a provider (explicit
+	// ErrProviderNotBound means the request names a provider (explicit
 	// "provider/model" prefix or alias) that has no credential slot on
 	// this VK. Dispatching anyway would hand a mismatched credential to
 	// the provider selected by the model prefix, which surfaces as opaque

--- a/services/aigateway/domain/errors.go
+++ b/services/aigateway/domain/errors.go
@@ -63,9 +63,15 @@ const (
 	ErrGuardrailUpstreamUnavailable = herr.Code("guardrail_upstream_unavailable")
 	ErrPolicyViolation              = herr.Code("policy_violation")
 	ErrModelNotAllowed              = herr.Code("model_not_allowed")
-	ErrProviderError                = herr.Code("provider_error")
-	ErrPayloadTooLarge              = herr.Code("payload_too_large")
-	ErrBadRequest                   = herr.Code("bad_request")
+	// ErrProviderNotBound: the request names a provider (explicit
+	// "provider/model" prefix or alias) that has no credential slot on
+	// this VK. Dispatching anyway would hand a mismatched credential to
+	// the provider selected by the model prefix, which surfaces as opaque
+	// provider-config errors ("deployments not set", HTML error pages).
+	ErrProviderNotBound = herr.Code("model_provider_not_bound")
+	ErrProviderError    = herr.Code("provider_error")
+	ErrPayloadTooLarge  = herr.Code("payload_too_large")
+	ErrBadRequest       = herr.Code("bad_request")
 	// ErrMissingModel is a request-shape error with its own stable identity so
 	// clients and rejection metrics do not have to infer it from prose.
 	ErrMissingModel    = herr.Code("missing_model")

--- a/services/aigateway/domain/provider.go
+++ b/services/aigateway/domain/provider.go
@@ -49,6 +49,42 @@ const (
 	ProviderOpenAICodex ProviderID = "openai_codex"
 )
 
+// NormalizeProviderID maps the provider spellings that reach the gateway
+// onto the canonical ProviderID constants above.
+//
+// Two vocabularies feed in and they must agree. Requests carry the prefix
+// the caller typed ("vertex_ai/gemini-2.5-flash" — LiteLLM's spelling, the
+// one most SDKs emit); credentials carry the provider type the control
+// plane stored ("google_vertex"). Both sides used to keep their own switch,
+// and the tables had drifted: the credential side accepted "vertex_ai" and
+// the request side did not. A caller with a working Vertex credential then
+// resolved to provider "vertex_ai", matched no credential named "vertex",
+// and their traffic died against whichever credential the chain reached
+// first. Normalizing through one table is what keeps that from recurring.
+//
+// Unknown values pass through verbatim, so a provider added to the control
+// plane before this build knows its name still routes on its own ID.
+func NormalizeProviderID(raw string) ProviderID {
+	switch raw {
+	case "azure", "azure_openai":
+		return ProviderAzure
+	case "bedrock", "aws_bedrock":
+		return ProviderBedrock
+	case "vertex", "vertex_ai", "google_vertex":
+		return ProviderVertex
+	case "gemini", "google_gemini":
+		return ProviderGemini
+	case "anthropic":
+		return ProviderAnthropic
+	case "openai":
+		return ProviderOpenAI
+	case "openai_codex":
+		return ProviderOpenAICodex
+	default:
+		return ProviderID(raw)
+	}
+}
+
 // CodexTokenRefresher exchanges a codex provider row's stored refresh token
 // for a fresh access token via the control plane (which owns storage and
 // rotation). A dead session (refresh rejected — the user must sign in again)

--- a/services/aigateway/domain/provider.go
+++ b/services/aigateway/domain/provider.go
@@ -78,6 +78,9 @@ func NormalizeProviderID(raw string) ProviderID {
 		return ProviderAnthropic
 	case "openai":
 		return ProviderOpenAI
+	// Listed for completeness only: the spelling already equals the
+	// constant, so the default branch returns the same value and no test
+	// can distinguish this case being present from it being absent.
 	case "openai_codex":
 		return ProviderOpenAICodex
 	default:

--- a/services/aigateway/domain/provider.go
+++ b/services/aigateway/domain/provider.go
@@ -78,11 +78,6 @@ func NormalizeProviderID(raw string) ProviderID {
 		return ProviderAnthropic
 	case "openai":
 		return ProviderOpenAI
-	// Listed for completeness only: the spelling already equals the
-	// constant, so the default branch returns the same value and no test
-	// can distinguish this case being present from it being absent.
-	case "openai_codex":
-		return ProviderOpenAICodex
 	default:
 		return ProviderID(raw)
 	}

--- a/services/aigateway/domain/provider_test.go
+++ b/services/aigateway/domain/provider_test.go
@@ -58,3 +58,34 @@ func TestWithDeploymentSelfMap_HonorsExplicitDeploymentOverBareModel(t *testing.
 		t.Fatalf("explicit deployment ignored: got %q, want %q", got, "my-custom-deploy")
 	}
 }
+
+// The request side and the credential side each used to carry their own
+// spelling table, and they drifted: "vertex_ai" normalized on one side
+// only, so a caller with a working Vertex credential resolved to a
+// provider that matched none of their credentials. Both now share
+// NormalizeProviderID; this pins the spellings that must survive.
+func TestNormalizeProviderID(t *testing.T) {
+	cases := map[string]ProviderID{
+		"azure":         ProviderAzure,
+		"azure_openai":  ProviderAzure,
+		"bedrock":       ProviderBedrock,
+		"aws_bedrock":   ProviderBedrock,
+		"vertex":        ProviderVertex,
+		"vertex_ai":     ProviderVertex,
+		"google_vertex": ProviderVertex,
+		"gemini":        ProviderGemini,
+		"google_gemini": ProviderGemini,
+		"anthropic":     ProviderAnthropic,
+		"openai":        ProviderOpenAI,
+		"openai_codex":  ProviderOpenAICodex,
+		// Unknown providers pass through so a control plane that knows a
+		// provider this build does not can still route on its own ID.
+		"some_new_provider": ProviderID("some_new_provider"),
+		"":                  ProviderID(""),
+	}
+	for raw, want := range cases {
+		if got := NormalizeProviderID(raw); got != want {
+			t.Errorf("NormalizeProviderID(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}

--- a/specs/ai-gateway/model-disambiguation.feature
+++ b/specs/ai-gateway/model-disambiguation.feature
@@ -101,12 +101,17 @@ Feature: AI Gateway — model disambiguation when a VK has multiple providers
     # The provider is clear (openai/), the MODEL is invalid. Ambiguity check
     # passed; upstream error pass-through takes over.
 
-  @integration @v1 @unimplemented
+  @integration @v1
   Scenario: Unknown provider prefix on VK returns 400 with clear envelope
     When I POST with body `{"model": "bedrock/claude-3-haiku", ...}` on "vk_multi" (no bedrock slot)
     Then the response status is 400
     And the response body.type is "model_provider_not_bound"
     And the response body.hint contains "bind a `bedrock` provider slot to this VK, or drop the prefix"
+    # Without this hard-fail the request would dispatch with a mismatched
+    # credential; Bifrost's model-prefix provider override then reads that
+    # credential through the wrong provider's key-config shape, surfacing
+    # opaque errors ("deployments not set", "no keys found that support
+    # model", raw HTML error pages) instead of the real problem.
 
   # ============================================================================
   # Observability — operators should be able to measure ambiguity incidence

--- a/specs/ai-gateway/model-disambiguation.feature
+++ b/specs/ai-gateway/model-disambiguation.feature
@@ -105,8 +105,8 @@ Feature: AI Gateway — model disambiguation when a VK has multiple providers
   Scenario: Unknown provider prefix on VK returns 400 with clear envelope
     When I POST with body `{"model": "bedrock/claude-3-haiku", ...}` on "vk_multi" (no bedrock slot)
     Then the response status is 400
-    And the response body.type is "model_provider_not_bound"
-    And the response body.hint contains "bind a `bedrock` provider slot to this VK, or drop the prefix"
+    And the response body.error.code is "model_provider_not_bound"
+    And the response body.error.hint contains "bind a \"bedrock\" provider slot to this virtual key"
     # Without this hard-fail the request would dispatch with a mismatched
     # credential; Bifrost's model-prefix provider override then reads that
     # credential through the wrong provider's key-config shape, surfacing

--- a/specs/ai-gateway/model-disambiguation.feature
+++ b/specs/ai-gateway/model-disambiguation.feature
@@ -105,10 +105,7 @@ Feature: AI Gateway — model disambiguation when a VK has multiple providers
   Scenario: Unknown provider prefix on VK returns 400 with clear envelope
     When I POST with body `{"model": "bedrock/claude-3-haiku", ...}` on "vk_multi" (no bedrock slot)
     Then the response status is 400
-    # body.error.code, not the body.type the @unimplemented scenarios above
-    # use: this is the only bound scenario in the file, so its assertions are
-    # checked against the envelope herr.WriteHTTP actually emits. Those
-    # scenarios' shape has never been validated against code.
+    # The provider-binding failure is exposed through the nested error envelope.
     And the response body.error.code is "model_provider_not_bound"
     And the response body.error.hint contains "bind a \"bedrock\" provider slot to this virtual key"
     # Without this hard-fail the request would dispatch with a mismatched

--- a/specs/ai-gateway/model-disambiguation.feature
+++ b/specs/ai-gateway/model-disambiguation.feature
@@ -105,6 +105,10 @@ Feature: AI Gateway — model disambiguation when a VK has multiple providers
   Scenario: Unknown provider prefix on VK returns 400 with clear envelope
     When I POST with body `{"model": "bedrock/claude-3-haiku", ...}` on "vk_multi" (no bedrock slot)
     Then the response status is 400
+    # body.error.code, not the body.type the @unimplemented scenarios above
+    # use: this is the only bound scenario in the file, so its assertions are
+    # checked against the envelope herr.WriteHTTP actually emits. Those
+    # scenarios' shape has never been validated against code.
     And the response body.error.code is "model_provider_not_bound"
     And the response body.error.hint contains "bind a \"bedrock\" provider slot to this virtual key"
     # Without this hard-fail the request would dispatch with a mismatched

--- a/specs/ai-gateway/model-provider-scoping.feature
+++ b/specs/ai-gateway/model-provider-scoping.feature
@@ -58,6 +58,15 @@ Feature: Cross-scope ModelProvider reuse
     Then "OpenAI-enterprise" is included
     And the binding picker labels it as "OpenAI (org: acme)"
 
+  @integration
+  Scenario: Safety-type providers are excluded from gateway dispatch chains
+    Given a ModelProvider "azure_safety" (registry type "safety") enabled at ORGANIZATION scope
+    When the gateway config for any VK in the org is materialised
+    Then "azure_safety" is NOT in the bundle's providers[] or fallback chain
+    # Safety providers hold evaluator credentials; the Go gateway has no
+    # dispatch adapter for them — including one makes fallback attempts
+    # fail with "unsupported provider: azure_safety".
+
   Scenario: Mixed-scope visibility composes
     Given ModelProviders at 3 scopes: ORG "OpenAI-ent", TEAM "OpenAI-plat", PROJECT "OpenAI-prod-only"
     When I call getAllAccessible as alice for projectId="acme-api" (team: acme-platform)

--- a/specs/ai-gateway/model-provider-scoping.feature
+++ b/specs/ai-gateway/model-provider-scoping.feature
@@ -60,12 +60,12 @@ Feature: Cross-scope ModelProvider reuse
 
   @integration
   Scenario: Safety-type providers are excluded from gateway dispatch chains
-    Given a ModelProvider "azure_safety" (registry type "safety") enabled at ORGANIZATION scope
-    When the gateway config for any VK in the org is materialised
-    Then "azure_safety" is NOT in the bundle's providers[] or fallback chain
-    # Safety providers hold evaluator credentials; the Go gateway has no
-    # dispatch adapter for them — including one makes fallback attempts
-    # fail with "unsupported provider: azure_safety".
+    Given an evaluator-only (safety) provider is enabled for the organization
+    When a virtual key in that organization sends a request through the gateway
+    Then the request is served by an available language model provider
+    And the evaluator-only provider is never attempted for dispatch
+    # Safety providers hold evaluator credentials and cannot serve chat
+    # traffic; attempting one would fail the request outright.
 
   Scenario: Mixed-scope visibility composes
     Given ModelProviders at 3 scopes: ORG "OpenAI-ent", TEAM "OpenAI-plat", PROJECT "OpenAI-prod-only"

--- a/specs/langy/langy-api-key-turns.feature
+++ b/specs/langy/langy-api-key-turns.feature
@@ -91,6 +91,40 @@ Feature: Starting Langy conversations with a project API key
     When the caller starts a turn and reads the event stream
     Then at least two distinct events arrive before the turn completes
 
+  # Synchronous delivery (RFC 7240 `Prefer: wait=<seconds>`). A plain HTTP
+  # client — a script, CI, or a scenario HTTP agent — has no way to consume the
+  # 202-then-stream contract, so the turn route itself can hold the connection
+  # until the turn settles on the durable fold and answer with the assistant's
+  # output in the body.
+
+  @unit
+  Scenario: A caller preferring to wait receives the assistant's output synchronously
+    Given an accepted turn started with a project API key
+    And the request carries a wait preference
+    When the turn settles with an assistant response
+    Then the response is synchronous and carries the assistant's output for that turn
+    And the response declares which preference was applied
+
+  @unit
+  Scenario: A wait is satisfied only by the turn this request started
+    Given a request waiting on its own accepted turn
+    When a different turn on the same conversation settles first
+    Then the wait continues until this request's own turn settles
+
+  @unit
+  Scenario: A failed turn settles the wait as a domain outcome, not a transport refusal
+    Given a request waiting on its own accepted turn
+    When the turn fails
+    Then the response is successful at the transport level
+    And it carries the turn's failed status and error with no assistant reply
+
+  @unit
+  Scenario: An expired wait degrades to the asynchronous acceptance
+    Given a request waiting on its own accepted turn
+    When the wait window expires before the turn settles
+    Then the response is the same asynchronous acceptance an unadorned request receives
+    And no applied preference is declared
+
   # ---------------------------------------------------------------------------
   # Failure modes
   # ---------------------------------------------------------------------------
@@ -186,6 +220,12 @@ Feature: Starting Langy conversations with a project API key
 #          -> Scenario: A key with langy:create starts a conversation without a browser session
 # AC 2:  "same caller continues the conversation, receives assistant output"
 #          -> Scenario: The same key continues an existing conversation
+#          (supporting, unit level: A caller preferring to wait receives the
+#           assistant's output synchronously / A wait is satisfied only by the
+#           turn this request started / A failed turn settles the wait as a
+#           domain outcome, not a transport refusal / An expired wait degrades
+#           to the asynchronous acceptance — the `Prefer: wait` delivery path
+#           for that output)
 # AC 3:  "incremental turn events before the turn completes, at least two"
 #          -> Scenario: The caller observes incremental events before the turn completes
 # AC 4:  "langy:view but not langy:create refused 403, no worker provisioned"

--- a/specs/langy/langy-api-key-turns.feature
+++ b/specs/langy/langy-api-key-turns.feature
@@ -119,6 +119,13 @@ Feature: Starting Langy conversations with a project API key
     And it carries the turn's failed status and error with no assistant reply
 
   @unit
+  Scenario: A plain-text message is accepted without the parts structure
+    Given a caller whose message shape is plain role-and-text
+    When it starts a turn with a project API key
+    Then the message is accepted as a single text part
+    And a message carrying both shapes keeps its structured parts
+
+  @unit
   Scenario: An expired wait degrades to the asynchronous acceptance
     Given a request waiting on its own accepted turn
     When the wait window expires before the turn settles
@@ -225,7 +232,8 @@ Feature: Starting Langy conversations with a project API key
 #           turn this request started / A failed turn settles the wait as a
 #           domain outcome, not a transport refusal / An expired wait degrades
 #           to the asynchronous acceptance — the `Prefer: wait` delivery path
-#           for that output)
+#           for that output; A plain-text message is accepted without the
+#           parts structure — the wire shape a generic client can produce)
 # AC 3:  "incremental turn events before the turn completes, at least two"
 #          -> Scenario: The caller observes incremental events before the turn completes
 # AC 4:  "langy:view but not langy:create refused 403, no worker provisioned"


### PR DESCRIPTION
## Problem

Two independent failures, both surfacing as opaque errors to customers, plus one capability gap that blocks dogfooding.

**1. Gateway routing and reporting.** Production traces across five customer projects show three opaque gateway error classes, reducible to two root causes:

- `no keys found that support model: gemini-…`, `deployments not set`, raw provider HTML — a request naming an explicit provider prefix (`gemini/…`, `azure/…`, `vertex_ai/…`) on a virtual key whose chain holds no credential for that provider fell through to the **full** credential chain. Bifrost honours the prefix over the credential's own provider (`services/aigateway/adapters/providers/bifrost.go`), so it read a mismatched credential through the wrong provider's key-config shape and produced errors naming neither the cause nor a fix.
- `failed to create provider for the given key: unsupported provider: azure_safety` — the control plane materialised `azure_safety` (registry type `"safety"`, an evaluator credential with no Bifrost adapter) into dispatch chains.

**2. Provider-spelling drift.** The request side and the credential side each carried their own normalisation table and they had drifted. The credential side mapped `vertex_ai` → `ProviderVertex`; the request side did not, so `vertex_ai/gemini-3.5-flash` resolved to provider `vertex_ai` and matched no credential named `vertex` **even when the caller's Vertex credential was fine**. That is the `vertex_ai` → "HTML response received from provider" cluster — 6 of the 14 failing traces.

**3. No request/response mode on the public langy turn API.** The surface is POST-then-stream with no public poll or stream-read endpoint, so any plain HTTP client — scripts, CI, scenario HTTP agents — had to mine traces to recover the reply. Dogfooding scenario against langy currently requires a local relay plus a cloudflared tunnel whose only job is adapting streaming to request/response.

## Fix

**Gateway (Go, `services/aigateway`)**

- `eligibleCredentials` returns `400 model_provider_not_bound` when the provider was explicit and nothing in the chain matches, with a message naming the provider and a hint to bind the slot or drop the prefix. Registered as `FaultCustomer` / HTTP 400.
- Implicit (unprefixed) model names keep the fallback safety net — there each attempt dispatches under the credential's own provider and surfaces that provider's real error.
- Both normalisation sides now share `domain.NormalizeProviderID`, and the union covers what each side previously knew alone (`vertex_ai`, `azure_openai`, `openai_codex`).
- Implements the previously `@unimplemented` scenario in `specs/ai-gateway/model-disambiguation.feature`.

**Control plane (TS, `platform/app/src/server/gateway`)**

- `scopeResolver` filters dispatch candidates to llm-type providers via the model-providers registry. Providers absent from the registry pass through, since they may postdate this build.
- New `@integration` scenario in `specs/ai-gateway/model-provider-scoping.feature`.

**`Prefer: wait` on the public langy turn endpoint (TS, `platform/app/src/server/routes/langy-api.ts`)**

- `POST /api/langy/conversations` with `Prefer: wait=<seconds>` (RFC 7240) holds the request until the turn settles, then answers 200 with the assistant's reply and `Preference-Applied: wait`. On expiry (capped at 120s) it degrades to the exact 202 the async path already returns. Without the header, behaviour is byte-identical to before.
- Alternative not taken: a separate `/sync` endpoint — rejected to keep one canonical route and let clients opt in per-request via a standard header.
- The wire schema now also accepts `{"role": "user", "content": "..."}` and normalizes it to a single text part (`parts` wins when both are sent), so a generic HTTP client — including a scenario HTTP agent's Liquid body template — can post turns without restructuring its message shape.
- Refusal-chain ordering (dark-404 parity, flag-before-ceiling) is untouched and still pinned by its test.

**New app-layer primitive `platform/app/src/server/app-layer/langy/streaming/awaitTurnSettlement.ts`**

- Buffer-first promptness, fold-only authority: the Redis token buffer (`follow()` on `XREAD BLOCK`) detects the terminal frame without polling, while the durable event fold (`getEventsAfter`) remains the **sole** settlement authority and the only thing the function ever returns from. Returns a discriminated `TurnSettlement` union (`succeeded` / `outcome` / `text` / `error`), decided once at the event-reading edge.
- Alternative not taken: settling from the Redis buffer directly — rejected because the buffer is best-effort and truncatable, and its terminal frame carries no reply text. It only accelerates the confirm cadence (5s → 250ms); it never decides. With no Redis it degrades to plain fold polling at 750ms.
- Waits are bounded by `AbortSignal.any([client disconnect, AbortSignal.timeout(waitSeconds)])`, so an abandoned caller stops costing reads immediately. Truncated fold pages are drained within a single pass; projection lag (`LangyConversationNotFoundError`) is treated as "not yet", not an error.

**Test fixtures.** Two audio tests asserted the old lenient path: both request an `elevenlabs/` prefix against a bundle holding only an OpenAI credential, and their 200 came from the mock provider ignoring the credential it was handed. Their real subject is model resolution and provider-error pass-through, so both now bind the ElevenLabs slot their scenario implies, through a shared `audioAuth` helper.

**Review-driven fixes.** The 8-reviewer fan-out produced fixes across 14 files (itemised in the [review verdict comment](https://github.com/langwatch/langwatch/pull/7006#issuecomment-5300136836)), including `getEvaluatorDefaultSettings` no longer crashing on the settings-less custom-evaluator definition shape (the `as any` at the legacy dispatch call site is gone, regression test added), and a cognitive-complexity refactor of `awaitTurnSettlement.ts` (pure helper extraction: `settlementFromEvent`, `isTerminalFrame`, `watchBufferForTerminal`, `armBufferWatch`, `waitForNextPoll`) to clear the Biome new-violations CI gate — no behaviour change, covered by the existing suite.

## Evidence

- CI at head `9bc2196b0ab1c504d41a8e8780ab58a009504268`: **104/104 checks green**, verified against truncation (`--paginate`, deduped latest-run-per-name) and against the hard-floor mask — all 4 unit and 6 integration shards printed real tallies with `hard-floor=0`.
- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` — all green. CI-shape `golangci-lint` two-pass — 0 issues.
- `pnpm typecheck` and `pnpm typecheck:tests` — 0 errors.
- Touched TS suites 17/17; `pnpm test:integration src/server/gateway/__tests__/config.materialiser.integration.test.ts` — 17/17, including the new `excludes safety-type providers (azure_safety) from the dispatch chain`.
- `pnpm check:feature-parity` — `OK: 6498 enforced scenario(s) bound`.
- Biome new-violations gate script reproduced locally against `origin/main` → 0 new. Local Biome is 2.5.1, matching the uncaretted `@biomejs/biome: "2.5.1"` pin CI installs with `--frozen-lockfile`.
- `make herrgen-check` — up to date (48 service codes, 28 node codes). The new `model_provider_not_bound` code has a user-facing presentation entry; without it `pnpm typecheck` fails by design.
- Revert-to-red on the `vertex_ai` fix: removing the case turns `TestNormalizeProviderID` and `TestResolve_ExplicitFormat_NormalizedProviders/vertex_ai` red; restoring it turns them green.

## Scope

This fixes how the gateway *reports* and *routes* these cases. The affected customers' own provider configs (a Vertex credential returning HTML, a request for a nonexistent `gpt-5.3-chat`) are separate remediation, not addressed here.

Follow-ups filed: [#7026](https://github.com/langwatch/langwatch/issues/7026) (per-key concurrency cap / 429 on `Prefer: wait` holds), [#7025](https://github.com/langwatch/langwatch/issues/7025) (TS↔Go provider-manifest contract test).

## Deployment Impact

**Env vars added/changed:** none. **Helm values added/changed:** none. No chart, template, or `values.yaml` is touched. No schema change, no persisted state, nothing to backfill, no restart ordering.

**Default behaviour on a vanilla `helm install` with no overrides:** unchanged in configuration, but three deliberate runtime behaviour changes operators should know about.

1. A request whose model string carries an explicit `provider/` prefix that the virtual key has no credential slot for now returns `400 model_provider_not_bound` instead of silently dispatching down the full credential chain. Callers who were getting a confusing 5xx now get an actionable 400. No caller who was succeeding starts failing: the hard-fail only triggers where no credential matched the named provider, which is precisely the path that could not have succeeded.
2. Provider aliases are normalised through one shared table, so a stored provider type of `vertex_ai` (and likewise `azure_openai`, `google_vertex`, `aws_bedrock`, `google_gemini`) now resolves to its canonical provider. This strictly turns failing requests into working ones; it cannot break a request that already worked.
3. `Prefer: wait` holds a connection for up to 120s. Operators should keep that below their ingress idle timeout (default cloud LB timeouts are typically ≥300s). The surface remains dark unless `release_langy_api_key_turns_enabled` is on, and the behaviour triggers only when a caller sends the header.

**BYOC dataplane impact:** none structurally. A BYOC dataplane runs the same gateway image and picks up the gateway behaviours on its next image bump, with no coordination against the control plane, no schema change, and no new outbound dependency.

<!-- deployment-impact-check: re-triggered after a concurrent rerun cancelled the edit event -->

## Human verification

Not yet performed on a deployed host — backend-only change; requesting reviewer verification via the calls below.

1. With `release_langy_api_key_turns_enabled` on and a user-owned API key, `curl -X POST https://<host>/api/langy/conversations -H 'X-Auth-Token: <key>' -H 'Prefer: wait=60' -d '{"messages":[{"role":"user","content":"hi"}],"idempotencyKey":"<unique>"}'` returns 200 with `Preference-Applied: wait` and a `reply.text`.
2. The same request without the `Prefer` header returns the unchanged async 202.
3. A model string with an unbound explicit provider prefix returns `400 model_provider_not_bound` with actionable copy, not an opaque upstream error.

## How I can prove I was successful

After merge and deploy, point a scenario HTTP agent at `https://app.langwatch.ai/api/langy/conversations` with `Prefer: wait=120` and confirm the suite passes with the local relay and cloudflared tunnel shut down — the capability gap that motivated the wait mode, closed end to end.

Backend-only: no UI surface is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The public conversation API can now return a completed reply in a single request via a standard wait preference header, instead of requiring a streaming connection.
  * Messages can be sent as plain text as well as structured parts.
* **Bug Fixes**
  * Requests using an unconfigured provider prefix now return a clear HTTP 400 error.
  * Provider selection now correctly reports configuration issues instead of misleading downstream errors.
  * Unsupported provider types are excluded from gateway routing and fallback options.
  * Inferred provider routing preserves fallback credentials when no direct match is available.
* **Tests**
  * Added coverage for wait mode, unknown providers, unsupported provider types, scoped provider filtering, fallback behavior, and provider-prefixed audio requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- no-ui-surface -->
