### PR TITLE
test(costs): pin that the cost registry reads the merged catalog, not the generated file

### DIFF
--- a/platform/app/src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts
@@ -24,9 +24,14 @@ import {
   matchModelCostWithFallbacks,
 } from "~/server/tracer/collector/cost";
 import { getStaticModelCosts } from "../llmModelCost";
+import * as baseRaw from "../llmModels.json";
 import * as overlayRaw from "../llmModels.overlay.json";
 import type { LLMModelEntry } from "../llmModels.types";
 import { llmModels, overlayOverriddenModelIds } from "../loadModelCatalog";
+
+const baseModels = (
+  baseRaw as unknown as { models: Record<string, LLMModelEntry> }
+).models;
 
 const overlayModels = (
   overlayRaw as unknown as { models: Record<string, LLMModelEntry> }
@@ -273,6 +278,56 @@ describe("overlay precedence", () => {
         expect(entry!.pricing.audioCostPerToken).toBe(1e-5);
         expect(entry!.pricing.inputCostPerToken).toBe(6e-7);
         expect(overlayOverriddenModelIds).toContain("openai/gpt-audio-mini");
+      });
+    });
+  });
+
+  // Everything above reads the merged catalog object. That is not the thing
+  // that bills. `getStaticModelCosts` builds the cost registry, and if it
+  // were ever pointed at the generated file instead of the merged catalog,
+  // every assertion above would still pass while billing quietly stopped
+  // honouring the overlay. These two pin the wiring itself.
+  describe("given the cost registry the runtime bills from", () => {
+    describe("when a model exists only in the overlay", () => {
+      it("still reaches the registry, at the overlay's rates", () => {
+        // gpt-5.3-chat was delisted from the generated catalog while still
+        // reachable through the gateway. It survives only because the overlay
+        // carries it. Without it the id prefix-matches openai/gpt-5 and bills
+        // 29 percent under, which is what this asserts against.
+        const overlayOnly = Object.keys(overlayModels).filter(
+          (id) => !(id in baseModels),
+        );
+        expect(
+          overlayOnly,
+          "expected at least one overlay-only model to test the wiring with",
+        ).toContain("openai/gpt-5.3-chat");
+
+        const costs = getStaticModelCosts();
+        for (const id of overlayOnly) {
+          if (isPricedElsewhere(id)) continue;
+          const matched = matchModelCostWithFallbacks(id, costs);
+          expect(
+            matched?.model,
+            `${id} exists only in the overlay and the cost registry resolved it to ${matched?.model ?? "nothing"}, so the overlay is not reaching billing`,
+          ).toBe(id);
+        }
+      });
+    });
+
+    describe("when the overlay overrides a generated entry", () => {
+      it("bills the overlay's rate, not the generated one", () => {
+        const costs = getStaticModelCosts();
+        for (const id of overlayOverriddenModelIds) {
+          if (isPricedElsewhere(id)) continue;
+          const matched = matchModelCostWithFallbacks(id, costs);
+          expect(matched?.model, `${id} did not resolve to its own rule`).toBe(
+            id,
+          );
+          expect(
+            matched?.inputCostPerToken,
+            `${id} bills the generated input rate rather than the overlay's`,
+          ).toBe(overlayModels[id]?.pricing.inputCostPerToken);
+        }
       });
     });
   });

