### PR TITLE
docs(logging): identifiers are logged raw, and the linters now agree

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -93,10 +93,19 @@ reviews:
 
         FAIL when logging, analytics, or telemetry calls (console.*,
         logger.*, posthog.*, Sentry.*, captureException, track, identify)
-        include user-identifying fields — email, phone, name, IP, userId,
-        projectSlug, organizationId, apiKey, token — without an explicit
-        redaction wrapper (`redact(...)`, `hashEmail(...)`, masking) or a
-        comment marking it as intentional.
+        include personal data — email, phone, name, IP, postal address,
+        projectSlug — or credentials — apiKey, token, password, session
+        cookie — without an explicit redaction wrapper (`redact(...)`,
+        `hashEmail(...)`, masking) or a comment marking it as intentional.
+
+        Do NOT flag `userId`, `organizationId`, `projectId`, `traceId` or
+        `spanId`. Those are opaque internal identifiers and are logged raw
+        deliberately: they are what makes a log line attributable and what
+        lets an incident be filtered down to one tenant. Redacting them
+        costs that and protects nothing, because the identifier was never
+        the sensitive part. Asking for them to be hashed, truncated or
+        redacted is a false positive — see the "Identifiers Are Logged Raw,
+        On Purpose" section of dev/docs/best_practices/logging-and-tracing.md.
 
         FAIL when a new HTTP endpoint or tRPC procedure returns PII without
         both: (a) an explicit auth check (`ctx.session.user` consulted) and

--- a/.github/workflows/coderabbit-config-check.yml
+++ b/.github/workflows/coderabbit-config-check.yml
@@ -55,5 +55,10 @@ jobs:
         run: |
           python3 -c "import yaml; d=yaml.safe_load(open('dev/lint/semgrep/langwatch.yml')); r=next(x for x in d['rules'] if x['id']=='pii-in-logger-call'); r.pop('paths', None); yaml.safe_dump({'rules':[r]}, open('/tmp/pii_only.yml','w'))"
           n=$(semgrep --config /tmp/pii_only.yml dev/lint/semgrep/tests/pii-in-logger-call.ts --json --quiet | python3 -c "import sys, json; print(len(json.load(sys.stdin)['results']))")
-          echo "pii-in-logger-call matched $n line(s) in the fixture (expect 5)"
-          test "$n" -eq 5
+          echo "pii-in-logger-call matched $n line(s) in the fixture (expect 4)"
+          # 4, not 5: the userId case was removed when identifiers were made
+          # explicitly loggable. The fixture still contains userId,
+          # organizationId and projectId lines as `ok:` cases, so re-adding an
+          # identifier pattern to the rule pushes this count back above 4 and
+          # fails here rather than quietly reinstating the false positive.
+          test "$n" -eq 4

