### PR TITLE
fix(model-providers): classify credential fields fail-closed

### DIFF
--- a/platform/app/src/app/api/model-providers/__tests__/model-providers-api.integration.test.ts
+++ b/platform/app/src/app/api/model-providers/__tests__/model-providers-api.integration.test.ts
@@ -145,7 +145,7 @@ describe("Model Providers API", () => {
       });
     });
 
-    describe("when a provider stores credentials that are not named as keys", () => {
+    describe("given a provider stores credentials that are not named as keys", () => {
       // The response is reachable with a project API key, which customers
       // deploy into their own applications and CI. Nothing in it may carry a
       // credential value, whatever the field is called. The OAuth-device

--- a/platform/app/src/app/api/model-providers/__tests__/model-providers-api.integration.test.ts
+++ b/platform/app/src/app/api/model-providers/__tests__/model-providers-api.integration.test.ts
@@ -144,6 +144,82 @@ describe("Model Providers API", () => {
         expect(bodyStr).not.toContain("sk-real-key-12345");
       });
     });
+
+    describe("when a provider stores credentials that are not named as keys", () => {
+      // The response is reachable with a project API key, which customers
+      // deploy into their own applications and CI. Nothing in it may carry a
+      // credential value, whatever the field is called. The OAuth-device
+      // provider is the case that proves it: its credential set is a group
+      // of tokens, and a rule that looked for "KEY" in the field name let
+      // every one of them through.
+      // Every value is distinctive on purpose. A short one such as a plan
+      // name matches unrelated text elsewhere in the payload (model ids
+      // ending in "-pro"), which makes the leak assertion fail for the
+      // wrong reason.
+      const SECRET_VALUES = {
+        CODEX_ACCESS_TOKEN: "access-token-value-must-not-appear",
+        CODEX_REFRESH_TOKEN: "refresh-token-value-must-not-appear",
+        CODEX_ID_TOKEN: "id-token-value-must-not-appear",
+        CODEX_ACCOUNT_ID: "account-id-must-not-appear",
+        CODEX_EMAIL: "connected-person@example.invalid",
+        CODEX_PLAN: "plan-tier-must-not-appear",
+        CODEX_TOKENS_SAVED_AT: "2026-08-14T00:00:00.000Z",
+      };
+
+      beforeEach(async () => {
+        await prisma.modelProvider.create({
+          data: {
+            name: "Codex",
+            provider: "openai_codex",
+            enabled: true,
+            organizationId: testOrganization.id,
+            customKeys: SECRET_VALUES,
+            scopes: {
+              create: [{ scopeType: "PROJECT", scopeId: testProjectId }],
+            },
+          },
+        });
+      });
+
+      /** @scenario GET /api/model-providers returns no credential value for any provider */
+      it("masks every credential field it returns", async () => {
+        const res = await helpers.api.get("/api/model-providers");
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.openai_codex).toBeDefined();
+
+        for (const field of Object.keys(SECRET_VALUES)) {
+          expect(
+            body.openai_codex.customKeys[field],
+            `${field} must be masked`,
+          ).toBe(MASKED_KEY_PLACEHOLDER);
+        }
+      });
+
+      it("does not leak any stored credential value anywhere in the response", async () => {
+        const res = await helpers.api.get("/api/model-providers");
+
+        const bodyStr = JSON.stringify(await res.json());
+        for (const value of Object.values(SECRET_VALUES)) {
+          expect(bodyStr, `response contains a stored value`).not.toContain(
+            value,
+          );
+        }
+      });
+
+      it("still reports which credential fields are set", async () => {
+        // The CLI and MCP callers read presence, never values. Masking must
+        // not take that away, or both report an unconfigured provider.
+        const res = await helpers.api.get("/api/model-providers");
+
+        const body = await res.json();
+        expect(Object.keys(body.openai_codex.customKeys).sort()).toEqual(
+          Object.keys(SECRET_VALUES).sort(),
+        );
+        expect(body.openai_codex.enabled).toBe(true);
+      });
+    });
   });
 
   describe("PUT /api/model-providers/:provider", () => {

--- a/platform/app/src/components/settings/ModelProviderCredentialsSection.tsx
+++ b/platform/app/src/components/settings/ModelProviderCredentialsSection.tsx
@@ -10,7 +10,7 @@ import type {
 import { useRequiredCredentialKeys } from "../../hooks/useRequiredCredentialKeys";
 import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
 import { api } from "../../utils/api";
-import { isApiKeyField } from "../../utils/modelProviderHelpers";
+import { isSecretCredentialField } from "../../utils/modelProviderHelpers";
 import { SmallLabel } from "../SmallLabel";
 
 /**
@@ -102,7 +102,7 @@ export const CredentialsSection = ({
           // optional loses its marker the moment that URL is typed.
           const description = fieldMetadata?.[key]?.description;
           const isOptional = !requiredKeys.has(key);
-          const isPassword = isApiKeyField(key);
+          const isPassword = isSecretCredentialField(key);
           const isInvalid = Boolean(fieldErrors[key]);
 
           return (

--- a/platform/app/src/hooks/useModelProviderFields.ts
+++ b/platform/app/src/hooks/useModelProviderFields.ts
@@ -4,7 +4,7 @@ import {
   getDisplayKeysForProvider,
   getRequiredCredentialKeys,
   getSchemaShape,
-  isApiKeyField,
+  isSecretCredentialField,
 } from "../utils/modelProviderHelpers";
 
 export type ServerModelProviderKey = keyof typeof serverModelProviders;
@@ -20,7 +20,7 @@ export interface DerivedFieldMeta {
 }
 
 function deriveTypeFromKey(key: string): DerivedFieldType {
-  return isApiKeyField(key) ? "password" : "text";
+  return isSecretCredentialField(key) ? "password" : "text";
 }
 
 export interface UseModelProviderFieldsResult {

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.unit.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../../../utils/constants";
+import { MASKED_KEY_PLACEHOLDER } from "../../../../utils/constants";
+import { isSecretCredentialField } from "../../../../utils/modelProviderHelpers";
 import type { CustomModelEntry } from "../../../modelProviders/customModel.schema";
 import { customModelUpdateInputSchema } from "../../../modelProviders/customModel.schema";
 import type { MaybeStoredModelProvider } from "../../../modelProviders/registry";
@@ -21,7 +22,7 @@ function maskKeys(
   return Object.fromEntries(
     Object.entries(customKeys).map(([key, value]) => [
       key,
-      KEY_CHECK.some((k) => key.includes(k)) ? MASKED_KEY_PLACEHOLDER : value,
+      isSecretCredentialField(key) ? MASKED_KEY_PLACEHOLDER : value,
     ]),
   );
 }

--- a/platform/app/src/server/modelProviders/__tests__/credentialFieldClassification.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/credentialFieldClassification.unit.test.ts
@@ -30,99 +30,112 @@ function everyRegistryCredentialField(): { provider: string; field: string }[] {
 }
 
 describe("credential field classification", () => {
-  it("reads a field name from every provider in the registry", () => {
-    // Guards the walk itself: `getSchemaShape` returns {} for a wrapper it
-    // cannot unwrap, which would make every assertion below vacuous.
-    for (const [provider, definition] of Object.entries(modelProviders)) {
-      const fields = Object.keys(getSchemaShape(definition.keysSchema));
-      expect(
-        fields.length,
-        `${provider} yielded no credential fields`,
-      ).toBeGreaterThan(0);
-    }
-  });
+  describe("given the provider registry is walked for credential fields", () => {
+    it("reads a field name from every provider", () => {
+      // Guards the walk itself: `getSchemaShape` returns {} for a wrapper it
+      // cannot unwrap, which would make every assertion below vacuous.
+      for (const [provider, definition] of Object.entries(modelProviders)) {
+        const fields = Object.keys(getSchemaShape(definition.keysSchema));
+        expect(
+          fields.length,
+          `${provider} yielded no credential fields`,
+        ).toBeGreaterThan(0);
+      }
+    });
 
-  /** @scenario Credential fields are secret unless the registry declares them public */
-  it("treats an unrecognised field as a secret", () => {
-    expect(isSecretCredentialField("SOME_PROVIDER_NEW_CREDENTIAL")).toBe(true);
-    expect(isSecretCredentialField("")).toBe(true);
-  });
-
-  it("classifies every field a provider carrying secrets can store", () => {
-    // A field is either named in the public list or masked. Nothing is
-    // classified by accident, and a field the list forgets fails closed.
-    for (const { provider, field } of everyRegistryCredentialField()) {
-      const isPublic = PUBLIC_CREDENTIAL_FIELDS.has(field);
-      expect(
-        isSecretCredentialField(field),
-        `${provider}.${field} classification`,
-      ).toBe(!isPublic);
-    }
-  });
-
-  it("never lets the public list name a field that reads as a credential", () => {
-    for (const field of PUBLIC_CREDENTIAL_FIELDS) {
-      const marker = SECRET_CREDENTIAL_MARKERS.find((m) => field.includes(m));
-      expect(
-        marker,
-        `${field} is on the public list but contains "${marker}"`,
-      ).toBeUndefined();
-    }
-  });
-
-  it("keeps the public list free of names no provider stores", () => {
-    // A stale entry is a field that was renamed or removed. Left behind, it
-    // silently pre-approves the name for whatever claims it next.
-    const registryFields = new Set(
-      everyRegistryCredentialField().map(({ field }) => field),
-    );
-    // `MANAGED` is written by the managed-provider flow rather than declared
-    // in any provider's schema, so the registry cannot vouch for it.
-    registryFields.add("MANAGED");
-
-    for (const field of PUBLIC_CREDENTIAL_FIELDS) {
-      expect(registryFields.has(field), `${field} is not in the registry`).toBe(
-        true,
-      );
-    }
-  });
-
-  it("classifies the OAuth-device provider's whole token set as secret", () => {
-    // The provider that made the earlier name-pattern rule fail: an OAuth
-    // token set whose fields are called tokens, not keys.
-    const oauthProviders = Object.entries(modelProviders).filter(
-      ([, definition]) =>
-        (definition as { authFlow?: string }).authFlow === "oauth-device",
-    );
-    expect(oauthProviders.length).toBeGreaterThan(0);
-
-    for (const [provider, definition] of oauthProviders) {
-      for (const field of Object.keys(getSchemaShape(definition.keysSchema))) {
+    it("classifies every field a provider can store", () => {
+      // A field is either named in the public list or masked. Nothing is
+      // classified by accident, and a field the list forgets fails closed.
+      for (const { provider, field } of everyRegistryCredentialField()) {
+        const isPublic = PUBLIC_CREDENTIAL_FIELDS.has(field);
         expect(
           isSecretCredentialField(field),
-          `${provider}.${field} must never be serialized`,
-        ).toBe(true);
+          `${provider}.${field} classification`,
+        ).toBe(!isPublic);
       }
-    }
+    });
   });
 
-  it("keeps connection settings visible so the form can edit them", () => {
-    // The other half of the contract: masking everything would make an
-    // endpoint or a region unrecoverable once saved.
-    for (const field of [
-      "OPENAI_BASE_URL",
-      "AZURE_OPENAI_ENDPOINT",
-      "AZURE_OPENAI_API_VERSION",
-      "AWS_REGION_NAME",
-      "VERTEXAI_PROJECT",
-      "VERTEXAI_LOCATION",
-      "GEMINI_PROJECT",
-      "GEMINI_LOCATION",
-    ]) {
-      expect(
-        isSecretCredentialField(field),
-        `${field} should stay visible`,
-      ).toBe(false);
-    }
+  describe("when a field is not named in the public list", () => {
+    /** @scenario Credential fields are secret unless the registry declares them public */
+    it("treats it as a secret", () => {
+      expect(isSecretCredentialField("SOME_PROVIDER_NEW_CREDENTIAL")).toBe(
+        true,
+      );
+      expect(isSecretCredentialField("")).toBe(true);
+    });
+  });
+
+  describe("given a provider authenticates with an OAuth device flow", () => {
+    it("classifies its whole token set as secret", () => {
+      // The provider that made the earlier name-pattern rule fail: an OAuth
+      // token set whose fields are called tokens, not keys.
+      const oauthProviders = Object.entries(modelProviders).filter(
+        ([, definition]) =>
+          (definition as { authFlow?: string }).authFlow === "oauth-device",
+      );
+      expect(oauthProviders.length).toBeGreaterThan(0);
+
+      for (const [provider, definition] of oauthProviders) {
+        for (const field of Object.keys(
+          getSchemaShape(definition.keysSchema),
+        )) {
+          expect(
+            isSecretCredentialField(field),
+            `${provider}.${field} must never be serialized`,
+          ).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("given the public credential list", () => {
+    it("never names a field that reads as a credential", () => {
+      for (const field of PUBLIC_CREDENTIAL_FIELDS) {
+        const marker = SECRET_CREDENTIAL_MARKERS.find((m) => field.includes(m));
+        expect(
+          marker,
+          `${field} is on the public list but contains "${marker}"`,
+        ).toBeUndefined();
+      }
+    });
+
+    it("holds no name that no provider stores", () => {
+      // A stale entry is a field that was renamed or removed. Left behind, it
+      // silently pre-approves the name for whatever claims it next.
+      const registryFields = new Set(
+        everyRegistryCredentialField().map(({ field }) => field),
+      );
+      // `MANAGED` is written by the managed-provider flow rather than declared
+      // in any provider's schema, so the registry cannot vouch for it.
+      registryFields.add("MANAGED");
+
+      for (const field of PUBLIC_CREDENTIAL_FIELDS) {
+        expect(
+          registryFields.has(field),
+          `${field} is not in the registry`,
+        ).toBe(true);
+      }
+    });
+
+    it("keeps connection settings visible so the form can edit them", () => {
+      // The other half of the contract: masking everything would make an
+      // endpoint or a region unrecoverable once saved.
+      for (const field of [
+        "OPENAI_BASE_URL",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_API_VERSION",
+        "AWS_REGION_NAME",
+        "VERTEXAI_PROJECT",
+        "VERTEXAI_LOCATION",
+        "GEMINI_PROJECT",
+        "GEMINI_LOCATION",
+      ]) {
+        expect(
+          isSecretCredentialField(field),
+          `${field} should stay visible`,
+        ).toBe(false);
+      }
+    });
   });
 });

--- a/platform/app/src/server/modelProviders/__tests__/credentialFieldClassification.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/credentialFieldClassification.unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  PUBLIC_CREDENTIAL_FIELDS,
+  SECRET_CREDENTIAL_MARKERS,
+} from "../../../utils/constants";
+import {
+  getSchemaShape,
+  isSecretCredentialField,
+} from "../../../utils/modelProviderHelpers";
+import { modelProviders } from "../registry";
+
+/**
+ * The classifier decides what every read path masks and what a partial write
+ * keeps. It is name-based and global, so the provider registry can move
+ * underneath it: a provider that adds a credential field, or renames one,
+ * changes what the classifier is asked about without touching this file.
+ *
+ * These tests are the link between the two. They walk the registry rather
+ * than restating it, so a new provider is covered on the day it lands.
+ */
+
+/** Every credential field name any provider can store, from the registry. */
+function everyRegistryCredentialField(): { provider: string; field: string }[] {
+  return Object.entries(modelProviders).flatMap(([provider, definition]) =>
+    Object.keys(getSchemaShape(definition.keysSchema)).map((field) => ({
+      provider,
+      field,
+    })),
+  );
+}
+
+describe("credential field classification", () => {
+  it("reads a field name from every provider in the registry", () => {
+    // Guards the walk itself: `getSchemaShape` returns {} for a wrapper it
+    // cannot unwrap, which would make every assertion below vacuous.
+    for (const [provider, definition] of Object.entries(modelProviders)) {
+      const fields = Object.keys(getSchemaShape(definition.keysSchema));
+      expect(
+        fields.length,
+        `${provider} yielded no credential fields`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  /** @scenario Credential fields are secret unless the registry declares them public */
+  it("treats an unrecognised field as a secret", () => {
+    expect(isSecretCredentialField("SOME_PROVIDER_NEW_CREDENTIAL")).toBe(true);
+    expect(isSecretCredentialField("")).toBe(true);
+  });
+
+  it("classifies every field a provider carrying secrets can store", () => {
+    // A field is either named in the public list or masked. Nothing is
+    // classified by accident, and a field the list forgets fails closed.
+    for (const { provider, field } of everyRegistryCredentialField()) {
+      const isPublic = PUBLIC_CREDENTIAL_FIELDS.has(field);
+      expect(
+        isSecretCredentialField(field),
+        `${provider}.${field} classification`,
+      ).toBe(!isPublic);
+    }
+  });
+
+  it("never lets the public list name a field that reads as a credential", () => {
+    for (const field of PUBLIC_CREDENTIAL_FIELDS) {
+      const marker = SECRET_CREDENTIAL_MARKERS.find((m) => field.includes(m));
+      expect(
+        marker,
+        `${field} is on the public list but contains "${marker}"`,
+      ).toBeUndefined();
+    }
+  });
+
+  it("keeps the public list free of names no provider stores", () => {
+    // A stale entry is a field that was renamed or removed. Left behind, it
+    // silently pre-approves the name for whatever claims it next.
+    const registryFields = new Set(
+      everyRegistryCredentialField().map(({ field }) => field),
+    );
+    // `MANAGED` is written by the managed-provider flow rather than declared
+    // in any provider's schema, so the registry cannot vouch for it.
+    registryFields.add("MANAGED");
+
+    for (const field of PUBLIC_CREDENTIAL_FIELDS) {
+      expect(registryFields.has(field), `${field} is not in the registry`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("classifies the OAuth-device provider's whole token set as secret", () => {
+    // The provider that made the earlier name-pattern rule fail: an OAuth
+    // token set whose fields are called tokens, not keys.
+    const oauthProviders = Object.entries(modelProviders).filter(
+      ([, definition]) =>
+        (definition as { authFlow?: string }).authFlow === "oauth-device",
+    );
+    expect(oauthProviders.length).toBeGreaterThan(0);
+
+    for (const [provider, definition] of oauthProviders) {
+      for (const field of Object.keys(getSchemaShape(definition.keysSchema))) {
+        expect(
+          isSecretCredentialField(field),
+          `${provider}.${field} must never be serialized`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("keeps connection settings visible so the form can edit them", () => {
+    // The other half of the contract: masking everything would make an
+    // endpoint or a region unrecoverable once saved.
+    for (const field of [
+      "OPENAI_BASE_URL",
+      "AZURE_OPENAI_ENDPOINT",
+      "AZURE_OPENAI_API_VERSION",
+      "AWS_REGION_NAME",
+      "VERTEXAI_PROJECT",
+      "VERTEXAI_LOCATION",
+      "GEMINI_PROJECT",
+      "GEMINI_LOCATION",
+    ]) {
+      expect(
+        isSecretCredentialField(field),
+        `${field} should stay visible`,
+      ).toBe(false);
+    }
+  });
+});

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.service.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.service.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { isSecretCredentialField } from "../../../utils/modelProviderHelpers";
 import { mergeStoredCustomKeys } from "../credentialMerge";
 
 /**
@@ -7,14 +8,16 @@ import { mergeStoredCustomKeys } from "../credentialMerge";
  * These test the pure transformation functions and business rules.
  */
 
-// Test the key masking logic (extracted for testing)
+// Mirrors ModelProviderService.maskRowCustomKeys. It calls the real
+// classifier rather than restating the rule, so a change to what counts as a
+// secret reaches these expectations instead of passing against a stale copy.
 function maskApiKeys(
   customKeys: Record<string, unknown>,
 ): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(customKeys).map(([key, value]) => [
       key,
-      KEY_CHECK.some((k) => key.includes(k)) ? MASKED_KEY_PLACEHOLDER : value,
+      isSecretCredentialField(key) ? MASKED_KEY_PLACEHOLDER : value,
     ]),
   );
 }
@@ -49,12 +52,25 @@ function shouldKeepModelProvider(
 describe("ModelProviderService business logic", () => {
   describe("mergeStoredCustomKeys", () => {
     describe("given a row with nothing worth keeping", () => {
-      it("returns an empty bag when the write carries no credentials", () => {
+      it("drops visible configuration when the write carries no credentials", () => {
+        // A base URL is shown back, so a write that omits it is stating the
+        // configuration in full and the stored value goes.
         const result = mergeStoredCustomKeys({
           incoming: null,
-          stored: { existing: "value" },
+          stored: { OPENAI_BASE_URL: "https://old-url.com" },
         });
         expect(result).toEqual({});
+      });
+
+      it("keeps a stored secret the write never names", () => {
+        // The other half of the same rule. A secret is masked on read, so no
+        // caller can resend one it did not type, and omitting it cannot mean
+        // "delete it".
+        const result = mergeStoredCustomKeys({
+          incoming: null,
+          stored: { CODEX_ACCESS_TOKEN: "stored-token" },
+        });
+        expect(result).toEqual({ CODEX_ACCESS_TOKEN: "stored-token" });
       });
 
       it("returns the write untouched when the row is empty", () => {
@@ -192,7 +208,7 @@ describe("ModelProviderService business logic", () => {
 
   describe("maskApiKeys", () => {
     /** @scenario API key masking when editing existing provider */
-    it("masks fields containing KEY", () => {
+    it("masks the API key and leaves the base URL visible", () => {
       const customKeys = {
         OPENAI_API_KEY: "sk-actual-key",
         OPENAI_BASE_URL: "https://api.openai.com",
@@ -218,18 +234,32 @@ describe("ModelProviderService business logic", () => {
       expect(result.AWS_REGION_NAME).toBe("us-east-1");
     });
 
-    it("does not mask GOOGLE_APPLICATION_CREDENTIALS", () => {
+    it("masks the Vertex AI service account document", () => {
       const customKeys = {
         GOOGLE_APPLICATION_CREDENTIALS: "/path/to/credentials.json",
       };
 
       const result = maskApiKeys(customKeys);
 
-      // GOOGLE_APPLICATION_CREDENTIALS contains "CREDENTIALS" not "KEY"
-      // so it should be masked based on KEY_CHECK patterns
       expect(result.GOOGLE_APPLICATION_CREDENTIALS).toBe(
         MASKED_KEY_PLACEHOLDER,
       );
+    });
+
+    it("masks an OAuth token set whose fields are not named as keys", () => {
+      const customKeys = {
+        CODEX_ACCESS_TOKEN: "token-value",
+        CODEX_REFRESH_TOKEN: "refresh-value",
+        CODEX_ID_TOKEN: "id-value",
+        CODEX_EMAIL: "person@example.com",
+        CODEX_PLAN: "pro",
+      };
+
+      const result = maskApiKeys(customKeys);
+
+      for (const field of Object.keys(customKeys)) {
+        expect(result[field]).toBe(MASKED_KEY_PLACEHOLDER);
+      }
     });
 
     it("handles empty object", () => {

--- a/platform/app/src/server/modelProviders/credentialMerge.ts
+++ b/platform/app/src/server/modelProviders/credentialMerge.ts
@@ -1,13 +1,12 @@
-import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+import { isSecretCredentialField } from "../../utils/modelProviderHelpers";
 
 /**
  * Whether a credential field holds a secret, by the same test the read path
  * masks with. That shared test is the point: a value the server never shows
  * back is one no caller can resend.
  */
-export function isSecretCredential(key: string): boolean {
-  return KEY_CHECK.some((marker) => key.includes(marker));
-}
+export const isSecretCredential = isSecretCredentialField;
 
 /**
  * The credential bag to store, given what a write carries and what the row

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -322,10 +322,12 @@ export class ModelProviderService {
    * Gets model providers with API keys masked for frontend display.
    *
    * Business rules:
-   * - Only masks customKeys fields matching KEY_CHECK patterns (API keys)
+   * - Every customKeys field is masked unless `PUBLIC_CREDENTIAL_FIELDS`
+   *   names it, so a provider that adds a credential is covered by default
    * - Extra-header values are always masked — they routinely carry auth
    *   secrets for azure/custom providers
-   * - URLs and other values remain visible
+   * - Endpoints, API versions, regions and cloud project or location pairs
+   *   remain visible, because the settings form has to render them back
    *
    * Masking runs even when `includeKeys` is false: customKeys are already
    * nulled by that flag, but extraHeaders are returned regardless, so

--- a/platform/app/src/utils/constants.ts
+++ b/platform/app/src/utils/constants.ts
@@ -11,7 +11,52 @@ export const OPENAI_EMBEDDING_DIMENSION = 1536;
 
 export const DEFAULT_TOPIC_CLUSTERING_MODEL = "openai/gpt-5.2";
 
-export const KEY_CHECK = ["KEY", "GOOGLE_APPLICATION_CREDENTIALS"];
+/**
+ * The credential fields that carry no secret, listed by exact name.
+ *
+ * Everything a provider stores in `customKeys` is treated as a secret unless
+ * it appears here, so a provider that adds a field gets it masked with no
+ * further action. The list holds connection configuration the settings form
+ * has to render back to be editable: endpoints, API versions, regions, cloud
+ * project and location pairs, and the `MANAGED` marker.
+ *
+ * Add a name here only after checking that its value cannot authenticate
+ * anything. `modelProviderHelpers.isSecretCredentialField` is the single
+ * reader, and `credentialFieldClassification.unit.test.ts` walks the provider
+ * registry to keep this list and the registry in step.
+ */
+export const PUBLIC_CREDENTIAL_FIELDS: ReadonlySet<string> = new Set([
+  "ANTHROPIC_BASE_URL",
+  "AWS_REGION_NAME",
+  "AZURE_API_GATEWAY_BASE_URL",
+  "AZURE_API_GATEWAY_VERSION",
+  "AZURE_CONTENT_SAFETY_ENDPOINT",
+  "AZURE_OPENAI_API_VERSION",
+  "AZURE_OPENAI_ENDPOINT",
+  "CUSTOM_BASE_URL",
+  "GEMINI_LOCATION",
+  "GEMINI_PROJECT",
+  "GOOGLE_AGENT_PLATFORM_LOCATION",
+  "GOOGLE_AGENT_PLATFORM_PROJECT",
+  "MANAGED",
+  "OPENAI_BASE_URL",
+  "VERTEXAI_LOCATION",
+  "VERTEXAI_PROJECT",
+]);
+
+/**
+ * Name fragments that mark a field as a credential whatever else is decided
+ * about it. A field matching one of these can never be added to
+ * `PUBLIC_CREDENTIAL_FIELDS`; the classification test enforces that, so an
+ * allowlist entry cannot re-expose a secret by mistake.
+ */
+export const SECRET_CREDENTIAL_MARKERS = [
+  "KEY",
+  "TOKEN",
+  "SECRET",
+  "PASSWORD",
+  "CREDENTIAL",
+] as const;
 
 export const MASKED_KEY_PLACEHOLDER = "HAS_KEY••••••••••••••••••••••••";
 

--- a/platform/app/src/utils/modelProviderHelpers.ts
+++ b/platform/app/src/utils/modelProviderHelpers.ts
@@ -1,4 +1,4 @@
-import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "./constants";
+import { MASKED_KEY_PLACEHOLDER, PUBLIC_CREDENTIAL_FIELDS } from "./constants";
 
 /** Extracts provider key from model string (e.g., "openai/gpt-4" -> "openai") */
 export function getProviderFromModel(model: string): string {
@@ -26,9 +26,16 @@ export function getSchemaShape(schema: unknown): Record<string, unknown> {
   return {};
 }
 
-/** Whether a credential key holds a secret (drives password masking). */
-export function isApiKeyField(key: string): boolean {
-  return KEY_CHECK.some((k) => key.includes(k));
+/**
+ * Whether a credential field holds a secret. Drives password masking in the
+ * form, redaction on every read path, and which fields a partial write keeps.
+ *
+ * The answer defaults to yes: a field is public only when
+ * `PUBLIC_CREDENTIAL_FIELDS` names it, so a provider that adds a credential
+ * is covered before anyone remembers to classify it.
+ */
+export function isSecretCredentialField(key: string): boolean {
+  return !PUBLIC_CREDENTIAL_FIELDS.has(key);
 }
 
 /**
@@ -229,7 +236,7 @@ export function buildCustomKeyState(
     const storedValue = storedKeys[key];
     if (typeof storedValue === "string") {
       result[key] = storedValue;
-    } else if (isUsingEnvVars && isApiKeyField(key)) {
+    } else if (isUsingEnvVars && isSecretCredentialField(key)) {
       // Provider is enabled via env vars - show MASKED for API key fields
       result[key] = MASKED_KEY_PLACEHOLDER;
     } else {
@@ -252,7 +259,7 @@ export function hasUserEnteredNewApiKey(
 ): boolean {
   return Object.entries(customKeys).some(
     ([key, value]) =>
-      isApiKeyField(key) &&
+      isSecretCredentialField(key) &&
       value &&
       value.trim() !== "" &&
       value !== MASKED_KEY_PLACEHOLDER,
@@ -291,7 +298,7 @@ export function hasUserModifiedNonApiKeyFields(
 ): boolean {
   return Object.entries(customKeys).some(
     ([key, value]) =>
-      !isApiKeyField(key) &&
+      !isSecretCredentialField(key) &&
       credentialFieldChanged({ value, storedValue: initialKeys[key] }),
   );
 }

--- a/specs/features/platform-evaluator-and-model-provider-tools.feature
+++ b/specs/features/platform-evaluator-and-model-provider-tools.feature
@@ -115,6 +115,25 @@ Feature: Platform MCP tools for evaluators and model providers
     Then I receive all providers for the project
     And all API key values are masked
 
+  # A project API key reaches this endpoint, and customers deploy that key
+  # into their own applications and CI. The response therefore reports which
+  # credential fields are set, never what they hold.
+  @integration
+  Scenario: GET /api/model-providers returns no credential value for any provider
+    Given a provider stores credentials whose field names are not "API key"
+    When I send a GET request to /api/model-providers
+    Then every credential field comes back as the masked placeholder
+    And no stored credential value appears anywhere in the response
+    And the field names still show which credentials are set
+
+  @unit
+  Scenario: Credential fields are secret unless the registry declares them public
+    Given a provider adds a credential field to its key schema
+    When the field is not named in the public credential list
+    Then it is classified as a secret
+    And every read path masks it
+    And a write that omits it keeps the stored value
+
   @integration
   Scenario: PUT /api/model-providers/:provider upserts provider config
     When I send a PUT request with provider name and customKeys


### PR DESCRIPTION
## What

Model provider credentials are redacted before they leave the server. The rule that decided which fields to redact tested whether the field name contained the string `KEY`, so it only covered credentials that are named as keys. A provider that stores its credential under any other name had the value serialized.

This inverts the rule. A field in `customKeys` is a secret unless `PUBLIC_CREDENTIAL_FIELDS` names it. The public list holds the connection settings the settings form has to render back to stay editable: endpoints, API versions, regions, and cloud project and location pairs. A provider that adds a credential is redacted from the day it lands, with nothing to remember.

## Why this shape

Listing what is safe is short and stays short. Listing what is secret means predicting every name a future provider will pick, and a miss there is silent.

The rule also existed twice, once server side and once client side, with two more copies inside unit tests that asserted against their own version of it. A change to one could not reach the others. There is now one function, and the tests call it.

## Blast radius

Auditing every provider in the registry field by field, exactly one provider changes classification: the one that authenticates with an OAuth device flow and stores a token set rather than a key. It renders no credential inputs, so no form behaviour moves. Every other provider classifies identically before and after.

Endpoint consumers are unaffected. Both the CLI `model-provider list` and the MCP `platform_list_model_providers` tool read whether a credential is set, never its value, and the response still reports the field names.

## Tests

- `credentialFieldClassification.unit.test.ts` walks the provider registry and fails when a provider field is left unclassified, when the public list names something that reads as a credential, or when a list entry no longer matches any provider.
- `model-providers-api.integration.test.ts` asserts no stored credential value appears anywhere in the response, while the field names still report which credentials are set. Verified to fail against the previous rule and pass against this one.

## Deployment Impact

None. This is a serialization change inside the application.

- **Environment variables**: no new or changed variables.
- **Helm values**: no chart changes.
- **Vanilla install**: no action. No migration, no schema change, no stored data is read or written differently. Values already in `ModelProvider.customKeys` are untouched; only what is sent to a client changes.
- **BYOC dataplane**: no action. The gateway reads credentials from the control plane over its own signed channel and never consumed the redacted payload.
- **Rollback**: safe to revert with no cleanup. Reverting restores the previous serialization and nothing else.

One behaviour worth knowing when reading the diff: a write that omits a stored field now keeps that field when it is classified secret, matching the existing documented rule that a value the server never shows back cannot be deleted by omission. Visible configuration such as a base URL is still dropped when omitted, so the Azure API Gateway toggle continues to switch modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for model provider credentials by masking secret fields regardless of their names.
  * Unknown or undeclared credential fields are now treated as secret by default.
  * Preserved stored secrets when updating provider settings without resending them.
  * Continued displaying non-secret connection details and which credentials are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->