### PR TITLE
fix(ops): register the /ops/migrations route so the sidebar link opens

### DIFF
--- a/platform/app/src/__tests__/sidebarLinksAreRouted.unit.test.ts
+++ b/platform/app/src/__tests__/sidebarLinksAreRouted.unit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Every absolute link the sidebar renders must resolve to a real page.
+ *
+ * Spec: specs/ops/ops-navigation-reachability.feature
+ *
+ * `routes.tsx` is a hand-maintained table, not filesystem routing, so adding a
+ * page under `src/pages/` and linking to it from the menu is only two thirds of
+ * the work — and the missing third is silent. That is how the Ops -> Migrations
+ * link shipped in #7079 pointing at a page nobody could open: the page module
+ * and the menu entry both landed, the route entry did not, and the link fell
+ * through to the catch-all.
+ *
+ * Nothing else catches this. The page module typechecks, the href is just a
+ * string, and no test rendered the menu and followed it.
+ *
+ * "Resolves" has to mean what React Router means by it, not "matches some
+ * pattern in the file". The table ends in a `*` route that renders the 404
+ * page, so every path on earth matches something; and `/ops` also matches
+ * `/:project`, which is a different page entirely. `matchRoutes` applies the
+ * real ranking and hands back the route that would actually render, which is
+ * the only answer worth asserting on.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { matchRoutes } from "react-router";
+import { describe, expect, it } from "vitest";
+
+const MAIN_MENU_PATH = path.join(__dirname, "../components/MainMenu.tsx");
+const ROUTES_PATH = path.join(__dirname, "../routes.tsx");
+
+/** The pattern the router falls back to when nothing else claims a path. */
+const CATCH_ALL = "*";
+
+/** Absolute-path `href="..."` literals, in source order. */
+function sidebarHrefs(): string[] {
+  const source = readFileSync(MAIN_MENU_PATH, "utf-8");
+  return [...source.matchAll(/href="(\/[^"]*)"/g)].map((m) => m[1]!);
+}
+
+/**
+ * Every `path: "..."` the route table declares, as a flat list. The real table
+ * nests, but every path in it is absolute, so a flat list of the same strings
+ * ranks identically — nesting only matters for joining relative segments.
+ */
+function routePatterns(): string[] {
+  const source = readFileSync(ROUTES_PATH, "utf-8");
+  return [...source.matchAll(/\bpath:\s*"([^"]+)"/g)].map((m) => m[1]!);
+}
+
+/** The pattern that would win for `href`, or null if nothing matched at all. */
+function resolvedPattern({
+  href,
+  patterns,
+}: {
+  href: string;
+  patterns: string[];
+}): string | null {
+  const matches = matchRoutes(
+    patterns.map((pattern) => ({ path: pattern })),
+    href,
+  );
+  return matches?.[0]?.route.path ?? null;
+}
+
+describe("given the sidebar's absolute links", () => {
+  const hrefs = sidebarHrefs();
+  const patterns = routePatterns();
+
+  // Both scans are regexes over source, so a rename that stops one matching
+  // would otherwise leave a test that passes by finding nothing at all.
+  it("finds the links and the route table", () => {
+    expect(hrefs.length).toBeGreaterThanOrEqual(5);
+    expect(patterns.length).toBeGreaterThanOrEqual(20);
+    expect(patterns).toContain(CATCH_ALL);
+  });
+
+  describe("when each link is resolved the way the router would", () => {
+    /** @scenario "Every sidebar link opens a page" */
+    it.each(hrefs)("%s lands on a page, not the 404", (href) => {
+      expect(resolvedPattern({ href, patterns })).not.toBe(CATCH_ALL);
+    });
+
+    /** @scenario "A sidebar link opens the page it names" */
+    it.each(hrefs)("%s resolves to its own route, not a wildcard", (href) => {
+      // A link that only resolves via `/:project` or `/@project/*` is pointing
+      // at the project shell, which is not the page the label promises.
+      expect(resolvedPattern({ href, patterns })).toBe(href);
+    });
+  });
+});

--- a/platform/app/src/routes.tsx
+++ b/platform/app/src/routes.tsx
@@ -645,6 +645,10 @@ const routes: RouteObject[] = [
   },
   { path: "/ops/foundry", ...page(() => import("./pages/ops/foundry")) },
   {
+    path: "/ops/migrations",
+    ...page(() => import("./pages/ops/migrations")),
+  },
+  {
     path: "/ops/projections",
     ...page(() => import("./pages/ops/projections")),
   },

