### PR TITLE
fix(ai-gateway): bill audio endpoints by characters and seconds

### DIFF
--- a/platform/app/ee/governance/process-manager/gatewayDebits.process.ts
+++ b/platform/app/ee/governance/process-manager/gatewayDebits.process.ts
@@ -116,6 +116,8 @@ export const writeGatewayDebitsSchema = z.object({
       cache_read_input_tokens: z.number().int().min(0),
       cache_creation_input_tokens: z.number().int().min(0),
       reasoning_tokens: z.number().int().min(0),
+      input_chars: z.number().int().min(0).default(0),
+      audio_seconds: z.number().min(0).default(0),
     })
     .nullable(),
   /** The price the outcome event carried, in integer nano-USD. */
@@ -392,7 +394,9 @@ function movedNothing(outcome: SpendOutcome): boolean {
     usage.output_tokens === 0 &&
     usage.cache_read_input_tokens === 0 &&
     usage.cache_creation_input_tokens === 0 &&
-    usage.reasoning_tokens === 0
+    usage.reasoning_tokens === 0 &&
+    usage.input_chars === 0 &&
+    usage.audio_seconds === 0
   );
 }
 

--- a/platform/app/ee/webhooks/process-manager/webhookDelivery.process.ts
+++ b/platform/app/ee/webhooks/process-manager/webhookDelivery.process.ts
@@ -163,6 +163,8 @@ const spendUsagePayloadSchema = z.object({
   cache_read_input_tokens: z.number().int().min(0),
   cache_creation_input_tokens: z.number().int().min(0),
   reasoning_tokens: z.number().int().min(0),
+  input_chars: z.number().int().min(0).default(0),
+  audio_seconds: z.number().min(0).default(0),
 });
 
 /** Everything the deliver executor needs to rate, build the envelope, and

--- a/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/__tests__/spendPriceAgreement.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/__tests__/spendPriceAgreement.unit.test.ts
@@ -20,6 +20,18 @@ const CHEAP_CATALOG: MaybeStoredLLMModelCost[] = [
     inputCostPerToken: 0.0000025,
     outputCostPerToken: 0.00001,
   } as MaybeStoredLLMModelCost,
+  {
+    projectId: "",
+    model: "openai/tts-1",
+    regex: "^(openai\\/)?tts-1$",
+    inputCostPerCharacter: 0.000015,
+  } as MaybeStoredLLMModelCost,
+  {
+    projectId: "",
+    model: "openai/whisper-1",
+    regex: "^(openai\\/)?whisper-1$",
+    inputCostPerSecond: 0.0001,
+  } as MaybeStoredLLMModelCost,
 ];
 
 /** The same model repriced by a catalog deploy: ten times the money. */
