### PR TITLE
perf(automations): emit persist matches as bounded pages and size the lease to the page

### DIFF
--- a/platform/app/src/features/automations/providers/dataset/__tests__/client.integration.test.tsx
+++ b/platform/app/src/features/automations/providers/dataset/__tests__/client.integration.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { refetchMock, drawerPropsSpy } = vi.hoisted(() => ({
+  refetchMock: vi.fn(),
+  drawerPropsSpy: vi.fn(),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    dataset: {
+      getAll: {
+        useQuery: () => ({
+          data: [],
+          isLoading: false,
+          isError: false,
+          refetch: refetchMock,
+        }),
+      },
+    },
+  },
+}));
+
+// The real drawer pulls tRPC mutations and the whole dataset form in. What the
+// automation owns is the wiring: the picker's create affordance must open it,
+// and a created dataset must land on the slice.
+vi.mock("~/components/AddOrEditDatasetDrawer", () => ({
+  AddOrEditDatasetDrawer: (props: {
+    open?: boolean;
+    onSuccess: (dataset: {
+      datasetId: string;
+      name: string;
+      columnTypes: { name: string; type: string }[];
+    }) => void;
+  }) => {
+    drawerPropsSpy(props);
+    return props.open === true ? <div>new dataset drawer</div> : null;
+  },
+}));
+
+const { default: client } = await import("../client");
+
+const ConfigForm = client.ConfigForm;
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const renderForm = (onChange = vi.fn()) => {
+  render(
+    <ConfigForm
+      slice={client.initialSlice()}
+      onChange={onChange}
+      ctx={{ projectId: "project-1" } as never}
+    />,
+    { wrapper: Wrapper },
+  );
+  return onChange;
+};
+
+describe("dataset automation configuration", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("given the project has no dataset yet", () => {
+    /** @scenario "Creating a dataset from the automation is offered and works" */
+    it("opens the dataset creation drawer from the picker", async () => {
+      renderForm();
+
+      expect(screen.queryByText("new dataset drawer")).not.toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /create new/i }),
+      );
+
+      expect(screen.getByText("new dataset drawer")).toBeInTheDocument();
+    });
+
+    /** @scenario "Creating a dataset from the automation is offered and works" */
+    it("selects the created dataset and derives its column mapping", async () => {
+      const onChange = renderForm();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /create new/i }),
+      );
+
+      const props = drawerPropsSpy.mock.calls.at(-1)?.[0] as {
+        onSuccess: (dataset: {
+          datasetId: string;
+          name: string;
+          columnTypes: { name: string; type: string }[];
+        }) => void;
+      };
+      props.onSuccess({
+        datasetId: "dataset-1",
+        name: "Support traces",
+        columnTypes: [
+          { name: "input", type: "string" },
+          { name: "output", type: "string" },
+        ],
+      });
+
+      expect(refetchMock).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          datasetId: "dataset-1",
+          mapping: expect.objectContaining({
+            mapping: expect.objectContaining({
+              input: expect.objectContaining({ source: "input" }),
+              output: expect.objectContaining({ source: "output" }),
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/platform/app/src/features/automations/providers/dataset/client.tsx
+++ b/platform/app/src/features/automations/providers/dataset/client.tsx
@@ -1,8 +1,9 @@
-import { Text, VStack } from "@chakra-ui/react";
+import { Text, useDisclosure, VStack } from "@chakra-ui/react";
 import type { DatasetActionParams } from "@langwatch/automations/providers/dataset";
 import type { SavedTriggerRow } from "@langwatch/automations/providers/types";
 import { Database } from "lucide-react";
 import { useEffect } from "react";
+import { AddOrEditDatasetDrawer } from "~/components/AddOrEditDatasetDrawer";
 import { DatasetSelector } from "~/components/datasets/DatasetSelector";
 import type { Dataset } from "~/generated/prisma/client";
 import {
@@ -138,6 +139,7 @@ function DatasetConfigForm({
     { projectId: ctx.projectId },
     { enabled: !!ctx.projectId, refetchOnWindowFocus: false },
   );
+  const createDataset = useDisclosure();
 
   // Picking a dataset derives a default column mapping from that dataset's
   // columns and stores it on the slice, so the saved trigger carries a
@@ -176,14 +178,28 @@ function DatasetConfigForm({
         localStorageDatasetId={slice.datasetId}
         errors={{}}
         setValue={(_field: string, value: string) => selectDataset(value)}
-        onCreateNew={() => {
-          // noop
-        }}
+        onCreateNew={createDataset.onOpen}
       />
       <Text color="fg.muted" textStyle="xs">
         Columns map to the matching trace fields automatically; refine the
         mapping from the dataset view after creating.
       </Text>
+      {/* A project with no dataset yet has nothing to pick, so the automation
+          cannot be finished without creating one from here. The new dataset's
+          own columns drive the mapping, the same as picking an existing one. */}
+      <AddOrEditDatasetDrawer
+        open={createDataset.open}
+        onClose={createDataset.onClose}
+        onSuccess={({ datasetId, columnTypes }) => {
+          createDataset.onClose();
+          void datasets.refetch();
+          onChange({
+            ...slice,
+            datasetId,
+            mapping: deriveMappingFromColumns(columnTypes),
+          });
+        }}
+      />
     </VStack>
   );
 }

--- a/platform/app/src/server/event-sourcing/pipelines/automations/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/pipeline.ts
@@ -13,6 +13,7 @@ import {
   digestBatchKey,
   drainDue,
   INITIAL_SETTLEMENT_STATE,
+  pagePersistMatches,
   type SettlementState,
   settleBoundary,
 } from "./process-manager/triggerSettlement.process";
@@ -82,6 +83,12 @@ export function createAutomationsPipeline(deps: AutomationsPipelineDeps) {
         )
         .on(TRIGGER_MATCH_RECORDED_EVENT_TYPE, (state, data, ctx) => {
           const { state: nextState, flushed } = addPending(state, data, ctx.at);
+          const flushedPersist = flushed.filter(
+            ({ match }) => match.actionClass === "persist",
+          );
+          const flushedNotify = flushed.filter(
+            ({ match }) => match.actionClass !== "persist",
+          );
           return {
             state: nextState,
             // Cap hit: the oldest matches dispatch NOW instead of being
@@ -89,20 +96,26 @@ export function createAutomationsPipeline(deps: AutomationsPipelineDeps) {
             intents:
               flushed.length > 0
                 ? [
-                    ...flushed.map(({ traceId, match }) =>
-                      match.actionClass === "persist"
-                        ? ctx.intents.persistMatch(
-                            `persist:${traceId}:${match.settleWindowBucket}`,
-                            { triggerId: ctx.key, traceId },
-                          )
-                        : ctx.intents.notifyDigest(
-                            `digest:${match.dispatchDueAt}:${digestBatchKey([traceId])}`,
-                            {
-                              triggerId: ctx.key,
-                              traceIds: [traceId],
-                              boundary: match.dispatchDueAt,
-                            },
-                          ),
+                    ...pagePersistMatches(
+                      flushedPersist.map(({ traceId, match }) => ({
+                        traceId,
+                        settleWindowBucket: match.settleWindowBucket,
+                      })),
+                    ).map((page) =>
+                      ctx.intents.persistMatch(`persist:${page.pageKey}`, {
+                        triggerId: ctx.key,
+                        traceIds: page.traceIds,
+                      }),
+                    ),
+                    ...flushedNotify.map(({ traceId, match }) =>
+                      ctx.intents.notifyDigest(
+                        `digest:${match.dispatchDueAt}:${digestBatchKey([traceId])}`,
+                        {
+                          triggerId: ctx.key,
+                          traceIds: [traceId],
+                          boundary: match.dispatchDueAt,
+                        },
+                      ),
                     ),
                     // The message key is what the outbox dedups on, so it
                     // decides how many DURABLE ROWS a log line costs. Keyed on
@@ -146,20 +159,20 @@ export function createAutomationsPipeline(deps: AutomationsPipelineDeps) {
                   },
                 ),
               ),
-              ...due.settledMatches.map((match) =>
-                ctx.intents.persistMatch(
-                  `persist:${match.traceId}:${match.settleWindowBucket}`,
-                  {
-                    triggerId: ctx.key,
-                    traceId: match.traceId,
-                  },
-                ),
+              ...due.persistPages.map((page) =>
+                ctx.intents.persistMatch(`persist:${page.pageKey}`, {
+                  triggerId: ctx.key,
+                  traceIds: page.traceIds,
+                }),
               ),
             ],
             nextWakeAt: due.nextBoundary,
           };
         })
-        .outbox({ maxAttempts: 8, leaseDurationMs: 120_000 }),
+        // The lease covers a full page of degraded per-trace confirms with
+        // room to spare (see PERSIST_PAGE_MAX); the dispatcher releases any
+        // batch tail that would run past it.
+        .outbox({ maxAttempts: 8, leaseDurationMs: 300_000 }),
     )
     .withProcessManager("graphAlertSweep", (pm) =>
       pm

--- a/platform/app/src/server/event-sourcing/pipelines/automations/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/pipeline.ts
@@ -96,12 +96,12 @@ export function createAutomationsPipeline(deps: AutomationsPipelineDeps) {
             intents:
               flushed.length > 0
                 ? [
-                    ...pagePersistMatches(
-                      flushedPersist.map(({ traceId, match }) => ({
+                    ...pagePersistMatches({
+                      matches: flushedPersist.map(({ traceId, match }) => ({
                         traceId,
                         settleWindowBucket: match.settleWindowBucket,
                       })),
-                    ).map((page) =>
+                    }).map((page) =>
                       ctx.intents.persistMatch(`persist:${page.pageKey}`, {
                         triggerId: ctx.key,
                         traceIds: page.traceIds,

--- a/platform/app/src/server/event-sourcing/pipelines/automations/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/pipeline.ts
@@ -126,11 +126,15 @@ export function createAutomationsPipeline(deps: AutomationsPipelineDeps) {
                     // EVENT time, a storm coalesces to at most one row per
                     // trigger per minute, and a redelivery of the same event
                     // produces a byte-identical key so it dedups rather than
-                    // adding a row. `ctx.key` is in the key because the outbox
-                    // uniqueness is (processName, projectId, messageKey) and
-                    // carries no processKey of its own. The payload still
-                    // carries the running total, so the storm rate is
-                    // recoverable from any single surviving row.
+                    // adding a row. The payload still carries the running
+                    // total, so the storm rate is recoverable from any single
+                    // surviving row.
+                    //
+                    // A key written here only has to be unique inside ONE
+                    // trigger: the outbox unique index is (processName,
+                    // projectId, messageKey), and the runtime prefixes every
+                    // builder-authored key with `process:<processKey>:`, so
+                    // two triggers never collide on identical bodies.
                     ctx.intents.logOverflow(
                       `overflow:${ctx.key}:${Math.floor(ctx.at / 60_000)}`,
                       {

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
@@ -202,6 +202,54 @@ describe("trigger settlement process", () => {
     });
   });
 
+  describe("given two automations persist the same trace in one settle window", () => {
+    describe("when both settle rounds dispatch", () => {
+      /** @scenario "Two automations that match the same trace keep separate pages" */
+      it("keys each automation's page separately in the outbox", () => {
+        const definition = automationProcessDefinition({
+          name: "triggerSettlement",
+        });
+        const evolve =
+          definition.config.handlers[TRIGGER_MATCH_RECORDED_EVENT_TYPE]!;
+        // The runtime builds the intent factories with the process key, and
+        // that prefix is what separates two automations whose page bodies are
+        // byte-identical.
+        const pageKeysOf = (triggerId: string) => {
+          const context = {
+            key: triggerId,
+            projectId: "project-1",
+            intents: buildIntentFactories(definition.config.intents, {
+              processKey: triggerId,
+            }),
+          };
+          const round = evolve(
+            initialState(),
+            match({
+              triggerId,
+              action: TriggerAction.ADD_TO_DATASET,
+              actionClass: "persist",
+            }),
+            { ...context, at: 1_000, now: 1_000 },
+          );
+          return definition.config.onWake!(round.state, {
+            ...context,
+            at: 31_000,
+            now: 31_000,
+          }).intents?.map((intent) => intent.messageKey);
+        };
+
+        const pageBody = `persist:${digestBatchKey(["trace-1@30000-0"])}`;
+
+        expect(pageKeysOf("trigger-1")).toEqual([
+          `process:trigger-1:${pageBody}`,
+        ]);
+        expect(pageKeysOf("trigger-2")).toEqual([
+          `process:trigger-2:${pageBody}`,
+        ]);
+      });
+    });
+  });
+
   describe("given more pending matches than the state bound", () => {
     describe("when another match is recorded", () => {
       it("flushes the oldest match out of pending state without discarding it", () => {

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
@@ -6,8 +6,11 @@ import type { TriggerMatchRecordedEventData } from "~/server/event-sourcing/pipe
 import { automationProcessDefinition } from "../../__tests__/pipelineTestHarness";
 import {
   addPending,
+  digestBatchKey,
   drainDue,
   MAX_PENDING_MATCHES,
+  PERSIST_PAGE_MAX,
+  pagePersistMatches,
   type SettlementState,
   settleBoundary,
 } from "../triggerSettlement.process";
@@ -67,7 +70,8 @@ describe("trigger settlement process", () => {
         ]);
       });
 
-      it("emits persist matches independently", () => {
+      /** @scenario "Settled persist matches dispatch in bounded pages" */
+      it("pages the settled persist matches deterministically", () => {
         const state: SettlementState = {
           pendingMatches: {
             "trace-a": {
@@ -86,10 +90,36 @@ describe("trigger settlement process", () => {
           overflowFlushed: 0,
         };
 
-        expect(drainDue(state, 1_000).settledMatches).toEqual([
-          { traceId: "trace-a", settleWindowBucket: "30000-0" },
-          { traceId: "trace-b", settleWindowBucket: "30000-0" },
+        expect(drainDue(state, 1_000).persistPages).toEqual([
+          {
+            traceIds: ["trace-a", "trace-b"],
+            pageKey: digestBatchKey(["trace-a@30000-0", "trace-b@30000-0"]),
+          },
         ]);
+        // Identical state drains to byte-identical keys: what a revision
+        // conflict re-runs and an event redelivery replay must produce.
+        expect(drainDue(state, 1_000).persistPages).toEqual(
+          drainDue(state, 1_000).persistPages,
+        );
+      });
+
+      it("splits more settled matches than the page bound into multiple pages", () => {
+        const matches = Array.from(
+          { length: PERSIST_PAGE_MAX + 3 },
+          (_, index) => ({
+            traceId: `trace-${String(index).padStart(3, "0")}`,
+            settleWindowBucket: "30000-0",
+          }),
+        );
+
+        const pages = pagePersistMatches(matches);
+
+        expect(pages).toHaveLength(2);
+        expect(pages[0]!.traceIds).toHaveLength(PERSIST_PAGE_MAX);
+        expect(pages[1]!.traceIds).toHaveLength(3);
+        expect(pages[0]!.pageKey).not.toBe(pages[1]!.pageKey);
+        // Insertion order does not leak into the keys.
+        expect(pagePersistMatches([...matches].reverse())).toEqual(pages);
       });
 
       it("keeps the next future boundary durable", () => {
@@ -118,6 +148,7 @@ describe("trigger settlement process", () => {
 
   describe("given a persist match completed its settle round", () => {
     describe("when later activity arrives in a new settle window", () => {
+      /** @scenario "A later settlement round is never swallowed by a completed page" */
       it("creates a fresh persist intent for the later round", () => {
         const definition = automationProcessDefinition({
           name: "triggerSettlement",
@@ -158,11 +189,14 @@ describe("trigger settlement process", () => {
           now: 61_001,
         });
 
+        // The settle-window bucket is inside the page hash, so the second
+        // round's page cannot collide with the completed first round's
+        // outbox row and be swallowed by the dedup.
         expect(firstWake.intents?.map((intent) => intent.messageKey)).toEqual([
-          "persist:trace-1:30000-0",
+          `persist:${digestBatchKey(["trace-1@30000-0"])}`,
         ]);
         expect(secondWake.intents?.map((intent) => intent.messageKey)).toEqual([
-          "persist:trace-1:30000-1",
+          `persist:${digestBatchKey(["trace-1@30000-1"])}`,
         ]);
       });
     });
@@ -244,11 +278,11 @@ describe("trigger settlement process", () => {
         // running flush count. Nothing is discarded.
         expect(evolution.intents).toEqual([
           {
-            messageKey: "persist:trace-0:30000-0",
+            messageKey: `persist:${digestBatchKey(["trace-0@30000-0"])}`,
             intentType: "persistMatch",
             payload: {
               triggerId: "trigger-1",
-              traceId: "trace-0",
+              traceIds: ["trace-0"],
             },
           },
           {

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
@@ -214,7 +214,7 @@ describe("trigger settlement process", () => {
         // The runtime builds the intent factories with the process key, and
         // that prefix is what separates two automations whose page bodies are
         // byte-identical.
-        const pageKeysOf = (triggerId: string) => {
+        const pageKeysOf = ({ triggerId }: { triggerId: string }) => {
           const context = {
             key: triggerId,
             projectId: "project-1",
@@ -240,10 +240,10 @@ describe("trigger settlement process", () => {
 
         const pageBody = `persist:${digestBatchKey(["trace-1@30000-0"])}`;
 
-        expect(pageKeysOf("trigger-1")).toEqual([
+        expect(pageKeysOf({ triggerId: "trigger-1" })).toEqual([
           `process:trigger-1:${pageBody}`,
         ]);
-        expect(pageKeysOf("trigger-2")).toEqual([
+        expect(pageKeysOf({ triggerId: "trigger-2" })).toEqual([
           `process:trigger-2:${pageBody}`,
         ]);
       });

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlement.process.unit.test.ts
@@ -112,14 +112,16 @@ describe("trigger settlement process", () => {
           }),
         );
 
-        const pages = pagePersistMatches(matches);
+        const pages = pagePersistMatches({ matches });
 
         expect(pages).toHaveLength(2);
         expect(pages[0]!.traceIds).toHaveLength(PERSIST_PAGE_MAX);
         expect(pages[1]!.traceIds).toHaveLength(3);
         expect(pages[0]!.pageKey).not.toBe(pages[1]!.pageKey);
         // Insertion order does not leak into the keys.
-        expect(pagePersistMatches([...matches].reverse())).toEqual(pages);
+        expect(pagePersistMatches({ matches: [...matches].reverse() })).toEqual(
+          pages,
+        );
       });
 
       it("keeps the next future boundary durable", () => {

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlementIntentHandlers.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlementIntentHandlers.unit.test.ts
@@ -674,6 +674,31 @@ describe("trigger settlement intent handlers integration", () => {
       expect(isDispatchError(thrown)).toBe(false);
     });
 
+    /** @scenario "A retrying page names the failure that caused the retry" */
+    it("names the failing error on the page retry record", async () => {
+      const { deps, raw } = makeDeps(datasetTrigger());
+      raw.addToDataset.mockRejectedValue(
+        new DispatchError({ message: "clickhouse read timed out", retryable: true }),
+      );
+
+      await createPersistMatchHandler(deps)(
+        { triggerId: "trigger-1", traceIds: ["trace-1"] },
+        context("process:trigger-1:persist:page-1"),
+      ).catch(() => undefined);
+
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-1",
+          triggerId: "trigger-1",
+          failed: 1,
+          pageSize: 1,
+          errorType: "DispatchError",
+          errorMessage: "clickhouse read timed out",
+        }),
+        "Persist page had retryable failures. Retrying the page; claimed traces no-op on the retry",
+      );
+    });
+
     it("dispatches a repeated trace of a page only once", async () => {
       const { deps, triggers, raw } = makeDeps(datasetTrigger());
 

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlementIntentHandlers.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/__tests__/triggerSettlementIntentHandlers.unit.test.ts
@@ -678,7 +678,10 @@ describe("trigger settlement intent handlers integration", () => {
     it("names the failing error on the page retry record", async () => {
       const { deps, raw } = makeDeps(datasetTrigger());
       raw.addToDataset.mockRejectedValue(
-        new DispatchError({ message: "clickhouse read timed out", retryable: true }),
+        new DispatchError({
+          message: "clickhouse read timed out",
+          retryable: true,
+        }),
       );
 
       await createPersistMatchHandler(deps)(

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlement.process.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlement.process.ts
@@ -119,8 +119,10 @@ export interface PersistPage {
 export function pagePersistMatches(
   matches: Array<{ traceId: string; settleWindowBucket: string }>,
 ): PersistPage[] {
+  // Byte order, not localeCompare: the page key must never depend on the
+  // process locale or ICU version.
   const sorted = [...matches].sort((left, right) =>
-    left.traceId.localeCompare(right.traceId),
+    left.traceId < right.traceId ? -1 : left.traceId > right.traceId ? 1 : 0,
   );
   const pages: PersistPage[] = [];
   for (let start = 0; start < sorted.length; start += PERSIST_PAGE_MAX) {

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlement.process.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlement.process.ts
@@ -116,9 +116,11 @@ export interface PersistPage {
  * byte-identical page keys — the sort is what guarantees it regardless of
  * pending-map insertion order.
  */
-export function pagePersistMatches(
-  matches: Array<{ traceId: string; settleWindowBucket: string }>,
-): PersistPage[] {
+export function pagePersistMatches({
+  matches,
+}: {
+  matches: Array<{ traceId: string; settleWindowBucket: string }>;
+}): PersistPage[] {
   // Byte order, not localeCompare: the page key must never depend on the
   // process locale or ICU version.
   const sorted = [...matches].sort((left, right) =>
@@ -167,7 +169,7 @@ export function drainDue(state: SettlementState, at: number) {
       key,
       traceIds: traceIds.sort(),
     })),
-    persistPages: pagePersistMatches(settledMatches),
+    persistPages: pagePersistMatches({ matches: settledMatches }),
     nextBoundary: nextWakeFrom(nextState),
   };
 }

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlement.process.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlement.process.ts
@@ -10,6 +10,13 @@ import type {
 
 export const TRIGGER_SETTLEMENT_PROCESS_NAME = "triggerSettlement" as const;
 export const MAX_PENDING_MATCHES = 1_000;
+/**
+ * Traces per persist-match outbox message. Sized so a page stays well
+ * inside the outbox lease even when the per-trace confirm degrades to
+ * seconds: 25 traces through the handler's 4-wide pool at a degraded ~4s
+ * per trace is ~25-30s against a 300s lease.
+ */
+export const PERSIST_PAGE_MAX = 25;
 export type SettlementState = TriggerSettlementState;
 
 export const INITIAL_SETTLEMENT_STATE: SettlementState = {
@@ -90,6 +97,44 @@ export function digestBatchKey(traceIds: readonly string[]): string {
     .slice(0, 16);
 }
 
+/** One persist-match outbox message: a bounded page of settled traces. */
+export interface PersistPage {
+  traceIds: string[];
+  /**
+   * Deterministic message-key body. The settle window bucket is INSIDE the
+   * hash on purpose: keyed on traceIds alone, a later settlement round over
+   * the same traces would collide with the completed page's outbox row and
+   * be swallowed by the outbox dedup.
+   */
+  pageKey: string;
+}
+
+/**
+ * Chunks settled persist matches into deterministic pages: sorted by
+ * traceId, sliced by PERSIST_PAGE_MAX. Evolve retries and event redelivery
+ * re-run this on identical state, so identical input must produce
+ * byte-identical page keys — the sort is what guarantees it regardless of
+ * pending-map insertion order.
+ */
+export function pagePersistMatches(
+  matches: Array<{ traceId: string; settleWindowBucket: string }>,
+): PersistPage[] {
+  const sorted = [...matches].sort((left, right) =>
+    left.traceId.localeCompare(right.traceId),
+  );
+  const pages: PersistPage[] = [];
+  for (let start = 0; start < sorted.length; start += PERSIST_PAGE_MAX) {
+    const page = sorted.slice(start, start + PERSIST_PAGE_MAX);
+    pages.push({
+      traceIds: page.map((match) => match.traceId),
+      pageKey: digestBatchKey(
+        page.map((match) => `${match.traceId}@${match.settleWindowBucket}`),
+      ),
+    });
+  }
+  return pages;
+}
+
 export function drainDue(state: SettlementState, at: number) {
   const remaining: SettlementState["pendingMatches"] = {};
   const notifyByBoundary = new Map<number, string[]>();
@@ -120,7 +165,7 @@ export function drainDue(state: SettlementState, at: number) {
       key,
       traceIds: traceIds.sort(),
     })),
-    settledMatches,
+    persistPages: pagePersistMatches(settledMatches),
     nextBoundary: nextWakeFrom(nextState),
   };
 }

--- a/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlementIntentHandlers.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/automations/process-manager/triggerSettlementIntentHandlers.ts
@@ -1017,11 +1017,29 @@ function throwIfPageShouldRetry(params: {
     );
   }
 
+  const representative = retryableFailures[0];
   logger.warn(
-    { projectId, triggerId, failed: retryableFailures.length, pageSize },
+    {
+      projectId,
+      triggerId,
+      failed: retryableFailures.length,
+      pageSize,
+      // The cause, not only the count. A retryable failure is rethrown into
+      // the outbox, which redacts the message before it logs the attempt, so
+      // without this line a page that retries to its attempt ceiling reports
+      // "failed: 1" and nothing an operator can act on.
+      errorType:
+        representative instanceof Error
+          ? representative.name
+          : typeof representative,
+      errorMessage:
+        representative instanceof Error
+          ? representative.message
+          : String(representative),
+    },
     "Persist page had retryable failures. Retrying the page; claimed traces no-op on the retry",
   );
-  throw retryableFailures[0];
+  throw representative;
 }
 
 /**

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts
@@ -423,6 +423,81 @@ describe("OutboxDispatcherService", () => {
     });
   });
 
+  describe("given a domain whose slow deliveries earn it a large lease", () => {
+    describe("when a delivery would start with less than the scaled margin", () => {
+      it("scales the safety margin with the lease instead of capping it", async () => {
+        for (let index = 0; index < 2; index++) {
+          await service.handleEvent({
+            envelope: pilotEvent({
+              eventId: `evt_large_${index}`,
+              processKey: `conv_large_${index}`,
+              payload: { turnId: `turn_large_${index}` },
+            }),
+            now: T0,
+          });
+        }
+        let elapsed = 0;
+        const handler = vi.fn().mockImplementation(async () => {
+          elapsed += 85_000;
+        });
+        const dispatcher = new OutboxDispatcherService({
+          store,
+          handlers: { "worker-dispatch": handler },
+          leaseDurationMs: 100_000,
+          clock: () => elapsed,
+        });
+
+        // Margin is 20_000ms (20% of the lease). After the first delivery
+        // 15_000ms remain: under a flat 10_000ms cap the second delivery
+        // would start and outlive the lease; the scaled margin releases it.
+        const report = await dispatcher.runOnce({ now: T0 + 1 });
+
+        expect(report.dispatched).toHaveLength(1);
+        expect(report.released).toHaveLength(1);
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("given a lease query slowed by the same degraded store", () => {
+    describe("when the query consumes most of the lease before any delivery", () => {
+      it("counts the query time against the lease budget", async () => {
+        await commitStartedTurn();
+        let elapsed = 0;
+        const slowLeasingStore = new Proxy(store, {
+          get(target, property, receiver) {
+            if (property !== "leaseDueMessages") {
+              return Reflect.get(target, property, receiver);
+            }
+            return async (
+              params: Parameters<typeof store.leaseDueMessages>[0],
+            ) => {
+              // The store anchors leasedUntil before the query runs, so a
+              // slow query burns real lease time before any delivery starts.
+              elapsed += 900;
+              return target.leaseDueMessages(params);
+            };
+          },
+        });
+        const handler = vi.fn().mockResolvedValue(undefined);
+        const dispatcher = new OutboxDispatcherService({
+          store: slowLeasingStore,
+          handlers: { "worker-dispatch": handler },
+          leaseDurationMs: 1_000,
+          clock: () => elapsed,
+        });
+
+        // 900ms of the 1_000ms lease went to the query; 100ms remain, under
+        // the 200ms margin, so the delivery must not start.
+        const report = await dispatcher.runOnce({ now: T0 + 1 });
+
+        expect(report.dispatched).toHaveLength(0);
+        expect(report.released).toHaveLength(1);
+        expect(handler).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("given a message whose leases keep lapsing without any acknowledgement", () => {
     beforeEach(commitStartedTurn);
 

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
@@ -98,8 +98,13 @@ export interface DispatchReport {
 const DEFAULT_MAX_ATTEMPTS = 10;
 export const DEFAULT_LEASE_DURATION_MS = 30_000;
 const SLOW_OUTBOX_DELIVERY_MS = 10_000;
-/** Never start a delivery with less lease budget left than this. */
-const LEASE_SAFETY_MARGIN_CAP_MS = 10_000;
+/**
+ * Fraction of the lease held back as the budget a delivery needs to fit
+ * before it may start. A domain sizes its lease to its slowest expected
+ * delivery, so the reserve must scale with the lease: a flat cap ceilinged
+ * the reserve of a 300s lease at 10s, which let a tail delivery start with
+ * 10s of budget against a 30s expected duration and fence anyway.
+ */
 const LEASE_SAFETY_MARGIN_FRACTION = 0.2;
 
 function identityOf(message: LeasedOutboxMessageRecord): OutboxMessageIdentity {
@@ -164,10 +169,8 @@ export class OutboxDispatcherService {
     this.processNames = options.processNames;
     this.concurrency = Math.max(1, options.concurrency ?? 1);
     this.clock = options.clock ?? Date.now;
-    this.leaseSafetyMarginMs = Math.min(
-      this.leaseDurationMs * LEASE_SAFETY_MARGIN_FRACTION,
-      LEASE_SAFETY_MARGIN_CAP_MS,
-    );
+    this.leaseSafetyMarginMs =
+      this.leaseDurationMs * LEASE_SAFETY_MARGIN_FRACTION;
     this.tracer =
       options.tracer ?? trace.getTracer("langwatch.process-manager");
     this.logger =
@@ -178,13 +181,17 @@ export class OutboxDispatcherService {
     now: number;
     limit?: number;
   }): Promise<DispatchReport> {
+    // The store anchors `leasedUntil` at `now`, which is captured BEFORE the
+    // lease query runs, so the budget clock starts before it too: a slow
+    // lease query (degraded Postgres is exactly when this matters) spends
+    // lease budget and must not be counted as free.
+    const leaseStartedAt = this.clock();
     const leased = await this.store.leaseDueMessages({
       now: params.now,
       limit: params.limit ?? 10,
       leaseDurationMs: this.leaseDurationMs,
       ...(this.processNames ? { processNames: this.processNames } : {}),
     });
-    const leaseStartedAt = this.clock();
 
     const report: DispatchReport = {
       dispatched: [],

--- a/specs/automations/authoring-drawer.feature
+++ b/specs/automations/authoring-drawer.feature
@@ -168,6 +168,18 @@ Feature: Staged automation authoring drawer
       Then the user selects the target dataset
       And no template section is shown
 
+    # A project with no dataset has nothing to select, so the create
+    # affordance is the only way out of the section. It was rendered
+    # without a handler, which left the first add-to-dataset automation of
+    # every new project unfinishable from the drawer.
+    @integration
+    Scenario: Creating a dataset from the automation is offered and works
+      Given the user is configuring an add-to-dataset action
+      And the project has no dataset yet
+      When the user chooses to create a dataset
+      Then the dataset creation form opens
+      And the created dataset becomes the automation's target
+
   Rule: The Slack channel list never claims to be complete when it isn't
 
     The picker is populated from what the bot token can see, and there are

--- a/specs/automations/process-manager-dispatch.feature
+++ b/specs/automations/process-manager-dispatch.feature
@@ -77,6 +77,13 @@ Feature: Automation dispatch on the process-manager substrate
     Then the later round produces a distinct page message
 
   @unit
+  Scenario: Two automations that match the same trace keep separate pages
+    Given two automations on one project that add matched traces to a dataset
+    And both match the same trace in the same settle window
+    When the settled matches dispatch
+    Then each automation dispatches its own page
+
+  @unit
   Scenario: An old single-trace persist intent still dispatches after the paging change
     Given a pending persist intent written before the paging change
     When the intent dispatches

--- a/specs/automations/process-manager-dispatch.feature
+++ b/specs/automations/process-manager-dispatch.feature
@@ -71,6 +71,12 @@ Feature: Automation dispatch on the process-manager substrate
     And a retry of a page re-runs only the traces not yet claimed
 
   @unit
+  Scenario: A later settlement round is never swallowed by a completed page
+    Given a page dispatched for a settle round
+    When the same trace matches again in a later settle window
+    Then the later round produces a distinct page message
+
+  @unit
   Scenario: An old single-trace persist intent still dispatches after the paging change
     Given a pending persist intent written before the paging change
     When the intent dispatches

--- a/specs/automations/process-manager-dispatch.feature
+++ b/specs/automations/process-manager-dispatch.feature
@@ -109,6 +109,17 @@ Feature: Automation dispatch on the process-manager substrate
     Then the page is retried for the failed trace
     And the dispatched trace can run again instead of being lost
 
+  # A retryable failure is rethrown into the outbox, and the outbox redacts an
+  # error message before it logs the attempt. The page's own retry line was the
+  # only place the cause could still be named, and it carried a count alone, so
+  # a page that retried to its attempt ceiling told an operator "one trace
+  # failed" and nothing about why.
+  @unit
+  Scenario: A retrying page names the failure that caused the retry
+    Given a page where one trace fails with a retryable error
+    When the page decides to retry
+    Then the retry record names the failing error type and message
+
   @unit
   Scenario: A daily-ceiling breach is reported once per page
     Given a page whose traces exceed the automation's daily ceiling


### PR DESCRIPTION
# Related Issue

- Resolves #7016

Part 3 of #7016 (part 1: #7037, part 2: #7039). The settlement process now emits `persistMatch` intents as bounded pages, and the `triggerSettlement` outbox lease grows from 120s to 300s.

Stacked on #7039 and must merge only after #7039 is fully deployed: outbox rows are durable, and a pod without the bilingual reader would fail to parse a paged row into the retry ladder. With #7039 everywhere, both shapes parse on every pod and this change is free to roll out.

## Changes

**`drainDue` returns pages, not individual matches.** Settled persist matches are sorted by trace id and chunked by `PERSIST_PAGE_MAX` (25). The page key hashes `traceId@settleWindowBucket` pairs; the settle window bucket is inside the hash so a later settlement round over the same traces produces a distinct outbox row instead of colliding with the completed page and being swallowed by the dedup. Sorting makes the keys byte-identical across evolve retries and event redelivery replays.

**The overflow flush pages too.** When the pending-match bound flushes old matches to immediate dispatch, the persist-class ones are paged the same way; notify-class flushes are unchanged.

**Message keys change shape during the rolling deploy.** The persist key moves from `persist:<traceId>:<settleWindowBucket>` to `persist:<pageKey>`. While both pod versions run, a redelivery of the same event across the boundary writes a second outbox row instead of deduping against the first, so a trace can be dispatched twice. That is safe: the per-trace `TriggerSent` claim keeps the side effect at-most-once, and the paged reader filters claimed traces before it does any work, so the duplicate page finds nothing left to run. Every message key also carries its automation, because the runtime prefixes builder-authored keys with `process:<processKey>:`, so two automations that page the same trace in the same settle window still write two rows. A unit test now pins that prefix.

**Lease 120s to 300s.** The old lease was a flat literal with no relation to handler cost, and 10 sequential messages at 12s crossed it (the #7016 self-sustaining collapse). The new lease covers a full page of degraded per-trace confirms (25 traces through the 4-wide pool at ~4s each is ~25-30s) with 10x headroom, and the dispatcher from #7037 releases any batch tail that would run past it. Dispatcher `concurrency`/`batchSize` stay at defaults on purpose: raising concurrency would also parallelize same-trigger digests and multiply pressure on the same stores whose slowness causes the backlog.

## Effect on the #7016 arithmetic

Before: a burst of 5 to 14 matches per second, one message each, drained at 10 pods x 1 message per handler-latency. At 16 to 26s handler latency the fleet drained ~0.6 messages per second and the backlog aged at wall-clock rate for hours, pinned at the histogram top bucket.

After: the same burst is ~25x fewer messages, each message amortizes the fixed reads once and confirms 4 traces at a time, and the lease-batch crossover moves from 12s mean per message to ~30s per trace sustained, which no observed regime reaches. If a store still degrades past that, #7037's budget check sheds tails cleanly and the fenced counter says so, instead of silent duplicate redelivery.

## Proof

`specs/automations/process-manager-dispatch.feature` 8/8 scenarios bound (adds "A later settlement round is never swallowed by a completed page" and "Two automations that match the same trace keep separate pages"). Unit tests pin page determinism (identical state drains to identical keys, insertion order does not leak), chunking above `PERSIST_PAGE_MAX`, later-round key distinctness, and paged overflow flushes. Full automations unit (433) and integration suites pass; `pnpm typecheck:all` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create a dataset directly from the automation configuration drawer.
  - Newly created datasets are automatically selected and mapped to the automation.

- **Performance**
  - Improved automation settlement processing with bounded, paginated persistence updates.
  - Extended processing lease time for longer-running page operations.

- **Reliability**
  - Added stable page identifiers to prevent duplicate or missed updates.
  - Improved lease handling by accounting for query time and proportional safety margins.
  - Enhanced retry logging with detailed failure information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Dogfooding proof

Full end-to-end run on a local stack (`pnpm dev`, workers in process) against native ClickHouse, Postgres and Redis, with Mailpit as the mailbox. A fresh project got two automations on the same condition `label:support`: one persist class (`Add to dataset`) and one notify class (`Email`, immediate cadence). 86 traces were sent through `/api/collector` in two bursts of 40 plus warm-up traces.

Result: both automations fired, 74 rows landed in the dataset, 13 alert emails arrived in the mailbox, and the outbox drained to zero.

**Automations page, both automations firing.** The condition, the action, the last fired time and the 30-day fire count per automation.

![Automations list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/01-automations-list.png)

**Recent fires on the persist automation.** Each entry is one dispatched page, so a page of several traces reads as "Fired N times" in one entry.

![Automation recent fires](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/02-automation-recent-fires.png)

**Automations overview.** Fired count across every automation and the live activity feed.

![Automations overview](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/03-automations-overview.png)

**The dataset the persist automation writes to.** 74 rows, each one a matched trace with its input, output and cost.

![Dataset rows](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/04-dataset-rows.png)

**The alert email, opened in Mailpit.** One notify digest listing the traces of that dispatch.

![Trigger email in Mailpit](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/05-mailbox-trigger-email.png)

### Paged messages, observed

The largest page this run emitted carried 9 traces in one outbox message, where the pre-paging emitter would have written 9 messages:

```
messageKey process:trigger_0007W3KIECG7pV6bzM1wpsrMdfxlA:persist:4b2b4df75daf46a6
status     dispatched
payload    {"traceIds": ["page-proof-trace-009", ..., "page-proof-trace-017"],
            "triggerId": "trigger_0007W3KIECG7pV6bzM1wpsrMdfxlA"}
```

Page sizes emitted by this build: 9, 6, 3, 2, 2, 2 and singles. The 25-message cap is pinned by unit tests rather than by this run.

Note on the environment: three local stacks share one Postgres, and the other two run pre-paging code. Their wake workers drained some of the same settlement rounds and wrote single-trace messages for them. That is the rolling-deploy shape the union payload schema exists for, and both shapes dispatched correctly through this build's handler.

### Worker metrics after the run

```
es_process_outbox_total{process_name="triggerSettlement",intent_type="persistMatch",status="dispatched"} 58
es_process_outbox_total{process_name="triggerSettlement",intent_type="persistMatch",status="released"}   8
es_process_outbox_total{process_name="triggerSettlement",intent_type="notifyDigest",status="dispatched"}  4
pm_outbox_pending{process_name="triggerSettlement"}          0
pm_outbox_overdue_pending{process_name="triggerSettlement"}  0
pm_outbox_lapsed_leases{process_name="triggerSettlement"}    0
pm_outbox_dead{process_name="triggerSettlement"}             7
es_process_outbox_stuck_drains_total                         (no samples)
automation_match_records_total       80
automation_overflow_flush_total       0
automation_ceiling_breach_total       0
automation_containment_failed_total   0
```

`fenced` never appears for `triggerSettlement`: no acknowledgement lost its lease. `released` at 8 is the batch-tail shedding doing its job, since a single dispatch took seconds on this loaded laptop and the batch would otherwise have run past its lease. The 7 dead messages all date from a window where the local object storage path was not writable, so they burned their 8 attempts and retired, which is the designed behavior.

### Bugs found and fixed on this branch

**A retrying persist page never said what failed** (`fix(automations): a retrying persist page records what failed`). Every page retried for minutes with `failed: 1, pageSize: 1` and no cause. A retryable failure is rethrown into the outbox, and the outbox redacts the message before logging the attempt, so the page's own retry line was the last place the cause could be named. It now carries the error type and message. The fix paid for itself immediately: the first line after it named `StorageNotWritableError` and the run moved on.

**The add-to-dataset action could not create its dataset** (`fix(automations): the add-to-dataset action can create its dataset`). The dataset picker in the automation drawer rendered a "Create New" button wired to a no-op. In a project with no dataset the picker also has nothing to select, so the first add-to-dataset automation of every new project could not be finished from the drawer at all. It now opens the same dataset creation form the datasets page uses, and the created dataset becomes the automation's target with its columns already mapped.

![Create dataset from the automation](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/06-fix-create-dataset-form.png)

![The created dataset becomes the target](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7040/07-fix-created-dataset-selected.png)
