### PR TITLE
feat(scenarios): per-scenario max turns cap in the UI

### DIFF
--- a/platform/app/prisma/migrations/20260816120000_scenario_max_turns/migration.sql
+++ b/platform/app/prisma/migrations/20260816120000_scenario_max_turns/migration.sql
@@ -1,0 +1,13 @@
+-- Per-scenario cap on conversation turns.
+--
+-- Runs triggered from the UI always used the scenario SDK default of 10
+-- turns because nothing carried a cap. This column stores an optional
+-- per-scenario value. NULL means "use the SDK default", which is what every
+-- existing row already does, so there is no backfill.
+-- See specs/scenarios/scenario-max-turns.feature.
+
+-- AlterTable
+ALTER TABLE "Scenario" ADD COLUMN "maxTurns" INTEGER;
+
+-- Down (manual): reverses this migration; run only to roll back.
+--   ALTER TABLE "Scenario" DROP COLUMN "maxTurns";

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -2213,6 +2213,10 @@ model Scenario {
   // DEFAULT-role models. See specs/scenarios/scenario-model-selection.feature.
   simulatorModel  String?
   judgeModel      String?
+  // Optional cap on conversation turns for a run. When null the run uses
+  // the scenario SDK default (10). See
+  // specs/scenarios/scenario-max-turns.feature.
+  maxTurns        Int?
   lastUpdatedById String?
   lastUpdatedBy   User?     @relation(fields: [lastUpdatedById], references: [id])
   archivedAt      DateTime?

--- a/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
@@ -34,6 +34,7 @@ import {
   discoverFeatureFiles,
   isEntryModule,
   isInert,
+  TEST_FILE_RE,
 } from "../check-feature-parity";
 
 let root = "";
@@ -289,6 +290,33 @@ describe("isInert", () => {
         // Nothing was claimed, so nothing is being overclaimed.
         expect(isInert({ scenarios: [], totalScenarios: 0 })).toBe(false);
       });
+    });
+  });
+});
+
+describe("TEST_FILE_RE", () => {
+  // Playwright happy-path specs use `.spec.ts`; widening the regex to
+  // accept them is a binding-policy change, so the accepted and rejected
+  // shapes are pinned here.
+  describe("given vitest and playwright test file names", () => {
+    it.each([
+      "foo.test.ts",
+      "foo.test.tsx",
+      "foo.spec.ts",
+      "foo.spec.tsx",
+    ])("matches %s", (name) => {
+      expect(TEST_FILE_RE.test(name)).toBe(true);
+    });
+  });
+
+  describe("given plain source file names", () => {
+    it.each([
+      "foo.ts",
+      "foo.tsx",
+      "foo.spec.ts.bak",
+      "spec.ts",
+    ])("does not match %s", (name) => {
+      expect(TEST_FILE_RE.test(name)).toBe(false);
     });
   });
 });

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -79,6 +79,10 @@ const DEFAULT_TEST_ROOTS: string[] = [
   // assistant's rules are tested here (and nowhere else), so scenarios about
   // what an instruction teaches can only bind from this root.
   "skills/_tests",
+  // The CI-run playwright suite (`.spec.ts`, .github/workflows/e2e-ci.yml).
+  // It is the only place a browser-driven @e2e scenario can bind — without
+  // this root every such scenario would be stuck on @unimplemented.
+  "tests/agentic-e2e/tests",
   // CI guards run under `node --test` from the workflow that uses them, not
   // vitest, and their tests live beside them. Without this root, a scenario
   // describing what a guard refuses could only ever be @unimplemented.
@@ -649,7 +653,10 @@ const LEGACY_INERT: string[] = [
   "specs/workflows/workflow-management.feature",
 ];
 
-const TEST_FILE_RE = /\.test\.tsx?$/;
+// `.spec.ts` is the playwright naming convention under
+// tests/agentic-e2e/tests. Exported so the policy is pinned by
+// scripts/__tests__/check-feature-parity.unit.test.ts.
+export const TEST_FILE_RE = /\.(test|spec)\.tsx?$/;
 const BATS_FILE_RE = /\.bats$/;
 const SHELL_TEST_FILE_RE = /\.sh$/;
 const GO_TEST_FILE_RE = /_test\.go$/;

--- a/platform/app/src/components/scenarios/ScenarioForm.tsx
+++ b/platform/app/src/components/scenarios/ScenarioForm.tsx
@@ -1,9 +1,19 @@
 import { Field, Input, Text, Textarea, VStack } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useRef } from "react";
-import { Controller, type UseFormReturn, useForm } from "react-hook-form";
+import {
+  Controller,
+  type FieldError,
+  type UseFormRegister,
+  type UseFormReturn,
+  useForm,
+} from "react-hook-form";
 import { z } from "zod";
 import { scenarioParameterDefinitionsSchema } from "~/server/scenarios/parameters";
+import {
+  DEFAULT_SCENARIO_MAX_TURNS,
+  MAX_SCENARIO_MAX_TURNS,
+} from "~/server/scenarios/scenario.constants";
 import { CriteriaInput } from "./ui/CriteriaInput";
 import { SectionHeader } from "./ui/SectionHeader";
 
