### PR TITLE
feat(ops): discard dead letters, redrive in bulk, and record why each one died

### DIFF
--- a/platform/app/prisma/migrations/20260817120000_outbox_discard_and_attempt_log/migration.sql
+++ b/platform/app/prisma/migrations/20260817120000_outbox_discard_and_attempt_log/migration.sql
@@ -37,7 +37,12 @@ ALTER TABLE "ProcessManagerOutboxAttempt"
     FOREIGN KEY ("outboxId") REFERENCES "ProcessManagerOutbox"("id")
     ON DELETE CASCADE ON UPDATE CASCADE;
 
--- To roll back, uncomment and run manually. Dropping the table discards the
--- recorded failure history; removing an enum value is not supported in place.
+-- IRREVERSIBLE: the enum change cannot be undone. PostgreSQL has no
+-- `ALTER TYPE ... DROP VALUE`, so reverting `discarded` means recreating the
+-- type and rewriting every column that uses it, on the highest-volume table
+-- in the system. Treat this migration as forward-only.
+--
+-- The table below IS droppable. To roll it back, uncomment and run manually;
+-- doing so discards the recorded failure history.
 -- DROP TABLE "ProcessManagerOutboxAttempt";
 -- DROP TYPE "ProcessManagerOutboxAttemptOutcome";

--- a/platform/app/prisma/migrations/20260817120000_outbox_discard_and_attempt_log/migration.sql
+++ b/platform/app/prisma/migrations/20260817120000_outbox_discard_and_attempt_log/migration.sql
@@ -1,0 +1,43 @@
+-- Dead-letter recovery (specs/ops/dead-letter-recovery.feature): an operator
+-- can mark a dead outbox message as never-to-be-sent, and every failed
+-- delivery attempt is recorded so the reason a message died is on the page
+-- rather than only on a span.
+
+-- 'discarded' is a mark, not a delete: the row is retained as its own audit
+-- trail. The dispatcher's claim query filters status = 'pending', so it never
+-- sees the new value.
+ALTER TYPE "ProcessManagerOutboxStatus" ADD VALUE 'discarded';
+
+CREATE TYPE "ProcessManagerOutboxAttemptOutcome" AS ENUM ('retry_scheduled', 'dead');
+
+-- One row per FAILED attempt; successes write nothing, so the table grows
+-- with trouble, not with traffic. ON DELETE CASCADE is the retention story:
+-- attempt rows die with their message under the existing retention sweep.
+CREATE TABLE "ProcessManagerOutboxAttempt" (
+    "id" TEXT NOT NULL,
+    "outboxId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "attempt" INTEGER NOT NULL,
+    "occurredAt" TIMESTAMPTZ(3) NOT NULL,
+    "outcome" "ProcessManagerOutboxAttemptOutcome" NOT NULL,
+    "errorType" TEXT NOT NULL,
+    "errorMessage" TEXT NOT NULL,
+    "retryAfterMs" INTEGER,
+
+    CONSTRAINT "ProcessManagerOutboxAttempt_pkey" PRIMARY KEY ("id")
+);
+
+-- Also what makes the cascade delete affordable: Postgres does not index the
+-- referencing side of a foreign key on its own.
+CREATE INDEX "ProcessManagerOutboxAttempt_outboxId_attempt_idx"
+    ON "ProcessManagerOutboxAttempt"("outboxId", "attempt");
+
+ALTER TABLE "ProcessManagerOutboxAttempt"
+    ADD CONSTRAINT "ProcessManagerOutboxAttempt_outboxId_fkey"
+    FOREIGN KEY ("outboxId") REFERENCES "ProcessManagerOutbox"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- To roll back, uncomment and run manually. Dropping the table discards the
+-- recorded failure history; removing an enum value is not supported in place.
+-- DROP TABLE "ProcessManagerOutboxAttempt";
+-- DROP TYPE "ProcessManagerOutboxAttemptOutcome";

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -3666,6 +3666,15 @@ enum ProcessManagerOutboxStatus {
   pending
   dispatched
   dead
+  /// An operator marked this dead message as never-to-be-sent
+  /// (specs/ops/dead-letter-recovery.feature). A mark, not a delete: the row
+  /// is retained as its own audit trail and the dispatcher never leases it.
+  discarded
+}
+
+enum ProcessManagerOutboxAttemptOutcome {
+  retry_scheduled
+  dead
 }
 
 /// Transactional intents emitted by a durable process transition.
@@ -3700,6 +3709,33 @@ model ProcessManagerOutbox {
   // The index is ops-managed instead: built with CREATE INDEX CONCURRENTLY,
   // see dev/docs/runbooks/process-manager-table-purge.md. The sweep works
   // without it on the bounded table it maintains.
+
+  attemptLog ProcessManagerOutboxAttempt[]
+}
+
+/// Why an outbox delivery failed, one row per FAILED attempt
+/// (specs/ops/dead-letter-recovery.feature). Successes write nothing, so the
+/// table grows with trouble, not with traffic. Rows die with their message:
+/// the cascade delete is the retention story, riding the existing sweep.
+model ProcessManagerOutboxAttempt {
+  id           String                             @id @default(nanoid())
+  outboxId     String
+  projectId    String
+  /// 1-based attempt number, as the dispatcher counts it.
+  attempt      Int
+  occurredAt   DateTime                           @db.Timestamptz(3)
+  outcome      ProcessManagerOutboxAttemptOutcome
+  errorType    String
+  /// The safe failure diagnostic the dispatcher already computes for its
+  /// span — never a raw provider body.
+  errorMessage String
+  retryAfterMs Int?
+
+  outbox ProcessManagerOutbox @relation(fields: [outboxId], references: [id], onDelete: Cascade)
+
+  // Also what makes the cascade delete affordable: Postgres does not index
+  // the referencing side of a foreign key on its own.
+  @@index([outboxId, attempt])
 }
 
 /// Per-project topic clustering run status (ADR-051): the rebuildable

