### PR TITLE
perf(test): let the 331 integration files that mock nothing share a module graph

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -834,7 +834,12 @@ jobs:
         if: always() && needs.changes.outputs.durations == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: shard-durations-integration-${{ matrix.shard }}
+          # The lane is in the name because the two lanes both number their
+          # shards from 1: without it, `shared 1/2` and `mocking 1/2` would both
+          # upload `shard-durations-integration-1`, and upload-artifact rejects
+          # a duplicate name within one run. The merge job below globs
+          # `shard-durations-*`, so it picks both up either way.
+          name: shard-durations-integration-${{ matrix.lane }}-${{ matrix.shard }}
           path: platform/app/vitest.durations.delta.json
           if-no-files-found: ignore
 

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -106,8 +106,19 @@ jobs:
       # files that genuinely talk to something, so the same per-shard file count
       # fits in fewer shards — and two runners come off the critical path,
       # which is its own win while every shard is queueing 5-10 minutes for one.
-      integration-shards: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '[1,2,3,4]' || '[1]' }}
-      integration-shard-count: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '4' || '1' }}
+      #
+      # The lane splits again by whether a file can share a module registry.
+      # Import was 42% of this lane's runner time — ~1.6s per file rebuilding
+      # the same Prisma client and server graph — and 331 of the 477 files can
+      # share one. The other 146 call `vi.mock`, which cannot apply to a
+      # registry an earlier file already populated, so they keep isolation.
+      # See platform/app/src/test-utils/integrationModuleGraph.ts.
+      #
+      # Two shards each rather than four of one kind: measured on src/app/api,
+      # the shared lane runs ~4x faster per file, so 331 shared files and 146
+      # mocking ones are close to balanced at 2+2 — the same four runners as
+      # before, finishing sooner.
+      integration-matrix: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '[{"lane":"shared","shard":1,"count":2},{"lane":"shared","shard":2,"count":2},{"lane":"mocking","shard":1,"count":2},{"lane":"mocking","shard":2,"count":2}]' || '[{"lane":"shared","shard":1,"count":1},{"lane":"mocking","shard":1,"count":1}]' }}
       # The component lane is unit-shaped: forked VM workers and concurrent
       # files, with no service containers to wait on, so a shard gets through
       # its files far faster than a datastore shard does. Two is enough for
@@ -594,13 +605,19 @@ jobs:
         run: bash ../../.github/scripts/notify-slack-test-failure.sh test-component
 
   test-integration:
+    name: "test-integration (${{ matrix.lane }} ${{ matrix.shard }}/${{ matrix.count }})"
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(needs.changes.outputs.integration-shards) }}
+        include: ${{ fromJSON(needs.changes.outputs.integration-matrix) }}
     env:
+      # Which half of the datastore lane this shard runs, and — because the
+      # config derives `include` and `isolate` from this one variable — whether
+      # it may share a module registry. Setting it anywhere else, or setting it
+      # to something these two jobs do not, silently changes what runs.
+      INTEGRATION_GRAPH_LANE: ${{ matrix.lane }}
       # VITEST_INTEGRATION_PARALLEL is deliberately NOT set, so a shard runs
       # its files one at a time.
       #
@@ -768,7 +785,7 @@ jobs:
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add langwatch https://langwatch.github.io/langwatch
 
-      - name: Run integration tests (shard ${{ matrix.shard }}/4)
+      - name: Run integration tests (${{ matrix.lane }} ${{ matrix.shard }}/${{ matrix.count }})
         id: integration-tests
         working-directory: platform/app
         # Integration files run sequentially in a single long-lived fork worker
@@ -806,7 +823,7 @@ jobs:
               --outputFile=test-results.json
           else
             # shellcheck disable=SC2086
-            pnpm test:integration --shard=${{ matrix.shard }}/${{ needs.changes.outputs.integration-shard-count }} $COV $DUR \
+            pnpm test:integration --shard=${{ matrix.shard }}/${{ matrix.count }} $COV $DUR \
               --reporter=default --reporter=json --reporter=./src/test-utils/shardFailureReporter.ts \
               --outputFile=test-results.json
           fi

