### PR TITLE
fix(costs): unbreak the price guard, and correct the gpt-realtime-2 text output rate

### DIFF
--- a/.github/scripts/guard-breaking-change-scope.test.ts
+++ b/.github/scripts/guard-breaking-change-scope.test.ts
@@ -28,6 +28,29 @@ const scriptPath = resolve(
   "guard-breaking-change-scope.ts",
 );
 
+/**
+ * The version the manifest currently records for a component path.
+ *
+ * Read rather than hardcoded: the guard prints the live version, so a literal
+ * here goes stale the moment that component is released, and the guard's own
+ * test suite fails on a pull request that has nothing to do with it. That is
+ * what happened when typescript-sdk went to 1.5.0.
+ */
+const currentVersion = (path: string): string => {
+  const manifest = JSON.parse(
+    readFileSync(resolve(repoRoot, ".github/.release-please-manifest.json"), "utf8"),
+  ) as Record<string, string>;
+  const version = manifest[path];
+  assert.ok(version, `no manifest version for ${path}`);
+  return version;
+};
+
+/** A version one minor above the given one, so a pin is always ahead. */
+const nextMinor = (version: string): string => {
+  const [major, minor] = version.split(".");
+  return `${major}.${Number(minor) + 1}.0`;
+};
+
 const liveComponents = () =>
   releaseComponents(
     JSON.parse(
@@ -419,18 +442,20 @@ describe("breaking-change scope guard", () => {
 
     /** @scenario "A break spanning two components fails" */
     it("fails while more than one bumped component is still unpinned", () => {
+      const now = currentVersion("sdks/typescript");
+      const pinned = nextMinor(now);
       const result = runGuard(
         checkout({
           files: [...threeComponents, typescriptShim],
-          messages: [breakingCommit, pinCommit("typescript-sdk", "1.5.0")],
-          shims: { [typescriptShim]: shimSaying("1.5.0") },
+          messages: [breakingCommit, pinCommit("typescript-sdk", pinned)],
+          shims: { [typescriptShim]: shimSaying(pinned) },
         }),
       );
 
       assert.equal(result.status, 1);
       assert.ok(
         result.stderr.includes(
-          "- typescript-sdk (sdks/typescript), now 1.4.0, pinned to 1.5.0",
+          `- typescript-sdk (sdks/typescript), now ${now}, pinned to ${pinned}`,
         ),
         result.stderr,
       );

--- a/platform/app/src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts
@@ -104,12 +104,7 @@ const BILLING_UNITS: Record<string, "token" | "character" | "second"> = {
  * A line here is a promise to remove it. The honesty test below fails once
  * the entry is corrected, so the baseline cannot outlive the defect.
  */
-const KNOWN_UNIT_MISMATCH: Record<string, string> = {
-  "openai/gpt-4o-transcribe":
-    "Prices per second while the transcription response reports tokens and no duration, so it rates zero on every call. Corrected to token pricing on langwatch#7021.",
-  "openai/gpt-4o-mini-transcribe":
-    "Same per-second-versus-token mismatch, corrected on the same pull request.",
-};
+const KNOWN_UNIT_MISMATCH: Record<string, string> = {};
 
 const catalogEntries = Object.entries(llmModels.models);
 

--- a/platform/app/src/server/modelProviders/llmModels.overlay.json
+++ b/platform/app/src/server/modelProviders/llmModels.overlay.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Hand-curated model entries for direct-API providers that the upstream model-catalog source does not carry (Voyage AI's direct API today, others later). Merged into llmModels at module load \u2014 see loadModelCatalog.ts. The base llmModels.json is regenerated periodically and overwriting hand-added entries would silently drop these providers; the overlay file is never touched by the regen task. Add entries here when integrating a provider whose models aren't reachable via the upstream catalog. Audio entries here are the ones litellm's price registry cannot serve correctly: models it lacks (ElevenLabs flash/turbo, gpt-transcribe), models it prices without audio units (gpt-4o-mini-tts, the gpt-4o transcribe pair), and models where its rate lags a provider price change (eleven_multilingual_v2 still carries the pre-cut rate upstream). An overlay entry only takes effect when the base catalog has no key of the same name, because the merge lets the base win on collision. Entries litellm carries correctly (tts-1, tts-1-hd, whisper-1, scribe_v1) were retired from the overlay and flow in via the weekly sync.",
+	"_comment": "Hand-curated model entries for direct-API providers that the upstream model-catalog source does not carry (Voyage AI's direct API today, others later). Merged into llmModels at module load — see loadModelCatalog.ts. The base llmModels.json is regenerated periodically and overwriting hand-added entries would silently drop these providers; the overlay file is never touched by the regen task. Add entries here when integrating a provider whose models aren't reachable via the upstream catalog. Audio entries here are the ones litellm's price registry cannot serve correctly: models it lacks (ElevenLabs flash/turbo, gpt-transcribe), models it prices without audio units (gpt-4o-mini-tts, the gpt-4o transcribe pair), and models where its rate lags a provider price change (eleven_multilingual_v2 still carries the pre-cut rate upstream). An overlay entry only takes effect when the base catalog has no key of the same name, because the merge lets the base win on collision. Entries litellm carries correctly (tts-1, tts-1-hd, whisper-1, scribe_v1) were retired from the overlay and flow in via the weekly sync.",
 	"models": {
 		"voyage/voyage-3.5": {
 			"id": "voyage/voyage-3.5",
@@ -192,7 +192,7 @@
 			"pricing": {
 				"inputCostPerToken": 0,
 				"outputCostPerToken": 0,
-				"inputCostPerSecond": 5.666666666666667e-4
+				"inputCostPerSecond": 0.0005666666666666667
 			},
 			"contextLength": 0,
 			"maxCompletionTokens": null,
@@ -213,7 +213,7 @@
 			"pricing": {
 				"inputCostPerToken": 0,
 				"outputCostPerToken": 0,
-				"inputCostPerSecond": 2.8333333333333335e-4
+				"inputCostPerSecond": 0.00028333333333333335
 			},
 			"contextLength": 0,
 			"maxCompletionTokens": null,
@@ -421,6 +421,114 @@
 			"supportsAudioInput": true,
 			"supportsImageOutput": false,
 			"supportsAudioOutput": true
+		},
+		"openai/o3-deep-research": {
+			"id": "openai/o3-deep-research",
+			"name": "OpenAI: o3 Deep Research",
+			"provider": "openai",
+			"pricing": {
+				"inputCostPerToken": 1e-5,
+				"outputCostPerToken": 4e-5,
+				"inputCacheReadPerToken": 2.5e-6,
+				"webSearchCostPerQuery": 0.01
+			},
+			"contextLength": 200000,
+			"maxCompletionTokens": 100000,
+			"supportedParameters": [],
+			"defaultParameters": null,
+			"modality": "text+image+file->text",
+			"mode": "chat",
+			"description": "Delisted from the model catalog source on 2026-08-16 while still live. Input $10.00 and output $40.00 per million, cached input $2.50 (https://developers.openai.com/api/docs/models/o3-deep-research, verified 2026-08-16, not marked deprecated). Without this entry it prefix-matches openai/o3 and bills 80 percent under.",
+			"supportsImageInput": true,
+			"supportsAudioInput": false,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": false
+		},
+		"openai/o4-mini-deep-research": {
+			"id": "openai/o4-mini-deep-research",
+			"name": "OpenAI: o4 Mini Deep Research",
+			"provider": "openai",
+			"pricing": {
+				"inputCostPerToken": 2e-6,
+				"outputCostPerToken": 8e-6,
+				"inputCacheReadPerToken": 5e-7,
+				"webSearchCostPerQuery": 0.01
+			},
+			"contextLength": 200000,
+			"maxCompletionTokens": 100000,
+			"supportedParameters": [],
+			"defaultParameters": null,
+			"modality": "text+image+file->text",
+			"mode": "chat",
+			"description": "Delisted from the model catalog source on 2026-08-16. The second price source still carries $2.00 input and $8.00 output per million, matching what this catalog held before the delisting. Without this entry it prefix-matches openai/o4-mini and bills 45 percent under.",
+			"supportsImageInput": true,
+			"supportsAudioInput": false,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": false
+		},
+		"openai/gpt-5.3-chat": {
+			"id": "openai/gpt-5.3-chat",
+			"name": "OpenAI: GPT-5.3 Chat",
+			"provider": "openai",
+			"pricing": {
+				"inputCostPerToken": 1.75e-6,
+				"outputCostPerToken": 1.4e-5,
+				"inputCacheReadPerToken": 1.75e-7,
+				"webSearchCostPerQuery": 0.01
+			},
+			"contextLength": 128000,
+			"maxCompletionTokens": 16384,
+			"supportedParameters": [],
+			"defaultParameters": null,
+			"modality": "text+image+file->text",
+			"mode": "chat",
+			"description": "Delisted from the model catalog source on 2026-08-16. The second price source still carries $1.75 input and $14.00 output per million, matching what this catalog held before. Without this entry it prefix-matches openai/gpt-5 and bills 29 percent under.",
+			"supportsImageInput": true,
+			"supportsAudioInput": false,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": false
+		},
+		"mistralai/devstral-2512": {
+			"id": "mistralai/devstral-2512",
+			"name": "Mistral: Devstral 2 2512",
+			"provider": "mistralai",
+			"pricing": {
+				"inputCostPerToken": 4e-7,
+				"outputCostPerToken": 2e-6,
+				"inputCacheReadPerToken": 4e-8
+			},
+			"contextLength": 262144,
+			"maxCompletionTokens": null,
+			"supportedParameters": [],
+			"defaultParameters": null,
+			"modality": "text+file->text",
+			"mode": "chat",
+			"description": "Delisted from the model catalog source on 2026-08-16. The second price source still carries $0.40 input and $2.00 output per million, matching what this catalog held before. Without this entry no rule matches it at all and it bills zero.",
+			"supportsImageInput": false,
+			"supportsAudioInput": false,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": false
+		},
+		"poolside/laguna-m.1": {
+			"id": "poolside/laguna-m.1",
+			"name": "Poolside: Laguna M.1",
+			"provider": "poolside",
+			"pricing": {
+				"inputCostPerToken": 2e-7,
+				"outputCostPerToken": 4e-7,
+				"inputCacheReadPerToken": 1e-7
+			},
+			"contextLength": 262144,
+			"maxCompletionTokens": 32768,
+			"supportedParameters": [],
+			"defaultParameters": null,
+			"modality": "text->text",
+			"mode": "chat",
+			"description": "Delisted from the model catalog source on 2026-08-16 and absent from the second source, so these are the rates this catalog itself carried on 2026-07-27, kept so the model bills something rather than zero. No source can confirm them now. Retire this entry once the model is known to be gone, or correct it once a source carries it again.",
+			"supportsImageInput": false,
+			"supportsAudioInput": false,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": false
 		}
 	}
 }

--- a/platform/app/src/server/modelProviders/llmModels.overlay.json
+++ b/platform/app/src/server/modelProviders/llmModels.overlay.json
@@ -393,8 +393,31 @@
 			"defaultParameters": null,
 			"modality": "text+audio->text+audio",
 			"mode": "chat",
-			"description": "A cost-efficient version of GPT Audio. Text input and output are priced by the fields above. Audio input is priced by audioCostPerToken. The audio output rate is twice the audio input rate; the cost layer cannot price audio tokens yet, and langwatch#7021 adds both the audio-token pricing and the derivation that produces the output rate from the input rate. Rates verified 2026-08-15 on https://developers.openai.com/api/docs/pricing, which lists audio input $10.00 and audio output $20.00 per million for this model. Note the per-model page at /api/docs/models/gpt-audio-mini carries the text rates only, so the pricing page is the source for the audio side. This entry exists because one upstream source reports the audio input rate as the text rate, which billed audio at a sixteenth of the published price. The other source carries the correct rate. Retire this entry once the wrong source is corrected; the weekly price audit reports the disagreement until then.",
+			"description": "A cost-efficient version of GPT Audio. Text input and output are priced by the fields above. Audio input is priced by audioCostPerToken, and the cost layer derives the audio output rate as twice the audio input rate. Rates verified 2026-08-15 on https://developers.openai.com/api/docs/pricing, which lists audio input $10.00 and audio output $20.00 per million for this model. Note the per-model page at /api/docs/models/gpt-audio-mini carries the text rates only, so the pricing page is the source for the audio side. This entry exists because one upstream source reports the audio input rate as the text rate, which billed audio at a sixteenth of the published price. The other source carries the correct rate. Retire this entry once the wrong source is corrected; the weekly price audit reports the disagreement until then.",
 			"supportsImageInput": false,
+			"supportsAudioInput": true,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": true
+		},
+		"openai/gpt-realtime-2": {
+			"id": "openai/gpt-realtime-2",
+			"name": "OpenAI: GPT Realtime 2",
+			"provider": "openai",
+			"pricing": {
+				"inputCostPerToken": 4e-6,
+				"outputCostPerToken": 2.4e-5,
+				"inputCacheReadPerToken": 4e-7,
+				"audioCostPerToken": 3.2e-5,
+				"audioOutputCostPerToken": 6.4e-5
+			},
+			"contextLength": 0,
+			"maxCompletionTokens": null,
+			"supportedParameters": [],
+			"defaultParameters": null,
+			"modality": "audio->audio",
+			"mode": "audio",
+			"description": "OpenAI's realtime speech model, second generation. Text input $4.00, text output $24.00, audio input $32.00 and audio output $64.00 per million tokens, with cached input at $0.40 (https://developers.openai.com/api/docs/models/gpt-realtime-2, verified 2026-08-16). This entry exists for the text output rate only: the price registry the sync imports from carries $16.00 there, which is the previous generation's rate and a third under what the provider charges. Every other rate here matches that registry. Retire this entry once the registry is corrected; the weekly price audit reports the disagreement until then.",
+			"supportsImageInput": true,
 			"supportsAudioInput": true,
 			"supportsImageOutput": false,
 			"supportsAudioOutput": true


### PR DESCRIPTION
**Merge this before #7059.** The catalog refresh in that pull request drops ten previously priced models, and five of them start billing wrong the moment it lands. This adds the entries that stop it, so the refresh costs nothing.

## The five that would break

The model catalog source delisted ten models it used to price. Five prefix-match a sibling carrying identical rates, so they are harmless. These five are not:

| Model | Without this | Would anything notice? |
|---|---|---|
| `openai/o3-deep-research` | bills at `openai/o3`, **80% under** | **no** |
| `openai/o4-mini-deep-research` | bills at `openai/o4-mini`, **45% under** | **no** |
| `openai/gpt-5.3-chat` | bills at `openai/gpt-5`, **29% under** | **no** |
| `mistralai/devstral-2512` | no rule matches, rates zero | yes, at runtime |
| `poolside/laguna-m.1` | no rule matches, rates zero | yes, at runtime |

The three that misroute are the worse case, not the two that zero. A rule matches, the quantities price, a plausible number is written, no warning fires and the row settles. The two that rate zero at least emit `spend_rating.no_rate_rule`.

The coverage guard does not catch either kind: it iterates the merged catalog, and a model deleted from the catalog is not in the set it iterates. Delisting is invisible to it by construction.

**Delisting does not close the route.** The gateway resolves a model against the virtual key's allowlist, and `AllowsResolvedModel` returns `true` when that list is empty, so any key without an explicit `models_allowed` can still reach these ids. The price catalog is not consulted for routing.

Rates verified rather than copied: `o3-deep-research` is live on the provider's page at $10.00 and $40.00 per million with no deprecation marker. The second price source carries current, matching rates for three of the others. `poolside/laguna-m.1` is gone from every source, so its entry records the rates this catalog itself last carried and says exactly that.

Checked by running all ten delisted ids through the real cost matcher against the refreshed catalog: every one resolves to its own rule at its original rates.

## gpt-realtime-2 text output, a third under

The provider publishes text output at **$24.00 per million**; the price registry the sync imports from carries **$16.00**, the previous generation's rate. Every other rate for that model matches.

Source: https://developers.openai.com/api/docs/models/gpt-realtime-2, verified 2026-08-16.

This one cannot be caught automatically. The realtime family has no second automated price source, because the model catalog source carries none of these models, so the cross-source check in the weekly audit has nothing to compare against. It matters now because langwatch/langwatch-saas#1074 brings the whole realtime family into the catalog.

## The price guard baseline

`catalogPriceCoverage.unit.test.ts` was failing on `main`. It carries a baseline of known unit mismatches plus a test that fails once a baselined entry is corrected, so the baseline shrinks rather than rots. #7021 corrected both transcribe entries to token pricing, which is that condition. The baseline is now empty.

## The release-scope guard, also failing on main

`main` asserts `now 1.4.0` for `typescript-sdk` in the release guard's own test. That component was released to 1.5.0 yesterday in 178f164127, so the literal is stale and the case fails on any pull request whose checkout carries it, including #7059. The fix reads the version from the manifest the guard itself reads.

Worth noting: #7055 and #7057 independently fix the same line. Three separate fixes to one assertion is the sign that `main` is the broken thing. Whichever lands first, the other two get a one-hunk conflict that resolves to the same behaviour.

## Tests

```
src/server/modelProviders + src/server/tracer/collector
Test Files  46 passed (46)
     Tests  628 passed | 1 skipped (629)

.github/scripts/guard-breaking-change-scope.test.ts
tests 32, pass 32, fail 0
```

## Deployment Impact

None beyond the price values.

- **Environment variables:** none added, changed or removed.
- **Helm values:** unchanged.
- **Vanilla install:** unchanged. The catalog is compiled into the app.
- **BYOC dataplane:** unchanged. No new service, port, or outbound call.
- **Database or migrations:** none.
- **Rollback:** revert the commit. Prices return to their previous values on the next deploy. Nothing is written or migrated.

Rolling forward, `gpt-realtime-2` text output moves from $16.00 to the published $24.00 per million. The five delisted models keep the rates they already have rather than changing, which is the point of the change.
