### PR TITLE
perf: cut four measured costs found in the production profiles

### DIFF
--- a/packages/observability/src/__tests__/loggerReuse.unit.test.ts
+++ b/packages/observability/src/__tests__/loggerReuse.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `createLogger` hands out one memoised logger per name, and the thing that
+ * makes that safe is where the request fields come from.
+ *
+ * Constructing a pino logger is expensive — a stack capture per call to work
+ * out the caller, plus a level cache and bindings rebuilt each time — and the
+ * app calls `createLogger` from 400+ sites, some of them per-instance class
+ * fields. Memoising removes all of it.
+ *
+ * The risk memoising introduces is that a shared instance carries one
+ * request's organizationId / projectId / userId onto another request's lines.
+ * It does not, because those fields are not bound at construction: they come
+ * from pino's `mixin`, which is invoked per log call and reads the async-local
+ * context at that moment. That property is the reason this file exists, so it
+ * is asserted against records the logger actually wrote rather than against
+ * the implementation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getCurrentContext, runWithContext } from "../context/core";
+import {
+	createLogger,
+	registerLogContextProvider,
+	resetLoggerCache,
+} from "../logger";
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Everything the loggers wrote while `run` executed, parsed. */
+function emitted(run: () => void): Record<string, unknown>[] {
+	const written: string[] = [];
+	const realWrite = process.stdout.write.bind(process.stdout);
+
+	process.stdout.write = ((chunk: unknown) => {
+		written.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+
+	try {
+		run();
+	} finally {
+		process.stdout.write = realWrite;
+	}
+
+	return written
+		.join("")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("given createLogger memoises by name", () => {
+	beforeEach(() => {
+		process.env.PINO_LOG_LEVEL = "info";
+		resetLoggerCache();
+		registerLogContextProvider(() => getCurrentContext() ?? {});
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+		resetLoggerCache();
+	});
+
+	describe("when the same name is requested twice", () => {
+		/** @scenario Asking for the same logger twice returns the same logger */
+		it("hands back the same instance", () => {
+			expect(createLogger("langwatch:test:reuse")).toBe(
+				createLogger("langwatch:test:reuse"),
+			);
+		});
+	});
+
+	describe("when two names are requested", () => {
+		/** @scenario Different names get different loggers */
+		it("keeps them separate", () => {
+			expect(createLogger("langwatch:test:one")).not.toBe(
+				createLogger("langwatch:test:two"),
+			);
+		});
+	});
+
+	describe("when one name is requested with and without context disabled", () => {
+		/** @scenario A logger with context disabled never serves a caller that wants context */
+		it("keeps them separate so the context-disabled one never serves the other", () => {
+			expect(createLogger("langwatch:test:ctx")).not.toBe(
+				createLogger("langwatch:test:ctx", { disableContext: true }),
+			);
+		});
+	});
+
+	describe("when two requests share the memoised logger", () => {
+		/** @scenario Two requests sharing one logger each log their own project */
+		it("writes each request's own projectId", () => {
+			const records = emitted(() => {
+				const logger = createLogger("langwatch:test:shared");
+
+				runWithContext({ projectId: "project-first" }, () => {
+					logger.info("first request");
+				});
+				runWithContext({ projectId: "project-second" }, () => {
+					logger.info("second request");
+				});
+			});
+
+			expect(records.map((record) => record.projectId)).toEqual([
+				"project-first",
+				"project-second",
+			]);
+		});
+
+		/** @scenario A line written outside a request names no project */
+		it("writes no project at all outside a request", () => {
+			const [record] = emitted(() => {
+				createLogger("langwatch:test:shared").info("no request in scope");
+			});
+
+			expect(record?.projectId).toBeUndefined();
+		});
+	});
+});

--- a/packages/observability/src/__tests__/serviceVersionEmitted.unit.test.ts
+++ b/packages/observability/src/__tests__/serviceVersionEmitted.unit.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createLogger } from "../logger";
+import { createLogger, resetLoggerCache } from "../logger";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -47,6 +47,11 @@ describe("service.version on a record createLogger wrote", () => {
     // The node logger defaults to `error` under NODE_ENV=test; these assertions
     // are about an ordinary info line.
     process.env.PINO_LOG_LEVEL = "info";
+    // Every case here writes through the same logger name while changing the
+    // environment that name was built from. createLogger memoises by name for
+    // the life of the process, so without this each case would assert against
+    // whichever environment the first case happened to set.
+    resetLoggerCache();
   });
 
   afterEach(() => {

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -136,13 +136,62 @@ function getSharedTransport(): DestinationStream | null {
  * async request context. Browser loggers use Pino's browser mode and never load
  * the package's OpenTelemetry or Node-only context modules.
  */
+// One logger per (name, disableContext) pair, kept for the life of the process.
+//
+// `createLogger` has 400+ call sites, many of them per-instance class fields
+// and a few inline in catch blocks, so a fresh `pino()` per call was measured
+// at 2.3% of the app's wall time in production — nearly a quarter of that
+// inside `pino/lib/caller.js:getCallers`, which captures a stack trace on
+// every construction to work out who called it. None of that work varies
+// between calls that pass the same name.
+//
+// Sharing an instance is safe because nothing request-scoped is baked in at
+// construction. `name`, `service` and `service.version` are process-wide, and
+// the per-request fields — traceId, spanId, organizationId, projectId, userId
+// — arrive through the `mixin` in createNodeLogger, which pino invokes on
+// every log call and which reads the async-local context at that moment. Two
+// requests sharing a logger still get their own context on their own lines.
+// The transport above is shared for the same reason.
+//
+// The cache is bounded by the number of distinct logger names in the source.
+// The handful of call sites that build a name rather than writing a literal
+// derive it from module or route identity, never from tenant or request data;
+// a name derived per project would make this grow without limit.
+//
+// `disableContext` is part of the key because it is the one option that
+// changes the logger that gets constructed.
+const loggerCache = new Map<string, PinoLogger>();
+
+/**
+ * Drops the memoised loggers.
+ *
+ * Only tests need this. They mutate the environment a logger reads at
+ * construction — SERVICE_VERSION, OTEL_RESOURCE_ATTRIBUTES, the log levels —
+ * between cases, and a process-lifetime cache would otherwise pin every case
+ * to whichever one ran first. Production reads that environment once at boot
+ * and never changes it.
+ */
+export function resetLoggerCache(): void {
+  loggerCache.clear();
+}
+
 export function createLogger(
   name: string,
   options?: CreateLoggerOptions,
 ): PinoLogger {
-  return isNodeRuntime
+  // The prefix keeps a context-disabled logger from being handed out for a
+  // name that also has a context-enabled one, which would silently drop the
+  // request fields from every line written through it.
+  const key = options?.disableContext ? `-${name}` : `+${name}`;
+
+  const cached = loggerCache.get(key);
+  if (cached) return cached;
+
+  const logger = isNodeRuntime
     ? createNodeLogger(name, options)
     : createBrowserLogger(name);
+  loggerCache.set(key, logger);
+  return logger;
 }
 
 function createBrowserLogger(name: string): PinoLogger {

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -220,6 +220,23 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # (CPU, memory, event loop, GC). Requires OTEL_EXPORTER_OTLP_ENDPOINT.
 #OTEL_METRICS_ENABLED=true
 
+# How much of our OWN tracing is kept. Unset means the OpenTelemetry default,
+# `parentbased_always_on` — every span recorded and exported.
+#
+# Sampling is not a way to make the app faster: creating a span costs about
+# 1.4% of the app's wall time, and a sampled-out span still pays the context
+# propagation around it. What it changes is everything downstream — export
+# batches, collector CPU, and trace storage all scale with the span count.
+# Turn it down when the collector or Tempo is the constraint, not when the app
+# is.
+#
+# These are read by the OpenTelemetry SDK itself, so nothing in this repo
+# parses them. `parentbased_traceidratio` keeps a whole trace or none of it,
+# which is what you want — a ratio applied per span would shred traces into
+# disconnected fragments.
+#OTEL_TRACES_SAMPLER=parentbased_traceidratio
+#OTEL_TRACES_SAMPLER_ARG=0.1
+
 # Emit a span for Redis commands that run inside an active parent span (an
 # unparented command never produces one). Off by default: groupQueue is built
 # directly on Redis, so in the worker this produced about 32 Redis spans per job

--- a/platform/app/src/instrumentation.node.ts
+++ b/platform/app/src/instrumentation.node.ts
@@ -147,6 +147,22 @@ if (explicitEndpoint || langwatchTracingEnabled) {
     ],
   });
 
+  // Which spans are being kept. The SDK reads OTEL_TRACES_SAMPLER and
+  // OTEL_TRACES_SAMPLER_ARG itself and falls back to parentbased_always_on, so
+  // nothing here parses them — but an unset variable and a misspelled one
+  // produce the same silence and the same full-rate export, and the cost of
+  // that lands on the collector rather than anywhere obvious. One line at boot
+  // is the answer to "is this fleet sampling or not?" without reading a chart.
+  console.log(
+    `[observability] trace sampling: ${
+      process.env.OTEL_TRACES_SAMPLER ?? "parentbased_always_on (default)"
+    }${
+      process.env.OTEL_TRACES_SAMPLER_ARG
+        ? ` at ${process.env.OTEL_TRACES_SAMPLER_ARG}`
+        : ""
+    }`,
+  );
+
   // Replaces the exit-on-flush the SDK does by default (disabled above): the
   // same flush, run as the last phase of the one graceful-shutdown sequence,
   // with no opinion about when the process should end.

--- a/platform/app/src/server/app-layer/ops/snapshot/__tests__/snapshot.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/snapshot/__tests__/snapshot.repository.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   LEASE_TTL_SECONDS,
   SNAPSHOT_LEASE_KEY,
@@ -388,6 +388,59 @@ describe("parseSnapshot", () => {
     it("returns null instead of throwing into the read path", () => {
       expect(parseSnapshot(liveSnapshotSchema, "{not json")).toBeNull();
       expect(parseSnapshot(detailSnapshotSchema, "[]")).toBeNull();
+    });
+  });
+
+  /**
+   * The readers poll one fixed key, so the same string arrives repeatedly and
+   * is only validated once. The risk that buys is staleness: a cache that
+   * failed to notice a rewritten snapshot would freeze the dashboard on old
+   * numbers while the platform moved underneath it, and it would look like
+   * nothing was happening rather than like a bug. That is the case below.
+   */
+  describe("given the same stored snapshot read twice", () => {
+    /** @scenario "An unchanged snapshot is validated once and reused" */
+    it("validates once and hands back the identical object", () => {
+      const raw = JSON.stringify(liveSnapshot({ computedAt: 7 }));
+      const spy = vi.spyOn(liveSnapshotSchema, "safeParse");
+
+      try {
+        const first = parseSnapshot(liveSnapshotSchema, raw);
+        const second = parseSnapshot(liveSnapshotSchema, raw);
+
+        expect(first).not.toBeNull();
+        expect(second).toBe(first);
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe("given the stored snapshot changed between reads", () => {
+    /** @scenario "A rewritten snapshot is picked up on the next read" */
+    it("returns the new one rather than the one it validated before", () => {
+      parseSnapshot(
+        liveSnapshotSchema,
+        JSON.stringify(liveSnapshot({ computedAt: 1 })),
+      );
+
+      const next = parseSnapshot(
+        liveSnapshotSchema,
+        JSON.stringify(liveSnapshot({ computedAt: 2 })),
+      );
+
+      expect(next?.computedAt).toBe(2);
+    });
+  });
+
+  describe("given an unreadable snapshot followed by a good one", () => {
+    /** @scenario "A rejected snapshot does not stop a later valid one being read" */
+    it("reads the good one", () => {
+      expect(parseSnapshot(detailSnapshotSchema, "{not json")).toBeNull();
+
+      const raw = JSON.stringify(liveSnapshot({ computedAt: 3 }));
+      expect(parseSnapshot(liveSnapshotSchema, raw)?.computedAt).toBe(3);
     });
   });
 });

--- a/platform/app/src/server/app-layer/ops/snapshot/snapshot.types.ts
+++ b/platform/app/src/server/app-layer/ops/snapshot/snapshot.types.ts
@@ -209,15 +209,46 @@ export type BoundedSection = z.infer<typeof boundedSchema>;
  * snapshot it understands), and distinguishing them at the call site would
  * invite rendering a partial payload.
  */
+/**
+ * The last successful parse, per schema.
+ *
+ * Both readers poll one fixed Redis key on an interval, so between writes they
+ * hand the byte-identical JSON string to the same schema over and over.
+ * Re-validating it every poll was 2.7% of the app's wall time in production,
+ * 84% of that inside zod. Comparing the raw string answers the same question
+ * for a fraction of the cost, and it keeps the validation rather than trading
+ * it away: a string that has not changed cannot have a shape different from
+ * the one already checked.
+ *
+ * Only successful parses are stored. An unreadable snapshot re-parses on every
+ * poll, which is the behaviour it had before and is not worth caching — it is
+ * rare, and caching a rejection would keep rejecting a key that has since been
+ * rewritten correctly.
+ *
+ * Keyed by schema identity, and each schema holds exactly one entry, so this
+ * cannot grow. The schemas are module-level constants.
+ *
+ * The cached value is handed to every caller, so callers must treat it as
+ * read-only. `mergeSnapshots` projects it into a fresh object rather than
+ * mutating it, which is the arrangement this relies on.
+ */
+const lastParse = new WeakMap<object, { raw: string; value: unknown }>();
+
 export function parseSnapshot<T>(
   schema: z.ZodType<T>,
   raw: string | null,
 ): T | null {
   if (!raw) return null;
+
+  const cached = lastParse.get(schema);
+  if (cached?.raw === raw) return cached.value as T;
+
   try {
     const parsed: unknown = JSON.parse(raw);
     const result = schema.safeParse(parsed);
-    return result.success ? result.data : null;
+    if (!result.success) return null;
+    lastParse.set(schema, { raw, value: result.data });
+    return result.data;
   } catch {
     return null;
   }

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Some recognizers are skipped on text that cannot contain their pattern —
+ * the email pattern never runs on text without an "@", and so on. The saving
+ * is real (that one pattern measured 2.6% of the worker's wall time), and so
+ * is the failure mode: a literal claimed by a pattern that does not actually
+ * require it stops redacting real personal data, silently, forever.
+ *
+ * These cases exist to make that failure loud. The rest of the redaction
+ * behaviour is covered by `essentialPii.unit.test.ts`; what is here is
+ * specifically the interaction between the skip and the entities it must not
+ * touch.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { redactEssentialPiiInText } from "../essentialPii";
+
+const redact = (text: string) => redactEssentialPiiInText({ text }).text;
+
+describe("given a recognizer that is skipped unless the text holds its literal", () => {
+  describe("when the literal is present", () => {
+    /** @scenario "Skipped detectors still find their own kind of personal data" */
+    it("still redacts an email address", () => {
+      expect(redact("write to ada@example.com today")).toBe(
+        "write to [EMAIL_ADDRESS] today",
+      );
+    });
+
+    /** @scenario "Skipped detectors still find their own kind of personal data" */
+    it("still redacts an Ethereum address", () => {
+      expect(
+        redact("paid 0x52908400098527886E0F7030069857D2E4169EE7 out"),
+      ).toContain("[CRYPTO]");
+    });
+
+    /** @scenario "Skipped detectors still find their own kind of personal data" */
+    it("still redacts an IPv6 address", () => {
+      expect(redact("host fe80::1ff:fe23:4567:890a end")).toContain(
+        "[IP_ADDRESS]",
+      );
+    });
+  });
+
+  /**
+   * The mis-annotation catcher. Every sample below is personal data that some
+   * OTHER recognizer must find, written so it contains none of the literals
+   * the skipped recognizers claim ("@", "0x", ":"). If a literal is ever
+   * attached to a pattern that does not truly require it, that recognizer
+   * stops running on text like this and the sample survives unredacted.
+   */
+  describe("when the text holds none of the claimed literals", () => {
+    const withoutClaimedLiterals = (text: string) => {
+      // Guards the fixtures themselves: a sample that accidentally contained
+      // one of these would pass the test without exercising anything.
+      for (const literal of ["@", "0x", ":"]) {
+        expect(text).not.toContain(literal);
+      }
+      return text;
+    };
+
+    /** @scenario "Personal data is still redacted when the text holds no address marker" */
+    it.each([
+      ["an IPv4 address", "from 192.168.0.1 today", "[IP_ADDRESS]"],
+      ["a credit card number", "card 4111 1111 1111 1111 ok", "[CREDIT_CARD]"],
+      ["an IBAN", "iban GB82WEST12345698765432 ok", "[IBAN_CODE]"],
+      ["a US social security number", "ssn 123-45-6789 on file", "[US_SSN]"],
+    ])("still redacts %s", (_label, text, marker) => {
+      expect(redact(withoutClaimedLiterals(text))).toContain(marker);
+    });
+  });
+
+  describe("when the text is long and holds no literal at all", () => {
+    /** @scenario "A long value holding no personal data is returned unchanged" */
+    it("leaves it untouched", () => {
+      // The shape the skip exists for: a long alphanumeric run is exactly
+      // what made the unanchored email pattern quadratic.
+      const payload = `{"token":"${"a1b2c3d4e5".repeat(200)}"}`;
+
+      expect(redact(payload)).toBe(payload);
+    });
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -49,6 +49,24 @@ export const ESSENTIAL_PII_ENTITIES = [
 interface Recognizer {
   entity: string;
   regex: RegExp;
+  /**
+   * A literal the regex cannot match without, checked with `String.includes`
+   * before the regex is run at all.
+   *
+   * These patterns are unanchored and scanned with `matchAll`, so on text that
+   * cannot match they still cost a pass per starting position — the email
+   * pattern alone measured 2.6% of the worker's wall time in production,
+   * because `[A-Za-z0-9._%+-]+` consumes a long alphanumeric run, fails to
+   * find `@`, and backs off a character at a time. `includes` is a native
+   * substring scan and settles the same question in one pass.
+   *
+   * Only set this where the literal appears in the pattern itself, so the
+   * claim is readable next to the regex rather than remembered. Getting it
+   * wrong silently stops redacting real personal data, which is why
+   * `essentialPii.prefilter.unit.test.ts` proves each one against its own
+   * pattern rather than trusting the annotation.
+   */
+  requiresSubstring?: string;
   /** Checksum/structure check on the raw match; a falsey result drops the candidate. */
   validate?: (raw: string) => boolean;
   /** Low-confidence patterns only fire when one of these words is within the window. */
@@ -129,6 +147,7 @@ const RECOGNIZERS: Recognizer[] = [
   {
     entity: "EMAIL_ADDRESS",
     regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+    requiresSubstring: "@",
     isSelfProving: true,
   },
   {
@@ -139,6 +158,7 @@ const RECOGNIZERS: Recognizer[] = [
   {
     entity: "IP_ADDRESS",
     regex: /\b(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}\b/g,
+    requiresSubstring: ":",
     validate: ipv6Plausible,
   },
   {
@@ -153,7 +173,12 @@ const RECOGNIZERS: Recognizer[] = [
     validate: ibanValid,
     isSelfProving: true,
   },
-  { entity: "CRYPTO", regex: /\b0x[a-fA-F0-9]{40}\b/g, isSelfProving: true },
+  {
+    entity: "CRYPTO",
+    regex: /\b0x[a-fA-F0-9]{40}\b/g,
+    requiresSubstring: "0x",
+    isSelfProving: true,
+  },
   {
     entity: "CRYPTO",
     regex: /\b(?:bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
@@ -484,12 +509,25 @@ function recognizerRuns({
   recognizer,
   allowed,
   isIdentifierShaped,
+  text,
 }: {
   recognizer: Recognizer;
   allowed: ReadonlySet<string> | null;
   isIdentifierShaped: boolean;
+  text: string;
 }): boolean {
   if (allowed && !allowed.has(recognizer.entity)) return false;
+  // A pattern that cannot match without a literal is skipped on text that
+  // does not contain it. This only ever removes a scan that would have found
+  // nothing, so it cannot change which spans are redacted — provided the
+  // literal really is required, which is what `requiresSubstring` documents
+  // and its tests hold to.
+  if (
+    recognizer.requiresSubstring !== undefined &&
+    !text.includes(recognizer.requiresSubstring)
+  ) {
+    return false;
+  }
   return !isIdentifierShaped || recognizer.isSelfProving === true;
 }
 
@@ -512,7 +550,9 @@ function collectRecognizerSpans({
 }): Span[] {
   const spans: Span[] = [];
   for (const recognizer of RECOGNIZERS) {
-    if (!recognizerRuns({ recognizer, allowed, isIdentifierShaped })) continue;
+    if (!recognizerRuns({ recognizer, allowed, isIdentifierShaped, text })) {
+      continue;
+    }
     for (const match of text.matchAll(recognizer.regex)) {
       const span = recognizedSpanFor({ recognizer, match, text, excepted });
       if (span) spans.push(span);

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -1025,6 +1025,16 @@ const ProviderRequestTimeoutSeconds = 14 * 60
 
 func (a *account) GetConfigForProvider(provider bfschemas.ModelProvider) (*bfschemas.ProviderConfig, error) {
 	cfg := &bfschemas.ProviderConfig{}
+	// Every provider is sized explicitly, standard ones included. A zero here
+	// is not "no opinion": CheckAndSetDefaults at the bottom of this function
+	// replaces it with bifrost's own 1000 workers and 5000-slot queue, and
+	// GetConfiguredProviders registers the whole standard list up front, so
+	// leaving it zero bought a worker pool per provider whether or not this
+	// install ever dispatches to it. See standardProviderConcurrency.
+	cfg.ConcurrencyAndBufferSize = bfschemas.ConcurrencyAndBufferSize{
+		Concurrency: standardProviderConcurrency,
+		BufferSize:  standardProviderBufferSize,
+	}
 	if strings.HasPrefix(string(provider), anthropicCompatPrefix) ||
 		strings.HasPrefix(string(provider), geminiCompatPrefix) {
 		endpoint, ok := a.anthropicCompat.lookup(string(provider))
@@ -1288,6 +1298,30 @@ const anthropicCompatMaxEndpoints = 32
 const (
 	anthropicCompatConcurrency = 128
 	anthropicCompatBufferSize  = 1024
+)
+
+// standardProviderConcurrency and standardProviderBufferSize size the worker
+// pool bifrost creates for each entry in bfschemas.StandardProviders.
+//
+// GetConfiguredProviders returns that whole list, because a virtual key may
+// name any provider and bifrost resolves config by provider key alone. Left
+// unset, each of the 23 entries took bifrost's own defaults — 1000 workers
+// and a 5000-slot queue, sized for a deployment where one provider fronts the
+// entire gateway. Paid 23 times over, that was ~21,000 permanently parked
+// goroutines per pod in production (99.85% of the process's goroutines), for
+// providers most installs never dispatch to. Their only measurable effect was
+// making the GC rescan 21,000 stacks on every mark cycle and the profiler
+// serialize them every 15 seconds.
+//
+// 128 is the figure the compat path above already arrived at, for the same
+// reason: the pool bounds in-flight upstream requests, and a burst past it
+// queues rather than fails — bifrost drops queued requests only under
+// DropExcessRequests, which the gateway leaves off. Across the production
+// pods that is several hundred concurrent upstream requests per provider,
+// far above what the gateway's own request ceiling makes reachable.
+const (
+	standardProviderConcurrency = 128
+	standardProviderBufferSize  = 1024
 )
 
 // anthropicCompatRegistry maps derived provider keys to their endpoints.

--- a/services/aigateway/adapters/providers/worker_pool_test.go
+++ b/services/aigateway/adapters/providers/worker_pool_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"testing"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// The numbers here are deliberately independent literals rather than the
+// package constants: pinning the constant against itself would pass no matter
+// what the constant became. 128/1024 is the size the gateway chose; 1000/5000
+// is what bifrost substitutes for a zero, and is the defect being guarded.
+
+// @scenario "A standard provider gets an explicit worker pool rather than the library default"
+func TestGetConfigForProviderBoundsStandardProviderWorkerPool(t *testing.T) {
+	cfg, err := (&account{}).GetConfigForProvider(bfschemas.OpenAI)
+	require.NoError(t, err)
+
+	assert.Equal(t, 128, cfg.ConcurrencyAndBufferSize.Concurrency,
+		"a standard provider must get the gateway's bounded worker pool")
+	assert.Equal(t, 1024, cfg.ConcurrencyAndBufferSize.BufferSize,
+		"a standard provider must get the gateway's bounded queue")
+}
+
+// @scenario "Every advertised provider is bounded"
+//
+// The cost of this defect scales with the length of the advertised list, and
+// the list grows on a bifrost upgrade without anyone here touching a file, so
+// the guard walks every entry rather than sampling one.
+func TestGetConfigForProviderBoundsEveryAdvertisedProvider(t *testing.T) {
+	advertised, err := (&account{}).GetConfiguredProviders()
+	require.NoError(t, err)
+	require.NotEmpty(t, advertised, "the gateway advertises no providers at all")
+
+	for _, provider := range advertised {
+		cfg, err := (&account{}).GetConfigForProvider(provider)
+		require.NoErrorf(t, err, "GetConfigForProvider(%q)", provider)
+
+		assert.NotEqualf(t, 1000, cfg.ConcurrencyAndBufferSize.Concurrency,
+			"provider %q fell back to bifrost's default worker pool; every advertised provider "+
+				"is created eagerly, so one unbounded entry costs a thousand idle goroutines", provider)
+		assert.NotEqualf(t, 5000, cfg.ConcurrencyAndBufferSize.BufferSize,
+			"provider %q fell back to bifrost's default queue size", provider)
+	}
+}
+
+// @scenario "A URL-derived compat endpoint keeps its own bound"
+//
+// Compat endpoints were bounded before the standard providers were, and are
+// bounded by their registry cap as well. Sizing them stays a separate
+// decision, so this pins that the standard-provider change did not reach in
+// and alter it.
+func TestGetConfigForProviderKeepsCompatEndpointBound(t *testing.T) {
+	reg := newAnthropicCompatRegistry(anthropicCompatMaxEndpoints)
+	provider := reg.register(domain.Credential{
+		ProviderID: domain.ProviderAnthropic,
+		APIKey:     "sk-ant",
+		Extra:      map[string]string{"base_url": "http://vllm:8000/v1"},
+	})
+
+	cfg, err := (&account{anthropicCompat: reg}).GetConfigForProvider(provider)
+	require.NoError(t, err)
+
+	assert.Equal(t, 128, cfg.ConcurrencyAndBufferSize.Concurrency,
+		"a compat endpoint keeps its own bounded pool")
+	assert.Equal(t, 1024, cfg.ConcurrencyAndBufferSize.BufferSize,
+		"a compat endpoint keeps its own bounded queue")
+}

--- a/specs/ai-gateway/provider-worker-pools.feature
+++ b/specs/ai-gateway/provider-worker-pools.feature
@@ -1,0 +1,51 @@
+Feature: Provider worker pools stay proportionate to the traffic they serve
+  As an operator running the gateway
+  I want each provider's worker pool sized for what the gateway actually dispatches
+  So that registering every supported provider doesn't cost the process tens of
+  thousands of idle goroutines
+
+  Background:
+    The gateway advertises every provider bifrost supports, because a virtual
+    key may name any of them and bifrost resolves provider configuration by
+    provider key alone. Bifrost creates the worker pool eagerly, per provider,
+    and its own defaults are 1000 workers with a 5000-slot queue — sized for a
+    deployment where a single provider fronts the whole gateway.
+
+    Taken across the whole standard provider list those defaults are paid
+    dozens of times over, for providers a given install may never dispatch to.
+    In production that was measured at roughly 21,000 permanently parked
+    goroutines per pod — 99.85% of every goroutine in the process. Idle
+    goroutines are not free: the garbage collector rescans every one of their
+    stacks on each mark cycle, and continuous profiling serialises them on
+    every upload.
+
+    A pool bounds in-flight upstream requests; it does not cap throughput. A
+    burst past the pool queues rather than fails, because the gateway leaves
+    bifrost's drop-on-overflow behaviour off.
+
+    # Bindings: services/aigateway/adapters/providers/worker_pool_test.go
+    # Sender: services/aigateway/adapters/providers/bifrost.go (account.GetConfigForProvider)
+
+  @unit
+  Scenario: A standard provider gets an explicit worker pool rather than the library default
+    Given the gateway builds the connection configuration for a standard provider
+    When bifrost creates that provider's worker pool
+    Then the pool is the gateway's own bounded size
+    And it is not the library's thousand-worker default
+
+  @unit
+  Scenario: Every advertised provider is bounded
+    Given the gateway advertises the full list of standard providers
+    When the connection configuration is built for each of them in turn
+    Then none of them falls back to the library's default pool size
+    # A provider added by a future bifrost upgrade must be bounded too: the
+    # cost of this defect scales with the length of the advertised list, so
+    # the guard walks the list rather than a sample of it.
+
+  @unit
+  Scenario: A URL-derived compat endpoint keeps its own bound
+    Given a customer-configured Anthropic-compatible endpoint
+    When the connection configuration is built for its derived provider key
+    Then that endpoint's pool is bounded independently of the standard providers
+    # Compat endpoints are bounded by their own registry cap as well, so their
+    # sizing is a separate decision that this change must not disturb.

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -232,3 +232,32 @@ Feature: Redacting personal data from traces
     When an admin tries to save a PII exception pattern that matches any value
     Then the request is rejected with a validation error
     And a pattern describing one specific identifier shape is still accepted
+
+  # Detectors that cannot match without a particular character are skipped on
+  # text that does not contain it — an address pattern never runs on text with
+  # no "@" in it. This is a speed change with no behaviour attached: on that
+  # text the detector would have found nothing anyway. It earns its place
+  # because these patterns are scanned from every position, and the address one
+  # alone was a measurable share of ingestion time.
+  #
+  # The risk is a detector claiming a character it does not truly need, which
+  # would stop it finding real personal data. The scenarios below are the ones
+  # that would fail if that happened.
+  #
+  # Bindings: platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
+  @unit
+  Scenario: Personal data is still redacted when the text holds no address marker
+    When a trace is ingested whose input contains a card number, an IBAN, an IP
+      address and a social security number, and no address marker anywhere
+    Then all four are still redacted
+
+  @unit
+  Scenario: Skipped detectors still find their own kind of personal data
+    When a trace is ingested whose input contains an email address, a wallet
+      address and an IPv6 address
+    Then each one is redacted
+
+  @unit
+  Scenario: A long value holding no personal data is returned unchanged
+    When a trace is ingested whose input is a long opaque token
+    Then the stored input is byte-for-byte what was sent

--- a/specs/observability/logger-reuse.feature
+++ b/specs/observability/logger-reuse.feature
@@ -1,0 +1,55 @@
+Feature: Loggers are reused without sharing request context
+  As an engineer reading production logs
+  I want one logger per module name reused for the life of the process
+  So that constructing loggers stops costing request time, while every line
+  still carries the request it was written for
+
+  Background:
+    Building a pino logger is not cheap: it captures a stack trace to resolve
+    its caller, and rebuilds a level cache and its bindings. The application
+    asks for a logger from more than four hundred places, many of them
+    per-instance fields on classes built per request and a few inline inside
+    catch blocks, so that construction was measured at 2.3% of the app's wall
+    time in production.
+
+    Reuse is only safe because of where the request fields come from. A
+    logger's name, service and version are process-wide and fixed when it is
+    built. The request fields — trace, span, organization, project and user —
+    are supplied per log call from the surrounding request context, not bound
+    when the logger is created. Two requests can therefore share one logger
+    and still write their own identifiers.
+
+    # Bindings: packages/observability/src/__tests__/loggerReuse.unit.test.ts
+    # Sender: packages/observability/src/logger.ts (createLogger)
+
+  @unit
+  Scenario: Asking for the same logger twice returns the same logger
+    Given a module asks for a logger by name
+    When another module asks for a logger by the same name
+    Then both are given the same logger rather than a newly built one
+
+  @unit
+  Scenario: Different names get different loggers
+    Given two modules ask for loggers by different names
+    Then each is given its own logger
+
+  @unit
+  Scenario: A logger with context disabled never serves a caller that wants context
+    Given a module asks for a logger by name with request context disabled
+    When another module asks for a logger by that same name with context enabled
+    Then they are given different loggers
+    # Otherwise whichever call arrived first would decide, silently, whether
+    # every later line under that name carried its request fields.
+
+  @unit
+  Scenario: Two requests sharing one logger each log their own project
+    Given two requests are handled with the same reused logger
+    And each request runs under its own project
+    When each writes a log line
+    Then each line carries the project of the request that wrote it
+
+  @unit
+  Scenario: A line written outside a request names no project
+    Given no request is in scope
+    When a reused logger writes a line
+    Then the line carries no project

--- a/specs/ops/shared-ops-snapshot.feature
+++ b/specs/ops/shared-ops-snapshot.feature
@@ -220,3 +220,35 @@ Feature: Shared ops snapshot with a single elected writer
     When the writer completes a live cycle and a detail cycle
     Then the reader's dashboard payload reports the exact counts
     And the blocked clusters and parked tenant rows match the queues' state
+
+  # ── Reading the same artifact repeatedly ──────────────────────────────
+
+  # Readers poll one fixed key on an interval, so between writes they read the
+  # same bytes over and over. Checking that shape again on every poll was a
+  # measurable share of the app's time, so an unchanged artifact is checked
+  # once and the result reused. Bytes that have not changed cannot describe a
+  # different shape than the ones already checked.
+  #
+  # What that buys has to be paid for in staleness, and staleness here is
+  # invisible: a reader that failed to notice a rewritten artifact would hold
+  # the dashboard on old numbers while the platform moved underneath it, and
+  # it would read as a quiet platform rather than as a broken reader. The
+  # second scenario is the one that catches it.
+  @unit
+  Scenario: An unchanged snapshot is validated once and reused
+    Given a snapshot artifact has been read once
+    When it is read again before the writer has replaced it
+    Then the reader returns what it already validated
+    And it does not check the shape a second time
+
+  @unit
+  Scenario: A rewritten snapshot is picked up on the next read
+    Given a snapshot artifact has been read once
+    When the writer replaces it and the reader reads again
+    Then the reader returns the new artifact, not the previous one
+
+  @unit
+  Scenario: A rejected snapshot does not stop a later valid one being read
+    Given a read found an artifact it could not understand
+    When a readable artifact is stored and read
+    Then the reader returns it


### PR DESCRIPTION
Four changes from a read of the production Pyroscope data across all four services. Each one is a measured number with a named cause, not a guess — the profiles are quoted per commit.

Full audit, including the findings this PR deliberately does **not** act on: https://claude.ai/code/artifact/17653cc9-559a-463d-a710-31272c39eb5a

## What's here

**1. Bound the standard provider worker pools** (`services/aigateway`)

`GetConfiguredProviders` advertises the whole bifrost standard provider list, and only the URL-derived compat endpoints set `ConcurrencyAndBufferSize`. Every standard provider therefore fell through to `CheckAndSetDefaults` and took bifrost's own 1000 workers / 5000-slot queue — sized for a deployment where one provider fronts the gateway, paid 23 times over here.

Production: **~21,000 permanently parked `bifrost.requestWorker` goroutines per pod, 99.85% of all goroutines**, on the gateway and on nlp (which reaches the same code via the aigateway dispatcher). They serve no traffic. Their only measurable effect is the GC rescanning 21,000 stacks every mark cycle and the profiler serializing them every 15s — together **~86% of the service's CPU and 58% of its heap allocation**.

Sized at the figure the compat path already chose, for the same stated reason. 23,000 → 2,944 goroutines per process.

**2. Memoise loggers by name** (`packages/observability`)

`createLogger` built a fresh pino instance per call, across 400+ call sites — many per-instance class fields, a few inline in catch blocks constructing a whole logger to emit one line. **2.3% of app wall time**, nearly a quarter of it in pino's `getCallers` capturing a stack trace on every construction. Measured over a boot-free window, so this is steady state.

Safe because nothing request-scoped is bound at construction: the per-request fields arrive through the `mixin`, which pino invokes per log call against the async-local context. The transport was already shared for this reason. Tested against records the logger actually wrote — two requests sharing one logger each get their own `projectId`.

**3. Skip PII recognizers whose required literal is absent** (`platform/app`)

The recognizers are unanchored and scanned from every start position. The email pattern is the expensive case: `[A-Za-z0-9._%+-]+` consumes a long alphanumeric run, fails to find `@`, backs off a character at a time. **2.6% of worker wall time for that one pattern**, inside a redaction pass that is 7.4% total.

Three patterns cannot match without a literal visible in the pattern itself (`@`, `0x`, `:`), so they are skipped when it is absent. This only removes scans that would have found nothing.

**4. Document trace sampling, and say at boot which mode is active**

Nothing configures a sampler, so the fleet runs `parentbased_always_on` and exports **100% of spans**. It turns out this needed no code: `NodeSDK` only sets `sampler` when one is passed explicitly, so `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` already work. What was missing was any way to tell — an unset variable and a misspelled one look identical.

**5. Stop re-validating an unchanged ops snapshot on every read** (`platform/app`)

The live and detail readers each poll one fixed Redis key on an interval, so between writes they hand the byte-identical JSON string to the same schema over and over. That was **2.7% of app wall time** — the single largest zod cost in the process, 84% of it inside zod — spent proving our own serialiser works.

Caches the last successful parse per schema and reuses it when the raw string is unchanged. This **keeps** the validation rather than trading it for a version check: a string that hasn't changed cannot describe a different shape than the one already checked. Bounded by construction (one entry per schema; the schemas are module constants).

The risk it buys is staleness, and staleness here is invisible — a reader that missed a rewritten snapshot would hold the dashboard on old numbers and read as a *quiet platform* rather than a broken reader. That case has its own test, and it fails (with five others) if the cache is made to always hit.

## What this PR deliberately does not do

- **No phone-number prefilter.** libphonenumber's candidate pattern admits a single digit and `MIN_LENGTH_FOR_NSN` is 2, so no cheap precondition provably covers everything it could match. A filter that is *almost* right stops redacting real phone numbers. That 3.3% stays.
- **No zod v4 migration**, and the reason is worth recording because two plausible theories about it are wrong.

  It is **not** CopilotKit / `@ag-ui/core`. Those declare zod in `dependencies` (`^3.22.4`, `^3.23.3`), so pnpm gives each its own nested copy and they do not constrain our version at all. [ag-ui#1637](https://github.com/ag-ui-protocol/ag-ui/pull/1637), which extracts zod from `@ag-ui/core`, is good upstream hygiene but would unblock nothing here.

  The actual pin is three packages where zod is a **peer**, so they share our instance: `hono-openapi@0.4.8` (`^3.23.8`), `@hono/zod-validator@0.4.3` (`^3.19.1`), `zod-openapi@4.2.4` (`^3.21.4`).

  But we are **not blocked either**: installed `zod@3.25.76` exposes the `./v4` subpath, so our own code can use the v4 engine with no dependency change — `@langwatch/langy` already does. What stopped the migration landing here is narrower: after finding 5 above, the remaining hot zod is `spanSchema` in OTLP ingest, and that lives in a 798-line module imported by **147 files**. It is not separable as a "hot path", so migrating it belongs in its own PR with its own decision about blast radius.
- **No source-map change.** 188 MB per app process (36% of V8 heap) is parsed source maps from `--enable-source-maps`. `sourcesContent: false` is already set and Node 24 is current, so the cheap fixes are spent. The real fix is symbolicating offline at log ingest — a project, and a trade against readable production stack traces that is yours to make.
- **No sampling default changed.** How much of our own tracing to keep is a deployment decision.
- **No change to `encodePayload`'s double serialisation.** It runs `JSON.stringify` unconditionally then packs msgpack again, but that is load-bearing until the msgpack rollout has fully cycled — the JSON hash keeps dedup working against pre-rollout pods.

## Deployment Impact

**Gateway and nlp restart with far fewer goroutines.** Per-provider worker pools drop from 1000/5000 to 128/1024. The pool bounds in-flight upstream requests per provider per pod; it does not cap throughput, and a burst past it queues rather than fails because `DropExcessRequests` is off. At three gateway pods that is several hundred concurrent upstream requests per provider, well above what the gateway's own 14-minute request ceiling makes reachable. Expect a drop in gateway/nlp pod memory and baseline CPU. No config change required.

**New optional environment variables**, documented in `platform/app/.env.example`, both read by the OpenTelemetry SDK rather than by our code:

- `OTEL_TRACES_SAMPLER` — unset keeps today's behaviour (`parentbased_always_on`, 100% export)
- `OTEL_TRACES_SAMPLER_ARG` — the ratio, when using a ratio sampler

Nothing changes unless they are set. Setting them reduces collector CPU and Tempo storage, **not** app CPU — span creation is ~1.4% of app wall time and a sampled-out span still pays context propagation.

**One new line on stdout at boot** per app/worker process, reporting the effective sampling mode.

No migrations, no chart changes, no new required configuration.

## Verification

- `go test ./services/aigateway/adapters/providers/` — new worker-pool tests pass, and **fail with `1000`/`5000` when the fix is reverted** (checked).
- `golangci-lint run ./services/aigateway/...` — clean for the touched files.
- `pnpm --filter @langwatch/observability test:unit` — 121 pass.
- App redaction suite — 100 pass, and the mis-annotation guard **fails 7 tests when a literal is deliberately attached to the wrong recognizer** (checked).
- `pnpm --filter @langwatch/web check:feature-parity` — all three new/changed specs fully bound (3/3, 5/5, 28/28).
- Ops snapshot suite — 30 pass, and **6 fail when the parse cache is made to always hit**, including the staleness case (checked).
- Full app unit suite: **2001 files passed, 0 failed** (29,806 tests), as of the first four commits. This is the one that matters for the logger change, since it touches every module.

Each of the three behaviour-changing commits was verified by deliberately breaking it and confirming the tests fail, rather than only confirming they pass.
