### PR TITLE
perf(ci): open release-please PRs as drafts, so a version bump stops running the full suite

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -417,5 +417,6 @@
     }
   },
   "bootstrap-sha": "HEAD",
-  "separate-pull-requests": true
+  "separate-pull-requests": true,
+  "draft-pull-request": true
 }

--- a/.github/workflows/release-please-sdks.yml
+++ b/.github/workflows/release-please-sdks.yml
@@ -12,6 +12,31 @@ on:
 # so two overlapping runs compute their plan from the same history and race on
 # the same PRs — the observable results are a duplicate release PR, or one run
 # reverting the other's version bump.
+#
+# Why the release PRs open as drafts (`draft-pull-request` in
+# release-please-config.json, which is strict JSON and cannot hold this note).
+#
+# "creates-or-updates ... per package" above is also a CI cost. Every merge to
+# main force-pushes each affected release branch, and a release PR's diff is a
+# changelog plus version fields in `package.json`, `platform/app/package.json`
+# and three `Chart.yaml`s. Nine workflows path-filter on `package.json` —
+# correctly, since a dependency bump touches exactly those files — and a path
+# filter cannot tell a version bump from a dependency bump. So a nine-file
+# metadata change pulled the full suite: ten test shards, four kind-cluster
+# e2e legs, both CodeQL systems. Measured at 88 check runs per push, against
+# ~21 merges to main a day, on eight of these branches at once.
+#
+# Twelve workflows already route their heavy jobs through the `heavy` output of
+# .github/actions/detect-changes, which is false on a draft. Opening these PRs
+# as drafts therefore buys the whole reduction with no new mechanism, and the
+# full suite still runs before anything ships: marking the PR ready to review
+# fires `ready_for_review`, which those workflows list in their
+# `pull_request.types` precisely so the heavy jobs get their run then. A draft
+# cannot be merged, so "ready" is the same click as "I am releasing this".
+#
+# Setting it here rather than by hand matters on the NEXT cycle: release-please
+# updates an existing release PR, but once one merges it opens a fresh PR for
+# the following version, and that one would be non-draft again.
 concurrency:
   group: release-please-sdks-${{ github.ref }}
   # Queue, never cancel. A cancelled run can land between "PR created" and


### PR DESCRIPTION
Release PRs were the largest single consumer of the org's Actions capacity, for pull requests that change no code and don't merge until a release.

## The mechanism

release-please creates-or-updates a release PR per package on **every merge to main** — and main takes ~21 merges a day. A release PR's diff is a changelog plus version fields:

```
.github/.release-please-manifest.json   charts/langwatch/Chart.lock
CHANGELOG.md                            charts/langwatch/values.yaml
charts/gateway/Chart.yaml               charts/langyagent/Chart.yaml
charts/langwatch/Chart.yaml             package.json
                                        platform/app/package.json
```

Nine workflows path-filter on `package.json` — correctly, since a dependency bump touches exactly those files — and **a path filter cannot tell a version bump from a dependency bump**. So those nine metadata files pulled the full suite: ten test shards, four kind-cluster e2e legs, both CodeQL systems.

| Measurement | |
|---|---|
| Check runs per push (PR #6930) | **88** — more than a 100-file feature PR |
| Workflow runs on one release branch, 4 hours | **300** (the sample cap, not the total) |
| Merges to main per day | **~21** |
| Release branches churning at once | **8** |

## The fix, and why it needs no new machinery

`"draft-pull-request": true`.

Twelve workflows already route their heavy jobs through the `heavy` output of `.github/actions/detect-changes`, which is `false` on a draft. So this buys the whole reduction with no new mechanism — no label convention, no new trigger, no code path that isn't already load-bearing and tested.

**The full run still happens before anything ships.** Marking a release PR ready fires `ready_for_review`, which those workflows list in their `pull_request.types` precisely so the heavy jobs get their run at that point. And a draft can't be merged — so "Ready for review" is the same click as "I'm releasing this."

Worth stating explicitly: **a green draft is not evidence of a full pass.** `go-ci` skips `build` and the race tests on drafts. That's the entire reason the ready-flip exists, and it's why this doesn't quietly weaken release validation.

## Why config rather than by hand

The eight open release PRs were marked draft manually. That works right now, but release-please *updates* an existing release PR and opens a **fresh** one for the next version once a release merges — and a fresh PR would be non-draft again. Without this the manual step repeats every release cycle, on eight PRs.

The rationale lives in the `release-please-sdks.yml` header comment because `release-please-config.json` is strict JSON and can't carry one.

## Not covered here

`langwatch-chart` has no gate job and doesn't read `heavy`, so its e2e legs — **the most expensive in the repo at 697s and 348s**, by the workflow's own measurement — still run on a draft release PR. A release PR does touch `charts/**`, so they fire every time. That gate belongs in #7096, which is already restructuring that workflow, rather than here where it would conflict.

Options considered and not taken: a `full-ci` label (invents a convention, needs a `labeled` trigger everywhere, and once applied it *stays* applied so every subsequent force-push re-runs the full suite); and a merge queue (the better long-term answer — 14 workflows already declare `merge_group` — but it changes how everyone merges, so it deserves its own decision).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release pull requests are now created as drafts.
  * Package releases continue to use separate pull requests.
  * Added documentation clarifying release workflow behavior and testing triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->