### PR TITLE
fix(python-sdk): send X-Project-Id for keys that cannot name their own project

### DIFF
--- a/sdks/python/src/langwatch/utils/auth.py
+++ b/sdks/python/src/langwatch/utils/auth.py
@@ -13,7 +13,7 @@ Supports three token families that share the same HTTP surface:
    a project is configured. Without it the server can only infer a project
    when the key holds exactly one project-scoped role binding, and refuses the
    request otherwise. The two ``sk-lw-*`` families are told apart by body
-   shape, not by the presence of an underscore — see ``requires_project_id``.
+   shape, not by the presence of an underscore — see ``requires_project_header``.
 
 3. ``pat-lw-*`` — Personal Access Tokens. PATs are user-owned and must
    be paired with a ``project_id`` so the server can resolve the correct
@@ -46,7 +46,7 @@ def is_personal_access_token(token: str) -> bool:
     return bool(token) and token.startswith(PAT_PREFIX)
 
 
-def requires_project_id(token: str) -> bool:
+def requires_project_header(token: str) -> bool:
     """Returns ``True`` when ``token`` cannot identify its own project.
 
     New-format API keys (``sk-lw-{16}_{48}``) and ingestion keys (``ik-lw-*``)
@@ -100,8 +100,8 @@ def build_auth_headers(
             "X-Auth-Token": api_key,
         }
 
-    # Legacy sk-lw-* key: preserve dual-header shape for callers that
-    # read either header.
+    # Every non-PAT key (legacy sk-lw-*, new-format sk-lw-*, ik-lw-*) keeps the
+    # dual-header shape for callers that read either header.
     headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Auth-Token": api_key,
@@ -110,7 +110,7 @@ def build_auth_headers(
     # New-format sk-lw-* and ik-lw-* keys carry no project of their own, so the
     # request has to name one. Legacy keys are left untouched: the server
     # resolves them from the token alone and ignores a supplied project.
-    if resolved_project_id and requires_project_id(api_key):
+    if resolved_project_id and requires_project_header(api_key):
         headers["X-Project-Id"] = resolved_project_id
 
     return headers

--- a/sdks/python/src/langwatch/utils/auth.py
+++ b/sdks/python/src/langwatch/utils/auth.py
@@ -1,13 +1,21 @@
 """Authentication header assembly for the LangWatch Python SDK.
 
-Supports two token families that share the same HTTP surface:
+Supports three token families that share the same HTTP surface:
 
-1. ``sk-lw-*`` — legacy project API keys. The token itself carries the
-   project identity, so we emit both ``Authorization: Bearer <token>``
+1. ``sk-lw-<48 chars>`` — legacy project API keys. The token itself carries
+   the project identity, so we emit both ``Authorization: Bearer <token>``
    and ``X-Auth-Token: <token>`` for backwards compatibility with older
-   endpoints that only read the legacy header.
+   endpoints that only read the legacy header. A supplied ``project_id`` is
+   ignored by the server for these, so we do not send one.
 
-2. ``pat-lw-*`` — Personal Access Tokens. PATs are user-owned and must
+2. ``sk-lw-<16 chars>_<48 chars>`` and ``ik-lw-*`` — new-format API keys and
+   ingestion keys. These carry no project, so we add ``X-Project-Id`` whenever
+   a project is configured. Without it the server can only infer a project
+   when the key holds exactly one project-scoped role binding, and refuses the
+   request otherwise. The two ``sk-lw-*`` families are told apart by body
+   shape, not by the presence of an underscore — see ``requires_project_id``.
+
+3. ``pat-lw-*`` — Personal Access Tokens. PATs are user-owned and must
    be paired with a ``project_id`` so the server can resolve the correct
    role binding. When a ``project_id`` is available we encode both into a
    single ``Authorization: Basic base64(project_id:token)`` header — the
@@ -18,14 +26,45 @@ from __future__ import annotations
 
 import base64
 import os
+import re
 from typing import Dict, Optional
 
 PAT_PREFIX = "pat-lw-"
+API_KEY_PREFIX = "sk-lw-"
+INGEST_KEY_PREFIX = "ik-lw-"
+
+# Mirrors the server's strict new-format body shape:
+# {16-char lookupId}_{48-char secret}, both from an alphanumeric alphabet
+# (see `getTokenType` in platform/app/src/server/api-key/api-key-token.utils.ts).
+# Legacy project keys were minted from alphabets that include `_` and `-`, so
+# the mere presence of an underscore does not identify a new-format key.
+_NEW_FORMAT_BODY_RE = re.compile(r"^[0-9A-Za-z]{16}_[0-9A-Za-z]{48}$")
 
 
 def is_personal_access_token(token: str) -> bool:
     """Returns ``True`` when ``token`` looks like a Personal Access Token."""
     return bool(token) and token.startswith(PAT_PREFIX)
