### PR TITLE
feat(scenarios): open the parameters editor with a row ready to fill

### DIFF
--- a/platform/app/src/components/scenarios/__tests__/ScenarioFormParameters.integration.test.tsx
+++ b/platform/app/src/components/scenarios/__tests__/ScenarioFormParameters.integration.test.tsx
@@ -287,12 +287,40 @@ describe("scenario editor parameters", () => {
   });
 
   describe("given a scenario that declares none", () => {
+    describe("when the parameters editor opens", () => {
+      /** @scenario "The parameters editor opens ready to declare the first parameter" */
+      it("offers an empty row with an example name in the name field", async () => {
+        const user = renderDrawer();
+
+        await openParametersEditor(user);
+
+        const name = screen.getByTestId("scenario-parameter-name-0");
+        expect(name).toHaveValue("");
+        expect(name).toHaveAttribute("placeholder", "e.g. account_tier");
+        expect(
+          screen.getByTestId("scenario-parameter-description-0"),
+        ).toHaveValue("");
+        expect(screen.getByTestId("scenario-parameter-default-0")).toHaveValue(
+          "",
+        );
+      });
+
+      /** @scenario "The parameters editor opens ready to declare the first parameter" */
+      it("saves no parameters when the editor closes untouched", async () => {
+        const user = renderDrawer();
+
+        await openParametersEditor(user);
+        await clickDone(user);
+
+        expect(await save(user)).toMatchObject({ parameters: [] });
+      });
+    });
+
     describe("when a parameter is added and the scenario is saved", () => {
       it("carries the new declaration in the saved scenario", async () => {
         const user = renderDrawer();
 
         await openParametersEditor(user);
-        await user.click(screen.getByText("Add the first parameter"));
         await user.type(
           screen.getByTestId("scenario-parameter-name-0"),
           "region",
@@ -322,7 +350,6 @@ describe("scenario editor parameters", () => {
         const user = renderDrawer();
 
         await openParametersEditor(user);
-        await user.click(screen.getByText("Add the first parameter"));
         await user.type(
           screen.getByTestId("scenario-parameter-name-0"),
           "region",
@@ -339,7 +366,6 @@ describe("scenario editor parameters", () => {
         const user = renderDrawer();
 
         await openParametersEditor(user);
-        await user.click(screen.getByText("Add the first parameter"));
         await user.type(
           screen.getByTestId("scenario-parameter-name-0"),
           "seats",
@@ -361,7 +387,6 @@ describe("scenario editor parameters", () => {
         const user = renderDrawer();
 
         await openParametersEditor(user);
-        await user.click(screen.getByText("Add the first parameter"));
         await user.type(
           screen.getByTestId("scenario-parameter-name-0"),
           "account tier",

--- a/platform/app/src/components/scenarios/ui/ParameterDefinitionsInput.tsx
+++ b/platform/app/src/components/scenarios/ui/ParameterDefinitionsInput.tsx
@@ -19,6 +19,11 @@ type ParameterDefinitionsInputProps = {
  * Editor for the parameters a scenario declares: a name, an optional
  * description, and an optional default value per row.
  *
+ * The editor always shows a row to type in, so an empty list renders one blank
+ * row. That row becomes a declaration on the first keystroke, which keeps a
+ * scenario that declares nothing free of an empty declaration it would have to
+ * name before it could save.
+ *
  * @see specs/scenarios/scenario-run-parameters.feature
  */
 export function ParameterDefinitionsInput({
@@ -27,8 +32,10 @@ export function ParameterDefinitionsInput({
   rowErrors,
   disabled = false,
 }: ParameterDefinitionsInputProps) {
+  const rows = value.length > 0 ? value : [BLANK_DEFINITION];
+
   const handleAdd = () => {
-    onChange([...value, { name: "" }]);
+    onChange([...rows, { name: "" }]);
   };
 
   const handleRemove = (index: number) => {
@@ -39,24 +46,22 @@ export function ParameterDefinitionsInput({
     index: number,
     patch: Partial<ScenarioParameterDefinition>,
   ) => {
-    const definition = value[index];
+    const definition = rows[index];
     if (!definition) return;
-    const updated = [...value];
+    const updated = [...rows];
     updated[index] = { ...definition, ...patch };
     onChange(updated);
   };
 
   return (
     <VStack align="stretch" gap={2} data-testid="scenario-parameters-list">
-      {value.length > 0 && (
-        <HStack gap={2} paddingRight={8}>
-          <ColumnLabel flex={1}>Name</ColumnLabel>
-          <ColumnLabel flex={2}>Description</ColumnLabel>
-          <ColumnLabel flex={1}>Default value</ColumnLabel>
-        </HStack>
-      )}
+      <HStack gap={2} paddingRight={8}>
+        <ColumnLabel flex={NAME_FLEX}>Name</ColumnLabel>
+        <ColumnLabel flex={DESCRIPTION_FLEX}>Description</ColumnLabel>
+        <ColumnLabel flex={DEFAULT_VALUE_FLEX}>Default value</ColumnLabel>
+      </HStack>
 
-      {value.map((definition, index) => (
+      {rows.map((definition, index) => (
         <ParameterRow
           // Rows are addressed by position: a name is empty while it is being
           // typed, so it cannot key the row.
@@ -80,12 +85,26 @@ export function ParameterDefinitionsInput({
           data-testid="add-scenario-parameter-button"
         >
           <Plus size={14} />
-          {value.length === 0 ? "Add the first parameter" : "Add parameter"}
+          Add parameter
         </Button>
       )}
     </VStack>
   );
 }
+
+/** The row the editor shows when a scenario declares nothing yet. */
+const BLANK_DEFINITION: ScenarioParameterDefinition = { name: "" };
+
+/**
+ * How the three fields share the row.
+ *
+ * The name column carries a monospace example placeholder, so it needs more
+ * room than the quarter of the row an even split with the description would
+ * leave it.
+ */
+const NAME_FLEX = 1.35;
+const DESCRIPTION_FLEX = 1.65;
+const DEFAULT_VALUE_FLEX = 1;
 
 function ParameterRow({
   index,
@@ -111,9 +130,9 @@ function ParameterRow({
         <Input
           value={definition.name}
           onChange={(e) => onUpdate(index, { name: e.target.value })}
-          placeholder="account_tier"
+          placeholder="e.g. account_tier"
           size="sm"
-          flex={1}
+          flex={NAME_FLEX}
           fontFamily="mono"
           fontSize="13px"
           disabled={disabled}
@@ -129,7 +148,7 @@ function ParameterRow({
           }
           placeholder="Which plan the customer is on"
           size="sm"
-          flex={2}
+          flex={DESCRIPTION_FLEX}
           disabled={disabled}
           aria-label={`Parameter ${index + 1} description`}
           data-testid={`scenario-parameter-description-${index}`}
@@ -143,7 +162,7 @@ function ParameterRow({
           }
           placeholder="gold"
           size="sm"
-          flex={1}
+          flex={DEFAULT_VALUE_FLEX}
           fontFamily="mono"
           fontSize="13px"
           disabled={disabled}

--- a/specs/scenarios/scenario-run-parameters.feature
+++ b/specs/scenarios/scenario-run-parameters.feature
@@ -21,6 +21,14 @@ Feature: Scenario run parameters
     When the scenario is saved and read back
     Then the declaration is still there with its description and its default
 
+  @integration
+  Scenario: The parameters editor opens ready to declare the first parameter
+    Given a scenario that declares no parameters
+    When its parameters editor opens
+    Then an empty row is ready with its name, description and default value fields
+    And the name field hints an example name
+    And closing the editor without typing leaves the scenario declaring none
+
   @unit
   Scenario: A run-time value overrides the scenario's default value
     Given a scenario declaring "account_tier" with the default "gold"


### PR DESCRIPTION
## What

The scenario parameters editor opened on an empty state with an **Add the first parameter** button. Declaring a parameter took one click before any field appeared, and the empty dialog did not show what a parameter is made of.

The editor now always shows one row. An empty list renders a blank row with the Name, Description and Default value fields ready to fill.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/7045/parameters-dialog-before.png) | ![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/7045/parameters-dialog-after.png) |

The name field hints an example name, `e.g. account_tier`, and the name column is wider so the hint fits.

## How

The blank row is a render-time row, not a stored declaration. A scenario that declares nothing keeps an empty list, so:

- Opening the editor and closing it saves no parameters, the same as before.
- The blank row becomes a declaration on the first keystroke.
- Removing the last row leaves the blank row in place, so there is always a row to type in.

This matters because a parameter name cannot be empty. A stored blank row would block the scenario from saving until someone named it.

## Tests

- New spec scenario: "The parameters editor opens ready to declare the first parameter", bound by two integration tests (the row is offered with the example hint, and closing untouched saves no parameters).
- `ScenarioFormParameters.integration.test.tsx`: 12 tests pass. The tests that clicked the add button now type straight into the first row.
- `check:feature-parity`: 21/21 scenarios bound for this feature file.

## Verified in the browser

Ran the app locally against the real database:

- A new scenario opens the editor with the blank row and the full `e.g. account_tier` hint, no truncation.
- Typing a name adds the chip to the editor footer.
- Opening and closing the editor without typing leaves no declaration and no validation error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The scenario parameter editor now opens with an empty row ready for input.
  * Name, description, and default-value fields are displayed immediately with clearer placeholders.
  * The add-parameter action now uses consistent wording and layout.

* **Bug Fixes**
  * Closing an untouched parameter editor no longer changes the scenario.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->