--- a/dev/docs/best_practices/logging-and-tracing.md
+++ b/dev/docs/best_practices/logging-and-tracing.md
@@ -88,13 +88,43 @@ updateCurrentContext({
 });
 ```
 
+## Identifiers Are Logged Raw, On Purpose
+
+`userId`, `organizationId` and `projectId` — along with `traceId` and `spanId` —
+go into log lines unredacted. This is a deliberate decision, not an oversight,
+and it is not up for renegotiation one pull request at a time.
+
+They are opaque internal identifiers. They are not names, not email addresses,
+and not anything a person outside our systems can resolve to a human. What they
+*are* is the only thing that makes a log line attributable: they are how you
+filter Loki down to one tenant during an incident, how you answer "did this
+customer's request actually reach us", and how a support question becomes a
+query instead of a guess. A redacted identifier costs all of that and protects
+nothing, because the identifier was never the sensitive part.
+
+So: a review comment asking for these to be hashed, truncated or redacted
+should be declined with a link to this section. Automated reviewers flag them
+periodically because "id near a logger" pattern-matches to PII; it isn't, here.
+
+What genuinely must never be logged is unchanged, and none of it is an
+identifier:
+
+- Credentials of any kind — passwords, API keys, tokens, session cookies,
+  signing secrets.
+- Customer content — prompt and completion bodies, dataset rows, span
+  input/output, anything a customer typed or a model produced.
+- Personal data proper — email addresses, names, phone numbers, postal
+  addresses. These are what the PII redaction pass exists for; see
+  `platform/app/src/server/data-privacy/`.
+
 ## Anti-Patterns
 
 | Don't | Do |
 |-------|-----|
 | `logger.info("User " + userId + " logged in")` | `logger.info({ userId }, "User logged in")` |
 | `logger.error("Error: " + error.message)` | `logger.error({ error }, "Operation failed")` |
-| `logger.info({ password }, "...")` | Never log sensitive data |
+| `logger.info({ password, apiKey }, "...")` | Never log credentials, customer content, or personal data — see above |
+| `logger.info({ userId: hash(userId) }, "...")` | `logger.info({ userId }, "...")` — identifiers go in raw |
 | `logger.info("msg", { data })` | `logger.info({ data }, "msg")` — object first in Pino |
 | `{ ...getLogContext(), ...data }` | Context is automatic via mixin |
 

--- a/dev/lint/semgrep/langwatch.yml
+++ b/dev/lint/semgrep/langwatch.yml
@@ -13,10 +13,13 @@ rules:
   # to a follow-up if AC6 shows the shape mismatters).
   - id: pii-in-logger-call
     message: >
-      Logger call references PII fields (email, phone, name, ip, userId,
-      apiKey, token, etc.) without redaction. Wrap with `redact(...)` or
+      Logger call references PII fields (email, phone, name, ip, apiKey,
+      token, etc.) without redaction. Wrap with `redact(...)` or
       `hashEmail(...)`, or pass the minimal non-identifying fields needed
       for debugging. See #3754 AC2.
+
+      Note: userId, organizationId and projectId are deliberately NOT
+      flagged — see dev/docs/best_practices/logging-and-tracing.md.
     severity: WARNING
     languages: [typescript, javascript]
     paths:
@@ -35,13 +38,19 @@ rules:
           # Literal PII keys anywhere in an object argument. Semgrep ellipsis is
           # `...` (the bare token); `$...` is NOT valid semgrep and fails to
           # parse — see #3754 (semgrep --validate is now a CI gate).
+          # userId / organizationId / projectId are deliberately absent from
+          # this list and must not be added back. They are opaque internal
+          # identifiers, logged raw on purpose: they are what makes a log line
+          # attributable and what lets an incident be filtered to one tenant.
+          # Redacting them costs that and protects nothing, because the
+          # identifier was never the sensitive part. See the "Identifiers Are
+          # Logged Raw, On Purpose" section of
+          # dev/docs/best_practices/logging-and-tracing.md.
           - pattern: 'logger.$LEVEL(..., { ..., email: $E, ... }, ...)'
           - pattern: 'logger.$LEVEL(..., { ..., phone: $P, ... }, ...)'
-          - pattern: 'logger.$LEVEL(..., { ..., userId: $U, ... }, ...)'
           - pattern: 'logger.$LEVEL(..., { ..., apiKey: $K, ... }, ...)'
           - pattern: 'logger.$LEVEL(..., { ..., token: $T, ... }, ...)'
           - pattern: 'console.$LEVEL(..., { ..., email: $E, ... }, ...)'
-          - pattern: 'console.$LEVEL(..., { ..., userId: $U, ... }, ...)'
           - pattern: 'console.$LEVEL(..., { ..., apiKey: $K, ... }, ...)'
           - pattern: 'console.$LEVEL(..., { ..., token: $T, ... }, ...)'
           # Spread of a user/session/account object.

--- a/dev/lint/semgrep/tests/pii-in-logger-call.ts
+++ b/dev/lint/semgrep/tests/pii-in-logger-call.ts
@@ -1,8 +1,6 @@
 // ruleid: pii-in-logger-call
 logger.info("login", { email: user.email, id: 1 });
 // ruleid: pii-in-logger-call
-logger.warn({ userId: u.id });
-// ruleid: pii-in-logger-call
 console.error("oops", { token: t });
 // ruleid: pii-in-logger-call
 logger.debug({ ...currentUser });
@@ -12,3 +10,10 @@ logger.info({ user });
 logger.info("clean", { id: 1, role: "admin" });
 // ok: pii-in-logger-call
 logger.warn("just a message");
+// Identifiers are logged raw on purpose and must stay unflagged. These cases
+// are here so re-adding a userId/organizationId/projectId pattern to the rule
+// fails the test rather than quietly reinstating the false positive.
+// ok: pii-in-logger-call
+logger.warn({ userId: u.id });
+// ok: pii-in-logger-call
+logger.info("scoped", { organizationId: org.id, projectId: project.id });


### PR DESCRIPTION
`userId`, `organizationId` and `projectId` go into log lines unredacted. That has always been true in practice — the log context mixin injects them on every line — but nothing in the repo *said* so, and two linters said the opposite.

The result was that the rule got relitigated one review comment at a time, and the answer depended on who was reading. Most recently on #7083, where a reviewer asked for `organizationId` to be redacted before logging.

## The rule

They are opaque internal identifiers, not personal data. They aren't names, aren't email addresses, and aren't anything someone outside our systems can resolve to a human.

What they *are* is the only thing that makes a log line attributable: they're how you filter Loki to one tenant during an incident, how you answer "did this customer's request actually reach us", and how a support question becomes a query instead of a guess. Redacting them costs all of that and protects nothing, because the identifier was never the sensitive part.

What must never be logged is unchanged, and none of it is an identifier — credentials, customer content, and personal data proper. The doc keeps those separate from the identifier rule so the distinction is the readable part rather than a footnote.

## Making the tooling agree

Stating the rule isn't enough if the linters keep flagging it:

- **`dev/lint/semgrep/langwatch.yml`** — `pii-in-logger-call` drops its two `userId` patterns. This was the binding one: it runs in CI, not just in review.
- **`.coderabbit.yaml`** — stops listing `userId` / `organizationId` as fail conditions, and says *why*, so the bot has the reasoning rather than just an exception to memorise.

`projectSlug` stays flagged. A slug is a human-readable name, which is a different question from an opaque id, and not one this change answers.

## Guarding against silent reinstatement

The semgrep fixture keeps `userId`, `organizationId` and `projectId` as `ok:` cases. Re-adding an identifier pattern to the rule makes those match, which pushes the fixture count above the asserted value and fails `coderabbit-config-check` — rather than quietly reinstating the false positive.

That check asserts an exact match count, which drops **5 → 4** with the `userId` case removed. The workflow is updated with the new count and a comment explaining both the number and the guard.

## Deployment Impact

None. This changes documentation and two lint configurations; no runtime code, no dependencies, no configuration anyone deploys.

The only behavioural change is to review tooling: `pii-in-logger-call` stops firing on `userId` in logger calls, and CodeRabbit stops raising identifier redaction as a security finding. Existing log output is untouched — this documents what the code already does.

## Verification

- All three changed YAML files parse (semgrep ruleset, `.coderabbit.yaml`, the workflow).
- The `pii-in-logger-call` rule retains 15 patterns and **no** identifier pattern remains.
- Fixture is 4 `ruleid:` cases and 4 `ok:` cases, matching the workflow's updated assertion.
- `semgrep` isn't installed locally, so the rule was not executed here — `coderabbit-config-check` runs it on this PR and is the real check, and it is triggered by these paths.
