### PR TITLE
fix(sso): count Auth0 SAML logins as verified emails so account linking works

### DIFF
--- a/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
+++ b/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
@@ -69,7 +69,7 @@ Forces and constraints (locked 2026-08-14):
 
 | Name | Value | Purpose |
 |---|---|---|
-| SAML sub prefix | `"samlp\|"` (7 chars, trailing pipe included) | The only strategy prefix granted the override; trailing pipe prevents matching a hypothetical `samlpx` strategy |
+| SAML sub prefix | `"samlp\|"` (6 chars, trailing pipe included) | The only strategy prefix granted the override; trailing pipe prevents matching a hypothetical `samlpx` strategy |
 
 ## Invariants
 
@@ -85,7 +85,7 @@ Forces and constraints (locked 2026-08-14):
 | Assumption | What breaks if false |
 |---|---|
 | Auth0 SAML subs always start `samlp\|` | Fix silently doesn't fire; user stays locked out — incomplete, not wrong. Verified against Auth0 docs; first real sign-in (debug logs are on) confirms on our tenant |
-| No self-signup path yields a `samlp\|` sub | Account takeover via linking. Holds by construction: SAML connections are operator-created in Auth0 |
+| No tenant-side self-signup path yields a `samlp\|` sub | Account takeover via linking. Holds tenant-side: Auth0 database signups mint `auth0\|` subs, and only operator-created SAML connections mint `samlp\|`. IdP-side self-registration (an open-registration IdP behind a SAML connection) is NOT excluded by construction — that risk is the load-bearing assumption below |
 | Every SAML connection in the tenant maps `email` from an IdP-controlled attribute | **This is the load-bearing assumption (red-team, v2).** `samlp\|` proves *authenticated via SAML*, not *owns this email*. If any SAML connection in the configured Auth0 tenant sources email from a user-editable attribute or an open-registration IdP, an attacker can assert a victim's email and link into their existing account — the exact link today's code refuses. The domain guard does not stop it: existing users are soft-flagged, only first-time signups hard-block (`hooks.ts`). Holds when the operator creates connections deliberately against trusted corporate IdPs — the same trust class as the tenant's client secret |
 | `mapProfileToUser` return overrides the claim | Fix is a no-op. Verified by reading BetterAuth 1.6.23 source (`routes.mjs:~209`) — pinned-version fact, re-check on BetterAuth upgrades |
 

--- a/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
+++ b/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
@@ -69,13 +69,13 @@ Forces and constraints (locked 2026-08-14):
 
 | Name | Value | Purpose |
 |---|---|---|
-| SAML sub prefix | `"samlp|"` (7 chars, trailing pipe included) | The only strategy prefix granted the override; trailing pipe prevents matching a hypothetical `samlpx` strategy |
+| SAML sub prefix | `"samlp\|"` (7 chars, trailing pipe included) | The only strategy prefix granted the override; trailing pipe prevents matching a hypothetical `samlpx` strategy |
 
 ## Invariants
 
 | Invariant | Meaning | Satisfied by / test anchor |
 |---|---|---|
-| Only `samlp|` subs are upgraded | `auth0\|…`, `google-oauth2\|…`, `waad\|…`, absent/non-string subs never gain `emailVerified: true` | `isSamlSub` unit cases + mapped-profile assertion in `ee/sso/__tests__` |
+| Only `samlp\|` subs are upgraded | `auth0\|…`, `google-oauth2\|…`, `waad\|…`, absent/non-string subs never gain `emailVerified: true` | `isSamlSub` unit cases + mapped-profile assertion in `ee/sso/__tests__` |
 | Non-SAML profiles are untouched | The mapped object contains no `emailVerified` key for non-SAML subs (claim value flows through) | assertion `"emailVerified" not in mapped` |
 | SAML profiles map to `emailVerified: true` | Linking gate passes for SAML sign-ins | assertion on mapped object |
 | Rest of the mapping unchanged | name/email/image behavior identical to before | existing `fallbackName` tests keep passing |
