### PR TITLE
feat(github): keep pull request history, add a GitHub Enterprise Server host, document restricted networks

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -57685,7 +57685,7 @@ GITHUB_LANGY_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRI
 ```
 
 <Warning>
-`GITHUB_LANGY_PRIVATE_KEY` is the only credential for the whole GitHub integration and grants write access to installed repos. Keep it in a secrets manager, never in version control, and never expose it to a worker. It stays in the control plane.
+`GITHUB_LANGY_PRIVATE_KEY` is the only credential for the whole GitHub integration and grants write access to installed repos. Keep it in a secrets manager, never in version control, and never let it reach the Langy agent pod. It stays in the control plane.
 </Warning>
 
 There is no client id or secret; the bot-authored flow uses no user OAuth. `CREDENTIALS_SECRET` (already required for any production install) signs the install round-trip's state, so nothing new is needed there.
@@ -57709,7 +57709,9 @@ app:
       value: github.acme-corp.internal
 ```
 
-Set the same values on `workers` when you run the workers as their own deployment. The periodic branch recheck runs there, and without the private key it cannot mint a token.
+Set the same values on `workers` when you run the LangWatch workers as their own deployment. The periodic branch recheck runs there, and without the private key it cannot mint a token.
+
+The LangWatch `workers` deployment is part of the control plane. It is not the Langy agent pod, which runs customer code in a sandbox and never receives the private key.
 
 ## GitHub Enterprise Server
 
@@ -57775,8 +57777,8 @@ Go to **Settings > Integrations > Disconnect**, which opens GitHub's uninstall p
 
 ## Operational notes
 
-- **Token in worker, not on disk.** Workers receive a 1-hour installation token via `GH_TOKEN` env. The github skill wires `git config credential.helper '!gh auth git-credential'` so git pushes read it from env, with no `.gitconfig` and no `.git-credentials`. The clone directory lives inside the per-worker home that the idle reaper deletes (within 10 min).
-- **Nothing at rest.** No token or refresh token is stored control-plane side. The app private key is the only credential; it never leaves the control plane and never goes near a worker. Tokens are minted per turn, cached in Redis a hair under their 1h lifetime, and self-expire.
+- **Token in the agent pod, not on disk.** Langy workers receive a 1-hour installation token via `GH_TOKEN` env. The github skill wires `git config credential.helper '!gh auth git-credential'` so git pushes read it from env, with no `.gitconfig` and no `.git-credentials`. The clone directory lives inside the per-worker home that the idle reaper deletes (within 10 min).
+- **Nothing at rest.** No token or refresh token is stored control-plane side. The app private key is the only credential; it never leaves the control plane and never reaches the Langy agent pod. Tokens are minted per turn, cached in Redis a hair under their 1h lifetime, and self-expire. The cache key carries the GitHub host, so two GitHub instances cannot share an entry.
 - **Least privilege at mint time.** Tokens are minted with only `contents:write` and `pull_requests:write`, scoped to the installation's repositories (or a single repository when the turn targets one).
 - **Sticky worker tokens.** A worker spawned with token T keeps T until the idle reaper kills it. Removing the installation cuts off new turns immediately; a live worker may hold a token for up to the idle TTL (within 10 min) or until it self-expires (within 1h).
 - **Egress.** The control plane reaches `api.github.com` to mint installation tokens and read installation metadata, or `<GITHUB_LANGY_HOST>` when one is set. Workers need `github.com`, `api.github.com`, and `codeload.github.com` to clone and push, which requires outbound egress to be enabled. See [Networking and egress](/self-hosting/langy/networking-and-egress).
@@ -57820,7 +57822,7 @@ That is why per-worker egress control lives at L7, in a per-worker CONNECT proxy
 | In-cluster LangWatch AI Gateway | All LLM traffic (traced, budgeted, policed) | Always, in-cluster |
 | In-cluster LangWatch app | The `langwatch` CLI (per-session key) | Always, in-cluster |
 | `github.com`, `api.github.com`, `codeload.github.com` | Clone and push for pull requests | Only when egress is on |
-| `api.github.com` (from the control plane, not the worker) | Mint 1-hour installation tokens, read installation metadata, and list pull requests for a branch | Control plane |
+| `api.github.com`, or `GITHUB_LANGY_HOST` when one is set (from the control plane, not the agent pod) | Mint 1-hour installation tokens, read installation metadata, and list pull requests for a branch | Control plane |
 
 Private ranges (RFC 1918), CGNAT (`100.64.0.0/10`), and the cloud metadata service are blocked at L3/L4 regardless of the egress toggle, which is the SSRF and IMDS protection.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -57582,14 +57582,15 @@ The mirror lane copies each turn's trace into a LangWatch project you designate,
 
 ## GitHub
 
-Set these on the control plane to enable bot-authored pull requests. If `GITHUB_LANGY_PRIVATE_KEY` is unset, the GitHub feature is silently off. See [Register the Langy GitHub App](/self-hosting/langy/github-app) for the registration walkthrough.
+Set these on the control plane to enable bot-authored pull requests and coding-agent pull request linkage. If `GITHUB_LANGY_PRIVATE_KEY` is unset, the GitHub feature is silently off. See [Register the GitHub App](/self-hosting/langy/github-app) for the registration walkthrough.
 
 | Variable | Description | Required | Default |
 |---|---|---|---|
 | `GITHUB_LANGY_APP_ID` | GitHub App id (JWT `iss`). | For GitHub | unset (feature off) |
 | `GITHUB_LANGY_PRIVATE_KEY` | App RSA private key PEM (mints install tokens). The only credential; control-plane only. Escape newlines as `\n` in a single-line value. | For GitHub | unset (feature off) |
