### PR TITLE
fix(python-sdk): preserve project for scoped API keys

### DIFF
--- a/sdks/python/src/langwatch/utils/auth.py
+++ b/sdks/python/src/langwatch/utils/auth.py
@@ -1,13 +1,16 @@
 """Authentication header assembly for the LangWatch Python SDK.
 
-Supports two token families that share the same HTTP surface:
+Supports three token families that share the same HTTP surface:
 
 1. ``sk-lw-*`` — legacy project API keys. The token itself carries the
    project identity, so we emit both ``Authorization: Bearer <token>``
    and ``X-Auth-Token: <token>`` for backwards compatibility with older
    endpoints that only read the legacy header.
 
-2. ``pat-lw-*`` — Personal Access Tokens. PATs are user-owned and must
+2. ``sk-lw-{16}_{48}`` — scoped API keys. These keys do not necessarily
+   identify a project, so a configured project is sent in ``X-Project-Id``.
+
+3. ``pat-lw-*`` — Personal Access Tokens. PATs are user-owned and must
    be paired with a ``project_id`` so the server can resolve the correct
    role binding. When a ``project_id`` is available we encode both into a
    single ``Authorization: Basic base64(project_id:token)`` header — the
@@ -18,9 +21,10 @@ from __future__ import annotations
 
 import base64
 import os
-from typing import Dict, Optional
+import re
 
 PAT_PREFIX = "pat-lw-"
+_NEW_API_KEY_PATTERN = re.compile(r"^sk-lw-[0-9A-Za-z]{16}_[0-9A-Za-z]{48}$")
 
 
 def is_personal_access_token(token: str) -> bool:
@@ -28,10 +32,15 @@ def is_personal_access_token(token: str) -> bool:
     return bool(token) and token.startswith(PAT_PREFIX)
 
 
+def _is_new_format_api_key(token: str) -> bool:
+    """Returns whether ``token`` has the server's scoped API-key shape."""
+    return bool(_NEW_API_KEY_PATTERN.fullmatch(token))
+
+
 def build_auth_headers(
     api_key: str,
-    project_id: Optional[str] = None,
-) -> Dict[str, str]:
+    project_id: str | None = None,
+) -> dict[str, str]:
     """Build the HTTP headers required to authenticate against the API.
 
     Args:
@@ -49,7 +58,7 @@ def build_auth_headers(
 
     if is_personal_access_token(api_key):
         if resolved_project_id:
-            credential = f"{resolved_project_id}:{api_key}".encode("utf-8")
+            credential = f"{resolved_project_id}:{api_key}".encode()
             encoded = base64.b64encode(credential).decode("utf-8")
             return {"Authorization": f"Basic {encoded}"}
 
@@ -61,9 +70,13 @@ def build_auth_headers(
             "X-Auth-Token": api_key,
         }
 
-    # Legacy sk-lw-* key: preserve dual-header shape for callers that
-    # read either header.
-    return {
+    # Preserve the dual-header shape for every sk-lw-* caller. New-format
+    # scoped keys additionally need an explicit project unless the server can
+    # infer one from exactly one project-scoped role binding.
+    headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Auth-Token": api_key,
     }
+    if resolved_project_id and _is_new_format_api_key(api_key):
+        headers["X-Project-Id"] = resolved_project_id
+    return headers

--- a/sdks/python/tests/utils/test_auth.py
+++ b/sdks/python/tests/utils/test_auth.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 
 import pytest
-
 from langwatch.utils.auth import build_auth_headers, is_personal_access_token
 
 
@@ -31,14 +30,32 @@ class TestBuildAuthHeaders:
             "X-Auth-Token": "sk-lw-legacy",
         }
 
+    # @scenario "A configured project accompanies a new-format API key"
+    def test_new_format_key_emits_configured_project(self) -> None:
+        api_key = f"sk-lw-{'a' * 16}_{'b' * 48}"
+
+        headers = build_auth_headers(api_key=api_key, project_id="project_123")
+
+        assert headers == {
+            "Authorization": f"Bearer {api_key}",
+            "X-Auth-Token": api_key,
+            "X-Project-Id": "project_123",
+        }
+
+    # @scenario "A legacy project key remains self-identifying"
+    def test_legacy_key_with_underscore_keeps_legacy_headers(self) -> None:
+        api_key = "sk-lw-legacy_key"
+
+        headers = build_auth_headers(api_key=api_key, project_id="project_123")
+
+        assert "X-Project-Id" not in headers
+
     def test_pat_with_project_id_emits_basic_auth(self) -> None:
         headers = build_auth_headers(
             api_key="pat-lw-abc_secret",
             project_id="project_123",
         )
-        expected = base64.b64encode(
-            b"project_123:pat-lw-abc_secret"
-        ).decode("utf-8")
+        expected = base64.b64encode(b"project_123:pat-lw-abc_secret").decode("utf-8")
         assert headers == {"Authorization": f"Basic {expected}"}
 
     def test_pat_falls_back_to_env_project_id(

--- a/specs/python-sdk/api-key-authentication.feature
+++ b/specs/python-sdk/api-key-authentication.feature
@@ -1,0 +1,18 @@
+Feature: Python SDK API-key project authentication
+  As a Python SDK user with a scoped API key
+  I want the configured project to accompany credentials that cannot identify one
+  So that organization- and team-scoped keys can authenticate to project endpoints
+
+  @regression @unit
+  Scenario: A configured project accompanies a new-format API key
+    Given a new-format API key that is not bound to exactly one project
+    And the Python SDK has a project configured
+    When the SDK builds authentication headers
+    Then the headers carry the configured project
+
+  @regression @unit
+  Scenario: A legacy project key remains self-identifying
+    Given a legacy project key
+    And the Python SDK has a project configured
+    When the SDK builds authentication headers
+    Then the legacy authentication header contract is unchanged


### PR DESCRIPTION
## Summary

- distinguish new-format `sk-lw-{16}_{48}` scoped API keys using the server-compatible strict shape
- include `X-Project-Id` when a project is configured for those keys
- preserve the existing Bearer and `X-Auth-Token` contract for legacy keys and PAT behavior
- document the behavior as regression scenarios and cover the legacy-underscore compatibility edge

Fixes #7118.

## Verification

- `uv run --project sdks/python --group examples --group tests pytest sdks/python/tests/utils -q` — 62 passed
- `uv run --project sdks/python --extra dev ruff check sdks/python/src/langwatch/utils/auth.py sdks/python/tests/utils/test_auth.py` — passed
- `uv run --project sdks/python --group dev black --check sdks/python/src/langwatch/utils/auth.py sdks/python/tests/utils/test_auth.py` — passed
- `git diff --check` — passed

A wider credential-free SDK run reached 632 passing tests; example tests require live provider credentials and generated-contract coverage requires the full monorepo checkout, so I have not represented that partial run as a passing full suite.

## Compatibility review

The extra header is emitted only when both conditions hold: a project is configured and the token exactly matches the server new-format regex. Legacy keys—including old keys containing `_` or `-`—retain their previous dual-header shape. Calls without a configured project are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for scoped API keys in the Python SDK.
  - Automatically includes the configured project identifier for supported scoped keys.

- **Bug Fixes**
  - Preserved legacy authentication header behavior for existing API keys.

- **Tests**
  - Added coverage for scoped-key project propagation and legacy authentication compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->