### PR TITLE
perf(go-ci): give the build cache a rotating key, and put the cheap checks on one runner

### DIFF
--- a/.github/actions/go-build-cache/action.yml
+++ b/.github/actions/go-build-cache/action.yml
@@ -1,0 +1,50 @@
+# A Go BUILD cache that actually learns.
+#
+# `actions/setup-go` caches `~/go/pkg/mod` and `~/.cache/go-build` together
+# under one key derived from `go.sum`. That is right for the module cache — a
+# dependency set is immutable, so an immutable key is correct — and wrong for
+# the build cache, which changes with every commit.
+#
+# The consequence is visible in any go-ci run's log:
+#
+#   Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-<hash of go.sum>
+#   Cache restored successfully
+#   ...
+#   Cache hit occurred on the primary key ..., not saving cache.
+#
+# `actions/cache` never saves on a primary-key hit. So while `go.sum` is
+# unchanged — which is most of the time — the build cache is frozen at whenever
+# that key was first written, every run recompiles whatever has drifted since,
+# and throws the result away. Under `-race`, which roughly doubles compile
+# time, that was 164s of the 188s `test` job.
+#
+# The key here carries the commit, so it always misses and therefore always
+# saves; `restore-keys` falls back to the newest cache for the same `go.sum`,
+# then to any cache for the platform. The result is a cache that tracks the
+# code instead of decaying away from it.
+#
+# `setup-go`'s own cache is deliberately left on: it still handles the module
+# cache, which is the half it gets right. This action restores AFTER it, so the
+# build-cache directory it lays down wins.
+name: go-build-cache
+description: Restore and save the Go build cache under a key that rotates with the commit.
+
+inputs:
+  suffix:
+    description: >-
+      Distinguishes caches whose contents are not interchangeable. Race-
+      instrumented objects are compiled differently from plain ones, so a job
+      running `-race` should not restore a cache written without it.
+    required: false
+    default: default
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suffix }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+        restore-keys: |
+          go-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suffix }}-${{ hashFiles('go.sum') }}-
+          go-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.suffix }}-

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -97,26 +97,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+      - uses: ./.github/actions/go-build-cache
       - run: go mod verify
       - run: go build ./cmd/... ./tools/thuishaven/...
-
-  # CI's own invariant: every checkout leaves the marketing media on the
-  # server. It regresses silently — a job without the sparse-checkout does not
-  # fail, it just pulls 165 MB it never reads — so it is asserted, not
-  # reviewed.
-  ci-guards:
-    needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ciguards == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      - run: go test ./tools/ciguard/...
-      - run: go run ./cmd/ciguard
 
   test:
     needs: changes
@@ -129,13 +112,42 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+      # `race` keeps this cache separate from the plain one: race-instrumented
+      # objects are compiled differently, and restoring the wrong set would
+      # rebuild everything anyway. This step is where the rotating key pays for
+      # itself — 164s of this job's 188s was `go test`, most of it recompiling
+      # under `-race` against a cache that could never update.
+      - uses: ./.github/actions/go-build-cache
+        with:
+          suffix: race
       - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/... ./cmd/linkcheck/...
 
-  lint:
+  # lint, the generated-code check and CI's own guards, on ONE runner.
+  #
+  # They were four jobs (lint 118s, vet 103s, generated 39s, ci-guards 35s),
+  # each leasing a runner and each paying ~25s of checkout and toolchain setup
+  # to do it. Under a saturated queue the lease, not the work, is the cost: a
+  # 35s job can wait twenty minutes for a slot it holds for half a minute.
+  #
+  # Serial here is ~192s against `test`'s 185s, so this does not become the
+  # critical path — but that is only true because the redundant `vet` job is
+  # gone (see the thuishaven step below). With it the total was 295s and this
+  # WOULD have been the critical path, costing ~110s of wall clock to save
+  # three slots. Check that arithmetic again before adding a fourth thing here.
+  #
+  # Every step carries `!cancelled()` so one failure does not hide the next
+  # four: a run reports everything that is broken, the way four separate jobs
+  # did. The job still fails, because a failed step fails its job.
+  checks:
+    name: "lint · gen · guards"
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
+    # The union of the old gates. `ci-guards` ran on `go OR ciguards` because
+    # it reads workflow files, not Go source; everything else ran on `go`. The
+    # steps below keep that distinction individually, so a workflow-only change
+    # still does not pay for golangci-lint.
+    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ciguards == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -146,6 +158,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+
+      - uses: ./.github/actions/go-build-cache
       # tools/thuishaven is deliberately absent here while it is present in the
       # build, test and vet jobs. Measured at v2.11.4 it carries 231 pre-existing
       # findings: misspell 75 (US spelling enforced against prose written in