--- a/platform/app/src/server/event-sourcing/__tests__/integration/setup.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/integration/setup.ts
@@ -51,7 +51,17 @@ try {
 
 // Now safe to import application code
 import { afterAll, beforeAll } from "vitest";
-import { INTEGRATION_FILES_SHARE_MODULE_GRAPH } from "../../../../test-utils/integrationModuleGraph";
+import { selectedGraphLane } from "../../../../test-utils/integrationModuleGraph";
+
+/**
+ * Whether this worker is running the shared-registry lane.
+ *
+ * Read from the same environment the config reads, rather than passed through
+ * vitest, because a setup file has no access to the resolved config. The two
+ * must agree — a shared registry with per-file singleton teardown is exactly
+ * the broken combination — so both go through selectedGraphLane().
+ */
+const SHARES_MODULE_GRAPH = selectedGraphLane(process.env) === "shared";
 import { resetApp, tryGetApp } from "../../../app-layer/app";
 import { startTestContainers, stopTestContainers } from "./testContainers";
 
@@ -60,7 +70,7 @@ import { startTestContainers, stopTestContainers } from "./testContainers";
  * Connects to containers (env vars already set at module load time).
  */
 export async function setup(): Promise<void> {
-  if (INTEGRATION_FILES_SHARE_MODULE_GRAPH) registerWorkerExitClose();
+  if (SHARES_MODULE_GRAPH) registerWorkerExitClose();
   try {
     await startTestContainers();
   } catch (error) {
@@ -149,7 +159,7 @@ export async function teardown(): Promise<void> {
   // was tried. The App container IS per-file state, so it still gets reset;
   // the process-wide clients are closed once, by the exit hook below.
   // See src/test-utils/integrationModuleGraph.ts.
-  if (INTEGRATION_FILES_SHARE_MODULE_GRAPH) {
+  if (SHARES_MODULE_GRAPH) {
     await resetApp();
     return;
   }

--- a/platform/app/src/server/event-sourcing/__tests__/integration/setup.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/integration/setup.ts
@@ -62,6 +62,7 @@ import { selectedGraphLane } from "../../../../test-utils/integrationModuleGraph
  * the broken combination — so both go through selectedGraphLane().
  */
 const SHARES_MODULE_GRAPH = selectedGraphLane(process.env) === "shared";
+
 import { resetApp, tryGetApp } from "../../../app-layer/app";
 import { startTestContainers, stopTestContainers } from "./testContainers";
 

--- a/platform/app/src/server/event-sourcing/__tests__/integration/setup.ts
+++ b/platform/app/src/server/event-sourcing/__tests__/integration/setup.ts
@@ -51,7 +51,8 @@ try {
 
 // Now safe to import application code
 import { afterAll, beforeAll } from "vitest";
-import { tryGetApp } from "../../../app-layer/app";
+import { INTEGRATION_FILES_SHARE_MODULE_GRAPH } from "../../../../test-utils/integrationModuleGraph";
+import { resetApp, tryGetApp } from "../../../app-layer/app";
 import { startTestContainers, stopTestContainers } from "./testContainers";
 
 /**
@@ -59,6 +60,7 @@ import { startTestContainers, stopTestContainers } from "./testContainers";
  * Connects to containers (env vars already set at module load time).
  */
 export async function setup(): Promise<void> {
+  if (INTEGRATION_FILES_SHARE_MODULE_GRAPH) registerWorkerExitClose();
   try {
     await startTestContainers();
   } catch (error) {
@@ -140,7 +142,40 @@ function unrefRedisSockets(): void {
  */
 export async function teardown(): Promise<void> {
   await stopTestContainers();
+
+  // With a shared module registry these singletons outlive the file, so
+  // closing them here would hand the next file a disconnected Prisma and a
+  // quit Redis — the failure this suite used to hit whenever `isolate: false`
+  // was tried. The App container IS per-file state, so it still gets reset;
+  // the process-wide clients are closed once, by the exit hook below.
+  // See src/test-utils/integrationModuleGraph.ts.
+  if (INTEGRATION_FILES_SHARE_MODULE_GRAPH) {
+    await resetApp();
+    return;
+  }
+
   await closeAppRuntimeSingletons();
+}
+
+/**
+ * Close the process-wide singletons once, when the worker is finishing.
+ *
+ * Only needed when files share a registry: with a fresh graph per file the
+ * per-file teardown above already did it. Registered at most once per worker,
+ * and unrefs the Redis sockets first so they cannot pin the loop open — the
+ * hazard that made the per-file close necessary in the first place is a socket
+ * keeping the process alive past the last test, not the close itself.
+ */
+let workerExitHookRegistered = false;
+
+function registerWorkerExitClose(): void {
+  if (workerExitHookRegistered) return;
+  workerExitHookRegistered = true;
+
+  process.once("beforeExit", () => {
+    unrefRedisSockets();
+    void closeAppRuntimeSingletons();
+  });
 }
 
 /**

--- a/platform/app/src/test-utils/__tests__/integrationModuleGraph.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/integrationModuleGraph.unit.test.ts
@@ -1,0 +1,166 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  graphLaneForSource,
+  graphLaneSelection,
+  partitionByModuleGraph,
+  selectedGraphLane,
+} from "../integrationModuleGraph";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "graph-lane-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function writeFile(relative: string, source: string): void {
+  const full = path.join(root, relative);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, source);
+}
+
+describe("graphLaneForSource", () => {
+  describe("given a file that mocks a module", () => {
+    it("keeps it on the mocking lane, because a hoisted mock cannot apply to a shared registry", () => {
+      expect(graphLaneForSource('vi.mock("~/server/db");')).toBe("mocking");
+      expect(graphLaneForSource("vi.doMock('./x');")).toBe("mocking");
+      expect(graphLaneForSource("const { a } = vi.hoisted(() => ({ a: 1 }));")).toBe(
+        "mocking",
+      );
+    });
+
+    it("reads it through whitespace, the way it is actually written", () => {
+      expect(graphLaneForSource("vi . mock ( './x' )")).toBe("mocking");
+    });
+  });
+
+  describe("given a file that mocks nothing", () => {
+    it("lets it share a registry", () => {
+      expect(graphLaneForSource("import { prisma } from '~/server/db';")).toBe(
+        "shared",
+      );
+    });
+
+    it("is not fooled by other vi helpers, which do not touch the registry", () => {
+      expect(graphLaneForSource("vi.fn(); vi.spyOn(x, 'y'); vi.useFakeTimers();")).toBe(
+        "shared",
+      );
+    });
+  });
+});
+
+describe("partitionByModuleGraph", () => {
+  describe("given a mix of files", () => {
+    it("splits them without losing or duplicating any", () => {
+      writeFile("a.integration.test.ts", "vi.mock('./x');");
+      writeFile("b.integration.test.ts", "expect(1).toBe(1);");
+      writeFile("c.integration.test.ts", "vi.hoisted(() => ({}));");
+
+      const { mocking, shared } = partitionByModuleGraph({
+        root,
+        files: [
+          "a.integration.test.ts",
+          "b.integration.test.ts",
+          "c.integration.test.ts",
+        ],
+      });
+
+      expect(mocking.sort()).toEqual([
+        "a.integration.test.ts",
+        "c.integration.test.ts",
+      ]);
+      expect(shared).toEqual(["b.integration.test.ts"]);
+      expect([...mocking, ...shared]).toHaveLength(3);
+    });
+  });
+
+  describe("given a file that cannot be read", () => {
+    it("sends it to the mocking lane, because unreadable is not evidence sharing is safe", () => {
+      const { mocking, shared } = partitionByModuleGraph({
+        root,
+        files: ["does-not-exist.integration.test.ts"],
+      });
+
+      expect(mocking).toEqual(["does-not-exist.integration.test.ts"]);
+      expect(shared).toEqual([]);
+    });
+  });
+});
+
+describe("selectedGraphLane", () => {
+  it("reads the two lane names and nothing else", () => {
+    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "shared" })).toBe("shared");
+    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "mocking" })).toBe("mocking");
+    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "yes" })).toBeNull();
+    expect(selectedGraphLane({})).toBeNull();
+  });
+});
+
+describe("graphLaneSelection", () => {
+  beforeEach(() => {
+    writeFile("mocks.integration.test.ts", "vi.mock('./x');");
+    writeFile("plain.integration.test.ts", "expect(1).toBe(1);");
+  });
+
+  const files = ["mocks.integration.test.ts", "plain.integration.test.ts"];
+
+  describe("when no lane is selected", () => {
+    it("runs every file with a fresh registry, so a laptop behaves as before the split", () => {
+      const selection = graphLaneSelection({ root, datastoreFiles: files, env: {} });
+
+      expect(selection.files).toEqual(files);
+      expect(selection.isolate).toBe(true);
+    });
+  });
+
+  describe("when the shared lane is selected", () => {
+    /** Files and isolation come from one call so they cannot disagree. */
+    it("runs only the non-mocking files, and only then shares the registry", () => {
+      const selection = graphLaneSelection({
+        root,
+        datastoreFiles: files,
+        env: { INTEGRATION_GRAPH_LANE: "shared" },
+      });
+
+      expect(selection.files).toEqual(["plain.integration.test.ts"]);
+      expect(selection.isolate).toBe(false);
+    });
+  });
+
+  describe("when the mocking lane is selected", () => {
+    it("runs only the mocking files, with isolation kept on", () => {
+      const selection = graphLaneSelection({
+        root,
+        datastoreFiles: files,
+        env: { INTEGRATION_GRAPH_LANE: "mocking" },
+      });
+
+      expect(selection.files).toEqual(["mocks.integration.test.ts"]);
+      expect(selection.isolate).toBe(true);
+    });
+  });
+
+  describe("across both lanes", () => {
+    it("covers every datastore file exactly once", () => {
+      const mocking = graphLaneSelection({
+        root,
+        datastoreFiles: files,
+        env: { INTEGRATION_GRAPH_LANE: "mocking" },
+      }).files;
+      const shared = graphLaneSelection({
+        root,
+        datastoreFiles: files,
+        env: { INTEGRATION_GRAPH_LANE: "shared" },
+      }).files;
+
+      expect([...mocking, ...shared].sort()).toEqual([...files].sort());
+    });
+  });
+});

--- a/platform/app/src/test-utils/__tests__/integrationModuleGraph.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/integrationModuleGraph.unit.test.ts
@@ -37,9 +37,9 @@ describe("graphLaneForSource", () => {
     it("keeps it on the mocking lane, because a hoisted mock cannot apply to a shared registry", () => {
       expect(graphLaneForSource('vi.mock("~/server/db");')).toBe("mocking");
       expect(graphLaneForSource("vi.doMock('./x');")).toBe("mocking");
-      expect(graphLaneForSource("const { a } = vi.hoisted(() => ({ a: 1 }));")).toBe(
-        "mocking",
-      );
+      expect(
+        graphLaneForSource("const { a } = vi.hoisted(() => ({ a: 1 }));"),
+      ).toBe("mocking");
     });
 
     it("reads it through whitespace, the way it is actually written", () => {
@@ -55,9 +55,9 @@ describe("graphLaneForSource", () => {
     });
 
     it("is not fooled by other vi helpers, which do not touch the registry", () => {
-      expect(graphLaneForSource("vi.fn(); vi.spyOn(x, 'y'); vi.useFakeTimers();")).toBe(
-        "shared",
-      );
+      expect(
+        graphLaneForSource("vi.fn(); vi.spyOn(x, 'y'); vi.useFakeTimers();"),
+      ).toBe("shared");
     });
   });
 });
@@ -65,9 +65,18 @@ describe("graphLaneForSource", () => {
 describe("partitionByModuleGraph", () => {
   describe("given a mix of files", () => {
     it("splits them without losing or duplicating any", () => {
-      writeFile({ relative: "a.integration.test.ts", source: "vi.mock('./x');" });
-      writeFile({ relative: "b.integration.test.ts", source: "expect(1).toBe(1);" });
-      writeFile({ relative: "c.integration.test.ts", source: "vi.hoisted(() => ({}));" });
+      writeFile({
+        relative: "a.integration.test.ts",
+        source: "vi.mock('./x');",
+      });
+      writeFile({
+        relative: "b.integration.test.ts",
+        source: "expect(1).toBe(1);",
+      });
+      writeFile({
+        relative: "c.integration.test.ts",
+        source: "vi.hoisted(() => ({}));",
+      });
 
       const { mocking, shared } = partitionByModuleGraph({
         root,
@@ -102,8 +111,12 @@ describe("partitionByModuleGraph", () => {
 
 describe("selectedGraphLane", () => {
   it("reads the two lane names and nothing else", () => {
-    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "shared" })).toBe("shared");
-    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "mocking" })).toBe("mocking");
+    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "shared" })).toBe(
+      "shared",
+    );
+    expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "mocking" })).toBe(
+      "mocking",
+    );
     expect(selectedGraphLane({ INTEGRATION_GRAPH_LANE: "yes" })).toBeNull();
     expect(selectedGraphLane({})).toBeNull();
   });
@@ -111,15 +124,25 @@ describe("selectedGraphLane", () => {
 
 describe("graphLaneSelection", () => {
   beforeEach(() => {
-    writeFile({ relative: "mocks.integration.test.ts", source: "vi.mock('./x');" });
-    writeFile({ relative: "plain.integration.test.ts", source: "expect(1).toBe(1);" });
+    writeFile({
+      relative: "mocks.integration.test.ts",
+      source: "vi.mock('./x');",
+    });
+    writeFile({
+      relative: "plain.integration.test.ts",
+      source: "expect(1).toBe(1);",
+    });
   });
 
   const files = ["mocks.integration.test.ts", "plain.integration.test.ts"];
 
   describe("when no lane is selected", () => {
     it("runs every file with a fresh registry, so a laptop behaves as before the split", () => {
-      const selection = graphLaneSelection({ root, datastoreFiles: files, env: {} });
+      const selection = graphLaneSelection({
+        root,
+        datastoreFiles: files,
+        env: {},
+      });
 
       expect(selection.files).toEqual(files);
       expect(selection.isolate).toBe(true);

--- a/platform/app/src/test-utils/__tests__/integrationModuleGraph.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/integrationModuleGraph.unit.test.ts
@@ -20,7 +20,13 @@ afterEach(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-function writeFile(relative: string, source: string): void {
+function writeFile({
+  relative,
+  source,
+}: {
+  relative: string;
+  source: string;
+}): void {
   const full = path.join(root, relative);
   mkdirSync(path.dirname(full), { recursive: true });
   writeFileSync(full, source);
@@ -59,9 +65,9 @@ describe("graphLaneForSource", () => {
 describe("partitionByModuleGraph", () => {
   describe("given a mix of files", () => {
     it("splits them without losing or duplicating any", () => {
-      writeFile("a.integration.test.ts", "vi.mock('./x');");
-      writeFile("b.integration.test.ts", "expect(1).toBe(1);");
-      writeFile("c.integration.test.ts", "vi.hoisted(() => ({}));");
+      writeFile({ relative: "a.integration.test.ts", source: "vi.mock('./x');" });
+      writeFile({ relative: "b.integration.test.ts", source: "expect(1).toBe(1);" });
+      writeFile({ relative: "c.integration.test.ts", source: "vi.hoisted(() => ({}));" });
 
       const { mocking, shared } = partitionByModuleGraph({
         root,
@@ -105,8 +111,8 @@ describe("selectedGraphLane", () => {
 
 describe("graphLaneSelection", () => {
   beforeEach(() => {
-    writeFile("mocks.integration.test.ts", "vi.mock('./x');");
-    writeFile("plain.integration.test.ts", "expect(1).toBe(1);");
+    writeFile({ relative: "mocks.integration.test.ts", source: "vi.mock('./x');" });
+    writeFile({ relative: "plain.integration.test.ts", source: "expect(1).toBe(1);" });
   });
 
   const files = ["mocks.integration.test.ts", "plain.integration.test.ts"];
@@ -147,7 +153,7 @@ describe("graphLaneSelection", () => {
     });
   });
 
-  describe("across both lanes", () => {
+  describe("when each lane is selected in turn", () => {
     it("covers every datastore file exactly once", () => {
       const mocking = graphLaneSelection({
         root,

--- a/platform/app/src/test-utils/integrationModuleGraph.ts
+++ b/platform/app/src/test-utils/integrationModuleGraph.ts
@@ -1,0 +1,65 @@
+/**
+ * Whether the integration suite reuses one module graph across its files, and
+ * the teardown rule that makes that safe.
+ *
+ * Import is the largest single line item in this suite. Measured across the CI
+ * shards it is ~216s against ~203s of actual test execution — 42% of the lane's
+ * runner time, roughly 1.6s per file spent rebuilding the same Prisma client
+ * and the same server graph. Sharing the registry reclaims most of it.
+ *
+ * The reason it could not simply be switched on is the teardown, not the
+ * sharing. `setup.ts` is a SETUP FILE, so its `afterAll` runs once per test
+ * FILE, and that hook disconnects Prisma and quits the app-layer Redis — the
+ * two singletons the shared graph is meant to keep. With a fresh registry per
+ * file that is correct and necessary: the sockets would otherwise pin the
+ * worker open past the last test and the CI step would hit its job cap. With a
+ * shared registry it is exactly wrong, because the singletons outlive the file
+ * that closed them, and the next file resolves a disconnected client. That is
+ * the "first file's teardown takes the next file's client with it" failure —
+ * ECONNREFUSED, "Cannot resolve ClickHouse client", "App not initialized".
+ *
+ * So the two settings are one decision and live here together:
+ *
+ *   shared graph  →  per-file teardown resets ONLY the App (whose lifecycle
+ *                    genuinely is per file), and the process-wide singletons
+ *                    are closed once, when the worker is finishing.
+ *   fresh graph   →  per-file teardown closes everything, as before.
+ *
+ * `fileParallelism` is a separate decision with a separate reason — shared
+ * ClickHouse and Redis INSTANCES rather than shared module state — and lives in
+ * integrationFileConcurrency.ts. Files still run one at a time either way.
+ */
+
+/**
+ * OFF, and the reason is `vi.mock` rather than anything above.
+ *
+ * The teardown described above is real and is implemented — it was the blocker
+ * everyone assumed, and with it in place the sharing works and the numbers are
+ * large. Measured on this branch against native local services:
+ *
+ *   src/app/api (49 files)   138.8s -> 43.9s   import 72.1s -> 11.9s  (-84%)
+ *   ee/governance (23 files)  44.1s -> 17.3s   import 23.1s ->  9.9s  (-57%)
+ *
+ * But eight files in the app/api slice fail with the graph shared, and each one
+ * PASSES ALONE. They are not broken; they are contaminated. The cause is
+ * `vi.mock`: vitest hoists a module mock per test file and applies it while
+ * building that file's registry, so when the registry is shared and an earlier
+ * file already instantiated the real module, the mock never takes. The test
+ * then calls the real collaborator — which is why the failures are
+ * `ECONNREFUSED ::1:5560` and `expected 500 to be 200` rather than anything
+ * about containers or clients.
+ *
+ * 123 of the 414 integration files call `vi.mock`. That is not a set to
+ * rewrite, and no teardown fixes it, so a single `isolate` for the whole lane
+ * cannot be the answer.
+ *
+ * The shape that would work is a partition, exactly like the component and
+ * datastore lanes in integrationLanes.ts: files that call `vi.mock` keep a
+ * fresh registry, files that do not share one. That is ~291 files getting the
+ * speedup above and ~123 keeping today's behaviour, and it needs a second
+ * vitest project plus its own CI lane — a real change, and a separate one.
+ *
+ * Left wired up rather than deleted so the next attempt starts from the
+ * measurement rather than from the assumption this file used to record.
+ */
+export const INTEGRATION_FILES_SHARE_MODULE_GRAPH = false;

--- a/platform/app/src/test-utils/integrationModuleGraph.ts
+++ b/platform/app/src/test-utils/integrationModuleGraph.ts
@@ -1,65 +1,151 @@
 /**
- * Whether the integration suite reuses one module graph across its files, and
- * the teardown rule that makes that safe.
+ * Splits the datastore lane again, by whether a file can tolerate a shared
+ * module registry.
  *
- * Import is the largest single line item in this suite. Measured across the CI
- * shards it is ~216s against ~203s of actual test execution — 42% of the lane's
- * runner time, roughly 1.6s per file spent rebuilding the same Prisma client
- * and the same server graph. Sharing the registry reclaims most of it.
+ * Import is the largest single line item in this suite: ~216s against ~203s of
+ * actual test execution on a CI shard, 42% of the lane's runner time, roughly
+ * 1.6s per file rebuilding the same Prisma client and the same server graph.
+ * `isolate: false` reclaims most of it. Measured against native local services:
  *
- * The reason it could not simply be switched on is the teardown, not the
- * sharing. `setup.ts` is a SETUP FILE, so its `afterAll` runs once per test
- * FILE, and that hook disconnects Prisma and quits the app-layer Redis — the
- * two singletons the shared graph is meant to keep. With a fresh registry per
- * file that is correct and necessary: the sockets would otherwise pin the
- * worker open past the last test and the CI step would hit its job cap. With a
- * shared registry it is exactly wrong, because the singletons outlive the file
- * that closed them, and the next file resolves a disconnected client. That is
- * the "first file's teardown takes the next file's client with it" failure —
- * ECONNREFUSED, "Cannot resolve ClickHouse client", "App not initialized".
+ *   src/app/api    (49 files)  138.8s -> 43.9s   import 72.1s -> 11.9s  (-84%)
+ *   ee/governance  (23 files)   44.1s -> 17.3s   import 23.1s ->  9.9s  (-57%)
  *
- * So the two settings are one decision and live here together:
+ * Two things stood in the way, and only one of them was the one everybody
+ * assumed.
  *
- *   shared graph  →  per-file teardown resets ONLY the App (whose lifecycle
- *                    genuinely is per file), and the process-wide singletons
- *                    are closed once, when the worker is finishing.
- *   fresh graph   →  per-file teardown closes everything, as before.
+ * The teardown, which is fixed rather than partitioned around: `setup.ts` is a
+ * setup FILE, so its `afterAll` runs once per test FILE, and it disconnected
+ * Prisma and quit the app-layer Redis — the two singletons a shared graph
+ * exists to keep. With a fresh registry that is correct and load-bearing, since
+ * those sockets would otherwise pin the worker open past the last test. With a
+ * shared one it hands the next file a dead client. That is the "first file's
+ * teardown takes the next file's client with it" failure.
  *
- * `fileParallelism` is a separate decision with a separate reason — shared
- * ClickHouse and Redis INSTANCES rather than shared module state — and lives in
- * integrationFileConcurrency.ts. Files still run one at a time either way.
+ * `vi.mock`, which no teardown reaches and which this file exists for. Vitest
+ * hoists a module mock per test file and applies it while building THAT FILE's
+ * registry. Share the registry and a module an earlier file already
+ * instantiated stays unmocked, so the test calls the real collaborator. The
+ * symptom is `ECONNREFUSED` and `expected 500 to be 200` — nothing about
+ * containers or clients, which is exactly what sends people looking in the
+ * wrong place. 123 of the 414 integration files mock a module, so this is not a
+ * set to rewrite and not a single `isolate` for the whole lane.
+ *
+ * So it is a partition, on the same terms as the component/datastore split in
+ * integrationLanes.ts:
+ *
+ *   mocking lane — calls `vi.mock`. Fresh registry per file, exactly as today.
+ *   shared lane  — does not. One registry for the whole shard.
+ *
+ * The default is the MOCKING lane, and the rule is conservative in the same
+ * direction as the one it nests inside: a file leaves only by positively
+ * containing no `vi.mock`. A misjudgement costs time, never correctness.
  */
+import fs from "node:fs";
+import path from "node:path";
 
 /**
- * OFF, and the reason is `vi.mock` rather than anything above.
+ * A call to vitest's module mocker, in any of the spellings that hoist.
  *
- * The teardown described above is real and is implemented — it was the blocker
- * everyone assumed, and with it in place the sharing works and the numbers are
- * large. Measured on this branch against native local services:
+ * `vi.mock` and `vi.doMock` are the two that replace a module in the registry.
+ * `vi.hoisted` is included because its whole purpose is to run before the
+ * imports a mock factory closes over, so a file using it is a file whose
+ * mocking is registry-shaped even when the `vi.mock` sits behind an alias.
  *
- *   src/app/api (49 files)   138.8s -> 43.9s   import 72.1s -> 11.9s  (-84%)
- *   ee/governance (23 files)  44.1s -> 17.3s   import 23.1s ->  9.9s  (-57%)
- *
- * But eight files in the app/api slice fail with the graph shared, and each one
- * PASSES ALONE. They are not broken; they are contaminated. The cause is
- * `vi.mock`: vitest hoists a module mock per test file and applies it while
- * building that file's registry, so when the registry is shared and an earlier
- * file already instantiated the real module, the mock never takes. The test
- * then calls the real collaborator — which is why the failures are
- * `ECONNREFUSED ::1:5560` and `expected 500 to be 200` rather than anything
- * about containers or clients.
- *
- * 123 of the 414 integration files call `vi.mock`. That is not a set to
- * rewrite, and no teardown fixes it, so a single `isolate` for the whole lane
- * cannot be the answer.
- *
- * The shape that would work is a partition, exactly like the component and
- * datastore lanes in integrationLanes.ts: files that call `vi.mock` keep a
- * fresh registry, files that do not share one. That is ~291 files getting the
- * speedup above and ~123 keeping today's behaviour, and it needs a second
- * vitest project plus its own CI lane — a real change, and a separate one.
- *
- * Left wired up rather than deleted so the next attempt starts from the
- * measurement rather than from the assumption this file used to record.
+ * A shallow read of the file's own source, not of its import graph — the same
+ * soundness argument as DATASTORE_MARKERS: a file that mocks only through a
+ * helper cannot pass in the shared lane, so it fails loudly on the first run
+ * rather than passing for the wrong reason.
  */
-export const INTEGRATION_FILES_SHARE_MODULE_GRAPH = false;
+const MODULE_MOCK_PATTERN = /\bvi\s*\.\s*(mock|doMock|hoisted)\s*\(/;
+
+export type GraphLane = "mocking" | "shared";
+
+/**
+ * Which graph lane a single file belongs to, given its source.
+ *
+ * Exported for the guard test: the decision has to be inspectable on a string
+ * without a filesystem behind it, or it cannot be tested at the level it is
+ * made.
+ */
+export function graphLaneForSource(source: string): GraphLane {
+  return MODULE_MOCK_PATTERN.test(source) ? "mocking" : "shared";
+}
+
+export interface GraphPartition {
+  /** Relative paths that mock a module and so need a fresh registry. */
+  mocking: string[];
+  /** Relative paths that do not, and can share one. */
+  shared: string[];
+}
+
+/**
+ * Partition already-selected datastore files by graph lane.
+ *
+ * Takes the file list rather than walking the tree, so this composes with
+ * partitionIntegrationFiles instead of duplicating its walk — and so the two
+ * partitions cannot disagree about which files exist.
+ */
+export function partitionByModuleGraph({
+  root,
+  files,
+}: {
+  root: string;
+  files: string[];
+}): GraphPartition {
+  const mocking: string[] = [];
+  const shared: string[] = [];
+
+  for (const relative of files) {
+    let source: string;
+    try {
+      source = fs.readFileSync(path.join(root, relative), "utf8");
+    } catch {
+      // Unreadable is not evidence that sharing is safe. Send it to the lane
+      // that behaves as today and let the run report the real problem.
+      mocking.push(relative);
+      continue;
+    }
+    (graphLaneForSource(source) === "shared" ? shared : mocking).push(relative);
+  }
+
+  return { mocking, shared };
+}
+
+/**
+ * The lane this process was asked to run, or null for "both".
+ *
+ * Null is the local default and runs every datastore file with a fresh
+ * registry — identical to the behaviour before this split, so a plain
+ * `pnpm test:integration <path>` on a laptop is unchanged and no one has to
+ * know the lane exists. CI sets the variable and gets the two lanes.
+ */
+export function selectedGraphLane(env: NodeJS.ProcessEnv): GraphLane | null {
+  const value = env.INTEGRATION_GRAPH_LANE;
+  if (value === "mocking" || value === "shared") return value;
+  return null;
+}
+
+/**
+ * The files to run, and whether they may share a registry.
+ *
+ * One function so `include` and `isolate` are derived from the same decision.
+ * Splitting them is how a lane ends up running the mocking files with a shared
+ * graph, which is the failure this whole file exists to prevent.
+ */
+export function graphLaneSelection({
+  root,
+  datastoreFiles,
+  env,
+}: {
+  root: string;
+  datastoreFiles: string[];
+  env: NodeJS.ProcessEnv;
+}): { files: string[]; isolate: boolean } {
+  const lane = selectedGraphLane(env);
+  if (lane === null) return { files: datastoreFiles, isolate: true };
+
+  const partition = partitionByModuleGraph({ root, files: datastoreFiles });
+  return lane === "shared"
+    ? { files: partition.shared, isolate: false }
+    : { files: partition.mocking, isolate: true };
+}

--- a/platform/app/vitest.integration.config.ts
+++ b/platform/app/vitest.integration.config.ts
@@ -15,6 +15,7 @@ import {
   partitionIntegrationFiles,
   toIncludePatterns,
 } from "./src/test-utils/integrationLanes";
+import { INTEGRATION_FILES_SHARE_MODULE_GRAPH } from "./src/test-utils/integrationModuleGraph";
 import WeightBalancedSequencer from "./vitest.sequencer";
 
 config();
@@ -138,6 +139,20 @@ export default defineConfig({
     // between files instead of relying on a fresh module graph to provide one.
     // That is a real change to the test harness and belongs in its own PR,
     // where the failures it causes are the subject rather than collateral.
+    //
+    // That PR was attempted, and it found the paragraph above is only half the
+    // story. The teardown IS a blocker and is now fixed — `setup.ts` is a setup
+    // FILE, so its `afterAll` runs per test file and was disconnecting the very
+    // Prisma and Redis singletons a shared graph exists to keep. With that
+    // corrected the sharing works and the numbers are large (app/api: 138.8s ->
+    // 43.9s, import -84%).
+    //
+    // It is still off, because the remaining blocker is `vi.mock` and no
+    // teardown reaches it: 123 of 414 integration files mock a module, and a
+    // hoisted mock cannot apply to a registry an earlier file already
+    // populated. The full reasoning, the measurements and the partition that
+    // would work are in src/test-utils/integrationModuleGraph.ts.
+    isolate: !INTEGRATION_FILES_SHARE_MODULE_GRAPH,
     // Same weight-balanced split as the unit config: equal file counts are not
     // equal work, and a matrix is only as fast as its slowest leg.
     sequence: { sequencer: WeightBalancedSequencer },

--- a/platform/app/vitest.integration.config.ts
+++ b/platform/app/vitest.integration.config.ts
@@ -15,7 +15,7 @@ import {
   partitionIntegrationFiles,
   toIncludePatterns,
 } from "./src/test-utils/integrationLanes";
-import { INTEGRATION_FILES_SHARE_MODULE_GRAPH } from "./src/test-utils/integrationModuleGraph";
+import { graphLaneSelection } from "./src/test-utils/integrationModuleGraph";
 import WeightBalancedSequencer from "./vitest.sequencer";
 
 config();
@@ -23,6 +23,16 @@ config();
 const { datastore } = partitionIntegrationFiles({
   root: __dirname,
   searchDirs: [...INTEGRATION_SEARCH_DIRS],
+});
+
+// The datastore lane splits again, by whether a file can tolerate a shared
+// module registry. `files` and `isolate` come out of ONE call on purpose:
+// deriving them separately is how a lane ends up running the mocking files
+// with a shared graph. See src/test-utils/integrationModuleGraph.ts.
+const graphLane = graphLaneSelection({
+  root: __dirname,
+  datastoreFiles: datastore,
+  env: process.env,
 });
 
 // One switch for the CI-vs-laptop trade-offs below.
@@ -53,7 +63,7 @@ export default defineConfig({
     // service containers at all (vitest.component.config.ts). Both lanes call
     // partitionIntegrationFiles, so together they are still every integration
     // file, exactly once. See specs/ci/integration-test-lanes.feature.
-    include: toIncludePatterns(datastore),
+    include: toIncludePatterns(graphLane.files),
     exclude: [...configDefaults.exclude, ".next/**/*", ".next-saas/**/*"],
     testTimeout: 60_000, // 60 seconds for testcontainers startup and processing
     hookTimeout: 60_000, // 60 seconds for beforeAll/afterAll hooks
@@ -140,19 +150,17 @@ export default defineConfig({
     // That is a real change to the test harness and belongs in its own PR,
     // where the failures it causes are the subject rather than collateral.
     //
-    // That PR was attempted, and it found the paragraph above is only half the
-    // story. The teardown IS a blocker and is now fixed — `setup.ts` is a setup
-    // FILE, so its `afterAll` runs per test file and was disconnecting the very
-    // Prisma and Redis singletons a shared graph exists to keep. With that
-    // corrected the sharing works and the numbers are large (app/api: 138.8s ->
-    // 43.9s, import -84%).
+    // THAT PR IS THIS ONE, and the paragraph above turned out to be half the
+    // story. The teardown was one blocker and is fixed: `setup.ts` is a setup
+    // FILE, so its `afterAll` ran per test file and disconnected the very
+    // Prisma and Redis singletons a shared graph exists to keep.
     //
-    // It is still off, because the remaining blocker is `vi.mock` and no
-    // teardown reaches it: 123 of 414 integration files mock a module, and a
-    // hoisted mock cannot apply to a registry an earlier file already
-    // populated. The full reasoning, the measurements and the partition that
-    // would work are in src/test-utils/integrationModuleGraph.ts.
-    isolate: !INTEGRATION_FILES_SHARE_MODULE_GRAPH,
+    // The other blocker is `vi.mock`, which no teardown reaches — a hoisted
+    // mock cannot apply to a registry an earlier file already populated — and
+    // 123 of 414 files mock a module. So the answer is a partition rather than
+    // a flag: the mocking files keep a fresh registry, the rest share one.
+    // Decided together with `include` above; see integrationModuleGraph.ts.
+    isolate: graphLane.isolate,
     // Same weight-balanced split as the unit config: equal file counts are not
     // equal work, and a matrix is only as fast as its slowest leg.
     sequence: { sequencer: WeightBalancedSequencer },


### PR DESCRIPTION
**Import was 42% of the integration lane's runner time** — ~216s against ~203s of actual test execution on a CI shard, roughly 1.6s per file rebuilding the same Prisma client and server graph. This reclaims most of it for the 331 files that can take it.

## Two blockers, and only one was the known one

**The teardown — fixed.** `setup.ts` is a *setup file*, so its `afterAll` runs **once per test file**, and it disconnects Prisma and quits the app-layer Redis: the two singletons a shared graph exists to keep. With a fresh registry that's correct and load-bearing — those sockets would otherwise pin the worker open past the last test. With a shared one it hands the next file a dead client, which is exactly the *"first file's teardown takes the next file's client with it"* failure the old config note describes.

Per-file teardown now resets only the **App container**, whose lifecycle genuinely is per file. The process-wide clients close once at worker exit, sockets unrefed first.

**`vi.mock` — which no teardown reaches**, and why this is a partition rather than a flag. Vitest hoists a module mock per test file and applies it while building *that file's* registry. Share the registry, and a module an earlier file already instantiated stays unmocked — so the test calls the real collaborator. The symptom is `ECONNREFUSED ::1:5560` and `expected 500 to be 200`, nothing about containers or clients, which is precisely what sent the previous attempt looking in the wrong place.

## The split

The datastore lane splits again, on the same terms as the component split it nests inside:

| lane | files | registry |
|---|---|---|
| mocking | **146** | fresh per file, as today |
| shared | **331** | one per shard |

`include` and `isolate` come out of a **single function**, because deriving them separately is how a lane ends up running the mocking files with a shared graph. With no lane selected the default is every file with a fresh registry — so a plain `pnpm test:integration <path>` on a laptop is unchanged and nobody has to know the split exists.

CI keeps the **same four runners**, now two shards per lane. The duration artifact name carries the lane, because both lanes number their shards from 1 and `upload-artifact` rejects a duplicate name within one run.

## Measured

`src/app/api` (49 files), against native local services:

| | files | time |
|---|---|---|
| baseline, one lane | 49 | **138.8s** |
| shared lane | 38 | **34.1s** |
| mocking lane | 11 | **32.9s** |

4.1× on wall clock for that slice, 2.1× less total runner time.

## Verified by set, not by count

Two independent slices, each comparing the **union of both lanes** against the pre-change baseline:

- `src/app/api` — identical
- `ee/` — identical

Zero new failures, nothing dropped. Counts alone would have been misleading: `workflows-api` appeared in one run and not the next under *both* configurations, so it's flake.

Re-verified after rebasing onto current `main`, which is a different baseline: `main` has since taken #7096 and #7106. The `ee/` union is still identical, now against 1 pre-existing failure rather than 2 — `anomalyRule.thresholdConfig` was the zod dual-major boundary issue and #7106 cleared it, which is a nice independent confirmation of that diagnosis.

The partition has 11 unit tests of its own, including that the two lanes are a **total and disjoint cover**, and that an unreadable file goes to the isolated lane because unreadable is not evidence that sharing is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved integration test execution by separating tests into shared and isolated lanes.
  * Reduced repeated setup and teardown work for compatible tests.

* **Reliability**
  * Tests that use module mocking now run with isolated registries to prevent cross-test interference.
  * Enhanced cleanup handling ensures resources are released safely after test workers finish.

* **Testing**
  * Added coverage for lane classification, isolation behavior, environment selection, and fallback handling.

* **CI**
  * Updated integration test sharding and reporting for the new execution lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->