@@ -84,9 +84,9 @@ Forces and constraints (locked 2026-08-14):
 
 | Assumption | What breaks if false |
 |---|---|
-| Auth0 SAML subs always start `samlp|` | Fix silently doesn't fire; user stays locked out — incomplete, not wrong. Verified against Auth0 docs; first real sign-in (debug logs are on) confirms on our tenant |
-| No self-signup path yields a `samlp|` sub | Account takeover via linking. Holds by construction: SAML connections are operator-created in Auth0 |
-| Every SAML connection in the tenant maps `email` from an IdP-controlled attribute | **This is the load-bearing assumption (red-team, v2).** `samlp|` proves *authenticated via SAML*, not *owns this email*. If any SAML connection in the configured Auth0 tenant sources email from a user-editable attribute or an open-registration IdP, an attacker can assert a victim's email and link into their existing account — the exact link today's code refuses. The domain guard does not stop it: existing users are soft-flagged, only first-time signups hard-block (`hooks.ts`). Holds when the operator creates connections deliberately against trusted corporate IdPs — the same trust class as the tenant's client secret |
+| Auth0 SAML subs always start `samlp\|` | Fix silently doesn't fire; user stays locked out — incomplete, not wrong. Verified against Auth0 docs; first real sign-in (debug logs are on) confirms on our tenant |
+| No self-signup path yields a `samlp\|` sub | Account takeover via linking. Holds by construction: SAML connections are operator-created in Auth0 |
+| Every SAML connection in the tenant maps `email` from an IdP-controlled attribute | **This is the load-bearing assumption (red-team, v2).** `samlp\|` proves *authenticated via SAML*, not *owns this email*. If any SAML connection in the configured Auth0 tenant sources email from a user-editable attribute or an open-registration IdP, an attacker can assert a victim's email and link into their existing account — the exact link today's code refuses. The domain guard does not stop it: existing users are soft-flagged, only first-time signups hard-block (`hooks.ts`). Holds when the operator creates connections deliberately against trusted corporate IdPs — the same trust class as the tenant's client secret |
 | `mapProfileToUser` return overrides the claim | Fix is a no-op. Verified by reading BetterAuth 1.6.23 source (`routes.mjs:~209`) — pinned-version fact, re-check on BetterAuth upgrades |
 
 ## Gates
@@ -163,26 +163,20 @@ None. No migrations, no env vars, no config keys.
   trust, high blast radius, samlp-prefix + no-schema + one-PR constraints);
   forks locked: exported named helper over inline one-liner, one-off over
   shared capability.
