### PR TITLE
perf(ci): stop leasing runners to decide nothing changed, and fix a Go cache that never saved

### DIFF
--- a/.github/actions/go-build-cache/action.yml
+++ b/.github/actions/go-build-cache/action.yml
@@ -1,0 +1,50 @@
+# A Go BUILD cache that actually learns.
+#
+# `actions/setup-go` caches `~/go/pkg/mod` and `~/.cache/go-build` together
+# under one key derived from `go.sum`. That is right for the module cache — a
+# dependency set is immutable, so an immutable key is correct — and wrong for
+# the build cache, which changes with every commit.
+#
+# The consequence is visible in any go-ci run's log:
+#
+#   Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-<hash of go.sum>
+#   Cache restored successfully
+#   ...
+#   Cache hit occurred on the primary key ..., not saving cache.
+#
+# `actions/cache` never saves on a primary-key hit. So while `go.sum` is
+# unchanged — which is most of the time — the build cache is frozen at whenever
+# that key was first written, every run recompiles whatever has drifted since,
+# and throws the result away. Under `-race`, which roughly doubles compile
+# time, that was 164s of the 188s `test` job.
+#
+# The key here carries the commit, so it always misses and therefore always
+# saves; `restore-keys` falls back to the newest cache for the same `go.sum`,
+# then to any cache for the platform. The result is a cache that tracks the
+# code instead of decaying away from it.
+#
+# `setup-go`'s own cache is deliberately left on: it still handles the module
+# cache, which is the half it gets right. This action restores AFTER it, so the
+# build-cache directory it lays down wins.
+name: go-build-cache
+description: Restore and save the Go build cache under a key that rotates with the commit.
+
+inputs:
+  suffix:
+    description: >-
+      Distinguishes caches whose contents are not interchangeable. Race-
+      instrumented objects are compiled differently from plain ones, so a job
+      running `-race` should not restore a cache written without it.
+    required: false
+    default: default
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suffix }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+        restore-keys: |
+          go-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suffix }}-${{ hashFiles('go.sum') }}-
+          go-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suffix }}-

--- a/.github/scripts/guard-path-filters.test.ts
+++ b/.github/scripts/guard-path-filters.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  aggregatorJobs,
+  covers,
+  gateFilterPaths,
+  inspect,
+  pullRequestPaths,
+} from "./guard-path-filters.ts";
+
+const gated = (onPaths: string[], filterPaths: string[]): string =>
+  [
+    "name: example",
+    "on:",
+    "  pull_request:",
+    "    paths:",
+    ...onPaths.map((p) => `      - "${p}"`),
+    "jobs:",
+    "  changes:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: dorny/paths-filter@v4",
+    "        with:",
+    "          filters: |",
+    "            relevant:",
+    ...filterPaths.map((p) => `              - '${p}'`),
+    "  work:",
+    "    needs: changes",
+    "    runs-on: ubuntu-latest",
+  ].join("\n");
+
+describe("given a workflow that filters in on.pull_request.paths", () => {
+  describe("when every gate filter path is covered", () => {
+    it("reports no issue", () => {
+      const source = gated(["pkg/**", "go.mod"], ["pkg/ssrf/address.go", "go.mod"]);
+      assert.deepEqual(inspect("example.yml", source), []);
+    });
+  });
+
+  describe("when a gate filter names a path on.paths does not cover", () => {
+    /** @scenario "A path filter covers every path the workflow's gate consults" */
+    it("reports R1, because that job would silently never run", () => {
+      const source = gated(["pkg/**"], ["pkg/ssrf/address.go", "charts/gateway/values.yaml"]);
+      const issues = inspect("example.yml", source);
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0]?.rule, "R1");
+      assert.match(issues[0]?.detail ?? "", /charts\/gateway\/values\.yaml/);
+    });
+  });
+
+  describe("when the workflow also declares an alls-green aggregator", () => {
+    /** @scenario "A workflow that filters in on.paths declares no aggregator" */
+    it("reports R2, because a filtered workflow never reports", () => {
+      const source = [
+        "name: example",
+        "on:",
+        "  pull_request:",
+        "    paths:",
+        '      - "pkg/**"',
+        "jobs:",
+        "  work:",
+        "    runs-on: ubuntu-latest",
+        "  example-complete:",
+        "    needs: [work]",
+        "    runs-on: ubuntu-latest",
+      ].join("\n");
+      const issues = inspect("example.yml", source);
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0]?.rule, "R2");
+      assert.match(issues[0]?.detail ?? "", /example-complete/);
+    });
+  });
+});
+
+describe("given a workflow with no on.pull_request.paths", () => {
+  describe("when it keeps the always-run gate and aggregator", () => {
+    it("reports nothing, because that is the pattern required checks need", () => {
+      const source = [
+        "name: example",
+        "on:",
+        "  pull_request:",
+        "jobs:",
+        "  changes:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - uses: dorny/paths-filter@v4",
+        "        with:",
+        "          filters: |",
+        "            relevant:",
+        "              - 'anything/at/all'",
+        "  example-complete:",
+        "    runs-on: ubuntu-latest",
+      ].join("\n");
+      assert.deepEqual(inspect("example.yml", source), []);
+    });
+  });
+});
+
+describe("pullRequestPaths", () => {
+  describe("when the workflow declares none", () => {
+    it("returns null rather than an empty list", () => {
+      assert.equal(pullRequestPaths("on:\n  pull_request:\njobs:\n  a:\n"), null);
+    });
+  });
+
+  describe("when push declares paths but pull_request does not", () => {
+    /** @scenario "A push filter is not treated as a pull-request filter" */
+    it("still returns null, because only the PR filter is guarded", () => {
+      const source = [
+        "on:",
+        "  push:",
+        "    paths:",
+        '      - "pkg/**"',
+        "  pull_request:",
+        "jobs:",
+        "  a:",
+      ].join("\n");
+      assert.equal(pullRequestPaths(source), null);
+    });
+  });
+});
+
+describe("covers", () => {
+  it("treats a /** suffix as covering everything beneath it", () => {
+    assert.equal(covers("pkg/**", "pkg/ssrf/address.go"), true);
+    assert.equal(covers("pkg/**", "pkgother/x.go"), false);
+  });
+
+  it("requires an exact match otherwise", () => {
+    assert.equal(covers("go.mod", "go.mod"), true);
+    assert.equal(covers("go.mod", "go.sum"), false);
+  });
+});
+
+describe("gateFilterPaths", () => {
+  it("ignores commented-out entries", () => {
+    const source = [
+      "jobs:",
+      "  changes:",
+      "    steps:",
+      "      - with:",
+      "          filters: |",
+      "            relevant:",
+      "              # - 'commented/out.go'",
+      "              - 'real/path.go'",
+    ].join("\n");
+    assert.deepEqual(gateFilterPaths(source), ["real/path.go"]);
+  });
+});
+
+describe("aggregatorJobs", () => {
+  it("finds only job names ending in -complete", () => {
+    const source = ["jobs:", "  build:", "  thing-complete:", "  other:"].join("\n");
+    assert.deepEqual(aggregatorJobs(source), ["thing-complete"]);
+  });
+});

--- a/.github/scripts/guard-path-filters.test.ts
+++ b/.github/scripts/guard-path-filters.test.ts
@@ -8,6 +8,7 @@ import {
   inspect,
   listEntries,
   pullRequestFilter,
+  stripComment,
 } from "./guard-path-filters.ts";
 
 const gated = (onPaths: string[], filterPaths: string[]): string =>
@@ -170,6 +171,30 @@ describe("given a paths key carrying a trailing comment", () => {
       kind: "filtered",
       entries: ["pkg/**"],
     });
+  });
+
+  it("keeps a # that YAML treats as scalar content, not a comment", () => {
+    const source = ["on:", "  pull_request:", '    paths: ["pkg # b/**"]'].join("\n");
+    assert.deepEqual(pullRequestFilter(source), {
+      kind: "filtered",
+      entries: ["pkg # b/**"],
+    });
+  });
+});
+
+describe("stripComment", () => {
+  it("drops a comment that starts outside quotes", () => {
+    assert.equal(stripComment("paths: # only Go"), "paths:");
+    assert.equal(stripComment('paths: ["a"] # why'), 'paths: ["a"]');
+  });
+
+  it("keeps a # inside a quoted scalar", () => {
+    assert.equal(stripComment('paths: ["pkg # b/**"]'), 'paths: ["pkg # b/**"]');
+    assert.equal(stripComment("paths: ['a#b']"), "paths: ['a#b']");
+  });
+
+  it("requires whitespace before an unquoted # so a#b is not a comment", () => {
+    assert.equal(stripComment("paths: a#b"), "paths: a#b");
   });
 });
 

--- a/.github/scripts/guard-path-filters.test.ts
+++ b/.github/scripts/guard-path-filters.test.ts
@@ -132,6 +132,45 @@ describe("given a filter shape this guard cannot decompose", () => {
       assert.equal(issues[0]?.rule, "R3");
     });
   });
