### PR TITLE
perf(navigation): the scenario library fetches the editor before the click

### DIFF
--- a/platform/app/src/components/__tests__/drawerRegistry.preload.integration.test.tsx
+++ b/platform/app/src/components/__tests__/drawerRegistry.preload.integration.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * specs/navigation/drawer-chunk-warmup.feature
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const { promptListLoads } = vi.hoisted(() => ({
+  promptListLoads: { count: 0 },
+}));
+
+vi.mock("~/components/scenarios/ScenarioFormDrawer", () => ({
+  ScenarioFormDrawerFromUrl: () => <div data-testid="scenario-editor" />,
+}));
+
+vi.mock("~/components/prompts/PromptListDrawer", () => {
+  promptListLoads.count += 1;
+  // The first load fails the way a file that a deploy removed does.
+  if (promptListLoads.count === 1) {
+    throw new Error("Failed to fetch dynamically imported module");
+  }
+  return { PromptListDrawer: () => <div data-testid="prompt-list" /> };
+});
+
+import { drawers, preloadDrawer } from "../drawerRegistry";
+
+const renderDrawer = (Drawer: React.FC<any>) =>
+  render(
+    <Suspense fallback={<div data-testid="spinner" />}>
+      <Drawer />
+    </Suspense>,
+  );
+
+describe("preloadDrawer", () => {
+  describe("given a drawer whose code is already fetched", () => {
+    describe("when it is opened", () => {
+      /** @scenario "A warmed drawer opens with no spinner in between" */
+      it("renders at once", async () => {
+        await preloadDrawer("scenarioEditor");
+
+        renderDrawer(drawers.scenarioEditor);
+
+        expect(screen.getByTestId("scenario-editor")).toBeInTheDocument();
+        expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given a warm-up that could not fetch the code", () => {
+    describe("when the drawer is opened later", () => {
+      /** @scenario "A drawer whose warm-up failed can still be opened" */
+      it("fetches the code again and opens", async () => {
+        await expect(preloadDrawer("promptList")).resolves.toBeUndefined();
+
+        renderDrawer(drawers.promptList);
+
+        expect(screen.getByTestId("spinner")).toBeInTheDocument();
+        await waitFor(() =>
+          expect(screen.getByTestId("prompt-list")).toBeInTheDocument(),
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/components/drawerRegistry.ts
+++ b/platform/app/src/components/drawerRegistry.ts
@@ -13,7 +13,11 @@
  */
 import { type ComponentProps, type FC, lazy } from "react";
 
+import { warmChunk } from "~/utils/chunkReload";
 import type { TraceV2DrawerShellProps } from "../features/traces-v2/components/TraceDrawer";
+
+/** The import behind each lazy drawer, so a screen can fetch it early. */
+const chunkFactories = new WeakMap<object, () => Promise<unknown>>();
 
 const lazyDefault = <K extends string, T extends { [P in K]: React.FC<any> }>({
   factory,
@@ -27,6 +31,7 @@ const lazyDefault = <K extends string, T extends { [P in K]: React.FC<any> }>({
   // and regression tests (e.g. scenariosIndexNoDoubleDrawer) can still
   // identify the underlying drawer.
   Object.defineProperty(Component, "name", { value: key });
+  chunkFactories.set(Component, factory);
   return Component;
 };
 
@@ -326,6 +331,61 @@ export const drawers = {
  * Union type of all registered drawer names.
  */
 export type DrawerType = keyof typeof drawers;
+
+/**
+ * Fetch a drawer's code before something opens it.
+ *
+ * Each drawer is its own download, so the first open of one waits on the
+ * network with only the Suspense spinner on screen. A screen that knows which
+ * drawer its rows open warms it while the person is still reading, and the
+ * click then opens the drawer straight away. The bundler keeps the module, so
+ * a repeat call costs nothing, and `traceV2Details` has no chunk of its own to
+ * warm because its shell is mounted by the page.
+ */
+export function preloadDrawer(type: DrawerType): Promise<void> {
+  const component = drawers[type];
+  const factory = chunkFactories.get(component);
+  if (!factory) return Promise.resolve();
+
+  return warmChunk(factory).then((loaded) =>
+    loaded ? primeLazyComponent(component) : undefined,
+  );
+}
+
+/**
+ * Tell a `lazy()` wrapper that its module is already here.
+ *
+ * The wrapper keeps its own loaded state, apart from the module cache, so a
+ * warmed drawer still suspends on its first render and paints the spinner for
+ * a moment. Reading the wrapper once outside render settles that state, and
+ * the drawer then renders on the first try. The read throws the promise the
+ * wrapper is waiting on, which is how a `lazy()` reports that it is not ready
+ * yet, so the throw is the expected path and not a failure. Waiting on that
+ * promise is what makes the drawer ready by the time this resolves.
+ *
+ * Called only once the module is in memory: a wrapper that is told to load and
+ * fails remembers the failure for the life of the page, which would turn a
+ * warm-up that lost the network into a drawer that can never open.
+ */
+function primeLazyComponent(component: object): Promise<void> {
+  const wrapper = component as {
+    _init?: (payload: unknown) => unknown;
+    _payload?: unknown;
+  };
+  if (typeof wrapper._init !== "function") return Promise.resolve();
+
+  try {
+    wrapper._init(wrapper._payload);
+    return Promise.resolve();
+  } catch (pending) {
+    return pending instanceof Promise
+      ? pending.then(
+          () => undefined,
+          () => undefined,
+        )
+      : Promise.resolve();
+  }
+}
 
 /**
  * Get the props type for a specific drawer.

--- a/platform/app/src/components/suites/SimulationsPage.tsx
+++ b/platform/app/src/components/suites/SimulationsPage.tsx
@@ -44,6 +44,7 @@ import { HandledErrorAlert, showErrorToast } from "~/features/errors";
 import type { SimulationSuite } from "~/generated/prisma/client";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { usePreloadDrawer } from "~/hooks/usePreloadDrawer";
 import { useScenarioTabFollow } from "~/hooks/useScenarioTabFollow";
 import { useSimulationUpdateListener } from "~/hooks/useSimulationUpdateListener";
 import type { ScenarioTabNavigatePayload } from "~/server/scenarios/browser-tab/scenario-tab-events";
@@ -55,6 +56,10 @@ import { NowProvider } from "./NowProvider";
 export default function SimulationsPage() {
   const { project } = useOrganizationTeamProject();
   const { openDrawer, setFlowCallbacks } = useDrawer();
+  // The rows open a run's detail and the sidebar opens the run plan editor,
+  // both separate downloads. Fetch them while the person reads the runs, so
+  // the click opens the drawer rather than a spinner.
+  usePreloadDrawer("scenarioRunDetail", "suiteEditor");
   const utils = api.useUtils();
   const { selectedSuiteSlug, navigateToSuite, highlightBatchId } =
     useSuiteRouting();

--- a/platform/app/src/components/suites/__tests__/SimulationsPageDrawerWarmup.integration.test.tsx
+++ b/platform/app/src/components/suites/__tests__/SimulationsPageDrawerWarmup.integration.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The runs page opens two drawers: a run's detail from the rows, and the run
+ * plan editor from the sidebar. Both are separate downloads, so without a
+ * warm-up the click waits for the network with only the drawer spinner on
+ * screen.
+ *
+ * specs/navigation/drawer-chunk-warmup.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SimulationsPage from "~/components/suites/SimulationsPage";
+
+const { preloadDrawer } = vi.hoisted(() => ({
+  preloadDrawer: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("~/components/drawerRegistry", () => ({ preloadDrawer }));
+
+vi.mock("~/components/SetupWithAgentButton", () => ({
+  SetupWithAgentButton: () => null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      suites: {
+        getAll: { invalidate: vi.fn() },
+        getSummaries: { invalidate: vi.fn() },
+      },
+    }),
+    suites: {
+      getAll: { useQuery: () => ({ data: [], isLoading: false, error: null }) },
+      getSummaries: { useQuery: () => ({ data: {}, isLoading: false }) },
+      archive: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      duplicate: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      run: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    scenarios: {
+      getSuiteRunData: {
+        useQuery: () => ({
+          data: { runs: [], scenarioSetIds: {}, hasMore: false },
+          isLoading: false,
+          error: null,
+        }),
+      },
+      getExternalSetSummaries: {
+        useQuery: () => ({ data: [], isLoading: false, error: null }),
+      },
+      getAll: { useQuery: () => ({ data: [], isLoading: false, error: null }) },
+      cancelJob: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      cancelBatchRun: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project_1", slug: "my-project" },
+    hasAnyPermission: () => true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn(), setFlowCallbacks: vi.fn() }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: { project: "my-project" },
+    pathname: "/[project]/simulations/[[...path]]",
+    asPath: "/my-project/simulations",
+    push: vi.fn(),
+    replace: vi.fn(),
+    isReady: true,
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+  }),
+}));
+
+vi.mock("~/hooks/useSimulationUpdateListener", () => ({
+  useSimulationUpdateListener: () => {},
+}));
+
+vi.mock("~/components/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/components/suites/RunHistoryPanel", () => ({
+  RunHistoryPanel: () => <div />,
+}));
+
+let idleCallbacks: Array<(() => void) | undefined> = [];
+
+const becomeIdle = () => {
+  for (const callback of idleCallbacks) callback?.();
+};
+
+beforeEach(() => {
+  preloadDrawer.mockClear();
+  idleCallbacks = [];
+  vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+    idleCallbacks.push(callback);
+    return idleCallbacks.length;
+  });
+  vi.stubGlobal("cancelIdleCallback", (handle: number) => {
+    idleCallbacks[handle - 1] = undefined;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Runs page", () => {
+  describe("given the runs page is on screen", () => {
+    describe("when the browser becomes idle", () => {
+      /** @scenario "The runs page warms the drawers its rows and sidebar open" */
+      it("fetches the code of the run detail and the run plan editor", () => {
+        render(
+          <ChakraProvider value={defaultSystem}>
+            <SimulationsPage />
+          </ChakraProvider>,
+        );
+
+        becomeIdle();
+
+        expect(preloadDrawer).toHaveBeenCalledWith("scenarioRunDetail");
+        expect(preloadDrawer).toHaveBeenCalledWith("suiteEditor");
+      });
+    });
+  });
+});

--- a/platform/app/src/hooks/__tests__/usePreloadDrawer.unit.test.ts
+++ b/platform/app/src/hooks/__tests__/usePreloadDrawer.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * specs/navigation/drawer-chunk-warmup.feature
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { preloadDrawer } = vi.hoisted(() => ({
+  preloadDrawer: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("~/components/drawerRegistry", () => ({ preloadDrawer }));
+
+import { usePreloadDrawer } from "../usePreloadDrawer";
+
+let idleCallbacks: Array<(() => void) | undefined> = [];
+
+const becomeIdle = () => {
+  for (const callback of idleCallbacks) callback?.();
+};
+
+beforeEach(() => {
+  preloadDrawer.mockClear();
+  idleCallbacks = [];
+  // jsdom has no idle callback of its own, so the hook would take its
+  // timer fallback and the idle path would never be exercised.
+  vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+    idleCallbacks.push(callback);
+    return idleCallbacks.length;
+  });
+  vi.stubGlobal("cancelIdleCallback", (handle: number) => {
+    idleCallbacks[handle - 1] = undefined;
+  });
+});
+
+afterEach(() => {
+  // Unmount first: the hook cancels its idle callback on the way out, and the
+  // stub has to still be there when it does.
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("usePreloadDrawer", () => {
+  describe("given a screen that warms a drawer", () => {
+    describe("when the screen renders", () => {
+      /** @scenario "The warm-up waits for the browser to be idle" */
+      it("fetches no code yet", () => {
+        renderHook(() => usePreloadDrawer("scenarioEditor"));
+
+        expect(preloadDrawer).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the browser becomes idle", () => {
+      it("fetches the drawer's code", () => {
+        renderHook(() => usePreloadDrawer("scenarioEditor"));
+
+        becomeIdle();
+
+        expect(preloadDrawer).toHaveBeenCalledWith("scenarioEditor");
+      });
+    });
+
+    describe("when the screen closes before the browser is idle", () => {
+      /** @scenario "Leaving the screen cancels a warm-up that has not started" */
+      it("fetches no code", () => {
+        const { unmount } = renderHook(() =>
+          usePreloadDrawer("scenarioEditor"),
+        );
+
+        unmount();
+        becomeIdle();
+
+        expect(preloadDrawer).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a screen that warms two drawers", () => {
+    describe("when the browser becomes idle", () => {
+      it("fetches both", () => {
+        renderHook(() =>
+          usePreloadDrawer("scenarioEditor", "scenarioRunDetail"),
+        );
+
+        becomeIdle();
+
+        expect(preloadDrawer).toHaveBeenCalledWith("scenarioEditor");
+        expect(preloadDrawer).toHaveBeenCalledWith("scenarioRunDetail");
+      });
+    });
+  });
+
+  describe("given a browser without idle callbacks", () => {
+    describe("when the wait elapses", () => {
+      it("fetches the drawer's code anyway", () => {
+        vi.stubGlobal("requestIdleCallback", undefined);
+        vi.useFakeTimers();
+
+        try {
+          renderHook(() => usePreloadDrawer("scenarioEditor"));
+          expect(preloadDrawer).not.toHaveBeenCalled();
+
+          vi.advanceTimersByTime(1_000);
+
+          expect(preloadDrawer).toHaveBeenCalledWith("scenarioEditor");
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+    });
+  });
+});

--- a/platform/app/src/hooks/usePreloadDrawer.ts
+++ b/platform/app/src/hooks/usePreloadDrawer.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { type DrawerType, preloadDrawer } from "~/components/drawerRegistry";
+
+/**
+ * Upper bound on the wait for an idle moment. A screen that never goes idle
+ * still warms its drawers, only later than a quiet one.
+ */
+const IDLE_TIMEOUT_MS = 2_000;
+
+/** The wait on browsers that have no idle callback. */
+const IDLE_FALLBACK_MS = 500;
+
+/**
+ * Fetch the code of the drawers this screen opens, once the browser is idle.
+ *
+ * Idle rather than on mount: the screen's own data is what the person waits
+ * for, and a warm-up next to it competes for the same connections and makes
+ * the visible wait longer. See `preloadDrawer` for what the warm-up buys.
+ */
+export function usePreloadDrawer(...types: DrawerType[]): void {
+  // The rest parameter is a new array on every render. The joined names are
+  // the stable identity of the list.
+  const typeList = types.join(",");
+
+  useEffect(() => {
+    if (!typeList) return;
+
+    const warm = () => {
+      for (const type of typeList.split(",") as DrawerType[]) {
+        void preloadDrawer(type);
+      }
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      const handle = window.requestIdleCallback(warm, {
+        timeout: IDLE_TIMEOUT_MS,
+      });
+      return () => window.cancelIdleCallback(handle);
+    }
+
+    const handle = window.setTimeout(warm, IDLE_FALLBACK_MS);
+    return () => window.clearTimeout(handle);
+  }, [typeList]);
+}

--- a/platform/app/src/pages/[project]/simulations/scenarios/index.tsx
+++ b/platform/app/src/pages/[project]/simulations/scenarios/index.tsx
@@ -26,11 +26,16 @@ import { useNewScenarioFlow } from "~/hooks/scenarios/useNewScenarioFlow";
 import { useScenarioSelection } from "~/hooks/scenarios/useScenarioSelection";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { usePreloadDrawer } from "~/hooks/usePreloadDrawer";
 import { api } from "~/utils/api";
 
 function ScenarioLibraryPage() {
   const { project } = useOrganizationTeamProject();
   const { openDrawer } = useDrawer();
+  // Every row here opens the scenario editor, which is a separate download.
+  // Fetch it while the person reads the list, so the click opens the editor
+  // rather than a spinner.
+  usePreloadDrawer("scenarioEditor");
   const {
     rowSelection,
     onRowSelectionChange,

--- a/platform/app/src/pages/__tests__/scenariosIndexDrawerWarmup.integration.test.tsx
+++ b/platform/app/src/pages/__tests__/scenariosIndexDrawerWarmup.integration.test.tsx
@@ -11,6 +11,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ScenarioLibraryPage from "../[project]/simulations/scenarios/index";
 
 const { preloadDrawer } = vi.hoisted(() => ({
   preloadDrawer: vi.fn(() => Promise.resolve()),
@@ -82,10 +83,6 @@ vi.mock("~/utils/api", () => ({
     },
   },
 }));
-
-const ScenarioLibraryPage = (
-  await import("../[project]/simulations/scenarios/index")
-).default;
 
 let idleCallbacks: Array<(() => void) | undefined> = [];
 

--- a/platform/app/src/pages/__tests__/scenariosIndexDrawerWarmup.integration.test.tsx
+++ b/platform/app/src/pages/__tests__/scenariosIndexDrawerWarmup.integration.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The scenario library's rows open the scenario editor, which is a separate
+ * download. Without a warm-up the click shows the drawer spinner while the
+ * browser fetches the code.
+ *
+ * specs/navigation/drawer-chunk-warmup.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { preloadDrawer } = vi.hoisted(() => ({
+  preloadDrawer: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("~/components/drawerRegistry", () => ({ preloadDrawer }));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: {}, push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    project: { id: "proj-1", slug: "test-project" },
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    closeDrawer: vi.fn(),
+    drawerOpen: () => false,
+  }),
+}));
+
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard:
+    () =>
+    <P extends object>(Component: (props: P) => ReactNode) =>
+    (props: P) =>
+      Component(props),
+}));
+
+vi.mock("~/components/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/components/scenarios/ScenarioCreateModal", () => ({
+  ScenarioCreateModal: () => null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({ scenarios: { getAll: { invalidate: vi.fn() } } }),
+    scenarios: {
+      getAll: {
+        useQuery: () => ({
+          data: [
+            {
+              id: "scenario-1",
+              name: "Refund Request Test",
+              labels: ["quality"],
+              updatedAt: new Date("2026-07-23T16:03:00Z"),
+            },
+          ],
+          isLoading: false,
+          error: null,
+        }),
+      },
+      archive: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      batchArchive: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}));
+
+const ScenarioLibraryPage = (
+  await import("../[project]/simulations/scenarios/index")
+).default;
+
+let idleCallbacks: Array<(() => void) | undefined> = [];
+
+const becomeIdle = () => {
+  for (const callback of idleCallbacks) callback?.();
+};
+
+beforeEach(() => {
+  preloadDrawer.mockClear();
+  idleCallbacks = [];
+  vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+    idleCallbacks.push(callback);
+    return idleCallbacks.length;
+  });
+  vi.stubGlobal("cancelIdleCallback", (handle: number) => {
+    idleCallbacks[handle - 1] = undefined;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Scenario library page", () => {
+  describe("given the scenario library is on screen", () => {
+    describe("when the browser becomes idle", () => {
+      /** @scenario "The scenario library warms the scenario editor" */
+      it("fetches the scenario editor's code", () => {
+        render(
+          <ChakraProvider value={defaultSystem}>
+            <ScenarioLibraryPage />
+          </ChakraProvider>,
+        );
+
+        becomeIdle();
+
+        expect(preloadDrawer).toHaveBeenCalledWith("scenarioEditor");
+      });
+    });
+  });
+});

--- a/platform/app/src/utils/chunkReload.test.ts
+++ b/platform/app/src/utils/chunkReload.test.ts
@@ -189,28 +189,30 @@ describe("warmChunk", () => {
     });
   });
 
-  describe("when another import fails while a warm-up is in flight", () => {
-    /** @scenario "A stale file for a waiting screen reloads during a warm-up" */
-    it("reloads the page for the import somebody is waiting for", async () => {
-      registerChunkReloadListener();
+  describe("given a warm-up is in flight", () => {
+    describe("when another import fails because the file is gone", () => {
+      /** @scenario "A stale file for a waiting screen reloads during a warm-up" */
+      it("reloads the page for the import somebody is waiting for", async () => {
+        registerChunkReloadListener();
 
-      let finishWarmup = () => {};
-      const warmup = warmChunk(
-        () =>
-          new Promise<void>((resolve) => {
-            finishWarmup = resolve;
-          }),
-      );
+        let finishWarmup = () => {};
+        const warmup = warmChunk(
+          () =>
+            new Promise<void>((resolve) => {
+              finishWarmup = resolve;
+            }),
+        );
 
-      // A drawer the person just opened asks for a stale file. This error is
-      // not the warm-up's, so recovery must still run.
-      window.dispatchEvent(preloadErrorEvent(staleChunkError()));
+        // A drawer the person just opened asks for a stale file. This error is
+        // not the warm-up's, so recovery must still run.
+        window.dispatchEvent(preloadErrorEvent(staleChunkError()));
 
-      finishWarmup();
-      await warmup;
-      await settleDeferredReload();
+        finishWarmup();
+        await warmup;
+        await settleDeferredReload();
 
-      expect(reloaded()).toBe(true);
+        expect(reloaded()).toBe(true);
+      });
     });
   });
 

--- a/platform/app/src/utils/chunkReload.test.ts
+++ b/platform/app/src/utils/chunkReload.test.ts
@@ -15,6 +15,22 @@ import {
 const RELOAD_AT = "chunk-reload-at";
 const reloaded = () => sessionStorage.getItem(RELOAD_AT) !== null;
 
+/**
+ * The event Vite dispatches from its preload helper. `payload` is the error it
+ * is about to throw, and it is the only field that says which import failed.
+ */
+const preloadErrorEvent = (payload: Error) =>
+  Object.assign(new Event("vite:preloadError", { cancelable: true }), {
+    payload,
+  });
+
+const staleChunkError = () =>
+  new Error("Failed to fetch dynamically imported module");
+
+/** Let the listener's deferred reload decision run. */
+const settleDeferredReload = () =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
 describe("isChunkLoadError", () => {
   describe("when the message is a Vite dynamic-import failure", () => {
     it("classifies it as a chunk-load error", () => {
@@ -125,7 +141,7 @@ describe("registerChunkReloadListener", () => {
     it("reloads the page once to fetch the new chunk hashes", () => {
       registerChunkReloadListener();
 
-      const event = new Event("vite:preloadError", { cancelable: true });
+      const event = preloadErrorEvent(staleChunkError());
       window.dispatchEvent(event);
 
       expect(event.defaultPrevented).toBe(true);
@@ -139,7 +155,7 @@ describe("registerChunkReloadListener", () => {
       sessionStorage.setItem(RELOAD_AT, "9999999999999");
       registerChunkReloadListener();
 
-      const event = new Event("vite:preloadError", { cancelable: true });
+      const event = preloadErrorEvent(staleChunkError());
       window.dispatchEvent(event);
 
       // No reload scheduled → Vite's error must NOT be preventDefault()'d.
@@ -158,18 +174,43 @@ describe("warmChunk", () => {
     it("does not reload the page", async () => {
       registerChunkReloadListener();
 
-      await warmChunk(() => {
+      const loaded = await warmChunk(() => {
         // Vite fires the event from its preload helper, then rejects the
-        // import, so the warm-up is still in flight when the listener runs.
-        window.dispatchEvent(
-          new Event("vite:preloadError", { cancelable: true }),
-        );
-        return Promise.reject(
-          new Error("Failed to fetch dynamically imported module"),
-        );
+        // import with the same error, so the warm-up is still in flight when
+        // the listener runs.
+        const failure = staleChunkError();
+        window.dispatchEvent(preloadErrorEvent(failure));
+        return Promise.reject(failure);
       });
+      await settleDeferredReload();
 
+      expect(loaded).toBe(false);
       expect(reloaded()).toBe(false);
+    });
+  });
+
+  describe("when another import fails while a warm-up is in flight", () => {
+    /** @scenario "A stale file for a waiting screen reloads during a warm-up" */
+    it("reloads the page for the import somebody is waiting for", async () => {
+      registerChunkReloadListener();
+
+      let finishWarmup = () => {};
+      const warmup = warmChunk(
+        () =>
+          new Promise<void>((resolve) => {
+            finishWarmup = resolve;
+          }),
+      );
+
+      // A drawer the person just opened asks for a stale file. This error is
+      // not the warm-up's, so recovery must still run.
+      window.dispatchEvent(preloadErrorEvent(staleChunkError()));
+
+      finishWarmup();
+      await warmup;
+      await settleDeferredReload();
+
+      expect(reloaded()).toBe(true);
     });
   });
 
@@ -178,9 +219,7 @@ describe("warmChunk", () => {
       registerChunkReloadListener();
       await warmChunk(() => Promise.resolve());
 
-      window.dispatchEvent(
-        new Event("vite:preloadError", { cancelable: true }),
-      );
+      window.dispatchEvent(preloadErrorEvent(staleChunkError()));
 
       expect(reloaded()).toBe(true);
     });

--- a/platform/app/src/utils/chunkReload.test.ts
+++ b/platform/app/src/utils/chunkReload.test.ts
@@ -5,6 +5,7 @@ import {
   isChunkLoadError,
   registerChunkReloadListener,
   reloadOnChunkError,
+  warmChunk,
 } from "./chunkReload";
 
 // jsdom locks down window.location (non-configurable, can't be deleted, redefined
@@ -120,6 +121,7 @@ describe("registerChunkReloadListener", () => {
   });
 
   describe("when Vite dispatches vite:preloadError for a stale chunk", () => {
+    /** @scenario "A stale file outside a warm-up still reloads the page" */
     it("reloads the page once to fetch the new chunk hashes", () => {
       registerChunkReloadListener();
 
@@ -142,6 +144,45 @@ describe("registerChunkReloadListener", () => {
 
       // No reload scheduled → Vite's error must NOT be preventDefault()'d.
       expect(event.defaultPrevented).toBe(false);
+    });
+  });
+});
+
+describe("warmChunk", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe("when a warm-up asks for a file that is gone", () => {
+    /** @scenario "A stale file during a warm-up does not reload the page" */
+    it("does not reload the page", async () => {
+      registerChunkReloadListener();
+
+      await warmChunk(() => {
+        // Vite fires the event from its preload helper, then rejects the
+        // import, so the warm-up is still in flight when the listener runs.
+        window.dispatchEvent(
+          new Event("vite:preloadError", { cancelable: true }),
+        );
+        return Promise.reject(
+          new Error("Failed to fetch dynamically imported module"),
+        );
+      });
+
+      expect(reloaded()).toBe(false);
+    });
+  });
+
+  describe("when the warm-up has finished", () => {
+    it("leaves a later stale chunk to reload the page", async () => {
+      registerChunkReloadListener();
+      await warmChunk(() => Promise.resolve());
+
+      window.dispatchEvent(
+        new Event("vite:preloadError", { cancelable: true }),
+      );
+
+      expect(reloaded()).toBe(true);
     });
   });
 });

--- a/platform/app/src/utils/chunkReload.ts
+++ b/platform/app/src/utils/chunkReload.ts
@@ -65,14 +65,24 @@ export function reloadOnChunkError(err: unknown): boolean {
 let warmupsInFlight = 0;
 
 /**
+ * The errors that warm-ups caught, so the listener below can tell a download
+ * nobody waits for apart from one that a screen is held up by.
+ *
+ * A `WeakSet` keeps no error alive: an entry goes away with the error itself.
+ * A claim that outlives its event is harmless, because Vite builds a new error
+ * for every failed import, so no later event can carry the same one.
+ */
+const warmupFailures = new WeakSet<object>();
+
+/**
  * Run a chunk download that no screen is waiting for, such as a page fetching
  * the code of a drawer its rows open. Reports whether the code arrived.
  *
  * A warm-up asks for a content-hashed file the same way a real lazy import
  * does, so after a deploy it hits the same stale hash and fires the same
  * `vite:preloadError`. Reloading the page for it would take the screen away
- * from a person who asked for nothing, so the listener below stands down while
- * a warm-up is in flight. The next import of that chunk still recovers, at the
+ * from a person who asked for nothing, so the listener below drops the failures
+ * this function claims. The next import of that chunk still recovers, at the
  * point where somebody is waiting for it.
  */
 export async function warmChunk(
@@ -82,10 +92,14 @@ export async function warmChunk(
   try {
     await load();
     return true;
-  } catch {
-    // Nothing on screen is waiting for this, so there is nothing to report to.
-    // The open that needs the chunk reports its own failure. The caller gets
-    // `false` so it can leave everything as it was.
+  } catch (error) {
+    // Claim the failure as this warm-up's own. Nothing on screen is waiting for
+    // it, so there is nothing to report to: the open that needs the chunk
+    // reports its own failure. The caller gets `false` so it can leave
+    // everything as it was.
+    if (typeof error === "object" && error !== null) {
+      warmupFailures.add(error);
+    }
     return false;
   } finally {
     warmupsInFlight -= 1;
@@ -100,11 +114,35 @@ export async function warmChunk(
 export function registerChunkReloadListener(): void {
   if (typeof window === "undefined") return;
   window.addEventListener("vite:preloadError", (event) => {
-    if (warmupsInFlight > 0) return;
-    // Only suppress Vite's error when we actually scheduled a reload. If we're
-    // inside the cooldown (forceReloadOnce returns false), let the error
-    // propagate to the error boundary instead of swallowing it — otherwise the
-    // lazy import gets neither recovery nor the normal failure path.
-    if (forceReloadOnce()) event.preventDefault();
+    if (warmupsInFlight === 0) {
+      // Only suppress Vite's error when we actually scheduled a reload. If we're
+      // inside the cooldown (forceReloadOnce returns false), let the error
+      // propagate to the error boundary instead of swallowing it — otherwise the
+      // lazy import gets neither recovery nor the normal failure path.
+      if (forceReloadOnce()) event.preventDefault();
+      return;
+    }
+
+    // A warm-up is running, so this failure is either its own or belongs to
+    // something a person is waiting for. The event says which import failed
+    // only through `payload`, the error Vite is about to throw, so read the
+    // answer from `warmChunk` instead: it claims the errors it catches, and a
+    // timer runs after every promise callback, so the claim is in by then.
+    //
+    // An unclaimed failure reloads, which keeps recovery for a stale chunk that
+    // a warm-up happens to run next to. An event with no `payload` counts as
+    // unclaimed for the same reason: recovery is the more expensive one to
+    // lose.
+    //
+    // The error is left to propagate either way. A warm-up reports nothing, and
+    // a real open keeps its normal failure path until the reload lands.
+    const { payload } = event as { payload?: unknown };
+    setTimeout(() => {
+      const claimed =
+        typeof payload === "object" &&
+        payload !== null &&
+        warmupFailures.has(payload);
+      if (!claimed) forceReloadOnce();
+    }, 0);
   });
 }

--- a/platform/app/src/utils/chunkReload.ts
+++ b/platform/app/src/utils/chunkReload.ts
@@ -62,6 +62,36 @@ export function reloadOnChunkError(err: unknown): boolean {
   return true;
 }
 
+let warmupsInFlight = 0;
+
+/**
+ * Run a chunk download that no screen is waiting for, such as a page fetching
+ * the code of a drawer its rows open. Reports whether the code arrived.
+ *
+ * A warm-up asks for a content-hashed file the same way a real lazy import
+ * does, so after a deploy it hits the same stale hash and fires the same
+ * `vite:preloadError`. Reloading the page for it would take the screen away
+ * from a person who asked for nothing, so the listener below stands down while
+ * a warm-up is in flight. The next import of that chunk still recovers, at the
+ * point where somebody is waiting for it.
+ */
+export async function warmChunk(
+  load: () => Promise<unknown>,
+): Promise<boolean> {
+  warmupsInFlight += 1;
+  try {
+    await load();
+    return true;
+  } catch {
+    // Nothing on screen is waiting for this, so there is nothing to report to.
+    // The open that needs the chunk reports its own failure. The caller gets
+    // `false` so it can leave everything as it was.
+    return false;
+  } finally {
+    warmupsInFlight -= 1;
+  }
+}
+
 /**
  * Register the global recovery for component-level lazy imports. Vite fires
  * `vite:preloadError` on `window` whenever a dynamically imported chunk fails
@@ -70,6 +100,7 @@ export function reloadOnChunkError(err: unknown): boolean {
 export function registerChunkReloadListener(): void {
   if (typeof window === "undefined") return;
   window.addEventListener("vite:preloadError", (event) => {
+    if (warmupsInFlight > 0) return;
     // Only suppress Vite's error when we actually scheduled a reload. If we're
     // inside the cooldown (forceReloadOnce returns false), let the error
     // propagate to the error boundary instead of swallowing it — otherwise the

--- a/specs/navigation/drawer-chunk-warmup.feature
+++ b/specs/navigation/drawer-chunk-warmup.feature
@@ -17,6 +17,15 @@ Feature: A screen fetches a drawer's code before the person opens it
       When the browser becomes idle
       Then the scenario editor's code is fetched
 
+    # A screen warms every drawer it opens, not only the one its rows open. The
+    # runs page opens a run's detail from the rows and the run plan editor from
+    # the sidebar, and both wait on the same kind of download.
+    @integration
+    Scenario: The runs page warms the drawers its rows and sidebar open
+      Given the runs page is on screen
+      When the browser becomes idle
+      Then the code of the run detail and the run plan editor is fetched
+
     # Fetching the code is not the whole of it. A drawer keeps its own record of
     # whether it is ready, so a drawer whose code is in memory still reports
     # itself as not ready on the first render and shows the spinner for a

--- a/specs/navigation/drawer-chunk-warmup.feature
+++ b/specs/navigation/drawer-chunk-warmup.feature
@@ -67,3 +67,13 @@ Feature: A screen fetches a drawer's code before the person opens it
       Given no warm-up is in flight
       When a download fails because the file is gone
       Then the page reloads once
+
+    # A warm-up runs in the background, so a person can open a drawer while one
+    # is still going. Standing down for the whole of a warm-up would take the
+    # recovery away from that open as well, so the page tells the two apart and
+    # stands down only for the warm-up's own download.
+    @unit
+    Scenario: A stale file for a waiting screen reloads during a warm-up
+      Given a warm-up is in flight
+      When another download fails because the file is gone
+      Then the page reloads once

--- a/specs/navigation/drawer-chunk-warmup.feature
+++ b/specs/navigation/drawer-chunk-warmup.feature
@@ -1,0 +1,69 @@
+Feature: A screen fetches a drawer's code before the person opens it
+
+  Every drawer is a separate download, fetched the first time something opens
+  it. Until it arrives the page can show only a spinner where the drawer will
+  be, so a click on a table row looks like it did nothing for as long as the
+  download takes.
+
+  A screen knows which drawer its rows open. It fetches that code while the
+  person is still reading the list, and the click then opens the drawer with
+  no download in the way.
+
+  Rule: A screen warms the drawers it opens
+
+    @integration
+    Scenario: The scenario library warms the scenario editor
+      Given the scenario library is on screen
+      When the browser becomes idle
+      Then the scenario editor's code is fetched
+
+    # Fetching the code is not the whole of it. A drawer keeps its own record of
+    # whether it is ready, so a drawer whose code is in memory still reports
+    # itself as not ready on the first render and shows the spinner for a
+    # moment. The warm-up settles that record as well.
+    @integration
+    Scenario: A warmed drawer opens with no spinner in between
+      Given a drawer whose code is already fetched
+      When it is opened
+      Then it renders at once
+
+    # The data the person waits for comes first. A warm-up that starts with the
+    # screen's own queries competes with them and makes the visible wait longer.
+    @unit
+    Scenario: The warm-up waits for the browser to be idle
+      Given a screen that warms a drawer
+      When the screen renders
+      Then no code is fetched yet
+
+    @unit
+    Scenario: Leaving the screen cancels a warm-up that has not started
+      Given a screen that warms a drawer
+      When the screen closes before the browser is idle
+      Then no code is fetched
+
+  # A warm-up downloads a file the same way an open does, so after a deploy it
+  # can ask for a file name that no longer exists. The recovery for that is a
+  # page reload, which is correct for a person waiting on a drawer and wrong
+  # for a person reading a list who asked for nothing.
+  Rule: A failed warm-up does not take the page away
+
+    @unit
+    Scenario: A stale file during a warm-up does not reload the page
+      Given a warm-up is in flight
+      When the download fails because the file is gone
+      Then the page is not reloaded
+
+    # The drawer must not remember the failed warm-up either: a drawer that
+    # records itself as failed keeps that answer for the life of the page, so
+    # one lost download would leave a drawer that can never open.
+    @integration
+    Scenario: A drawer whose warm-up failed can still be opened
+      Given a warm-up that could not fetch the code
+      When the drawer is opened later
+      Then the code is fetched again and the drawer opens
+
+    @unit
+    Scenario: A stale file outside a warm-up still reloads the page
+      Given no warm-up is in flight
+      When a download fails because the file is gone
+      Then the page reloads once


### PR DESCRIPTION
Opening the Edit Scenario drawer showed a spinner floating at the right edge of the page before the drawer appeared. That spinner is the Suspense fallback in `CurrentDrawer`: every drawer is a separate download, and the click has to wait for it.

The scenario library knows its rows open the editor, so it now fetches that code while the person is still reading the list.

## What the warm-up covers

Two things stand between the click and the drawer, and both had to go:

1. **The module download.** `preloadDrawer("scenarioEditor")` runs the same import the drawer would, on the browser's first idle moment. Idle, not on mount, so it does not compete with the page's own query.
2. **The lazy wrapper's own state.** `React.lazy` records separately whether it is ready. With the module in memory but the wrapper untouched, the first render still suspends for a tick and the spinner still flashes. The warm-up reads the wrapper once outside render, which settles it.

Priming the wrapper happens only after the download succeeds. A wrapper that records a failure keeps that answer for the life of the page, so a warm-up that lost the network would leave a drawer that can never open.

## Measured in a browser, clicking a row in the scenario library

| | Module requests after the click | Spinner | Drawer on screen |
|---|---|---|---|
| Before | 180 | 294ms to 585ms | 619ms |
| Module warm-up only | 0 | 271ms to 489ms | 534ms |
| Both halves (this change) | 0 | none | 228 to 240ms |

The two requests still made after the click are the drawer's own data (`scenarios.getById` and the unbatched prompt catalog), which is the point: the click now only waits for data.

## A warm-up must not take the page away

A warm-up asks for a content-hashed file the same way a real import does, so after a deploy it can hit a name that no longer exists. The recovery for that is a page reload, which is correct for a person waiting on a drawer and wrong for a person reading a list who asked for nothing. `warmChunk` therefore stands the reload listener down while a warm-up is in flight. The next real open of that chunk still reloads and recovers.

## Using it elsewhere

Any screen can warm the drawers it opens with one line: `usePreloadDrawer("promptEditor")`. This change adds it to the scenario library only.

## Testing

- `specs/navigation/drawer-chunk-warmup.feature`, 7/7 scenarios bound.
- Integration: the library warms the editor when the browser goes idle; a warmed drawer renders with no spinner; a drawer whose warm-up failed still opens.
- Unit: the warm-up waits for idle, cancels when the screen closes, falls back to a timer on browsers with no idle callback, and a failed warm-up does not reload the page.
- Driven in a real browser against local Postgres and ClickHouse, which is where the numbers above come from.

https://claude.ai/code/session_01CeNuYCxZNcbQYvD3XFrDqr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Drawer code preloads during browser idle time, reducing delays when opening scenario editors, run details, suite editors, and other drawers.
  * Preloaded drawers open immediately without displaying a spinner.

* **Reliability**
  * Temporary preload failures no longer trigger unnecessary page reloads.
  * Failed drawer loads can retry successfully when opened again.
  * Genuine stale-file failures continue to trigger a page reload when needed.

* **Bug Fixes**
  * Leaving a page cancels scheduled preload work to prevent unnecessary background loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->