### PR TITLE
fix(ai-gateway): a provider-native route decides its own vendor

### DIFF
--- a/services/aigateway/adapters/httpapi/body_encoding_test.go
+++ b/services/aigateway/adapters/httpapi/body_encoding_test.go
@@ -391,7 +391,7 @@ func TestRouter_PeekLane_CompressionBombPastThePeekWindow(t *testing.T) {
 func TestRouter_GeminiPassthrough_DecodesBodyAndDropsEncodingHeader(t *testing.T) {
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
+			return geminiBundle(), nil
 		},
 	}
 	var got *domain.Request

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
@@ -58,7 +58,9 @@ func (s *ttfbSpyWriter) Write(p []byte) (int, error) {
 func newHeartbeatRouter(provider *mockProvider, interval time.Duration) http.Handler {
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
+			// Covers the Gemini passthrough as well as the /v1 routes, so
+			// the bundle carries the Google slot that surface requires.
+			return geminiBundle(), nil
 		},
 	}
 	reg := health.New("test")

--- a/services/aigateway/adapters/httpapi/provider_not_bound_test.go
+++ b/services/aigateway/adapters/httpapi/provider_not_bound_test.go
@@ -71,3 +71,69 @@ func TestChat_UnknownProviderPrefixReturnsNotBoundEnvelope(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "bedrock")
 	assert.Contains(t, rec.Body.String(), "virtual key")
 }
