### PR TITLE
test(automations): stop the Slack picker tests depending on per-character typing

### DIFF
--- a/platform/app/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
+++ b/platform/app/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
@@ -10,7 +10,13 @@
  * asserted through their wrapper test ids.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -370,6 +376,38 @@ describe("SlackConfigForm channel picker", () => {
     // typist can win, and not the bug under test.
     const typist = () => userEvent.setup({ delay: 10 });
 
+    /**
+     * Type into the combobox, then wait for the box to actually hold it.
+     *
+     * The cadence above makes the resync race unlikely, not impossible: on a
+     * loaded CI runner a keystroke is still occasionally lost, and a fixed
+     * delay only moves the threshold rather than removing it.
+     *
+     * What this changes is WHERE the loss shows up. A test that types and then
+     * goes on to tab, click or press Enter carries the corrupted value forward,
+     * so the drop surfaces several interactions later as something that reads
+     * like a real defect — "expected ['#ahoc'] to deeply equal ['#adhoc']"
+     * about which item carries a tick. Settling on the typed value keeps the
+     * failure at the point the typing failed, and lets the retry that the
+     * `waitFor` performs absorb a race that is not what any of these tests are
+     * about.
+     *
+     * Tests that type and immediately assert the value do NOT need this: there
+     * the dropped character IS the assertion, and it should fail.
+     */
+    const typeAndSettle = async ({
+      user,
+      input,
+      text,
+    }: {
+      user: ReturnType<typeof typist>;
+      input: HTMLElement;
+      text: string;
+    }): Promise<void> => {
+      await user.type(input, text);
+      await waitFor(() => expect(input).toHaveValue(text));
+    };
+
     describe("when the author types a channel name to search", () => {
       it("keeps every typed character in the box", async () => {
         const user = typist();
@@ -388,7 +426,7 @@ describe("SlackConfigForm channel picker", () => {
         const input = screen.getByPlaceholderText(/#alerts or c0123/i);
 
         await user.click(input);
-        await user.type(input, "signoff");
+        await typeAndSettle({ user, input, text: "signoff" });
 
         expect(screen.getByText("#release-signoff")).toBeInTheDocument();
         expect(screen.queryByText("#support")).not.toBeInTheDocument();
@@ -411,10 +449,11 @@ describe("SlackConfigForm channel picker", () => {
         const onChangeSpy = vi.fn();
         renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
 
-        await user.type(
-          screen.getByPlaceholderText(/#alerts or c0123/i),
-          "#adhoc",
-        );
+        await typeAndSettle({
+          user,
+          input: screen.getByPlaceholderText(/#alerts or c0123/i),
+          text: "#adhoc",
+        });
         await user.tab();
 
         expect(onChangeSpy).toHaveBeenLastCalledWith(
@@ -427,10 +466,15 @@ describe("SlackConfigForm channel picker", () => {
         const onChangeSpy = vi.fn();
         renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
 
-        await user.type(
-          screen.getByPlaceholderText(/#alerts or c0123/i),
-          "#adhoc{Enter}",
-        );
+        // Enter is sent separately so the settle can assert the typed value —
+        // with `#adhoc{Enter}` in one call there is no point at which the box
+        // is expected to hold exactly `#adhoc`.
+        await typeAndSettle({
+          user,
+          input: screen.getByPlaceholderText(/#alerts or c0123/i),
+          text: "#adhoc",
+        });
+        await user.keyboard("{Enter}");
 
         expect(onChangeSpy).toHaveBeenLastCalledWith(
           expect.objectContaining({ channelId: "#adhoc" }),
@@ -466,7 +510,7 @@ describe("SlackConfigForm channel picker", () => {
         const input = screen.getByPlaceholderText(/#alerts or c0123/i);
 
         await user.click(input);
-        await user.type(input, "signoff");
+        await typeAndSettle({ user, input, text: "signoff" });
         await user.keyboard("{ArrowDown}{Enter}");
 
         expect(onChangeSpy).toHaveBeenLastCalledWith(
@@ -488,7 +532,7 @@ describe("SlackConfigForm channel picker", () => {
         await user.click(input);
         await user.click(await screen.findByText("#release-signoff"));
         await user.clear(input);
-        await user.type(input, "#adhoc");
+        await typeAndSettle({ user, input, text: "#adhoc" });
         await user.tab();
         await user.click(input);
 
@@ -516,7 +560,7 @@ describe("SlackConfigForm channel picker", () => {
         await user.click(input);
         await user.click(await screen.findByText("#release-signoff"));
         await user.clear(input);
-        await user.type(input, "#adhoc");
+        await typeAndSettle({ user, input, text: "#adhoc" });
         await user.tab();
 
         expect(input).toHaveValue("#adhoc");

--- a/platform/app/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
+++ b/platform/app/src/features/automations/providers/slack/__tests__/client.integration.test.tsx
@@ -377,23 +377,52 @@ describe("SlackConfigForm channel picker", () => {
     const typist = () => userEvent.setup({ delay: 10 });
 
     /**
-     * Type into the combobox, then wait for the box to actually hold it.
+     * Put a channel in the box in ONE input event, for the tests that are not
+     * about typing.
      *
-     * The cadence above makes the resync race unlikely, not impossible: on a
-     * loaded CI runner a keystroke is still occasionally lost, and a fixed
-     * delay only moves the threshold rather than removing it.
+     * The race costs a character only because each keystroke is appended to
+     * whatever the box is holding at that moment: if a resync rewrites the box
+     * from stale text between two keystrokes, the next character lands on the
+     * stale text and the one before it is gone from the combobox's own state
+     * for good. A single event has no "between", so there is nothing to lose —
+     * and this holds whatever it is that makes the resync late, which is worth
+     * something, because that has not been pinned down.
      *
-     * What this changes is WHERE the loss shows up. A test that types and then
-     * goes on to tab, click or press Enter carries the corrupted value forward,
-     * so the drop surfaces several interactions later as something that reads
-     * like a real defect — "expected ['#ahoc'] to deeply equal ['#adhoc']"
-     * about which item carries a tick. Settling on the typed value keeps the
-     * failure at the point the typing failed, and lets the retry that the
-     * `waitFor` performs absorb a race that is not what any of these tests are
-     * about.
+     * This is a real thing authors do (paste a channel name or an ID), and for
+     * a test that goes on to blur, press Enter or pick from the list it says
+     * exactly as much as typing did: the box holds the channel.
+     */
+    const enterChannel = async ({
+      user,
+      input,
+      text,
+    }: {
+      user: ReturnType<typeof typist>;
+      input: HTMLElement;
+      text: string;
+    }): Promise<void> => {
+      await user.click(input);
+      await user.paste(text);
+      await waitFor(() => expect(input).toHaveValue(text));
+    };
+
+    /**
+     * Type one character at a time, waiting for the box to hold each prefix
+     * before sending the next.
      *
-     * Tests that type and immediately assert the value do NOT need this: there
-     * the dropped character IS the assertion, and it should fail.
+     * Only for the test whose subject IS the per-keystroke path — that the
+     * search filters on the whole term rather than the last letter, which is
+     * the defect that made a long channel name unreachable. Pasting would walk
+     * straight past it, so that test keeps typing and this keeps it honest:
+     * nothing is typed onto a box that is not already holding what came
+     * before, so a stale value is caught while it is still recoverable rather
+     * than being carried into the assertion.
+     *
+     * The tests that type and immediately assert the value use neither helper.
+     * There the dropped character IS the assertion, and it should fail.
+     *
+     * `text` is literal text — key descriptors like `{Enter}` do not survive
+     * being split per character.
      */
     const typeAndSettle = async ({
       user,
@@ -404,8 +433,12 @@ describe("SlackConfigForm channel picker", () => {
       input: HTMLElement;
       text: string;
     }): Promise<void> => {
-      await user.type(input, text);
-      await waitFor(() => expect(input).toHaveValue(text));
+      let typed = "";
+      for (const character of text) {
+        await user.type(input, character);
+        typed += character;
+        await waitFor(() => expect(input).toHaveValue(typed));
+      }
     };
 
     describe("when the author types a channel name to search", () => {
@@ -449,7 +482,7 @@ describe("SlackConfigForm channel picker", () => {
         const onChangeSpy = vi.fn();
         renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
 
-        await typeAndSettle({
+        await enterChannel({
           user,
           input: screen.getByPlaceholderText(/#alerts or c0123/i),
           text: "#adhoc",
@@ -466,10 +499,7 @@ describe("SlackConfigForm channel picker", () => {
         const onChangeSpy = vi.fn();
         renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
 
-        // Enter is sent separately so the settle can assert the typed value —
-        // with `#adhoc{Enter}` in one call there is no point at which the box
-        // is expected to hold exactly `#adhoc`.
-        await typeAndSettle({
+        await enterChannel({
           user,
           input: screen.getByPlaceholderText(/#alerts or c0123/i),
           text: "#adhoc",
@@ -509,8 +539,7 @@ describe("SlackConfigForm channel picker", () => {
         renderForm({ initial: botSlice({ channelId: "" }), onChangeSpy });
         const input = screen.getByPlaceholderText(/#alerts or c0123/i);
 
-        await user.click(input);
-        await typeAndSettle({ user, input, text: "signoff" });
+        await enterChannel({ user, input, text: "signoff" });
         await user.keyboard("{ArrowDown}{Enter}");
 
         expect(onChangeSpy).toHaveBeenLastCalledWith(
@@ -532,7 +561,7 @@ describe("SlackConfigForm channel picker", () => {
         await user.click(input);
         await user.click(await screen.findByText("#release-signoff"));
         await user.clear(input);
-        await typeAndSettle({ user, input, text: "#adhoc" });
+        await enterChannel({ user, input, text: "#adhoc" });
         await user.tab();
         await user.click(input);
 
@@ -560,7 +589,7 @@ describe("SlackConfigForm channel picker", () => {
         await user.click(input);
         await user.click(await screen.findByText("#release-signoff"));
         await user.clear(input);
-        await typeAndSettle({ user, input, text: "#adhoc" });
+        await enterChannel({ user, input, text: "#adhoc" });
         await user.tab();
 
         expect(input).toHaveValue("#adhoc");


### PR DESCRIPTION
The Slack channel-picker suite drops a keystroke on CI. Observed twice, **a different character each time**:

```
expected [ '#adoc' ] to deeply equal [ '#adhoc' ]     ← lost the 'h'
expected [ '#ahoc' ] to deeply equal [ '#adhoc' ]     ← lost the 'd'
```

## The character is gone from the combobox's own state

That assertion is `expect(checked).toEqual(["#adhoc"])` — the label on the ticked item. That label comes from the collection entry the component creates from the typed text, which is set from `pendingText`, which is written from the combobox's `inputValue`. So by the time the tick is read, the combobox itself is holding `#adoc`.

Nothing re-types, so that never repairs itself. Each keystroke is appended to whatever the box holds at that moment, so if a resync rewrites the box from stale text between two characters, the next character lands on the stale text and the one before it is lost for good:

```
type "#ad"   → box "#ad"
             (a render lands late, the input is resynced from stale state)
             → box "#a"
type "h"     → box "#ah"       ← appended to the STALE text
                                 the 'd' is gone, permanently
```

**This is why the first version of this PR was wrong.** It waited for the box to hold the typed value after the whole string. `waitFor` retries the assertion, never the typing, so against the failure above it would have polled for a second and failed anyway — a clearer message, same red build.

## What this does instead

Five of the six sites are not about typing at all. They blur, press Enter, or pick from the list; typing was only how a channel got into the box. Those now **paste** — one input event, no gap between characters, so there is nothing for a late resync to eat. It removes the race by construction rather than by timing, and it holds whatever the underlying cause turns out to be. Pasting a channel name or an ID is also a thing authors actually do.

The one site that *is* about the per-keystroke path — the search filtering on the whole term rather than only the last letter, the defect that once made long channel names unreachable — keeps typing, and now settles **between** keystrokes. Nothing is typed onto a box that isn't already holding what came before, so a stale value is caught while it is still recoverable instead of being carried into the assertion.

**Two sites are deliberately untouched** — the ones that type and immediately assert the value. There the dropped character *is* the assertion, and it should fail.

## What I could not establish

I could not reproduce the drop locally, and I could not identify what makes the resync land late.

The suspect was the `startTransition`-wrapped `filter()` in `client.tsx` — during typing it is the only render the component performs, and a transition is scheduled through React's scheduler rather than flushed with the keystroke. I probed it directly: replaying the exact failing sequence with `delay: null` (no gap at all between keystrokes), with and without the transition.

| | result |
|---|---|
| with `startTransition`, no gap between keystrokes | passes |
| without `startTransition`, no gap between keystrokes | passes |

Both pass, because `act()` drains the transition between keystrokes anyway. So the transition is **not** shown to be the cause, and I have not changed the component. The only edit here is to the test file.

That is also why the fix is the one that doesn't depend on the mechanism. A single input event has no "between" for a late render to corrupt, whatever it is that makes a render late.

## Verification

`33/33` pass, three consecutive runs. That is not evidence the CI flake is gone — the unfixed suite passed locally too, which is exactly the trap the first version of this PR fell into. The argument for the change is structural: five tests no longer depend on per-character interleaving they were never testing, and the one that does now checks its own premise between keystrokes.

If it recurs, it can now only recur in a test whose subject really is the typing, and it will say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Slack channel-picker integration test reliability by waiting for search input updates to settle before continuing interactions.
  * Expanded coverage for channel search, blur behavior, Enter-key selection, suggestion selection, and replacing an existing channel.
  * Added more realistic typing and complete-text entry scenarios to validate channel selection flows consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->