### PR TITLE
fix(billing): stop warning every five minutes about ordinary pricing (#6495)

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -468,7 +468,6 @@ const LEGACY_INERT: string[] = [
   "specs/langy/langy-shutdown-handoff.feature",
   "specs/langy/langy-workbench-sidebar.feature",
   "specs/langy/langy-worker-isolation.feature",
-  "specs/licensing/billing-meter-dispatch.feature",
   "specs/licensing/dual-pricing-model.feature",
   "specs/licensing/enforcement-hono-api.feature",
   "specs/licensing/license-activation-ui.feature",

--- a/platform/app/src/server/app-layer/organizations/__tests__/organization.prisma.repository.billing-lookup.integration.test.ts
+++ b/platform/app/src/server/app-layer/organizations/__tests__/organization.prisma.repository.billing-lookup.integration.test.ts
@@ -1,0 +1,94 @@
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Organization } from "~/generated/prisma/client";
+import { PricingModel } from "~/generated/prisma/client";
+import { prisma } from "~/server/db";
+import { PrismaOrganizationRepository } from "../repositories/organization.prisma.repository";
+
+/**
+ * The three-way verdict of the billing lookup, pinned at the layer that
+ * decides it.
+ *
+ * The usage-reporting handler's own unit tests mock this method, so they can
+ * only check what it does with an answer, never which answer it gives. That
+ * gap is where the defect lived: the query filtered on `pricingModel`, so an
+ * organization that simply does not buy usage came back indistinguishable from
+ * one that does not exist, and the handler reported the ordinary case at the
+ * anomaly's severity because it had no way to tell them apart.
+ *
+ * The middle case below is the regression. The two either side of it are what
+ * stop the fix from being written as "always answer not_usage_billed".
+ */
+describe("PrismaOrganizationRepository billing lookup", () => {
+  let repository: PrismaOrganizationRepository;
+  let usageBilled: Organization;
+  let tiered: Organization;
+  const namespace = `billing-lookup-${nanoid(8)}`;
+
+  beforeAll(async () => {
+    repository = new PrismaOrganizationRepository(prisma);
+
+    usageBilled = await prisma.organization.create({
+      data: {
+        name: `Usage billed ${namespace}`,
+        slug: `usage-billed-${namespace}`,
+        pricingModel: PricingModel.SEAT_EVENT,
+      },
+    });
+
+    tiered = await prisma.organization.create({
+      data: {
+        name: `Tiered ${namespace}`,
+        slug: `tiered-${namespace}`,
+        pricingModel: PricingModel.TIERED,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: { id: { in: [usageBilled.id, tiered.id] } },
+    });
+  });
+
+  describe("given an organization on usage-based pricing", () => {
+    describe("when the lookup runs", () => {
+      it("answers usage_billed and carries the organization", async () => {
+        const result = await repository.getOrganizationForBilling(
+          usageBilled.id,
+        );
+
+        expect(result.outcome).toBe("usage_billed");
+        if (result.outcome !== "usage_billed") return;
+        expect(result.organization.id).toBe(usageBilled.id);
+        // The pricing model is read to classify, not published: it is not part
+        // of what the handler needs, and leaking it would invite a second
+        // check of the same condition at the call site.
+        expect(result.organization).not.toHaveProperty("pricingModel");
+      });
+    });
+  });
+
+  describe("given an organization that is not on usage-based pricing", () => {
+    describe("when the lookup runs", () => {
+      /** @scenario "The billing lookup tells an absent organization from one that does not buy usage" */
+      it("answers not_usage_billed rather than not_found", async () => {
+        const result = await repository.getOrganizationForBilling(tiered.id);
+
+        expect(result.outcome).toBe("not_usage_billed");
+      });
+    });
+  });
+
+  describe("given no such organization", () => {
+    describe("when the lookup runs", () => {
+      it("answers not_found", async () => {
+        const result = await repository.getOrganizationForBilling(
+          `missing-${namespace}`,
+        );
+
+        expect(result.outcome).toBe("not_found");
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/organizations/__tests__/organization.prisma.repository.billing-lookup.integration.test.ts
+++ b/platform/app/src/server/app-layer/organizations/__tests__/organization.prisma.repository.billing-lookup.integration.test.ts
@@ -24,6 +24,12 @@ describe("PrismaOrganizationRepository billing lookup", () => {
   let usageBilled: Organization;
   let tiered: Organization;
   const namespace = `billing-lookup-${nanoid(8)}`;
+  /**
+   * Cleanup reads this, not the fixtures. A create that throws leaves its
+   * fixture undefined, and a teardown that dereferences one fails with an
+   * error of its own in front of the one that actually broke the run.
+   */
+  const createdIds: string[] = [];
 
   beforeAll(async () => {
     repository = new PrismaOrganizationRepository(prisma);
@@ -35,6 +41,7 @@ describe("PrismaOrganizationRepository billing lookup", () => {
         pricingModel: PricingModel.SEAT_EVENT,
       },
     });
+    createdIds.push(usageBilled.id);
 
     tiered = await prisma.organization.create({
       data: {
@@ -43,11 +50,13 @@ describe("PrismaOrganizationRepository billing lookup", () => {
         pricingModel: PricingModel.TIERED,
       },
     });
+    createdIds.push(tiered.id);
   });
 
   afterAll(async () => {
+    if (createdIds.length === 0) return;
     await prisma.organization.deleteMany({
-      where: { id: { in: [usageBilled.id, tiered.id] } },
+      where: { id: { in: createdIds } },
     });
   });
 

--- a/platform/app/src/server/app-layer/organizations/organization.service.ts
+++ b/platform/app/src/server/app-layer/organizations/organization.service.ts
@@ -40,11 +40,11 @@ import {
 } from "./errors";
 import type {
   AuditLogFilters,
+  BillingOrganizationLookup,
   CreateAndAssignResult,
   EnrichedAuditLog,
   FullyLoadedOrganization,
   MemberTeamBinding,
-  OrganizationForBilling,
   OrganizationMemberSummary,
   OrganizationMemberWithUser,
   OrganizationProvisioningSummary,
@@ -308,7 +308,7 @@ export class OrganizationService {
 
   async getOrganizationForBilling(
     organizationId: string,
-  ): Promise<OrganizationForBilling | null> {
+  ): Promise<BillingOrganizationLookup> {
     return this.repo.getOrganizationForBilling(organizationId);
   }
 

--- a/platform/app/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -36,6 +36,7 @@ import {
 } from "../errors";
 import type {
   AuditLogFilters,
+  BillingOrganizationLookup,
   CreateAndAssignInput,
   CreateAndAssignResult,
   CreateForProvisioningInput,
@@ -43,7 +44,6 @@ import type {
   EnrichedAuditLog,
   FullyLoadedOrganization,
   MemberTeamBinding,
-  OrganizationForBilling,
   OrganizationMemberSummary,
   OrganizationMemberWithUser,
   OrganizationProvisioningSummary,
@@ -444,11 +444,17 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
 
   async getOrganizationForBilling(
     organizationId: string,
-  ): Promise<OrganizationForBilling | null> {
-    return this.prisma.organization.findFirst({
-      where: { id: organizationId, pricingModel: PricingModel.SEAT_EVENT },
+  ): Promise<BillingOrganizationLookup> {
+    // The pricing model is SELECTED rather than filtered on, so one query
+    // still answers both questions. Filtering on it made a non-usage-billed
+    // organization indistinguishable from an absent row, and the only way to
+    // tell them apart afterwards would have been a second query on the exact
+    // path this lookup is trying to keep cheap.
+    const organization = await this.prisma.organization.findFirst({
+      where: { id: organizationId },
       select: {
         id: true,
+        pricingModel: true,
         stripeCustomerId: true,
         subscriptions: {
           where: {
@@ -461,6 +467,14 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
         },
       },
     });
+
+    if (!organization) return { outcome: "not_found" };
+    if (organization.pricingModel !== PricingModel.SEAT_EVENT) {
+      return { outcome: "not_usage_billed" };
+    }
+
+    const { pricingModel: _pricingModel, ...forBilling } = organization;
+    return { outcome: "usage_billed", organization: forBilling };
   }
 
   async createAndAssign(

--- a/platform/app/src/server/app-layer/organizations/repositories/organization.repository.ts
+++ b/platform/app/src/server/app-layer/organizations/repositories/organization.repository.ts
@@ -86,6 +86,20 @@ export interface OrganizationForBilling {
 }
 
 /**
+ * Why the billing lookup did or did not yield an organization.
+ *
+ * A nullable return cannot carry this: "there is no such organization" is an
+ * anomaly worth a warning, and "this organization does not buy usage" is the
+ * ordinary state of every free and legacy plan. Collapsing both into `null`
+ * left the caller with one branch and therefore one severity, so the routine
+ * case was reported at the anomaly's.
+ */
+export type BillingOrganizationLookup =
+  | { outcome: "usage_billed"; organization: OrganizationForBilling }
+  | { outcome: "not_found" }
+  | { outcome: "not_usage_billed" };
+
+/**
  * Input for creating an organization and assigning the user as admin.
  */
 export interface CreateAndAssignInput {
@@ -365,7 +379,7 @@ export interface OrganizationRepository {
   ): Promise<OrganizationIntent | null>;
   getOrganizationForBilling(
     organizationId: string,
-  ): Promise<OrganizationForBilling | null>;
+  ): Promise<BillingOrganizationLookup>;
 
   // --- New methods for router delegation ---
 
@@ -560,8 +574,8 @@ export class NullOrganizationRepository implements OrganizationRepository {
 
   async getOrganizationForBilling(
     _organizationId: string,
-  ): Promise<OrganizationForBilling | null> {
-    return null;
+  ): Promise<BillingOrganizationLookup> {
+    return { outcome: "not_found" };
   }
 
   async createAndAssign(

--- a/platform/app/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
@@ -25,19 +25,25 @@ const {
   mockCaptureException,
   mockQueryBillableEventsTotal,
   createMockLogger,
+  mockLogger,
 } = vi.hoisted(() => {
   const mockReportUsageDelta = vi.fn();
   const mockSelfDispatch = vi.fn();
   const mockCaptureException = vi.fn();
   const mockQueryBillableEventsTotal = vi.fn();
 
-  const createMockLogger = () => ({
+  const createMockLogger = (): Record<string, unknown> => ({
     info: vi.fn(),
     debug: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
     child: vi.fn(() => createMockLogger()),
   });
+
+  // One instance, not one per `createLogger` call: the severity a skip is
+  // reported at is the whole point of these tests, and it is only observable
+  // if the handler's logger is the one they can read.
+  const mockLogger = createMockLogger();
 
   const mockOrganizations = {
     getOrganizationForBilling: vi.fn(),
@@ -59,6 +65,7 @@ const {
     mockCaptureException,
     mockQueryBillableEventsTotal,
     createMockLogger,
+    mockLogger,
   };
 });
 
@@ -67,7 +74,7 @@ const {
 // ---------------------------------------------------------------------------
 
 vi.mock("@langwatch/observability", () => ({
-  createLogger: vi.fn(() => createMockLogger()),
+  createLogger: vi.fn(() => mockLogger),
 }));
 
 // Disable the org-level TtlCache so tests don't share cached org data across runs
@@ -114,7 +121,7 @@ function makeCommand(
   };
 }
 
-function makeOrg({
+function usageBilledOrg({
   id = "org-1",
   stripeCustomerId = "cus_123",
   hasSubscription = true,
@@ -124,9 +131,12 @@ function makeOrg({
   hasSubscription?: boolean;
 } = {}) {
   return {
-    id,
-    stripeCustomerId,
-    subscriptions: hasSubscription ? [{ id: "sub-1" }] : [],
+    outcome: "usage_billed" as const,
+    organization: {
+      id,
+      stripeCustomerId,
+      subscriptions: hasSubscription ? [{ id: "sub-1" }] : [],
+    },
   };
 }
 
@@ -163,7 +173,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given org not found", () => {
     it("returns empty events without reporting", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(null);
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue({
+        outcome: "not_found",
+      });
       const handler = await createHandler();
 
       const result = await handler.handle(makeCommand());
@@ -172,12 +184,56 @@ describe("ReportUsageForMonthCommand", () => {
       expect(mockReportUsageDelta).not.toHaveBeenCalled();
       expect(mockSelfDispatch).not.toHaveBeenCalled();
     });
+
+    /** @scenario "A dispatch naming an organization that does not exist is a warning" */
+    it("warns, because a dispatch naming an absent organization is an anomaly", async () => {
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue({
+        outcome: "not_found",
+      });
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given org is not on usage-based pricing", () => {
+    it("returns empty events without reporting", async () => {
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue({
+        outcome: "not_usage_billed",
+      });
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+      expect(mockSelfDispatch).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "An organization that does not buy usage is skipped quietly" */
+    it("logs at debug, not warn, because every free and legacy plan lands here every cycle", async () => {
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue({
+        outcome: "not_usage_billed",
+      });
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      // The regression this file exists to hold: the old handler could not
+      // tell this case from a missing organization, so it warned on both and
+      // the routine one recurred forever.
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("given org has no stripeCustomerId", () => {
     it("returns empty events without reporting", async () => {
       mockOrganizations.getOrganizationForBilling.mockResolvedValue(
-        makeOrg({ stripeCustomerId: null }),
+        usageBilledOrg({ stripeCustomerId: null }),
       );
       const handler = await createHandler();
 
@@ -191,7 +247,7 @@ describe("ReportUsageForMonthCommand", () => {
   describe("given org has no active subscription", () => {
     it("returns empty events without reporting", async () => {
       mockOrganizations.getOrganizationForBilling.mockResolvedValue(
-        makeOrg({ hasSubscription: false }),
+        usageBilledOrg({ hasSubscription: false }),
       );
       const handler = await createHandler();
 
@@ -204,7 +260,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given ClickHouse not available", () => {
     it("returns empty events without reporting", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue(null);
       mockQueryBillableEventsTotal.mockResolvedValue(null);
       const handler = await createHandler();
@@ -219,7 +277,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given delta is zero", () => {
     it("returns empty events without reporting", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 100,
         pendingReportedTotal: null,
@@ -241,7 +301,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given org with billable events and active subscription", () => {
     it("reports delta, updates checkpoint, and self-dispatches", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 100,
         pendingReportedTotal: null,
@@ -292,7 +354,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given first run for new org (no checkpoint)", () => {
     it("creates checkpoint at reported total", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue(null);
       mockQueryBillableEventsTotal.mockResolvedValue(50);
       mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
@@ -327,7 +391,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given pending checkpoint (crash recovery)", () => {
     it("uses pending value with same idempotency key", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 100,
         pendingReportedTotal: 200,
@@ -363,7 +429,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given permanent Stripe rejection", () => {
     it("clears pending, increments failures, does NOT self-dispatch", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 100,
         pendingReportedTotal: null,
@@ -403,7 +471,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given transient Stripe error", () => {
     it("catches error, increments failures, and self-dispatches for retry", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 0,
         pendingReportedTotal: null,
@@ -454,7 +524,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given 5 consecutive failures (circuit-breaker threshold)", () => {
     it("does NOT self-dispatch and logs alarm", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 100,
         pendingReportedTotal: null,
@@ -474,7 +546,9 @@ describe("ReportUsageForMonthCommand", () => {
 
   describe("given circuit-breaker reset after successful report", () => {
     it("resets consecutiveFailures to 0 on success", async () => {
-      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        usageBilledOrg(),
+      );
       mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
         lastReportedTotal: 100,
         pendingReportedTotal: null,

--- a/platform/app/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
@@ -24,7 +24,6 @@ const {
   mockSelfDispatch,
   mockCaptureException,
   mockQueryBillableEventsTotal,
-  createMockLogger,
   mockLogger,
 } = vi.hoisted(() => {
   const mockReportUsageDelta = vi.fn();
@@ -64,7 +63,6 @@ const {
     mockSelfDispatch,
     mockCaptureException,
     mockQueryBillableEventsTotal,
-    createMockLogger,
     mockLogger,
   };
 });

--- a/platform/app/src/server/event-sourcing/pipelines/billing-reporting/commands/reportUsageForMonth.command.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/billing-reporting/commands/reportUsageForMonth.command.ts
@@ -9,6 +9,7 @@ import type { queryBillableEventsTotal as QueryBillableEventsTotalFn } from "../
 import type { UsageReportingService } from "../../../../../../ee/billing/services/usageReportingService";
 import type { BillingCheckpointService } from "../../../../app-layer/billing/billingCheckpoint.service";
 import type { OrganizationService } from "../../../../app-layer/organizations/organization.service";
+import type { BillingOrganizationLookup } from "../../../../app-layer/organizations/repositories/organization.repository";
 import type { Command, CommandHandler } from "../../../";
 import { defineCommandSchema } from "../../../";
 import type { Event } from "../../../domain/types";
@@ -28,13 +29,20 @@ const MAX_CONSECUTIVE_FAILURES = 5;
 
 const ONE_MINUTE_MS = 60 * 1000;
 
-type CachedOrgData = {
-  id: string;
-  stripeCustomerId: string | null;
-  subscriptions: { id: string }[];
-};
-
-const orgCache = new TtlCache<CachedOrgData>(
+/**
+ * The whole lookup verdict is cached, not just a hit, so a skip costs the same
+ * as anything else on a second pass within the window.
+ *
+ * Worth knowing what this does and does not buy: the window is one minute and
+ * the dispatch that drives this handler is suppressed to one per organization
+ * per five (`BILLING_METER_DISPATCH_SUPPRESS_MS`), so in the steady state the
+ * entry has always expired before the next command arrives and the query runs
+ * regardless. What it saves is the bursts, where two commands for one
+ * organization land together: the grace window at the start of a month
+ * dispatches the previous month alongside the current one, and those carry
+ * different dedup keys, so both run.
+ */
+const orgCache = new TtlCache<BillingOrganizationLookup>(
   ONE_MINUTE_MS,
   "ttlcache:billing:orgData:",
 );
@@ -112,24 +120,38 @@ export class ReportUsageForMonthCommand
     let shouldSelfDispatch = false;
     try {
       // 1. Skip conditions
-      let org = (await orgCache.get(organizationId)) ?? null;
-      if (!org) {
-        org =
+      let lookup = await orgCache.get(organizationId);
+      if (!lookup) {
+        lookup =
           await this.deps.organizations.getOrganizationForBilling(
             organizationId,
           );
-        if (org) {
-          await orgCache.set(organizationId, org);
-        }
+        // The skip verdicts are cached too. Only a hit was cached before, so
+        // the organizations that reach this handler and can never do anything
+        // here were the only ones paying for the query every time.
+        await orgCache.set(organizationId, lookup);
       }
 
-      if (!org) {
-        logger.warn(
+      if (lookup.outcome === "not_found") {
+        logger.warn({ organizationId }, "organization not found, skipping");
+        return [];
+      }
+
+      if (lookup.outcome === "not_usage_billed") {
+        // Debug, like the two skips below it. A free or legacy plan reaching
+        // this handler is the system working: the dispatch is per active
+        // organization and takes no view on pricing, so every one of them
+        // arrives here and stops. Reporting that at warn put a permanent,
+        // recurring line in front of whoever greps for warnings during an
+        // incident.
+        logger.debug(
           { organizationId },
-          "organization not found or not SEAT_EVENT, skipping",
+          "organization is not on usage-based pricing, skipping usage reporting",
         );
         return [];
       }
+
+      const org = lookup.organization;
 
       if (!org.stripeCustomerId) {
         logger.debug(

--- a/specs/licensing/billing-meter-dispatch.feature
+++ b/specs/licensing/billing-meter-dispatch.feature
@@ -74,6 +74,35 @@ Feature: Billing Meter Dispatch
     Then only one reporting job is active for the organization
 
   # ============================================================================
+  # Skip conditions: what is an anomaly, and what is Tuesday
+  # ============================================================================
+
+  # The dispatch is per active organization and takes no view on pricing, so
+  # every organization reaches the reporting handler and most of them stop
+  # there. Which of those stops deserves an operator's attention is the point
+  # of these three.
+
+  @unit
+  Scenario: An organization that does not buy usage is skipped quietly
+    Given an organization that is not on usage-based pricing
+    When the usage reporting handler runs for it
+    Then no usage is reported
+    And the skip is recorded at debug, not as a warning
+
+  @unit
+  Scenario: A dispatch naming an organization that does not exist is a warning
+    Given a dispatch for an organization id that no organization has
+    When the usage reporting handler runs for it
+    Then no usage is reported
+    And the skip is recorded as a warning
+
+  @integration
+  Scenario: The billing lookup tells an absent organization from one that does not buy usage
+    Given an organization on usage-based pricing and another on tiered pricing
+    When the billing lookup runs for each of them and for an unused id
+    Then it answers usage_billed, not_usage_billed, and not_found respectively
+
+  # ============================================================================
   # Known Limitations (v1)
   # ============================================================================
 


### PR DESCRIPTION
## Ticket

Closes #6495.

Every organization not on usage-based pricing produced a WARN every five minutes, forever, on every worker: `organization not found or not SEAT_EVENT, skipping`. A completely ordinary state, logged at the severity on-call greps for during an incident.

## Why one line could not say which

`getOrganizationForBilling` filtered on the pricing model:

```ts
findFirst({ where: { id: organizationId, pricingModel: PricingModel.SEAT_EVENT } })
```

So `null` meant either "no such organization", a real anomaly, or "this organization does not buy usage", the steady state of every free and legacy plan. One return value, therefore one branch in the handler, therefore one severity. The routine case got the anomaly's.

## Change

The lookup answers a verdict instead of a nullable row:

```ts
export type BillingOrganizationLookup =
  | { outcome: "usage_billed"; organization: OrganizationForBilling }
  | { outcome: "not_found" }
  | { outcome: "not_usage_billed" };
```

`pricingModel` is now SELECTed rather than filtered on, so one query still answers both questions. Filtering it was what made the two cases indistinguishable, and the only way to separate them afterwards would have been a second query on the exact path this lookup exists to keep cheap.

The handler gets the branch it was missing: `not_found` keeps the warning, `not_usage_billed` goes to debug alongside the two skips already below it. The pricing model is not published on the result, so the call site cannot re-check the condition the repository just decided.

Three states also make the old bug unrepresentable rather than merely fixed: a future caller cannot collapse "does not buy usage" into "missing" without deleting a branch the compiler is asking for.

## On the ticket's second half

The ticket also asks to cache the negative result, noting `null` is never cached so every dispatch re-queries Postgres. The caching is done, but it is worth being straight about what it buys, because the reasoning does not survive contact with the intervals:

- `orgCache` TTL is `ONE_MINUTE_MS`.
- The dispatch that drives this handler is suppressed to one per organization per five minutes (`BILLING_METER_DISPATCH_SUPPRESS_MS = 300_000`).

The entry has therefore always expired before the next command arrives, so in the steady state the query runs either way. That was already true of the positive cache. What the negative one genuinely saves is bursts, where two commands for one organization land together: the grace window at the start of a month dispatches the previous month alongside the current one, and those carry different dedup keys, so both run.

Raising the TTL would make the cache do what the ticket describes, but that is a billing-freshness decision rather than a logging fix, so it is not in this PR. Happy to open it separately if wanted.

## Evidence

**Five mutations, five caught,** each applied to the shipped tree and reverted between runs:

| # | Mutation | Fails |
|---|---|---|
| M1 | `not_usage_billed` logs warn instead of debug | the debug test, only |
| M2 | `not_found` logs debug instead of warn | the warn test, only |
| M3 | repository re-conflates non-SEAT_EVENT with absent (the original bug) | the classification test, only |
| M4 | repository leaks `pricingModel` onto the returned organization | the usage_billed test, only |
| M5 | one `@scenario` annotation removed | the parity gate, `2/3 scenarios bound` |

M3 is the one that matters, and it is why there is an integration test at all: the handler's unit tests mock `getOrganizationForBilling`, so they can only check what it does with an answer, never which answer it gives. The defect lived on the side they cannot see. M1 and M2 are the mirror pair that stop the fix from being written as "log everything at debug".

**Tests.** 40 unit across the organizations and billing-reporting slices, 3 new integration against a real Postgres.

**Types.** `pnpm typecheck` and `pnpm typecheck:tests` both report 0 errors, run separately, since the first failing locally would otherwise stop the second from running at all.

**Specs.** The behaviour is now three bound scenarios in `specs/licensing/billing-meter-dispatch.feature`. That file was in the parity script's `LEGACY_INERT` allow-list because every scenario in it was `@unimplemented`; binding these made the gate fail with "1 file(s) in LEGACY_INERT now enforce scenarios", so the entry is removed. `check:feature-parity` exits 0, and reports `3/3 scenarios bound` for the file.

**Lint.** Zero error-level Biome diagnostics across all seven changed files.

## Deployment impact

None. No migration, no config, no wire or API change. One log line drops from warn to debug and one becomes more specific; the admission conditions for reporting usage are untouched.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage reporting for organizations without usage-based billing.
  * Skips non-usage-billed organizations quietly while warning when organizations cannot be found.
  * Prevents repeated billing lookups by caching successful and skipped results.
  * Billing lookups now clearly distinguish usage-billed, non-usage-billed, and missing organizations.

* **Tests**
  * Added coverage for all billing lookup outcomes.
  * Added end-to-end checks for reporting, logging, and skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->