### PR TITLE
fix(ops): close the type-argument list that made the dead-letter read a comparison

### DIFF
--- a/platform/app/src/server/app-layer/ops/repositories/__tests__/process-ops.prisma.repository.dead-letters.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/__tests__/process-ops.prisma.repository.dead-letters.unit.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { ProcessOpsPrismaRepository } from "../process-ops.prisma.repository";
+
+/**
+ * The dead-letter reads, executed against a stubbed Prisma.
+ *
+ * These live on the unit lane deliberately. `findDeadMessages` shipped with an
+ * unbalanced type-argument list — `$queryRaw<Array<…>(sql)` closed `Array<`
+ * but never `$queryRaw<`, so TypeScript fell back to parsing the whole
+ * expression as a `<` comparison and emitted `$queryRaw < Array(sql)`. The
+ * query never reached Postgres, `rows` was a boolean, and every call to
+ * /ops/event-sourcing/dead-letters died on `rows.map is not a function` in
+ * 3ms. It typechecked clean, because a comparison is valid TypeScript.
+ *
+ * Nothing about that is visible in the source text, so the guard has to be a
+ * test that calls the method and looks at what came back. The integration
+ * suite covers the same methods against a real Postgres, but it needs a
+ * datastore lane; this one runs everywhere, on every change.
+ *
+ * Spec: specs/ops/process-manager-visibility.feature
+ */
+
+const NOW = new Date("2026-08-17T09:00:00.000Z");
+
+const deadRow = {
+  id: "msg_1",
+  processName: "triggerSettlement",
+  projectId: "project_1",
+  processKey: "trigger_abc",
+  messageKey: "settle:trigger_abc:1",
+  intentType: "lw.settle_trigger",
+  status: "dead" as const,
+  attempts: 7,
+  nextAttemptAt: NOW,
+  leasedUntil: null,
+  createdAt: NOW,
+  updatedAt: NOW,
+  sourceEventId: "evt_1",
+  traceCarrier: null,
+  payload: { triggerId: "trigger_abc" },
+};
+
+/**
+ * Answers each `$queryRaw` in call order, so a method issuing two queries in
+ * one `Promise.all` gets the row page and the total in the order it asked.
+ */
+const repoAnswering = (results: unknown[]) => {
+  const queryRaw = vi.fn();
+  for (const result of results) queryRaw.mockResolvedValueOnce(result);
+  const prisma = { $queryRaw: queryRaw } as unknown as PrismaClient;
+  return { repo: new ProcessOpsPrismaRepository(prisma), queryRaw };
+};
+
+describe("ProcessOpsPrismaRepository dead-letter reads", () => {
+  describe("given the fleet holds a dead message", () => {
+    describe("when findDeadMessages is called", () => {
+      it("issues the queries and maps the rows it got back", async () => {
+        const { repo, queryRaw } = repoAnswering([[deadRow], [{ total: 1 }]]);
+
+        const result = await repo.findDeadMessages({ page: 1, pageSize: 25 });
+
+        expect(queryRaw).toHaveBeenCalledTimes(2);
+        expect(result.total).toBe(1);
+        expect(result.messages).toEqual([
+          {
+            id: "msg_1",
+            processName: "triggerSettlement",
+            projectId: "project_1",
+            processKey: "trigger_abc",
+            messageKey: "settle:trigger_abc:1",
+            intentType: "lw.settle_trigger",
+            status: "dead",
+            attempts: 7,
+            nextAttemptAt: NOW.getTime(),
+            leasedUntil: null,
+            createdAt: NOW.getTime(),
+            updatedAt: NOW.getTime(),
+            sourceEventId: "evt_1",
+            traceId: null,
+            payload: { triggerId: "trigger_abc" },
+          },
+        ]);
+      });
+
+      it("passes the page's SQL the tenancy opt-out marker the guard requires", async () => {
+        const { repo, queryRaw } = repoAnswering([[], [{ total: 0 }]]);
+
+        await repo.findDeadMessages({ page: 1, pageSize: 25 });
+
+        // `strings` is the Prisma.Sql fragment list; the marker sits in the
+        // first chunk. Without it dbMultiTenancyProtection rejects the read,
+        // which no amount of correct SQL would survive.
+        const sql = queryRaw.mock.calls[0]![0] as { strings: string[] };
+        expect(sql.strings.join(" ")).toContain("-- @tenancy:");
+      });
+    });
+
+    describe("when a processName narrows the read", () => {
+      it("still returns a mapped page rather than the filter fragment", async () => {
+        const { repo } = repoAnswering([[deadRow], [{ total: 1 }]]);
+
+        const result = await repo.findDeadMessages({
+          processName: "triggerSettlement",
+          page: 2,
+          pageSize: 10,
+        });
+
+        expect(result.messages).toHaveLength(1);
+        expect(result.messages[0]?.processName).toBe("triggerSettlement");
+      });
+    });
+  });
+
+  describe("given the fleet holds no dead messages", () => {
+    describe("when findDeadMessages is called", () => {
+      it("reports an empty page instead of throwing", async () => {
+        const { repo } = repoAnswering([[], []]);
+
+        const result = await repo.findDeadMessages({ page: 1, pageSize: 25 });
+
+        expect(result).toEqual({ messages: [], total: 0 });
+      });
+    });
+  });
+
+  describe("given dead messages spread across two processes", () => {
+    describe("when countDeadByProcessName is called", () => {
+      it("maps each group's total and oldest retirement", async () => {
+        const { repo } = repoAnswering([
+          [
+            {
+              processName: "triggerSettlement",
+              count: 92,
+              oldestUpdatedAt: NOW,
+            },
+            { processName: "webhookDelivery", count: 12, oldestUpdatedAt: NOW },
+          ],
+        ]);
+
+        const counts = await repo.countDeadByProcessName();
+
+        expect(counts).toEqual([
+          {
+            processName: "triggerSettlement",
+            count: 92,
+            oldestUpdatedAt: NOW.getTime(),
+          },
+          {
+            processName: "webhookDelivery",
+            count: 12,
+            oldestUpdatedAt: NOW.getTime(),
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
@@ -308,7 +308,7 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
       : Prisma.empty;
 
     const [rows, totals] = await Promise.all([
-      this.prisma.$queryRaw <
+      this.prisma.$queryRaw<
         Array<
           Omit<
             DeadOutboxMessageView,
@@ -320,7 +320,8 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
             updatedAt: Date;
             traceCarrier: unknown;
           }
-        >(Prisma.sql`
+        >
+      >(Prisma.sql`
         -- @tenancy: cross-tenant ops dead-letter read; the surface is ops-gated
         SELECT "id", "processName", "projectId", "processKey", "messageKey",
                "intentType", "status", "attempts", "nextAttemptAt",


### PR DESCRIPTION
## What

`/ops/event-sourcing/dead-letters` spun for several seconds and then rendered a generic error header. In production the request was not slow — it failed in **3ms** with HTTP 500, `errorType: UncausedServerError`. The sibling `langwatch:trpc` log line carried the real cause:

```
trpc call — rows.map is not a function   path=ops.listDeadLetters
```

The long spin was react-query retrying a fast failure; the header was the generic fallback for an unhandled error.

## Why it happened

`findDeadMessages` opened two type-argument lists and closed only one before `(`:

```ts
this.prisma.$queryRaw<          // ← opened
  Array<                        // ← opened
    Omit<…> & { … }
  >(Prisma.sql`…`)              // ← only ONE `>` — `$queryRaw<` never closed
```

That is not a syntax error. TypeScript cannot parse it as a call with type arguments, so it falls back to parsing the whole expression as a `<` comparison, and both `tsc` and the bundler emit:

```js
this.prisma.$queryRaw < Array(Prisma.sql`…`)
```

So the query never reached Postgres, `rows` was the boolean result of comparing a function to an array, and `rows.map` was undefined.

`pnpm typecheck` cannot catch this — a comparison is valid TypeScript. The only visible trace was biome printing `$queryRaw <` with a space, because it too read the expression as a binary operator.

## The fix

Close both lists. The corrected form now matches the four other `$queryRaw` sites in the same file.

## Verification

- The emitted JavaScript for all nine `$queryRaw` sites in the file is now a call, not a comparison.
- Swept every `$queryRaw` / `$executeRaw` site in `platform/app/src` and `platform/app/ee` by diffing emitted JavaScript — this was the only affected one.
- The three dead-letter SQL statements were run against a real Postgres schema and are valid. They had never executed before, so this is the first time that SQL has been exercised.

## Test

The existing coverage for these methods is integration-only. Added `process-ops.prisma.repository.dead-letters.unit.test.ts`, which calls `findDeadMessages` and `countDeadByProcessName` against a stubbed Prisma and asserts on the mapped result. It is a real execution guard, not a string assertion:

- With the fix: 5 passed.
- With the fix reverted: 4 failed with `TypeError: rows.map is not a function` — the exact production error.

`pnpm test:unit run src/server/app-layer/ops` — 18 files, 179 tests, all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for viewing dead-letter messages, including pagination, totals, tenancy indicators, process-name filtering, empty results, and per-process message counts with timestamps.
* **Refactor**
  * Improved internal query formatting without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->