### PR TITLE
fix(errors): recognise a validation failure whichever zod threw it

### DIFF
--- a/packages/api/src/errors.ts
+++ b/packages/api/src/errors.ts
@@ -1,7 +1,11 @@
-import { HandledError, ValidationError } from "@langwatch/handled-error";
+import {
+  HandledError,
+  isZodLikeError,
+  ValidationError,
+  type ZodLikeError,
+} from "@langwatch/handled-error";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { ZodError } from "zod";
 
 import { httpStatusText } from "./types.js";
 
@@ -36,8 +40,13 @@ class SchemaFailure extends HandledError {
  * `getLogLevelForRequest`). A bare `ZodError` has neither `httpStatus` nor
  * `fault`, so it was logged as a 500 `error` while the response went out 422 —
  * validation noise landing in the 5xx error budget.
+ *
+ * Typed `ZodLikeError`, not `ZodError`: routes mounted on this app validate
+ * with whichever zod their schema was authored against, and the repo now runs
+ * both majors. `issue.code`, `issue.path` and `issue.message` are identical
+ * across them, so the reasons this builds are too.
  */
-function validationErrorFromZod(err: ZodError): ValidationError {
+function validationErrorFromZod(err: ZodLikeError): ValidationError {
   return new ValidationError("Validation error", {
     reasons: err.issues.map(
       (issue) =>
@@ -152,7 +161,10 @@ function formatError({
   }
 
   // 2. ZodError -- promoted to a ValidationError so it travels the same path.
-  if (err instanceof ZodError) {
+  //    Matched by shape, so a route whose schema is on `zod/v4` is promoted
+  //    the same as one still on v3; an `instanceof` would see only one major
+  //    and drop the other's rejections through to the unknown-error 500 below.
+  if (isZodLikeError(err)) {
     return handledErrorToResponse({
       err: validationErrorFromZod(err),
       isVersioned,
@@ -236,8 +248,7 @@ export function createErrorHandler(): (
     // Promote first so the response and the log agree on one error. Reporting
     // the raw ZodError would log it as unhandled, at `error`, against the 500
     // it no longer is.
-    const effective =
-      err instanceof ZodError ? validationErrorFromZod(err) : err;
+    const effective = isZodLikeError(err) ? validationErrorFromZod(err) : err;
     const { status, body } = formatError({ err: effective, isVersioned });
 
     const resolved: ResolvedError = {

--- a/packages/handled-error/src/handled-error.ts
+++ b/packages/handled-error/src/handled-error.ts
@@ -415,6 +415,13 @@ export class NotFoundError extends HandledError {
   }
 }
 
+/** One zod issue, in the shape both v3 and v4 agree on. */
+export interface ZodLikeIssue {
+  code: string;
+  path: PropertyKey[];
+  message: string;
+}
+
 /**
  * Structural stand-in for zod's `ZodError`. The package is consumed by the app
  * (zod 3.x classic), mcp-server (zod 4) and SDKs — importing `ZodError` from
@@ -422,11 +429,45 @@ export class NotFoundError extends HandledError {
  * error with zod's `flatten()` shape qualifies.
  */
 export interface ZodLikeError {
+  name: string;
   message: string;
+  issues: ZodLikeIssue[];
   flatten(): {
     formErrors: string[];
     fieldErrors: Record<string, string[] | undefined>;
   };
+}
+
+/**
+ * Is this a zod error, whichever zod threw it?
+ *
+ * `err instanceof ZodError` answers "did the zod *I* imported throw this",
+ * which is a different question the moment a repo runs two zod entrypoints —
+ * and this one does: most schemas are authored against the default (v3)
+ * export, a growing set against `zod/v4`. The two ship separate `ZodError`
+ * classes, so a v4 error fails `instanceof` a v3 `ZodError` and vice versa.
+ *
+ * That is not a cosmetic mismatch. Every validation boundary is an
+ * `instanceof` gate deciding whether a failure is the *caller's* fault, so a
+ * missed gate does not merely lose formatting: the error stops being a 422
+ * `validation_error` the customer can act on and becomes an unnamed 500,
+ * logged against the platform's error budget. Moving one leaf schema to
+ * `zod/v4` is enough to do it, with nothing at the seam to say so — the
+ * schema and the gate that catches it are usually different files, and
+ * typecheck sees no disagreement between them.
+ *
+ * So the gates ask about shape instead of identity. `name` plus `issues`
+ * plus `flatten` is the intersection both versions satisfy and the whole of
+ * what the consumers here read.
+ */
+export function isZodLikeError(err: unknown): err is ZodLikeError {
+  if (typeof err !== "object" || err === null) return false;
+  const candidate = err as Partial<ZodLikeError>;
+  return (
+    candidate.name === "ZodError" &&
+    Array.isArray(candidate.issues) &&
+    typeof candidate.flatten === "function"
+  );
 }
 
 /**

--- a/packages/handled-error/src/index.ts
+++ b/packages/handled-error/src/index.ts
@@ -3,6 +3,7 @@ export {
   NotFoundError,
   ValidationError,
   handledErrorFromHerr,
+  isZodLikeError,
   setTraceUrlProvider,
 } from "./handled-error";
 export type {
@@ -13,6 +14,7 @@ export type {
   SerializedReason,
   TraceUrlProvider,
   ZodLikeError,
+  ZodLikeIssue,
 } from "./handled-error";
 export { goErrorCodes, nodeErrorCodes } from "./codes.generated";
 export type { GoErrorCode, NodeErrorCode } from "./codes.generated";

--- a/platform/app/ee/governance/routers/anomalyRules.ts
+++ b/platform/app/ee/governance/routers/anomalyRules.ts
@@ -23,7 +23,7 @@ import {
   SUPPORTED_SCOPES,
   SUPPORTED_SEVERITIES,
 } from "@ee/governance/services/activity-monitor/anomalyRule.service";
-import { ValidationError } from "@langwatch/handled-error";
+import { isZodLikeError, ValidationError } from "@langwatch/handled-error";
 import { z } from "zod";
 
 import {
@@ -58,12 +58,19 @@ const enterpriseGate = requireEnterprisePlan(
  * `ValidationError` from `thresholdConfig.schema.ts`, so it falls through the
  * re-throw below and the boundary serialises it with its own `meta`.
  * Anything else re-throws unchanged so genuine internal errors stay visible.
+ *
+ * `isZodLikeError`, not `instanceof z.ZodError`: the two schemas this gate
+ * catches are on different zod majors — `thresholdConfig.schema.ts` is on
+ * `zod/v4`, `destinationConfig.schema.ts` still on v3 — and each major throws
+ * its own `ZodError` class. An `instanceof` against either one silently stops
+ * recognising the other's failures, which then leave here as unnamed 500s
+ * instead of the 422 the admin can act on.
  */
 function translateConfigValidationError(
   err: unknown,
   ruleType?: string,
 ): never {
-  if (err instanceof z.ZodError) {
+  if (isZodLikeError(err)) {
     // Detect which config the issues belong to so the error message
     // points the admin at the right field. Both threshold-config and
     // destination-config (Phase 2C C3) validation produce ZodError;

--- a/platform/app/src/server/api/__tests__/trpc-error-formatter.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/trpc-error-formatter.unit.test.ts
@@ -7,6 +7,7 @@ import { StackContextManager } from "@opentelemetry/sdk-trace-web";
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
+import { z as z4 } from "zod/v4";
 import { errorFormatter } from "../trpc";
 
 function format(error: TRPCError) {
@@ -230,6 +231,30 @@ describe("tRPC error response boundary", () => {
         const formatted = format(error);
 
         expect(formatted.data).not.toHaveProperty("zodError");
+        expect(formatted.data.error).toMatchObject({
+          code: "validation_error",
+          meta: { fieldErrors: { name: expect.any(Array) } },
+        });
+      });
+    });
+
+    describe("when the schema was authored against the other zod major", () => {
+      /** @scenario "Validation failures travel that channel whichever zod threw them" */
+      it("promotes it the same, rather than letting it pass as an unknown 500", () => {
+        // Parsed for real, not hand-built: the defect being pinned is that a
+        // v4 `ZodError` is not `instanceof` the v3 class this boundary used to
+        // import, and only the object zod itself throws carries that. A
+        // literal shaped like an error would pass a broken gate.
+        const parsed = z4.object({ name: z4.string().min(1) }).safeParse({});
+        const cause = parsed.error;
+        const error = new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: cause!.message,
+          cause,
+        });
+
+        const formatted = format(error);
+
         expect(formatted.data.error).toMatchObject({
           code: "validation_error",
           meta: { fieldErrors: { name: expect.any(Array) } },

--- a/platform/app/src/server/api/trpc.ts
+++ b/platform/app/src/server/api/trpc.ts
@@ -38,11 +38,14 @@ interface CreateNextContextOptions {
 
 import { auditLog } from "@ee/audit-log/auditLog";
 import type { AuthzPermission } from "@langwatch/authz";
-import { HandledError, ValidationError } from "@langwatch/handled-error";
+import {
+  HandledError,
+  isZodLikeError,
+  ValidationError,
+} from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import { getLogLevelFromStatusCode } from "@langwatch/observability/request";
 import superjson from "superjson";
-import { ZodError } from "zod";
 import type { OrganizationUserRole } from "~/generated/prisma/client";
 import type { Session } from "~/server/auth";
 import { getServerAuthSession } from "~/server/auth";
@@ -240,10 +243,12 @@ export function errorFormatter({
   // other failure: `fromZodError` flattens the issues into
   // `meta.fieldErrors` / `meta.formErrors`, which is where the contents of the
   // old sidecar `data.zodError` field now live. Mirrors what the Hono handler
-  // already does (packages/api/src/errors.ts::validationErrorFromZod).
+  // already does (packages/api/src/errors.ts::validationErrorFromZod). Matched
+  // by shape, since the routers behind this one boundary no longer share a
+  // single zod and an `instanceof` sees one major only — see `isZodLikeError`.
   const handled = HandledError.isHandled(error.cause)
     ? error.cause
-    : error.cause instanceof ZodError
+    : isZodLikeError(error.cause)
       ? ValidationError.fromZodError(error.cause)
       : null;
 

--- a/specs/features/domain-error-contract.feature
+++ b/specs/features/domain-error-contract.feature
@@ -83,6 +83,19 @@ Feature: Handled errors — the handled-error boundary
     And the failing fields ride in its meta, not a separate zodError field
     So clients read validation detail exactly where they read every other fact
 
+  # The repo runs two zod majors while schemas migrate to `zod/v4` a leaf at a
+  # time, and each major ships its own `ZodError` class. A boundary that asks
+  # `instanceof` recognises only the major it imported, so moving one schema
+  # turned its rejections into unnamed 500s — the customer lost the reason
+  # their input was refused, and the platform wore the 5xx.
+  @unit @bdd @domain-errors
+  Scenario: Validation failures travel that channel whichever zod threw them
+    Given a schema authored against a different zod major than the boundary imports
+    When its rejection reaches that boundary
+    Then it is still a handled error of code "validation_error"
+    And the failing fields still ride in its meta
+    So which zod a schema was written against is invisible to the caller
+
   # --------------------------------------------------------------------------
   # Request validation — the REST boundary's own schema failures
   #


### PR DESCRIPTION
## What broke

`refactor(zod): move the three genuinely leaf schemas to zod/v4` moved
`thresholdConfig.schema.ts` onto `zod/v4`. Every rejection that schema
produces then stopped being a validation failure as far as the app was
concerned, and started arriving as an unnamed 500.

The gate that catches it asks `err instanceof z.ZodError` against the **v3**
class its own file imports. A v4 `ZodError` is a different class, so the
check is simply false:

```
v3 error instanceof v3 ZodError -> true    v3 error instanceof v4 ZodError -> false
v4 error instanceof v3 ZodError -> false   v4 error instanceof v4 ZodError -> true
```

What the admin got instead of a 422 they could act on:

```
code:  INTERNAL_SERVER_ERROR        (was: UNPROCESSABLE_CONTENT)
cause: ZodError { ... }             (was: { code: "validation_error", meta.formErrors })
```

Nothing at the seam could say so — the schema and the gate that catches it
are different files, and typecheck sees no disagreement between them. It
surfaced only as 7 red scenarios in integration shard 1.

## The fix

`instanceof` asks "did the zod *I* imported throw this", which is the wrong
question while the repo runs two majors and migrates schemas a leaf at a
time. The boundaries now ask about shape.

`isZodLikeError` sits beside the `ZodLikeError` interface that already models
zod structurally for exactly this reason — `@langwatch/handled-error`
deliberately imports no zod, because it is consumed by trees on either major.
`name` + `issues` + `flatten` is the intersection both versions satisfy and
the whole of what the consumers read.

Applied at the three shared gates:

| Gate | Why it matters |
|---|---|
| `ee/governance/routers/anomalyRules.ts` | Its two config schemas are now on **different majors** — `thresholdConfig` on v4, `destinationConfig` on v3 — so one `instanceof` could never have covered both |
| `src/server/api/trpc.ts` | The boundary for **every** router; any v4 schema's rejection was landing as a 500 |
| `packages/api/src/errors.ts` | Same for every Hono route, and it also decides the log level — a bare ZodError was logged as a 5xx against the platform's error budget |

## Verification

Run locally against native Postgres/ClickHouse/Redis:

- `anomalyRule.thresholdConfig.integration.test.ts` — **12/12 pass** (the 7 that were red in shard 1)
- `trpc-error-formatter.unit.test.ts` — 20/20, including a new scenario that parses a **real** v4 schema rather than hand-building an error, since a literal shaped like a ZodError would sail through a broken gate
- `packages/handled-error` 26/26, `packages/api` 165/165
- `tsc --noEmit` clean on both touched packages; biome clean (the 4 remaining warnings are pre-existing complexity findings on untouched functions in `trpc.ts`)

Spec: new scenario in `specs/features/domain-error-contract.feature`, bound
by `@scenario` annotation.

## Not in scope

Per-route hand-rolled gates (`misc.ts`, `evaluations-legacy.ts`,
`collector.ts`, `monitors.ts`, `agents/app.ts`, `aiTools.ts`, `tenantId.ts`)
still use `instanceof`. They guard v3-only schemas today so they are correct
as they stand — but they are the same trap for the next schema that moves,
and each should switch as its schema does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation error handling so form fields receive consistent, actionable feedback.
  - Validation failures are now correctly recognized across supported schema versions.
  - Prevented technical schema details from appearing in responses to callers.
  - Unrelated server errors continue to be handled normally.

- **Tests**
  - Added coverage confirming field-level validation metadata and consistent error responses across schema versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->