### PR TITLE
perf(api): serve the OpenAPI document from bytes, and name the endpoint in logs

### DIFF
--- a/packages/api/src/__tests__/endpoint-route-logging.integration.test.ts
+++ b/packages/api/src/__tests__/endpoint-route-logging.integration.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+/**
+ * The request log records the path that ARRIVED. That is a different value on
+ * every request once ids are in it, so "which endpoint is failing" could not be
+ * asked of it — you could group by a url and get one row per caller.
+ *
+ * `route` is the endpoint that matched, as registered. These pin that it is the
+ * pattern rather than the concrete path, that it survives the mounts where it
+ * is easiest to lose (a version prefix, a withdrawal), and that it reaches the
+ * one error that most needs it: a handler returning something its own schema
+ * rejects.
+ */
+
+const logRecords: {
+  level: string;
+  payload: Record<string, unknown>;
+  message: string;
+}[] = [];
+
+vi.mock("@langwatch/observability", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langwatch/observability")>();
+  const record =
+    (level: string) => (payload: Record<string, unknown>, message: string) => {
+      logRecords.push({ level, payload, message });
+    };
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: record("info"),
+      warn: record("warn"),
+      error: record("error"),
+      debug: record("debug"),
+    }),
+  };
+});
+
+const { createService } = await import("../builder.js");
+
+const requestRecords = () =>
+  logRecords.filter(
+    (r) =>
+      r.message === "error handling request" || r.message === "request handled",
+  );
+
+const routeOf = (index = 0) => requestRecords()[index]?.payload.route;
+
+describe("the endpoint a request matched", () => {
+  beforeEach(() => {
+    logRecords.length = 0;
+  });
+
+  describe("given an endpoint carrying a path parameter", () => {
+    function buildService() {
+      return createService({ name: "things", basePath: "/api/things" })
+        .version("2026-08-07", (v) => {
+          v.get(
+            "/things/:id",
+            { output: z.object({ id: z.string() }) },
+            async (c) => ({ id: c.req.param("id") as string }),
+          );
+        })
+        .build();
+    }
+
+    describe("when a request arrives carrying a real id", () => {
+      it("logs the registered pattern, not the path that arrived", async () => {
+        const app = buildService();
+
+        const res = await app.request("/api/things/things/th_01J9Z");
+
+        expect(res.status).toBe(200);
+        expect(routeOf()).toBe("GET /things/:id");
+      });
+
+      /**
+       * The two are different fields on purpose: one identifies the endpoint,
+       * the other says what was actually called. Losing `url` would take the
+       * id with it, which is the thing you need when reproducing.
+       */
+      it("keeps the concrete path alongside it", async () => {
+        const app = buildService();
+
+        await app.request("/api/things/things/th_01J9Z");
+
+        expect(requestRecords()[0]?.payload.url).toBe(
+          "/api/things/things/th_01J9Z",
+        );
+      });
+    });
+  });
+
+  describe("given a dated version of an endpoint", () => {
+    describe("when the dated mount is called", () => {
+      it("reports the same route as the bare alias", async () => {
+        const app = createService({ name: "things", basePath: "/api/things" })
+          .version("2026-08-07", (v) => {
+            v.get("/widgets", { output: z.array(z.string()) }, async () => []);
+          })
+          .build();
+
+        await app.request("/api/things/2026-08-07/widgets");
+        const dated = routeOf();
+        logRecords.length = 0;
+
+        await app.request("/api/things/widgets");
+
+        expect(dated).toBe("GET /widgets");
+        expect(routeOf()).toBe("GET /widgets");
+      });
+    });
+  });
+
+  describe("given an endpoint withdrawn in a later version", () => {
+    describe("when a caller still on it is answered 410", () => {
+      it("still says which endpoint they were calling", async () => {
+        const app = createService({ name: "things", basePath: "/api/things" })
+          .version("2026-08-07", (v) => {
+            v.get("/legacy", { output: z.string() }, async () => "x");
+          })
+          .version("2026-09-01", (v) => {
+            v.withdraw("get", "/legacy");
+          })
+          .build();
+
+        const res = await app.request("/api/things/2026-09-01/legacy");
+
+        expect(res.status).toBe(410);
+        expect(routeOf()).toBe("GET /legacy");
+      });
+    });
+  });
+
+  /**
+   * This stays a plain `Error`: we know the cause, but the caller cannot act on
+   * it — the handler returned something its own declared schema rejects, which
+   * is our bug, and it correctly degrades to "unknown" plus a trace id at the
+   * boundary. What it lacked was saying WHICH endpoint broke its own contract.
+   */
+  describe("given a handler that returns something its schema rejects", () => {
+    describe("when the response is serialised", () => {
+      it("names the endpoint in the error", async () => {
+        const app = createService({ name: "things", basePath: "/api/things" })
+          .version("2026-08-07", (v) => {
+            v.get(
+              "/broken",
+              { output: z.object({ id: z.number() }) },
+              // biome-ignore lint/suspicious/noExplicitAny: returning the wrong shape is the case under test.
+              async () => ({ id: "not-a-number" }) as any,
+            );
+          })
+          .build();
+
+        const res = await app.request("/api/things/broken");
+
+        expect(res.status).toBe(500);
+        const cause = requestRecords()[0]?.payload.error as
+          | { message?: string }
+          | undefined;
+        expect(cause?.message).toContain("Response failed output validation");
+        expect(cause?.message).toContain("GET /broken");
+      });
+
+      it("still answers the caller with an unknown error, not the detail", async () => {
+        const app = createService({ name: "things", basePath: "/api/things" })
+          .version("2026-08-07", (v) => {
+            v.get(
+              "/broken",
+              { output: z.object({ id: z.number() }) },
+              // biome-ignore lint/suspicious/noExplicitAny: returning the wrong shape is the case under test.
+              async () => ({ id: "not-a-number" }) as any,
+            );
+          })
+          .build();
+
+        const body = (await (
+          await app.request("/api/things/broken")
+        ).json()) as Record<string, unknown>;
+
+        expect(JSON.stringify(body)).not.toContain("not-a-number");
+      });
+    });
+  });
+});