+
+// @scenario "A provider-native route refuses a key with no provider that speaks it"
+//
+// The Gemini surface forwards the body and the URL path to Google as they
+// arrived, so a key with no Google credential has to be refused. Before this,
+// the chain fell through and the body went to OpenAI, which answered 404 for
+// a model it never had. Asserted at the HTTP boundary because the point of
+// the scenario is that the caller reads a refusal naming the missing slot,
+// and that no vendor saw the prompt.
+func TestGeminiPassthrough_NoGoogleCredentialRefusesBeforeAnyProvider(t *testing.T) {
+	for _, path := range []string{
+		"/v1beta/models/gemini-2.5-flash:generateContent",
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+	} {
+		t.Run(path, func(t *testing.T) {
+			dispatched := false
+			provider := &mockStreamProvider{
+				mockProvider: mockProvider{
+					dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+						dispatched = true
+						return successResponse(), nil
+					},
+				},
+				dispatchStreamFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (domain.StreamIterator, error) {
+					dispatched = true
+					return &emptyStreamIter{}, nil
+				},
+			}
+			auth := &mockAuth{
+				resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+					// An OpenAI slot and nothing else. The key works; it just
+					// cannot reach Google.
+					return testBundle(), nil
+				},
+			}
+			router := buildRouter(
+				app.WithAuth(auth),
+				app.WithProviders(provider),
+				app.WithModels(modelresolver.New()),
+				app.WithLogger(zap.NewNop()),
+			)
+
+			body := `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+			req.Header.Set("X-Goog-Api-Key", "vk-lw-test")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+			assert.False(t, dispatched, "the prompt must not reach any provider on a route this key cannot speak")
+
+			var env struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), "body: %s", rec.Body.String())
+			assert.Equal(t, string(domain.ErrProviderNotBound), env.Error.Code)
+			// Naming both providers is what makes the refusal actionable: the
+			// caller has to know which slot to bind.
+			assert.Contains(t, rec.Body.String(), "gemini")
+			assert.Contains(t, rec.Body.String(), "vertex")
+		})
+	}
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -479,6 +479,11 @@ func transcriptionsHandler(deps RouterDeps) http.HandlerFunc {
 // doesn't translate body shape — the upstream response is proxied
 // back verbatim. Streaming paths get raw SSE chunks (upstream already
 // emits `event:`/`data:` framing).
+//
+// The handler states its own vendor through domain.GeminiSurface(). The
+// model id comes from the URL path and so carries no provider prefix; left
+// to the credential chain, a key with no Google credential forwarded the
+// body to whichever vendor came first.
 func geminiPassthroughHandler(deps RouterDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		bundle, ok := requireBundle(w, r, deps.Logger)
@@ -509,6 +514,7 @@ func geminiPassthroughHandler(deps RouterDeps) http.HandlerFunc {
 			RawQuery: r.URL.RawQuery,
 			Headers:  forwardedPassthroughHeaders(r.Header),
 			Stream:   isStream,
+			Surface:  domain.GeminiSurface(),
 		}
 
 		if isStream {

--- a/services/aigateway/adapters/httpapi/router_test.go
+++ b/services/aigateway/adapters/httpapi/router_test.go
@@ -88,6 +88,21 @@ func testBundle() *domain.Bundle {
 	}
 }
 
+// geminiBundle is testBundle plus the Google slot the /v1beta surface needs.
+// That surface hands the caller's body and URL path to Google unchanged, so
+// the gateway refuses it on a key with no Google credential rather than
+// forwarding the body to another vendor. A test whose subject is anything
+// else on that route binds the slot its own scenario implies; leaving it
+// unbound only proved that a mock provider ignores the credential it is
+// handed.
+func geminiBundle() *domain.Bundle {
+	bundle := testBundle()
+	bundle.Credentials = append(bundle.Credentials, domain.Credential{
+		ID: "cred-gemini", ProviderID: domain.ProviderGemini, APIKey: "goog-test",
+	})
+	return bundle
+}
+
 func successResponse() *domain.Response {
 	return &domain.Response{
 		Body:       []byte(`{"choices":[{"message":{"content":"hello"}}]}`),
@@ -602,7 +617,7 @@ func TestGeminiModelFromPath(t *testing.T) {
 func TestRouter_GeminiPassthrough_NonStreaming(t *testing.T) {
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
+			return geminiBundle(), nil
 		},
 	}
 
@@ -651,7 +666,7 @@ func TestRouter_GeminiPassthrough_NonStreaming(t *testing.T) {
 func TestRouter_GeminiPassthrough_Streaming_PicksStream(t *testing.T) {
 	auth := &mockAuth{
 		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
+			return geminiBundle(), nil
 		},
 	}
 

--- a/services/aigateway/app/dispatch.go
+++ b/services/aigateway/app/dispatch.go
@@ -119,10 +119,11 @@ func translateWalkError(ctx context.Context, err error) error {
 // candidateChain assembles the credentials this request may be dispatched to,
 // in fallback order, or the error that explains why there are none:
 //
-//  1. Model-aware trim: providers that cannot serve the resolved model are
-//     skipped (eligibleCredentials). A provider the request named that the
-//     key cannot reach refuses here rather than dispatching to whichever
-//     vendor happens to be left.
+//  1. Routability trim (routableChain): the inbound route's own providers
+//     first, then the providers that can serve the resolved model. A vendor
+//     the request named, by route or by model prefix, that the key cannot
+//     reach refuses here rather than dispatching to whichever vendor
+//     happens to be left.
 //  2. Provider allowlist: a key narrowed to specific providers cannot
 //     dispatch outside them even if the bundle's credential chain is stale
 //     or hand-crafted. The control plane already materializes the chain
@@ -135,7 +136,7 @@ func translateWalkError(ctx context.Context, err error) error {
 //     iterated; with several simultaneous exclusions any of them is an
 //     accurate answer to "why was nothing dispatchable").
 func (a *App) candidateChain(ctx context.Context, call *pipeline.Call) ([]domain.Credential, error) {
-	creds, err := eligibleCredentials(ctx, call.Bundle.Credentials, call.Request.Resolved)
+	creds, err := routableChain(ctx, call.Request, call.Bundle.Credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/services/aigateway/app/eligible.go
+++ b/services/aigateway/app/eligible.go
@@ -3,11 +3,74 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
+
+// routableChain trims the credential chain to the credentials that could
+// actually serve this request: first to the providers the inbound route
+// speaks, then to the providers the resolved model names.
+func routableChain(ctx context.Context, req *domain.Request, creds []domain.Credential) ([]domain.Credential, error) {
+	creds, err := surfaceCredentials(ctx, creds, req)
+	if err != nil {
+		return nil, err
+	}
+	return eligibleCredentials(ctx, creds, req.Resolved)
+}
+
+// surfaceCredentials keeps only the credentials whose provider speaks the
+// wire of the route the request arrived on.
+//
+// A raw-forward route sends the caller's body and URL path to the vendor
+// unchanged, so the route decides the vendor. Before this trim, the Gemini
+// /v1beta surface let the credential chain decide instead: a key holding an
+// OpenAI credential and no Google one sent a Gemini-shaped body to OpenAI,
+// which answered 404 for a model it never had. The 404 hides the real cost.
+// The prompt had already left for a vendor the caller never named.
+//
+// Routes the gateway translates pin nothing and are untouched here. Under
+// /v1 the body is rewritten per provider before it leaves, so any provider
+// can serve the request and eligibleCredentials makes the choice.
+func surfaceCredentials(ctx context.Context, creds []domain.Credential, req *domain.Request) ([]domain.Credential, error) {
+	surface := req.InboundSurface()
+	if len(creds) == 0 || len(surface.Providers) == 0 {
+		return creds, nil
+	}
+
+	out := make([]domain.Credential, 0, len(creds))
+	for _, c := range creds {
+		if slices.Contains(surface.Providers, c.ProviderID) {
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 {
+		names := providerNames(surface.Providers)
+		return nil, herr.New(ctx, domain.ErrProviderNotBound, herr.M{
+			"message": fmt.Sprintf("%s sends the request to the provider unchanged, so only %s can serve it, and this key has none of them",
+				surface.Name, names),
+			"hint": fmt.Sprintf("bind one of %s to this virtual key, or send the request to /v1/chat/completions, which the gateway translates for any provider",
+				names),
+			"fault": "customer",
+		})
+	}
+	return out, nil
+}
+
+// providerNames renders a provider list for an error message, as
+// `"gemini" or "vertex"`.
+func providerNames(providers []domain.ProviderID) string {
+	quoted := make([]string, len(providers))
+	for i, p := range providers {
+		quoted[i] = fmt.Sprintf("%q", string(p))
+	}
+	if len(quoted) < 2 {
+		return strings.Join(quoted, "")
+	}
+	return strings.Join(quoted[:len(quoted)-1], ", ") + " or " + quoted[len(quoted)-1]
+}
 
 // eligibleCredentials returns the subset of `creds` that can serve the
 // resolved model, preserving caller-supplied order so the existing

--- a/services/aigateway/app/eligible_test.go
+++ b/services/aigateway/app/eligible_test.go
@@ -186,3 +186,164 @@ func TestEligibleCredentialsEmptyChainDefersToNoProviderConfigured(t *testing.T)
 		t.Errorf("expected empty chain to pass through, got %v", got)
 	}
 }
+
+// geminiPassthrough is a request on the Gemini /v1beta route, the shape
+// gemini-cli and the @google/genai SDK send.
+func geminiPassthrough() *domain.Request {
+	return &domain.Request{
+		Type:        domain.RequestTypePassthrough,
+		Model:       "gemini-2.5-flash",
+		Passthrough: domain.PassthroughRequest{Surface: domain.GeminiSurface()},
+	}
+}
+
+// @scenario "Either Google credential serves the provider-native route"
+func TestSurfaceCredentialsKeepsEveryProviderThatSpeaksTheRoute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		creds   []domain.Credential
+		wantIDs []string
+	}{
+		{
+			name: "gemini credential serves it",
+			creds: []domain.Credential{
+				{ID: "openai_1", ProviderID: domain.ProviderOpenAI},
+				{ID: "gemini_1", ProviderID: domain.ProviderGemini},
+			},
+			wantIDs: []string{"gemini_1"},
+		},
+		{
+			// Bifrost's Vertex passthrough rewrites an inbound Google path
+			// into the project-and-location form, so a Vertex credential
+			// reaches Google for this route too. Pinning the route to Gemini
+			// alone would refuse a key that can serve the request.
+			name: "vertex credential serves it with no gemini credential present",
+			creds: []domain.Credential{
+				{ID: "openai_1", ProviderID: domain.ProviderOpenAI},
+				{ID: "vertex_1", ProviderID: domain.ProviderVertex},
+			},
+			wantIDs: []string{"vertex_1"},
+		},
+		{
+			name: "both Google credentials stay, in chain order",
+			creds: []domain.Credential{
+				{ID: "vertex_1", ProviderID: domain.ProviderVertex},
+				{ID: "elevenlabs_1", ProviderID: domain.ProviderElevenLabs},
+				{ID: "gemini_1", ProviderID: domain.ProviderGemini},
+			},
+			wantIDs: []string{"vertex_1", "gemini_1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := surfaceCredentials(context.Background(), tc.creds, geminiPassthrough())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotIDs := make([]string, len(got))
+			for i, c := range got {
+				gotIDs[i] = c.ID
+			}
+			if !equalSlices(gotIDs, tc.wantIDs) {
+				t.Errorf("got %v want %v", gotIDs, tc.wantIDs)
+			}
+		})
+	}
+}
+
+func TestSurfaceCredentialsRefusesAKeyThatCannotSpeakTheRoute(t *testing.T) {
+	t.Parallel()
+
+	// The reported defect: this chain used to survive the trim, and the
+	// Gemini-shaped body went to whichever credential came first.
+	creds := []domain.Credential{
+		{ID: "openai_1", ProviderID: domain.ProviderOpenAI},
+		{ID: "elevenlabs_1", ProviderID: domain.ProviderElevenLabs},
+	}
+	got, err := surfaceCredentials(context.Background(), creds, geminiPassthrough())
+	if !herr.IsCode(err, domain.ErrProviderNotBound) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrProviderNotBound)
+	}
+	if got != nil {
+		t.Errorf("a refusal must hand back no credentials, got %v", got)
+	}
+}
+
+// @scenario "A translated route leaves the provider choice to the model"
+func TestSurfaceCredentialsLeavesTranslatedRoutesAlone(t *testing.T) {
+	t.Parallel()
+
+	// Everything under /v1 is rewritten per provider before it leaves, so
+	// any provider can serve it and the resolved model makes the choice.
+	creds := []domain.Credential{
+		{ID: "openai_1", ProviderID: domain.ProviderOpenAI},
+		{ID: "anthropic_1", ProviderID: domain.ProviderAnthropic},
+	}
+	got, err := surfaceCredentials(context.Background(), creds,
+		&domain.Request{Type: domain.RequestTypeChat, Model: "gpt-4o"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("a translated route must not trim the chain, got %v", got)
+	}
+}
+
+func TestSurfaceCredentialsEmptyChainDefersToNoProviderConfigured(t *testing.T) {
+	t.Parallel()
+
+	// A key with nothing configured is a different customer problem than a
+	// key missing one provider, and "bind a Google slot" is the wrong advice
+	// for it. Stay silent and let candidateChain raise no_provider_configured.
+	got, err := surfaceCredentials(context.Background(), nil, geminiPassthrough())
+	if err != nil {
+		t.Fatalf("empty chain must not hard-fail here: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected the empty chain to pass through, got %v", got)
+	}
+}
+
+// @scenario "A bare model name whose guessed vendor is absent still uses the key"
+func TestEligibleCredentialsBareNameKeepsAnotherVendorsGateway(t *testing.T) {
+	t.Parallel()
+
+	// What the fallthrough is for. "gpt-4o" reads as OpenAI, but Azure,
+	// Bedrock and Vertex all serve models under another vendor's bare name,
+	// and a key holding only one of them must keep working. Removing the
+	// fallthrough would refuse every Azure-only key that names a bare
+	// OpenAI model, which is the common way to configure one.
+	creds := []domain.Credential{{ID: "azure_1", ProviderID: domain.ProviderAzure}}
+	got, err := eligibleCredentials(context.Background(), creds,
+		&domain.ResolvedModel{ProviderID: "", ModelID: "gpt-4o", Source: domain.ModelSourceImplicit})
+	if err != nil {
+		t.Fatalf("a bare model name must not hard-fail: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "azure_1" {
+		t.Errorf("the Azure credential must still serve a bare OpenAI model name, got %v", got)
+	}
+}
+
+func TestProviderNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   []domain.ProviderID
+		want string
+	}{
+		{in: []domain.ProviderID{domain.ProviderGemini}, want: `"gemini"`},
+		{in: []domain.ProviderID{domain.ProviderGemini, domain.ProviderVertex}, want: `"gemini" or "vertex"`},
+		{
+			in:   []domain.ProviderID{domain.ProviderGemini, domain.ProviderVertex, domain.ProviderAzure},
+			want: `"gemini", "vertex" or "azure"`,
+		},
+	}
+	for _, tc := range cases {
+		if got := providerNames(tc.in); got != tc.want {
+			t.Errorf("providerNames(%v) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}

--- a/services/aigateway/domain/request.go
+++ b/services/aigateway/domain/request.go
@@ -36,6 +36,16 @@ type Request struct {
 	Transcription *TranscriptionUpload
 }
 
+// InboundSurface reports the route this request arrived on when that route
+// pins its own providers, and the zero Surface when it does not. Only the
+// raw-forward routes pin.
+func (r *Request) InboundSurface() Surface {
+	if r == nil || r.Type != RequestTypePassthrough {
+		return Surface{}
+	}
+	return r.Passthrough.Surface
+}
+
 // TranscriptionUpload is the normalized content of a /v1/audio/transcriptions
 // multipart form: the audio file plus the OpenAI-wire optional parameters.
 type TranscriptionUpload struct {
@@ -57,6 +67,40 @@ type PassthroughRequest struct {
 	RawQuery string            // Query string without leading "?"
 	Headers  map[string]string // Forwarded client headers (auth already stripped)
 	Stream   bool              // True when the path resolves to a streaming endpoint
+	// Surface is the route this request arrived on, stated by the handler
+	// registered there. A raw-forward route knows its vendor from its own
+	// registration; leaving it to be guessed from the model name is what
+	// sent Gemini-shaped bodies to other vendors.
+	Surface Surface
+}
+
+// Surface is an inbound route the gateway forwards verbatim, and the
+// providers that can answer it. The body and the URL path reach the vendor
+// unchanged on such a route, so the route decides the vendor, not the model
+// name in it.
+//
+// Translated routes carry no Surface. Everything under /v1 is rewritten per
+// provider before it leaves, so any provider can serve those and the model
+// resolver picks.
+type Surface struct {
+	// Name is the route as the caller wrote it, for use in a refusal.
+	Name string
+	// Providers can serve this route's wire format. Order is not priority:
+	// the credential chain keeps its own order.
+	Providers []ProviderID
+}
+
+// GeminiSurface is the /v1beta route: Google's generative-language wire,
+// used by gemini-cli and the @google/genai SDK.
+//
+// Vertex is on the list with Gemini because the same request reaches Google
+// through either. Bifrost's Vertex passthrough rewrites an inbound Google
+// path into the project-and-location form, so a caller who sends the Vertex
+// path shape to /v1beta is served by a Vertex credential. No provider
+// outside these two serves this wire, so no other credential may receive
+// the body.
+func GeminiSurface() Surface {
+	return Surface{Name: "/v1beta", Providers: []ProviderID{ProviderGemini, ProviderVertex}}
 }
 
 // RequestType classifies the inbound endpoint.

--- a/specs/ai-gateway/model-disambiguation.feature
+++ b/specs/ai-gateway/model-disambiguation.feature
@@ -227,3 +227,23 @@ Feature: AI Gateway — model disambiguation when a VK has multiple providers
       When a request names model "anthropic/gpt-4"
       Then the request is refused as model not allowed
       And the refusal names "anthropic/gpt-4" rather than the model half alone
+
+  Rule: A named vendor is a rule, and a bare model name is a hint
+
+    A model name with a provider prefix, or an alias the key owner wrote,
+    states which vendor gets the request. If the key holds no credential for
+    that vendor the request fails and says which slot is missing. It never
+    goes to a different vendor.
+
+    A bare model name states no vendor. The gateway guesses one from a short
+    prefix table, and the guess is wrong in ways that matter: a key whose
+    only credential is Azure serves "gpt-4o" from Azure, and a key whose
+    only credential is Bedrock serves "claude-sonnet-4-5" from Bedrock. So a
+    guess that matches no credential leaves the chain alone, and each
+    credential then answers for its own vendor with its own error.
+
+    @unit
+    Scenario: A bare model name whose guessed vendor is absent still uses the key
+      Given a key whose only credential is Azure
+      When a request names the bare model "gpt-4o"
+      Then the Azure credential serves it

--- a/specs/ai-gateway/provider-routing.feature
+++ b/specs/ai-gateway/provider-routing.feature
@@ -224,3 +224,38 @@ Feature: Model → provider routing via VK config
       # The materialised chain already respects the allowlist; this is the
       # dispatch-side check that keeps a stale or hand-crafted bundle from
       # turning a narrowing the UI displays as active into a decoration.
+
+  Rule: A route that forwards a request unchanged decides the vendor
+
+    The Gemini surface at /v1beta sends the caller's body and URL path to
+    Google as they arrived. The model id comes from that path, so it carries
+    no provider prefix, and the credential chain picked the vendor instead.
+    A key with an OpenAI credential and no Google one sent the body to
+    OpenAI, which answered 404 for a model it never had. The 404 is the
+    small part. The prompt had already left for a vendor the caller never
+    named.
+
+    A route that forwards bytes unchanged knows its own vendors from the
+    registration. Gemini and Vertex both serve this wire, so either
+    credential can answer it. No other credential may receive the body.
+
+    @unit
+    Scenario: A provider-native route refuses a key with no provider that speaks it
+      Given a key with an OpenAI credential and no Google credential
+      When a request arrives on the Gemini route at /v1beta
+      Then the request is refused as model provider not bound
+      And the refusal names the providers that serve the route
+      And no call is made to any provider
+
+    @unit
+    Scenario: Either Google credential serves the provider-native route
+      Given a key with a Vertex credential and no Gemini credential
+      When a request arrives on the Gemini route at /v1beta
+      Then the Vertex credential serves it
+
+    @unit
+    Scenario: A translated route leaves the provider choice to the model
+      Given a key with credentials for several providers
+      When a request arrives on /v1/chat/completions
+      Then the route pins no provider
+      And the resolved model decides which credential serves the request


### PR DESCRIPTION
Closes #7035.

## What was wrong

The Gemini surface at `/v1beta` sends the caller's body and URL path to Google as they arrived. The model id comes from that path, so it carries no provider prefix, and the credential chain picked the vendor instead. A key holding an OpenAI credential and no Google one sent the Gemini-shaped body to OpenAI, which answered 404 for a model it never had.

The 404 is the small part. The prompt had already left for a vendor the caller never named. On a mixed-provider key that is a data-handling problem, not a routing one.

The sibling half of #7035, an explicit `anthropic/` prefix falling through to another vendor, was already fixed by #7006 earlier the same day. The issue was written from a checkout that predated that merge. This change covers the passthrough surface, which #7006 did not, and adds the live proof for both.

## What changed

`domain.GeminiSurface()` names the route and the providers that serve its wire. The handler states it instead of leaving it to be guessed:

```go
meta := domain.PassthroughRequest{
    ...
    Surface: domain.GeminiSurface(),
}
```

`surfaceCredentials` trims the credential chain to those providers before model resolution runs. A key with none of them is refused with 400 `model_provider_not_bound` naming both slots, and no provider is dialed.

Vertex is on the list with Gemini because Bifrost's Vertex passthrough rewrites an inbound Google path into the project-and-location form, so a caller who sends the Vertex path shape to `/v1beta` is served by a Vertex credential. Pinning to Gemini alone would refuse a key that can serve the request.

## What was deliberately kept

The credential fallthrough for bare model names stays. A bare name states no vendor: the gateway guesses one from a short prefix table, and the guess is wrong in ways that matter. A key whose only credential is Azure serves `gpt-4o` from Azure. A key whose only credential is Bedrock serves `claude-sonnet-4-5` from Bedrock. Removing the fallthrough would refuse both, which is the common way those keys are set up. That case now has its own test and its own spec scenario.

Translated routes are untouched. Under `/v1` the body is rewritten per provider before it leaves, so any provider can serve it and the resolved model makes the choice.

## Proof against a live gateway

Two gateway processes against the same local control plane, one built from main and one from this branch, both driven by real virtual keys narrowed to one provider set each. `gateway_provider_attempts_total` is the gateway's own outbound accounting, so it says whether a request left.

Before, on main, a Gemini `/v1beta` call on a key whose only credential is OpenAI:

```
HTTP 404
{"error":{"type":"provider_error","code":"provider_error","meta":{"status":404,"provider":"openai"}}}
```

The same defect on the pre-#7006 build, reproducing the issue text with the vendors swapped. `{"model":"anthropic/claude-sonnet-4-5"}` came back with OpenAI's own body:

```
HTTP 404
{"error":{"message":"The model `claude-sonnet-4-5` does not exist or you do not have access to it.", ...}}
```

Only OpenAI writes that sentence. The prompt reached OpenAI.

After, the same call on the same key:

```
HTTP 400
{"error":{"type":"model_provider_not_bound",
  "message":"/v1beta sends the request to the provider unchanged, so only \"gemini\" or \"vertex\" can serve it, and this key has none of them",
  "meta":{"hint":"bind one of \"gemini\" or \"vertex\" to this virtual key, or send the request to /v1/chat/completions, which the gateway translates for any provider"},
  "fault":"customer"}}
```

Counters after the same five requests on each build:

| credential | before | after |
| --- | --- | --- |
| OpenAI | `not_found` 4, `success` 1 | `success` 1 |
| ElevenLabs | `timeout` 2, `non_retryable` 1 | `non_retryable` 1 |
| Gemini | `success` 1 | `success` 1 |

Before, four prompts reached OpenAI that had named Anthropic or Google. After, the only OpenAI attempt is the one that asked for OpenAI. Refusals dial nothing at all.

The cases that must keep working, all live:

- Gemini `/v1beta` on a key with the Gemini credential: 200 from Google.
- Bare `tts-1` on a key whose only credential is ElevenLabs: the prefix table says OpenAI, the key has no OpenAI slot, and the request still reaches ElevenLabs and comes back with ElevenLabs' own error. That is the fallthrough doing its job.
- `openai/gpt-4o-mini` on a key with the OpenAI credential: 200.

## Deployment Impact

None. No env vars, no helm values, no migrations, no new dependency.

- Env vars: none added, changed or removed.
- Helm values: unchanged.
- Vanilla install: unchanged.
- BYOC dataplane: unchanged.
- Rollback: revert the commit. The change is a request-time routing check with no persisted state.

Behaviour change worth naming in release notes: a `/v1beta` call on a virtual key with no Gemini and no Vertex credential now returns 400 `model_provider_not_bound` where it used to return whatever the wrong vendor answered, usually a 404. Any caller relying on that 404 was already getting a failed request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added route-aware provider selection for Gemini passthrough requests.
  - Gemini and Vertex credentials are supported for Gemini-native routes.
  - Requests without a compatible credential now receive a clear error before any upstream provider is contacted.

- **Bug Fixes**
  - Improved provider handling for passthrough routes while preserving model-based selection for translated routes.

- **Tests**
  - Expanded coverage for Gemini and Vertex routing, missing credentials, streaming, and non-streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->