### PR TITLE
fix(costs): correct the MiniMax M3 context window and token rates

### DIFF
--- a/platform/app/src/server/modelProviders/llmModels.overlay.json
+++ b/platform/app/src/server/modelProviders/llmModels.overlay.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Hand-curated model entries for direct-API providers that the upstream model-catalog source does not carry (Voyage AI's direct API today, others later). Merged into llmModels at module load — see loadModelCatalog.ts. The base llmModels.json is regenerated periodically and overwriting hand-added entries would silently drop these providers; the overlay file is never touched by the regen task. Add entries here when integrating a provider whose models aren't reachable via the upstream catalog. Audio entries here are the ones litellm's price registry cannot serve correctly: models it lacks (ElevenLabs flash/turbo, gpt-transcribe), models it prices without audio units (gpt-4o-mini-tts, the gpt-4o transcribe pair), and models where its rate lags a provider price change (eleven_multilingual_v2 still carries the pre-cut rate upstream). An overlay entry only takes effect when the base catalog has no key of the same name, because the merge lets the base win on collision. Entries litellm carries correctly (tts-1, tts-1-hd, whisper-1, scribe_v1) were retired from the overlay and flow in via the weekly sync.",
+	"_comment": "Hand-curated model entries for direct-API providers that the upstream model-catalog source does not carry (Voyage AI's direct API today, others later). Merged into llmModels at module load — see loadModelCatalog.ts. The base llmModels.json is regenerated periodically and overwriting hand-added entries would silently drop these providers; the overlay file is never touched by the regen task. Add entries here when integrating a provider whose models aren't reachable via the upstream catalog. Audio entries here are the ones litellm's price registry cannot serve correctly: models it lacks (ElevenLabs flash/turbo, gpt-transcribe), models it prices without audio units (gpt-4o-mini-tts, the gpt-4o transcribe pair), and models where its rate lags a provider price change (eleven_multilingual_v2 still carries the pre-cut rate upstream). An overlay entry also takes effect when the base catalog carries a key of the same name, because the merge lets the overlay win on collision — that is the correction lane for a generated entry whose values are wrong, and such an entry replaces the generated one whole rather than field by field. Entries litellm carries correctly (tts-1, tts-1-hd, whisper-1, scribe_v1) were retired from the overlay and flow in via the weekly sync.",
 	"models": {
 		"voyage/voyage-3.5": {
 			"id": "voyage/voyage-3.5",
@@ -526,6 +526,51 @@
 			"mode": "chat",
 			"description": "Delisted from the model catalog source on 2026-08-16 and absent from the second source, so these are the rates this catalog itself carried on 2026-07-27, kept so the model bills something rather than zero. No source can confirm them now. Retire this entry once the model is known to be gone, or correct it once a source carries it again.",
 			"supportsImageInput": false,
+			"supportsAudioInput": false,
+			"supportsImageOutput": false,
+			"supportsAudioOutput": false
+		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax: MiniMax M3",
+			"provider": "minimax",
+			"pricing": {
+				"inputCostPerToken": 6e-7,
+				"outputCostPerToken": 0.0000024,
+				"inputCacheReadPerToken": 1.2e-7
+			},
+			"contextLength": 1000000,
+			"maxCompletionTokens": 512000,
+			"supportedParameters": [
+				"frequency_penalty",
+				"include_reasoning",
+				"logit_bias",
+				"logprobs",
+				"max_tokens",
+				"min_p",
+				"presence_penalty",
+				"reasoning",
+				"repetition_penalty",
+				"response_format",
+				"seed",
+				"stop",
+				"structured_outputs",
+				"temperature",
+				"tool_choice",
+				"tools",
+				"top_k",
+				"top_logprobs",
+				"top_p"
+			],
+			"defaultParameters": {
+				"temperature": 1,
+				"topP": 0.95,
+				"frequencyPenalty": null
+			},
+			"modality": "text+image+video->text",
+			"mode": "chat",
+			"description": "A multimodal foundation model taking text, image and video input with text output, suited for long-horizon agentic work, coding and long-context tasks. This entry exists for the context window and the token rates. The generated catalog carries a 1,048,576-token window with $0.30 input, $1.20 output and $0.06 cached input per million tokens, while the provider documents a 1,000,000-token window (https://platform.minimax.io/docs/api-reference/api-overview, verified 2026-08-17, which also notes the limit spans input and output together) and charges $0.60 input, $2.40 output and $0.12 cached input per million tokens, so the generated rates bill this model at half of what it costs. Every other field here matches the generated entry, including the parameter lists, which are carried through because an overlay entry replaces the generated one whole. Retire this entry once the sync carries these values; the weekly price audit reports the disagreement until then.",
+			"supportsImageInput": true,
 			"supportsAudioInput": false,
 			"supportsImageOutput": false,
 			"supportsAudioOutput": false


### PR DESCRIPTION
Reason: The generated catalog prices `minimax/minimax-m3` at half its published rate and carries a context window above the documented limit, and the open registry sync leaves both values unchanged.

## What is wrong

`llmModels.json` carries `minimax/minimax-m3` with a 1,048,576-token context window and $0.30 input, $1.20 output and $0.06 cached input per million tokens. The provider documents a 1,000,000-token window and charges $0.60 / $2.40 / $0.12 per million, so every call on this model is billed at half of what it costs and the advertised window is over the real limit. The open sync (#7082) regenerates the file without changing either value, so the correction has to live in the overlay.

## Changes

- Add a `minimax/minimax-m3` entry to `llmModels.overlay.json` with `contextLength: 1000000` and the $0.60 / $2.40 / $0.12 per-million rates. The context window is verified against https://platform.minimax.io/docs/api-reference/api-overview, which also notes the limit spans input and output together.
- Every other field is copied from the generated entry, including `supportedParameters`, `defaultParameters`, `maxCompletionTokens`, the modality string and the multimodal flags. This matters because the merge in `loadModelCatalog.ts` replaces a colliding generated entry whole rather than field by field, so an omitted field would silently drop capability rather than inherit it.
- The entry's `description` records why it exists and the condition for retiring it, following the entries already in the file.
- Correct the one sentence in the overlay header that still said an entry only takes effect when the base catalog has no key of the same name. That describes the merge direction from before #7046 and would tell a reader this override does nothing.

No reasoning configuration is added: the documented thinking modes for this model have no representation in `ReasoningConfig`, whose `allowedValues` are effort levels, and the generated entry carries no `reasoningConfig` today. That is left as it is rather than guessed at.

## Checks

- `npx @biomejs/biome@2.5.1 check ./src/server/modelProviders/llmModels.overlay.json` (the version this repo pins, run from `platform/app`, against the repo config) — clean, no diagnostics. Note the overlay file is linted and formatted, unlike the Biome-ignored generated file.
- Confirmed the file parses and that the entry's field set is identical to the generated one, differing only in `contextLength`, `pricing` and `description`.
- Reproduced the merge in `loadModelCatalog.ts` and the rule generation, `:`-suffix filtering and specificity sort in `llmModelCost.tsx` against the changed files, and confirmed that `minimax/minimax-m3` resolves to its own rule at the new rates rather than prefix-matching another entry, that both token rates stay above zero so the model remains priced and rankable, and that `minimax/minimax-m2.7` is unaffected. This is the invariant the `when the overlay overrides a generated entry` case in `catalogPriceCoverage.unit.test.ts` asserts; that entry becomes the second id in `overlayOverriddenModelIds`.

I could not run the `pnpm test:unit` lane here: the environment had no `node_modules` and too little free disk to install this workspace, so I verified the change's behaviour directly instead of reporting a test run I did not do. The unit lane is worth a look in CI, in particular `src/server/modelProviders/__tests__/catalogPriceCoverage.unit.test.ts`.

## Note, out of scope

`minimax/minimax-m3:batch` is dropped from the cost registry by the pre-existing rule that removes a `:` key when the un-suffixed key exists, so the batch variant already prices from the non-batch rule and this change moves it from $0.30 to $0.60 rather than to its own published batch rate. That behaviour predates this diff and is left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the MiniMax M3 model.
  * Documented model catalog behavior when custom entries conflict with generated entries.
  * Included the model’s multimodal capabilities, context limit, pricing, supported settings, and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->