### PR TITLE
fix(ci): give the component lane a hard floor sized for its own shards

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -481,6 +481,26 @@ jobs:
       VITEST_MAX_WORKERS: "4" # physical core count on GitHub-hosted ubuntu runners
       BUILD_TIME: "true"
       CI: "true"
+      # This lane inherits the UNIT lane's hard floor and needs a bigger one.
+      #
+      # vitest.component.config.ts spreads `...unitTest`, so it also inherits
+      # `globalSetup: ["./src/test-unit-global-setup.ts"]` and its
+      # DEFAULT_HARD_FLOOR_MS of 4 minutes. That number is sized for a unit
+      # shard, which the file says finishes in ~3 min. A component shard does
+      # not: measured over recent runs the median is 297s — 4.95 min — so the
+      # floor fires on a HEALTHY shard, mid-run, whenever it lands on the slow
+      # side of its own average.
+      #
+      # The failure reads as a hang and is not one. The floor says so itself:
+      # "the shard still had files to start, so the floor cut a run that was
+      # working rather than one that was wedged. Read that as a shard too slow
+      # for the floor, not as a hang." Observed on main (run 32011... shard 2)
+      # as well as on pull requests, so it is intermittent rather than new.
+      #
+      # 12 minutes keeps the floor doing its job — a finalize wedge still gets
+      # cut well before the 25-minute job cap below, which is the outcome the
+      # floor exists to avoid — while leaving a healthy 5-minute shard alone.
+      LANGWATCH_UNIT_HARD_FLOOR_MS: "720000"
     runs-on: ubuntu-latest
     # No services, so nothing here can wedge on a container. The cap matches
     # test-unit's reasoning rather than test-integration's: a vitest finalize


### PR DESCRIPTION
`test-component` fails intermittently with what reads as a hang. **It isn't one** — it's a healthy shard being cut mid-run by a floor sized for a different lane.

## The mechanism

`vitest.component.config.ts` spreads `...unitTest`, so it inherits `globalSetup: ["./src/test-unit-global-setup.ts"]` — and with it `DEFAULT_HARD_FLOOR_MS = 4 * 60 * 1000`.

That 4 minutes is sized for a unit shard, and the file says so:

> A healthy unit shard finishes in ~3 min, so a 4-min floor only fires on a wedge.

**A component shard does not finish in ~3 min.** Measured over recent runs, the median is **297s — 4.95 minutes**. So the floor fires on a *healthy* shard, part way through its files, whenever it lands on the slow side of its own average.

## The floor already tells you this

Worth quoting, because it's what stops the next person debugging a phantom infinite render loop:

```
[unit globalSetup] the shard still had files to start, so the floor cut a run that
was working rather than one that was wedged. Read that as a shard too slow for the
floor, not as a hang.
```

## Not new, and it takes a required check with it

Seen on `main` as well as on pull requests — one of the last three `main` runs lost shard 2 exactly this way. It's intermittent rather than newly introduced.

And each time it fails it takes **`langwatch-app-complete`** down with it, which *is* a required check. So this is a periodic, unexplained block on merging anything.

## The fix

`LANGWATCH_UNIT_HARD_FLOOR_MS`, the knob the setup file already exposes for precisely this, set on the component job only: **12 minutes**.

The floor keeps doing its job — a genuine finalize wedge is still cut well before the 25-minute job cap, which is the outcome it exists to avoid — while a healthy 5-minute shard is left alone. The unit lane keeps its 4-minute default, because its shards really do finish in ~3.

## Why its own PR

Unrelated to anything else in flight, and every PR is exposed to it. Found while driving #7107, where it failed both component shards and turned that PR red for a reason that had nothing to do with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the maximum runtime allowed for component test shards, helping prevent longer-running test suites from being terminated prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->