--- a/specs/ops/ops-navigation-reachability.feature
+++ b/specs/ops/ops-navigation-reachability.feature
@@ -1,0 +1,28 @@
+# Routing in the app is a hand-maintained table in platform/app/src/routes.tsx,
+# not filesystem-based. Adding a page and linking to it are two edits; the third
+# — registering the route — is the one nothing complains about.
+
+Feature: Ops navigation reachability
+  As an operator opening a page from the ops sidebar
+  I want every link in the menu to open the page it names
+  So that a shipped feature is not invisible behind a dead link
+
+  Context: the Ops -> Migrations page shipped in #7079 with its page module and
+  its sidebar entry, but no entry in the route table. The link was rendered,
+  enabled and correctly labelled, and clicking it landed on the 404 page. The
+  page module typechecked, the href was a plain string, and no test rendered the
+  menu and followed it, so nothing in CI had an opinion. The feature was
+  unreachable in production for as long as nobody clicked it.
+
+  @unit
+  Scenario: Every sidebar link opens a page
+    Given the ops sidebar renders a set of links
+    When each link is resolved against the application's route table
+    Then no link falls through to the catch-all route
+
+  @unit
+  Scenario: A sidebar link opens the page it names
+    Given the ops sidebar renders a set of links
+    When each link is resolved against the application's route table
+    Then each one resolves to a route registered for that exact path
+    And no link is served by a wildcard route belonging to another surface


### PR DESCRIPTION
## Why

The Ops → Migrations page 404s in production.

It shipped in #7079 with two of the three edits it needed: the page module (`platform/app/src/pages/ops/migrations.tsx`) and the sidebar entry (`MainMenu.tsx:459`, linking to `/ops/migrations`). The third — an entry in `platform/app/src/routes.tsx` — was never added.

Routing in this app is a hand-maintained table, not filesystem-based, so nothing complained. The link rendered, was enabled, was correctly labelled, and landed on the catch-all 404. The page module typechecks, the href is a plain string, and no test rendered the menu and followed it. The feature has been unreachable for as long as nobody clicked it.

## What changed

Three files:

- **`platform/app/src/routes.tsx`** — registers `/ops/migrations`. This is the fix.
- **`platform/app/src/__tests__/sidebarLinksAreRouted.unit.test.ts`** — a guard so the next hand-added page can't repeat it.
- **`specs/ops/ops-navigation-reachability.feature`** — the spec the guard binds to.

## How it works

The guard resolves every absolute `href` in `MainMenu.tsx` against the route table and asserts it opens the page it names.

The interesting part is what "resolves" has to mean. My first cut asked whether each href matched *some* pattern in the file, using `matchPath` — and **it passed with the route deleted**. Two reasons, both worth knowing:

- the table ends in a `*` route that renders the 404, so every path on earth matches something;
- `/ops` also matches `/:project`, which is a different page entirely.

So the guard uses `matchRoutes` instead, which applies React Router's real ranking and returns the route that would actually render. It then asserts the winner is the href's own route — not the catch-all, and not a wildcard belonging to another surface.

Both scans are regexes over source, so there's an explicit sanity assertion that they found the links and the table at all. Otherwise a rename could leave a test that passes by finding nothing.

## Test plan

- `pnpm test:unit run src/__tests__/sidebarLinksAreRouted.unit.test.ts` → 15 passed (1 sanity check + 7 sidebar links × 2 assertions).
- **Fails without the fix.** Reverted `routes.tsx` and re-ran: 2 failed, `expected '*' to be '/ops/migrations'`. That's the assertion worth having, and it's the one the `matchPath` version couldn't make.
- `check-feature-parity.ts` reports the new spec as `2/2 scenarios bound` / `✓ all bound` — not the vacuous `0/0` an untagged feature file would give.
- Biome clean on both changed files; targeted typecheck of the new test exits 0.

## Anything surprising?

I swept the rest of `src/pages` for the same defect. **`/ops/migrations` was the only real instance** — every other page file lacking a literal route entry resolves through a directory-index import (e.g. `/:project/automations` → `pages/[project]/automations`).

Two things deliberately left alone:

- **`pages/dev/error-test.tsx`** is also unrouted, but nothing links to it, so it's plausibly intentional. Not touched.
- **`src/utils/compat/next-router.ts`** carries its own `ROUTE_PATTERNS` list that is already missing most ops routes (`event-sourcing`, `feature-flags`, `blobs`, `scheduler`, `backoffice`). It only affects `router.pathname` resolution, and for a static path it falls through to the raw path unchanged — so `/ops/migrations` needs no entry there. Worth a separate tidy-up, not this PR.

The guard covers the sidebar, which is where this bug lived. It does not cover links rendered elsewhere (command bar, in-page navigation) — a broader version is possible if reviewers want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Ops Migrations page accessible through the `/ops/migrations` route.

- **Bug Fixes**
  - Ensured sidebar links resolve to their intended pages instead of fallback routes.

- **Tests**
  - Added automated coverage verifying sidebar navigation matches registered routes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->