+
+
+def requires_project_id(token: str) -> bool:
+    """Returns ``True`` when ``token`` cannot identify its own project.
+
+    New-format API keys (``sk-lw-{16}_{48}``) and ingestion keys (``ik-lw-*``)
+    live in the ``ApiKey`` table and carry no project. The server infers one
+    only when the key holds exactly one project-scoped role binding; keys
+    scoped at organization or team level stay ambiguous and are rejected
+    unless the request names a project.
+
+    PATs also need a project, but carry it via Basic auth rather than the
+    ``X-Project-Id`` header, so they are excluded here.
+    """
+    if not token:
+        return False
+    if token.startswith(INGEST_KEY_PREFIX):
+        return True
+    if token.startswith(API_KEY_PREFIX):
+        return bool(_NEW_FORMAT_BODY_RE.match(token[len(API_KEY_PREFIX) :]))
+    return False
 
 
 def build_auth_headers(
@@ -63,7 +102,15 @@ def build_auth_headers(
 
     # Legacy sk-lw-* key: preserve dual-header shape for callers that
     # read either header.
-    return {
+    headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Auth-Token": api_key,
     }
+
+    # New-format sk-lw-* and ik-lw-* keys carry no project of their own, so the
+    # request has to name one. Legacy keys are left untouched: the server
+    # resolves them from the token alone and ignores a supplied project.
+    if resolved_project_id and requires_project_id(api_key):
+        headers["X-Project-Id"] = resolved_project_id
+
+    return headers

--- a/sdks/python/tests/utils/test_auth.py
+++ b/sdks/python/tests/utils/test_auth.py
@@ -6,7 +6,16 @@ import base64
 
 import pytest
 
-from langwatch.utils.auth import build_auth_headers, is_personal_access_token
+from langwatch.utils.auth import (
+    build_auth_headers,
+    is_personal_access_token,
+    requires_project_id,
+)
+
+# A token whose body matches the server's strict new-format shape:
+# {16 alphanumerics}_{48 alphanumerics}.
+NEW_FORMAT_KEY = "sk-lw-" + "a" * 16 + "_" + "b" * 48
+INGEST_KEY = "ik-lw-" + "c" * 16 + "_" + "d" * 48
 
 
 class TestIsPersonalAccessToken:
@@ -18,6 +27,34 @@ class TestIsPersonalAccessToken:
 
     def test_returns_false_for_empty_string(self) -> None:
         assert is_personal_access_token("") is False
+
+
+class TestRequiresProjectId:
+    def test_new_format_api_key_requires_a_project(self) -> None:
+        assert requires_project_id(NEW_FORMAT_KEY) is True
+
+    def test_ingest_key_requires_a_project(self) -> None:
+        assert requires_project_id(INGEST_KEY) is True
+
+    def test_legacy_project_key_does_not(self) -> None:
+        assert requires_project_id("sk-lw-" + "a" * 48) is False
+
+    def test_underscore_alone_does_not_make_a_key_new_format(self) -> None:
+        # Legacy keys were minted from alphabets that include `_` and `-`, so
+        # the mere presence of an underscore must not reclassify them.
+        assert requires_project_id("sk-lw-abc_def") is False
+        assert requires_project_id("sk-lw-" + "a" * 16 + "_" + "b" * 47) is False
+        assert requires_project_id("sk-lw-" + "a" * 15 + "_" + "b" * 48) is False
+
+    def test_dash_in_body_is_not_new_format(self) -> None:
+        assert requires_project_id("sk-lw-" + "a" * 16 + "_" + "b" * 47 + "-") is False
+
+    def test_pat_does_not_use_the_project_header(self) -> None:
+        # PATs need a project too, but carry it via Basic auth instead.
+        assert requires_project_id("pat-lw-abc_secret") is False
+
+    def test_empty_string(self) -> None:
+        assert requires_project_id("") is False
 
 
 class TestBuildAuthHeaders:
@@ -57,4 +94,48 @@ class TestBuildAuthHeaders:
         assert headers == {
             "Authorization": "Bearer pat-lw-nopid",
             "X-Auth-Token": "pat-lw-nopid",
+        }
+
+    def test_new_format_key_emits_project_header(self) -> None:
+        headers = build_auth_headers(
+            api_key=NEW_FORMAT_KEY,
+            project_id="project_123",
+        )
+        assert headers == {
+            "Authorization": f"Bearer {NEW_FORMAT_KEY}",
+            "X-Auth-Token": NEW_FORMAT_KEY,
+            "X-Project-Id": "project_123",
+        }
+
+    def test_new_format_key_falls_back_to_env_project_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LANGWATCH_PROJECT_ID", "env_project")
+        headers = build_auth_headers(api_key=NEW_FORMAT_KEY)
+        assert headers["X-Project-Id"] == "env_project"
+
+    def test_new_format_key_without_project_id_omits_the_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("LANGWATCH_PROJECT_ID", raising=False)
+        headers = build_auth_headers(api_key=NEW_FORMAT_KEY)
+        assert headers == {
+            "Authorization": f"Bearer {NEW_FORMAT_KEY}",
+            "X-Auth-Token": NEW_FORMAT_KEY,
+        }
+
+    def test_ingest_key_emits_project_header(self) -> None:
+        headers = build_auth_headers(api_key=INGEST_KEY, project_id="project_123")
+        assert headers["X-Project-Id"] == "project_123"
+
+    def test_legacy_key_with_project_id_omits_the_header(self) -> None:
+        # Legacy keys are self-identifying and the server ignores a supplied
+        # project for them, so their header shape must not change.
+        headers = build_auth_headers(
+            api_key="sk-lw-legacy",
+            project_id="project_123",
+        )
+        assert headers == {
+            "Authorization": "Bearer sk-lw-legacy",
+            "X-Auth-Token": "sk-lw-legacy",
         }

--- a/sdks/python/tests/utils/test_auth.py
+++ b/sdks/python/tests/utils/test_auth.py
@@ -9,7 +9,7 @@ import pytest
 from langwatch.utils.auth import (
     build_auth_headers,
     is_personal_access_token,
-    requires_project_id,
+    requires_project_header,
 )
 
 # A token whose body matches the server's strict new-format shape:
@@ -29,32 +29,33 @@ class TestIsPersonalAccessToken:
         assert is_personal_access_token("") is False
 
 
-class TestRequiresProjectId:
+class TestRequiresProjectHeader:
     def test_new_format_api_key_requires_a_project(self) -> None:
-        assert requires_project_id(NEW_FORMAT_KEY) is True
+        assert requires_project_header(NEW_FORMAT_KEY) is True
 
     def test_ingest_key_requires_a_project(self) -> None:
-        assert requires_project_id(INGEST_KEY) is True
+        assert requires_project_header(INGEST_KEY) is True
 
     def test_legacy_project_key_does_not(self) -> None:
-        assert requires_project_id("sk-lw-" + "a" * 48) is False
+        assert requires_project_header("sk-lw-" + "a" * 48) is False
 
     def test_underscore_alone_does_not_make_a_key_new_format(self) -> None:
         # Legacy keys were minted from alphabets that include `_` and `-`, so
         # the mere presence of an underscore must not reclassify them.
-        assert requires_project_id("sk-lw-abc_def") is False
-        assert requires_project_id("sk-lw-" + "a" * 16 + "_" + "b" * 47) is False
-        assert requires_project_id("sk-lw-" + "a" * 15 + "_" + "b" * 48) is False
+        assert requires_project_header("sk-lw-abc_def") is False
+        assert requires_project_header("sk-lw-" + "a" * 16 + "_" + "b" * 47) is False
+        assert requires_project_header("sk-lw-" + "a" * 15 + "_" + "b" * 48) is False
 
     def test_dash_in_body_is_not_new_format(self) -> None:
-        assert requires_project_id("sk-lw-" + "a" * 16 + "_" + "b" * 47 + "-") is False
+        dashed = "sk-lw-" + "a" * 16 + "_" + "b" * 47 + "-"
+        assert requires_project_header(dashed) is False
 
     def test_pat_does_not_use_the_project_header(self) -> None:
         # PATs need a project too, but carry it via Basic auth instead.
-        assert requires_project_id("pat-lw-abc_secret") is False
+        assert requires_project_header("pat-lw-abc_secret") is False
 
     def test_empty_string(self) -> None:
-        assert requires_project_id("") is False
+        assert requires_project_header("") is False
 
 
 class TestBuildAuthHeaders:


### PR DESCRIPTION
Fixes #7118. Root cause of #6988.

## Cause

`sdks/python/src/langwatch/utils/auth.py:64-69` (before this change) resolved the configured project and then discarded it for every token that is not a `pat-lw-` PAT, returning only `{"Authorization": "Bearer …", "X-Auth-Token": …}`.

Two credential classes share the `sk-lw-` prefix and only one is self-identifying:

- **legacy project key** — `sk-lw-` + 48 chars, stored on `Project.apiKey`. Self-identifying; the server ignores a supplied project for it (`platform/app/src/server/api-key/token-resolver.ts:114-127`).
- **new-format API key** — `sk-lw-{16}_{48}`, plus ingestion keys `ik-lw-*`, stored in the `ApiKey` table. These carry no project. The server infers one only when the key holds exactly one project-scoped role binding (`token-resolver.ts:143-157`); keys scoped at organization or team level stay ambiguous (`:140-141`) and resolution returns null (`:159`) → flat `401 {"error":"Unauthorized","message":"Invalid credentials"}`.

`auth.py` treated both as the first kind, so the second class could never authenticate through this client on any endpoint.

## Fix

`requires_project_header()` mirrors the server's `getTokenType` (`platform/app/src/server/api-key/api-key-token.utils.ts:191-201`): `ik-lw-*` always needs a project, `sk-lw-*` needs one only when the body matches the strict `^[0-9A-Za-z]{16}_[0-9A-Za-z]{48}$` shape. `build_auth_headers` then adds `X-Project-Id` when a project is configured and the token needs it.

**Deliberately not the `includes("_")` test the TypeScript SDK uses** (`sdks/typescript/src/internal/api/auth.ts:44-51`). Legacy keys were minted from alphabets containing `_` and `-` (`api-key-token.utils.ts:170-175`), so the underscore test is safe only for keys minted today and misclassifies exactly the older keys the strict shape exists for.

Legacy keys keep their byte-identical header shape — a test pins that.

## Failing test, before the fix

The three header tests were written first and run against the unfixed `build_auth_headers`:

```
...............FF.F.                                                     [100%]
_______ TestBuildAuthHeaders.test_new_format_key_emits_project_header ________
E       AssertionError: assert {'Authorizati...bbbbbbbbbbbb'} == {'Authorizati...'project_123'}
E         Right contains 1 more item:
E         {'X-Project-Id': 'project_123'}
___ TestBuildAuthHeaders.test_new_format_key_falls_back_to_env_project_id ____
E       KeyError: 'X-Project-Id'
_________ TestBuildAuthHeaders.test_ingest_key_emits_project_header _________
E       KeyError: 'X-Project-Id'
3 failed, 17 passed in 0.20s
```

## Passing, after

```
20 passed in 0.07s                          # tests/utils/test_auth.py
551 passed, 174 deselected in 49.25s        # make test-unit (the CI target)
```

## Behaviour change worth knowing

For a new-format key with exactly one project binding, the server used to self-scope and ignore whatever project the SDK held. It now honours the configured project. A `LANGWATCH_PROJECT_ID` that disagrees with the key's binding used to be silently ignored and will now take effect — the server still validates that the project belongs to the key's organization and still applies the permission ceiling (`token-resolver.ts:158-215`), so this cannot reach a project the key is not entitled to; it can surface a misconfiguration that was previously masked.

## Sweep

- `gateway_budgets.py:55-58` and `virtual_keys.py:56-59` already send `X-Project-Id` unconditionally — same carrier, no change needed.
- ~20 other `build_auth_headers(...)` call sites (`batch_evaluation.py`, `dspy/__init__.py`, `experiment/experiment.py`, `experiment/platform_run.py`, `evaluation/__init__.py`, `workflow/__init__.py`, `telemetry/tracing.py`) pass only the api key. They pick the project up from the `LANGWATCH_PROJECT_ID` env fallback inside `build_auth_headers`, so this fix reaches them — **but not** a project set programmatically via `langwatch.setup(project_id=…)`, which only `client.py:714` and `:755` forward. See "not fixed here" below.
- The other SDKs were checked: Go (`sdks/go/client/auth.go:18-33`) always sends the header; TypeScript (`sdks/typescript/src/internal/api/auth.ts:69-77`) sends Basic auth. Neither has this defect.

## Noticed, deliberately not fixed here

1. **Programmatic `project_id` is dropped outside the two client call sites.** A user who calls `langwatch.setup(project_id=…)` with no `LANGWATCH_PROJECT_ID` set gets a project on the OTLP exporter and the REST client only; evaluations, experiments, dspy, workflows and batch evaluation still send none. This affects PATs today too, needs a public `project_id` accessor on the client and its protocol (only `Client._project_id` exists, `client.py:42`), and is a separate change — filed as #7139.
2. **TypeScript's `includes("_")` classifier** should be tightened to the same regex. Noted in #7118, not touched here.
3. **Pre-existing `ruff`/`black` findings** in both files (`typing.Dict`, `Optional[...]`, `.encode("utf-8")`, one formatting diff in a PAT test). CI runs `make test-unit` only, no lint gate; left alone rather than mixing unrelated churn into a fix.
4. **#7119 is untouched and still blocks the reporter of #6988.** An organization-scoped key with `All` permissions is refused `traces:view` even with a valid project attached, so #6988 goes from a 401 to a 403 until that is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new-format API keys, ingestion keys, and personal access tokens.
  * Authentication requests now include the appropriate project header when required.
  * Added support for dual authentication headers for non-personal access tokens.

* **Bug Fixes**
  * Preserved legacy key behavior while improving project identification for newer key formats.
  * Improved handling of malformed, empty, and project-less credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
