### PR TITLE
fix(lint): let Biome run from the repo root

### DIFF
--- a/.github/scripts/biome-new-violations.sh
+++ b/.github/scripts/biome-new-violations.sh
@@ -91,6 +91,17 @@ BASE_APP="$(app_dir "$BASE_TREE")"
 rm -f "$BASE_TREE/$BASE_APP"/biome.json "$BASE_TREE/$BASE_APP"/biome.jsonc
 cp "$REPO_ROOT/$HEAD_APP/biome.jsonc" "$BASE_TREE/$BASE_APP/biome.jsonc"
 
+# The app config is a NESTED config (`"root": false`, `"extends": "//"`), so the
+# repo-root config has to come across with it. A nested config whose root is
+# missing does not fail -- Biome silently falls back to its built-in defaults,
+# which turns every disabled rule back on and reformats to the default style.
+# On the subset used to verify this, that is 179 diagnostics becoming 1232, all
+# of them counted as new. Copy the root, and only from HEAD, for the same reason
+# the app config is copied from HEAD: the base is judged by the rules we are
+# adopting. A merge base from before the root config existed has none to remove.
+rm -f "$BASE_TREE"/biome.json "$BASE_TREE"/biome.jsonc
+cp "$REPO_ROOT/biome.jsonc" "$BASE_TREE/biome.jsonc"
+
 # Both sides must resolve the same dependencies or the type-aware rules
 # (noFloatingPromises, noMisusedPromises) disagree for reasons that have nothing
 # to do with the diff. Symlinking is enough -- biome only reads them.

--- a/.github/scripts/biome-new-violations.sh
+++ b/.github/scripts/biome-new-violations.sh
@@ -99,6 +99,11 @@ cp "$REPO_ROOT/$HEAD_APP/biome.jsonc" "$BASE_TREE/$BASE_APP/biome.jsonc"
 # of them counted as new. Copy the root, and only from HEAD, for the same reason
 # the app config is copied from HEAD: the base is judged by the rules we are
 # adopting. A merge base from before the root config existed has none to remove.
+if [ ! -f "$REPO_ROOT/biome.jsonc" ]; then
+  echo "::error::no biome.jsonc at the repo root -- $HEAD_APP/biome.jsonc is nested and falls back to Biome's defaults without it, which reports the tree's whole backlog as new" >&2
+  exit 2
+fi
+
 rm -f "$BASE_TREE"/biome.json "$BASE_TREE"/biome.jsonc
 cp "$REPO_ROOT/biome.jsonc" "$BASE_TREE/biome.jsonc"
 

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -961,16 +961,18 @@ jobs:
           # run. They must agree: a path linted on one side and not the other
           # reads as that file's whole backlog appearing or vanishing.
           # `./packages` is GONE from this list, and deliberately not replaced
-          # with `../../packages`. The nine workspace packages now live in one
-          # repo-root tree, which is outside biome's project root here (the app
-          # directory, where biome.jsonc lives). Biome reports out-of-root files
+          # with `../../packages`. The nine workspace packages live in one
+          # repo-root tree that this run does not reach: it is started from the
+          # app directory, and /biome.jsonc scopes the workspace to
+          # platform/app/** anyway. Biome reports files outside the project root
           # by ABSOLUTE path, and the gate keys counts on the reported path, so
           # the base tree's temp-dir prefix can never match the head's: all 268
           # of their diagnostics read as brand new every run. Restoring coverage
