### PR TITLE
fix(ai-gateway): provider access allows scope-reachable providers and the gateway says why a request was blocked

### DIFF
--- a/platform/app/src/components/gateway/VirtualKeyProviderAccessSection.tsx
+++ b/platform/app/src/components/gateway/VirtualKeyProviderAccessSection.tsx
@@ -135,9 +135,10 @@ export function VirtualKeyProviderAccessSection({
         : {
             ...value,
             allProviders: false,
-            // Start from everything selected so narrowing is one
-            // uncheck away instead of N re-checks.
-            providerIds: eligible.map((mp) => mp.id),
+            // Unchecking "All providers" clears the selection, so no row
+            // stays checked. The invalid-reason note then asks the operator
+            // to pick at least one provider or re-check "All".
+            providerIds: [],
           },
     );
   };

--- a/platform/app/src/components/gateway/__tests__/VirtualKeyCreateDrawer.integration.test.tsx
+++ b/platform/app/src/components/gateway/__tests__/VirtualKeyCreateDrawer.integration.test.tsx
@@ -387,9 +387,9 @@ describe("given the new-virtual-key drawer", () => {
       renderDrawer();
 
       await userEvent.click(screen.getByTestId("vk-providers-all"));
-      // Unticking All starts from everything selected; narrowing is one
-      // uncheck away.
-      await userEvent.click(screen.getByTestId("vk-provider-mp-anthropic"));
+      // Unchecking "All providers" clears the selection; pick one provider to
+      // narrow the key to exactly it.
+      await userEvent.click(screen.getByTestId("vk-provider-mp-openai"));
       await userEvent.type(screen.getByPlaceholderText("e.g. codex-prod"), "k");
       await submit();
 
@@ -403,9 +403,9 @@ describe("given the new-virtual-key drawer", () => {
     it("refuses to save and says why", async () => {
       renderDrawer();
 
+      // Unchecking "All providers" clears the selection, so no provider is
+      // picked and the drawer refuses the save.
       await userEvent.click(screen.getByTestId("vk-providers-all"));
-      await userEvent.click(screen.getByTestId("vk-provider-mp-openai"));
-      await userEvent.click(screen.getByTestId("vk-provider-mp-anthropic"));
       await userEvent.type(screen.getByPlaceholderText("e.g. codex-prod"), "k");
 
       expect(screen.getByTestId("vk-providers-invalid").textContent).toContain(

--- a/platform/app/src/components/gateway/__tests__/VirtualKeyProviderAccessSection.integration.test.tsx
+++ b/platform/app/src/components/gateway/__tests__/VirtualKeyProviderAccessSection.integration.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The "Provider access" section of the virtual-key drawers. The "All
+ * providers" master checkbox: checking it stores the wildcard (every provider
+ * in scope, current and future); unchecking it clears the selection, so no row
+ * stays checked and the section asks the operator to pick at least one
+ * provider.
+ *
+ * Renders the real component tree (real ProviderRow, real Chakra) with no
+ * mocks.
+ *
+ * Spec: specs/ai-gateway/governance/vk-provider-access.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OrgModelProvider } from "../eligibleModelProviders";
+import {
+  ALL_PROVIDERS,
+  type ProviderAccessValue,
+  VirtualKeyProviderAccessSection,
+} from "../VirtualKeyProviderAccessSection";
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const ORG_ID = "org-acme";
+const TEAM_ID = "team-platform";
+const PROJECT_ID = "project-doc-chat";
+
+const availableTeams = [{ id: TEAM_ID, name: "platform" }];
+const availableProjects = [
+  { id: PROJECT_ID, name: "Doc Chat · platform", teamId: TEAM_ID },
+];
+const projectScope = [{ scopeType: "PROJECT" as const, scopeId: PROJECT_ID }];
+
+const ORG_PROVIDER_ID = "mp-org-alpha";
+const PROJECT_PROVIDER_ID = "mp-proj-beta";
+
+const orgProvider: OrgModelProvider = {
+  id: ORG_PROVIDER_ID,
+  name: "Alpha Org",
+  provider: "openai",
+  enabled: true,
+  scopes: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+  models: ["gpt-5-mini"],
+};
+
+const projectProvider: OrgModelProvider = {
+  id: PROJECT_PROVIDER_ID,
+  name: "Beta Project",
+  provider: "openai",
+  enabled: true,
+  scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+  models: ["gpt-5-mini"],
+};
+
+/**
+ * Controlled harness: holds the value the way a drawer does, and forwards each
+ * change to a spy so a test can assert both the payload and the re-rendered
+ * state after an interaction.
+ */
+function Harness({
+  initial,
+  onChange,
+  providers = [orgProvider, projectProvider],
+}: {
+  initial: ProviderAccessValue;
+  onChange?: (next: ProviderAccessValue) => void;
+  providers?: OrgModelProvider[];
+}) {
+  const [value, setValue] = useState<ProviderAccessValue>(initial);
+  return (
+    <Wrapper>
+      <VirtualKeyProviderAccessSection
+        value={value}
+        onChange={(next) => {
+          onChange?.(next);
+          setValue(next);
+        }}
+        scopes={projectScope}
+        organizationId={ORG_ID}
+        organizationName="Acme"
+        availableTeams={availableTeams}
+        availableProjects={availableProjects}
+        providers={providers}
+      />
+    </Wrapper>
+  );
+}
+
+describe("VirtualKeyProviderAccessSection", () => {
+  afterEach(() => cleanup());
+
+  describe("given the master 'All providers' checkbox", () => {
+    describe("when the box is unchecked", () => {
+      /** @scenario Unchecking All providers clears the selection */
+      it("clears the selection and asks for a provider", async () => {
+        const onChange = vi.fn();
+        render(<Harness initial={ALL_PROVIDERS} onChange={onChange} />);
+
+        await userEvent.click(screen.getByTestId("vk-providers-all"));
+
+        expect(onChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ allProviders: false, providerIds: [] }),
+        );
+        expect(
+          screen.getByRole("checkbox", { name: "Alpha Org" }),
+        ).not.toBeChecked();
+        expect(
+          screen.getByRole("checkbox", { name: "Beta Project" }),
+        ).not.toBeChecked();
+        expect(screen.getByTestId("vk-providers-invalid")).toHaveTextContent(
+          "Select at least one provider, or allow all providers.",
+        );
+      });
+    });
+
+    describe("when the box is checked", () => {
+      it("stores the wildcard", async () => {
+        const onChange = vi.fn();
+        render(
+          <Harness
+            initial={{
+              allProviders: false,
+              providerIds: [],
+              modelsAllowed: [],
+            }}
+            onChange={onChange}
+          />,
+        );
+
+        await userEvent.click(screen.getByTestId("vk-providers-all"));
+
+        expect(onChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ allProviders: true, providerIds: [] }),
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
+++ b/platform/app/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
@@ -207,4 +207,59 @@ describe("resolveEligible", () => {
       expect(resolveEligible(keyAtProject, [noSignal], hierarchy)).toEqual([]);
     });
   });
+
+  describe("when providers live at different scope tiers", () => {
+    const mixedTierProviders: OrgModelProvider[] = [
+      {
+        id: "mp-org-z",
+        name: "Zeta Org",
+        provider: "openai",
+        enabled: true,
+        scopes: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+        models: [],
+      },
+      {
+        id: "mp-org-a",
+        name: "Alpha Org",
+        provider: "openai",
+        enabled: true,
+        scopes: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+        models: [],
+      },
+      {
+        id: "mp-team",
+        name: "Mid Team",
+        provider: "openai",
+        enabled: true,
+        scopes: [{ scopeType: "TEAM", scopeId: TEAM_ID }],
+        models: [],
+      },
+      {
+        id: "mp-proj",
+        name: "Proj",
+        provider: "openai",
+        enabled: true,
+        scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+        models: [],
+      },
+    ];
+
+    /** @scenario Provider access lists organization scope before team before project */
+    it("lists organization first, then team, then project, by name within a scope", () => {
+      const rows = resolveEligible(keyAtProject, mixedTierProviders, hierarchy);
+
+      expect(rows.map((r) => r.label)).toEqual([
+        "Alpha Org",
+        "Zeta Org",
+        "Mid Team",
+        "Proj",
+      ]);
+      expect(rows.map((r) => r.definedAt.scopeType)).toEqual([
+        "ORGANIZATION",
+        "ORGANIZATION",
+        "TEAM",
+        "PROJECT",
+      ]);
+    });
+  });
 });

--- a/platform/app/src/components/gateway/eligibleModelProviders.ts
+++ b/platform/app/src/components/gateway/eligibleModelProviders.ts
@@ -1,5 +1,6 @@
 import { modelProviderRegistry } from "~/features/onboarding/regions/model-providers/registry";
 import { isDispatchableProvider } from "~/server/modelProviders/registry";
+import { SCOPE_BREADTH, scopeBreadthRank } from "~/utils/scopeBreadth";
 
 /**
  * A scope a VirtualKey is reachable from: the org/team/project triad the
@@ -123,9 +124,9 @@ function isRoutable(provider: OrgModelProvider): boolean {
 }
 
 /**
- * Resolves the union eligible-ModelProvider set for a multi-scope VirtualKey
- * client-side, mirroring `scopeResolver.eligibleModelProvidersForVk` on the
- * server. Inheritance rule from specs/ai-gateway/governance/vk-scope-inheritance.feature:
+ * Resolves the union scope-reachable ModelProvider set for a multi-scope
+ * VirtualKey client-side, mirroring `scopeResolver.scopeReachableModelProvidersForVk`
+ * on the server. Inheritance rule from specs/ai-gateway/governance/vk-scope-inheritance.feature:
  *
  *   "A VK at scope S sees a ModelProvider P iff P's scope is an ancestor
  *    of S OR equal to S. ORG is the broadest, then TEAM, then PROJECT."
@@ -133,6 +134,14 @@ function isRoutable(provider: OrgModelProvider): boolean {
  * Each surviving MP carries the broadest of its OWN scopes that the key
  * reaches, which is what the scope chip in the picker UI names. Keyed by
  * row id, so a provider attached at several scopes resolves once.
+ *
+ * Scope only: a key's routing policy narrows what the gateway DISPATCHES to,
+ * never what its provider allowlist may name. A provider the scope reaches
+ * but the policy omits stays offered here and is savable; the policy blocks
+ * it at dispatch, not at save.
+ *
+ * Rows come back broadest scope first (ORGANIZATION, then TEAM, then
+ * PROJECT), and by name within a scope.
  */
 export function resolveEligible(
   scopes: VirtualKeyScopeEntry[],
@@ -164,7 +173,6 @@ export function resolveEligible(
 
   // Rank the tiers so a provider attached at several scopes is attributed to
   // the broadest one (ORG > TEAM > PROJECT) it reaches the key through.
-  const scopeBreadth = { ORGANIZATION: 0, TEAM: 1, PROJECT: 2 } as const;
   const result = new Map<string, EligibleModelProvider>();
   for (const provider of providers) {
     if (!provider.id) continue;
@@ -174,7 +182,7 @@ export function resolveEligible(
       if (!scopes.some((vkScope) => matchesScope(mpScope, vkScope))) continue;
       if (
         !definedAt ||
-        scopeBreadth[mpScope.scopeType] < scopeBreadth[definedAt.scopeType]
+        SCOPE_BREADTH[mpScope.scopeType] < SCOPE_BREADTH[definedAt.scopeType]
       ) {
         definedAt = mpScope;
       }
@@ -197,8 +205,11 @@ export function resolveEligible(
       ),
     });
   }
-  return Array.from(result.values()).sort((a, b) =>
-    a.label.localeCompare(b.label),
+  return Array.from(result.values()).sort(
+    (a, b) =>
+      scopeBreadthRank(a.definedAt.scopeType) -
+        scopeBreadthRank(b.definedAt.scopeType) ||
+      a.label.localeCompare(b.label),
   );
 }
 

--- a/platform/app/src/components/settings/DefaultModelsSection.tsx
+++ b/platform/app/src/components/settings/DefaultModelsSection.tsx
@@ -54,6 +54,7 @@ import {
   resolveScopeFilter,
   type ScopeHierarchy,
 } from "~/utils/filterProvidersByScope";
+import { scopeBreadthRank } from "~/utils/scopeBreadth";
 // Wrapped Menu uses a Portal under the hood so Menu.Content overlays
 // the page instead of rendering inline inside the <td>, which would
 // push the row's other cells to a wrapped line on open (caught on
@@ -77,6 +78,30 @@ const ROLE_LABEL: Record<ModelRoleKey, string> = {
   LANGY: "Langy",
   EMBEDDINGS: "Embeddings",
 };
+
+/**
+ * Broadest scope a config attaches to, in breadth order (organization, then
+ * team, then project), tie-broken by name. Drives the table row order so a
+ * config sorts by the widest tier it reaches.
+ */
+function broadestScopeOfConfig(
+  scopes: ConfigRow["scopes"],
+): ConfigRow["scopes"][number] | undefined {
+  return [...scopes].sort(
+    (a, b) =>
+      scopeBreadthRank(a.type) - scopeBreadthRank(b.type) ||
+      (a.name ?? "").localeCompare(b.name ?? ""),
+  )[0];
+}
+
+/** Orders config rows broadest scope first, then by that scope's name. */
+function compareConfigsByScopeThenName(a: ConfigRow, b: ConfigRow): number {
+  const sa = broadestScopeOfConfig(a.scopes);
+  const sb = broadestScopeOfConfig(b.scopes);
+  const ra = sa ? scopeBreadthRank(sa.type) : Number.MAX_SAFE_INTEGER;
+  const rb = sb ? scopeBreadthRank(sb.type) : Number.MAX_SAFE_INTEGER;
+  return ra - rb || (sa?.name ?? "").localeCompare(sb?.name ?? "");
+}
 
 interface DefaultModelsSectionProps {
   /** Optional controlled filter from the page-level header dropdown.
@@ -173,16 +198,22 @@ export function DefaultModelsSection({
       currentTeamId: team?.id ?? null,
       currentProjectId: project?.id ?? null,
     });
-    if (resolved.kind === "all") return all;
-    return all.filter((c) =>
-      c.scopes.some((s) =>
-        isScopeInFilter(
-          { scopeType: s.type, scopeId: s.id },
-          resolved,
-          effectiveHierarchy,
-        ),
-      ),
-    );
+    const filtered =
+      resolved.kind === "all"
+        ? all
+        : all.filter((c) =>
+            c.scopes.some((s) =>
+              isScopeInFilter(
+                { scopeType: s.type, scopeId: s.id },
+                resolved,
+                effectiveHierarchy,
+              ),
+            ),
+          );
+    // Rows read broadest scope first (organization, then team, then project),
+    // and by scope name within a tier, so the same order the Model Providers
+    // table above and the virtual-key picker use.
+    return [...filtered].sort(compareConfigsByScopeThenName);
   }, [
     dataQuery.data?.configs,
     filter,

--- a/platform/app/src/pages/settings/model-providers.tsx
+++ b/platform/app/src/pages/settings/model-providers.tsx
@@ -47,6 +47,7 @@ import {
   providerDeprecation,
 } from "../../server/modelProviders/registry";
 import { filterProvidersByScope } from "../../utils/filterProvidersByScope";
+import { broadestScopeRank } from "../../utils/scopeBreadth";
 
 export default function ModelsPage() {
   const { project, organization, team, hasPermission } =
@@ -138,15 +139,32 @@ export default function ModelsPage() {
   // Client-side filter for the scope dropdown at the top of the page.
   // The list query returns every provider the caller can see; this just
   // narrows the visible rows. See specs/model-providers/scope-filter.feature.
-  const enabledProviders = useMemo(
-    () =>
-      filterProvidersByScope(allEnabledProviders, scopeFilter, {
-        hierarchy,
-        currentTeamId: team?.id,
-        currentProjectId: project?.id,
-      }),
-    [allEnabledProviders, scopeFilter, hierarchy, team?.id, project?.id],
-  );
+  // Rows read broadest scope first (organization, then team, then project),
+  // and by name within a scope, so the same order the virtual-key picker uses.
+  const enabledProviders = useMemo(() => {
+    const filtered = filterProvidersByScope(allEnabledProviders, scopeFilter, {
+      hierarchy,
+      currentTeamId: team?.id,
+      currentProjectId: project?.id,
+    });
+    const scopeTypesOf = (p: (typeof filtered)[number]): string[] => {
+      const scopes = (p as { scopes?: Array<{ scopeType: string }> }).scopes;
+      if (scopes && scopes.length > 0) return scopes.map((s) => s.scopeType);
+      const fallback = (p as { scopeType?: string }).scopeType;
+      return fallback ? [fallback] : [];
+    };
+    const labelOf = (p: (typeof filtered)[number]): string =>
+      (p as { name?: string }).name ??
+      modelProvidersRegistry[p.provider as keyof typeof modelProvidersRegistry]
+        ?.name ??
+      p.provider;
+    return [...filtered].sort(
+      (a, b) =>
+        broadestScopeRank(scopeTypesOf(a)) -
+          broadestScopeRank(scopeTypesOf(b)) ||
+        labelOf(a).localeCompare(labelOf(b)),
+    );
+  }, [allEnabledProviders, scopeFilter, hierarchy, team?.id, project?.id]);
 
   // Every registry provider is always addable — iter 109 allows multiple
   // rows per provider type so users can configure "OpenAI" at org scope

--- a/platform/app/src/server/gateway/__tests__/budgetsEveryDimension.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budgetsEveryDimension.integration.test.ts
@@ -993,6 +993,49 @@ describe("budgets on every dimension (real PG + real CH)", () => {
       ).rejects.toThrow(/providers_allowed_empty/);
     });
 
+    /** @scenario A scope-reachable provider can be allowed on a key even when the routing policy omits it */
+    it("allows a scope-reachable provider the routing policy omits", async () => {
+      const policyId = `rp-nxn-omit-${suffix}`;
+      await prisma.routingPolicy.create({
+        data: {
+          id: policyId,
+          organizationId: ORG_ID,
+          name: `omit-policy-${suffix}`,
+          // Lists only OpenAI: Anthropic is reachable from the project scope
+          // but this policy omits it.
+          modelProviderIds: [MP_OPENAI_ID],
+          scopes: { create: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }] },
+        },
+      });
+      const service = VirtualKeyService.create(prisma);
+      try {
+        // Anthropic is scope-reachable but omitted by the policy. The save must
+        // succeed: the policy blocks it at dispatch, not at save.
+        const { virtualKey } = await service.create({
+          organizationId: ORG_ID,
+          name: `policy-omit-key-${suffix}`,
+          actorUserId: USER_ID,
+          scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+          routingMode: "POLICY",
+          routingPolicyId: policyId,
+          config: { providersAllowed: [MP_ANTHROPIC_ID] },
+        });
+        createdVirtualKeyIds.push(virtualKey.id);
+        const stored = await prisma.virtualKey.findUnique({
+          where: { id: virtualKey.id },
+        });
+        expect(
+          (stored?.config as { providersAllowed?: string[] } | null)
+            ?.providersAllowed,
+        ).toContain(MP_ANTHROPIC_ID);
+      } finally {
+        await prisma.routingPolicyScope.deleteMany({
+          where: { routingPolicyId: policyId },
+        });
+        await prisma.routingPolicy.deleteMany({ where: { id: policyId } });
+      }
+    });
+
     /** @scenario "A new key defaults to no fallback" */
     it("defaults a newly created key to routing mode NONE", async () => {
       const service = VirtualKeyService.create(prisma);

--- a/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -61,11 +61,18 @@ const MP_ANTHROPIC_PLAIN_ID = `mp-mat-anthropic-plain-${suffix}`;
 const MP_ANTHROPIC_KEYLESS_ID = `mp-mat-anthropic-keyless-${suffix}`;
 const MP_SAFETY_ID = `mp-mat-safety-${suffix}`;
 const RP_ID = `rp-mat-${suffix}`;
+// A dispatchable, org-scoped provider the routing policy deliberately leaves
+// OUT of its modelProviderIds. Scope-reachable, so savable in a key's
+// allowlist, but the policy must keep it out of the dispatch chain.
+const MP_POLICY_OMITTED_ID = `mp-mat-omitted-${suffix}`;
 const GUARDRAIL_ID = `gr-mat-${suffix}`;
 const VK_ID = `vk-mat-${suffix}`;
 const VK_NO_RP_ID = `vk-mat-norp-${suffix}`;
 const VK_NO_PROJECT_ID = `vk-mat-noproj-${suffix}`;
 const VK_TAGSTORM_ID = `vk-mat-tagstorm-${suffix}`;
+// A VK on the routing policy whose allowlist names the policy-omitted
+// provider. Dispatch must still exclude it.
+const VK_POLICY_ALLOWLIST_ID = `vk-mat-policy-allow-${suffix}`;
 
 describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
   beforeAll(async () => {
@@ -273,6 +280,22 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         },
       },
     });
+    // Dispatchable + scope-reachable, but intentionally NOT in the routing
+    // policy below. A key can still allowlist it; the policy keeps it out of
+    // dispatch.
+    await prisma.modelProvider.create({
+      data: {
+        id: MP_POLICY_OMITTED_ID,
+        name: "openai-omitted",
+        provider: "openai",
+        enabled: true,
+        organizationId: ORG_ID,
+        customKeys: { OPENAI_API_KEY: "sk-omitted-test" },
+        scopes: {
+          create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+        },
+      },
+    });
     await prisma.routingPolicy.create({
       data: {
         id: RP_ID,
@@ -408,12 +431,40 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         },
       },
     });
+    // VK 5 — on the routing policy, project-scoped, with an allowlist that
+    // names the policy-omitted provider. Dispatch must still exclude it: the
+    // policy narrows the chain even though the allowlist would keep it.
+    await prisma.virtualKey.create({
+      data: {
+        id: VK_POLICY_ALLOWLIST_ID,
+        organizationId: ORG_ID,
+        name: "vk-policy-allowlist",
+        hashedSecret: `hash-policy-allow-${suffix}`,
+        displayPrefix: "lw_vk_live_xxx_5",
+        principalUserId: USER_ID,
+        createdById: USER_ID,
+        traceProjectId: PROJECT_ID,
+        routingPolicyId: RP_ID,
+        config: { providersAllowed: [MP_ID, MP_POLICY_OMITTED_ID] },
+        scopes: {
+          create: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+        },
+      },
+    });
   }, 60_000);
 
   afterAll(async () => {
     await prisma.virtualKey.deleteMany({
       where: {
-        id: { in: [VK_ID, VK_NO_RP_ID, VK_NO_PROJECT_ID, VK_TAGSTORM_ID] },
+        id: {
+          in: [
+            VK_ID,
+            VK_NO_RP_ID,
+            VK_NO_PROJECT_ID,
+            VK_TAGSTORM_ID,
+            VK_POLICY_ALLOWLIST_ID,
+          ],
+        },
       },
     });
     await prisma.gatewayGuardrail.deleteMany({
@@ -437,6 +488,7 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       MP_ANTHROPIC_PLAIN_ID,
       MP_ANTHROPIC_KEYLESS_ID,
       MP_SAFETY_ID,
+      MP_POLICY_OMITTED_ID,
     ];
     await prisma.modelProviderScope.deleteMany({
       where: {
@@ -704,6 +756,72 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       expect(bundle.guardrail_attachments).toEqual([]);
       // RP still hydrates the policy side regardless of traceProject.
       expect(bundle.model_aliases).toEqual({ "gpt-5": "gpt-5-mini" });
+    });
+  });
+
+  describe("when a VK on a routing policy allowlists a provider the policy omits", () => {
+    /** @scenario The routing policy still narrows the dispatch chain when the allowlist names an omitted provider */
+    it("excludes the policy-omitted provider from dispatch even though the allowlist names it", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_POLICY_ALLOWLIST_ID, ORG_ID);
+      const mat = new GatewayConfigMaterialiser(prisma, null);
+      const bundle = await mat.materialise(vk!);
+
+      const dispatchIds = bundle.providers.map((p) => p.id);
+      // The allowlist named MP_ID and the policy-omitted provider; only MP_ID
+      // survives, because the routing policy keeps the omitted provider out of
+      // dispatch regardless of the allowlist. The allowlist narrows within the
+      // policy's set, it cannot widen past it.
+      expect(dispatchIds).toContain(MP_ID);
+      expect(dispatchIds).not.toContain(MP_POLICY_OMITTED_ID);
+      expect(bundle.fallback.chain).not.toContain(MP_POLICY_OMITTED_ID);
+    });
+
+    /** @scenario The bundle names why each undispatchable provider was dropped */
+    it("names why each undispatchable provider was dropped, so the gateway can say the reason", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_POLICY_ALLOWLIST_ID, ORG_ID);
+      const mat = new GatewayConfigMaterialiser(prisma, null);
+      const bundle = await mat.materialise(vk!);
+
+      // Routing dropped the policy-omitted provider: scope-reachable and
+      // allowed, but not in the policy's own list.
+      expect(bundle.routing_excluded_providers).toEqual([
+        { id: MP_POLICY_OMITTED_ID, type: "openai" },
+      ]);
+      // Provider access dropped every scope-reachable dispatchable provider
+      // the allowlist leaves out. The non-dispatchable safety provider is not
+      // scope-reachable for dispatch, so it is in neither list.
+      expect(
+        new Set(bundle.access_excluded_providers.map((p) => p.id)),
+      ).toEqual(
+        new Set([
+          MP_CUSTOM_ID,
+          MP_OPENAI_BASE_ID,
+          MP_ANTHROPIC_BASE_ID,
+          MP_ANTHROPIC_PLAIN_ID,
+          MP_ANTHROPIC_KEYLESS_ID,
+        ]),
+      );
+      expect(bundle.access_excluded_providers.map((p) => p.id)).not.toContain(
+        MP_SAFETY_ID,
+      );
+      expect(bundle.routing_policy_name).toBe(`mat-rp-${suffix}`);
+    });
+  });
+
+  describe("when a VK reaches every provider it is scoped to", () => {
+    it("reports no provider exclusions and no routing policy name", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_NO_RP_ID, ORG_ID);
+      const mat = new GatewayConfigMaterialiser(prisma, null);
+      const bundle = await mat.materialise(vk!);
+
+      // No allowlist and no routing policy: nothing is dropped, so there is no
+      // reason to name.
+      expect(bundle.routing_excluded_providers).toEqual([]);
+      expect(bundle.access_excluded_providers).toEqual([]);
+      expect(bundle.routing_policy_name).toBeNull();
     });
   });
 });

