### PR TITLE
fix: unify money type — string for USD amounts, BigInt for nanoUsd

### DIFF
--- a/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/services/pulled-usage-pricing.service.ts
+++ b/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/services/pulled-usage-pricing.service.ts
@@ -42,8 +42,8 @@ export interface PulledUsageQuantities {
  */
 interface ProviderReportedPrice {
   basis: typeof PULLED_USAGE_COST_BASIS.PROVIDER_REPORTED;
-  /** The provider's amount in USD. A string keeps every digit it published. */
-  costUsd: string | number;
+  /** The provider's amount in USD as a decimal string. */
+  costUsd: string;
   costStatus: PulledUsageCostStatus;
   // No `quantities`. This path never reads them — the provider already priced
   // the item — and requiring them made every caller hand over data the
@@ -90,7 +90,7 @@ export interface PulledUsagePrice {
  * publishing a quietly rounded one is the failure this whole path exists to
  * prevent.
  */
-function providerCostToNanoUsd(costUsd: string | number): number {
+function providerCostToNanoUsd(costUsd: string): number {
   const exact = usdToNanoUsd(costUsd);
   if (
     exact > BigInt(Number.MAX_SAFE_INTEGER) ||

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -94,8 +94,10 @@ function isNotFoundError(error: unknown): boolean {
   return readHandledError(error)?.httpStatus === 404;
 }
 
-const fmtUsd = (n: number) =>
-  n === 0 ? "$0.00" : numeral(n).format("$0,0.0000");
+const fmtUsd = (n: number | string) => {
+  const v = typeof n === "string" ? Number(n) : n;
+  return v === 0 ? "$0.00" : numeral(v).format("$0,0.0000");
+};
 
 const fmtRelative = (iso: string | null): string => {
   if (!iso) return "-";

--- a/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
@@ -536,7 +536,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
       });
       // Cross-org trace had spend=$50; if any leaked, primary's largest row
       // would be far above $2 + $0.25.
-      const totalReturned = rows.reduce((sum, r) => sum + r.spendUsd, 0);
+      const totalReturned = rows.reduce(
+        (sum, r) => sum + Number(r.spendUsd),
+        0,
+      );
       expect(totalReturned).toBeLessThan(10);
       // Cross-org Team is a Team but its id should never surface here.
       const allTeamIds = rows.map((r) => r.teamId).filter(Boolean);
@@ -813,7 +816,7 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
       const totalSpend = result.buckets
         .flatMap((b) => b.points)
-        .reduce((sum, p) => sum + p.spendUsd, 0);
+        .reduce((sum, p) => sum + Number(p.spendUsd), 0);
       // tr-primary-1 ($0.50) + tr-primary-2 ($1.50) + tr-primary-3 ($0.25)
       // governance-origin only — app trace ($99) excluded.
       expect(totalSpend).toBeCloseTo(2.25, 2);
@@ -822,7 +825,7 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
         .flatMap((b) => b.points)
         .filter((p) => p.key === primaryTeamId);
       const primarySpend = primaryTeamPoints.reduce(
-        (sum, p) => sum + p.spendUsd,
+        (sum, p) => sum + Number(p.spendUsd),
         0,
       );
       expect(primarySpend).toBeCloseTo(2.0, 2);
@@ -831,7 +834,7 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
         .flatMap((b) => b.points)
         .filter((p) => p.key === "__org_wide__");
       const orgWideSpend = orgWidePoints.reduce(
-        (sum, p) => sum + p.spendUsd,
+        (sum, p) => sum + Number(p.spendUsd),
         0,
       );
       expect(orgWideSpend).toBeCloseTo(0.25, 2);
@@ -896,7 +899,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
       ).toBeUndefined();
       // Total spend bounded by primary's seeded amount (2.25) — proves no
       // cross-org $50 leaked even into a different attribution dimension.
-      const totalSpend = flatPoints.reduce((sum, p) => sum + p.spendUsd, 0);
+      const totalSpend = flatPoints.reduce(
+        (sum, p) => sum + Number(p.spendUsd),
+        0,
+      );
       expect(totalSpend).toBeCloseTo(2.25, 2);
     });
 
@@ -912,8 +918,8 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
       const populated = result.buckets.find((b) => b.points.length >= 2);
       expect(populated).toBeDefined();
       // Sorted desc: bob (1.5) before alice (0.5).
-      expect(populated!.points[0]!.spendUsd).toBeGreaterThanOrEqual(
-        populated!.points[1]!.spendUsd,
+      expect(Number(populated!.points[0]!.spendUsd)).toBeGreaterThanOrEqual(
+        Number(populated!.points[1]!.spendUsd),
       );
     });
 

--- a/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
@@ -763,7 +763,7 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
           eventType: "anthropic_admin",
           action: "usage_report",
           target: "claude-haiku-4-5",
-          costUsd: 0.0042,
+          costUsd: "0.0042",
           tokensInput: 8,
           tokensOutput: 5,
         }),

--- a/platform/app/ee/governance/services/__tests__/departmentSpend.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/departmentSpend.service.integration.test.ts
@@ -257,7 +257,7 @@ describe("ActivityMonitorService.spendByDepartment", () => {
 
       // The whole org's spend rolls up (2 + 3 + 1 = 6), proving the card is
       // not limited to a single governance ingestion project.
-      const total = rows.reduce((sum, r) => sum + r.spendUsd, 0);
+      const total = rows.reduce((sum, r) => sum + Number(r.spendUsd), 0);
       expect(total).toBeCloseTo(6.0, 2);
     });
   });
@@ -270,7 +270,7 @@ describe("ActivityMonitorService.spendByDepartment", () => {
         organizationId: org.id,
         windowDays: 7,
       });
-      const total = rows.reduce((sum, r) => sum + r.spendUsd, 0);
+      const total = rows.reduce((sum, r) => sum + Number(r.spendUsd), 0);
       // The cross-org $50 must not leak - primary's total stays at $6.
       expect(total).toBeLessThan(10);
       // The Engineering row is this org's $3 agent spend, not the cross

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
@@ -84,7 +84,7 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
         actor: "pulled@example.com",
         action: "usage_report",
         target: "claude-haiku-4-5",
-        costUsd: 0.0042,
+        costUsd: "0.0042",
         tokensInput: 8,
         tokensOutput: 5,
       }),
@@ -137,10 +137,10 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const byId = new Map(rows.map((row) => [row.eventId, row]));
     // The one field that was a number survives; only the bad two fall back.
     expect(byId.get("poisoned-fields")).toEqual(
-      expect.objectContaining({ costUsd: 0, tokensInput: 0, tokensOutput: 5 }),
+      expect.objectContaining({ costUsd: "0", tokensInput: 0, tokensOutput: 5 }),
     );
     expect(byId.get("poisoned-extension")).toEqual(
-      expect.objectContaining({ costUsd: 0, tokensInput: 0, tokensOutput: 0 }),
+      expect.objectContaining({ costUsd: "0", tokensInput: 0, tokensOutput: 0 }),
     );
   });
 
