### PR TITLE
fix(data-privacy): keep identifier-shaped attribute values out of phone redaction

### DIFF
--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.nativeScopedPolicy.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.nativeScopedPolicy.test.ts
@@ -227,6 +227,20 @@ describe("OtlpSpanPiiRedactionService scoped-policy native redaction", () => {
       expect(batchSpy).not.toHaveBeenCalled();
     });
 
+    it("keeps a datestamped identifier attribute whole and still redacts a phone number in text", async () => {
+      const { service, batchSpy } = makeService(mkPolicy({}));
+      const span = spanWith({
+        "deployment.name": "hosted-eu-20260812-09",
+        input: "ref 2026081209 checkpoint",
+      });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "deployment.name")).toBe("hosted-eu-20260812-09");
+      expect(attr(span, "input")).toBe("ref [PHONE_NUMBER] checkpoint");
+      expect(batchSpy).not.toHaveBeenCalled();
+    });
+
     /** @scenario A credit card number is validated before being redacted */
     it("redacts a Luhn-valid card but keeps a random 16-digit order id", async () => {
       const { service, batchSpy } = makeService(mkPolicy({}));

--- a/platform/app/src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts
@@ -162,6 +162,90 @@ describe("redactAttributeNative", () => {
   });
 });
 
+describe("redactAttributeNative on identifier-shaped values", () => {
+  const stored = (value: string) =>
+    redactAttributeNative({ key: "deployment.name", value, policy: policy({}) })
+      .text;
+
+  describe("given a value that is exclusively one identifier-shaped token", () => {
+    /** @scenario "A datestamped identifier attribute value is not read as a phone number" */
+    it("keeps a datestamped identifier whole", () => {
+      expect(stored("hosted-eu-20260812-09")).toBe("hosted-eu-20260812-09");
+    });
+
+    /** @scenario "A uuid or a digest attribute value is left alone" */
+    it("keeps a uuid and a hex digest whole", () => {
+      expect(stored("550e8400-e29b-41d4-a716-446655440000")).toBe(
+        "550e8400-e29b-41d4-a716-446655440000",
+      );
+      expect(stored("da39a3ee5e6b4b0d3255bfef95601890afd80709")).toBe(
+        "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+      );
+    });
+
+    /** @scenario "A host identifier that embeds an address is left alone" */
+    it("keeps a host identifier that embeds an address", () => {
+      expect(stored("pod-10.0.0.1")).toBe("pod-10.0.0.1");
+    });
+
+    it("still scrubs a credential sent as the whole value", () => {
+      expect(stored("sk-ant-" + "A".repeat(40))).toBe("[SECRET]");
+    });
+  });
+
+  describe("given a value the recognizers can prove", () => {
+    /** @scenario "A card number inside an identifier-shaped value is still redacted" */
+    it("redacts a checksum-valid card behind an identifier prefix", () => {
+      expect(stored("ref-4111111111111111")).toBe("ref-[CREDIT_CARD]");
+    });
+
+    /** @scenario "An email address that is the whole attribute value is still redacted" */
+    it("redacts an email address that holds digits", () => {
+      expect(stored("jane.doe1985@example.com")).toBe("[EMAIL_ADDRESS]");
+    });
+
+    it("redacts an email address mentioned inside prose", () => {
+      expect(stored("write to jane.doe1985@example.com today")).toBe(
+        "write to [EMAIL_ADDRESS] today",
+      );
+    });
+  });
+
+  describe("given a value made of digits and separators only", () => {
+    /** @scenario "A phone number that is the whole attribute value is still redacted" */
+    it("redacts an international number written with spaces", () => {
+      expect(stored("+31 6 12345678")).toBe("[PHONE_NUMBER]");
+    });
+
+    /** @scenario "A value of digits and separators with no letters is still redacted" */
+    it("redacts a digit run split by a separator", () => {
+      expect(stored("20260812-09")).toBe("[PHONE_NUMBER]");
+    });
+  });
+
+  describe("given a value that is a sentence rather than one token", () => {
+    it("redacts a phone number mentioned between words", () => {
+      expect(stored("ref 2026081209 checkpoint")).toBe(
+        "ref [PHONE_NUMBER] checkpoint",
+      );
+    });
+  });
+
+  describe("given a value that is structure holding data, not an identifier", () => {
+    it("redacts a phone number inside minified JSON", () => {
+      expect(stored('{"phone":"+14155552671"}')).toBe(
+        '{"phone":"[PHONE_NUMBER]"}',
+      );
+    });
+
+    it("redacts a phone number inside a URL", () => {
+      expect(stored("https://acme.example/u/2026081209")).toBe(
+        "https://acme.example/u/[PHONE_NUMBER]",
+      );
+    });
+  });
+});
+
 describe("redactStringNative with policy PII exceptions", () => {
   it("keeps a fully matched value and redacts everything else", () => {
     const p = policy({ exceptPatterns: ["00\\d{12}"] });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
@@ -75,6 +75,58 @@ describe("redactEssentialPiiInText", () => {
     });
   });
 
+  describe("given a phone-shaped digit run inside a longer token", () => {
+    /** @scenario "An identifier mentioned inside a sentence keeps its digits" */
+    it("keeps an identifier that carries letters whole", () => {
+      const input = "note hosted-eu-20260812-09 attached";
+      const { text, redactedCount } = redact(input);
+      expect(text).toBe(input);
+      expect(redactedCount).toBe(0);
+    });
+
+    it("keeps the digits of a prefixed session id", () => {
+      const input = "session sess_2026081209 opened";
+      expect(redact(input).text).toBe(input);
+    });
+
+    /** @scenario "A digit run that reads as a phone number is still redacted in a sentence" */
+    it("still redacts the same digits standing on their own", () => {
+      expect(redact("ref 2026081209 checkpoint").text).toBe(
+        "ref [PHONE_NUMBER] checkpoint",
+      );
+      expect(redact("call 2026081209 now").text).toBe(
+        "call [PHONE_NUMBER] now",
+      );
+    });
+
+    it("still redacts a digit run split by a separator, with no letters around", () => {
+      expect(redact("dial 20260812-09 please").text).toBe(
+        "dial [PHONE_NUMBER] please",
+      );
+    });
+
+    it("still redacts a spaced international number after a letter run", () => {
+      const { text } = redact("mobile: +31 6 12345678");
+      expect(text).toContain("[PHONE_NUMBER]");
+      expect(text).not.toContain("12345678");
+    });
+
+    it("still redacts a number carried by minified JSON, and keeps an id in the same payload", () => {
+      const { text } = redact(
+        '{"id":"hosted-eu-20260812-09","phone":"+14155552671"}',
+      );
+      expect(text).toBe(
+        '{"id":"hosted-eu-20260812-09","phone":"[PHONE_NUMBER]"}',
+      );
+    });
+
+    it("still redacts a number in a URL path", () => {
+      expect(redact("see https://acme.example/u/2026081209 now").text).toBe(
+        "see https://acme.example/u/[PHONE_NUMBER] now",
+      );
+    });
+  });
+
   describe("given a bare nine-digit run", () => {
     it("leaves it intact without context", () => {
       const input = "ref 123456789 logged";
@@ -215,6 +267,56 @@ describe("redactEssentialPiiInText", () => {
         "mail test@example.com cpf 529.982.247-25",
       );
       expect(redactedCount).toBe(2);
+    });
+  });
+
+  describe("when the text is one attribute value", () => {
+    const asValue = (text: string) =>
+      redactEssentialPiiInText({ text, isAttributeValue: true });
+
+    describe("given a value that is exclusively one identifier-shaped token", () => {
+      it.each([
+        "hosted-eu-20260812-09",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "pod-10.0.0.1",
+        "cache-1:ab:cd:ef",
+        "license-AB1234567",
+      ])("leaves %s exactly as it was sent", (value) => {
+        const { text, redactedCount } = asValue(value);
+        expect(text).toBe(value);
+        expect(redactedCount).toBe(0);
+      });
+    });
+
+    describe("given a value the recognizers can prove", () => {
+      it("still redacts a checksum-valid card behind an identifier prefix", () => {
+        expect(asValue("ref-4111111111111111").text).toBe("ref-[CREDIT_CARD]");
+      });
+
+      it("still redacts an email address that holds digits", () => {
+        expect(asValue("jane.doe1985@example.com").text).toBe(
+          "[EMAIL_ADDRESS]",
+        );
+      });
+    });
+
+    describe("given a value with no letters in it", () => {
+      it.each([
+        "+31 6 12345678",
+        "20260812-09",
+        "2026081209",
+      ])("still redacts %s", (value) => {
+        expect(asValue(value).text).toBe("[PHONE_NUMBER]");
+      });
+    });
+
+    describe("given a value that is a sentence rather than one token", () => {
+      it("redacts as it does anywhere else", () => {
+        expect(asValue("ref 2026081209 checkpoint").text).toBe(
+          "ref [PHONE_NUMBER] checkpoint",
+        );
+      });
     });
   });
 });

--- a/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
+++ b/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
@@ -50,17 +50,23 @@ export function nativePiiEntitiesForPolicy(
  * entirely; secrets still run when enabled (they are an independent concern).
  *
  * Pure and synchronous so it can run per string in the hot ingestion path.
+ *
+ * `isAttributeValue` marks the text as one attribute value, which lets the PII
+ * pass hold identifier-shaped values back from the recognizers that have only a
+ * shape to go on. Free text (bodies, status messages) leaves it off.
  */
 export function redactStringNative({
   text,
   policy,
   compiledSecretPatterns,
   compiledPiiExceptions,
+  isAttributeValue = false,
 }: {
   text: string;
   policy: ResolvedDataPrivacy;
   compiledSecretPatterns?: readonly RegExp[];
   compiledPiiExceptions?: readonly RegExp[];
+  isAttributeValue?: boolean;
 }): { text: string; redactedCount: number } {
   let result = text;
   let redactedCount = 0;
@@ -83,6 +89,7 @@ export function redactStringNative({
       text: result,
       entities: piiEntities === "all" ? undefined : piiEntities,
       exceptPatterns: compiledPiiExceptions,
+      isAttributeValue,
     });
     result = pii.text;
     redactedCount += pii.redactedCount;
@@ -126,7 +133,8 @@ const NAME_RULE_EXEMPT_ATTRIBUTES: ReadonlySet<string> = new Set([
  * the whole value is replaced regardless of its shape — the Sentry-style
  * field-name deny-list, minus {@link NAME_RULE_EXEMPT_ATTRIBUTES}. Otherwise
  * the value runs through the normal native passes (secrets value-scan +
- * essential PII).
+ * essential PII), marked as an attribute value so the PII pass can hold an
+ * identifier-shaped value back from the recognizers that go on shape alone.
  */
 export function redactAttributeNative({
   key,
@@ -154,6 +162,7 @@ export function redactAttributeNative({
     policy,
     compiledSecretPatterns,
     compiledPiiExceptions,
+    isAttributeValue: true,
   });
 }
 

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -14,6 +14,11 @@ import { findPhoneNumbersInText } from "libphonenumber-js";
  * a nearby context word, merge overlapping spans preferring the longer, then
  * rebuild the string in one pass replacing each survivor with its typed marker
  * (`[EMAIL_ADDRESS]`, `[PHONE_NUMBER]`, ...).
+ *
+ * Machine identifiers are held out of that: an attribute value that is
+ * exclusively one identifier-shaped token runs only the self-proving
+ * recognizers, and a phone number inside a longer token that carries letters is
+ * dropped wherever it appears.
  */
 
 const MAX_SCAN_LENGTH = 250_000;
@@ -49,6 +54,13 @@ interface Recognizer {
   /** Low-confidence patterns only fire when one of these words is within the window. */
   contextRequired?: boolean;
   contextWords?: string[];
+  /**
+   * The match carries its own proof: a checksum, or a marker no machine
+   * identifier holds by accident. Only these recognizers keep running on a
+   * value that is exclusively one identifier-shaped token
+   * (see {@link isIdentifierShapedValue}).
+   */
+  selfProving?: boolean;
 }
 
 function luhnValid(raw: string): boolean {
@@ -117,6 +129,7 @@ const RECOGNIZERS: Recognizer[] = [
   {
     entity: "EMAIL_ADDRESS",
     regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+    selfProving: true,
   },
   {
     entity: "IP_ADDRESS",
@@ -132,16 +145,19 @@ const RECOGNIZERS: Recognizer[] = [
     entity: "CREDIT_CARD",
     regex: /\b\d(?:[ -]?\d){12,18}\b/g,
     validate: luhnValid,
+    selfProving: true,
   },
   {
     entity: "IBAN_CODE",
     regex: /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g,
     validate: ibanValid,
+    selfProving: true,
   },
-  { entity: "CRYPTO", regex: /\b0x[a-fA-F0-9]{40}\b/g },
+  { entity: "CRYPTO", regex: /\b0x[a-fA-F0-9]{40}\b/g, selfProving: true },
   {
     entity: "CRYPTO",
     regex: /\b(?:bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
+    selfProving: true,
   },
   // Hyphenated US SSN is distinctive enough to fire without context.
   { entity: "US_SSN", regex: /\b\d{3}-\d{2}-\d{4}\b/g },
@@ -226,6 +242,7 @@ const RECOGNIZERS: Recognizer[] = [
     entity: "BR_CPF",
     regex: /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/g,
     validate: cpfValid,
+    selfProving: true,
   },
 ];
 
@@ -234,6 +251,81 @@ interface Span {
   end: number;
   /** The PII entity that matched here, written as the redaction marker. */
   entity: string;
+}
+
+const HAS_WHITESPACE = /\s/;
+const HAS_LETTER = /[A-Za-z]/;
+const HAS_DIGIT = /\d/;
+const HAS_LOWERCASE = /[a-z]/;
+const HAS_UPPERCASE = /[A-Z]/;
+const UUID_VALUE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEX_RUN_VALUE = /^[0-9a-f]{16,}$/i;
+const BASE64ISH_VALUE = /^[A-Za-z0-9+/_=-]{16,}$/;
+
+/**
+ * The characters an identifier is written with: letters, digits, and the
+ * separators ids use. A quote, a brace, a comma or a slash means the text is
+ * structure that HOLDS values rather than one identifier, so minified JSON and
+ * URLs stay fully scanned.
+ */
+const IDENTIFIER_VALUE = /^[A-Za-z0-9._:-]+$/;
+
+/**
+ * The characters that carry on an identifier around a detected span. Narrower
+ * than {@link IDENTIFIER_VALUE}: a dot or a colon ends the token here, so
+ * sentence punctuation and `"phone":"+1..."` in minified JSON cannot pull a
+ * detected number into an identifier that surrounds it.
+ */
+const IDENTIFIER_TOKEN_CHAR = /[A-Za-z0-9_-]/;
+
+/**
+ * How far the identifier rules read. Identifiers people send as references are
+ * far shorter, and the cap keeps both checks flat in the ingestion path however
+ * long the text is.
+ */
+const MAX_IDENTIFIER_LENGTH = 256;
+
+/**
+ * Whether a whole attribute value is exclusively one identifier-shaped token:
+ * letters together with digits and identifier separators
+ * (`hosted-eu-20260812-09`), or the shape of a uuid, a hex digest, or a
+ * base64-style token.
+ *
+ * The letter requirement is what keeps personal data in scope. A value built
+ * only from digits and separators (`+31 6 12345678`, `20260812-09`, a bare card
+ * number) is never identifier-shaped here, however much a customer means it as
+ * a reference.
+ */
+function isIdentifierShapedValue(value: string): boolean {
+  if (value.length > MAX_IDENTIFIER_LENGTH || !HAS_LETTER.test(value)) {
+    return false;
+  }
+  if (HAS_DIGIT.test(value) && IDENTIFIER_VALUE.test(value)) return true;
+  if (UUID_VALUE.test(value) || HEX_RUN_VALUE.test(value)) return true;
+  return (
+    BASE64ISH_VALUE.test(value) &&
+    HAS_LOWERCASE.test(value) &&
+    HAS_UPPERCASE.test(value)
+  );
+}
+
+/**
+ * Whether a match sits inside a longer identifier: the identifier characters
+ * around it reach past the match and carry a letter, as the `20260812-09` in
+ * `hosted-eu-20260812-09` does. A match that itself holds whitespace
+ * (`+31 6 12345678`) covers more than one token, so it is never inside one.
+ */
+function insideIdentifierToken(text: string, span: Span): boolean {
+  if (HAS_WHITESPACE.test(text.slice(span.start, span.end))) return false;
+  const floor = Math.max(0, span.start - MAX_IDENTIFIER_LENGTH);
+  let start = span.start;
+  while (start > floor && IDENTIFIER_TOKEN_CHAR.test(text[start - 1]!)) start--;
+  const ceiling = Math.min(text.length, span.end + MAX_IDENTIFIER_LENGTH);
+  let end = span.end;
+  while (end < ceiling && IDENTIFIER_TOKEN_CHAR.test(text[end]!)) end++;
+  if (start === span.start && end === span.end) return false;
+  return HAS_LETTER.test(text.slice(start, end));
 }
 
 function hasContextWord(
@@ -382,8 +474,28 @@ function recognizedSpanFor({
 }
 
 /**
- * Regex/checksum recognizer pass: every `RECOGNIZERS` entry allowed by
- * `allowed`, reduced match-by-match via `recognizedSpanFor`. Split out of
+ * Whether one recognizer runs in this pass: the custom level can narrow the
+ * set through `allowed`, and on an identifier-shaped value only the recognizers
+ * that prove their own finding run. That value is one token a customer sends as
+ * a reference, so a shape, or a word inside that same token, is not evidence of
+ * personal data.
+ */
+function recognizerRuns({
+  recognizer,
+  allowed,
+  identifierValue,
+}: {
+  recognizer: Recognizer;
+  allowed: ReadonlySet<string> | null;
+  identifierValue: boolean;
+}): boolean {
+  if (allowed && !allowed.has(recognizer.entity)) return false;
+  return !identifierValue || recognizer.selfProving === true;
+}
+
+/**
+ * Regex/checksum recognizer pass: every `RECOGNIZERS` entry `recognizerRuns`
+ * keeps, reduced match-by-match via `recognizedSpanFor`. Split out of
  * `collectCandidateSpans` so each pass stays independently under the
  * cognitive-complexity budget.
  */
@@ -391,14 +503,16 @@ function collectRecognizerSpans({
   text,
   allowed,
   excepted,
+  identifierValue,
 }: {
   text: string;
   allowed: ReadonlySet<string> | null;
   excepted: (span: Span) => boolean;
+  identifierValue: boolean;
 }): Span[] {
   const spans: Span[] = [];
   for (const recognizer of RECOGNIZERS) {
-    if (allowed && !allowed.has(recognizer.entity)) continue;
+    if (!recognizerRuns({ recognizer, allowed, identifierValue })) continue;
     for (const match of text.matchAll(recognizer.regex)) {
       const span = recognizedSpanFor({ recognizer, match, text, excepted });
       if (span) spans.push(span);
@@ -412,16 +526,24 @@ function collectRecognizerSpans({
  * the regex recognizers. Kept separate from `collectRecognizerSpans`: it is a
  * different library and match shape (`startsAt`/`endsAt`, not a regex match),
  * not a different set of rules.
+ *
+ * The detector has no checksum and no context word to prove a finding: any
+ * digit run that parses as a dialable number matches. Two rules hold it to
+ * digits a customer wrote as a number. It never runs on an identifier-shaped
+ * value, and a match inside a longer token that carries letters is dropped.
  */
 function collectPhoneSpans({
   text,
   allowed,
   excepted,
+  identifierValue,
 }: {
   text: string;
   allowed: ReadonlySet<string> | null;
   excepted: (span: Span) => boolean;
+  identifierValue: boolean;
 }): Span[] {
+  if (identifierValue) return [];
   if (allowed && !allowed.has("PHONE_NUMBER")) return [];
   const spans: Span[] = [];
   try {
@@ -433,6 +555,7 @@ function collectPhoneSpans({
         end: phone.endsAt,
         entity: "PHONE_NUMBER",
       };
+      if (insideIdentifierToken(text, span)) continue;
       if (excepted(span)) continue;
       spans.push(span);
     }
@@ -454,11 +577,13 @@ function collectCandidateSpans({
   allowed,
   exceptPatterns,
   protectedRanges,
+  identifierValue,
 }: {
   text: string;
   allowed: ReadonlySet<string> | null;
   exceptPatterns: readonly RegExp[] | undefined;
   protectedRanges: ProtectedRange[];
+  identifierValue: boolean;
 }): Span[] {
   const excepted = (span: Span): boolean => {
     const veto =
@@ -470,8 +595,8 @@ function collectCandidateSpans({
   };
 
   return [
-    ...collectRecognizerSpans({ text, allowed, excepted }),
-    ...collectPhoneSpans({ text, allowed, excepted }),
+    ...collectRecognizerSpans({ text, allowed, excepted, identifierValue }),
+    ...collectPhoneSpans({ text, allowed, excepted, identifierValue }),
   ];
 }
 
@@ -522,15 +647,23 @@ function maskSpans({
  * `exceptPatterns` are the policy's do-not-redact exceptions (pre-anchored via
  * `compilePiiExceptPatterns`): a detected span whose entire matched text
  * matches one of them is left as it was.
+ *
+ * `isAttributeValue` says the text is one attribute value rather than free
+ * text. A value that is exclusively one identifier-shaped token then runs only
+ * the self-proving recognizers, because customers send identifiers on purpose
+ * and a shape alone does not make one personal data. Free text never takes the
+ * exemption: a document with no spaces in it is still a document.
  */
 export function redactEssentialPiiInText({
   text,
   entities,
   exceptPatterns,
+  isAttributeValue = false,
 }: {
   text: string;
   entities?: readonly string[];
   exceptPatterns?: readonly RegExp[];
+  isAttributeValue?: boolean;
 }): PiiRedactionResult {
   if (
     typeof text !== "string" ||
@@ -546,6 +679,7 @@ export function redactEssentialPiiInText({
     allowed: entities ? new Set(entities) : null,
     exceptPatterns,
     protectedRanges,
+    identifierValue: isAttributeValue && isIdentifierShapedValue(text),
   });
   if (spans.length === 0) return { text, redactedCount: 0 };
 

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -60,7 +60,7 @@ interface Recognizer {
    * value that is exclusively one identifier-shaped token
    * (see {@link isIdentifierShapedValue}).
    */
-  selfProving?: boolean;
+  isSelfProving?: boolean;
 }
 
 function luhnValid(raw: string): boolean {
@@ -129,7 +129,7 @@ const RECOGNIZERS: Recognizer[] = [
   {
     entity: "EMAIL_ADDRESS",
     regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
-    selfProving: true,
+    isSelfProving: true,
   },
   {
     entity: "IP_ADDRESS",
@@ -145,19 +145,19 @@ const RECOGNIZERS: Recognizer[] = [
     entity: "CREDIT_CARD",
     regex: /\b\d(?:[ -]?\d){12,18}\b/g,
     validate: luhnValid,
-    selfProving: true,
+    isSelfProving: true,
   },
   {
     entity: "IBAN_CODE",
     regex: /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g,
     validate: ibanValid,
-    selfProving: true,
+    isSelfProving: true,
   },
-  { entity: "CRYPTO", regex: /\b0x[a-fA-F0-9]{40}\b/g, selfProving: true },
+  { entity: "CRYPTO", regex: /\b0x[a-fA-F0-9]{40}\b/g, isSelfProving: true },
   {
     entity: "CRYPTO",
     regex: /\b(?:bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
-    selfProving: true,
+    isSelfProving: true,
   },
   // Hyphenated US SSN is distinctive enough to fire without context.
   { entity: "US_SSN", regex: /\b\d{3}-\d{2}-\d{4}\b/g },
@@ -242,7 +242,7 @@ const RECOGNIZERS: Recognizer[] = [
     entity: "BR_CPF",
     regex: /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/g,
     validate: cpfValid,
-    selfProving: true,
+    isSelfProving: true,
   },
 ];
 
@@ -483,14 +483,14 @@ function recognizedSpanFor({
 function recognizerRuns({
   recognizer,
   allowed,
-  identifierValue,
+  isIdentifierShaped,
 }: {
   recognizer: Recognizer;
   allowed: ReadonlySet<string> | null;
-  identifierValue: boolean;
+  isIdentifierShaped: boolean;
 }): boolean {
   if (allowed && !allowed.has(recognizer.entity)) return false;
-  return !identifierValue || recognizer.selfProving === true;
+  return !isIdentifierShaped || recognizer.isSelfProving === true;
 }
 
 /**
@@ -503,16 +503,16 @@ function collectRecognizerSpans({
   text,
   allowed,
   excepted,
-  identifierValue,
+  isIdentifierShaped,
 }: {
   text: string;
   allowed: ReadonlySet<string> | null;
   excepted: (span: Span) => boolean;
-  identifierValue: boolean;
+  isIdentifierShaped: boolean;
 }): Span[] {
   const spans: Span[] = [];
   for (const recognizer of RECOGNIZERS) {
-    if (!recognizerRuns({ recognizer, allowed, identifierValue })) continue;
+    if (!recognizerRuns({ recognizer, allowed, isIdentifierShaped })) continue;
     for (const match of text.matchAll(recognizer.regex)) {
       const span = recognizedSpanFor({ recognizer, match, text, excepted });
       if (span) spans.push(span);
@@ -536,14 +536,14 @@ function collectPhoneSpans({
   text,
   allowed,
   excepted,
-  identifierValue,
+  isIdentifierShaped,
 }: {
   text: string;
   allowed: ReadonlySet<string> | null;
   excepted: (span: Span) => boolean;
-  identifierValue: boolean;
+  isIdentifierShaped: boolean;
 }): Span[] {
-  if (identifierValue) return [];
+  if (isIdentifierShaped) return [];
   if (allowed && !allowed.has("PHONE_NUMBER")) return [];
   const spans: Span[] = [];
   try {
@@ -577,13 +577,13 @@ function collectCandidateSpans({
   allowed,
   exceptPatterns,
   protectedRanges,
-  identifierValue,
+  isIdentifierShaped,
 }: {
   text: string;
   allowed: ReadonlySet<string> | null;
   exceptPatterns: readonly RegExp[] | undefined;
   protectedRanges: ProtectedRange[];
-  identifierValue: boolean;
+  isIdentifierShaped: boolean;
 }): Span[] {
   const excepted = (span: Span): boolean => {
     const veto =
@@ -595,8 +595,8 @@ function collectCandidateSpans({
   };
 
   return [
-    ...collectRecognizerSpans({ text, allowed, excepted, identifierValue }),
-    ...collectPhoneSpans({ text, allowed, excepted, identifierValue }),
+    ...collectRecognizerSpans({ text, allowed, excepted, isIdentifierShaped }),
+    ...collectPhoneSpans({ text, allowed, excepted, isIdentifierShaped }),
   ];
 }
 
@@ -679,7 +679,7 @@ export function redactEssentialPiiInText({
     allowed: entities ? new Set(entities) : null,
     exceptPatterns,
     protectedRanges,
-    identifierValue: isAttributeValue && isIdentifierShapedValue(text),
+    isIdentifierShaped: isAttributeValue && isIdentifierShapedValue(text),
   });
   if (spans.length === 0) return { text, redactedCount: 0 };
 

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -108,6 +108,72 @@ Feature: Redacting personal data from traces
     Then the stored input has the name redacted
     And the analysis service was called
 
+  # Phone numbers are the one essential identifier with neither a checksum nor a
+  # nearby word to confirm them: any digit run that reads as a dialable number
+  # matches. Machine identifiers hit that by accident, so a datestamped id such
+  # as "hosted-eu-20260812-09" was stored as "hosted-eu-[PHONE_NUMBER]". Two
+  # rules keep such identifiers whole. An attribute value that is exclusively
+  # one identifier-shaped token (letters together with digits, a uuid, a hex
+  # digest) is scanned only for the identifiers that prove themselves, which are
+  # the checksum-validated ones and email addresses. And a phone number that
+  # sits inside a longer token carrying letters is kept everywhere, prose
+  # included. A value of digits and separators alone keeps no exemption, so a
+  # phone number written on its own is still redacted.
+
+  @unit
+  Scenario: A datestamped identifier attribute value is not read as a phone number
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is the identifier "hosted-eu-20260812-09"
+    Then the stored attribute still reads "hosted-eu-20260812-09"
+
+  @unit
+  Scenario: A digit run that reads as a phone number is still redacted in a sentence
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input reads "ref 2026081209 checkpoint"
+    Then the stored input has the digit run redacted as a phone number
+
+  @unit
+  Scenario: An identifier mentioned inside a sentence keeps its digits
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input mentions the identifier "hosted-eu-20260812-09" between words
+    Then the stored input still contains the whole identifier
+
+  @unit
+  Scenario: A phone number that is the whole attribute value is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is an international phone number
+    Then the stored attribute has the phone number redacted
+
+  @unit
+  Scenario: A value of digits and separators with no letters is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a digit run with a separator
+    Then the stored attribute has the digit run redacted as a phone number
+
+  @unit
+  Scenario: A uuid or a digest attribute value is left alone
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with attributes whose whole values are a uuid and a hex digest
+    Then the stored attributes still read as they were sent
+
+  @unit
+  Scenario: A host identifier that embeds an address is left alone
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is the host identifier "pod-10.0.0.1"
+    Then the stored attribute still reads "pod-10.0.0.1"
+
+  @unit
+  Scenario: A card number inside an identifier-shaped value is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a reference holding a valid card number
+    Then the stored attribute has the card number redacted
+
+  @unit
+  Scenario: An email address that is the whole attribute value is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is an email address with digits in it
+    Then the stored attribute has the email address redacted
+
   # Detection heuristics over-trigger on business identifiers that merely look
   # like PII: a 14-digit reservation number reads as a credit card, an
   # "orders@acme.internal" queue address reads as a personal email. Exception


### PR DESCRIPTION
## Problem

The native essential PII pass finds phone numbers with libphonenumber
(`findPhoneNumbersInText`, `defaultCountry: "US"`). That detector has no
checksum and no context word to prove a finding, so any digit run that parses as
a dialable number matches. The pass runs on every string attribute of every
span.

Machine identifiers hit this by accident. The attribute value
`hosted-eu-20260812-09` holds the digits `2026081209`, which parse as the valid
US number (202) 608-1209, so the value was stored as `hosted-eu-[PHONE_NUMBER]`.
Every identifier with a `2026` datestamp is in this class.

Repro before this change:

```ts
redactEssentialPiiInText({ text: "hosted-eu-20260812-09" }).text;
// "hosted-eu-[PHONE_NUMBER]"
```

## The rule

Two rules, both inside the native pass:

1. An attribute value that is exclusively one identifier-shaped token runs only
   the recognizers that prove their own finding. Identifier-shaped means letters
   together with digits and identifier separators (`hosted-eu-20260812-09`), or
   the shape of a uuid, a hex digest, or a base64-style token, up to 256
   characters. Self-proving means a checksum, or a marker that no identifier
   holds by accident: email addresses, credit cards, IBANs, CPFs and crypto
   addresses.
2. A phone number whose match sits inside a longer identifier token that carries
   letters is dropped. This rule applies to attribute values and to free text,
   so `note hosted-eu-20260812-09 attached` also keeps the identifier.

## Safe-side boundaries

- A value of digits and separators alone is never identifier-shaped. `+31 6
  12345678` and `20260812-09` are still redacted as whole values.
- Structure that holds data is not an identifier. A quote, a brace, a comma or a
  slash ends a token, so a phone number in minified JSON
  (`{"phone":"+14155552671"}`) or in a URL is still redacted.
- Email redaction is unchanged. An email address is not identifier-shaped
  (the `@` is not an identifier character), and the recognizer is self-proving.
- Secrets redaction is untouched. The key-name rule and the value rules run
  before PII, so a credential sent as a whole value is still `[SECRET]`.
- Free text keeps its old behavior apart from rule 2. Span bodies and status
  messages take no whole-value exemption.
- Span names, the analysis-service path, DLP and the exception-pattern feature
  are untouched.

## Trade

On an identifier-shaped value, the recognizers that go on shape alone, or on a
word inside that same token, no longer run. `pod-10.0.0.1` and
`license-AB1234567` keep their value. The checksum-proved recognizers still run
there, so a card number behind an identifier prefix (`ref-4111111111111111`) is
still redacted.

## Tests

- `specs/data-privacy/pii-redaction.feature`: 9 scenarios for the identifier
  rules, each bound to a test.
- `essentialPii.unit.test.ts`: the token rule in free text, minified JSON and
  URLs, plus the whole-value rule per shape.
- `applyContentRedaction.unit.test.ts`: the same values as attributes, including
  the card, email and secret cases that must still be redacted.
- `span-pii-redaction.nativeScopedPolicy.test.ts`: the repro through the
  ingestion service, with the identifier attribute kept and a phone number in
  text still redacted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy redaction for identifier-like attribute values, reducing false positives on deployment timestamps, UUIDs, digests, host identifiers, and similar values.
  * Sensitive information such as phone numbers, email addresses, credentials, and valid payment-card numbers continues to be redacted, including when embedded in text, JSON, or URLs.
  * Refined handling of phone-like digit sequences within longer identifiers while preserving protection for standalone phone numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->