### PR TITLE
fix(scim): read PATCH operation names without regard to case, so Entra can offboard

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -42683,7 +42683,7 @@
           }
         ],
         "summary": "Update a provisioned user",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operation names are read without regard to case, so the capitalized `Replace` that Entra ID writes is understood. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
         "security": [
           {
             "scim_bearer": []
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operations outside that set are accepted and change nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operation names are read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are understood. Operations outside that set are accepted and change nothing.",
         "security": [
           {
             "scim_bearer": []

--- a/platform/app/ee/scim/__tests__/scim-patch-op-casing.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-patch-op-casing.unit.test.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Microsoft Entra sends PATCH operations with a capitalized `op` value —
+ * `"Replace"`, `"Add"`, `"Remove"` — the way Microsoft's own SCIM provisioning
+ * tutorial documents them, even though RFC 7644 §3.5.2 defines the values in
+ * lowercase. Our schema used to accept only the lowercase spelling, so every
+ * Entra offboard (`active: false`) and every group-membership change was
+ * rejected with a 400 before reaching a handler.
+ *
+ * These tests drive the real parse-then-apply path with the capitalized
+ * payloads rather than asserting on the schema alone, because the service layer
+ * below it also compares `operation.op` against lowercase literals: normalising
+ * at only one of the two seams would still drop the operation on the floor.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScimService } from "../scim.service";
+import { scimPatchRequestSchema } from "../scim.types";
+import { ScimGroupService } from "../scim-group.service";
+
+// An App carrying no Redis, so the revoke helper reachable from the SCIM
+// deactivation paths takes its Postgres-only path instead of talking to a real
+// Redis from a unit test.
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({ redis: null }),
+  tryGetApp: () => ({ redis: null }),
+}));
+
+const PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
+function parsePatch(body: unknown) {
+  const parsed = scimPatchRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error(
+      `SCIM PATCH rejected at the schema: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+function createMockPrisma() {
+  const mock = {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    organizationUser: {
+      findUnique: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([{ userId: "user-1" }]),
+    },
+    roleBinding: {
+      create: vi.fn().mockResolvedValue({}),
+      deleteMany: vi.fn().mockResolvedValue({}),
+    },
+    session: {
+      findMany: vi.fn().mockResolvedValue([]),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    group: {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "group-1",
+        name: "Engineering",
+        organizationId: "org-1",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        updatedAt: new Date("2024-01-02T00:00:00Z"),
+      }),
+      findUniqueOrThrow: vi.fn().mockResolvedValue({
+        id: "group-1",
+        name: "Engineering",
+        organizationId: "org-1",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        updatedAt: new Date("2024-01-02T00:00:00Z"),
+      }),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    groupMembership: {
+      upsert: vi.fn().mockResolvedValue({}),
+      deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    $transaction: vi
+      .fn()
+      .mockImplementation((ops: unknown[]) => Promise.all(ops)),
+  };
+  return mock as unknown as Parameters<typeof ScimService.create>[0] &
+    Parameters<typeof ScimGroupService.create>[0] &
+    typeof mock;
+}
+
+describe("SCIM PATCH op casing", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+  });
+
+  describe("given an identity provider sends a capitalized op value", () => {
+    describe("when the request is parsed", () => {
+      it("accepts it and normalizes the op to the RFC spelling", () => {
+        const parsed = parsePatch({
+          schemas: [PATCH_SCHEMA],
+          Operations: [
+            { op: "Replace", path: "active", value: false },
+            { op: "Add", path: "members", value: [{ value: "user-1" }] },
+            { op: "Remove", path: 'members[value eq "user-1"]' },
+          ],
+        });
+
+        expect(parsed.Operations.map((operation) => operation.op)).toEqual([
+          "replace",
+          "add",
+          "remove",
+        ]);
+      });
+    });
+
+    describe("when the operation deactivates a user", () => {
+      it("deactivates the user", async () => {
+        const user = {
+          id: "user-1",
+          name: "Alice Smith",
+          email: "alice@acme.com",
+          deactivatedAt: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-02T00:00:00Z"),
+        };
+        (
+          prisma.organizationUser.findUnique as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({ userId: "user-1", organizationId: "org-1" });
+        (prisma.user.update as ReturnType<typeof vi.fn>).mockResolvedValue({
+          ...user,
+          deactivatedAt: new Date(),
+        });
+        (prisma.user.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+          ...user,
+          deactivatedAt: new Date(),
+        });
+
+        const result = await ScimService.create(prisma).updateUser({
+          id: "user-1",
+          organizationId: "org-1",
+          patchRequest: parsePatch({
+            schemas: [PATCH_SCHEMA],
+            Operations: [{ op: "Replace", path: "active", value: false }],
+          }),
+        });
+
+        expect(prisma.user.update).toHaveBeenCalledWith({
+          where: { id: "user-1" },
+          data: { deactivatedAt: expect.any(Date) },
+        });
+        expect(result).toHaveProperty("active", false);
+      });
+    });
+
+    describe("when the operation adds a group member", () => {
+      it("adds the member to the group", async () => {
+        await ScimGroupService.create(prisma).updateGroup({
+          externalScimId: "group-1",
+          organizationId: "org-1",
+          patchRequest: parsePatch({
+            schemas: [PATCH_SCHEMA],
+            Operations: [
+              { op: "Add", path: "members", value: [{ value: "user-1" }] },
+            ],
+          }),
+        });
+
+        expect(prisma.groupMembership.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            create: { userId: "user-1", groupId: "group-1" },
+          }),
+        );
+      });
+    });
+
+    describe("when the operation removes a group member", () => {
+      it("removes the member from the group", async () => {
+        await ScimGroupService.create(prisma).updateGroup({
+          externalScimId: "group-1",
+          organizationId: "org-1",
+          patchRequest: parsePatch({
+            schemas: [PATCH_SCHEMA],
+            Operations: [{ op: "Remove", path: 'members[value eq "user-1"]' }],
+          }),
+        });
+
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-1"] } },
+        });
+      });
+    });
+
+    describe("when the operation renames the group", () => {
+      it("renames the group", async () => {
+        await ScimGroupService.create(prisma).updateGroup({
+          externalScimId: "group-1",
+          organizationId: "org-1",
+          patchRequest: parsePatch({
+            schemas: [PATCH_SCHEMA],
+            Operations: [
+              { op: "Replace", path: "displayName", value: "Platform" },
+            ],
+          }),
+        });
+
+        expect(prisma.group.update).toHaveBeenCalledWith({
+          where: { id: "group-1" },
+          data: { name: "Platform" },
+        });
+      });
+    });
+  });
+
+  describe("given an identity provider sends the RFC lowercase op value", () => {
+    describe("when the request is parsed", () => {
+      it("still accepts it", () => {
+        const parsed = parsePatch({
+          schemas: [PATCH_SCHEMA],
+          Operations: [{ op: "replace", value: { active: false } }],
+        });
+
+        expect(parsed.Operations[0]?.op).toBe("replace");
+      });
+    });
+  });
+
+  describe("given an op value that is not a SCIM operation", () => {
+    describe("when the request is parsed", () => {
+      it("is rejected", () => {
+        expect(
+          scimPatchRequestSchema.safeParse({
+            schemas: [PATCH_SCHEMA],
+            Operations: [{ op: "Delete", value: {} }],
+          }).success,
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/platform/app/ee/scim/openapi.ts
+++ b/platform/app/ee/scim/openapi.ts
@@ -478,7 +478,7 @@ export const PATCH_USER: DescribeRouteOptions = {
   operationId: "scimPatchUser",
   summary: "Update a provisioned user",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operation names are read without regard to case, so the capitalized `Replace` that Entra ID writes is understood. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch user id.")],
@@ -598,7 +598,7 @@ export const PATCH_GROUP: DescribeRouteOptions = {
   operationId: "scimPatchGroup",
   summary: "Update a provisioned group",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operations outside that set are accepted and change nothing.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operation names are read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are understood. Operations outside that set are accepted and change nothing.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch group id.")],

--- a/platform/app/ee/scim/scim.types.ts
+++ b/platform/app/ee/scim/scim.types.ts
@@ -36,8 +36,24 @@ export interface ScimError {
   detail: string;
 }
 
+/**
+ * RFC 7644 §3.5.2 spells the operation values in lowercase, but Microsoft
+ * Entra sends them capitalized — `"Replace"`, `"Add"`, `"Remove"` — the way
+ * Microsoft's own SCIM provisioning tutorial documents them. Normalising here
+ * keeps every `operation.op === "replace"` comparison downstream working
+ * against one spelling instead of spreading the tolerance across the services.
+ *
+ * Only strings are lowercased: a missing or non-string `op` falls through to
+ * the enum so it still fails as a bad value rather than as the string
+ * `"undefined"`.
+ */
+const scimPatchOpSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value.toLowerCase() : value),
+  z.enum(["replace", "add", "remove"]),
+);
+
 export const scimPatchOperationSchema = z.object({
-  op: z.enum(["replace", "add", "remove"]),
+  op: scimPatchOpSchema,
   path: z.string().optional(),
   value: z.unknown().optional(),
 });

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -42683,7 +42683,7 @@
           }
         ],
         "summary": "Update a provisioned user",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operation names are read without regard to case, so the capitalized `Replace` that Entra ID writes is understood. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
         "security": [
           {
             "scim_bearer": []
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operations outside that set are accepted and change nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operation names are read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are understood. Operations outside that set are accepted and change nothing.",
         "security": [
           {
             "scim_bearer": []


### PR DESCRIPTION
# Related Issue

- Resolves #6972

## For humans

If a company connects their Microsoft directory to LangWatch to manage who has
access, everything looked fine at first — new people showed up. But the moment
they tried to **remove** someone, or change who is in a group, LangWatch said no.
Nothing was logged as an error on their side; the change just never took.

The reason is a spelling mismatch. The standard says these commands are written
in lowercase (`replace`), Microsoft writes them capitalized (`Replace`), and we
were only accepting the lowercase spelling. Now we accept both, which is what
the rest of the industry does.

The part that matters: this was the offboarding path. Someone who left the
company would keep their LangWatch access until an admin noticed and removed
them by hand.

## What changed

`scimPatchOperationSchema` lowercases the `op` value before checking it against
the allowed set:

```ts
const scimPatchOpSchema = z.preprocess(
  (value) => (typeof value === "string" ? value.toLowerCase() : value),
  z.enum(["replace", "add", "remove"]),
);
```

Normalised **once, at the schema seam** rather than at each comparison, because
both `ScimService` and `ScimGroupService` compare `operation.op` against
lowercase literals in five places. Tolerating the casing at only one of the two
seams would have turned a loud 400 into a silent no-op, which is worse.

Only strings are lowercased — a missing or non-string `op` falls through to the
enum and still fails as a bad value rather than as the string `"undefined"`.

The two SCIM PATCH descriptions in the API reference claimed "a provider sending
its full patch set is never rejected", which was untrue for capitalized ops.
Both now say the operation name is read without regard to case.

## Blast radius

Contained: `scimPatchRequestSchema` is imported only by `ee/scim/routes.ts` and
the new test. The change is strictly a widening — every payload that parsed
before still parses, and the inferred `ScimPatchOperation` type is unchanged.

## Tests

`ee/scim/__tests__/scim-patch-op-casing.unit.test.ts` — 7 tests, written first
and observed failing with `invalid_enum_value ... received 'Replace'` before the
fix. They drive the real parse-then-apply path (schema → service → Prisma call)
with the capitalized payloads rather than asserting on the schema alone, so a
future regression at either seam fails the test:

- capitalized `Replace` / `Add` / `Remove` parse, and normalise to the RFC spelling
- `{"op":"Replace","path":"active","value":false}` deactivates the user
- `{"op":"Add","path":"members",...}` adds the member
- `{"op":"Remove","path":"members[value eq \"...\"]"}` removes the member
- `{"op":"Replace","path":"displayName",...}` renames the group
- lowercase still parses
- an op that is not a SCIM operation (`"Delete"`) is still rejected

## Checks run

- `pnpm test:unit run ee/scim/` — 46/46 across 5 files
- `pnpm typecheck` and `pnpm typecheck:tests` — clean
- `biome check` on the three changed files — clean
- `pnpm check:openapi-completeness`, `pnpm check:openapi-route-coverage` — OK

## Noticed and deliberately not fixed

Same shape, no evidence of a live break, and each would need its own care:

1. **SCIM filter parsing is case-sensitive.** `parseUserNameFilter`
   (`scim.service.ts:537`) and `parseDisplayNameFilter`
   (`scim-group.service.ts:428`) match `/^userName\s+eq\s+"..."/` — RFC 7644
   §3.4.2.2 says attribute names *and operators* in filters are case-insensitive,
   so `USERNAME EQ` would be rejected. Every IdP we know of sends the documented
   casing.
2. **PATCH `path` values are compared case-sensitively** (`"active"`, `"members"`,
   `"displayName"`). RFC 7643 §2.1 makes attribute names case-insensitive. This
   one must **not** be fixed by lowercasing the path string: the remove path
   carries a member id inside a filter (`members[value eq "cm7AbC..."]`), and
   lowercasing it would corrupt the id. It needs the attribute prefix normalised
   separately from the filter value.

Neither is claimed by this issue; both are worth a follow-up if a provider ever
trips on them.

Fixes #6972


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SCIM PATCH operations now accept case-insensitive values, including capitalized `Replace`, `Add`, and `Remove`.
  * Supported operations correctly handle user deactivation, group membership changes, and group renaming.

* **Documentation**
  * Updated SCIM API documentation to describe case-insensitive operation names.

* **Bug Fixes**
  * Invalid operation values continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->