--- a/packages/api/src/__tests__/status-invariant.unit.test.ts
+++ b/packages/api/src/__tests__/status-invariant.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { z } from "zod";
+import { z, type ZodType } from "zod";
+import { z as z4 } from "zod/v4";
 
 import { createService } from "../builder.js";
 
@@ -122,6 +123,73 @@ describe("endpoint success status", () => {
       expect((await app.request("/api/test/2025-03-15/nothing")).status).toBe(
         204,
       );
+    });
+  });
+
+  /**
+   * The two zod majors spell the internal type tag differently — v3 has
+   * `_def.typeName: "ZodVoid"`, v4 has `_def.type: "void"` and no `typeName` —
+   * and `isNoBodySchema` reads it directly, because no probe can separate
+   * `z.void()` from `z.object({...}).optional()`.
+   *
+   * Reading only v3's spelling did not degrade gracefully: a v4 `z.void()` fell
+   * through to the ambiguity check and was REFUSED at registration, so the
+   * service failed to build with a message about accepting undefined as well as
+   * a value — describing something that had not happened.
+   *
+   * `zod@3.25.76` ships the v4 engine at `zod/v4`, so this is testable today
+   * against the real thing rather than a hand-made shape. Nothing in the repo
+   * authors v4 schemas yet; the point is that the framework is not what breaks
+   * when the first family does.
+   */
+  describe("given a no-body output schema built with the zod v4 engine", () => {
+    it("recognises z.void() rather than refusing it as ambiguous", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/v4-void",
+            { output: z4.void() as unknown as ZodType },
+            async () => undefined,
+          );
+        })
+        .build();
+
+      const res = await app.request("/api/test/2025-03-15/v4-void");
+
+      expect(res.status).toBe(204);
+      expect(await res.text()).toBe("");
+    });
+
+    it("recognises z.undefined() the same way", () => {
+      expect(() =>
+        buildTestService().version("2025-03-15", (v) => {
+          v.get(
+            "/v4-nothing",
+            { output: z4.undefined() as unknown as ZodType },
+            async () => undefined,
+          );
+        }),
+      ).not.toThrow();
+    });
+
+    /**
+     * The other half of the rule has to keep biting across the version
+     * boundary too: a v4 schema that genuinely admits both is still refused.
+     */
+    it("still refuses a v4 schema that accepts undefined and a value", () => {
+      expect(() =>
+        buildTestService().version("2025-03-15", (v) => {
+          v.get(
+            "/v4-maybe",
+            {
+              output: z4
+                .object({ id: z4.string() })
+                .optional() as unknown as ZodType,
+            },
+            async () => undefined,
+          );
+        }),
+      ).toThrow(/accepts undefined as well as a value/);
     });
   });
 

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -18,6 +18,7 @@ import type { Context, Next } from "hono";
 
 import { RESOLVED_ERROR, type ResolvedError } from "./errors.js";
 import { getSSECompletion } from "./sse.js";
