### PR TITLE
fix(ci): treat an allow-list checkout as already lean

### DIFF
--- a/specs/ci/lean-checkout.feature
+++ b/specs/ci/lean-checkout.feature
@@ -53,6 +53,18 @@ Feature: CI checkouts leave the marketing media on the server
     And it is not required to name the media exclusions
 
   @unit
+  Scenario: A checkout that names the files it wants is already lean
+    Given a checkout step declares a sparse-checkout that names only paths it wants
+    And it names no whole-tree entry and no exclusion
+    Then it is not required to name the media exclusions
+    # An allowlist cannot pull the media: anything it does not name is never
+    # checked out. The shard-durations job takes one file — the committed
+    # vitest.durations.json — and requiring three negations there would be
+    # asserting the absence of directories it never asked for. Only a
+    # denylist, which starts from the whole tree, can pull the media by
+    # accident.
+
+  @unit
   Scenario: Cone mode is refused because it would drop a new top-level directory
     Given a checkout step that excludes the media
     Then it does not use cone mode

--- a/tools/ciguard/leancheckout.go
+++ b/tools/ciguard/leancheckout.go
@@ -45,6 +45,38 @@ const wholeDocsExclusion = "!/docs/"
 // no working tree at all.
 const gateOnlyPattern = ".github"
 