-- **v2 (2026-08-14, red-team, 4-lens panel):** the mechanism and premise
-  **held** — `samlp|` cannot be forged from non-SAML connections (a
-  database user id of `samlp|x` yields sub `auth0|samlp|x`), the
-  `typeof`+prefix check has no type or unicode holes, and no better
-  mechanism exists in BetterAuth 1.6.23 (`trustedProviders` is
-  provider-wide and matched pre-token-exchange; per-config trust flags
-  exist in `handleOAuthUserInfo` but are never passed by any route; hooks
-  fire after the link gate and can only block, never permit). The
-  **universal** safety claim was refuted: SAML authentication proves
-  identity at the IdP, not ownership of the asserted email — the residual
-  risk is captured in the load-bearing assumption above and is the same
-  class the tenant's OIDC enterprise connections (`waad|`, `okta|`)
-  already carry, as their linked account pairs in production show.
-  Connection-bound hardening deferred (see Open questions); scope
-  unchanged from v1.
-- **v2 (2026-08-14, red-team, 4 lenses):** claim survives narrowed. Held:
-  `samlp|` cannot be forged from non-SAML connections (a database user_id
-  of `samlp|x` yields sub `auth0|samlp|x`); no safer BetterAuth mechanism
-  exists in 1.6.23. Narrowed: safety is conditional on every SAML
-  connection in the tenant mapping email from an IdP-controlled attribute
-  — promoted to the load-bearing assumption above. Allowlist alternative
-  re-asked and rejected (see Rejected alternatives). Boundary decision:
-  document + code-comment, keep prefix-only.
+- **v2 (2026-08-14, red-team, 4-lens panel):** claim survives narrowed.
+  Held: `samlp|` cannot be forged from non-SAML connections (a database
+  user id of `samlp|x` yields sub `auth0|samlp|x`), the `typeof`+prefix
+  check has no type or unicode holes, and no better mechanism exists in
+  BetterAuth 1.6.23 (`trustedProviders` is provider-wide and matched
+  pre-token-exchange; per-config trust flags exist in
+  `handleOAuthUserInfo` but are never passed by any route; hooks fire
+  after the link gate and can only block, never permit). Narrowed: the
+  **universal** safety claim was refuted — SAML authentication proves
+  identity at the IdP, not ownership of the asserted email. Safety is
+  conditional on every SAML connection in the tenant mapping email from
+  an IdP-controlled attribute, promoted to the load-bearing assumption
+  above; same risk class as the tenant's OIDC enterprise connections
+  (`waad|`, `okta|`), as their linked account pairs in production show.
+  Per-connection allowlist re-asked and rejected (see Rejected
+  alternatives). Boundary decision: document + code-comment, keep
+  prefix-only. Scope unchanged from v1.