+
+  describe("when the workflow also declares an aggregator", () => {
+    it("still reports R2, because an unreadable filter is still a filter", () => {
+      const source = [
+        "on:",
+        "  pull_request:",
+        "    paths-ignore:",
+        '      - "docs/**"',
+        "jobs:",
+        "  work:",
+        "  example-complete:",
+      ].join("\n");
+      const rules = inspect("example.yml", source).map((i) => i.rule).sort();
+      assert.deepEqual(rules, ["R2", "R3"]);
+    });
+  });
+});
+
+describe("given a paths key carrying a trailing comment", () => {
+  it("reads the block list beneath it instead of reporting R3", () => {
+    const source = [
+      "on:",
+      "  pull_request:",
+      "    paths: # only the Go tree",
+      '      - "pkg/**"',
+    ].join("\n");
+    assert.deepEqual(pullRequestFilter(source), {
+      kind: "filtered",
+      entries: ["pkg/**"],
+    });
+  });
+
+  it("still reads a flow list with a comment after it", () => {
+    const source = ["on:", "  pull_request:", '    paths: ["pkg/**"] # why'].join("\n");
+    assert.deepEqual(pullRequestFilter(source), {
+      kind: "filtered",
+      entries: ["pkg/**"],
+    });
+  });
 });
 
 describe("pullRequestFilter", () => {
@@ -248,5 +287,15 @@ describe("aggregatorJobs", () => {
   it("finds only job names ending in -complete", () => {
     const source = ["jobs:", "  build:", "  thing-complete:", "  other:"].join("\n");
     assert.deepEqual(aggregatorJobs(source), ["thing-complete"]);
+  });
+
+  it("reads the job indent from the file rather than assuming two spaces", () => {
+    const source = ["jobs:", "    build:", "    thing-complete:"].join("\n");
+    assert.deepEqual(aggregatorJobs(source), ["thing-complete"]);
+  });
+
+  it("does not mistake a nested key for a job", () => {
+    const source = ["jobs:", "  build:", "    steps:", "    nested-complete:"].join("\n");
+    assert.deepEqual(aggregatorJobs(source), []);
   });
 });

--- a/.github/scripts/guard-path-filters.test.ts
+++ b/.github/scripts/guard-path-filters.test.ts
@@ -4,9 +4,10 @@ import { describe, it } from "node:test";
 import {
   aggregatorJobs,
   covers,
-  gateFilterPaths,
+  gateFilters,
   inspect,
-  pullRequestPaths,
+  listEntries,
+  pullRequestFilter,
 } from "./guard-path-filters.ts";
 
 const gated = (onPaths: string[], filterPaths: string[]): string =>
@@ -30,7 +31,7 @@ const gated = (onPaths: string[], filterPaths: string[]): string =>
     "    runs-on: ubuntu-latest",
   ].join("\n");
 
-describe("given a workflow that filters in on.pull_request.paths", () => {
+describe("given a workflow that filters the pull-request trigger by path", () => {
   describe("when every gate filter path is covered", () => {
     it("reports no issue", () => {
       const source = gated(["pkg/**", "go.mod"], ["pkg/ssrf/address.go", "go.mod"]);
@@ -46,6 +47,17 @@ describe("given a workflow that filters in on.pull_request.paths", () => {
       assert.equal(issues.length, 1);
       assert.equal(issues[0]?.rule, "R1");
       assert.match(issues[0]?.detail ?? "", /charts\/gateway\/values\.yaml/);
+    });
+  });
+
+  describe("when a negated entry excludes a path a broader entry matched", () => {
+    /** @scenario "A negated path filter entry removes the coverage it appears to grant" */
+    it("reports R1, because GitHub applies the exclusion and the job never runs", () => {
+      const source = gated(["pkg/**", "!pkg/ssrf/**"], ["pkg/ssrf/address.go"]);
+      const issues = inspect("example.yml", source);
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0]?.rule, "R1");
+      assert.match(issues[0]?.detail ?? "", /pkg\/ssrf\/address\.go/);
     });
   });
 
@@ -73,40 +85,91 @@ describe("given a workflow that filters in on.pull_request.paths", () => {
   });
 });
 
-describe("given a workflow with no on.pull_request.paths", () => {
-  describe("when it keeps the always-run gate and aggregator", () => {
-    it("reports nothing, because that is the pattern required checks need", () => {
+describe("given a filter shape this guard cannot decompose", () => {
+  describe("when the trigger uses paths-ignore", () => {
+    /** @scenario "A filter the guard cannot read is reported, never passed" */
+    it("reports R3 rather than reading as unfiltered", () => {
       const source = [
-        "name: example",
         "on:",
         "  pull_request:",
+        "    paths-ignore:",
+        '      - "docs/**"',
+        "jobs:",
+        "  a:",
+      ].join("\n");
+      const issues = inspect("example.yml", source);
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0]?.rule, "R3");
+      assert.match(issues[0]?.detail ?? "", /paths-ignore/);
+    });
+  });
+
+  describe("when filters names a file instead of an inline block", () => {
+    it("reports R3, because the declared paths are not visible here", () => {
+      const source = [
+        "on:",
+        "  pull_request:",
+        "    paths:",
+        '      - "pkg/**"',
         "jobs:",
         "  changes:",
-        "    runs-on: ubuntu-latest",
         "    steps:",
-        "      - uses: dorny/paths-filter@v4",
-        "        with:",
-        "          filters: |",
-        "            relevant:",
-        "              - 'anything/at/all'",
-        "  example-complete:",
-        "    runs-on: ubuntu-latest",
+        "      - with:",
+        "          filters: .github/filters.yml",
       ].join("\n");
-      assert.deepEqual(inspect("example.yml", source), []);
+      const issues = inspect("example.yml", source);
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0]?.rule, "R3");
+      assert.match(issues[0]?.detail ?? "", /filters\.yml/);
+    });
+  });
+
+  describe("when paths is declared but empty", () => {
+    it("reports R3 rather than treating it as covering nothing", () => {
+      const source = ["on:", "  pull_request:", "    paths:", "jobs:", "  a:"].join("\n");
+      const issues = inspect("example.yml", source);
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0]?.rule, "R3");
     });
   });
 });
 
-describe("pullRequestPaths", () => {
-  describe("when the workflow declares none", () => {
-    it("returns null rather than an empty list", () => {
-      assert.equal(pullRequestPaths("on:\n  pull_request:\njobs:\n  a:\n"), null);
+describe("pullRequestFilter", () => {
+  describe("when the trigger key is quoted", () => {
+    it("still finds the filter, because YAML 1.1 makes \"on\" a common spelling", () => {
+      const source = ['"on":', "  pull_request:", "    paths:", '      - "pkg/**"'].join("\n");
+      assert.deepEqual(pullRequestFilter(source), { kind: "filtered", entries: ["pkg/**"] });
+    });
+  });
+
+  describe("when paths uses flow style", () => {
+    it("reads the entries", () => {
+      const source = ["on:", "  pull_request:", '    paths: ["pkg/**", go.mod]'].join("\n");
+      assert.deepEqual(pullRequestFilter(source), {
+        kind: "filtered",
+        entries: ["pkg/**", "go.mod"],
+      });
+    });
+  });
+
+  describe("when the workflow uses pull_request_target", () => {
+    it("is filtered just the same", () => {
+      const source = ["on:", "  pull_request_target:", "    paths:", "      - a/**"].join("\n");
+      assert.deepEqual(pullRequestFilter(source), { kind: "filtered", entries: ["a/**"] });
+    });
+  });
+
+  describe("when the workflow declares no path filter", () => {
+    it("reports none", () => {
+      assert.deepEqual(pullRequestFilter("on:\n  pull_request:\njobs:\n  a:\n"), {
+        kind: "none",
+      });
     });
   });
 
   describe("when push declares paths but pull_request does not", () => {
     /** @scenario "A push filter is not treated as a pull-request filter" */
-    it("still returns null, because only the PR filter is guarded", () => {
+    it("reports none, because only the PR filter is guarded", () => {
       const source = [
         "on:",
         "  push:",
@@ -116,36 +179,68 @@ describe("pullRequestPaths", () => {
         "jobs:",
         "  a:",
       ].join("\n");
-      assert.equal(pullRequestPaths(source), null);
+      assert.deepEqual(pullRequestFilter(source), { kind: "none" });
     });
   });
 });
 
 describe("covers", () => {
   it("treats a /** suffix as covering everything beneath it", () => {
-    assert.equal(covers("pkg/**", "pkg/ssrf/address.go"), true);
-    assert.equal(covers("pkg/**", "pkgother/x.go"), false);
+    assert.equal(covers(["pkg/**"], "pkg/ssrf/address.go"), true);
+    assert.equal(covers(["pkg/**"], "pkgother/x.go"), false);
   });
 
-  it("requires an exact match otherwise", () => {
-    assert.equal(covers("go.mod", "go.mod"), true);
-    assert.equal(covers("go.mod", "go.sum"), false);
+  it("lets a later negation remove coverage an earlier entry granted", () => {
+    assert.equal(covers(["pkg/**", "!pkg/ssrf/**"], "pkg/ssrf/address.go"), false);
+    assert.equal(covers(["pkg/**", "!pkg/ssrf/**"], "pkg/other/x.go"), true);
+  });
+
+  it("matches a leading double-star", () => {
+    assert.equal(covers(["**/*.go"], "tools/x/y.go"), true);
+    assert.equal(covers(["**/*.go"], "tools/x/y.ts"), false);
+  });
+
+  it("matches a middle single-star without crossing a separator", () => {
+    assert.equal(covers(["platform/*/prisma/**"], "platform/app/prisma/schema.prisma"), true);
+    assert.equal(covers(["platform/*/prisma/**"], "platform/a/b/prisma/schema.prisma"), false);
+  });
+
+  it("requires an exact match for a literal", () => {
+    assert.equal(covers(["go.mod"], "go.mod"), true);
+    assert.equal(covers(["go.mod"], "go.sum"), false);
   });
 });
 
-describe("gateFilterPaths", () => {
+describe("listEntries", () => {
   it("ignores commented-out entries", () => {
+    const lines = ["  # - 'commented/out.go'", "  - 'real/path.go'"];
+    assert.deepEqual(listEntries(lines), ["real/path.go"]);
+  });
+
+  it("drops a trailing comment, quoted or not", () => {
+    assert.deepEqual(listEntries(["  - 'pkg/**' # why", "  - go.mod # also"]), [
+      "pkg/**",
+      "go.mod",
+    ]);
+  });
+});
+
+describe("gateFilters", () => {
+  it("reads a folded block scalar", () => {
     const source = [
       "jobs:",
       "  changes:",
       "    steps:",
       "      - with:",
-      "          filters: |",
+      "          filters: >-",
       "            relevant:",
-      "              # - 'commented/out.go'",
       "              - 'real/path.go'",
     ].join("\n");
-    assert.deepEqual(gateFilterPaths(source), ["real/path.go"]);
+    assert.deepEqual(gateFilters(source), { kind: "filtered", entries: ["real/path.go"] });
+  });
+
+  it("reports none when the workflow has no gate", () => {
+    assert.deepEqual(gateFilters("jobs:\n  a:\n"), { kind: "none" });
   });
 });
 

--- a/.github/scripts/guard-path-filters.ts
+++ b/.github/scripts/guard-path-filters.ts
@@ -128,9 +128,25 @@ const findKeyAnyIndent = (
     return keys.some((key) => new RegExp(`^(['"]?)${key}\\1\\s*:`).test(trimmed));
   });
 
-/** The text after `key:` on its own line. */
+/**
+ * The text after `key:` on its own line, with any trailing comment removed.
+ *
+ * `paths:  # only the Go tree` is a block list with a note on the key line, not
+ * an inline value. Without the strip it read as the value `# only the Go tree`,
+ * which is not decomposable, so the guard reported R3 against a perfectly legal
+ * shape — a false positive, and the kind that teaches people to ignore it.
+ *
+ * Only a comment preceded by whitespace is stripped, so a `#` inside a quoted
+ * entry (`["a#b"]`) survives.
+ */
 const inlineValue = (line: string): string =>
-  line.trim().replace(/^(['"]?)[a-z_-]+\1\s*:\s*/i, "").trim();
+  line
+    .trim()
+    // Comment first, THEN the key: stripping the key first would leave a bare
+    // `# note` with no preceding whitespace for `\s+#` to match.
+    .replace(/\s+#.*$/, "")
+    .replace(/^(['"]?)[a-z_-]+\1\s*:\s*/i, "")
+    .trim();
 
 /**
  * Does the pull-request trigger filter by path, and if so, on what?
@@ -201,23 +217,18 @@ export const pullRequestFilter = (source: string): FilterResult => {
 export const gateFilters = (source: string): FilterResult => {
   const lines = source.split("\n");
   const out: string[] = [];
-  let sawBlock = false;
+  let hasInlineBlock = false;
 
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i]!.match(/^\s*filters:\s*(.*)$/);
     if (!match) continue;
     const value = match[1]!.trim();
 
-    // Block scalars: `|`, `|-`, `>`, `>-`, `|+` … all introduce the literal
-    // filter body this guard can read.
-    if (/^[|>][-+]?\d*$/.test(value)) {
-      sawBlock = true;
-      out.push(...listEntries(blockUnder(lines, i, indentOf(lines[i]!))));
-      continue;
-    }
-
-    if (value === "") {
-      sawBlock = true;
+    // Two spellings of the same thing: a block scalar (`|`, `|-`, `>`, `>-`,
+    // `|+` …) or nothing at all, both introducing a filter body on the lines
+    // beneath that this guard can read.
+    if (value === "" || /^[|>][-+]?\d*$/.test(value)) {
+      hasInlineBlock = true;
       out.push(...listEntries(blockUnder(lines, i, indentOf(lines[i]!))));
       continue;
     }
@@ -232,17 +243,31 @@ export const gateFilters = (source: string): FilterResult => {
     };
   }
 
-  if (!sawBlock) return { kind: "none" };
+  if (!hasInlineBlock) return { kind: "none" };
   return { kind: "filtered", entries: out };
 };
 
-/** Job names at the two-space level that end in `-complete`. */
+/**
+ * Job names ending in `-complete`.
+ *
+ * The job-key indent is read from the `jobs:` block rather than assumed to be
+ * two, because two-space is a convention and not a rule. Hardcoding it meant a
+ * four-space workflow had no detectable aggregators, so R2 could not fire and
+ * the aggregator-plus-filter contradiction passed silently — the same fail-open
+ * R3 exists to prevent, one rule over.
+ */
 export const aggregatorJobs = (source: string): string[] => {
   const lines = source.split("\n");
   const jobsIndex = findKeyIndex(lines, "jobs", 0);
   if (jobsIndex === -1) return [];
-  return blockUnder(lines, jobsIndex, 0)
-    .filter((l) => indentOf(l) === 2 && /^[a-z0-9_-]+:\s*$/i.test(l.trim()))
+
+  const block = blockUnder(lines, jobsIndex, 0);
+  const first = block.find((l) => !isBlank(l));
+  if (first === undefined) return [];
+  const jobIndent = indentOf(first);
+
+  return block
+    .filter((l) => !isBlank(l) && indentOf(l) === jobIndent && /^[a-z0-9_-]+:\s*$/i.test(l.trim()))
     .map((l) => l.trim().slice(0, -1))
     .filter((name) => name.endsWith("-complete"));
 };
@@ -308,13 +333,19 @@ export const covers = (patterns: string[], target: string): boolean => {
 
 export const inspect = (file: string, source: string): WorkflowIssue[] => {
   const filter = pullRequestFilter(source);
-
-  if (filter.kind === "unparsed") {
-    return [{ file, rule: "R3", detail: filter.detail }];
-  }
   if (filter.kind === "none") return [];
 
   const issues: WorkflowIssue[] = [];
+
+  // An unparsed filter is still a FILTER — `pullRequestFilter` only reaches
+  // this state having found a paths-like key under the pull-request trigger.
+  // So R2 still applies and is still checked below; only R1 is impossible,
+  // because there are no entries to compare against. Returning here instead
+  // would let the aggregator contradiction through on exactly the files the
+  // guard has already admitted it cannot fully read.
+  if (filter.kind === "unparsed") {
+    issues.push({ file, rule: "R3", detail: filter.detail });
+  }
 
   for (const aggregator of aggregatorJobs(source)) {
     issues.push({
@@ -326,6 +357,10 @@ export const inspect = (file: string, source: string): WorkflowIssue[] => {
         `reports; a path filter is what stops it reporting. Drop one.`,
     });
   }
+
+  // R1 compares the gate's paths against the trigger's. With an unparsed
+  // trigger there is nothing to compare, and R3 has already said so.
+  if (filter.kind !== "filtered") return issues;
 
   const gate = gateFilters(source);
   if (gate.kind === "unparsed") {

--- a/.github/scripts/guard-path-filters.ts
+++ b/.github/scripts/guard-path-filters.ts
@@ -129,6 +129,34 @@ const findKeyAnyIndent = (
   });
 
 /**
+ * Drop a trailing `# comment`, but only where YAML would treat it as one.
+ *
+ * A `#` starts a comment only outside a quoted scalar and only when preceded by
+ * whitespace, so `paths: ["pkg # b/**"]` keeps its hash — a blanket
+ * `/\s+#.*$/` truncated that to `paths: ["pkg` and the guard then reported R3
+ * against a legal filter. Quoted entries also survive with no preceding space,
+ * e.g. `["a#b"]`.
+ */
+export const stripComment = (line: string): string => {
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]!;
+    if (quote) {
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      continue;
+    }
+    if (c === "#" && (i === 0 || /\s/.test(line[i - 1]!))) {
+      return line.slice(0, i).trimEnd();
+    }
+  }
+  return line;
+};
+
+/**
  * The text after `key:` on its own line, with any trailing comment removed.
  *
  * `paths:  # only the Go tree` is a block list with a note on the key line, not
@@ -140,11 +168,7 @@ const findKeyAnyIndent = (
  * entry (`["a#b"]`) survives.
  */
 const inlineValue = (line: string): string =>
-  line
-    .trim()
-    // Comment first, THEN the key: stripping the key first would leave a bare
-    // `# note` with no preceding whitespace for `\s+#` to match.
-    .replace(/\s+#.*$/, "")
+  stripComment(line.trim())
     .replace(/^(['"]?)[a-z_-]+\1\s*:\s*/i, "")
     .trim();
 

--- a/.github/scripts/guard-path-filters.ts
+++ b/.github/scripts/guard-path-filters.ts
@@ -1,0 +1,186 @@
+// Guards the two rules that make a native `on.paths` filter safe.
+//
+// Background. Most CI workflows here run unconditionally and decide internally
+// whether to do real work, then report through an `alls-green` aggregator named
+// `<name>-complete`. That shape exists so branch protection always has a check
+// to require: a workflow GitHub filters out never reports at all, and a
+// REQUIRED check that never reports leaves the pull request waiting forever.
+//
+// The cost is that deciding "nothing to do" still leases a runner — a gate job
+// spends five to eight seconds doing it. Workflows with no required check can
+// skip that entirely by filtering in `on:`, which GitHub evaluates before it
+// allocates anything. Two things go silently wrong when they do:
+//
+//   R1  A workflow keeps a `changes` gate for per-job filters AND adds
+//       `on.pull_request.paths`. If the `on.paths` list is not a superset of
+//       every path the gate filters on, the workflow never starts for those
+//       paths, so the job that filter guards never runs — and the pull request
+//       goes green having tested nothing.
+//
+//   R2  A workflow has both `on.pull_request.paths` and a `*-complete`
+//       aggregator. Those two are contradictory: the aggregator exists to give
+//       branch protection a stable check, and the filter is what stops it
+//       reporting. Whichever was intended, the pair is a bug.
+//
+// Deliberately dependency-free and line-based, matching guard-pull-request-
+// target.ts: these run on a bare runner with `node --experimental-strip-types`
+// and no install step.
+//
+// Spec: specs/ci/path-filters.feature
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export interface WorkflowIssue {
+  file: string;
+  rule: "R1" | "R2";
+  detail: string;
+}
+
+const indentOf = (line: string): number => line.length - line.trimStart().length;
+
+/** Lines of the block introduced by `key` at `indent`, excluding the key line. */
+export const blockUnder = (
+  lines: string[],
+  startIndex: number,
+  indent: number,
+): string[] => {
+  const out: string[] = [];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      out.push(line);
+      continue;
+    }
+    if (indentOf(line) <= indent) break;
+    out.push(line);
+  }
+  return out;
+};
+
+const findKey = (
+  lines: string[],
+  key: string,
+  indent: number,
+): number => lines.findIndex((l) => indentOf(l) === indent && l.trim() === `${key}:`);
+
+/** Every `- value` entry in a block, unquoted, comments dropped. */
+export const listEntries = (lines: string[]): string[] => {
+  const out: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("- ")) continue;
+    const raw = trimmed.slice(2).trim();
+    if (raw.startsWith("#")) continue;
+    out.push(raw.replace(/^['"]/, "").replace(/['"]$/, ""));
+  }
+  return out;
+};
+
+/** `on.pull_request.paths`, or null when the workflow declares none. */
+export const pullRequestPaths = (source: string): string[] | null => {
+  const lines = source.split("\n");
+  const onIndex = findKey(lines, "on", 0);
+  if (onIndex === -1) return null;
+  const onBlock = blockUnder(lines, onIndex, 0);
+  const prIndex = findKey(onBlock, "pull_request", 2);
+  if (prIndex === -1) return null;
+  const prBlock = blockUnder(onBlock, prIndex, 2);
+  const pathsIndex = findKey(prBlock, "paths", 4);
+  if (pathsIndex === -1) return null;
+  return listEntries(blockUnder(prBlock, pathsIndex, 4));
+};
+
+/** Every path named inside any `filters:` literal block in the file. */
+export const gateFilterPaths = (source: string): string[] => {
+  const lines = source.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*filters:\s*\|/.test(lines[i]!)) continue;
+    out.push(...listEntries(blockUnder(lines, i, indentOf(lines[i]!))));
+  }
+  return out;
+};
+
+/** Job names at the two-space level that end in `-complete`. */
+export const aggregatorJobs = (source: string): string[] => {
+  const lines = source.split("\n");
+  const jobsIndex = findKey(lines, "jobs", 0);
+  if (jobsIndex === -1) return [];
+  return blockUnder(lines, jobsIndex, 0)
+    .filter((l) => indentOf(l) === 2 && /^[a-z0-9_-]+:\s*$/i.test(l.trim()))
+    .map((l) => l.trim().slice(0, -1))
+    .filter((name) => name.endsWith("-complete"));
+};
+
+/** Does an `on.paths` pattern cover a path a gate filter names? */
+export const covers = (pattern: string, target: string): boolean => {
+  if (pattern === target) return true;
+  if (pattern.endsWith("/**")) return target.startsWith(pattern.slice(0, -2));
+  if (pattern.endsWith("**")) return target.startsWith(pattern.slice(0, -2));
+  return false;
+};
+
+export const inspect = (file: string, source: string): WorkflowIssue[] => {
+  const paths = pullRequestPaths(source);
+  if (paths === null) return [];
+
+  const issues: WorkflowIssue[] = [];
+
+  for (const aggregator of aggregatorJobs(source)) {
+    issues.push({
+      file,
+      rule: "R2",
+      detail:
+        `declares on.pull_request.paths AND the aggregator job "${aggregator}". ` +
+        `An aggregator exists so a required check always reports; a path filter ` +
+        `is what stops it reporting. Drop one.`,
+    });
+  }
+
+  for (const declared of new Set(gateFilterPaths(source))) {
+    if (paths.some((pattern) => covers(pattern, declared))) continue;
+    issues.push({
+      file,
+      rule: "R1",
+      detail:
+        `gate filter names "${declared}", which no on.pull_request.paths entry ` +
+        `covers. A change to it would never start this workflow, so the job that ` +
+        `filter guards would silently not run.`,
+    });
+  }
+
+  return issues;
+};
+
+export const main = (dir = ".github/workflows"): number => {
+  const issues: WorkflowIssue[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    if (!name.endsWith(".yml") && !name.endsWith(".yaml")) continue;
+    issues.push(...inspect(name, readFileSync(join(dir, name), "utf8")));
+  }
+
+  if (issues.length > 0) {
+    console.error("Path-filter guard failed:");
+    for (const issue of issues) {
+      console.error(`- [${issue.rule}] ${issue.file}: ${issue.detail}`);
+    }
+    return 1;
+  }
+
+  console.log("path-filter guard passed");
+  return 0;
+};
+
+const isEntrypoint = (): boolean =>
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isEntrypoint()) {
+  // The workflows directory is an argument so CI can point a trusted copy of
+  // this script at the pull request's checkout, the way the pull_request_target
+  // guard does — a pull request must not be able to disable its own guard by
+  // editing the script in the same commit.
+  process.exitCode = main(process.argv[2] ?? ".github/workflows");
+}

--- a/.github/scripts/guard-path-filters.ts
+++ b/.github/scripts/guard-path-filters.ts
@@ -1,4 +1,4 @@
-// Guards the two rules that make a native `on.paths` filter safe.
+// Guards the rules that make a native `on.paths` filter safe.
 //
 // Background. Most CI workflows here run unconditionally and decide internally
 // whether to do real work, then report through an `alls-green` aggregator named
@@ -9,7 +9,7 @@
 // The cost is that deciding "nothing to do" still leases a runner — a gate job
 // spends five to eight seconds doing it. Workflows with no required check can
 // skip that entirely by filtering in `on:`, which GitHub evaluates before it
-// allocates anything. Two things go silently wrong when they do:
+// allocates anything. Three things go silently wrong when they do:
 //
 //   R1  A workflow keeps a `changes` gate for per-job filters AND adds
 //       `on.pull_request.paths`. If the `on.paths` list is not a superset of
@@ -17,14 +17,22 @@
 //       paths, so the job that filter guards never runs — and the pull request
 //       goes green having tested nothing.
 //
-//   R2  A workflow has both `on.pull_request.paths` and a `*-complete`
+//   R2  A workflow has both a pull-request path filter and a `*-complete`
 //       aggregator. Those two are contradictory: the aggregator exists to give
 //       branch protection a stable check, and the filter is what stops it
 //       reporting. Whichever was intended, the pair is a bug.
 //
+//   R3  This parser meets a filter it cannot decompose. A guard that cannot
+//       read a file must SAY SO rather than pass it. Every unreadable shape is
+//       reported, because silently returning "not filtered" would make the
+//       guard's own green meaningless — which is the failure mode R1 and R2
+//       exist to prevent, reproduced inside the guard.
+//
 // Deliberately dependency-free and line-based, matching guard-pull-request-
 // target.ts: these run on a bare runner with `node --experimental-strip-types`
-// and no install step.
+// and no install step, so there is no YAML library available. That is why R3
+// exists — hand parsing has blind spots, and the honest response to one is to
+// fail closed.
 //
 // Spec: specs/ci/path-filters.feature
 
@@ -34,13 +42,22 @@ import { pathToFileURL } from "node:url";
 
 export interface WorkflowIssue {
   file: string;
-  rule: "R1" | "R2";
+  rule: "R1" | "R2" | "R3";
   detail: string;
 }
 
+/** What the pull-request trigger says about path filtering. */
+export type FilterResult =
+  | { kind: "none" }
+  | { kind: "filtered"; entries: string[] }
+  | { kind: "unparsed"; detail: string };
+
 const indentOf = (line: string): number => line.length - line.trimStart().length;
 
-/** Lines of the block introduced by `key` at `indent`, excluding the key line. */
+const isBlank = (line: string): boolean =>
+  line.trim() === "" || line.trim().startsWith("#");
+
+/** Lines of the block introduced at `startIndex`, excluding the key line. */
 export const blockUnder = (
   lines: string[],
   startIndex: number,
@@ -49,7 +66,7 @@ export const blockUnder = (
   const out: string[] = [];
   for (let i = startIndex + 1; i < lines.length; i++) {
     const line = lines[i]!;
-    if (line.trim() === "" || line.trim().startsWith("#")) {
+    if (isBlank(line)) {
       out.push(line);
       continue;
     }
@@ -59,11 +76,12 @@ export const blockUnder = (
   return out;
 };
 
-const findKey = (
-  lines: string[],
-  key: string,
-  indent: number,
-): number => lines.findIndex((l) => indentOf(l) === indent && l.trim() === `${key}:`);
+/** Strip one layer of matching quotes, and any trailing `# comment`. */
+const unquote = (raw: string): string => {
+  const quoted = raw.match(/^(['"])(.*?)\1\s*(?:#.*)?$/);
+  if (quoted) return quoted[2]!;
+  return raw.replace(/\s+#.*$/, "").trim();
+};
 
 /** Every `- value` entry in a block, unquoted, comments dropped. */
 export const listEntries = (lines: string[]): string[] => {
@@ -73,40 +91,155 @@ export const listEntries = (lines: string[]): string[] => {
     if (!trimmed.startsWith("- ")) continue;
     const raw = trimmed.slice(2).trim();
     if (raw.startsWith("#")) continue;
-    out.push(raw.replace(/^['"]/, "").replace(/['"]$/, ""));
+    const value = unquote(raw);
+    if (value !== "") out.push(value);
   }
   return out;
 };
 
-/** `on.pull_request.paths`, or null when the workflow declares none. */
-export const pullRequestPaths = (source: string): string[] | null => {
+/** `[a, "b", 'c']` → the three entries. */
+const flowEntries = (value: string): string[] =>
+  value
+    .slice(1, -1)
+    .split(",")
+    .map((part) => unquote(part.trim()))
+    .filter((part) => part !== "");
+
+/**
+ * Index of a key at exactly `indent`, allowing the quoted forms. YAML 1.1
+ * reads a bare `on` as the boolean true, so `"on":` is a legitimate spelling
+ * and used to slip past this guard entirely.
+ */
+const findKeyIndex = (lines: string[], key: string, indent: number): number =>
+  lines.findIndex((line) => {
+    if (isBlank(line) || indentOf(line) !== indent) return false;
+    return new RegExp(`^(['"]?)${key}\\1\\s*:`).test(line.trim());
+  });
+
+/** Index of a key at ANY indent greater than `minIndent`. */
+const findKeyAnyIndent = (
+  lines: string[],
+  keys: string[],
+  minIndent: number,
+): number =>
+  lines.findIndex((line) => {
+    if (isBlank(line) || indentOf(line) <= minIndent) return false;
+    const trimmed = line.trim();
+    return keys.some((key) => new RegExp(`^(['"]?)${key}\\1\\s*:`).test(trimmed));
+  });
+
+/** The text after `key:` on its own line. */
+const inlineValue = (line: string): string =>
+  line.trim().replace(/^(['"]?)[a-z_-]+\1\s*:\s*/i, "").trim();
+
+/**
+ * Does the pull-request trigger filter by path, and if so, on what?
+ *
+ * Covers `pull_request` and `pull_request_target`, `paths` and `paths-ignore`,
+ * block and flow sequences, quoted keys, and any indentation. Anything else
+ * that looks like a filter but cannot be decomposed comes back `unparsed`
+ * rather than `none`.
+ */
+export const pullRequestFilter = (source: string): FilterResult => {
   const lines = source.split("\n");
-  const onIndex = findKey(lines, "on", 0);
-  if (onIndex === -1) return null;
+  const onIndex = findKeyIndex(lines, "on", 0);
+  if (onIndex === -1) return { kind: "none" };
+
   const onBlock = blockUnder(lines, onIndex, 0);
-  const prIndex = findKey(onBlock, "pull_request", 2);
-  if (prIndex === -1) return null;
-  const prBlock = blockUnder(onBlock, prIndex, 2);
-  const pathsIndex = findKey(prBlock, "paths", 4);
-  if (pathsIndex === -1) return null;
-  return listEntries(blockUnder(prBlock, pathsIndex, 4));
+  const prIndex = findKeyAnyIndent(
+    onBlock,
+    ["pull_request", "pull_request_target"],
+    -1,
+  );
+  if (prIndex === -1) return { kind: "none" };
+
+  const prLine = onBlock[prIndex]!;
+  const prBlock = blockUnder(onBlock, prIndex, indentOf(prLine));
+  const pathsIndex = findKeyAnyIndent(prBlock, ["paths", "paths-ignore"], -1);
+  if (pathsIndex === -1) return { kind: "none" };
+
+  const pathsLine = prBlock[pathsIndex]!;
+  const key = pathsLine.trim().split(":")[0]!.replace(/['"]/g, "");
+  const value = inlineValue(pathsLine);
+
+  // `paths-ignore` filters the workflow just as much as `paths` — it is the
+  // same R2 contradiction — but its entries are exclusions, so treating them
+  // as a coverage list would be wrong. Report rather than guess.
+  if (key === "paths-ignore") {
+    return {
+      kind: "unparsed",
+      detail:
+        "uses `paths-ignore`, which filters the workflow but whose entries " +
+        "are exclusions rather than a coverage list. This guard cannot check " +
+        "R1 against it — express the filter as `paths` instead.",
+    };
+  }
+
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return { kind: "filtered", entries: flowEntries(value) };
+  }
+
+  if (value !== "") {
+    return {
+      kind: "unparsed",
+      detail: `\`${key}\` has the inline value \`${value}\`, which this guard cannot decompose into entries.`,
+    };
+  }
+
+  const entries = listEntries(blockUnder(prBlock, pathsIndex, indentOf(pathsLine)));
+  if (entries.length === 0) {
+    return {
+      kind: "unparsed",
+      detail: `\`${key}\` is declared but no entries could be read from it.`,
+    };
+  }
+
+  return { kind: "filtered", entries };
 };
 
-/** Every path named inside any `filters:` literal block in the file. */
-export const gateFilterPaths = (source: string): string[] => {
+/** Every path named inside any `filters:` block in the file. */
+export const gateFilters = (source: string): FilterResult => {
   const lines = source.split("\n");
   const out: string[] = [];
+  let sawBlock = false;
+
   for (let i = 0; i < lines.length; i++) {
-    if (!/^\s*filters:\s*\|/.test(lines[i]!)) continue;
-    out.push(...listEntries(blockUnder(lines, i, indentOf(lines[i]!))));
+    const match = lines[i]!.match(/^\s*filters:\s*(.*)$/);
+    if (!match) continue;
+    const value = match[1]!.trim();
+
+    // Block scalars: `|`, `|-`, `>`, `>-`, `|+` … all introduce the literal
+    // filter body this guard can read.
+    if (/^[|>][-+]?\d*$/.test(value)) {
+      sawBlock = true;
+      out.push(...listEntries(blockUnder(lines, i, indentOf(lines[i]!))));
+      continue;
+    }
+
+    if (value === "") {
+      sawBlock = true;
+      out.push(...listEntries(blockUnder(lines, i, indentOf(lines[i]!))));
+      continue;
+    }
+
+    // dorny/paths-filter also accepts a path to a filters FILE. The paths it
+    // declares are then somewhere this guard is not looking.
+    return {
+      kind: "unparsed",
+      detail:
+        `\`filters: ${value}\` is not an inline block, so the paths it declares ` +
+        `are not visible here and R1 cannot be checked.`,
+    };
   }
-  return out;
+
+  if (!sawBlock) return { kind: "none" };
+  return { kind: "filtered", entries: out };
 };
 
 /** Job names at the two-space level that end in `-complete`. */
 export const aggregatorJobs = (source: string): string[] => {
   const lines = source.split("\n");
-  const jobsIndex = findKey(lines, "jobs", 0);
+  const jobsIndex = findKeyIndex(lines, "jobs", 0);
   if (jobsIndex === -1) return [];
   return blockUnder(lines, jobsIndex, 0)
     .filter((l) => indentOf(l) === 2 && /^[a-z0-9_-]+:\s*$/i.test(l.trim()))
@@ -114,17 +247,72 @@ export const aggregatorJobs = (source: string): string[] => {
     .filter((name) => name.endsWith("-complete"));
 };
 
-/** Does an `on.paths` pattern cover a path a gate filter names? */
-export const covers = (pattern: string, target: string): boolean => {
+/** Glob pattern to anchored regex: `**` spans separators, `*` does not. */
+const globToRegExp = (pattern: string): RegExp => {
+  let out = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i]!;
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        // `a/**` also covers `a` itself; `**/x` also covers a bare `x`.
+        if (pattern[i + 2] === "/") {
+          out += "(?:.*/)?";
+          i += 2;
+        } else {
+          out += ".*";
+          i += 1;
+        }
+        continue;
+      }
+      out += "[^/]*";
+      continue;
+    }
+    if (c === "?") {
+      out += "[^/]";
+      continue;
+    }
+    out += c.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  }
+  return new RegExp(`^${out}$`);
+};
+
+const matches = (pattern: string, target: string): boolean => {
   if (pattern === target) return true;
-  if (pattern.endsWith("/**")) return target.startsWith(pattern.slice(0, -2));
-  if (pattern.endsWith("**")) return target.startsWith(pattern.slice(0, -2));
-  return false;
+  // `pkg/**` covers `pkg/anything`; the trailing `/` is kept out of the
+  // prefix so it can never cover `pkgother/`.
+  if (pattern.endsWith("/**") && target.startsWith(pattern.slice(0, -2))) {
+    return true;
+  }
+  return globToRegExp(pattern).test(target);
+};
+
+/**
+ * Does the `on.paths` list, as a whole, cover `target`?
+ *
+ * Order matters and negation is real: GitHub applies `!pattern` entries as
+ * exclusions, so `[pkg/**, !pkg/ssrf/**]` does NOT cover `pkg/ssrf/address.go`
+ * even though the first entry matches it. Checking entries independently would
+ * let the exact R1 failure through the rule that exists to catch it.
+ */
+export const covers = (patterns: string[], target: string): boolean => {
+  let covered = false;
+  for (const pattern of patterns) {
+    if (pattern.startsWith("!")) {
+      if (matches(pattern.slice(1), target)) covered = false;
+      continue;
+    }
+    if (matches(pattern, target)) covered = true;
+  }
+  return covered;
 };
 
 export const inspect = (file: string, source: string): WorkflowIssue[] => {
-  const paths = pullRequestPaths(source);
-  if (paths === null) return [];
+  const filter = pullRequestFilter(source);
+
+  if (filter.kind === "unparsed") {
+    return [{ file, rule: "R3", detail: filter.detail }];
+  }
+  if (filter.kind === "none") return [];
 
   const issues: WorkflowIssue[] = [];
 
@@ -133,21 +321,28 @@ export const inspect = (file: string, source: string): WorkflowIssue[] => {
       file,
       rule: "R2",
       detail:
-        `declares on.pull_request.paths AND the aggregator job "${aggregator}". ` +
-        `An aggregator exists so a required check always reports; a path filter ` +
-        `is what stops it reporting. Drop one.`,
+        `declares a pull-request path filter AND the aggregator job ` +
+        `"${aggregator}". An aggregator exists so a required check always ` +
+        `reports; a path filter is what stops it reporting. Drop one.`,
     });
   }
 
-  for (const declared of new Set(gateFilterPaths(source))) {
-    if (paths.some((pattern) => covers(pattern, declared))) continue;
+  const gate = gateFilters(source);
+  if (gate.kind === "unparsed") {
+    issues.push({ file, rule: "R3", detail: gate.detail });
+    return issues;
+  }
+  if (gate.kind === "none") return issues;
+
+  for (const declared of new Set(gate.entries)) {
+    if (covers(filter.entries, declared)) continue;
     issues.push({
       file,
       rule: "R1",
       detail:
-        `gate filter names "${declared}", which no on.pull_request.paths entry ` +
-        `covers. A change to it would never start this workflow, so the job that ` +
-        `filter guards would silently not run.`,
+        `gate filter names "${declared}", which the on.pull_request.paths list ` +
+        `does not cover. A change to it would never start this workflow, so ` +
+        `the job that filter guards would silently not run.`,
     });
   }
 

--- a/.github/workflows/agent-plugin-ci.yml
+++ b/.github/workflows/agent-plugin-ci.yml
@@ -1,6 +1,10 @@
-# Always-run workflow with internal path gating + aggregator. See #3223.
-# Upstream jobs skip when paths don't match, and `alls-green` reports the
-# final status.
+# Path-gated in `on:`, with no gate job and no aggregator. This workflow has
+# no required status check, which is what makes that safe — GitHub evaluates
+# `on.paths` before allocating anything, so an irrelevant PR costs zero runner
+# slots instead of two (a gate job to decide, and an aggregator to report the
+# decision). A filtered-out workflow never reports at all, so a workflow whose
+# `*-complete` IS required must keep the always-run pattern; see #3223 and the
+# ones that still do.
 #
 # What it guards: the plugin is published as a directory of hand-authored JSON
 # plus one bundled script, so nothing about it is checked by any other job. Its
@@ -11,14 +15,35 @@
 name: agent-plugin-ci
 
 on:
+  # Only `pull_request` is filtered. "Push to main always runs all workflows"
+  # (specs/ci/path-filters.feature) — every commit that lands on main keeps its
+  # own validation, which is the same reason `cancel-in-progress` is off there.
   push:
     branches:
       - main
   pull_request:
     # ready_for_review is NOT a default pull_request activity type. Without
-    # it, taking a PR out of draft fires no event at all, so the jobs gated
-    # on `heavy` below would never get their first non-draft run.
+    # it, taking a PR out of draft fires no event at all, so the job's draft
+    # guard below would never get its first non-draft run.
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # The hook script is bundled from the SDK sources below, so a change to
+      # any of them changes what the published plugin runs.
+      - "plugins/**"
+      - "sdks/typescript/src/cli/plugin/**"
+      - "sdks/typescript/src/cli/commands/ingestion/**"
+      - "sdks/typescript/src/internal/endpoint.ts"
+      - "sdks/typescript/tsup.plugin-hook.config.ts"
+      - "sdks/typescript/package.json"
+      # The single lockfile, workspace definition, root manifest and hoist
+      # config live at the repo root since ADR-076; a dependency or override
+      # change touches only these.
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - ".npmrc"
+      - ".github/workflows/agent-plugin-ci.yml"
+      - ".github/actions/setup-pnpm-node/**"
   merge_group:
   workflow_dispatch:
 
@@ -33,49 +58,11 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      relevant: ${{ steps.detect.outputs.relevant }}
-      # Draft PRs keep the cheap signal and release the runner slots;
-      # everything heavy returns on ready_for_review and in the merge queue.
-      heavy: ${{ steps.detect.outputs.heavy }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          # The gate reads no working-tree content: on pull_request events
-          # dorny/paths-filter takes the changed-file list from the API, and
-          # every file this job needs on disk lives under .github/.
-          sparse-checkout: .github
-      - uses: ./.github/actions/detect-changes
-        id: detect
-        with:
-          filters: |
-            relevant:
-              - 'plugins/**'
-              # The hook script is bundled from these, so a change to any of
-              # them changes what the published plugin runs.
-              - 'sdks/typescript/src/cli/plugin/**'
-              - 'sdks/typescript/src/cli/commands/ingestion/**'
-              - 'sdks/typescript/src/internal/endpoint.ts'
-              - 'sdks/typescript/tsup.plugin-hook.config.ts'
-              - 'sdks/typescript/package.json'
-              # The single lockfile, workspace definition, root manifest and
-              # hoist config live at the repo root since ADR-076; a dependency
-              # or override change touches only these.
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-              - 'package.json'
-              - '.npmrc'
-              - '.github/workflows/agent-plugin-ci.yml'
-              - '.github/actions/setup-pnpm-node/**'
-              # The gate itself: a change here decides whether any of the
-              # filters above are ever consulted, so it has to match too.
-              - '.github/actions/detect-changes/**'
-
   build_and_test:
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true' && needs.changes.outputs.heavy == 'true'
+    # Draft PRs release the runner slot entirely; the work returns on
+    # ready_for_review and in the merge queue. This was `needs.changes.outputs
+    # .heavy`, which cost a whole gate job to compute the same expression.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -106,12 +93,10 @@ jobs:
       - name: Run tests
         run: pnpm --filter @langwatch/agent-plugin run test
 
-  agent-plugin-complete:
-    needs: [changes, build_and_test]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-        with:
-          jobs: ${{ toJSON(needs) }}
-          allowed-skips: build_and_test
+  # `agent-plugin-complete` used to sit here. It existed only so branch
+  # protection had one stable check to require while the real job skipped —
+  # but it was never added to the ruleset, so it was reporting to nobody at
+  # the cost of a runner lease on every push. If this workflow is ever
+  # promoted to a required check, the aggregator AND the always-run trigger
+  # have to come back together: `on.paths` and a required check are mutually
+  # exclusive, because a filtered-out workflow never reports at all.

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -34,8 +34,9 @@ jobs:
       # ciguard reads workflow files, not Go source, so it needs its own key:
       # a checkout added to langwatch-app-ci touches no .go file.
       ciguards: ${{ steps.filter.outputs.ciguards || steps.force.outputs.go }}
-      # Draft PRs keep lint + vet (seconds) and skip the race-detector test
-      # run and the build. Both come back on ready_for_review.
+      # Draft PRs keep the cheap signal — lint, the generated-code check, the
+      # CI guards — and skip the race-detector test run and the build. Both
+      # come back on ready_for_review.
       heavy: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -101,6 +102,24 @@ jobs:
       - run: go mod verify
       - run: go build ./cmd/... ./tools/thuishaven/...
 
+  # CI's own invariant: every checkout leaves the marketing media on the
+  # server. It regresses silently — a job without the sparse-checkout does not
+  # fail, it just pulls 165 MB it never reads — so it is asserted, not
+  # reviewed.
+  ci-guards:
+    needs: changes
+    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ciguards == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - run: go test ./tools/ciguard/...
+      - run: go run ./cmd/ciguard
+
   test:
     needs: changes
     if: ${{ needs.changes.outputs.go == 'true' && needs.changes.outputs.heavy == 'true' }}
@@ -114,7 +133,7 @@ jobs:
           cache-dependency-path: go.sum
       # `race` keeps this cache separate from the plain one: race-instrumented
       # objects are compiled differently, and restoring the wrong set would
-      # rebuild everything anyway. This step is where the rotating key pays for
+      # rebuild everything anyway. This is where the rotating key pays for
       # itself — 164s of this job's 188s was `go test`, most of it recompiling
       # under `-race` against a cache that could never update.
       - uses: ./.github/actions/go-build-cache
@@ -122,32 +141,11 @@ jobs:
           suffix: race
       - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/... ./cmd/linkcheck/...
 
-  # lint, the generated-code check and CI's own guards, on ONE runner.
-  #
-  # They were four jobs (lint 118s, vet 103s, generated 39s, ci-guards 35s),
-  # each leasing a runner and each paying ~25s of checkout and toolchain setup
-  # to do it. Under a saturated queue the lease, not the work, is the cost: a
-  # 35s job can wait twenty minutes for a slot it holds for half a minute.
-  #
-  # Serial here is ~192s against `test`'s 185s, so this does not become the
-  # critical path — but that is only true because the redundant `vet` job is
-  # gone (see the thuishaven step below). With it the total was 295s and this
-  # WOULD have been the critical path, costing ~110s of wall clock to save
-  # three slots. Check that arithmetic again before adding a fourth thing here.
-  #
-  # Every step carries `!cancelled()` so one failure does not hide the next
-  # four: a run reports everything that is broken, the way four separate jobs
-  # did. The job still fails, because a failed step fails its job.
-  checks:
-    name: "lint · gen · guards"
+  lint:
     needs: changes
-    # The union of the old gates. `ci-guards` ran on `go OR ciguards` because
-    # it reads workflow files, not Go source; everything else ran on `go`. The
-    # steps below keep that distinction individually, so a workflow-only change
-    # still does not pay for golangci-lint.
-    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ciguards == 'true' }}
+    if: ${{ needs.changes.outputs.go == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -158,10 +156,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-
-      - uses: ./.github/actions/go-build-cache
       # tools/thuishaven is deliberately absent here while it is present in the
-      # build, test and vet jobs. Measured at v2.11.4 it carries 231 pre-existing
+      # build and test jobs. Measured at v2.11.4 it carries 231 pre-existing
       # findings: misspell 75 (US spelling enforced against prose written in
       # British English), gosec 72 (of which 41 are file modes on a local dev
       # tool and 23 are G204 on locally-built argv), gocritic 30, noctx 19,
@@ -169,8 +165,9 @@ jobs:
       # outside .golangci.yml's excludes was reviewed by hand; none is an
       # exploitable defect in a single-user local CLI.
       # Clearing them is a judgement-heavy sweep that belongs in its own change,
-      # not bundled into unrelated work — but building, testing and vetting it
-      # costs nothing and is worth having now. That sweep should also decide
+      # not bundled into unrelated work — but building and testing it costs
+      # nothing and is worth having now. (It was vetted too until the `vet` job
+      # went; see the note where that job used to be.) That sweep should also decide
       # whether adapters/dashboard's gosec G203/G704 hits are false positives
       # and record it, since this exclusion currently silences them too.
       #
@@ -181,8 +178,6 @@ jobs:
       # --disable below drops the three house-rule linters; they are gated on
       # changed lines only in the step after this one.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        id: golangci
-        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         with:
           version: v2.11.4
           args: >-
@@ -204,8 +199,6 @@ jobs:
       # a v1 golangci-lint binary refuses this v2 config outright, which is why
       # the make target resolves the pinned version instead of trusting PATH.
       - name: House rules (new/changed lines only)
-        id: house_rules
-        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4
@@ -215,95 +208,51 @@ jobs:
             ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
             ./tools/...
 
-      # All that survives of the `vet` job, and the only part of it that was
-      # ever doing work: govet is one of golangci-lint's always-on defaults
-      # (.golangci.yml, "Defaults (always on): errcheck, govet, ineffassign,
-      # staticcheck, unused"), so vetting the packages the step above lints was
-      # running the same analyser twice for 103s and a runner lease.
-      #
-      # tools/thuishaven is the exception, and the reason this step exists
-      # rather than the job simply being deleted: it is deliberately absent
-      # from the lint scope above — 231 pre-existing findings, see that step's
-      # comment — while the old vet job did cover it. Dropping vet wholesale
-      # would have silently ended govet on it. `./tools/ciguard/...` goes the
-      # other way and is linted but was never vetted, so it needs nothing here.
-      - name: "go vet (tools/thuishaven — the one package lint does not cover)"
-        id: vet_thuishaven
-        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
-        run: go vet ./tools/thuishaven/...
+  # There is no `vet` job. govet is one of golangci-lint's always-on defaults
+  # (.golangci.yml: "Defaults (always on): errcheck, govet, ineffassign,
+  # staticcheck, unused"), and `lint` runs golangci-lint over the same package
+  # list this job used, so it was running the same analyser twice for 103s and
+  # a runner lease.
+  #
+  # One package is NOT covered by that argument and is now unvetted:
+  # `./tools/thuishaven/...`, which `lint` deliberately excludes (231
+  # pre-existing findings — see the note in that job). It is a local dev CLI,
+  # so the exposure is a printf or lock-copy mistake shipping to developers
+  # rather than to production. To restore it, the whole job is one step:
+  #
+  #     - run: go vet ./tools/thuishaven/...
+  #
+  # `./tools/ciguard/...` goes the other way — linted but never vetted — so it
+  # loses nothing here.
 
-      # packages/handled-error/src/codes.generated.ts mirrors the services' herr
-      # codes; the TypeScript presentation registry is keyed off it, so a Go code
-      # added without regenerating would silently ship with no customer copy.
+  # packages/handled-error/src/codes.generated.ts mirrors the services' herr
+  # codes; the TypeScript presentation registry is keyed off it, so a Go code
+  # added without regenerating would silently ship with no customer copy.
+  # Spec: specs/ci/herr-codes-generation.feature
+  generated:
+    needs: changes
+    if: ${{ needs.changes.outputs.go == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
       # Through the Makefile, so the check CI runs and the check a developer
       # runs cannot drift apart.
-      # Spec: specs/ci/herr-codes-generation.feature
-      - name: Generated herr codes are current
-        id: herrgen
-        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
-        run: make herrgen-check
-
-      # CI's own invariant: every checkout leaves the marketing media on the
-      # server. It regresses silently — a job without the sparse-checkout does
-      # not fail, it just pulls 165 MB it never reads — so it is asserted, not
-      # reviewed. Runs on a workflow-only change too, which is why this job's
-      # `if:` is the union of the two gates.
-      - name: CI guards
-        id: ci_guards
-        if: ${{ !cancelled() }}
-        run: go test ./tools/ciguard/...
-
-      - name: CI guards (live repo)
-        id: ci_guards_live
-        if: ${{ !cancelled() }}
-        run: go run ./cmd/ciguard
-
-      # Four checks in one job means four places to look when it goes red, and
-      # the step list does not say which of them mattered without scrolling.
-      # This names every failure in one line, at the end, the way four separate
-      # jobs did on the PR's check list.
-      #
-      # It re-fails on purpose. The job is already red — a failed step fails its
-      # job even with `!cancelled()` letting the rest run — so this adds no
-      # gating, only a readable verdict at the bottom of the log.
-      - name: Summary
-        if: ${{ !cancelled() }}
-        env:
-          GOLANGCI: ${{ steps.golangci.outcome }}
-          HOUSE_RULES: ${{ steps.house_rules.outcome }}
-          VET_THUISHAVEN: ${{ steps.vet_thuishaven.outcome }}
-          HERRGEN: ${{ steps.herrgen.outcome }}
-          CI_GUARDS: ${{ steps.ci_guards.outcome }}
-          CI_GUARDS_LIVE: ${{ steps.ci_guards_live.outcome }}
-        run: |
-          set -uo pipefail
-          failed=()
-          for check in \
-            GOLANGCI HOUSE_RULES VET_THUISHAVEN HERRGEN CI_GUARDS CI_GUARDS_LIVE
-          do
-            outcome="${!check}"
-            case "$outcome" in
-              success) echo "ok       ${check}" ;;
-              skipped|"") echo "skipped  ${check}" ;;
-              *) echo "FAIL     ${check}"; failed+=("${check}") ;;
-            esac
-          done
-
-          if [ "${#failed[@]}" -gt 0 ]; then
-            echo
-            echo "checks that failed: ${failed[*]}"
-            exit 1
-          fi
+      - run: make herrgen-check
 
   # The single required status check. Every job above is `if:`-gated and so
   # cannot be required directly — a skipped job never reports, and branch
   # protection would wait forever. This one always runs and consolidates them.
   go-ci-complete:
-    needs: [changes, build, test, checks]
+    needs: [changes, build, test, lint, generated, ci-guards]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: build, test, checks
+          allowed-skips: build, test, lint, generated, ci-guards

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -181,6 +181,7 @@ jobs:
       # --disable below drops the three house-rule linters; they are gated on
       # changed lines only in the step after this one.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        id: golangci
         if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         with:
           version: v2.11.4
@@ -203,6 +204,7 @@ jobs:
       # a v1 golangci-lint binary refuses this v2 config outright, which is why
       # the make target resolves the pinned version instead of trusting PATH.
       - name: House rules (new/changed lines only)
+        id: house_rules
         if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -226,6 +228,7 @@ jobs:
       # would have silently ended govet on it. `./tools/ciguard/...` goes the
       # other way and is linted but was never vetted, so it needs nothing here.
       - name: "go vet (tools/thuishaven — the one package lint does not cover)"
+        id: vet_thuishaven
         if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         run: go vet ./tools/thuishaven/...
 
@@ -236,6 +239,7 @@ jobs:
       # runs cannot drift apart.
       # Spec: specs/ci/herr-codes-generation.feature
       - name: Generated herr codes are current
+        id: herrgen
         if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         run: make herrgen-check
 
@@ -245,12 +249,51 @@ jobs:
       # reviewed. Runs on a workflow-only change too, which is why this job's
       # `if:` is the union of the two gates.
       - name: CI guards
+        id: ci_guards
         if: ${{ !cancelled() }}
         run: go test ./tools/ciguard/...
 
       - name: CI guards (live repo)
+        id: ci_guards_live
         if: ${{ !cancelled() }}
         run: go run ./cmd/ciguard
+
+      # Four checks in one job means four places to look when it goes red, and
+      # the step list does not say which of them mattered without scrolling.
+      # This names every failure in one line, at the end, the way four separate
+      # jobs did on the PR's check list.
+      #
+      # It re-fails on purpose. The job is already red — a failed step fails its
+      # job even with `!cancelled()` letting the rest run — so this adds no
+      # gating, only a readable verdict at the bottom of the log.
+      - name: Summary
+        if: ${{ !cancelled() }}
+        env:
+          GOLANGCI: ${{ steps.golangci.outcome }}
+          HOUSE_RULES: ${{ steps.house_rules.outcome }}
+          VET_THUISHAVEN: ${{ steps.vet_thuishaven.outcome }}
+          HERRGEN: ${{ steps.herrgen.outcome }}
+          CI_GUARDS: ${{ steps.ci_guards.outcome }}
+          CI_GUARDS_LIVE: ${{ steps.ci_guards_live.outcome }}
+        run: |
+          set -uo pipefail
+          failed=()
+          for check in \
+            GOLANGCI HOUSE_RULES VET_THUISHAVEN HERRGEN CI_GUARDS CI_GUARDS_LIVE
+          do
+            outcome="${!check}"
+            case "$outcome" in
+              success) echo "ok       ${check}" ;;
+              skipped|"") echo "skipped  ${check}" ;;
+              *) echo "FAIL     ${check}"; failed+=("${check}") ;;
+            esac
+          done
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo
+            echo "checks that failed: ${failed[*]}"
+            exit 1
+          fi
 
   # The single required status check. Every job above is `if:`-gated and so
   # cannot be required directly — a skipped job never reports, and branch

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -34,9 +34,8 @@ jobs:
       # ciguard reads workflow files, not Go source, so it needs its own key:
       # a checkout added to langwatch-app-ci touches no .go file.
       ciguards: ${{ steps.filter.outputs.ciguards || steps.force.outputs.go }}
-      # Draft PRs keep the cheap signal — lint, the generated-code check, the
-      # CI guards — and skip the race-detector test run and the build. Both
-      # come back on ready_for_review.
+      # Draft PRs keep lint + vet (seconds) and skip the race-detector test
+      # run and the build. Both come back on ready_for_review.
       heavy: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -157,7 +156,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       # tools/thuishaven is deliberately absent here while it is present in the
-      # build and test jobs. Measured at v2.11.4 it carries 231 pre-existing
+      # build, test and vet jobs. Measured at v2.11.4 it carries 231 pre-existing
       # findings: misspell 75 (US spelling enforced against prose written in
       # British English), gosec 72 (of which 41 are file modes on a local dev
       # tool and 23 are G204 on locally-built argv), gocritic 30, noctx 19,
@@ -165,9 +164,8 @@ jobs:
       # outside .golangci.yml's excludes was reviewed by hand; none is an
       # exploitable defect in a single-user local CLI.
       # Clearing them is a judgement-heavy sweep that belongs in its own change,
-      # not bundled into unrelated work — but building and testing it costs
-      # nothing and is worth having now. (It was vetted too until the `vet` job
-      # went; see the note where that job used to be.) That sweep should also decide
+      # not bundled into unrelated work — but building, testing and vetting it
+      # costs nothing and is worth having now. That sweep should also decide
       # whether adapters/dashboard's gosec G203/G704 hits are false positives
       # and record it, since this exclusion currently silences them too.
       #
@@ -208,22 +206,29 @@ jobs:
             ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
             ./tools/...
 
-  # There is no `vet` job. govet is one of golangci-lint's always-on defaults
-  # (.golangci.yml: "Defaults (always on): errcheck, govet, ineffassign,
-  # staticcheck, unused"), and `lint` runs golangci-lint over the same package
-  # list this job used, so it was running the same analyser twice for 103s and
-  # a runner lease.
-  #
-  # One package is NOT covered by that argument and is now unvetted:
-  # `./tools/thuishaven/...`, which `lint` deliberately excludes (231
-  # pre-existing findings — see the note in that job). It is a local dev CLI,
-  # so the exposure is a printf or lock-copy mistake shipping to developers
-  # rather than to production. To restore it, the whole job is one step:
-  #
-  #     - run: go vet ./tools/thuishaven/...
-  #
-  # `./tools/ciguard/...` goes the other way — linted but never vetted — so it
-  # loses nothing here.
+  vet:
+    needs: changes
+    if: ${{ needs.changes.outputs.go == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      # `go vet` type-checks everything it inspects, so it benefits from the
+      # same build cache as `build`. Plain, not `race`: it compiles the same
+      # objects `build` does.
+      #
+      # This job overlaps heavily with `lint` — govet is one of golangci-lint's
+      # always-on defaults and `lint` covers every package below except
+      # tools/thuishaven. It is kept anyway: golangci-lint runs govet with its
+      # OWN default analyser set, and .golangci.yml has no `govet` block
+      # pinning that to what `go vet` runs, so "already covered" is likely but
+      # not guaranteed. A cheap job is the wrong thing to bet coverage on.
+      - uses: ./.github/actions/go-build-cache
+      - run: go vet ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/...
 
   # packages/handled-error/src/codes.generated.ts mirrors the services' herr
   # codes; the TypeScript presentation registry is keyed off it, so a Go code
@@ -248,11 +253,11 @@ jobs:
   # cannot be required directly — a skipped job never reports, and branch
   # protection would wait forever. This one always runs and consolidates them.
   go-ci-complete:
-    needs: [changes, build, test, lint, generated, ci-guards]
+    needs: [changes, build, test, lint, vet, generated, ci-guards]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: build, test, lint, generated, ci-guards
+          allowed-skips: build, test, lint, vet, generated, ci-guards

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -97,26 +97,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+      - uses: ./.github/actions/go-build-cache
       - run: go mod verify
       - run: go build ./cmd/... ./tools/thuishaven/...
-
-  # CI's own invariant: every checkout leaves the marketing media on the
-  # server. It regresses silently — a job without the sparse-checkout does not
-  # fail, it just pulls 165 MB it never reads — so it is asserted, not
-  # reviewed.
-  ci-guards:
-    needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ciguards == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      - run: go test ./tools/ciguard/...
-      - run: go run ./cmd/ciguard
 
   test:
     needs: changes
@@ -129,13 +112,42 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+      # `race` keeps this cache separate from the plain one: race-instrumented
+      # objects are compiled differently, and restoring the wrong set would
+      # rebuild everything anyway. This step is where the rotating key pays for
+      # itself — 164s of this job's 188s was `go test`, most of it recompiling
+      # under `-race` against a cache that could never update.
+      - uses: ./.github/actions/go-build-cache
+        with:
+          suffix: race
       - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/... ./cmd/linkcheck/...
 
-  lint:
+  # lint, the generated-code check and CI's own guards, on ONE runner.
+  #
+  # They were four jobs (lint 118s, vet 103s, generated 39s, ci-guards 35s),
+  # each leasing a runner and each paying ~25s of checkout and toolchain setup
+  # to do it. Under a saturated queue the lease, not the work, is the cost: a
+  # 35s job can wait twenty minutes for a slot it holds for half a minute.
+  #
+  # Serial here is ~192s against `test`'s 185s, so this does not become the
+  # critical path — but that is only true because the redundant `vet` job is
+  # gone (see the thuishaven step below). With it the total was 295s and this
+  # WOULD have been the critical path, costing ~110s of wall clock to save
+  # three slots. Check that arithmetic again before adding a fourth thing here.
+  #
+  # Every step carries `!cancelled()` so one failure does not hide the next
+  # four: a run reports everything that is broken, the way four separate jobs
+  # did. The job still fails, because a failed step fails its job.
+  checks:
+    name: "lint · gen · guards"
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
+    # The union of the old gates. `ci-guards` ran on `go OR ciguards` because
+    # it reads workflow files, not Go source; everything else ran on `go`. The
+    # steps below keep that distinction individually, so a workflow-only change
+    # still does not pay for golangci-lint.
+    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ciguards == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -146,6 +158,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+
+      - uses: ./.github/actions/go-build-cache
       # tools/thuishaven is deliberately absent here while it is present in the
       # build, test and vet jobs. Measured at v2.11.4 it carries 231 pre-existing
       # findings: misspell 75 (US spelling enforced against prose written in
@@ -167,6 +181,7 @@ jobs:
       # --disable below drops the three house-rule linters; they are gated on
       # changed lines only in the step after this one.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         with:
           version: v2.11.4
           args: >-
@@ -188,6 +203,7 @@ jobs:
       # a v1 golangci-lint binary refuses this v2 config outright, which is why
       # the make target resolves the pinned version instead of trusting PATH.
       - name: House rules (new/changed lines only)
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4
@@ -197,47 +213,54 @@ jobs:
             ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
             ./tools/...
 
-  vet:
-    needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      - run: go vet ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/...
+      # All that survives of the `vet` job, and the only part of it that was
+      # ever doing work: govet is one of golangci-lint's always-on defaults
+      # (.golangci.yml, "Defaults (always on): errcheck, govet, ineffassign,
+      # staticcheck, unused"), so vetting the packages the step above lints was
+      # running the same analyser twice for 103s and a runner lease.
+      #
+      # tools/thuishaven is the exception, and the reason this step exists
+      # rather than the job simply being deleted: it is deliberately absent
+      # from the lint scope above — 231 pre-existing findings, see that step's
+      # comment — while the old vet job did cover it. Dropping vet wholesale
+      # would have silently ended govet on it. `./tools/ciguard/...` goes the
+      # other way and is linted but was never vetted, so it needs nothing here.
+      - name: "go vet (tools/thuishaven — the one package lint does not cover)"
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
+        run: go vet ./tools/thuishaven/...
 
-  # packages/handled-error/src/codes.generated.ts mirrors the services' herr
-  # codes; the TypeScript presentation registry is keyed off it, so a Go code
-  # added without regenerating would silently ship with no customer copy.
-  # Spec: specs/ci/herr-codes-generation.feature
-  generated:
-    needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+      # packages/handled-error/src/codes.generated.ts mirrors the services' herr
+      # codes; the TypeScript presentation registry is keyed off it, so a Go code
+      # added without regenerating would silently ship with no customer copy.
       # Through the Makefile, so the check CI runs and the check a developer
       # runs cannot drift apart.
-      - run: make herrgen-check
+      # Spec: specs/ci/herr-codes-generation.feature
+      - name: Generated herr codes are current
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
+        run: make herrgen-check
+
+      # CI's own invariant: every checkout leaves the marketing media on the
+      # server. It regresses silently — a job without the sparse-checkout does
+      # not fail, it just pulls 165 MB it never reads — so it is asserted, not
+      # reviewed. Runs on a workflow-only change too, which is why this job's
+      # `if:` is the union of the two gates.
+      - name: CI guards
+        if: ${{ !cancelled() }}
+        run: go test ./tools/ciguard/...
+
+      - name: CI guards (live repo)
+        if: ${{ !cancelled() }}
+        run: go run ./cmd/ciguard
 
   # The single required status check. Every job above is `if:`-gated and so
   # cannot be required directly — a skipped job never reports, and branch
   # protection would wait forever. This one always runs and consolidates them.
   go-ci-complete:
-    needs: [changes, build, test, lint, vet, generated, ci-guards]
+    needs: [changes, build, test, checks]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: build, test, lint, vet, generated, ci-guards
+          allowed-skips: build, test, checks

--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -1,9 +1,57 @@
 name: go-services
 
+# The `changes` gate below stays, because this workflow runs three jobs off
+# three DIFFERENT filters and `on.paths` is workflow-wide. What `on.paths`
+# buys is the case where none of the three match at all: today that still
+# leases a runner for six seconds to conclude "nothing to do", and GitHub can
+# reach the same answer for free before allocating anything.
+#
+# DANGER, and the reason this list is written as a plain concatenation: it MUST
+# be a superset of every filter in the `changes` job. A path present in a
+# sub-filter but missing here means the workflow never starts, so the job that
+# sub-filter guards never runs — and the PR goes green having tested nothing.
+# `charts/gateway/**` is the whole reason the `helm` job exists; drop it here
+# and that job silently stops existing. When you add a path to a filter below,
+# add it here in the same edit.
+#
+# (`pkg/config/server.go` and `services/aigateway/config.go` from the `chart`
+# filter are already covered by `pkg/**` and `services/aigateway/**`.)
+#
+# Only `pull_request` carries the list. Pushes to main keep running the gate
+# unconditionally, exactly as before — that is the branch we deploy from, so
+# full coverage there is worth one six-second job, and it means this list
+# lives in ONE place instead of being duplicated across two triggers. (The
+# Actions parser does not reliably resolve YAML anchors, so a shared list
+# would have had to be a literal copy.)
 on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      # from `service`
+      - "services/aigateway/**"
+      - "pkg/**"
+      - "cmd/**"
+      - "go.mod"
+      - "go.sum"
+      - "infra/docker/Dockerfile.go_service"
+      - ".github/workflows/go-services.yaml"
+      # from `chart`
+      - "charts/gateway/**"
+      # from `langyagent`
+      - "services/langyagent/**"
+      - "sdks/go/**"
+      - "infra/docker/Dockerfile.langyagent"
+      - "sdks/typescript/**"
+      - "packages/langy/**"
+      - "skills/**"
+      - "feature-map.json"
+      - "platform/app/src/server/tracer/types.ts"
+      - "platform/app/src/server/filters/types.ts"
+      - "platform/app/src/server/evaluations/types.ts"
+      - "platform/app/src/server/modelProviders/llmModels.json"
+      - "platform/app/src/app/api/openapiLangWatch.json"
+      - "services/langevals/ts-integration/evaluators.generated.ts"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -185,7 +185,23 @@ jobs:
               # Composite actions are covered by ci-scripts-test through the
               # scripts they call, so an edit that only touches an action.yml
               # has to reach the gate too.
-              - '.github/actions/**'
+              #
+              # NAMED, not `.github/actions/**`. This flag gates nine jobs —
+              # typecheck, all ten test shards, build, e2e — and the glob
+              # matched every composite action in the repository, including
+              # ones this workflow has never used. A pull request adding
+              # `.github/actions/go-build-cache` for go-ci ran the entire app
+              # suite on two Go CI files and nothing else.
+              #
+              # The trade is real and worth stating: a list can go stale where
+              # a glob cannot. If you add a `uses: ./.github/actions/<name>`
+              # step to this workflow, add it here in the same edit, or an
+              # edit to that action will silently not re-run the suite it
+              # feeds. These three are every action this file currently uses
+              # (`grep -o "uses: \./\.github/actions/[a-z-]*"`).
+              - '.github/actions/detect-changes/**'
+              - '.github/actions/prepare-generated-files/**'
+              - '.github/actions/setup-pnpm-node/**'
             # The parity scanner binds @scenario annotations from test files
             # across many roots, not just specs/ and platform/app/. This list MUST
             # cover every root the scanner reads (DEFAULT_TEST_ROOTS,

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1038,43 +1038,14 @@ jobs:
   # Scans changed files only. The rules are severity: warning during rollout,
   # so this reports without failing; promote a rule to severity: error in its
   # .yml once its baseline is clean and this job starts gating on it.
-  # ast-grep, feature parity, OpenAPI completeness and CI's own two self-tests,
-  # on ONE runner.
-  #
-  # They were five jobs of 16-85s each (ast-grep 26, parity 49, openapi 85,
-  # ci-scripts 16, ci-self 41), and three of them independently ran
-  # `setup-pnpm-node` with the same `@langwatch/web...` filter. Under a
-  # saturated queue the lease, not the work, is the cost — and the duplicated
-  # pnpm install was most of the work. Serial here is ~217s of steps against
-  # `test-integration`'s ~700s, so this never becomes the critical path, and
-  # collapsing three installs into one makes the real figure lower still.
-  #
-  # `lint` is deliberately NOT here. It carries a job-scoped
-  # `pull-requests: write` so reviewdog can annotate the diff, and the whole
-  # point of scoping it to that job is that nothing else gains the write. See
-  # its own comment.
-  #
-  # `typecheck` and `build` are deliberately NOT here either: branch protection
-  # requires them by bare name, so folding them into another job would delete
-  # the check it waits for and block every pull request.
-  #
-  # Every step carries `!cancelled()`, so one failure does not hide the next
-  # four — a run reports everything broken, the way five jobs did.
-  checks:
-    name: "ast-grep · parity · openapi · ci-tests"
+  ast-grep:
     needs: changes
-    # The union of the two gates the five jobs used. `feature-parity` has its
-    # own flag because it tracks specs and test roots rather than app source;
-    # the steps below keep that distinction individually.
-    if: ${{ needs.changes.outputs.relevant == 'true' || needs.changes.outputs.feature-parity == 'true' }}
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
-          # fetch-depth 0 is ast-grep's requirement: it diffs against the merge
-          # base to scan only changed files.
           fetch-depth: 0
           persist-credentials: false
           # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
@@ -1089,36 +1060,19 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
-        if: ${{ needs.changes.outputs.relevant == 'true' }}
         with:
           python-version: "3.12"
 
-      # One install for the three steps that used to do their own.
-      - uses: ./.github/actions/setup-pnpm-node
-        with:
-          install: "@langwatch/web..."
-
-      # Only the OpenAPI check needs these, but it is the union's cost and it
-      # is small next to the install above.
-      - uses: ./.github/actions/prepare-generated-files
-        if: ${{ needs.changes.outputs.relevant == 'true' }}
-
-      # ── ast-grep ────────────────────────────────────────────────────────
       # Pinned to the same version coderabbit-config-check.yml uses —
       # rule-matching behaviour is version-sensitive. Bump both together.
       - name: Install pinned ast-grep
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         run: pip install "ast-grep-cli==0.42.3"
 
       - name: Rule fixtures must still pass
-        id: ast_grep_fixtures
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         working-directory: dev/lint/ast-grep
         run: ast-grep test -c sgconfig.yml -t rule-tests
 
       - name: Scan changed files
-        id: ast_grep_scan
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         run: |
           BASE="${{ github.base_ref || 'main' }}"
           git fetch --no-tags origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"
@@ -1131,120 +1085,86 @@ jobs:
           # shellcheck disable=SC2086
           ast-grep scan -c dev/lint/ast-grep/sgconfig.yml $files
 
-      # ── feature parity ──────────────────────────────────────────────────
+      - name: Notify Slack on failure
+        if: failure() && github.ref == 'refs/heads/main'
+        env:
+          SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/notify-slack-job-failure.sh ast-grep
+
+  feature-parity:
+    needs: changes
+    if: needs.changes.outputs.feature-parity == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
+          sparse-checkout: |
+            /*
+            !/docs/media/
+            !/docs/images/
+            !/assets/
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          install: "@langwatch/web..."
+
       - name: Check feature-file parity
-        id: parity
-        if: ${{ !cancelled() && needs.changes.outputs.feature-parity == 'true' }}
         working-directory: platform/app
         run: pnpm check:feature-parity
-
-      # ── OpenAPI completeness ────────────────────────────────────────────
-      # The generated OpenAPI document is what external integrators compile
-      # clients from, and an operation missing its body, parameters or success
-      # response still appears in it. This turns each omission into a failure.
-      - name: Check OpenAPI completeness
-        id: openapi
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        working-directory: platform/app
-        run: pnpm check:openapi-completeness
-
-      # ── CI's own script tests ───────────────────────────────────────────
-      - name: Test extract-failures.sh
-        id: script_extract_failures
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        run: bash .github/scripts/__tests__/extract-failures.test.sh
-
-      - name: Test start-clickhouse-with-storage-policy.sh
-        id: script_clickhouse
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        run: bash .github/scripts/__tests__/start-clickhouse-with-storage-policy.test.sh
-
-      - name: Test start-boxd-ssh-agent.sh
-        id: script_boxd
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        run: bash .github/scripts/__tests__/start-boxd-ssh-agent.test.sh
-
-      # ── CI self-test: prove a failing test actually fails the run ───────
-      - name: Stage canary fixture inside vitest root
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        working-directory: platform/app
-        run: cp ../../.github/scripts/__fixtures__/intentional-failure.test.ts ./_ci_canary.test.ts
-
-      - name: Run intentional failure
-        id: canary
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        continue-on-error: true
-        working-directory: platform/app
-        run: |
-          pnpm vitest run _ci_canary.test.ts \
-            --reporter=default --reporter=json --outputFile=test-results.json
-
-      - name: Extract failures
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        working-directory: platform/app
-        run: bash ../../.github/scripts/extract-failures.sh test-results.json test-failures.txt
-
-      - name: Assert detection worked
-        id: ci_self_test
-        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
-        run: |
-          if [ "${{ steps.canary.outcome }}" != "failure" ]; then
-            echo "FAIL: canary step should have failed (vitest should exit non-zero for a failing test), got outcome=${{ steps.canary.outcome }}"
-            exit 1
-          fi
-          if [ ! -s platform/app/test-failures.txt ]; then
-            echo "FAIL: test-failures.txt is missing or empty — failure extraction did not work"
-            exit 1
-          fi
-          echo "PASS: canary failed as expected and failures were extracted"
-          cat platform/app/test-failures.txt
-
-      # Five checks in one job means five places to look when it goes red, and
-      # the step list does not say which of them mattered without scrolling.
-      # This names every failure in one line, at the end, the way five separate
-      # jobs did on the PR's check list.
-      #
-      # It re-fails on purpose. The job is already red — a failed step fails its
-      # job even with `!cancelled()` letting the rest run — so this adds no
-      # gating, only a readable verdict at the bottom of the log.
-      - name: Summary
-        if: ${{ !cancelled() }}
-        env:
-          AST_GREP_FIXTURES: ${{ steps.ast_grep_fixtures.outcome }}
-          AST_GREP_SCAN: ${{ steps.ast_grep_scan.outcome }}
-          FEATURE_PARITY: ${{ steps.parity.outcome }}
-          OPENAPI: ${{ steps.openapi.outcome }}
-          SCRIPT_EXTRACT_FAILURES: ${{ steps.script_extract_failures.outcome }}
-          SCRIPT_CLICKHOUSE: ${{ steps.script_clickhouse.outcome }}
-          SCRIPT_BOXD: ${{ steps.script_boxd.outcome }}
-          CI_SELF_TEST: ${{ steps.ci_self_test.outcome }}
-        run: |
-          set -uo pipefail
-          failed=()
-          for check in \
-            AST_GREP_FIXTURES AST_GREP_SCAN FEATURE_PARITY OPENAPI \
-            SCRIPT_EXTRACT_FAILURES SCRIPT_CLICKHOUSE SCRIPT_BOXD CI_SELF_TEST
-          do
-            outcome="${!check}"
-            case "$outcome" in
-              success) echo "ok       ${check}" ;;
-              skipped|"") echo "skipped  ${check}" ;;
-              *) echo "FAIL     ${check}"; failed+=("${check}") ;;
-            esac
-          done
-
-          if [ "${#failed[@]}" -gt 0 ]; then
-            echo
-            echo "checks that failed: ${failed[*]}"
-            exit 1
-          fi
 
       - name: Notify Slack on failure
         if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
           GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/notify-slack-job-failure.sh checks
+        run: bash .github/scripts/notify-slack-job-failure.sh feature-parity
+
+  # The generated OpenAPI document is what external integrators compile
+  # clients from, and an operation missing its body, parameters or success
+  # response still appears in it. This turns each omission into a failure.
+  openapi-completeness:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
+          sparse-checkout: |
+            /*
+            !/docs/media/
+            !/docs/images/
+            !/assets/
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          install: "@langwatch/web..."
+
+      - uses: ./.github/actions/prepare-generated-files
+
+      - name: Check OpenAPI completeness
+        working-directory: platform/app
+        run: pnpm check:openapi-completeness
+
+      # The completeness check only inspects operations already in the
+      # document. This one catches the route that never got there: a handler
+      # with no describeRoute, or one whose app the generator never imports.
+      - name: Check OpenAPI route coverage
+        working-directory: platform/app
+        run: pnpm check:openapi-route-coverage
+
+      - name: Notify Slack on failure
+        if: failure() && github.ref == 'refs/heads/main'
+        env:
+          SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/notify-slack-job-failure.sh openapi-completeness
 
   build:
     needs: changes
@@ -1366,6 +1286,88 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/notify-slack-job-failure.sh build
 
+  ci-scripts-test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
+          sparse-checkout: |
+            /*
+            !/docs/media/
+            !/docs/images/
+            !/assets/
+          sparse-checkout-cone-mode: false
+
+      - name: Test extract-failures.sh
+        run: bash .github/scripts/__tests__/extract-failures.test.sh
+
+      - name: Test start-clickhouse-with-storage-policy.sh
+        run: bash .github/scripts/__tests__/start-clickhouse-with-storage-policy.test.sh
+
+      - name: Test start-boxd-ssh-agent.sh
+        run: bash .github/scripts/__tests__/start-boxd-ssh-agent.test.sh
+
+  ci-self-test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
+          sparse-checkout: |
+            /*
+            !/docs/media/
+            !/docs/images/
+            !/assets/
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          install: "@langwatch/web..."
+
+      - name: Stage canary fixture inside vitest root
+        working-directory: platform/app
+        run: cp ../../.github/scripts/__fixtures__/intentional-failure.test.ts ./_ci_canary.test.ts
+
+      - name: Run intentional failure
+        id: canary
+        continue-on-error: true
+        working-directory: platform/app
+        run: |
+          pnpm vitest run _ci_canary.test.ts \
+            --reporter=default --reporter=json --outputFile=test-results.json
+
+      - name: Extract failures
+        if: always()
+        working-directory: platform/app
+        run: bash ../../.github/scripts/extract-failures.sh test-results.json test-failures.txt
+
+      - name: Assert detection worked
+        if: always()
+        run: |
+          if [ "${{ steps.canary.outcome }}" != "failure" ]; then
+            echo "FAIL: canary step should have failed (vitest should exit non-zero for a failing test), got outcome=${{ steps.canary.outcome }}"
+            exit 1
+          fi
+          if [ ! -s platform/app/test-failures.txt ]; then
+            echo "FAIL: test-failures.txt is missing or empty — failure extraction did not work"
+            exit 1
+          fi
+          echo "PASS: canary failed as expected and failures were extracted"
+          cat platform/app/test-failures.txt
+
+  # Assemble the shard sequencer's weights from the lanes that just ran.
+  #
+  # Only on a dispatched run, and it produces an ARTIFACT rather than a commit:
+  # the manifest has to be identical for every shard that reads it, so it lands
+  # in the repo through a reviewed change like anything else. Download
+  # `shard-durations`, drop it at platform/app/vitest.durations.json, commit.
   shard-durations:
     needs: [changes, test-unit, test-component, test-integration]
     if: always() && needs.changes.outputs.durations == 'true'
@@ -1434,11 +1436,11 @@ jobs:
           path: vitest.durations.json
 
   langwatch-app-complete:
-    needs: [changes, typecheck, test-unit, test-component, test-integration, lint, checks, build]
+    needs: [changes, typecheck, test-unit, test-component, test-integration, lint, ast-grep, feature-parity, openapi-completeness, build, ci-scripts-test, ci-self-test]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: typecheck, test-unit, test-component, test-integration, lint, checks, build
+          allowed-skips: typecheck, test-unit, test-component, test-integration, lint, ast-grep, feature-parity, openapi-completeness, build, ci-scripts-test, ci-self-test

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1038,14 +1038,43 @@ jobs:
   # Scans changed files only. The rules are severity: warning during rollout,
   # so this reports without failing; promote a rule to severity: error in its
   # .yml once its baseline is clean and this job starts gating on it.
-  ast-grep:
+  # ast-grep, feature parity, OpenAPI completeness and CI's own two self-tests,
+  # on ONE runner.
+  #
+  # They were five jobs of 16-85s each (ast-grep 26, parity 49, openapi 85,
+  # ci-scripts 16, ci-self 41), and three of them independently ran
+  # `setup-pnpm-node` with the same `@langwatch/web...` filter. Under a
+  # saturated queue the lease, not the work, is the cost — and the duplicated
+  # pnpm install was most of the work. Serial here is ~217s of steps against
+  # `test-integration`'s ~700s, so this never becomes the critical path, and
+  # collapsing three installs into one makes the real figure lower still.
+  #
+  # `lint` is deliberately NOT here. It carries a job-scoped
+  # `pull-requests: write` so reviewdog can annotate the diff, and the whole
+  # point of scoping it to that job is that nothing else gains the write. See
+  # its own comment.
+  #
+  # `typecheck` and `build` are deliberately NOT here either: branch protection
+  # requires them by bare name, so folding them into another job would delete
+  # the check it waits for and block every pull request.
+  #
+  # Every step carries `!cancelled()`, so one failure does not hide the next
+  # four — a run reports everything broken, the way five jobs did.
+  checks:
+    name: "ast-grep · parity · openapi · ci-tests"
     needs: changes
-    if: needs.changes.outputs.relevant == 'true'
+    # The union of the two gates the five jobs used. `feature-parity` has its
+    # own flag because it tracks specs and test roots rather than app source;
+    # the steps below keep that distinction individually.
+    if: ${{ needs.changes.outputs.relevant == 'true' || needs.changes.outputs.feature-parity == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
+          # fetch-depth 0 is ast-grep's requirement: it diffs against the merge
+          # base to scan only changed files.
           fetch-depth: 0
           persist-credentials: false
           # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
@@ -1060,19 +1089,36 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        if: ${{ needs.changes.outputs.relevant == 'true' }}
         with:
           python-version: "3.12"
 
+      # One install for the three steps that used to do their own.
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          install: "@langwatch/web..."
+
+      # Only the OpenAPI check needs these, but it is the union's cost and it
+      # is small next to the install above.
+      - uses: ./.github/actions/prepare-generated-files
+        if: ${{ needs.changes.outputs.relevant == 'true' }}
+
+      # ── ast-grep ────────────────────────────────────────────────────────
       # Pinned to the same version coderabbit-config-check.yml uses —
       # rule-matching behaviour is version-sensitive. Bump both together.
       - name: Install pinned ast-grep
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         run: pip install "ast-grep-cli==0.42.3"
 
       - name: Rule fixtures must still pass
+        id: ast_grep_fixtures
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         working-directory: dev/lint/ast-grep
         run: ast-grep test -c sgconfig.yml -t rule-tests
 
       - name: Scan changed files
+        id: ast_grep_scan
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         run: |
           BASE="${{ github.base_ref || 'main' }}"
           git fetch --no-tags origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"
@@ -1085,86 +1131,120 @@ jobs:
           # shellcheck disable=SC2086
           ast-grep scan -c dev/lint/ast-grep/sgconfig.yml $files
 
-      - name: Notify Slack on failure
-        if: failure() && github.ref == 'refs/heads/main'
-        env:
-          SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
-          GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/notify-slack-job-failure.sh ast-grep
-
-  feature-parity:
-    needs: changes
-    if: needs.changes.outputs.feature-parity == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
-          sparse-checkout: |
-            /*
-            !/docs/media/
-            !/docs/images/
-            !/assets/
-          sparse-checkout-cone-mode: false
-
-      - uses: ./.github/actions/setup-pnpm-node
-        with:
-          install: "@langwatch/web..."
-
+      # ── feature parity ──────────────────────────────────────────────────
       - name: Check feature-file parity
+        id: parity
+        if: ${{ !cancelled() && needs.changes.outputs.feature-parity == 'true' }}
         working-directory: platform/app
         run: pnpm check:feature-parity
 
-      - name: Notify Slack on failure
-        if: failure() && github.ref == 'refs/heads/main'
-        env:
-          SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
-          GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/notify-slack-job-failure.sh feature-parity
-
-  # The generated OpenAPI document is what external integrators compile
-  # clients from, and an operation missing its body, parameters or success
-  # response still appears in it. This turns each omission into a failure.
-  openapi-completeness:
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
-          sparse-checkout: |
-            /*
-            !/docs/media/
-            !/docs/images/
-            !/assets/
-          sparse-checkout-cone-mode: false
-
-      - uses: ./.github/actions/setup-pnpm-node
-        with:
-          install: "@langwatch/web..."
-
-      - uses: ./.github/actions/prepare-generated-files
-
+      # ── OpenAPI completeness ────────────────────────────────────────────
+      # The generated OpenAPI document is what external integrators compile
+      # clients from, and an operation missing its body, parameters or success
+      # response still appears in it. This turns each omission into a failure.
       - name: Check OpenAPI completeness
+        id: openapi
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         working-directory: platform/app
         run: pnpm check:openapi-completeness
 
-      # The completeness check only inspects operations already in the
-      # document. This one catches the route that never got there: a handler
-      # with no describeRoute, or one whose app the generator never imports.
-      - name: Check OpenAPI route coverage
+      # ── CI's own script tests ───────────────────────────────────────────
+      - name: Test extract-failures.sh
+        id: script_extract_failures
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
+        run: bash .github/scripts/__tests__/extract-failures.test.sh
+
+      - name: Test start-clickhouse-with-storage-policy.sh
+        id: script_clickhouse
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
+        run: bash .github/scripts/__tests__/start-clickhouse-with-storage-policy.test.sh
+
+      - name: Test start-boxd-ssh-agent.sh
+        id: script_boxd
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
+        run: bash .github/scripts/__tests__/start-boxd-ssh-agent.test.sh
+
+      # ── CI self-test: prove a failing test actually fails the run ───────
+      - name: Stage canary fixture inside vitest root
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
         working-directory: platform/app
-        run: pnpm check:openapi-route-coverage
+        run: cp ../../.github/scripts/__fixtures__/intentional-failure.test.ts ./_ci_canary.test.ts
+
+      - name: Run intentional failure
+        id: canary
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
+        continue-on-error: true
+        working-directory: platform/app
+        run: |
+          pnpm vitest run _ci_canary.test.ts \
+            --reporter=default --reporter=json --outputFile=test-results.json
+
+      - name: Extract failures
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
+        working-directory: platform/app
+        run: bash ../../.github/scripts/extract-failures.sh test-results.json test-failures.txt
+
+      - name: Assert detection worked
+        id: ci_self_test
+        if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' }}
+        run: |
+          if [ "${{ steps.canary.outcome }}" != "failure" ]; then
+            echo "FAIL: canary step should have failed (vitest should exit non-zero for a failing test), got outcome=${{ steps.canary.outcome }}"
+            exit 1
+          fi
+          if [ ! -s platform/app/test-failures.txt ]; then
+            echo "FAIL: test-failures.txt is missing or empty — failure extraction did not work"
+            exit 1
+          fi
+          echo "PASS: canary failed as expected and failures were extracted"
+          cat platform/app/test-failures.txt
+
+      # Five checks in one job means five places to look when it goes red, and
+      # the step list does not say which of them mattered without scrolling.
+      # This names every failure in one line, at the end, the way five separate
+      # jobs did on the PR's check list.
+      #
+      # It re-fails on purpose. The job is already red — a failed step fails its
+      # job even with `!cancelled()` letting the rest run — so this adds no
+      # gating, only a readable verdict at the bottom of the log.
+      - name: Summary
+        if: ${{ !cancelled() }}
+        env:
+          AST_GREP_FIXTURES: ${{ steps.ast_grep_fixtures.outcome }}
+          AST_GREP_SCAN: ${{ steps.ast_grep_scan.outcome }}
+          FEATURE_PARITY: ${{ steps.parity.outcome }}
+          OPENAPI: ${{ steps.openapi.outcome }}
+          SCRIPT_EXTRACT_FAILURES: ${{ steps.script_extract_failures.outcome }}
+          SCRIPT_CLICKHOUSE: ${{ steps.script_clickhouse.outcome }}
+          SCRIPT_BOXD: ${{ steps.script_boxd.outcome }}
+          CI_SELF_TEST: ${{ steps.ci_self_test.outcome }}
+        run: |
+          set -uo pipefail
+          failed=()
+          for check in \
+            AST_GREP_FIXTURES AST_GREP_SCAN FEATURE_PARITY OPENAPI \
+            SCRIPT_EXTRACT_FAILURES SCRIPT_CLICKHOUSE SCRIPT_BOXD CI_SELF_TEST
+          do
+            outcome="${!check}"
+            case "$outcome" in
+              success) echo "ok       ${check}" ;;
+              skipped|"") echo "skipped  ${check}" ;;
+              *) echo "FAIL     ${check}"; failed+=("${check}") ;;
+            esac
+          done
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo
+            echo "checks that failed: ${failed[*]}"
+            exit 1
+          fi
 
       - name: Notify Slack on failure
         if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
           GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/notify-slack-job-failure.sh openapi-completeness
+        run: bash .github/scripts/notify-slack-job-failure.sh checks
 
   build:
     needs: changes
@@ -1286,88 +1366,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/notify-slack-job-failure.sh build
 
-  ci-scripts-test:
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
-          sparse-checkout: |
-            /*
-            !/docs/media/
-            !/docs/images/
-            !/assets/
-          sparse-checkout-cone-mode: false
-
-      - name: Test extract-failures.sh
-        run: bash .github/scripts/__tests__/extract-failures.test.sh
-
-      - name: Test start-clickhouse-with-storage-policy.sh
-        run: bash .github/scripts/__tests__/start-clickhouse-with-storage-policy.test.sh
-
-      - name: Test start-boxd-ssh-agent.sh
-        run: bash .github/scripts/__tests__/start-boxd-ssh-agent.test.sh
-
-  ci-self-test:
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
-          sparse-checkout: |
-            /*
-            !/docs/media/
-            !/docs/images/
-            !/assets/
-          sparse-checkout-cone-mode: false
-
-      - uses: ./.github/actions/setup-pnpm-node
-        with:
-          install: "@langwatch/web..."
-
-      - name: Stage canary fixture inside vitest root
-        working-directory: platform/app
-        run: cp ../../.github/scripts/__fixtures__/intentional-failure.test.ts ./_ci_canary.test.ts
-
-      - name: Run intentional failure
-        id: canary
-        continue-on-error: true
-        working-directory: platform/app
-        run: |
-          pnpm vitest run _ci_canary.test.ts \
-            --reporter=default --reporter=json --outputFile=test-results.json
-
-      - name: Extract failures
-        if: always()
-        working-directory: platform/app
-        run: bash ../../.github/scripts/extract-failures.sh test-results.json test-failures.txt
-
-      - name: Assert detection worked
-        if: always()
-        run: |
-          if [ "${{ steps.canary.outcome }}" != "failure" ]; then
-            echo "FAIL: canary step should have failed (vitest should exit non-zero for a failing test), got outcome=${{ steps.canary.outcome }}"
-            exit 1
-          fi
-          if [ ! -s platform/app/test-failures.txt ]; then
-            echo "FAIL: test-failures.txt is missing or empty — failure extraction did not work"
-            exit 1
-          fi
-          echo "PASS: canary failed as expected and failures were extracted"
-          cat platform/app/test-failures.txt
-
-  # Assemble the shard sequencer's weights from the lanes that just ran.
-  #
-  # Only on a dispatched run, and it produces an ARTIFACT rather than a commit:
-  # the manifest has to be identical for every shard that reads it, so it lands
-  # in the repo through a reviewed change like anything else. Download
-  # `shard-durations`, drop it at platform/app/vitest.durations.json, commit.
   shard-durations:
     needs: [changes, test-unit, test-component, test-integration]
     if: always() && needs.changes.outputs.durations == 'true'
@@ -1436,11 +1434,11 @@ jobs:
           path: vitest.durations.json
 
   langwatch-app-complete:
-    needs: [changes, typecheck, test-unit, test-component, test-integration, lint, ast-grep, feature-parity, openapi-completeness, build, ci-scripts-test, ci-self-test]
+    needs: [changes, typecheck, test-unit, test-component, test-integration, lint, checks, build]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: typecheck, test-unit, test-component, test-integration, lint, ast-grep, feature-parity, openapi-completeness, build, ci-scripts-test, ci-self-test
+          allowed-skips: typecheck, test-unit, test-component, test-integration, lint, checks, build

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -69,42 +69,25 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  lint-template:
-    name: "template (${{ matrix.name }})"
+  # One runner renders every published preset and runs every rendered-output
+  # assertion. This used to be seventeen jobs — a twelve-leg `helm template`
+  # matrix plus five single-script jobs — and each one spent ~17s installing
+  # helm and building chart dependencies to do 1-5s of real work. Every leg
+  # measured under 30s end to end, so the runner lease, not the rendering,
+  # was what this workflow actually cost.
+  #
+  # Diagnostic parity with the old matrix is deliberate and load-bearing. A
+  # `fail-fast: false` matrix named every preset that broke in one run; a
+  # naive loop would stop at the first. So the render step keeps going after a
+  # failure and reports them together at the end, and each assertion step
+  # carries `if: '!cancelled()'` so one failing assertion does not hide the
+  # next four.
+  render:
+    name: "render + assertions"
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: charts/langwatch
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Overlays
-          - name: default
-            flags: "--set autogen.enabled=true"
-          - name: dev+nodeport
-            flags: "--set autogen.enabled=true -f examples/overlays/size-dev.yaml -f examples/overlays/access-nodeport.yaml"
-          - name: minimal+nodeport
-            flags: "--set autogen.enabled=true -f examples/overlays/size-minimal.yaml -f examples/overlays/access-nodeport.yaml"
-          - name: prod+ingress
-            flags: "--set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/access-ingress.yaml"
-          - name: ha+ingress+replicated
-            flags: "--set autogen.enabled=true -f examples/overlays/size-ha.yaml -f examples/overlays/access-ingress.yaml -f examples/overlays/clickhouse-replicated.yaml"
-          - name: langy-gvisor
-            flags: "--set autogen.enabled=true -f examples/overlays/langy-gvisor.yaml"
-          - name: langy-disabled
-            flags: "--set autogen.enabled=true -f examples/overlays/langy-disabled.yaml"
-          - name: prod+external-ch
-            flags: "--set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/clickhouse-external.yaml"
-          - name: prod+ext-pg+ext-redis
-            flags: "--set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/access-ingress.yaml -f examples/overlays/postgres-external.yaml -f examples/overlays/redis-external.yaml"
-          # Profiles
-          - name: local
-            flags: "-f examples/values-local.yaml"
-          - name: hosted-prod
-            flags: "-f examples/values-hosted-prod.yaml"
-          - name: scalable-prod
-            flags: "-f examples/values-scalable-prod.yaml"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
@@ -113,106 +96,86 @@ jobs:
       - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
       - run: helm repo add langwatch https://langwatch.github.io/langwatch
       - run: helm dependency build .
-      - name: "helm template (${{ matrix.name }})"
-        run: helm template lw . ${{ matrix.flags }} > /dev/null
 
-  langevals-sizing:
-    name: "langevals sizing"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: charts/langwatch
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
-        with:
-          version: v3.12.0
-      - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-      - run: helm repo add langwatch https://langwatch.github.io/langwatch
-      - run: helm dependency build .
-      # lint-template above only proves the YAML renders. This asserts the
+      # No `set -e`: a preset that fails to render must not abort the ones
+      # after it, or a chart broken in three places reports one.
+      - name: "render every published preset"
+        run: |
+          set -uo pipefail
+          failed=()
+          render() {
+            local name="$1"
+            shift
+            if helm template lw . "$@" >/dev/null 2>"${RUNNER_TEMP}/${name}.err"; then
+              echo "ok    ${name}"
+            else
+              echo "FAIL  ${name}"
+              sed 's/^/        /' "${RUNNER_TEMP}/${name}.err"
+              failed+=("${name}")
+            fi
+          }
+
+          # Overlays
+          render default --set autogen.enabled=true
+          render dev+nodeport --set autogen.enabled=true -f examples/overlays/size-dev.yaml -f examples/overlays/access-nodeport.yaml
+          render minimal+nodeport --set autogen.enabled=true -f examples/overlays/size-minimal.yaml -f examples/overlays/access-nodeport.yaml
+          render prod+ingress --set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/access-ingress.yaml
+          render ha+ingress+replicated --set autogen.enabled=true -f examples/overlays/size-ha.yaml -f examples/overlays/access-ingress.yaml -f examples/overlays/clickhouse-replicated.yaml
+          render langy-gvisor --set autogen.enabled=true -f examples/overlays/langy-gvisor.yaml
+          render langy-disabled --set autogen.enabled=true -f examples/overlays/langy-disabled.yaml
+          render prod+external-ch --set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/clickhouse-external.yaml
+          render prod+ext-pg+ext-redis --set autogen.enabled=true -f examples/overlays/size-prod.yaml -f examples/overlays/access-ingress.yaml -f examples/overlays/postgres-external.yaml -f examples/overlays/redis-external.yaml
+
+          # Profiles
+          render local -f examples/values-local.yaml
+          render hosted-prod -f examples/values-hosted-prod.yaml
+          render scalable-prod -f examples/values-scalable-prod.yaml
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo
+            echo "presets that failed to render: ${failed[*]}"
+            exit 1
+          fi
+
+      # The render step above only proves the YAML parses. This asserts the
       # numbers that reach the pod: the worker count the chart computed from
       # the CPU allowance, and a memory ceiling that count can live within.
       - name: "assert rendered worker count and memory ceiling"
+        if: "!cancelled()"
         run: ./tests/langevals-sizing.sh
 
-  restricted-rbac:
-    name: "restricted rbac"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: charts/langwatch
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # No helm, on purpose. Every `lookup` in the matrix above renders against
-      # no cluster and so returns empty, which is exactly what a lookup the
-      # installer is FORBIDDEN to make does not do — that one aborts the render.
-      # The templates have to be read to see it.
+      # Static on purpose, and helm being installed here changes nothing.
+      # Every `lookup` in the render step runs against no cluster and so
+      # returns empty, which is exactly what a lookup the installer is
+      # FORBIDDEN to make does not do — that one aborts the render. The
+      # templates have to be read to see it.
       - name: "assert no template needs cluster-scoped read access"
+        if: "!cancelled()"
         run: ./tests/restricted-rbac.sh
 
-  email-gateway:
-    name: "email gateway"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: charts/langwatch
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
-        with:
-          version: v3.12.0
-      - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-      - run: helm repo add langwatch https://langwatch.github.io/langwatch
-      - run: helm dependency build .
       # The overlays above never enable email, so nothing there would notice a
       # gateway that reaches only one Deployment. This renders both and compares
       # them, and checks that an unconfigurable provider stops the render.
       - name: "assert rendered email configuration"
+        if: "!cancelled()"
         run: ./tests/email-gateway.sh
 
-  sso-providers:
-    name: "sso providers"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: charts/langwatch
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
-        with:
-          version: v3.12.0
-      - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-      - run: helm repo add langwatch https://langwatch.github.io/langwatch
-      - run: helm dependency build .
       # A provider can be documented in the README and validated in the helpers
       # while the Deployment never emits its variables, which looks exactly like
       # the provider not being supported. Only rendering the container shows it.
       - name: "assert rendered SSO provider configuration"
+        if: "!cancelled()"
         run: ./tests/sso-providers.sh
 
-  workers-shutdown:
-    name: "workers shutdown"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: charts/langwatch
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
-        with:
-          version: v3.12.0
-      - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-      - run: helm repo add langwatch https://langwatch.github.io/langwatch
-      - run: helm dependency build .
       # Workers drain in-flight queue jobs and their ClickHouse writes on
       # SIGTERM. Too short a grace period turns that drain into a SIGKILL,
       # which severs in-flight statements — invisible in the template source,
       # visible only in the rendered value.
       - name: "assert workers get long enough to drain"
+        if: "!cancelled()"
         run: ./tests/workers-shutdown.sh
 
-  # The render matrix above proves the chart PARSES; these vitest suites
+  # The render job above proves the chart PARSES; these vitest suites
   # assert on what it EMITS (env selection per provider, identity guards,
   # migration postures, validation failures). They normally run inside the
   # app CI's integration shards, but that workflow deliberately does not
@@ -253,7 +216,7 @@ jobs:
   e2e:
     name: "e2e: ${{ matrix.name }}"
     runs-on: ubuntu-latest
-    needs: lint-template
+    needs: render
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -97,10 +97,16 @@ jobs:
       - run: helm repo add langwatch https://langwatch.github.io/langwatch
       - run: helm dependency build .
 
-      # No `set -e`: a preset that fails to render must not abort the ones
-      # after it, or a chart broken in three places reports one.
+      # `set +e` is deliberate and load-bearing. Actions runs `run:` steps with
+      # `-e` already on, and `set -uo pipefail` does not clear it — so without
+      # this line a preset that fails to render would abort the ones after it,
+      # and a chart broken in three places would report one. The `if` around
+      # the helm call below is exempt from `-e` on its own, but that exemption
+      # is a property of `if`, not of this step: the next unguarded command
+      # anyone adds would silently reintroduce fail-fast.
       - name: "render every published preset"
         run: |
+          set +e
           set -uo pipefail
           failed=()
           render() {

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -2,6 +2,10 @@ name: langwatch-chart
 
 on:
   pull_request:
+    # ready_for_review is NOT a default activity type, and the two heaviest
+    # jobs below skip on a draft. Without it, taking a PR out of draft fires
+    # no event at all and they would never get their non-draft run.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "charts/langwatch/**"
       - "charts/clickhouse-serverless/**"
@@ -189,6 +193,9 @@ jobs:
   # every behavioral guarantee while CI stays green.
   behavioral:
     name: "behavioral (rendered-output assertions)"
+    # Skipped on a draft, like the e2e legs below. This workflow has no
+    # `changes` gate to read `heavy` from, so the draft check is inline.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -221,6 +228,18 @@ jobs:
 
   e2e:
     name: "e2e: ${{ matrix.name }}"
+    # These two legs are the most expensive jobs in the repository — `e2e:
+    # infra` runs to 697s and `e2e: overlays` to 348s, both building images and
+    # standing up a kind cluster — so a draft releases the slots and they come
+    # back on ready_for_review.
+    #
+    # This matters most for the release-please pull requests, which touch
+    # `charts/**` and `package.json` on every merge to main and so fire this
+    # workflow every time. Twelve workflows already skip their heavy jobs on a
+    # draft via detect-changes' `heavy` output; this one has no gate job to
+    # read it from, which left it the last heavy thing running on a version
+    # bump.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs: render
     strategy:

--- a/.github/workflows/migration-order.yml
+++ b/.github/workflows/migration-order.yml
@@ -24,6 +24,23 @@ name: migration-order
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # This workflow has no required status check, so filtering here is safe:
+    # a workflow GitHub filters out never reports, and a *required* check that
+    # never reports leaves a PR waiting forever. The always-run + green
+    # aggregator pattern the gated workflows use exists for exactly that
+    # reason, and none of them lose it.
+    #
+    # The two directories are the ones tools/migrationorder actually scans
+    # (tools/migrationorder/set.go). A PR that touches neither adds no
+    # migration, so there is no ordering to judge.
+    paths:
+      - "platform/app/prisma/migrations/**"
+      - "platform/app/src/server/clickhouse/migrations/**"
+      # The checker and its own gate: a change to either has to run against
+      # the real migration sets, not just its unit tests.
+      - "tools/migrationorder/**"
+      - "cmd/migrationorder/**"
+      - ".github/workflows/migration-order.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/ssrf-conformance.yaml
+++ b/.github/workflows/ssrf-conformance.yaml
@@ -13,10 +13,25 @@
 # vector here too; this is the gate that makes that non-optional.
 name: ssrf-conformance
 
+# Filtering happens in `on:` rather than in a gate job. This workflow has no
+# required status check, which is what makes that safe: GitHub evaluates
+# `on.paths` BEFORE allocating a runner, so an irrelevant PR costs nothing at
+# all — where a gate job costs a full runner lease to reach the same verdict in
+# six seconds. A workflow filtered out this way never reports, so a *required*
+# check must never be filtered here; the always-run + green-aggregator pattern
+# stays exactly as it is for the workflows that have one.
 on:
+  # Only `pull_request` is filtered. "Push to main always runs all workflows"
+  # (specs/ci/path-filters.feature) — every commit that lands on main keeps its
+  # own validation, which is the same reason `cancel-in-progress` is off there.
   push:
     branches: [main]
   pull_request:
+    paths:
+      - "pkg/ssrf/**"
+      - "packages/ssrf/**"
+      - ".github/workflows/ssrf-conformance.yaml"
+  # No paths here on purpose: a manual dispatch is an explicit request to run.
   workflow_dispatch:
 
 permissions:
@@ -31,31 +46,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      ssrf: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.ssrf }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # The gate reads no working-tree content: on pull_request events
-          # dorny/paths-filter takes the changed-file list from the API, and
-          # every file this job needs on disk lives under .github/. Checking
-          # out the rest of the tree is pure runner time.
-          sparse-checkout: .github
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        if: github.event_name != 'workflow_dispatch'
-        id: filter
-        with:
-          filters: |
-            ssrf:
-              - 'pkg/ssrf/**'
-              - 'packages/ssrf/**'
-              - '.github/workflows/ssrf-conformance.yaml'
-
   conformance:
-    needs: changes
-    if: ${{ needs.changes.outputs.ssrf == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/workflow-security-guard.yml
+++ b/.github/workflows/workflow-security-guard.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/*.yaml"
       - ".github/actions/**"
       - ".github/scripts/guard-pull-request-target*.ts"
+      - ".github/scripts/guard-path-filters*.ts"
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - ".github/workflows/*.yaml"
       - ".github/actions/**"
       - ".github/scripts/guard-pull-request-target*.ts"
+      - ".github/scripts/guard-path-filters*.ts"
   workflow_dispatch:
 
 concurrency:
@@ -70,6 +72,28 @@ jobs:
         if: github.event_name == 'pull_request'
         run: node --test --experimental-strip-types pr/.github/scripts/guard-pull-request-target.test.ts
 
+      # Same trusted-script rule as above: run the BASE copy of the path-filter
+      # guard against the PR's workflows, so a pull request cannot disable the
+      # guard in the same commit that breaks a filter. Falls back to the PR's
+      # copy only when base has none, which is the commit that adds it.
+      - name: Resolve trusted path-filter guard
+        if: github.event_name == 'pull_request'
+        id: path-filter-script
+        run: |
+          if [ -f base/.github/scripts/guard-path-filters.ts ]; then
+            echo "path=base/.github/scripts/guard-path-filters.ts" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=pr/.github/scripts/guard-path-filters.ts" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check path filters on PR
+        if: github.event_name == 'pull_request'
+        run: node --experimental-strip-types "${{ steps.path-filter-script.outputs.path }}" pr/.github/workflows
+
+      - name: Check path-filter guard tests on PR
+        if: github.event_name == 'pull_request'
+        run: node --test --experimental-strip-types pr/.github/scripts/guard-path-filters.test.ts
+
       - name: Checkout repository
         if: github.event_name != 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -83,3 +107,11 @@ jobs:
       - name: Check guard tests
         if: github.event_name != 'pull_request'
         run: node --test --experimental-strip-types .github/scripts/guard-pull-request-target.test.ts
+
+      - name: Check path filters
+        if: github.event_name != 'pull_request'
+        run: node --experimental-strip-types .github/scripts/guard-path-filters.ts
+
+      - name: Check path-filter guard tests
+        if: github.event_name != 'pull_request'
+        run: node --test --experimental-strip-types .github/scripts/guard-path-filters.test.ts

--- a/specs/ci/path-filters.feature
+++ b/specs/ci/path-filters.feature
@@ -4,51 +4,55 @@ Feature: CI path filters skip unnecessary workflows on non-code changes
   So that PR feedback is faster and CI minutes are not wasted
 
   Background:
-    Given the repository uses complementary workflow pairs
-    And each real workflow has a matching "-unmodified" stub
-    And stub job names match real workflow job names exactly
+    Given a workflow filtered out by "on.paths" never reports a status at all
+    And a required status check that never reports blocks the pull request forever
+    And so a workflow whose aggregator is required must run unconditionally instead
 
   # ============================================================================
-  # Stub job name alignment (Phase 1 — fix pre-existing bugs)
+  # Two ways to skip work, and which one a workflow is allowed to use
   # ============================================================================
+  #
+  # The "-unmodified" stub pairs this spec used to describe are gone. They were
+  # replaced (#3223) by "always run, gate internally, report through an
+  # alls-green aggregator", because a stub that drifts from its real workflow's
+  # job names is a silently unsatisfiable required check.
+  #
+  # That pattern costs a runner lease to decide "nothing to do". Workflows with
+  # no required check avoid the lease entirely by filtering in "on:", which
+  # GitHub evaluates before allocating anything.
 
-  Scenario: langwatch-app-ci stub matches real workflow job names
-    Given langwatch-app-ci.yml defines jobs "typecheck", "test-unit", "test-integration", "lint", "build"
-    When a PR does not touch platform/app/ files
-    Then langwatch-app-ci-unmodified.yml reports success for the same job names
+  Scenario: A workflow whose aggregator is required runs on every pull request
+    Given the ruleset requires that workflow's "-complete" check
+    When a pull request touches none of the paths it cares about
+    Then the workflow still runs
+    And its real jobs are skipped
+    And its aggregator reports success, so the required check resolves
 
-  Scenario: mcp-javascript-ci stub matches real workflow job names
-    Given mcp-javascript-ci.yml defines jobs "typecheck", "build_and_test"
-    When a PR does not touch mcp/typescript/ files
-    Then mcp-javascript-ci-unmodified.yml reports success for the same job names
+  @unit
+  Scenario: A workflow that filters in on.paths declares no aggregator
+    Given a workflow declares "on.pull_request.paths"
+    When it also declares a job whose name ends in "-complete"
+    Then the path-filter guard fails
+    And it says the aggregator and the filter contradict each other
 
-  Scenario: sdk-javascript-ci stub matches real workflow job names
-    Given sdk-javascript-ci.yml defines jobs "ci", "e2e"
-    When a PR does not touch sdks/typescript/ files
-    Then sdk-javascript-ci-unmodified.yml reports success for the same job names
+  @unit
+  Scenario: A path filter covers every path the workflow's gate consults
+    Given a workflow keeps an internal gate for per-job filters
+    And it also declares "on.pull_request.paths"
+    When the gate filters on a path the "on.paths" list does not cover
+    Then the path-filter guard fails
+    And it names the uncovered path
+    And it says the job that filter guards would silently not run
 
-  # ============================================================================
-  # Missing stubs (Phase 2)
-  # ============================================================================
-
-  Scenario: e2e-ci has a complementary stub
-    Given e2e-ci.yml triggers on platform/app/, sdks/python/, and tests/agentic-e2e/ changes
-    When a PR does not touch those directories
-    Then e2e-ci-unmodified.yml reports success for all e2e-ci job names
-
-  Scenario: codeql has a complementary stub
-    Given codeql.yml triggers on code file changes only
-    When a PR touches only documentation or config files
-    Then codeql-unmodified.yml reports success for analyze jobs
-
-  # ============================================================================
-  # Path filter behavior
-  # ============================================================================
+  @unit
+  Scenario: A push filter is not treated as a pull-request filter
+    Given a workflow declares "paths" under "push" but not under "pull_request"
+    Then the path-filter guard does not treat it as filtered
 
   Scenario: CodeQL skips docs-only PRs
     When a PR changes only files in docs/, .claude/, specs/, or markdown files
-    Then codeql.yml does not run
-    And codeql-unmodified.yml reports success for required checks
+    Then codeql.yml does not run its analysis
+    And its aggregator still reports success for the required check
 
   Scenario: Push to main always runs all workflows
     When a commit is pushed to the main branch
@@ -104,11 +108,6 @@ Feature: CI path filters skip unnecessary workflows on non-code changes
   # ============================================================================
 
   Scenario: No PR is permanently blocked by missing status checks
-    Given all workflow pairs have matching job names
+    Given every required check is a "-complete" aggregator on an always-run workflow
     When any combination of files is changed in a PR
-    Then every required status check receives a result from either the real workflow or its stub
-
-  Scenario: Negation patterns are not used in path filters
-    Given the complementary pair system cannot support negation
-    Then no workflow uses negation patterns like "!path" in paths filters
-    And path exclusions are achieved only through the stub's paths-ignore
+    Then every required status check receives a result

--- a/specs/ci/path-filters.feature
+++ b/specs/ci/path-filters.feature
@@ -45,6 +45,25 @@ Feature: CI path filters skip unnecessary workflows on non-code changes
     And it says the job that filter guards would silently not run
 
   @unit
+  Scenario: A negated path filter entry removes the coverage it appears to grant
+    Given a workflow's "on.pull_request.paths" contains "pkg/**" and "!pkg/ssrf/**"
+    When its gate filters on a path under "pkg/ssrf"
+    Then the path-filter guard fails
+    # GitHub applies the exclusion, so the workflow never starts for that path.
+    # Checking each entry independently would let the exact R1 failure through
+    # the rule written to catch it.
+
+  @unit
+  Scenario: A filter the guard cannot read is reported, never passed
+    Given a workflow declares a pull-request path filter
+    When the guard cannot decompose it into entries
+    Then the guard fails and says which shape it could not read
+    # The guard hand-parses YAML, because it runs on a bare runner with no
+    # dependencies. Hand parsing has blind spots, and returning "not filtered"
+    # for one would make the guard's own green meaningless — the same silent
+    # pass that R1 and R2 exist to prevent, reproduced inside the guard.
+
+  @unit
   Scenario: A push filter is not treated as a pull-request filter
     Given a workflow declares "paths" under "push" but not under "pull_request"
     Then the path-filter guard does not treat it as filtered


### PR DESCRIPTION
CI here is **allocation-bound, not compute-bound**. This stops paying runner leases for jobs that only decide there's nothing to do, and fixes the Go build cache that made the slowest job slow.

Combines the go-ci work from #7103 (closed in favour of this).

## What the measurements said

| | |
|---|---|
| Peak concurrent jobs (org-wide ceiling) | **76** |
| Runs queued / in progress at snapshot | **477 / 23** |
| Queue delay | p50 **0s**, p90 **1283s (21 min)**, max **1688s** |
| Successful jobs finishing under 90s | **220 of 239** |
| Check runs on PR #6902 (100 files) | **82** |
| Runners allocated by PR #7080, which touched only `.github/` | **56**, of which **16** were `changes` gates |

Queue delay is bimodal — instant, or about twenty minutes, nothing between. That's a hard cap, not slow hardware. One PR can exceed the whole org's Actions capacity.

## The always-run pattern is not being removed

A workflow filtered out by `on.paths` **never reports a status**, and a required check that never reports leaves a PR at "Expected — waiting for status" forever. So every workflow whose `-complete` check is in the ruleset keeps running unconditionally and keeps reporting green on an untouched PR. Only workflows with **no** required check are filtered, and rule R2 below enforces that mechanically.

## Job consolidation — 47 job legs become 28

| workflow | job legs |
|---|---|
| `langwatch-chart` | 20 → **4** |
| `agent-plugin-ci` | 3 → **1** |
| `ssrf-conformance` | 2 → **1** |
| **total** | **47 → 28** |

**One check per job is a deliberate limit here.** An earlier revision of this PR also batched go-ci's `lint`/`generated`/`ci-guards` and the app suite's five cheap checks onto shared runners. That was reverted: a red `checks` job says only that *something* in it broke, where five red job names on the PR say *which*, without opening anything. The slots were never the scarce thing once the queue came down. So the consolidation below is limited to cases where the jobs were genuinely the same check repeated.

**`langwatch-chart`: 20 legs → 4.** A twelve-leg `helm template` matrix plus five single-script jobs each spent ~17s installing helm and building chart dependencies to do 1–5s of work. They now share one runner. Diagnostic parity with `fail-fast: false` is preserved — the render step keeps going after a failure and names every preset that broke, verified against a stub `helm` under `bash -e`. Its e2e legs (697s and 348s, the most expensive in the repo) now release their slots on a draft.

**`ssrf-conformance` and `agent-plugin-ci`: 3 jobs → 1 each**, and 0 when irrelevant. These lose nothing: the removed jobs were a path gate and an aggregator for a check nobody requires, not checks in their own right.

**`go-ci` keeps all eight jobs.** It gains only the build cache below.

## The Go build cache, and a job that only looked redundant

**`go-ci`'s build cache never saved.** `setup-go` keys `~/go/pkg/mod` and `~/.cache/go-build` together on `go.sum` — right for modules (immutable dep set), wrong for the build cache. Every run logs `Cache hit occurred on the primary key ..., not saving cache`, so while `go.sum` sits still the cache is frozen at whenever that key was written. Each run recompiles the drift under `-race` and bins it: **164s of the test job's 188s**. New `go-build-cache` action keys on the commit, so it always saves, with `restore-keys` falling back.

**`vet` looked redundant and is kept anyway.** govet is one of golangci-lint's always-on defaults (`.golangci.yml`: *"Defaults (always on): errcheck, govet, ineffassign, staticcheck, unused"*), and `lint` covers every package `vet` does except `tools/thuishaven` — so an earlier revision deleted it as duplicate work worth 103s.

That was more confident than the evidence supports: golangci-lint runs govet with its *own* default analyser set, and `.golangci.yml` has no `govet` block pinning that to what `go vet` runs. The overlap is likely, not guaranteed, and a cheap job is the wrong thing to bet coverage on. The reasoning now lives in the job, so the next person to notice the overlap finds the answer instead of repeating the change.

## Path filters, only where nothing is required

`ssrf-conformance`, `agent-plugin-ci`, `go-services` and `migration-order` move their filters into `on:`, which GitHub evaluates before allocating anything. Only `pull_request` is filtered — pushes to main still run everything, per `specs/ci/path-filters.feature`.

**`langwatch-app-ci`'s `.github/actions/**` was over-broad.** It matched every composite action in the repo, and that one flag gates nine jobs. A PR adding `.github/actions/go-build-cache` for go-ci ran the entire app suite — four unit shards, four integration shards, two component shards, typecheck, build, e2e — on two Go CI files. Now names the three actions the workflow actually uses.

**`code-scanners` deliberately stays always-run.** It carries the gitleaks/trufflehog secrets scan, and secrets land in any file type. The spec already says so: *"gitleaks, trufflehog and semgrep still run."*

## New guard, because these failure modes are silent

`.github/scripts/guard-path-filters.ts`, wired into `workflow-security-guard` and run **from the base checkout** so a PR can't disable the guard in the same commit that breaks a filter.

- **R1** — `on.paths` must be a superset of the workflow's own gate filters. Drop `charts/gateway/**` from `go-services` and the `helm` job stops existing with the PR green. Verified against the real file.
- **R2** — no workflow may have both a pull-request path filter and a `-complete` aggregator, since the filter is what stops the aggregator reporting.
- **R3** — a filter the parser can't decompose is reported, never passed. The guard hand-parses YAML (no deps on a bare runner), and returning "not filtered" for a blind spot would make its own green meaningless.

31 unit tests, including ones asserting the guard *catches* R1, R2 and R3 rather than only that it passes. `covers` honours `!` negation and uses real glob matching, and comment-stripping tracks quote state so a `#` YAML treats as scalar content (`paths: ["pkg # b/**"]`) survives.

`specs/ci/path-filters.feature` described `-unmodified` stub pairs that #3223 replaced and which no longer exist; rewritten to describe what's actually there, and fully bound (8/8).

## Not in scope, and why

Two findings need a settings change landing simultaneously, so they're called out rather than attempted:

1. **CodeQL runs twice.** GitHub's default setup is enabled at **org** level and analyses go / javascript-typescript / python / **ruby** on every PR — ~816 runner-seconds, 4 slots — on top of this repo's own tuned `codeql.yml`. There is no Ruby here. Needs `admin:org`.
2. **Legacy branch protection requires bare `build` and `typecheck`.** `build` is a job name in six workflows, `typecheck` in three, so nothing decides which satisfies the requirement — and both are already covered by `langwatch-app-complete`. **This is why `go-ci` and `sdk-python-ci` are not path-filtered here**; both expose a job named `build`.

Full measurements: https://claude.ai/code/artifact/84f67c4a-ada7-4142-b3a7-3fc8b0b34a75