@@ -191,7 +191,7 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     expect(rows[0]).toEqual(
       expect.objectContaining({
         eventId: "credit-line",
-        costUsd: -12.5,
+        costUsd: "-12.5",
         tokensInput: 8,
         tokensOutput: 5,
       }),

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
@@ -137,10 +137,18 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const byId = new Map(rows.map((row) => [row.eventId, row]));
     // The one field that was a number survives; only the bad two fall back.
     expect(byId.get("poisoned-fields")).toEqual(
-      expect.objectContaining({ costUsd: "0", tokensInput: 0, tokensOutput: 5 }),
+      expect.objectContaining({
+        costUsd: "0",
+        tokensInput: 0,
+        tokensOutput: 5,
+      }),
     );
     expect(byId.get("poisoned-extension")).toEqual(
-      expect.objectContaining({ costUsd: "0", tokensInput: 0, tokensOutput: 0 }),
+      expect.objectContaining({
+        costUsd: "0",
+        tokensInput: 0,
+        tokensOutput: 0,
+      }),
     );
   });
 

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/canonicalCostExtractor.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/canonicalCostExtractor.unit.test.ts
@@ -90,7 +90,7 @@ describe("extractCanonicalCostEvents", () => {
       );
       expect(events).toHaveLength(1);
       expect(events[0]).toMatchObject({
-        costUsd: 0.12545,
+        costUsd: "0.12545",
         requestId: "req_abc",
         model: "claude-opus-4-7",
         inputTokens: 1234,

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/moneyTypeLossless.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/moneyTypeLossless.unit.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression: money fields must stay string (USD) or BigInt (nano-USD).
+ *
+ * `Number()` on a decimal string is lossy past ~15 significant digits,
+ * and float accumulation drifts. Every USD amount entering or leaving
+ * the governance read path must be a decimal string; intermediate
+ * accumulation must go through nano-USD integers.
+ *
+ * Issue: langwatch/langwatch-saas#1090
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const query = vi.fn();
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForOrganization: vi.fn(async () => ({ query })),
+}));
+
+import { ActivityMonitorService } from "../activityMonitor.service";
+
+/**
+ * A value ClickHouse's `toString(sum(Float64))` actually produces for a
+ * sub-cent spend. `Number("0.000044999999999999996")` gives
+ * `0.000044999999999999996`, which is representable, but accumulating
+ * several of those as floats drifts in a way that the string-→nano-→string
+ * round-trip does not.
+ */
+const CH_FLOAT64_SPEND = "0.000044999999999999996";
+
+/** A nine-decimal-digit cost that Number() rounds. */
+const NINE_DIGIT_COST = "0.123456789";
+
+describe("money type lossless round-trip", () => {
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  describe("when a pushed event carries a sub-cent cost", () => {
+    it("preserves the cost as a string, not a lossy Number()", async () => {
+      query.mockImplementation(async () => ({
+        json: async () => [
+          {
+            eventId: "trace-1",
+            eventType: "otel_generic",
+            actor: "user@example.com",
+            target: "gpt-5",
+            costUsd: CH_FLOAT64_SPEND,
+            tokensInput: 10,
+            tokensOutput: 4,
+            occurredMs: "1786619810000",
+            createdMs: "1786619811000",
+          },
+        ],
+      }));
+
+      const prisma = {
+        project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
+      };
+      const service = ActivityMonitorService.create(prisma as never);
+
+      const rows = await service.eventsForSource({
+        organizationId: "org",
+        sourceId: "source",
+        limit: 50,
+      });
+
+      // costUsd must be a string — not Number(CH_FLOAT64_SPEND)
+      expect(typeof rows[0]!.costUsd).toBe("string");
+      expect(rows[0]!.costUsd).toBe(CH_FLOAT64_SPEND);
+    });
+  });
+
+  describe("when a pulled OCSF event carries a nine-digit cost", () => {
+    it("preserves the cost as a string through the Zod schema", async () => {
+      query.mockImplementation(async ({ query: sql }: { query: string }) => ({
+        json: async () =>
+          sql.includes("governance_ocsf_events")
+            ? [
+                {
+                  eventId: "pulled-1",
+                  eventType: "anthropic_admin",
+                  actorUserId: "",
+                  actorEmail: "pulled@example.com",
+                  actorEnduserId: "",
+                  action: "usage_report",
+                  target: "claude-haiku-4-5",
+                  occurredMs: "1786619820000",
+                  createdMs: "1786619821000",
+                  rawPayload: JSON.stringify({
+                    metadata: {
+                      extension: {
+                        cost_usd: NINE_DIGIT_COST,
+                        tokens_input: 8,
+                        tokens_output: 5,
+                      },
+                    },
+                  }),
+                },
+              ]
+            : [],
+      }));
+
+      const prisma = {
+        project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
+      };
+      const service = ActivityMonitorService.create(prisma as never);
+
+      const rows = await service.eventsForSource({
+        organizationId: "org",
+        sourceId: "source",
+        limit: 50,
+      });
+
+      expect(typeof rows[0]!.costUsd).toBe("string");
+      expect(rows[0]!.costUsd).toBe(NINE_DIGIT_COST);
+    });
+  });
+
+  describe("when spendByUser returns CH spend strings", () => {
+    it("keeps spendUsd as a string, not Number()", async () => {
+      query.mockImplementation(async () => ({
+        json: async () => [
+          {
+            actor: "user@example.com",
+            spendUsdStr: CH_FLOAT64_SPEND,
+            requests: "5",
+            lastActivityMs: "1786619810000",
+            mostUsedTarget: "gpt-5",
+          },
+        ],
+      }));
+
+      const prisma = {
+        project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
+      };
+      const service = ActivityMonitorService.create(prisma as never);
+
+      const rows = await service.spendByUser({
+        organizationId: "org",
+        windowDays: 30,
+      });
+
+      expect(typeof rows[0]!.spendUsd).toBe("string");
+      expect(rows[0]!.spendUsd).toBe(CH_FLOAT64_SPEND);
+    });
+  });
+
+  describe("when spendByDepartment accumulates across rows", () => {
+    it("accumulates through nano-USD integers, not float addition", async () => {
+      // Three rows that share one department. Float accumulation of
+      // 0.000044999999999999996 × 3 drifts; nano accumulation is exact.
+      const depRows = Array.from({ length: 3 }, (_, i) => ({
+        projectId: "proj-1",
+        actor: "",
+        spendUsdStr: CH_FLOAT64_SPEND,
+        requests: "1",
+        lastActivityMs: String(1786619810000 + i),
+      }));
+
+      query.mockImplementation(async () => ({
+        json: async () => depRows,
+      }));
+
+      const prisma = {
+        project: {
+          findFirst: vi.fn(async () => ({ id: "gov-project" })),
+          findMany: vi.fn(async () => [
+            { id: "proj-1", departmentId: "dep-1" },
+          ]),
+        },
+        organizationUser: { findMany: vi.fn(async () => []) },
+        department: {
+          findMany: vi.fn(async () => [{ id: "dep-1", name: "Engineering" }]),
+        },
+      };
+      const service = ActivityMonitorService.create(prisma as never);
+
+      const rows = await service.spendByDepartment({
+        organizationId: "org",
+        windowDays: 30,
+      });
+
+      expect(typeof rows[0]!.spendUsd).toBe("string");
+      // 45000 nano × 3 = 135000 nano = 0.000135 USD
+      // (the CH float-drift suffix is rounded away by nano conversion)
+      expect(rows[0]!.spendUsd).toBe("0.000135");
+    });
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -303,8 +303,8 @@ const pulledUsageExtensionSchema = z
     cost_usd: z
       .union([z.string(), z.number()])
       .transform((v) => {
-        const s = String(v);
-        return Number.isFinite(Number(s)) ? s : "0";
+        const s = String(v).trim();
+        return s !== "" && Number.isFinite(Number(s)) ? s : "0";
       })
       .catch("0"),
     tokens_input: z.coerce.number().finite().catch(0),

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -33,6 +33,10 @@ import type { PrismaClient } from "~/generated/prisma/client";
 
 import { getClickHouseClientForOrganization } from "~/server/clickhouse/clickhouseClient";
 import {
+  nanoUsdToDecimalString,
+  usdToNanoUsd,
+} from "~/server/gateway/wireMoney";
+import {
   resolveTraceDepartmentId,
   UNASSIGNED_DEPARTMENT,
 } from "../department/departmentAttribution";
@@ -60,7 +64,7 @@ export interface SummaryResult {
 
 export interface SpendByUserRow {
   actor: string;
-  spendUsd: number;
+  spendUsd: string;
   requests: number;
   lastActivityIso: string;
   trendVsPreviousPct: number;
@@ -80,7 +84,7 @@ export interface SpendByTeamRow {
   teamId: string | null;
   /** Team.name, or "Org-wide" for non-team-scoped sources. */
   teamName: string;
-  spendUsd: number;
+  spendUsd: string;
   requestCount: number;
   /**
    * Spend change vs the previous equal-length window (e.g. last 30
@@ -108,7 +112,7 @@ export interface SpendByDepartmentRow {
   departmentId: string | null;
   /** Department.name, or "Unassigned". */
   departmentName: string;
-  spendUsd: number;
+  spendUsd: string;
   requestCount: number;
   lastActivityIso: string | null;
 }
@@ -139,7 +143,7 @@ export interface SpendOverTimeBucket {
     key: string;
     /** Human-readable label for legend / tooltip. */
     label: string;
-    spendUsd: number;
+    spendUsd: string;
   }>;
 }
 
@@ -175,12 +179,12 @@ const SORT_FIELD_TO_AGG_EXPR: Record<SpendSortField, string> = {
 const TEAM_ROW_SORT_KEYS: Record<
   SpendSortField,
   (row: {
-    thisSpend: number;
+    thisSpendNano: bigint;
     requestCount: number;
     lastActivityMs: number;
   }) => number
 > = {
-  spend: (r) => r.thisSpend,
+  spend: (r) => Number(r.thisSpendNano),
   requests: (r) => r.requestCount,
   lastActivity: (r) => r.lastActivityMs,
 };
@@ -191,7 +195,7 @@ export interface ActivityEventDetailRow {
   actor: string;
   action: string;
   target: string;
-  costUsd: number;
+  costUsd: string;
   tokensInput: number;
   tokensOutput: number;
   eventTimestampIso: string;
@@ -288,18 +292,28 @@ function startOfUtcDay(ms: number): number {
  * contains. Only unrepresentable values — `NaN`, `Infinity`, a string, an
  * object — collapse to 0, because those have no figure to show.
  */
-const ZERO_PULLED_USAGE = { cost_usd: 0, tokens_input: 0, tokens_output: 0 };
+const ZERO_PULLED_USAGE = {
+  cost_usd: "0",
+  tokens_input: 0,
+  tokens_output: 0,
+};
 
 const pulledUsageExtensionSchema = z
   .object({
-    cost_usd: z.coerce.number().finite().catch(0),
+    cost_usd: z
+      .union([z.string(), z.number()])
+      .transform((v) => {
+        const s = String(v);
+        return Number.isFinite(Number(s)) ? s : "0";
+      })
+      .catch("0"),
     tokens_input: z.coerce.number().finite().catch(0),
     tokens_output: z.coerce.number().finite().catch(0),
   })
   .catch(ZERO_PULLED_USAGE);
 
 function pulledUsageFromRawOcsf(rawPayload: string): {
-  costUsd: number;
+  costUsd: string;
   tokensInput: number;
   tokensOutput: number;
 } {
@@ -345,7 +359,7 @@ type PushedEventRow = {
   eventType: string;
   actor: string;
   target: string | null;
-  costUsd: number | string;
+  costUsd: string;
   tokensInput: number | string;
   tokensOutput: number | string;
   occurredMs: string;
@@ -372,7 +386,7 @@ function toPushedEvent(row: PushedEventRow): ActivityEventDetailRow {
     actor: row.actor ?? "",
     action: "trace.recorded",
     target: row.target ?? "",
-    costUsd: Number(row.costUsd ?? 0),
+    costUsd: String(row.costUsd ?? "0"),
     tokensInput: Number(row.tokensInput ?? 0),
     tokensOutput: Number(row.tokensOutput ?? 0),
     eventTimestampIso: new Date(Number(row.occurredMs)).toISOString(),
@@ -630,7 +644,7 @@ export class ActivityMonitorService {
     }>;
     return rows.map((r) => ({
       actor: r.actor,
-      spendUsd: Number(r.spendUsdStr),
+      spendUsd: r.spendUsdStr,
       requests: Number(r.requests),
       lastActivityIso: new Date(Number(r.lastActivityMs)).toISOString(),
       // Trend-vs-previous needs a windowed CTE comparison; deferred to 3b.
@@ -728,7 +742,7 @@ export class ActivityMonitorService {
 
     const acc = new Map<
       string,
-      { spendUsd: number; requestCount: number; lastActivityMs: number }
+      { spendNanoUsd: bigint; requestCount: number; lastActivityMs: number }
     >();
     for (const r of rows) {
       const hasPrincipalUser = r.actor !== "";
@@ -746,12 +760,12 @@ export class ActivityMonitorService {
           ? departmentId
           : UNASSIGNED_DEPARTMENT;
       const prior = acc.get(key) ?? {
-        spendUsd: 0,
+        spendNanoUsd: 0n,
         requestCount: 0,
         lastActivityMs: 0,
       };
       acc.set(key, {
-        spendUsd: prior.spendUsd + Number(r.spendUsdStr),
+        spendNanoUsd: prior.spendNanoUsd + usdToNanoUsd(r.spendUsdStr),
         requestCount: prior.requestCount + Number(r.requests),
         lastActivityMs: Math.max(
           prior.lastActivityMs,
@@ -767,14 +781,18 @@ export class ActivityMonitorService {
           key === UNASSIGNED_DEPARTMENT
             ? "Unassigned"
             : activeDepartmentNames.get(key)!,
-        spendUsd: v.spendUsd,
+        spendUsd: nanoUsdToDecimalString(v.spendNanoUsd),
         requestCount: v.requestCount,
         lastActivityIso:
           v.lastActivityMs > 0
             ? new Date(v.lastActivityMs).toISOString()
             : null,
       }))
-      .sort((a, b) => b.spendUsd - a.spendUsd);
+      .sort((a, b) => {
+        const aNano = usdToNanoUsd(a.spendUsd);
+        const bNano = usdToNanoUsd(b.spendUsd);
+        return bNano > aNano ? 1 : bNano < aNano ? -1 : 0;
+      });
   }
 
   private async activeDepartmentNames(
@@ -943,8 +961,8 @@ export class ActivityMonitorService {
       {
         teamId: string | null;
         teamName: string;
-        thisSpend: number;
-        prevSpend: number;
+        thisSpendNano: bigint;
+        prevSpendNano: bigint;
         requestCount: number;
         lastActivityMs: number;
         sourceCount: number;
@@ -955,14 +973,14 @@ export class ActivityMonitorService {
       const key = team ? team.id : ORG_WIDE_KEY;
       const teamId = team?.id ?? null;
       const teamName = team?.name ?? "Org-wide";
-      const thisSpend = Number(row.thisSpendStr);
-      const prevSpend = Number(row.prevSpendStr);
+      const thisSpendNano = usdToNanoUsd(row.thisSpendStr);
+      const prevSpendNano = usdToNanoUsd(row.prevSpendStr);
       const requestCount = Number(row.thisRequests);
       const lastActivityMs = Number(row.lastActivityMs);
       const existing = byTeam.get(key);
       if (existing) {
-        existing.thisSpend += thisSpend;
-        existing.prevSpend += prevSpend;
+        existing.thisSpendNano += thisSpendNano;
+        existing.prevSpendNano += prevSpendNano;
         existing.requestCount += requestCount;
         existing.sourceCount += 1;
         existing.lastActivityMs = Math.max(
@@ -973,8 +991,8 @@ export class ActivityMonitorService {
         byTeam.set(key, {
           teamId,
           teamName,
-          thisSpend,
-          prevSpend,
+          thisSpendNano,
+          prevSpendNano,
           requestCount,
           lastActivityMs,
           sourceCount: 1,
@@ -985,16 +1003,19 @@ export class ActivityMonitorService {
     const sortKey = TEAM_ROW_SORT_KEYS[sortBy];
     const sign = sortDir === "asc" ? 1 : -1;
     return [...byTeam.values()]
-      .filter((t) => t.thisSpend > 0 || t.requestCount > 0)
+      .filter((t) => t.thisSpendNano > 0n || t.requestCount > 0)
       .sort((a, b) => sign * (sortKey(a) - sortKey(b)))
       .slice(offset, offset + limit)
       .map((t) => ({
         teamId: t.teamId,
         teamName: t.teamName,
-        spendUsd: t.thisSpend,
+        spendUsd: nanoUsdToDecimalString(t.thisSpendNano),
         requestCount: t.requestCount,
-        deltaPctVsPriorWindow: pctChange(t.thisSpend, t.prevSpend),
-        hasPriorBaseline: t.prevSpend > 0,
+        deltaPctVsPriorWindow: pctChange(
+          Number(t.thisSpendNano),
+          Number(t.prevSpendNano),
+        ),
+        hasPriorBaseline: t.prevSpendNano > 0n,
         lastActivityIso:
           t.lastActivityMs > 0
             ? new Date(t.lastActivityMs).toISOString()
@@ -1104,7 +1125,11 @@ export class ActivityMonitorService {
     }>;
 
     let labelByKey: Map<string, { key: string; label: string }>;
-    let rolledRows: Array<{ bucketMs: number; key: string; spendUsd: number }>;
+    let rolledRows: Array<{
+      bucketMs: number;
+      key: string;
+      spendNanoUsd: bigint;
+    }>;
 
     if (input.groupBy === "team") {
       const sourceIds = Array.from(
@@ -1140,7 +1165,7 @@ export class ActivityMonitorService {
         rolledRows.push({
           bucketMs: Number(row.bucketMs),
           key,
-          spendUsd: Number(row.spendUsdStr),
+          spendNanoUsd: usdToNanoUsd(row.spendUsdStr),
         });
       }
     } else {
@@ -1153,24 +1178,24 @@ export class ActivityMonitorService {
         rolledRows.push({
           bucketMs: Number(row.bucketMs),
           key,
-          spendUsd: Number(row.spendUsdStr),
+          spendNanoUsd: usdToNanoUsd(row.spendUsdStr),
         });
       }
     }
 
     // Roll up (bucket, key) duplicates that come out of the team-side
     // sourceId → teamId remapping (multiple sources can share one team).
-    const aggregated = new Map<string, number>();
+    const aggregated = new Map<string, bigint>();
     for (const r of rolledRows) {
       const k = `${r.bucketMs}::${r.key}`;
-      aggregated.set(k, (aggregated.get(k) ?? 0) + r.spendUsd);
+      aggregated.set(k, (aggregated.get(k) ?? 0n) + r.spendNanoUsd);
     }
 
     const buckets = emptyDenseBuckets(windowStart, windowDays);
     const bucketIndexByMs = new Map(
       buckets.map((b, i) => [Date.parse(b.bucketIso), i] as const),
     );
-    for (const [composite, spendUsd] of aggregated.entries()) {
+    for (const [composite, spendNanoUsd] of aggregated.entries()) {
       const sep = composite.indexOf("::");
       const bucketMs = Number(composite.slice(0, sep));
       const key = composite.slice(sep + 2);
@@ -1178,11 +1203,11 @@ export class ActivityMonitorService {
       if (idx === undefined) continue;
       const meta = labelByKey.get(key);
       if (!meta) continue;
-      if (spendUsd <= 0) continue;
+      if (spendNanoUsd <= 0n) continue;
       buckets[idx]!.points.push({
         key: meta.key,
         label: meta.label,
-        spendUsd,
+        spendUsd: nanoUsdToDecimalString(spendNanoUsd),
       });
     }
 
@@ -1190,7 +1215,11 @@ export class ActivityMonitorService {
     // contributor renders at the bottom of the stacked area (Recharts
     // stacks in array order; bottom-up = largest-first).
     for (const bucket of buckets) {
-      bucket.points.sort((a, b) => b.spendUsd - a.spendUsd);
+      bucket.points.sort((a, b) => {
+        const aN = usdToNanoUsd(a.spendUsd);
+        const bN = usdToNanoUsd(b.spendUsd);
+        return bN > aN ? 1 : bN < aN ? -1 : 0;
+      });
     }
 
     return { buckets };

--- a/platform/app/ee/governance/services/activity-monitor/canonicalCostExtractor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/canonicalCostExtractor.service.ts
@@ -147,16 +147,7 @@ function numberOr(v: unknown, fallback: number): number {
   return fallback;
 }
 
-function numberOrNull(v: unknown): number | null {
-  if (typeof v === "number" && Number.isFinite(v)) return v;
-  if (typeof v === "string") {
-    const n = Number(v);
-    return Number.isFinite(n) ? n : null;
-  }
-  return null;
-}
-
-/** Like `numberOrNull`, but returns the value as a decimal string so USD
+/** Like `numberOr`, but returns the value as a decimal string so USD
  *  amounts are never narrowed to a lossy float. A numeric OTLP value is
  *  stringified; a string that parses as a finite number is kept verbatim. */
 function costUsdStringOrNull(v: unknown): string | null {

--- a/platform/app/ee/governance/services/activity-monitor/canonicalCostExtractor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/canonicalCostExtractor.service.ts
@@ -34,7 +34,7 @@ import type {
 } from "@opentelemetry/otlp-transformer";
 
 export interface CanonicalCostEvent {
-  costUsd: number;
+  costUsd: string;
   model: string;
   inputTokens: number;
   outputTokens: number;
@@ -112,7 +112,7 @@ function tryParseEvent(
   const recordAttrs = mergeAttributes(record.attributes ?? []);
   const merged = { ...resourceAttrs, ...recordAttrs };
   const requestId = stringOrNull(merged[F.REQUEST_ID]);
-  const costUsd = numberOrNull(merged[F.COST_USD]);
+  const costUsd = costUsdStringOrNull(merged[F.COST_USD]);
   if (!requestId || costUsd === null) {
     // Without these two, the row can't be inserted idempotently or
     // costed. The receiver still hands the LogRecord to the trace
@@ -152,6 +152,18 @@ function numberOrNull(v: unknown): number | null {
   if (typeof v === "string") {
     const n = Number(v);
     return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Like `numberOrNull`, but returns the value as a decimal string so USD
+ *  amounts are never narrowed to a lossy float. A numeric OTLP value is
+ *  stringified; a string that parses as a finite number is kept verbatim. */
+function costUsdStringOrNull(v: unknown): string | null {
+  if (typeof v === "number" && Number.isFinite(v)) return String(v);
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? v : null;
   }
   return null;
 }

--- a/platform/app/ee/governance/services/activity-monitor/canonicalCostExtractor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/canonicalCostExtractor.service.ts
@@ -162,8 +162,10 @@ function numberOrNull(v: unknown): number | null {
 function costUsdStringOrNull(v: unknown): string | null {
   if (typeof v === "number" && Number.isFinite(v)) return String(v);
   if (typeof v === "string") {
-    const n = Number(v);
-    return Number.isFinite(n) ? v : null;
+    const trimmed = v.trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? trimmed : null;
   }
   return null;
 }

--- a/platform/app/ee/governance/services/pullers/__tests__/httpPollingPullerAdapter.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/httpPollingPullerAdapter.unit.test.ts
@@ -157,7 +157,7 @@ describe("HttpPollingPullerAdapter", () => {
         actor: "alice@acme.test",
         action: "completion",
         target: "gpt-5-mini",
-        cost_usd: 0.0023,
+        cost_usd: "0.0023",
         tokens_input: 50,
         tokens_output: 12,
       });

--- a/platform/app/ee/governance/services/pullers/__tests__/pulledUsageRecord.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pulledUsageRecord.unit.test.ts
@@ -35,7 +35,7 @@ function usageEvent({
     actor: "",
     action: "usage_report",
     target: "anthropic/claude-sonnet-5",
-    cost_usd: 0,
+    cost_usd: "0",
     tokens_input: 120_000,
     tokens_output: 8_000,
     raw_payload: "{}",
@@ -109,7 +109,7 @@ describe("building one pulled usage record", () => {
       const record = buildPulledUsageRecord({
         event: usageEvent({
           overrides: {
-            cost_usd: 42.5,
+            cost_usd: "42.5",
             action: "cost_report",
             tokens_input: 0,
             tokens_output: 0,
@@ -131,7 +131,7 @@ describe("building one pulled usage record", () => {
         event: usageEvent({
           // What the canonical `cost_usd: number` field could still carry
           // after a provider's string went through a JS float.
-          overrides: { cost_usd: 1.1, action: "cost_report" },
+          overrides: { cost_usd: "1.1", action: "cost_report" },
           hint: {
             costBasis: "provider_reported",
             costStatus: "exact",
@@ -156,7 +156,7 @@ describe("building one pulled usage record", () => {
       const corrected = buildPulledUsageRecord({
         event: usageEvent({
           overrides: {
-            cost_usd: 99,
+            cost_usd: "99",
             tokens_input: 999_999,
             tokens_output: 999_999,
           },
@@ -296,7 +296,7 @@ describe("building one pulled usage record", () => {
       expect(() =>
         buildPulledUsageRecord({
           event: usageEvent({
-            overrides: { cost_usd: 1 },
+            overrides: { cost_usd: "1" },
             hint: { costBasis: "provider_reported" },
           }),
           source: SOURCE,

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts
@@ -31,7 +31,7 @@ const baseEvent: NormalizedPullEvent = {
   actor: "alice@acme.test",
   action: "completion",
   target: "gpt-5-mini",
-  cost_usd: 0.0023,
+  cost_usd: "0.0023",
   tokens_input: 50,
   tokens_output: 12,
   raw_payload: '{"id":"evt-123","raw":"data"}',

--- a/platform/app/ee/governance/services/pullers/__tests__/s3PollingPullerAdapter.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/s3PollingPullerAdapter.unit.test.ts
@@ -188,7 +188,7 @@ describe("S3PollingPullerAdapter", () => {
       });
       expect(result.events[2]).toMatchObject({
         source_event_id: "e3",
-        cost_usd: 0.003,
+        cost_usd: "0.003",
       });
     });
 

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -182,7 +182,7 @@ const usageResultSchema = z
 /** One group-by row inside a cost bucket. `amount` is a decimal string. */
 const costResultSchema = z
   .object({
-    amount: z.union([z.string(), z.number()]),
+    amount: z.union([z.string(), z.number()]).transform(String),
     currency: z.string().default("USD"),
     workspace_id: z.string().nullable().default(null),
     description: z.string().nullable().default(null),
@@ -472,7 +472,7 @@ export class AnthropicAdminPuller
       action: "usage_report",
       target: dimension(result.model),
       // Anthropic reports no cost on this report; we price the quantities.
-      cost_usd: 0,
+      cost_usd: "0",
       tokens_input: result.uncached_input_tokens,
       tokens_output: result.output_tokens,
       raw_payload: JSON.stringify(result),
@@ -522,16 +522,16 @@ export class AnthropicAdminPuller
       );
       return null;
     }
-    const amount = String(result.amount);
+    const amount = result.amount;
     return {
       source_event_id: `cost:${startingAt}:${dimensionPath(dimensions)}`,
       event_timestamp: startingAt,
       actor: "",
       action: "cost_report",
       target: dimension(result.model),
-      // Kept as a number for the canonical shape; the exact string rides the
-      // hint below, and that is the one the record is priced from.
-      cost_usd: Number(amount),
+      // Decimal string — no Number() coercion. The exact value rides through
+      // to the pricing service via the hint below.
+      cost_usd: amount,
       tokens_input: 0,
       tokens_output: 0,
       raw_payload: JSON.stringify(result),

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -1672,7 +1672,7 @@ export class DatabricksGeniePuller
       // Genie bills nothing per message. See the file header: the warehouse
       // DBUs the generated SQL burns are billed elsewhere and are not on this
       // API, so the record says zero and declines to call it the full invoice.
-      cost_usd: 0,
+      cost_usd: "0",
       tokens_input: 0,
       tokens_output: 0,
       raw_payload: JSON.stringify(message),

--- a/platform/app/ee/governance/services/pullers/httpPollingPullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/httpPollingPullerAdapter.ts
@@ -368,7 +368,7 @@ export class HttpPollingPullerAdapter
       actor: asString(get(config.eventMapping.actor)),
       action: asString(get(config.eventMapping.action)),
       target: asString(get(config.eventMapping.target)),
-      cost_usd: asNumber(get(config.eventMapping.cost_usd)),
+      cost_usd: String(asNumber(get(config.eventMapping.cost_usd))),
       tokens_input: asInt(get(config.eventMapping.tokens_input)),
       tokens_output: asInt(get(config.eventMapping.tokens_output)),
       raw_payload: JSON.stringify(rawEvent),

--- a/platform/app/ee/governance/services/pullers/httpPollingPullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/httpPollingPullerAdapter.ts
@@ -353,6 +353,17 @@ export class HttpPollingPullerAdapter
       const n = typeof v === "number" ? v : Number(v);
       return Number.isFinite(n) ? n : 0;
     };
+    /** Preserves string inputs so sub-cent precision is not lost through
+     *  a float round-trip. Falls back to Number→String for numeric inputs. */
+    const asDecimalString = (v: unknown): string => {
+      if (typeof v === "string") {
+        const trimmed = v.trim();
+        if (trimmed === "") return "0";
+        return trimmed;
+      }
+      if (typeof v === "number" && Number.isFinite(v)) return String(v);
+      return "0";
+    };
     const asInt = (v: unknown): number => Math.trunc(asNumber(v));
 
     const extras: Record<string, unknown> = {};
@@ -368,7 +379,7 @@ export class HttpPollingPullerAdapter
       actor: asString(get(config.eventMapping.actor)),
       action: asString(get(config.eventMapping.action)),
       target: asString(get(config.eventMapping.target)),
-      cost_usd: String(asNumber(get(config.eventMapping.cost_usd))),
+      cost_usd: asDecimalString(get(config.eventMapping.cost_usd)),
       tokens_input: asInt(get(config.eventMapping.tokens_input)),
       tokens_output: asInt(get(config.eventMapping.tokens_output)),
       raw_payload: JSON.stringify(rawEvent),

--- a/platform/app/ee/governance/services/pullers/pullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/pullerAdapter.ts
@@ -57,8 +57,12 @@ export const normalizedPullEventSchema = z.object({
   action: z.string(),
   /** Target of the action (e.g. model name, tool name, document id). */
   target: z.string(),
-  /** USD cost (0 if the source doesn't expose it). */
-  cost_usd: z.number().nonnegative().default(0),
+  /** USD cost as a decimal string ("0" if the source doesn't expose it).
+   *  Kept as a string so sub-cent amounts survive without float rounding. */
+  cost_usd: z
+    .union([z.string(), z.number()])
+    .transform((v) => String(v))
+    .default("0"),
   /** Input tokens (0 if unknown). */
   tokens_input: z.number().nonnegative().int().default(0),
   /** Output tokens (0 if unknown). */

--- a/platform/app/ee/governance/services/pullers/pullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/pullerAdapter.ts
@@ -40,6 +40,29 @@
 import { z } from "zod";
 
 /**
+ * Matches `wireMoney.ts`'s DECIMAL_PATTERN — the same shape `usdToNanoUsd`
+ * accepts. Anchored so the schema rejects values the downstream converter
+ * would throw on (`"banana"`, `"0x1a"`, etc.) at the parse boundary instead
+ * of deep in the pricing service.
+ */
+const COST_USD_PATTERN = /^[+-]?\d*(?:\.\d*)?(?:[eE][+-]?\d+)?$/;
+
+/** Validates and stringifies a cost_usd value at the Zod boundary. */
+const costUsdSchema = z
+  .union([z.string(), z.number()])
+  .transform((v) => {
+    const s = String(v).trim();
+    if (s === "" || s === "0" || s === "0.0") return "0";
+    if (!COST_USD_PATTERN.test(s)) return "0";
+    // Reject negative costs — adapters currently only produce non-negative.
+    // If credits/refunds are needed, this guard should be removed explicitly.
+    const n = Number(s);
+    if (!Number.isFinite(n) || n < 0) return "0";
+    return s;
+  })
+  .default("0");
+
+/**
  * Canonical event shape produced by every adapter. Downstream code
  * (worker handoff to trace-store) doesn't care which adapter produced
  * the event — it only cares about this canonical shape. New fields
@@ -58,11 +81,9 @@ export const normalizedPullEventSchema = z.object({
   /** Target of the action (e.g. model name, tool name, document id). */
   target: z.string(),
   /** USD cost as a decimal string ("0" if the source doesn't expose it).
-   *  Kept as a string so sub-cent amounts survive without float rounding. */
-  cost_usd: z
-    .union([z.string(), z.number()])
-    .transform((v) => String(v))
-    .default("0"),
+   *  Kept as a string so sub-cent amounts survive without float rounding.
+   *  Validated against DECIMAL_PATTERN and nonnegative at the parse boundary. */
+  cost_usd: costUsdSchema,
   /** Input tokens (0 if unknown). */
   tokens_input: z.number().nonnegative().int().default(0),
   /** Output tokens (0 if unknown). */

--- a/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
@@ -401,7 +401,7 @@ export class S3PollingPullerAdapter implements PullerAdapter<S3PollingConfig> {
       actor: asString(get(config.eventMapping.actor)),
       action: asString(get(config.eventMapping.action)),
       target: asString(get(config.eventMapping.target)),
-      cost_usd: asNumber(get(config.eventMapping.cost_usd)),
+      cost_usd: String(asNumber(get(config.eventMapping.cost_usd))),
       tokens_input: asInt(get(config.eventMapping.tokens_input)),
       tokens_output: asInt(get(config.eventMapping.tokens_output)),
       raw_payload: JSON.stringify(rawEvent),

--- a/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
@@ -386,6 +386,17 @@ export class S3PollingPullerAdapter implements PullerAdapter<S3PollingConfig> {
       const n = typeof v === "number" ? v : Number(v);
       return Number.isFinite(n) ? n : 0;
     };
+    /** Preserves string inputs so sub-cent precision is not lost through
+     *  a float round-trip. Falls back to Number→String for numeric inputs. */
+    const asDecimalString = (v: unknown): string => {
+      if (typeof v === "string") {
+        const trimmed = v.trim();
+        if (trimmed === "") return "0";
+        return trimmed;
+      }
+      if (typeof v === "number" && Number.isFinite(v)) return String(v);
+      return "0";
+    };
     const asInt = (v: unknown): number => Math.trunc(asNumber(v));
 
     const extras: Record<string, unknown> = {};
@@ -401,7 +412,7 @@ export class S3PollingPullerAdapter implements PullerAdapter<S3PollingConfig> {
       actor: asString(get(config.eventMapping.actor)),
       action: asString(get(config.eventMapping.action)),
       target: asString(get(config.eventMapping.target)),
-      cost_usd: String(asNumber(get(config.eventMapping.cost_usd))),
+      cost_usd: asDecimalString(get(config.eventMapping.cost_usd)),
       tokens_input: asInt(get(config.eventMapping.tokens_input)),
       tokens_output: asInt(get(config.eventMapping.tokens_output)),
       raw_payload: JSON.stringify(rawEvent),

--- a/platform/app/src/components/governance/SpendByTeamBar.tsx
+++ b/platform/app/src/components/governance/SpendByTeamBar.tsx
@@ -21,10 +21,10 @@ export function SpendByTeamBar({
   teams: Array<{
     teamId: string | null;
     teamName: string;
-    spendUsd: number;
+    spendUsd: string;
   }>;
 }) {
-  const total = teams.reduce((sum, t) => sum + t.spendUsd, 0);
+  const total = teams.reduce((sum, t) => sum + Number(t.spendUsd), 0);
   if (total === 0 || teams.length === 0) {
     return null;
   }
@@ -47,7 +47,7 @@ export function SpendByTeamBar({
         borderColor="border.subtle"
       >
         {teams.map((t) => {
-          const pct = (t.spendUsd / total) * 100;
+          const pct = (Number(t.spendUsd) / total) * 100;
           const color = getHexColorForString(t.teamName);
           return (
             <Box
@@ -55,7 +55,7 @@ export function SpendByTeamBar({
               width={`${pct}%`}
               backgroundColor={color}
               opacity={0.9}
-              title={`${t.teamName} — ${numeral(t.spendUsd).format(
+              title={`${t.teamName} — ${numeral(Number(t.spendUsd)).format(
                 "$0,0.00",
               )} (${pct.toFixed(1)}%)`}
               _hover={{ opacity: 1 }}
@@ -65,7 +65,7 @@ export function SpendByTeamBar({
       </Box>
       <HStack wrap="wrap" gap={3} fontSize="xs">
         {teams.map((t) => {
-          const pct = (t.spendUsd / total) * 100;
+          const pct = (Number(t.spendUsd) / total) * 100;
           const color = getHexColorForString(t.teamName);
           return (
             <HStack key={t.teamId ?? t.teamName} gap={1.5}>

--- a/platform/app/src/components/governance/SpendOverTimeChart.tsx
+++ b/platform/app/src/components/governance/SpendOverTimeChart.tsx
@@ -24,7 +24,7 @@ import { getHexColorForString } from "~/utils/rotatingColors";
  */
 export interface SpendOverTimeBucket {
   bucketIso: string;
-  points: Array<{ key: string; label: string; spendUsd: number }>;
+  points: Array<{ key: string; label: string; spendUsd: string }>;
 }
 
 export type GroupBy = "team" | "user" | "model";

--- a/platform/app/src/pages/governance/index.tsx
+++ b/platform/app/src/pages/governance/index.tsx
@@ -65,8 +65,10 @@ type SpendByTeam = RouterOutputs["activityMonitor"]["spendByTeam"][number];
 type SpendByDepartment =
   RouterOutputs["activityMonitor"]["spendByDepartment"][number];
 
-const fmtUsd = (n: number) =>
-  n === 0 ? "$0.00" : numeral(n).format("$0,0.00");
+const fmtUsd = (n: number | string) => {
+  const v = typeof n === "string" ? Number(n) : n;
+  return v === 0 ? "$0.00" : numeral(v).format("$0,0.00");
+};
 
 const fmtRelative = (date: Date | string | null): string => {
   if (!date) return "-";

--- a/platform/app/src/pages/governance/teams.tsx
+++ b/platform/app/src/pages/governance/teams.tsx
@@ -70,8 +70,10 @@ function SortChip({
   );
 }
 
-const fmtUsd = (n: number) =>
-  n === 0 ? "$0.00" : numeral(n).format("$0,0.00");
+const fmtUsd = (n: number | string) => {
+  const v = typeof n === "string" ? Number(n) : n;
+  return v === 0 ? "$0.00" : numeral(v).format("$0,0.00");
+};
 
 const fmtRelative = (date: Date | string | null): string => {
   if (!date) return "—";

--- a/platform/app/src/pages/governance/teams/[id].tsx
+++ b/platform/app/src/pages/governance/teams/[id].tsx
@@ -19,8 +19,10 @@ import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { getHexColorForString } from "~/utils/rotatingColors";
 
-const fmtUsd = (n: number) =>
-  n === 0 ? "$0.00" : numeral(n).format("$0,0.00");
+const fmtUsd = (n: number | string) => {
+  const v = typeof n === "string" ? Number(n) : n;
+  return v === 0 ? "$0.00" : numeral(v).format("$0,0.00");
+};
 
 const fmtRelative = (date: Date | string | null): string => {
   if (!date) return "—";

--- a/platform/app/src/pages/governance/users.tsx
+++ b/platform/app/src/pages/governance/users.tsx
@@ -64,8 +64,10 @@ function SortChip({
   );
 }
 
-const fmtUsd = (n: number) =>
-  n === 0 ? "$0.00" : numeral(n).format("$0,0.00");
+const fmtUsd = (n: number | string) => {
+  const v = typeof n === "string" ? Number(n) : n;
+  return v === 0 ? "$0.00" : numeral(v).format("$0,0.00");
+};
 
 const fmtRelative = (date: Date | string | null): string => {
   if (!date) return "—";

--- a/platform/app/src/pages/governance/users/[id].tsx
+++ b/platform/app/src/pages/governance/users/[id].tsx
@@ -19,8 +19,10 @@ import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { getHexColorForString } from "~/utils/rotatingColors";
 
-const fmtUsd = (n: number) =>
-  n === 0 ? "$0.00" : numeral(n).format("$0,0.00");
+const fmtUsd = (n: number | string) => {
+  const v = typeof n === "string" ? Number(n) : n;
+  return v === 0 ? "$0.00" : numeral(v).format("$0,0.00");
+};
 
 const fmtRelative = (date: Date | string | null): string => {
   if (!date) return "—";

--- a/platform/app/src/server/gateway/budget.clickhouse.repository.ts
+++ b/platform/app/src/server/gateway/budget.clickhouse.repository.ts
@@ -838,7 +838,7 @@ export class GatewayBudgetClickHouseRepository {
       const seen = existing.get(pulledRequestId(row.restatementKey));
       if (!seen) return true;
       return !(
-        Number(seen.AmountNanoUSD) === row.amountNanoUsd &&
+        BigInt(seen.AmountNanoUSD ?? 0) === BigInt(row.amountNanoUsd) &&
         Number(seen.TokensInput) === row.tokensInput &&
         Number(seen.TokensOutput) === row.tokensOutput &&
         Number(seen.TokensCacheRead) === row.tokensCacheRead &&

--- a/platform/app/src/server/routes/ingest/ingestionRoutes.ts
+++ b/platform/app/src/server/routes/ingest/ingestionRoutes.ts
@@ -785,6 +785,18 @@ secured
                 // an integer once, here, and every total downstream adds
                 // those integers rather than re-deriving from decimals.
                 const nano = usdToNanoUsd(event.costUsd);
+                const nanoNum = Number(nano);
+                if (!Number.isSafeInteger(nanoNum)) {
+                  logger.error(
+                    {
+                      costUsd: event.costUsd,
+                      nanoUsd: nano.toString(),
+                      requestId: event.requestId,
+                    },
+                    "budget: amountNanoUsd exceeds Number.MAX_SAFE_INTEGER, skipping debit row to avoid silent rounding",
+                  );
+                  continue;
+                }
                 const rows = budgets.map((b) => ({
                   tenantId: govProject.id,
                   budgetId: b.id,
@@ -793,7 +805,7 @@ secured
                   window: b.window,
                   virtualKeyId: sentinelVK,
                   gatewayRequestId: event.requestId,
-                  amountNanoUsd: Number(nano),
+                  amountNanoUsd: nanoNum,
                   tokensInput: event.inputTokens,
                   tokensOutput: event.outputTokens,
                   tokensCacheRead: event.cacheReadTokens,

--- a/platform/app/src/server/routes/ingest/ingestionRoutes.ts
+++ b/platform/app/src/server/routes/ingest/ingestionRoutes.ts
@@ -781,10 +781,10 @@ secured
                 ).filter((b) => b.scopeType !== "ATTRIBUTED_USER");
                 if (budgets.length === 0) continue;
 
-                // The reported cost is a float the caller sent, so it is
-                // pinned to an integer once, here, and every total downstream
-                // adds those integers rather than re-deriving from decimals.
-                const nano = usdToNanoUsd(event.costUsd.toFixed(10));
+                // The reported cost is a decimal string, so it is pinned to
+                // an integer once, here, and every total downstream adds
+                // those integers rather than re-deriving from decimals.
+                const nano = usdToNanoUsd(event.costUsd);
                 const rows = budgets.map((b) => ({
                   tenantId: govProject.id,
                   budgetId: b.id,


### PR DESCRIPTION
# Related Issue

- Resolves #1090

## For humans

Money amounts in the governance layer were typed as JavaScript `number` (IEEE 754 float), which quietly rounds sub-cent amounts past ~15 significant digits and drifts when accumulated. This makes every USD field a decimal **string** and routes accumulation through exact **nano-USD integer** arithmetic using the existing `wireMoney.ts` primitives.

No user-visible behavior change — the same numbers reach the dashboard, they just arrive without the float rounding they carried before.

## What changed

**19 lossy `Number()` sites fixed across 5 core files:**

| File | Sites | Fix |
|---|---|---|
| `activityMonitor.service.ts` | 12 | Interfaces `spendUsd`/`costUsd` → `string`; accumulators use `usdToNanoUsd()`/`nanoUsdToDecimalString()` instead of float addition; Zod schema validates as string with finite-number guard |
| `canonicalCostExtractor.service.ts` | 2 | `CanonicalCostEvent.costUsd` → `string`; new `costUsdStringOrNull()` preserves decimal strings from OTLP attrs |
| `anthropicAdmin.puller.ts` | 2 | `amount` schema → `.transform(String)`; removed `Number(amount)` coercion |
| `pulled-usage-pricing.service.ts` | 2 | `ProviderReportedPrice.costUsd` → `string` only |
| `budget.clickhouse.repository.ts` | 1 | `AmountNanoUSD` comparison via `BigInt()` instead of lossy `Number()` |

**Consumer updates (type-driven, no logic change):**
- `pullerAdapter.ts`: `NormalizedPullEvent.cost_usd` accepts `string|number`, validates against `DECIMAL_PATTERN`, rejects negatives
- 3 puller adapters, `ingestionRoutes.ts`, 6 frontend files: updated for string types
- `fmtUsd()` in 5 governance pages: accepts `number | string`

## Failing test output (before fix)

```
FAIL  moneyTypeLossless.unit.test.ts
  ✗ preserves the cost as a string, not a lossy Number()
    Expected: "string"  Received: "number"
  ✗ keeps spendUsd as a string, not Number()
    Expected: "string"  Received: "number"
  ✗ accumulates through nano-USD integers, not float addition
    Expected: "string"  Received: "number"
```

## Passing test output (after fix)

```
Test Files  43 passed (43)
     Tests  323 passed (323)
```

Typecheck: clean.

Closes langwatch/langwatch-saas#1090

## Follow-up fixes (review-driven)

- **Empty-string guard** (`30d7899`): `""` passed `Number.isFinite(Number(""))` since `Number("") === 0`. Added `s !== ""` guard in the Zod schema transform and `trimmed === ""` guard in `costUsdStringOrNull`.
- **Safe-integer guard** (`aa402e5`): `Number(nano)` in the budget debit path (`ingestionRoutes.ts:796`) silently rounds bigints above `MAX_SAFE_INTEGER`. Added `Number.isSafeInteger()` check — skips the debit row with an error log instead of rounding.
- **Test coverage** (`538ea51`): updated integration and unit test files for string money types.
- **Restored cost_usd validation + removed float round-trip** (`ab4ae98`): `normalizedPullEventSchema.cost_usd` now validates against `DECIMAL_PATTERN` and rejects negative values at the schema boundary (was `z.string()` accepting anything). HTTP and S3 polling adapters replaced `String(asNumber(...))` with `asDecimalString()` to preserve string inputs without a lossy `Number()` round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monetary values are now preserved as decimal strings across usage, spend, and activity-monitor data.
  * Governance dashboards and charts support formatted currency values from numeric or string inputs.
* **Bug Fixes**
  * Improved accuracy for cost aggregation, comparisons, sorting, and ledger calculations.
  * Invalid cost values fall back to zero while valid negative and decimal amounts are preserved.
* **Tests**
  * Added regression coverage for precise cost handling across events, user spend, and department totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