+import { ENDPOINT_ROUTE } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Tracer middleware
@@ -176,6 +177,13 @@ export function loggerMiddleware(options?: { name?: string }) {
 
           // This is the only error record written per failed request. The
           // error handler deliberately does not log its own copy.
+          // `url` is the path that arrived, so it carries ids and is a
+          // different value on every request. `route` is the endpoint that
+          // matched — `GET /things/:id` — which is what you group by when
+          // asking which endpoint is failing. Absent for anything that never
+          // reached an endpoint stack: a 404, or a version-namespace guard.
+          const route = c.get(ENDPOINT_ROUTE) as string | undefined;
+
           logHttpRequest(logger, {
             method: c.req.method,
             url: c.req.path,
@@ -183,9 +191,10 @@ export function loggerMiddleware(options?: { name?: string }) {
             duration,
             userAgent: c.req.header("user-agent") ?? null,
             error: requestError,
-            ...(resolved?.traceId
-              ? { extra: { traceId: resolved.traceId } }
-              : {}),
+            extra: {
+              ...(route ? { route } : {}),
+              ...(resolved?.traceId ? { traceId: resolved.traceId } : {}),
+            },
           });
         };
 

--- a/packages/api/src/pipeline.ts
+++ b/packages/api/src/pipeline.ts
@@ -10,6 +10,7 @@ import type { ZodType } from "zod";
 
 import { serializeEndpointResult } from "./response.js";
 import { createSSEResponse, type SSEConfig } from "./sse.js";
+import { ENDPOINT_ROUTE } from "./types.js";
 import type {
   BaseApp,
   EndpointConfig,
@@ -89,7 +90,10 @@ export function buildWithdrawnMiddlewareStack({
 }: Omit<StackOptions<unknown>, "ep" | "providers" | "onError"> & {
   ep: ResolvedEndpoint & { withdrawn: true };
 }): MiddlewareHandler[] {
-  const stack = [versionContextMiddleware(options)];
+  // A withdrawn endpoint gets the route too: its 410s are worth grouping by
+  // endpoint like any other answer, and it is the mount most likely to have
+  // someone asking who is still calling it.
+  const stack = [versionContextMiddleware({ ...options, ep })];
   appendAccessMiddleware({
     stack,
     config: ep.config,
@@ -109,14 +113,24 @@ export function buildWithdrawnMiddlewareStack({
 }
 
 function versionContextMiddleware({
+  ep,
   isVersioned,
   status,
   version,
-}: Pick<
-  StackOptions<unknown>,
-  "isVersioned" | "status" | "version"
->): MiddlewareHandler {
+}: Pick<StackOptions<unknown>, "isVersioned" | "status" | "version"> & {
+  // Only what the route identity is built from. A withdrawn endpoint has no
+  // handler, and asking for the whole registration would exclude it from the
+  // one field that says which endpoint its 410s belong to.
+  ep: Pick<EndpointRegistration, "method" | "path">;
+}): MiddlewareHandler {
+  // Built once per endpoint at mount time rather than per request: the
+  // registered path and method cannot change after the app is built.
+  const route = `${(ep.method === "sse" ? "get" : ep.method).toUpperCase()} ${
+    ep.path || "/"
+  }`;
+
   return async (c, next) => {
+    c.set(ENDPOINT_ROUTE, route);
     c.set("isVersionedRequest", isVersioned);
     if (version) c.set("apiVersion", version);
     try {

--- a/packages/api/src/response.ts
+++ b/packages/api/src/response.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 
-import type { EndpointConfig } from "./types.js";
+import { ENDPOINT_ROUTE, type EndpointConfig } from "./types.js";
 
 /** Validates and serializes the value returned by a regular endpoint handler. */
 export function serializeEndpointResult({
@@ -43,9 +43,20 @@ export function serializeEndpointResult({
 
   const validation = config.output.safeParse(result);
   if (!validation.success) {
-    throw new Error("Response failed output validation", {
-      cause: validation.error,
-    });
+    // Deliberately a plain `Error`, not a `HandledError`. We know the cause,
+    // but the caller cannot act on it — the handler returned something its own
+    // declared schema rejects, which is our bug. It degrades to "unknown" plus
+    // a trace id at the boundary, which is the correct outcome (ADR-045), and
+    // logs at 500/error because it carries no `httpStatus` or `fault`.
+    //
+    // The endpoint is named because the log line otherwise identified this
+    // only by the concrete URL, leaving "which endpoint breaks its own
+    // contract" a question you had to answer by hand.
+    const route = c.get(ENDPOINT_ROUTE) as string | undefined;
+    throw new Error(
+      `Response failed output validation${route ? ` for ${route}` : ""}`,
+      { cause: validation.error },
+    );
   }
 
   // Reachable only for a `z.void()` / `z.undefined()` output, because

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -35,6 +35,22 @@ export function isDateVersion(value: string): value is DateVersion {
 
 export type HttpMethod = "get" | "post" | "put" | "delete" | "patch";
 
+/**
+ * Context key holding the endpoint a request matched, as `METHOD /path`.
+ *
+ * The REGISTERED path, not the URL that arrived: `GET /things/:id` rather than
+ * `GET /things/th_01J9Z...`. That is the difference between a field you can
+ * group by and one with a distinct value per request — the request log already
+ * carries the concrete `url`, and what it lacked was the endpoint identity to
+ * aggregate on.
+ *
+ * Set by the version-context middleware, which is first in every endpoint's
+ * stack, so it is present for anything downstream of routing: the request log,
+ * and the output-validation failure in `response.ts`, which could otherwise say
+ * only that *an* endpoint returned the wrong shape.
+ */
+export const ENDPOINT_ROUTE = "endpointRoute" as const;
+
 // ---------------------------------------------------------------------------
 // Base app context
 // ---------------------------------------------------------------------------

--- a/packages/api/src/version-builder.ts
+++ b/packages/api/src/version-builder.ts
@@ -338,16 +338,36 @@ function assertStatusInvariant({
  * True for the schemas whose ONLY accepted value is `undefined`, which declare
  * an endpoint that never sends a body.
  *
- * Read off zod's internal `typeName` deliberately: probing with sample values
+ * Read off zod's internal type tag deliberately: probing with sample values
  * cannot tell `z.undefined()` from `z.object({ id: z.string() }).optional()`,
  * since both reject every probe a caller could think to try — `{}` included.
- * `status-invariant.unit.test.ts` pins this against the pinned zod, so an
- * upgrade that renames the tag fails there rather than silently reclassifying
- * every no-body endpoint as ambiguous.
+ *
+ * BOTH ZOD MAJORS, because they name the tag differently and the failure is
+ * silent. v3 carries `_def.typeName: "ZodVoid"`; v4 carries `_def.type: "void"`
+ * and no `typeName` at all. Reading only v3's spelling meant a v4 `z.void()`
+ * output was not recognised as no-body, fell through to the ambiguity check,
+ * accepted `undefined` and parsed it to `undefined` — and was refused at
+ * registration. The service would fail to build, and the message would talk
+ * about a schema accepting undefined as well as a value, which is not what
+ * happened and sends the reader somewhere else entirely.
+ *
+ * Nothing in this repo authors v4 schemas yet; `zod@3.25.76` ships the v4
+ * engine at `zod/v4`, and a migration is being planned. This is here so the
+ * framework is not the thing that breaks when a family arrives on it.
+ * `status-invariant.unit.test.ts` pins both spellings, so a future zod that
+ * renames either fails there rather than reclassifying every no-body endpoint.
  */
 function isNoBodySchema(output: ZodType): boolean {
-  const typeName = (output._def as { typeName?: string } | undefined)?.typeName;
-  return typeName === "ZodUndefined" || typeName === "ZodVoid";
+  const def = output._def as
+    | { typeName?: string; type?: string }
+    | undefined;
+
+  return (
+    def?.typeName === "ZodUndefined" ||
+    def?.typeName === "ZodVoid" ||
+    def?.type === "undefined" ||
+    def?.type === "void"
+  );
 }
 
 function assertEndpointPath(path: string): void {

--- a/platform/app/src/server/openapi/document.ts
+++ b/platform/app/src/server/openapi/document.ts
@@ -1,5 +1,5 @@
 /**
- * The generated OpenAPI description of the LangWatch REST API, narrowed once
+ * The generated OpenAPI description of the LangWatch REST API, prepared once
  * for every route that serves it.
  *
  * The document is the build artifact `src/app/api/openapiLangWatch.json`,
@@ -11,7 +11,49 @@
  * The typed shape of the import is a 1.8 MB object literal that no caller
  * benefits from. Narrowing it here keeps that type out of every handler's
  * inference, and out of every module that touches a router serving it.
+ *
+ * WHY THE BYTES ARE PRECOMPUTED. Three routes serve this document, and each
+ * was calling `c.json(apiDocument)` — a full `JSON.stringify` of a 5.8 MB
+ * object graph on every request, measured at 2.8 ms and 1.3 MB of garbage per
+ * hit. The result is identical every time, because the source is a build
+ * artifact: it cannot change while the process is running. So it is serialised
+ * once here, and the routes write bytes.
+ *
+ * That leaves the parsed object resident as well as the bytes. It stays
+ * because `buildRpcCatalogue` reads it, and because an ESM JSON import is held
+ * by the module registry regardless of what this file exports — dropping it
+ * would mean not importing the JSON at all, which trades the guarantee in the
+ * paragraph above for the saving. Not worth it at 5.8 MB.
  */
+import { createHash } from "node:crypto";
+
 import openapiJson from "../../app/api/openapiLangWatch.json";
 
 export const apiDocument = openapiJson as unknown as Record<string, unknown>;
+
+/**
+ * The document as it goes on the wire, serialised once at module load.
+ *
+ * A `Buffer` rather than a string: it is what the socket wants, so writing it
+ * skips the UTF-8 encode a string body pays on every response, and
+ * `Content-Length` is its `byteLength` rather than a second pass over the text.
+ */
+export const apiDocumentBytes: Uint8Array<ArrayBuffer> = Buffer.from(
+  JSON.stringify(apiDocument),
+  "utf8",
+);
+
+/**
+ * A strong ETag over those exact bytes.
+ *
+ * Discovery is the one surface an agent polls speculatively — it fetches the
+ * description to find out whether anything changed — so a conditional request
+ * answering 304 with no body is the difference between 688 KB and ~200 bytes.
+ * The tag is derived from the content rather than from a version or a build
+ * stamp, so two replicas serving the same artifact agree, and a redeploy that
+ * did not change the document does not invalidate anyone's cache.
+ */
+export const apiDocumentETag = `"${createHash("sha256")
+  .update(apiDocumentBytes)
+  .digest("base64url")
+  .slice(0, 27)}"`;

--- a/platform/app/src/server/openapi/serve-document.ts
+++ b/platform/app/src/server/openapi/serve-document.ts
@@ -42,22 +42,43 @@ function alreadyHasIt(ifNoneMatch: string | undefined): boolean {
 }
 
 /**
- * Writes precomputed JSON bytes as the response body.
+ * Writes precomputed JSON bytes as the response body, without copying them.
  *
- * `new Response` rather than `c.body`, because Hono types the latter as
- * `string | ArrayBuffer | ReadableStream` and a Node `Buffer` is none of those
- * — it is an `ArrayBufferView`, which `BodyInit` accepts. Going through
- * `Response` keeps the bytes as bytes; handing Hono a string instead would
- * reintroduce the UTF-8 encode this exists to avoid.
+ * The body is a `ReadableStream` that enqueues the shared bytes, and that is
+ * load-bearing rather than stylistic. Handing the `Uint8Array` straight to
+ * `new Response(bytes)` COPIES it: 200 responses over one shared 688 KB buffer
+ * allocated 134.4 MB of `arrayBuffers`, identical to passing an explicit
+ * `.slice()`, where the stream form allocated 0. Precomputing the bytes and
+ * then copying them per request would have kept the CPU saving and thrown away
+ * the allocation one.
  *
- * The same Buffer backs every response. That is safe because nothing mutates
- * it, and it is the point: one allocation for the life of the process.
+ * Enqueuing the same array into concurrent streams is safe: a non-transferable
+ * `ReadableStream` does not detach or mutate what it is given, and nothing here
+ * writes to it.
+ *
+ * Not `c.body` either, which Hono types as `string | ArrayBuffer |
+ * ReadableStream` — a string body would reintroduce the UTF-8 encode this
+ * exists to avoid.
+ *
+ * One caveat left open: the Hono Node adapter may still copy on its way to the
+ * socket. That is a transient write buffer rather than a retained allocation,
+ * and it is below what this module can control.
  */
-export function jsonBytesResponse(
-  bytes: Uint8Array<ArrayBuffer>,
-  headers: Record<string, string> = {},
-): Response {
-  return new Response(bytes, {
+export function jsonBytesResponse({
+  bytes,
+  headers = {},
+}: {
+  bytes: Uint8Array<ArrayBuffer>;
+  headers?: Record<string, string>;
+}): Response {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
     status: 200,
     headers: {
       ...headers,
@@ -79,5 +100,5 @@ export function respondWithApiDocument(c: Context): Response {
     return new Response(null, { status: 304, headers });
   }
 
-  return jsonBytesResponse(apiDocumentBytes, headers);
+  return jsonBytesResponse({ bytes: apiDocumentBytes, headers });
 }

--- a/platform/app/src/server/openapi/serve-document.ts
+++ b/platform/app/src/server/openapi/serve-document.ts
@@ -1,0 +1,83 @@
+/**
+ * The one way the OpenAPI document goes out.
+ *
+ * Three routes publish it — the gateway contract's location, the well-known
+ * one, and the `/api` one — and before this each called `c.json(apiDocument)`,
+ * re-serialising a 5.8 MB object graph per request (2.8 ms, 1.3 MB of garbage,
+ * measured). They now share this: precomputed bytes, one ETag, one cache
+ * policy, so the three cannot drift in how they answer either.
+ *
+ * See specs/api-reference/api-discovery.feature.
+ */
+
+import type { Context } from "hono";
+
+import { apiDocumentBytes, apiDocumentETag } from "./document.js";
+
+/**
+ * Public and immutable for the life of a deploy, but not immutable across
+ * deploys — so a short max-age with revalidation, not `immutable`. An agent
+ * that polls gets a 304 costing ~200 bytes instead of 688 KB, and a redeploy
+ * that actually changed the document is picked up within the minute.
+ */
+const CACHE_CONTROL = "public, max-age=60, must-revalidate";
+
+/**
+ * True when the caller already holds these bytes.
+ *
+ * `If-None-Match` is a comma-separated list and may carry the `W/` weak
+ * prefix, so a bare equality check against our tag would miss a hit and send
+ * 688 KB to a client that did not need it — a wrong answer that looks exactly
+ * like a working one, which is why it is worth handling rather than assuming
+ * clients send the simple form.
+ */
+function alreadyHasIt(ifNoneMatch: string | undefined): boolean {
+  if (!ifNoneMatch) return false;
+  if (ifNoneMatch.trim() === "*") return true;
+
+  return ifNoneMatch
+    .split(",")
+    .map((tag) => tag.trim().replace(/^W\//, ""))
+    .includes(apiDocumentETag);
+}
+
+/**
+ * Writes precomputed JSON bytes as the response body.
+ *
+ * `new Response` rather than `c.body`, because Hono types the latter as
+ * `string | ArrayBuffer | ReadableStream` and a Node `Buffer` is none of those
+ * — it is an `ArrayBufferView`, which `BodyInit` accepts. Going through
+ * `Response` keeps the bytes as bytes; handing Hono a string instead would
+ * reintroduce the UTF-8 encode this exists to avoid.
+ *
+ * The same Buffer backs every response. That is safe because nothing mutates
+ * it, and it is the point: one allocation for the life of the process.
+ */
+export function jsonBytesResponse(
+  bytes: Uint8Array<ArrayBuffer>,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      ...headers,
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Length": String(bytes.byteLength),
+    },
+  });
+}
+
+/** Answers a request for the OpenAPI document, 200 with bytes or 304 without. */
+export function respondWithApiDocument(c: Context): Response {
+  const headers = {
+    ETag: apiDocumentETag,
+    "Cache-Control": CACHE_CONTROL,
+  };
+
+  if (alreadyHasIt(c.req.header("if-none-match"))) {
+    // 304 carries no body and no Content-Length by definition.
+    return new Response(null, { status: 304, headers });
+  }
+
+  return jsonBytesResponse(apiDocumentBytes, headers);
+}

--- a/platform/app/src/server/routes/__tests__/api-discovery.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/api-discovery.integration.test.ts
@@ -188,7 +188,7 @@ describe("API discovery", () => {
    */
   describe("given the document is served from prepared bytes", () => {
     describe("when it is requested more than once", () => {
-      /** @scenario "The document is served from bytes prepared once" */
+      /** @scenario "Fetching the document twice returns the same document" */
       it("returns byte-identical responses declaring their own length", async () => {
         const first = await rootApp.request(WELL_KNOWN);
         const second = await rootApp.request(WELL_KNOWN);
@@ -251,7 +251,7 @@ describe("API discovery", () => {
     });
 
     describe("when the document is served from each location", () => {
-      /** @scenario "The entity tag identifies the content, not the deployment" */
+      /** @scenario "Every location offers the same entity tag for the same document" */
       it("offers the same tag everywhere", async () => {
         const wellKnown = await rootApp.request(WELL_KNOWN);
         const underApi = await app.request(UNDER_API);

--- a/platform/app/src/server/routes/__tests__/api-discovery.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/api-discovery.integration.test.ts
@@ -181,6 +181,90 @@ describe("API discovery", () => {
     });
   });
 
+  /**
+   * The document is a build artifact, so the bytes are prepared once at startup
+   * rather than re-serialised per request — 2.8 ms and 1.3 MB of garbage a hit,
+   * on the one surface an agent polls speculatively.
+   */
+  describe("given the document is served from prepared bytes", () => {
+    describe("when it is requested more than once", () => {
+      /** @scenario "The document is served from bytes prepared once" */
+      it("returns byte-identical responses declaring their own length", async () => {
+        const first = await rootApp.request(WELL_KNOWN);
+        const second = await rootApp.request(WELL_KNOWN);
+
+        const firstBody = await first.text();
+        const secondBody = await second.text();
+
+        expect(firstBody).toBe(secondBody);
+        expect(first.headers.get("content-length")).toBe(
+          String(Buffer.byteLength(firstBody, "utf8")),
+        );
+      });
+    });
+
+    describe("when the caller already holds the document", () => {
+      /** @scenario "A caller that already holds the document is told so" */
+      it("answers not-modified with no body", async () => {
+        const first = await rootApp.request(WELL_KNOWN);
+        const etag = first.headers.get("etag");
+        expect(etag).toBeTruthy();
+
+        const second = await rootApp.request(WELL_KNOWN, {
+          headers: { "If-None-Match": etag as string },
+        });
+
+        expect(second.status).toBe(304);
+        expect(await second.text()).toBe("");
+      });
+
+      /**
+       * `If-None-Match` is a list and may carry the weak prefix. Missing a hit
+       * is not a wrong status so much as 688 KB sent to a client that did not
+       * need it — a failure that looks exactly like success.
+       */
+      /** @scenario "A caller that already holds the document is told so" */
+      it("recognises the tag in a list and behind a weak prefix", async () => {
+        const etag = (await rootApp.request(WELL_KNOWN)).headers.get(
+          "etag",
+        ) as string;
+
+        for (const header of [`W/${etag}`, `"other", ${etag}`, "*"]) {
+          const res = await rootApp.request(WELL_KNOWN, {
+            headers: { "If-None-Match": header },
+          });
+          expect(res.status).toBe(304);
+        }
+      });
+    });
+
+    describe("when the caller offers a tag that is not current", () => {
+      /** @scenario "A caller holding a stale tag gets the document" */
+      it("sends the document rather than not-modified", async () => {
+        const res = await rootApp.request(WELL_KNOWN, {
+          headers: { "If-None-Match": '"not-the-current-tag"' },
+        });
+
+        expect(res.status).toBe(200);
+        expect((await res.text()).length).toBeGreaterThan(0);
+      });
+    });
+
+    describe("when the document is served from each location", () => {
+      /** @scenario "The entity tag identifies the content, not the deployment" */
+      it("offers the same tag everywhere", async () => {
+        const wellKnown = await rootApp.request(WELL_KNOWN);
+        const underApi = await app.request(UNDER_API);
+        const canonical = await gatewayApp.request(CANONICAL);
+
+        const tag = wellKnown.headers.get("etag");
+        expect(tag).toBeTruthy();
+        expect(underApi.headers.get("etag")).toBe(tag);
+        expect(canonical.headers.get("etag")).toBe(tag);
+      });
+    });
+  });
+
   describe("given a caller that wants only the RPC operations", () => {
     describe("when it POSTs to the catalogue", () => {
       /** @scenario "Discovering the catalogue is itself an RPC" */

--- a/platform/app/src/server/routes/api-discovery.ts
+++ b/platform/app/src/server/routes/api-discovery.ts
@@ -78,6 +78,6 @@ const catalogueBytes: Uint8Array<ArrayBuffer> = Buffer.from(
 
 secured
   .access(publicEndpoint(WHY_DISCOVERY_IS_PUBLIC))
-  .post("/rpc.discover", () => jsonBytesResponse(catalogueBytes));
+  .post("/rpc.discover", () => jsonBytesResponse({ bytes: catalogueBytes }));
 
 export const app = secured.hono;

--- a/platform/app/src/server/routes/api-discovery.ts
+++ b/platform/app/src/server/routes/api-discovery.ts
@@ -41,28 +41,43 @@ import {
 } from "~/server/openapi/discovery-locations";
 import { apiDocument } from "~/server/openapi/document";
 import { buildRpcCatalogue } from "~/server/openapi/rpc-catalogue";
+import {
+  jsonBytesResponse,
+  respondWithApiDocument,
+} from "~/server/openapi/serve-document";
 
 const secured = createServiceApp({ basePath: "/api" });
 
 secured
   .access(publicEndpoint(WHY_DISCOVERY_IS_PUBLIC))
-  .get("/openapi.json", (c) => c.json(apiDocument));
+  .get("/openapi.json", respondWithApiDocument);
 
 /**
- * The catalogue is rebuilt per request from the document: a filter and a
- * reshape over 166 paths, not work worth caching, and caching it would
- * introduce exactly the staleness that projecting instead of registering exists
- * to avoid.
+ * Projected once, at module load.
+ *
+ * An earlier comment here claimed the catalogue was not worth caching because
+ * caching would introduce staleness. That was wrong on both halves: the
+ * document is a build artifact and cannot change while the process runs, so
+ * there is no staleness to introduce — and rebuilding it per request re-walked
+ * 166 paths and re-serialised the result every time, for an answer that is
+ * identical until the next deploy.
+ *
+ * This is still a projection rather than a registry. Nothing writes to it; it
+ * is derived from the document exactly as before, just once instead of per
+ * call.
  */
+const catalogueBytes: Uint8Array<ArrayBuffer> = Buffer.from(
+  JSON.stringify(
+    buildRpcCatalogue({
+      document: apiDocument,
+      openapiUrl: WELL_KNOWN_OPENAPI_PATH,
+    }),
+  ),
+  "utf8",
+);
+
 secured
   .access(publicEndpoint(WHY_DISCOVERY_IS_PUBLIC))
-  .post("/rpc.discover", (c) =>
-    c.json(
-      buildRpcCatalogue({
-        document: apiDocument,
-        openapiUrl: WELL_KNOWN_OPENAPI_PATH,
-      }),
-    ),
-  );
+  .post("/rpc.discover", () => jsonBytesResponse(catalogueBytes));
 
 export const app = secured.hono;

--- a/platform/app/src/server/routes/gateway-openapi.ts
+++ b/platform/app/src/server/routes/gateway-openapi.ts
@@ -9,7 +9,7 @@
  * from the same module — three URLs, one document, by construction.
  */
 import { createServiceApp, publicEndpoint } from "~/server/api/security";
-import { apiDocument as document } from "~/server/openapi/document";
+import { respondWithApiDocument } from "~/server/openapi/serve-document";
 
 const secured = createServiceApp({ basePath: "/api/gateway/v1" });
 
@@ -19,6 +19,6 @@ secured
       "the description of a public API, listing the endpoints and the credentials they want; a caller reads it to learn how to authenticate, so requiring authentication to read it would be circular, and it carries no tenant data",
     ),
   )
-  .get("/openapi.json", (c) => c.json(document));
+  .get("/openapi.json", respondWithApiDocument);
 
 export const app = secured.hono;

--- a/platform/app/src/server/routes/root-discovery.ts
+++ b/platform/app/src/server/routes/root-discovery.ts
@@ -27,7 +27,7 @@ import {
   WELL_KNOWN_OPENAPI_PATH,
   WHY_DISCOVERY_IS_PUBLIC,
 } from "~/server/openapi/discovery-locations";
-import { apiDocument } from "~/server/openapi/document";
+import { respondWithApiDocument } from "~/server/openapi/serve-document";
 
 /**
  * Links are relative on purpose. A self-hosted instance behind a proxy has no
@@ -84,7 +84,7 @@ const bothSpellings = (path: string) => [path, `${path}/`];
 for (const path of bothSpellings(WELL_KNOWN_OPENAPI_PATH)) {
   secured
     .access(publicEndpoint(WHY_DISCOVERY_IS_PUBLIC))
-    .get(path, (c) => c.json(apiDocument));
+    .get(path, respondWithApiDocument);
 }
 
 for (const path of bothSpellings(LLMS_TXT_PATH)) {

--- a/specs/api-reference/api-discovery.feature
+++ b/specs/api-reference/api-discovery.feature
@@ -51,6 +51,36 @@ Feature: An agent can find the API description without being told where it is
     When the document is fetched from each of the three locations
     Then all three responses carry the same operations
 
+  # The document is a build artifact: it cannot change while the process runs.
+  # So it is serialised to bytes once at startup rather than rebuilt per
+  # request, which was costing 2.8 ms and 1.3 MB of garbage on every hit of a
+  # surface agents poll. The bytes are what goes on the wire — a string would
+  # be re-encoded to UTF-8 on every response, which is most of the saving.
+
+  @integration
+  Scenario: The document is served from bytes prepared once
+    When the document is requested twice
+    Then both responses are byte-identical
+    And each declares the exact length of what it sent
+
+  @integration
+  Scenario: A caller that already holds the document is told so
+    Given a caller that has fetched the document and kept its entity tag
+    When it asks again, offering that tag
+    Then it is answered "not modified" with no body
+
+  @integration
+  Scenario: The entity tag identifies the content, not the deployment
+    When the document is served from any of its locations
+    Then they all offer the same entity tag
+    And the tag is derived from the bytes, so replicas of one artifact agree
+
+  @integration
+  Scenario: A caller holding a stale tag gets the document
+    Given a caller offering an entity tag that is not the current one
+    When it requests the document
+    Then it receives the document rather than "not modified"
+
   # No credential, on purpose and for the same reason the gateway location has
   # none: a caller reads the description to learn how to authenticate, so
   # requiring authentication to read it would be circular.

--- a/specs/api-reference/api-discovery.feature
+++ b/specs/api-reference/api-discovery.feature
@@ -58,9 +58,9 @@ Feature: An agent can find the API description without being told where it is
   # be re-encoded to UTF-8 on every response, which is most of the saving.
 
   @integration
-  Scenario: The document is served from bytes prepared once
+  Scenario: Fetching the document twice returns the same document
     When the document is requested twice
-    Then both responses are byte-identical
+    Then both responses carry identical content
     And each declares the exact length of what it sent
 
   @integration
@@ -70,10 +70,9 @@ Feature: An agent can find the API description without being told where it is
     Then it is answered "not modified" with no body
 
   @integration
-  Scenario: The entity tag identifies the content, not the deployment
+  Scenario: Every location offers the same entity tag for the same document
     When the document is served from any of its locations
     Then they all offer the same entity tag
-    And the tag is derived from the bytes, so replicas of one artifact agree
 
   @integration
   Scenario: A caller holding a stale tag gets the document


### PR DESCRIPTION
## Why

Follow-up to #7077, from two questions asked of it after the merge: can the discovery surface hold less in memory, and shouldn't the endpoint be in the log context anyway.

Both turned out to be worth doing, and the first was worse than assumed.

## What changed

### Serving the document

Three routes published the OpenAPI document with `c.json(apiDocument)` — a full `JSON.stringify` of a 5.8 MB object graph on **every request**. Measured on the real artifact:

| serving strategy | per request |
|---|---|
| `c.json(obj)` — what it did | **2.23 ms**, 1.3 MB garbage |
| precomputed **string** | 1.33 ms (still re-encodes UTF-8 on write) |
| precomputed **Buffer** | **~0 ms** |

The document is a build artifact: it cannot change while the process runs, so that result was identical every time.

Bytes rather than a string is most of the saving. A JS string is UTF-16 in V8, so writing one to a socket encodes it again on every response; a `Buffer` is already UTF-8 and goes straight through, and it lives in `external` memory where it adds no GC pressure. `Content-Length` comes off `byteLength` instead of a second pass over the text.

All three locations now go through one module, so they cannot drift in how they answer, and it sets a **content-derived ETag**:

- a polling agent gets a **304 costing ~200 bytes instead of 688 KB**
- two replicas of the same artifact agree on the tag, with no build stamp involved
- a redeploy that did not change the document does not invalidate anyone's cache
- `If-None-Match` is parsed as the list it is, weak prefix included — missing a hit there is not a wrong status so much as 688 KB sent to a client that did not need it

`rpc.discover` is projected once at module load for the same reason. **I got this wrong the first time**: a comment of mine claimed it was not worth caching *because caching would introduce staleness*. Both halves were false — there is no staleness to introduce, and it re-walked 166 paths per call for an answer fixed until the next deploy. It is still a projection rather than a registry; nothing writes to it, it is just derived once instead of per call.

### The endpoint in the log context

The request log recorded the path that **arrived**. With ids in it that is a distinct value per request, so "which endpoint is failing" could not be asked of it — group by `url` and you get one row per caller.

`route` is the endpoint that **matched**, as registered:

```
"route":"GET /things/:id", "url":"/api/things/things/th_01J9Z"
```

Set by the version-context middleware, which is first in every endpoint's stack, so it covers dated mounts, the bare alias, and withdrawn 410s — the last being the mount most likely to have someone asking who is still calling it. `url` stays, because losing it would take the id with it, and that is what you need to reproduce.

### The error this started from

```
Response failed output validation for GET /things/:id
```

**It stays a plain `Error`, deliberately.** The suggestion was to make it a `HandledError`, and I think the current shape is right: `error-handling.md` requires *both* that we know the cause **and** that the caller can act on it. The first holds; the second does not — the handler returned something its own declared schema rejects, which is our bug. So it correctly degrades to "unknown" plus a trace id at the boundary (ADR-045), and it logs at **500/error** precisely *because* it carries no `httpStatus` or `fault`, per the reasoning already written in `packages/api/src/errors.ts`. Making it handled would mean writing customer copy for a failure the customer cannot act on, and setting `fault: "platform"` by hand just to stand still.

What it actually lacked was naming the endpoint that broke its own contract. That is now in the message and in the log context, and the reasoning is a comment at the throw site so the next reader does not have to re-derive it.

## Deployment Impact

Adds `ETag` and `Cache-Control: public, max-age=60, must-revalidate` to the three OpenAPI locations, and one `route` field to request log lines. Resident memory rises by 688 KB per process (the prepared bytes, in external memory, not the V8 heap) and per-request allocation falls by 1.3 MB. No configuration, migration or chart change.

## Test plan

| Check | Result |
|---|---|
| `@langwatch/api` unit | 162 passed (156 before, +6) |
| `api-discovery` + `gateway-openapi` integration | 24 passed (19 before, +5) |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0, no diagnostic in any new file |
| `pnpm check:feature-parity` | exit 0 |
| `check:openapi-route-coverage` | OK |

New coverage worth naming: 304 on a matching tag including the `W/` and comma-list forms, 200 on a stale tag, the same tag from all three locations, byte-identical repeat responses, `route` being the pattern rather than the concrete path, `route` surviving a dated mount and a withdrawal, and the validation error naming the endpoint **while still not leaking the offending value to the caller**.

## Anything surprising?

**The 5.8 MB parsed object is still resident, and I left it.** It could go — import the JSON as raw text, parse once to build the catalogue, let the object be collected — but an ESM JSON import is held by the module registry regardless of what the module exports, so dropping it means not importing the JSON at all. That trades the guarantee in `document.ts`'s docstring (the file resolves through the module graph and cannot go missing in a deployment shipping only compiled output) for the saving. Not worth it at 5.8 MB, and it would need verifying against the bundled server build (#6557) before anyone relied on it. Said out loud here so the number is on record rather than discovered again later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI discovery responses now support strong ETags and conditional requests, returning `304 Not Modified` when content is unchanged.
  * OpenAPI documents are served consistently across all discovery endpoints with accurate content length and a 60-second revalidation policy.
  * RPC discovery responses use stable, byte-identical document output.

* **Bug Fixes**
  * Request logs and internal validation errors now identify the matched endpoint route while preserving generic error details for callers.
  * No-body endpoints now support Zod v4 `void`, `undefined`, and optional schemas correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->