--- a/platform/app/src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts
@@ -310,12 +310,28 @@ describe("overlay precedence", () => {
             matched?.model,
             `${id} exists only in the overlay and the cost registry resolved it to ${matched?.model ?? "nothing"}, so the overlay is not reaching billing`,
           ).toBe(id);
+          // Resolving to the right id is not the same as carrying the right
+          // rates: a rule can take the overlay's name and stale numbers.
+          expect(
+            matched?.inputCostPerToken,
+            `${id} resolved to its own rule but not at the overlay's input rate`,
+          ).toBe(overlayModels[id]?.pricing.inputCostPerToken ?? 0);
+          expect(
+            matched?.outputCostPerToken,
+            `${id} resolved to its own rule but not at the overlay's output rate`,
+          ).toBe(overlayModels[id]?.pricing.outputCostPerToken ?? 0);
         }
       });
     });
 
     describe("when the overlay overrides a generated entry", () => {
       it("bills the overlay's rate, not the generated one", () => {
+        // Note on reach: today's only override, gpt-audio-mini, corrects
+        // `audioCostPerToken`, and the cost registry does not carry that
+        // field, so the token-rate assertions below cannot tell the two
+        // sources apart for it. Precedence itself is caught by the
+        // catalog-level test above. These bite the moment an override
+        // corrects a token rate, which is the common case.
         const costs = getStaticModelCosts();
         for (const id of overlayOverriddenModelIds) {
           if (isPricedElsewhere(id)) continue;
@@ -326,7 +342,11 @@ describe("overlay precedence", () => {
           expect(
             matched?.inputCostPerToken,
             `${id} bills the generated input rate rather than the overlay's`,
-          ).toBe(overlayModels[id]?.pricing.inputCostPerToken);
+          ).toBe(overlayModels[id]?.pricing.inputCostPerToken ?? 0);
+          expect(
+            matched?.outputCostPerToken,
+            `${id} bills the generated output rate rather than the overlay's`,
+          ).toBe(overlayModels[id]?.pricing.outputCostPerToken ?? 0);
         }
       });
     });


### PR DESCRIPTION
**`main` is not red.** I checked before changing anything, and the two failures reported are stale check-runs from #7059's pre-merge head. Both fixes are on `main` and both tests pass there. Details below, then the one real gap this surfaced, which is what this pull request closes.

## Failure 1: the known-mismatch baseline

Reported as `expected [] to deeply equal [ "openai/gpt-4o-mini-transcribe", "openai/gpt-4o-transcribe" ]`.

`main` carries `const KNOWN_UNIT_MISMATCH: Record<string, string> = {};`. It is already empty, so the assertion compares `[]` with `[]` and passes. Nothing was dropped by the merge.

## Failure 2: gpt-5.3-chat resolving to openai/gpt-5

Reported as `expected 'openai/gpt-5' to be 'openai/gpt-5.3-chat'`. This one was worth taking seriously, because if true it meant the overlay was not reaching billing and the 29 percent underbill was live.

It is not true. Measured on `main`:

```
in generated llmModels.json : false
in merged loadModelCatalog  : true
getStaticModelCosts resolves: openai/gpt-5.3-chat  in=0.00000175 out=0.000014
```

The id is absent from the generated file and present only in the overlay, and the cost registry resolves it to its own rule at the correct rates. So the runtime does consult the overlay. Neither of the two possibilities was the case: the test and the runtime read the same merged catalog.

## Where the report came from

Both failures carry `head_sha=32e0b217`, which is #7059's head before it merged. #7058 merged as `8168415cee` and #7059 as `5e0a8ad44c`, in that order. #7059 was merged without pushing another commit, so its last check-run results stayed pinned to the pre-merge SHA, where those failures were real. I had diagnosed exactly those three on #7059 and confirmed #7058 fixed them.

No hunk was silently dropped. A merged pull request's stale checks are simply not `main`'s status.

Evidence for `main` itself:

```
main 5e0a8ad44c        0 failures across 49 completed checks
local, main's tree     133 files, 2364 tests passed
```

## The real gap, which is what this changes

The reported failure was wrong, but the hypothesis behind it was not unreasonable, and checking it showed nothing pinned the wiring.

Every precedence assertion reads the merged catalog **object**. That is not the thing that bills. `getStaticModelCosts` builds the cost registry, and if it were ever pointed at `llmModels.json` instead of `loadModelCatalog`, all of those assertions would still pass while billing quietly stopped honouring the overlay. The scenario was untestable, which is why it could not be ruled out by reading.

Two cases now assert through `matchModelCostWithFallbacks` over `getStaticModelCosts`, the path a request is actually priced by:

- a model existing **only** in the overlay still reaches the registry and resolves to its own rule
- a model the overlay **overrides** bills the overlay's rate, not the generated one

Verified in both directions. Pointing `getStaticModelCosts` at the generated file fails three cases, the new one naming the cause:

```
× still reaches the registry, at the overlay's rates
  AssertionError: voyage/voyage-3.5 exists only in the overlay and the cost
  registry resolved it to nothing, so the overlay is not reaching billing
```

Restoring the import goes green. Neither existing test was weakened.

## Tests

```
src/server/modelProviders + src/server/tracer/collector + src/server/app-layer/traces
Test Files  133 passed (133)
     Tests  2366 passed | 1 skipped (2367)
```

## Deployment Impact

None. Test-only change, no runtime code touched.

- **Environment variables:** none added, changed or removed.
- **Helm values:** unchanged.
- **Vanilla install:** unchanged.
- **BYOC dataplane:** unchanged.
- **Database or migrations:** none.
- **Rollback:** revert the commit. No behaviour to undo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for loading base catalog data and extracting base models.
  * Added validation that overlay-only models use their configured pricing rules.
  * Added validation that overridden models are billed using overlay pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->