+// wholeTreePatterns are the sparse-checkout entries that ask for everything.
+// Their presence is what turns a pattern list into a denylist, and a denylist
+// is the only shape that can pull the media by accident.
+var wholeTreePatterns = []string{"/*", "*", "/**", "**"}
+
+// isAllowlist reports whether the patterns name what the job wants rather than
+// taking the whole tree and carving pieces back out.
+//
+// An allowlist cannot pull the media, because anything it does not name is
+// never checked out — `sparse-checkout: platform/app/vitest.durations.json`
+// takes exactly one file. Requiring the media exclusions of such a step is
+// noise: the negations would be three lines asserting the absence of
+// directories the step already never asked for, and under a non-cone allowlist
+// they change nothing at all.
+//
+// This generalises the `.github` gate exemption above, which is the same idea
+// hardcoded to one pattern.
+func isAllowlist(patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+
+	for _, pattern := range patterns {
+		trimmed := strings.TrimSpace(pattern)
+		if strings.HasPrefix(trimmed, "!") || slices.Contains(wholeTreePatterns, trimmed) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // LeanCheckout reports every checkout that would pull the media.
 func LeanCheckout(repoRoot string) ([]string, error) {
 	var problems []string
@@ -80,6 +112,13 @@ func leanCheckoutStep(step ciscan.CheckoutStep) []string {
 	patterns := step.Step.SparsePatterns()
 	if len(patterns) == 0 {
 		return []string{fmt.Sprintf("%s declares no sparse-checkout, so it pulls the media too", where)}
+	}
+
+	// An allowlist is lean by construction, so the media exclusions have
+	// nothing to do. Checked after the empty case above, so a job with no
+	// sparse-checkout at all is still reported.
+	if isAllowlist(patterns) {
+		return nil
 	}
 
 	problems := keepsDocsProse(where, patterns)

--- a/tools/ciguard/leancheckout_test.go
+++ b/tools/ciguard/leancheckout_test.go
@@ -45,6 +45,29 @@ const bareJob = `jobs:
         run: echo hi
 `
 
+// allowlistJob names one file and nothing else, the way shard-durations takes
+// only the committed vitest.durations.json.
+const allowlistJob = `jobs:
+  shard-durations:
+    steps:
+      - uses: actions/checkout@abc123
+        with:
+          sparse-checkout: platform/app/vitest.durations.json
+          sparse-checkout-cone-mode: false
+`
+
+// denylistJob starts from the whole tree, which is the shape that CAN pull the
+// media, so the exclusions are still required of it.
+const denylistJob = `jobs:
+  build:
+    steps:
+      - uses: actions/checkout@abc123
+        with:
+          sparse-checkout: |
+            /*
+          sparse-checkout-cone-mode: false
+`
+
 // writeWorkflows lays out a throwaway repo containing only the workflows the
 // lean-checkout guard reads.
 func writeWorkflows(t *testing.T, contents map[string]string) string {
@@ -95,6 +118,35 @@ func TestLeanCheckoutExemptsAGateJob(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, problems)
+}
+
+// @scenario "A checkout that names the files it wants is already lean"
+func TestLeanCheckoutExemptsAnAllowlistCheckout(t *testing.T) {
+	root := writeWorkflows(t, map[string]string{
+		ciguard.LeanCheckoutWorkflows[0]: allowlistJob,
+	})
+
+	problems, err := ciguard.LeanCheckout(root)
+
+	require.NoError(t, err)
+	assert.Empty(t, problems)
+}
+
+// The exemption must not swallow the case it exists to catch: a list that
+// starts from the whole tree is a denylist, and the media is back in scope.
+func TestLeanCheckoutStillRequiresExclusionsOnAWholeTreeCheckout(t *testing.T) {
+	root := writeWorkflows(t, map[string]string{
+		ciguard.LeanCheckoutWorkflows[0]: denylistJob,
+	})
+
+	problems, err := ciguard.LeanCheckout(root)
+
+	require.NoError(t, err)
+	require.Len(t, problems, 3)
+	joined := strings.Join(problems, "\n")
+	assert.Contains(t, joined, "does not exclude /docs/media/")
+	assert.Contains(t, joined, "does not exclude /docs/images/")
+	assert.Contains(t, joined, "does not exclude /assets/")
 }
 
 // @scenario "Prose under docs/ is kept, because CI reads it"


### PR DESCRIPTION
**`go-ci / test` is red on `main`, and it takes every open PR with it** — GitHub tests the merge ref, so this lands on branches that touch nothing related.

Run [31998757865](https://github.com/langwatch/langwatch/actions/runs/31998757865) at `60fa445a`:

```
--- FAIL: TestLeanCheckoutHoldsInTheLiveRepo
    Should be empty, but was [
      langwatch-app-ci.yml job "shard-durations" does not exclude /docs/media/
      ... /docs/images/
      ... /assets/ ]
```

## It's a guard false positive, not a leanness problem

The `shard-durations` job checks out **one file**:

```yaml
sparse-checkout: platform/app/vitest.durations.json
sparse-checkout-cone-mode: false
```

That cannot pull `docs/media/`, because it pulls a single JSON file. But `leanCheckoutStep` exempted exactly one hardcoded value — `gateOnlyPattern`, `.github` — and required the three `!` exclusions of everything else. So an **allow-list** checkout was judged by a rule written for **exclusion-list** checkouts.

Satisfying it literally would mean putting three negations next to a single named file: lines asserting the absence of directories the step never asked for, and which under a non-cone allow-list do nothing whatsoever.

## The fix

Generalise the existing special case rather than adding a second one.

A sparse-checkout that names no whole-tree entry (`/*`, `*`, `/**`, `**`) and no exclusion is an allow-list, and **an allow-list is lean by construction** — anything it doesn't name is never checked out. `.github` is simply an instance of that, so `gateOnlyPattern` becomes a documented example rather than the only escape hatch.

A denylist — one starting from `/*` — still has to name the exclusions. `TestLeanCheckoutStillRequiresExclusionsOnAWholeTreeCheckout` covers exactly that, so the exemption can't swallow the case it exists to catch, and it now asserts all three missing exclusions rather than two of the three it requires a count of.

## Verification

- `TestLeanCheckoutHoldsInTheLiveRepo` **passes** on this branch, which is `main` plus only this change — that's the direct proof it unblocks the queue.
- `go test ./tools/ciguard/...` green.
- `specs/ci/lean-checkout.feature` gains the scenario and is `8/8 scenarios bound`.

## The alternative, and why not

Adding the three exclusion lines to `shard-durations` also unblocks main in one commit. It bakes a redundant incantation into the workflow and leaves the next allow-list checkout to trip the same wire. Worth having in your pocket as an emergency lever if this PR is slow to land.

## Relationship to #7096

The identical fix is also in #7096, a larger CI-restructuring PR still under review. This is deliberately split out: everyone is blocked *now*, and that shouldn't wait on a big diff's review. #7096 carries byte-identical content for these files, so it reconciles without conflict whichever order they merge.