@@ -194,6 +206,50 @@ beforeEach(() => {
 
 describe("one price per gateway request", () => {
   /** @scenario The price is fixed when the outcome is recorded and every surface repeats it */
+  /** @scenario Character- and second-priced audio usage prices the same in billing as in observability */
+  it("audio outcomes price by characters and seconds instead of zero", () => {
+    const ttsUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      reasoning_tokens: 0,
+      input_chars: 12000,
+      audio_seconds: 0,
+    };
+    const pricedTts = rateSpendNanoUsd({ model: "openai/tts-1", usage: ttsUsage });
+    expect(pricedTts.costNanoUsd).toBe(180_000_000);
+
+    const sttUsage = {
+      ...ttsUsage,
+      input_chars: 0,
+      audio_seconds: 3,
+    };
+    const pricedStt = rateSpendNanoUsd({
+      model: "openai/whisper-1",
+      usage: sttUsage,
+    });
+    expect(pricedStt.costNanoUsd).toBe(300_000);
+
+    const confirmed: ConfirmSpendCommandData = {
+      gateway_request_id: REQUEST,
+      occurred_at: T0 + 3800,
+      tenantId: TENANT,
+      model: "openai/tts-1",
+      model_provider_id: "mp_1",
+      usage: ttsUsage,
+      cost_nano_usd: pricedTts.costNanoUsd,
+      rate_version: pricedTts.rateVersion,
+      duration_ms: 1200,
+    };
+    const debit = intentPayloadFor(
+      (builder) => gatewayDebitsPM({} as never)(builder as never),
+      "writeDebits",
+      confirmed,
+    );
+    expect(debit.cost_nano_usd).toBe(pricedTts.costNanoUsd);
+  });
+
   it("the ledger, the budget debit, and the webhook envelope agree across a catalog change", () => {
     // The ingest seam prices the outcome once, against the catalog of the
     // moment, and stamps the figure onto the command it appends.

--- a/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/__tests__/spendPriceAgreement.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/__tests__/spendPriceAgreement.unit.test.ts
@@ -206,48 +206,52 @@ beforeEach(() => {
 
 describe("one price per gateway request", () => {
   /** @scenario The price is fixed when the outcome is recorded and every surface repeats it */
-  /** @scenario Character- and second-priced audio usage prices the same in billing as in observability */
-  it("audio outcomes price by characters and seconds instead of zero", () => {
-    const ttsUsage = {
-      input_tokens: 0,
-      output_tokens: 0,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-      reasoning_tokens: 0,
-      input_chars: 12000,
-      audio_seconds: 0,
-    };
-    const pricedTts = rateSpendNanoUsd({ model: "openai/tts-1", usage: ttsUsage });
-    expect(pricedTts.costNanoUsd).toBe(180_000_000);
+  describe("given an audio outcome", () => {
+    describe("when the spend is rated", () => {
+    /** @scenario Character- and second-priced audio usage prices the same in billing as in observability */
+    it("audio outcomes price by characters and seconds instead of zero", () => {
+      const ttsUsage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning_tokens: 0,
+        input_chars: 12000,
+        audio_seconds: 0,
+      };
+      const pricedTts = rateSpendNanoUsd({ model: "openai/tts-1", usage: ttsUsage });
+      expect(pricedTts.costNanoUsd).toBe(180_000_000);
 
-    const sttUsage = {
-      ...ttsUsage,
-      input_chars: 0,
-      audio_seconds: 3,
-    };
-    const pricedStt = rateSpendNanoUsd({
-      model: "openai/whisper-1",
-      usage: sttUsage,
+      const sttUsage = {
+        ...ttsUsage,
+        input_chars: 0,
+        audio_seconds: 3,
+      };
+      const pricedStt = rateSpendNanoUsd({
+        model: "openai/whisper-1",
+        usage: sttUsage,
+      });
+      expect(pricedStt.costNanoUsd).toBe(300_000);
+
+      const confirmed: ConfirmSpendCommandData = {
+        gateway_request_id: REQUEST,
+        occurred_at: T0 + 3800,
+        tenantId: TENANT,
+        model: "openai/tts-1",
+        model_provider_id: "mp_1",
+        usage: ttsUsage,
+        cost_nano_usd: pricedTts.costNanoUsd,
+        rate_version: pricedTts.rateVersion,
+        duration_ms: 1200,
+      };
+      const debit = intentPayloadFor(
+        (builder) => gatewayDebitsPM({} as never)(builder as never),
+        "writeDebits",
+        confirmed,
+      );
+      expect(debit.cost_nano_usd).toBe(pricedTts.costNanoUsd);
     });
-    expect(pricedStt.costNanoUsd).toBe(300_000);
-
-    const confirmed: ConfirmSpendCommandData = {
-      gateway_request_id: REQUEST,
-      occurred_at: T0 + 3800,
-      tenantId: TENANT,
-      model: "openai/tts-1",
-      model_provider_id: "mp_1",
-      usage: ttsUsage,
-      cost_nano_usd: pricedTts.costNanoUsd,
-      rate_version: pricedTts.rateVersion,
-      duration_ms: 1200,
-    };
-    const debit = intentPayloadFor(
-      (builder) => gatewayDebitsPM({} as never)(builder as never),
-      "writeDebits",
-      confirmed,
-    );
-    expect(debit.cost_nano_usd).toBe(pricedTts.costNanoUsd);
+    });
   });
 
   it("the ledger, the budget debit, and the webhook envelope agree across a catalog change", () => {

--- a/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/schemas/commands.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/schemas/commands.ts
@@ -57,6 +57,8 @@ export const spendUsageSchema = z.object({
   cache_read_input_tokens: z.number().int().min(0).default(0),
   cache_creation_input_tokens: z.number().int().min(0).default(0),
   reasoning_tokens: z.number().int().min(0).default(0),
+  input_chars: z.number().int().min(0).default(0),
+  audio_seconds: z.number().min(0).default(0),
 });
 export type SpendUsage = z.infer<typeof spendUsageSchema>;
 

--- a/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/services/spend-rating.service.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/services/spend-rating.service.ts
@@ -64,6 +64,8 @@ export function rateSpendNanoUsd({
         outputTokens: usage.output_tokens,
         cacheReadTokens: usage.cache_read_input_tokens,
         cacheCreationTokens: usage.cache_creation_input_tokens,
+        inputCharacters: usage.input_chars,
+        audioSeconds: usage.audio_seconds,
       })
     : 0;
   return {

--- a/services/aigateway/adapters/spendemitter/contract_test.go
+++ b/services/aigateway/adapters/spendemitter/contract_test.go
@@ -125,6 +125,36 @@ func TestContractConfirmedPayload(t *testing.T) {
 }
 
 /** @scenario The failed payload keeps the full error taxonomy */
+
+/** @scenario Audio usage quantities ride the spend wire for character- and second-priced models */
+func TestContractConfirmedAudioPayload(t *testing.T) {
+	s := openTestSpool(t, t.TempDir())
+	defer s.Close()
+	e := NewEmitter(s)
+
+	e.ConfirmSpend(pipeline.SpendOutcome{
+		GatewayRequestID: "req_audio",
+		OccurredAt:       time.Now(),
+		ProjectID:        "proj_x",
+		Usage: domain.Usage{
+			InputChars:   12000,
+			AudioSeconds: 3.4,
+		},
+		Model:           "openai/tts-1",
+		ModelProviderID: "mp_1",
+		Duration:        1200 * time.Millisecond,
+	})
+
+	records := drainRecords(t, s, 1)
+	require.Equal(t, "confirmSpend", records[0].Command)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(records[0].Payload, &payload))
+	usage, ok := payload["usage"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 12000, usage["input_chars"])
+	assert.EqualValues(t, 3.4, usage["audio_seconds"])
+}
+
 func TestContractFailedPayload(t *testing.T) {
 	s := openTestSpool(t, t.TempDir())
 	defer s.Close()

--- a/services/aigateway/adapters/spendemitter/record.go
+++ b/services/aigateway/adapters/spendemitter/record.go
@@ -34,15 +34,17 @@ type Record struct {
 	PodSeq  uint64          `json:"pod_seq"`
 }
 
-// UsagePayload is the token-class breakdown carried by confirm and fail
-// payloads. Token counts only: rating happens in the pipeline, so cost
-// never travels on this wire.
+// UsagePayload is the token and audio-quantity breakdown carried by confirm
+// and fail payloads. Quantities only: rating happens in the pipeline, so
+// cost never travels on this wire.
 type UsagePayload struct {
-	InputTokens         int `json:"input_tokens"`
-	OutputTokens        int `json:"output_tokens"`
-	CacheReadTokens     int `json:"cache_read_input_tokens"`
-	CacheCreationTokens int `json:"cache_creation_input_tokens"`
-	ReasoningTokens     int `json:"reasoning_tokens"`
+	InputTokens         int     `json:"input_tokens"`
+	OutputTokens        int     `json:"output_tokens"`
+	CacheReadTokens     int     `json:"cache_read_input_tokens"`
+	CacheCreationTokens int     `json:"cache_creation_input_tokens"`
+	ReasoningTokens     int     `json:"reasoning_tokens"`
+	InputChars          int     `json:"input_chars"`
+	AudioSeconds        float64 `json:"audio_seconds"`
 }
 
 // AdmittedPayload records that a request entered the gateway: identity and
@@ -113,5 +115,7 @@ func usageFromDomain(u domain.Usage, reasoning int) UsagePayload {
 		CacheReadTokens:     u.CacheReadTokens,
 		CacheCreationTokens: u.CacheCreationTokens,
 		ReasoningTokens:     reasoning,
+		InputChars:          u.InputChars,
+		AudioSeconds:        u.AudioSeconds,
 	}
 }


### PR DESCRIPTION
## Problem

Every call through the gateway audio endpoints (`POST /v1/audio/speech` and `POST /v1/audio/transcriptions`) was billed at zero. The gateway measures the quantity correctly (`InputChars` for TTS, `AudioSeconds` for STT on `domain.Usage`), but the spend wire carried only the five token counts, so the rater priced zero and `movedNothing` suppressed the outcome entirely. Budgets never moved for audio, while the trace explorer priced the same request correctly (observability and billing disagree on the same call).

Fixes #6934.

## Fix

- `services/aigateway/adapters/spendemitter/record.go`: `UsagePayload` now carries `input_chars` and `audio_seconds`; `usageFromDomain` copies them from `domain.Usage`.
- `schemas/commands.ts` + the two process-manager usage schemas (`gatewayDebits.process.ts`, `webhookDelivery.process.ts`): the two new fields, with `0` defaults so existing events parse unchanged.
- `spend-rating.service.ts`: `rateSpendNanoUsd` passes `inputCharacters` and `audioSeconds` into `estimateCost`, the same cascade the trace pipeline uses.
- `gatewayDebits.process.ts` `movedNothing`: an outcome with zero tokens but non-zero audio quantities is no longer treated as "nothing" and mints its debit.

## Test

- New Go contract test `TestContractConfirmedAudioPayload`: the wire carries `input_chars` and `audio_seconds`.
- New `spendPriceAgreement` case: TTS prices 12000 chars at `1.5e-05` to `180_000_000` nano-USD, STT prices 3 seconds at `1e-04` to `300_000` nano-USD, and the debit intent is emitted for the audio outcome.

```
cd services/aigateway && go test ./adapters/spendemitter/...
ok  	github.com/langwatch/langwatch/services/aigateway/adapters/spendemitter
pnpm test:unit src/server/event-sourcing/pipelines/gateway-spend-processing/__tests__/spendPriceAgreement.unit.test.ts
2 passed
pnpm test:unit src/server/event-sourcing/pipelines/gateway-spend-processing/__tests__/spendCommandSchemas.unit.test.ts
3 passed
```

`gofmt` clean on both Go files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking input character usage and audio duration alongside token usage.
  - Preserved character and audio usage in spend, webhook, and gateway debit records.
  - Added pricing support for text-to-speech character usage and speech-to-text audio duration.

- **Bug Fixes**
  - Activities with character or audio usage are no longer incorrectly discarded.
  - Confirmed spend payloads now retain audio and character usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->