### PR TITLE
fix(cli): make scenario run --wait count only its own batch

### DIFF
--- a/platform/app/src/app/api/simulation-runs/[[...route]]/app.ts
+++ b/platform/app/src/app/api/simulation-runs/[[...route]]/app.ts
@@ -110,8 +110,10 @@ secured.access(requires("scenarios:view")).get(
 
     const simulationRuns = getApp().simulations.runs;
 
-    if (batchRunId && scenarioSetId) {
-      // Get runs for a specific batch
+    if (batchRunId) {
+      // Get runs for a specific batch. The scenario set id narrows the query
+      // when given, but the batch id alone is enough: the CLI's --wait polls
+      // with just the batch id it was handed at scheduling time.
       const result = await simulationRuns.getRunDataForBatchRun({
         projectId: project.id,
         scenarioSetId,

--- a/platform/app/src/app/api/simulation-runs/__tests__/simulation-runs-batch-filter.integration.test.ts
+++ b/platform/app/src/app/api/simulation-runs/__tests__/simulation-runs-batch-filter.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * GET /api/simulation-runs?batchRunId= must filter by the batch id on its
+ * own. The route used to require scenarioSetId alongside it and silently fell
+ * through to the unfiltered project listing otherwise, which is what made the
+ * CLI's --wait count stale runs from old batches and time out.
+ *
+ * @see specs/features/simulation-runs-batch-filter.feature
+ */
+
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import type { Organization, Project, Team } from "~/generated/prisma/client";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import { NullSimulationRepository } from "~/server/app-layer/simulations/repositories/simulation.repository";
+import { SimulationRunService } from "~/server/app-layer/simulations/simulation-run.service";
+import { prisma } from "~/server/db";
+import { ScenarioRunExportService } from "~/server/export/scenario-runs/scenario-run-export.service";
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
+import { app } from "../[[...route]]/app";
+
+function makeRun(overrides: Partial<ScenarioRunData> = {}): ScenarioRunData {
+  return {
+    scenarioId: "scenario_1",
+    batchRunId: "batch_1",
+    scenarioRunId: "run_1",
+    scenarioSetId: "set_1",
+    name: "Login flow",
+    description: null,
+    status: ScenarioRunStatus.SUCCESS,
+    results: null,
+    messages: [],
+    timestamp: Date.now(),
+    updatedAt: Date.now(),
+    durationInMs: 1200,
+    ...overrides,
+  };
+}
+
+describe("Feature: simulation runs list filters by batch id alone", () => {
+  let testApiKey: string;
+  let testProjectId: string;
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let testProject: Project;
+
+  beforeEach(async () => {
+    await resetApp();
+
+    testOrganization = await prisma.organization.create({
+      data: { name: "Test Organization", slug: `test-org-${nanoid()}` },
+    });
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `test-team-${nanoid()}`,
+        organizationId: testOrganization.id,
+      },
+    });
+    testProject = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: `demo-${nanoid()}` }),
+        teamId: testTeam.id,
+        personalFeatures: {},
+      },
+    });
+    testApiKey = testProject.apiKey;
+    testProjectId = testProject.id;
+  });
+
+  afterEach(async () => {
+    if (!testProjectId) return;
+    await prisma.project.delete({ where: { id: testProjectId } });
+    await prisma.team.delete({ where: { id: testTeam.id } });
+    await prisma.organization.delete({ where: { id: testOrganization.id } });
+  });
+
+  /**
+   * Records which repository method the route reached and with which params.
+   * The batch method serves only the batch's runs; the all-suites method
+   * serves the whole project, which is the fall-through the fix removes.
+   */
+  class RecordingSimulationRepository extends NullSimulationRepository {
+    batchCalls: Array<{
+      projectId: string;
+      scenarioSetId?: string;
+      batchRunId: string;
+    }> = [];
+    allSuitesCalls = 0;
+
+    // The base class declares the method parameterless, so the override's
+    // parameter must be optional to stay assignable; the route always passes
+    // it.
+    override async getRunDataForBatchRun(params?: {
+      projectId: string;
+      scenarioSetId?: string;
+      batchRunId: string;
+    }) {
+      if (!params) throw new Error("expected params");
+      this.batchCalls.push(params);
+      return {
+        changed: true as const,
+        lastUpdatedAt: Date.now(),
+        runs: [makeRun({ batchRunId: params.batchRunId })],
+      };
+    }
+
+    override async getRunDataForAllSuites() {
+      this.allSuitesCalls += 1;
+      return {
+        changed: true as const,
+        lastUpdatedAt: Date.now(),
+        runs: [
+          makeRun({ batchRunId: "batch_1" }),
+          makeRun({
+            batchRunId: "batch_stale",
+            scenarioRunId: "run_stale",
+            status: ScenarioRunStatus.IN_PROGRESS,
+          }),
+        ],
+        scenarioSetIds: {},
+        hasMore: false,
+      };
+    }
+  }
+
+  function withRepository() {
+    const repository = new RecordingSimulationRepository();
+    globalForApp.__langwatch_app = createTestApp({
+      simulations: {
+        runs: new SimulationRunService(repository),
+        export: ScenarioRunExportService.create(repository),
+      },
+    });
+    return repository;
+  }
+
+  const get = (path: string) =>
+    app.request(path, { headers: { "X-Auth-Token": testApiKey } });
+
+  describe("When the list is requested with only a batchRunId", () => {
+    /** @scenario "A batch id alone filters the list" */
+    it("serves the batch's runs, never the whole project", async () => {
+      const repository = withRepository();
+
+      const res = await get("/api/simulation-runs?batchRunId=batch_1");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        runs: Array<{ batchRunId: string }>;
+      };
+
+      expect(repository.allSuitesCalls).toBe(0);
+      expect(repository.batchCalls).toEqual([
+        {
+          projectId: testProjectId,
+          scenarioSetId: undefined,
+          batchRunId: "batch_1",
+        },
+      ]);
+      expect(body.runs.map((r) => r.batchRunId)).toEqual(["batch_1"]);
+    });
+  });
+
+  describe("When the list is requested with both batchRunId and scenarioSetId", () => {
+    /** @scenario "A batch id with a scenario set id keeps working" */
+    it("passes both filters through to the batch query", async () => {
+      const repository = withRepository();
+
+      const res = await get(
+        "/api/simulation-runs?batchRunId=batch_1&scenarioSetId=set_1",
+      );
+      expect(res.status).toBe(200);
+
+      expect(repository.batchCalls).toEqual([
+        {
+          projectId: testProjectId,
+          scenarioSetId: "set_1",
+          batchRunId: "batch_1",
+        },
+      ]);
+    });
+  });
+});