@@ -19,6 +29,17 @@ export const scenarioFormSchema = z.object({
   situation: z.string(),
   criteria: z.array(z.string()),
   labels: z.array(z.string()),
+  // null means "use the default turn cap". The register call normalizes an
+  // empty input to null before this schema runs.
+  maxTurns: z
+    .number({ invalid_type_error: "Maximum turns must be a whole number" })
+    .int("Maximum turns must be a whole number")
+    .min(1, `Maximum turns must be between 1 and ${MAX_SCENARIO_MAX_TURNS}`)
+    .max(
+      MAX_SCENARIO_MAX_TURNS,
+      `Maximum turns must be between 1 and ${MAX_SCENARIO_MAX_TURNS}`,
+    )
+    .nullable(),
   parameters: scenarioParameterDefinitionsSchema,
 });
 
@@ -49,6 +70,7 @@ export function ScenarioForm({ defaultValues, formRef }: ScenarioFormProps) {
       situation: "",
       criteria: [],
       labels: [],
+      maxTurns: null,
       parameters: [],
       ...defaultValues,
     },
@@ -128,6 +150,52 @@ export function ScenarioForm({ defaultValues, formRef }: ScenarioFormProps) {
           )}
         />
       </VStack>
+
+      {/* MAXIMUM TURNS Section */}
+      <MaxTurnsField register={register} error={errors.maxTurns} />
+    </VStack>
+  );
+}
+
+/**
+ * Empty input means "use the default", so it stores null. Non-numeric text
+ * passes through untouched so the schema rejects it visibly instead of
+ * silently falling back to the default.
+ */
+function normalizeMaxTurnsInput(value: unknown): unknown {
+  if (value === "" || value === null || value === undefined) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? value : parsed;
+}
+
+function MaxTurnsField({
+  register,
+  error,
+}: {
+  register: UseFormRegister<ScenarioFormData>;
+  error?: FieldError;
+}) {
+  return (
+    <VStack align="stretch" gap={3}>
+      <Field.Root invalid={!!error}>
+        <Field.Label>
+          <SectionHeader as="span">Maximum turns</SectionHeader>
+        </Field.Label>
+        <Text fontSize="13px" color="fg.muted">
+          How many conversation turns the simulation may take before it stops.
+          Leave empty to use the default of {DEFAULT_SCENARIO_MAX_TURNS} turns.
+        </Text>
+        <Input
+          type="number"
+          width="120px"
+          min={1}
+          max={MAX_SCENARIO_MAX_TURNS}
+          {...register("maxTurns", { setValueAs: normalizeMaxTurnsInput })}
+        />
+        <Field.ErrorText>{error?.message}</Field.ErrorText>
+      </Field.Root>
     </VStack>
   );
 }
@@ -154,6 +222,7 @@ function useResetOnDefaultsChange({
           defaultValues.situation,
           defaultValues.criteria,
           defaultValues.labels,
+          defaultValues.maxTurns,
           defaultValues.parameters,
         ])
       : null;
@@ -165,6 +234,7 @@ function useResetOnDefaultsChange({
           situation: "",
           criteria: [],
           labels: [],
+          maxTurns: null,
           parameters: [],
           ...defaultValues,
         });

