### PR TITLE
fix(scim): a group PATCH that names no members no longer empties the group

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1280,7 +1280,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so with a list. A `members` path whose value is missing, or is something other than a list, is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Operations like this are left unapplied and recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A `members` value that is missing, or is something other than a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1280,7 +1280,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, or a non-`null` value that is not a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, a non-`null` value that is not a list, or a list holding entries without a string `value`, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1280,7 +1280,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, a non-`null` value that is not a list, or a list holding entries without a string `value`, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, a non-`null` value that is not a list, or a list holding entries without a usable id — no string `value`, or a blank one — says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1280,7 +1280,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so, either with an empty list or with an explicit `null`. A `members` value that is missing, or is something other than a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, or a non-`null` value that is not a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1278,7 +1278,9 @@ LangWatch supports the following SCIM group operations:
 | `replace displayName` | Rename the group | Group name updated in LangWatch |
 | `replace members` | Full member replacement | Adds new, removes old members |
 
-A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group.
+A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
+
+To clear a group you have to say so with a list. A `members` path whose value is missing, or is something other than a list, is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Operations like this are left unapplied and recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1278,6 +1278,8 @@ LangWatch supports the following SCIM group operations:
 | `replace displayName` | Rename the group | Group name updated in LangWatch |
 | `replace members` | Full member replacement | Adds new, removes old members |
 
+A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group.
+
 ### Supported Filter
 
 Groups can be filtered by `displayName` using a case-insensitive `eq` filter:

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -152,7 +152,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so with a list. A `members` path whose value is missing, or is something other than a list, is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Operations like this are left unapplied and recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A `members` value that is missing, or is something other than a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -152,7 +152,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so, either with an empty list or with an explicit `null`. A `members` value that is missing, or is something other than a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, or a non-`null` value that is not a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -150,7 +150,9 @@ LangWatch supports the following SCIM group operations:
 | `replace displayName` | Rename the group | Group name updated in LangWatch |
 | `replace members` | Full member replacement | Adds new, removes old members |
 
-A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group.
+A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
+
+To clear a group you have to say so with a list. A `members` path whose value is missing, or is something other than a list, is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Operations like this are left unapplied and recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -152,7 +152,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, a non-`null` value that is not a list, or a list holding entries without a string `value`, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, a non-`null` value that is not a list, or a list holding entries without a usable id — no string `value`, or a blank one — says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -152,7 +152,7 @@ LangWatch supports the following SCIM group operations:
 
 A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group, as does an explicit `null`.
 
-To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, or a non-`null` value that is not a list, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
+To clear a group you have to say so, either with an empty list or with an explicit `null`. A missing `members` value, a non-`null` value that is not a list, or a list holding entries without a string `value`, says nothing we can act on and is treated as saying nothing about membership rather than as saying "no members" — a malformed payload should not revoke anyone's access. Only the member replacement is left unapplied: any other recognized attribute in the same operation, such as `displayName`, still takes effect. The unapplied part is recorded in the server logs.
 
 ### Supported Filter
 

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -150,6 +150,8 @@ LangWatch supports the following SCIM group operations:
 | `replace displayName` | Rename the group | Group name updated in LangWatch |
 | `replace members` | Full member replacement | Adds new, removes old members |
 
+A `replace` that carries no member list leaves the group's membership alone — replacing an unrelated attribute never removes anyone. Sending `members` as an empty list is a member list, and does clear the group.
+
 ### Supported Filter
 
 Groups can be filtered by `displayName` using a case-insensitive `eq` filter:

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -263,6 +263,18 @@ describe("SCIM group PATCH membership", () => {
         expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
       });
 