-          # means giving packages/ its own biome root and its own gate run, which
-          # is a change to the lint setup rather than to this move -- tracked as
-          # a follow-up. The app tree, which is what this job is named for, is
-          # still fully covered.
+          # means giving packages/ a nested config of its own, adding it to the
+          # root config's includes, and giving it its own gate run -- a change to
+          # the lint setup rather than to this list, tracked as a follow-up. The
+          # app tree, which is what this job is named for, is still fully
+          # covered.
           BIOME_PATHS=(./src ./ee ./scripts ./e2e ./prisma ./vite)
 
           # Biome exits non-zero whenever it reports anything; the gate is the

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+
+	// A MARKER, NOT A RULESET. The rules live in /platform/app/biome.jsonc and
+	// stay there; this file exists so that one can declare itself nested.
+	//
+	// Biome 2 makes whatever directory it is invoked from the workspace root --
+	// the built-in defaults, when no config file sits there -- and a config
+	// found below one that also claims to be root is a hard error:
+	//
+	//   × Found a nested root configuration, but there's already a root
+	//     configuration.
+	//
+	// It prints that and exits before checking a single file. Every scripted run
+	// (`pnpm lint`, `lint:fix`, `lint:plugins`, `format`, and the CI gate in
+	// ./.github/scripts/biome-new-violations.sh) invokes Biome from platform/app,
+	// so none of them ever hit it. An editor, an agent, or anyone running
+	// `biome check` from the repo root hit it every time.
+	"root": true,
+
+	// Scope is deliberately platform/app and nothing else, so that a run started
+	// from the repo root checks exactly what `pnpm lint` checks.
+	//
+	// Without this the rest of the repo -- packages/, sdks/, services/, mcp/,
+	// tests/ -- would be pulled in under the DEFAULT ruleset, since none of it
+	// has a config of its own: 58 diagnostics in packages/api/src alone, mostly
+	// formatting. That is noise on `check` and damage on `check --write`, which
+	// would reformat packages/ (tabs) to the default style (spaces) in a tree no
+	// CI job gates.
+	//
+	// Adding a second config below this one means adding its directory here too.
+	"files": {
+		"includes": ["platform/app/**"]
+	},
+
+	// Inherited by the nested config, which sets it again for when it is invoked
+	// directly from platform/app.
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	}
+}

--- a/platform/app/biome.jsonc
+++ b/platform/app/biome.jsonc
@@ -1,6 +1,21 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
 
+	// Nested under /biome.jsonc, which is a marker rather than a ruleset -- see
+	// the comment there for why it has to exist. Everything below is still the
+	// whole of this project's configuration; `extends: "//"` inherits only the
+	// vcs block.
+	//
+	// KEEP THESE TWO KEYS TOGETHER. `root: false` without a reachable root does
+	// not fail -- Biome falls back to its built-in defaults in silence, which
+	// turns every rule disabled below back on and reformats to the default
+	// style. On the subset used to check this, 179 diagnostics became 1232. A
+	// tree with this file but no /biome.jsonc (an export, a sparse checkout, a
+	// base tree built from a commit that predates the root) lints clean-looking
+	// nonsense rather than erroring, so there is nothing to notice.
+	"root": false,
+	"extends": "//",
+
 	// SEVERITY IS THE TIER.
 	//
 	//   error — baseline is clean; blocks everywhere, for everyone.


### PR DESCRIPTION
## Why

`biome check` from the repo root has never worked in this repo. It fails with:

```
platform/app/biome.jsonc configuration ━━━━━━━━━━
  × Found a nested root configuration, but there's already a root configuration.
  i The other configuration was found in <repo root>.
```

and exits before checking a single file.

`platform/app/biome.jsonc` is the only Biome config in the tree and it does not sit at the root. Biome 2 makes whatever directory it is invoked from the workspace root — the built-in defaults, when no config file is there — and a config found below one that also claims `root` is a hard error.

Every scripted run invokes Biome from `platform/app`, which is why this has gone unnoticed:

| Path | Invoked from | Hits the bug |
| --- | --- | --- |
| `pnpm lint` / `lint:fix` / `lint:plugins` / `format` | `platform/app` (via `--filter`) | no |
| CI reviewdog step (`pnpm --dir platform/app exec biome`) | `platform/app` | no |
| CI delta gate (`cd "$BASE_TREE/$BASE_APP"`) | app dir | no |
| An editor, an agent, a human — anything at the repo root | repo root | **every time** |

Reproduces on `main`, and `platform/app/biome.jsonc` is byte-identical to `main` on the branches I checked. Not branch-specific, and not new.

## What changed

Four files, +83 / -7.

1. **`/biome.jsonc` (new)** — a marker, not a ruleset. It exists so the app config can declare itself nested. All rules stay exactly where they are.
2. **`platform/app/biome.jsonc`** — `"root": false` + `"extends": "//"`, plus a comment explaining why those two keys must travel together. Otherwise untouched.
3. **`.github/scripts/biome-new-violations.sh`** — the delta gate now copies the root config into its base tree alongside the app config, and fails with a named error if the root config is missing.
4. **`.github/workflows/langwatch-app-ci.yml`** — a comment corrected, see below.

The root's scope is deliberately `platform/app/**` and nothing else, so a run started from the root checks exactly what `pnpm lint` checks. Left unscoped, the rest of the repo — `packages/`, `sdks/`, `services/`, `mcp/`, `tests/` — gets pulled in under the DEFAULT ruleset, none of it having a config of its own: 58 diagnostics in `packages/api/src` alone, mostly formatting. Noise on `check`, and damage on `check --write`, which would reformat `packages/` from tabs to the default spaces in a tree no CI job gates.