--- a/platform/app/src/server/gateway/__tests__/eligibleModelProviders.parity.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/eligibleModelProviders.parity.integration.test.ts
@@ -2,9 +2,11 @@
  * @vitest-environment node
  *
  * Parity between the two resolvers that answer "which providers can this key
- * reach": the gateway's `eligibleModelProvidersForVk` (what actually gets
- * dispatched to) and the client-side `resolveEligible` the virtual-key
- * drawers render (what the user is promised before issuing the key).
+ * reach through its scope": the server's `scopeReachableModelProvidersForVk`
+ * (what a key's provider allowlist may name) and the client-side
+ * `resolveEligible` the virtual-key drawers render (what the user may pick
+ * before issuing the key). Both are scope-only: a routing policy narrows the
+ * DISPATCH set (`eligibleModelProvidersForVk`), never the allowlist.
  *
  * The drawer resolver is a second implementation of the same rule, fed by
  * `listOrgModelProvidersForFrontend`. Any filter present on one side and
@@ -31,7 +33,10 @@ import {
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
 import { ModelProviderService } from "~/server/modelProviders/modelProvider.service";
-import { eligibleModelProvidersForVk } from "../scopeResolver";
+import {
+  eligibleModelProvidersForVk,
+  scopeReachableModelProvidersForVk,
+} from "../scopeResolver";
 import { VirtualKeyRepository } from "../virtualKey.repository";
 
 const suffix = nanoid(8);
@@ -48,6 +53,14 @@ const MP_ORG_WITHDRAWN_ID = `mp-elig-org-withdrawn-${suffix}`;
 const MP_PROJECT_ID = `mp-elig-project-${suffix}`;
 const MP_SIBLING_ID = `mp-elig-sibling-${suffix}`;
 const MP_MULTISCOPE_ID = `mp-elig-multiscope-${suffix}`;
+
+const RP_ID = `rp-elig-${suffix}`;
+const VK_POLICY_ID = `vk-elig-policy-${suffix}`;
+// The routing policy lists a strict subset of the set a project key reaches
+// ({ORG, MULTISCOPE, PROJECT}): it leaves MULTISCOPE out. The gateway
+// intersects the DISPATCH set with this list, so MULTISCOPE never dispatches.
+// It stays scope-reachable, so it is still savable in the key's allowlist.
+const RP_PROVIDER_IDS = [MP_ORG_ID, MP_PROJECT_ID];
 
 /**
  * Mirrors what `VirtualKeyCreateDrawer` hands the preview: the org-wide
@@ -181,10 +194,40 @@ describe("eligible model providers - drawer / gateway parity on real PG", () => 
         },
       },
     });
+
+    await prisma.routingPolicy.create({
+      data: {
+        id: RP_ID,
+        organizationId: ORG_ID,
+        name: `Elig Policy ${suffix}`,
+        modelProviderIds: RP_PROVIDER_IDS,
+        scopes: {
+          create: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+        },
+      },
+    });
+    await prisma.virtualKey.create({
+      data: {
+        id: VK_POLICY_ID,
+        organizationId: ORG_ID,
+        name: `elig-policy-${suffix}`,
+        hashedSecret: "hash-policy",
+        displayPrefix: "vk-lw-elig-p",
+        createdById: USER_ID,
+        routingMode: "POLICY",
+        routingPolicyId: RP_ID,
+        scopes: {
+          create: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+        },
+      },
+    });
   }, 120_000);
 
   afterAll(async () => {
     await prisma.virtualKey.deleteMany({ where: { organizationId: ORG_ID } });
+    await prisma.routingPolicy.deleteMany({
+      where: { organizationId: ORG_ID },
+    });
     await prisma.modelProvider.deleteMany({
       where: { organizationId: ORG_ID },
     });
@@ -222,14 +265,16 @@ describe("eligible model providers - drawer / gateway parity on real PG", () => 
     it("resolves the same provider set on both sides", async () => {
       const repo = new VirtualKeyRepository(prisma);
       const vk = await repo.findById(VK_ID, ORG_ID);
-      const gatewayIds = (await eligibleModelProvidersForVk(prisma, vk!))
+      const reachableIds = (
+        await scopeReachableModelProvidersForVk(prisma, vk!)
+      )
         .map((p) => p.id)
         .sort();
       const drawerIds = (await resolveAsTheDrawerWould())
         .map((p) => p.id)
         .sort();
 
-      expect(drawerIds).toEqual(gatewayIds);
+      expect(drawerIds).toEqual(reachableIds);
       expect(drawerIds).toEqual(
         [MP_ORG_ID, MP_MULTISCOPE_ID, MP_PROJECT_ID].sort(),
       );
@@ -286,6 +331,55 @@ describe("eligible model providers - drawer / gateway parity on real PG", () => 
         scopeType: "PROJECT",
         scopeId: PROJECT_ID,
       });
+    });
+  });
+
+  describe("given a key on a routing policy that omits a reachable provider", () => {
+    /** @scenario A scope-reachable provider can be allowed on a key even when the routing policy omits it */
+    it("keeps the omitted provider savable (scope-reachable + drawer) but out of dispatch", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_POLICY_ID, ORG_ID);
+
+      // The scope-reachable set (allowlist validation + drawer) ignores the
+      // policy, so the multi-scope provider the policy omits stays in it.
+      const reachableIds = (
+        await scopeReachableModelProvidersForVk(prisma, vk!)
+      )
+        .map((p) => p.id)
+        .sort();
+      // The dispatch set (materialiser) applies the policy, so the omitted
+      // provider is excluded from what the gateway routes to.
+      const dispatchIds = (await eligibleModelProvidersForVk(prisma, vk!))
+        .map((p) => p.id)
+        .sort();
+
+      const service = ModelProviderService.create(prisma);
+      const providers: OrgModelProvider[] =
+        await service.listOrgModelProvidersForFrontend(ORG_ID);
+      const hierarchy = buildScopeHierarchy(
+        [
+          { id: PROJECT_ID, teamId: TEAM_ID },
+          { id: SIBLING_PROJECT_ID, teamId: TEAM_ID },
+        ],
+        ORG_ID,
+      );
+      const drawerIds = resolveEligible(
+        [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+        providers,
+        hierarchy,
+      )
+        .map((p) => p.id)
+        .sort();
+
+      // The drawer offers exactly the scope-reachable set: the policy never
+      // narrows what a key's provider allowlist may hold.
+      expect(drawerIds).toEqual(reachableIds);
+      // The policy-omitted provider stays offered, so it is savable ...
+      expect(reachableIds).toContain(MP_MULTISCOPE_ID);
+      expect(drawerIds).toContain(MP_MULTISCOPE_ID);
+      // ... but the gateway's dispatch set excludes it: blocked at dispatch,
+      // not at save.
+      expect(dispatchIds).not.toContain(MP_MULTISCOPE_ID);
     });
   });
 });