+      // A blank id is a string, so it survives every check that asks about
+      // types and lengths, and still names nobody — leaving every current
+      // member outside the requested set, which is to say removed.
+      it("leaves it untouched for a blank id", async () => {
+        await patchGroup([
+          { op: "replace", path: "members", value: [{ value: "  " }] },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
+      });
+
       it("leaves it untouched even when only some entries are readable", async () => {
         await patchGroup([
           {

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -242,9 +242,35 @@ describe("SCIM group PATCH membership", () => {
       });
     });
 
-    describe("when the member array contains entries without a string value key", () => {
+    // The narrow shape of the same bug: a list that plainly meant to name
+    // somebody, but whose entries carry no `value`, reduces to zero readable
+    // ids. Reading that as "this group has no members" empties the group over a
+    // typo — the entries that could not be read are exactly the members that
+    // would be removed.
+    describe("when a member list holds entries with no usable id", () => {
       it("leaves the group's membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", path: "members", value: [{ display: "Alice" }] },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+
+      it("leaves it untouched for an entry with no keys at all", async () => {
         await patchGroup([{ op: "replace", path: "members", value: [{}] }]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
+      });
+
+      it("leaves it untouched even when only some entries are readable", async () => {
+        await patchGroup([
+          {
+            op: "replace",
+            path: "members",
+            value: [{ value: "user-3" }, { display: "Alice" }],
+          },
+        ]);
 
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
         expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -16,6 +16,12 @@
  * never mentions members must leave membership alone, and an explicit
  * `members: []` must still clear the group, because that is a legitimate
  * request the IdP is entitled to make.
+ *
+ * Every assertion here is on the writes, not on the response body: the Prisma
+ * mock returns a fixed membership for every read, so the group returned by a
+ * "clears the group" case still lists its old members. That is deliberate — the
+ * write is the behaviour under test, and end-state verification belongs to a
+ * test with a real database.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -90,6 +96,10 @@ describe("SCIM group PATCH membership", () => {
   });
 
   describe("given a replace operation that names no members", () => {
+    // externalId stands in for any attribute PATCH does not handle. That it is
+    // unhandled is a gap rather than a decision — see #7141 — so this asserts
+    // only what the fix is about: an operation about something else must not
+    // touch membership.
     describe("when it replaces an unrelated attribute", () => {
       it("leaves the group's membership untouched", async () => {
         await patchGroup([

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -241,6 +241,15 @@ describe("SCIM group PATCH membership", () => {
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
       });
     });
+
+    describe("when the member array contains entries without a string value key", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([{ op: "replace", path: "members", value: [{}] }]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("given a replace operation that names an empty member list", () => {

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * A SCIM group PATCH used to read the *absence* of a member list as an
+ * instruction to have no members: any `replace` that was not a `displayName`
+ * rename fell into the full-member-replace block, computed "every current
+ * member" as the set to remove, and silently emptied the group. An identity
+ * provider replacing an unrelated attribute — or renaming a group with the
+ * no-path form Entra ID writes — revoked access for everyone in it, with a
+ * 200 and a valid ScimGroup body to show for it.
+ *
+ * These tests drive the real `ScimGroupService` with only Prisma mocked, so
+ * they observe the membership writes the service actually issues rather than
+ * asserting on the shape of the branch that issues them. Absent and empty are
+ * the two sides of the same rule and both are pinned here: an operation that
+ * never mentions members must leave membership alone, and an explicit
+ * `members: []` must still clear the group, because that is a legitimate
+ * request the IdP is entitled to make.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { scimPatchRequestSchema } from "../scim.types";
+import { ScimGroupService } from "../scim-group.service";
+
+const PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
+function parsePatch(operations: unknown[]) {
+  const parsed = scimPatchRequestSchema.safeParse({
+    schemas: [PATCH_SCHEMA],
+    Operations: operations,
+  });
+  if (!parsed.success) {
+    throw new Error(
+      `SCIM PATCH rejected at the schema: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+const GROUP = {
+  id: "group-1",
+  name: "Engineering",
+  organizationId: "org-1",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  updatedAt: new Date("2024-01-02T00:00:00Z"),
+};
+
+/** A group already holding `user-1` and `user-2`. */
+function createMockPrisma() {
+  const mock = {
+    organizationUser: {
+      findMany: vi
+        .fn()
+        .mockResolvedValue([
+          { userId: "user-1" },
+          { userId: "user-2" },
+          { userId: "user-3" },
+        ]),
+    },
+    group: {
+      findFirst: vi.fn().mockResolvedValue(GROUP),
+      findUniqueOrThrow: vi.fn().mockResolvedValue(GROUP),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    groupMembership: {
+      upsert: vi.fn().mockResolvedValue({}),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      findMany: vi.fn().mockResolvedValue([
+        { userId: "user-1", user: { id: "user-1", email: null, name: null } },
+        { userId: "user-2", user: { id: "user-2", email: null, name: null } },
+      ]),
+    },
+  };
+  return mock as unknown as Parameters<typeof ScimGroupService.create>[0] &
+    typeof mock;
+}
+
+describe("SCIM group PATCH membership", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  const patchGroup = async (operations: unknown[]) =>
+    ScimGroupService.create(prisma).updateGroup({
+      externalScimId: "group-1",
+      organizationId: "org-1",
+      patchRequest: parsePatch(operations),
+    });
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+  });
+
+  describe("given a replace operation that names no members", () => {
+    describe("when it replaces an unrelated attribute", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", path: "externalId", value: "abc-123" },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when it renames the group with no path", () => {
+      it("renames it and leaves the membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", value: { displayName: "Platform" } },
+        ]);
+
+        expect(prisma.group.update).toHaveBeenCalledWith({
+          where: { id: "group-1" },
+          data: { name: "Platform" },
+        });
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when it renames the group with a displayName path", () => {
+      it("renames it and leaves the membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", path: "displayName", value: "Platform" },
+        ]);
+
+        expect(prisma.group.update).toHaveBeenCalledWith({
+          where: { id: "group-1" },
+          data: { name: "Platform" },
+        });
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when it targets a filtered member path we do not understand", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([
+          {
+            op: "replace",
+            path: 'members[value eq "user-1"].display',
+            value: "Alice",
+          },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a replace operation that names an empty member list", () => {
+    describe("when the list is under a members path", () => {
+      it("clears the group", async () => {
+        await patchGroup([{ op: "replace", path: "members", value: [] }]);
+
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-1", "user-2"] } },
+        });
+      });
+    });
+
+    describe("when the list is inside a no-path value object", () => {
+      it("clears the group", async () => {
+        await patchGroup([{ op: "replace", value: { members: [] } }]);
+
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-1", "user-2"] } },
+        });
+      });
+    });
+  });
+
+  describe("given a replace operation that names a member list", () => {
+    describe("when the list differs from the current membership", () => {
+      it("adds the newcomers and removes the ones left out", async () => {
+        await patchGroup([
+          {
+            op: "replace",
+            path: "members",
+            value: [{ value: "user-2" }, { value: "user-3" }],
+          },
+        ]);
+
+        expect(prisma.groupMembership.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            create: { userId: "user-3", groupId: "group-1" },
+          }),
+        );
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-1"] } },
+        });
+      });
+    });
+
+    describe("when the no-path value object also renames the group", () => {
+      it("applies both the rename and the membership replacement", async () => {
+        await patchGroup([
+          {
+            op: "replace",
+            value: { displayName: "Platform", members: [{ value: "user-1" }] },
+          },
+        ]);
+
+        expect(prisma.group.update).toHaveBeenCalledWith({
+          where: { id: "group-1" },
+          data: { name: "Platform" },
+        });
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-2"] } },
+        });
+      });
+    });
+  });
+
+  describe("given an add operation that names no members", () => {
+    describe("when it targets an unrelated attribute", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([{ op: "add", path: "externalId", value: "abc-123" }]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -28,6 +28,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { scimPatchRequestSchema } from "../scim.types";
 import { ScimGroupService } from "../scim-group.service";
 
+/**
+ * The warn log is behaviour here, not decoration. Leaving membership alone is
+ * the safe answer to a payload we cannot read, but it is a silent one, so the
+ * log is the only thing that makes a misconfigured sync findable. That makes
+ * two things worth pinning: that it fires when we genuinely understood nothing,
+ * and that it stays quiet on a supported operation — a warning on every rename
+ * trains people to ignore the one that matters.
+ */
+const { warn } = vi.hoisted(() => ({ warn: vi.fn() }));
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    warn,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 const PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
 
 function parsePatch(operations: unknown[]) {
@@ -93,6 +111,7 @@ describe("SCIM group PATCH membership", () => {
 
   beforeEach(() => {
     prisma = createMockPrisma();
+    warn.mockClear();
   });
 
   describe("given a replace operation that names no members", () => {
@@ -109,6 +128,17 @@ describe("SCIM group PATCH membership", () => {
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
         expect(prisma.groupMembership.upsert).not.toHaveBeenCalled();
       });
+
+      it("says in the logs that it understood nothing", async () => {
+        await patchGroup([
+          { op: "replace", path: "externalId", value: "abc-123" },
+        ]);
+
+        expect(warn).toHaveBeenCalledWith(
+          expect.objectContaining({ groupId: "group-1" }),
+          expect.stringContaining("matched no known attribute"),
+        );
+      });
     });
 
     describe("when it renames the group with no path", () => {
@@ -122,6 +152,16 @@ describe("SCIM group PATCH membership", () => {
           data: { name: "Platform" },
         });
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+
+      // A rename that mentions no members is complete and supported. Warning on
+      // it would fire on every ordinary Entra rename, which is most of them.
+      it("does not warn, because it understood the operation", async () => {
+        await patchGroup([
+          { op: "replace", value: { displayName: "Platform" } },
+        ]);
+
+        expect(warn).not.toHaveBeenCalled();
       });
     });
 
@@ -158,9 +198,7 @@ describe("SCIM group PATCH membership", () => {
     // []` is false, and the operation is correctly read as naming nothing.
     describe("when its value is a bare array rather than an attribute object", () => {
       it("leaves the group's membership untouched", async () => {
-        await patchGroup([
-          { op: "replace", value: [{ value: "user-1" }] },
-        ]);
+        await patchGroup([{ op: "replace", value: [{ value: "user-1" }] }]);
 
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
       });
@@ -178,19 +216,27 @@ describe("SCIM group PATCH membership", () => {
 
     describe("when a members path carries something that is not a list", () => {
       it("leaves the group's membership untouched", async () => {
-        await patchGroup([
-          { op: "replace", path: "members", value: "user-1" },
-        ]);
+        await patchGroup([{ op: "replace", path: "members", value: "user-1" }]);
 
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+
+      // Distinct from the unrecognised-attribute warning: this payload did name
+      // members, so it is an IdP sending a shape worth fixing, not an operation
+      // that was simply about something else.
+      it("says in the logs that the member list was the problem", async () => {
+        await patchGroup([{ op: "replace", path: "members", value: "user-1" }]);
+
+        expect(warn).toHaveBeenCalledWith(
+          expect.objectContaining({ groupId: "group-1", path: "members" }),
+          expect.stringContaining("did not give a list"),
+        );
       });
     });
 
     describe("when a no-path value object holds a members key that is not a list", () => {
       it("leaves the group's membership untouched", async () => {
-        await patchGroup([
-          { op: "replace", value: { members: "user-1" } },
-        ]);
+        await patchGroup([{ op: "replace", value: { members: "user-1" } }]);
 
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
       });

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -157,7 +157,47 @@ describe("SCIM group PATCH membership", () => {
     });
   });
 
+  describe("given a replace operation whose member list is missing or malformed", () => {
+    describe("when a members path carries no value at all", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([{ op: "replace", path: "members" }]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a members path carries something that is not a list", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", path: "members", value: "user-1" },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a no-path value object holds a members key that is not a list", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", value: { members: "user-1" } },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("given a replace operation that names an empty member list", () => {
+    describe("when the list is written out as null", () => {
+      it("clears the group", async () => {
+        await patchGroup([{ op: "replace", path: "members", value: null }]);
+
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-1", "user-2"] } },
+        });
+      });
+    });
+
     describe("when the list is under a members path", () => {
       it("clears the group", async () => {
         await patchGroup([{ op: "replace", path: "members", value: [] }]);
@@ -195,6 +235,23 @@ describe("SCIM group PATCH membership", () => {
             create: { userId: "user-3", groupId: "group-1" },
           }),
         );
+        expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
+          where: { groupId: "group-1", userId: { in: ["user-1"] } },
+        });
+      });
+    });
+
+    describe("when an operation that names no members comes first", () => {
+      it("still applies the member list from the later operation", async () => {
+        await patchGroup([
+          { op: "replace", path: "externalId", value: "abc-123" },
+          {
+            op: "replace",
+            path: "members",
+            value: [{ value: "user-2" }, { value: "user-3" }],
+          },
+        ]);
+
         expect(prisma.groupMembership.deleteMany).toHaveBeenCalledWith({
           where: { groupId: "group-1", userId: { in: ["user-1"] } },
         });

--- a/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-group-patch-membership.unit.test.ts
@@ -142,6 +142,19 @@ describe("SCIM group PATCH membership", () => {
         expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
       });
     });
+
+    // An array is an object, so a bare-array value is the one shape where
+    // "does this carry a member list" could quietly answer yes: `"members" in
+    // []` is false, and the operation is correctly read as naming nothing.
+    describe("when its value is a bare array rather than an attribute object", () => {
+      it("leaves the group's membership untouched", async () => {
+        await patchGroup([
+          { op: "replace", value: [{ value: "user-1" }] },
+        ]);
+
+        expect(prisma.groupMembership.deleteMany).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("given a replace operation that names an empty member list", () => {

--- a/platform/app/ee/scim/scim-group.service.ts
+++ b/platform/app/ee/scim/scim-group.service.ts
@@ -520,7 +520,14 @@ export class ScimGroupService {
   private readMemberList(value: unknown): MemberInstruction {
     if (value === null) return { kind: "list", ids: [] };
     if (!Array.isArray(value)) return { kind: "malformed" };
-    return { kind: "list", ids: this.extractMemberIds(value) };
+    const ids = this.extractMemberIds(value);
+    // Every entry in the array must carry a string `value` key. A non-empty
+    // array with malformed entries is not a valid member list — treating it as
+    // one could silently revoke access (if all entries are bad, ids is empty
+    // and the group is cleared) or misrepresent the IdP's intent (if some are
+    // good but others are dropped). Only `[]` and `null` may clear membership.
+    if (ids.length !== value.length) return { kind: "malformed" };
+    return { kind: "list", ids };
   }
 
   private extractMemberIdsFromPath(path: string, value: unknown): string[] {

--- a/platform/app/ee/scim/scim-group.service.ts
+++ b/platform/app/ee/scim/scim-group.service.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 import { generate } from "@langwatch/ksuid";
+import { createLogger } from "@langwatch/observability";
 import type { Group, PrismaClient } from "~/generated/prisma/client";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { slugify } from "~/utils/slugify";
@@ -12,6 +13,8 @@ import type {
   ScimPatchRequest,
   ScimReplaceGroupRequest,
 } from "./scim.types";
+
+const logger = createLogger("langwatch:scim:group");
 
 /**
  * Handles SCIM 2.0 Group resources backed by the Group / GroupMembership tables.
@@ -357,8 +360,20 @@ export class ScimGroupService {
       // Full member replace (path="members" or no path with members in value).
       // Only when the operation actually carries a member list: an operation
       // that never mentions members carries no membership instruction at all.
-      const members = this.extractMemberList(operation);
-      if (!members) return;
+      const members = this.extractRequestedMemberIds(operation);
+      // `null` is "said nothing about members", `[]` is "said: no members".
+      // Checked explicitly because `[]` is falsy and must not be read as silence.
+      if (members === null) {
+        // Doing nothing is the safe answer, but it is also a silent one: an IdP
+        // sending a shape we do not parse would otherwise look like a success
+        // forever. Logged so a misconfigured sync is findable without an
+        // access-loss incident pointing at it.
+        logger.warn(
+          { groupId: group.id, path: operation.path },
+          "SCIM group replace matched no known attribute; leaving the group unchanged",
+        );
+        return;
+      }
 
       const current = await this.prisma.groupMembership.findMany({
         where: { groupId: group.id },
@@ -451,10 +466,18 @@ export class ScimGroupService {
    * list at all — collapsing that to `[]` reads it as "this group should have
    * no members" and revokes access for everyone in it. An explicit `members: []`
    * genuinely does mean clear the group, so the two have to stay distinguishable.
+   *
+   * Naming `members` is not enough on its own: the value has to actually be a
+   * list. A missing or malformed one (`{"op":"replace","path":"members"}`, or a
+   * string where an array belongs) states no membership we can act on, and
+   * reading it as "clear the group" turns a malformed payload into revoked
+   * access. Only `null` is honoured as a written-out empty list.
    */
-  private extractMemberList(operation: ScimPatchOperation): string[] | null {
+  private extractRequestedMemberIds(
+    operation: ScimPatchOperation,
+  ): string[] | null {
     if (operation.path === "members")
-      return this.extractMemberIds(operation.value);
+      return this.readMemberList(operation.value);
 
     if (
       !operation.path &&
@@ -462,12 +485,19 @@ export class ScimGroupService {
       operation.value !== null &&
       "members" in operation.value
     ) {
-      return this.extractMemberIds(
+      return this.readMemberList(
         (operation.value as Record<string, unknown>).members,
       );
     }
 
     return null;
+  }
+
+  /** A written-out member list, or `null` when the value is not one. */
+  private readMemberList(value: unknown): string[] | null {
+    if (value === null) return [];
+    if (!Array.isArray(value)) return null;
+    return this.extractMemberIds(value);
   }
 
   private extractMemberIdsFromPath(path: string, value: unknown): string[] {

--- a/platform/app/ee/scim/scim-group.service.ts
+++ b/platform/app/ee/scim/scim-group.service.ts
@@ -529,6 +529,13 @@ export class ScimGroupService {
     // written out as empty may clear it.
     if (ids.length !== value.length) return { kind: "malformed" };
 
+    // A blank id is well-formed enough to survive the check above and still
+    // names nobody: `[{"value":""}]` matches no member, so every current member
+    // falls outside the requested set and is removed. An id that refers to
+    // someone outside the organization is a different matter and stays allowed
+    // — that is a membership question, resolved later. This is a shape problem.
+    if (ids.some((id) => id.trim() === "")) return { kind: "malformed" };
+
     return { kind: "list", ids };
   }
 

--- a/platform/app/ee/scim/scim-group.service.ts
+++ b/platform/app/ee/scim/scim-group.service.ts
@@ -354,12 +354,12 @@ export class ScimGroupService {
         }
       }
 
-      // Full member replace (path="members" or no path with members in value)
-      const members = this.extractMemberIds(
-        operation.path === "members"
-          ? operation.value
-          : (operation.value as Record<string, unknown> | undefined)?.members,
-      );
+      // Full member replace (path="members" or no path with members in value).
+      // Only when the operation actually carries a member list: an operation
+      // that never mentions members carries no membership instruction at all.
+      const members = this.extractMemberList(operation);
+      if (!members) return;
+
       const current = await this.prisma.groupMembership.findMany({
         where: { groupId: group.id },
       });
@@ -440,6 +440,34 @@ export class ScimGroupService {
           typeof (m as { value: unknown }).value === "string",
       )
       .map((m) => (m as { value: string }).value);
+  }
+
+  /**
+   * The member list a `replace` operation asks us to install, or `null` when it
+   * asks for nothing about membership.
+   *
+   * Absent is not the same as empty. An IdP replacing an unrelated attribute,
+   * or renaming a group with the no-path form Entra ID writes, sends no member
+   * list at all — collapsing that to `[]` reads it as "this group should have
+   * no members" and revokes access for everyone in it. An explicit `members: []`
+   * genuinely does mean clear the group, so the two have to stay distinguishable.
+   */
+  private extractMemberList(operation: ScimPatchOperation): string[] | null {
+    if (operation.path === "members")
+      return this.extractMemberIds(operation.value);
+
+    if (
+      !operation.path &&
+      typeof operation.value === "object" &&
+      operation.value !== null &&
+      "members" in operation.value
+    ) {
+      return this.extractMemberIds(
+        (operation.value as Record<string, unknown>).members,
+      );
+    }
+
+    return null;
   }
 
   private extractMemberIdsFromPath(path: string, value: unknown): string[] {

--- a/platform/app/ee/scim/scim-group.service.ts
+++ b/platform/app/ee/scim/scim-group.service.ts
@@ -17,6 +17,16 @@ import type {
 const logger = createLogger("langwatch:scim:group");
 
 /**
+ * What a PATCH operation said about a group's membership. `absent` and
+ * `malformed` both mean "change nothing", but only one of them is a payload
+ * anybody needs to hear about.
+ */
+type MemberInstruction =
+  | { kind: "list"; ids: string[] }
+  | { kind: "malformed" }
+  | { kind: "absent" };
+
+/**
  * Handles SCIM 2.0 Group resources backed by the Group / GroupMembership tables.
  * Groups pushed from an IdP arrive here unmapped — admins assign role bindings
  * via the Groups settings page.
@@ -340,6 +350,7 @@ export class ScimGroupService {
       }
 
       // Handle value object containing "displayName" (no path variant)
+      let renamed = false;
       if (
         !operation.path &&
         typeof operation.value === "object" &&
@@ -354,26 +365,35 @@ export class ScimGroupService {
             where: { id: group.id },
             data: { name: valueObj.displayName },
           });
+          renamed = true;
         }
       }
 
       // Full member replace (path="members" or no path with members in value).
       // Only when the operation actually carries a member list: an operation
       // that never mentions members carries no membership instruction at all.
-      const members = this.extractRequestedMemberIds(operation);
-      // `null` is "said nothing about members", `[]` is "said: no members".
-      // Checked explicitly because `[]` is falsy and must not be read as silence.
-      if (members === null) {
+      const instruction = this.extractRequestedMemberIds(operation);
+      if (instruction.kind !== "list") {
         // Doing nothing is the safe answer, but it is also a silent one: an IdP
         // sending a shape we do not parse would otherwise look like a success
         // forever. Logged so a misconfigured sync is findable without an
         // access-loss incident pointing at it.
-        logger.warn(
-          { groupId: group.id, path: operation.path },
-          "SCIM group replace matched no known attribute; leaving the group unchanged",
-        );
+        if (instruction.kind === "malformed") {
+          logger.warn(
+            { groupId: group.id, path: operation.path },
+            "SCIM group replace named members but did not give a list; membership left unchanged",
+          );
+        } else if (!renamed) {
+          // Nothing recognised at all. A rename that mentions no members is a
+          // complete, supported operation, so it must not warn.
+          logger.warn(
+            { groupId: group.id, path: operation.path },
+            "SCIM group replace matched no known attribute; leaving the group unchanged",
+          );
+        }
         return;
       }
+      const members = instruction.ids;
 
       const current = await this.prisma.groupMembership.findMany({
         where: { groupId: group.id },
@@ -458,8 +478,7 @@ export class ScimGroupService {
   }
 
   /**
-   * The member list a `replace` operation asks us to install, or `null` when it
-   * asks for nothing about membership.
+   * What a `replace` operation asks us to do about membership.
    *
    * Absent is not the same as empty. An IdP replacing an unrelated attribute,
    * or renaming a group with the no-path form Entra ID writes, sends no member
@@ -472,10 +491,14 @@ export class ScimGroupService {
    * string where an array belongs) states no membership we can act on, and
    * reading it as "clear the group" turns a malformed payload into revoked
    * access. Only `null` is honoured as a written-out empty list.
+   *
+   * `malformed` and `absent` both leave membership alone, but they are told
+   * apart so the logs can be: one is a payload worth fixing, the other is an
+   * ordinary operation that simply had nothing to say about members.
    */
   private extractRequestedMemberIds(
     operation: ScimPatchOperation,
-  ): string[] | null {
+  ): MemberInstruction {
     if (operation.path === "members")
       return this.readMemberList(operation.value);
 
@@ -490,14 +513,14 @@ export class ScimGroupService {
       );
     }
 
-    return null;
+    return { kind: "absent" };
   }
 
-  /** A written-out member list, or `null` when the value is not one. */
-  private readMemberList(value: unknown): string[] | null {
-    if (value === null) return [];
-    if (!Array.isArray(value)) return null;
-    return this.extractMemberIds(value);
+  /** A written-out member list, or `malformed` when the value is not one. */
+  private readMemberList(value: unknown): MemberInstruction {
+    if (value === null) return { kind: "list", ids: [] };
+    if (!Array.isArray(value)) return { kind: "malformed" };
+    return { kind: "list", ids: this.extractMemberIds(value) };
   }
 
   private extractMemberIdsFromPath(path: string, value: unknown): string[] {

--- a/platform/app/ee/scim/scim-group.service.ts
+++ b/platform/app/ee/scim/scim-group.service.ts
@@ -520,13 +520,15 @@ export class ScimGroupService {
   private readMemberList(value: unknown): MemberInstruction {
     if (value === null) return { kind: "list", ids: [] };
     if (!Array.isArray(value)) return { kind: "malformed" };
+
     const ids = this.extractMemberIds(value);
-    // Every entry in the array must carry a string `value` key. A non-empty
-    // array with malformed entries is not a valid member list — treating it as
-    // one could silently revoke access (if all entries are bad, ids is empty
-    // and the group is cleared) or misrepresent the IdP's intent (if some are
-    // good but others are dropped). Only `[]` and `null` may clear membership.
+    // A list we only partly understood is not a list we can act on. The entries
+    // that fell out are precisely the members that would then be removed, so
+    // reading `[{"display":"Alice"}]` as "this group has no members" empties the
+    // group over a payload that plainly meant to name somebody. Only a list
+    // written out as empty may clear it.
     if (ids.length !== value.length) return { kind: "malformed" };
+
     return { kind: "list", ids };
   }
 


### PR DESCRIPTION
# Related Issue

- Resolves #7131

## For humans

A group sync from your identity provider could quietly empty a group. If the provider updated any attribute on the group other than its name — or renamed it using the form Microsoft Entra ID writes — everyone in that group was removed as a side effect. Since group membership is what grants access, that revoked access for all of them. Nothing failed; the response looked normal, just with no members left. A later re-sync would often put the members back, which is why this looked intermittent rather than obviously broken.

After this change, an update that says nothing about members leaves the members alone. Asking explicitly for an empty group still empties it, because that is a real thing a provider is entitled to ask for.

## The cause

`ScimGroupService.applyPatch` (`platform/app/ee/scim/scim-group.service.ts:356`, pre-fix) read the absence of a member list as `[]`:

```ts
const members = this.extractMemberIds(
  operation.path === "members"
    ? operation.value
    : (operation.value as Record<string, unknown> | undefined)?.members,
);
```

Every `replace` that was not a `path: "displayName"` rename reached this block. With no `members` key anywhere in the operation, `members` came out `[]`, `toRemove` became *every current member*, and `removeMembers` ran. Absent was collapsed into empty.

## The fix

`extractMemberList(operation)` returns the member list a `replace` actually asks for, or `null` when it asks for nothing about membership. The full-member-replace block returns early on `null`. Absent and empty stay distinguishable.

The issue also suggested a `return` after the no-path `displayName` rename. **Deliberately not taken** — a no-path value object carrying both `displayName` and `members` is one operation that must do both, and an early return would drop the membership half. Gating on the member list subsumes the rename case anyway, so the extra return would only remove behaviour. A test pins the combined shape.

One behaviour change beyond the reported bug: a `replace` on a filtered member path we do not parse (e.g. `members[value eq "x"].display`) used to wipe the group and is now a no-op. A no-op is the conservative reading; inferring a single-member replace from a filter expression would be guessing.

## Evidence

Regression test written first, run against the unfixed code — 3 failed, 6 passed:

```
FAIL  when it replaces an unrelated attribute > leaves the group's membership untouched
  expected "vi.fn()" to not be called at all, but actually been called 1 times
    { where: { groupId: "group-1", userId: { in: ["user-1", "user-2"] } } }

FAIL  when it renames the group with no path > renames it and leaves the membership untouched
  expected "vi.fn()" to not be called at all, but actually been called 1 times
    { where: { groupId: "group-1", userId: { in: ["user-1", "user-2"] } } }

FAIL  when it targets a filtered member path we do not understand > leaves the group's membership untouched
  expected "vi.fn()" to not be called at all, but actually been called 1 times
    { where: { groupId: "group-1", userId: { in: ["user-1", "user-2"] } } }

Test Files  1 failed (1)
     Tests  3 failed | 6 passed (9)
```

The 6 that passed pre-fix are the guards: the pathed rename, both explicit-empty forms, the real member replacement, the combined rename-plus-members operation, and a non-`replace` op.

After the fix:

```
Test Files  1 passed (1)      Tests  9 passed (9)     # new file
Test Files  6 passed (6)      Tests  55 passed (55)   # whole ee/scim suite
```

`pnpm typecheck:all` clean, biome clean on both changed files.

## Sweep

Same shape hunted across the SCIM module — "an absent value collapsed to empty, then acted on as an instruction":

| Site | Verdict |
|---|---|
| `scim-group.service.ts:356` (pre-fix) | **Same bug.** Fixed here. |
| `replaceGroup` — `request.members ?? []` (`scim-group.service.ts:169`) | Same shape, **safe**: this is `PUT`, where RFC 7644 §3.5.1 defines omitted modifiable attributes as removed. Absent-means-clear is the spec for a replace of the whole resource. |
| `ScimService.updateUser` (`scim.service.ts:386-420`) | **Not this.** Every field is guarded with `"x" in value`. |
| `costCenterFromPatchOp` / `costCenterFromRequest` (`scim.service.ts:84-122`) | **Not this** — already returns `{present:false}` / `undefined` for absent, explicitly to keep it distinct from cleared. |

The discipline already existed in the user half of the module; the group service was the outlier.

## Added after review

Review found the same defect one shape further in, and it is fixed here too.

Naming `members` was not enough on its own. `{"op":"replace","path":"members"}` with **no value**, or a string where an array belongs, still reached `extractMemberIds`, which returns `[]` for anything non-array — so a malformed payload still read as "this group should have no members" and emptied it. Only an explicit `null` is now honoured as a written-out empty list.

Executed proof, run against the previous commit on this branch:

```
FAIL  when a members path carries no value at all > leaves the group's membership untouched
FAIL  when a members path carries something that is not a list > leaves the group's membership untouched
FAIL  when a no-path value object holds a members key that is not a list > leaves the group's membership untouched
Tests  3 failed | 12 passed (15)
```

All 15 pass on this branch; `ee/scim` is 61/61.

Also from review:

- `if (!members)` is now `if (members === null)`. `[]` is falsy, and truthiness is the one idiom guaranteed to erase the absent-vs-empty distinction this change rests on.
- A **warn log** when a `replace` matches no known attribute. Doing nothing is the safe answer but a silent one — the old behaviour at least failed loudly, and an IdP sending a shape we do not parse should be findable without an access-loss incident pointing at it.
- `extractMemberList` → `extractRequestedMemberIds`. Both it and `extractMemberIds` return user ids; the difference is nullability, not list-vs-ids.
- Tests for a bare-array value (an array *is* an object, so it is the one shape where "does this name members" could answer wrong), for an explicit `null`, and for a no-member operation preceding a real member replace in one request — proving the early return ends the operation, not the loop over `Operations`.

## Added after the second review round

The warn log above turned out to fire on operations that were understood perfectly well. A no-path `{"value":{"displayName":"..."}}` — the form Entra ID writes — renames the group, then reaches the membership check, finds no member list, and logged *"matched no known attribute; leaving the group unchanged"*. Both halves were false, on the most ordinary rename there is. A warning on the common case is a warning nobody reads, which costs the log the only job it was added for.

Membership answers are now three-way — a list, a malformed member value, or nothing said about members — rather than `string[] | null`:

- The unrecognized-attribute warning fires only when nothing at all was recognized.
- A malformed member value gets its own message. "You named members but did not give a list" is a payload worth fixing; "this operation was about something else" is not, and the two should not read the same in a log.
- Two tests pin it — a rename must not warn, a non-list `members` value must warn about the list specifically. Against the previous commit: `2 failed | 16 passed (18)`.

Two documentation lines were wrong and are corrected: an explicit `null` clears a group, so "to clear a group you have to say so with a list" contradicted the line above it; and only the *member replacement* is left unapplied, so a combined operation still renames.

## The same bug in a narrower shape

Review then found the original bug still alive inside the member list itself. `{"path":"members","value":[{"display":"Alice"}]}` plainly means to name somebody, but no entry carries a `value`, so the id filter reduced it to `[]` — which the new code then read as a written-out empty list and used to empty the group.

A list is only a list we can act on when every entry in it can be read, because the entries that fall out are precisely the members that would be removed. Only `[]` and an explicit `null` clear a group now; a partly-readable list is malformed and leaves membership alone. Pinned by three tests — `[{}]`, `[{display}]`, and a mixed list with one readable entry and one not.

A further round found the last shape that slipped through: `[{"value":""}]` is well-formed by every one of those checks — object entry, string `value`, non-empty list — and still names nobody, so every current member falls outside the requested set and is removed. A group emptied by a mapping expression that returned blank. Blank and whitespace-only ids are now malformed too.

The line is drawn at shape, not existence: an id referring to somebody outside the organization stays allowed, because that is a membership question resolved later, and rejecting it would break legitimate partial syncs.

## Not fixed here

Both filed rather than guessed at, because each changes behaviour this PR does not test:

- **#7140** — `path` matching is case-sensitive, so `"Members"` or the schema-qualified `urn:…:Group:members` is silently ignored. Pre-existing; before this PR those shapes emptied the group instead. The fix belongs at the schema seam next to the `op` normalisation added for Entra in #7121, and it changes the `add`/`remove` branches too.
- **#7141** — a group PATCH cannot update `externalId`; the value set at creation never changes. The test here uses `externalId` as its "unrelated attribute" example, with a comment saying that is a gap rather than a decision it pins.

Fixes #7131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified SCIM group membership replacement behavior.
  * Omitting membership data preserves existing members.
  * An empty list or explicit `null` removes all members.
  * Invalid or unsupported membership values are ignored and logged without changing access.

* **Bug Fixes**
  * Prevented unintended membership removal during group updates.
  * Ensured valid group attribute changes still apply when membership data is invalid.
  * Group renaming and membership changes now work together correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