@@ -167,6 +181,7 @@ jobs:
       # --disable below drops the three house-rule linters; they are gated on
       # changed lines only in the step after this one.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         with:
           version: v2.11.4
           args: >-
@@ -188,6 +203,7 @@ jobs:
       # a v1 golangci-lint binary refuses this v2 config outright, which is why
       # the make target resolves the pinned version instead of trusting PATH.
       - name: House rules (new/changed lines only)
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4
@@ -197,47 +213,54 @@ jobs:
             ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
             ./tools/...
 
-  vet:
-    needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      - run: go vet ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/... ./tools/thuishaven/... ./tools/herrgen/... ./tools/linkcheck/...
+      # All that survives of the `vet` job, and the only part of it that was
+      # ever doing work: govet is one of golangci-lint's always-on defaults
+      # (.golangci.yml, "Defaults (always on): errcheck, govet, ineffassign,
+      # staticcheck, unused"), so vetting the packages the step above lints was
+      # running the same analyser twice for 103s and a runner lease.
+      #
+      # tools/thuishaven is the exception, and the reason this step exists
+      # rather than the job simply being deleted: it is deliberately absent
+      # from the lint scope above — 231 pre-existing findings, see that step's
+      # comment — while the old vet job did cover it. Dropping vet wholesale
+      # would have silently ended govet on it. `./tools/ciguard/...` goes the
+      # other way and is linted but was never vetted, so it needs nothing here.
+      - name: "go vet (tools/thuishaven — the one package lint does not cover)"
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
+        run: go vet ./tools/thuishaven/...
 
-  # packages/handled-error/src/codes.generated.ts mirrors the services' herr
-  # codes; the TypeScript presentation registry is keyed off it, so a Go code
-  # added without regenerating would silently ship with no customer copy.
-  # Spec: specs/ci/herr-codes-generation.feature
-  generated:
-    needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+      # packages/handled-error/src/codes.generated.ts mirrors the services' herr
+      # codes; the TypeScript presentation registry is keyed off it, so a Go code
+      # added without regenerating would silently ship with no customer copy.
       # Through the Makefile, so the check CI runs and the check a developer
       # runs cannot drift apart.
-      - run: make herrgen-check
+      # Spec: specs/ci/herr-codes-generation.feature
+      - name: Generated herr codes are current
+        if: ${{ !cancelled() && needs.changes.outputs.go == 'true' }}
+        run: make herrgen-check
+
+      # CI's own invariant: every checkout leaves the marketing media on the
+      # server. It regresses silently — a job without the sparse-checkout does
+      # not fail, it just pulls 165 MB it never reads — so it is asserted, not
+      # reviewed. Runs on a workflow-only change too, which is why this job's
+      # `if:` is the union of the two gates.
+      - name: CI guards
+        if: ${{ !cancelled() }}
+        run: go test ./tools/ciguard/...
+
+      - name: CI guards (live repo)
+        if: ${{ !cancelled() }}
+        run: go run ./cmd/ciguard
 
   # The single required status check. Every job above is `if:`-gated and so
   # cannot be required directly — a skipped job never reports, and branch
   # protection would wait forever. This one always runs and consolidates them.
   go-ci-complete:
-    needs: [changes, build, test, lint, vet, generated, ci-guards]
+    needs: [changes, build, test, checks]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: build, test, lint, vet, generated, ci-guards
+          allowed-skips: build, test, checks


### PR DESCRIPTION
**Eight jobs become five**, and the slowest one stops recompiling against a cache that could never learn.