--- a/platform/app/src/server/gateway/config.materialiser.ts
+++ b/platform/app/src/server/gateway/config.materialiser.ts
@@ -30,7 +30,11 @@ import {
 } from "./budgetResolution.service";
 import { GatewayCacheRuleService } from "./cacheRule.service";
 import { withTierFallthrough } from "./modelTierFallthrough";
-import { eligibleModelProvidersForVk, traceProjectFor } from "./scopeResolver";
+import {
+  eligibleModelProvidersForVk,
+  scopeReachableModelProvidersForVk,
+  traceProjectFor,
+} from "./scopeResolver";
 import { parseVirtualKeyConfig } from "./virtualKey.config";
 import type { VirtualKeyWithScopes } from "./virtualKey.repository";
 
@@ -71,6 +75,17 @@ export type ProviderSlot = {
   region?: string;
   deployment_map?: Record<string, string>;
   config: Record<string, unknown>;
+};
+
+/**
+ * A ModelProvider row the gateway will not dispatch to, named so a
+ * request-time block can say why. `type` is the provider kind (ModelProvider.provider),
+ * carried alongside the row id because the gateway matches a resolved request
+ * by provider kind and these rows are absent from `providers[]`.
+ */
+export type ProviderExclusionWire = {
+  id: string;
+  type: string;
 };
 
 export type GatewayConfigPayload = {
@@ -120,6 +135,28 @@ export type GatewayConfigPayload = {
    * RoutingPolicy decides.
    */
   routing_mode: "none" | "fallback_all" | "policy";
+  /**
+   * Contract §4.2. Providers a request could resolve to but the gateway will
+   * NOT dispatch to, split by WHY, so a request-time block can name the
+   * reason instead of failing opaque. Each entry is a ModelProvider row id
+   * plus its provider type, the same `{id, type}` shape `providers[]` carries,
+   * because the gateway matches the provider a request resolved to by TYPE and
+   * these rows are absent from `providers[]`.
+   *
+   * routing_excluded_providers: reachable from the key's scope AND inside its
+   * provider access, but dropped by the routing policy (named by
+   * routing_policy_name). access_excluded_providers: reachable from scope but
+   * outside providers_allowed (empty when the key allows all providers). A
+   * provider in neither list and absent from `providers[]` is not reachable
+   * from the key's scope at all.
+   */
+  routing_excluded_providers: ProviderExclusionWire[];
+  access_excluded_providers: ProviderExclusionWire[];
+  /**
+   * Display name of the key's routing policy, used to name the routing-block
+   * reason. Null when the key is not on a routing policy.
+   */
+  routing_policy_name: string | null;
   cache: { mode: "respect" | "force" | "disable"; ttl_s: number };
   // Flat per-project guardrail catalog the VK is allowed to reference.
   // The Go dispatcher looks up entries by id from guardrail_attachments
@@ -213,6 +250,49 @@ export class GatewayConfigMaterialiser {
     private readonly chRepo: GatewayBudgetClickHouseRepository | null = null,
   ) {}
 
+  /**
+   * The providers this key dispatches to, plus the three wire fields that let
+   * the gateway name why a resolved provider was not used. An explicit allowlist
+   * narrows dispatch; absence means every scope-reachable provider, now and
+   * later, so the filter runs here rather than being frozen into stored scope
+   * rows. `eligibleProviders` is already routing-policy-applied, so the
+   * scope-reachable set minus dispatch is what the policy dropped, and the
+   * allowlist complement is what provider access dropped.
+   */
+  private async dispatchAndExclusions(
+    vk: VirtualKeyWithScopes,
+    eligibleProviders: ModelProvider[],
+    allowed: string[] | null,
+  ): Promise<{
+    providers: ModelProvider[];
+    exclusions: {
+      routing_excluded_providers: ProviderExclusionWire[];
+      access_excluded_providers: ProviderExclusionWire[];
+      routing_policy_name: string | null;
+    };
+  }> {
+    const providers = allowed
+      ? eligibleProviders.filter((mp) => allowed.includes(mp.id))
+      : eligibleProviders;
+    const scopeReachable = await scopeReachableModelProvidersForVk(
+      this.prisma,
+      vk,
+    );
+    const { routingExcluded, accessExcluded } = providerExclusions({
+      scopeReachable,
+      eligibleProviders,
+      allowed,
+    });
+    return {
+      providers,
+      exclusions: {
+        routing_excluded_providers: routingExcluded.map(providerExclusionWire),
+        access_excluded_providers: accessExcluded.map(providerExclusionWire),
+        routing_policy_name: vk.routingPolicy?.name ?? null,
+      },
+    };
+  }
+
   async materialise(vk: VirtualKeyWithScopes): Promise<GatewayConfigPayload> {
     const eligibleProviders = await eligibleModelProvidersForVk(
       this.prisma,
@@ -223,14 +303,11 @@ export class GatewayConfigMaterialiser {
     const spendByBudgetId = await this.loadCurrentSpend(vk, budgets);
     const cacheRules = await this.applicableCacheRules(vk.organizationId);
     const config = parseVirtualKeyConfig(vk.config);
-    // An explicit allowlist narrows what the key can reach; absence means
-    // "all current and future providers in scope", which is why the filter
-    // runs here rather than being frozen into stored scope rows.
-    const providers = config.providersAllowed
-      ? eligibleProviders.filter((mp) =>
-          config.providersAllowed!.includes(mp.id),
-        )
-      : eligibleProviders;
+    const { providers, exclusions } = await this.dispatchAndExclusions(
+      vk,
+      eligibleProviders,
+      config.providersAllowed,
+    );
     const policySides = resolvePolicySideOfBundle(vk, config);
     const guardrailSides = await this.resolveGuardrailSideOfBundle(
       vk,
@@ -270,6 +347,7 @@ export class GatewayConfigMaterialiser {
       models_allowed: config.modelsAllowed,
       providers_allowed: config.providersAllowed,
       routing_mode: routingModeToWire(vk.routingMode),
+      ...exclusions,
       cache: { mode: config.cache.mode, ttl_s: config.cache.ttlS },
       guardrails: guardrailSides.guardrails,
       guardrail_attachments: guardrailSides.attachments,
@@ -742,6 +820,35 @@ function routingModeToWire(
     case "POLICY":
       return "policy";
   }
+}
+
+function providerExclusionWire(mp: ModelProvider): ProviderExclusionWire {
+  return { id: mp.id, type: mp.provider };
+}
+
+/**
+ * Splits the scope-reachable providers the dispatch chain drops into the two
+ * reasons the gateway names at request time: the routing policy dropped it
+ * (inside provider access, but not dispatchable), or provider access dropped it
+ * (outside the allowlist). A provider that dispatches is in neither list.
+ */
+function providerExclusions({
+  scopeReachable,
+  eligibleProviders,
+  allowed,
+}: {
+  scopeReachable: ModelProvider[];
+  eligibleProviders: ModelProvider[];
+  allowed: string[] | null;
+}): { routingExcluded: ModelProvider[]; accessExcluded: ModelProvider[] } {
+  const dispatchIds = new Set(eligibleProviders.map((mp) => mp.id));
+  const routingExcluded = scopeReachable.filter(
+    (mp) => (!allowed || allowed.includes(mp.id)) && !dispatchIds.has(mp.id),
+  );
+  const accessExcluded = allowed
+    ? scopeReachable.filter((mp) => !allowed.includes(mp.id))
+    : [];
+  return { routingExcluded, accessExcluded };
 }
 
 type BudgetWire = GatewayConfigPayload["budgets"][number];

--- a/platform/app/src/server/gateway/scopeResolver.ts
+++ b/platform/app/src/server/gateway/scopeResolver.ts
@@ -39,7 +39,18 @@ import type { ScopeInput, VirtualKeyWithScopes } from "./virtualKey.repository";
 
 export type EligibleModelProvider = ModelProvider;
 
-export async function eligibleModelProvidersForVk(
+/**
+ * The providers a VK reaches through its scope graph alone: scope cascade
+ * (pass 1) intersected with routable rows (enabled, not withdrawn, registry
+ * dispatchable). The routing policy is NOT applied here.
+ *
+ * This is the set a key's provider allowlist may name, and the set the drawer
+ * offers. A routing policy narrows what the gateway DISPATCHES to, never what
+ * the allowlist may hold: a provider the scope reaches but the policy omits is
+ * still savable, and the policy blocks it at dispatch (see
+ * `eligibleModelProvidersForVk` + `config.materialiser`), not at save.
+ */
+export async function scopeReachableModelProvidersForVk(
   prisma: PrismaClient,
   vk: VirtualKeyWithScopes,
   tx?: Prisma.TransactionClient,
@@ -49,7 +60,7 @@ export async function eligibleModelProvidersForVk(
   const scopePredicates = await buildScopePredicates(client, vk);
   if (scopePredicates.length === 0) return [];
 
-  const candidates = (
+  return (
     await client.modelProvider.findMany({
       where: {
         enabled: true,
@@ -58,6 +69,24 @@ export async function eligibleModelProvidersForVk(
       },
     })
   ).filter((mp) => isDispatchableProvider(mp.provider));
+}
+
+/**
+ * The providers a VK DISPATCHES to, in dispatch order. Scope-reachable set
+ * (above) then, when the VK carries a `routingPolicyId`, intersected with the
+ * policy's `modelProviderIds` and returned in policy order. Used by the
+ * gateway-config materialiser to build the flat `providers[]` chain. For the
+ * allowlist-validation and UI-parity set, use `scopeReachableModelProvidersForVk`.
+ */
+export async function eligibleModelProvidersForVk(
+  prisma: PrismaClient,
+  vk: VirtualKeyWithScopes,
+  tx?: Prisma.TransactionClient,
+): Promise<EligibleModelProvider[]> {
+  const client = tx ?? prisma;
+
+  const candidates = await scopeReachableModelProvidersForVk(prisma, vk, tx);
+  if (candidates.length === 0) return [];
 
   if (vk.routingPolicyId) {
     const policy = await client.routingPolicy.findUnique({

--- a/platform/app/src/server/gateway/virtualKey.repository.ts
+++ b/platform/app/src/server/gateway/virtualKey.repository.ts
@@ -27,6 +27,7 @@ import { keysetAfter } from "./wirePagination";
  */
 export const ROUTING_POLICY_SELECT = {
   id: true,
+  name: true,
   modelAliases: true,
   defaultModel: true,
   policyRules: true,
@@ -41,6 +42,7 @@ export type VirtualKeyWithScopes = VirtualKey & {
   } | null;
   routingPolicy?: {
     id: string;
+    name: string;
     modelAliases: Prisma.JsonValue;
     defaultModel: string | null;
     policyRules: Prisma.JsonValue;

--- a/platform/app/src/server/gateway/virtualKey.service.ts
+++ b/platform/app/src/server/gateway/virtualKey.service.ts
@@ -39,7 +39,7 @@ import {
 } from "./resourceMetadata";
 import {
   decideTraceDestination,
-  eligibleModelProvidersForVk,
+  scopeReachableModelProvidersForVk,
   type TraceDestinationInput,
 } from "./scopeResolver";
 import {
@@ -998,10 +998,13 @@ export class VirtualKeyService {
   }
 
   /**
-   * An explicit provider allowlist may only name providers the key can
-   * actually reach through its scope graph. Without this a key could be
-   * saved pointing at another team's provider row and the mistake would
-   * only surface as an unexplained "model not available" at dispatch.
+   * An explicit provider allowlist may only name providers the key can reach
+   * through its SCOPE graph. It is validated against the scope-reachable set,
+   * not the routing-policy-narrowed dispatch set: a provider the scope reaches
+   * but the key's routing policy omits is still a valid allowlist entry,
+   * because the policy blocks it at dispatch, not at save. Blocking the save
+   * too would be over-strict. A provider the scope does not reach at all still
+   * fails here, so a key can never point at another team's provider row.
    */
   private async assertProvidersAllowedReachable(
     vk: VirtualKeyWithScopes,
@@ -1009,9 +1012,13 @@ export class VirtualKeyService {
     tx: Prisma.TransactionClient,
   ): Promise<void> {
     if (!providersAllowed) return;
-    const eligible = await eligibleModelProvidersForVk(this.prisma, vk, tx);
-    const eligibleIds = new Set(eligible.map((mp) => mp.id));
-    const unreachable = providersAllowed.filter((id) => !eligibleIds.has(id));
+    const reachable = await scopeReachableModelProvidersForVk(
+      this.prisma,
+      vk,
+      tx,
+    );
+    const reachableIds = new Set(reachable.map((mp) => mp.id));
+    const unreachable = providersAllowed.filter((id) => !reachableIds.has(id));
     if (unreachable.length > 0) {
       throw new TRPCError({
         code: "BAD_REQUEST",

--- a/platform/app/src/utils/scopeBreadth.ts
+++ b/platform/app/src/utils/scopeBreadth.ts
@@ -1,0 +1,35 @@
+/**
+ * Scope breadth order, broadest first: ORGANIZATION reaches the most, then
+ * TEAM, then PROJECT. Settings tables and the virtual-key provider picker
+ * share this order so an organization-wide row always sits above a team row,
+ * which sits above a project row, and rows at the same scope read in name
+ * order.
+ */
+export const SCOPE_BREADTH = {
+  ORGANIZATION: 0,
+  TEAM: 1,
+  PROJECT: 2,
+} as const;
+
+export type BreadthScopeType = keyof typeof SCOPE_BREADTH;
+
+/**
+ * Breadth rank of one scope type. A type outside the triad (a department or
+ * group chip on another surface) sorts after every triad scope rather than
+ * throwing, so a shared table never crashes on an unexpected scope kind.
+ */
+export function scopeBreadthRank(scopeType: string): number {
+  return (
+    SCOPE_BREADTH[scopeType as BreadthScopeType] ?? SCOPE_BREADTH.PROJECT + 1
+  );
+}
+
+/**
+ * Breadth rank of a row that carries several scopes: the broadest one it has.
+ * A row scoped at both ORGANIZATION and PROJECT ranks by ORGANIZATION. A row
+ * with no scopes ranks after every scoped row.
+ */
+export function broadestScopeRank(scopeTypes: readonly string[]): number {
+  if (scopeTypes.length === 0) return SCOPE_BREADTH.PROJECT + 2;
+  return Math.min(...scopeTypes.map(scopeBreadthRank));
+}

--- a/services/aigateway/adapters/controlplane/budgets_contract_test.go
+++ b/services/aigateway/adapters/controlplane/budgets_contract_test.go
@@ -122,6 +122,36 @@ func TestConfigWireProvidersAllowedAndRoutingMode(t *testing.T) {
 	})
 }
 
+// The gateway is told, per provider it will not dispatch to, WHY: dropped by
+// the routing policy, or outside the key's provider access. The kind rides the
+// wire (not just the row id) because a request resolves to a provider kind and
+// these rows are absent from providers[]. This pins the {id, type} decode and
+// the block-reason classification so a rename cannot leave the gateway unable
+// to name the reason.
+func TestConfigWireProviderExclusions(t *testing.T) {
+	body := []byte(`{
+		"routing_excluded_providers": [{"id": "mp_anthropic", "type": "anthropic"}],
+		"access_excluded_providers": [{"id": "mp_gemini", "type": "google_gemini"}],
+		"routing_policy_name": "Cheap models"
+	}`)
+	var wire configWire
+	require.NoError(t, json.Unmarshal(body, &wire))
+	cfg := wire.toDomain()
+
+	require.Len(t, cfg.RoutingExcludedProviders, 1)
+	assert.Equal(t, "mp_anthropic", cfg.RoutingExcludedProviders[0].ID)
+	assert.Equal(t, domain.ProviderAnthropic, cfg.RoutingExcludedProviders[0].ProviderID)
+
+	require.Len(t, cfg.AccessExcludedProviders, 1)
+	// google_gemini normalizes to the canonical gemini kind, same as a credential.
+	assert.Equal(t, domain.ProviderGemini, cfg.AccessExcludedProviders[0].ProviderID)
+
+	assert.Equal(t, "Cheap models", cfg.RoutingPolicyName)
+	assert.Equal(t, domain.ProviderBlockRouting, cfg.BlockedProviderReason(domain.ProviderAnthropic))
+	assert.Equal(t, domain.ProviderBlockAccess, cfg.BlockedProviderReason(domain.ProviderGemini))
+	assert.Equal(t, domain.ProviderBlockNone, cfg.BlockedProviderReason(domain.ProviderOpenAI))
+}
+
 // The other half of the bundle contract lives in the control plane's
 // materializer module. Reading it here keeps a TypeScript-side rename from
 // silently stripping the provider filter (or the routing mode) off the
@@ -135,6 +165,9 @@ func TestControlPlaneMaterialiserEmitsTheBudgetContract(t *testing.T) {
 		`principal_id`,
 		`providers_allowed: config.providersAllowed`,
 		`routing_mode: routingModeToWire(vk.routingMode)`,
+		`routing_excluded_providers: routingExcluded.map(providerExclusionWire)`,
+		`access_excluded_providers: accessExcluded.map(providerExclusionWire)`,
+		`routing_policy_name: vk.routingPolicy?.name ?? null`,
 	} {
 		if !strings.Contains(src, needle) {
 			t.Errorf("config.materialiser.ts no longer emits %q: the bundle contract has drifted", needle)

--- a/services/aigateway/adapters/controlplane/config_wire.go
+++ b/services/aigateway/adapters/controlplane/config_wire.go
@@ -25,8 +25,14 @@ type configWire struct {
 	// plane normalises [] back to null on read).
 	ProvidersAllowed []string `json:"providers_allowed"`
 	// RoutingMode is none | fallback_all | policy (contract §4.2).
-	RoutingMode string         `json:"routing_mode"`
-	RateLimits  rateLimitsWire `json:"rate_limits"`
+	RoutingMode string `json:"routing_mode"`
+	// RoutingExcludedProviders / AccessExcludedProviders / RoutingPolicyName
+	// name why a provider a request could resolve to is absent from Providers,
+	// so a block can say the reason instead of failing opaque (contract §4.2).
+	RoutingExcludedProviders []excludedProviderWire `json:"routing_excluded_providers"`
+	AccessExcludedProviders  []excludedProviderWire `json:"access_excluded_providers"`
+	RoutingPolicyName        string                 `json:"routing_policy_name"`
+	RateLimits               rateLimitsWire         `json:"rate_limits"`
 	// Guardrails is the flat per-project catalog every VK in the project
 	// may reference; GuardrailAttachments is this VK's opt-in tuples
 	// (control-plane materialiser config.materialiser.ts, bug-7 step vd).
@@ -44,6 +50,15 @@ type configWire struct {
 	// | "skip"). Present and non-skip only for Langy virtual keys, so ordinary
 	// customer traffic is never mirrored. Empty/absent ⇒ no mirror.
 	LangyMirrorTier string `json:"langy_mirror_tier"`
+}
+
+// excludedProviderWire is one provider the gateway will not dispatch to,
+// carried with its type so the gateway can match it against the provider a
+// request resolved to (these rows are absent from Providers, so the type is
+// not otherwise knowable). Mirrors the {id, type} shape of providerSlotWire.
+type excludedProviderWire struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
 }
 
 type providerSlotWire struct {
@@ -167,15 +182,18 @@ func (w *configWire) toDomain() domain.BundleConfig {
 	}
 
 	cfg := domain.BundleConfig{
-		Credentials:      creds,
-		TraceProjectID:   w.ProjectID,
-		ProjectOTLPToken: w.ProjectOTLPToken,
-		MirrorTier:       w.LangyMirrorTier,
-		VKDisplayPrefix:  w.DisplayPrefix,
-		VKTags:           w.VKTags,
-		AllowedModels:    w.ModelsAllowed,
-		ProvidersAllowed: w.ProvidersAllowed,
-		RoutingMode:      w.RoutingMode,
+		Credentials:              creds,
+		TraceProjectID:           w.ProjectID,
+		ProjectOTLPToken:         w.ProjectOTLPToken,
+		MirrorTier:               w.LangyMirrorTier,
+		VKDisplayPrefix:          w.DisplayPrefix,
+		VKTags:                   w.VKTags,
+		AllowedModels:            w.ModelsAllowed,
+		ProvidersAllowed:         w.ProvidersAllowed,
+		RoutingMode:              w.RoutingMode,
+		RoutingExcludedProviders: toExcludedProviders(w.RoutingExcludedProviders),
+		AccessExcludedProviders:  toExcludedProviders(w.AccessExcludedProviders),
+		RoutingPolicyName:        w.RoutingPolicyName,
 		Fallback: domain.FallbackConfig{
 			MaxAttempts: w.Fallback.MaxAttempts,
 		},
@@ -204,23 +222,7 @@ func (w *configWire) toDomain() domain.BundleConfig {
 		}
 	}
 
-	cfg.Budget.Scopes = make([]domain.BudgetScope, len(w.Budgets))
-	for i := range w.Budgets {
-		b := &w.Budgets[i]
-		cfg.Budget.Scopes[i] = domain.BudgetScope{
-			ID:            b.ID,
-			Scope:         b.Scope,
-			ScopeID:       b.ScopeID,
-			PrincipalID:   b.PrincipalID,
-			PerUser:       b.PerUser,
-			ProviderKey:   b.ProviderKey,
-			Window:        b.Window,
-			LimitMicroUSD: b.LimitMicroUSD,
-			SpentMicroUSD: b.SpentMicroUSD,
-			OnBreach:      b.OnBreach,
-		}
-	}
-
+	cfg.Budget.Scopes = toBudgetScopes(w.Budgets)
 	cfg.PolicyRules = buildPolicyRules(w.PolicyRules)
 	cfg.CacheRules = buildCacheRules(w.CacheRules)
 
@@ -381,6 +383,43 @@ func buildCacheRules(wires []cacheRuleWire) []domain.CacheRule {
 		}
 	}
 	return rules
+}
+
+func toBudgetScopes(ws []budgetWire) []domain.BudgetScope {
+	scopes := make([]domain.BudgetScope, len(ws))
+	for i := range ws {
+		b := &ws[i]
+		scopes[i] = domain.BudgetScope{
+			ID:            b.ID,
+			Scope:         b.Scope,
+			ScopeID:       b.ScopeID,
+			PrincipalID:   b.PrincipalID,
+			PerUser:       b.PerUser,
+			ProviderKey:   b.ProviderKey,
+			Window:        b.Window,
+			LimitMicroUSD: b.LimitMicroUSD,
+			SpentMicroUSD: b.SpentMicroUSD,
+			OnBreach:      b.OnBreach,
+		}
+	}
+	return scopes
+}
+
+// toExcludedProviders maps the {id, type} exclusion wire entries onto domain
+// rows, normalizing the provider type the same way credentials are so the
+// gateway matches a resolved request's provider kind consistently.
+func toExcludedProviders(ws []excludedProviderWire) []domain.ExcludedModelProvider {
+	if len(ws) == 0 {
+		return nil
+	}
+	out := make([]domain.ExcludedModelProvider, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, domain.ExcludedModelProvider{
+			ID:         w.ID,
+			ProviderID: domain.NormalizeProviderID(w.Type),
+		})
+	}
+	return out
 }
 
 func providerSlotToCredential(p providerSlotWire) domain.Credential {

--- a/services/aigateway/adapters/httpapi/provider_not_bound_test.go
+++ b/services/aigateway/adapters/httpapi/provider_not_bound_test.go
@@ -65,11 +65,11 @@ func TestChat_UnknownProviderPrefixReturnsNotBoundEnvelope(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), "body: %s", rec.Body.String())
 	assert.Equal(t, string(domain.ErrProviderNotBound), env.Error.Code)
-	// Naming the provider is what separates this from the opaque errors it
-	// replaces; a hint that does not say which slot is missing would leave
-	// the caller exactly where they started.
+	// Naming the provider AND why it is unavailable is what separates this
+	// from the opaque errors it replaces: a caller must learn both which
+	// provider was refused and that it is not reachable from the key's scope.
 	assert.Contains(t, rec.Body.String(), "bedrock")
-	assert.Contains(t, rec.Body.String(), "virtual key")
+	assert.Contains(t, rec.Body.String(), "not reachable from this key's scope")
 }
 
 // @scenario "A provider-native route refuses a key with no provider that speaks it"

--- a/services/aigateway/app/dispatch.go
+++ b/services/aigateway/app/dispatch.go
@@ -136,7 +136,7 @@ func translateWalkError(ctx context.Context, err error) error {
 //     iterated; with several simultaneous exclusions any of them is an
 //     accurate answer to "why was nothing dispatchable").
 func (a *App) candidateChain(ctx context.Context, call *pipeline.Call) ([]domain.Credential, error) {
-	creds, err := routableChain(ctx, call.Request, call.Bundle.Credentials)
+	creds, err := routableChain(ctx, call.Bundle, call.Request)
 	if err != nil {
 		return nil, err
 	}

--- a/services/aigateway/app/eligible.go
+++ b/services/aigateway/app/eligible.go
@@ -12,13 +12,52 @@ import (
 
 // routableChain trims the credential chain to the credentials that could
 // actually serve this request: first to the providers the inbound route
-// speaks, then to the providers the resolved model names.
-func routableChain(ctx context.Context, req *domain.Request, creds []domain.Credential) ([]domain.Credential, error) {
-	creds, err := surfaceCredentials(ctx, creds, req)
+// speaks (surface trim), then to the providers the resolved model names
+// (model-aware trim).
+//
+// When the model-aware trim leaves an explicitly named provider with no
+// credential, the failure names WHY, from what the control plane reported on
+// the bundle: the routing policy dropped it, provider access dropped it, or it
+// is not reachable from the key's scope. An empty chain gets the same reason: a
+// bundle whose allowlist names only an excluded provider carries no dispatchable
+// credential by design, and that is named rather than reported as an
+// organization with no provider configured.
+func routableChain(ctx context.Context, bundle *domain.Bundle, req *domain.Request) ([]domain.Credential, error) {
+	creds, err := surfaceCredentials(ctx, bundle.Credentials, req)
 	if err != nil {
+		// A raw-forward surface with no credential left can be a routing-policy
+		// or provider-access exclusion in disguise: the provider the route
+		// speaks was dropped from dispatch, so none of its credentials remain.
+		// Give that reason when the resolved provider is one the route speaks;
+		// otherwise the surface's own not-reachable message stands.
+		if reason := reasonForBlockedSurface(ctx, req, bundle.Config); reason != nil {
+			return nil, reason
+		}
 		return nil, err
 	}
-	return eligibleCredentials(ctx, creds, req.Resolved)
+	creds, err = eligibleCredentials(ctx, creds, req.Resolved)
+	if err != nil {
+		// eligibleCredentials refused an explicitly named provider that has no
+		// credential (the not-reachable-from-scope reason). When the control
+		// plane reported a routing-policy or provider-access exclusion for that
+		// provider, that is the more specific reason to give.
+		if reason := reasonForBlockedProvider(ctx, req.Resolved, bundle.Config); reason != nil {
+			return nil, reason
+		}
+		return nil, err
+	}
+	// An empty chain with no error means the bundle carries no dispatchable
+	// credential. That is a genuinely unconfigured organization, unless the key's
+	// allowlist names only a provider the routing policy or provider access
+	// dropped: then `providers[]` is empty by design and the reason is on the
+	// bundle. Name it here, so candidateChain does not fall back to the generic
+	// no_provider_configured for a request Phase 2 can explain.
+	if len(creds) == 0 {
+		if reason := reasonForEmptyChain(ctx, req, bundle.Config); reason != nil {
+			return nil, reason
+		}
+	}
+	return creds, nil
 }
 
 // surfaceCredentials keeps only the credentials whose provider speaks the
@@ -100,14 +139,14 @@ func providerNames(providers []domain.ProviderID) string {
 // credential's own provider and fails with that provider's real error.
 //
 // Explicitly-named providers (a "provider/model" prefix or an alias) get
-// the opposite treatment: an empty filter is a hard fail with
-// ErrProviderNotBound. Dispatching anyway would forward the prefixed
-// model string with a mismatched credential, and Bifrost's model-prefix
-// provider override then reads that credential through the wrong
-// provider's key-config shape — surfacing as opaque errors like
-// "deployments not set" (Azure), "no keys found that support model"
-// (Gemini), or raw HTML error pages (Vertex) instead of telling the
-// caller the provider isn't configured.
+// the opposite treatment: an empty filter is a hard fail with the
+// not-reachable-from-scope reason. `routableChain` upgrades that to the
+// routing-policy or provider-access reason when the control plane reported
+// one for the provider. Dispatching anyway would forward the prefixed model
+// string with a mismatched credential, and Bifrost's model-prefix provider
+// override then reads that credential through the wrong provider's key-config
+// shape — surfacing as opaque errors like "deployments not set" (Azure), "no
+// keys found that support model" (Gemini), or raw HTML error pages (Vertex).
 func eligibleCredentials(ctx context.Context, creds []domain.Credential, resolved *domain.ResolvedModel) ([]domain.Credential, error) {
 	if len(creds) == 0 || resolved == nil {
 		return creds, nil
@@ -122,22 +161,136 @@ func eligibleCredentials(ctx context.Context, creds []domain.Credential, resolve
 		return creds, nil
 	}
 
+	if out := credentialsForProvider(creds, target); len(out) > 0 {
+		return out, nil
+	}
+	if explicit {
+		return nil, providerNotReachable(ctx, target)
+	}
+	return creds, nil
+}
+
+// credentialsForProvider keeps the credentials that can serve the target
+// provider kind, preserving order so fallback semantics survive.
+func credentialsForProvider(creds []domain.Credential, target domain.ProviderID) []domain.Credential {
 	out := make([]domain.Credential, 0, len(creds))
 	for _, c := range creds {
 		if c.ProviderID == target {
 			out = append(out, c)
 		}
 	}
-	if len(out) == 0 {
-		if explicit {
-			return nil, herr.New(ctx, domain.ErrProviderNotBound, herr.M{
-				"message": fmt.Sprintf("no %q provider is configured for this key", target),
-				"hint":    fmt.Sprintf("bind a %q provider slot to this virtual key, or drop the %q model prefix", target, target),
-			})
-		}
-		return creds, nil
+	return out
+}
+
+// reasonForEmptyChain names why an empty dispatch chain blocked the request, or
+// nil when nothing the control plane reported explains it, so the caller keeps
+// no_provider_configured for a genuinely unconfigured bundle. A raw-forward
+// route is pinned to its surface, so it reads through the surface-guarded
+// reason; a translated route reads the resolved provider directly.
+func reasonForEmptyChain(ctx context.Context, req *domain.Request, cfg domain.BundleConfig) error {
+	if len(req.InboundSurface().Providers) > 0 {
+		return reasonForBlockedSurface(ctx, req, cfg)
 	}
-	return out, nil
+	return reasonForBlockedProvider(ctx, req.Resolved, cfg)
+}
+
+// reasonForBlockedProvider names the routing-policy or provider-access reason
+// the control plane reported for the request's resolved provider, or nil when
+// it reported neither (the caller then keeps the not-reachable-from-scope
+// reason).
+func reasonForBlockedProvider(ctx context.Context, resolved *domain.ResolvedModel, cfg domain.BundleConfig) error {
+	if resolved == nil {
+		return nil
+	}
+	target := resolved.ProviderID
+	if target == "" {
+		target = inferProviderFromModel(resolved.ModelID)
+	}
+	if target == "" {
+		return nil
+	}
+	return blockedProviderError(ctx, target, cfg)
+}
+
+// reasonForBlockedSurface names the routing-policy or provider-access reason for
+// a raw-forward route that has no credential left, when the resolved provider is
+// one the route speaks and the control plane reported an exclusion for it. It
+// returns nil otherwise, so the caller keeps the surface's not-reachable
+// message. The surface-provider guard stops a mismatched resolved provider from
+// borrowing another provider's reason.
+func reasonForBlockedSurface(ctx context.Context, req *domain.Request, cfg domain.BundleConfig) error {
+	if req == nil || req.Resolved == nil {
+		return nil
+	}
+	target := req.Resolved.ProviderID
+	if target == "" {
+		target = inferProviderFromModel(req.Resolved.ModelID)
+	}
+	if target == "" {
+		return nil
+	}
+	if !slices.Contains(req.InboundSurface().Providers, target) {
+		return nil
+	}
+	return blockedProviderError(ctx, target, cfg)
+}
+
+// blockedProviderError names why the control plane dropped the resolved provider
+// from the dispatch chain, or nil when nothing it reported excluded it.
+func blockedProviderError(ctx context.Context, target domain.ProviderID, cfg domain.BundleConfig) error {
+	switch cfg.BlockedProviderReason(target) {
+	case domain.ProviderBlockRouting:
+		return providerBlockedByRouting(ctx, target, cfg.RoutingPolicyName)
+	case domain.ProviderBlockAccess:
+		return providerBlockedByAccess(ctx, target)
+	case domain.ProviderBlockNone:
+		return nil
+	}
+	return nil
+}
+
+// providerBlockedByRouting is the block when the key's routing policy leaves the
+// resolved provider out of the dispatch chain. Names the policy when known.
+func providerBlockedByRouting(ctx context.Context, kind domain.ProviderID, policyName string) error {
+	msg := fmt.Sprintf(
+		"The %q provider is not available on this key: its routing policy does not include this provider. Ask the key's owner to add it to the routing policy, or send the request to a provider the policy allows.",
+		kind,
+	)
+	if policyName != "" {
+		msg = fmt.Sprintf(
+			"The %q provider is not available on this key: its routing policy %q does not include this provider. Ask the key's owner to add it to the routing policy, or send the request to a provider the policy allows.",
+			kind, policyName,
+		)
+	}
+	return herr.New(ctx, domain.ErrModelNotAllowed, herr.M{
+		"message": msg,
+		"fault":   "customer",
+	})
+}
+
+// providerBlockedByAccess is the block when the resolved provider is reachable
+// from the key's scope but outside its provider access allowlist.
+func providerBlockedByAccess(ctx context.Context, kind domain.ProviderID) error {
+	return herr.New(ctx, domain.ErrModelNotAllowed, herr.M{
+		"message": fmt.Sprintf(
+			"The %q provider is not in this key's provider access. Ask the key's owner to add it to the key's allowed providers.",
+			kind,
+		),
+		"fault": "customer",
+	})
+}
+
+// providerNotReachable is the block when the resolved provider is not reachable
+// from the key's scope at all, so no credential is configured for it.
+func providerNotReachable(ctx context.Context, kind domain.ProviderID) error {
+	return herr.New(ctx, domain.ErrProviderNotBound, herr.M{
+		"message": fmt.Sprintf(
+			"The %q provider is not reachable from this key's scope, so no credential is configured for it. Ask the key's owner to add the provider, or send the request to a configured provider.",
+			kind,
+		),
+		"hint":  fmt.Sprintf("add a %q provider in this key's scope, or drop the %q model prefix", kind, kind),
+		"fault": "customer",
+	})
 }
 
 // inferProviderFromModel maps a bare model name to the provider that

--- a/services/aigateway/app/eligible_test.go
+++ b/services/aigateway/app/eligible_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/langwatch/langwatch/pkg/herr"
@@ -72,7 +74,7 @@ func TestEligibleCredentials(t *testing.T) {
 			wantIDs:  []string{"anthropic_1", "openai_1", "gemini_1", "anthropic_2"},
 		},
 		{
-			name:     "explicit provider with no matching cred hard-fails as not bound",
+			name:     "explicit provider not reachable from scope hard-fails as not bound",
 			resolved: &domain.ResolvedModel{ProviderID: domain.ProviderBedrock, ModelID: "bedrock-only"},
 			wantErr:  domain.ErrProviderNotBound,
 		},
@@ -345,5 +347,276 @@ func TestProviderNames(t *testing.T) {
 		if got := providerNames(tc.in); got != tc.want {
 			t.Errorf("providerNames(%v) = %s, want %s", tc.in, got, tc.want)
 		}
+	}
+}
+
+func herrMessage(t *testing.T, err error) string {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var e herr.E
+	if !errors.As(err, &e) {
+		t.Fatalf("error is not a herr.E: %v", err)
+	}
+	msg, _ := e.Meta["message"].(string)
+	return msg
+}
+
+// translatedChat is a /v1 request (no surface pin) resolved to an explicit
+// provider, so routableChain's surface trim is a no-op and the model-aware
+// trim decides. Used to drive the reason branches.
+func translatedChat(kind domain.ProviderID) *domain.Request {
+	return &domain.Request{
+		Type:     domain.RequestTypeChat,
+		Model:    "claude-3-5-sonnet",
+		Resolved: &domain.ResolvedModel{ProviderID: kind, ModelID: "claude-3-5-sonnet"},
+	}
+}
+
+// A key on a routing policy that omits the resolved provider is blocked with a
+// message that names the routing policy, so the caller learns WHY the request
+// was blocked rather than seeing an opaque wrong-provider failure.
+//
+// @scenario "A blocked request names why the resolved provider was not used"
+func TestRoutableChain_BlockedByRoutingNamesPolicy(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+		Config: domain.BundleConfig{
+			RoutingExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "anthropic_1", ProviderID: domain.ProviderAnthropic},
+			},
+			RoutingPolicyName: "Cheap models",
+		},
+	}
+	_, err := routableChain(context.Background(), bundle, translatedChat(domain.ProviderAnthropic))
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "routing policy") || !strings.Contains(msg, "Cheap models") {
+		t.Errorf("message must name the routing policy: %q", msg)
+	}
+}
+
+func TestRoutableChain_BlockedByProviderAccess(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+		Config: domain.BundleConfig{
+			AccessExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "anthropic_1", ProviderID: domain.ProviderAnthropic},
+			},
+		},
+	}
+	_, err := routableChain(context.Background(), bundle, translatedChat(domain.ProviderAnthropic))
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "provider access") {
+		t.Errorf("message must name provider access: %q", msg)
+	}
+}
+
+func TestRoutableChain_NotReachableFromScope(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+	}
+	_, err := routableChain(context.Background(), bundle, translatedChat(domain.ProviderAnthropic))
+	if !herr.IsCode(err, domain.ErrProviderNotBound) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrProviderNotBound)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "not reachable from this key's scope") {
+		t.Errorf("message must name the scope reason: %q", msg)
+	}
+}
+
+// The surface trim runs BEFORE the model-aware trim: a raw-forward route whose
+// key lacks the route's provider refuses on the surface, even when the model
+// does not infer a provider (so the model-aware trim would otherwise let the
+// chain through and dispatch the route-shaped body to a wrong vendor).
+func TestRoutableChain_RawForwardSurfaceRefusesBeforeModelTrim(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+	}
+	req := geminiPassthrough()
+	// A model that does not infer a provider: only the surface trim can catch
+	// the wrong-vendor dispatch here.
+	req.Resolved = &domain.ResolvedModel{ProviderID: "", ModelID: "some-unlisted-model"}
+
+	_, err := routableChain(context.Background(), bundle, req)
+	if !herr.IsCode(err, domain.ErrProviderNotBound) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrProviderNotBound)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "gemini") {
+		t.Errorf("the surface refusal must name the route's providers: %q", msg)
+	}
+}
+
+// A raw-forward Gemini route whose key has no Google credential because the
+// routing policy dropped Gemini names the routing policy, not the generic
+// surface not-reachable message. The surface trim empties the chain first, so
+// the reason has to reach the caller through the surface-miss branch.
+func TestRoutableChain_RawForwardSurfaceBlockedByRouting(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+		Config: domain.BundleConfig{
+			RoutingExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "gemini_1", ProviderID: domain.ProviderGemini},
+			},
+			RoutingPolicyName: "Cheap models",
+		},
+	}
+	req := geminiPassthrough()
+	req.Resolved = &domain.ResolvedModel{ProviderID: domain.ProviderGemini, ModelID: "gemini-2.5-flash"}
+
+	_, err := routableChain(context.Background(), bundle, req)
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "routing policy") || !strings.Contains(msg, "Cheap models") {
+		t.Errorf("message must name the routing policy: %q", msg)
+	}
+}
+
+// The same raw-forward surface miss, but Gemini sits outside the key's provider
+// access rather than being dropped by the routing policy.
+func TestRoutableChain_RawForwardSurfaceBlockedByProviderAccess(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+		Config: domain.BundleConfig{
+			AccessExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "gemini_1", ProviderID: domain.ProviderGemini},
+			},
+		},
+	}
+	req := geminiPassthrough()
+	req.Resolved = &domain.ResolvedModel{ProviderID: domain.ProviderGemini, ModelID: "gemini-2.5-flash"}
+
+	_, err := routableChain(context.Background(), bundle, req)
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "provider access") {
+		t.Errorf("message must name provider access: %q", msg)
+	}
+}
+
+// A raw-forward surface miss where the route's provider is genuinely not
+// reachable from the key's scope keeps the surface's own message: nothing in
+// the excluded lists names it, so there is no more specific reason to give.
+func TestRoutableChain_RawForwardSurfaceMissWithoutExclusionKeepsSurfaceReason(t *testing.T) {
+	bundle := &domain.Bundle{
+		Credentials: []domain.Credential{{ID: "openai_1", ProviderID: domain.ProviderOpenAI}},
+	}
+	req := geminiPassthrough()
+	req.Resolved = &domain.ResolvedModel{ProviderID: domain.ProviderGemini, ModelID: "gemini-2.5-flash"}
+
+	_, err := routableChain(context.Background(), bundle, req)
+	if !herr.IsCode(err, domain.ErrProviderNotBound) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrProviderNotBound)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "gemini") {
+		t.Errorf("the surface refusal must name the route's providers: %q", msg)
+	}
+}
+
+// The Phase 1 configuration that surfaced this gap: a key whose allowlist names
+// only a scope-reachable provider its routing policy omits. The bundle then
+// carries no dispatchable credential at all, so the chain is empty. An explicit
+// request for that provider must still be told the routing policy blocked it,
+// not the generic no_provider_configured that candidateChain raises from an
+// empty chain. No spare credential is seeded: an unrelated one is exactly what
+// hid the gap.
+func TestRoutableChain_EmptyChainBlockedByRoutingNamesPolicy(t *testing.T) {
+	bundle := &domain.Bundle{
+		Config: domain.BundleConfig{
+			RoutingExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "anthropic_1", ProviderID: domain.ProviderAnthropic},
+			},
+			RoutingPolicyName: "Cheap models",
+		},
+	}
+	_, err := routableChain(context.Background(), bundle, translatedChat(domain.ProviderAnthropic))
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	if herr.IsCode(err, domain.ErrNoProviderConfigured) {
+		t.Fatal("an excluded provider must not read as an unconfigured organization")
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "routing policy") || !strings.Contains(msg, "Cheap models") {
+		t.Errorf("message must name the routing policy: %q", msg)
+	}
+}
+
+// The raw-forward variant of the empty-chain gap: a Gemini passthrough whose key
+// dispatches to nothing because Gemini is the only allowlisted provider and the
+// routing policy omits it.
+func TestRoutableChain_EmptyChainRawForwardBlockedByRoutingNamesPolicy(t *testing.T) {
+	bundle := &domain.Bundle{
+		Config: domain.BundleConfig{
+			RoutingExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "gemini_1", ProviderID: domain.ProviderGemini},
+			},
+			RoutingPolicyName: "Cheap models",
+		},
+	}
+	req := geminiPassthrough()
+	req.Resolved = &domain.ResolvedModel{ProviderID: domain.ProviderGemini, ModelID: "gemini-2.5-flash"}
+
+	_, err := routableChain(context.Background(), bundle, req)
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	if herr.IsCode(err, domain.ErrNoProviderConfigured) {
+		t.Fatal("an excluded provider must not read as an unconfigured organization")
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "routing policy") || !strings.Contains(msg, "Cheap models") {
+		t.Errorf("message must name the routing policy: %q", msg)
+	}
+}
+
+// The same empty chain, but the only allowlisted provider is outside provider
+// access rather than dropped by the routing policy.
+func TestRoutableChain_EmptyChainBlockedByProviderAccess(t *testing.T) {
+	bundle := &domain.Bundle{
+		Config: domain.BundleConfig{
+			AccessExcludedProviders: []domain.ExcludedModelProvider{
+				{ID: "anthropic_1", ProviderID: domain.ProviderAnthropic},
+			},
+		},
+	}
+	_, err := routableChain(context.Background(), bundle, translatedChat(domain.ProviderAnthropic))
+	if !herr.IsCode(err, domain.ErrModelNotAllowed) {
+		t.Fatalf("got err %v, want code %s", err, domain.ErrModelNotAllowed)
+	}
+	msg := herrMessage(t, err)
+	if !strings.Contains(msg, "provider access") {
+		t.Errorf("message must name provider access: %q", msg)
+	}
+}
+
+// An empty chain with no exclusion metadata is a genuinely unconfigured bundle:
+// routableChain leaves it empty with no error, so candidateChain still raises
+// no_provider_configured. The reason branch must not manufacture a block here.
+func TestRoutableChain_EmptyChainNoExclusionStaysUnconfigured(t *testing.T) {
+	bundle := &domain.Bundle{}
+	creds, err := routableChain(
+		context.Background(),
+		bundle,
+		translatedChat(domain.ProviderAnthropic),
+	)
+	if err != nil {
+		t.Fatalf("a bundle with no exclusion metadata must stay unconfigured, got %v", err)
+	}
+	if len(creds) != 0 {
+		t.Errorf("expected an empty chain, got %v", creds)
 	}
 }