--- a/platform/app/src/components/scenarios/__tests__/ScenarioFormMaxTurns.integration.test.tsx
+++ b/platform/app/src/components/scenarios/__tests__/ScenarioFormMaxTurns.integration.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the "Maximum turns" field on the scenario form.
+ *
+ * @see specs/scenarios/scenario-max-turns.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UseFormReturn } from "react-hook-form";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_SCENARIO_MAX_TURNS } from "~/server/scenarios/scenario.constants";
+import { ScenarioForm, type ScenarioFormData } from "../ScenarioForm";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+/** Renders the form and hands back its react-hook-form instance. */
+function renderForm(defaultValues?: Partial<ScenarioFormData>) {
+  let form: UseFormReturn<ScenarioFormData> | null = null;
+  render(
+    <ScenarioForm
+      defaultValues={defaultValues}
+      formRef={(instance) => {
+        form = instance;
+      }}
+    />,
+    { wrapper: Wrapper },
+  );
+  if (!form) throw new Error("form instance was not exposed via formRef");
+  return form as UseFormReturn<ScenarioFormData>;
+}
+
+/** Submits through react-hook-form and returns the validated payload, or null on validation failure. */
+async function submit(
+  form: UseFormReturn<ScenarioFormData>,
+): Promise<ScenarioFormData | null> {
+  const onValid = vi.fn();
+  await form.handleSubmit(onValid)();
+  return onValid.mock.calls.length > 0
+    ? (onValid.mock.calls[0]?.[0] as ScenarioFormData)
+    : null;
+}
+
+describe("<ScenarioForm/> Maximum turns", () => {
+  afterEach(() => cleanup());
+
+  describe("given the form is filled with a valid maximum turns value", () => {
+    describe("when the form is submitted", () => {
+      /** @scenario "The scenario form lets me set the maximum turns" */
+      it("carries the entered value on the payload", async () => {
+        const user = userEvent.setup();
+        const form = renderForm({ name: "Refund flow" });
+
+        const input = screen.getByLabelText("Maximum turns");
+        await user.type(input, "3");
+
+        const payload = await submit(form);
+        expect(payload).not.toBeNull();
+        expect(payload?.maxTurns).toBe(3);
+      });
+    });
+  });
+
+  describe("given the maximum turns field is left empty", () => {
+    describe("when the form is submitted", () => {
+      /** @scenario "The scenario form lets me set the maximum turns" */
+      it("submits null, meaning the default cap", async () => {
+        const form = renderForm({ name: "Refund flow" });
+
+        const payload = await submit(form);
+        expect(payload).not.toBeNull();
+        expect(payload?.maxTurns).toBeNull();
+      });
+
+      it("submits null after a previously entered value is cleared", async () => {
+        const user = userEvent.setup();
+        const form = renderForm({ name: "Refund flow", maxTurns: 4 });
+
+        const input = screen.getByLabelText("Maximum turns");
+        await user.clear(input);
+
+        const payload = await submit(form);
+        expect(payload).not.toBeNull();
+        expect(payload?.maxTurns).toBeNull();
+      });
+    });
+  });
+
+  describe("given an out-of-bounds maximum turns value", () => {
+    describe("when the form is submitted with 0", () => {
+      /** @scenario "The scenario form rejects an out-of-bounds maximum turns" */
+      it("shows a validation error and does not submit", async () => {
+        const user = userEvent.setup();
+        const form = renderForm({ name: "Refund flow" });
+
+        const input = screen.getByLabelText("Maximum turns");
+        await user.type(input, "0");
+
+        const payload = await submit(form);
+        expect(payload).toBeNull();
+        await waitFor(() => {
+          expect(
+            screen.getByText(
+              `Maximum turns must be between 1 and ${MAX_SCENARIO_MAX_TURNS}`,
+            ),
+          ).toBeInTheDocument();
+        });
+      });
+    });
+
+    describe(`when the form is submitted with ${MAX_SCENARIO_MAX_TURNS + 1}`, () => {
+      /** @scenario "The scenario form rejects an out-of-bounds maximum turns" */
+      it("shows a validation error and does not submit", async () => {
+        const user = userEvent.setup();
+        const form = renderForm({ name: "Refund flow" });
+
+        const input = screen.getByLabelText("Maximum turns");
+        await user.type(input, String(MAX_SCENARIO_MAX_TURNS + 1));
+
+        const payload = await submit(form);
+        expect(payload).toBeNull();
+        await waitFor(() => {
+          expect(
+            screen.getByText(
+              `Maximum turns must be between 1 and ${MAX_SCENARIO_MAX_TURNS}`,
+            ),
+          ).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
+  describe("given a decimal maximum turns value", () => {
+    describe("when the form is submitted", () => {
+      it("shows the whole-number validation error and does not submit", async () => {
+        const user = userEvent.setup();
+        const form = renderForm({ name: "Refund flow" });
+
+        const input = screen.getByLabelText("Maximum turns");
+        await user.type(input, "3.5");
+
+        const payload = await submit(form);
+        expect(payload).toBeNull();
+        await waitFor(() => {
+          expect(
+            screen.getByText("Maximum turns must be a whole number"),
+          ).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
+  describe("given a scenario being edited already has a maximum turns value", () => {
+    describe("when the form renders", () => {
+      it("prefills the field with the stored value", () => {
+        renderForm({ name: "Refund flow", maxTurns: 7 });
+
+        const input = screen.getByLabelText<HTMLInputElement>("Maximum turns");
+        expect(input.value).toBe("7");
+      });
+    });
+  });
+});

--- a/platform/app/src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx
+++ b/platform/app/src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx
@@ -40,6 +40,7 @@ function makeScenario(
     parameters: null,
     simulatorModel: null,
     judgeModel: null,
+    maxTurns: null,
     lastUpdatedById: null,
     archivedAt: null,
     createdAt: now,

--- a/platform/app/src/server/api/routers/scenarios/__tests__/scenario-crud.schema.unit.test.ts
+++ b/platform/app/src/server/api/routers/scenarios/__tests__/scenario-crud.schema.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the scenario create/update input schemas. The tRPC schema
+ * is the only line enforcing the turn cap bounds (the service below it is a
+ * pass-through), so the bounds are pinned here.
+ *
+ * @see specs/scenarios/scenario-max-turns.feature
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createScenarioSchema,
+  updateScenarioSchema,
+} from "../scenario-crud.router";
+
+const baseCreateInput = {
+  projectId: "proj_1",
+  name: "Refund flow",
+  situation: "User asks for a refund",
+  criteria: ["Agent is polite"],
+  labels: [],
+};
+
+const baseUpdateInput = {
+  projectId: "proj_1",
+  id: "scen_1",
+};
+
+describe("scenario create/update input schemas", () => {
+  describe("given a maximum turns value out of bounds", () => {
+    /** @scenario "The scenario form rejects an out-of-bounds maximum turns" */
+    it.each([0, 51])("rejects %s on create", (maxTurns) => {
+      const result = createScenarioSchema.safeParse({
+        ...baseCreateInput,
+        maxTurns,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    /** @scenario "The scenario form rejects an out-of-bounds maximum turns" */
+    it.each([0, 51])("rejects %s on update", (maxTurns) => {
+      const result = updateScenarioSchema.safeParse({
+        ...baseUpdateInput,
+        maxTurns,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a non-integer value on create", () => {
+      const result = createScenarioSchema.safeParse({
+        ...baseCreateInput,
+        maxTurns: 2.5,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("given a maximum turns value within bounds", () => {
+    /** @scenario "The turn cap persists on scenario create and update" */
+    it.each([1, 50])("accepts %s on create", (maxTurns) => {
+      const result = createScenarioSchema.safeParse({
+        ...baseCreateInput,
+        maxTurns,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxTurns).toBe(maxTurns);
+      }
+    });
+
+    /** @scenario "The turn cap persists on scenario create and update" */
+    it.each([1, 50])("accepts %s on update", (maxTurns) => {
+      const result = updateScenarioSchema.safeParse({
+        ...baseUpdateInput,
+        maxTurns,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxTurns).toBe(maxTurns);
+      }
+    });
+  });
+
+  describe("given no maximum turns value", () => {
+    it("accepts null on create, meaning clear back to the default", () => {
+      const result = createScenarioSchema.safeParse({
+        ...baseCreateInput,
+        maxTurns: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxTurns).toBeNull();
+      }
+    });
+
+    it("accepts null on update, meaning clear back to the default", () => {
+      const result = updateScenarioSchema.safeParse({
+        ...baseUpdateInput,
+        maxTurns: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxTurns).toBeNull();
+      }
+    });
+
+    it("accepts an absent field on create", () => {
+      const result = createScenarioSchema.safeParse(baseCreateInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxTurns).toBeUndefined();
+      }
+    });
+
+    it("accepts an absent field on update", () => {
+      const result = updateScenarioSchema.safeParse(baseUpdateInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maxTurns).toBeUndefined();
+      }
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/scenarios/scenario-crud.router.ts
+++ b/platform/app/src/server/api/routers/scenarios/scenario-crud.router.ts
@@ -6,6 +6,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { trackServerEvent } from "~/server/posthog";
 import { ScenarioNotFoundError } from "~/server/scenarios/errors";
 import { scenarioParameterDefinitionsSchema } from "~/server/scenarios/parameters";
+import { MAX_SCENARIO_MAX_TURNS } from "~/server/scenarios/scenario.constants";
 import { ScenarioService } from "~/server/scenarios/scenario.service";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { checkProjectPermission } from "../../rbac";
@@ -13,7 +14,7 @@ import { projectSchema } from "./schemas";
 
 const logger = createLogger("langwatch:api:scenarios:crud");
 
-const createScenarioSchema = projectSchema.extend({
+export const createScenarioSchema = projectSchema.extend({
   name: z.string().min(1),
   situation: z.string(),
   criteria: z.array(z.string()).default([]),
@@ -22,12 +23,14 @@ const createScenarioSchema = projectSchema.extend({
   // default (scenarios.user_simulator / scenarios.judge).
   simulatorModel: z.string().nullish(),
   judgeModel: z.string().nullish(),
+  // Optional cap on conversation turns; null clears back to the SDK default.
+  maxTurns: z.number().int().min(1).max(MAX_SCENARIO_MAX_TURNS).nullish(),
   // The parameters the scenario declares, each with an optional description
   // and default. A run supplies values for these names.
   parameters: scenarioParameterDefinitionsSchema.optional(),
 });
 
-const updateScenarioSchema = projectSchema.extend({
+export const updateScenarioSchema = projectSchema.extend({
   id: z.string(),
   name: z.string().min(1).optional(),
   situation: z.string().optional(),
@@ -35,6 +38,7 @@ const updateScenarioSchema = projectSchema.extend({
   labels: z.array(z.string()).optional(),
   simulatorModel: z.string().nullish(),
   judgeModel: z.string().nullish(),
+  maxTurns: z.number().int().min(1).max(MAX_SCENARIO_MAX_TURNS).nullish(),
   parameters: scenarioParameterDefinitionsSchema.optional(),
 });
 

--- a/platform/app/src/server/scenarios/__tests__/scenario.constants.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenario.constants.unit.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment node
+ *
+ * Pins DEFAULT_SCENARIO_MAX_TURNS to the scenario SDK's own default. The
+ * constant claims to mirror the SDK and the form copy promises "default of
+ * 10 turns", so a vendored SDK bump that moves the default fails here
+ * instead of silently lying to the user. The SDK import lives only in this
+ * test: scenario.constants.ts is shared with the client bundle and must not
+ * pull the SDK in.
+ *
+ * @see specs/scenarios/scenario-max-turns.feature
+ */
+import { DEFAULT_MAX_TURNS } from "@langwatch/scenario";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SCENARIO_MAX_TURNS } from "../scenario.constants";
+
+describe("DEFAULT_SCENARIO_MAX_TURNS", () => {
+  describe("given the vendored scenario SDK", () => {
+    /** @scenario "A scenario without a turn cap runs with the engine default" */
+    it("matches the SDK's own default turn cap", () => {
+      expect(DEFAULT_SCENARIO_MAX_TURNS).toBe(DEFAULT_MAX_TURNS);
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/__tests__/scenarioMaxTurnsPersistence.integration.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenarioMaxTurnsPersistence.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment node
+ *
+ * Real-Postgres integration coverage for persisting the per-scenario turn
+ * cap on a Scenario.
+ *
+ * Requires: PostgreSQL (Prisma). Runs unconditionally — every harness
+ * provides Postgres.
+ *
+ * @see specs/scenarios/scenario-max-turns.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { prisma } from "../../db";
+import { ScenarioService } from "../scenario.service";
+
+describe("Scenario turn cap persistence (real DB)", () => {
+  const ns = `max-turns-${nanoid(8)}`;
+  let projectId: string;
+  let teamId: string;
+  let organizationId: string;
+
+  beforeAll(async () => {
+    const org = await prisma.organization.create({
+      data: { name: `Turns Org ${ns}`, slug: `--turns-${ns}` },
+    });
+    organizationId = org.id;
+    const team = await prisma.team.create({
+      data: {
+        name: `Turns Team ${ns}`,
+        slug: `--turns-team-${ns}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+    const project = await prisma.project.create({
+      data: {
+        name: `Turns Proj ${ns}`,
+        slug: `--turns-proj-${ns}`,
+        teamId,
+        language: "typescript",
+        framework: "other",
+        apiKey: `turns-key-${ns}`,
+      },
+    });
+    projectId = project.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestRows(prisma, [
+      ["scenario", { projectId }],
+      ["project", { id: projectId }],
+      ["team", { id: teamId }],
+      ["organization", { id: organizationId }],
+    ]);
+  });
+
+  describe("given a scenario", () => {
+    describe("when it is created and updated with a maximum turns value", () => {
+      /** @scenario "The turn cap persists on scenario create and update" */
+      it("stores the value, and clearing it stores null again", async () => {
+        const service = ScenarioService.create(prisma);
+        const created = await service.create({
+          projectId,
+          name: `Scenario ${ns}`,
+          situation: "User asks for a refund",
+          criteria: ["Agent is polite"],
+          labels: [],
+        });
+        // No cap until explicitly chosen.
+        expect(created.maxTurns).toBeNull();
+
+        const updated = await service.update(created.id, projectId, {
+          maxTurns: 3,
+        });
+        expect(updated.maxTurns).toBe(3);
+
+        const reread = await prisma.scenario.findFirst({
+          where: { id: created.id, projectId },
+        });
+        expect(reread?.maxTurns).toBe(3);
+
+        const cleared = await service.update(created.id, projectId, {
+          maxTurns: null,
+        });
+        expect(cleared.maxTurns).toBeNull();
+
+        const rereadCleared = await prisma.scenario.findFirst({
+          where: { id: created.id, projectId },
+        });
+        expect(rereadCleared?.maxTurns).toBeNull();
+      });
+    });
+
+    describe("when it is updated without touching the maximum turns field", () => {
+      /** @scenario "The turn cap persists on scenario create and update" */
+      it("keeps the stored value", async () => {
+        const service = ScenarioService.create(prisma);
+        const created = await service.create({
+          projectId,
+          name: `Scenario omit ${ns}`,
+          situation: "User asks a question",
+          criteria: ["Agent answers"],
+          labels: [],
+          maxTurns: 3,
+        });
+        expect(created.maxTurns).toBe(3);
+
+        // maxTurns absent from the update: undefined is a no-op in Prisma,
+        // so the cap must survive a rename.
+        const renamed = await service.update(created.id, projectId, {
+          name: `Scenario omit renamed ${ns}`,
+        });
+        expect(renamed.name).toBe(`Scenario omit renamed ${ns}`);
+        expect(renamed.maxTurns).toBe(3);
+
+        const reread = await prisma.scenario.findFirst({
+          where: { id: created.id, projectId },
+        });
+        expect(reread?.maxTurns).toBe(3);
+      });
+    });
+
+    describe("when it is created with a maximum turns value", () => {
+      /** @scenario "The turn cap persists on scenario create and update" */
+      it("stores the value on create", async () => {
+        const service = ScenarioService.create(prisma);
+        const created = await service.create({
+          projectId,
+          name: `Scenario create ${ns}`,
+          situation: "User asks a question",
+          criteria: ["Agent answers"],
+          labels: [],
+          maxTurns: 5,
+        });
+        expect(created.maxTurns).toBe(5);
+
+        const reread = await prisma.scenario.findFirst({
+          where: { id: created.id, projectId },
+        });
+        expect(reread?.maxTurns).toBe(5);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/execution/__tests__/childProcessJobData.schema.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/childProcessJobData.schema.unit.test.ts
@@ -16,6 +16,8 @@
  * @see specs/scenarios/simulation-run-model-resolution.feature
  *   ("A job payload missing every model params field fails at schema
  *   parse", "An older job payload shape still parses and runs")
+ * @see specs/scenarios/scenario-max-turns.feature
+ *   ("A job queued before the turn cap existed still runs")
  */
 import { describe, expect, it } from "vitest";
 
@@ -124,6 +126,53 @@ describe("ChildProcessJobDataSchema", () => {
       const roleModelParams = selectRoleModelParams(result.data);
       expect(roleModelParams.simulator).toEqual(litellmParams);
       expect(roleModelParams.judge).toEqual(litellmParams);
+    });
+  });
+
+  describe("given a job payload serialized before the turn cap existed", () => {
+    // Frozen literal — the scenario shape a worker queued before maxTurns
+    // was introduced. Queued jobs straddle a deploy, so this is the payload
+    // a freshly-deployed child process actually meets.
+    const preTurnCapPayload = {
+      ...basePayload,
+      modelParams: litellmParams,
+    };
+
+    /** @scenario "A job queued before the turn cap existed still runs" */
+    it("parses, with no turn cap so the SDK default applies", () => {
+      const result = ChildProcessJobDataSchema.safeParse(preTurnCapPayload);
+      expect(result.success).toBe(true);
+      if (!result.success) {
+        expect.fail("expected the pre-turn-cap payload to parse");
+        return;
+      }
+      expect(result.data.scenario.maxTurns).toBeUndefined();
+    });
+  });
+
+  describe("given a job payload carrying a turn cap on the scenario", () => {
+    /** @scenario "A scenario's turn cap is carried into the run" */
+    it("parses and keeps the cap on the scenario config", () => {
+      const result = ChildProcessJobDataSchema.safeParse({
+        ...basePayload,
+        scenario: { ...scenario, maxTurns: 2 },
+        modelParams: litellmParams,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) {
+        expect.fail("expected the payload with a turn cap to parse");
+        return;
+      }
+      expect(result.data.scenario.maxTurns).toBe(2);
+    });
+
+    it("rejects a cap below 1", () => {
+      const result = ChildProcessJobDataSchema.safeParse({
+        ...basePayload,
+        scenario: { ...scenario, maxTurns: 0 },
+        modelParams: litellmParams,
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/platform/app/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -706,6 +706,84 @@ describe("prefetchScenarioData", () => {
     });
   });
 
+  describe("turn cap propagation", () => {
+    const httpAgent = {
+      id: "agent_http",
+      type: "http" as const,
+      name: "HTTP Agent",
+      projectId: "proj_123",
+      config: {
+        url: "https://api.example.com/chat",
+        method: "POST",
+        headers: [],
+      },
+      workflowId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      archivedAt: null,
+    };
+    const httpTarget: TargetConfig = {
+      type: "http",
+      referenceId: "agent_http",
+    };
+
+    describe("given a scenario with a maximum turns value", () => {
+      describe("when prefetching the run data", () => {
+        /** @scenario "A scenario's turn cap is carried into the run" */
+        it("carries the turn cap on the serialized scenario config", async () => {
+          const deps = createMockDeps({
+            scenarioFetcher: {
+              getById: vi.fn().mockResolvedValue({
+                ...defaultScenario,
+                maxTurns: 3,
+              }),
+            },
+            agentFetcher: { findById: vi.fn().mockResolvedValue(httpAgent) },
+          });
+
+          const result = await prefetchScenarioData({
+            context: defaultContext,
+            target: httpTarget,
+            deps,
+          });
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.data.scenario.maxTurns).toBe(3);
+          }
+        });
+      });
+    });
+
+    describe("given a scenario with no maximum turns value", () => {
+      describe("when prefetching the run data", () => {
+        /** @scenario "A scenario without a turn cap runs with the engine default" */
+        it("leaves the turn cap undefined so the SDK default applies", async () => {
+          const deps = createMockDeps({
+            scenarioFetcher: {
+              getById: vi.fn().mockResolvedValue({
+                ...defaultScenario,
+                maxTurns: null,
+              }),
+            },
+            agentFetcher: { findById: vi.fn().mockResolvedValue(httpAgent) },
+          });
+
+          const result = await prefetchScenarioData({
+            context: defaultContext,
+            target: httpTarget,
+            deps,
+          });
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.data.scenario.maxTurns).toBeUndefined();
+          }
+        });
+      });
+    });
+  });
+
   describe("error handling", () => {
     describe("given scenario does not exist", () => {
       describe("when prefetching scenario data", () => {

--- a/platform/app/src/server/scenarios/execution/data-prefetcher.ts
+++ b/platform/app/src/server/scenarios/execution/data-prefetcher.ts
@@ -76,6 +76,8 @@ export interface ScenarioFetcher {
     simulatorModel?: string | null;
     /** Per-scenario judge model override (null = use default). */
     judgeModel?: string | null;
+    /** Per-scenario turn cap (null = SDK default). */
+    maxTurns?: number | null;
     /** The parameters the scenario declares, as stored on its JSON column. */
     parameters?: unknown;
   } | null>;
@@ -602,6 +604,7 @@ async function fetchScenario({
       situation: rendered.situation,
       criteria: rendered.criteria,
       labels: scenario.labels,
+      maxTurns: scenario.maxTurns ?? undefined,
     },
     parameters,
     simulatorModel: scenario.simulatorModel ?? null,

--- a/platform/app/src/server/scenarios/execution/scenario-child-process.ts
+++ b/platform/app/src/server/scenarios/execution/scenario-child-process.ts
@@ -182,6 +182,8 @@ async function executeScenario(jobData: ChildProcessJobData): Promise<void> {
       id: scenario.id,
       name: scenario.name,
       description: scenario.situation,
+      // undefined lets the SDK apply its own default of 10 turns.
+      maxTurns: scenario.maxTurns,
       setId: context.setId,
       agents: [
         adapter,

--- a/platform/app/src/server/scenarios/execution/types.ts
+++ b/platform/app/src/server/scenarios/execution/types.ts
@@ -236,6 +236,11 @@ export const ScenarioConfigSchema = z.object({
   situation: z.string(),
   criteria: z.array(z.string()),
   labels: z.array(z.string()),
+  /**
+   * Cap on conversation turns. Optional so a job queued before the field
+   * existed still parses; absent means the scenario SDK default (10).
+   */
+  maxTurns: z.number().int().min(1).optional(),
 });
 export type ScenarioConfig = z.infer<typeof ScenarioConfigSchema>;
 

--- a/platform/app/src/server/scenarios/scenario.constants.ts
+++ b/platform/app/src/server/scenarios/scenario.constants.ts
@@ -49,3 +49,12 @@ export const CHILD_PROCESS = {
  * only truth — nothing derives STALLED at read time anymore.
  */
 export const STALL_THRESHOLD_MS = CHILD_PROCESS.TIMEOUT_MS * 2;
+
+/**
+ * Turn cap the scenario engine uses when a scenario sets none. Mirrors the
+ * @langwatch/scenario SDK default. Used only in copy and hints, never sent.
+ */
+export const DEFAULT_SCENARIO_MAX_TURNS = 10;
+
+/** Upper bound for a per-scenario turn cap. Keeps run cost bounded. */
+export const MAX_SCENARIO_MAX_TURNS = 50;

--- a/specs/scenarios/scenario-max-turns.feature
+++ b/specs/scenarios/scenario-max-turns.feature
@@ -1,0 +1,72 @@
+Feature: Per-scenario maximum conversation turns
+  As a user running agent scenario simulations
+  I want to cap how many conversation turns a scenario can take
+  So that a simulation stops at a bound I chose instead of always
+  running up to the platform default
+
+  # Background
+  # ----------
+  # A scenario run is a conversation between the user-simulator and the
+  # agent under test, refereed by the judge. The scenario engine stops the
+  # conversation after a maximum number of turns; on the last turn it
+  # forces the judge to give a verdict, and a run that reaches the cap
+  # without a conclusion fails.
+  #
+  # The cap is optional and lives on the scenario itself. A scenario with
+  # no cap runs with the engine default of 10 turns. There is no run-plan
+  # (suite) override yet; that is a follow-up.
+
+  Background:
+    Given I am logged in
+    And I have access to a project with an enabled model provider
+
+  @unit
+  Scenario: A scenario's turn cap is carried into the run
+    Given a scenario with a maximum turns value configured
+    When the run data is prefetched
+    Then the serialized run configuration carries that turn cap
+
+  @unit
+  Scenario: A scenario without a turn cap runs with the engine default
+    Given a scenario with no maximum turns value configured
+    When the run data is prefetched
+    Then the serialized run configuration carries no turn cap
+    And the run uses the engine default of 10 turns
+
+  @unit
+  Scenario: A job queued before the turn cap existed still runs
+    Given a job payload serialized before the turn cap was introduced
+    When the payload is parsed at the execution boundary
+    Then it is accepted
+    And the run uses the engine default of 10 turns
+
+  @integration
+  Scenario: The turn cap persists on scenario create and update
+    Given a scenario
+    When I update the scenario with a maximum turns value
+    Then the stored scenario carries that value
+    And clearing the value stores no cap again
+
+  @integration
+  Scenario: The scenario form lets me set the maximum turns
+    Given I am editing a scenario
+    When I fill in the "Maximum turns" field
+    Then saving the scenario carries the value I entered
+    And leaving the field empty saves the scenario with no cap
+
+  @integration
+  Scenario: The scenario form rejects an out-of-bounds maximum turns
+    Given I am editing a scenario
+    When I enter a maximum turns value below 1 or above the allowed maximum
+    Then the form shows a validation error
+    And the scenario is not saved
+
+  @e2e
+  Scenario: A turn cap set in the scenario editor survives saving and reopening
+    Given I am creating a scenario in the editor
+    When I set the maximum turns to 2 and save
+    And I reopen the scenario
+    Then the maximum turns field shows 2
+    When I clear the maximum turns and save
+    And I reopen the scenario
+    Then the maximum turns field is empty, meaning the default applies

--- a/tests/agentic-e2e/tests/scenarios/README.md
+++ b/tests/agentic-e2e/tests/scenarios/README.md
@@ -8,6 +8,7 @@ These tests implement scenarios from:
 - `specs/scenarios/scenario-library.feature`
 - `specs/scenarios/scenario-editor.feature`
 - `specs/scenarios/scenario-execution.feature`
+- `specs/scenarios/scenario-max-turns.feature`
 
 ## Test Files
 
@@ -17,6 +18,7 @@ These tests implement scenarios from:
 | `scenario-library.spec.ts` | Library | Navigation, empty state |
 | `scenario-editor.spec.ts` | Editor | Create, edit, workflow lifecycle |
 | `scenario-execution.spec.ts` | Execution | Page loads, content display |
+| `scenario-turn-cap.spec.ts` | Max turns | Turn cap create/reopen/clear round trip |
 
 ## Architecture
 

--- a/tests/agentic-e2e/tests/scenarios/scenario-turn-cap.spec.ts
+++ b/tests/agentic-e2e/tests/scenarios/scenario-turn-cap.spec.ts
@@ -1,0 +1,84 @@
+import { test } from "@playwright/test";
+import {
+  givenIAmLoggedIntoProject,
+  givenIAmOnTheScenariosListPage,
+  thenMaximumTurnsShows,
+  whenIArchiveScenarioFromListIfPresent,
+  whenIClickNewScenario,
+  whenIClickOnScenarioInList,
+  whenIClickSave,
+  whenICloseTheEditor,
+  whenIFillInMaximumTurnsWith,
+  whenIFillInNameWith,
+  whenIFillInSituationWith,
+} from "./steps";
+
+/**
+ * Feature: Per-scenario maximum conversation turns
+ * Source: specs/scenarios/scenario-max-turns.feature
+ *
+ * As a user running agent scenario simulations
+ * I want to cap how many conversation turns a scenario can take
+ * So that a simulation stops at a bound I chose
+ */
+test.describe("Scenario turn cap", () => {
+  test.slow();
+  // Background: Given I am logged into project
+  test.beforeEach(async ({ page }) => {
+    await givenIAmLoggedIntoProject(page);
+  });
+
+  /**
+   * Workflow test: create with a cap, reopen, clear the cap, reopen.
+   * A unique name keeps reruns from colliding, and the finally block
+   * archives whatever the test managed to create even when an assertion
+   * in the middle failed.
+   */
+  /** @scenario "A turn cap set in the scenario editor survives saving and reopening" */
+  test("turn cap survives saving and reopening", async ({ page }) => {
+    const scenarioName = `Turn Cap Test ${Date.now()}`;
+
+    await givenIAmOnTheScenariosListPage(page);
+
+    try {
+      // -----------------------------------------------------------------------
+      // Create a scenario with Maximum turns 2 and save
+      // -----------------------------------------------------------------------
+      await whenIClickNewScenario(page);
+      await whenIFillInNameWith(page, scenarioName);
+      await whenIFillInSituationWith(
+        page,
+        "A user asks the agent a simple question"
+      );
+      await whenIFillInMaximumTurnsWith(page, "2");
+      await whenIClickSave(page);
+
+      // -----------------------------------------------------------------------
+      // Reopen: the cap survived the save
+      // -----------------------------------------------------------------------
+      await givenIAmOnTheScenariosListPage(page);
+      await whenIClickOnScenarioInList(page, scenarioName);
+      await thenMaximumTurnsShows(page, "2");
+
+      // -----------------------------------------------------------------------
+      // Clear the cap and save
+      // -----------------------------------------------------------------------
+      await whenIFillInMaximumTurnsWith(page, "");
+      await whenIClickSave(page);
+
+      // -----------------------------------------------------------------------
+      // Reopen: the field is empty, so the default applies
+      // -----------------------------------------------------------------------
+      await givenIAmOnTheScenariosListPage(page);
+      await whenIClickOnScenarioInList(page, scenarioName);
+      await thenMaximumTurnsShows(page, "");
+      await whenICloseTheEditor(page);
+    } finally {
+      // Archive the scenario this test created, even when an assertion
+      // above failed. The navigation resets whatever drawer or dialog the
+      // failure left open; with nothing created there is nothing to clean.
+      await givenIAmOnTheScenariosListPage(page);
+      await whenIArchiveScenarioFromListIfPresent(page, scenarioName);
+    }
+  });
+});

--- a/tests/agentic-e2e/tests/scenarios/steps.ts
+++ b/tests/agentic-e2e/tests/scenarios/steps.ts
@@ -206,6 +206,54 @@ export async function thenCriterionAppearsInList(page: Page, criterion: string) 
 }
 
 /**
+ * When I fill in "Maximum turns" with "<value>"
+ * An empty value clears the cap back to the default.
+ * Unlike Name/Situation, this field has a real Field.Label association,
+ * so getByLabel works.
+ */
+export async function whenIFillInMaximumTurnsWith(page: Page, value: string) {
+  await page.getByLabel("Maximum turns").last().fill(value);
+}
+
+/**
+ * Then the "Maximum turns" field shows "<value>"
+ * An empty value means the scenario runs with the default cap.
+ */
+export async function thenMaximumTurnsShows(page: Page, value: string) {
+  await expect(page.getByLabel("Maximum turns").last()).toHaveValue(value);
+}
+
+/**
+ * When I archive "<name>" from the list, when it exists
+ * Guarded so a cleanup block can call it even when the create step never
+ * ran — with nothing to archive it returns without failing.
+ */
+export async function whenIArchiveScenarioFromListIfPresent(
+  page: Page,
+  name: string
+) {
+  const actionsButton = page.getByRole("button", {
+    name: `Actions for ${name}`,
+  });
+  const present = await actionsButton
+    .waitFor({ state: "visible", timeout: 10000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!present) return;
+
+  await actionsButton.click();
+  await page.getByRole("menuitem", { name: "Archive" }).last().click();
+  await page
+    .getByRole("button", { name: "Archive", exact: true })
+    .last()
+    .click();
+  // The confirm dialog renders the scenario name too, so assert on the
+  // table row — a bare getByText(name) resolves two elements and trips
+  // strict mode while the dialog is still mounted.
+  await expect(page.getByRole("row", { name })).toBeHidden();
+}
+
+/**
  * When I click "Save"
  * Handles the "Save and Run" popover by clicking "Save without running"
  */


### PR DESCRIPTION
## What

Scenarios created in the UI can now set a **Maximum turns** cap (1–50). Empty means the scenario SDK default of 10 turns. Until now the cap only existed for code-based scenarios (`scenario.run({ maxTurns })`); platform-triggered runs always used the default.

## How

- `Scenario.maxTurns Int?` (nullable column, no backfill) + migration.
- tRPC create/update schemas: `maxTurns` nullish int, bounds shared via `MAX_SCENARIO_MAX_TURNS`.
- Execution chain: serialized scenario config → prefetcher → child process → `ScenarioRunner.run({ maxTurns })`. The job-payload schema validates only `min(1)` on purpose, so queued jobs never fail if the upper bound changes; payloads queued before the field existed still parse.
- Editor form: "Maximum turns" numeric field, empty input normalized to `null`, customer-safe validation copy. `DEFAULT_SCENARIO_MAX_TURNS` is pinned to the SDK's exported `DEFAULT_MAX_TURNS` by a unit test so the hint copy can't silently drift.

## Tests

Spec-first: `specs/scenarios/scenario-max-turns.feature` — 7/7 scenarios bound.

- Unit: router schema bounds, prefetch propagation, pre-deploy payload compatibility, SDK default pin.
- Integration: persistence round-trip (set / clear / omit-preserves), form behavior (valid, empty→null, out-of-bounds, decimal input, edit prefill).
- E2E (agentic suite): editor round-trip — create with cap 2, reopen shows 2, clear, reopen shows empty, archive cleanup.

Enabling the e2e binding required two small changes to `check-feature-parity.ts`: it now walks `tests/agentic-e2e/tests` and accepts `.spec.ts`, with the file-name policy pinned by unit tests. Before this, no `@e2e` scenario in the repo could ever count as bound.

## Out of scope (follow-ups)

- Exposing `maxTurns` on REST v1 / OpenAPI / MCP tools (`simulatorModel`/`judgeModel` have the same gap today — worth one PR fixing both).
- Suite-level override, mirroring the model-override precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Maximum turns” setting for scenarios.
  * Supports values from 1 to 50 turns; leaving it blank uses the default limit of 10.
  * The setting is saved, editable, and applied when running scenarios.

* **Bug Fixes**
  * Improved compatibility with existing scenarios and older run data when no turn limit is configured.

* **Tests**
  * Added coverage for validation, persistence, execution, and end-to-end scenario workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->