### PR TITLE
fix(ops): drop the namespace the dead-letter block stopped using

### DIFF
--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -75,8 +75,6 @@ async function seedMessage(params: {
   return row.id;
 }
 
-/** A second process name, so the fleet-wide dead read has more than one. */
-const nsB = `${ns}.b`;
 /**
  * The dead-letter block seeds under its own names.
  *


### PR DESCRIPTION
Follow-up to #7099, which merged one commit before this landed.

#7099 gave the dead-letter block in `process-ops.integration.test.ts` its own `nsDead` / `nsDeadB` namespaces, so that its fleet-wide assertions stop counting the two dead rows the fleet-count block seeds under plain `ns`. That left `nsB` declared and unreferenced.

`noUnusedVariables` is a warning rather than an error, so a whole-tree `pnpm lint` still exits 0 — which is exactly why this slipped through locally. CI gates on the **delta** instead, and reported `lint/correctness/noUnusedVariables: 0 -> 1`.

## Test plan

- `biome check src` reports zero `noUnusedVariables` findings.
- Removal only; no test logic touched. `nsDeadB` (the namespace that replaced `nsB` in that block) is untouched and still referenced.

## Deployment Impact

None. Test-file only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for dead-letter message listing, ordering, filtering, and per-process counts.
  * Added verification of trace IDs and redriving messages using returned process references.
  * Improved test isolation and cleanup for dead-letter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->