--- a/services/aigateway/domain/bundle.go
+++ b/services/aigateway/domain/bundle.go
@@ -103,6 +103,68 @@ type BundleConfig struct {
 	// RoutingModeNone by the control plane AND at wire decode, so a drifted
 	// control plane cannot silently re-arm fallback on a no-fallback key).
 	RoutingMode string
+
+	// RoutingExcludedProviders and AccessExcludedProviders are ModelProvider
+	// rows a request could resolve to but that are absent from Credentials,
+	// split by WHY, so a request-time block can name the reason instead of
+	// failing opaque (contract §4.2). Routing: reachable from the key's scope
+	// and inside its provider access, but dropped by the routing policy.
+	// Access: reachable from scope but outside providers_allowed. A provider in
+	// neither list with no credential is not reachable from the key's scope.
+	RoutingExcludedProviders []ExcludedModelProvider
+	AccessExcludedProviders  []ExcludedModelProvider
+
+	// RoutingPolicyName is the display name of the key's routing policy, used
+	// only to name the routing-exclusion reason. Empty when the key is not on a
+	// routing policy.
+	RoutingPolicyName string
+}
+
+// ExcludedModelProvider is a ModelProvider row the control plane dropped from a
+// key's dispatch chain, paired with its provider kind. The kind is carried, not
+// just the row id, because a request resolves to a provider KIND and an
+// excluded row is absent from Credentials, so its kind is not otherwise
+// knowable at the gateway.
+type ExcludedModelProvider struct {
+	// ID is the ModelProvider row id, in the same id space as Credentials and
+	// ProvidersAllowed.
+	ID string
+	// ProviderID is the provider kind (openai, anthropic, ...), the axis a
+	// resolved request is matched on.
+	ProviderID ProviderID
+}
+
+// ProviderBlockReason names why a provider a request resolved to is not in the
+// dispatch chain, so a block can say which of the key's own settings removed it.
+type ProviderBlockReason int
+
+const (
+	// ProviderBlockNone means nothing the control plane reported excludes this
+	// provider kind; the chain simply carries no credential for it (the
+	// provider is not reachable from the key's scope).
+	ProviderBlockNone ProviderBlockReason = iota
+	// ProviderBlockRouting means the key's routing policy dropped this provider.
+	ProviderBlockRouting
+	// ProviderBlockAccess means the key's provider access (allowlist) dropped it.
+	ProviderBlockAccess
+)
+
+// BlockedProviderReason reports why a resolved provider kind has no dispatchable
+// credential on this key. Routing takes precedence over access: a provider the
+// policy dropped is named by the policy even if the allowlist would also drop a
+// different row of the same kind.
+func (c BundleConfig) BlockedProviderReason(kind ProviderID) ProviderBlockReason {
+	for _, e := range c.RoutingExcludedProviders {
+		if e.ProviderID == kind {
+			return ProviderBlockRouting
+		}
+	}
+	for _, e := range c.AccessExcludedProviders {
+		if e.ProviderID == kind {
+			return ProviderBlockAccess
+		}
+	}
+	return ProviderBlockNone
 }
 
 // ConfigFetchResult is one answer from the control plane's virtual-key config