--- a/platform/app/src/components/ops/__tests__/recoveryVerbs.integration.test.tsx
+++ b/platform/app/src/components/ops/__tests__/recoveryVerbs.integration.test.tsx
@@ -34,91 +34,97 @@ afterEach(cleanup);
 
 describe("dead-letter recovery vocabulary", () => {
   describe("given both substrates render their row controls", () => {
-    /** @scenario Recovery verbs are the same on both substrates */
-    it("calls the acts redrive and discard on each, and never replay", () => {
-      const { unmount } = renderWithChakra(
-        <DeadLettersTable
-          messages={[
-            {
-              id: "msg_1",
-              processName: "webhookDelivery",
-              projectId: "project_1",
-              processKey: "req_aaaabbbbccccdddd",
-              messageKey: "process:req_01:deliver",
-              intentType: "deliver",
-              attempts: 11,
-              updatedAt: NOW - 60_000,
-              traceId: null,
-              payload: {},
-            },
-          ]}
-          now={NOW}
-          canManage
-          expandedId={null}
-          redrivingId={null}
-          discardingId={null}
-          onToggle={vi.fn()}
-          onRedrive={vi.fn()}
-          onDiscard={vi.fn()}
-        />,
-      );
+    describe("when the operator can manage", () => {
+      /** @scenario Recovery verbs are the same on both substrates */
+      it("calls the acts redrive and discard on each, and never replay", () => {
+        const { unmount } = renderWithChakra(
+          <DeadLettersTable
+            messages={[
+              {
+                id: "msg_1",
+                processName: "webhookDelivery",
+                projectId: "project_1",
+                processKey: "req_aaaabbbbccccdddd",
+                messageKey: "process:req_01:deliver",
+                intentType: "deliver",
+                attempts: 11,
+                updatedAt: NOW - 60_000,
+                traceId: null,
+                payload: {},
+              },
+            ]}
+            now={NOW}
+            canManage
+            expandedId={null}
+            redrivingId={null}
+            discardingId={null}
+            onToggle={vi.fn()}
+            onRedrive={vi.fn()}
+            onDiscard={vi.fn()}
+          />,
+        );
 
-      const outboxButtons = screen
-        .getAllByRole("button")
-        .map((b) => b.textContent);
-      expect(outboxButtons).toContain("Redrive");
-      expect(outboxButtons).toContain("Discard");
-      expect(outboxButtons.join(" ")).not.toMatch(/Replay/);
-      unmount();
+        const outboxButtons = screen
+          .getAllByRole("button")
+          .map((b) => b.textContent);
+        expect(outboxButtons).toContain("Redrive");
+        expect(outboxButtons).toContain("Discard");
+        expect(outboxButtons.join(" ")).not.toMatch(/Replay/);
+        unmount();
 
-      renderWithChakra(
-        <Table.Root>
-          <Table.Body>
-            <DlqRow
-              group={{
-                queueName: "queue-a",
-                queueDisplayName: "Queue A",
-                groupId: "group-1",
-                pipelineName: "traces",
-                error: "HTTP 500",
-                jobCount: 3,
-              }}
-              canManage
-              onAct={vi.fn()}
-            />
-          </Table.Body>
-        </Table.Root>,
-      );
+        renderWithChakra(
+          <Table.Root>
+            <Table.Body>
+              <DlqRow
+                group={{
+                  queueName: "queue-a",
+                  queueDisplayName: "Queue A",
+                  groupId: "group-1",
+                  pipelineName: "traces",
+                  error: "HTTP 500",
+                  jobCount: 3,
+                }}
+                canManage
+                onAct={vi.fn()}
+              />
+            </Table.Body>
+          </Table.Root>,
+        );
 
-      const queueButtons = screen
-        .getAllByRole("button")
-        .map((b) => b.textContent);
-      expect(queueButtons).toContain("Redrive");
-      expect(queueButtons).toContain("Discard");
-      expect(queueButtons.join(" ")).not.toMatch(/Replay/);
+        const queueButtons = screen
+          .getAllByRole("button")
+          .map((b) => b.textContent);
+        expect(queueButtons).toContain("Redrive");
+        expect(queueButtons).toContain("Discard");
+        expect(queueButtons.join(" ")).not.toMatch(/Replay/);
+      });
     });
 
-    it("withholds both verbs from a view-only operator on each surface", () => {
-      renderWithChakra(
-        <Table.Root>
-          <Table.Body>
-            <DlqRow
-              group={{
-                queueName: "queue-a",
-                queueDisplayName: "Queue A",
-                groupId: "group-1",
-                pipelineName: null,
-                error: null,
-                jobCount: 1,
-              }}
-              canManage={false}
-              onAct={vi.fn()}
-            />
-          </Table.Body>
-        </Table.Root>,
-      );
-      expect(screen.queryAllByRole("button")).toHaveLength(0);
-      expect(within(screen.getByRole("row")).queryByText("Discard")).toBeNull();
+    describe("when the operator is view-only", () => {
+      it("withholds both verbs on each surface", () => {
+        renderWithChakra(
+          <Table.Root>
+            <Table.Body>
+              <DlqRow
+                group={{
+                  queueName: "queue-a",
+                  queueDisplayName: "Queue A",
+                  groupId: "group-1",
+                  pipelineName: null,
+                  error: null,
+                  jobCount: 1,
+                }}
+                canManage={false}
+                onAct={vi.fn()}
+              />
+            </Table.Body>
+          </Table.Root>,
+        );
+        expect(screen.queryAllByRole("button")).toHaveLength(0);
+        expect(
+          within(screen.getByRole("row")).queryByText("Discard"),
+        ).toBeNull();
+      });
     });
   });
 });

--- a/platform/app/src/components/ops/__tests__/recoveryVerbs.integration.test.tsx
+++ b/platform/app/src/components/ops/__tests__/recoveryVerbs.integration.test.tsx
@@ -26,6 +26,33 @@ vi.mock("~/utils/api", () => ({
 
 const NOW = Date.UTC(2026, 7, 17, 12, 0, 0);
 
+function deadLetter() {
+  return {
+    id: "msg_1",
+    processName: "webhookDelivery",
+    projectId: "project_1",
+    processKey: "req_aaaabbbbccccdddd",
+    messageKey: "process:req_01:deliver",
+    intentType: "deliver",
+    attempts: 11,
+    updatedAt: NOW - 60_000,
+    traceId: null,
+    payload: {},
+  };
+}
+
+function dlqGroup(overrides: Record<string, unknown> = {}) {
+  return {
+    queueName: "queue-a",
+    queueDisplayName: "Queue A",
+    groupId: "group-1",
+    pipelineName: "traces",
+    error: "HTTP 500",
+    jobCount: 3,
+    ...overrides,
+  };
+}
+
 function renderWithChakra(ui: React.ReactElement) {
   return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
 }
@@ -39,20 +66,7 @@ describe("dead-letter recovery vocabulary", () => {
       it("calls the acts redrive and discard on each, and never replay", () => {
         const { unmount } = renderWithChakra(
           <DeadLettersTable
-            messages={[
-              {
-                id: "msg_1",
-                processName: "webhookDelivery",
-                projectId: "project_1",
-                processKey: "req_aaaabbbbccccdddd",
-                messageKey: "process:req_01:deliver",
-                intentType: "deliver",
-                attempts: 11,
-                updatedAt: NOW - 60_000,
-                traceId: null,
-                payload: {},
-              },
-            ]}
+            messages={[deadLetter()]}
             now={NOW}
             canManage
             expandedId={null}
@@ -75,18 +89,7 @@ describe("dead-letter recovery vocabulary", () => {
         renderWithChakra(
           <Table.Root>
             <Table.Body>
-              <DlqRow
-                group={{
-                  queueName: "queue-a",
-                  queueDisplayName: "Queue A",
-                  groupId: "group-1",
-                  pipelineName: "traces",
-                  error: "HTTP 500",
-                  jobCount: 3,
-                }}
-                canManage
-                onAct={vi.fn()}
-              />
+              <DlqRow group={dlqGroup()} canManage onAct={vi.fn()} />
             </Table.Body>
           </Table.Root>,
         );
@@ -102,18 +105,28 @@ describe("dead-letter recovery vocabulary", () => {
 
     describe("when the operator is view-only", () => {
       it("withholds both verbs on each surface", () => {
+        const outbox = renderWithChakra(
+          <DeadLettersTable
+            messages={[deadLetter()]}
+            now={NOW}
+            canManage={false}
+            expandedId={null}
+            redrivingId={null}
+            discardingId={null}
+            onToggle={vi.fn()}
+            onRedrive={vi.fn()}
+            onDiscard={vi.fn()}
+          />,
+        );
+        expect(screen.queryByText("Redrive")).toBeNull();
+        expect(screen.queryByText("Discard")).toBeNull();
+        outbox.unmount();
+
         renderWithChakra(
           <Table.Root>
             <Table.Body>
               <DlqRow
-                group={{
-                  queueName: "queue-a",
-                  queueDisplayName: "Queue A",
-                  groupId: "group-1",
-                  pipelineName: null,
-                  error: null,
-                  jobCount: 1,
-                }}
+                group={dlqGroup({ pipelineName: null, error: null })}
                 canManage={false}
                 onAct={vi.fn()}
               />

--- a/platform/app/src/components/ops/__tests__/recoveryVerbs.integration.test.tsx
+++ b/platform/app/src/components/ops/__tests__/recoveryVerbs.integration.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * One vocabulary across both dead-letter substrates
+ * (specs/ops/dead-letter-recovery.feature).
+ *
+ * The two surfaces retire work through different machinery and were built at
+ * different times, which is exactly how they drifted: the queue card said
+ * "Replay" while the outbox said "Redrive" for the same act. This renders the
+ * row from each and holds them to the same words — including that "Replay" is
+ * gone from here, because it means projection rebuilds elsewhere in ops.
+ */
+import { ChakraProvider, defaultSystem, Table } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeadLettersTable } from "../deadLetters/DeadLettersCard";
+import { DlqRow } from "../queues/DlqCard";
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    ops: {
+      listOutboxAttempts: { useQuery: () => ({ isPending: false, data: [] }) },
+    },
+  },
+}));
+
+const NOW = Date.UTC(2026, 7, 17, 12, 0, 0);
+
+function renderWithChakra(ui: React.ReactElement) {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+afterEach(cleanup);
+
+describe("dead-letter recovery vocabulary", () => {
+  describe("given both substrates render their row controls", () => {
+    /** @scenario Recovery verbs are the same on both substrates */
+    it("calls the acts redrive and discard on each, and never replay", () => {
+      const { unmount } = renderWithChakra(
+        <DeadLettersTable
+          messages={[
+            {
+              id: "msg_1",
+              processName: "webhookDelivery",
+              projectId: "project_1",
+              processKey: "req_aaaabbbbccccdddd",
+              messageKey: "process:req_01:deliver",
+              intentType: "deliver",
+              attempts: 11,
+              updatedAt: NOW - 60_000,
+              traceId: null,
+              payload: {},
+            },
+          ]}
+          now={NOW}
+          canManage
+          expandedId={null}
+          redrivingId={null}
+          discardingId={null}
+          onToggle={vi.fn()}
+          onRedrive={vi.fn()}
+          onDiscard={vi.fn()}
+        />,
+      );
+
+      const outboxButtons = screen
+        .getAllByRole("button")
+        .map((b) => b.textContent);
+      expect(outboxButtons).toContain("Redrive");
+      expect(outboxButtons).toContain("Discard");
+      expect(outboxButtons.join(" ")).not.toMatch(/Replay/);
+      unmount();
+
+      renderWithChakra(
+        <Table.Root>
+          <Table.Body>
+            <DlqRow
+              group={{
+                queueName: "queue-a",
+                queueDisplayName: "Queue A",
+                groupId: "group-1",
+                pipelineName: "traces",
+                error: "HTTP 500",
+                jobCount: 3,
+              }}
+              canManage
+              onAct={vi.fn()}
+            />
+          </Table.Body>
+        </Table.Root>,
+      );
+
+      const queueButtons = screen
+        .getAllByRole("button")
+        .map((b) => b.textContent);
+      expect(queueButtons).toContain("Redrive");
+      expect(queueButtons).toContain("Discard");
+      expect(queueButtons.join(" ")).not.toMatch(/Replay/);
+    });
+
+    it("withholds both verbs from a view-only operator on each surface", () => {
+      renderWithChakra(
+        <Table.Root>
+          <Table.Body>
+            <DlqRow
+              group={{
+                queueName: "queue-a",
+                queueDisplayName: "Queue A",
+                groupId: "group-1",
+                pipelineName: null,
+                error: null,
+                jobCount: 1,
+              }}
+              canManage={false}
+              onAct={vi.fn()}
+            />
+          </Table.Body>
+        </Table.Root>,
+      );
+      expect(screen.queryAllByRole("button")).toHaveLength(0);
+      expect(within(screen.getByRole("row")).queryByText("Discard")).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/components/ops/dashboard/StatStrip.tsx
+++ b/platform/app/src/components/ops/dashboard/StatStrip.tsx
@@ -6,6 +6,7 @@ import {
 } from "~/components/ops/shared/formatters";
 import type { DashboardData } from "~/server/app-layer/ops/types";
 import { LATENCY_SAMPLE_SIZE } from "~/shared/ops/latency";
+import { api } from "~/utils/api";
 import { LinkedStat } from "./LinkedStat";
 import { RedisStatTile } from "./RedisStatTile";
 
@@ -35,6 +36,19 @@ export function StatStrip({ data }: { data: DashboardData }) {
     0,
   );
   const totalDlq = data.queues.reduce((sum, q) => sum + q.dlqCount, 0);
+  // The other dead-letter substrate. The queue figure alone once read "0"
+  // while 94 process-outbox messages sat dead further down the page — the
+  // headline number must be the union or it lies
+  // (specs/ops/dead-letter-recovery.feature). Same source the navigation
+  // badge and the DLQ card poll, so the figures can never disagree.
+  const outboxDeadQuery = api.ops.listDeadLetterCounts.useQuery(undefined, {
+    refetchInterval: 30_000,
+  });
+  const outboxDead = (outboxDeadQuery.data ?? []).reduce(
+    (sum, row) => sum + row.count,
+    0,
+  );
+  const totalDead = totalDlq + outboxDead;
 
   return (
     <HStack
@@ -93,9 +107,15 @@ export function StatStrip({ data }: { data: DashboardData }) {
         hint={LATENCY_BASIS}
       />
       <LinkedStat
-        label="Dead-letter queue"
-        value={formatCount(totalDlq)}
-        color={totalDlq > 0 ? "orange.500" : undefined}
+        label="Dead letters"
+        href="/ops/event-sourcing/dead-letters"
+        value={formatCount(totalDead)}
+        sublabel={
+          totalDead > 0
+            ? `${formatCount(totalDlq)} queue · ${formatCount(outboxDead)} outbox`
+            : undefined
+        }
+        color={totalDead > 0 ? "red.500" : undefined}
       />
       <RedisStatTile data={data} />
     </HStack>

--- a/platform/app/src/components/ops/dashboard/StatStrip.tsx
+++ b/platform/app/src/components/ops/dashboard/StatStrip.tsx
@@ -48,7 +48,6 @@ export function StatStrip({ data }: { data: DashboardData }) {
     (sum, row) => sum + row.count,
     0,
   );
-  const totalDead = totalDlq + outboxDead;
 
   return (
     <HStack
@@ -57,6 +56,33 @@ export function StatStrip({ data }: { data: DashboardData }) {
       overflowX="auto"
       data-testid="ops-stat-strip"
     >
+      <ThroughputStats data={data} />
+      <LinkedStat
+        label="Blocked"
+        value={formatCount(totalBlocked)}
+        sublabel={`${formatCount(data.totalGroups)} groups`}
+        color={totalBlocked > 0 ? "red.500" : undefined}
+      />
+      <LinkedStat
+        label="Parked"
+        value={formatCount(totalParked)}
+        // Says what it MEANS, not just what it counts: parked is a capacity
+        // limit doing its job, and an unexplained orange six-figure number
+        // reads as an outage to whoever is on call.
+        sublabel={totalParked > 0 ? "at capacity limit" : "none at limit"}
+        color={totalParked > 0 ? "orange.500" : undefined}
+      />
+      <LatencyStats data={data} />
+      <DeadLetterStat queueDead={totalDlq} outboxDead={outboxDead} />
+      <RedisStatTile data={data} />
+    </HStack>
+  );
+}
+
+/** Rate tiles: what is arriving, finishing, and failing right now. */
+function ThroughputStats({ data }: { data: DashboardData }) {
+  return (
+    <>
       <LinkedStat
         label="Staged/s"
         value={formatRate(data.throughputIngestedPerSec)}
@@ -79,21 +105,14 @@ export function StatStrip({ data }: { data: DashboardData }) {
         }
         color={data.failedPerSec > 0 ? "red.500" : undefined}
       />
-      <LinkedStat
-        label="Blocked"
-        value={formatCount(totalBlocked)}
-        sublabel={`${formatCount(data.totalGroups)} groups`}
-        color={totalBlocked > 0 ? "red.500" : undefined}
-      />
-      <LinkedStat
-        label="Parked"
-        value={formatCount(totalParked)}
-        // Says what it MEANS, not just what it counts: parked is a capacity
-        // limit doing its job, and an unexplained orange six-figure number
-        // reads as an outage to whoever is on call.
-        sublabel={totalParked > 0 ? "at capacity limit" : "none at limit"}
-        color={totalParked > 0 ? "orange.500" : undefined}
-      />
+    </>
+  );
+}
+
+/** Percentile tiles, both stating the sample they are measured over. */
+function LatencyStats({ data }: { data: DashboardData }) {
+  return (
+    <>
       <LinkedStat
         label="P50"
         value={formatMs(data.latencyP50Ms)}
@@ -106,18 +125,39 @@ export function StatStrip({ data }: { data: DashboardData }) {
         sublabel={`peak ${formatMs(data.peakLatencyP99Ms)} · last ${LATENCY_SAMPLE_SIZE} jobs`}
         hint={LATENCY_BASIS}
       />
-      <LinkedStat
-        label="Dead letters"
-        href="/ops/event-sourcing/dead-letters"
-        value={formatCount(totalDead)}
-        sublabel={
-          totalDead > 0
-            ? `${formatCount(totalDlq)} queue · ${formatCount(outboxDead)} outbox`
-            : undefined
-        }
-        color={totalDead > 0 ? "red.500" : undefined}
-      />
-      <RedisStatTile data={data} />
-    </HStack>
+    </>
+  );
+}
+
+/**
+ * Dead work across BOTH substrates, as one figure.
+ *
+ * The GroupQueue DLQ and the process-manager outbox retire work through
+ * different machinery, and this tile used to count only the first — so it read
+ * "0" on a page that had 94 dead outbox messages on it. An operator asking
+ * "has anything stopped?" is not asking about a mechanism, so the headline is
+ * the union and the sublabel says where it lives
+ * (specs/ops/dead-letter-recovery.feature).
+ */
+function DeadLetterStat({
+  queueDead,
+  outboxDead,
+}: {
+  queueDead: number;
+  outboxDead: number;
+}) {
+  const total = queueDead + outboxDead;
+  return (
+    <LinkedStat
+      label="Dead letters"
+      href="/ops/event-sourcing/dead-letters"
+      value={formatCount(total)}
+      sublabel={
+        total > 0
+          ? `${formatCount(queueDead)} queue · ${formatCount(outboxDead)} outbox`
+          : undefined
+      }
+      color={total > 0 ? "red.500" : undefined}
+    />
   );
 }

--- a/platform/app/src/components/ops/dashboard/StatStrip.tsx
+++ b/platform/app/src/components/ops/dashboard/StatStrip.tsx
@@ -76,7 +76,7 @@ export function StatStrip({ data }: { data: DashboardData }) {
       <DeadLetterStat
         queueDead={totalDlq}
         outboxDead={outboxDead}
-        outboxKnown={outboxDeadQuery.data !== undefined}
+        isOutboxCountKnown={outboxDeadQuery.data !== undefined}
       />
       <RedisStatTile data={data} />
     </HStack>
@@ -146,17 +146,17 @@ function LatencyStats({ data }: { data: DashboardData }) {
 function DeadLetterStat({
   queueDead,
   outboxDead,
-  outboxKnown,
+  isOutboxCountKnown,
 }: {
   queueDead: number;
   outboxDead: number;
-  outboxKnown: boolean;
+  isOutboxCountKnown: boolean;
 }) {
   // Half the union is not the union. Until the outbox answer lands, showing
   // the queue figure alone would state a total that is wrong, then jump and
   // turn red when the rest arrives — which on an ops surface reads as a new
   // incident rather than as the tile finishing loading. An unknown says so.
-  if (!outboxKnown) {
+  if (!isOutboxCountKnown) {
     return <LinkedStat label="Dead letters" value="—" sublabel="counting" />;
   }
   const total = queueDead + outboxDead;

--- a/platform/app/src/components/ops/dashboard/StatStrip.tsx
+++ b/platform/app/src/components/ops/dashboard/StatStrip.tsx
@@ -73,7 +73,11 @@ export function StatStrip({ data }: { data: DashboardData }) {
         color={totalParked > 0 ? "orange.500" : undefined}
       />
       <LatencyStats data={data} />
-      <DeadLetterStat queueDead={totalDlq} outboxDead={outboxDead} />
+      <DeadLetterStat
+        queueDead={totalDlq}
+        outboxDead={outboxDead}
+        outboxKnown={outboxDeadQuery.data !== undefined}
+      />
       <RedisStatTile data={data} />
     </HStack>
   );
@@ -142,10 +146,19 @@ function LatencyStats({ data }: { data: DashboardData }) {
 function DeadLetterStat({
   queueDead,
   outboxDead,
+  outboxKnown,
 }: {
   queueDead: number;
   outboxDead: number;
+  outboxKnown: boolean;
 }) {
+  // Half the union is not the union. Until the outbox answer lands, showing
+  // the queue figure alone would state a total that is wrong, then jump and
+  // turn red when the rest arrives — which on an ops surface reads as a new
+  // incident rather than as the tile finishing loading. An unknown says so.
+  if (!outboxKnown) {
+    return <LinkedStat label="Dead letters" value="—" sublabel="counting" />;
+  }
   const total = queueDead + outboxDead;
   return (
     <LinkedStat

--- a/platform/app/src/components/ops/dashboard/__tests__/StatStrip.integration.test.tsx
+++ b/platform/app/src/components/ops/dashboard/__tests__/StatStrip.integration.test.tsx
@@ -9,9 +9,25 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardData, PhaseMetrics } from "~/server/app-layer/ops/types";
 import { StatStrip } from "../StatStrip";
+
+// The dead-letters tile reads the process-outbox side through the same query
+// the navigation badge uses; the strip itself is otherwise snapshot-driven.
+vi.mock("~/utils/api", () => ({
+  api: {
+    ops: {
+      listDeadLetterCounts: {
+        useQuery: () => ({
+          data: [
+            { processName: "webhookDelivery", count: 94, oldestUpdatedAt: 0 },
+          ],
+        }),
+      },
+    },
+  },
+}));
 
 const emptyPhase = (): PhaseMetrics => ({
   pending: 0,
@@ -106,6 +122,30 @@ describe("StatStrip", () => {
         expect(strip.textContent).toContain("327ms");
         expect(strip.textContent).toContain("1.6s");
       });
+    });
+  });
+
+  describe("given dead letters exist on both substrates", () => {
+    /** @scenario The dashboard's dead-letter figure covers both substrates */
+    it("headlines the union and states how many come from each", () => {
+      renderStrip({
+        queues: [
+          {
+            name: "queue-a",
+            displayName: "Queue A",
+            pendingGroupCount: 0,
+            blockedGroupCount: 0,
+            activeGroupCount: 0,
+            totalPendingJobs: 0,
+            dlqCount: 6,
+            parkedGroupCount: 0,
+          },
+        ],
+      });
+      const strip = screen.getByTestId("ops-stat-strip");
+      expect(strip.textContent).toContain("Dead letters");
+      expect(strip.textContent).toContain("100");
+      expect(strip.textContent).toContain("6 queue · 94 outbox");
     });
   });
 });

--- a/platform/app/src/components/ops/dashboard/__tests__/StatStrip.integration.test.tsx
+++ b/platform/app/src/components/ops/dashboard/__tests__/StatStrip.integration.test.tsx
@@ -15,17 +15,14 @@ import { StatStrip } from "../StatStrip";
 
 // The dead-letters tile reads the process-outbox side through the same query
 // the navigation badge uses; the strip itself is otherwise snapshot-driven.
+const outboxDeadQuery = vi.fn(() => ({
+  data: [{ processName: "webhookDelivery", count: 94, oldestUpdatedAt: 0 }] as
+    | Array<{ processName: string; count: number; oldestUpdatedAt: number }>
+    | undefined,
+}));
 vi.mock("~/utils/api", () => ({
   api: {
-    ops: {
-      listDeadLetterCounts: {
-        useQuery: () => ({
-          data: [
-            { processName: "webhookDelivery", count: 94, oldestUpdatedAt: 0 },
-          ],
-        }),
-      },
-    },
+    ops: { listDeadLetterCounts: { useQuery: () => outboxDeadQuery() } },
   },
 }));
 
@@ -146,6 +143,29 @@ describe("StatStrip", () => {
       expect(strip.textContent).toContain("Dead letters");
       expect(strip.textContent).toContain("100");
       expect(strip.textContent).toContain("6 queue · 94 outbox");
+    });
+
+    it("says the figure is unknown until the outbox count arrives", () => {
+      // Half the union is not the union: rendering the queue figure alone
+      // would state a wrong total, then jump and redden when the rest lands.
+      outboxDeadQuery.mockReturnValueOnce({ data: undefined });
+      renderStrip({
+        queues: [
+          {
+            name: "queue-a",
+            displayName: "Queue A",
+            pendingGroupCount: 0,
+            blockedGroupCount: 0,
+            activeGroupCount: 0,
+            totalPendingJobs: 0,
+            dlqCount: 6,
+            parkedGroupCount: 0,
+          },
+        ],
+      });
+      const strip = screen.getByTestId("ops-stat-strip");
+      expect(strip.textContent).toContain("counting");
+      expect(strip.textContent).not.toContain("6 queue");
     });
   });
 });

--- a/platform/app/src/components/ops/deadLetters/DeadLettersCard.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersCard.tsx
@@ -328,6 +328,11 @@ function DeadLetterRow({
  * only exists for messages that failed, and only an opened row needs it.
  * Messages retired before the attempt log existed have no entries; the trace
  * id above remains the join for those.
+ *
+ * Ordered chronologically rather than by attempt number, because a redrive
+ * resets the count: a message that failed, was redriven, and failed again
+ * carries two entries numbered 1, and only time puts them in the order they
+ * happened.
  */
 function AttemptHistory({
   outboxId,
@@ -354,8 +359,10 @@ function AttemptHistory({
       </Text>
       <VStack align="stretch" gap={1}>
         {rows.map((row) => (
+          // Keyed by row id, not attempt number: a redrive resets the count,
+          // so one message can hold two entries numbered 1.
           <HStack
-            key={row.attempt}
+            key={row.id}
             gap={2}
             align="start"
             data-testid={`dead-attempt-${row.attempt}`}

--- a/platform/app/src/components/ops/deadLetters/DeadLettersCard.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersCard.tsx
@@ -4,14 +4,16 @@ import {
   Button,
   Card,
   HStack,
+  Spinner,
   Table,
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { RotateCcw, Skull } from "lucide-react";
+import { RotateCcw, Skull, XCircle } from "lucide-react";
 import { JsonViewer } from "~/components/ops/JsonViewer";
 import { middleEllipsis } from "~/components/ops/queues/clusterGroups";
 import { formatTimeAgo } from "~/components/ops/shared/formatters";
+import { api } from "~/utils/api";
 
 /** Exactly what this surface renders; a structural subset of the server view. */
 export interface DeadLetterMessage {
@@ -134,16 +136,20 @@ export function DeadLettersTable({
   canManage,
   expandedId,
   redrivingId,
+  discardingId,
   onToggle,
   onRedrive,
+  onDiscard,
 }: {
   messages: DeadLetterMessage[];
   now: number;
   canManage: boolean;
   expandedId: string | null;
   redrivingId: string | null;
+  discardingId: string | null;
   onToggle: (id: string) => void;
   onRedrive: (message: DeadLetterMessage) => void;
+  onDiscard: (message: DeadLetterMessage) => void;
 }) {
   return (
     <Card.Root>
@@ -168,8 +174,10 @@ export function DeadLettersTable({
                 canManage={canManage}
                 isExpanded={expandedId === message.id}
                 isRedriving={redrivingId === message.id}
+                isDiscarding={discardingId === message.id}
                 onToggle={() => onToggle(message.id)}
                 onRedrive={() => onRedrive(message)}
+                onDiscard={() => onDiscard(message)}
               />
             ))}
           </Table.Body>
@@ -185,16 +193,20 @@ function DeadLetterRow({
   canManage,
   isExpanded,
   isRedriving,
+  isDiscarding,
   onToggle,
   onRedrive,
+  onDiscard,
 }: {
   message: DeadLetterMessage;
   now: number;
   canManage: boolean;
   isExpanded: boolean;
   isRedriving: boolean;
+  isDiscarding: boolean;
   onToggle: () => void;
   onRedrive: () => void;
+  onDiscard: () => void;
 }) {
   return (
     <>
@@ -249,19 +261,35 @@ function DeadLetterRow({
         </Table.Cell>
         <Table.Cell textAlign="end">
           {canManage && (
-            <Button
-              size="xs"
-              variant="outline"
-              loading={isRedriving}
-              data-testid={`dead-redrive-${message.messageKey}`}
-              onClick={(event) => {
-                event.stopPropagation();
-                onRedrive();
-              }}
-            >
-              <RotateCcw size={12} />
-              Redrive
-            </Button>
+            <HStack gap={1} justify="end">
+              <Button
+                size="xs"
+                variant="outline"
+                loading={isRedriving}
+                data-testid={`dead-redrive-${message.messageKey}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRedrive();
+                }}
+              >
+                <RotateCcw size={12} />
+                Redrive
+              </Button>
+              <Button
+                size="xs"
+                variant="outline"
+                colorPalette="red"
+                loading={isDiscarding}
+                data-testid={`dead-discard-${message.messageKey}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDiscard();
+                }}
+              >
+                <XCircle size={12} />
+                Discard
+              </Button>
+            </HStack>
           )}
         </Table.Cell>
       </Table.Row>
@@ -273,12 +301,13 @@ function DeadLetterRow({
                 <Labelled label="Message key" value={message.messageKey} />
                 <Labelled label="Project" value={message.projectId} />
                 {message.traceId ? (
-                  // The failure reason is not on this row: the dispatcher
-                  // records it on the span and in the log line. The trace id
-                  // is the join back to it.
                   <Labelled label="Trace" value={message.traceId} />
                 ) : null}
               </HStack>
+              <AttemptHistory
+                outboxId={message.id}
+                projectId={message.projectId}
+              />
               <Box>
                 <Text textStyle="2xs" color="fg.muted" marginBottom={1}>
                   Payload
@@ -290,6 +319,65 @@ function DeadLetterRow({
         </Table.Row>
       )}
     </>
+  );
+}
+
+/**
+ * Why the message died, on the page: its failed attempts, oldest first
+ * (specs/ops/dead-letter-recovery.feature). Fetched on expand — the history
+ * only exists for messages that failed, and only an opened row needs it.
+ * Messages retired before the attempt log existed have no entries; the trace
+ * id above remains the join for those.
+ */
+function AttemptHistory({
+  outboxId,
+  projectId,
+}: {
+  outboxId: string;
+  projectId: string;
+}) {
+  const attempts = api.ops.listOutboxAttempts.useQuery({ outboxId, projectId });
+  if (attempts.isPending) return <Spinner size="xs" />;
+  const rows = attempts.data ?? [];
+  if (rows.length === 0) {
+    return (
+      <Text textStyle="xs" color="fg.muted">
+        No recorded attempts — this message was retired before failures were
+        recorded per attempt.
+      </Text>
+    );
+  }
+  return (
+    <Box>
+      <Text textStyle="2xs" color="fg.muted" marginBottom={1}>
+        Attempts
+      </Text>
+      <VStack align="stretch" gap={1}>
+        {rows.map((row) => (
+          <HStack
+            key={row.attempt}
+            gap={2}
+            align="start"
+            data-testid={`dead-attempt-${row.attempt}`}
+          >
+            <Badge
+              size="xs"
+              colorPalette={row.outcome === "dead" ? "red" : "orange"}
+              variant="subtle"
+              flexShrink={0}
+            >
+              {row.attempt}
+            </Badge>
+            <Text textStyle="xs" fontFamily="mono" color="red.500">
+              {row.errorType}
+            </Text>
+            <Text textStyle="xs" color="fg.muted">
+              {row.errorMessage}
+            </Text>
+          </HStack>
+        ))}
+      </VStack>
+    </Box>
   );
 }
 

--- a/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
@@ -164,6 +164,16 @@ function BulkConfirms({
   const plural = shownCount === 1 ? "message" : "messages";
   return (
     <>
+      {/* Discard asks even for one row, because nothing un-discards it: no
+          redrive path selects a discarded message. */}
+      <ConfirmDialog
+        open={!!actions.discardTarget}
+        onClose={() => actions.setDiscardTarget(null)}
+        onConfirm={actions.confirmDiscard}
+        title="Discard dead letter"
+        description={`Mark "${actions.discardTarget?.intentType}" on ${actions.discardTarget?.processName} as never to be sent. The row is kept as the audit record, and it cannot be redriven afterwards.`}
+        isLoading={actions.discardingId !== null}
+      />
       <ConfirmDialog
         open={actions.confirmBulk === "redrive"}
         onClose={() => actions.setConfirmBulk(null)}
@@ -175,9 +185,16 @@ function BulkConfirms({
       <ConfirmDialog
         open={actions.confirmBulk === "discard"}
         onClose={() => actions.setConfirmBulk(null)}
-        onConfirm={() => actions.discardAll.mutate({ processName })}
+        onConfirm={() =>
+          actions.discardAll.mutate(
+            // The fleet-wide form crosses every tenant, so the API refuses it
+            // without an explicit confirmation rather than treating a missing
+            // process name as "all".
+            processName ? { processName } : { confirm: "DISCARD ALL" },
+          )
+        }
         title="Discard dead letters"
-        description={`Mark all ${shownCount} dead ${plural} for ${shownScope} as never to be sent. The rows are kept as the audit record; the work will not run.`}
+        description={`Mark all ${shownCount} dead ${plural} for ${shownScope} as never to be sent. The rows are kept as the audit record, the work will not run, and none of it can be redriven afterwards.`}
         isLoading={actions.discardAll.isPending}
       />
     </>

--- a/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
@@ -2,11 +2,14 @@ import {
   Button,
   Center,
   HStack,
+  Spacer,
   Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { RotateCcw, XCircle } from "lucide-react";
 import { useState } from "react";
+import { ConfirmDialog } from "~/components/ops/shared/ConfirmDialog";
 import { toaster } from "~/components/ui/toaster";
 import { showErrorToast } from "~/features/errors";
 import { useOpsPermission } from "~/hooks/useOpsPermission";
@@ -35,6 +38,10 @@ export function DeadLettersContent() {
   const [page, setPage] = useState(1);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [redrivingId, setRedrivingId] = useState<string | null>(null);
+  const [discardingId, setDiscardingId] = useState<string | null>(null);
+  const [confirmBulk, setConfirmBulk] = useState<"redrive" | "discard" | null>(
+    null,
+  );
 
   const utils = api.useUtils();
   const query = api.ops.listDeadLetters.useQuery(
@@ -54,6 +61,57 @@ export function DeadLettersContent() {
     onError: (error) => {
       setRedrivingId(null);
       showErrorToast({ error, fallbackTitle: "Couldn't redrive the message" });
+    },
+  });
+  const discard = api.ops.processDiscardDeadMessage.useMutation({
+    onSuccess: (data) => {
+      toaster.create({
+        title: data.discarded
+          ? "Message discarded"
+          : "Message is no longer dead",
+        type: data.discarded ? "success" : "error",
+      });
+      setDiscardingId(null);
+      void utils.ops.invalidate();
+    },
+    onError: (error) => {
+      setDiscardingId(null);
+      showErrorToast({ error, fallbackTitle: "Couldn't discard the message" });
+    },
+  });
+  const redriveAll = api.ops.redriveDeadLetters.useMutation({
+    onSuccess: (data) => {
+      toaster.create({
+        title: `Redrove ${data.redriven} ${
+          data.redriven === 1 ? "message" : "messages"
+        }`,
+        type: "success",
+      });
+      setConfirmBulk(null);
+      void utils.ops.invalidate();
+    },
+    onError: (error) => {
+      setConfirmBulk(null);
+      showErrorToast({ error, fallbackTitle: "Couldn't redrive the messages" });
+    },
+  });
+  const discardAll = api.ops.discardDeadLetters.useMutation({
+    onSuccess: (data) => {
+      toaster.create({
+        title: `Discarded ${data.discarded} ${
+          data.discarded === 1 ? "message" : "messages"
+        }`,
+        type: "success",
+      });
+      setConfirmBulk(null);
+      void utils.ops.invalidate();
+    },
+    onError: (error) => {
+      setConfirmBulk(null);
+      showErrorToast({
+        error,
+        fallbackTitle: "Couldn't discard the messages",
+      });
     },
   });
 
@@ -82,6 +140,23 @@ export function DeadLettersContent() {
       messageId: message.id,
     });
   };
+  const onDiscard = (message: DeadLetterMessage) => {
+    setDiscardingId(message.id);
+    discard.mutate({
+      processName: message.processName,
+      projectId: message.projectId,
+      processKey: message.processKey,
+      messageId: message.id,
+    });
+  };
+
+  // The bulk actions act on exactly what the filter shows: one process, or
+  // the whole fleet when no chip is selected. The count in the button IS the
+  // blast radius, restated in the confirmation.
+  const shownCount = processName
+    ? (byProcess.find((row) => row.processName === processName)?.count ?? 0)
+    : fleetTotal;
+  const shownScope = processName ?? "every process";
 
   return (
     <VStack align="stretch" gap={4}>
@@ -94,20 +169,66 @@ export function DeadLettersContent() {
           setPage(1);
         }}
       />
+      {hasAccess && shownCount > 0 && (
+        <HStack gap={2}>
+          <Spacer />
+          <Button
+            size="xs"
+            variant="outline"
+            data-testid="dead-redrive-shown"
+            onClick={() => setConfirmBulk("redrive")}
+          >
+            <RotateCcw size={12} />
+            Redrive shown ({shownCount})
+          </Button>
+          <Button
+            size="xs"
+            variant="outline"
+            colorPalette="red"
+            data-testid="dead-discard-shown"
+            onClick={() => setConfirmBulk("discard")}
+          >
+            <XCircle size={12} />
+            Discard shown ({shownCount})
+          </Button>
+        </HStack>
+      )}
       <DeadLettersTable
         messages={messages}
         now={now}
         canManage={hasAccess}
         expandedId={expandedId}
         redrivingId={redrivingId}
+        discardingId={discardingId}
         onToggle={(id) => setExpandedId(expandedId === id ? null : id)}
         onRedrive={onRedrive}
+        onDiscard={onDiscard}
       />
       <Pager
         page={page}
         total={total}
         shown={messages.length}
         onPage={setPage}
+      />
+      <ConfirmDialog
+        open={confirmBulk === "redrive"}
+        onClose={() => setConfirmBulk(null)}
+        onConfirm={() => redriveAll.mutate({ processName })}
+        title="Redrive dead letters"
+        description={`Return all ${shownCount} dead ${
+          shownCount === 1 ? "message" : "messages"
+        } for ${shownScope} to pending with a fresh attempt budget. Their deliveries will run again.`}
+        isLoading={redriveAll.isPending}
+      />
+      <ConfirmDialog
+        open={confirmBulk === "discard"}
+        onClose={() => setConfirmBulk(null)}
+        onConfirm={() => discardAll.mutate({ processName })}
+        title="Discard dead letters"
+        description={`Mark all ${shownCount} dead ${
+          shownCount === 1 ? "message" : "messages"
+        } for ${shownScope} as never to be sent. The rows are kept as the audit record; the work will not run.`}
+        isLoading={discardAll.isPending}
       />
     </VStack>
   );

--- a/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
@@ -10,16 +10,14 @@ import {
 import { RotateCcw, XCircle } from "lucide-react";
 import { useState } from "react";
 import { ConfirmDialog } from "~/components/ops/shared/ConfirmDialog";
-import { toaster } from "~/components/ui/toaster";
-import { showErrorToast } from "~/features/errors";
 import { useOpsPermission } from "~/hooks/useOpsPermission";
 import { api } from "~/utils/api";
 import {
-  type DeadLetterMessage,
   DeadLetterSummary,
   DeadLettersEmpty,
   DeadLettersTable,
 } from "./DeadLettersCard";
+import { useDeadLetterActions } from "./useDeadLetterActions";
 
 const PAGE_SIZE = 25;
 
@@ -37,83 +35,12 @@ export function DeadLettersContent() {
   const [processName, setProcessName] = useState<string | undefined>(undefined);
   const [page, setPage] = useState(1);
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [redrivingId, setRedrivingId] = useState<string | null>(null);
-  const [discardingId, setDiscardingId] = useState<string | null>(null);
-  const [confirmBulk, setConfirmBulk] = useState<"redrive" | "discard" | null>(
-    null,
-  );
+  const actions = useDeadLetterActions();
 
-  const utils = api.useUtils();
   const query = api.ops.listDeadLetters.useQuery(
     { processName, page, pageSize: PAGE_SIZE },
     { refetchInterval: 30_000 },
   );
-
-  const redrive = api.ops.processRedriveDeadMessage.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: data.redriven ? "Message redriven" : "Message is no longer dead",
-        type: data.redriven ? "success" : "error",
-      });
-      setRedrivingId(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) => {
-      setRedrivingId(null);
-      showErrorToast({ error, fallbackTitle: "Couldn't redrive the message" });
-    },
-  });
-  const discard = api.ops.processDiscardDeadMessage.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: data.discarded
-          ? "Message discarded"
-          : "Message is no longer dead",
-        type: data.discarded ? "success" : "error",
-      });
-      setDiscardingId(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) => {
-      setDiscardingId(null);
-      showErrorToast({ error, fallbackTitle: "Couldn't discard the message" });
-    },
-  });
-  const redriveAll = api.ops.redriveDeadLetters.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: `Redrove ${data.redriven} ${
-          data.redriven === 1 ? "message" : "messages"
-        }`,
-        type: "success",
-      });
-      setConfirmBulk(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) => {
-      setConfirmBulk(null);
-      showErrorToast({ error, fallbackTitle: "Couldn't redrive the messages" });
-    },
-  });
-  const discardAll = api.ops.discardDeadLetters.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: `Discarded ${data.discarded} ${
-          data.discarded === 1 ? "message" : "messages"
-        }`,
-        type: "success",
-      });
-      setConfirmBulk(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) => {
-      setConfirmBulk(null);
-      showErrorToast({
-        error,
-        fallbackTitle: "Couldn't discard the messages",
-      });
-    },
-  });
 
   if (query.isPending) {
     return (
@@ -131,32 +58,12 @@ export function DeadLettersContent() {
 
   if (fleetTotal === 0) return <DeadLettersEmpty />;
 
-  const onRedrive = (message: DeadLetterMessage) => {
-    setRedrivingId(message.id);
-    redrive.mutate({
-      processName: message.processName,
-      projectId: message.projectId,
-      processKey: message.processKey,
-      messageId: message.id,
-    });
-  };
-  const onDiscard = (message: DeadLetterMessage) => {
-    setDiscardingId(message.id);
-    discard.mutate({
-      processName: message.processName,
-      projectId: message.projectId,
-      processKey: message.processKey,
-      messageId: message.id,
-    });
-  };
-
   // The bulk actions act on exactly what the filter shows: one process, or
   // the whole fleet when no chip is selected. The count in the button IS the
   // blast radius, restated in the confirmation.
   const shownCount = processName
     ? (byProcess.find((row) => row.processName === processName)?.count ?? 0)
     : fleetTotal;
-  const shownScope = processName ?? "every process";
 
   return (
     <VStack align="stretch" gap={4}>
@@ -170,39 +77,22 @@ export function DeadLettersContent() {
         }}
       />
       {hasAccess && shownCount > 0 && (
-        <HStack gap={2}>
-          <Spacer />
-          <Button
-            size="xs"
-            variant="outline"
-            data-testid="dead-redrive-shown"
-            onClick={() => setConfirmBulk("redrive")}
-          >
-            <RotateCcw size={12} />
-            Redrive shown ({shownCount})
-          </Button>
-          <Button
-            size="xs"
-            variant="outline"
-            colorPalette="red"
-            data-testid="dead-discard-shown"
-            onClick={() => setConfirmBulk("discard")}
-          >
-            <XCircle size={12} />
-            Discard shown ({shownCount})
-          </Button>
-        </HStack>
+        <BulkActionBar
+          shownCount={shownCount}
+          onRedriveAll={() => actions.setConfirmBulk("redrive")}
+          onDiscardAll={() => actions.setConfirmBulk("discard")}
+        />
       )}
       <DeadLettersTable
         messages={messages}
         now={now}
         canManage={hasAccess}
         expandedId={expandedId}
-        redrivingId={redrivingId}
-        discardingId={discardingId}
+        redrivingId={actions.redrivingId}
+        discardingId={actions.discardingId}
         onToggle={(id) => setExpandedId(expandedId === id ? null : id)}
-        onRedrive={onRedrive}
-        onDiscard={onDiscard}
+        onRedrive={actions.onRedrive}
+        onDiscard={actions.onDiscard}
       />
       <Pager
         page={page}
@@ -210,27 +100,87 @@ export function DeadLettersContent() {
         shown={messages.length}
         onPage={setPage}
       />
-      <ConfirmDialog
-        open={confirmBulk === "redrive"}
-        onClose={() => setConfirmBulk(null)}
-        onConfirm={() => redriveAll.mutate({ processName })}
-        title="Redrive dead letters"
-        description={`Return all ${shownCount} dead ${
-          shownCount === 1 ? "message" : "messages"
-        } for ${shownScope} to pending with a fresh attempt budget. Their deliveries will run again.`}
-        isLoading={redriveAll.isPending}
-      />
-      <ConfirmDialog
-        open={confirmBulk === "discard"}
-        onClose={() => setConfirmBulk(null)}
-        onConfirm={() => discardAll.mutate({ processName })}
-        title="Discard dead letters"
-        description={`Mark all ${shownCount} dead ${
-          shownCount === 1 ? "message" : "messages"
-        } for ${shownScope} as never to be sent. The rows are kept as the audit record; the work will not run.`}
-        isLoading={discardAll.isPending}
+      <BulkConfirms
+        actions={actions}
+        shownCount={shownCount}
+        shownScope={processName ?? "every process"}
+        processName={processName}
       />
     </VStack>
+  );
+}
+
+/** Redrive or discard everything the current filter shows. */
+function BulkActionBar({
+  shownCount,
+  onRedriveAll,
+  onDiscardAll,
+}: {
+  shownCount: number;
+  onRedriveAll: () => void;
+  onDiscardAll: () => void;
+}) {
+  return (
+    <HStack gap={2}>
+      <Spacer />
+      <Button
+        size="xs"
+        variant="outline"
+        data-testid="dead-redrive-shown"
+        onClick={onRedriveAll}
+      >
+        <RotateCcw size={12} />
+        Redrive shown ({shownCount})
+      </Button>
+      <Button
+        size="xs"
+        variant="outline"
+        colorPalette="red"
+        data-testid="dead-discard-shown"
+        onClick={onDiscardAll}
+      >
+        <XCircle size={12} />
+        Discard shown ({shownCount})
+      </Button>
+    </HStack>
+  );
+}
+
+/**
+ * Both bulk confirmations, each naming its blast radius in the operator's own
+ * terms (best_practices/ops-dashboard.md).
+ */
+function BulkConfirms({
+  actions,
+  shownCount,
+  shownScope,
+  processName,
+}: {
+  actions: ReturnType<typeof useDeadLetterActions>;
+  shownCount: number;
+  shownScope: string;
+  processName: string | undefined;
+}) {
+  const plural = shownCount === 1 ? "message" : "messages";
+  return (
+    <>
+      <ConfirmDialog
+        open={actions.confirmBulk === "redrive"}
+        onClose={() => actions.setConfirmBulk(null)}
+        onConfirm={() => actions.redriveAll.mutate({ processName })}
+        title="Redrive dead letters"
+        description={`Return all ${shownCount} dead ${plural} for ${shownScope} to pending with a fresh attempt budget. Their deliveries will run again.`}
+        isLoading={actions.redriveAll.isPending}
+      />
+      <ConfirmDialog
+        open={actions.confirmBulk === "discard"}
+        onClose={() => actions.setConfirmBulk(null)}
+        onConfirm={() => actions.discardAll.mutate({ processName })}
+        title="Discard dead letters"
+        description={`Mark all ${shownCount} dead ${plural} for ${shownScope} as never to be sent. The rows are kept as the audit record; the work will not run.`}
+        isLoading={actions.discardAll.isPending}
+      />
+    </>
   );
 }
 

--- a/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
@@ -175,8 +175,8 @@ function BulkConfirms({
   // same phrase, which stops a script reaching this breadth by omitting a
   // field; this is what makes the ask a human one too.
   const [typed, setTyped] = useState("");
-  const fleetWide = processName === undefined;
-  const phraseOk = !fleetWide || typed.trim() === FLEET_DISCARD_PHRASE;
+  const isFleetWide = processName === undefined;
+  const isPhraseValid = !isFleetWide || typed.trim() === FLEET_DISCARD_PHRASE;
   return (
     <>
       {/* Discard asks even for one row, because nothing un-discards it: no
@@ -211,9 +211,9 @@ function BulkConfirms({
         title="Discard dead letters"
         description={`Mark all ${shownCount} dead ${plural} for ${shownScope} as never to be sent. The rows are kept as the audit record, the work will not run, and none of it can be redriven afterwards.`}
         isLoading={actions.discardAll.isPending}
-        confirmDisabled={!phraseOk}
+        confirmDisabled={!isPhraseValid}
       >
-        {fleetWide && (
+        {isFleetWide && (
           <Input
             marginTop={3}
             size="sm"

--- a/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
+++ b/platform/app/src/components/ops/deadLetters/DeadLettersContent.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Center,
   HStack,
+  Input,
   Spacer,
   Spinner,
   Text,
@@ -20,6 +21,13 @@ import {
 import { useDeadLetterActions } from "./useDeadLetterActions";
 
 const PAGE_SIZE = 25;
+
+/**
+ * What an operator types to discard every process's dead letters. The API
+ * requires the same phrase, so neither a mis-click nor a script that omits
+ * `processName` can reach that breadth.
+ */
+const FLEET_DISCARD_PHRASE = "DISCARD ALL";
 
 /**
  * Every message the substrate has permanently given up on.
@@ -162,6 +170,13 @@ function BulkConfirms({
   processName: string | undefined;
 }) {
   const plural = shownCount === 1 ? "message" : "messages";
+  // The fleet-wide discard crosses every tenant and cannot be undone, so the
+  // operator types the phrase rather than clicking once. The API asks for the
+  // same phrase, which stops a script reaching this breadth by omitting a
+  // field; this is what makes the ask a human one too.
+  const [typed, setTyped] = useState("");
+  const fleetWide = processName === undefined;
+  const phraseOk = !fleetWide || typed.trim() === FLEET_DISCARD_PHRASE;
   return (
     <>
       {/* Discard asks even for one row, because nothing un-discards it: no
@@ -184,19 +199,32 @@ function BulkConfirms({
       />
       <ConfirmDialog
         open={actions.confirmBulk === "discard"}
-        onClose={() => actions.setConfirmBulk(null)}
+        onClose={() => {
+          setTyped("");
+          actions.setConfirmBulk(null);
+        }}
         onConfirm={() =>
           actions.discardAll.mutate(
-            // The fleet-wide form crosses every tenant, so the API refuses it
-            // without an explicit confirmation rather than treating a missing
-            // process name as "all".
-            processName ? { processName } : { confirm: "DISCARD ALL" },
+            processName ? { processName } : { confirm: FLEET_DISCARD_PHRASE },
           )
         }
         title="Discard dead letters"
         description={`Mark all ${shownCount} dead ${plural} for ${shownScope} as never to be sent. The rows are kept as the audit record, the work will not run, and none of it can be redriven afterwards.`}
         isLoading={actions.discardAll.isPending}
-      />
+        confirmDisabled={!phraseOk}
+      >
+        {fleetWide && (
+          <Input
+            marginTop={3}
+            size="sm"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={FLEET_DISCARD_PHRASE}
+            aria-label={`Type ${FLEET_DISCARD_PHRASE} to confirm`}
+            data-testid="dead-discard-all-phrase"
+          />
+        )}
+      </ConfirmDialog>
     </>
   );
 }

--- a/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
+++ b/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
@@ -11,6 +11,39 @@ import {
   DeadLettersTable,
 } from "../DeadLettersCard";
 
+// The expanded row's attempt history reads through the tRPC client; the
+// fixtures here stand in for the ops.listOutboxAttempts read.
+const listOutboxAttemptsQuery = vi.fn(() => ({
+  isPending: false,
+  data: [
+    {
+      attempt: 1,
+      occurredAt: 0,
+      outcome: "retry_scheduled",
+      errorType: "DispatchError",
+      errorMessage: "receiver returned 503",
+      retryAfterMs: null,
+    },
+    {
+      attempt: 2,
+      occurredAt: 0,
+      outcome: "dead",
+      errorType: "DispatchError",
+      errorMessage: "receiver returned 410",
+      retryAfterMs: null,
+    },
+  ],
+}));
+vi.mock("~/utils/api", () => ({
+  api: {
+    ops: {
+      listOutboxAttempts: {
+        useQuery: (input: unknown) => listOutboxAttemptsQuery(input),
+      },
+    },
+  },
+}));
+
 const NOW = Date.UTC(2026, 7, 17, 12, 0, 0);
 
 /** Repeating-pattern fixtures, not credentials: a realistic ULID or trace id
@@ -107,8 +140,10 @@ describe("DeadLettersCard", () => {
           canManage
           expandedId={null}
           redrivingId={null}
+          discardingId={null}
           onToggle={vi.fn()}
           onRedrive={vi.fn()}
+          onDiscard={vi.fn()}
         />,
       );
 
@@ -131,8 +166,10 @@ describe("DeadLettersCard", () => {
           canManage
           expandedId={null}
           redrivingId={null}
+          discardingId={null}
           onToggle={vi.fn()}
           onRedrive={onRedrive}
+          onDiscard={vi.fn()}
         />,
       );
 
@@ -158,8 +195,10 @@ describe("DeadLettersCard", () => {
           canManage={false}
           expandedId={null}
           redrivingId={null}
+          discardingId={null}
           onToggle={vi.fn()}
           onRedrive={vi.fn()}
+          onDiscard={vi.fn()}
         />,
       );
 
@@ -177,15 +216,78 @@ describe("DeadLettersCard", () => {
           canManage
           expandedId={message.id}
           redrivingId={null}
+          discardingId={null}
           onToggle={vi.fn()}
           onRedrive={vi.fn()}
+          onDiscard={vi.fn()}
         />,
       );
 
-      // The reason a message died is on its span, not on the row, so the
-      // trace id is the operator's route to it.
       expect(screen.getByText(message.traceId!)).toBeTruthy();
       expect(screen.getByText("Payload")).toBeTruthy();
+    });
+
+    /** @scenario A dead letter shows why it died without leaving the page */
+    it("shows the failed attempts oldest first, each with its diagnostic", () => {
+      const message = makeMessage();
+      renderWithChakra(
+        <DeadLettersTable
+          messages={[message]}
+          now={NOW}
+          canManage
+          expandedId={message.id}
+          redrivingId={null}
+          discardingId={null}
+          onToggle={vi.fn()}
+          onRedrive={vi.fn()}
+          onDiscard={vi.fn()}
+        />,
+      );
+
+      expect(listOutboxAttemptsQuery).toHaveBeenCalledWith({
+        outboxId: message.id,
+        projectId: message.projectId,
+      });
+      const first = screen.getByTestId("dead-attempt-1");
+      const second = screen.getByTestId("dead-attempt-2");
+      expect(first.textContent).toContain("receiver returned 503");
+      expect(second.textContent).toContain("receiver returned 410");
+      // Oldest first: the story reads top to bottom.
+      expect(
+        first.compareDocumentPosition(second) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
+    /** @scenario Discarding a dead message marks it and keeps it */
+    /** @scenario Recovery verbs are the same on both substrates */
+    it("offers Redrive and Discard side by side, and Discard carries the full ref", () => {
+      const onDiscard = vi.fn();
+      const message = makeMessage();
+      renderWithChakra(
+        <DeadLettersTable
+          messages={[message]}
+          now={NOW}
+          canManage
+          expandedId={null}
+          redrivingId={null}
+          discardingId={null}
+          onToggle={vi.fn()}
+          onRedrive={vi.fn()}
+          onDiscard={onDiscard}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByTestId("dead-discard-process:req_01:deliver:confirmed"),
+      );
+      expect(onDiscard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          processName: "webhookDelivery",
+          projectId: "project_1",
+          processKey: FIXTURE_PROCESS_KEY,
+        }),
+      );
     });
   });
 

--- a/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
+++ b/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
@@ -261,8 +261,11 @@ describe("DeadLettersCard", () => {
       ).toBeTruthy();
     });
 
-    /** @scenario Discarding a dead message marks it and keeps it */
-    /** @scenario Recovery verbs are the same on both substrates */
+    // No @scenario here: what this asserts is that the row offers both verbs
+    // and hands the discard its full ref. That the mark is kept, and that
+    // both substrates use the same verbs, are claims the integration suite
+    // and the DLQ card own — binding them here would report them covered
+    // while asserting neither.
     it("offers Redrive and Discard side by side, and Discard carries the full ref", () => {
       const onDiscard = vi.fn();
       const message = makeMessage();

--- a/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
+++ b/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
@@ -261,11 +261,14 @@ describe("DeadLettersCard", () => {
       ).toBeTruthy();
     });
 
-    // No @scenario here: what this asserts is that the row offers both verbs
-    // and hands the discard its full ref. That the mark is kept, and that
-    // both substrates use the same verbs, are claims the integration suite
-    // and the DLQ card own — binding them here would report them covered
-    // while asserting neither.
+    // Deliberately unbound. What this asserts is that the row offers both
+    // verbs and hands the discard its full ref. That the mark is kept, and
+    // that both substrates use the same verbs, are claims the integration
+    // suite and the vocabulary suite own — binding them here would report
+    // them covered while asserting neither. The binding token is not spelled
+    // out even in prose: the parity scanner matches it anywhere in a comment,
+    // so writing it here would register a binding for a scenario that does
+    // not exist.
     it("offers Redrive and Discard side by side, and Discard carries the full ref", () => {
       const onDiscard = vi.fn();
       const message = makeMessage();

--- a/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
+++ b/platform/app/src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx
@@ -13,10 +13,11 @@ import {
 
 // The expanded row's attempt history reads through the tRPC client; the
 // fixtures here stand in for the ops.listOutboxAttempts read.
-const listOutboxAttemptsQuery = vi.fn(() => ({
+const listOutboxAttemptsQuery = vi.fn((_input: unknown) => ({
   isPending: false,
   data: [
     {
+      id: "att_1",
       attempt: 1,
       occurredAt: 0,
       outcome: "retry_scheduled",
@@ -25,6 +26,7 @@ const listOutboxAttemptsQuery = vi.fn(() => ({
       retryAfterMs: null,
     },
     {
+      id: "att_2",
       attempt: 2,
       occurredAt: 0,
       outcome: "dead",

--- a/platform/app/src/components/ops/deadLetters/useDeadLetterActions.ts
+++ b/platform/app/src/components/ops/deadLetters/useDeadLetterActions.ts
@@ -11,23 +11,25 @@ export type BulkDeadLetterAction = "redrive" | "discard" | null;
 
 const plural = (count: number) => (count === 1 ? "message" : "messages");
 
-/**
- * The Dead Letters page's four mutations and their pending state
- * (specs/ops/dead-letter-recovery.feature). Returns state and callbacks only,
- * never JSX — same shape as `useProcessInstanceActions`, which owns the
- * equivalent set for one process instance.
- */
-export function useDeadLetterActions() {
-  const utils = api.useUtils();
+const refOf = (message: DeadLetterMessage) => ({
+  processName: message.processName,
+  projectId: message.projectId,
+  processKey: message.processKey,
+  messageId: message.id,
+});
+
+/** Redrive or discard one dead letter from its row. */
+function useRowActions(onSettled: () => void) {
   const [redrivingId, setRedrivingId] = useState<string | null>(null);
   const [discardingId, setDiscardingId] = useState<string | null>(null);
-  const [confirmBulk, setConfirmBulk] = useState<BulkDeadLetterAction>(null);
-
+  const [discardTarget, setDiscardTarget] = useState<DeadLetterMessage | null>(
+    null,
+  );
   const settle = () => {
     setRedrivingId(null);
     setDiscardingId(null);
-    setConfirmBulk(null);
-    void utils.ops.invalidate();
+    setDiscardTarget(null);
+    onSettled();
   };
 
   const redrive = api.ops.processRedriveDeadMessage.useMutation(
@@ -46,6 +48,34 @@ export function useDeadLetterActions() {
       failure: "Couldn't discard the message",
     }),
   );
+
+  return {
+    redrivingId,
+    discardingId,
+    discardTarget,
+    setDiscardTarget,
+    onRedrive: (message: DeadLetterMessage) => {
+      setRedrivingId(message.id);
+      redrive.mutate(refOf(message));
+    },
+    /** Asks first: nothing un-discards a message. */
+    onDiscard: (message: DeadLetterMessage) => setDiscardTarget(message),
+    confirmDiscard: () => {
+      if (!discardTarget) return;
+      setDiscardingId(discardTarget.id);
+      discard.mutate(refOf(discardTarget));
+    },
+  };
+}
+
+/** Redrive or discard everything the current filter shows. */
+function useBulkActions(onSettled: () => void) {
+  const [confirmBulk, setConfirmBulk] = useState<BulkDeadLetterAction>(null);
+  const settle = () => {
+    setConfirmBulk(null);
+    onSettled();
+  };
+
   const redriveAll = api.ops.redriveDeadLetters.useMutation(
     countOutcomeHandlers({
       onSettled: settle,
@@ -61,27 +91,20 @@ export function useDeadLetterActions() {
     }),
   );
 
-  const refOf = (message: DeadLetterMessage) => ({
-    processName: message.processName,
-    projectId: message.projectId,
-    processKey: message.processKey,
-    messageId: message.id,
-  });
+  return { confirmBulk, setConfirmBulk, redriveAll, discardAll };
+}
 
+/**
+ * The Dead Letters page's mutations and their pending state
+ * (specs/ops/dead-letter-recovery.feature). Returns state and callbacks only,
+ * never JSX — same shape as `useProcessInstanceActions`, which owns the
+ * equivalent set for one process instance.
+ */
+export function useDeadLetterActions() {
+  const utils = api.useUtils();
+  const invalidate = () => void utils.ops.invalidate();
   return {
-    redrivingId,
-    discardingId,
-    confirmBulk,
-    setConfirmBulk,
-    redriveAll,
-    discardAll,
-    onRedrive: (message: DeadLetterMessage) => {
-      setRedrivingId(message.id);
-      redrive.mutate(refOf(message));
-    },
-    onDiscard: (message: DeadLetterMessage) => {
-      setDiscardingId(message.id);
-      discard.mutate(refOf(message));
-    },
+    ...useRowActions(invalidate),
+    ...useBulkActions(invalidate),
   };
 }

--- a/platform/app/src/components/ops/deadLetters/useDeadLetterActions.ts
+++ b/platform/app/src/components/ops/deadLetters/useDeadLetterActions.ts
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import {
+  countOutcomeHandlers,
+  mutationOutcomeHandlers,
+} from "~/components/ops/shared/mutationOutcome";
+import { api } from "~/utils/api";
+import type { DeadLetterMessage } from "./DeadLettersCard";
+
+/** Which bulk act is awaiting confirmation, if any. */
+export type BulkDeadLetterAction = "redrive" | "discard" | null;
+
+const plural = (count: number) => (count === 1 ? "message" : "messages");
+
+/**
+ * The Dead Letters page's four mutations and their pending state
+ * (specs/ops/dead-letter-recovery.feature). Returns state and callbacks only,
+ * never JSX — same shape as `useProcessInstanceActions`, which owns the
+ * equivalent set for one process instance.
+ */
+export function useDeadLetterActions() {
+  const utils = api.useUtils();
+  const [redrivingId, setRedrivingId] = useState<string | null>(null);
+  const [discardingId, setDiscardingId] = useState<string | null>(null);
+  const [confirmBulk, setConfirmBulk] = useState<BulkDeadLetterAction>(null);
+
+  const settle = () => {
+    setRedrivingId(null);
+    setDiscardingId(null);
+    setConfirmBulk(null);
+    void utils.ops.invalidate();
+  };
+
+  const redrive = api.ops.processRedriveDeadMessage.useMutation(
+    mutationOutcomeHandlers({
+      onSettled: settle,
+      applied: "Message redriven",
+      missed: "Message is no longer dead",
+      failure: "Couldn't redrive the message",
+    }),
+  );
+  const discard = api.ops.processDiscardDeadMessage.useMutation(
+    mutationOutcomeHandlers({
+      onSettled: settle,
+      applied: "Message discarded",
+      missed: "Message is no longer dead",
+      failure: "Couldn't discard the message",
+    }),
+  );
+  const redriveAll = api.ops.redriveDeadLetters.useMutation(
+    countOutcomeHandlers({
+      onSettled: settle,
+      title: (n) => `Redrove ${n} ${plural(n)}`,
+      failure: "Couldn't redrive the messages",
+    }),
+  );
+  const discardAll = api.ops.discardDeadLetters.useMutation(
+    countOutcomeHandlers({
+      onSettled: settle,
+      title: (n) => `Discarded ${n} ${plural(n)}`,
+      failure: "Couldn't discard the messages",
+    }),
+  );
+
+  const refOf = (message: DeadLetterMessage) => ({
+    processName: message.processName,
+    projectId: message.projectId,
+    processKey: message.processKey,
+    messageId: message.id,
+  });
+
+  return {
+    redrivingId,
+    discardingId,
+    confirmBulk,
+    setConfirmBulk,
+    redriveAll,
+    discardAll,
+    onRedrive: (message: DeadLetterMessage) => {
+      setRedrivingId(message.id);
+      redrive.mutate(refOf(message));
+    },
+    onDiscard: (message: DeadLetterMessage) => {
+      setDiscardingId(message.id);
+      discard.mutate(refOf(message));
+    },
+  };
+}

--- a/platform/app/src/components/ops/dejaview/ManagerCard.tsx
+++ b/platform/app/src/components/ops/dejaview/ManagerCard.tsx
@@ -23,6 +23,7 @@ const OUTBOX_PALETTE: Record<
   pending: "yellow",
   dispatched: "green",
   dead: "red",
+  discarded: "gray",
 };
 
 function instanceStatus(instance: AggregateProcessManagerInstance | null): {

--- a/platform/app/src/components/ops/processes/instanceDrawer/OutboxMessageCard.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/OutboxMessageCard.tsx
@@ -24,7 +24,13 @@ function StatusBadge({
   status: ProcessOutboxMessageView["status"];
 }) {
   const palette =
-    status === "dead" ? "red" : status === "dispatched" ? "green" : "blue";
+    status === "dead"
+      ? "red"
+      : status === "discarded"
+        ? "gray"
+        : status === "dispatched"
+          ? "green"
+          : "blue";
   return (
     <Badge size="xs" colorPalette={palette} variant="subtle">
       {status}
@@ -82,6 +88,7 @@ function MessageMetaRow({
   traceHref,
   canManage,
   onRedrive,
+  onDiscard,
   onReleaseLease,
   actionPending,
 }: {
@@ -91,6 +98,7 @@ function MessageMetaRow({
   traceHref: string | null;
   canManage: boolean;
   onRedrive?: (messageId: string) => void;
+  onDiscard?: (messageId: string) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
 }) {
@@ -129,6 +137,18 @@ function MessageMetaRow({
           Redrive
         </Button>
       )}
+      {canManage && message.status === "dead" && onDiscard && (
+        <Button
+          size="2xs"
+          variant="outline"
+          colorPalette="red"
+          loading={actionPending}
+          title="A mark, not a delete: the row is kept as the audit record and the message is never sent."
+          onClick={() => onDiscard(message.id)}
+        >
+          Discard
+        </Button>
+      )}
       {canManage && leaseLapsed && onReleaseLease && (
         <Button
           size="2xs"
@@ -158,6 +178,7 @@ export function OutboxMessageCard({
   grafana,
   canManage,
   onRedrive,
+  onDiscard,
   onReleaseLease,
   actionPending,
 }: {
@@ -166,6 +187,7 @@ export function OutboxMessageCard({
   grafana?: GrafanaDeepLinkConfig | null;
   canManage: boolean;
   onRedrive?: (messageId: string) => void;
+  onDiscard?: (messageId: string) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
 }) {
@@ -195,6 +217,7 @@ export function OutboxMessageCard({
           traceHref={traceHref}
           canManage={canManage}
           onRedrive={onRedrive}
+          onDiscard={onDiscard}
           onReleaseLease={onReleaseLease}
           actionPending={actionPending}
         />

--- a/platform/app/src/components/ops/processes/instanceDrawer/OutboxMessageCard.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/OutboxMessageCard.tsx
@@ -99,7 +99,7 @@ function MessageMetaRow({
   traceHref: string | null;
   canManage: boolean;
   onRedrive?: (messageId: string) => void;
-  onDiscard?: (messageId: string) => void;
+  onDiscard?: (message: { id: string; intentType: string }) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
 }) {
@@ -145,7 +145,9 @@ function MessageMetaRow({
           colorPalette="red"
           loading={actionPending}
           title="A mark, not a delete: the row is kept as the audit record and the message is never sent."
-          onClick={() => onDiscard(message.id)}
+          onClick={() =>
+            onDiscard({ id: message.id, intentType: message.intentType })
+          }
         >
           Discard
         </Button>
@@ -188,7 +190,7 @@ export function OutboxMessageCard({
   grafana?: GrafanaDeepLinkConfig | null;
   canManage: boolean;
   onRedrive?: (messageId: string) => void;
-  onDiscard?: (messageId: string) => void;
+  onDiscard?: (message: { id: string; intentType: string }) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
 }) {

--- a/platform/app/src/components/ops/processes/instanceDrawer/OutboxMessageCard.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/OutboxMessageCard.tsx
@@ -18,19 +18,20 @@ import {
 
 const NO_PINNED_KEYS: ReadonlySet<string> = new Set();
 
+/** Exhaustive by type, so the next status has to declare its own colour. */
+const STATUS_PALETTES: Record<ProcessOutboxMessageView["status"], string> = {
+  pending: "blue",
+  dispatched: "green",
+  dead: "red",
+  discarded: "gray",
+};
+
 function StatusBadge({
   status,
 }: {
   status: ProcessOutboxMessageView["status"];
 }) {
-  const palette =
-    status === "dead"
-      ? "red"
-      : status === "discarded"
-        ? "gray"
-        : status === "dispatched"
-          ? "green"
-          : "blue";
+  const palette = STATUS_PALETTES[status];
   return (
     <Badge size="xs" colorPalette={palette} variant="subtle">
       {status}

--- a/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceContent.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceContent.tsx
@@ -79,6 +79,7 @@ interface OutboxSectionProps {
   grafana?: GrafanaDeepLinkConfig | null;
   canManage: boolean;
   onRedriveMessage?: (messageId: string) => void;
+  onDiscardMessage?: (messageId: string) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
   now: number;
@@ -93,6 +94,7 @@ function InstanceOutboxSection({
   grafana,
   canManage,
   onRedriveMessage,
+  onDiscardMessage,
   onReleaseLease,
   actionPending,
   now,
@@ -141,6 +143,7 @@ function InstanceOutboxSection({
               grafana={grafana}
               canManage={canManage}
               onRedrive={onRedriveMessage}
+              onDiscard={onDiscardMessage}
               onReleaseLease={onReleaseLease}
               actionPending={actionPending}
             />
@@ -173,6 +176,7 @@ export function ProcessInstanceContent({
   grafana,
   canManage,
   onRedriveMessage,
+  onDiscardMessage,
   onReleaseLease,
   actionPending,
   now = Date.now(),
@@ -187,6 +191,7 @@ export function ProcessInstanceContent({
   grafana?: GrafanaDeepLinkConfig | null;
   canManage?: boolean;
   onRedriveMessage?: (messageId: string) => void;
+  onDiscardMessage?: (messageId: string) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
   now?: number;
@@ -243,6 +248,7 @@ export function ProcessInstanceContent({
         grafana={grafana}
         canManage={canManage ?? false}
         onRedriveMessage={onRedriveMessage}
+        onDiscardMessage={onDiscardMessage}
         onReleaseLease={onReleaseLease}
         actionPending={actionPending}
         now={now}

--- a/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceContent.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceContent.tsx
@@ -79,7 +79,7 @@ interface OutboxSectionProps {
   grafana?: GrafanaDeepLinkConfig | null;
   canManage: boolean;
   onRedriveMessage?: (messageId: string) => void;
-  onDiscardMessage?: (messageId: string) => void;
+  onDiscardMessage?: (message: { id: string; intentType: string }) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
   now: number;
@@ -191,7 +191,7 @@ export function ProcessInstanceContent({
   grafana?: GrafanaDeepLinkConfig | null;
   canManage?: boolean;
   onRedriveMessage?: (messageId: string) => void;
-  onDiscardMessage?: (messageId: string) => void;
+  onDiscardMessage?: (message: { id: string; intentType: string }) => void;
   onReleaseLease?: (messageId: string) => void;
   actionPending?: boolean;
   now?: number;

--- a/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceDrawer.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceDrawer.tsx
@@ -100,6 +100,23 @@ function InstanceActionConfirms({
         description={`Return every dead outbox message of "${label}" to pending, due now, with a fresh attempt budget. Deliveries may reach customers; duplicates are absorbed by each message's key.`}
         isLoading={actions.redriveInstanceMutation.isPending}
       />
+      {/* Discard asks, because nothing un-discards: no redrive path selects a
+          discarded row, so a mis-click is permanent. */}
+      <ConfirmDialog
+        open={!!actions.discardTarget}
+        onClose={() => actions.setDiscardTarget(null)}
+        onConfirm={() => {
+          if (actions.discardTarget) {
+            actions.discardMessageMutation.mutate({
+              ...target,
+              messageId: actions.discardTarget,
+            });
+          }
+        }}
+        title="Discard Dead Message"
+        description={`Mark this message of "${label}" as never to be sent. The row is kept as the audit record, and it cannot be redriven afterwards.`}
+        isLoading={actions.discardMessageMutation.isPending}
+      />
     </>
   );
 }
@@ -168,7 +185,7 @@ export function ProcessInstanceDrawer({
                 actions.redriveMessageMutation.mutate({ ...target, messageId })
               }
               onDiscardMessage={(messageId) =>
-                actions.discardMessageMutation.mutate({ ...target, messageId })
+                actions.setDiscardTarget(messageId)
               }
               onReleaseLease={(messageId) =>
                 actions.releaseLeaseMutation.mutate({ ...target, messageId })

--- a/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceDrawer.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceDrawer.tsx
@@ -167,11 +167,15 @@ export function ProcessInstanceDrawer({
               onRedriveMessage={(messageId) =>
                 actions.redriveMessageMutation.mutate({ ...target, messageId })
               }
+              onDiscardMessage={(messageId) =>
+                actions.discardMessageMutation.mutate({ ...target, messageId })
+              }
               onReleaseLease={(messageId) =>
                 actions.releaseLeaseMutation.mutate({ ...target, messageId })
               }
               actionPending={
                 actions.redriveMessageMutation.isPending ||
+                actions.discardMessageMutation.isPending ||
                 actions.releaseLeaseMutation.isPending
               }
               now={detailQuery.dataUpdatedAt || undefined}

--- a/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceDrawer.tsx
+++ b/platform/app/src/components/ops/processes/instanceDrawer/ProcessInstanceDrawer.tsx
@@ -109,12 +109,12 @@ function InstanceActionConfirms({
           if (actions.discardTarget) {
             actions.discardMessageMutation.mutate({
               ...target,
-              messageId: actions.discardTarget,
+              messageId: actions.discardTarget.id,
             });
           }
         }}
         title="Discard Dead Message"
-        description={`Mark this message of "${label}" as never to be sent. The row is kept as the audit record, and it cannot be redriven afterwards.`}
+        description={`Mark "${actions.discardTarget?.intentType}" on "${label}" as never to be sent. The row is kept as the audit record, and it cannot be redriven afterwards.`}
         isLoading={actions.discardMessageMutation.isPending}
       />
     </>
@@ -184,9 +184,7 @@ export function ProcessInstanceDrawer({
               onRedriveMessage={(messageId) =>
                 actions.redriveMessageMutation.mutate({ ...target, messageId })
               }
-              onDiscardMessage={(messageId) =>
-                actions.setDiscardTarget(messageId)
-              }
+              onDiscardMessage={actions.setDiscardTarget}
               onReleaseLease={(messageId) =>
                 actions.releaseLeaseMutation.mutate({ ...target, messageId })
               }

--- a/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
+++ b/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
@@ -1,5 +1,8 @@
 import { useState } from "react";
-import { mutationOutcomeHandlers } from "~/components/ops/shared/mutationOutcome";
+import {
+  countOutcomeHandlers,
+  mutationOutcomeHandlers,
+} from "~/components/ops/shared/mutationOutcome";
 import { toaster } from "~/components/ui/toaster";
 import { showErrorToast } from "~/features/errors";
 import { api } from "~/utils/api";
@@ -10,13 +13,15 @@ export interface ProcessInstanceTarget {
   processKey: string;
 }
 
-/** The drawer's mutations and confirm state; returns state and callbacks only. */
-export function useProcessInstanceActions() {
-  const utils = api.useUtils();
+/** Acts on the instance as a whole, both behind the footer's confirmations. */
+function useInstanceWideActions(onSettled: () => void) {
   const [confirmAction, setConfirmAction] = useState<"wake" | "redrive" | null>(
     null,
   );
-  const invalidate = () => void utils.ops.invalidate();
+  const settle = () => {
+    setConfirmAction(null);
+    onSettled();
+  };
 
   const wakeMutation = api.ops.processWakeNow.useMutation({
     onSuccess: (data) => {
@@ -26,36 +31,42 @@ export function useProcessInstanceActions() {
           : "Instance no longer exists",
         type: data.woke ? "success" : "error",
       });
-      setConfirmAction(null);
-      void utils.ops.invalidate();
     },
     onError: (error) =>
       showErrorToast({ error, fallbackTitle: "Couldn't wake the process" }),
+    onSettled: settle,
   });
 
   const redriveInstanceMutation =
-    api.ops.processRedriveDeadInstance.useMutation({
-      onSuccess: (data) => {
-        toaster.create({
-          title:
-            data.requeued > 0
-              ? `Redrove ${data.requeued} dead messages`
-              : "No dead messages to redrive",
-          type: "success",
-        });
-        setConfirmAction(null);
-        void utils.ops.invalidate();
-      },
-      onError: (error) =>
-        showErrorToast({
-          error,
-          fallbackTitle: "Couldn't redrive the dead messages",
-        }),
-    });
+    api.ops.processRedriveDeadInstance.useMutation(
+      countOutcomeHandlers({
+        onSettled: settle,
+        title: (n) =>
+          n > 0 ? `Redrove ${n} dead messages` : "No dead messages to redrive",
+        failure: "Couldn't redrive the dead messages",
+      }),
+    );
+
+  return {
+    confirmAction,
+    setConfirmAction,
+    wakeMutation,
+    redriveInstanceMutation,
+  };
+}
+
+/** Acts on one outbox message, from its own card. */
+function useMessageActions(onSettled: () => void) {
+  /**
+   * The message a discard is pending on. Discard is the one act here with no
+   * way back — no redrive path selects a discarded row — so it asks first,
+   * while redrive and release-lease stay one click (both are recoverable).
+   */
+  const [discardTarget, setDiscardTarget] = useState<string | null>(null);
 
   const redriveMessageMutation = api.ops.processRedriveDeadMessage.useMutation(
     mutationOutcomeHandlers({
-      onSettled: invalidate,
+      onSettled,
       applied: "Message redriven",
       missed: "Message is no longer dead",
       failure: "Couldn't redrive the message",
@@ -64,7 +75,10 @@ export function useProcessInstanceActions() {
 
   const discardMessageMutation = api.ops.processDiscardDeadMessage.useMutation(
     mutationOutcomeHandlers({
-      onSettled: invalidate,
+      onSettled: () => {
+        setDiscardTarget(null);
+        onSettled();
+      },
       applied: "Message discarded",
       missed: "Message is no longer dead",
       failure: "Couldn't discard the message",
@@ -73,7 +87,7 @@ export function useProcessInstanceActions() {
 
   const releaseLeaseMutation = api.ops.processReleaseLapsedLease.useMutation(
     mutationOutcomeHandlers({
-      onSettled: invalidate,
+      onSettled,
       applied: "Lease released — message due now",
       missed: "Lease is no longer lapsed",
       failure: "Couldn't release the lease",
@@ -81,12 +95,20 @@ export function useProcessInstanceActions() {
   );
 
   return {
-    confirmAction,
-    setConfirmAction,
-    wakeMutation,
-    redriveInstanceMutation,
+    discardTarget,
+    setDiscardTarget,
     redriveMessageMutation,
     discardMessageMutation,
     releaseLeaseMutation,
+  };
+}
+
+/** The drawer's mutations and confirm state; returns state and callbacks only. */
+export function useProcessInstanceActions() {
+  const utils = api.useUtils();
+  const invalidate = () => void utils.ops.invalidate();
+  return {
+    ...useInstanceWideActions(invalidate),
+    ...useMessageActions(invalidate),
   };
 }

--- a/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
+++ b/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { mutationOutcomeHandlers } from "~/components/ops/shared/mutationOutcome";
 import { toaster } from "~/components/ui/toaster";
 import { showErrorToast } from "~/features/errors";
 import { api } from "~/utils/api";
@@ -15,6 +16,7 @@ export function useProcessInstanceActions() {
   const [confirmAction, setConfirmAction] = useState<"wake" | "redrive" | null>(
     null,
   );
+  const invalidate = () => void utils.ops.invalidate();
 
   const wakeMutation = api.ops.processWakeNow.useMutation({
     onSuccess: (data) => {
@@ -51,45 +53,32 @@ export function useProcessInstanceActions() {
         }),
     });
 
-  const redriveMessageMutation = api.ops.processRedriveDeadMessage.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: data.redriven ? "Message redriven" : "Message is no longer dead",
-        type: data.redriven ? "success" : "error",
-      });
-      void utils.ops.invalidate();
-    },
-    onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't redrive the message" }),
-  });
+  const redriveMessageMutation = api.ops.processRedriveDeadMessage.useMutation(
+    mutationOutcomeHandlers({
+      onSettled: invalidate,
+      applied: "Message redriven",
+      missed: "Message is no longer dead",
+      failure: "Couldn't redrive the message",
+    }),
+  );
 
-  const discardMessageMutation = api.ops.processDiscardDeadMessage.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: data.discarded
-          ? "Message discarded"
-          : "Message is no longer dead",
-        type: data.discarded ? "success" : "error",
-      });
-      void utils.ops.invalidate();
-    },
-    onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't discard the message" }),
-  });
+  const discardMessageMutation = api.ops.processDiscardDeadMessage.useMutation(
+    mutationOutcomeHandlers({
+      onSettled: invalidate,
+      applied: "Message discarded",
+      missed: "Message is no longer dead",
+      failure: "Couldn't discard the message",
+    }),
+  );
 
-  const releaseLeaseMutation = api.ops.processReleaseLapsedLease.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: data.released
-          ? "Lease released — message due now"
-          : "Lease is no longer lapsed",
-        type: data.released ? "success" : "error",
-      });
-      void utils.ops.invalidate();
-    },
-    onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't release the lease" }),
-  });
+  const releaseLeaseMutation = api.ops.processReleaseLapsedLease.useMutation(
+    mutationOutcomeHandlers({
+      onSettled: invalidate,
+      applied: "Lease released — message due now",
+      missed: "Lease is no longer lapsed",
+      failure: "Couldn't release the lease",
+    }),
+  );
 
   return {
     confirmAction,

--- a/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
+++ b/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
@@ -62,7 +62,10 @@ function useMessageActions(onSettled: () => void) {
    * way back — no redrive path selects a discarded row — so it asks first,
    * while redrive and release-lease stay one click (both are recoverable).
    */
-  const [discardTarget, setDiscardTarget] = useState<string | null>(null);
+  const [discardTarget, setDiscardTarget] = useState<{
+    id: string;
+    intentType: string;
+  } | null>(null);
 
   const redriveMessageMutation = api.ops.processRedriveDeadMessage.useMutation(
     mutationOutcomeHandlers({

--- a/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
+++ b/platform/app/src/components/ops/processes/instanceDrawer/useProcessInstanceActions.ts
@@ -63,6 +63,20 @@ export function useProcessInstanceActions() {
       showErrorToast({ error, fallbackTitle: "Couldn't redrive the message" }),
   });
 
+  const discardMessageMutation = api.ops.processDiscardDeadMessage.useMutation({
+    onSuccess: (data) => {
+      toaster.create({
+        title: data.discarded
+          ? "Message discarded"
+          : "Message is no longer dead",
+        type: data.discarded ? "success" : "error",
+      });
+      void utils.ops.invalidate();
+    },
+    onError: (error) =>
+      showErrorToast({ error, fallbackTitle: "Couldn't discard the message" }),
+  });
+
   const releaseLeaseMutation = api.ops.processReleaseLapsedLease.useMutation({
     onSuccess: (data) => {
       toaster.create({
@@ -83,6 +97,7 @@ export function useProcessInstanceActions() {
     wakeMutation,
     redriveInstanceMutation,
     redriveMessageMutation,
+    discardMessageMutation,
     releaseLeaseMutation,
   };
 }

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -13,10 +13,9 @@ import { useMemo, useRef, useState } from "react";
 import { ConfirmDialog } from "~/components/ops/shared/ConfirmDialog";
 import { VirtualizedTableRows } from "~/components/ops/shared/VirtualizedTableRows";
 import { Link } from "~/components/ui/link";
-import { toaster } from "~/components/ui/toaster";
-import { showErrorToast } from "~/features/errors";
 import { useOpsPermission } from "~/hooks/useOpsPermission";
 import { api } from "~/utils/api";
+import { type PendingDlqAction, useDlqActions } from "./useDlqActions";
 
 const DLQ_VIEWPORT_HEIGHT = 360;
 const DLQ_ROW_HEIGHT = 36;
@@ -68,18 +67,198 @@ function ProcessOutboxDeadRow({
   );
 }
 
-/** What a pending bulk or single act covers — named fully in the confirm. */
-interface PendingDlqAction {
-  kind: "redrive" | "discard";
+/** One shown DLQ group, as the card reads it. */
+type ShownDlqGroup = {
   queueName: string;
   queueDisplayName: string;
-  groupIds: string[];
+  groupId: string;
+};
+
+/** Everything one table row renders. */
+type DlqRowGroup = ShownDlqGroup & {
+  pipelineName: string | null;
+  error: string | null;
+  jobCount: number;
+};
+
+/**
+ * Narrow the list to what the operator typed — group id, pipeline, or error,
+ * matched case-insensitively. What this returns IS what the bulk actions act
+ * on, so the confirmation and the act cover the same groups.
+ */
+function filterDlqGroups<T extends DlqRowGroup>(groups: T[], filter: string) {
+  const needle = filter.trim().toLowerCase();
+  if (!needle) return groups;
+  return groups.filter(
+    (g) =>
+      g.groupId.toLowerCase().includes(needle) ||
+      (g.pipelineName ?? "").toLowerCase().includes(needle) ||
+      (g.error ?? "").toLowerCase().includes(needle),
+  );
+}
+
+/** The pending act for a whole queue's shown groups. */
+function bulkActionFor(
+  kind: "redrive" | "discard",
+  queueName: string,
+  shownGroups: ShownDlqGroup[],
+): PendingDlqAction {
+  const inQueue = shownGroups.filter((g) => g.queueName === queueName);
+  return {
+    kind,
+    queueName,
+    queueDisplayName: inQueue[0]?.queueDisplayName ?? queueName,
+    groupIds: inQueue.map((g) => g.groupId),
+  };
+}
+
+/**
+ * The manage-gated controls: per-queue bulk acts over the SHOWN groups, and
+ * the canary. Counts come from the filtered set, so each button states the
+ * blast radius it will actually apply.
+ */
+function DlqToolbar({
+  queueNames,
+  shownGroups,
+  canaryCount,
+  onCanaryCountChange,
+  onBulk,
+  onCanary,
+}: {
+  queueNames: string[];
+  shownGroups: ShownDlqGroup[];
+  canaryCount: number;
+  onCanaryCountChange: (count: number) => void;
+  onBulk: (kind: "redrive" | "discard", queueName: string) => void;
+  onCanary: (queueName: string) => void;
+}) {
+  return (
+    <HStack gap={1.5} flexWrap="wrap">
+      {queueNames.map((qn) => {
+        const shown = shownGroups.filter((g) => g.queueName === qn);
+        const displayName = shown[0]?.queueDisplayName ?? qn;
+        return (
+          <HStack key={qn} gap={1}>
+            <Button
+              variant="outline"
+              size="2xs"
+              colorPalette="green"
+              data-testid={`dlq-redrive-shown-${qn}`}
+              onClick={() => onBulk("redrive", qn)}
+            >
+              Redrive shown {displayName} ({shown.length})
+            </Button>
+            <Button
+              variant="outline"
+              size="2xs"
+              colorPalette="red"
+              data-testid={`dlq-discard-shown-${qn}`}
+              onClick={() => onBulk("discard", qn)}
+            >
+              Discard shown ({shown.length})
+            </Button>
+          </HStack>
+        );
+      })}
+      <HStack gap={1}>
+        <Text textStyle="xs" color="fg.muted">
+          Canary:
+        </Text>
+        <Input
+          size="xs"
+          type="number"
+          value={canaryCount}
+          onChange={(e) =>
+            onCanaryCountChange(
+              Math.max(1, Math.min(100, parseInt(e.target.value) || 5)),
+            )
+          }
+          width="50px"
+        />
+        {queueNames.map((qn) => (
+          <Button
+            key={`c-${qn}`}
+            variant="ghost"
+            size="2xs"
+            onClick={() => onCanary(qn)}
+          >
+            Go
+          </Button>
+        ))}
+      </HStack>
+    </HStack>
+  );
+}
+
+/** One dead-lettered group, with its per-row recovery verbs. */
+function DlqRow({
+  group,
+  canManage,
+  onAct,
+}: {
+  group: DlqRowGroup;
+  canManage: boolean;
+  onAct: (kind: "redrive" | "discard", group: DlqRowGroup) => void;
+}) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Badge size="xs" variant="subtle">
+          {group.queueDisplayName}
+        </Badge>
+      </Table.Cell>
+      <Table.Cell>
+        <Text textStyle="xs" fontFamily="mono" truncate maxWidth="160px">
+          {group.groupId}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text textStyle="xs" color="fg.muted">
+          {group.pipelineName ?? "\u2014"}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text
+          textStyle="xs"
+          color="red.500"
+          truncate
+          maxWidth="220px"
+          title={group.error ?? undefined}
+        >
+          {group.error ?? ""}
+        </Text>
+      </Table.Cell>
+      <Table.Cell textAlign="end">
+        <Text textStyle="xs">{group.jobCount}</Text>
+      </Table.Cell>
+      {canManage && (
+        <Table.Cell>
+          <HStack gap={1}>
+            <Button
+              variant="outline"
+              size="2xs"
+              colorPalette="green"
+              onClick={() => onAct("redrive", group)}
+            >
+              Redrive
+            </Button>
+            <Button
+              variant="outline"
+              size="2xs"
+              colorPalette="red"
+              onClick={() => onAct("discard", group)}
+            >
+              Discard
+            </Button>
+          </HStack>
+        </Table.Cell>
+      )}
+    </Table.Row>
+  );
 }
 
 export function DlqCard({ queueNames }: { queueNames: string[] }) {
   const { hasAccess } = useOpsPermission();
-  const utils = api.useUtils();
-
   const dlqQuery = api.ops.listAllDlqGroups.useQuery(undefined, {
     refetchInterval: 10000,
   });
@@ -90,75 +269,18 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
   });
 
   const [filterText, setFilterText] = useState("");
-  const [pending, setPending] = useState<PendingDlqAction | null>(null);
-  const [canaryTarget, setCanaryTarget] = useState<string | null>(null);
   const [canaryCount, setCanaryCount] = useState(5);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  // Both the row action and the per-queue bulk go through the explicit-id
-  // endpoints: one verb, one audit shape, and the confirmation covers exactly
-  // the ids that were shown when the operator clicked
-  // (specs/ops/dead-letter-recovery.feature).
-  const redriveMutation = api.ops.redriveManyFromDlq.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: `Redrove ${data.redrivenCount} ${
-          data.redrivenCount === 1 ? "group" : "groups"
-        } (${data.jobsRedriven} jobs)`,
-        type: "success",
-      });
-      setPending(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't redrive the groups" }),
-  });
-  const discardMutation = api.ops.discardManyFromDlq.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: `Discarded ${data.discardedCount} ${
-          data.discardedCount === 1 ? "group" : "groups"
-        } (${data.jobsDiscarded} jobs)`,
-        type: "success",
-      });
-      setPending(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't discard the groups" }),
-  });
-  const canaryRedriveMutation = api.ops.canaryRedrive.useMutation({
-    onSuccess: (data) => {
-      toaster.create({
-        title: `Canary redrove ${data.redrivenCount}`,
-        type: "success",
-      });
-      setCanaryTarget(null);
-      void utils.ops.invalidate();
-    },
-    onError: (error) =>
-      showErrorToast({
-        error,
-        fallbackTitle: "Couldn't run the canary redrive",
-      }),
-  });
+  const actions = useDlqActions();
 
   const groups = dlqQuery.data ?? [];
-  // The filter narrows what is SHOWN, and the bulk actions act on exactly
-  // that — group id, pipeline, or error, matched case-insensitively.
-  const shownGroups = useMemo(() => {
-    const needle = filterText.trim().toLowerCase();
-    if (!needle) return groups;
-    return groups.filter(
-      (g) =>
-        g.groupId.toLowerCase().includes(needle) ||
-        (g.pipelineName ?? "").toLowerCase().includes(needle) ||
-        (g.error ?? "").toLowerCase().includes(needle),
-    );
-  }, [groups, filterText]);
-  const dlqQueueNames = [...new Set(shownGroups.map((g) => g.queueName))];
+  const shownGroups = useMemo(
+    () => filterDlqGroups(groups, filterText),
+    [groups, filterText],
+  );
   const processDead = processDeadQuery.data ?? [];
   const processDeadTotal = processDead.reduce((sum, r) => sum + r.count, 0);
+  const stillLoading = dlqQuery.isLoading || processDeadQuery.isLoading;
 
   // Two mechanisms, one heading: an operator asking "what has stopped?" should
   // not have to know that a GroupQueue job and a process-manager intent retire
@@ -168,129 +290,28 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
   // card mounts on the queue answer alone and then flips a red row in a
   // moment later, which on an ops surface reads as a new incident rather than
   // as the same page finishing loading.
-  if (
-    dlqQuery.isLoading ||
-    processDeadQuery.isLoading ||
-    (groups.length === 0 && processDeadTotal === 0)
-  ) {
+  if (stillLoading || (groups.length === 0 && processDeadTotal === 0)) {
     return null;
   }
-
-  const bulkFor = (
-    kind: "redrive" | "discard",
-    queueName: string,
-  ): PendingDlqAction => {
-    const inQueue = shownGroups.filter((g) => g.queueName === queueName);
-    return {
-      kind,
-      queueName,
-      queueDisplayName: inQueue[0]?.queueDisplayName ?? queueName,
-      groupIds: inQueue.map((g) => g.groupId),
-    };
-  };
-
-  const confirmPending = () => {
-    if (!pending) return;
-    const input = { queueName: pending.queueName, groupIds: pending.groupIds };
-    if (pending.kind === "redrive") redriveMutation.mutate(input);
-    else discardMutation.mutate(input);
-  };
 
   return (
     <>
       <Card.Root>
         <Card.Body padding={0}>
-          <HStack
-            paddingX={4}
-            paddingY={2.5}
-            borderBottom="1px solid"
-            borderBottomColor="border"
-            gap={2}
-            flexWrap="wrap"
-          >
-            {/* The card now renders for either source, so the queue heading
-                stands down when the queue itself is clean rather than
-                printing "0 groups" above a red process-outbox count. */}
-            {groups.length > 0 && (
-              <Text textStyle="sm" fontWeight="medium" color="orange.500">
-                Dead Letter Queue —{" "}
-                {filterText.trim()
-                  ? `${shownGroups.length} of ${groups.length}`
-                  : groups.length}{" "}
-                group{groups.length !== 1 ? "s" : ""}
-              </Text>
-            )}
-            {groups.length > 0 && (
-              <Input
-                size="xs"
-                width="220px"
-                placeholder="Filter by group, pipeline, or error"
-                value={filterText}
-                onChange={(e) => setFilterText(e.target.value)}
-                data-testid="dlq-filter"
-              />
-            )}
-            <Spacer />
-            {hasAccess && (
-              <HStack gap={1.5} flexWrap="wrap">
-                {dlqQueueNames.map((qn) => {
-                  const shown = shownGroups.filter((g) => g.queueName === qn);
-                  const displayName = shown[0]?.queueDisplayName ?? qn;
-                  return (
-                    <HStack key={qn} gap={1}>
-                      <Button
-                        variant="outline"
-                        size="2xs"
-                        colorPalette="green"
-                        data-testid={`dlq-redrive-shown-${qn}`}
-                        onClick={() => setPending(bulkFor("redrive", qn))}
-                      >
-                        Redrive shown {displayName} ({shown.length})
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="2xs"
-                        colorPalette="red"
-                        data-testid={`dlq-discard-shown-${qn}`}
-                        onClick={() => setPending(bulkFor("discard", qn))}
-                      >
-                        Discard shown ({shown.length})
-                      </Button>
-                    </HStack>
-                  );
-                })}
-                <HStack gap={1}>
-                  <Text textStyle="xs" color="fg.muted">
-                    Canary:
-                  </Text>
-                  <Input
-                    size="xs"
-                    type="number"
-                    value={canaryCount}
-                    onChange={(e) =>
-                      setCanaryCount(
-                        Math.max(
-                          1,
-                          Math.min(100, parseInt(e.target.value) || 5),
-                        ),
-                      )
-                    }
-                    width="50px"
-                  />
-                  {dlqQueueNames.map((qn) => (
-                    <Button
-                      key={`c-${qn}`}
-                      variant="ghost"
-                      size="2xs"
-                      onClick={() => setCanaryTarget(qn)}
-                    >
-                      Go
-                    </Button>
-                  ))}
-                </HStack>
-              </HStack>
-            )}
-          </HStack>
+          <DlqCardHeader
+            groupCount={groups.length}
+            shownCount={shownGroups.length}
+            filterText={filterText}
+            onFilterChange={setFilterText}
+            canManage={hasAccess}
+            shownGroups={shownGroups}
+            canaryCount={canaryCount}
+            onCanaryCountChange={setCanaryCount}
+            onBulk={(kind, queueName) =>
+              actions.setPending(bulkActionFor(kind, queueName, shownGroups))
+            }
+            onCanary={actions.setCanaryTarget}
+          />
 
           <ProcessOutboxDeadRow
             byProcess={processDead}
@@ -298,164 +319,210 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
             hasQueueGroups={groups.length > 0}
           />
 
-          <Box
-            ref={scrollContainerRef}
-            maxHeight={`${DLQ_VIEWPORT_HEIGHT}px`}
-            overflowY="auto"
+          <DlqTable
+            shownGroups={shownGroups}
             hidden={groups.length === 0}
-          >
-            <Table.Root
-              size="sm"
-              variant="line"
-              css={{ "& tr:last-child td": { borderBottom: "none" } }}
-            >
-              <Table.Header position="sticky" top={0} zIndex={1} bg="bg.panel">
-                <Table.Row>
-                  <Table.ColumnHeader>Queue</Table.ColumnHeader>
-                  <Table.ColumnHeader>Group ID</Table.ColumnHeader>
-                  <Table.ColumnHeader>Pipeline</Table.ColumnHeader>
-                  <Table.ColumnHeader>Error</Table.ColumnHeader>
-                  <Table.ColumnHeader textAlign="end" width="50px">
-                    Jobs
-                  </Table.ColumnHeader>
-                  {hasAccess && (
-                    <Table.ColumnHeader width="130px">
-                      Actions
-                    </Table.ColumnHeader>
-                  )}
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                <VirtualizedTableRows
-                  count={shownGroups.length}
-                  rowHeight={DLQ_ROW_HEIGHT}
-                  columnCount={hasAccess ? 6 : 5}
-                  scrollContainerRef={scrollContainerRef}
-                  getItemKey={(i) => {
-                    const g = shownGroups[i]!;
-                    return `${g.queueName}:${g.groupId}`;
-                  }}
-                  renderRow={(i) => {
-                    const group = shownGroups[i]!;
-                    return (
-                      <Table.Row key={`${group.queueName}:${group.groupId}`}>
-                        <Table.Cell>
-                          <Badge size="xs" variant="subtle">
-                            {group.queueDisplayName}
-                          </Badge>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Text
-                            textStyle="xs"
-                            fontFamily="mono"
-                            truncate
-                            maxWidth="160px"
-                          >
-                            {group.groupId}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Text textStyle="xs" color="fg.muted">
-                            {group.pipelineName ?? "—"}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Text
-                            textStyle="xs"
-                            color="red.500"
-                            truncate
-                            maxWidth="220px"
-                            title={group.error ?? undefined}
-                          >
-                            {group.error ?? ""}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell textAlign="end">
-                          <Text textStyle="xs">{group.jobCount}</Text>
-                        </Table.Cell>
-                        {hasAccess && (
-                          <Table.Cell>
-                            <HStack gap={1}>
-                              <Button
-                                variant="outline"
-                                size="2xs"
-                                colorPalette="green"
-                                onClick={() =>
-                                  setPending({
-                                    kind: "redrive",
-                                    queueName: group.queueName,
-                                    queueDisplayName: group.queueDisplayName,
-                                    groupIds: [group.groupId],
-                                  })
-                                }
-                              >
-                                Redrive
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="2xs"
-                                colorPalette="red"
-                                onClick={() =>
-                                  setPending({
-                                    kind: "discard",
-                                    queueName: group.queueName,
-                                    queueDisplayName: group.queueDisplayName,
-                                    groupIds: [group.groupId],
-                                  })
-                                }
-                              >
-                                Discard
-                              </Button>
-                            </HStack>
-                          </Table.Cell>
-                        )}
-                      </Table.Row>
-                    );
-                  }}
-                />
-              </Table.Body>
-            </Table.Root>
-          </Box>
+            canManage={hasAccess}
+            scrollContainerRef={scrollContainerRef}
+            onAct={(kind, group) =>
+              actions.setPending({
+                kind,
+                queueName: group.queueName,
+                queueDisplayName: group.queueDisplayName,
+                groupIds: [group.groupId],
+              })
+            }
+          />
         </Card.Body>
       </Card.Root>
 
+      <DlqConfirms actions={actions} canaryCount={canaryCount} />
+    </>
+  );
+}
+
+/** Heading, filter, and the manage-gated controls, on one row. */
+function DlqCardHeader({
+  groupCount,
+  shownCount,
+  filterText,
+  onFilterChange,
+  canManage,
+  shownGroups,
+  canaryCount,
+  onCanaryCountChange,
+  onBulk,
+  onCanary,
+}: {
+  groupCount: number;
+  shownCount: number;
+  filterText: string;
+  onFilterChange: (value: string) => void;
+  canManage: boolean;
+  shownGroups: DlqRowGroup[];
+  canaryCount: number;
+  onCanaryCountChange: (count: number) => void;
+  onBulk: (kind: "redrive" | "discard", queueName: string) => void;
+  onCanary: (queueName: string) => void;
+}) {
+  const filtering = filterText.trim().length > 0;
+  const queueNames = [...new Set(shownGroups.map((g) => g.queueName))];
+  return (
+    <HStack
+      paddingX={4}
+      paddingY={2.5}
+      borderBottom="1px solid"
+      borderBottomColor="border"
+      gap={2}
+      flexWrap="wrap"
+    >
+      {/* The card renders for either source, so the queue heading stands down
+          when the queue itself is clean rather than printing "0 groups" above
+          a red process-outbox count. */}
+      {groupCount > 0 && (
+        <>
+          <Text textStyle="sm" fontWeight="medium" color="orange.500">
+            Dead Letter Queue — {filtering ? `${shownCount} of ` : ""}
+            {groupCount} group{groupCount !== 1 ? "s" : ""}
+          </Text>
+          <Input
+            size="xs"
+            width="220px"
+            placeholder="Filter by group, pipeline, or error"
+            value={filterText}
+            onChange={(e) => onFilterChange(e.target.value)}
+            data-testid="dlq-filter"
+          />
+        </>
+      )}
+      <Spacer />
+      {canManage && (
+        <DlqToolbar
+          queueNames={queueNames}
+          shownGroups={shownGroups}
+          canaryCount={canaryCount}
+          onCanaryCountChange={onCanaryCountChange}
+          onBulk={onBulk}
+          onCanary={onCanary}
+        />
+      )}
+    </HStack>
+  );
+}
+
+/** The dead-lettered groups themselves, virtualized. */
+function DlqTable({
+  shownGroups,
+  hidden,
+  canManage,
+  scrollContainerRef,
+  onAct,
+}: {
+  shownGroups: DlqRowGroup[];
+  hidden: boolean;
+  canManage: boolean;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  onAct: (kind: "redrive" | "discard", group: DlqRowGroup) => void;
+}) {
+  return (
+    <Box
+      ref={scrollContainerRef}
+      maxHeight={`${DLQ_VIEWPORT_HEIGHT}px`}
+      overflowY="auto"
+      hidden={hidden}
+    >
+      <Table.Root
+        size="sm"
+        variant="line"
+        css={{ "& tr:last-child td": { borderBottom: "none" } }}
+      >
+        <Table.Header position="sticky" top={0} zIndex={1} bg="bg.panel">
+          <Table.Row>
+            <Table.ColumnHeader>Queue</Table.ColumnHeader>
+            <Table.ColumnHeader>Group ID</Table.ColumnHeader>
+            <Table.ColumnHeader>Pipeline</Table.ColumnHeader>
+            <Table.ColumnHeader>Error</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="end" width="50px">
+              Jobs
+            </Table.ColumnHeader>
+            {canManage && (
+              <Table.ColumnHeader width="130px">Actions</Table.ColumnHeader>
+            )}
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <VirtualizedTableRows
+            count={shownGroups.length}
+            rowHeight={DLQ_ROW_HEIGHT}
+            columnCount={canManage ? 6 : 5}
+            scrollContainerRef={scrollContainerRef}
+            getItemKey={(i) => {
+              const g = shownGroups[i]!;
+              return `${g.queueName}:${g.groupId}`;
+            }}
+            renderRow={(i) => (
+              <DlqRow
+                group={shownGroups[i]!}
+                canManage={canManage}
+                onAct={onAct}
+              />
+            )}
+          />
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+}
+
+/**
+ * The three confirmations, each naming its blast radius in the operator's own
+ * terms (best_practices/ops-dashboard.md): which groups, in which queue, and
+ * for a discard, that the audit trail is what survives.
+ */
+function DlqConfirms({
+  actions,
+  canaryCount,
+}: {
+  actions: ReturnType<typeof useDlqActions>;
+  canaryCount: number;
+}) {
+  const { pending, canaryTarget } = actions;
+  const one = pending?.groupIds.length === 1;
+  const target = one
+    ? `"${pending?.groupIds[0]}"`
+    : `${pending?.groupIds.length} shown groups`;
+  return (
+    <>
       <ConfirmDialog
         open={pending?.kind === "redrive"}
-        onClose={() => setPending(null)}
-        onConfirm={confirmPending}
+        onClose={() => actions.setPending(null)}
+        onConfirm={actions.confirmPending}
         title="Redrive from the dead-letter queue"
-        description={
-          pending?.groupIds.length === 1
-            ? `Return "${pending.groupIds[0]}" in "${pending.queueDisplayName}" to the main queue for reprocessing.`
-            : `Return ${pending?.groupIds.length} shown groups in "${pending?.queueDisplayName}" to the main queue for reprocessing.`
-        }
-        isLoading={redriveMutation.isPending}
+        description={`Return ${target} in "${pending?.queueDisplayName}" to the main queue for reprocessing.`}
+        isLoading={actions.redrive.isPending}
       />
       <ConfirmDialog
         open={pending?.kind === "discard"}
-        onClose={() => setPending(null)}
-        onConfirm={confirmPending}
+        onClose={() => actions.setPending(null)}
+        onConfirm={actions.confirmPending}
         title="Discard from the dead-letter queue"
-        description={
-          pending?.groupIds.length === 1
-            ? `Mark "${pending.groupIds[0]}" in "${pending.queueDisplayName}" as never to be run. The act is recorded in the audit trail with the group's last error; the jobs will not run.`
-            : `Mark ${pending?.groupIds.length} shown groups in "${pending?.queueDisplayName}" as never to be run. The act is recorded in the audit trail with each group's last error; the jobs will not run.`
-        }
-        isLoading={discardMutation.isPending}
+        description={`Mark ${target} in "${pending?.queueDisplayName}" as never to be run. The act is recorded in the audit trail with the last error; the jobs will not run.`}
+        isLoading={actions.discard.isPending}
       />
       <ConfirmDialog
         open={!!canaryTarget}
-        onClose={() => setCanaryTarget(null)}
+        onClose={() => actions.setCanaryTarget(null)}
         onConfirm={() => {
-          if (canaryTarget)
-            canaryRedriveMutation.mutate({
+          if (canaryTarget) {
+            actions.canaryRedrive.mutate({
               queueName: canaryTarget,
               count: canaryCount,
             });
+          }
         }}
         title="Canary Redrive"
         description={`Redrive ${canaryCount} random dead-letter groups from "${canaryTarget}" as a canary.`}
-        isLoading={canaryRedriveMutation.isPending}
+        isLoading={actions.canaryRedrive.isPending}
       />
     </>
   );

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -189,6 +189,9 @@ function DlqToolbar({
             key={`c-${qn}`}
             variant="ghost"
             size="2xs"
+            // Every one of these reads "Go", so the queue has to come from the
+            // accessible name or a screen reader hears the same button twice.
+            aria-label={`Canary redrive from ${qn}`}
             onClick={() => onCanary(qn)}
           >
             Go

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -9,7 +9,7 @@ import {
   Table,
   Text,
 } from "@chakra-ui/react";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { ConfirmDialog } from "~/components/ops/shared/ConfirmDialog";
 import { VirtualizedTableRows } from "~/components/ops/shared/VirtualizedTableRows";
 import { Link } from "~/components/ui/link";
@@ -68,6 +68,14 @@ function ProcessOutboxDeadRow({
   );
 }
 
+/** What a pending bulk or single act covers — named fully in the confirm. */
+interface PendingDlqAction {
+  kind: "redrive" | "discard";
+  queueName: string;
+  queueDisplayName: string;
+  groupIds: string[];
+}
+
 export function DlqCard({ queueNames }: { queueNames: string[] }) {
   const { hasAccess } = useOpsPermission();
   const utils = api.useUtils();
@@ -81,38 +89,43 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
     refetchInterval: 30_000,
   });
 
-  const [replayTarget, setReplayTarget] = useState<{
-    queueName: string;
-    groupId: string;
-  } | null>(null);
-  const [replayAllTarget, setReplayAllTarget] = useState<string | null>(null);
+  const [filterText, setFilterText] = useState("");
+  const [pending, setPending] = useState<PendingDlqAction | null>(null);
   const [canaryTarget, setCanaryTarget] = useState<string | null>(null);
   const [canaryCount, setCanaryCount] = useState(5);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  const replayMutation = api.ops.replayFromDlq.useMutation({
+  // Both the row action and the per-queue bulk go through the explicit-id
+  // endpoints: one verb, one audit shape, and the confirmation covers exactly
+  // the ids that were shown when the operator clicked
+  // (specs/ops/dead-letter-recovery.feature).
+  const redriveMutation = api.ops.redriveManyFromDlq.useMutation({
     onSuccess: (data) => {
       toaster.create({
-        title: `Replayed ${data.jobsReplayed} jobs`,
+        title: `Redrove ${data.redrivenCount} ${
+          data.redrivenCount === 1 ? "group" : "groups"
+        } (${data.jobsRedriven} jobs)`,
         type: "success",
       });
-      setReplayTarget(null);
+      setPending(null);
       void utils.ops.invalidate();
     },
     onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't replay the group" }),
+      showErrorToast({ error, fallbackTitle: "Couldn't redrive the groups" }),
   });
-  const replayAllMutation = api.ops.replayAllFromDlq.useMutation({
+  const discardMutation = api.ops.discardManyFromDlq.useMutation({
     onSuccess: (data) => {
       toaster.create({
-        title: `Replayed ${data.replayedCount} groups`,
+        title: `Discarded ${data.discardedCount} ${
+          data.discardedCount === 1 ? "group" : "groups"
+        } (${data.jobsDiscarded} jobs)`,
         type: "success",
       });
-      setReplayAllTarget(null);
+      setPending(null);
       void utils.ops.invalidate();
     },
     onError: (error) =>
-      showErrorToast({ error, fallbackTitle: "Couldn't replay the groups" }),
+      showErrorToast({ error, fallbackTitle: "Couldn't discard the groups" }),
   });
   const canaryRedriveMutation = api.ops.canaryRedrive.useMutation({
     onSuccess: (data) => {
@@ -131,7 +144,19 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
   });
 
   const groups = dlqQuery.data ?? [];
-  const dlqQueueNames = [...new Set(groups.map((g) => g.queueName))];
+  // The filter narrows what is SHOWN, and the bulk actions act on exactly
+  // that — group id, pipeline, or error, matched case-insensitively.
+  const shownGroups = useMemo(() => {
+    const needle = filterText.trim().toLowerCase();
+    if (!needle) return groups;
+    return groups.filter(
+      (g) =>
+        g.groupId.toLowerCase().includes(needle) ||
+        (g.pipelineName ?? "").toLowerCase().includes(needle) ||
+        (g.error ?? "").toLowerCase().includes(needle),
+    );
+  }, [groups, filterText]);
+  const dlqQueueNames = [...new Set(shownGroups.map((g) => g.queueName))];
   const processDead = processDeadQuery.data ?? [];
   const processDeadTotal = processDead.reduce((sum, r) => sum + r.count, 0);
 
@@ -151,6 +176,26 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
     return null;
   }
 
+  const bulkFor = (
+    kind: "redrive" | "discard",
+    queueName: string,
+  ): PendingDlqAction => {
+    const inQueue = shownGroups.filter((g) => g.queueName === queueName);
+    return {
+      kind,
+      queueName,
+      queueDisplayName: inQueue[0]?.queueDisplayName ?? queueName,
+      groupIds: inQueue.map((g) => g.groupId),
+    };
+  };
+
+  const confirmPending = () => {
+    if (!pending) return;
+    const input = { queueName: pending.queueName, groupIds: pending.groupIds };
+    if (pending.kind === "redrive") redriveMutation.mutate(input);
+    else discardMutation.mutate(input);
+  };
+
   return (
     <>
       <Card.Root>
@@ -168,28 +213,50 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
                 printing "0 groups" above a red process-outbox count. */}
             {groups.length > 0 && (
               <Text textStyle="sm" fontWeight="medium" color="orange.500">
-                Dead Letter Queue — {groups.length} group
-                {groups.length !== 1 ? "s" : ""}
+                Dead Letter Queue —{" "}
+                {filterText.trim()
+                  ? `${shownGroups.length} of ${groups.length}`
+                  : groups.length}{" "}
+                group{groups.length !== 1 ? "s" : ""}
               </Text>
+            )}
+            {groups.length > 0 && (
+              <Input
+                size="xs"
+                width="220px"
+                placeholder="Filter by group, pipeline, or error"
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                data-testid="dlq-filter"
+              />
             )}
             <Spacer />
             {hasAccess && (
               <HStack gap={1.5} flexWrap="wrap">
                 {dlqQueueNames.map((qn) => {
-                  const count = groups.filter((g) => g.queueName === qn).length;
-                  const displayName =
-                    groups.find((g) => g.queueName === qn)?.queueDisplayName ??
-                    qn;
+                  const shown = shownGroups.filter((g) => g.queueName === qn);
+                  const displayName = shown[0]?.queueDisplayName ?? qn;
                   return (
-                    <Button
-                      key={qn}
-                      variant="outline"
-                      size="2xs"
-                      colorPalette="green"
-                      onClick={() => setReplayAllTarget(qn)}
-                    >
-                      Replay All {displayName} ({count})
-                    </Button>
+                    <HStack key={qn} gap={1}>
+                      <Button
+                        variant="outline"
+                        size="2xs"
+                        colorPalette="green"
+                        data-testid={`dlq-redrive-shown-${qn}`}
+                        onClick={() => setPending(bulkFor("redrive", qn))}
+                      >
+                        Redrive shown {displayName} ({shown.length})
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="2xs"
+                        colorPalette="red"
+                        data-testid={`dlq-discard-shown-${qn}`}
+                        onClick={() => setPending(bulkFor("discard", qn))}
+                      >
+                        Discard shown ({shown.length})
+                      </Button>
+                    </HStack>
                   );
                 })}
                 <HStack gap={1}>
@@ -252,7 +319,7 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
                     Jobs
                   </Table.ColumnHeader>
                   {hasAccess && (
-                    <Table.ColumnHeader width="70px">
+                    <Table.ColumnHeader width="130px">
                       Actions
                     </Table.ColumnHeader>
                   )}
@@ -260,16 +327,16 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
               </Table.Header>
               <Table.Body>
                 <VirtualizedTableRows
-                  count={groups.length}
+                  count={shownGroups.length}
                   rowHeight={DLQ_ROW_HEIGHT}
                   columnCount={hasAccess ? 6 : 5}
                   scrollContainerRef={scrollContainerRef}
                   getItemKey={(i) => {
-                    const g = groups[i]!;
+                    const g = shownGroups[i]!;
                     return `${g.queueName}:${g.groupId}`;
                   }}
                   renderRow={(i) => {
-                    const group = groups[i]!;
+                    const group = shownGroups[i]!;
                     return (
                       <Table.Row key={`${group.queueName}:${group.groupId}`}>
                         <Table.Cell>
@@ -308,19 +375,38 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
                         </Table.Cell>
                         {hasAccess && (
                           <Table.Cell>
-                            <Button
-                              variant="outline"
-                              size="2xs"
-                              colorPalette="green"
-                              onClick={() =>
-                                setReplayTarget({
-                                  queueName: group.queueName,
-                                  groupId: group.groupId,
-                                })
-                              }
-                            >
-                              Replay
-                            </Button>
+                            <HStack gap={1}>
+                              <Button
+                                variant="outline"
+                                size="2xs"
+                                colorPalette="green"
+                                onClick={() =>
+                                  setPending({
+                                    kind: "redrive",
+                                    queueName: group.queueName,
+                                    queueDisplayName: group.queueDisplayName,
+                                    groupIds: [group.groupId],
+                                  })
+                                }
+                              >
+                                Redrive
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="2xs"
+                                colorPalette="red"
+                                onClick={() =>
+                                  setPending({
+                                    kind: "discard",
+                                    queueName: group.queueName,
+                                    queueDisplayName: group.queueDisplayName,
+                                    groupIds: [group.groupId],
+                                  })
+                                }
+                              >
+                                Discard
+                              </Button>
+                            </HStack>
                           </Table.Cell>
                         )}
                       </Table.Row>
@@ -334,25 +420,28 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
       </Card.Root>
 
       <ConfirmDialog
-        open={!!replayTarget}
-        onClose={() => setReplayTarget(null)}
-        onConfirm={() => {
-          if (replayTarget) replayMutation.mutate(replayTarget);
-        }}
-        title="Replay from DLQ"
-        description={`Move "${replayTarget?.groupId}" back to main queue for reprocessing.`}
-        isLoading={replayMutation.isPending}
+        open={pending?.kind === "redrive"}
+        onClose={() => setPending(null)}
+        onConfirm={confirmPending}
+        title="Redrive from the dead-letter queue"
+        description={
+          pending?.groupIds.length === 1
+            ? `Return "${pending.groupIds[0]}" in "${pending.queueDisplayName}" to the main queue for reprocessing.`
+            : `Return ${pending?.groupIds.length} shown groups in "${pending?.queueDisplayName}" to the main queue for reprocessing.`
+        }
+        isLoading={redriveMutation.isPending}
       />
       <ConfirmDialog
-        open={!!replayAllTarget}
-        onClose={() => setReplayAllTarget(null)}
-        onConfirm={() => {
-          if (replayAllTarget)
-            replayAllMutation.mutate({ queueName: replayAllTarget });
-        }}
-        title="Replay All from DLQ"
-        description={`Move all DLQ groups in "${replayAllTarget}" back to main queue.`}
-        isLoading={replayAllMutation.isPending}
+        open={pending?.kind === "discard"}
+        onClose={() => setPending(null)}
+        onConfirm={confirmPending}
+        title="Discard from the dead-letter queue"
+        description={
+          pending?.groupIds.length === 1
+            ? `Mark "${pending.groupIds[0]}" in "${pending.queueDisplayName}" as never to be run. The act is recorded in the audit trail with the group's last error; the jobs will not run.`
+            : `Mark ${pending?.groupIds.length} shown groups in "${pending?.queueDisplayName}" as never to be run. The act is recorded in the audit trail with each group's last error; the jobs will not run.`
+        }
+        isLoading={discardMutation.isPending}
       />
       <ConfirmDialog
         open={!!canaryTarget}
@@ -365,7 +454,7 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
             });
         }}
         title="Canary Redrive"
-        description={`Replay ${canaryCount} random DLQ groups from "${canaryTarget}" as canary.`}
+        description={`Redrive ${canaryCount} random dead-letter groups from "${canaryTarget}" as a canary.`}
         isLoading={canaryRedriveMutation.isPending}
       />
     </>

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -98,11 +98,15 @@ function filterDlqGroups<T extends DlqRowGroup>(groups: T[], filter: string) {
 }
 
 /** The pending act for a whole queue's shown groups. */
-function bulkActionFor(
-  kind: "redrive" | "discard",
-  queueName: string,
-  shownGroups: ShownDlqGroup[],
-): PendingDlqAction {
+function bulkActionFor({
+  kind,
+  queueName,
+  shownGroups,
+}: {
+  kind: "redrive" | "discard";
+  queueName: string;
+  shownGroups: ShownDlqGroup[];
+}): PendingDlqAction {
   const inQueue = shownGroups.filter((g) => g.queueName === queueName);
   return {
     kind,
@@ -314,7 +318,9 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
             canaryCount={canaryCount}
             onCanaryCountChange={setCanaryCount}
             onBulk={(kind, queueName) =>
-              actions.setPending(bulkActionFor(kind, queueName, shownGroups))
+              actions.setPending(
+                bulkActionFor({ kind, queueName, shownGroups }),
+              )
             }
             onCanary={actions.setCanaryTarget}
           />
@@ -373,7 +379,7 @@ function DlqCardHeader({
   onBulk: (kind: "redrive" | "discard", queueName: string) => void;
   onCanary: (queueName: string) => void;
 }) {
-  const filtering = filterText.trim().length > 0;
+  const isFiltering = filterText.trim().length > 0;
   const shownQueueNames = [...new Set(shownGroups.map((g) => g.queueName))];
   const allQueueNames = [...new Set(allGroups.map((g) => g.queueName))];
   return (
@@ -391,7 +397,7 @@ function DlqCardHeader({
       {groupCount > 0 && (
         <>
           <Text textStyle="sm" fontWeight="medium" color="orange.500">
-            Dead Letter Queue — {filtering ? `${shownCount} of ` : ""}
+            Dead Letter Queue — {isFiltering ? `${shownCount} of ` : ""}
             {groupCount} group{groupCount !== 1 ? "s" : ""}
           </Text>
           <Input

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -292,7 +292,7 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
   );
   const processDead = processDeadQuery.data ?? [];
   const processDeadTotal = processDead.reduce((sum, r) => sum + r.count, 0);
-  const stillLoading = dlqQuery.isLoading || processDeadQuery.isLoading;
+  const isStillLoading = dlqQuery.isLoading || processDeadQuery.isLoading;
 
   // Two mechanisms, one heading: an operator asking "what has stopped?" should
   // not have to know that a GroupQueue job and a process-manager intent retire
@@ -302,7 +302,7 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
   // card mounts on the queue answer alone and then flips a red row in a
   // moment later, which on an ops surface reads as a new incident rather than
   // as the same page finishing loading.
-  if (stillLoading || (groups.length === 0 && processDeadTotal === 0)) {
+  if (isStillLoading || (groups.length === 0 && processDeadTotal === 0)) {
     return null;
   }
 
@@ -506,8 +506,8 @@ function DlqConfirms({
   canaryCount: number;
 }) {
   const { pending, canaryTarget } = actions;
-  const one = pending?.groupIds.length === 1;
-  const target = one
+  const isSingleGroup = pending?.groupIds.length === 1;
+  const target = isSingleGroup
     ? `"${pending?.groupIds[0]}"`
     : `${pending?.groupIds.length} shown groups`;
   return (

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -191,7 +191,7 @@ function DlqToolbar({
 }
 
 /** One dead-lettered group, with its per-row recovery verbs. */
-function DlqRow({
+export function DlqRow({
   group,
   canManage,
   onAct,

--- a/platform/app/src/components/ops/queues/DlqCard.tsx
+++ b/platform/app/src/components/ops/queues/DlqCard.tsx
@@ -118,14 +118,19 @@ function bulkActionFor(
  * blast radius it will actually apply.
  */
 function DlqToolbar({
-  queueNames,
+  shownQueueNames,
+  allQueueNames,
   shownGroups,
   canaryCount,
   onCanaryCountChange,
   onBulk,
   onCanary,
 }: {
-  queueNames: string[];
+  /** Queues with rows in the current filter — what the bulk acts cover. */
+  shownQueueNames: string[];
+  /** Every queue holding dead letters. The canary samples a QUEUE, not the
+   *  filtered rows, so a filter matching nothing must not take it away. */
+  allQueueNames: string[];
   shownGroups: ShownDlqGroup[];
   canaryCount: number;
   onCanaryCountChange: (count: number) => void;
@@ -134,7 +139,7 @@ function DlqToolbar({
 }) {
   return (
     <HStack gap={1.5} flexWrap="wrap">
-      {queueNames.map((qn) => {
+      {shownQueueNames.map((qn) => {
         const shown = shownGroups.filter((g) => g.queueName === qn);
         const displayName = shown[0]?.queueDisplayName ?? qn;
         return (
@@ -175,7 +180,7 @@ function DlqToolbar({
           }
           width="50px"
         />
-        {queueNames.map((qn) => (
+        {allQueueNames.map((qn) => (
           <Button
             key={`c-${qn}`}
             variant="ghost"
@@ -305,6 +310,7 @@ export function DlqCard({ queueNames }: { queueNames: string[] }) {
             onFilterChange={setFilterText}
             canManage={hasAccess}
             shownGroups={shownGroups}
+            allGroups={groups}
             canaryCount={canaryCount}
             onCanaryCountChange={setCanaryCount}
             onBulk={(kind, queueName) =>
@@ -349,6 +355,7 @@ function DlqCardHeader({
   onFilterChange,
   canManage,
   shownGroups,
+  allGroups,
   canaryCount,
   onCanaryCountChange,
   onBulk,
@@ -360,13 +367,15 @@ function DlqCardHeader({
   onFilterChange: (value: string) => void;
   canManage: boolean;
   shownGroups: DlqRowGroup[];
+  allGroups: DlqRowGroup[];
   canaryCount: number;
   onCanaryCountChange: (count: number) => void;
   onBulk: (kind: "redrive" | "discard", queueName: string) => void;
   onCanary: (queueName: string) => void;
 }) {
   const filtering = filterText.trim().length > 0;
-  const queueNames = [...new Set(shownGroups.map((g) => g.queueName))];
+  const shownQueueNames = [...new Set(shownGroups.map((g) => g.queueName))];
+  const allQueueNames = [...new Set(allGroups.map((g) => g.queueName))];
   return (
     <HStack
       paddingX={4}
@@ -398,7 +407,8 @@ function DlqCardHeader({
       <Spacer />
       {canManage && (
         <DlqToolbar
-          queueNames={queueNames}
+          shownQueueNames={shownQueueNames}
+          allQueueNames={allQueueNames}
           shownGroups={shownGroups}
           canaryCount={canaryCount}
           onCanaryCountChange={onCanaryCountChange}

--- a/platform/app/src/components/ops/queues/useDlqActions.ts
+++ b/platform/app/src/components/ops/queues/useDlqActions.ts
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { countOutcomeHandlers } from "~/components/ops/shared/mutationOutcome";
+import { api } from "~/utils/api";
+
+/** What a pending bulk or single act covers — named fully in the confirm. */
+export interface PendingDlqAction {
+  kind: "redrive" | "discard";
+  queueName: string;
+  queueDisplayName: string;
+  groupIds: string[];
+}
+
+const plural = (count: number) => (count === 1 ? "group" : "groups");
+
+/**
+ * The DLQ card's recovery mutations (specs/ops/dead-letter-recovery.feature).
+ *
+ * Both the row action and the per-queue bulk go through the explicit-id
+ * endpoints: one verb, one audit shape, and the confirmation covers exactly
+ * the ids that were shown when the operator clicked.
+ */
+export function useDlqActions() {
+  const utils = api.useUtils();
+  const [pending, setPending] = useState<PendingDlqAction | null>(null);
+  const [canaryTarget, setCanaryTarget] = useState<string | null>(null);
+
+  const settle = () => {
+    setPending(null);
+    setCanaryTarget(null);
+    void utils.ops.invalidate();
+  };
+
+  const redrive = api.ops.redriveManyFromDlq.useMutation(
+    countOutcomeHandlers({
+      onSettled: settle,
+      title: (n) => `Redrove ${n} ${plural(n)}`,
+      failure: "Couldn't redrive the groups",
+    }),
+  );
+  const discard = api.ops.discardManyFromDlq.useMutation(
+    countOutcomeHandlers({
+      onSettled: settle,
+      title: (n) => `Discarded ${n} ${plural(n)}`,
+      failure: "Couldn't discard the groups",
+    }),
+  );
+  const canaryRedrive = api.ops.canaryRedrive.useMutation(
+    countOutcomeHandlers({
+      onSettled: settle,
+      title: (n) => `Canary redrove ${n} ${plural(n)}`,
+      failure: "Couldn't run the canary redrive",
+    }),
+  );
+
+  return {
+    pending,
+    setPending,
+    canaryTarget,
+    setCanaryTarget,
+    redrive,
+    discard,
+    canaryRedrive,
+    confirmPending: () => {
+      if (!pending) return;
+      const input = {
+        queueName: pending.queueName,
+        groupIds: pending.groupIds,
+      };
+      if (pending.kind === "redrive") redrive.mutate(input);
+      else discard.mutate(input);
+    },
+  };
+}

--- a/platform/app/src/components/ops/shared/mutationOutcome.ts
+++ b/platform/app/src/components/ops/shared/mutationOutcome.ts
@@ -8,6 +8,10 @@ import { showErrorToast } from "~/features/errors";
  * moved on under the operator — a message that was redriven by someone else a
  * second earlier is not an error, it is a different outcome — so each one
  * needs three strings: it worked, it no longer applied, it failed.
+ *
+ * `onSettled` runs on BOTH paths. It is what clears the caller's pending
+ * state, and a failure that left the row spinning forever would be worse than
+ * the failure itself.
  */
 export function mutationOutcomeHandlers({
   onSettled,
@@ -27,10 +31,10 @@ export function mutationOutcomeHandlers({
         title: ok ? applied : missed,
         type: ok ? ("success" as const) : ("error" as const),
       });
-      onSettled();
     },
     onError: (error: unknown) =>
       showErrorToast({ error, fallbackTitle: failure }),
+    onSettled,
   };
 }
 
@@ -54,9 +58,9 @@ export function countOutcomeHandlers({
         (value): value is number => typeof value === "number",
       );
       toaster.create({ title: title(count ?? 0), type: "success" as const });
-      onSettled();
     },
     onError: (error: unknown) =>
       showErrorToast({ error, fallbackTitle: failure }),
+    onSettled,
   };
 }

--- a/platform/app/src/components/ops/shared/mutationOutcome.ts
+++ b/platform/app/src/components/ops/shared/mutationOutcome.ts
@@ -26,10 +26,10 @@ export function mutationOutcomeHandlers({
 }) {
   return {
     onSuccess: (data: Record<string, unknown>) => {
-      const ok = Object.values(data).some((value) => value === true);
+      const isApplied = Object.values(data).some((value) => value === true);
       toaster.create({
-        title: ok ? applied : missed,
-        type: ok ? ("success" as const) : ("error" as const),
+        title: isApplied ? applied : missed,
+        type: isApplied ? ("success" as const) : ("error" as const),
       });
     },
     onError: (error: unknown) =>

--- a/platform/app/src/components/ops/shared/mutationOutcome.ts
+++ b/platform/app/src/components/ops/shared/mutationOutcome.ts
@@ -1,0 +1,62 @@
+import { toaster } from "~/components/ui/toaster";
+import { showErrorToast } from "~/features/errors";
+
+/**
+ * The handler shape every ops recovery mutation shares.
+ *
+ * These endpoints answer with a boolean rather than throwing when the row
+ * moved on under the operator — a message that was redriven by someone else a
+ * second earlier is not an error, it is a different outcome — so each one
+ * needs three strings: it worked, it no longer applied, it failed.
+ */
+export function mutationOutcomeHandlers({
+  onSettled,
+  applied,
+  missed,
+  failure,
+}: {
+  onSettled: () => void;
+  applied: string;
+  missed: string;
+  failure: string;
+}) {
+  return {
+    onSuccess: (data: Record<string, unknown>) => {
+      const ok = Object.values(data).some((value) => value === true);
+      toaster.create({
+        title: ok ? applied : missed,
+        type: ok ? ("success" as const) : ("error" as const),
+      });
+      onSettled();
+    },
+    onError: (error: unknown) =>
+      showErrorToast({ error, fallbackTitle: failure }),
+  };
+}
+
+/**
+ * The same, for a mutation that returns a COUNT rather than a boolean: bulk
+ * acts report how much moved, and zero is a legitimate answer worth saying
+ * out loud.
+ */
+export function countOutcomeHandlers({
+  onSettled,
+  title,
+  failure,
+}: {
+  onSettled: () => void;
+  title: (count: number) => string;
+  failure: string;
+}) {
+  return {
+    onSuccess: (data: Record<string, unknown>) => {
+      const count = Object.values(data).find(
+        (value): value is number => typeof value === "number",
+      );
+      toaster.create({ title: title(count ?? 0), type: "success" as const });
+      onSettled();
+    },
+    onError: (error: unknown) =>
+      showErrorToast({ error, fallbackTitle: failure }),
+  };
+}

--- a/platform/app/src/server/api/routers/ops.ts
+++ b/platform/app/src/server/api/routers/ops.ts
@@ -669,6 +669,72 @@ export const opsRouter = createTRPCRouter({
       });
     }),
 
+  /** Mark one dead message never-to-be-sent — a mark, not a delete. */
+  processDiscardDeadMessage: protectedProcedure
+    .use(opsManagePermission)
+    .input(
+      z.object({
+        processName: z.string().min(1).max(200),
+        projectId: z.string().min(1).max(200),
+        processKey: z.string().min(1).max(500),
+        messageId: z.string().min(1).max(64),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { messageId, ...ref } = input;
+      return requireOps().managerExplorer.discardDeadMessage({
+        ref,
+        messageId,
+        actorUserId: ctx.session.user.id,
+      });
+    }),
+
+  /**
+   * Every dead letter back to pending — one process, or the fleet when
+   * `processName` is omitted (specs/ops/dead-letter-recovery.feature).
+   */
+  redriveDeadLetters: protectedProcedure
+    .use(opsManagePermission)
+    .input(
+      z.object({
+        processName: z.string().min(1).max(200).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return requireOps().managerExplorer.redriveDeadLetters({
+        ...input,
+        actorUserId: ctx.session.user.id,
+      });
+    }),
+
+  /** Every dead letter marked discarded; same scoping. */
+  discardDeadLetters: protectedProcedure
+    .use(opsManagePermission)
+    .input(
+      z.object({
+        processName: z.string().min(1).max(200).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return requireOps().managerExplorer.discardDeadLetters({
+        ...input,
+        actorUserId: ctx.session.user.id,
+      });
+    }),
+
+  /** The message's failed attempts, oldest first — why a dead letter died. */
+  listOutboxAttempts: protectedProcedure
+    .use(opsViewPermission)
+    .input(
+      z.object({
+        outboxId: z.string().min(1).max(64),
+        projectId: z.string().min(1).max(200),
+      }),
+    )
+    .query(async ({ input }) => {
+      return requireOps().managerExplorer.getOutboxAttempts(input);
+    }),
+
   processReleaseLapsedLease: protectedProcedure
     .use(opsManagePermission)
     .input(
@@ -900,6 +966,45 @@ export const opsRouter = createTRPCRouter({
     .mutation(async ({ input }) => {
       const ops = requireOps();
       return ops.queues.replayAllFromDlq(input);
+    }),
+
+  /**
+   * Redrive exactly the DLQ groups the operator's filter showed
+   * (specs/ops/dead-letter-recovery.feature) — explicit ids, so the
+   * confirmation and the act cover the same groups.
+   */
+  redriveManyFromDlq: protectedProcedure
+    .use(opsManagePermission)
+    .input(
+      z.object({
+        queueName: z.string(),
+        groupIds: z.array(z.string().min(1).max(500)).min(1).max(2000),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return requireOps().queues.redriveManyFromDlq({
+        ...input,
+        requestedBy: ctx.session.user.id,
+      });
+    }),
+
+  /**
+   * Discard exactly the shown DLQ groups: their jobs never run again. The
+   * audit row is the retained mark — the Redis entries expire regardless.
+   */
+  discardManyFromDlq: protectedProcedure
+    .use(opsManagePermission)
+    .input(
+      z.object({
+        queueName: z.string(),
+        groupIds: z.array(z.string().min(1).max(500)).min(1).max(2000),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return requireOps().queues.discardManyFromDlq({
+        ...input,
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   canaryRedrive: protectedProcedure

--- a/platform/app/src/server/api/routers/ops.ts
+++ b/platform/app/src/server/api/routers/ops.ts
@@ -707,17 +707,32 @@ export const opsRouter = createTRPCRouter({
       });
     }),
 
-  /** Every dead letter marked discarded; same scoping. */
+  /**
+   * Every dead letter marked discarded; same scoping as the redrive.
+   *
+   * The fleet-wide form — no `processName` — crosses every tenant and cannot
+   * be undone, since no redrive path selects a discarded row. It therefore
+   * takes a typed confirmation, the same shape the blob-store delete uses:
+   * the destructive breadth has to be reached deliberately, not by omitting
+   * a field (best_practices/ops-dashboard.md).
+   */
   discardDeadLetters: protectedProcedure
     .use(opsManagePermission)
     .input(
-      z.object({
-        processName: z.string().min(1).max(200).optional(),
-      }),
+      z
+        .object({
+          processName: z.string().min(1).max(200).optional(),
+          confirm: z.literal("DISCARD ALL").optional(),
+        })
+        .refine((input) => !!input.processName || input.confirm !== undefined, {
+          message:
+            "Discarding every process's dead letters requires an explicit confirmation",
+          path: ["confirm"],
+        }),
     )
     .mutation(async ({ ctx, input }) => {
       return requireOps().managerExplorer.discardDeadLetters({
-        ...input,
+        ...(input.processName ? { processName: input.processName } : {}),
         actorUserId: ctx.session.user.id,
       });
     }),

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts
@@ -1,0 +1,115 @@
+import type { Redis } from "ioredis";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { QueueRedisRepository } from "../../repositories/queue.redis.repository";
+
+/**
+ * Discard and explicit-id redrive against a real Redis
+ * (specs/ops/dead-letter-recovery.feature). Discard removes the group's DLQ
+ * entries — the durable mark is the audit row the service writes, which the
+ * queue.service unit suite covers; here the substrate contract is that the
+ * jobs are gone and cannot come back.
+ */
+let redis: Redis;
+beforeAll(async () => {
+  ({ redisConnection: redis } = await startTestContainers());
+});
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+// Module-level incrementing counter for unique queue names — no Date.now().
+let queueCounter = 0;
+
+describe("DLQ discard and explicit-id redrive", () => {
+  function freshQueue(): { queueName: string; prefix: string } {
+    queueCounter++;
+    const queueName = `dlq-discard-${queueCounter}`;
+    return { queueName, prefix: `${queueName}:gq:` };
+  }
+
+  async function seedDlqGroup(
+    prefix: string,
+    groupId: string,
+    { jobs = 2, error = "boom" }: { jobs?: number; error?: string } = {},
+  ): Promise<void> {
+    for (let i = 1; i <= jobs; i++) {
+      await redis.zadd(`${prefix}dlq:${groupId}:jobs`, 1000 + i, `job-${i}`);
+      await redis.hset(`${prefix}dlq:${groupId}:data`, `job-${i}`, "{}");
+    }
+    await redis.hset(
+      `${prefix}dlq:${groupId}:error`,
+      "message",
+      error,
+      "timestamp",
+      "1723800000000",
+    );
+    await redis.sadd(`${prefix}dlq`, groupId);
+  }
+
+  /** @scenario Discarding a DLQ group removes it and remembers the act */
+  it("removes the group's entries and returns what the audit row must record", async () => {
+    const { queueName, prefix } = freshQueue();
+    const repo = new QueueRedisRepository(redis);
+    await seedDlqGroup(prefix, "group-a", { jobs: 3, error: "HTTP 500" });
+
+    const result = await repo.discardManyFromDlq({
+      queueName,
+      groupIds: ["group-a"],
+    });
+
+    expect(result.discardedCount).toBe(1);
+    expect(result.jobsDiscarded).toBe(3);
+    expect(result.lastErrors).toEqual(["HTTP 500"]);
+    expect(await redis.exists(`${prefix}dlq:group-a:jobs`)).toBe(0);
+    expect(await redis.exists(`${prefix}dlq:group-a:data`)).toBe(0);
+    expect(await redis.exists(`${prefix}dlq:group-a:error`)).toBe(0);
+    expect(await redis.smembers(`${prefix}dlq`)).toEqual([]);
+    expect(await repo.listDlqGroups({ queueName })).toEqual([]);
+  });
+
+  /** @scenario A discarded DLQ group cannot be redriven afterwards */
+  it("keeps a discarded group out of every later redrive", async () => {
+    const { queueName, prefix } = freshQueue();
+    const repo = new QueueRedisRepository(redis);
+    await seedDlqGroup(prefix, "group-a");
+    await seedDlqGroup(prefix, "group-b");
+
+    await repo.discardManyFromDlq({ queueName, groupIds: ["group-a"] });
+
+    // An explicit redrive naming the discarded id finds nothing to move.
+    const explicit = await repo.redriveManyFromDlq({
+      queueName,
+      groupIds: ["group-a", "group-b"],
+    });
+    expect(explicit.redrivenCount).toBe(1);
+    expect(await redis.exists(`${prefix}group:group-a:jobs`)).toBe(0);
+    expect(await redis.zcard(`${prefix}group:group-b:jobs`)).toBe(2);
+
+    // A queue-wide redrive cannot resurrect it either.
+    const all = await repo.replayAllFromDlq({ queueName });
+    expect(all.replayedCount).toBe(0);
+  });
+
+  /** @scenario Bulk DLQ actions act on exactly what is shown */
+  it("redrives only the named ids and leaves the rest dead-lettered", async () => {
+    const { queueName, prefix } = freshQueue();
+    const repo = new QueueRedisRepository(redis);
+    await seedDlqGroup(prefix, "group-a");
+    await seedDlqGroup(prefix, "group-b");
+
+    const result = await repo.redriveManyFromDlq({
+      queueName,
+      groupIds: ["group-a"],
+    });
+
+    expect(result.redrivenCount).toBe(1);
+    expect(result.jobsRedriven).toBe(2);
+    expect(await redis.zcard(`${prefix}group:group-a:jobs`)).toBe(2);
+    expect(await redis.smembers(`${prefix}dlq`)).toEqual(["group-b"]);
+    expect(await redis.exists(`${prefix}dlq:group-b:jobs`)).toBe(1);
+  });
+});

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts
@@ -50,70 +50,72 @@ describe("DLQ discard and explicit-id redrive", () => {
     await redis.sadd(`${prefix}dlq`, groupId);
   }
 
-  describe("when the operator discards a group", () => {
-    /** @scenario Discarding a DLQ group removes it and remembers the act */
-    it("removes the group's entries and returns what the audit row must record", async () => {
-      const { queueName, prefix } = freshQueue();
-      const repo = new QueueRedisRepository(redis);
-      await seedDlqGroup(prefix, "group-a", { jobs: 3, error: "HTTP 500" });
+  describe("given a queue holding dead-lettered groups", () => {
+    describe("when the operator discards a group", () => {
+      /** @scenario Discarding a DLQ group removes it and remembers the act */
+      it("removes the group's entries and returns what the audit row must record", async () => {
+        const { queueName, prefix } = freshQueue();
+        const repo = new QueueRedisRepository(redis);
+        await seedDlqGroup(prefix, "group-a", { jobs: 3, error: "HTTP 500" });
 
-      const result = await repo.discardManyFromDlq({
-        queueName,
-        groupIds: ["group-a"],
+        const result = await repo.discardManyFromDlq({
+          queueName,
+          groupIds: ["group-a"],
+        });
+
+        expect(result.discardedCount).toBe(1);
+        expect(result.jobsDiscarded).toBe(3);
+        expect(result.lastErrors).toEqual(["HTTP 500"]);
+        expect(await redis.exists(`${prefix}dlq:group-a:jobs`)).toBe(0);
+        expect(await redis.exists(`${prefix}dlq:group-a:data`)).toBe(0);
+        expect(await redis.exists(`${prefix}dlq:group-a:error`)).toBe(0);
+        expect(await redis.smembers(`${prefix}dlq`)).toEqual([]);
+        expect(await repo.listDlqGroups({ queueName })).toEqual([]);
       });
 
-      expect(result.discardedCount).toBe(1);
-      expect(result.jobsDiscarded).toBe(3);
-      expect(result.lastErrors).toEqual(["HTTP 500"]);
-      expect(await redis.exists(`${prefix}dlq:group-a:jobs`)).toBe(0);
-      expect(await redis.exists(`${prefix}dlq:group-a:data`)).toBe(0);
-      expect(await redis.exists(`${prefix}dlq:group-a:error`)).toBe(0);
-      expect(await redis.smembers(`${prefix}dlq`)).toEqual([]);
-      expect(await repo.listDlqGroups({ queueName })).toEqual([]);
+      /** @scenario A discarded DLQ group cannot be redriven afterwards */
+      it("keeps a discarded group out of every later redrive", async () => {
+        const { queueName, prefix } = freshQueue();
+        const repo = new QueueRedisRepository(redis);
+        await seedDlqGroup(prefix, "group-a");
+        await seedDlqGroup(prefix, "group-b");
+
+        await repo.discardManyFromDlq({ queueName, groupIds: ["group-a"] });
+
+        // An explicit redrive naming the discarded id finds nothing to move.
+        const explicit = await repo.redriveManyFromDlq({
+          queueName,
+          groupIds: ["group-a", "group-b"],
+        });
+        expect(explicit.redrivenCount).toBe(1);
+        expect(await redis.exists(`${prefix}group:group-a:jobs`)).toBe(0);
+        expect(await redis.zcard(`${prefix}group:group-b:jobs`)).toBe(2);
+
+        // A queue-wide redrive cannot resurrect it either.
+        const all = await repo.replayAllFromDlq({ queueName });
+        expect(all.replayedCount).toBe(0);
+      });
     });
 
-    /** @scenario A discarded DLQ group cannot be redriven afterwards */
-    it("keeps a discarded group out of every later redrive", async () => {
-      const { queueName, prefix } = freshQueue();
-      const repo = new QueueRedisRepository(redis);
-      await seedDlqGroup(prefix, "group-a");
-      await seedDlqGroup(prefix, "group-b");
+    describe("when the operator redrives an explicit set", () => {
+      /** @scenario Bulk DLQ actions act on exactly what is shown */
+      it("redrives only the named ids and leaves the rest dead-lettered", async () => {
+        const { queueName, prefix } = freshQueue();
+        const repo = new QueueRedisRepository(redis);
+        await seedDlqGroup(prefix, "group-a");
+        await seedDlqGroup(prefix, "group-b");
 
-      await repo.discardManyFromDlq({ queueName, groupIds: ["group-a"] });
+        const result = await repo.redriveManyFromDlq({
+          queueName,
+          groupIds: ["group-a"],
+        });
 
-      // An explicit redrive naming the discarded id finds nothing to move.
-      const explicit = await repo.redriveManyFromDlq({
-        queueName,
-        groupIds: ["group-a", "group-b"],
+        expect(result.redrivenCount).toBe(1);
+        expect(result.jobsRedriven).toBe(2);
+        expect(await redis.zcard(`${prefix}group:group-a:jobs`)).toBe(2);
+        expect(await redis.smembers(`${prefix}dlq`)).toEqual(["group-b"]);
+        expect(await redis.exists(`${prefix}dlq:group-b:jobs`)).toBe(1);
       });
-      expect(explicit.redrivenCount).toBe(1);
-      expect(await redis.exists(`${prefix}group:group-a:jobs`)).toBe(0);
-      expect(await redis.zcard(`${prefix}group:group-b:jobs`)).toBe(2);
-
-      // A queue-wide redrive cannot resurrect it either.
-      const all = await repo.replayAllFromDlq({ queueName });
-      expect(all.replayedCount).toBe(0);
-    });
-  });
-
-  describe("when the operator redrives an explicit set", () => {
-    /** @scenario Bulk DLQ actions act on exactly what is shown */
-    it("redrives only the named ids and leaves the rest dead-lettered", async () => {
-      const { queueName, prefix } = freshQueue();
-      const repo = new QueueRedisRepository(redis);
-      await seedDlqGroup(prefix, "group-a");
-      await seedDlqGroup(prefix, "group-b");
-
-      const result = await repo.redriveManyFromDlq({
-        queueName,
-        groupIds: ["group-a"],
-      });
-
-      expect(result.redrivenCount).toBe(1);
-      expect(result.jobsRedriven).toBe(2);
-      expect(await redis.zcard(`${prefix}group:group-a:jobs`)).toBe(2);
-      expect(await redis.smembers(`${prefix}dlq`)).toEqual(["group-b"]);
-      expect(await redis.exists(`${prefix}dlq:group-b:jobs`)).toBe(1);
     });
   });
 });

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts
@@ -50,66 +50,70 @@ describe("DLQ discard and explicit-id redrive", () => {
     await redis.sadd(`${prefix}dlq`, groupId);
   }
 
-  /** @scenario Discarding a DLQ group removes it and remembers the act */
-  it("removes the group's entries and returns what the audit row must record", async () => {
-    const { queueName, prefix } = freshQueue();
-    const repo = new QueueRedisRepository(redis);
-    await seedDlqGroup(prefix, "group-a", { jobs: 3, error: "HTTP 500" });
+  describe("when the operator discards a group", () => {
+    /** @scenario Discarding a DLQ group removes it and remembers the act */
+    it("removes the group's entries and returns what the audit row must record", async () => {
+      const { queueName, prefix } = freshQueue();
+      const repo = new QueueRedisRepository(redis);
+      await seedDlqGroup(prefix, "group-a", { jobs: 3, error: "HTTP 500" });
 
-    const result = await repo.discardManyFromDlq({
-      queueName,
-      groupIds: ["group-a"],
+      const result = await repo.discardManyFromDlq({
+        queueName,
+        groupIds: ["group-a"],
+      });
+
+      expect(result.discardedCount).toBe(1);
+      expect(result.jobsDiscarded).toBe(3);
+      expect(result.lastErrors).toEqual(["HTTP 500"]);
+      expect(await redis.exists(`${prefix}dlq:group-a:jobs`)).toBe(0);
+      expect(await redis.exists(`${prefix}dlq:group-a:data`)).toBe(0);
+      expect(await redis.exists(`${prefix}dlq:group-a:error`)).toBe(0);
+      expect(await redis.smembers(`${prefix}dlq`)).toEqual([]);
+      expect(await repo.listDlqGroups({ queueName })).toEqual([]);
     });
 
-    expect(result.discardedCount).toBe(1);
-    expect(result.jobsDiscarded).toBe(3);
-    expect(result.lastErrors).toEqual(["HTTP 500"]);
-    expect(await redis.exists(`${prefix}dlq:group-a:jobs`)).toBe(0);
-    expect(await redis.exists(`${prefix}dlq:group-a:data`)).toBe(0);
-    expect(await redis.exists(`${prefix}dlq:group-a:error`)).toBe(0);
-    expect(await redis.smembers(`${prefix}dlq`)).toEqual([]);
-    expect(await repo.listDlqGroups({ queueName })).toEqual([]);
+    /** @scenario A discarded DLQ group cannot be redriven afterwards */
+    it("keeps a discarded group out of every later redrive", async () => {
+      const { queueName, prefix } = freshQueue();
+      const repo = new QueueRedisRepository(redis);
+      await seedDlqGroup(prefix, "group-a");
+      await seedDlqGroup(prefix, "group-b");
+
+      await repo.discardManyFromDlq({ queueName, groupIds: ["group-a"] });
+
+      // An explicit redrive naming the discarded id finds nothing to move.
+      const explicit = await repo.redriveManyFromDlq({
+        queueName,
+        groupIds: ["group-a", "group-b"],
+      });
+      expect(explicit.redrivenCount).toBe(1);
+      expect(await redis.exists(`${prefix}group:group-a:jobs`)).toBe(0);
+      expect(await redis.zcard(`${prefix}group:group-b:jobs`)).toBe(2);
+
+      // A queue-wide redrive cannot resurrect it either.
+      const all = await repo.replayAllFromDlq({ queueName });
+      expect(all.replayedCount).toBe(0);
+    });
   });
 
-  /** @scenario A discarded DLQ group cannot be redriven afterwards */
-  it("keeps a discarded group out of every later redrive", async () => {
-    const { queueName, prefix } = freshQueue();
-    const repo = new QueueRedisRepository(redis);
-    await seedDlqGroup(prefix, "group-a");
-    await seedDlqGroup(prefix, "group-b");
+  describe("when the operator redrives an explicit set", () => {
+    /** @scenario Bulk DLQ actions act on exactly what is shown */
+    it("redrives only the named ids and leaves the rest dead-lettered", async () => {
+      const { queueName, prefix } = freshQueue();
+      const repo = new QueueRedisRepository(redis);
+      await seedDlqGroup(prefix, "group-a");
+      await seedDlqGroup(prefix, "group-b");
 
-    await repo.discardManyFromDlq({ queueName, groupIds: ["group-a"] });
+      const result = await repo.redriveManyFromDlq({
+        queueName,
+        groupIds: ["group-a"],
+      });
 
-    // An explicit redrive naming the discarded id finds nothing to move.
-    const explicit = await repo.redriveManyFromDlq({
-      queueName,
-      groupIds: ["group-a", "group-b"],
+      expect(result.redrivenCount).toBe(1);
+      expect(result.jobsRedriven).toBe(2);
+      expect(await redis.zcard(`${prefix}group:group-a:jobs`)).toBe(2);
+      expect(await redis.smembers(`${prefix}dlq`)).toEqual(["group-b"]);
+      expect(await redis.exists(`${prefix}dlq:group-b:jobs`)).toBe(1);
     });
-    expect(explicit.redrivenCount).toBe(1);
-    expect(await redis.exists(`${prefix}group:group-a:jobs`)).toBe(0);
-    expect(await redis.zcard(`${prefix}group:group-b:jobs`)).toBe(2);
-
-    // A queue-wide redrive cannot resurrect it either.
-    const all = await repo.replayAllFromDlq({ queueName });
-    expect(all.replayedCount).toBe(0);
-  });
-
-  /** @scenario Bulk DLQ actions act on exactly what is shown */
-  it("redrives only the named ids and leaves the rest dead-lettered", async () => {
-    const { queueName, prefix } = freshQueue();
-    const repo = new QueueRedisRepository(redis);
-    await seedDlqGroup(prefix, "group-a");
-    await seedDlqGroup(prefix, "group-b");
-
-    const result = await repo.redriveManyFromDlq({
-      queueName,
-      groupIds: ["group-a"],
-    });
-
-    expect(result.redrivenCount).toBe(1);
-    expect(result.jobsRedriven).toBe(2);
-    expect(await redis.zcard(`${prefix}group:group-a:jobs`)).toBe(2);
-    expect(await redis.smembers(`${prefix}dlq`)).toEqual(["group-b"]);
-    expect(await redis.exists(`${prefix}dlq:group-b:jobs`)).toBe(1);
   });
 });

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -664,10 +664,15 @@ describe("process ops against a real Postgres", () => {
         retiredAt: new Date(NOW - 15_000),
       });
 
+      // The jitter window is measured from the redrive itself, not from module
+      // load: a slow suite reaching this test a minute late would otherwise
+      // fail a perfectly good spread.
+      const redrivenAtStart = Date.now();
       const result = await service.redriveDeadLetters({
         processName: nsBulkA,
         actorUserId: ACTOR,
       });
+      const redrivenAtEnd = Date.now();
       expect(result.redriven).toBe(2);
 
       const rows = await prisma.processManagerOutbox.findMany({
@@ -700,8 +705,8 @@ describe("process ops against a real Postgres", () => {
       });
       const dueTimes = redriven.map((row) => row.nextAttemptAt.getTime());
       for (const due of dueTimes) {
-        expect(due).toBeGreaterThanOrEqual(NOW - 1_000);
-        expect(due).toBeLessThanOrEqual(NOW + 61_000);
+        expect(due).toBeGreaterThanOrEqual(redrivenAtStart);
+        expect(due).toBeLessThanOrEqual(redrivenAtEnd + 60_000);
       }
     });
 

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -682,10 +682,14 @@ describe("process ops against a real Postgres", () => {
       const audit = await prisma.auditLog.findFirst({
         where: {
           action: "process_redrive_dead_letters",
-          targetId: { startsWith: nsBulkA },
+          // A bulk act names no instance, so its target is the fleet marker
+          // and the scope it ran under lives in metadata.
+          targetId: "fleet",
+          metadata: { equals: { redriven: 2, scope: nsBulkA } },
         },
       });
-      expect(audit?.metadata).toMatchObject({ redriven: 2 });
+      expect(audit?.projectId).toBeNull();
+      expect(audit?.metadata).toMatchObject({ redriven: 2, scope: nsBulkA });
     });
 
     /** @scenario Every dead letter shown can be discarded in one act */
@@ -721,10 +725,12 @@ describe("process ops against a real Postgres", () => {
       const audit = await prisma.auditLog.findFirst({
         where: {
           action: "process_discard_dead_letters",
-          targetId: { startsWith: nsBulkA },
+          targetId: "fleet",
+          metadata: { equals: { discarded: 1, scope: nsBulkA } },
         },
       });
-      expect(audit?.metadata).toMatchObject({ discarded: 1 });
+      expect(audit?.projectId).toBeNull();
+      expect(audit?.metadata).toMatchObject({ discarded: 1, scope: nsBulkA });
     });
 
     /** @scenario Each failed delivery records why it failed */

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -690,6 +690,19 @@ describe("process ops against a real Postgres", () => {
       });
       expect(audit?.projectId).toBeNull();
       expect(audit?.metadata).toMatchObject({ redriven: 2, scope: nsBulkA });
+
+      // Due times are spread, not stacked on one instant: a fleet redrive
+      // that made every message due simultaneously would hand the dispatcher
+      // one batch the size of the backlog.
+      const redriven = await prisma.processManagerOutbox.findMany({
+        where: { id: { in: [a1, a2] }, projectId: PROJECT },
+        select: { nextAttemptAt: true },
+      });
+      const dueTimes = redriven.map((row) => row.nextAttemptAt.getTime());
+      for (const due of dueTimes) {
+        expect(due).toBeGreaterThanOrEqual(NOW - 1_000);
+        expect(due).toBeLessThanOrEqual(NOW + 61_000);
+      }
     });
 
     /** @scenario Every dead letter shown can be discarded in one act */

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -775,6 +775,107 @@ describe("process ops against a real Postgres", () => {
       expect(attempts[1]?.outcome).toBe("dead");
     });
 
+    /** @scenario Discarded messages age out on the dead-letter window */
+    it("reaps discarded rows on the dead-letter retention window", async () => {
+      const nsSweep = `${ns}.sweep.discarded`;
+      const staleId = await seedDeadMessage({
+        processName: nsSweep,
+        processKey: "dl-sweep",
+        messageKey: "discard-stale",
+        retiredAt: new Date(NOW - 60_000),
+      });
+      const freshId = await seedDeadMessage({
+        processName: nsSweep,
+        processKey: "dl-sweep",
+        messageKey: "discard-fresh",
+        retiredAt: new Date(NOW - 60_000),
+      });
+      for (const [id, key] of [
+        [staleId, "discard-stale"],
+        [freshId, "discard-fresh"],
+      ] as const) {
+        await service.discardDeadMessage({
+          ref: {
+            processName: nsSweep,
+            projectId: PROJECT,
+            processKey: "dl-sweep",
+          },
+          messageId: id,
+          actorUserId: ACTOR,
+        });
+        expect(key).toBeTruthy();
+      }
+      // Discard stamps updatedAt, so age the stale one past the window by
+      // hand — the sweep reaps by that column.
+      await prisma.processManagerOutbox.updateMany({
+        where: { id: staleId, projectId: PROJECT },
+        data: { updatedAt: new Date(NOW - 40 * 24 * 60 * 60 * 1000) },
+      });
+
+      const deleted = await store.deleteDeadOutboxBatch({
+        before: NOW - 30 * 24 * 60 * 60 * 1000,
+        limit: 100,
+      });
+      expect(deleted).toBeGreaterThanOrEqual(1);
+
+      const survivors = await prisma.processManagerOutbox.findMany({
+        where: { id: { in: [staleId, freshId] }, projectId: PROJECT },
+        select: { id: true },
+      });
+      expect(survivors.map((row) => row.id)).toEqual([freshId]);
+    });
+
+    /** @scenario A redriven message keeps the history of both its lives */
+    it("orders a redriven message's attempts by when they happened, not by number", async () => {
+      const nsLives = `${ns}.lives`;
+      const id = await seedDeadMessage({
+        processName: nsLives,
+        processKey: "dl-lives",
+        messageKey: "dead-lives",
+        retiredAt: new Date(NOW - 5_000),
+      });
+      const identity = {
+        processName: nsLives,
+        projectId: PROJECT,
+        messageKey: "dead-lives",
+      };
+
+      // First life, then a redrive resets the counter, then a second life —
+      // so both lives carry an attempt numbered 1.
+      await store.recordFailedAttempt({
+        identity,
+        attempt: {
+          attempt: 1,
+          occurredAt: NOW - 30_000,
+          outcome: "dead",
+          errorType: "DispatchError",
+          errorMessage: "first life",
+        },
+      });
+      await store.recordFailedAttempt({
+        identity,
+        attempt: {
+          attempt: 1,
+          occurredAt: NOW - 10_000,
+          outcome: "dead",
+          errorType: "DispatchError",
+          errorMessage: "second life",
+        },
+      });
+
+      const attempts = await service.getOutboxAttempts({
+        outboxId: id,
+        projectId: PROJECT,
+      });
+      expect(attempts.map((a) => a.errorMessage)).toEqual([
+        "first life",
+        "second life",
+      ]);
+      // Row identity, not the attempt number, is what stays unique.
+      expect(new Set(attempts.map((a) => a.id)).size).toBe(2);
+      expect(new Set(attempts.map((a) => a.attempt)).size).toBe(1);
+    });
+
     /** @scenario Attempt history dies with its message */
     it("cascades attempt rows when the message row is deleted", async () => {
       const nsCascade = `${ns}.cascade`;

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -790,11 +790,8 @@ describe("process ops against a real Postgres", () => {
         messageKey: "discard-fresh",
         retiredAt: new Date(NOW - 60_000),
       });
-      for (const [id, key] of [
-        [staleId, "discard-stale"],
-        [freshId, "discard-fresh"],
-      ] as const) {
-        await service.discardDeadMessage({
+      for (const id of [staleId, freshId]) {
+        const { discarded } = await service.discardDeadMessage({
           ref: {
             processName: nsSweep,
             projectId: PROJECT,
@@ -803,7 +800,7 @@ describe("process ops against a real Postgres", () => {
           messageId: id,
           actorUserId: ACTOR,
         });
-        expect(key).toBeTruthy();
+        expect(discarded).toBe(true);
       }
       // Discard stamps updatedAt, so age the stale one past the window by
       // hand — the sweep reaps by that column.
@@ -812,11 +809,13 @@ describe("process ops against a real Postgres", () => {
         data: { updatedAt: new Date(NOW - 40 * 24 * 60 * 60 * 1000) },
       });
 
-      const deleted = await store.deleteDeadOutboxBatch({
+      // The sweep is fleet-wide, so its returned count includes whatever else
+      // the database holds; what this asserts is which of THESE two rows it
+      // took.
+      await store.deleteDeadOutboxBatch({
         before: NOW - 30 * 24 * 60 * 60 * 1000,
         limit: 100,
       });
-      expect(deleted).toBeGreaterThanOrEqual(1);
 
       const survivors = await prisma.processManagerOutbox.findMany({
         where: { id: { in: [staleId, freshId] }, projectId: PROJECT },

--- a/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts
@@ -514,4 +514,298 @@ describe("process ops against a real Postgres", () => {
       expect(row.attempts).toBe(0);
     });
   });
+
+  // ── Dead-letter recovery (specs/ops/dead-letter-recovery.feature) ────────
+
+  describe("when the operator discards and bulk-recovers dead letters", () => {
+    const store = new PrismaProcessStore(prisma);
+
+    /** @scenario Discarding a dead message marks it and keeps it */
+    it("marks the row discarded, keeps it, audits it, and the dispatcher never leases it", async () => {
+      const nsDiscard = `${ns}.discard.one`;
+      const id = await seedDeadMessage({
+        processName: nsDiscard,
+        processKey: "dl-discard",
+        messageKey: "dead-discard",
+        retiredAt: new Date(NOW - 30_000),
+      });
+
+      const result = await service.discardDeadMessage({
+        ref: {
+          processName: nsDiscard,
+          projectId: PROJECT,
+          processKey: "dl-discard",
+        },
+        messageId: id,
+        actorUserId: ACTOR,
+      });
+      expect(result.discarded).toBe(true);
+
+      // A mark, not a delete: the row is retained as its own audit trail.
+      const row = await prisma.processManagerOutbox.findFirstOrThrow({
+        where: { id, projectId: PROJECT },
+      });
+      expect(row.status).toBe("discarded");
+
+      // The dispatcher's claim only sees pending rows, so a discarded row is
+      // never leased even when it is long past due.
+      const leased = await store.leaseDueMessages({
+        now: NOW + 60 * 60_000,
+        limit: 100,
+        leaseDurationMs: 1000,
+        processNames: [nsDiscard],
+      });
+      expect(leased).toEqual([]);
+
+      const audit = await prisma.auditLog.findFirst({
+        where: {
+          action: "process_discard_dead_message",
+          targetId: { startsWith: nsDiscard },
+        },
+      });
+      expect(audit?.userId).toBe(ACTOR);
+      expect(audit?.metadata).toMatchObject({ messageKey: "dead-discard" });
+    });
+
+    /** @scenario Only a dead message can be discarded */
+    it("leaves a pending message unchanged and reports it was not dead", async () => {
+      const nsGuard = `${ns}.discard.guard`;
+      const row = await prisma.processManagerOutbox.create({
+        data: {
+          processName: nsGuard,
+          projectId: PROJECT,
+          processKey: "dl-guard",
+          tenantId: PROJECT,
+          messageKey: "pending-guard",
+          intentType: "opstest.intent",
+          payload: {},
+          traceCarrier: {},
+          status: "pending",
+          nextAttemptAt: new Date(NOW),
+          createdAt: new Date(NOW),
+          updatedAt: new Date(NOW),
+        },
+      });
+
+      const result = await service.discardDeadMessage({
+        ref: {
+          processName: nsGuard,
+          projectId: PROJECT,
+          processKey: "dl-guard",
+        },
+        messageId: row.id,
+        actorUserId: ACTOR,
+      });
+      expect(result.discarded).toBe(false);
+
+      const after = await prisma.processManagerOutbox.findFirstOrThrow({
+        where: { id: row.id, projectId: PROJECT },
+      });
+      expect(after.status).toBe("pending");
+    });
+
+    /** @scenario Discarded messages leave the dead-letter count */
+    it("drops discarded rows from the listing and the counts", async () => {
+      const nsCount = `${ns}.discard.count`;
+      const keepId = await seedDeadMessage({
+        processName: nsCount,
+        processKey: "dl-count",
+        messageKey: "dead-count-keep",
+        retiredAt: new Date(NOW - 20_000),
+      });
+      const dropId = await seedDeadMessage({
+        processName: nsCount,
+        processKey: "dl-count",
+        messageKey: "dead-count-drop",
+        retiredAt: new Date(NOW - 10_000),
+      });
+
+      await service.discardDeadMessage({
+        ref: {
+          processName: nsCount,
+          projectId: PROJECT,
+          processKey: "dl-count",
+        },
+        messageId: dropId,
+        actorUserId: ACTOR,
+      });
+
+      const { messages, byProcess } = await service.getDeadLetters({
+        processName: nsCount,
+        page: 1,
+        pageSize: 10,
+      });
+      expect(messages.map((m) => m.id)).toEqual([keepId]);
+      expect(byProcess.find((row) => row.processName === nsCount)?.count).toBe(
+        1,
+      );
+    });
+
+    /** @scenario Every dead letter shown can be redriven in one act */
+    it("redrives one process name's dead letters and leaves the others dead", async () => {
+      const nsBulkA = `${ns}.bulk.redrive.a`;
+      const nsBulkB = `${ns}.bulk.redrive.b`;
+      const a1 = await seedDeadMessage({
+        processName: nsBulkA,
+        processKey: "dl-bulk-a",
+        messageKey: "bulk-a-1",
+        retiredAt: new Date(NOW - 20_000),
+      });
+      const a2 = await seedDeadMessage({
+        processName: nsBulkA,
+        processKey: "dl-bulk-a2",
+        messageKey: "bulk-a-2",
+        retiredAt: new Date(NOW - 10_000),
+      });
+      const b1 = await seedDeadMessage({
+        processName: nsBulkB,
+        processKey: "dl-bulk-b",
+        messageKey: "bulk-b-1",
+        retiredAt: new Date(NOW - 15_000),
+      });
+
+      const result = await service.redriveDeadLetters({
+        processName: nsBulkA,
+        actorUserId: ACTOR,
+      });
+      expect(result.redriven).toBe(2);
+
+      const rows = await prisma.processManagerOutbox.findMany({
+        where: { id: { in: [a1, a2, b1] }, projectId: PROJECT },
+      });
+      const byId = new Map(rows.map((row) => [row.id, row]));
+      expect(byId.get(a1)?.status).toBe("pending");
+      expect(byId.get(a1)?.attempts).toBe(0);
+      expect(byId.get(a2)?.status).toBe("pending");
+      expect(byId.get(b1)?.status).toBe("dead");
+
+      const audit = await prisma.auditLog.findFirst({
+        where: {
+          action: "process_redrive_dead_letters",
+          targetId: { startsWith: nsBulkA },
+        },
+      });
+      expect(audit?.metadata).toMatchObject({ redriven: 2 });
+    });
+
+    /** @scenario Every dead letter shown can be discarded in one act */
+    it("discards one process name's dead letters and leaves the others dead", async () => {
+      const nsBulkA = `${ns}.bulk.discard.a`;
+      const nsBulkB = `${ns}.bulk.discard.b`;
+      const a1 = await seedDeadMessage({
+        processName: nsBulkA,
+        processKey: "dl-bulkd-a",
+        messageKey: "bulkd-a-1",
+        retiredAt: new Date(NOW - 20_000),
+      });
+      const b1 = await seedDeadMessage({
+        processName: nsBulkB,
+        processKey: "dl-bulkd-b",
+        messageKey: "bulkd-b-1",
+        retiredAt: new Date(NOW - 15_000),
+      });
+
+      const result = await service.discardDeadLetters({
+        processName: nsBulkA,
+        actorUserId: ACTOR,
+      });
+      expect(result.discarded).toBe(1);
+
+      const rows = await prisma.processManagerOutbox.findMany({
+        where: { id: { in: [a1, b1] }, projectId: PROJECT },
+      });
+      const byId = new Map(rows.map((row) => [row.id, row]));
+      expect(byId.get(a1)?.status).toBe("discarded");
+      expect(byId.get(b1)?.status).toBe("dead");
+
+      const audit = await prisma.auditLog.findFirst({
+        where: {
+          action: "process_discard_dead_letters",
+          targetId: { startsWith: nsBulkA },
+        },
+      });
+      expect(audit?.metadata).toMatchObject({ discarded: 1 });
+    });
+
+    /** @scenario Each failed delivery records why it failed */
+    it("stores one entry per failed attempt, oldest first, with the killer marked", async () => {
+      const nsAttempts = `${ns}.attempts`;
+      const id = await seedDeadMessage({
+        processName: nsAttempts,
+        processKey: "dl-attempts",
+        messageKey: "dead-attempts",
+        retiredAt: new Date(NOW - 5_000),
+      });
+      const identity = {
+        processName: nsAttempts,
+        projectId: PROJECT,
+        messageKey: "dead-attempts",
+      };
+
+      await store.recordFailedAttempt({
+        identity,
+        attempt: {
+          attempt: 1,
+          occurredAt: NOW - 10_000,
+          outcome: "retry_scheduled",
+          errorType: "DispatchError",
+          errorMessage: "receiver returned 503",
+          retryAfterMs: 90_000,
+        },
+      });
+      await store.recordFailedAttempt({
+        identity,
+        attempt: {
+          attempt: 2,
+          occurredAt: NOW - 5_000,
+          outcome: "dead",
+          errorType: "DispatchError",
+          errorMessage: "receiver returned 410",
+        },
+      });
+
+      const attempts = await service.getOutboxAttempts({
+        outboxId: id,
+        projectId: PROJECT,
+      });
+      expect(attempts.map((a) => a.attempt)).toEqual([1, 2]);
+      expect(attempts[0]?.outcome).toBe("retry_scheduled");
+      expect(attempts[0]?.errorMessage).toBe("receiver returned 503");
+      expect(attempts[0]?.retryAfterMs).toBe(90_000);
+      expect(attempts[1]?.outcome).toBe("dead");
+    });
+
+    /** @scenario Attempt history dies with its message */
+    it("cascades attempt rows when the message row is deleted", async () => {
+      const nsCascade = `${ns}.cascade`;
+      const id = await seedDeadMessage({
+        processName: nsCascade,
+        processKey: "dl-cascade",
+        messageKey: "dead-cascade",
+        retiredAt: new Date(NOW - 5_000),
+      });
+      await store.recordFailedAttempt({
+        identity: {
+          processName: nsCascade,
+          projectId: PROJECT,
+          messageKey: "dead-cascade",
+        },
+        attempt: {
+          attempt: 1,
+          occurredAt: NOW - 5_000,
+          outcome: "dead",
+          errorType: "DispatchError",
+          errorMessage: "receiver returned 410",
+        },
+      });
+
+      await prisma.processManagerOutbox.deleteMany({
+        where: { id, projectId: PROJECT },
+      });
+      const orphaned = await prisma.processManagerOutboxAttempt.findMany({
+        where: { outboxId: id, projectId: PROJECT },
+      });
+      expect(orphaned).toEqual([]);
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -130,7 +130,13 @@ describe("QueueService", () => {
         discardManyFromDlq: vi.fn().mockResolvedValue({
           discardedCount: 1,
           jobsDiscarded: 1,
-          lastErrors: ["failed for user alice@example.com on card 4111"],
+          lastErrors: [
+            "failed for user alice@example.com on card 4111",
+            // Leading with the address: an error's first words are no safer
+            // than its last, which a "keep the first few words" reduction
+            // would have missed.
+            "bob@example.com could not be charged",
+          ],
         }),
       });
       const append = vi.fn().mockResolvedValue(undefined);
@@ -144,7 +150,9 @@ describe("QueueService", () => {
 
       const recorded = JSON.stringify(append.mock.calls[0]![0].metadata);
       expect(recorded).not.toContain("alice@example.com");
+      expect(recorded).not.toContain("bob@example.com");
       expect(recorded).not.toContain("4111");
+      expect(recorded).toContain("untyped_error");
     });
 
     it("audits a redrive with what moved and skips the audit when nothing did", async () => {

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -92,12 +92,12 @@ function createMockRepo(
 describe("QueueService", () => {
   describe("dead-letter recovery audit", () => {
     /** @scenario Discarding a DLQ group removes it and remembers the act */
-    it("records the queue, the groups, the job count and the last errors on a discard", async () => {
+    it("records the queue, the groups and the job count on a discard", async () => {
       const repo = createMockRepo({
         discardManyFromDlq: vi.fn().mockResolvedValue({
           discardedCount: 2,
           jobsDiscarded: 5,
-          lastErrors: ["HTTP 500"],
+          lastErrors: ["TimeoutError: upstream did not answer"],
         }),
       });
       const append = vi.fn().mockResolvedValue(undefined);
@@ -117,11 +117,34 @@ describe("QueueService", () => {
         metadata: {
           groupIds: ["g1", "g2"],
           requestedGroups: 2,
-          lastErrors: ["HTTP 500"],
+          // The shape of the failure, not its text.
+          lastErrorTypes: ["TimeoutError"],
           discardedCount: 2,
           jobsDiscarded: 5,
         },
       });
+    });
+
+    it("keeps arbitrary job error text out of the durable audit row", async () => {
+      const repo = createMockRepo({
+        discardManyFromDlq: vi.fn().mockResolvedValue({
+          discardedCount: 1,
+          jobsDiscarded: 1,
+          lastErrors: ["failed for user alice@example.com on card 4111"],
+        }),
+      });
+      const append = vi.fn().mockResolvedValue(undefined);
+      const service = new QueueService(repo, { append });
+
+      await service.discardManyFromDlq({
+        queueName: "queue-a",
+        groupIds: ["g1"],
+        requestedBy: "user_1",
+      });
+
+      const recorded = JSON.stringify(append.mock.calls[0]![0].metadata);
+      expect(recorded).not.toContain("alice@example.com");
+      expect(recorded).not.toContain("4111");
     });
 
     it("audits a redrive with what moved and skips the audit when nothing did", async () => {

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -101,7 +101,7 @@ describe("QueueService", () => {
         }),
       });
       const append = vi.fn().mockResolvedValue(undefined);
-      const service = new QueueService(repo, { append });
+      const service = new QueueService({ repo, audit: { append } });
 
       const result = await service.discardManyFromDlq({
         queueName: "queue-a",
@@ -140,7 +140,7 @@ describe("QueueService", () => {
         }),
       });
       const append = vi.fn().mockResolvedValue(undefined);
-      const service = new QueueService(repo, { append });
+      const service = new QueueService({ repo, audit: { append } });
 
       await service.discardManyFromDlq({
         queueName: "queue-a",
@@ -163,7 +163,7 @@ describe("QueueService", () => {
           .mockResolvedValueOnce({ redrivenCount: 0, jobsRedriven: 0 }),
       });
       const append = vi.fn().mockResolvedValue(undefined);
-      const service = new QueueService(repo, { append });
+      const service = new QueueService({ repo, audit: { append } });
 
       await service.redriveManyFromDlq({
         queueName: "queue-a",
@@ -205,7 +205,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([queue]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroups({
           queueName: "q1",
@@ -225,7 +225,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([queue]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroups({
           queueName: "q1",
@@ -243,7 +243,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([queue]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroups({
           queueName: "q1",
@@ -261,7 +261,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroups({
           queueName: "missing",
@@ -293,7 +293,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([queue]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroupDetail({
           queueName: "q1",
@@ -320,7 +320,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([queue]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroupDetail({
           queueName: "q1",
@@ -336,7 +336,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           scanQueues: vi.fn().mockResolvedValue([]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getGroupDetail({
           queueName: "missing",
@@ -378,7 +378,7 @@ describe("QueueService", () => {
             .mockResolvedValueOnce(dlq1)
             .mockResolvedValueOnce(dlq2),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getAllDlqGroups();
 
@@ -403,7 +403,7 @@ describe("QueueService", () => {
             },
           ]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getAllDlqGroups();
 
@@ -436,7 +436,7 @@ describe("QueueService", () => {
           discoverQueueNames: vi.fn().mockResolvedValue(["q:gq"]),
           listDlqGroups: vi.fn().mockResolvedValue(dlq),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.getAllDlqGroups();
 
@@ -452,7 +452,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           unblockGroup: vi.fn().mockResolvedValue({ wasBlocked: true }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.unblockGroup({
           queueName: "q1",
@@ -472,7 +472,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           unblockGroup: vi.fn().mockResolvedValue({ wasBlocked: false }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.unblockGroup({
           queueName: "q1",
@@ -490,7 +490,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           drainGroup: vi.fn().mockResolvedValue({ jobsRemoved: 5 }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.drainGroup({
           queueName: "q1",
@@ -512,7 +512,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           moveToDlq: vi.fn().mockResolvedValue({ jobsMoved: 3 }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.moveToDlq({
           queueName: "q1",
@@ -534,7 +534,7 @@ describe("QueueService", () => {
         const repo = createMockRepo({
           unblockAll: vi.fn().mockResolvedValue({ unblockedCount: 7 }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.unblockAll({ queueName: "q1" });
 
@@ -553,7 +553,7 @@ describe("QueueService", () => {
             groupIds: ["g1", "g2", "g3"],
           }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.canaryRedrive({
           queueName: "q1",
@@ -582,7 +582,7 @@ describe("QueueService", () => {
             .fn()
             .mockResolvedValue({ unblockedCount: 2, groupIds: ["g1", "g2"] }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.canaryUnblock({
           queueName: "q1",
@@ -603,7 +603,7 @@ describe("QueueService", () => {
       /** @scenario Pausing a tenant halts dispatch for that tenant only */
       it("delegates to the repository with tenantId", async () => {
         const repo = createMockRepo();
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         await service.pauseTenant({ queueName: "q1", tenantId: "project_X" });
 
@@ -618,7 +618,7 @@ describe("QueueService", () => {
       /** @scenario Unpausing a tenant resumes dispatch immediately */
       it("delegates to the repository (which signals the dispatcher)", async () => {
         const repo = createMockRepo();
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         await service.unpauseTenant({ queueName: "q1", tenantId: "project_X" });
 
@@ -636,7 +636,7 @@ describe("QueueService", () => {
             .fn()
             .mockResolvedValue(["project_A", "project_B"]),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.listPausedTenants({ queueName: "q1" });
 
@@ -652,7 +652,7 @@ describe("QueueService", () => {
             .fn()
             .mockResolvedValue({ groupsDrained: 1234, jobsDrained: 5678 }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.drainTenant({
           queueName: "q1",
@@ -677,7 +677,7 @@ describe("QueueService", () => {
             .fn()
             .mockResolvedValue({ groupsDrained: 3, jobsDrained: 12 }),
         });
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         const result = await service.drainTenant({
           queueName: "q1",
@@ -690,7 +690,7 @@ describe("QueueService", () => {
       /** @scenario drainTenant supports an optional groupIdContains substring filter */
       it("forwards groupIdContains substring filter to the repository", async () => {
         const repo = createMockRepo();
-        const service = new QueueService(repo);
+        const service = new QueueService({ repo });
 
         await service.drainTenant({
           queueName: "q1",

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -59,6 +59,14 @@ function createMockRepo(
     replayAllFromDlq: vi
       .fn()
       .mockResolvedValue({ replayedCount: 0, jobsReplayed: 0 }),
+    redriveManyFromDlq: vi
+      .fn()
+      .mockResolvedValue({ redrivenCount: 0, jobsRedriven: 0 }),
+    discardManyFromDlq: vi.fn().mockResolvedValue({
+      discardedCount: 0,
+      jobsDiscarded: 0,
+      lastErrors: [],
+    }),
     canaryRedrive: vi
       .fn()
       .mockResolvedValue({ redrivenCount: 0, groupIds: [] }),
@@ -82,6 +90,69 @@ function createMockRepo(
 }
 
 describe("QueueService", () => {
+  describe("dead-letter recovery audit", () => {
+    /** @scenario Discarding a DLQ group removes it and remembers the act */
+    it("records the queue, the groups, the job count and the last errors on a discard", async () => {
+      const repo = createMockRepo({
+        discardManyFromDlq: vi.fn().mockResolvedValue({
+          discardedCount: 2,
+          jobsDiscarded: 5,
+          lastErrors: ["HTTP 500"],
+        }),
+      });
+      const append = vi.fn().mockResolvedValue(undefined);
+      const service = new QueueService(repo, { append });
+
+      const result = await service.discardManyFromDlq({
+        queueName: "queue-a",
+        groupIds: ["g1", "g2"],
+        requestedBy: "user_1",
+      });
+
+      expect(result).toEqual({ discardedCount: 2, jobsDiscarded: 5 });
+      expect(append).toHaveBeenCalledWith({
+        actorUserId: "user_1",
+        action: "queue_discard_dlq_groups",
+        queueName: "queue-a",
+        metadata: {
+          groupIds: ["g1", "g2"],
+          requestedGroups: 2,
+          lastErrors: ["HTTP 500"],
+          discardedCount: 2,
+          jobsDiscarded: 5,
+        },
+      });
+    });
+
+    it("audits a redrive with what moved and skips the audit when nothing did", async () => {
+      const repo = createMockRepo({
+        redriveManyFromDlq: vi
+          .fn()
+          .mockResolvedValueOnce({ redrivenCount: 1, jobsRedriven: 3 })
+          .mockResolvedValueOnce({ redrivenCount: 0, jobsRedriven: 0 }),
+      });
+      const append = vi.fn().mockResolvedValue(undefined);
+      const service = new QueueService(repo, { append });
+
+      await service.redriveManyFromDlq({
+        queueName: "queue-a",
+        groupIds: ["g1"],
+        requestedBy: "user_1",
+      });
+      expect(append).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "queue_redrive_dlq_groups" }),
+      );
+
+      append.mockClear();
+      await service.redriveManyFromDlq({
+        queueName: "queue-a",
+        groupIds: ["g-gone"],
+        requestedBy: "user_1",
+      });
+      expect(append).not.toHaveBeenCalled();
+    });
+  });
+
   describe("getGroups()", () => {
     const groups = Array.from({ length: 25 }, (_, i) =>
       createGroup({ groupId: `g${i}` }),

--- a/platform/app/src/server/app-layer/ops/__tests__/reconcile-pending.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/reconcile-pending.unit.test.ts
@@ -48,6 +48,14 @@ function createMockRepo(
     replayAllFromDlq: vi
       .fn()
       .mockResolvedValue({ replayedCount: 0, jobsReplayed: 0 }),
+    redriveManyFromDlq: vi
+      .fn()
+      .mockResolvedValue({ redrivenCount: 0, jobsRedriven: 0 }),
+    discardManyFromDlq: vi.fn().mockResolvedValue({
+      discardedCount: 0,
+      jobsDiscarded: 0,
+      lastErrors: [],
+    }),
     canaryRedrive: vi
       .fn()
       .mockResolvedValue({ redrivenCount: 0, groupIds: [] }),

--- a/platform/app/src/server/app-layer/ops/manager-explorer.service.ts
+++ b/platform/app/src/server/app-layer/ops/manager-explorer.service.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   DeadLetterCount,
   DeadOutboxMessageView,
+  OutboxAttemptView,
   ProcessInstanceRow,
   ProcessOpsRepository,
   ProcessOutboxMessageView,
@@ -67,7 +68,7 @@ export interface AggregateProcessManagerInstance {
 export interface AggregateProcessManagerOutboxMessage {
   messageKey: string;
   intentType: string;
-  status: "pending" | "dispatched" | "dead";
+  status: "pending" | "dispatched" | "dead" | "discarded";
   attempts: number;
   nextAttemptAt: number;
   createdAt: number;
@@ -301,6 +302,87 @@ export class ManagerExplorerService {
       metadata: { messageKey: result.messageKey },
     });
     return { redriven: true };
+  }
+
+  /**
+   * One dead message marked never-to-be-sent, audited. A mark, not a
+   * delete — the row stays as its own audit trail
+   * (specs/ops/dead-letter-recovery.feature).
+   */
+  async discardDeadMessage(params: {
+    ref: ProcessRef;
+    messageId: string;
+    actorUserId: string;
+  }): Promise<{ discarded: boolean }> {
+    const result = await this.fleet.discardDeadMessage({
+      ref: params.ref,
+      messageId: params.messageId,
+      now: Date.now(),
+    });
+    if (!result) return { discarded: false };
+    await this.audit.append({
+      actorUserId: params.actorUserId,
+      action: "process_discard_dead_message",
+      ...params.ref,
+      metadata: { messageKey: result.messageKey },
+    });
+    return { discarded: true };
+  }
+
+  /**
+   * Every dead letter back to pending — one process name, or the whole
+   * fleet when omitted. The audit row records a fleet pseudo-ref; the count
+   * is the blast radius.
+   */
+  async redriveDeadLetters(params: {
+    processName?: string;
+    actorUserId: string;
+  }): Promise<{ redriven: number }> {
+    const redriven = await this.fleet.redriveAllDeadMessages({
+      ...(params.processName ? { processName: params.processName } : {}),
+      now: Date.now(),
+    });
+    if (redriven > 0) {
+      await this.audit.append({
+        actorUserId: params.actorUserId,
+        action: "process_redrive_dead_letters",
+        processName: params.processName ?? "__all__",
+        projectId: "__fleet__",
+        processKey: "__all__",
+        metadata: { redriven },
+      });
+    }
+    return { redriven };
+  }
+
+  /** Every dead letter marked discarded; same scoping, audited with count. */
+  async discardDeadLetters(params: {
+    processName?: string;
+    actorUserId: string;
+  }): Promise<{ discarded: number }> {
+    const discarded = await this.fleet.discardAllDeadMessages({
+      ...(params.processName ? { processName: params.processName } : {}),
+      now: Date.now(),
+    });
+    if (discarded > 0) {
+      await this.audit.append({
+        actorUserId: params.actorUserId,
+        action: "process_discard_dead_letters",
+        processName: params.processName ?? "__all__",
+        projectId: "__fleet__",
+        processKey: "__all__",
+        metadata: { discarded },
+      });
+    }
+    return { discarded };
+  }
+
+  /** The message's failed attempts, oldest first — why a dead letter died. */
+  async getOutboxAttempts(params: {
+    outboxId: string;
+    projectId: string;
+  }): Promise<OutboxAttemptView[]> {
+    return this.fleet.findAttempts(params);
   }
 
   /**

--- a/platform/app/src/server/app-layer/ops/manager-explorer.service.ts
+++ b/platform/app/src/server/app-layer/ops/manager-explorer.service.ts
@@ -330,9 +330,10 @@ export class ManagerExplorerService {
   }
 
   /**
-   * Every dead letter back to pending — one process name, or the whole
-   * fleet when omitted. The audit row records a fleet pseudo-ref; the count
-   * is the blast radius.
+   * Dead letters back to pending — one process name, or every process when
+   * omitted. Bounded per call by the repository, so the returned count is
+   * what moved rather than what existed; pressing again takes the next
+   * batch. The count is the blast radius the audit row records.
    */
   async redriveDeadLetters(params: {
     processName?: string;
@@ -357,7 +358,7 @@ export class ManagerExplorerService {
     return { redriven };
   }
 
-  /** Every dead letter marked discarded; same scoping, audited with count. */
+  /** Dead letters marked discarded; same scoping and bound, audited with count. */
   async discardDeadLetters(params: {
     processName?: string;
     actorUserId: string;

--- a/platform/app/src/server/app-layer/ops/manager-explorer.service.ts
+++ b/platform/app/src/server/app-layer/ops/manager-explorer.service.ts
@@ -346,10 +346,12 @@ export class ManagerExplorerService {
       await this.audit.append({
         actorUserId: params.actorUserId,
         action: "process_redrive_dead_letters",
-        processName: params.processName ?? "__all__",
-        projectId: "__fleet__",
-        processKey: "__all__",
-        metadata: { redriven },
+        // No single process, and no single project: the scope this act ran
+        // under is the metadata, not a placeholder in the identity columns.
+        processName: params.processName ?? null,
+        projectId: null,
+        processKey: null,
+        metadata: { redriven, scope: params.processName ?? "every process" },
       });
     }
     return { redriven };
@@ -368,10 +370,10 @@ export class ManagerExplorerService {
       await this.audit.append({
         actorUserId: params.actorUserId,
         action: "process_discard_dead_letters",
-        processName: params.processName ?? "__all__",
-        projectId: "__fleet__",
-        processKey: "__all__",
-        metadata: { discarded },
+        processName: params.processName ?? null,
+        projectId: null,
+        processKey: null,
+        metadata: { discarded, scope: params.processName ?? "every process" },
       });
     }
     return { discarded };

--- a/platform/app/src/server/app-layer/ops/process-audit.repository.ts
+++ b/platform/app/src/server/app-layer/ops/process-audit.repository.ts
@@ -80,9 +80,13 @@ export class ProcessAuditRepository implements ProcessAuditSink {
         organizationId: null,
         action: entry.action,
         targetKind: TARGET_KIND,
-        targetId: entry.processName
-          ? `${entry.processName}/${entry.projectId}/${entry.processKey}`
-          : FLEET_TARGET_ID,
+        // The triple only when all three parts are real. A process-scoped
+        // bulk act has a name but no instance, and `foo/null/null` would
+        // read as an instance that does not exist; the scope is in metadata.
+        targetId:
+          entry.processName && entry.projectId && entry.processKey
+            ? `${entry.processName}/${entry.projectId}/${entry.processKey}`
+            : FLEET_TARGET_ID,
         metadata: (entry.metadata ?? {}) as Prisma.InputJsonValue,
       },
     });

--- a/platform/app/src/server/app-layer/ops/process-audit.repository.ts
+++ b/platform/app/src/server/app-layer/ops/process-audit.repository.ts
@@ -25,15 +25,21 @@ export interface ProcessAuditSink {
   append(entry: {
     actorUserId: string;
     action: ProcessControlAction;
-    processName: string;
-    projectId: string;
-    processKey: string;
+    /** Null for a fleet-scoped act, which belongs to no one process. */
+    processName: string | null;
+    /** Null for a cross-tenant act. Never a placeholder: a made-up id in
+     *  this column reads as a real project to everything that queries it. */
+    projectId: string | null;
+    processKey: string | null;
     metadata?: Record<string, unknown>;
   }): Promise<void>;
   listRecent(params: { limit: number }): Promise<ProcessAuditEntryView[]>;
 }
 
 const TARGET_KIND = "process_instance";
+
+/** Target of an act that names no single instance; the scope is in metadata. */
+const FLEET_TARGET_ID = "fleet";
 
 /** For app presets that run without Postgres. */
 export class NullProcessAuditSink implements ProcessAuditSink {
@@ -57,9 +63,9 @@ export class ProcessAuditRepository implements ProcessAuditSink {
   async append(entry: {
     actorUserId: string;
     action: ProcessControlAction;
-    processName: string;
-    projectId: string;
-    processKey: string;
+    processName: string | null;
+    projectId: string | null;
+    processKey: string | null;
     metadata?: Record<string, unknown>;
   }): Promise<void> {
     await this.prisma.auditLog.create({
@@ -67,11 +73,16 @@ export class ProcessAuditRepository implements ProcessAuditSink {
         userId: entry.actorUserId,
         // Scheduled singletons run under the `__global__` pseudo-project; the
         // audit row records the ref verbatim rather than inventing a scope.
+        // A fleet-scoped act has no project at all and records null, the same
+        // as the queue sink: a placeholder here would read as a real project
+        // to every query over this column.
         projectId: entry.projectId,
         organizationId: null,
         action: entry.action,
         targetKind: TARGET_KIND,
-        targetId: `${entry.processName}/${entry.projectId}/${entry.processKey}`,
+        targetId: entry.processName
+          ? `${entry.processName}/${entry.projectId}/${entry.processKey}`
+          : FLEET_TARGET_ID,
         metadata: (entry.metadata ?? {}) as Prisma.InputJsonValue,
       },
     });

--- a/platform/app/src/server/app-layer/ops/process-audit.repository.ts
+++ b/platform/app/src/server/app-layer/ops/process-audit.repository.ts
@@ -4,6 +4,12 @@ export type ProcessControlAction =
   | "process_wake_now"
   | "process_redrive_dead_instance"
   | "process_redrive_dead_message"
+  | "process_discard_dead_message"
+  /** Fleet-scoped acts record a pseudo-ref (`__fleet__`/`__all__`), the same
+   *  shape scheduled singletons use for their `__global__` pseudo-project;
+   *  the count moved lives in metadata. */
+  | "process_redrive_dead_letters"
+  | "process_discard_dead_letters"
   | "process_release_lapsed_lease";
 
 export interface ProcessAuditEntryView {

--- a/platform/app/src/server/app-layer/ops/queue-audit.repository.ts
+++ b/platform/app/src/server/app-layer/ops/queue-audit.repository.ts
@@ -1,0 +1,56 @@
+import type { Prisma, PrismaClient } from "~/generated/prisma/client";
+
+export type QueueControlAction =
+  | "queue_redrive_dlq_groups"
+  | "queue_discard_dlq_groups";
+
+/**
+ * Audit sink for GroupQueue dead-letter recovery
+ * (specs/ops/dead-letter-recovery.feature). The Redis substrate forgets DLQ
+ * entries at their TTL, so for a discard THIS row is the retained mark: the
+ * queue, the groups, how many jobs they held, and their last errors survive
+ * here after the entries themselves are gone.
+ */
+export interface QueueAuditSink {
+  append(entry: {
+    actorUserId: string;
+    action: QueueControlAction;
+    queueName: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void>;
+}
+
+const TARGET_KIND = "queue_dlq";
+
+/** For app presets that run without Postgres. */
+export class NullQueueAuditSink implements QueueAuditSink {
+  async append(): Promise<void> {
+    // no-op
+  }
+}
+
+/** Writes queue dead-letter operator actions to the shared audit log. */
+export class QueueAuditRepository implements QueueAuditSink {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async append(entry: {
+    actorUserId: string;
+    action: QueueControlAction;
+    queueName: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    await this.prisma.auditLog.create({
+      data: {
+        userId: entry.actorUserId,
+        // Queues are cross-project worker infrastructure; there is no single
+        // project to scope the act to, and inventing one would mislead.
+        projectId: null,
+        organizationId: null,
+        action: entry.action,
+        targetKind: TARGET_KIND,
+        targetId: entry.queueName,
+        metadata: (entry.metadata ?? {}) as Prisma.InputJsonValue,
+      },
+    });
+  }
+}

--- a/platform/app/src/server/app-layer/ops/queue.service.ts
+++ b/platform/app/src/server/app-layer/ops/queue.service.ts
@@ -11,6 +11,22 @@ import type {
 } from "./repositories/queue.repository";
 import type { GroupInfo, ParkedGroupInfo, QueueSummaryInfo } from "./types";
 
+/**
+ * Reduce raw job errors to something safe to keep: the leading error class or
+ * first few words, capped, deduped. Enough for an operator to recognise "these
+ * all died the same way" without copying arbitrary thrown text — which can
+ * include customer payload — into a durable audit row.
+ */
+function summarizeErrorShapes(messages: string[]): string[] {
+  const shapes = new Set<string>();
+  for (const message of messages) {
+    const named = /^([A-Za-z][A-Za-z0-9_]*(?:Error|Exception))\b/.exec(message);
+    shapes.add(named?.[1] ?? message.trim().split(/\s+/).slice(0, 3).join(" "));
+    if (shapes.size >= 5) break;
+  }
+  return [...shapes].map((shape) => shape.slice(0, 80));
+}
+
 export class QueueService {
   private readonly audit: QueueAuditSink;
 
@@ -309,7 +325,11 @@ export class QueueService {
         metadata: {
           groupIds: params.groupIds.slice(0, 50),
           requestedGroups: params.groupIds.length,
-          lastErrors,
+          // A job's error message is arbitrary thrown text and can carry
+          // customer payload; the audit log is long-lived and widely read, so
+          // it records the SHAPE of the failure rather than its content. The
+          // full message stays where it already was, on the failing job.
+          lastErrorTypes: summarizeErrorShapes(lastErrors),
           ...result,
         },
       });

--- a/platform/app/src/server/app-layer/ops/queue.service.ts
+++ b/platform/app/src/server/app-layer/ops/queue.service.ts
@@ -34,13 +34,12 @@ function summarizeErrorShapes(messages: string[]): string[] {
 }
 
 export class QueueService {
+  readonly repo: QueueRepository;
   private readonly audit: QueueAuditSink;
 
-  constructor(
-    readonly repo: QueueRepository,
-    audit?: QueueAuditSink,
-  ) {
-    this.audit = audit ?? new NullQueueAuditSink();
+  constructor(params: { repo: QueueRepository; audit?: QueueAuditSink }) {
+    this.repo = params.repo;
+    this.audit = params.audit ?? new NullQueueAuditSink();
   }
 
   async getQueues(): Promise<QueueSummaryInfo[]> {

--- a/platform/app/src/server/app-layer/ops/queue.service.ts
+++ b/platform/app/src/server/app-layer/ops/queue.service.ts
@@ -1,3 +1,7 @@
+import {
+  NullQueueAuditSink,
+  type QueueAuditSink,
+} from "./queue-audit.repository";
 import type {
   BlockedSummary,
   DlqGroupInfo,
@@ -8,7 +12,14 @@ import type {
 import type { GroupInfo, ParkedGroupInfo, QueueSummaryInfo } from "./types";
 
 export class QueueService {
-  constructor(readonly repo: QueueRepository) {}
+  private readonly audit: QueueAuditSink;
+
+  constructor(
+    readonly repo: QueueRepository,
+    audit?: QueueAuditSink,
+  ) {
+    this.audit = audit ?? new NullQueueAuditSink();
+  }
 
   async getQueues(): Promise<QueueSummaryInfo[]> {
     const queueNames = await this.repo.discoverQueueNames();
@@ -249,6 +260,61 @@ export class QueueService {
     errorFilter?: string;
   }): Promise<{ replayedCount: number; jobsReplayed: number }> {
     return this.repo.replayAllFromDlq(params);
+  }
+
+  /**
+   * Redrive exactly the DLQ groups the operator's filter showed, audited.
+   * Explicit ids, not a re-evaluated filter: the confirmation and the act
+   * must cover the same groups (specs/ops/dead-letter-recovery.feature).
+   */
+  async redriveManyFromDlq(params: {
+    queueName: string;
+    groupIds: string[];
+    requestedBy: string;
+  }): Promise<{ redrivenCount: number; jobsRedriven: number }> {
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.redriveManyFromDlq(rest);
+    if (result.redrivenCount > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_redrive_dlq_groups",
+        queueName: params.queueName,
+        metadata: {
+          groupIds: params.groupIds.slice(0, 50),
+          requestedGroups: params.groupIds.length,
+          ...result,
+        },
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Discard exactly the DLQ groups the operator's filter showed. The Redis
+   * entries are removed (they TTL away regardless); the audit row IS the
+   * retained mark, carrying the queue, groups, job counts and last errors.
+   */
+  async discardManyFromDlq(params: {
+    queueName: string;
+    groupIds: string[];
+    requestedBy: string;
+  }): Promise<{ discardedCount: number; jobsDiscarded: number }> {
+    const { requestedBy, ...rest } = params;
+    const { lastErrors, ...result } = await this.repo.discardManyFromDlq(rest);
+    if (result.discardedCount > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_discard_dlq_groups",
+        queueName: params.queueName,
+        metadata: {
+          groupIds: params.groupIds.slice(0, 50),
+          requestedGroups: params.groupIds.length,
+          lastErrors,
+          ...result,
+        },
+      });
+    }
+    return result;
   }
 
   async canaryRedrive(params: {

--- a/platform/app/src/server/app-layer/ops/queue.service.ts
+++ b/platform/app/src/server/app-layer/ops/queue.service.ts
@@ -11,20 +11,26 @@ import type {
 } from "./repositories/queue.repository";
 import type { GroupInfo, ParkedGroupInfo, QueueSummaryInfo } from "./types";
 
+/** What an error with no recognizable class name is recorded as. */
+const UNTYPED_ERROR_SHAPE = "untyped_error";
+
 /**
- * Reduce raw job errors to something safe to keep: the leading error class or
- * first few words, capped, deduped. Enough for an operator to recognise "these
- * all died the same way" without copying arbitrary thrown text — which can
- * include customer payload — into a durable audit row.
+ * Reduce raw job errors to something safe to keep in a durable audit row.
+ *
+ * Only a leading error CLASS survives — `TimeoutError`, `HttpError`. Anything
+ * else becomes a fixed placeholder, because a job's error text is arbitrary
+ * and its first words are no safer than its last: `"alice@example.com payment
+ * failed"` leads with the address. Enough for an operator to see "these all
+ * died the same way" and no more; the full message stays on the failing job.
  */
 function summarizeErrorShapes(messages: string[]): string[] {
   const shapes = new Set<string>();
   for (const message of messages) {
     const named = /^([A-Za-z][A-Za-z0-9_]*(?:Error|Exception))\b/.exec(message);
-    shapes.add(named?.[1] ?? message.trim().split(/\s+/).slice(0, 3).join(" "));
+    shapes.add(named?.[1]?.slice(0, 80) ?? UNTYPED_ERROR_SHAPE);
     if (shapes.size >= 5) break;
   }
-  return [...shapes].map((shape) => shape.slice(0, 80));
+  return [...shapes];
 }
 
 export class QueueService {

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
@@ -31,6 +31,9 @@ function traceIdFromCarrier(carrier: unknown): string | null {
  */
 const BULK_RECOVERY_LIMIT = 5_000;
 
+/** How many attempt entries one message's history returns. */
+const ATTEMPT_HISTORY_LIMIT = 200;
+
 /** Escape LIKE wildcards so a search term matches literally. */
 function escapeLike(term: string): string {
   return term.replace(/[\\%_]/g, (m) => `\\${m}`);
@@ -581,6 +584,10 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
       // ordering by it would interleave a message's second life with its
       // first. `id` breaks ties within a millisecond.
       orderBy: [{ occurredAt: "asc" }, { id: "asc" }],
+      // Bounded: this sits behind a tRPC query an operator can open on any
+      // message, and a message redriven repeatedly accumulates an attempt row
+      // per failure with no ceiling of its own.
+      take: ATTEMPT_HISTORY_LIMIT,
     });
     return rows.map((r) => ({
       id: r.id,

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
@@ -21,6 +21,16 @@ function traceIdFromCarrier(carrier: unknown): string | null {
   return TRACEPARENT_RE.exec(traceparent)?.[1] ?? null;
 }
 
+/**
+ * How many dead letters one bulk act moves.
+ *
+ * An unbounded UPDATE over this table holds row locks for as long as it takes,
+ * on the highest-volume write path in the system. The cap makes the act
+ * bounded and repeatable instead: the count comes back, the operator sees what
+ * moved, and pressing again takes the next slice.
+ */
+const BULK_RECOVERY_LIMIT = 5_000;
+
 /** Escape LIKE wildcards so a search term matches literally. */
 function escapeLike(term: string): string {
   return term.replace(/[\\%_]/g, (m) => `\\${m}`);
@@ -513,12 +523,21 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
       UPDATE "ProcessManagerOutbox"
       SET "status" = 'pending',
           "attempts" = 0,
-          "nextAttemptAt" = ${now},
+          -- Spread over a minute rather than making every message due at the
+          -- same instant: a fleet redrive can release thousands of intents,
+          -- and handing the dispatcher one due batch the size of the whole
+          -- backlog is how a recovery becomes the next incident.
+          "nextAttemptAt" =
+            CAST(${now} AS timestamptz) + (random() * interval '60 seconds'),
           "leasedUntil" = NULL,
           "leaseToken" = NULL,
           "updatedAt" = ${now}
-      WHERE "status" = 'dead'
-      ${nameFilter}
+      WHERE "id" IN (
+        SELECT "id" FROM "ProcessManagerOutbox"
+        WHERE "status" = 'dead'
+        ${nameFilter}
+        LIMIT ${BULK_RECOVERY_LIMIT}
+      )
     `);
   }
 
@@ -535,8 +554,12 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
       UPDATE "ProcessManagerOutbox"
       SET "status" = 'discarded',
           "updatedAt" = ${now}
-      WHERE "status" = 'dead'
-      ${nameFilter}
+      WHERE "id" IN (
+        SELECT "id" FROM "ProcessManagerOutbox"
+        WHERE "status" = 'dead'
+        ${nameFilter}
+        LIMIT ${BULK_RECOVERY_LIMIT}
+      )
     `);
   }
 

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
@@ -3,6 +3,7 @@ import type { ProcessRef } from "~/server/event-sourcing/process-manager/process
 import type {
   DeadLetterCount,
   DeadOutboxMessageView,
+  OutboxAttemptView,
   ProcessInstanceRow,
   ProcessNameCounts,
   ProcessOpsRepository,
@@ -461,6 +462,100 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
     });
     if (updated.count === 0) return null;
     return { messageKey: message.messageKey };
+  }
+
+  async discardDeadMessage(params: {
+    ref: ProcessRef;
+    messageId: string;
+    now: number;
+  }): Promise<{ messageKey: string } | null> {
+    const message = await this.prisma.processManagerOutbox.findFirst({
+      where: {
+        id: params.messageId,
+        projectId: params.ref.projectId,
+        processName: params.ref.processName,
+        processKey: params.ref.processKey,
+        status: "dead",
+      },
+      select: { messageKey: true },
+    });
+    if (!message) return null;
+    // A mark, not a delete: the row is retained as its own audit trail.
+    // Guarded on status in the WHERE, same as the redrive: only a dead row
+    // can be discarded, so a racing redrive keeps its win.
+    const updated = await this.prisma.processManagerOutbox.updateMany({
+      where: {
+        id: params.messageId,
+        projectId: params.ref.projectId,
+        status: "dead",
+      },
+      data: {
+        status: "discarded",
+        updatedAt: new Date(params.now),
+      },
+    });
+    if (updated.count === 0) return null;
+    return { messageKey: message.messageKey };
+  }
+
+  async redriveAllDeadMessages(params: {
+    processName?: string;
+    now: number;
+  }): Promise<number> {
+    const now = new Date(params.now);
+    const nameFilter = params.processName
+      ? Prisma.sql`AND "processName" = ${params.processName}`
+      : Prisma.empty;
+    // Raw, like the fleet-wide reads: a dead-letter sweep has no single
+    // project to name for the tenancy guard, and the surface is ops-gated.
+    return await this.prisma.$executeRaw(Prisma.sql`
+      -- @tenancy: cross-tenant ops dead-letter recovery; the surface is ops-gated
+      UPDATE "ProcessManagerOutbox"
+      SET "status" = 'pending',
+          "attempts" = 0,
+          "nextAttemptAt" = ${now},
+          "leasedUntil" = NULL,
+          "leaseToken" = NULL,
+          "updatedAt" = ${now}
+      WHERE "status" = 'dead'
+      ${nameFilter}
+    `);
+  }
+
+  async discardAllDeadMessages(params: {
+    processName?: string;
+    now: number;
+  }): Promise<number> {
+    const now = new Date(params.now);
+    const nameFilter = params.processName
+      ? Prisma.sql`AND "processName" = ${params.processName}`
+      : Prisma.empty;
+    return await this.prisma.$executeRaw(Prisma.sql`
+      -- @tenancy: cross-tenant ops dead-letter recovery; the surface is ops-gated
+      UPDATE "ProcessManagerOutbox"
+      SET "status" = 'discarded',
+          "updatedAt" = ${now}
+      WHERE "status" = 'dead'
+      ${nameFilter}
+    `);
+  }
+
+  async findAttempts(params: {
+    outboxId: string;
+    projectId: string;
+  }): Promise<OutboxAttemptView[]> {
+    const rows = await this.prisma.processManagerOutboxAttempt.findMany({
+      where: { outboxId: params.outboxId, projectId: params.projectId },
+      orderBy: { attempt: "asc" },
+    });
+    return rows.map((r) => ({
+      attempt: r.attempt,
+      occurredAt: r.occurredAt.getTime(),
+      outcome: r.outcome,
+      errorType: r.errorType,
+      errorMessage: r.errorMessage,
+      retryAfterMs: r.retryAfterMs,
+    }));
   }
 
   async releaseLapsedLease(params: {

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
@@ -546,9 +546,13 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
   }): Promise<OutboxAttemptView[]> {
     const rows = await this.prisma.processManagerOutboxAttempt.findMany({
       where: { outboxId: params.outboxId, projectId: params.projectId },
-      orderBy: { attempt: "asc" },
+      // Chronological, not by attempt number: a redrive resets `attempts`, so
+      // ordering by it would interleave a message's second life with its
+      // first. `id` breaks ties within a millisecond.
+      orderBy: [{ occurredAt: "asc" }, { id: "asc" }],
     });
     return rows.map((r) => ({
+      id: r.id,
       attempt: r.attempt,
       occurredAt: r.occurredAt.getTime(),
       outcome: r.outcome,

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.prisma.repository.ts
@@ -532,12 +532,18 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
           "leasedUntil" = NULL,
           "leaseToken" = NULL,
           "updatedAt" = ${now}
-      WHERE "id" IN (
-        SELECT "id" FROM "ProcessManagerOutbox"
-        WHERE "status" = 'dead'
-        ${nameFilter}
-        LIMIT ${BULK_RECOVERY_LIMIT}
-      )
+      -- The status guard is repeated on the UPDATE itself, not left to the
+      -- subquery. The subquery picks ids under one snapshot and the UPDATE
+      -- locks them under another, so a concurrent single-row redrive or
+      -- discard that landed in between would otherwise be clobbered. The
+      -- single-row paths guard the same way for the same reason.
+      WHERE "status" = 'dead'
+        AND "id" IN (
+          SELECT "id" FROM "ProcessManagerOutbox"
+          WHERE "status" = 'dead'
+          ${nameFilter}
+          LIMIT ${BULK_RECOVERY_LIMIT}
+        )
     `);
   }
 
@@ -554,12 +560,14 @@ export class ProcessOpsPrismaRepository implements ProcessOpsRepository {
       UPDATE "ProcessManagerOutbox"
       SET "status" = 'discarded',
           "updatedAt" = ${now}
-      WHERE "id" IN (
-        SELECT "id" FROM "ProcessManagerOutbox"
-        WHERE "status" = 'dead'
-        ${nameFilter}
-        LIMIT ${BULK_RECOVERY_LIMIT}
-      )
+      -- Guarded on the UPDATE too; see redriveAllDeadMessages.
+      WHERE "status" = 'dead'
+        AND "id" IN (
+          SELECT "id" FROM "ProcessManagerOutbox"
+          WHERE "status" = 'dead'
+          ${nameFilter}
+          LIMIT ${BULK_RECOVERY_LIMIT}
+        )
     `);
   }
 

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.repository.ts
@@ -85,6 +85,12 @@ export interface DeadLetterCount {
  * dead letter died, on the page (specs/ops/dead-letter-recovery.feature).
  */
 export interface OutboxAttemptView {
+  /**
+   * Row identity, not the attempt number. A redrive resets `attempts` to 0,
+   * so a message that failed, was redriven, and failed again holds two
+   * entries numbered 1 — the number is not unique over a message's life.
+   */
+  id: string;
   attempt: number;
   occurredAt: number;
   /** "dead" marks the failure that killed the message. */

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.repository.ts
@@ -42,7 +42,7 @@ export interface ProcessOutboxMessageView {
   id: string;
   messageKey: string;
   intentType: string;
-  status: "pending" | "dispatched" | "dead";
+  status: "pending" | "dispatched" | "dead" | "discarded";
   attempts: number;
   nextAttemptAt: number;
   leasedUntil: number | null;
@@ -61,9 +61,8 @@ export interface ProcessOutboxMessageView {
  * to — and the fleet table only ever showed them a count. This view is the
  * fleet-wide read: it carries the full ref so a row can be redriven straight
  * from the list, and the trace id so the operator can reach the failure
- * itself. The outbox row does not store WHY a message died; the dispatcher
- * records that on the span and the log line, and `traceId` is the join back
- * to it.
+ * itself. WHY it died is in the attempt history (`findAttempts`); `traceId`
+ * remains the deeper join to the producing trace.
  */
 export interface DeadOutboxMessageView extends ProcessOutboxMessageView {
   processName: string;
@@ -79,6 +78,20 @@ export interface DeadLetterCount {
   count: number;
   /** Oldest retirement in this group, so the operator can age the incident. */
   oldestUpdatedAt: number;
+}
+
+/**
+ * One FAILED delivery attempt of an outbox message, oldest first — why a
+ * dead letter died, on the page (specs/ops/dead-letter-recovery.feature).
+ */
+export interface OutboxAttemptView {
+  attempt: number;
+  occurredAt: number;
+  /** "dead" marks the failure that killed the message. */
+  outcome: "retry_scheduled" | "dead";
+  errorType: string;
+  errorMessage: string;
+  retryAfterMs: number | null;
 }
 
 export interface ProcessOpsRepository {
@@ -141,6 +154,40 @@ export interface ProcessOpsRepository {
   }): Promise<{ messageKey: string } | null>;
 
   /**
+   * One dead message marked never-to-be-sent. A mark, not a delete: the row
+   * is retained as its own audit trail and the dispatcher never leases a
+   * discarded row. Returns the message key for the audit trail, or null when
+   * the message was not dead (or not that instance's).
+   */
+  discardDeadMessage(params: {
+    ref: ProcessRef;
+    messageId: string;
+    now: number;
+  }): Promise<{ messageKey: string } | null>;
+
+  /**
+   * Every dead message back to pending with a fresh budget, due now —
+   * narrowed to one process name, or the whole fleet when omitted. Returns
+   * how many messages moved, for the audit trail.
+   */
+  redriveAllDeadMessages(params: {
+    processName?: string;
+    now: number;
+  }): Promise<number>;
+
+  /** Every dead message marked discarded; same scoping and count contract. */
+  discardAllDeadMessages(params: {
+    processName?: string;
+    now: number;
+  }): Promise<number>;
+
+  /** The message's failed attempts, oldest first. */
+  findAttempts(params: {
+    outboxId: string;
+    projectId: string;
+  }): Promise<OutboxAttemptView[]>;
+
+  /**
    * Clear a LAPSED lease so the dispatcher can pick the message up now
    * instead of waiting out the lease. Guarded in the write itself: only a
    * pending message whose lease already expired is touched, so a live
@@ -191,6 +238,18 @@ export class NullProcessOpsRepository implements ProcessOpsRepository {
   }
   async redriveDeadMessage(): Promise<null> {
     return null;
+  }
+  async discardDeadMessage(): Promise<null> {
+    return null;
+  }
+  async redriveAllDeadMessages(): Promise<number> {
+    return 0;
+  }
+  async discardAllDeadMessages(): Promise<number> {
+    return 0;
+  }
+  async findAttempts(): Promise<OutboxAttemptView[]> {
+    return [];
   }
   async releaseLapsedLease(): Promise<null> {
     return null;

--- a/platform/app/src/server/app-layer/ops/repositories/process-ops.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/process-ops.repository.ts
@@ -172,16 +172,27 @@ export interface ProcessOpsRepository {
   }): Promise<{ messageKey: string } | null>;
 
   /**
-   * Every dead message back to pending with a fresh budget, due now —
-   * narrowed to one process name, or the whole fleet when omitted. Returns
-   * how many messages moved, for the audit trail.
+   * Dead messages back to pending with a fresh budget — narrowed to one
+   * process name, or every process when omitted.
+   *
+   * BOUNDED, not exhaustive: an implementation moves at most one batch per
+   * call, because an unbounded UPDATE holds row locks on the highest-volume
+   * table in the system for as long as it runs. The returned count is what
+   * actually moved, so a caller wanting the rest calls again — and an
+   * operator pressing the button again is exactly that.
+   *
+   * Due times are spread rather than set to a single instant: releasing
+   * thousands of intents all due now hands the dispatcher one batch the size
+   * of the backlog.
    */
   redriveAllDeadMessages(params: {
     processName?: string;
     now: number;
   }): Promise<number>;
 
-  /** Every dead message marked discarded; same scoping and count contract. */
+  /**
+   * Dead messages marked discarded; same scoping, and bounded the same way.
+   */
   discardAllDeadMessages(params: {
     processName?: string;
     now: number;

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -394,7 +394,6 @@ const SSCAN_BATCH = 500;
 /** Page size for the index reads that enumerate a queue's groups. */
 const PENDING_RECONCILE_PAGE_SIZE = 1000;
 
-/** Split an explicit id list into pipeline-sized batches. */
 function chunk<T>(items: T[], size: number): T[][] {
   const batches: T[][] = [];
   for (let i = 0; i < items.length; i += size) {
@@ -1772,8 +1771,9 @@ export class QueueRedisRepository implements QueueRepository {
           discardedCount++;
           jobsDiscarded += Number(count);
         }
-        // A sample, not the set: the audit row names why these groups died,
-        // and five distinct messages is enough to recognise the cause.
+        // A sample. The service reduces these to error shapes before they
+        // reach the audit row, and five distinct failures is enough to tell
+        // "they all died the same way" from "these are unrelated".
         if (lastError && lastErrors.size < 5) lastErrors.add(lastError);
       },
     });

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -284,6 +284,29 @@ redis.call("LTRIM", signalKey, 0, 999)
 return count
 `;
 
+// Discard a DLQ group: the operator marking its jobs never-to-run
+// (specs/ops/dead-letter-recovery.feature). The Redis substrate already
+// forgets DLQ entries at their TTL, so the durable mark lives in the audit
+// row the service writes — this script's job is to remove the group and
+// hand back what that audit row must record: the job count and last error.
+const DISCARD_FROM_DLQ_LUA = `
+local dlqJobsKey   = KEYS[1]
+local dlqDataKey   = KEYS[2]
+local dlqErrorKey  = KEYS[3]
+local dlqIndexKey  = KEYS[4]
+local groupId      = ARGV[1]
+
+local count = redis.call("ZCARD", dlqJobsKey)
+local lastError = redis.call("HGET", dlqErrorKey, "message")
+
+redis.call("DEL", dlqJobsKey)
+redis.call("DEL", dlqDataKey)
+redis.call("DEL", dlqErrorKey)
+redis.call("SREM", dlqIndexKey, groupId)
+
+return {count, lastError or ""}
+`;
+
 // Re-arm (or drop, when the requested TTL is not positive) the pending-reconcile
 // single-flight marker, but only while the caller still holds it. A marker that
 // lapsed mid-pass may already have been re-acquired by another instance, and
@@ -357,6 +380,7 @@ const unblockScript = new CachedLuaScript(UNBLOCK_LUA);
 const drainGroupScript = new CachedLuaScript(DRAIN_GROUP_LUA);
 const moveToDlqScript = new CachedLuaScript(MOVE_TO_DLQ_LUA);
 const replayFromDlqScript = new CachedLuaScript(REPLAY_FROM_DLQ_LUA);
+const discardFromDlqScript = new CachedLuaScript(DISCARD_FROM_DLQ_LUA);
 const reconcileMarkerTtlScript = new CachedLuaScript(RECONCILE_MARKER_TTL_LUA);
 const reconcileWriteScript = new CachedLuaScript(RECONCILE_WRITE_LUA);
 const pendingIndexPruneScript = new CachedLuaScript(PENDING_INDEX_PRUNE_LUA);
@@ -369,6 +393,15 @@ const SSCAN_BATCH = 500;
 
 /** Page size for the index reads that enumerate a queue's groups. */
 const PENDING_RECONCILE_PAGE_SIZE = 1000;
+
+/** Split an explicit id list into pipeline-sized batches. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
 
 /** Number of ZCARDs sent per pipeline round trip during a reconcile pass. */
 const PENDING_RECONCILE_ZCARD_BATCH = 1000;
@@ -1633,6 +1666,102 @@ export class QueueRedisRepository implements QueueRepository {
     } while (cursor !== "0");
 
     return { replayedCount, jobsReplayed };
+  }
+
+  /**
+   * Redrive an explicit set of DLQ groups. The list comes from what the
+   * operator's filter SHOWED, so acting on ids rather than re-evaluating a
+   * filter server-side means the confirmation and the act cover the same
+   * groups (specs/ops/dead-letter-recovery.feature).
+   */
+  async redriveManyFromDlq(params: {
+    queueName: string;
+    groupIds: string[];
+  }): Promise<{ redrivenCount: number; jobsRedriven: number }> {
+    const prefix = `${params.queueName}:gq:`;
+    let redrivenCount = 0;
+    let jobsRedriven = 0;
+    for (const batch of chunk(params.groupIds, SSCAN_BATCH)) {
+      const pipeline = this.redis.pipeline();
+      const argsByIndex = batch.map((groupId) => [
+        `${prefix}dlq:${groupId}:jobs`,
+        `${prefix}dlq:${groupId}:data`,
+        `${prefix}dlq:${groupId}:error`,
+        `${prefix}group:${groupId}:jobs`,
+        `${prefix}group:${groupId}:data`,
+        `${prefix}ready`,
+        `${prefix}signal`,
+        `${prefix}dlq`,
+        groupId,
+        String(Date.now()),
+      ]);
+      for (const args of argsByIndex) {
+        replayFromDlqScript.queue(pipeline, 8, ...args);
+      }
+      const results = await execWithNoScriptRecovery(pipeline, (index) =>
+        replayFromDlqScript.run(this.redis, 8, ...argsByIndex[index]!),
+      );
+      if (results) {
+        for (const [err, result] of results) {
+          if (!err) {
+            const replayed = Number(result);
+            if (replayed > 0) {
+              redrivenCount++;
+              jobsRedriven += replayed;
+            }
+          }
+        }
+      }
+    }
+    return { redrivenCount, jobsRedriven };
+  }
+
+  /**
+   * Discard an explicit set of DLQ groups: their jobs never run again. The
+   * substrate forgets DLQ entries at their TTL anyway, so the durable record
+   * is the audit row the service writes from what this returns — per-group
+   * job counts and a sample of the last errors.
+   */
+  async discardManyFromDlq(params: {
+    queueName: string;
+    groupIds: string[];
+  }): Promise<{
+    discardedCount: number;
+    jobsDiscarded: number;
+    lastErrors: string[];
+  }> {
+    const prefix = `${params.queueName}:gq:`;
+    let discardedCount = 0;
+    let jobsDiscarded = 0;
+    const lastErrors = new Set<string>();
+    for (const batch of chunk(params.groupIds, SSCAN_BATCH)) {
+      const pipeline = this.redis.pipeline();
+      const argsByIndex = batch.map((groupId) => [
+        `${prefix}dlq:${groupId}:jobs`,
+        `${prefix}dlq:${groupId}:data`,
+        `${prefix}dlq:${groupId}:error`,
+        `${prefix}dlq`,
+        groupId,
+      ]);
+      for (const args of argsByIndex) {
+        discardFromDlqScript.queue(pipeline, 4, ...args);
+      }
+      const results = await execWithNoScriptRecovery(pipeline, (index) =>
+        discardFromDlqScript.run(this.redis, 4, ...argsByIndex[index]!),
+      );
+      if (results) {
+        for (const [err, result] of results) {
+          if (err) continue;
+          const [count, lastError] = result as [number, string];
+          if (Number(count) > 0) {
+            discardedCount++;
+            jobsDiscarded += Number(count);
+          }
+          if (lastError && lastErrors.size < 5) lastErrors.add(lastError);
+        }
+      }
+    }
+    return { discardedCount, jobsDiscarded, lastErrors: [...lastErrors] };
   }
 
   // ── Canary Operations ───────────────────────────────────────────

--- a/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1681,9 +1681,11 @@ export class QueueRedisRepository implements QueueRepository {
     const prefix = `${params.queueName}:gq:`;
     let redrivenCount = 0;
     let jobsRedriven = 0;
-    for (const batch of chunk(params.groupIds, SSCAN_BATCH)) {
-      const pipeline = this.redis.pipeline();
-      const argsByIndex = batch.map((groupId) => [
+    await this.runOverDlqGroups({
+      groupIds: params.groupIds,
+      script: replayFromDlqScript,
+      keyCount: 8,
+      argsFor: (groupId) => [
         `${prefix}dlq:${groupId}:jobs`,
         `${prefix}dlq:${groupId}:data`,
         `${prefix}dlq:${groupId}:error`,
@@ -1694,26 +1696,45 @@ export class QueueRedisRepository implements QueueRepository {
         `${prefix}dlq`,
         groupId,
         String(Date.now()),
-      ]);
+      ],
+      onResult: (result) => {
+        const replayed = Number(result);
+        if (replayed > 0) {
+          redrivenCount++;
+          jobsRedriven += replayed;
+        }
+      },
+    });
+    return { redrivenCount, jobsRedriven };
+  }
+
+  /**
+   * Run one Lua script over an explicit group-id list, batched into pipelines.
+   * Shared by the two explicit-id recovery paths, which differ only in their
+   * script, their key arity and what they count. Errored replies are skipped
+   * — a group that failed its script simply does not count as acted on.
+   */
+  private async runOverDlqGroups(params: {
+    groupIds: string[];
+    script: CachedLuaScript;
+    keyCount: number;
+    argsFor: (groupId: string) => string[];
+    onResult: (result: unknown) => void;
+  }): Promise<void> {
+    for (const batch of chunk(params.groupIds, SSCAN_BATCH)) {
+      const pipeline = this.redis.pipeline();
+      const argsByIndex = batch.map(params.argsFor);
       for (const args of argsByIndex) {
-        replayFromDlqScript.queue(pipeline, 8, ...args);
+        params.script.queue(pipeline, params.keyCount, ...args);
       }
       const results = await execWithNoScriptRecovery(pipeline, (index) =>
-        replayFromDlqScript.run(this.redis, 8, ...argsByIndex[index]!),
+        params.script.run(this.redis, params.keyCount, ...argsByIndex[index]!),
       );
-      if (results) {
-        for (const [err, result] of results) {
-          if (!err) {
-            const replayed = Number(result);
-            if (replayed > 0) {
-              redrivenCount++;
-              jobsRedriven += replayed;
-            }
-          }
-        }
+      for (const [err, result] of results ?? []) {
+        if (err) continue;
+        params.onResult(result);
       }
     }
-    return { redrivenCount, jobsRedriven };
   }
 
   /**
@@ -1734,33 +1755,28 @@ export class QueueRedisRepository implements QueueRepository {
     let discardedCount = 0;
     let jobsDiscarded = 0;
     const lastErrors = new Set<string>();
-    for (const batch of chunk(params.groupIds, SSCAN_BATCH)) {
-      const pipeline = this.redis.pipeline();
-      const argsByIndex = batch.map((groupId) => [
+    await this.runOverDlqGroups({
+      groupIds: params.groupIds,
+      script: discardFromDlqScript,
+      keyCount: 4,
+      argsFor: (groupId) => [
         `${prefix}dlq:${groupId}:jobs`,
         `${prefix}dlq:${groupId}:data`,
         `${prefix}dlq:${groupId}:error`,
         `${prefix}dlq`,
         groupId,
-      ]);
-      for (const args of argsByIndex) {
-        discardFromDlqScript.queue(pipeline, 4, ...args);
-      }
-      const results = await execWithNoScriptRecovery(pipeline, (index) =>
-        discardFromDlqScript.run(this.redis, 4, ...argsByIndex[index]!),
-      );
-      if (results) {
-        for (const [err, result] of results) {
-          if (err) continue;
-          const [count, lastError] = result as [number, string];
-          if (Number(count) > 0) {
-            discardedCount++;
-            jobsDiscarded += Number(count);
-          }
-          if (lastError && lastErrors.size < 5) lastErrors.add(lastError);
+      ],
+      onResult: (result) => {
+        const [count, lastError] = result as [number, string];
+        if (Number(count) > 0) {
+          discardedCount++;
+          jobsDiscarded += Number(count);
         }
-      }
-    }
+        // A sample, not the set: the audit row names why these groups died,
+        // and five distinct messages is enough to recognise the cause.
+        if (lastError && lastErrors.size < 5) lastErrors.add(lastError);
+      },
+    });
     return { discardedCount, jobsDiscarded, lastErrors: [...lastErrors] };
   }
 

--- a/platform/app/src/server/app-layer/ops/repositories/queue.repository.ts
+++ b/platform/app/src/server/app-layer/ops/repositories/queue.repository.ts
@@ -178,6 +178,25 @@ export interface QueueRepository {
     errorFilter?: string;
   }): Promise<{ replayedCount: number; jobsReplayed: number }>;
 
+  /** Redrive an explicit set of DLQ groups — the operator's shown set. */
+  redriveManyFromDlq(params: {
+    queueName: string;
+    groupIds: string[];
+  }): Promise<{ redrivenCount: number; jobsRedriven: number }>;
+
+  /**
+   * Discard an explicit set of DLQ groups: their jobs never run again.
+   * Returns what the audit row must record — counts and an error sample.
+   */
+  discardManyFromDlq(params: {
+    queueName: string;
+    groupIds: string[];
+  }): Promise<{
+    discardedCount: number;
+    jobsDiscarded: number;
+    lastErrors: string[];
+  }>;
+
   canaryRedrive(params: {
     queueName: string;
     count?: number;
@@ -296,6 +315,21 @@ export class NullQueueRepository implements QueueRepository {
     jobsReplayed: number;
   }> {
     return { replayedCount: 0, jobsReplayed: 0 };
+  }
+
+  async redriveManyFromDlq(): Promise<{
+    redrivenCount: number;
+    jobsRedriven: number;
+  }> {
+    return { redrivenCount: 0, jobsRedriven: 0 };
+  }
+
+  async discardManyFromDlq(): Promise<{
+    discardedCount: number;
+    jobsDiscarded: number;
+    lastErrors: string[];
+  }> {
+    return { discardedCount: 0, jobsDiscarded: 0, lastErrors: [] };
   }
 
   async canaryRedrive(): Promise<{

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1620,7 +1620,10 @@ export function initializeDefaultApp(options?: {
     : new NullEventExplorerRepository();
 
   const ops = {
-    queues: new QueueService(queueRepo, new QueueAuditRepository(prisma)),
+    queues: new QueueService({
+      repo: queueRepo,
+      audit: new QueueAuditRepository(prisma),
+    }),
     scheduler: new SchedulerOpsService({
       repo: new PrismaScheduledJobRepository(prisma),
       audit: new SchedulerAuditRepository(prisma),
@@ -2140,7 +2143,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
     nurturing: undefined,
     usageLimits: UsageLimitService.createNull(),
     ops: {
-      queues: new QueueService(new NullQueueRepository()),
+      queues: new QueueService({ repo: new NullQueueRepository() }),
       scheduler: new SchedulerOpsService({
         repo: new NullScheduledJobRepository(),
       }),

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -247,6 +247,7 @@ import {
   ProcessAuditRepository,
 } from "./ops/process-audit.repository";
 import { QueueService } from "./ops/queue.service";
+import { QueueAuditRepository } from "./ops/queue-audit.repository";
 import { ReplayService } from "./ops/replay.service";
 import { BlobStoreRedisRepository } from "./ops/repositories/blob-store.redis.repository";
 import { NullBlobStoreRepository } from "./ops/repositories/blob-store.repository";
@@ -1619,7 +1620,7 @@ export function initializeDefaultApp(options?: {
     : new NullEventExplorerRepository();
 
   const ops = {
-    queues: new QueueService(queueRepo),
+    queues: new QueueService(queueRepo, new QueueAuditRepository(prisma)),
     scheduler: new SchedulerOpsService({
       repo: new PrismaScheduledJobRepository(prisma),
       audit: new SchedulerAuditRepository(prisma),

--- a/platform/app/src/server/event-sourcing/process-manager/__tests__/processRuntime.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/__tests__/processRuntime.unit.test.ts
@@ -44,6 +44,7 @@ function makeStubStore(overrides: Partial<ProcessStore> = {}): ProcessStore {
     leaseDueMessages: async () => [],
     markDispatched: async () => ({ applied: true }),
     markFailed: async () => ({ applied: true }),
+    recordFailedAttempt: async () => undefined,
     releaseLease: async () => ({ applied: true }),
     findDueWakes: async () => [],
     requeueDeadMessages: async () => 0,

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts
@@ -171,6 +171,7 @@ describe("OutboxDispatcherService", () => {
         // DispatchError's shape: a deliberately-written delivery diagnostic,
         // which the attempt log preserves verbatim.
         const transient = Object.assign(new Error("receiver returned 503"), {
+          name: "DispatchError",
           retryable: true,
         });
         const handler = vi.fn().mockRejectedValue(transient);
@@ -202,6 +203,29 @@ describe("OutboxDispatcherService", () => {
         const dispatcher = new OutboxDispatcherService({
           store,
           handlers: { "worker-dispatch": handler },
+          retryDelayMs: () => 1_000,
+          maxAttempts: 2,
+        });
+
+        await dispatcher.runOnce({ now: T0 + 1 });
+
+        const attempts = store.findFailedAttempts({
+          processName: pilotRef.processName,
+          projectId: pilotRef.projectId,
+          messageKey: "dispatch:turn_1:1",
+        });
+        expect(attempts[0]?.errorMessage).not.toContain("sk-secret");
+      });
+
+      it("redacts an error that merely claims to be retryable", async () => {
+        // `retryable` alone is not proof of provenance: anything can carry it,
+        // and only our own class stamps the DispatchError name.
+        const impostor = Object.assign(new Error("raw payload: sk-secret"), {
+          retryable: true,
+        });
+        const dispatcher = new OutboxDispatcherService({
+          store,
+          handlers: { "worker-dispatch": vi.fn().mockRejectedValue(impostor) },
           retryDelayMs: () => 1_000,
           maxAttempts: 2,
         });

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts
@@ -165,6 +165,91 @@ describe("OutboxDispatcherService", () => {
       });
     });
 
+    describe("when failed deliveries are recorded to the attempt log", () => {
+      /** @scenario Each failed delivery records why it failed */
+      it("appends one entry per failed attempt, oldest first, with the killer marked dead", async () => {
+        // DispatchError's shape: a deliberately-written delivery diagnostic,
+        // which the attempt log preserves verbatim.
+        const transient = Object.assign(new Error("receiver returned 503"), {
+          retryable: true,
+        });
+        const handler = vi.fn().mockRejectedValue(transient);
+        const dispatcher = new OutboxDispatcherService({
+          store,
+          handlers: { "worker-dispatch": handler },
+          retryDelayMs: () => 1_000,
+          maxAttempts: 2,
+        });
+
+        await dispatcher.runOnce({ now: T0 + 1 });
+        await dispatcher.runOnce({ now: T0 + 2_000 });
+
+        const attempts = store.findFailedAttempts({
+          processName: pilotRef.processName,
+          projectId: pilotRef.projectId,
+          messageKey: "dispatch:turn_1:1",
+        });
+        expect(attempts.map((a) => a.attempt)).toEqual([1, 2]);
+        expect(attempts[0]?.outcome).toBe("retry_scheduled");
+        expect(attempts[1]?.outcome).toBe("dead");
+        expect(attempts[1]?.errorMessage).toBe("receiver returned 503");
+      });
+
+      it("redacts the diagnostic for an untyped error, which can carry anything", async () => {
+        const handler = vi
+          .fn()
+          .mockRejectedValue(new Error("raw payload: sk-secret"));
+        const dispatcher = new OutboxDispatcherService({
+          store,
+          handlers: { "worker-dispatch": handler },
+          retryDelayMs: () => 1_000,
+          maxAttempts: 2,
+        });
+
+        await dispatcher.runOnce({ now: T0 + 1 });
+
+        const attempts = store.findFailedAttempts({
+          processName: pilotRef.processName,
+          projectId: pilotRef.projectId,
+          messageKey: "dispatch:turn_1:1",
+        });
+        expect(attempts[0]?.errorMessage).not.toContain("sk-secret");
+      });
+
+      /** @scenario A recording failure never fails the delivery accounting */
+      it("retries and retires exactly as it would have when the attempt log write throws", async () => {
+        const failingStore = new Proxy(store, {
+          get(target, prop, receiver) {
+            if (prop === "recordFailedAttempt") {
+              return () => Promise.reject(new Error("attempt log down"));
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        });
+        const handler = vi.fn().mockRejectedValue(new Error("always broken"));
+        const dispatcher = new OutboxDispatcherService({
+          store: failingStore,
+          handlers: { "worker-dispatch": handler },
+          retryDelayMs: () => 1_000,
+          maxAttempts: 2,
+        });
+
+        const first = await dispatcher.runOnce({ now: T0 + 1 });
+        expect(first.retried).toEqual(["dispatch:turn_1:1"]);
+        const second = await dispatcher.runOnce({ now: T0 + 2_000 });
+        expect(second.dead).toEqual(["dispatch:turn_1:1"]);
+
+        // The missing attempt entry is the only loss.
+        expect(
+          store.findFailedAttempts({
+            processName: pilotRef.processName,
+            projectId: pilotRef.projectId,
+            messageKey: "dispatch:turn_1:1",
+          }),
+        ).toEqual([]);
+      });
+    });
+
     describe("when the handler throws a terminal error", () => {
       /** @scenario A permanent receiver error retires the batch immediately */
       it("dead-letters on that attempt instead of burning the remaining ladder", async () => {

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
@@ -16,6 +16,7 @@ import {
 import { toSafeFailureDiagnostic } from "../failureDiagnostic";
 import type { JsonValue } from "../json";
 import type {
+  FailedOutboxAttempt,
   LeasedOutboxMessageRecord,
   OutboxMessageIdentity,
   ProcessStore,
@@ -139,6 +140,30 @@ function retryAfterMsOf(error: unknown): number | undefined {
 function isTerminalError(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
   return Reflect.get(error, "retryable") === false;
+}
+
+/**
+ * What the attempt log records (specs/ops/dead-letter-recovery.feature).
+ *
+ * `toSafeFailureDiagnostic` redacts every message, because an arbitrary
+ * thrown error can carry payload. A DispatchError's message is different: it
+ * is the delivery diagnostic our own dispatch endpoints assembled on purpose
+ * (ADR-027), and the attempt log is the admin-gated ops surface such a
+ * diagnostic exists for — redacting it there would leave the operator with
+ * "Operation failed" eight times over. Same duck-typed shape as
+ * `isTerminalError`, since a boundary may have stripped the class.
+ */
+function toAttemptDiagnostic(error: unknown): {
+  errorType: string;
+  errorMessage: string;
+} {
+  if (
+    error instanceof Error &&
+    typeof Reflect.get(error, "retryable") === "boolean"
+  ) {
+    return { errorType: error.name, errorMessage: error.message };
+  }
+  return toSafeFailureDiagnostic(error);
 }
 
 /**
@@ -295,6 +320,21 @@ export class OutboxDispatcherService {
       intentType: message.intentType,
       status: "dead",
     });
+    // A retirement kills the message without a delivery error to record, so
+    // the kill still gets an attempt entry — otherwise the one death mode
+    // with no exception would be the one with no history.
+    await this.recordAttemptBestEffort({
+      message,
+      attempt: {
+        attempt: message.attempts,
+        occurredAt: now,
+        outcome: "dead",
+        errorType: "AttemptsExhausted",
+        errorMessage:
+          "Exhausted delivery attempts without ever acknowledging — the " +
+          "handler is either not settling or repeatedly outliving the lease.",
+      },
+    });
     // Intentionally retain this opaque operational ID for retirement diagnostics.
     this.logger.error(
       {
@@ -310,6 +350,36 @@ export class OutboxDispatcherService {
         "acknowledging — retiring it as dead. Its handler is either not " +
         "settling or repeatedly outliving the lease.",
     );
+  }
+
+  /**
+   * The attempt log is diagnosis, not accounting: a failed history write must
+   * never fail the delivery bookkeeping, so the entry is the only loss
+   * (specs/ops/dead-letter-recovery.feature).
+   */
+  private async recordAttemptBestEffort(params: {
+    message: LeasedOutboxMessageRecord;
+    attempt: FailedOutboxAttempt;
+  }): Promise<void> {
+    try {
+      await this.store.recordFailedAttempt({
+        identity: identityOf(params.message),
+        attempt: params.attempt,
+      });
+    } catch (error) {
+      const { errorType, errorMessage } = toSafeFailureDiagnostic(error);
+      this.logger.warn(
+        {
+          processName: params.message.processName,
+          messageKey: params.message.messageKey,
+          intentType: params.message.intentType,
+          attempt: params.attempt.attempt,
+          errorType,
+          errorMessage,
+        },
+        "Failed to record an outbox attempt entry; delivery accounting is unaffected",
+      );
+    }
   }
 
   /** Hand a batch tail back to the pool because the lease budget ran out. */
@@ -508,6 +578,20 @@ export class OutboxDispatcherService {
             processName: message.processName,
             intentType: message.intentType,
             status: dead ? "dead" : "retried",
+          });
+          const attemptRetryAfterMs = retryAfterMsOf(error);
+          const attemptDiagnostic = toAttemptDiagnostic(error);
+          await this.recordAttemptBestEffort({
+            message,
+            attempt: {
+              attempt,
+              occurredAt: now,
+              outcome: dead ? "dead" : "retry_scheduled",
+              ...attemptDiagnostic,
+              ...(attemptRetryAfterMs !== undefined
+                ? { retryAfterMs: attemptRetryAfterMs }
+                : {}),
+            },
           });
           if (dead || attempt === 1) {
             // Intentionally retain this opaque operational ID for delivery diagnostics.

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
@@ -150,8 +150,14 @@ function isTerminalError(error: unknown): boolean {
  * is the delivery diagnostic our own dispatch endpoints assembled on purpose
  * (ADR-027), and the attempt log is the admin-gated ops surface such a
  * diagnostic exists for — redacting it there would leave the operator with
- * "Operation failed" eight times over. Same duck-typed shape as
- * `isTerminalError`, since a boundary may have stripped the class.
+ * "Operation failed" eight times over.
+ *
+ * The gate is the stable `name`, not the `retryable` field alone. Anything can
+ * carry a boolean `retryable`; only our own class stamps `DispatchError` in
+ * its constructor. Checked by name rather than `instanceof` because the error
+ * may have crossed a worker or serialisation boundary that stripped the
+ * prototype, which is the same reason the house rule prefers a code to a
+ * class check.
  */
 function toAttemptDiagnostic(error: unknown): {
   errorType: string;
@@ -159,6 +165,7 @@ function toAttemptDiagnostic(error: unknown): {
 } {
   if (
     error instanceof Error &&
+    error.name === "DispatchError" &&
     typeof Reflect.get(error, "retryable") === "boolean"
   ) {
     return { errorType: error.name, errorMessage: error.message };

--- a/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
@@ -368,11 +368,14 @@ export class InMemoryProcessStore implements ProcessStore {
     limit: number;
   }): Promise<number> {
     // Reaped by `updatedAt`, the same column the durable store uses, which
-    // the markFailed that retired the row stamped.
+    // the markFailed that retired the row stamped. `discarded` rides the same
+    // family for the reason given on the durable store: no other predicate
+    // matches it, so leaving it out makes it immortal.
     return this.deleteOutboxBatch(
       params,
       (message) =>
-        message.status === "dead" && message.updatedAt < params.before,
+        (message.status === "dead" || message.status === "discarded") &&
+        message.updatedAt < params.before,
     );
   }
 
@@ -401,6 +404,9 @@ export class InMemoryProcessStore implements ProcessStore {
       if (deleted >= params.limit) break;
       if (!matches(message)) continue;
       this.messages.delete(key);
+      // The durable store cascades attempt rows with their message; a fake
+      // that kept them would model a leak the real store does not have.
+      this.attempts.delete(key);
       deleted++;
     }
     return deleted;

--- a/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
@@ -4,6 +4,7 @@ import type {
   AppendIntentsResult,
   CommitResult,
   DueWake,
+  FailedOutboxAttempt,
   LeasedOutboxMessageRecord,
   NewOutboxMessage,
   OutboxMessageIdentity,
@@ -81,6 +82,7 @@ export class InMemoryProcessStore implements ProcessStore {
   /** Inbox key to the epoch ms it was consumed at, which retention reaps by. */
   private readonly inbox = new Map<string, number>();
   private readonly messages = new Map<string, StoredMessage>();
+  private readonly attempts = new Map<string, FailedOutboxAttempt[]>();
 
   async findByRef<State = unknown>(params: {
     ref: ProcessRef;
@@ -270,6 +272,21 @@ export class InMemoryProcessStore implements ProcessStore {
     message.leaseToken = null;
     message.updatedAt = params.now;
     return { applied: true };
+  }
+
+  async recordFailedAttempt(params: {
+    identity: OutboxMessageIdentity;
+    attempt: FailedOutboxAttempt;
+  }): Promise<void> {
+    if (!this.messages.has(messageKeyOf(params.identity))) return;
+    const existing = this.attempts.get(messageKeyOf(params.identity)) ?? [];
+    existing.push(params.attempt);
+    this.attempts.set(messageKeyOf(params.identity), existing);
+  }
+
+  /** Test read for the attempt history, mirroring the durable table. */
+  findFailedAttempts(identity: OutboxMessageIdentity): FailedOutboxAttempt[] {
+    return this.attempts.get(messageKeyOf(identity)) ?? [];
   }
 
   async releaseLease(params: {

--- a/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
@@ -344,10 +344,21 @@ export class InMemoryProcessStore implements ProcessStore {
         message.dispatchedAt >= params.before
       )
         continue;
-      this.messages.delete(key);
+      this.deleteMessage(key);
       deleted++;
     }
     return deleted;
+  }
+
+  /**
+   * Every outbox deletion goes through here, so the attempt rows leave with
+   * their message on all of them — the durable store cascades, and a fake
+   * that shed them on only one path would model a leak the real one does not
+   * have.
+   */
+  private deleteMessage(key: string): void {
+    this.messages.delete(key);
+    this.attempts.delete(key);
   }
 
   async deleteDispatchedOutboxBatch(params: {
@@ -403,10 +414,7 @@ export class InMemoryProcessStore implements ProcessStore {
     for (const [key, message] of this.messages) {
       if (deleted >= params.limit) break;
       if (!matches(message)) continue;
-      this.messages.delete(key);
-      // The durable store cascades attempt rows with their message; a fake
-      // that kept them would model a leak the real store does not have.
-      this.attempts.delete(key);
+      this.deleteMessage(key);
       deleted++;
     }
     return deleted;

--- a/platform/app/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
@@ -658,11 +658,22 @@ export class PrismaProcessStore implements ProcessStore {
     // that retired them, so it IS the moment the row became a failure record.
     // No new index: `dead` is a rare status, so the existing
     // (status, nextAttemptAt, leasedUntil) index already makes this selective.
+    //
+    // `discarded` is reaped on the same window and by the same sweep. It is
+    // the terminal state an operator writes rather than one the dispatcher
+    // writes, but it means the same thing to retention — a record of work
+    // that will never run, kept for as long as the operator might ask about
+    // it. Leaving it out is what would make it immortal: no other family's
+    // predicate matches it, and this is the highest-volume table in the
+    // system (specs/ops/dead-letter-recovery.feature).
     return await this.prisma.$executeRaw`
       DELETE FROM "ProcessManagerOutbox"
       WHERE "id" IN (
         SELECT "id" FROM "ProcessManagerOutbox"
-        WHERE "status" = 'dead'::"ProcessManagerOutboxStatus"
+        WHERE "status" IN (
+            'dead'::"ProcessManagerOutboxStatus",
+            'discarded'::"ProcessManagerOutboxStatus"
+          )
           AND "updatedAt" < ${asDate(params.before)}
         LIMIT ${params.limit}
       )

--- a/platform/app/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
@@ -13,6 +13,7 @@ import type {
   AppendIntentsResult,
   CommitResult,
   DueWake,
+  FailedOutboxAttempt,
   LeasedOutboxMessageRecord,
   NewOutboxMessage,
   OutboxMessageIdentity,
@@ -476,6 +477,35 @@ export class PrismaProcessStore implements ProcessStore {
       },
     });
     return { applied: result.count === 1 };
+  }
+
+  async recordFailedAttempt(params: {
+    identity: OutboxMessageIdentity;
+    attempt: FailedOutboxAttempt;
+  }): Promise<void> {
+    // Two queries, failure path only: the attempt row needs the outbox row's
+    // id, and updateMany cannot return it. The read uses the uniqueness
+    // contract, so it is index-covered either way.
+    const row = await this.prisma.processManagerOutbox.findUnique({
+      where: {
+        projectId: params.identity.projectId,
+        processName_projectId_messageKey: params.identity,
+      },
+      select: { id: true, projectId: true },
+    });
+    if (!row) return;
+    await this.prisma.processManagerOutboxAttempt.create({
+      data: {
+        outboxId: row.id,
+        projectId: row.projectId,
+        attempt: params.attempt.attempt,
+        occurredAt: asDate(params.attempt.occurredAt),
+        outcome: params.attempt.outcome,
+        errorType: params.attempt.errorType,
+        errorMessage: params.attempt.errorMessage,
+        retryAfterMs: params.attempt.retryAfterMs ?? null,
+      },
+    });
   }
 
   async releaseLease(params: {

--- a/platform/app/src/server/event-sourcing/process-manager/stores/processStore.types.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/processStore.types.ts
@@ -24,7 +24,30 @@ export interface PersistedProcessInstance<State = unknown> {
   updatedAt: number;
 }
 
-export type OutboxMessageStatus = "pending" | "dispatched" | "dead";
+export type OutboxMessageStatus =
+  | "pending"
+  | "dispatched"
+  | "dead"
+  /** Operator-marked never-to-be-sent (specs/ops/dead-letter-recovery.feature).
+   *  A mark, not a delete: the row stays as its own audit trail. */
+  | "discarded";
+
+/**
+ * One FAILED delivery attempt, recorded so a dead letter can say why it died
+ * without a span lookup (specs/ops/dead-letter-recovery.feature). Successes
+ * write nothing.
+ */
+export interface FailedOutboxAttempt {
+  /** 1-based attempt number, as the dispatcher counts it. */
+  attempt: number;
+  occurredAt: number;
+  /** Whether this failure retired the message or scheduled a retry. */
+  outcome: "retry_scheduled" | "dead";
+  errorType: string;
+  /** The safe failure diagnostic — never a raw provider body. */
+  errorMessage: string;
+  retryAfterMs?: number;
+}
 
 export interface NewOutboxMessage {
   messageKey: string;
@@ -215,6 +238,16 @@ export interface ProcessStore {
     nextAttemptAt: number;
     dead: boolean;
   }): Promise<{ applied: boolean }>;
+
+  /**
+   * Append one failed attempt to the message's history. Best-effort by
+   * contract: callers wrap it so a history write that fails never fails the
+   * delivery accounting (the attempt entry is the only loss).
+   */
+  recordFailedAttempt(params: {
+    identity: OutboxMessageIdentity;
+    attempt: FailedOutboxAttempt;
+  }): Promise<void>;
 
   /**
    * Return a leased message to the pool WITHOUT running it: clears the lease

--- a/specs/ops/dead-letter-recovery.feature
+++ b/specs/ops/dead-letter-recovery.feature
@@ -92,7 +92,7 @@ Feature: Dead-letter recovery
   Scenario: Discarded messages age out on the dead-letter window
     Given a discarded outbox row older than the dead retention window
     And a discarded outbox row inside the dead retention window
-    When the retention sweep runs
+    When the dead-letter retention batch is reaped
     Then only the row past the window is deleted
 
   # Redrive resets the attempt counter, so the number stops being unique over

--- a/specs/ops/dead-letter-recovery.feature
+++ b/specs/ops/dead-letter-recovery.feature
@@ -85,6 +85,25 @@ Feature: Dead-letter recovery
     When the retention sweep removes the message
     Then its attempt entries are removed with it
 
+  # A discarded row is terminal like a dead one, and no other family's
+  # predicate matches it. Left out of the sweep it would be the one state that
+  # never ages out, on the highest-volume table in the system.
+  @integration
+  Scenario: Discarded messages age out on the dead-letter window
+    Given a discarded outbox row older than the dead retention window
+    And a discarded outbox row inside the dead retention window
+    When the retention sweep runs
+    Then only the row past the window is deleted
+
+  # Redrive resets the attempt counter, so the number stops being unique over
+  # a message's life and only time orders the entries correctly.
+  @integration
+  Scenario: A redriven message keeps the history of both its lives
+    Given a message that failed, was redriven, and failed again
+    When its attempt history is read
+    Then every failure from both lives is present
+    And they read in the order they happened
+
   @unit
   Scenario: A dead letter shows why it died without leaving the page
     Given a dead message with recorded attempts

--- a/specs/ops/dead-letter-recovery.feature
+++ b/specs/ops/dead-letter-recovery.feature
@@ -30,7 +30,7 @@ Feature: Dead-letter recovery
     Given a pending outbox message
     When an operator attempts to discard it
     Then the message is unchanged
-    And the refusal says the message is not dead
+    And the act reports that it did not apply
 
   @integration
   Scenario: Discarded messages leave the dead-letter count

--- a/specs/ops/dead-letter-recovery.feature
+++ b/specs/ops/dead-letter-recovery.feature
@@ -1,0 +1,135 @@
+# Companion to process-manager-visibility.feature (which put dead letters on a
+# page) — this spec is what an operator can DO about them, on both dead-letter
+# substrates: the process-manager outbox (Postgres) and the GroupQueue DLQ
+# (Redis). Controls follow best_practices/ops-dashboard.md: explicit,
+# manage-gated, audited, blast radius named.
+
+Feature: Dead-letter recovery
+  As an operator triaging dead letters
+  I want to redrive what should run again and discard what never should
+  So that the dead-letter count returns to zero without clicking one row at a time
+
+  Context: dead letters could only be redriven, one at a time, and nothing
+  could ever be discarded — a permanently poisoned message sat in the count
+  forever, indistinguishable from work still worth redriving. Discard is a
+  mark, not a delete: the outbox row is retained as its own audit trail, and
+  the substrate never sends the message again.
+
+  # ── Discard: the outbox ───────────────────────────────────────────────
+
+  @integration
+  Scenario: Discarding a dead message marks it and keeps it
+    Given a dead outbox message
+    When the operator discards it
+    Then the message is marked discarded, not deleted
+    And the dispatcher never leases it again
+    And the discard lands in the audit trail
+
+  @integration
+  Scenario: Only a dead message can be discarded
+    Given a pending outbox message
+    When an operator attempts to discard it
+    Then the message is unchanged
+    And the refusal says the message is not dead
+
+  @integration
+  Scenario: Discarded messages leave the dead-letter count
+    Given dead messages on one process
+    When the operator discards one of them
+    Then the dead-letter listing and its counts no longer include it
+
+  # ── Bulk recovery, scoped to what is shown ────────────────────────────
+
+  @integration
+  Scenario: Every dead letter shown can be redriven in one act
+    Given dead messages belonging to several process names
+    When the operator redrives all dead letters for one process name
+    Then that process name's dead messages return to pending with a fresh budget
+    And the other process names' dead messages stay dead
+    And the audit trail records the act with how many messages it moved
+
+  @integration
+  Scenario: Every dead letter shown can be discarded in one act
+    Given dead messages belonging to several process names
+    When the operator discards all dead letters for one process name
+    Then that process name's dead messages are marked discarded
+    And the other process names' dead messages stay dead
+    And the audit trail records the act with how many messages it marked
+
+  # ── Attempt history ───────────────────────────────────────────────────
+
+  # Reverses the v1 decision that the failure reason lives only on the span
+  # and the log line: an operator reading a dead letter should not need
+  # Grafana to learn why it died, and log retention is shorter than an
+  # operator's questions. Failures only — a first-try success writes nothing,
+  # so the table grows with trouble, not with traffic.
+
+  @integration
+  Scenario: Each failed delivery records why it failed
+    Given an outbox message whose delivery fails twice and then dies
+    When its attempt history is read
+    Then it holds one entry per failed attempt, oldest first
+    And each entry carries the attempt number, when it happened, and the failure diagnostic
+    And the final entry is marked as the one that killed the message
+
+  @unit
+  Scenario: A recording failure never fails the delivery accounting
+    Given an outbox delivery that fails while the attempt log is unavailable
+    When the dispatcher records the failure
+    Then the message still retries or dies exactly as it would have
+    And the missing attempt entry is the only loss
+
+  @integration
+  Scenario: Attempt history dies with its message
+    Given a dispatched outbox message with recorded attempts
+    When the retention sweep removes the message
+    Then its attempt entries are removed with it
+
+  @unit
+  Scenario: A dead letter shows why it died without leaving the page
+    Given a dead message with recorded attempts
+    When its row is expanded
+    Then the attempts read oldest to newest, each with its failure diagnostic
+
+  # ── Discard: the GroupQueue DLQ ───────────────────────────────────────
+
+  # The Redis substrate already forgets DLQ entries after their TTL, so the
+  # retained mark lives in the operator audit trail rather than on the entry.
+
+  @integration
+  Scenario: Discarding a DLQ group removes it and remembers the act
+    Given a queue with a group in its dead-letter queue
+    When the operator discards the group
+    Then the group's jobs never run again
+    And the audit trail records the queue, the group, how many jobs it held, and its last error
+
+  @integration
+  Scenario: A discarded DLQ group cannot be redriven afterwards
+    Given a DLQ group the operator has discarded
+    When a redrive of that queue's dead letters runs
+    Then the discarded group is not among the redriven
+
+  @unit
+  Scenario: Bulk DLQ actions act on exactly what is shown
+    Given the dead-letter list is narrowed by a filter
+    When the operator applies a bulk redrive or discard
+    Then only the groups that matched the filter are acted on
+    And the confirmation states how many groups that is
+
+  # ── One vocabulary ────────────────────────────────────────────────────
+
+  @unit
+  Scenario: Recovery verbs are the same on both substrates
+    Given both dead-letter surfaces render their controls
+    Then returning a dead letter to its queue is called redrive everywhere
+    And marking one as never-to-be-sent is called discard everywhere
+    And replay stays reserved for projection rebuilds
+
+  # ── The headline number ───────────────────────────────────────────────
+
+  @unit
+  Scenario: The dashboard's dead-letter figure covers both substrates
+    Given dead letters exist in the GroupQueue DLQ and the process outbox
+    When the ops dashboard's stat strip renders
+    Then the dead-letters statistic is the total across both
+    And it states how many come from each

--- a/specs/ops/process-manager-visibility.feature
+++ b/specs/ops/process-manager-visibility.feature
@@ -77,10 +77,11 @@ Feature: Process-manager visibility in ops
   # feature (best_practices/ops-dashboard.md), and dead work is the one state
   # this substrate reports that never resolves on its own.
   #
-  # The outbox row does not record WHY a message died: the dispatcher puts the
-  # diagnostic on the span and the log line. Each row carries its trace id
-  # instead, so the reason is one hop away rather than duplicated into
-  # Postgres.
+  # v1 did not record WHY a message died — the dispatcher put the diagnostic
+  # on the span and the log line, and each row carried its trace id as the
+  # join back to it. dead-letter-recovery.feature reverses that: failed
+  # attempts are recorded per message, so the reason is on the page. The
+  # trace id remains as the deeper join.
 
   @integration
   Scenario: Dead messages are listed across the whole fleet


### PR DESCRIPTION
## Why

Dead letters could only be redriven, one row at a time, and nothing could ever
be discarded. A permanently poisoned message therefore sat in the count for
good, indistinguishable from work still worth retrying, and clearing a real
incident meant clicking Redrive once per row.

Two smaller things came out of the same bug bash. The `/ops` stat strip read
"Dead-letter queue: 0" while 94 process-outbox messages sat dead further down
the page, because the tile only ever summed the GroupQueue side. And a dead
letter never recorded *why* it died: the dispatcher put the diagnostic on a
span and a log line, so answering "what broke" meant leaving the page for
Grafana, on data whose retention is shorter than the question.

## What changed

Discard is a mark, not a delete. On the outbox a discarded row keeps its place
in the table as its own audit record, and the dispatcher's claim never sees it
again. On the GroupQueue side the Redis entries go (they expire on their own TTL
regardless) and the audit row is the retained mark, carrying the queue, the
groups, their job counts and the shape of what killed them.

Discard asks before it acts, on every surface and at every scale. Nothing
un-discards a message - no redrive path selects a discarded row - so a
mis-click would be permanent. Redrive and release-lease stay one click,
because both are recoverable. The fleet-wide form, which crosses every tenant,
additionally takes a typed confirmation at the API rather than being reachable
by omitting a field.

Bulk recovery acts on exactly what the operator is looking at. The Dead Letters
page gets "Redrive shown" / "Discard shown" honouring the process filter; the
DLQ card gets a text filter over group, pipeline and error, and its bulk buttons
send the explicit id list rather than a filter for the server to re-evaluate, so
the confirmation and the act cover the same groups by construction.

Failed deliveries are now recorded per attempt, so a dead letter says why it
died where it is read. Successes write nothing.

One vocabulary across both substrates: redrive to put work back, discard to mark
it never-to-run. The DLQ card's "Replay" buttons are renamed, leaving replay to
mean projection rebuilds, which is what it means everywhere else.

## How it works

`ProcessManagerOutboxAttempt` holds one row per *failed* attempt, so the table
grows with trouble rather than with traffic - which matters, because its parent
is the highest-volume write path in the system. Rows cascade with their message,
so the existing retention sweep is the whole retention story and no new sweeper
was needed.

The recorded diagnostic needed a judgement call. `toSafeFailureDiagnostic`
redacts every message, because an arbitrary thrown error can carry payload -
which would have left an operator reading "Operation failed" eight times over.
A `DispatchError` is different: its message is the delivery diagnostic our own
dispatch endpoints assemble on purpose (ADR-027), and this admin-gated surface
is what such a diagnostic exists for. So typed dispatch failures keep their
message and everything else stays redacted, with a test pinning both sides.

Recording is best-effort by contract: a failed history write logs and moves on,
so the attempt entry is the only thing lost and the delivery accounting is
untouched.

## Test plan

- [ ] `pnpm test:unit run src/server/event-sourcing/process-manager/outbox/__tests__/outboxDispatcherService.unit.test.ts` - 22 pass, covering attempt ordering, the killer attempt marked dead, redaction of untyped errors and of an impostor claiming to be retryable, and a failing attempt-log write leaving retry/retire behaviour unchanged
- [ ] `pnpm test:unit run src/server/app-layer/ops/__tests__/queue.service.unit.test.ts` - 26 pass, covering the discard audit payload, the audit being skipped when nothing moved, and job error text with an address in it never reaching the audit row
- [ ] `pnpm test:integration run src/server/app-layer/ops/__tests__/integration/process-ops.integration.test.ts` - 20 pass against a real Postgres: discarded rows retained and never leased, only a dead message discardable, discarded rows leaving the counts, per-process bulk redrive and discard leaving other processes alone, discarded rows ageing out on the dead-letter window, a redriven message keeping both lives of its history, and attempt rows cascading on delete
- [ ] `pnpm test:integration run src/server/app-layer/ops/__tests__/integration/dlq-discard.integration.test.ts` - 3 pass against a real Redis: discard removes the group's keys and returns the audit facts, a discarded group cannot be redriven afterwards by either path, and explicit-id redrive touches only the named groups
- [ ] `pnpm test:component run src/components/ops/deadLetters/__tests__/DeadLettersCard.integration.test.tsx src/components/ops/__tests__/recoveryVerbs.integration.test.tsx` - 11 pass, the second holding a row from each substrate to the same verbs
- [ ] `pnpm check:feature-parity` - `specs/ops/dead-letter-recovery.feature` reports 16/16 bound
- [ ] On `/ops`, confirm the Dead letters tile totals both substrates and splits them in its sublabel

## Anything surprising?

**This PR adds a migration.** A new `ProcessManagerOutboxAttempt` table plus a
`discarded` value on `ProcessManagerOutboxStatus`. Both are additive and the
enum value is only ever written by an operator action, so a deploy where the
migration lands before the code is inert. The new table's only index is created
with it, so there is no `CREATE INDEX` against the existing hot table - the
constraint the schema comments already warn about.

**The Redis side deviates from "mark, don't delete".** DLQ entries already
expire at a 7-day TTL, so there is nowhere durable on the entry for a mark to
live; the audit row carries it instead. Flagging it because it is a knowing
choice, not an oversight. That audit row is also written after the act rather
than before it, so a crash between the two loses the record - a window every
destructive act in that file already shares, now tracked as #7134.

**Bulk acts are capped and staggered.** A fleet redrive is bounded at 5,000
rows per press and spreads its due times over a minute, so a recovery does not
hand the dispatcher one due batch the size of the whole backlog.

**Two findings from the audit pass, fixed in the second commit.** The
retention sweep has three families - dispatched, dead, inbox - and none of
their predicates matched `discarded`, so the one terminal state an operator
writes would have been the only one that never ages out. It now rides the dead
family. And because a redrive resets `attempts` to 0, a message that failed,
was redriven and failed again holds two entries numbered 1; the attempt number
was serving as both React key and sort key, so the history is now keyed by row
id and ordered by when each failure happened.

**Not in scope:** the outbox does not guarantee FIFO delivery. A retryable
failure reschedules its message behind its batch-mates, and concurrent
dispatchers claim with `SKIP LOCKED`, so ordering is best-effort on the happy
path only. Fixing that means per-process-key serialisation in the claim query,
which is a throughput trade that deserves its own decision rather than a rider
here.

**Superseded by main:** the plan this came from also plotted folding the
mid-page `ProcessFleetStrip` into a section heading. That surface has since been
split into its own routes, so the cohesion work here is just the headline tile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added discard actions for individual and bulk process dead letters and selected queue dead-letter groups.
  * Added confirmation dialogs, progress states, affected-item counts, and operation feedback.
  * Added expandable delivery-attempt history with failure diagnostics and retry details.
  * Updated dashboards to combine queue and process dead-letter totals.
  * Added audit visibility for recovery operations and discarded messages.

* **Bug Fixes**
  * Improved dead-letter filtering and limited bulk actions to visible results.
  * Preserved discarded messages for traceability before retention cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->