--- a/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
+++ b/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
@@ -1,0 +1,188 @@
+# ADR-096: SAML logins through Auth0 count as verified emails
+
+**Date:** 2026-08-14
+
+**Status:** Accepted
+
+**Tracking:** internal issue (langwatch-saas#1053)
+
+> One-line: when an Auth0 profile's `sub` starts with **`samlp|`**, `mapProfileToUser` returns **`emailVerified: true`**, because the email was **asserted by the organization's own identity provider** — restoring account linking for existing users, and nothing else changes.
+
+## Context
+
+Enterprise SAML sign-in runs customer IdP → Auth0 (SAML connection) → LangWatch
+(OIDC via BetterAuth's genericOAuth plugin, ADR-027 gate in front). Auth0
+sets `email_verified: false` for every SAML connection user and offers no
+per-connection switch to change it — SAML is the only enterprise connection
+type without one.
+
+BetterAuth 1.6.23 refuses to link an OAuth sign-in to an existing user when
+the incoming profile's email is unverified
+(`dist/oauth2/link-account.mjs`: `!isTrustedProvider && !userInfo.emailVerified`),
+and our config declares no `trustedProviders`
+(`platform/app/src/server/better-auth/index.ts:270`). Net effect: any
+existing user whose organization switches to SAML SSO is locked out on
+their first SAML login. New users are unaffected (fresh `User` row, no
+linking step).
+
+The escape hatch is also in BetterAuth: the genericOAuth plugin builds the
+final profile as `{...userInfo, ...mapProfileToUser(profile)}`
+(`dist/plugins/generic-oauth/routes.mjs:~209`), so a `mapProfileToUser`
+return value can override the claim-derived `emailVerified`.
+
+Forces and constraints (locked 2026-08-14):
+
+- **Forcing function:** an enterprise customer's SSO go-live; their
+  existing users are locked out until this ships.
+- **Blast radius: high — security boundary.** Mis-scoped trust in
+  `emailVerified` is an account-takeover vector via linking.
+- **Hard constraints:** override scoped strictly to the `samlp|` sub
+  prefix; no schema or config changes; one PR; no customer names anywhere
+  in this public repo.
+
+## Decision
+
+1. **Trust the IdP's email assertion for SAML connections only, keyed on
+   the `sub` prefix.** Auth0 encodes the connection strategy in `sub` as
+   `{strategy}|{connection}|{id}`; SAML users arrive as `samlp|…`. A SAML
+   connection exists only because a LangWatch operator created it in the
+   Auth0 tenant and pointed it at one organization's IdP — there is no
+   self-signup path into a `samlp|` identity. The email in that profile was
+   asserted by the customer's own IdP, which is exactly the authority an
+   email verification loop would consult anyway. Rejects: trusting all of
+   Auth0 (see Rejected alternatives).
+
+2. **Implement as an exported named helper plus a spread in
+   `mapProfileToUser`** (`platform/app/ee/sso/providers.ts`, auth0 branch):
+   `isSamlSub(sub)` → `typeof sub === "string" && sub.startsWith("samlp|")`,
+   and `...(isSamlSub(profile.sub) ? { emailVerified: true } : {})`.
+   Exported for direct unit testing, matching the file's convention
+   (`fallbackName`, `parseIssuerUrl`). Non-SAML profiles get no
+   `emailVerified` key at all, so the claim-derived value flows through
+   untouched.
+
+3. **One-off, not a shared capability.** n=1. If Okta or plain-OIDC ever
+   need equivalent trust, that second occurrence is when a shared shape is
+   considered.
+
+## Constants
+
+| Name | Value | Purpose |
+|---|---|---|
+| SAML sub prefix | `"samlp|"` (7 chars, trailing pipe included) | The only strategy prefix granted the override; trailing pipe prevents matching a hypothetical `samlpx` strategy |
+
+## Invariants
+
+| Invariant | Meaning | Satisfied by / test anchor |
+|---|---|---|
+| Only `samlp|` subs are upgraded | `auth0\|…`, `google-oauth2\|…`, `waad\|…`, absent/non-string subs never gain `emailVerified: true` | `isSamlSub` unit cases + mapped-profile assertion in `ee/sso/__tests__` |
+| Non-SAML profiles are untouched | The mapped object contains no `emailVerified` key for non-SAML subs (claim value flows through) | assertion `"emailVerified" not in mapped` |
+| SAML profiles map to `emailVerified: true` | Linking gate passes for SAML sign-ins | assertion on mapped object |
+| Rest of the mapping unchanged | name/email/image behavior identical to before | existing `fallbackName` tests keep passing |
+
+## Assumptions
+
+| Assumption | What breaks if false |
+|---|---|
+| Auth0 SAML subs always start `samlp|` | Fix silently doesn't fire; user stays locked out — incomplete, not wrong. Verified against Auth0 docs; first real sign-in (debug logs are on) confirms on our tenant |
+| No self-signup path yields a `samlp|` sub | Account takeover via linking. Holds by construction: SAML connections are operator-created in Auth0 |
+| Every SAML connection in the tenant maps `email` from an IdP-controlled attribute | **This is the load-bearing assumption (red-team, v2).** `samlp|` proves *authenticated via SAML*, not *owns this email*. If any SAML connection in the configured Auth0 tenant sources email from a user-editable attribute or an open-registration IdP, an attacker can assert a victim's email and link into their existing account — the exact link today's code refuses. The domain guard does not stop it: existing users are soft-flagged, only first-time signups hard-block (`hooks.ts`). Holds when the operator creates connections deliberately against trusted corporate IdPs — the same trust class as the tenant's client secret |
+| `mapProfileToUser` return overrides the claim | Fix is a no-op. Verified by reading BetterAuth 1.6.23 source (`routes.mjs:~209`) — pinned-version fact, re-check on BetterAuth upgrades |
+
+## Gates
+
+| Path | Reversible? | Blast radius | Gate |
+|---|---|---|---|
+| SAML sign-in links to existing user | Code-revert yes; a wrong link made in the window is not | High (auth boundary) | Human review of the PR + invariant unit tests + first real sign-in verified against Auth0 debug logs before announcing |
+| Fresh SAML user created with `emailVerified: true` | Yes (flag flip in DB) | Small — skips a verification email for users their own IdP already vouched for | none |
+
+## Schema
+
+None. No migrations, no env vars, no config keys.
+
+## Rejected alternatives
+
+- **`trustedProviders: ["auth0"]`** — trusts every Auth0 connection,
+  including database signups where anyone can register any email
+  unverified: an account-takeover vector, the opposite of what the linking
+  gate exists to prevent.
+- **Ask the customer's IT to add an `email_verified` SAML claim** — an
+  extra round-trip with every future SSO customer's IT department; doesn't
+  scale and puts our correctness in their hands.
+- **Flip `emailVerified` in our DB per affected user** — already true for
+  the current users and still insufficient: the gate also checks the
+  *incoming* profile's flag (`!isTrustedProvider && !userInfo.emailVerified`).
+- **Per-connection allowlist (e.g. `SAML_TRUSTED_CONNECTIONS` env var)** —
+  raised by red-team (v2), re-asked, rejected: it violates the no-config
+  constraint, adds an env change + restart to every future SSO onboarding,
+  and the same operator who creates the connection would set the list — the
+  trust decision doesn't actually move.
+- **Any other BetterAuth 1.6.23 mechanism** — red-team (v2) verified none
+  is both reachable and narrower: `trustedProviders` matches by provider id
+  (would trust Auth0 database signups too); its function form only sees the
+  callback request, not the sub; per-config trust flags exist internally
+  but are not wired to genericOAuth; hooks fire only after the linking gate
+  already refused.
+
+## Consequences
+
+- **Positive:** existing users can sign in the first time their org moves
+  to SAML SSO; no per-customer manual work.
+- **Positive (side effect):** brand-new SAML users are created already
+  verified — no pointless verification email for an IdP-vouched address.
+- **Negative:** trust now rests on the `samlp|` prefix convention, an
+  Auth0 implementation detail. If Auth0 ever changed the format the fix
+  degrades to a no-op (locked-out users again), never to over-trust.
+- **Negative (red-team, v2):** the safety boundary moves from code to
+  tenant configuration. Self-hosted operators inherit the assumption that
+  their SAML connections assert operator-trusted emails; a code comment at
+  the helper states this. Auth0's other enterprise strategies (`adfs|`,
+  `ping|`) share the `email_verified: false` quirk and stay locked out —
+  deliberate (n=1); widening the predicate is a future decision, not a
+  default.
+- **Neutral:** Okta and plain-OIDC branches unchanged; their IdPs already
+  report verified emails.
+
+## Open questions
+
+- **Bind the trust to the org's pinned connection?** A stricter rule —
+  only upgrade `samlp|{conn}|…` when the asserted email's domain belongs
+  to the org whose `ssoProvider` is pinned to that exact connection —
+  would close the spoofed-out-of-domain-email and stray-connection cases.
+  It is infeasible today: one org can legitimately span several email
+  domains while `ssoDomain` holds exactly one (langwatch-saas#1050), so
+  strict binding would lock out a customer's secondary-domain users — the
+  very lockout this ADR fixes. Revisit once multi-domain lands; applies
+  equally to the OIDC enterprise strategies that already link.
+- Multi-domain SSO for the same customer is tracked separately (internal
+  issue langwatch-saas#1050).
+
+## Revisions
+
+- **v1 (2026-08-14, captain: Sergio Esteban):** framing locked (SAML-only
+  trust, high blast radius, samlp-prefix + no-schema + one-PR constraints);
+  forks locked: exported named helper over inline one-liner, one-off over
+  shared capability.
+- **v2 (2026-08-14, red-team, 4-lens panel):** the mechanism and premise
+  **held** — `samlp|` cannot be forged from non-SAML connections (a
+  database user id of `samlp|x` yields sub `auth0|samlp|x`), the
+  `typeof`+prefix check has no type or unicode holes, and no better
+  mechanism exists in BetterAuth 1.6.23 (`trustedProviders` is
+  provider-wide and matched pre-token-exchange; per-config trust flags
+  exist in `handleOAuthUserInfo` but are never passed by any route; hooks
+  fire after the link gate and can only block, never permit). The
+  **universal** safety claim was refuted: SAML authentication proves
+  identity at the IdP, not ownership of the asserted email — the residual
+  risk is captured in the load-bearing assumption above and is the same
+  class the tenant's OIDC enterprise connections (`waad|`, `okta|`)
+  already carry, as their linked account pairs in production show.
+  Connection-bound hardening deferred (see Open questions); scope
+  unchanged from v1.
+- **v2 (2026-08-14, red-team, 4 lenses):** claim survives narrowed. Held:
+  `samlp|` cannot be forged from non-SAML connections (a database user_id
+  of `samlp|x` yields sub `auth0|samlp|x`); no safer BetterAuth mechanism
+  exists in 1.6.23. Narrowed: safety is conditional on every SAML
+  connection in the tenant mapping email from an IdP-controlled attribute
+  — promoted to the load-bearing assumption above. Allowlist alternative
+  re-asked and rejected (see Rejected alternatives). Boundary decision:
+  document + code-comment, keep prefix-only.

--- a/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
+++ b/dev/docs/adr/096-saml-logins-count-as-verified-emails.md
@@ -93,12 +93,16 @@ Forces and constraints (locked 2026-08-14):
 
 | Path | Reversible? | Blast radius | Gate |
 |---|---|---|---|
-| SAML sign-in links to existing user | Code-revert yes; a wrong link made in the window is not | High (auth boundary) | Human review of the PR + invariant unit tests + first real sign-in verified against Auth0 debug logs before announcing |
-| Fresh SAML user created with `emailVerified: true` | Yes (flag flip in DB) | Small — skips a verification email for users their own IdP already vouched for | none |
+| SAML sign-in links to existing user | Code-revert yes; a wrong link made in the window is not | High (auth boundary) | Human review of the PR + invariant unit tests + first real sign-in verified end-to-end before announcing: Auth0 debug logs (the IdP side) AND the resulting `Account` row linked to the pre-existing `User` (read-only production query on `Account.providerAccountId LIKE 'samlp\|%'`) — Auth0 logs alone don't prove BetterAuth persisted the link |
+| Fresh SAML user created with `emailVerified: true` | Yes (flag flip in DB) | Small — skips a verification email for users their own IdP already vouched for | Covered by the same first-sign-in verification: the created `User` row's `emailVerified` is checked in the same read-only query |
 
 ## Schema
 
-None. No migrations, no env vars, no config keys.
+None. No migrations, no env vars, no config keys, no Helm values, no
+dataplane impact — the change is app-layer auth and ships in the app
+image. Rollback is a redeploy of the previous image; note that rollback
+does NOT undo `emailVerified` flags persisted or account links created
+while the change was live — those would need manual review.
 
 ## Rejected alternatives
 

--- a/platform/app/ee/sso/__tests__/samlEmailVerified.test.ts
+++ b/platform/app/ee/sso/__tests__/samlEmailVerified.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * SAML sign-ins through Auth0 count as verified emails (ADR-096).
+ *
+ * Auth0 reports `email_verified: false` for every SAML connection with no
+ * per-connection switch to change it, and BetterAuth refuses to link an
+ * OAuth sign-in with an unverified email to an existing user. The auth0
+ * `mapProfileToUser` therefore returns `emailVerified: true` when — and
+ * only when — the profile's `sub` carries the `samlp|` strategy prefix.
+ *
+ * These tests pin the security boundary from both sides: SAML subs are
+ * upgraded, and every other sub shape produces a mapped profile with NO
+ * `emailVerified` key at all, so the claim-derived value flows through
+ * untouched.
+ */
+import { describe, expect, it } from "vitest";
+import { buildGenericOAuthConfigs, isSamlSub } from "../providers";
+
+describe("isSamlSub", () => {
+  it("matches an Auth0 SAML sub", () => {
+    expect(isSamlSub("samlp|SomeConnection|user@acme.test")).toBe(true);
+  });
+
+  it("rejects other Auth0 connection strategies", () => {
+    expect(isSamlSub("auth0|507f1f77bcf86cd799439011")).toBe(false);
+    expect(isSamlSub("google-oauth2|103547991597142817347")).toBe(false);
+    expect(isSamlSub("waad|AbCdEf")).toBe(false);
+  });
+
+  it("rejects a forged sub from a database connection", () => {
+    // A database user_id of `samlp|x` still gets the strategy prefix:
+    expect(isSamlSub("auth0|samlp|x")).toBe(false);
+  });
+
+  it("requires the trailing pipe, so a samlpx strategy never matches", () => {
+    expect(isSamlSub("samlpx|whatever")).toBe(false);
+    expect(isSamlSub("samlp")).toBe(false);
+  });
+
+  it("rejects absent and non-string subs", () => {
+    expect(isSamlSub(undefined)).toBe(false);
+    expect(isSamlSub(null)).toBe(false);
+    expect(isSamlSub(42)).toBe(false);
+    expect(isSamlSub({})).toBe(false);
+  });
+});
+
+describe("auth0 mapProfileToUser emailVerified", () => {
+  const mapProfileToUser = () => {
+    const configs = buildGenericOAuthConfigs({
+      NEXTAUTH_PROVIDER: "auth0",
+      NEXTAUTH_URL: "https://langwatch.acme.test",
+      AUTH0_CLIENT_ID: "auth0-client-id",
+      AUTH0_CLIENT_SECRET: "auth0-client-secret",
+      AUTH0_ISSUER: "https://acme.eu.auth0.com",
+    } as any);
+    const auth0Config = configs.find(
+      (c) => (c as { providerId?: string }).providerId === "auth0",
+    ) as {
+      mapProfileToUser: (p: Record<string, any>) => Record<string, unknown>;
+    };
+    return auth0Config.mapProfileToUser;
+  };
+
+  const profile = (sub: unknown) => ({
+    sub,
+    name: "Alice Smith",
+    email: "alice@acme.test",
+    picture: "https://img.acme.test/alice.png",
+  });
+
+  /** @invariant SAML profiles map to emailVerified: true */
+  it("marks a SAML profile's email as verified", () => {
+    const mapped = mapProfileToUser()(profile("samlp|AcmeConn|alice"));
+    expect(mapped.emailVerified).toBe(true);
+  });
+
+  /** @invariant Non-SAML profiles get no emailVerified key */
+  it.each([
+    ["database", "auth0|507f1f77bcf86cd799439011"],
+    ["google social", "google-oauth2|103547991597142817347"],
+    ["azure enterprise", "waad|AbCdEf"],
+    ["forged database user_id", "auth0|samlp|x"],
+  ])("leaves emailVerified absent for a %s sub", (_label, sub) => {
+    const mapped = mapProfileToUser()(profile(sub));
+    expect("emailVerified" in mapped).toBe(false);
+  });
+
+  it("leaves emailVerified absent when sub is missing", () => {
+    const { sub: _sub, ...noSub } = profile("x");
+    const mapped = mapProfileToUser()(noSub);
+    expect("emailVerified" in mapped).toBe(false);
+  });
+
+  /** @invariant Rest of the mapping unchanged */
+  it("keeps name, email and image mapping identical for SAML profiles", () => {
+    const mapped = mapProfileToUser()(profile("samlp|AcmeConn|alice"));
+    expect(mapped).toEqual({
+      name: "Alice Smith",
+      email: "alice@acme.test",
+      image: "https://img.acme.test/alice.png",
+      emailVerified: true,
+    });
+  });
+});

--- a/platform/app/ee/sso/providers.ts
+++ b/platform/app/ee/sso/providers.ts
@@ -43,6 +43,28 @@ export const fallbackName = (profile: Record<string, any>): string => {
 };
 
 /**
+ * True when an Auth0 `sub` identifies a user who authenticated through a SAML
+ * connection. Auth0 encodes the connection strategy as the first
+ * pipe-delimited segment of `sub` (`{strategy}|{connection}|{id}`); SAML
+ * users arrive as `samlp|…`. The trailing pipe is part of the prefix so a
+ * hypothetical `samlpx` strategy never matches, and the prefix cannot be
+ * forged from other connection types — a database user_id of `samlp|x`
+ * yields the sub `auth0|samlp|x`.
+ *
+ * Used to mark SAML sign-ins as email-verified (ADR-096): Auth0 reports
+ * `email_verified: false` for every SAML connection with no way to change
+ * it, which would block BetterAuth from linking the sign-in to an existing
+ * user. Trust boundary: this assumes every SAML connection in the Auth0
+ * tenant maps `email` from an attribute the IdP controls — an operator who
+ * points a SAML connection at an IdP with user-editable emails or open
+ * registration re-opens the account-linking hole this flag closes.
+ *
+ * Exported for unit testing.
+ */
+export const isSamlSub = (sub: unknown): boolean =>
+  typeof sub === "string" && sub.startsWith("samlp|");
+
+/**
  * Subset of env needed to select and configure a `socialProviders` entry.
  */
 type SocialProviderEnv = Pick<
@@ -401,6 +423,12 @@ export const buildGenericOAuthConfigs = (
         name: fallbackName(profile),
         email: profile.email,
         image: profile.picture,
+        // SAML sign-ins count as verified: the email was asserted by the
+        // organization's own IdP, but Auth0 reports `email_verified: false`
+        // for every SAML connection, which would stop BetterAuth from
+        // linking to an existing user (ADR-096). Non-SAML profiles get no
+        // `emailVerified` key so the claim-derived value flows through.
+        ...(isSamlSub(profile.sub) ? { emailVerified: true } : {}),
       }),
     });
   }