Measured across 13 recent go-ci runs:

| job | median |
|---|---|
| test | **185s** |
| lint | 118s |
| vet | 103s |
| build | 87s |
| generated | 39s |
| ci-guards | 35s |
| changes | 8s |

## 1. The build cache never updates

`actions/setup-go` caches `~/go/pkg/mod` and `~/.cache/go-build` together under one key derived from `go.sum`. That's right for the module cache — a dependency set is immutable, so an immutable key is correct — and wrong for the build cache, which changes with every commit. Every run says so:

```
Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-<hash of go.sum>
Cache restored successfully
...
Cache hit occurred on the primary key ..., not saving cache.
```

`actions/cache` never saves on a primary-key hit. So while `go.sum` is unchanged — most of the time — **the build cache is frozen at whenever that key was first written**, every run recompiles whatever has drifted since, and throws the result away. Under `-race`, which roughly doubles compile time, that was **164s of the `test` job's 188s**.

`.github/actions/go-build-cache` keys on the commit, so it always misses and therefore always saves, with `restore-keys` falling back to the newest cache for the same `go.sum`. Race-instrumented objects get their own suffix — restoring plain objects into a `-race` build rebuilds everything anyway. `setup-go`'s cache stays on for the module half, which is the half it gets right.

## 2. `vet` was mostly running golangci-lint's work twice

`govet` is one of golangci-lint's always-on defaults — `.golangci.yml` says so in as many words: *"Defaults (always on): errcheck, govet, ineffassign, staticcheck, unused"*. So vetting the packages `lint` already lints ran the same analyser twice, for 103s and a runner lease.

**Mostly, not entirely** — and this is the part worth reviewing. `./tools/thuishaven/...` is deliberately outside the lint scope (231 pre-existing findings; see that step's comment), but the `vet` job *did* cover it. Deleting the job wholesale would have silently ended govet there, so that one package survives as a step. `./tools/ciguard/...` goes the other way — linted but never vetted — so it needs nothing.

## 3. The cheap checks share a runner

`lint`, `generated` and `ci-guards` each leased a runner and each paid ~25s of checkout and toolchain setup to do it. Under a saturated queue the lease, not the work, is the cost: a 35s job can wait twenty minutes for a slot it holds for half a minute. They're now one job, `lint · gen · guards`.

Serial, that's **~192s against `test`'s 185s**, so it doesn't become the critical path — but only because `vet` is gone. With it the total was 295s and this would have cost ~110s of wall clock to save three slots. That arithmetic is written into the job's comment, since it's the thing to recheck before anyone adds a fourth item.

**Two behaviours preserved deliberately:**

- `ci-guards` ran on `go OR ciguards` because it reads *workflow files*, not Go source. The job's `if:` is the union of the two gates, and the steps keep the distinction individually — so a workflow-only change still doesn't pay for golangci-lint.
- Every step carries `!cancelled()`, so one failure doesn't hide the next four. A run reports everything that's broken, the way four separate jobs did, and the job still fails because a failed step fails its job.

## Verified locally

- `go vet ./tools/thuishaven/...` — clean
- `go test ./tools/ciguard/...` — ok
- `go run ./cmd/ciguard` — passes `lean-checkout` and `go-version`
- `go-ci.yaml` is not in `LeanCheckoutWorkflows`, so the `fetch-depth: 0` checkout doesn't trip that rule

## Deliberately not here

`t.Parallel()`. 371 Go test files, zero use it — but Go already runs *packages* concurrently, so it only helps *within* a package, and under `-race` it raises peak memory. Worth doing for the few slowest packages after measuring with `go test -json`, not as a blanket sweep.

The same shape applies to `code-scanners` (5 sub-60s jobs), `go-services` and `clickhouse-serverless`. Worth landing this one first and reading the real numbers before repeating it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added build caching to speed up builds, tests, and checks.
  * Supports separate cache variants for incompatible build configurations.

* **CI Improvements**
  * Consolidated code quality and validation checks into a unified workflow.
  * Streamlined vetting to focus on relevant tooling.
  * Improved workflow handling when build, test, or validation jobs are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->