### PR TITLE
fix(langevals): stop self-hosted evaluators crashing on dspy thread-affinity and retry-storming 400s

### DIFF
--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -131,6 +131,17 @@ jobs:
             --ignore=evaluators/topic_clustering/tests/ \
             --ignore=tests/
 
+      - name: Run evaluator regression tests that need no provider
+        # `evaluators/langevals/tests/` is ignored by the step above because
+        # its LLM-judged tests are non-deterministic. This file is not one of
+        # them: it stubs the call to the provider, so it needs no key, makes no
+        # provider request and always gives the same answer. Naming it here is
+        # what makes it run, and it runs on forks too. It guards the dspy
+        # thread-affinity crash that broke every evaluation after the first one
+        # on a long-lived server.
+        working-directory: services/langevals
+        run: uv run pytest -x -v evaluators/langevals/tests/test_llm_answer_match_threading.py
+
   docker-build:
     needs: changes
     if: >

--- a/services/langevals/evaluators/langevals/langevals_langevals/llm_answer_match.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/llm_answer_match.py
@@ -74,7 +74,6 @@ class LLMAnswerMatchEvaluator(
             )
 
         lm = model_to_dspy_lm(self.settings.model)
-        dspy.settings.configure(experimental=True)
 
         answer_match = dspy.Predict(
             LLMAnswerMatchSignature.with_instructions(self.settings.prompt)

--- a/services/langevals/evaluators/langevals/tests/test_llm_answer_match.py
+++ b/services/langevals/evaluators/langevals/tests/test_llm_answer_match.py
@@ -1,5 +1,3 @@
-import threading
-
 from langevals_langevals.llm_answer_match import (
     LLMAnswerMatchEntry,
     LLMAnswerMatchEvaluator,
@@ -38,42 +36,6 @@ def test_llm_answer_match_without_question():
     assert result.passed == True
     assert result.details
     assert result.cost
-
-
-def test_llm_answer_match_runs_from_multiple_worker_threads():
-    """The server dispatches each request to a threadpool worker thread.
-
-    dspy pins global-settings ownership to the first thread that calls
-    `dspy.settings.configure`; a long-lived server that configured from one
-    worker thread then raised "dspy.settings can only be changed by the thread
-    that initially configured it." for every evaluation landing on any other
-    thread. The evaluator must not touch global dspy settings at all.
-    """
-    entry = LLMAnswerMatchEntry(
-        input="What genre do The Gaslight Anthem and Seaweed share?",
-        output="The Gaslight Anthem and Seaweed share the genre of rock music.",
-        expected_output="rock",
-    )
-    results: list = []
-    errors: list = []
-
-    def run():
-        try:
-            evaluator = LLMAnswerMatchEvaluator(
-                settings=LLMAnswerMatchSettings(model="openai/gpt-5-mini")
-            )
-            results.append(evaluator.evaluate(entry))
-        except Exception as error:
-            errors.append(error)
-
-    for _ in range(2):
-        thread = threading.Thread(target=run)
-        thread.start()
-        thread.join()
-
-    assert errors == []
-    assert len(results) == 2
-    assert all(result.status == "processed" for result in results)
 
 
 def test_llm_answer_does_not_match_match():

--- a/services/langevals/evaluators/langevals/tests/test_llm_answer_match.py
+++ b/services/langevals/evaluators/langevals/tests/test_llm_answer_match.py
@@ -1,3 +1,5 @@
+import threading
+
 from langevals_langevals.llm_answer_match import (
     LLMAnswerMatchEntry,
     LLMAnswerMatchEvaluator,
@@ -36,6 +38,42 @@ def test_llm_answer_match_without_question():
     assert result.passed == True
     assert result.details
     assert result.cost
+
+
+def test_llm_answer_match_runs_from_multiple_worker_threads():
+    """The server dispatches each request to a threadpool worker thread.
+
+    dspy pins global-settings ownership to the first thread that calls
+    `dspy.settings.configure`; a long-lived server that configured from one
+    worker thread then raised "dspy.settings can only be changed by the thread
+    that initially configured it." for every evaluation landing on any other
+    thread. The evaluator must not touch global dspy settings at all.
+    """
+    entry = LLMAnswerMatchEntry(
+        input="What genre do The Gaslight Anthem and Seaweed share?",
+        output="The Gaslight Anthem and Seaweed share the genre of rock music.",
+        expected_output="rock",
+    )
+    results: list = []
+    errors: list = []
+
+    def run():
+        try:
+            evaluator = LLMAnswerMatchEvaluator(
+                settings=LLMAnswerMatchSettings(model="openai/gpt-5-mini")
+            )
+            results.append(evaluator.evaluate(entry))
+        except Exception as error:
+            errors.append(error)
+
+    for _ in range(2):
+        thread = threading.Thread(target=run)
+        thread.start()
+        thread.join()
+
+    assert errors == []
+    assert len(results) == 2
+    assert all(result.status == "processed" for result in results)
 
 
 def test_llm_answer_does_not_match_match():

--- a/services/langevals/evaluators/langevals/tests/test_llm_answer_match_threading.py
+++ b/services/langevals/evaluators/langevals/tests/test_llm_answer_match_threading.py
@@ -1,0 +1,116 @@
+"""Regression test for the dspy thread-affinity crash on a long-lived server.
+
+The langevals server dispatches every request to a worker thread. dspy 3 records
+the identifier of the first thread that calls `dspy.settings.configure` and
+raises
+
+    dspy.settings can only be changed by the thread that initially configured it.
+
+for every later `configure` from any other thread. An evaluator that configured
+global settings therefore served the first request and then failed every request
+that landed on a different worker thread. A tier that gives each request a fresh
+process never saw this. A long-lived self-hosted server saw it from the second
+evaluation onwards.
+
+The workers must overlap for this test to mean anything. dspy compares
+`threading.get_ident()` values, and CPython reuses an identifier as soon as the
+thread holding it exits, so starting one worker and joining it before starting
+the next hands the second worker the first one's identifier and dspy's check
+passes by accident. A barrier holds every worker until they are all running,
+which is both the real shape of the server under load and the only shape that
+reproduces the crash every time.
+
+The transport to the model provider is stubbed with litellm's `mock_response`,
+so this file needs no API key and makes no network call to a provider. That is
+what lets it run in CI, unlike the LLM-judged tests next to it. Everything else
+is the real path: the real `model_to_dspy_lm`, the real `dspy.Predict`, the real
+adapter parsing.
+"""
+
+import threading
+
+import pytest
+
+from langevals_langevals import llm_answer_match
+from langevals_langevals.llm_answer_match import (
+    LLMAnswerMatchEntry,
+    LLMAnswerMatchEvaluator,
+    LLMAnswerMatchSettings,
+)
+
+WORKERS = 4
+
+REASONING = "Both answers name rock music."
+
+MOCK_COMPLETION = (
+    "[[ ## reasoning ## ]]\n"
+    f"{REASONING}\n"
+    "[[ ## is_correct ## ]]\n"
+    "True\n"
+    "[[ ## completed ## ]]\n"
+)
+
+ENTRY = LLMAnswerMatchEntry(
+    input="What genre do The Gaslight Anthem and Seaweed share?",
+    output="The Gaslight Anthem and Seaweed share the genre of rock music.",
+    expected_output="rock",
+)
+
+
+@pytest.fixture
+def stubbed_provider(monkeypatch):
+    """Keep the real dspy LM, replace only the call out to the provider."""
+    build_lm = llm_answer_match.model_to_dspy_lm
+
+    def build_stubbed_lm(model: str):
+        lm = build_lm(model)
+        lm.kwargs["mock_response"] = MOCK_COMPLETION
+        lm.cache = False
+        return lm
+
+    monkeypatch.setattr(llm_answer_match, "model_to_dspy_lm", build_stubbed_lm)
+
+
+def test_evaluates_from_worker_threads_running_at_the_same_time(stubbed_provider):
+    ready = threading.Barrier(WORKERS)
+    lock = threading.Lock()
+    results = []
+    errors = []
+    thread_ids = []
+
+    def evaluate_on_this_thread():
+        # Hold here until every worker is running, so no worker can inherit the
+        # identifier of one that already exited.
+        ready.wait(timeout=30)
+        with lock:
+            thread_ids.append(threading.get_ident())
+        try:
+            evaluator = LLMAnswerMatchEvaluator(
+                settings=LLMAnswerMatchSettings(model="openai/gpt-5-mini")
+            )
+            result = evaluator.evaluate(ENTRY)
+            with lock:
+                results.append(result)
+        except Exception as error:  # noqa: BLE001 - the crash is what we assert on
+            with lock:
+                errors.append(error)
+
+    threads = [
+        threading.Thread(target=evaluate_on_this_thread, name=f"worker-{index}")
+        for index in range(WORKERS)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert not any(thread.is_alive() for thread in threads)
+    # Every worker really was a distinct thread as far as dspy can tell. Without
+    # this the test could pass on recycled identifiers and guard nothing.
+    assert len(set(thread_ids)) == WORKERS
+    assert [repr(error) for error in errors] == []
+    assert [result.status for result in results] == ["processed"] * WORKERS
+    # Proves each evaluation went through the model call and parsed the
+    # response, rather than short-circuiting before it.
+    assert [result.details for result in results] == [REASONING] * WORKERS
+    assert all(result.passed for result in results)

--- a/services/langevals/langevals_core/langevals_core/base_evaluator.py
+++ b/services/langevals/langevals_core/langevals_core/base_evaluator.py
@@ -15,7 +15,13 @@ from typing import (
 )
 
 from pydantic import BaseModel, ConfigDict, Field
-from tenacity import Retrying, stop_after_attempt, wait_random_exponential
+import litellm
+from tenacity import (
+    Retrying,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 from tqdm.auto import tqdm as tqdm_auto
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from langevals_core.litellm_patch import patch_litellm
@@ -282,6 +288,13 @@ class BaseEvaluator(BaseModel, Generic[TEntry, TSettings, TResult], ABC):
         _disable_tqdm()
         try:
             retryer = Retrying(
+                # A 400 from the model provider is deterministic: a content
+                # policy block, a bad parameter, an oversized prompt. Retrying
+                # it only burns time and can push a single evaluation past the
+                # caller's request timeout, which turns a clear "content policy
+                # violation" into an opaque timeout. Fail fast and return the
+                # real error instead.
+                retry=retry_if_not_exception_type(litellm.BadRequestError),
                 stop=stop_after_attempt(retries),
                 wait=wait_random_exponential(multiplier=1, min=4, max=10),
                 reraise=True,

--- a/services/langevals/langevals_core/tests/test_retry_policy.py
+++ b/services/langevals/langevals_core/tests/test_retry_policy.py
@@ -1,0 +1,92 @@
+"""Unit tests for the retry policy in `BaseEvaluator._evaluate_entry`.
+
+A deterministic 400 from the provider (a content-policy block, a bad
+parameter) must not be retried: retrying only burns time and can push a single
+evaluation past the caller's request timeout, turning a clear error into an
+opaque one. A transient error (a 5xx, a rate limit) must still be retried.
+
+The fake evaluator counts calls through a module-level list, so every
+assertion is about how many attempts `_evaluate_entry` makes. No API keys and
+no network.
+"""
+
+import litellm
+from pydantic import Field
+
+from langevals_core.base_evaluator import (
+    BaseEvaluator,
+    EvaluationResult,
+    EvaluatorEntry,
+    LLMEvaluatorSettings,
+    SingleEvaluationResult,
+)
+
+
+class CountingEntry(EvaluatorEntry):
+    output: str = Field(default="")
+
+
+class CountingSettings(LLMEvaluatorSettings):
+    pass
+
+
+class CountingResult(EvaluationResult):
+    pass
+
+
+def make_evaluator(exception: Exception, calls: list):
+    class CountingEvaluator(
+        BaseEvaluator[CountingEntry, CountingSettings, CountingResult]
+    ):
+        name = "Counting"
+        category = "quality"
+        env_vars = []
+        is_guardrail = False
+
+        def evaluate(self, entry: CountingEntry) -> SingleEvaluationResult:
+            calls.append(1)
+            raise exception
+
+    return CountingEvaluator(settings=CountingSettings(model="azure/gpt-5.6-terra"))
+
+
+def test_content_policy_violation_is_not_retried():
+    calls: list = []
+    evaluator = make_evaluator(
+        litellm.ContentPolicyViolationError(
+            message="filtered", model="azure/gpt-5.6-terra", llm_provider="azure"
+        ),
+        calls,
+    )
+
+    result = evaluator._evaluate_entry(CountingEntry(output="x"), retries=3)
+
+    assert len(calls) == 1
+    assert result.status == "error"
+    assert result.error_type == "ContentPolicyViolationError"
+
+
+def test_bad_request_is_not_retried():
+    calls: list = []
+    evaluator = make_evaluator(
+        litellm.BadRequestError(
+            message="bad param", model="azure/gpt-5.6-terra", llm_provider="azure"
+        ),
+        calls,
+    )
+
+    result = evaluator._evaluate_entry(CountingEntry(output="x"), retries=3)
+
+    assert len(calls) == 1
+    assert result.status == "error"
+
+
+def test_transient_error_is_still_retried():
+    calls: list = []
+    evaluator = make_evaluator(RuntimeError("transient blip"), calls)
+
+    result = evaluator._evaluate_entry(CountingEntry(output="x"), retries=3)
+
+    assert len(calls) == 3
+    assert result.status == "error"
+    assert result.error_type == "RuntimeError"

--- a/services/langevals/langevals_core/tests/test_retry_policy.py
+++ b/services/langevals/langevals_core/tests/test_retry_policy.py
@@ -11,8 +11,11 @@ no network.
 """
 
 import litellm
+import pytest
 from pydantic import Field
+from tenacity import wait_none
 
+from langevals_core import base_evaluator
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluationResult,
@@ -20,6 +23,20 @@ from langevals_core.base_evaluator import (
     LLMEvaluatorSettings,
     SingleEvaluationResult,
 )
+
+
+@pytest.fixture(autouse=True)
+def no_backoff(monkeypatch):
+    """Drop the wait between attempts.
+
+    These tests assert on how many attempts happen, never on how long the
+    evaluator waits in between. Keeping the real backoff would make the
+    transient case sleep for seconds, and for a different number of seconds on
+    every run, without proving anything more.
+    """
+    monkeypatch.setattr(
+        base_evaluator, "wait_random_exponential", lambda **kwargs: wait_none()
+    )
 
 
 class CountingEntry(EvaluatorEntry):


### PR DESCRIPTION
## What

Two bugs that only bite self-hosted langevals, both found from a customer running the answer-match evaluator against their own Azure models.

### 1. dspy thread-affinity crash

`langevals/llm_answer_match` called `dspy.settings.configure(experimental=True)` on every evaluation. dspy 3 pins global-settings ownership to the thread that first calls `configure`; the langevals server runs evaluations on a 50-worker threadpool, so the first request configured dspy on one thread and every later request on another pool thread raised:

```
dspy.settings can only be changed by the thread that initially configured it.
```

On the SaaS lambda tier each request is a fresh process, so this never showed there, only on long-lived self-hosted deployments. The `experimental=True` flag is no longer needed by `dspy.Predict` in dspy 3, so the line is removed with no behaviour change.

Regression test runs the evaluator from 4 worker threads held on a barrier, so they overlap the way the server's threadpool does. It fails on the old code with the exact reported error and passes on the fix.

The workers have to overlap. dspy compares `threading.get_ident()` values, and CPython hands a new thread the identifier of one that just exited, so starting a worker and joining it before starting the next gives the second worker the first one's identifier and dspy's owner check passes by accident. A sequential version of this test reproduced the crash only some of the runs.

The test stubs the call out to the provider with litellm's `mock_response`, so it needs no API key and makes no provider request, and `langevals-ci` runs it. The rest of `evaluators/langevals/tests/` stays ignored in CI because those tests are LLM-judged and non-deterministic.

### 2. Provider 400s were retried instead of failing fast

A content-policy block or a bad parameter is a deterministic 400. The base retryer retried it 3 times. On a real Azure content filter the retry loop took ~138s, past the control plane's 120s request timeout, so the customer saw an opaque timeout instead of the real "content policy violation" message. The retryer now skips `litellm.BadRequestError` (parent of `ContentPolicyViolationError`) and returns the real error on the first attempt, which brought the same case down to ~44s. Transient errors (5xx, rate limits) still retry.

## Proof

- Thread crash: 10 out of 10 runs fail against the pre-fix evaluator with `RuntimeError('dspy.settings can only be changed by the thread that initially configured it.')`, and 10 out of 10 pass with the fix. No credentials in the environment, 0.6s per run.
- Retry policy: the 3 tests measure how many attempts happen, 1 attempt for a 400 and 3 for a transient error. They pass with no network.
- Azure content-filter case, reproduced live against real Azure credentials, went from 138s (3 retries, timed out on the platform) to 44s (one attempt, clean `ContentPolicyViolationError` with the full provider message).
- Swept the repo: no other server code calls `dspy.settings.configure` (the one remaining hit is a user-facing onboarding snippet).

Both regression tests now run in `langevals-ci`, which they did not before: the thread test was in a directory the workflow ignores, so it only ever ran on a developer's machine.

## Test plan

```
cd services/langevals
uv run pytest evaluators/langevals/tests/test_llm_answer_match_threading.py
uv run pytest langevals_core/tests/test_retry_policy.py
```

Neither needs an API key or network access to a provider.

## Deployment Impact

No new environment variables and no changed defaults for the existing ones. No
helm values added, removed or renamed, and no chart template touched.

On a vanilla `helm install` with no overrides, both fixes are active as soon as
the operator runs a langevals image that contains them. Neither fix needs
configuration to turn on. A self-hosted deployment pinned to an older langevals
image tag keeps the old behavior until it bumps the tag, so the fix reaches
operators through the normal image release, not through a values change.

Runtime behavior changes for every deployment that runs the evaluators:

- `langevals/llm_answer_match` no longer configures global dspy settings, so it
  keeps working on a long-lived server process instead of failing after the
  first evaluation. Scoring output is unchanged.
- A 400 from the model provider (content policy block, bad parameter, oversized
  prompt) now fails on the first attempt and returns the provider message.
  Before, it retried 3 times and often ran past the control plane 120s request
  timeout, so the operator saw a timeout instead of the real cause. Transient
  failures (5xx, rate limits, connection errors) still retry as before.

BYOC dataplanes get the same effect as any other self-hosted install, because
both changes live inside the langevals service image. There is no control-plane
coupling, no migration, and no rollback step beyond going back to the previous
image tag.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid provider requests from being retried unnecessarily, preserving the original error details.
  * Improved reliability when multiple evaluations run concurrently.
  * Removed an evaluation-time configuration change that could affect other operations.

* **Tests**
  * Added coverage for retry behavior and concurrent evaluator execution.
  * Added provider-independent continuous integration checks for threading regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->