### PR DESCRIPTION
Fixes langwatch/langwatch-saas#1053

## Problem

Auth0 reports `email_verified: false` for every SAML connection user, with no per-connection switch to change it (SAML is the only enterprise connection type without one). BetterAuth refuses to link an OAuth sign-in with an unverified email to an existing user (`oauth2/link-account.mjs`, v1.6.23). Net effect: any existing user whose organization switches to SAML SSO is locked out on their first SAML login.

## Fix

The auth0 `mapProfileToUser` returns `emailVerified: true` when — and only when — the profile `sub` carries the `samlp|` strategy prefix. The email was asserted by the organization's own IdP, which is exactly the authority an email-verification loop would consult. Non-SAML profiles get **no** `emailVerified` key, so the claim-derived value flows through untouched.

- `isSamlSub` helper, exported for testing; prefix can't be forged from other connection types (a database `user_id` of `samlp|x` yields sub `auth0|samlp|x`)
- 12 unit tests pinning both sides of the boundary
- ADR-096 records the decision, the red-team findings, and the trust boundary (every SAML connection in the tenant must map email from an IdP-controlled attribute)

No schema, env, or config changes.

## Deployment Impact

No env vars added or changed. No helm values added or changed. Vanilla `helm install` with no overrides: behavior identical unless Auth0 SSO is configured with SAML connections, in which case SAML sign-ins now link to existing users instead of erroring. No BYOC dataplane impact — the change is app-layer auth (control plane); ships in the app image, no migration, rollback is a redeploy of the previous image.

## Testing

`pnpm test:unit run ee/sso` — 113/113 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SAML sign-ins now recognize the associated email address as verified.
  * Non-SAML sign-ins retain their existing email verification behavior.
* **Bug Fixes**
  * Improved handling of malformed or incomplete SAML profile data.
* **Documentation**
  * Added guidance covering security considerations, expected behavior, and rollout requirements.
* **Tests**
  * Added coverage for valid and invalid SAML identifiers and preservation of existing profile details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
