### PR TITLE
fix(ai-gateway): stop double-charging cache tokens in spend

### DIFF
--- a/services/aigateway/adapters/spendemitter/contract_test.go
+++ b/services/aigateway/adapters/spendemitter/contract_test.go
@@ -110,7 +110,7 @@ func TestContractConfirmedPayload(t *testing.T) {
 	require.NoError(t, json.Unmarshal(records[0].Payload, &payload))
 	usage, ok := payload["usage"].(map[string]any)
 	require.True(t, ok)
-	assert.EqualValues(t, 869, usage["input_tokens"])
+	assert.EqualValues(t, 853, usage["input_tokens"])
 	assert.EqualValues(t, 207, usage["output_tokens"])
 	assert.EqualValues(t, 11, usage["cache_read_input_tokens"])
 	assert.EqualValues(t, 5, usage["cache_creation_input_tokens"])

--- a/services/aigateway/adapters/spendemitter/record.go
+++ b/services/aigateway/adapters/spendemitter/record.go
@@ -108,7 +108,7 @@ type ErrorPayload struct {
 // reasoning-token count today.
 func usageFromDomain(u domain.Usage, reasoning int) UsagePayload {
 	return UsagePayload{
-		InputTokens:         u.PromptTokens,
+		InputTokens:         u.PromptTokens - u.CacheReadTokens - u.CacheCreationTokens,
 		OutputTokens:        u.CompletionTokens,
 		CacheReadTokens:     u.CacheReadTokens,
 		CacheCreationTokens: u.CacheCreationTokens,


### PR DESCRIPTION
## Problem

Every cached token in the gateway billing path is charged twice: once at the input rate and once at the cache rate. On Anthropic pricing a cache-read token costs `2e-06 + 2e-07` instead of `2e-07`, an 11x overcharge on the cached share of a request. Cache-creation tokens are charged 1.8x. Budgets exhaust early on cache-heavy traffic, and billing disagrees with the trace explorer, which stamps the exclusive split.

Fixes #7018.

## Fix

`usageFromDomain` in `services/aigateway/adapters/spendemitter/record.go` now subtracts the cache buckets from `InputTokens`, matching the span emitter's exclusive split (`pkg/customertracebridge/emitter.go`):

```go
InputTokens: u.PromptTokens - u.CacheReadTokens - u.CacheCreationTokens,
```

The rating contract (`cost.ts` `estimateCost`) documents `inputTokens` as the exclusive (non-cached) input, so the two emitters now agree.

## Test

`TestContractConfirmedPayload` updated: with `PromptTokens: 869, CacheReadTokens: 11, CacheCreationTokens: 5`, the wire now carries `input_tokens == 853` (was 869).

```
cd services/aigateway && go test ./adapters/spendemitter/...
ok  github.com/langwatch/langwatch/services/aigateway/adapters/spendemitter  4.118s
```

`gofmt` clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage reporting by excluding cached tokens from total input token counts.
  * Preserved separate reporting for cache-read and cache-creation tokens.
  * Updated usage validation to reflect the corrected token totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->