## How it works

**The trap this had to work around: a nested config whose root is missing does not fail.** Biome silently falls back to its built-in defaults — every rule the app config disables turns back on, and the formatter reverts to default style. On the subset used to verify this, **179 diagnostics became 1232**, and nothing is printed to say so.

That is exactly the delta gate's base tree. It does `git worktree add --detach "$BASE_TREE" "$MERGE_BASE"`, and the merge base predates the root config, so the script only copying the app config across would leave a nested config with no root. Hence the two script changes:

- Copy the root config too, from HEAD, for the same reason the app config is copied from HEAD — the base is judged by the rules we are adopting.
- Guard the copy. Under `set -euo pipefail` a missing root config aborted with a bare "No such file or directory", which is a poor way to report the one failure this change exists to make loud.

Without the copy, the gate lints the base under defaults and reports every real diagnostic in the head as new: **179 phantom violations, CI red on a PR that changed nothing.** Verified by reverting the hunk and re-running.

The workflow comment fix is a consequence, not a drive-by. `langwatch-app-ci.yml` explained that `packages/` is out of scope because it sits outside Biome's project root, "the app directory, where biome.jsonc lives". As of this PR the project root is the repo root and there are two configs, so the reason `packages/` is excluded is now the root config's `includes`. The route to restoring that coverage changes too — a nested config plus an `includes` entry, rather than a second root.

## Test plan

- **All 3487 diagnostics byte-identical** before and after, over the full `pnpm lint` path set (`./src ./ee ./scripts ./e2e ./prisma ./vite`) — same paths, rules, lines and messages, compared as normalized rdjson. Same tree, only the config differing.
- The originally-failing root invocation now succeeds, and a root-invoked run on an app file still applies the **app's** rules (`noExcessiveCognitiveComplexity` fires; no `noExplicitAny` / `noNonNullAssertion` / `format` noise, which is what a defaults fallback would look like).
- `packages/api/src` from the repo root: 0 diagnostics (58 with an unscoped root config).
- Delta gate run end-to-end against `origin/main`: base 179, head 179, no new violations. Reverting the base-tree copy makes it report 179 phantom violations, so the hunk is load-bearing rather than defensive.
- Missing-root guard: removing `/biome.jsonc` produces the named `::error::` and exit 2, not a `cp` failure.
- `bash -n` clean; shellcheck reports only the pre-existing SC2329 on the `trap`-invoked `cleanup`. Workflow YAML parses (14 jobs).

## Anything surprising?

- **The silent-fallback behaviour is the real hazard here**, not the error message this PR removes. Any tree that carries `platform/app/biome.jsonc` without `/biome.jsonc` — a sparse checkout, an export, a Docker context that copies only `platform/app` — now lints under Biome's defaults and reports clean-looking nonsense rather than erroring. The comment sits at the two keys involved, and the delta gate asserts it, but there is no way to make Biome itself complain.
- **Found on the way, not fixed here:** the GritQL plugin `platform/app/biome-plugins/no-raw-error-toast.grit` is dormant. There is no `plugins` key in the config and no workflow step references it, so `pnpm lint:plugins` reports 0 regardless of the code. Its own fixtures file documents an "Enforce analyzer plugins" CI step that does not exist in `langwatch-app-ci.yml` — and that file exists precisely to stop a drifted pattern from passing silently. The rule itself is still covered by `src/features/errors/logic/__tests__/noRawErrorToasts.unit.test.ts`, so this is a missing gate rather than a missing check. Worth its own issue.
- **Follow-up this unblocks:** `packages/` has been uncovered by Biome since the ADR-076 restructure (268 diagnostics, dropped because out-of-root files are reported by absolute path and the gate keys on that path). A root config is the piece that was missing to fix it properly.

## Risk

Low. No rule, severity, override or formatter setting changes anywhere; `platform/app/biome.jsonc` is purely additive (2 keys + comments) and the 3487-diagnostic comparison is the evidence. The behaviour change is confined to invocations that previously hard-errored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linting and formatting configuration across the repository and application.
  * Added safeguards to ensure required configuration is present before validation runs.
  * Updated checks to consistently honor repository ignore rules and application scope.

* **Documentation**
  * Clarified lint workflow guidance, configuration inheritance, and future package coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->