--- a/specs/ai-gateway/_shared/contract.md
+++ b/specs/ai-gateway/_shared/contract.md
@@ -245,6 +245,23 @@ Returns the warm-cache config (fat, not on hot path). Supports conditional `If-N
                        so their behaviour is unchanged.
        policy        - ordering and rules come from the linked RoutingPolicy. */
   "routing_mode": "none",
+  /* Why a provider a request could resolve to is NOT in `providers[]`, so a
+     request-time block can name the reason instead of failing opaque. Each
+     entry is a ModelProvider id + its type, the same shape `providers[]`
+     carries, because the gateway matches a resolved request by provider type
+     and these rows are absent from `providers[]`.
+       routing_excluded_providers - reachable from the key's scope AND inside
+         provider access, but dropped by the routing policy (named by
+         routing_policy_name).
+       access_excluded_providers  - reachable from scope but outside
+         providers_allowed; empty when the key allows all providers.
+     A provider in neither list with no credential is not reachable from the
+     key's scope. */
+  "routing_excluded_providers": [{ "id": "pc_anthropic", "type": "anthropic" }],
+  "access_excluded_providers": [{ "id": "pc_gemini", "type": "gemini" }],
+  /* Display name of the key's routing policy, used to name the routing block.
+     null when the key is not on a routing policy. */
+  "routing_policy_name": null,
   "cache": { "mode": "respect|force|disable", "ttl_s": 3600 },
   "guardrails": {
     /* Both fail-open flags default false (fail-closed). Flip to true per

--- a/specs/ai-gateway/governance/vk-provider-access.feature
+++ b/specs/ai-gateway/governance/vk-provider-access.feature
@@ -1,0 +1,80 @@
+Feature: AI Gateway — Virtual Key provider access
+
+  The "Provider access" section of the virtual-key drawers lets an operator
+  pick which model providers a key may dispatch to. The list it offers is the
+  scope-reachable set: every provider the key reaches through its ownership.
+
+  A routing policy narrows what the gateway DISPATCHES to, never what the key's
+  provider allowlist may name. A provider the scope reaches but the policy
+  omits stays offered and is savable; the request to it is blocked at dispatch
+  by the policy intersection, not at save. Blocking the save too would be
+  over-strict, because the dispatch path already refuses the provider.
+
+  This feature pins the provider-access UI and its allowlist validation: the
+  routing-policy-versus-allowlist rule, the "All providers" master checkbox,
+  and the row order.
+
+  Background:
+    Given organization "acme"
+    And organization "acme" has team "platform" with project "demo"
+
+  # ============================================================================
+  # Routing policy narrows dispatch, not the allowlist
+  # ============================================================================
+
+  @integration
+  Scenario: A scope-reachable provider can be allowed on a key even when the routing policy omits it
+    Given a VirtualKey scoped to project "demo" on a routing policy
+    And the policy omits a provider the key's scope reaches
+    Then the omitted provider stays in the scope-reachable set the drawer offers
+    And the server accepts it in the key's provider allowlist
+    But the gateway dispatch set for the key excludes it
+
+  @integration
+  Scenario: The routing policy still narrows the dispatch chain when the allowlist names an omitted provider
+    Given a VirtualKey on a routing policy that omits provider "extra"
+    And the key's provider allowlist includes "extra"
+    When the gateway materialises the key's config
+    Then the dispatch providers exclude "extra"
+
+  # ============================================================================
+  # Request-time block names the reason
+  # ============================================================================
+
+  @integration
+  Scenario: The bundle names why each undispatchable provider was dropped
+    Given a VirtualKey on a routing policy, with an allowlist that omits some scope-reachable providers
+    When the gateway materialises the key's config
+    Then routing_excluded_providers names the providers the policy dropped, with their kind
+    And access_excluded_providers names the scope-reachable providers the allowlist dropped, with their kind
+    And routing_policy_name carries the policy's name
+
+  @integration
+  Scenario: A blocked request names why the resolved provider was not used
+    Given a request resolves to a provider that has no dispatchable credential on the key
+    Then the gateway blocks the request with a reason
+    And the reason names the routing policy when the policy dropped the provider
+    And the reason names the key's provider access when the allowlist dropped the provider
+    And the reason names the key's scope when the provider is not reachable from it
+
+  # ============================================================================
+  # "All providers" master checkbox
+  # ============================================================================
+
+  @integration
+  Scenario: Unchecking All providers clears the selection
+    Given the provider-access section with "All providers" checked
+    When the operator unchecks "All providers"
+    Then no provider row stays checked
+    And the section asks the operator to select at least one provider
+
+  # ============================================================================
+  # Row order — broadest scope first, then name
+  # ============================================================================
+
+  @unit
+  Scenario: Provider access lists organization scope before team before project
+    Given providers defined at organization, team and project scope
+    When the drawer resolves the eligible providers
+    Then organization-scoped providers come first, then team, then project
+    And providers at the same scope are ordered by name


### PR DESCRIPTION
## Summary

Two linked changes to the AI gateway Virtual Key "Provider access" flow.

1. A provider the key's scope reaches can now be allowed on the key even when the key's routing policy leaves it out.
2. When a request is later blocked, the gateway says why: the key's provider access, the routing policy, or the key's scope.

## Phase 1: provider access allows every scope-reachable provider

**Root cause.** The save-time allowlist check applied the routing policy. `eligibleModelProvidersForVk`, for a key on a routing policy, intersects the scope-reachable providers with the policy's own provider list. `assertProvidersAllowedReachable` validated the key's `providers_allowed` against that policy-narrowed set, so a provider the key's scope reaches but the policy omits was refused at save with `providers_not_in_scope`. That is over-strict: the dispatch path already intersects with the policy, so such a provider is blocked at dispatch anyway. The drawer picker hid the same providers, so the two sides matched each other but not what the user could actually use.

**Fix.**
- `scopeResolver.ts` splits into `scopeReachableModelProvidersForVk` (scope cascade, enabled, dispatchable, no policy) and `eligibleModelProvidersForVk` (the scope-reachable set then the routing-policy intersection for DISPATCH).
- `assertProvidersAllowedReachable` validates the allowlist against the scope-reachable set. A scope-reachable provider the policy omits now saves. A provider outside the key's scope still fails.
- `config.materialiser.ts` dispatch is unchanged: the chain is still routing-policy-then-allowlist filtered, so a policy-omitted provider never dispatches even when the allowlist names it.
- The client `resolveEligible` is scope-only again, so the drawer offers every scope-reachable provider.

**Also in Phase 1.**
- Master checkbox: unchecking "All providers" now clears the selection. It used to leave every row checked.
- Row order: provider rows and default-model rows sort broadest scope first (organization, then team, then project), then by name. Applied in `resolveEligible`, the Model Providers table, and the Default Models table on `/settings/model-providers`.

## Phase 2: the gateway says why a request was blocked

When a request resolves to a provider that has no dispatchable credential, the gateway returns a clear reason instead of the opaque wrong-provider fallback:
- the provider is not in this key's provider access,
- the provider is excluded by this key's routing policy (named), or
- the provider is not reachable from this key's scope.

**Wire (additive, contract §4.2 config bundle).**
- `routing_excluded_providers: [{ id, type }]`: reachable from the key's scope and inside its provider access, but dropped by the routing policy.
- `access_excluded_providers: [{ id, type }]`: reachable from the key's scope but outside `providers_allowed`; empty when the key allows all providers.
- `routing_policy_name: string | null`: the policy's name, to name the routing block.

Each entry carries the provider `type`, not just the row id, because the gateway matches a resolved request by provider kind and these rows are absent from `providers[]`. Two lists rather than one, because `providers_allowed` row ids alone cannot tell "outside provider access" apart from "not reachable from scope"; the second list is the minimum needed to name that third reason correctly.

**Gateway.** The drop point `eligibleCredentials` names the reason from `BundleConfig.BlockedProviderReason`. It reuses existing error codes, so there is no new `gateway_*` code and no docs-contract change: `model_not_allowed` for the routing and provider-access reasons, `model_provider_not_bound` for the scope reason. Messages are customer-safe and name the provider and the reason. The implicit bare-model safety net stays for a provider the control plane did not report as excluded.

## Tests

- Parity integration test: client `resolveEligible` equals the server scope-reachable set; a policy-omitted provider stays savable but is excluded from dispatch.
- Service test: a scope-reachable provider the policy omits saves; a provider outside the key's scope still fails.
- Materialiser test: dispatch excludes a policy-omitted provider even when the allowlist names it; the bundle names each excluded provider with its kind and carries the policy name.
- Go: `config_wire` decode test; three reason-branch unit tests plus the implicit-routing case; the not-bound envelope names the scope reason.
- Section integration test: the master checkbox both branches. Unit test: the scope-first sort.
- New spec `specs/ai-gateway/governance/vk-provider-access.feature` (tagged and bound); contract doc §4.2 updated.

## Gates

`pnpm typecheck:all`, `pnpm check:feature-parity`, `gofmt`, `go build ./...`, `go test ./services/aigateway/...`, `golangci-lint` (no new issues), and the touched TS gateway tests all pass.


## Deployment Impact

No new environment variables. No helm values changed. No database migration.

The change adds three optional fields to the gateway config bundle the control plane sends: `routing_excluded_providers`, `access_excluded_providers`, and `routing_policy_name`. The fields are additive. An older gateway ignores unknown fields, so it keeps its current behavior and returns the previous block message. A newer gateway that reads a bundle without the fields treats them as empty and keeps the implicit bare-model safety net. So the control plane and the gateway deploy in either order, and a mixed fleet stays safe.

Default `helm install` with no overrides: no change. The gateway reads the new fields from the same bundle endpoint it already calls. No new secret, port, or service.

BYOC dataplane: no change to the dataplane contract. A BYOC gateway on an older image keeps working and adopts the clearer block messages when its image is updated. No coordinated release is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved virtual key provider access handling by distinguishing scope availability, routing-policy exclusions, and access restrictions.
  * Added clearer blocked-provider messages and routing-policy details.
  * Added provider exclusion information to gateway configuration responses.
  * Provider lists are now ordered by scope breadth and name.

* **Bug Fixes**
  * Unchecking “All providers” now clears selections and prevents saving until a provider is selected or the option is re-enabled.
  * Providers omitted from routing policies can remain selected while correctly excluded from dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
