### PR TITLE
chore(db): drop the two RoutingPolicy columns the gateway never read

### DIFF
--- a/platform/app/prisma/migrations/20260815120003_drop_routing_policy_dead_fields/migration.sql
+++ b/platform/app/prisma/migrations/20260815120003_drop_routing_policy_dead_fields/migration.sql
@@ -1,0 +1,32 @@
+-- IRREVERSIBLE: dropping a column deletes what it holds, and there is no down
+-- step that could bring the values back. A rollback that re-adds the columns
+-- gets them empty, so any policy that had once carried an allowlist or a
+-- non-default strategy would come back without it.
+--
+-- What makes that acceptable is that neither column reaches the gateway.
+-- "modelAllowlist" never became part of the bundle: the gateway reads
+-- "models_allowed" off the virtual key, and the policy-level allow rules off
+-- "policyRules". "strategy" is never emitted at all; the chain is always tried
+-- in order. Both columns have been written by the product and read by nothing.
+--
+-- A production census on 2026-08-15 counted what this deletes:
+--   1 routing policy total
+--   0 with a non-empty modelAllowlist (0 entries, across 0 organizations)
+--   0 on a strategy other than the default 'priority'
+-- so this migration deletes no configuration a customer set. Re-run
+-- scripts/report-routing-policy-dead-fields.ts against any other deployment
+-- before applying it there; the script reports that the columns are already
+-- gone rather than failing obscurely.
+--
+-- To roll back, uncomment and run manually. The values are NOT restored:
+--
+-- ALTER TABLE "RoutingPolicy"
+--   ADD COLUMN "modelAllowlist" JSONB,
+--   ADD COLUMN "strategy" TEXT NOT NULL DEFAULT 'priority';
+
+-- Both drops ride one statement so the table takes its ACCESS EXCLUSIVE lock
+-- once. Dropping a column only rewrites the catalog, so the lock is held for
+-- the catalog update rather than for a scan of the table.
+ALTER TABLE "RoutingPolicy"
+  DROP COLUMN IF EXISTS "modelAllowlist",
+  DROP COLUMN IF EXISTS "strategy";


### PR DESCRIPTION
Follow-up to #6923, which removed `RoutingPolicy.modelAllowlist` and `RoutingPolicy.strategy` from `schema.prisma` but left the database columns in place until a production census said what dropping them deletes.

## The census

Run against production on 2026-08-15, read-only, with `scripts/report-routing-policy-dead-fields.ts`:

```
policies                                            1

modelAllowlist, never read by the gateway
  with a non-empty allowlist                        0
  with an empty allowlist                           0
  with no allowlist                                 1
  organizations owning a non-empty allowlist        0
  allowlist entries in total                        0

strategy, never emitted to the gateway
  on the default (priority)                         1
  on another strategy                               0
```

Cross-checked against direct SQL, because 1 policy against 17 in local development looked low enough to be a filter bug in the script: `total_policies=1, nonempty_allowlist=0, non_default_strategy=0, orgs=1`. The script agrees exactly. Production really does hold one routing policy.

So this migration deletes no configuration a customer set.

## Why the columns are dead

`modelAllowlist` never entered the gateway bundle. The gateway reads `models_allowed` off the virtual key, and the policy-level allow rules off `policyRules`. `strategy` was never emitted at all; the credential chain is always tried in order. Both columns were written by the product and read by nothing.

## This also closes a schema disagreement

`schema.prisma` already declares neither field, so every deployed database currently holds two columns the schema does not know about. Production has both today: `modelAllowlist jsonb NULL` and `strategy text NOT NULL DEFAULT 'priority'`. After this runs, `prisma migrate diff` reports nothing at all for `RoutingPolicy`.

## Verification

- Applied every migration to a fresh database from empty. All 250 apply, the new one included.
- After it, `RoutingPolicy` holds `createdAt, createdById, defaultModel, description, id, isDefault, modelAliases, modelProviderIds, name, organizationId, policyRules, updatedAt, updatedById`. Both dead columns gone, `defaultModel` from #6923 intact.
- `prisma migrate diff` against that database reports no `RoutingPolicy` statement of any kind. The drift it does report is pre-existing and repo-wide, mostly index names truncated by Postgres, and is untouched by this change.
- `migrationorder -base origin/main`: in order.

## Notes

The migration carries the `IRREVERSIBLE` block. A rollback re-adds the columns empty, which the block says plainly, and re-running the census script on another deployment reports that the columns are already gone rather than failing obscurely.

No feature file. Dropping a column nothing reads changes no behavior a customer can observe, and a scenario asserting that a column no longer exists is the implementation-detail spec `CLAUDE.md` warns against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Removed unused routing policy fields from the system.
  * Included safeguards and rollback guidance for the database change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->