### PR TITLE
docs(scim): say plainly that an unrecognized PATCH operation name is rejected

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -42683,7 +42683,7 @@
           }
         ],
         "summary": "Update a provisioned user",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operation names are read without regard to case, so the capitalized `Replace` that Entra ID writes is understood. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
         "security": [
           {
             "scim_bearer": []
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operation names are read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are understood. Operations outside that set are accepted and change nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
         "security": [
           {
             "scim_bearer": []

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -42683,7 +42683,7 @@
           }
         ],
         "summary": "Update a provisioned user",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected with a 400. An understood operation aimed at anything not listed above is accepted and changes nothing.",
         "security": [
           {
             "scim_bearer": []
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected with a 400. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
         "security": [
           {
             "scim_bearer": []

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
         "security": [
           {
             "scim_bearer": []

--- a/platform/app/ee/scim/openapi.ts
+++ b/platform/app/ee/scim/openapi.ts
@@ -598,7 +598,7 @@ export const PATCH_GROUP: DescribeRouteOptions = {
   operationId: "scimPatchGroup",
   summary: "Update a provisioned group",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch group id.")],

--- a/platform/app/ee/scim/openapi.ts
+++ b/platform/app/ee/scim/openapi.ts
@@ -478,7 +478,7 @@ export const PATCH_USER: DescribeRouteOptions = {
   operationId: "scimPatchUser",
   summary: "Update a provisioned user",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operation names are read without regard to case, so the capitalized `Replace` that Entra ID writes is understood. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch user id.")],
@@ -598,7 +598,7 @@ export const PATCH_GROUP: DescribeRouteOptions = {
   operationId: "scimPatchGroup",
   summary: "Update a provisioned group",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operation names are read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are understood. Operations outside that set are accepted and change nothing.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch group id.")],

--- a/platform/app/ee/scim/openapi.ts
+++ b/platform/app/ee/scim/openapi.ts
@@ -478,7 +478,7 @@ export const PATCH_USER: DescribeRouteOptions = {
   operationId: "scimPatchUser",
   summary: "Update a provisioned user",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected with a 400. An understood operation aimed at anything not listed above is accepted and changes nothing.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch user id.")],
@@ -598,7 +598,7 @@ export const PATCH_GROUP: DescribeRouteOptions = {
   operationId: "scimPatchGroup",
   summary: "Update a provisioned group",
   description:
-    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
+    "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected with a 400. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
   tags: TAGS,
   security: SCIM_SECURITY,
   parameters: [idParameter("The LangWatch group id.")],

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -42683,7 +42683,7 @@
           }
         ],
         "summary": "Update a provisioned user",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. Operation names are read without regard to case, so the capitalized `Replace` that Entra ID writes is understood. Operations outside that set are accepted and change nothing, so a provider sending its full patch set is never rejected.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
         "security": [
           {
             "scim_bearer": []
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. Operation names are read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are understood. Operations outside that set are accepted and change nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
         "security": [
           {
             "scim_bearer": []

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -42683,7 +42683,7 @@
           }
         ],
         "summary": "Update a provisioned user",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `replace` of `active` (deactivating or reactivating the account), of `userName`, and of `name.givenName` / `name.familyName`, written either as an operation path or as keys inside a value object; and `add`, `replace` or `remove` of the enterprise `costCenter`, which reassigns the member's department. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Replace` that Entra ID writes is accepted; any other name, or a missing or non-string one, is rejected with a 400. An understood operation aimed at anything not listed above is accepted and changes nothing.",
         "security": [
           {
             "scim_bearer": []
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected with a 400. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
         "security": [
           {
             "scim_bearer": []

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -43705,7 +43705,7 @@
           }
         ],
         "summary": "Update a provisioned group",
-        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An understood operation aimed at anything not listed above is accepted and changes nothing.",
+        "description": "Applies RFC 7644 section 3.5.2 patch operations. What is implemented: `add` of members, `remove` of members (named by a value filter on the path, as Entra ID writes it, or in the operation value), `replace` of `displayName`, and `replace` of the whole member list. `replace`, `add` and `remove` are the only operation names understood, read without regard to case, so the capitalized `Add` / `Remove` that Entra ID writes are accepted; any other name, or a missing or non-string one, is rejected as a bad request. An `add` or a `remove` aimed at anything other than members is accepted and changes nothing. A `replace` that is not a `displayName` rename is treated as a replacement of the whole member list, so one that carries no members empties the group.",
         "security": [
           {
             "scim_bearer": []


### PR DESCRIPTION
# Related Issue

- Resolves #7126

## For humans

Our SCIM PATCH documentation told integrators something that was not true: that
we accept whatever operations their identity provider sends and quietly ignore
the ones we have not implemented. We do not. Anything that is not `replace`,
`add` or `remove` comes back as a `400`.

Nobody was broken by it, because those three names are the only three RFC 7644
defines. But it is exactly the sentence someone reads to decide they do not need
to filter their patch set before sending it, and it is the sentence they would
come back to when a `400` turned up in their provisioning log.

This is wording only. No behaviour changes.

## What it said

> Operations outside that set are accepted and change nothing, so a provider
> sending its full patch set is never rejected.

## What it says now

> `replace`, `add` and `remove` are the only operation names understood, read
> without regard to case, so the capitalized `Replace` that Entra ID writes is
> accepted; any other name, or a missing or non-string one, is rejected as a bad
> request. An understood operation aimed at anything not listed above is
> accepted and changes nothing.

The old sentence collapsed two different behaviours into one. They are now
stated separately:

1. **An operation name we do not recognize** — rejected, `400`.
2. **A recognized name aimed at a target we have not implemented** — accepted,
   changes nothing.

## Why this is what the code does

`scimPatchOperationSchema` in `platform/app/ee/scim/scim.types.ts` validates `op`
against a three-value enum; both PATCH routes turn a parse failure into
`scimError(c, 400, ...)`. Executed against the schema:

| sent `op`   | result                                                                 |
| ----------- | ---------------------------------------------------------------------- |
| `"Replace"` | accepted, normalized to `replace`                                      |
| `"Delete"`  | rejected — `Expected 'replace' \| 'add' \| 'remove', received 'delete'` |
| `42`        | rejected — `Expected 'replace' \| 'add' \| 'remove', received number`   |
| missing     | rejected — `Required`                                                  |
| `null`      | rejected — `Expected 'replace' \| 'add' \| 'remove', received null`     |

## Files

- `platform/app/ee/scim/openapi.ts` — the two descriptions, the only hand-edited
  file.
- `platform/app/src/app/api/openapiLangWatch.json` and
  `docs/api-reference/openapiLangWatch.json` — regenerated, 2 lines each, no
  unrelated drift.

Regenerated with `pnpm task generateOpenAPISpec`, then
`cd docs && make sync-api-spec && make generate-api-reference`.

## Checks run

- `pnpm typecheck` — clean
- `biome check ee/scim/openapi.ts` — clean
- `pnpm check:openapi-completeness` — OK, 40 operations
- `pnpm check:openapi-route-coverage` — OK
- `pnpm test:unit run ee/scim/` — 46/46 across 5 files

## Noticed and deliberately not fixed

**Nothing in CI regenerates the spec artifacts from `openapi.ts`.** `docs-ci`
compares the two committed JSON copies against each other, and `make
sync-api-spec` copies one to the other — so editing `openapi.ts` alone leaves
both copies consistently stale and CI stays green. I hit this on #7121 and hit
it again here; both times the regeneration was a manual step I had to remember.
That is a trap waiting for the next person and deserves its own issue, but it is
a CI change and does not belong in a wording fix.

Carried forward from #7121, still unfixed and still not in scope here:

- `parseUserNameFilter` (`scim.service.ts:537`) and `parseDisplayNameFilter`
  (`scim-group.service.ts:428`) match the filter attribute name case-sensitively;
  RFC 7644 §3.4.2.2 says attribute names are case-insensitive.
- PATCH `path` values are compared case-sensitively against RFC 7643 §2.1. Note
  this one must **not** be fixed by lowercasing the path, because
  `members[value eq "..."]` carries a case-sensitive member id.

Fixes #7126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified SCIM user and group PATCH endpoint behavior.
  * Documented that `replace`, `add`, and `remove` operations are accepted case-insensitively.
  * Specified that missing, non-string, or unsupported operation names return a bad request.
  * Clarified that valid operations targeting unsupported fields are accepted without changes.
  * Documented that group `replace` operations can replace the complete member list, including clearing all members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->