-| `GITHUB_LANGY_WEBHOOK_SECRET` | Verifies the `X-Hub-Signature-256` on inbound webhooks. | For GitHub | unset |
-| `GITHUB_LANGY_APP_SLUG` | App slug for the install deep-link (`github.com/apps/<slug>`). | For GitHub | unset |
+| `GITHUB_LANGY_WEBHOOK_SECRET` | Verifies the `X-Hub-Signature-256` on inbound webhooks. Optional: without it the instance still connects, mints tokens and opens pull requests, but it reconciles late. Linkage then waits for the outbound recheck, and an uninstall clears only when a live read gets a 404. See [Restricted networks](/self-hosting/langy/github-app#restricted-networks). | No | unset |
+| `GITHUB_LANGY_APP_SLUG` | App slug for the install deep-link. | For GitHub | unset |
+| `GITHUB_LANGY_HOST` | The GitHub host this instance connects to. Set it to a GitHub Enterprise Server hostname (no scheme, no path) to bind the instance to that server. One instance connects to one host. | No | `github.com` |
 | `CREDENTIALS_SECRET` | Signs the GitHub install state round-trip and encrypts provider keys at rest. Already required in production, so nothing new is needed for GitHub. | Yes (prod) | none |
 
 <Warning>
@@ -57601,20 +57602,24 @@ Set these on the control plane to enable bot-authored pull requests. If `GITHUB_
 # FILE: ./self-hosting/langy/github-app.mdx
 
 ---
-title: Register the Langy GitHub App
-description: Deployment-time guide for the GitHub App that lets Langy open bot-authored pull requests, covering registration, permissions, the GITHUB_LANGY env vars, install, verify, and disconnect.
+title: Register the GitHub App
+description: Deployment-time guide for the GitHub App the organization connects, covering registration, permissions, the GITHUB_LANGY env vars, GitHub Enterprise Server, restricted networks, install, verify, and disconnect.
 sidebarTitle: GitHub App
 keywords:
   - langy github app
   - github_langy_app_id
+  - github enterprise server
   - bot-authored pull requests
 ---
 
-Langy opens pull requests through a GitHub App you register and install. PRs are authored by the app and credit the requesting user via a `Co-authored-by` trailer and a `Requested by @<login> via LangWatch` note in the body.
+One GitHub App serves the whole organization connection, and two features use it:
+
+- **Langy pull requests.** Langy opens pull requests through the App. They are authored by the App and credit the requesting user with a `Co-authored-by` trailer and a `Requested by @<login> via LangWatch` note in the body.
+- **Coding-agent pull request linkage.** LangWatch matches each coding-agent session to the pull request its branch became, so the Pull Requests page can report what each pull request cost in assistant usage. This part only reads.
 
 There is no per-user OAuth and no long-lived stored token: the app private key is the only credential, it lives only in the control-plane env, and installation tokens are minted on demand, cached in Redis a hair under their 1 hour lifetime, and never written to the database.
 
-To set it up: register a GitHub App, put its id, private key, webhook secret, and slug into the deployment env, and have org admins install it on the repos Langy may touch from **Settings > Integrations**.
+To set it up: register a GitHub App, put its id, private key, webhook secret, and slug into the deployment env, and have org admins install it on the repos LangWatch may touch from **Settings > Integrations**.
 
 <Info>
 **Also check:** [What Langy can do in your GitHub](/langy/security/github-access), [Setup](/self-hosting/langy/setup), [Environment variables](/self-hosting/langy/environment-variables).
@@ -57634,13 +57639,17 @@ Fill in these fields:
 |---|---|
 | App name | `LangWatch Langy` (or per environment, e.g. `LangWatch Langy (dev)`) |
 | Homepage URL | `https://app.langwatch.ai` (or your control-plane URL) |
-| Setup URL | `<BASE_URL>/api/github-langy/setup` |
+| Setup URL | `<BASE_URL>/api/github/setup` |
 | Redirect on update | ON (so re-configuring an install returns to the Setup URL) |
 | Request user authorization (OAuth) during installation | OFF. Langy is bot-authored, no user OAuth. |
-| Webhook > Active | ON |
-| Webhook URL | `<BASE_URL>/api/github-langy/webhook` |
+| Webhook > Active | ON (optional, see [Restricted networks](#restricted-networks)) |
+| Webhook URL | `<BASE_URL>/api/github/webhook` |
 | Webhook secret | Generate one (`openssl rand -hex 32`). You set it as `GITHUB_LANGY_WEBHOOK_SECRET`. |
 | Where can this GitHub App be installed? | Any account (recommended) or only this org |
+
+<Note>
+`/api/github-langy/setup` and `/api/github-langy/webhook` are the earlier paths. They stay mounted on the same handlers, so an App already registered with them keeps working. Use the paths above for a new registration.
+</Note>
 
 Set the repository permissions to exactly these, nothing more. Tighter scope means a smaller blast radius.
 
@@ -57657,12 +57666,12 @@ The `pull_request` event links a pull request to its coding-agent sessions as so
 Click **Create GitHub App**. On the resulting page:
 
 - copy the **App ID**
-- note the **app slug** (in the app's URL: `github.com/apps/<slug>`)
+- note the **app slug** (the last segment of the app's own URL)
 - **Generate a private key** and download the `.pem`
 
 ## Plumb the secrets
 
-Add these to the control-plane env (`.env`, `values.yaml`, or your secret manager). All are optional in the schema (`platform/app/src/env-create.mjs`); when the private key is unset the feature is silently off, the connect card reports the integration as unavailable, and no token can be minted.
+Add these to the control-plane env (`.env` or your secret manager). All are optional in the schema (`platform/app/src/env-create.mjs`); when the private key is unset the feature is silently off, the connect card reports the integration as unavailable, and no token can be minted.
 
 ```bash title=".env"
 GITHUB_LANGY_APP_ID="<App ID from registration>"
@@ -57671,6 +57680,8 @@ GITHUB_LANGY_WEBHOOK_SECRET="<the webhook secret you generated>"
 # The private key PEM. In a single-line env value, escape newlines as \n;
 # the token service normalises them back.
 GITHUB_LANGY_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+# Only for GitHub Enterprise Server. Unset means github.com.
+# GITHUB_LANGY_HOST="github.acme-corp.internal"
 ```
 
 <Warning>
@@ -57680,6 +57691,57 @@ GITHUB_LANGY_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRI
 There is no client id or secret; the bot-authored flow uses no user OAuth. `CREDENTIALS_SECRET` (already required for any production install) signs the install round-trip's state, so nothing new is needed there.
 
 For the full env-var reference, see [Environment variables](/self-hosting/langy/environment-variables#github).
+
+### Helm
+
+The chart has no `GITHUB_LANGY_*` keys of its own. Set the variables with `app.extraEnvs` or `app.extraEnvFrom`.
+
+`GITHUB_LANGY_PRIVATE_KEY` is a multi-line PEM, so put all four values in a Secret you manage and reference it with `app.extraEnvFrom`. That keeps the PEM out of your values file and lets you rotate it without a chart change.
+
+```yaml title="values.yaml"
+app:
+  extraEnvFrom:
+    - secretRef:
+        name: langwatch-github-app
+  extraEnvs:
+    # Only for GitHub Enterprise Server.
+    - name: GITHUB_LANGY_HOST
+      value: github.acme-corp.internal
+```
+
+Set the same values on `workers` when you run the workers as their own deployment. The periodic branch recheck runs there, and without the private key it cannot mint a token.
+
+## GitHub Enterprise Server
+
+One LangWatch instance connects to exactly one GitHub. To use GitHub Enterprise Server instead of github.com:
+
+1. Register the App on the Enterprise Server instance, at `https://<HOSTNAME>/settings/apps/new` under your organization or site admin settings. An App registered on github.com cannot be installed on an Enterprise Server, so this is a separate registration with its own id, key and slug.
+2. Set `GITHUB_LANGY_HOST` to the Enterprise Server hostname, for example `github.acme-corp.internal`. Give the hostname only, with no scheme and no path.
+3. Set the other four `GITHUB_LANGY_*` variables from the new registration.
+
+LangWatch then derives every address from that host: the REST API at `https://<HOSTNAME>/api/v3`, the install link at `https://<HOSTNAME>/github-apps/<slug>/installations/new`, and the uninstall link in settings. Egress from the control plane goes to the Enterprise Server host instead of `api.github.com`.
+
+Sessions are matched by the host their git remote reports, so an instance bound to an Enterprise Server links sessions on that host and leaves github.com sessions unlinked.
+
+<Note>
+`GITHUB_LANGY_HOST` covers the control plane: the connection, token minting, and coding-agent pull request linkage. Langy's own pull requests still go to github.com, because the worker clones with the `gh` command line, which reads its own host setting. Enterprise Server support for Langy pull requests is separate work.
+</Note>
+
+## Restricted networks
+
+GitHub must be able to reach `<BASE_URL>/api/github/webhook` to deliver webhooks. Many self-hosted instances sit behind a VPN or a private network, where that is not true.
+
+**The webhook is optional.** An instance with no inbound path connects and works. Connecting is a browser redirect through `/api/github/setup`, so only the admin's own browser has to reach the instance, not GitHub. You can leave **Webhook > Active** off, or leave it on and accept the failed deliveries.
+
+What changes without webhooks:
+
+| Behavior | With webhooks | Without webhooks |
+|---|---|---|
+| A pull request appears on the Pull Requests page | Within seconds of it being opened | On the next outbound recheck: about 15 to 25 minutes while sessions keep running on the branch, up to 24 hours for a branch that went quiet before its pull request was opened |
+| Uninstall and suspend | Reconciled at once | Reconciled late. The next live read gets a 404 from GitHub and removes the stale record |
+| Repository selection changes | Reconciled at once | Refreshed on the next live resolve |
+
+Everything else is outbound only and is not affected: minting installation tokens, Langy opening pull requests, the post-connect backfill, and the live pull request status the page reads.
 
 ## Install the app
 
@@ -57717,7 +57779,7 @@ Go to **Settings > Integrations > Disconnect**, which opens GitHub's uninstall p
 - **Nothing at rest.** No token or refresh token is stored control-plane side. The app private key is the only credential; it never leaves the control plane and never goes near a worker. Tokens are minted per turn, cached in Redis a hair under their 1h lifetime, and self-expire.
 - **Least privilege at mint time.** Tokens are minted with only `contents:write` and `pull_requests:write`, scoped to the installation's repositories (or a single repository when the turn targets one).
 - **Sticky worker tokens.** A worker spawned with token T keeps T until the idle reaper kills it. Removing the installation cuts off new turns immediately; a live worker may hold a token for up to the idle TTL (within 10 min) or until it self-expires (within 1h).
-- **Egress.** The control plane reaches `api.github.com` to mint installation tokens and read installation metadata. Workers need `github.com`, `api.github.com`, and `codeload.github.com` to clone and push, which requires outbound egress to be enabled. See [Networking and egress](/self-hosting/langy/networking-and-egress).
+- **Egress.** The control plane reaches `api.github.com` to mint installation tokens and read installation metadata, or `<GITHUB_LANGY_HOST>` when one is set. Workers need `github.com`, `api.github.com`, and `codeload.github.com` to clone and push, which requires outbound egress to be enabled. See [Networking and egress](/self-hosting/langy/networking-and-egress).
 
 ---
 
@@ -57758,9 +57820,17 @@ That is why per-worker egress control lives at L7, in a per-worker CONNECT proxy
 | In-cluster LangWatch AI Gateway | All LLM traffic (traced, budgeted, policed) | Always, in-cluster |
 | In-cluster LangWatch app | The `langwatch` CLI (per-session key) | Always, in-cluster |
 | `github.com`, `api.github.com`, `codeload.github.com` | Clone and push for pull requests | Only when egress is on |
-| `api.github.com` (from the control plane, not the worker) | Mint 1-hour installation tokens | Control plane |
+| `api.github.com` (from the control plane, not the worker) | Mint 1-hour installation tokens, read installation metadata, and list pull requests for a branch | Control plane |
 
 Private ranges (RFC 1918), CGNAT (`100.64.0.0/10`), and the cloud metadata service are blocked at L3/L4 regardless of the egress toggle, which is the SSRF and IMDS protection.
+
+With `GITHUB_LANGY_HOST` set to a GitHub Enterprise Server hostname, the control plane reaches that host instead of `api.github.com`. Workers keep using the github.com names, because they clone with the `gh` command line. See [GitHub Enterprise Server](/self-hosting/langy/github-app#github-enterprise-server).
+
+## Inbound
+
+Everything above is outbound. The one inbound path GitHub uses is the webhook, delivered to `<BASE_URL>/api/github/webhook`.
+
+It is optional. An instance GitHub cannot reach still connects and works, and reconciles late instead. For what changes, see [Restricted networks](/self-hosting/langy/github-app#restricted-networks).
 
 ## Enable outbound egress
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -615,7 +615,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 - [Self-Hosting Langy](https://langwatch.ai/docs/self-hosting/langy/overview.md): Requirements and architecture for running Langy on your own Kubernetes cluster, including the separate agent pod and the gVisor requirement.
 - [Langy Assistant](https://langwatch.ai/docs/self-hosting/langy/setup.md): Run LangWatch's in-product AI assistant on your own cluster
-- [Register the Langy GitHub App](https://langwatch.ai/docs/self-hosting/langy/github-app.md): Deployment-time guide for the GitHub App that lets Langy open bot-authored pull requests, covering registration, permissions, the GITHUB_LANGY env vars, install, verify, and disconnect.
+- [Register the GitHub App](https://langwatch.ai/docs/self-hosting/langy/github-app.md): Deployment-time guide for the GitHub App the organization connects, covering registration, permissions, the GITHUB_LANGY env vars, GitHub Enterprise Server, restricted networks, install, verify, and disconnect.
 - [Langy Environment Variables](https://langwatch.ai/docs/self-hosting/langy/environment-variables.md): The environment variable reference for the Langy agent pod and its control-plane integration, grouped by core, workers, egress, mirror lane, and GitHub.
 - [Langy Networking and Egress](https://langwatch.ai/docs/self-hosting/langy/networking-and-egress.md): The NetworkPolicy and L7 egress adapter that govern what the Langy agent pod can reach, the GitHub FQDN floor, and the cooperative-vs-mandatory enforcement limit.
 

--- a/docs/self-hosting/langy/environment-variables.mdx
+++ b/docs/self-hosting/langy/environment-variables.mdx
@@ -66,14 +66,15 @@ The mirror lane copies each turn's trace into a LangWatch project you designate,
 
 ## GitHub
 
-Set these on the control plane to enable bot-authored pull requests. If `GITHUB_LANGY_PRIVATE_KEY` is unset, the GitHub feature is silently off. See [Register the Langy GitHub App](/self-hosting/langy/github-app) for the registration walkthrough.
+Set these on the control plane to enable bot-authored pull requests and coding-agent pull request linkage. If `GITHUB_LANGY_PRIVATE_KEY` is unset, the GitHub feature is silently off. See [Register the GitHub App](/self-hosting/langy/github-app) for the registration walkthrough.
 
 | Variable | Description | Required | Default |
 |---|---|---|---|
 | `GITHUB_LANGY_APP_ID` | GitHub App id (JWT `iss`). | For GitHub | unset (feature off) |
 | `GITHUB_LANGY_PRIVATE_KEY` | App RSA private key PEM (mints install tokens). The only credential; control-plane only. Escape newlines as `\n` in a single-line value. | For GitHub | unset (feature off) |
-| `GITHUB_LANGY_WEBHOOK_SECRET` | Verifies the `X-Hub-Signature-256` on inbound webhooks. | For GitHub | unset |
-| `GITHUB_LANGY_APP_SLUG` | App slug for the install deep-link (`github.com/apps/<slug>`). | For GitHub | unset |
+| `GITHUB_LANGY_WEBHOOK_SECRET` | Verifies the `X-Hub-Signature-256` on inbound webhooks. Optional: without it the instance still connects, mints tokens and opens pull requests, but it reconciles late. Linkage then waits for the outbound recheck, and an uninstall clears only when a live read gets a 404. See [Restricted networks](/self-hosting/langy/github-app#restricted-networks). | No | unset |
+| `GITHUB_LANGY_APP_SLUG` | App slug for the install deep-link. | For GitHub | unset |
+| `GITHUB_LANGY_HOST` | The GitHub host this instance connects to. Set it to a GitHub Enterprise Server hostname (no scheme, no path) to bind the instance to that server. One instance connects to one host. | No | `github.com` |
 | `CREDENTIALS_SECRET` | Signs the GitHub install state round-trip and encrypts provider keys at rest. Already required in production, so nothing new is needed for GitHub. | Yes (prod) | none |
 
 <Warning>

--- a/docs/self-hosting/langy/github-app.mdx
+++ b/docs/self-hosting/langy/github-app.mdx
@@ -1,18 +1,22 @@
 ---
-title: Register the Langy GitHub App
-description: Deployment-time guide for the GitHub App that lets Langy open bot-authored pull requests, covering registration, permissions, the GITHUB_LANGY env vars, install, verify, and disconnect.
+title: Register the GitHub App
+description: Deployment-time guide for the GitHub App the organization connects, covering registration, permissions, the GITHUB_LANGY env vars, GitHub Enterprise Server, restricted networks, install, verify, and disconnect.
 sidebarTitle: GitHub App
 keywords:
   - langy github app
   - github_langy_app_id
+  - github enterprise server
   - bot-authored pull requests
 ---
 
-Langy opens pull requests through a GitHub App you register and install. PRs are authored by the app and credit the requesting user via a `Co-authored-by` trailer and a `Requested by @<login> via LangWatch` note in the body.
+One GitHub App serves the whole organization connection, and two features use it:
+
+- **Langy pull requests.** Langy opens pull requests through the App. They are authored by the App and credit the requesting user with a `Co-authored-by` trailer and a `Requested by @<login> via LangWatch` note in the body.
+- **Coding-agent pull request linkage.** LangWatch matches each coding-agent session to the pull request its branch became, so the Pull Requests page can report what each pull request cost in assistant usage. This part only reads.
 
 There is no per-user OAuth and no long-lived stored token: the app private key is the only credential, it lives only in the control-plane env, and installation tokens are minted on demand, cached in Redis a hair under their 1 hour lifetime, and never written to the database.
 
-To set it up: register a GitHub App, put its id, private key, webhook secret, and slug into the deployment env, and have org admins install it on the repos Langy may touch from **Settings > Integrations**.
+To set it up: register a GitHub App, put its id, private key, webhook secret, and slug into the deployment env, and have org admins install it on the repos LangWatch may touch from **Settings > Integrations**.
 
 <Info>
 **Also check:** [What Langy can do in your GitHub](/langy/security/github-access), [Setup](/self-hosting/langy/setup), [Environment variables](/self-hosting/langy/environment-variables).
@@ -32,13 +36,17 @@ Fill in these fields:
 |---|---|
 | App name | `LangWatch Langy` (or per environment, e.g. `LangWatch Langy (dev)`) |
 | Homepage URL | `https://app.langwatch.ai` (or your control-plane URL) |
-| Setup URL | `<BASE_URL>/api/github-langy/setup` |
+| Setup URL | `<BASE_URL>/api/github/setup` |
 | Redirect on update | ON (so re-configuring an install returns to the Setup URL) |
 | Request user authorization (OAuth) during installation | OFF. Langy is bot-authored, no user OAuth. |
-| Webhook > Active | ON |
-| Webhook URL | `<BASE_URL>/api/github-langy/webhook` |
+| Webhook > Active | ON (optional, see [Restricted networks](#restricted-networks)) |
+| Webhook URL | `<BASE_URL>/api/github/webhook` |
 | Webhook secret | Generate one (`openssl rand -hex 32`). You set it as `GITHUB_LANGY_WEBHOOK_SECRET`. |
 | Where can this GitHub App be installed? | Any account (recommended) or only this org |
+
+<Note>
+`/api/github-langy/setup` and `/api/github-langy/webhook` are the earlier paths. They stay mounted on the same handlers, so an App already registered with them keeps working. Use the paths above for a new registration.
+</Note>
 
 Set the repository permissions to exactly these, nothing more. Tighter scope means a smaller blast radius.
 
@@ -55,12 +63,12 @@ The `pull_request` event links a pull request to its coding-agent sessions as so
 Click **Create GitHub App**. On the resulting page:
 
 - copy the **App ID**
-- note the **app slug** (in the app's URL: `github.com/apps/<slug>`)
+- note the **app slug** (the last segment of the app's own URL)
 - **Generate a private key** and download the `.pem`
 
 ## Plumb the secrets
 
-Add these to the control-plane env (`.env`, `values.yaml`, or your secret manager). All are optional in the schema (`platform/app/src/env-create.mjs`); when the private key is unset the feature is silently off, the connect card reports the integration as unavailable, and no token can be minted.
+Add these to the control-plane env (`.env` or your secret manager). All are optional in the schema (`platform/app/src/env-create.mjs`); when the private key is unset the feature is silently off, the connect card reports the integration as unavailable, and no token can be minted.
 
 ```bash title=".env"
 GITHUB_LANGY_APP_ID="<App ID from registration>"
@@ -69,6 +77,8 @@ GITHUB_LANGY_WEBHOOK_SECRET="<the webhook secret you generated>"
 # The private key PEM. In a single-line env value, escape newlines as \n;
 # the token service normalises them back.
 GITHUB_LANGY_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+# Only for GitHub Enterprise Server. Unset means github.com.
+# GITHUB_LANGY_HOST="github.acme-corp.internal"
 ```
 
 <Warning>
@@ -78,6 +88,57 @@ GITHUB_LANGY_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRI
 There is no client id or secret; the bot-authored flow uses no user OAuth. `CREDENTIALS_SECRET` (already required for any production install) signs the install round-trip's state, so nothing new is needed there.
 
 For the full env-var reference, see [Environment variables](/self-hosting/langy/environment-variables#github).
+
+### Helm
+
+The chart has no `GITHUB_LANGY_*` keys of its own. Set the variables with `app.extraEnvs` or `app.extraEnvFrom`.
+
+`GITHUB_LANGY_PRIVATE_KEY` is a multi-line PEM, so put all four values in a Secret you manage and reference it with `app.extraEnvFrom`. That keeps the PEM out of your values file and lets you rotate it without a chart change.
+
+```yaml title="values.yaml"
+app:
+  extraEnvFrom:
+    - secretRef:
+        name: langwatch-github-app
+  extraEnvs:
+    # Only for GitHub Enterprise Server.
+    - name: GITHUB_LANGY_HOST
+      value: github.acme-corp.internal
+```
+
+Set the same values on `workers` when you run the workers as their own deployment. The periodic branch recheck runs there, and without the private key it cannot mint a token.
+
+## GitHub Enterprise Server
+
+One LangWatch instance connects to exactly one GitHub. To use GitHub Enterprise Server instead of github.com:
+
+1. Register the App on the Enterprise Server instance, at `https://<HOSTNAME>/settings/apps/new` under your organization or site admin settings. An App registered on github.com cannot be installed on an Enterprise Server, so this is a separate registration with its own id, key and slug.
+2. Set `GITHUB_LANGY_HOST` to the Enterprise Server hostname, for example `github.acme-corp.internal`. Give the hostname only, with no scheme and no path.
+3. Set the other four `GITHUB_LANGY_*` variables from the new registration.
+
+LangWatch then derives every address from that host: the REST API at `https://<HOSTNAME>/api/v3`, the install link at `https://<HOSTNAME>/github-apps/<slug>/installations/new`, and the uninstall link in settings. Egress from the control plane goes to the Enterprise Server host instead of `api.github.com`.
+
+Sessions are matched by the host their git remote reports, so an instance bound to an Enterprise Server links sessions on that host and leaves github.com sessions unlinked.
+
+<Note>
+`GITHUB_LANGY_HOST` covers the control plane: the connection, token minting, and coding-agent pull request linkage. Langy's own pull requests still go to github.com, because the worker clones with the `gh` command line, which reads its own host setting. Enterprise Server support for Langy pull requests is separate work.
+</Note>
+
+## Restricted networks
+
+GitHub must be able to reach `<BASE_URL>/api/github/webhook` to deliver webhooks. Many self-hosted instances sit behind a VPN or a private network, where that is not true.
+
+**The webhook is optional.** An instance with no inbound path connects and works. Connecting is a browser redirect through `/api/github/setup`, so only the admin's own browser has to reach the instance, not GitHub. You can leave **Webhook > Active** off, or leave it on and accept the failed deliveries.
+
+What changes without webhooks:
+
+| Behavior | With webhooks | Without webhooks |
+|---|---|---|
+| A pull request appears on the Pull Requests page | Within seconds of it being opened | On the next outbound recheck: about 15 to 25 minutes while sessions keep running on the branch, up to 24 hours for a branch that went quiet before its pull request was opened |
+| Uninstall and suspend | Reconciled at once | Reconciled late. The next live read gets a 404 from GitHub and removes the stale record |
+| Repository selection changes | Reconciled at once | Refreshed on the next live resolve |
+
+Everything else is outbound only and is not affected: minting installation tokens, Langy opening pull requests, the post-connect backfill, and the live pull request status the page reads.
 
 ## Install the app
 
@@ -115,4 +176,4 @@ Go to **Settings > Integrations > Disconnect**, which opens GitHub's uninstall p
 - **Nothing at rest.** No token or refresh token is stored control-plane side. The app private key is the only credential; it never leaves the control plane and never goes near a worker. Tokens are minted per turn, cached in Redis a hair under their 1h lifetime, and self-expire.
 - **Least privilege at mint time.** Tokens are minted with only `contents:write` and `pull_requests:write`, scoped to the installation's repositories (or a single repository when the turn targets one).
 - **Sticky worker tokens.** A worker spawned with token T keeps T until the idle reaper kills it. Removing the installation cuts off new turns immediately; a live worker may hold a token for up to the idle TTL (within 10 min) or until it self-expires (within 1h).
-- **Egress.** The control plane reaches `api.github.com` to mint installation tokens and read installation metadata. Workers need `github.com`, `api.github.com`, and `codeload.github.com` to clone and push, which requires outbound egress to be enabled. See [Networking and egress](/self-hosting/langy/networking-and-egress).
+- **Egress.** The control plane reaches `api.github.com` to mint installation tokens and read installation metadata, or `<GITHUB_LANGY_HOST>` when one is set. Workers need `github.com`, `api.github.com`, and `codeload.github.com` to clone and push, which requires outbound egress to be enabled. See [Networking and egress](/self-hosting/langy/networking-and-egress).

--- a/docs/self-hosting/langy/github-app.mdx
+++ b/docs/self-hosting/langy/github-app.mdx
@@ -82,7 +82,7 @@ GITHUB_LANGY_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRI
 ```
 
 <Warning>
-`GITHUB_LANGY_PRIVATE_KEY` is the only credential for the whole GitHub integration and grants write access to installed repos. Keep it in a secrets manager, never in version control, and never expose it to a worker. It stays in the control plane.
+`GITHUB_LANGY_PRIVATE_KEY` is the only credential for the whole GitHub integration and grants write access to installed repos. Keep it in a secrets manager, never in version control, and never let it reach the Langy agent pod. It stays in the control plane.
 </Warning>
 
 There is no client id or secret; the bot-authored flow uses no user OAuth. `CREDENTIALS_SECRET` (already required for any production install) signs the install round-trip's state, so nothing new is needed there.
@@ -106,7 +106,9 @@ app:
       value: github.acme-corp.internal
 ```
 
-Set the same values on `workers` when you run the workers as their own deployment. The periodic branch recheck runs there, and without the private key it cannot mint a token.
+Set the same values on `workers` when you run the LangWatch workers as their own deployment. The periodic branch recheck runs there, and without the private key it cannot mint a token.
+
+The LangWatch `workers` deployment is part of the control plane. It is not the Langy agent pod, which runs customer code in a sandbox and never receives the private key.
 
 ## GitHub Enterprise Server
 
@@ -172,8 +174,8 @@ Go to **Settings > Integrations > Disconnect**, which opens GitHub's uninstall p
 
 ## Operational notes
 
-- **Token in worker, not on disk.** Workers receive a 1-hour installation token via `GH_TOKEN` env. The github skill wires `git config credential.helper '!gh auth git-credential'` so git pushes read it from env, with no `.gitconfig` and no `.git-credentials`. The clone directory lives inside the per-worker home that the idle reaper deletes (within 10 min).
-- **Nothing at rest.** No token or refresh token is stored control-plane side. The app private key is the only credential; it never leaves the control plane and never goes near a worker. Tokens are minted per turn, cached in Redis a hair under their 1h lifetime, and self-expire.
+- **Token in the agent pod, not on disk.** Langy workers receive a 1-hour installation token via `GH_TOKEN` env. The github skill wires `git config credential.helper '!gh auth git-credential'` so git pushes read it from env, with no `.gitconfig` and no `.git-credentials`. The clone directory lives inside the per-worker home that the idle reaper deletes (within 10 min).
+- **Nothing at rest.** No token or refresh token is stored control-plane side. The app private key is the only credential; it never leaves the control plane and never reaches the Langy agent pod. Tokens are minted per turn, cached in Redis a hair under their 1h lifetime, and self-expire. The cache key carries the GitHub host, so two GitHub instances cannot share an entry.
 - **Least privilege at mint time.** Tokens are minted with only `contents:write` and `pull_requests:write`, scoped to the installation's repositories (or a single repository when the turn targets one).
 - **Sticky worker tokens.** A worker spawned with token T keeps T until the idle reaper kills it. Removing the installation cuts off new turns immediately; a live worker may hold a token for up to the idle TTL (within 10 min) or until it self-expires (within 1h).
 - **Egress.** The control plane reaches `api.github.com` to mint installation tokens and read installation metadata, or `<GITHUB_LANGY_HOST>` when one is set. Workers need `github.com`, `api.github.com`, and `codeload.github.com` to clone and push, which requires outbound egress to be enabled. See [Networking and egress](/self-hosting/langy/networking-and-egress).

--- a/docs/self-hosting/langy/networking-and-egress.mdx
+++ b/docs/self-hosting/langy/networking-and-egress.mdx
@@ -33,7 +33,7 @@ That is why per-worker egress control lives at L7, in a per-worker CONNECT proxy
 | In-cluster LangWatch AI Gateway | All LLM traffic (traced, budgeted, policed) | Always, in-cluster |
 | In-cluster LangWatch app | The `langwatch` CLI (per-session key) | Always, in-cluster |
 | `github.com`, `api.github.com`, `codeload.github.com` | Clone and push for pull requests | Only when egress is on |
-| `api.github.com` (from the control plane, not the worker) | Mint 1-hour installation tokens, read installation metadata, and list pull requests for a branch | Control plane |
+| `api.github.com`, or `GITHUB_LANGY_HOST` when one is set (from the control plane, not the agent pod) | Mint 1-hour installation tokens, read installation metadata, and list pull requests for a branch | Control plane |
 
 Private ranges (RFC 1918), CGNAT (`100.64.0.0/10`), and the cloud metadata service are blocked at L3/L4 regardless of the egress toggle, which is the SSRF and IMDS protection.
 

--- a/docs/self-hosting/langy/networking-and-egress.mdx
+++ b/docs/self-hosting/langy/networking-and-egress.mdx
@@ -33,9 +33,17 @@ That is why per-worker egress control lives at L7, in a per-worker CONNECT proxy
 | In-cluster LangWatch AI Gateway | All LLM traffic (traced, budgeted, policed) | Always, in-cluster |
 | In-cluster LangWatch app | The `langwatch` CLI (per-session key) | Always, in-cluster |
 | `github.com`, `api.github.com`, `codeload.github.com` | Clone and push for pull requests | Only when egress is on |
-| `api.github.com` (from the control plane, not the worker) | Mint 1-hour installation tokens | Control plane |
+| `api.github.com` (from the control plane, not the worker) | Mint 1-hour installation tokens, read installation metadata, and list pull requests for a branch | Control plane |
 
 Private ranges (RFC 1918), CGNAT (`100.64.0.0/10`), and the cloud metadata service are blocked at L3/L4 regardless of the egress toggle, which is the SSRF and IMDS protection.
+
+With `GITHUB_LANGY_HOST` set to a GitHub Enterprise Server hostname, the control plane reaches that host instead of `api.github.com`. Workers keep using the github.com names, because they clone with the `gh` command line. See [GitHub Enterprise Server](/self-hosting/langy/github-app#github-enterprise-server).
+
+## Inbound
+
+Everything above is outbound. The one inbound path GitHub uses is the webhook, delivered to `<BASE_URL>/api/github/webhook`.
+
+It is optional. An instance GitHub cannot reach still connects and works, and reconciles late instead. For what changes, see [Restricted networks](/self-hosting/langy/github-app#restricted-networks).
 
 ## Enable outbound egress
 

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -105,17 +105,21 @@ CREDENTIALS_SECRET="000000000000000000000000000000000000000000000000000000000000
 # Salt used to generate JWT tokens for API authentication, be sure to change it before deploying to production as well
 API_TOKEN_JWT_SECRET="change me to a random string"
 
-# Langy → GitHub: bot-authored PRs via a GitHub App installation. Separate from
-# the GITHUB_CLIENT_* identity-login app. Register the App (Setup URL
-# `<BASE_URL>/api/github-langy/setup`, Webhook URL
-# `<BASE_URL>/api/github-langy/webhook`, permissions: Contents R/W, Pull
-# requests R/W, Metadata R). See docs/langy-github-app.md. All optional — when
-# the private key is unset, Langy's GitHub feature is silently off. In a
-# single-line PEM value escape newlines as \n.
+# The organization GitHub connection: bot-authored PRs from Langy, and
+# coding-agent pull request linkage. Separate from the GITHUB_CLIENT_*
+# identity-login app. Register the App (Setup URL `<BASE_URL>/api/github/setup`,
+# Webhook URL `<BASE_URL>/api/github/webhook`, permissions: Contents R/W, Pull
+# requests R/W, Metadata R). See docs/self-hosting/langy/github-app.mdx. All
+# optional: when the private key is unset, the GitHub feature is silently off.
+# In a single-line PEM value escape newlines as \n.
 # GITHUB_LANGY_APP_ID=""
 # GITHUB_LANGY_APP_SLUG=""
 # GITHUB_LANGY_WEBHOOK_SECRET=""
 # GITHUB_LANGY_PRIVATE_KEY=""
+# The GitHub host this instance connects to. Unset means github.com. Set it to
+# a GitHub Enterprise Server hostname (no scheme, no path) to bind the instance
+# to that server.
+# GITHUB_LANGY_HOST=""
 
 # Usage tracking for product insights, set to true if you would like to disable this.
 # DISABLE_USAGE_STATS=

--- a/platform/app/src/app/api/coding-agent/[[...route]]/app.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/app.ts
@@ -8,6 +8,7 @@ import { getApp } from "~/server/app-layer/app";
 import { MAX_SESSION_EVENTS_PAGE_SIZE } from "~/server/app-layer/coding-agent/coding-agent-session.service";
 import type { SessionEventsCursor } from "~/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository";
 import { GithubPullRequestNotMappedError } from "~/server/app-layer/github/errors";
+import { getGithubHost } from "~/server/app-layer/github/githubHost";
 import { resolveCallerProjectScope } from "~/server/organizations/resolveCallerProjectScope";
 import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
@@ -336,8 +337,16 @@ const usageQuerySchema = z.object({
     message: "repository must be owner/name",
   }),
   pullRequest: z.coerce.number().int().positive(),
-  /** Defaults to github.com, the only host the mapping covers today. */
-  host: z.string().min(1).default("github.com"),
+  /**
+   * Defaults to the GitHub host this instance is bound to, which is github.com
+   * unless an operator named an Enterprise Server. The published document
+   * states github.com, which is the default every instance has until it names
+   * another host.
+   */
+  host: z
+    .string()
+    .min(1)
+    .default(() => getGithubHost()),
 });
 
 // GET /pull-request-usage: what one pull request cost in assistant usage,

--- a/platform/app/src/env-create.mjs
+++ b/platform/app/src/env-create.mjs
@@ -479,10 +479,15 @@ export function createEnvConfig() {
       //                                installation webhooks.
       //   GITHUB_LANGY_APP_SLUG      — the App's slug, for the install deep-link
       //                                github.com/apps/<slug>/installations/new.
+      //
+      // GITHUB_LANGY_HOST is the GitHub host this instance connects to. Unset
+      // means github.com. Set it to a GitHub Enterprise Server hostname to bind
+      // the instance to that server.
       GITHUB_LANGY_APP_ID: z.string().optional(),
       GITHUB_LANGY_PRIVATE_KEY: z.string().optional(),
       GITHUB_LANGY_WEBHOOK_SECRET: z.string().optional(),
       GITHUB_LANGY_APP_SLUG: z.string().optional(),
+      GITHUB_LANGY_HOST: z.string().optional(),
 
       // Gitlab
       GITLAB_CLIENT_ID: z.string().optional(),
@@ -701,6 +706,7 @@ export function createEnvConfig() {
       GITHUB_LANGY_PRIVATE_KEY: process.env.GITHUB_LANGY_PRIVATE_KEY,
       GITHUB_LANGY_WEBHOOK_SECRET: process.env.GITHUB_LANGY_WEBHOOK_SECRET,
       GITHUB_LANGY_APP_SLUG: process.env.GITHUB_LANGY_APP_SLUG,
+      GITHUB_LANGY_HOST: process.env.GITHUB_LANGY_HOST,
       GITLAB_CLIENT_ID: process.env.GITLAB_CLIENT_ID,
       GITLAB_CLIENT_SECRET: process.env.GITLAB_CLIENT_SECRET,
       GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,

--- a/platform/app/src/server/api/routers/__tests__/github.access-order.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/github.access-order.unit.test.ts
@@ -44,6 +44,15 @@ vi.mock("~/server/app-layer/github/githubAppConfig", () => ({
   getGithubAppConfig: () => appConfig,
 }));
 
+// The uninstall deep link is built from the GitHub host this instance is bound
+// to, so the suite controls that host as well.
+const { githubHost } = vi.hoisted(() => ({
+  githubHost: { webBase: "https://github.com" },
+}));
+vi.mock("~/server/app-layer/github/githubHost", () => ({
+  getGithubWebBase: () => githubHost.webBase,
+}));
+
 vi.mock("~/server/api/rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/server/api/rbac")>();
   return {
@@ -121,6 +130,37 @@ describe("githubRouter access gates", () => {
     listRepositoriesForOrganization.mockResolvedValue([]);
     hasOrgPermission.mockReturnValue(true);
     appConfig.configured = true;
+    githubHost.webBase = "https://github.com";
+  });
+
+  describe("when the instance is bound to a GitHub Enterprise Server host", () => {
+    /** @scenario "The uninstall link points at the configured host" */
+    it("points the uninstall link at that host", async () => {
+      githubHost.webBase = "https://github.acme-corp.internal";
+      isOrganizationMember.mockResolvedValue(true);
+      getAllForOrganization.mockResolvedValue([installationRow()]);
+
+      const result = await caller().getConnectionStatus({
+        organizationId: "org-1",
+      });
+
+      expect(result.installations[0]?.uninstallUrl).toBe(
+        "https://github.acme-corp.internal/organizations/acme/settings/installations/555",
+      );
+    });
+
+    it("points it at github.com when no host is named", async () => {
+      isOrganizationMember.mockResolvedValue(true);
+      getAllForOrganization.mockResolvedValue([installationRow()]);
+
+      const result = await caller().getConnectionStatus({
+        organizationId: "org-1",
+      });
+
+      expect(result.installations[0]?.uninstallUrl).toBe(
+        "https://github.com/organizations/acme/settings/installations/555",
+      );
+    });
   });
 
   describe("when the instance cannot start an installation", () => {

--- a/platform/app/src/server/api/routers/github.ts
+++ b/platform/app/src/server/api/routers/github.ts
@@ -35,6 +35,7 @@ import { getApp } from "~/server/app-layer";
 import { GithubNotConnectedError } from "~/server/app-layer/github/errors";
 import { MAX_STATUS_REFS } from "~/server/app-layer/github/github-pull-request-status.service";
 import { getGithubAppConfig } from "~/server/app-layer/github/githubAppConfig";
+import { getGithubWebBase } from "~/server/app-layer/github/githubHost";
 import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
@@ -68,17 +69,18 @@ const enforceOrganizationMembership: PermissionMiddleware<{
   return next();
 };
 
-// GitHub can only be uninstalled by a human on github.com. Deep-link to the
-// right settings page for the account type.
+// GitHub can only be uninstalled by a human on GitHub itself. Deep-link to the
+// right account settings page on the host this instance is bound to.
 function uninstallUrl(installation: {
   accountLogin: string;
   accountType: string;
   installationId: string;
 }): string {
+  const webBase = getGithubWebBase();
   if (installation.accountType === "Organization") {
-    return `https://github.com/organizations/${installation.accountLogin}/settings/installations/${installation.installationId}`;
+    return `${webBase}/organizations/${installation.accountLogin}/settings/installations/${installation.installationId}`;
   }
-  return `https://github.com/settings/installations/${installation.installationId}`;
+  return `${webBase}/settings/installations/${installation.installationId}`;
 }
 
 /**

--- a/platform/app/src/server/app-layer/coding-agent/coding-agent-sessions-list.service.ts
+++ b/platform/app/src/server/app-layer/coding-agent/coding-agent-sessions-list.service.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@langwatch/observability";
 
 import type { CodingAgentSessionRow } from "~/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection";
+import { normalizeGithubHost } from "../github/githubHost";
 import type {
   GithubPullRequestLookup,
   PullRequestBranchKey,
@@ -217,7 +218,7 @@ function branchDrivesOf(rows: CodingAgentSessionRow[]): BranchDrive[] {
   const drives: BranchDrive[] = [];
   for (const row of rows) {
     if (!row.repositoryOwner || !row.repositoryName) continue;
-    const repositoryHost = (row.repositoryHost || "github.com").toLowerCase();
+    const repositoryHost = normalizeGithubHost(row.repositoryHost ?? "");
     const repositoryFullName =
       `${row.repositoryOwner}/${row.repositoryName}`.toLowerCase();
     for (const headBranch of branchesOf(row)) {

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts
@@ -38,6 +38,7 @@
  * Spec: specs/coding-agent/pull-request-linkage.feature.
  */
 import { GithubPullRequestNotMappedError } from "../github/errors";
+import { normalizeGithubHost } from "../github/githubHost";
 import type {
   GithubPullRequestRow,
   GithubPullRequestsRepository,
@@ -1141,9 +1142,7 @@ function groupSessionsByRepository(
     // sees one repository listed twice with its usage divided between the
     // rows, and the group whose host is not already lower case matches no
     // mapping row and reports every branch as unlinked.
-    const repositoryHost = (
-      session.repositoryHost === "" ? "github.com" : session.repositoryHost
-    ).toLowerCase();
+    const repositoryHost = normalizeGithubHost(session.repositoryHost);
     const repositoryFullName =
       `${session.repositoryOwner}/${session.repositoryName}`.toLowerCase();
     const key = `${repositoryHost} ${repositoryFullName}`;

--- a/platform/app/src/server/app-layer/github/__tests__/github-branch-recheck.worker.unit.test.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/github-branch-recheck.worker.unit.test.ts
@@ -95,6 +95,26 @@ describe("runBranchRecheckPass", () => {
       );
     });
 
+    /**
+     * The sweep selects on `lastRequestedAt`, so a pass that presented itself
+     * as demand would renew the column it reads and no branch would ever leave
+     * the sweep. The origin is what the mapping service reads to decide.
+     */
+    /** @scenario "The sweep does not renew the demand it selects on" */
+    it("asks the mapping on its own account rather than as demand", async () => {
+      const mapBranch = vi.fn().mockResolvedValue(undefined);
+
+      await runBranchRecheckPass({
+        repository: repositoryHolding([checkRow({})]),
+        mapping: { mapBranch },
+        now: () => NOW,
+      });
+
+      expect(mapBranch).toHaveBeenCalledWith(
+        expect.objectContaining({ origin: "sweep" }),
+      );
+    });
+
     it("asks with a one-week activity window", async () => {
       const repository = repositoryHolding([]);
       await runBranchRecheckPass({
@@ -144,27 +164,26 @@ describe("runBranchRecheckPass", () => {
         repositoryOwner: "acme",
         repositoryName: "widgets",
         headBranch: "feat/linkage",
+        origin: "sweep",
       });
     });
   });
 });
 
 describe("runBranchRetentionPrune", () => {
-  describe("given rows nobody has asked about", () => {
+  describe("given rows outside the activity window", () => {
     /**
      * One horizon, not two. A branch outside the sweep's activity window has
      * already stopped being maintained by the feature, so keeping its
-     * bookkeeping and its pull requests keeps rows that are never read and
-     * never refreshed. Bounding the prune by a knob of its own would let the
-     * two drift into disagreeing about what "abandoned" means.
-     *
-     * @scenario "Linkage rows nobody asks about stop accumulating"
+     * bookkeeping keeps a row that is never read and never refreshed. Bounding
+     * the prune by a knob of its own would let the two drift into disagreeing
+     * about what "abandoned" means.
      */
     it("prunes at the same horizon the sweep stops sweeping at", async () => {
       const repository = repositoryHolding([]);
       repository.deleteStaleBefore = vi
         .fn()
-        .mockResolvedValue({ branchChecks: 7, pullRequests: 2 });
+        .mockResolvedValue({ branchChecks: 7 });
 
       const pruned = await runBranchRetentionPrune({
         repository,
@@ -174,7 +193,7 @@ describe("runBranchRetentionPrune", () => {
       expect(repository.deleteStaleBefore).toHaveBeenCalledWith({
         before: new Date(NOW - RECHECK_ACTIVE_WITHIN_MS),
       });
-      expect(pruned).toEqual({ branchChecks: 7, pullRequests: 2 });
+      expect(pruned).toEqual({ branchChecks: 7 });
     });
   });
 });

--- a/platform/app/src/server/app-layer/github/__tests__/github-pull-request-mapping.host.unit.test.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/github-pull-request-mapping.host.unit.test.ts
@@ -86,7 +86,7 @@ function parsed(payload: unknown) {
   return event;
 }
 
-describe("branch mapping on an Enterprise Server instance", () => {
+describe("given an instance bound to a GitHub Enterprise Server host", () => {
   beforeEach(() => {
     mockEnv.GITHUB_LANGY_HOST = GHES;
   });
@@ -115,6 +115,7 @@ describe("branch mapping on an Enterprise Server instance", () => {
   });
 
   describe("when a session reports a repository on the configured host", () => {
+    /** @scenario "A repository on the configured host is mapped" */
     it("maps the branch and keys it by that host", async () => {
       const { service, repository, listPullRequestsForHead } = serviceWith();
 
@@ -150,6 +151,7 @@ describe("branch mapping on an Enterprise Server instance", () => {
   });
 
   describe("when a session reports a github.com repository", () => {
+    /** @scenario "A repository on github.com is not mapped by an Enterprise Server instance" */
     it("asks GitHub nothing, because this instance has no connection there", async () => {
       const { service, repository, listPullRequestsForHead } = serviceWith();
 

--- a/platform/app/src/server/app-layer/github/__tests__/github-pull-request-mapping.host.unit.test.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/github-pull-request-mapping.host.unit.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment node
+ * @unit
+ *
+ * Branch mapping on an instance bound to a GitHub Enterprise Server host: which
+ * repositories it answers for, and which host the rows it writes carry.
+ *
+ * The repository is a spy rather than the real Postgres one, because what is
+ * under test is the host each write is keyed by, not that the write lands.
+ *
+ * @see specs/integrations/github-connection.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock factories are hoisted above top-level declarations, so the mutable
+// env object has to come from vi.hoisted to exist when the factory runs.
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: { GITHUB_LANGY_HOST: undefined as string | undefined },
+}));
+
+vi.mock("~/env.mjs", () => ({ env: mockEnv }));
+
+import { GithubPullRequestMappingService } from "../github-pull-request-mapping.service";
+import { parseGithubPullRequestEvent } from "../githubPullRequestEvent";
+
+const GHES = "github.acme-corp.internal";
+
+/** A delivery as GitHub sends it, trimmed to the fields the parser reads. */
+function delivery() {
+  return {
+    action: "opened",
+    installation: { id: 4242 },
+    repository: {
+      name: "widgets",
+      full_name: "acme/widgets",
+      owner: { login: "acme" },
+    },
+    pull_request: {
+      number: 7,
+      html_url: `https://${GHES}/acme/widgets/pull/7`,
+      title: "Link sessions to pull requests",
+      state: "open",
+      draft: false,
+      merged_at: null,
+      closed_at: null,
+      created_at: "2026-08-01T10:00:00.000Z",
+      updated_at: "2026-08-01T11:00:00.000Z",
+      user: { login: "someone" },
+      head: { ref: "feat/linkage", repo: { full_name: "acme/widgets" } },
+    },
+  };
+}
+
+function serviceWith() {
+  const repository = {
+    upsertPullRequests: vi.fn().mockResolvedValue(undefined),
+    findBranchCheck: vi.fn().mockResolvedValue(null),
+    upsertBranchCheck: vi.fn().mockResolvedValue(undefined),
+    bringBranchRecheckForward: vi.fn().mockResolvedValue(undefined),
+    claimBranchLookup: vi.fn().mockResolvedValue(true),
+    touchBranchCheckRequestedAt: vi.fn().mockResolvedValue(undefined),
+  };
+  const listPullRequestsForHead = vi.fn().mockResolvedValue([]);
+  const resolveInstallationForRepository = vi
+    .fn()
+    .mockResolvedValue({ installationId: "4242", repositoryId: "999" });
+  const service = new GithubPullRequestMappingService({
+    repository: repository as never,
+    installations: {
+      getByInstallationId: vi
+        .fn()
+        .mockResolvedValue({ organizationId: "org-1" }),
+      resolveInstallationForRepository,
+    } as never,
+    appTokens: { listPullRequestsForHead } as never,
+    resolveOrganizationId: vi.fn().mockResolvedValue("org-1"),
+    findProjectIds: vi.fn(),
+    sessions: { listRecent: vi.fn() },
+  });
+  return { service, repository, listPullRequestsForHead };
+}
+
+function parsed(payload: unknown) {
+  const event = parseGithubPullRequestEvent(payload);
+  if (!event) throw new Error("expected the delivery to parse");
+  return event;
+}
+
+describe("branch mapping on an Enterprise Server instance", () => {
+  beforeEach(() => {
+    mockEnv.GITHUB_LANGY_HOST = GHES;
+  });
+
+  describe("when GitHub announces a pull request", () => {
+    /** @scenario "A pull request announced over the webhook is recorded under the configured host" */
+    it("stores it under the configured host, not github.com", async () => {
+      const { service, repository } = serviceWith();
+
+      await expect(
+        service.applyPullRequestEvent(parsed(delivery())),
+      ).resolves.toBe(true);
+
+      const [written] =
+        repository.upsertPullRequests.mock.calls[0]![0].pullRequests;
+      expect(written).toMatchObject({
+        organizationId: "org-1",
+        repositoryHost: GHES,
+        repositoryFullName: "acme/widgets",
+        prNumber: 7,
+      });
+      expect(repository.upsertBranchCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryHost: GHES }),
+      );
+    });
+  });
+
+  describe("when a session reports a repository on the configured host", () => {
+    it("maps the branch and keys it by that host", async () => {
+      const { service, repository, listPullRequestsForHead } = serviceWith();
+
+      await service.requestBranchMapping({
+        tenantId: "project-1",
+        repositoryHost: GHES,
+        repositoryOwner: "acme",
+        repositoryName: "widgets",
+        headBranch: "feat/linkage",
+      });
+
+      expect(listPullRequestsForHead).toHaveBeenCalledTimes(1);
+      expect(repository.claimBranchLookup).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryHost: GHES }),
+      );
+    });
+
+    it("maps a session that reported no host at all onto that host", async () => {
+      const { service, repository } = serviceWith();
+
+      await service.requestBranchMapping({
+        tenantId: "project-1",
+        repositoryHost: "",
+        repositoryOwner: "acme",
+        repositoryName: "widgets",
+        headBranch: "feat/linkage",
+      });
+
+      expect(repository.claimBranchLookup).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryHost: GHES }),
+      );
+    });
+  });
+
+  describe("when a session reports a github.com repository", () => {
+    it("asks GitHub nothing, because this instance has no connection there", async () => {
+      const { service, repository, listPullRequestsForHead } = serviceWith();
+
+      await service.requestBranchMapping({
+        tenantId: "project-1",
+        repositoryHost: "github.com",
+        repositoryOwner: "acme",
+        repositoryName: "widgets",
+        headBranch: "feat/linkage",
+      });
+
+      expect(listPullRequestsForHead).not.toHaveBeenCalled();
+      expect(repository.claimBranchLookup).not.toHaveBeenCalled();
+      expect(repository.upsertBranchCheck).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/github/__tests__/github-pull-request-mapping.integration.test.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/github-pull-request-mapping.integration.test.ts
@@ -523,7 +523,8 @@ describe("branch pull-request mapping", () => {
       expect(check?.notFoundAt).toBeNull();
     });
 
-    it("leaves a branch nobody has asked about in a week out of the sweep", async () => {
+    /** @scenario "A branch with no session demand for a week leaves the sweep" */
+    it("leaves a branch with no session demand for a week out of the sweep", async () => {
       await seedInstallation();
       const { mapping } = servicesWith({
         listPullRequestsForHead: vi.fn().mockResolvedValue([]),
@@ -640,8 +641,9 @@ describe("branch pull-request mapping", () => {
   });
 
   describe("given branches on both sides of the activity horizon", () => {
-    /** @scenario "Linkage rows nobody asks about stop accumulating" */
-    it("prunes the abandoned branch and its pull requests, and keeps the live one", async () => {
+    /** @scenario "Bookkeeping for a branch outside the activity window is removed" */
+    /** @scenario "A linked pull request stays after its branch goes quiet" */
+    it("prunes the abandoned branch's bookkeeping and keeps every pull request", async () => {
       await seedInstallation();
       // A distinct pull request per branch: the stored row is unique on the
       // pull-request NUMBER, so reusing one would move it between branches
@@ -673,7 +675,6 @@ describe("branch pull-request mapping", () => {
       const pruned = await runBranchRetentionPrune({ repository });
 
       expect(pruned.branchChecks).toBe(1);
-      expect(pruned.pullRequests).toBeGreaterThanOrEqual(1);
 
       const remainingChecks =
         await prisma.githubBranchPullRequestCheck.findMany({
@@ -684,13 +685,127 @@ describe("branch pull-request mapping", () => {
         "feat/still-read",
       ]);
 
+      // Both pull requests survive, including the one whose branch went quiet.
+      // A merged pull request is exactly what the Pull Requests page is for,
+      // and its branch stops seeing folds the moment it is merged.
       const remainingPullRequests = await prisma.githubPullRequest.findMany({
         where: { organizationId },
-        select: { headBranch: true },
+        select: { headBranch: true, prNumber: true },
+        orderBy: { prNumber: "asc" },
       });
-      expect(remainingPullRequests.map((row) => row.headBranch)).toEqual([
-        "feat/still-read",
+      expect(remainingPullRequests).toEqual([
+        { headBranch: "feat/abandoned", prNumber: 51 },
+        { headBranch: "feat/still-read", prNumber: 52 },
       ]);
+    });
+
+    it("re-maps the pruned branch from GitHub when a session folds on it again", async () => {
+      await seedInstallation();
+      const listPullRequestsForHead = vi.fn().mockResolvedValue([]);
+      const { mapping } = servicesWith({ listPullRequestsForHead });
+      const request = {
+        tenantId: projectId,
+        repositoryHost: "github.com",
+        repositoryOwner: `acme-${tag}`,
+        repositoryName: "widgets",
+        headBranch: "feat/comes-back",
+      };
+      await mapping.requestBranchMapping(request);
+      await prisma.githubBranchPullRequestCheck.updateMany({
+        where: { organizationId, headBranch: "feat/comes-back" },
+        data: {
+          lastRequestedAt: new Date(Date.now() - RECHECK_ACTIVE_WITHIN_MS - 1),
+        },
+      });
+      await runBranchRetentionPrune({ repository });
+      expect(await branchCheckFor("feat/comes-back")).toBeNull();
+
+      await mapping.requestBranchMapping(request);
+
+      expect(listPullRequestsForHead).toHaveBeenCalledTimes(2);
+      expect(await branchCheckFor("feat/comes-back")).not.toBeNull();
+    });
+  });
+
+  describe("given a branch the sweep asks GitHub about", () => {
+    /**
+     * The sweep selects branches by `lastRequestedAt` and used to write it on
+     * the way past, through both the lookup claim and the answer. A branch that
+     * never gets a pull request therefore renewed its own place in the sweep
+     * and was asked about once a day for as long as the connection existed,
+     * and its bookkeeping never reached the retention horizon either.
+     */
+    /** @scenario "The sweep does not renew the demand it selects on" */
+    it("leaves the branch's last demand time exactly where the fold left it", async () => {
+      await seedInstallation();
+      const listPullRequestsForHead = vi.fn().mockResolvedValue([]);
+      const { mapping } = servicesWith({ listPullRequestsForHead });
+      await mapping.requestBranchMapping({
+        tenantId: projectId,
+        repositoryHost: "github.com",
+        repositoryOwner: `acme-${tag}`,
+        repositoryName: "widgets",
+        headBranch: "feat/swept",
+      });
+      const afterFold = await branchCheckFor("feat/swept");
+      // Due now, and last asked for six days ago: inside the sweep's window,
+      // so the pass really does pick it up.
+      const demandedAt = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000);
+      await prisma.githubBranchPullRequestCheck.updateMany({
+        where: { organizationId, headBranch: "feat/swept" },
+        data: {
+          recheckAfter: new Date(Date.now() - 1000),
+          lastRequestedAt: demandedAt,
+        },
+      });
+
+      await runBranchRecheckPass({ repository, mapping });
+
+      const afterSweep = await branchCheckFor("feat/swept");
+      // GitHub was asked again, and the ladder moved on.
+      expect(listPullRequestsForHead).toHaveBeenCalledTimes(2);
+      expect(afterSweep?.attempts).toBe((afterFold?.attempts ?? 0) + 1);
+      expect(afterSweep?.recheckAfter?.getTime()).toBeGreaterThan(Date.now());
+      // But the demand signal did not move, so the week still runs out.
+      expect(afterSweep?.lastRequestedAt.getTime()).toBe(demandedAt.getTime());
+    });
+  });
+
+  describe("given a session folding on a branch with no pull request", () => {
+    /** @scenario "A session folding on a branch records demand for it" */
+    it("moves the branch's last demand time to the time of the fold", async () => {
+      await seedInstallation();
+      const { mapping } = servicesWith({
+        listPullRequestsForHead: vi.fn().mockResolvedValue([]),
+      });
+      const request = {
+        tenantId: projectId,
+        repositoryHost: "github.com",
+        repositoryOwner: `acme-${tag}`,
+        repositoryName: "widgets",
+        headBranch: "feat/demanded",
+      };
+      await mapping.requestBranchMapping(request);
+      const staleDemand = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000);
+      // Age the demand, and let the branch out of both the claim lease and the
+      // freshness window so the next fold really performs a lookup.
+      await prisma.githubBranchPullRequestCheck.updateMany({
+        where: { organizationId, headBranch: "feat/demanded" },
+        data: {
+          lastRequestedAt: staleDemand,
+          recheckAfter: new Date(Date.now() - 1000),
+        },
+      });
+
+      await mapping.requestBranchMapping(request);
+
+      const check = await branchCheckFor("feat/demanded");
+      expect(check?.lastRequestedAt.getTime()).toBeGreaterThan(
+        staleDemand.getTime(),
+      );
+      expect(check?.lastRequestedAt.getTime()).toBeGreaterThan(
+        Date.now() - 60_000,
+      );
     });
   });
 
@@ -727,6 +842,7 @@ describe("branch pull-request mapping", () => {
         repositoryOwner: `acme-${tag}`,
         repositoryName: "widgets",
         headBranch: "feat/backed-off",
+        origin: "demand",
       });
       await armLongestBackoff("feat/backed-off");
 
@@ -752,6 +868,7 @@ describe("branch pull-request mapping", () => {
         repositoryOwner: `acme-${tag}`,
         repositoryName: "widgets",
         headBranch: "feat/backed-off",
+        origin: "demand",
       });
 
       const afterEmpty = await branchCheckFor("feat/backed-off");
@@ -836,6 +953,7 @@ describe("branch pull-request mapping", () => {
         repositoryOwner: `acme-${tag}`,
         repositoryName: "widgets",
         headBranch: "feat/two-pulls",
+        origin: "demand",
       });
       expect((await branchCheckFor("feat/two-pulls"))?.prCount).toBe(2);
 
@@ -859,6 +977,7 @@ describe("branch pull-request mapping", () => {
         repositoryOwner: `acme-${tag}`,
         repositoryName: "widgets",
         headBranch: "feat/missed-hook",
+        origin: "demand",
       });
 
       // The pull request is opened and the delivery never arrives, so only the
@@ -990,6 +1109,7 @@ describe("branch pull-request mapping", () => {
         repositoryOwner: `acme-${tag}`,
         repositoryName: "widgets",
         headBranch: "feat/slow-listing",
+        origin: "demand" as const,
       };
 
       const listing = mapping.mapBranch(target);

--- a/platform/app/src/server/app-layer/github/__tests__/githubHost.unit.test.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/githubHost.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment node
+ * @unit
+ *
+ * The GitHub host an instance is bound to, and the URLs derived from it. The
+ * default matters as much as the setting: an instance that names no host has to
+ * behave exactly as it did before the setting existed.
+ *
+ * @see specs/integrations/github-connection.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock factories are hoisted above top-level declarations, so the mutable
+// env object has to come from vi.hoisted to exist when the factory runs.
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: { GITHUB_LANGY_HOST: undefined as string | undefined },
+}));
+
+vi.mock("~/env.mjs", () => ({ env: mockEnv }));
+
+import {
+  getGithubApiBase,
+  getGithubAppInstallUrl,
+  getGithubHost,
+  getGithubWebBase,
+  isMappableGithubHost,
+  normalizeGithubHost,
+} from "../githubHost";
+
+const GHES = "github.acme-corp.internal";
+
+describe("the GitHub host this instance is bound to", () => {
+  beforeEach(() => {
+    mockEnv.GITHUB_LANGY_HOST = undefined;
+  });
+
+  describe("given the instance names no GitHub host", () => {
+    /** @scenario "An instance that names no host talks to github.com" */
+    it("resolves github.com, its public API and its app page", () => {
+      expect(getGithubHost()).toBe("github.com");
+      expect(getGithubApiBase()).toBe("https://api.github.com");
+      expect(getGithubWebBase()).toBe("https://github.com");
+      expect(getGithubAppInstallUrl("langwatch-langy")).toBe(
+        "https://github.com/apps/langwatch-langy/installations/new",
+      );
+    });
+
+    it("treats an empty or blank value as no host at all", () => {
+      mockEnv.GITHUB_LANGY_HOST = "";
+      expect(getGithubHost()).toBe("github.com");
+      mockEnv.GITHUB_LANGY_HOST = "   ";
+      expect(getGithubHost()).toBe("github.com");
+    });
+
+    it("maps a session that reported no host onto github.com", () => {
+      expect(normalizeGithubHost("")).toBe("github.com");
+      expect(isMappableGithubHost("")).toBe(true);
+      expect(isMappableGithubHost("github.com")).toBe(true);
+      // A host is case insensitive, and a session records whatever casing its
+      // git remote carried.
+      expect(isMappableGithubHost("GitHub.com")).toBe(true);
+      expect(normalizeGithubHost("GitHub.com")).toBe("github.com");
+      expect(isMappableGithubHost("gitlab.example.com")).toBe(false);
+    });
+  });
+
+  describe("given the instance names a GitHub Enterprise Server host", () => {
+    beforeEach(() => {
+      mockEnv.GITHUB_LANGY_HOST = GHES;
+    });
+
+    /** @scenario "An instance that names an Enterprise Server host talks to that host" */
+    it("resolves that host, its /api/v3 base and its /github-apps page", () => {
+      expect(getGithubHost()).toBe(GHES);
+      // Enterprise Server serves the REST API on the instance itself, not on a
+      // separate api. hostname.
+      expect(getGithubApiBase()).toBe(`https://${GHES}/api/v3`);
+      expect(getGithubWebBase()).toBe(`https://${GHES}`);
+      // And it serves an App's public page under /github-apps/, not /apps/.
+      expect(getGithubAppInstallUrl("langwatch-langy")).toBe(
+        `https://${GHES}/github-apps/langwatch-langy/installations/new`,
+      );
+    });
+
+    it("folds the configured host's own casing", () => {
+      mockEnv.GITHUB_LANGY_HOST = GHES.toUpperCase();
+
+      expect(getGithubHost()).toBe(GHES);
+      expect(isMappableGithubHost(GHES)).toBe(true);
+    });
+
+    /** @scenario "A repository on the configured host is mapped" */
+    it("maps a repository on that host, and one that reported no host", () => {
+      expect(isMappableGithubHost(GHES)).toBe(true);
+      expect(isMappableGithubHost(GHES.toUpperCase())).toBe(true);
+      // No host reported means the only GitHub this instance knows about.
+      expect(isMappableGithubHost("")).toBe(true);
+      expect(normalizeGithubHost("")).toBe(GHES);
+    });
+
+    /** @scenario "A repository on github.com is not mapped by an Enterprise Server instance" */
+    it("refuses github.com, which this instance has no connection to", () => {
+      expect(isMappableGithubHost("github.com")).toBe(false);
+    });
+
+    it("escapes an app slug into the install link", () => {
+      expect(getGithubAppInstallUrl("weird slug/../x")).toBe(
+        `https://${GHES}/github-apps/weird%20slug%2F..%2Fx/installations/new`,
+      );
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/github/__tests__/githubHost.unit.test.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/githubHost.unit.test.ts
@@ -89,7 +89,6 @@ describe("the GitHub host this instance is bound to", () => {
       expect(isMappableGithubHost(GHES)).toBe(true);
     });
 
-    /** @scenario "A repository on the configured host is mapped" */
     it("maps a repository on that host, and one that reported no host", () => {
       expect(isMappableGithubHost(GHES)).toBe(true);
       expect(isMappableGithubHost(GHES.toUpperCase())).toBe(true);
@@ -98,7 +97,6 @@ describe("the GitHub host this instance is bound to", () => {
       expect(normalizeGithubHost("")).toBe(GHES);
     });
 
-    /** @scenario "A repository on github.com is not mapped by an Enterprise Server instance" */
     it("refuses github.com, which this instance has no connection to", () => {
       expect(isMappableGithubHost("github.com")).toBe(false);
     });

--- a/platform/app/src/server/app-layer/github/github-branch-recheck.worker.ts
+++ b/platform/app/src/server/app-layer/github/github-branch-recheck.worker.ts
@@ -7,12 +7,15 @@
  * mapping cannot see that: it only runs when a session is folded, and by then
  * the branch may never be touched again. This pass is what closes that gap. It
  * picks up the branches that mapped to nothing, whose backoff has elapsed, and
- * that a reader still cares about, and asks GitHub once more.
+ * that a session has run on recently, and asks GitHub once more.
  *
- * "Still cares about" is the load-bearing cut. Without it the sweep would grow
- * without bound, asking GitHub daily about every branch any session ever ran on
- * since the connection was made. The same horizon bounds the retention prune,
- * so a branch that falls out of the sweep also stops costing storage.
+ * That last cut is what bounds the sweep. Without it, every branch any session
+ * ever ran on since the connection was made is asked about daily, for good. The
+ * cut works only because the sweep does not write the column it selects on: a
+ * pass runs with `origin: "sweep"`, which leaves `lastRequestedAt` alone, so a
+ * branch with no new folds ages out of the sweep on its own. The same horizon
+ * bounds the retention prune, so a branch that falls out of the sweep also
+ * stops costing a bookkeeping row. Its pull requests are kept.
  *
  * SCHEDULING LIVES ELSEWHERE. This module owns one pass and nothing else; the
  * `githubBranchRecheck` process manager (pipelines/github-maintenance) owns
@@ -24,10 +27,10 @@ import type { GithubPullRequestMappingService } from "./github-pull-request-mapp
 import type { GithubPullRequestsRepository } from "./repositories/github-pull-requests.repository";
 
 /**
- * How long since a reader last asked before a branch drops out of the sweep,
- * and past which its bookkeeping and its pull requests are pruned. A week is
- * generous for a branch someone is still working on and short enough that an
- * abandoned one stops costing GitHub calls and rows.
+ * How long since a session last folded on a branch before it drops out of the
+ * sweep, and past which its bookkeeping is pruned. A week is generous for a
+ * branch someone is still working on and short enough that an abandoned one
+ * stops costing GitHub calls and rows.
  */
 export const RECHECK_ACTIVE_WITHIN_MS = 7 * 24 * 60 * 60 * 1000;
 /** Branches per pass. Each one is a GitHub call, so the pass stays small. */
@@ -65,6 +68,9 @@ export async function runBranchRecheckPass({
       repositoryOwner: owner,
       repositoryName: name,
       headBranch: row.headBranch,
+      // The sweep asks on its own account, so the answer must not refresh the
+      // demand the sweep selected this branch by.
+      origin: "sweep",
     });
   }
 
@@ -72,15 +78,14 @@ export async function runBranchRecheckPass({
 }
 
 /**
- * One retention pass: drop the bookkeeping past the activity horizon, and the
- * pull requests it was the only reason to keep.
+ * One retention pass: drop the branch bookkeeping past the activity horizon.
+ * The pull requests it found stay.
  */
 export async function runBranchRetentionPrune({
   repository,
   now = () => Date.now(),
 }: Pick<GithubBranchRecheckDeps, "repository" | "now">): Promise<{
   branchChecks: number;
-  pullRequests: number;
 }> {
   return await repository.deleteStaleBefore({
     before: new Date(now() - RECHECK_ACTIVE_WITHIN_MS),

--- a/platform/app/src/server/app-layer/github/github-pull-request-mapping.service.ts
+++ b/platform/app/src/server/app-layer/github/github-pull-request-mapping.service.ts
@@ -515,7 +515,7 @@ export class GithubPullRequestMappingService {
       now: new Date(now),
       freshMappingMs: FRESH_MAPPING_MS,
       leaseMs: LOOKUP_CLAIM_LEASE_MS,
-      recordsDemand: origin === "demand",
+      shouldRecordDemand: origin === "demand",
     });
     if (claimed) return true;
     if (origin !== "demand") return false;

--- a/platform/app/src/server/app-layer/github/github-pull-request-mapping.service.ts
+++ b/platform/app/src/server/app-layer/github/github-pull-request-mapping.service.ts
@@ -28,6 +28,11 @@ import {
   GithubRateLimitedError,
 } from "./githubAppToken";
 import {
+  getGithubHost,
+  isMappableGithubHost,
+  normalizeGithubHost,
+} from "./githubHost";
+import {
   type GithubPullRequestEvent,
   LINKING_PULL_REQUEST_ACTIONS,
 } from "./githubPullRequestEvent";
@@ -37,9 +42,6 @@ import type {
 } from "./repositories/github-pull-requests.repository";
 
 const logger = createLogger("langwatch:github:pull-request-mapping");
-
-/** The only host this maps. An unset host is the default one. */
-export const GITHUB_HOST = "github.com";
 
 /** How long a branch that resolved to a pull request is trusted. */
 const FRESH_MAPPING_MS = 15 * 60 * 1000;
@@ -132,6 +134,19 @@ export interface GithubPullRequestMappingServiceDeps {
   now?: () => number;
 }
 
+/**
+ * Why a branch is being mapped.
+ *
+ * `demand` means someone asked: a session folded on the branch, or an operator
+ * connected GitHub and the backfill is catching up. `sweep` means the periodic
+ * recheck picked the branch off its own due list.
+ *
+ * The distinction decides one column. `lastRequestedAt` records demand, and the
+ * sweep selects branches by it, so a sweep that wrote it would keep renewing
+ * the very signal it reads and no branch would ever leave the sweep.
+ */
+export type BranchMappingOrigin = "demand" | "sweep";
+
 /** A repository and branch, already resolved to an organization. */
 export interface BranchMappingTarget {
   organizationId: string;
@@ -139,6 +154,7 @@ export interface BranchMappingTarget {
   repositoryOwner: string;
   repositoryName: string;
   headBranch: string;
+  origin: BranchMappingOrigin;
 }
 
 /** The same, addressed by the project a session was folded under. */
@@ -148,26 +164,6 @@ export interface BranchMappingRequest {
   repositoryOwner: string;
   repositoryName: string;
   headBranch: string;
-}
-
-/**
- * An unset host means github.com; anything else is a host we do not map.
- *
- * Case-folded, because a session records whatever casing its git remote
- * carries and a host is case insensitive. A literal comparison here refuses
- * `GitHub.com` outright, so that session is never mapped at all, and every
- * reader downstream folds its host and then looks for a mapping row nothing
- * ever wrote.
- */
-export function isMappableHost(repositoryHost: string): boolean {
-  const host = repositoryHost.toLowerCase();
-  return host === "" || host === GITHUB_HOST;
-}
-
-/** The host to store: the default, spelled out and folded, so rows compare. */
-export function normalizeHost(repositoryHost: string): string {
-  const host = repositoryHost.toLowerCase();
-  return host === "" ? GITHUB_HOST : host;
 }
 
 /**
@@ -206,7 +202,7 @@ export class GithubPullRequestMappingService {
    * mapping can fix.
    */
   async requestBranchMapping(request: BranchMappingRequest): Promise<void> {
-    if (!isMappableHost(request.repositoryHost)) return;
+    if (!isMappableGithubHost(request.repositoryHost)) return;
     const organizationId = await this.deps.resolveOrganizationId(
       request.tenantId,
     );
@@ -217,6 +213,7 @@ export class GithubPullRequestMappingService {
       repositoryOwner: request.repositoryOwner,
       repositoryName: request.repositoryName,
       headBranch: request.headBranch,
+      origin: "demand",
     };
     // This entry point, and only this one, means a session just folded on the
     // branch. The sweep and the backfill call `mapBranch` directly and carry no
@@ -297,8 +294,9 @@ export class GithubPullRequestMappingService {
 
     const scope = branchScopeFor({
       organizationId: installation.organizationId,
-      // The App is a github.com App, so a delivery can only ever be about it.
-      repositoryHost: GITHUB_HOST,
+      // The App is registered on one GitHub, so a delivery can only ever be
+      // about that one.
+      repositoryHost: getGithubHost(),
       repositoryOwner: event.repositoryOwner,
       repositoryName: event.repositoryName,
       headBranch: event.headBranch,
@@ -309,6 +307,9 @@ export class GithubPullRequestMappingService {
       scope,
       pullRequests: [event.pullRequest],
       isExhaustive: false,
+      // A delivery says a person just acted on the branch, which is demand by
+      // the same reading a fold is.
+      origin: "demand",
     });
     return true;
   }
@@ -333,7 +334,7 @@ export class GithubPullRequestMappingService {
     // immediately.
     if (!covering) return;
 
-    if (!(await this.claimLookup(scope))) return;
+    if (!(await this.claimLookup({ scope, origin: target.origin }))) return;
 
     try {
       const pullRequests = await this.deps.appTokens.listPullRequestsForHead({
@@ -343,9 +344,14 @@ export class GithubPullRequestMappingService {
         repo: target.repositoryName,
         branch: scope.headBranch,
       });
-      await this.recordAnswer({ scope, pullRequests, isExhaustive: true });
+      await this.recordAnswer({
+        scope,
+        pullRequests,
+        isExhaustive: true,
+        origin: target.origin,
+      });
     } catch (error) {
-      await this.recordFailure({ scope, error });
+      await this.recordFailure({ scope, error, origin: target.origin });
     }
   }
 
@@ -444,7 +450,7 @@ export class GithubPullRequestMappingService {
     organizationId: string;
     session: BackfillSessionRow;
   }): BranchMappingTarget | null {
-    if (!isMappableHost(session.repositoryHost)) return null;
+    if (!isMappableGithubHost(session.repositoryHost)) return null;
     if (
       !session.repositoryOwner ||
       !session.repositoryName ||
@@ -454,10 +460,13 @@ export class GithubPullRequestMappingService {
     }
     return {
       organizationId,
-      repositoryHost: normalizeHost(session.repositoryHost),
+      repositoryHost: normalizeGithubHost(session.repositoryHost),
       repositoryOwner: session.repositoryOwner,
       repositoryName: session.repositoryName,
       headBranch: session.gitBranch,
+      // An operator connecting GitHub is asking for these branches, as plainly
+      // as a fold does.
+      origin: "demand",
     };
   }
 
@@ -488,16 +497,28 @@ export class GithubPullRequestMappingService {
    * other, both read "nothing stored yet", and both call GitHub. Whichever
    * caller loses the claim still keeps the branch inside the sweep's activity
    * window, throttled — that touch is the whole reason a skip writes at all.
+   *
+   * Both writes carry the origin, so only a caller acting on demand records
+   * demand. A sweep that lost the claim writes nothing: it had no demand to
+   * record, and the caller holding the claim records its own.
    */
-  private async claimLookup(scope: BranchScope): Promise<boolean> {
+  private async claimLookup({
+    scope,
+    origin,
+  }: {
+    scope: BranchScope;
+    origin: BranchMappingOrigin;
+  }): Promise<boolean> {
     const now = nowMs(this.deps);
     const claimed = await this.deps.repository.claimBranchLookup({
       ...scope,
       now: new Date(now),
       freshMappingMs: FRESH_MAPPING_MS,
       leaseMs: LOOKUP_CLAIM_LEASE_MS,
+      recordsDemand: origin === "demand",
     });
     if (claimed) return true;
+    if (origin !== "demand") return false;
 
     await this.deps.repository.touchBranchCheckRequestedAt({
       ...scope,
@@ -515,6 +536,7 @@ export class GithubPullRequestMappingService {
     scope,
     pullRequests,
     isExhaustive,
+    origin,
   }: {
     scope: BranchScope;
     pullRequests: readonly GithubPullRequestSummary[];
@@ -526,6 +548,7 @@ export class GithubPullRequestMappingService {
      * which is the number the freshness guard on the lookup claim reads.
      */
     isExhaustive: boolean;
+    origin: BranchMappingOrigin;
   }): Promise<void> {
     const now = new Date(nowMs(this.deps));
     if (pullRequests.length > 0) {
@@ -553,7 +576,7 @@ export class GithubPullRequestMappingService {
         ? null
         : new Date(now.getTime() + backoffMsFor(attempts)),
       attempts,
-      lastRequestedAt: now,
+      lastRequestedAt: origin === "demand" ? now : null,
     });
   }
 
@@ -571,9 +594,11 @@ export class GithubPullRequestMappingService {
   private async recordFailure({
     scope,
     error,
+    origin,
   }: {
     scope: BranchScope;
     error: unknown;
+    origin: BranchMappingOrigin;
   }): Promise<void> {
     if (!(error instanceof GithubRateLimitedError)) {
       logger.warn({ error, ...scope }, "branch pull-request mapping failed");
@@ -589,7 +614,7 @@ export class GithubPullRequestMappingService {
       notFoundAt: existing?.notFoundAt ?? null,
       recheckAfter: new Date(now.getTime() + backoffMsFor(attempts)),
       attempts,
-      lastRequestedAt: now,
+      lastRequestedAt: origin === "demand" ? now : null,
     });
   }
 }
@@ -607,14 +632,16 @@ interface BranchScope {
  * connection can answer for. Every write in this service goes through it, so
  * the host fold and the owner/name/branch completeness check happen once.
  */
-function branchScopeFor(target: BranchMappingTarget): BranchScope | null {
-  if (!isMappableHost(target.repositoryHost)) return null;
+function branchScopeFor(
+  target: Omit<BranchMappingTarget, "origin">,
+): BranchScope | null {
+  if (!isMappableGithubHost(target.repositoryHost)) return null;
   if (!target.headBranch || !target.repositoryOwner || !target.repositoryName) {
     return null;
   }
   return {
     organizationId: target.organizationId,
-    repositoryHost: normalizeHost(target.repositoryHost),
+    repositoryHost: normalizeGithubHost(target.repositoryHost),
     repositoryFullName: `${target.repositoryOwner}/${target.repositoryName}`,
     headBranch: target.headBranch,
   };

--- a/platform/app/src/server/app-layer/github/githubAppConfig.ts
+++ b/platform/app/src/server/app-layer/github/githubAppConfig.ts
@@ -6,6 +6,9 @@
  * deployment and in every operator's secret store; renaming them is an infra
  * change with its own rollout, tracked separately. Nothing outside this module
  * should name them, so that rename is a one-file edit here plus the env schema.
+ *
+ * `GITHUB_LANGY_HOST` is read next door in `githubHost.ts`, which owns the host
+ * and the two base URLs derived from it.
  */
 import { env } from "~/env.mjs";
 
@@ -16,7 +19,7 @@ export interface GithubAppConfig {
   privateKey: string;
   /** Verifies X-Hub-Signature-256 on inbound installation webhooks. */
   webhookSecret: string;
-  /** The App's slug, for github.com/apps/<slug>/installations/new. */
+  /** The App's slug, which addresses its public installation page. */
   appSlug: string;
   /**
    * Whether an installation can actually be started and used: the key mints

--- a/platform/app/src/server/app-layer/github/githubAppToken.ts
+++ b/platform/app/src/server/app-layer/github/githubAppToken.ts
@@ -18,7 +18,7 @@ import { createHash, randomBytes } from "crypto";
 import jwt from "jsonwebtoken";
 
 import { GithubRepositoryNotAccessibleError } from "./errors";
-import { getGithubApiBase } from "./githubHost";
+import { GITHUB_DOT_COM, getGithubApiBase, getGithubHost } from "./githubHost";
 
 const logger = createLogger("langwatch:github:app-token");
 
@@ -275,6 +275,24 @@ export function computeRepoScopeKey({
     .slice(0, 16);
 }
 
+/**
+ * Redis key prefix for one installation's cached token and liveness marker.
+ *
+ * An installation id is unique within one GitHub, not across two. Without the
+ * host in the key, installation 42 on github.com and installation 42 on an
+ * Enterprise Server share a cache entry, and a live bearer token minted for one
+ * is handed to the other.
+ *
+ * github.com keeps the unqualified shape, so tokens cached before this existed
+ * stay valid and the default deployment sees no change at all.
+ */
+function installationCacheKeyPrefix(installationId: string): string {
+  const host = getGithubHost();
+  const hostSegment = host === GITHUB_DOT_COM ? "" : `${host}:`;
+  // The `langy:` prefix is kept so tokens cached before the deploy stay valid.
+  return `langy:gh:insttoken:${hostSegment}${installationId}`;
+}
+
 export class GithubAppTokenService {
   constructor(
     private readonly appId: string,
@@ -356,8 +374,7 @@ export class GithubAppTokenService {
   private async assertInstallationStillExists(
     installationId: string,
   ): Promise<void> {
-    // The `langy:` prefix is kept so tokens cached before the deploy stay valid.
-    const markerKey = `langy:gh:insttoken:${installationId}:liveness`;
+    const markerKey = `${installationCacheKeyPrefix(installationId)}:liveness`;
     if (await this.redisGet(markerKey)) return;
 
     // Lock-guarded the same way the mint path guards its own stampede: a
@@ -391,8 +408,9 @@ export class GithubAppTokenService {
       repositoryIds: args.repositoryIds,
       permissions: args.permissions,
     });
-    // The `langy:` prefix is kept so tokens cached before the deploy stay valid.
-    const cacheKey = `langy:gh:insttoken:${args.installationId}:${scopeKey}`;
+    const cacheKey = `${installationCacheKeyPrefix(
+      args.installationId,
+    )}:${scopeKey}`;
 
     const cached = await this.redisGet(cacheKey);
     if (cached) {

--- a/platform/app/src/server/app-layer/github/githubAppToken.ts
+++ b/platform/app/src/server/app-layer/github/githubAppToken.ts
@@ -18,10 +18,10 @@ import { createHash, randomBytes } from "crypto";
 import jwt from "jsonwebtoken";
 
 import { GithubRepositoryNotAccessibleError } from "./errors";
+import { getGithubApiBase } from "./githubHost";
 
 const logger = createLogger("langwatch:github:app-token");
 
-const GITHUB_API = "https://api.github.com";
 const HTTP_TIMEOUT_MS = 10_000;
 
 // App JWT lifetime. GitHub caps it at 10 minutes; use 9 with a -30s backdated
@@ -312,7 +312,7 @@ export class GithubAppTokenService {
     installationId: string,
   ): Promise<GithubInstallationDetails> {
     const res = await this.githubFetch(
-      `${GITHUB_API}/app/installations/${encodeURIComponent(installationId)}`,
+      `${getGithubApiBase()}/app/installations/${encodeURIComponent(installationId)}`,
       { headers: { Authorization: `Bearer ${this.signAppJwt()}` } },
     );
     if (!res.ok) {
@@ -459,7 +459,7 @@ export class GithubAppTokenService {
     page: number;
   }): Promise<{ id: number; full_name: string }[]> {
     const res = await this.githubFetch(
-      `${GITHUB_API}/installation/repositories?per_page=100&page=${page}`,
+      `${getGithubApiBase()}/installation/repositories?per_page=100&page=${page}`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
     if (!res.ok) {
@@ -557,7 +557,7 @@ export class GithubAppTokenService {
       >,
     });
     const res = await this.githubFetch(
-      `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${path}`,
+      `${getGithubApiBase()}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${path}`,
       { headers: { Authorization: `Bearer ${minted.token}` } },
     );
     if (!res.ok) {
@@ -588,7 +588,7 @@ export class GithubAppTokenService {
       payload.repository_ids = args.repositoryIds.map((id) => Number(id));
     }
     const res = await this.githubFetch(
-      `${GITHUB_API}/app/installations/${encodeURIComponent(
+      `${getGithubApiBase()}/app/installations/${encodeURIComponent(
         args.installationId,
       )}/access_tokens`,
       {

--- a/platform/app/src/server/app-layer/github/githubHost.ts
+++ b/platform/app/src/server/app-layer/github/githubHost.ts
@@ -27,7 +27,7 @@ export function getGithubHost(): string {
   return configured === "" ? GITHUB_DOT_COM : configured;
 }
 
-/** Where the REST API answers. */
+/** github.com answers on a separate hostname; Enterprise Server does not. */
 export function getGithubApiBase(): string {
   const host = getGithubHost();
   return host === GITHUB_DOT_COM
@@ -35,7 +35,7 @@ export function getGithubApiBase(): string {
     : `https://${host}/api/v3`;
 }
 
-/** Where the web pages live: app pages, account settings, uninstall. */
+/** The origin the account settings and uninstall pages are addressed from. */
 export function getGithubWebBase(): string {
   return `https://${getGithubHost()}`;
 }

--- a/platform/app/src/server/app-layer/github/githubHost.ts
+++ b/platform/app/src/server/app-layer/github/githubHost.ts
@@ -1,0 +1,78 @@
+/**
+ * The GitHub host this instance is bound to, and everything derived from it.
+ *
+ * One instance connects to exactly one GitHub. `GITHUB_LANGY_HOST` names it;
+ * unset means github.com, which is what every deployment gets unless an
+ * operator sets it. GitHub Enterprise Server differs from github.com in more
+ * than the hostname, so a caller cannot build these strings by substitution:
+ * the REST API lives under `/api/v3` on the instance itself instead of on a
+ * separate `api.` hostname, and an App's public page sits under `/github-apps/`
+ * instead of `/apps/`. Both shapes are derived here so no call site has to
+ * remember either one.
+ *
+ * Spec: specs/integrations/github-connection.feature.
+ */
+import { env } from "~/env.mjs";
+
+/** The public GitHub, and the host an instance that names none talks to. */
+export const GITHUB_DOT_COM = "github.com";
+
+/**
+ * The host this instance talks to, lowercased. Hosts are case insensitive, and
+ * this value is compared against hosts a session reported off its git remote,
+ * which carry whatever casing the developer's remote had.
+ */
+export function getGithubHost(): string {
+  const configured = (env.GITHUB_LANGY_HOST ?? "").trim().toLowerCase();
+  return configured === "" ? GITHUB_DOT_COM : configured;
+}
+
+/** Where the REST API answers. */
+export function getGithubApiBase(): string {
+  const host = getGithubHost();
+  return host === GITHUB_DOT_COM
+    ? "https://api.github.com"
+    : `https://${host}/api/v3`;
+}
+
+/** Where the web pages live: app pages, account settings, uninstall. */
+export function getGithubWebBase(): string {
+  return `https://${getGithubHost()}`;
+}
+
+/**
+ * The App's public installation page, where an install starts.
+ *
+ * github.com serves it under `/apps/`; an Enterprise Server instance serves the
+ * Apps registered on it under `/github-apps/`.
+ */
+export function getGithubAppInstallUrl(appSlug: string): string {
+  const host = getGithubHost();
+  const segment = host === GITHUB_DOT_COM ? "apps" : "github-apps";
+  return `https://${host}/${segment}/${encodeURIComponent(
+    appSlug,
+  )}/installations/new`;
+}
+
+/**
+ * Whether this instance's connection can answer for a repository on this host.
+ *
+ * An unset host means the configured one, because a session that reported no
+ * host is describing the only GitHub this instance knows about. Anything else
+ * is a host we have no connection to, including github.com itself on an
+ * instance bound to an Enterprise Server.
+ *
+ * Case-folded, because a session records whatever casing its git remote
+ * carries. A literal comparison refuses `GitHub.com` outright, so that session
+ * is never mapped at all, and every reader downstream folds its host and then
+ * looks for a mapping row nothing ever wrote.
+ */
+export function isMappableGithubHost(repositoryHost: string): boolean {
+  return normalizeGithubHost(repositoryHost) === getGithubHost();
+}
+
+/** The host to store: the configured one, spelled out and folded, so rows compare. */
+export function normalizeGithubHost(repositoryHost: string): string {
+  const host = repositoryHost.toLowerCase();
+  return host === "" ? getGithubHost() : host;
+}

--- a/platform/app/src/server/app-layer/github/repositories/github-pull-requests.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/github/repositories/github-pull-requests.prisma.repository.ts
@@ -325,6 +325,16 @@ export class PrismaGithubPullRequestsRepository
     return record ? toBranchCheckRow(record) : null;
   }
 
+  /**
+   * The bookkeeping write. `lastRequestedAt` is the one column a caller may
+   * decline to write: null leaves whatever demand is stored, which is what
+   * keeps the sweep from renewing the signal it selects on.
+   *
+   * A create still needs a value, because the column is not nullable, so it
+   * falls back to `lastCheckedAt`, the same instant. That only applies to a
+   * row a sweep somehow creates, and the sweep reads its branches off rows that
+   * already exist, so in practice every create comes from demand.
+   */
   async upsertBranchCheck(input: UpsertGithubBranchCheckInput): Promise<void> {
     const repositoryFullName = normalizeFullName(input.repositoryFullName);
     const bookkeeping = {
@@ -333,7 +343,6 @@ export class PrismaGithubPullRequestsRepository
       notFoundAt: input.notFoundAt,
       recheckAfter: input.recheckAfter,
       attempts: input.attempts,
-      lastRequestedAt: input.lastRequestedAt,
     };
     await this.prisma.githubBranchPullRequestCheck.upsert({
       where: {
@@ -350,8 +359,11 @@ export class PrismaGithubPullRequestsRepository
         repositoryFullName,
         headBranch: input.headBranch,
         ...bookkeeping,
+        lastRequestedAt: input.lastRequestedAt ?? input.lastCheckedAt,
       },
-      update: bookkeeping,
+      update: input.lastRequestedAt
+        ? { ...bookkeeping, lastRequestedAt: input.lastRequestedAt }
+        : bookkeeping,
     });
   }
 
@@ -369,6 +381,10 @@ export class PrismaGithubPullRequestsRepository
    * Both concurrent callers reach the same conflict target; Postgres serializes
    * them on the unique index, so the second evaluates its predicate against the
    * first's committed row and updates zero rows.
+   *
+   * `recordsDemand` picks whether the conflict path refreshes `lastRequestedAt`
+   * or keeps the stored value. A CASE rather than two statements, so the claim
+   * stays the one write it has to be.
    */
   async claimBranchLookup({
     organizationId,
@@ -378,6 +394,7 @@ export class PrismaGithubPullRequestsRepository
     now,
     freshMappingMs,
     leaseMs,
+    recordsDemand,
   }: {
     organizationId: string;
     repositoryHost: string;
@@ -386,6 +403,7 @@ export class PrismaGithubPullRequestsRepository
     now: Date;
     freshMappingMs: number;
     leaseMs: number;
+    recordsDemand: boolean;
   }): Promise<boolean> {
     const fullName = normalizeFullName(repositoryFullName);
     const host = normalizeHost(repositoryHost);
@@ -412,7 +430,10 @@ export class PrismaGithubPullRequestsRepository
       ON CONFLICT ("organizationId", "repositoryHost", "repositoryFullName", "headBranch")
       DO UPDATE SET
         "recheckAfter" = ${leaseUntil}::timestamp,
-        "lastRequestedAt" = ${at}::timestamp,
+        "lastRequestedAt" = CASE
+          WHEN ${recordsDemand}::boolean THEN ${at}::timestamp
+          ELSE "GithubBranchPullRequestCheck"."lastRequestedAt"
+        END,
         "updatedAt" = ${at}::timestamp
       WHERE
         ("GithubBranchPullRequestCheck"."recheckAfter" IS NULL
@@ -509,9 +530,10 @@ export class PrismaGithubPullRequestsRepository
   }
 
   /**
-   * The retention prune. Two statements, in this order: the branch bookkeeping
-   * past the horizon, then the pull requests whose branch no longer has a row
-   * at all. Reversing them would leave a pull request orphaned for a day.
+   * The retention prune: the branch bookkeeping past the horizon, and nothing
+   * else. `GithubPullRequest` rows are kept for good, because they are the
+   * answer the Pull Requests page reads and their count is bounded by the pull
+   * requests the organization actually opened.
    *
    * Raw SQL, with the `-- @tenancy:` opt-out every other retention sweep in the
    * platform uses. Retention is system-owned maintenance and cannot name an
@@ -519,15 +541,13 @@ export class PrismaGithubPullRequestsRepository
    * a delete per tenant, which is a query per tenant to do one table scan's
    * work.
    *
-   * Both are single unbounded DELETEs over a predicate with no index of its
-   * own, and that is the deliberate trade: this runs once a day, while an index
-   * to serve it would be paid on every write to a table that takes a row per
-   * agent branch. Measured on 200k rows: 254 ms for the branch checks, 32 ms
-   * for the anti-join (which does use the branch table's unique index).
+   * One unbounded DELETE over a predicate with no index of its own, and that is
+   * the deliberate trade: this runs once a day, while an index to serve it
+   * would be paid on every write to a table that takes a row per agent branch.
+   * Measured on 200k rows: 254 ms.
    */
   async deleteStaleBefore({ before }: { before: Date }): Promise<{
     branchChecks: number;
-    pullRequests: number;
   }> {
     const cutoff = toPgTimestampUtc(before);
     const branchChecks = await this.prisma.$executeRaw`
@@ -535,17 +555,6 @@ export class PrismaGithubPullRequestsRepository
       WHERE "lastRequestedAt" < ${cutoff}::timestamp
       -- @tenancy: GitHub branch bookkeeping retention sweep (system-owned maintenance)
     `;
-    const pullRequests = await this.prisma.$executeRaw`
-      DELETE FROM "GithubPullRequest" pr
-      WHERE NOT EXISTS (
-        SELECT 1 FROM "GithubBranchPullRequestCheck" bc
-        WHERE bc."organizationId" = pr."organizationId"
-          AND bc."repositoryHost" = pr."repositoryHost"
-          AND bc."repositoryFullName" = pr."repositoryFullName"
-          AND bc."headBranch" = pr."headBranch"
-      )
-      -- @tenancy: GitHub pull-request retention sweep (system-owned maintenance)
-    `;
-    return { branchChecks, pullRequests };
+    return { branchChecks };
   }
 }

--- a/platform/app/src/server/app-layer/github/repositories/github-pull-requests.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/github/repositories/github-pull-requests.prisma.repository.ts
@@ -382,9 +382,9 @@ export class PrismaGithubPullRequestsRepository
    * them on the unique index, so the second evaluates its predicate against the
    * first's committed row and updates zero rows.
    *
-   * `recordsDemand` picks whether the conflict path refreshes `lastRequestedAt`
-   * or keeps the stored value. A CASE rather than two statements, so the claim
-   * stays the one write it has to be.
+   * `shouldRecordDemand` picks whether the conflict path refreshes
+   * `lastRequestedAt` or keeps the stored value. A CASE rather than two
+   * statements, so the claim stays the one write it has to be.
    */
   async claimBranchLookup({
     organizationId,
@@ -394,7 +394,7 @@ export class PrismaGithubPullRequestsRepository
     now,
     freshMappingMs,
     leaseMs,
-    recordsDemand,
+    shouldRecordDemand,
   }: {
     organizationId: string;
     repositoryHost: string;
@@ -403,7 +403,7 @@ export class PrismaGithubPullRequestsRepository
     now: Date;
     freshMappingMs: number;
     leaseMs: number;
-    recordsDemand: boolean;
+    shouldRecordDemand: boolean;
   }): Promise<boolean> {
     const fullName = normalizeFullName(repositoryFullName);
     const host = normalizeHost(repositoryHost);
@@ -431,7 +431,7 @@ export class PrismaGithubPullRequestsRepository
       DO UPDATE SET
         "recheckAfter" = ${leaseUntil}::timestamp,
         "lastRequestedAt" = CASE
-          WHEN ${recordsDemand}::boolean THEN ${at}::timestamp
+          WHEN ${shouldRecordDemand}::boolean THEN ${at}::timestamp
           ELSE "GithubBranchPullRequestCheck"."lastRequestedAt"
         END,
         "updatedAt" = ${at}::timestamp

--- a/platform/app/src/server/app-layer/github/repositories/github-pull-requests.repository.ts
+++ b/platform/app/src/server/app-layer/github/repositories/github-pull-requests.repository.ts
@@ -100,7 +100,16 @@ export interface UpsertGithubBranchCheckInput {
   notFoundAt: Date | null;
   recheckAfter: Date | null;
   attempts: number;
-  lastRequestedAt: Date;
+  /**
+   * When demand for this branch was last recorded, or null to keep whatever is
+   * stored.
+   *
+   * The sweep passes null. It selects branches by this column, so writing it
+   * from inside the sweep renews the signal the sweep reads and no branch ever
+   * leaves it: an unmapped branch would be asked about once a day for as long
+   * as the connection existed.
+   */
+  lastRequestedAt: Date | null;
 }
 
 export interface GithubPullRequestsRepository {
@@ -202,12 +211,20 @@ export interface GithubPullRequestsRepository {
     freshMappingMs: number;
     /** How long the claim holds if the lookup never records an answer. */
     leaseMs: number;
+    /**
+     * Whether this claim is demand for the branch, and so refreshes
+     * `lastRequestedAt`. The sweep passes false: the branch is on its due list
+     * because of demand already recorded, and renewing it here would keep the
+     * branch on that list for good.
+     */
+    recordsDemand: boolean;
   }): Promise<boolean>;
 
   /**
-   * Record that a reader asked about this branch, whether or not we called
-   * GitHub — but only for a row whose `lastRequestedAt` is at or before
-   * `staleBefore`, so a page that reloads every few seconds writes once.
+   * Record demand for a branch whose lookup another caller is already holding,
+   * so losing the claim still keeps the branch inside the sweep's activity
+   * window, but only for a row whose `lastRequestedAt` is at or before
+   * `staleBefore`, so a burst of folds on one branch writes once.
    */
   touchBranchCheckRequestedAt(params: {
     organizationId: string;
@@ -259,20 +276,25 @@ export interface GithubPullRequestsRepository {
   }): Promise<GithubBranchCheckRow[]>;
 
   /**
-   * Delete the rows past the activity horizon, and the pull requests they were
-   * the only reason to keep.
+   * Delete the branch bookkeeping past the activity horizon.
+   *
+   * Bookkeeping ONLY. The pull requests a branch resolved to are kept for good:
+   * they are a record of work that was done, they are bounded by the number of
+   * pull requests the organization actually opened, and the Pull Requests page
+   * is mostly a place to look back at merged work. Deleting them with the
+   * bookkeeping emptied that page of every pull request whose branch had been
+   * quiet for a week.
    *
    * Bounded by the SAME horizon the sweep uses, deliberately rather than by a
-   * retention knob of its own: a branch nobody has asked about in a week has
+   * retention knob of its own: a branch with no session demand for a week has
    * already dropped out of the sweep, so the feature has already stopped
    * maintaining it. Keeping the row after that is keeping a row that is never
-   * read and never refreshed, at one row per agent branch per repository — the
-   * shape that turns into millions a year.
+   * read and never refreshed, at one row per agent branch per repository, which
+   * is the shape that turns into millions a year.
    *
    * Self-healing, which is what makes the horizon safe to be this short. A
-   * reader asking again re-maps the branch from GitHub and repopulates both
-   * tables; a page that is looked at keeps bumping `lastRequestedAt` and never
-   * reaches the horizon at all.
+   * session folding on the branch again re-maps it from GitHub and writes the
+   * bookkeeping back.
    *
    * Cross-tenant by nature, like the sweep it follows: system-owned
    * maintenance, so it takes the raw-SQL opt-out the platform's other retention
@@ -280,7 +302,6 @@ export interface GithubPullRequestsRepository {
    */
   deleteStaleBefore(params: { before: Date }): Promise<{
     branchChecks: number;
-    pullRequests: number;
   }>;
 }
 
@@ -310,10 +331,7 @@ export class NullGithubPullRequestsRepository
   async findRecheckDue(): Promise<GithubBranchCheckRow[]> {
     return [];
   }
-  async deleteStaleBefore(): Promise<{
-    branchChecks: number;
-    pullRequests: number;
-  }> {
-    return { branchChecks: 0, pullRequests: 0 };
+  async deleteStaleBefore(): Promise<{ branchChecks: number }> {
+    return { branchChecks: 0 };
   }
 }

--- a/platform/app/src/server/app-layer/github/repositories/github-pull-requests.repository.ts
+++ b/platform/app/src/server/app-layer/github/repositories/github-pull-requests.repository.ts
@@ -217,7 +217,7 @@ export interface GithubPullRequestsRepository {
      * because of demand already recorded, and renewing it here would keep the
      * branch on that list for good.
      */
-    recordsDemand: boolean;
+    shouldRecordDemand: boolean;
   }): Promise<boolean>;
 
   /**

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1124,7 +1124,7 @@ export function initializeDefaultApp(options?: {
     "recheckDueBranches",
   );
   const pruneStaleBranchLinkage = new Deferred<
-    () => Promise<{ branchChecks: number; pullRequests: number }>
+    () => Promise<{ branchChecks: number }>
   >("pruneStaleBranchLinkage");
 
   const registry = new PipelineRegistry({

--- a/platform/app/src/server/app-layer/traces/session-groups.pull-request-link.ts
+++ b/platform/app/src/server/app-layer/traces/session-groups.pull-request-link.ts
@@ -9,6 +9,7 @@
  * noticing, and the join can be exercised without a page of rollups.
  */
 import { assignSessionsToPullRequests } from "../coding-agent/pull-request-assignment";
+import { normalizeGithubHost } from "../github/githubHost";
 
 /** Identity only: the number, where it lives, and what it is called. */
 export interface SessionGroupPullRequestDto {
@@ -213,7 +214,7 @@ const repositoryBucketOf = (key: {
 /** The session's git identity as the mapping stores it: default host, lowercased repository. */
 function branchKeyOf(coding: LinkableCodingAgent): PullRequestBranchKey {
   return {
-    repositoryHost: (coding.repositoryHost ?? "github.com").toLowerCase(),
+    repositoryHost: normalizeGithubHost(coding.repositoryHost ?? ""),
     repositoryFullName:
       `${coding.repositoryOwner}/${coding.repositoryName}`.toLowerCase(),
     headBranch: coding.gitBranch!,

--- a/platform/app/src/server/event-sourcing/pipelineRegistry.ts
+++ b/platform/app/src/server/event-sourcing/pipelineRegistry.ts
@@ -377,11 +377,8 @@ export interface PipelineRegistryDeps {
   github?: {
     /** One recheck pass; returns how many branches were re-asked about. */
     recheckDueBranches: () => Promise<number>;
-    /** One retention pass over the two linkage tables. */
-    pruneStaleBranchLinkage: () => Promise<{
-      branchChecks: number;
-      pullRequests: number;
-    }>;
+    /** One retention pass over the branch bookkeeping. */
+    pruneStaleBranchLinkage: () => Promise<{ branchChecks: number }>;
   };
 }
 

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/reactors/__tests__/pullRequestMapping.reactor.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/reactors/__tests__/pullRequestMapping.reactor.unit.test.ts
@@ -38,8 +38,8 @@ function contextFor(state: CodingAgentSessionState) {
 }
 
 describe("pullRequestMapping reactor", () => {
-  describe("given a session whose repository host is not github.com", () => {
-    /** @scenario "A repository on a non-GitHub host never triggers a GitHub call" */
+  describe("given a session whose repository host is not the instance's GitHub host", () => {
+    /** @scenario "A repository on a host this instance cannot answer for never triggers a GitHub call" */
     it("requests no mapping", async () => {
       const requestBranchMapping = vi.fn().mockResolvedValue(undefined);
       const reactor = createPullRequestMappingReactor({

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/reactors/pullRequestMapping.reactor.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/reactors/pullRequestMapping.reactor.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@langwatch/observability";
 
+import { isMappableGithubHost } from "~/server/app-layer/github/githubHost";
 import type {
   ReactorContext,
   ReactorDefinition,
@@ -56,11 +57,10 @@ export function shouldMapPullRequests(
     "repositoryHost" | "repositoryOwner" | "repositoryName" | "gitBranch"
   >,
 ): boolean {
-  // Case-folded: a session records whatever casing its git remote carries, and
-  // a host is case insensitive, so a literal comparison drops `GitHub.com` and
-  // that session's branch is never mapped.
-  const host = (state.repositoryHost ?? "").toLowerCase();
-  if (host !== "" && host !== "github.com") return false;
+  // The same host rule the mapping service applies, read from the one place
+  // that knows which GitHub this instance is bound to. Applying it here as well
+  // is what keeps a job off the queue that the service would only drop.
+  if (!isMappableGithubHost(state.repositoryHost ?? "")) return false;
   return Boolean(
     state.repositoryOwner &&
       state.repositoryName &&
@@ -75,10 +75,10 @@ export function shouldMapPullRequests(
  * The dedup id: one job per (project, repository, branch).
  *
  * The host is deliberately absent, and that is safe rather than an oversight:
- * `shouldMapPullRequests` only lets `""` and `"github.com"` through, and both
- * normalize to the same host at the service, so two folds sharing this key
- * always name the same repository. Which is what makes collapsing them into one
- * job the same answer rather than a guess.
+ * `shouldMapPullRequests` only lets `""` and the instance's own GitHub host
+ * through, and both normalize to that one host at the service, so two folds
+ * sharing this key always name the same repository. Which is what makes
+ * collapsing them into one job the same answer rather than a guess.
  *
  * The owner and the name are folded, which is the other half of that same
  * argument. A session records whatever casing its git remote carries, and

--- a/platform/app/src/server/event-sourcing/pipelines/github-maintenance/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/github-maintenance/pipeline.ts
@@ -63,7 +63,7 @@ export function createGithubMaintenancePipeline(
           .onWake(githubBranchRecheckWake)
           // A pass is bounded at 50 branches and each one is a sequential GitHub
           // call, so the lease has to cover fifty round trips plus their retries.
-          // The prune shares it: two DELETEs, each a single statement.
+          // The prune shares it: one DELETE, a single statement.
           .outbox({ leaseDurationMs: 10 * 60 * 1000, maxAttempts: 3 }),
       )
       .build()

--- a/platform/app/src/server/event-sourcing/pipelines/github-maintenance/process-manager/githubBranchRecheck.process.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/github-maintenance/process-manager/githubBranchRecheck.process.ts
@@ -22,7 +22,7 @@ export const GITHUB_BRANCH_RECHECK_PROCESS_NAME = "githubBranchRecheck";
 export const GITHUB_BRANCH_RECHECK_INTERVAL_MS = 10 * 60 * 1000;
 
 /**
- * How often the two GitHub tables are pruned. Retention is a daily concern and
+ * How often the branch bookkeeping is pruned. Retention is a daily concern and
  * the sweep is a ten-minute one, so the prune rides the same schedule and fires
  * on the first wake past its own interval rather than carrying a second
  * singleton. This mirrors the automations pipeline, which hangs its
@@ -54,8 +54,8 @@ export const GITHUB_BRANCH_RECHECK_INITIAL_STATE: GithubBranchRecheckState = {
 export interface GithubBranchRecheckDeps {
   /** One sweep pass; returns how many branches were rechecked. */
   recheck: () => Promise<number>;
-  /** Deletes the rows past the activity horizon; returns what it removed. */
-  prune: () => Promise<{ branchChecks: number; pullRequests: number }>;
+  /** Deletes the bookkeeping past the activity horizon; returns what it removed. */
+  prune: () => Promise<{ branchChecks: number }>;
   deleteDispatchedBefore: (params: {
     processName: string;
     before: number;
@@ -112,11 +112,11 @@ export function runGithubBranchRecheck(deps: GithubBranchRecheckDeps) {
 export function runGithubRetentionPrune(deps: GithubBranchRecheckDeps) {
   return async (): Promise<void> => {
     const startedAt = (deps.now ?? Date.now)();
-    const { branchChecks, pullRequests } = await deps.prune();
-    if (branchChecks > 0 || pullRequests > 0) {
+    const { branchChecks } = await deps.prune();
+    if (branchChecks > 0) {
       logger.info(
-        { branchChecks, pullRequests },
-        "GitHub pull-request tables pruned past the activity horizon",
+        { branchChecks },
+        "GitHub branch bookkeeping pruned past the activity horizon",
       );
     }
 

--- a/platform/app/src/server/routes/github.ts
+++ b/platform/app/src/server/routes/github.ts
@@ -2,8 +2,9 @@
  * Hono routes for the organization's GitHub App installation flow.
  *
  * Surfaces:
- *   GET  /api/github/install: start, a session-gated redirect to
- *        github.com/apps/<slug>/installations/new with a signed state.
+ *   GET  /api/github/install: start, a session-gated redirect to the App's
+ *        public installation page on the configured GitHub host, with a signed
+ *        state.
  *   GET  /api/github/setup: GitHub's post-install redirect. Verify the
  *        signed state, record the installation against the organization it was
  *        bound to, then postMessage the opener (popup) or 302 back (redirect).
@@ -38,6 +39,7 @@ import {
 import { getApp } from "~/server/app-layer";
 import { GithubInstallationConflictError } from "~/server/app-layer/github/github-installations.service";
 import { getGithubAppConfig } from "~/server/app-layer/github/githubAppConfig";
+import { getGithubAppInstallUrl } from "~/server/app-layer/github/githubHost";
 import {
   consumeGithubInstallNonce,
   registerGithubInstallNonce,
@@ -73,7 +75,7 @@ const WEBHOOK_PUBLIC_REASON =
   "every payload is verified in-handler by its X-Hub-Signature-256 HMAC.";
 
 // /install is session-gated in-handler: it requires a logged-in user and an
-// org-membership check before signing state and redirecting to github.com.
+// org-membership check before signing state and redirecting to GitHub.
 const INSTALL_HANDLER_AUTH_REASON =
   "Install-start endpoint: requires a valid application session (checked " +
   "in-handler via getServerAuthSession) plus an org-membership check before " +
@@ -225,11 +227,7 @@ async function handleInstall(c: any): Promise<Response> {
 
   // GitHub redirects back to the App's configured Setup URL after install; the
   // signed `state` round-trips so /setup can bind the installation to the org.
-  const url = new URL(
-    `https://github.com/apps/${encodeURIComponent(
-      config.appSlug,
-    )}/installations/new`,
-  );
+  const url = new URL(getGithubAppInstallUrl(config.appSlug));
   url.searchParams.set("state", state);
   return c.redirect(url.toString(), 302);
 }
@@ -570,11 +568,13 @@ secured
   .access(publicEndpoint(WEBHOOK_PUBLIC_REASON))
   .post("/github/webhook", handleWebhook);
 
-// The GitHub App configuration on github.com points its Setup URL and its
-// webhook delivery at the legacy paths, so both stay mounted on the same
-// handlers until that configuration is flipped to the canonical paths above.
-// Removing these two mounts is a tracked follow-up. /install needs no alias: it
-// is ours to call, and every caller in this repo uses the canonical path.
+// `/api/github-langy/setup` and `/api/github-langy/webhook` are an external
+// contract, held by two sets of App registrations: the hosted App, and every
+// self-hosted App an operator registered while the documentation named these
+// paths. Both point their Setup URL and their webhook delivery here, so the
+// aliases stay mounted on the same handlers until there is a deprecation path
+// that can move a registration we do not own. /install needs no alias: it is
+// ours to call, and every caller in this repo uses the canonical path.
 secured
   .access(publicEndpoint(SETUP_PUBLIC_REASON))
   .get("/github-langy/setup", handleSetup);

--- a/specs/coding-agent/pull-request-linkage.feature
+++ b/specs/coding-agent/pull-request-linkage.feature
@@ -86,19 +86,9 @@ Rule: Branches map to their pull requests through the organization connection
     When the tick fires
     Then one sweep runs and the others stand down
 
-  # Nothing removed a branch's bookkeeping or its pull requests, ever, at one
-  # row per agent branch per repository.
   @unit
-  Scenario: Linkage rows nobody asks about stop accumulating
-    Given a branch outside the sweep's activity window
-    When the retention prune runs
-    Then its bookkeeping is removed
-    And the pull requests it was the only reason to keep are removed
-    And a reader asking again re-maps the branch from GitHub
-
-  @unit
-  Scenario: A repository on a non-GitHub host never triggers a GitHub call
-    Given a session whose repository host is not github.com
+  Scenario: A repository on a host this instance cannot answer for never triggers a GitHub call
+    Given a session whose repository host is not the instance's GitHub host
     When the mapping trigger evaluates the session
     Then no mapping is requested
 
@@ -107,6 +97,49 @@ Rule: Branches map to their pull requests through the organization connection
     Given sessions with repo and branch folded before any GitHub connection existed
     When the organization connects GitHub
     Then the recent branches are mapped without waiting for new sessions
+
+Rule: Demand is what a session asks for, and only demand keeps a branch in the sweep
+
+  # The column the sweep selects on was also written by the sweep itself, so a
+  # branch that never gets a pull request renewed its own place in the sweep and
+  # was asked about every day for as long as the connection existed.
+  @integration
+  Scenario: The sweep does not renew the demand it selects on
+    Given a branch with no pull request that the sweep asks GitHub about
+    When the sweep records the empty answer
+    Then the branch's last demand time is unchanged
+
+  @integration
+  Scenario: A session folding on a branch records demand for it
+    Given a branch with no pull request
+    When a session folds on that branch and the mapping runs
+    Then the branch's last demand time moves to the time of the fold
+
+  @integration
+  Scenario: A branch with no session demand for a week leaves the sweep
+    Given a branch whose last session demand is older than the activity window
+    When the periodic recheck selects branches
+    Then that branch is not selected
+
+Rule: Bookkeeping is pruned, and the pull requests it found are kept
+
+  # One bookkeeping row per agent branch per repository, and nothing removed
+  # them, so the table grew for as long as the connection existed.
+  @integration
+  Scenario: Bookkeeping for a branch outside the activity window is removed
+    Given a branch outside the sweep's activity window
+    When the retention prune runs
+    Then its bookkeeping is removed
+    And a session folding on that branch again re-maps it from GitHub
+
+  # A pull request is a record of work that was done. Removing it when the
+  # branch went quiet took merged work off the Pull Requests page, which is the
+  # work people most want to look back at.
+  @integration
+  Scenario: A linked pull request stays after its branch goes quiet
+    Given a branch outside the sweep's activity window whose pull request is linked
+    When the retention prune runs
+    Then the pull request is still stored for the organization
 
 Rule: A pull request links itself the moment GitHub announces it
 

--- a/specs/integrations/github-connection.feature
+++ b/specs/integrations/github-connection.feature
@@ -55,14 +55,61 @@ Rule: Connection state is visible to members, managed by organization managers
     Then I see that the GitHub integration is unavailable on this instance
     And I am not offered an Install button
 
-  # The install link is a deep link into github.com built from the App slug, so
-  # an instance holding an id and a key but no slug mints tokens perfectly well
-  # and still has nowhere to send someone who clicks Connect.
+  # The install link is a deep link into the GitHub host built from the App
+  # slug, so an instance holding an id and a key but no slug mints tokens
+  # perfectly well and still has nowhere to send someone who clicks Connect.
   @unit
   Scenario: An instance that cannot start an installation offers no install link
     Given the instance is missing part of what starting an installation needs
     When I read the connection status
     Then no install link comes back
+
+Rule: The instance binds to exactly one GitHub host
+
+  # GitHub Enterprise Server serves the REST API under /api/v3 and the App
+  # pages under /github-apps/, so naming the host is not enough on its own.
+  # Both bases come from the host in one place, and an instance that names no
+  # host behaves exactly as it did before the setting existed.
+  @unit
+  Scenario: An instance that names no host talks to github.com
+    Given the instance names no GitHub host
+    When the connection resolves the host it talks to
+    Then the host is github.com
+    And the API base is the public GitHub API
+    And the install link is the github.com app page
+
+  @unit
+  Scenario: An instance that names an Enterprise Server host talks to that host
+    Given the instance names a GitHub Enterprise Server host
+    When the connection resolves the host it talks to
+    Then the API base is that host under /api/v3
+    And the install link is that host's own app page
+
+  @unit
+  Scenario: The uninstall link points at the configured host
+    Given the instance names a GitHub Enterprise Server host
+    And the "acme" organization has an installation on "acme/service-x"
+    When I read where the installation is uninstalled
+    Then the link points at that host
+
+  @unit
+  Scenario: A repository on the configured host is mapped
+    Given the instance names a GitHub Enterprise Server host
+    When a session reports a repository on that host
+    Then the branch is mapped through the connection
+
+  @unit
+  Scenario: A repository on github.com is not mapped by an Enterprise Server instance
+    Given the instance names a GitHub Enterprise Server host
+    When a session reports a repository on github.com
+    Then no mapping is requested
+
+  @unit
+  Scenario: A pull request announced over the webhook is recorded under the configured host
+    Given the instance names a GitHub Enterprise Server host
+    And the "acme" organization has an installation on "acme/service-x"
+    When GitHub announces a pull request on a branch
+    Then the stored pull request carries that host
 
 Rule: The installation flow verifies who is installing what
 


### PR DESCRIPTION
Follow-up to #6849, which added the `pull_request` webhook and the recheck bring-forward to coding-agent pull request linkage. Three problems it left open: two retention bugs that lose data and burn GitHub calls, and no way to run any of this against GitHub Enterprise Server.

Backend and documentation only. No UI surface changed, so there are no screenshots.

## What was wrong

**1. A linked pull request disappeared after a week.** The retention prune deleted `GithubPullRequest` rows whose branch bookkeeping had aged out, through an anti-join. The bookkeeping ages out 7 days after the last session fold on the branch, and a branch stops seeing folds the moment its pull request merges. So the page emptied itself of exactly the merged work people look back at. The interface docblock said page reads keep the branch alive by bumping `lastRequestedAt`, but no read path ever did that: `touchBranchCheckRequestedAt` had one caller, inside the lookup claim.

**2. An unmapped branch was asked about every day, for good.** The sweep selects branches by `lastRequestedAt`, and the sweep also wrote it, through the claim and again through the recorded answer. A branch that never gets a pull request therefore renewed its own place in the sweep on every pass. It never left the sweep and its bookkeeping never reached the retention horizon, so the row count and the GitHub calls both grew without limit.

**3. The GitHub host was hardcoded in eight places.** `https://api.github.com` in the token service, `github.com/apps/<slug>/installations/new` in the install route, two uninstall links, and four independent copies of the `"github.com"` default in the reactor and the three readers. An instance could not connect to GitHub Enterprise Server at all.

## What this changes

### Retention: pull requests are permanent, bookkeeping is not

`deleteStaleBefore` now prunes `GithubBranchPullRequestCheck` rows only. A pull request is a record of work that was done, and the row count is bounded by the pull requests the organization actually opened, so there is nothing to reclaim. The bookkeeping is the row per agent branch per repository, which is the shape that grows, and it is still pruned at the sweep's own horizon. A session folding on a pruned branch re-maps it from GitHub and writes the bookkeeping back.

The repository and worker docblocks that described the anti-join and the imagined read-side touch are corrected to the new behavior.

### Demand: only a session asks for a branch

`mapBranch` now takes an `origin` of `demand` or `sweep`. The fold reactor and the post-connect backfill are demand; the periodic pass is sweep.

`lastRequestedAt` means session demand and nothing else. On a sweep the claim leaves the column alone, through a `CASE` inside the same single `INSERT ... ON CONFLICT` so the claim stays one atomic write, and the recorded answer passes null so the upsert omits the column. Everything else is identical for both origins: `notFoundAt`, `attempts` and the backoff ladder behave exactly as before.

Net effect: a branch with no fold for a week now falls out of the sweep, its bookkeeping is pruned on the next daily pass, and its pull requests stay.

### One GitHub host per instance

New optional `GITHUB_LANGY_HOST`. Unset means github.com, so every existing install is unchanged.

`platform/app/src/server/app-layer/github/githubHost.ts` is the one place the host is read and the only place the addresses are derived. GitHub Enterprise Server differs from github.com in more than the hostname, which is why derivation cannot be string substitution:

| | github.com | Enterprise Server |
|---|---|---|
| REST API | `https://api.github.com` | `https://<host>/api/v3` |
| App install page | `/apps/<slug>/installations/new` | `/github-apps/<slug>/installations/new` |

Every previously hardcoded site now calls that module: the token service's four API calls, the install redirect, both uninstall links, the fold reactor's host gate, the mapping service's host fold, the webhook write, the three reader join keys, and the REST `host` query parameter default.

An instance bound to an Enterprise Server maps repositories on that host and on no host reported, and refuses github.com, because it holds no connection there.

Not covered: Langy's own bot pull requests still target github.com. The worker clones with the `gh` command line, which resolves its own host, so that is a separate change across the Go service and the chart. The GitHub App page states this.

### Documentation

- `github-app.mdx`: names both consumers of the App, points registration at the canonical `/api/github/setup` and `/api/github/webhook` and explains the legacy aliases, adds a **GitHub Enterprise Server** section and a **Restricted networks** section, and replaces the misleading `values.yaml` wording with a Helm section that uses `app.extraEnvs` / `app.extraEnvFrom` and a Secret for the multi-line PEM.
- **Restricted networks** states the inbound requirement plainly: GitHub must reach `<BASE_URL>/api/github/webhook`. The webhook is optional. Connecting is a browser redirect, so only the admin's browser needs to reach the instance. A table gives what changes without it: linkage waits for the outbound recheck (about 15 to 25 minutes while sessions run on the branch, up to 24 hours for a branch that went quiet first), uninstall and suspend reconcile when a live read gets a 404, repository selection refreshes on the next live resolve. Everything else is outbound only.
- `networking-and-egress.mdx`: an **Inbound** note cross-linking the above, and the egress set changing under `GITHUB_LANGY_HOST`.
- `environment-variables.mdx`: the `GITHUB_LANGY_HOST` row, and the webhook secret marked optional with the cost of leaving it unset.
- `.env.example`: pointed at the live docs page instead of the deleted `docs/langy-github-app.md`, plus the new variable.

The legacy `/api/github-langy/*` route comment now states why both mounts stay: they are an external contract held by the hosted App registration and by every self-hosted registration made while the documentation named those paths.

## Deployment impact

Nothing to do for an existing install.

- One new **optional** environment variable, `GITHUB_LANGY_HOST`, defaulting to `github.com`. Unset, behavior is what it is today, and tests pin that.
- No database migration. No schema change.
- No chart change. The chart never carried `GITHUB_LANGY_*` keys, and the documentation now says how to set them.
- The first retention pass after deploy prunes fewer rows than before, because it no longer deletes pull requests. Pull requests already deleted by an earlier pass are re-mapped when a session folds on their branch again.

## Human verification

On github.com, with nothing set:

1. Run a coding-agent session on a branch, open a pull request for it, and check the pull request appears on **Pull Requests**.
2. In `GithubBranchPullRequestCheck`, set that branch's `lastRequestedAt` to 8 days ago and wait for the daily prune, or call the prune. The bookkeeping row goes; the pull request stays on the page.
3. Take an unmapped branch, set `recheckAfter` into the past, and let the sweep run. `attempts` goes up and `recheckAfter` moves out, and `lastRequestedAt` does not move.

On GitHub Enterprise Server:

1. Register the App on the Enterprise Server instance, set `GITHUB_LANGY_HOST` to its hostname plus the other four variables, and restart.
2. **Settings > Integrations > Connect** redirects to `https://<host>/github-apps/<slug>/installations/new`.
3. Complete the install, then run a session on a repository on that host and confirm its pull request links.
4. **Disconnect** opens the uninstall page on that host.

## How I can prove I was successful

Not claims, this is what the tests execute and observe.

**Against the real Postgres and ClickHouse** (`github-pull-request-mapping.integration.test.ts`, 25 tests):

- Two branches are mapped, each to its own pull request, one is aged past the horizon, and the prune runs. The test then reads both tables: one bookkeeping row is gone, and **both** pull request rows are still there, asserted by branch and number.
- A pruned branch is folded on again. GitHub is called a second time and the bookkeeping row exists again.
- A branch is folded on, its demand is aged to 6 days, and `runBranchRecheckPass` runs. The test observes GitHub called a second time and `attempts` incremented, so the sweep really did work, and `lastRequestedAt` byte-equal to the aged value.
- The same branch folded on again moves `lastRequestedAt` to now, so demand still registers.
- A branch whose demand is older than the window is absent from `findRecheckDue`.

**Unit** (`githubHost.unit.test.ts`, `github-pull-request-mapping.host.unit.test.ts`, `github-branch-recheck.worker.unit.test.ts`, `github.access-order.unit.test.ts`):

- With no host set: `github.com`, `https://api.github.com`, and the `/apps/` install link, plus empty and blank values treated as unset.
- With an Enterprise Server host: `https://<host>/api/v3` and the `/github-apps/` install link, and the uninstall link through the real tRPC router on that host, with the github.com case asserted alongside it.
- A `pull_request` delivery on an Enterprise Server instance writes `repositoryHost` as that host, checked on both the pull request write and the branch check write.
- The same instance refuses a github.com repository: no GitHub call, no claim, no write.
- The sweep calls `mapBranch` with `origin: "sweep"`.

**Checks run:** `pnpm typecheck` and `pnpm typecheck:tests` both clean. `pnpm check:feature-parity` exits 0 with 113/113 bound on `pull-request-linkage.feature` and 24/24 on `github-connection.feature`. Biome reports zero errors on the changed files. Unit sweep over the touched areas: 147 files, 2233 tests. Integration sweep over the GitHub and coding-agent surfaces: 6 files, 57 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Enterprise Server support through configurable host settings.
  * Enabled coding-agent pull request linkage alongside Langy-authored pull requests.
  * Added optional webhooks and delayed reconciliation for restricted or disconnected instances.
  * Updated installation, API, uninstall, and webhook links for the configured GitHub host.
  * Improved branch activity tracking so inactive branches are pruned without removing linked pull requests.

* **Documentation**
  * Expanded self-hosting, networking, Helm, environment-variable, and restricted-network guidance.
  * Documented updated setup and webhook paths, including legacy path compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->