--- a/platform/app/src/app/api/simulation-runs/__tests__/simulation-runs-batch-filter.integration.test.ts
+++ b/platform/app/src/app/api/simulation-runs/__tests__/simulation-runs-batch-filter.integration.test.ts
@@ -140,7 +140,7 @@ describe("Feature: simulation runs list filters by batch id alone", () => {
   const get = (path: string) =>
     app.request(path, { headers: { "X-Auth-Token": testApiKey } });
 
-  describe("When the list is requested with only a batchRunId", () => {
+  describe("when the list is requested with only a batchRunId", () => {
     /** @scenario "A batch id alone filters the list" */
     it("serves the batch's runs, never the whole project", async () => {
       const repository = withRepository();
@@ -163,7 +163,7 @@ describe("Feature: simulation runs list filters by batch id alone", () => {
     });
   });
 
-  describe("When the list is requested with both batchRunId and scenarioSetId", () => {
+  describe("when the list is requested with both batchRunId and scenarioSetId", () => {
     /** @scenario "A batch id with a scenario set id keeps working" */
     it("passes both filters through to the batch query", async () => {
       const repository = withRepository();

--- a/platform/app/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -299,12 +299,15 @@ describe("SimulationClickHouseRepository (integration)", () => {
       /** @scenario "An empty scenario set id still selects the default set" */
       it("keeps the default set filter instead of dropping it", async () => {
         const batchRunId = `batch-default-${nanoid()}`;
-        const defaultSetRunId = `run-default-${nanoid()}`;
+        // The default set holds both storage values: "" from rows written
+        // before the set id got its name, and "default" from rows after.
+        const legacyDefaultRunId = `run-legacy-default-${nanoid()}`;
+        const namedDefaultRunId = `run-named-default-${nanoid()}`;
 
         await insertRow(
           ch,
           makeInsertRow({
-            ScenarioRunId: defaultSetRunId,
+            ScenarioRunId: legacyDefaultRunId,
             BatchRunId: batchRunId,
             ScenarioSetId: "",
           }),
@@ -312,7 +315,15 @@ describe("SimulationClickHouseRepository (integration)", () => {
         await insertRow(
           ch,
           makeInsertRow({
-            ScenarioRunId: `run-named-${nanoid()}`,
+            ScenarioRunId: namedDefaultRunId,
+            BatchRunId: batchRunId,
+            ScenarioSetId: "default",
+          }),
+        );
+        await insertRow(
+          ch,
+          makeInsertRow({
+            ScenarioRunId: `run-other-set-${nanoid()}`,
             BatchRunId: batchRunId,
             ScenarioSetId: `set-named-${nanoid()}`,
           }),
@@ -326,9 +337,11 @@ describe("SimulationClickHouseRepository (integration)", () => {
 
         expect(result.changed).toBe(true);
         if (!result.changed) throw new Error("expected changed");
-        expect(result.runs.map((r) => r.scenarioRunId)).toEqual([
-          defaultSetRunId,
-        ]);
+        // The two default rows share a CreatedAt, so their order is not
+        // decided; only membership is.
+        expect(result.runs.map((r) => r.scenarioRunId).sort()).toEqual(
+          [legacyDefaultRunId, namedDefaultRunId].sort(),
+        );
       });
     });
   });

--- a/platform/app/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -271,6 +271,29 @@ describe("SimulationClickHouseRepository (integration)", () => {
         expect(result.runs[0]!.metadata).toEqual(metadata);
       });
     });
+
+    describe("when no scenario set id is given", () => {
+      /** @scenario "A batch id alone filters the list" */
+      it("returns the batch's runs and no others", async () => {
+        const batchRunId = `batch-only-${nanoid()}`;
+        const wantedRunId = `run-only-${nanoid()}`;
+
+        await insertRow(
+          ch,
+          makeInsertRow({ ScenarioRunId: wantedRunId, BatchRunId: batchRunId }),
+        );
+        await insertRow(ch, makeInsertRow({ Status: "IN_PROGRESS" }));
+
+        const result = await repo.getRunDataForBatchRun({
+          projectId: tenantId,
+          batchRunId,
+        });
+
+        expect(result.changed).toBe(true);
+        if (!result.changed) throw new Error("expected changed");
+        expect(result.runs.map((r) => r.scenarioRunId)).toEqual([wantedRunId]);
+      });
+    });
   });
 
   describe("getAllRunDataForScenarioSet()", () => {

--- a/platform/app/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -294,6 +294,43 @@ describe("SimulationClickHouseRepository (integration)", () => {
         expect(result.runs.map((r) => r.scenarioRunId)).toEqual([wantedRunId]);
       });
     });
+
+    describe("when the scenario set id is the empty string", () => {
+      /** @scenario "An empty scenario set id still selects the default set" */
+      it("keeps the default set filter instead of dropping it", async () => {
+        const batchRunId = `batch-default-${nanoid()}`;
+        const defaultSetRunId = `run-default-${nanoid()}`;
+
+        await insertRow(
+          ch,
+          makeInsertRow({
+            ScenarioRunId: defaultSetRunId,
+            BatchRunId: batchRunId,
+            ScenarioSetId: "",
+          }),
+        );
+        await insertRow(
+          ch,
+          makeInsertRow({
+            ScenarioRunId: `run-named-${nanoid()}`,
+            BatchRunId: batchRunId,
+            ScenarioSetId: `set-named-${nanoid()}`,
+          }),
+        );
+
+        const result = await repo.getRunDataForBatchRun({
+          projectId: tenantId,
+          scenarioSetId: "",
+          batchRunId,
+        });
+
+        expect(result.changed).toBe(true);
+        if (!result.changed) throw new Error("expected changed");
+        expect(result.runs.map((r) => r.scenarioRunId)).toEqual([
+          defaultSetRunId,
+        ]);
+      });
+    });
   });
 
   describe("getAllRunDataForScenarioSet()", () => {

--- a/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -672,11 +672,17 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     }
 
     // The batch id identifies the batch within the tenant on its own; the
-    // scenario set id narrows the scan when the caller has it. The CLI's
-    // --wait polls with just the batch id.
-    const setFilter = scenarioSetId
-      ? "AND ScenarioSetId IN ({scenarioSetIds:Array(String)})"
-      : "";
+    // scenario set id narrows the scan when the caller sends one. The CLI's
+    // --wait polls with just the batch id. An empty string is a real value
+    // that selects the default set, so only an absent id drops the predicate.
+    const scenarioSetIds =
+      scenarioSetId === undefined
+        ? undefined
+        : expandSetIdFilter(scenarioSetId);
+    const setFilter = (alias: string) =>
+      scenarioSetIds
+        ? `AND ${alias}ScenarioSetId IN ({scenarioSetIds:Array(String)})`
+        : "";
     const rows = await this.queryRows<
       ClickHouseSimulationRunRow & { ExportSortKey: string }
     >(
@@ -684,23 +690,21 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
-         ${scenarioSetId ? "AND t.ScenarioSetId IN ({scenarioSetIds:Array(String)})" : ""}
+         ${setFilter("t.")}
          AND t.BatchRunId = {batchRunId:String}
          AND t.ArchivedAt IS NULL
          AND (t.TenantId, t.ScenarioSetId, t.BatchRunId, t.ScenarioRunId, t.UpdatedAt) IN (
            SELECT TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, max(UpdatedAt)
            FROM ${TABLE_NAME}
            WHERE TenantId = {tenantId:String}
-             ${setFilter}
+             ${setFilter("")}
              AND BatchRunId = {batchRunId:String}
            GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
          )
        ORDER BY CreatedAt ASC`,
       {
         tenantId: projectId,
-        ...(scenarioSetId
-          ? { scenarioSetIds: expandSetIdFilter(scenarioSetId) }
-          : {}),
+        ...(scenarioSetIds ? { scenarioSetIds } : {}),
         batchRunId,
       },
     );

--- a/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -649,7 +649,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     sinceTimestamp,
   }: {
     projectId: string;
-    scenarioSetId: string;
+    scenarioSetId?: string;
     batchRunId: string;
     sinceTimestamp?: number;
   }): Promise<
@@ -671,6 +671,12 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       }
     }
 
+    // The batch id identifies the batch within the tenant on its own; the
+    // scenario set id narrows the scan when the caller has it. The CLI's
+    // --wait polls with just the batch id.
+    const setFilter = scenarioSetId
+      ? "AND ScenarioSetId IN ({scenarioSetIds:Array(String)})"
+      : "";
     const rows = await this.queryRows<
       ClickHouseSimulationRunRow & { ExportSortKey: string }
     >(
@@ -678,21 +684,23 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         toString(${EXPORT_SORT_KEY}) AS ExportSortKey
        FROM ${TABLE_NAME} AS t
        WHERE t.TenantId = {tenantId:String}
-         AND t.ScenarioSetId IN ({scenarioSetIds:Array(String)})
+         ${scenarioSetId ? "AND t.ScenarioSetId IN ({scenarioSetIds:Array(String)})" : ""}
          AND t.BatchRunId = {batchRunId:String}
          AND t.ArchivedAt IS NULL
          AND (t.TenantId, t.ScenarioSetId, t.BatchRunId, t.ScenarioRunId, t.UpdatedAt) IN (
            SELECT TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, max(UpdatedAt)
            FROM ${TABLE_NAME}
            WHERE TenantId = {tenantId:String}
-             AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
+             ${setFilter}
              AND BatchRunId = {batchRunId:String}
            GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
          )
        ORDER BY CreatedAt ASC`,
       {
         tenantId: projectId,
-        scenarioSetIds: expandSetIdFilter(scenarioSetId),
+        ...(scenarioSetId
+          ? { scenarioSetIds: expandSetIdFilter(scenarioSetId) }
+          : {}),
         batchRunId,
       },
     );

--- a/platform/app/src/server/app-layer/simulations/repositories/simulation.repository.ts
+++ b/platform/app/src/server/app-layer/simulations/repositories/simulation.repository.ts
@@ -60,7 +60,7 @@ export interface SimulationRepository {
 
   getRunDataForBatchRun(params: {
     projectId: string;
-    scenarioSetId: string;
+    scenarioSetId?: string;
     batchRunId: string;
     sinceTimestamp?: number;
   }): Promise<BatchRunDataResult>;

--- a/platform/app/src/server/app-layer/simulations/simulation-run.service.ts
+++ b/platform/app/src/server/app-layer/simulations/simulation-run.service.ts
@@ -53,7 +53,7 @@ export class SimulationRunService {
 
   async getRunDataForBatchRun(params: {
     projectId: string;
-    scenarioSetId: string;
+    scenarioSetId?: string;
     batchRunId: string;
     sinceTimestamp?: number;
   }): Promise<BatchRunDataResult> {

--- a/sdks/typescript/src/cli/utils/__tests__/batchRunProgress.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/batchRunProgress.unit.test.ts
@@ -31,7 +31,10 @@ const json = (body: unknown, status = 200): Response =>
 		headers: { "content-type": "application/json" },
 	});
 
-const run = (status: string, verdict?: string | null) => ({
+// The real endpoint stamps every run with its batch id; the stub does too,
+// because fetchBatchRuns keeps only the batch's own runs.
+const run = (status: string, verdict?: string | null, batchRunId = "batch_1") => ({
+	batchRunId,
 	status,
 	results: verdict === undefined ? null : { verdict },
 });
@@ -98,6 +101,39 @@ describe("batch run progress", () => {
 			const [requested] = mockFetch.mock.calls[0] as [URL];
 			expect(requested.pathname).toBe("/api/simulation-runs");
 			expect(requested.searchParams.get("batchRunId")).toBe("batch_1");
+		});
+	});
+
+	describe("given a server that answers with the whole project's runs", () => {
+		/** @scenario "Runs from other batches never count toward the wait" */
+		it("keeps only the batch's own runs", async () => {
+			// Deployed servers apply the batchRunId filter only when scenarioSetId
+			// is also present. Left unfiltered, the stale IN_PROGRESS run below
+			// would count as in flight forever and hold the wait open until its
+			// timeout.
+			serveRuns({
+				"": {
+					runs: [
+						run("SUCCESS", "success"),
+						run("IN_PROGRESS", undefined, "batch_stale"),
+						run("FAILED", "failure", "batch_other"),
+					],
+				},
+			});
+
+			const runs = await fetchBatchRuns({
+				endpoint: "https://app.langwatch.test",
+				batchRunId: "batch_1",
+				headers: {},
+			});
+
+			expect(runs).toHaveLength(1);
+			expect(tallyBatchRuns(runs)).toEqual({
+				total: 1,
+				completed: 1,
+				passed: 1,
+				failed: 0,
+			});
 		});
 	});
 

--- a/sdks/typescript/src/cli/utils/batchRunProgress.ts
+++ b/sdks/typescript/src/cli/utils/batchRunProgress.ts
@@ -13,6 +13,7 @@
 
 /** What the run list gives us. Narrower than the endpoint's full response. */
 interface BatchRun {
+	batchRunId?: string;
 	status?: string;
 	results?: { verdict?: string | null } | null;
 }
@@ -99,7 +100,13 @@ export async function fetchBatchRuns({
 			nextCursor?: string;
 		};
 
-		runs.push(...(page.runs ?? []));
+		// Deployed servers apply the batchRunId filter only when scenarioSetId
+		// is also present, and answer with the whole project's runs otherwise.
+		// Keep only the batch's own runs, or a stale in-progress run from an
+		// old batch holds the wait open until its timeout.
+		runs.push(
+			...(page.runs ?? []).filter((run) => run.batchRunId === batchRunId),
+		);
 		cursor = page.hasMore ? page.nextCursor : undefined;
 	} while (cursor);
 

--- a/specs/features/cli-wait-and-clone-endpoints.feature
+++ b/specs/features/cli-wait-and-clone-endpoints.feature
@@ -31,6 +31,15 @@ Feature: CLI commands address endpoints the app actually serves
     Then it follows the cursor until there are no more pages
     And the total counts every run, not just the first page
 
+  # Deployed servers only apply the batchRunId filter when scenarioSetId is
+  # also present, and answer with the whole project's runs otherwise. A stale
+  # in-progress run from an old batch then counts as in flight forever, and
+  # the wait times out even though the batch finished in seconds.
+  Scenario: Runs from other batches never count toward the wait
+    Given the run list endpoint answers with runs from the whole project
+    When the CLI polls for the batch's progress
+    Then only runs carrying the batch's own id are tallied
+
   Scenario: A status endpoint that answers 404 ends the wait
     Given the run list endpoint answers 404
     When the CLI polls for the batch's progress

--- a/specs/features/simulation-runs-batch-filter.feature
+++ b/specs/features/simulation-runs-batch-filter.feature
@@ -18,3 +18,11 @@ Feature: Simulation runs list filters by batch id alone
     Given runs exist in a batch that belongs to a scenario set
     When the list is requested with both batchRunId and scenarioSetId
     Then the response contains the runs of that batch
+
+  # An empty scenario set id is a value, not an absent filter: it selects the
+  # default set, which holds rows written both before and after the set id
+  # got its "default" name.
+  Scenario: An empty scenario set id still selects the default set
+    Given a batch holds one run in the default set and one in a named set
+    When the runs are read with the batch id and an empty scenario set id
+    Then only the default set run is returned

--- a/specs/features/simulation-runs-batch-filter.feature
+++ b/specs/features/simulation-runs-batch-filter.feature
@@ -1,0 +1,20 @@
+@integration
+Feature: Simulation runs list filters by batch id alone
+  As a consumer polling a batch of simulation runs over the REST API
+  I want GET /api/simulation-runs?batchRunId= to return only that batch
+  So that progress polling sees the batch it scheduled, not the whole project
+
+  # The route used to apply the batchRunId filter only when scenarioSetId was
+  # also present. The CLI's --wait sends batchRunId alone, so the server
+  # answered with every run in the project, and stale in-progress runs from
+  # old batches held the wait open until its timeout.
+
+  Scenario: A batch id alone filters the list
+    Given runs exist in two different batches
+    When the list is requested with only a batchRunId
+    Then the response contains the runs of that batch and no others
+
+  Scenario: A batch id with a scenario set id keeps working
+    Given runs exist in a batch that belongs to a scenario set
+    When the list is requested with both batchRunId and scenarioSetId
+    Then the response contains the runs of that batch


### PR DESCRIPTION
## What

`langwatch scenario run --wait` (and `suite run --wait`) timed out after 10 minutes even when the batch finished in under 90 seconds. Found while dogfooding the remote-traces flow against production.

## Why

`GET /api/simulation-runs` applied the `batchRunId` filter only when `scenarioSetId` was also present:

```ts
if (batchRunId && scenarioSetId) { ... }
```

The CLI polls with the batch id alone, so the route fell through to the unfiltered project listing. The tally then counted every run in the project, and one stale `IN_PROGRESS` run from an old batch was enough to hold the wait open until its timeout.

## How

Two sides, so the fix works now and stays correct:

- **Server**: `batchRunId` alone now selects the batch branch. `scenarioSetId` stays as an optional narrowing for the ClickHouse scan. Callers that pass both are unchanged.
- **CLI**: `fetchBatchRuns` keeps only runs that carry the polled batch id. This makes `--wait` correct against servers deployed before this change, which still answer with the whole project.

## Tests

- `specs/features/simulation-runs-batch-filter.feature` (new, @integration, 2/2 bound): batch id alone filters the list; batch id plus set id keeps working. Bound in the new route integration test and the ClickHouse repository integration test.
- `specs/features/cli-wait-and-clone-endpoints.feature`: new scenario "Runs from other batches never count toward the wait" (@unit, bound in `batchRunProgress.unit.test.ts`), where the stub server answers with the whole project's runs the way deployed servers do.
- Full `pnpm typecheck:all` clean; route, repository, and CLI suites green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulation runs can now be searched by batch ID without specifying a scenario set.
  * Scenario set filtering remains available as an optional additional filter.
  * Batch progress calculations now include only runs belonging to the selected batch.

* **Bug Fixes**
  * Prevented unrelated simulation runs from affecting batch results and progress totals.

* **Tests**
  * Added coverage for batch-only filtering and combined batch and scenario set filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->