### PR TITLE
fix(governance): change governance_kpis ReplacingMergeTree version column from LastEventOccurredAt to CreatedAt

### DIFF
--- a/platform/app/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -35,6 +35,7 @@ const NOT_ON_A_READ_PATH = new Set<string>([
   "gateway_budget_scope_totals_rebuild",
   "trace_analytics_rollup_rebuild",
   "evaluation_analytics_rollup_rebuild",
+  "governance_kpis_v2", // transient: created by 00083, immediately renamed to governance_kpis
 ]);
 
 /**

--- a/platform/app/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/__tests__/cold-scan-detector.coverage.unit.test.ts
@@ -35,7 +35,7 @@ const NOT_ON_A_READ_PATH = new Set<string>([
   "gateway_budget_scope_totals_rebuild",
   "trace_analytics_rollup_rebuild",
   "evaluation_analytics_rollup_rebuild",
-  "governance_kpis_v2", // transient: created by 00083, immediately renamed to governance_kpis
+  "governance_kpis_v2", // scratch: 00083 builds into it, swaps it in, then drops it
 ]);
 
 /**

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -10,13 +10,16 @@
  * are plain `sum(SpendUsd)` with no `FINAL` and no `argMax`, so nothing
  * compensated.
  *
- * These tests run the real migration file against a real `governance_kpis`,
- * staged into its pre-upgrade state, because the two things that can actually
- * break are properties of the swap procedure and not of ClickHouse:
- *   - the copy reads a snapshot, so a write arriving mid-migration must still
- *     survive (the reconciliation pass),
- *   - the runner may re-apply a partially executed file, so a second run must
- *     converge rather than wedge.
+ * The swap is a copy-and-EXCHANGE. It is only lossless if the KPI writer is
+ * QUIESCED while it runs: the writer inserts with async_insert = 1,
+ * wait_for_async_insert = 0 and is event-driven per trace (it never re-emits),
+ * so a contribution written mid-migration lands only in the pre-swap table and
+ * is lost for good when that table is dropped. No in-migration reconciliation
+ * can close that window — an async buffer can always flush between the last
+ * read and the DROP — so the migration does not try; it depends on the writer
+ * being stopped, and GUARDS that precondition (step 0) by aborting if
+ * `governance_kpis` shows a write in the last 60s. These tests exercise both
+ * the quiesced happy path and that guard.
  *
  * On its OWN endpoint, not the shared migrated one. Staging the pre-upgrade
  * state means dropping and recreating `governance_kpis`, and the shared
@@ -62,6 +65,34 @@ async function insertKpiRows(rows: KpiRow[]): Promise<void> {
       SourceType: "api_key",
       ...row,
     })),
+    format: "JSONEachRow",
+  });
+}
+
+/**
+ * Inserts a row the way the live writer would: no explicit `CreatedAt`, so the
+ * table's `DEFAULT now64(3)` stamps it at the current wall clock. This is what
+ * the step-0 guard is meant to see — a write that just happened — and it is
+ * the only thing in the suite dated to "now" rather than the fixed
+ * 2026-08-01 staging timestamps.
+ */
+async function insertLiveKpiRow(traceId: string): Promise<void> {
+  await ch.insert({
+    table: "governance_kpis",
+    values: [
+      {
+        TenantId: tenantId,
+        SourceId: sourceId,
+        HourBucket: hourBucket,
+        SourceType: "api_key",
+        TraceId: traceId,
+        SpendUsd: 0.5,
+        PromptTokens: 100,
+        CompletionTokens: 50,
+        // CreatedAt intentionally omitted -> DEFAULT now64(3).
+        LastEventOccurredAt: "2026-08-01 10:05:00.000",
+      },
+    ],
     format: "JSONEachRow",
   });
 }
@@ -118,62 +149,42 @@ afterAll(async () => {
 });
 
 describe("governance_kpis version column migration", () => {
-  describe("given the pre-upgrade table holds rows and a write lands mid-migration", () => {
-    /**
-     * Whether the injected write actually happened. Without this the whole
-     * test passes vacuously if the copy statement is ever renamed or
-     * reordered — the hook would simply never fire and the assertion below
-     * would be checking a row nobody raced.
-     */
-    let injectedDuringCopy = false;
-
+  describe("given the writer is quiesced and the pre-upgrade table holds rows", () => {
     beforeAll(async () => {
-      injectedDuringCopy = false;
       await stageThePreUpgradeTable();
-
+      // Staging timestamps are ~weeks before the test clock, so they never
+      // trip the step-0 recent-write guard.
       await insertKpiRows([
         {
-          TraceId: "trace-copied",
+          TraceId: "trace-a",
           SpendUsd: 0.25,
           PromptTokens: 100,
           CompletionTokens: 50,
           CreatedAt: "2026-08-01 10:00:01.000",
           LastEventOccurredAt: "2026-08-01 10:05:00.000",
         },
+        {
+          TraceId: "trace-b",
+          SpendUsd: 1.75,
+          PromptTokens: 300,
+          CompletionTokens: 150,
+          CreatedAt: "2026-08-01 10:00:02.000",
+          LastEventOccurredAt: "2026-08-01 10:06:00.000",
+        },
       ]);
 
+      // No afterStatement hook: the writer is stopped, nothing races the copy.
       await replayGooseMigrationUp({
         client: ch,
         fileName: VERSION_COLUMN_MIGRATION,
-        afterStatement: async ({ statement }) => {
-          // The copy is the statement that opens the loss window: everything
-          // written from here until the swap lands only in the pre-swap table.
-          if (!/INSERT INTO\s+\S*governance_kpis_v2/i.test(statement)) return;
-          injectedDuringCopy = true;
-          await insertKpiRows([
-            {
-              TraceId: "trace-raced-the-copy",
-              SpendUsd: 0.75,
-              PromptTokens: 300,
-              CompletionTokens: 150,
-              CreatedAt: "2026-08-01 10:00:02.000",
-              LastEventOccurredAt: "2026-08-01 09:55:00.000",
-            },
-          ]);
-        },
       });
     }, 120_000);
 
-    it("keeps both the copied row and the one that raced the copy", async () => {
-      expect(injectedDuringCopy).toBe(true);
-
+    it("preserves every row through the swap", async () => {
       const rows = await readKpiRows();
 
-      expect(rows.map((row) => row.TraceId)).toEqual([
-        "trace-copied",
-        "trace-raced-the-copy",
-      ]);
-      expect(rows.map((row) => row.SpendUsd)).toEqual([0.25, 0.75]);
+      expect(rows.map((row) => row.TraceId)).toEqual(["trace-a", "trace-b"]);
+      expect(rows.map((row) => row.SpendUsd)).toEqual([0.25, 1.75]);
     });
 
     it("versions the rebuilt table by CreatedAt", async () => {
@@ -198,10 +209,7 @@ describe("governance_kpis version column migration", () => {
     it("converges on the same rows rather than failing", async () => {
       const rows = await readKpiRows();
 
-      expect(rows.map((row) => row.TraceId)).toEqual([
-        "trace-copied",
-        "trace-raced-the-copy",
-      ]);
+      expect(rows.map((row) => row.TraceId)).toEqual(["trace-a", "trace-b"]);
       expect(await versionColumnOf("governance_kpis")).toContain(
         "ReplacingMergeTree(CreatedAt)",
       );
@@ -244,147 +252,43 @@ describe("governance_kpis version column migration", () => {
       expect(refolded[0]!.PromptTokens).toBe(300);
     });
   });
-  describe("given a previous run died after the swap, with a write that landed during the copy", () => {
+
+  describe("given the writer was NOT quiesced (a write landed within the guard window)", () => {
     /**
-     * The loss window a naive re-apply reopens: a write that lands AFTER the
-     * snapshot copy exists only in the pre-swap table, which the exchange
-     * moves under the scratch name. If the runner then dies before
-     * reconciliation, the first draft's unconditional `DROP` at the top of the
-     * re-apply would discard that write for good. The `trace-before-the-crash`
-     * row (copied into the snapshot) survives either way; `trace-stranded-by-
-     * the-crash` (raced the copy, then stranded by the crash) is the one that
-     * only survives because the re-apply recovers the scratch before dropping
-     * it. Without both flags below the test could pass vacuously — the copy
-     * hook or the crash hook silently never firing.
+     * The step-0 backstop. If an operator applies this without stopping the
+     * `workers` deployment first, the live writer is still inserting and the
+     * copy-and-swap would drop whatever it wrote during the window. The guard
+     * turns that silent loss into a loud, no-op failure: it aborts BEFORE any
+     * DDL, so the table is left exactly as it was.
      */
-    let crashedAfterExchange = false;
-    let racedAfterCopy = false;
+    let rejection: unknown;
 
     beforeAll(async () => {
       await stageThePreUpgradeTable();
-      await insertKpiRows([
-        {
-          TraceId: "trace-before-the-crash",
-          SpendUsd: 2,
-          PromptTokens: 10,
-          CompletionTokens: 5,
-          CreatedAt: "2026-08-01 10:00:03.000",
-          LastEventOccurredAt: "2026-08-01 10:06:00.000",
-        },
-      ]);
+      // A recent write (DEFAULT now64(3)) — the thing the guard exists to see.
+      await insertLiveKpiRow("trace-live");
 
-      await replayGooseMigrationUp({
+      rejection = await replayGooseMigrationUp({
         client: ch,
         fileName: VERSION_COLUMN_MIGRATION,
-        afterStatement: async ({ statement }) => {
-          // A write landing after the copy is absent from the rebuilt table
-          // and lives only in the pre-swap one.
-          if (/INSERT INTO\s+\S*governance_kpis_v2/i.test(statement)) {
-            racedAfterCopy = true;
-            await insertKpiRows([
-              {
-                TraceId: "trace-stranded-by-the-crash",
-                SpendUsd: 0.9,
-                PromptTokens: 40,
-                CompletionTokens: 20,
-                CreatedAt: "2026-08-01 10:00:04.000",
-                LastEventOccurredAt: "2026-08-01 10:07:00.000",
-              },
-            ]);
-            return;
-          }
-          // The runner then dies after the exchange but before step 7, the
-          // window where that write exists only under the scratch name.
-          if (/EXCHANGE TABLES/i.test(statement)) {
-            crashedAfterExchange = true;
-            throw new Error("simulated runner crash after the swap");
-          }
-        },
-      }).catch(() => undefined);
-
-      await replayGooseMigrationUp({
-        client: ch,
-        fileName: VERSION_COLUMN_MIGRATION,
-      });
+      }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
     }, 120_000);
 
-    it("recovers the stranded write on the rerun instead of dropping it", async () => {
-      expect(racedAfterCopy).toBe(true);
-      expect(crashedAfterExchange).toBe(true);
-
-      const rows = await readKpiRows();
-
-      expect(rows.map((row) => row.TraceId)).toEqual([
-        "trace-before-the-crash",
-        "trace-stranded-by-the-crash",
-      ]);
-      expect(rows.map((row) => row.SpendUsd)).toEqual([2, 0.9]);
-      expect(await versionColumnOf("governance_kpis")).toContain(
-        "ReplacingMergeTree(CreatedAt)",
-      );
+    it("aborts the migration instead of swapping under a live writer", () => {
+      expect(rejection).toBeInstanceOf(Error);
+      expect(String(rejection)).toMatch(/quiesce|workers|recent write/i);
     });
-  });
 
-  describe("given a later cumulative row for an already-copied trace races the copy", () => {
-    /**
-     * The accumulating-counter path: a trace already in the snapshot gets a
-     * newer cumulative row during the copy window. Reconciliation carries it
-     * over as a second part sharing the ORDER BY key, and the engine collapses
-     * it to the highest CreatedAt on merge — the same convergence a
-     * steady-state re-write of that trace produces. Reads are plain
-     * `sum(SpendUsd)` with no FINAL, so between merges the sum shows both
-     * parts; that transient is a property of the read path (identical with or
-     * without this migration), so the assertion is the merged result, taken
-     * after an explicit OPTIMIZE FINAL rather than racing a background merge.
-     */
-    let injectedDuringCopy = false;
-
-    beforeAll(async () => {
-      await stageThePreUpgradeTable();
-      await insertKpiRows([
-        {
-          TraceId: "trace-accumulating",
-          SpendUsd: 0.25,
-          PromptTokens: 100,
-          CompletionTokens: 50,
-          CreatedAt: "2026-08-01 10:00:01.000",
-          LastEventOccurredAt: "2026-08-01 10:05:00.000",
-        },
-      ]);
-
-      await replayGooseMigrationUp({
-        client: ch,
-        fileName: VERSION_COLUMN_MIGRATION,
-        afterStatement: async ({ statement }) => {
-          if (!/INSERT INTO\s+\S*governance_kpis_v2/i.test(statement)) return;
-          injectedDuringCopy = true;
-          // Same trace, a later cumulative total, higher CreatedAt.
-          await insertKpiRows([
-            {
-              TraceId: "trace-accumulating",
-              SpendUsd: 1.5,
-              PromptTokens: 300,
-              CompletionTokens: 150,
-              CreatedAt: "2026-08-01 10:00:02.000",
-              LastEventOccurredAt: "2026-08-01 09:55:00.000",
-            },
-          ]);
-        },
-      });
-    }, 120_000);
-
-    it("collapses to the latest cumulative total after merge", async () => {
-      expect(injectedDuringCopy).toBe(true);
-      await ch.command({ query: "OPTIMIZE TABLE governance_kpis FINAL" });
-
-      const rows = await readKpiRows();
-      const accumulating = rows.filter(
-        (row) => row.TraceId === "trace-accumulating",
+    it("leaves the pre-upgrade table untouched", async () => {
+      // Guard runs first, so the version column never changed and no scratch
+      // table was created.
+      expect(await versionColumnOf("governance_kpis")).toContain(
+        "ReplacingMergeTree(LastEventOccurredAt)",
       );
-
-      expect(accumulating).toHaveLength(1);
-      expect(accumulating[0]!.SpendUsd).toBe(1.5);
-      expect(accumulating[0]!.PromptTokens).toBe(300);
+      expect(await versionColumnOf("governance_kpis_v2")).toBe("");
     });
   });
 });

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Migration 00083: swap `governance_kpis` from
+ * Migration 00084: swap `governance_kpis` from
  * `ReplacingMergeTree(LastEventOccurredAt)` to `ReplacingMergeTree(CreatedAt)`.
  *
  * `LastEventOccurredAt` moves BACKWARD — the fold takes
@@ -38,7 +38,7 @@ import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoin
 import { replayGooseMigrationUp } from "./migrationReplay";
 
 const CREATE_MIGRATION = "00031_create_governance_kpis.sql";
-const VERSION_COLUMN_MIGRATION = "00083_governance_kpis_version_column_fix.sql";
+const VERSION_COLUMN_MIGRATION = "00084_governance_kpis_version_column_fix.sql";
 
 const tenantId = `test-kpis-${generate("tenant").toString()}`;
 const sourceId = "src-1";
@@ -125,7 +125,7 @@ async function versionColumnOf(table: string): Promise<string> {
 
 /**
  * Puts `governance_kpis` in the shape 00031 leaves it: the pre-upgrade engine,
- * empty. 00083 is what is under test, so every case has to start from before
+ * empty. 00084 is what is under test, so every case has to start from before
  * it ran — and each one starts from a clean table so the cases cannot read each
  * other's rows.
  */

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -30,8 +30,7 @@ import {
 import { replayGooseMigrationUp } from "./migrationReplay";
 
 const CREATE_MIGRATION = "00031_create_governance_kpis.sql";
-const VERSION_COLUMN_MIGRATION =
-  "00083_governance_kpis_version_column_fix.sql";
+const VERSION_COLUMN_MIGRATION = "00083_governance_kpis_version_column_fix.sql";
 
 const tenantId = `test-kpis-${generate("tenant").toString()}`;
 const sourceId = "src-1";
@@ -163,7 +162,6 @@ describe("governance_kpis version column migration", () => {
       });
     }, 120_000);
 
-    /** @scenario A trace written during the copy is not discarded by the swap */
     it("keeps both the copied row and the one that raced the copy", async () => {
       expect(injectedDuringCopy).toBe(true);
 
@@ -176,14 +174,12 @@ describe("governance_kpis version column migration", () => {
       expect(rows.map((row) => row.SpendUsd)).toEqual([0.25, 0.75]);
     });
 
-    /** @scenario The rebuilt table versions rows by a clock that only moves forward */
     it("versions the rebuilt table by CreatedAt", async () => {
       expect(await versionColumnOf("governance_kpis")).toContain(
         "ReplacingMergeTree(CreatedAt)",
       );
     });
 
-    /** @scenario The scratch table does not outlive the migration */
     it("leaves no scratch table behind", async () => {
       expect(await versionColumnOf("governance_kpis_v2")).toBe("");
     });
@@ -197,7 +193,6 @@ describe("governance_kpis version column migration", () => {
       });
     }, 120_000);
 
-    /** @scenario Re-applying a partially executed migration converges instead of wedging */
     it("converges on the same rows rather than failing", async () => {
       const rows = await readKpiRows();
 
@@ -238,7 +233,6 @@ describe("governance_kpis version column migration", () => {
       await ch.command({ query: "OPTIMIZE TABLE governance_kpis FINAL" });
     }, 120_000);
 
-    /** @scenario A merge keeps the latest fold, not the one with the latest event */
     it("keeps the cumulative totals after merge", async () => {
       const rows = await readKpiRows();
       const refolded = rows.filter((row) => row.TraceId === "trace-refolded");
@@ -285,7 +279,6 @@ describe("governance_kpis version column migration", () => {
       });
     }, 120_000);
 
-    /** @scenario Re-applying after a crash mid-swap converges instead of wedging */
     it("re-applies cleanly and keeps the rows", async () => {
       expect(crashed).toBe(true);
 
@@ -300,5 +293,4 @@ describe("governance_kpis version column migration", () => {
       );
     });
   });
-
 });

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -1,224 +1,304 @@
-import { type ClickHouseClient, createClient } from "@clickhouse/client";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
 /**
- * Regression: governance_kpis uses ReplacingMergeTree(LastEventOccurredAt),
- * but LastEventOccurredAt moves backward as earlier-starting spans arrive
- * (the fold takes min(occurredAt, span.startTimeUnixMs)). After background
- * merge, ClickHouse keeps the row with the HIGHER version column — the
- * stale, lower-spend row — and discards the correct cumulative one.
+ * Migration 00083: swap `governance_kpis` from
+ * `ReplacingMergeTree(LastEventOccurredAt)` to `ReplacingMergeTree(CreatedAt)`.
  *
- * Fix: migration 00083 swaps the version column to CreatedAt (wall-clock
- * monotonic via DEFAULT now64(3)).
+ * `LastEventOccurredAt` moves BACKWARD — the fold takes
+ * `min(occurredAt, span.startTimeUnixMs)`, so a later flush that folded in an
+ * earlier-starting span carries a LOWER value than the flush before it. The
+ * engine keeps the row with the HIGHEST version at merge time, so merges kept
+ * the stale, lower-spend row and discarded the correct cumulative one. Reads
+ * are plain `sum(SpendUsd)` with no `FINAL` and no `argMax`, so nothing
+ * compensated.
+ *
+ * These tests run the real migration file against the real table, staged into
+ * its pre-upgrade state, because the two things that can actually break are
+ * properties of the swap procedure and not of ClickHouse:
+ *   - the copy reads a snapshot, so a write arriving mid-migration must still
+ *     survive (the reconciliation pass),
+ *   - the runner may re-apply a partially executed file, so a second run must
+ *     converge rather than wedge.
  *
  * @see https://github.com/langwatch/langwatch-saas/issues/1089
  */
-describe("governance_kpis ReplacingMergeTree version column", () => {
-  let client: ClickHouseClient;
-  let database: string;
-  const TABLE = "test_governance_kpis_version_col";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { generate } from "@langwatch/ksuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { replayGooseMigrationUp } from "./migrationReplay";
 
-  beforeAll(async () => {
-    const connectionUrl =
-      process.env.CLICKHOUSE_URL ??
-      "http://default:langwatch@localhost:8123/langwatch";
-    const url = new URL(connectionUrl);
-    database = url.pathname.replace("/", "") || "langwatch";
-    client = createClient({ url: connectionUrl });
+const CREATE_MIGRATION = "00031_create_governance_kpis.sql";
+const VERSION_COLUMN_MIGRATION =
+  "00083_governance_kpis_version_column_fix.sql";
+
+const tenantId = `test-kpis-${generate("tenant").toString()}`;
+const sourceId = "src-1";
+const hourBucket = "2026-08-01 10:00:00";
+
+let ch: ClickHouseClient;
+
+interface KpiRow {
+  TraceId: string;
+  SpendUsd: number;
+  PromptTokens: number;
+  CompletionTokens: number;
+  CreatedAt: string;
+  LastEventOccurredAt: string;
+}
+
+async function insertKpiRows(rows: KpiRow[]): Promise<void> {
+  await ch.insert({
+    table: "governance_kpis",
+    values: rows.map((row) => ({
+      TenantId: tenantId,
+      SourceId: sourceId,
+      HourBucket: hourBucket,
+      SourceType: "api_key",
+      ...row,
+    })),
+    format: "JSONEachRow",
   });
+}
 
-  afterAll(async () => {
-    await client.command({
-      query: `DROP TABLE IF EXISTS ${database}.${TABLE}`,
-    });
-    await client.close();
+async function readKpiRows(): Promise<
+  { TraceId: string; SpendUsd: number; PromptTokens: number }[]
+> {
+  const result = await ch.query({
+    query: `
+      SELECT TraceId, SpendUsd, PromptTokens
+      FROM governance_kpis
+      WHERE TenantId = {tenantId:String}
+      ORDER BY TraceId
+    `,
+    query_params: { tenantId },
+    format: "JSONEachRow",
   });
+  return result.json();
+}
 
-  describe("given version column is CreatedAt (the fix)", () => {
-    beforeAll(async () => {
-      await client.command({
-        query: `DROP TABLE IF EXISTS ${database}.${TABLE}`,
-      });
-
-      // Mirrors governance_kpis schema but with CreatedAt as version column
-      await client.command({
-        query: `
-          CREATE TABLE ${database}.${TABLE} (
-            TenantId String,
-            SourceId String,
-            HourBucket DateTime,
-            TraceId String,
-            SourceType LowCardinality(String),
-            SpendUsd Float64,
-            PromptTokens UInt64,
-            CompletionTokens UInt64,
-            CreatedAt DateTime64(3),
-            LastEventOccurredAt DateTime64(3)
-          ) ENGINE = ReplacingMergeTree(CreatedAt)
-          PARTITION BY toYYYYMM(HourBucket)
-          ORDER BY (TenantId, SourceId, HourBucket, TraceId)
-        `,
-      });
-    });
-
-    it("keeps the latest-written row after merge even when LastEventOccurredAt moves backward", async () => {
-      const hourBucket = "2026-08-01 10:00:00";
-
-      // First flush: lower spend, higher LastEventOccurredAt, earlier CreatedAt
-      await client.insert({
-        table: `${database}.${TABLE}`,
-        values: [
-          {
-            TenantId: "t1",
-            SourceId: "src1",
-            HourBucket: hourBucket,
-            TraceId: "trace-abc",
-            SourceType: "api_key",
-            SpendUsd: 0.5,
-            PromptTokens: 100,
-            CompletionTokens: 50,
-            CreatedAt: "2026-08-01 10:00:01.000",
-            LastEventOccurredAt: "2026-08-01 10:05:00.000", // higher (later event)
-          },
-        ],
-        format: "JSONEachRow",
-      });
-
-      // Second flush: higher spend (cumulative), LOWER LastEventOccurredAt
-      // (because an earlier-starting span arrived), HIGHER CreatedAt (wall clock)
-      await client.insert({
-        table: `${database}.${TABLE}`,
-        values: [
-          {
-            TenantId: "t1",
-            SourceId: "src1",
-            HourBucket: hourBucket,
-            TraceId: "trace-abc",
-            SourceType: "api_key",
-            SpendUsd: 1.5,
-            PromptTokens: 300,
-            CompletionTokens: 150,
-            CreatedAt: "2026-08-01 10:00:02.000",
-            LastEventOccurredAt: "2026-08-01 09:55:00.000", // lower (earlier event folded in)
-          },
-        ],
-        format: "JSONEachRow",
-      });
-
-      // Force merge — ReplacingMergeTree dedup fires
-      await client.command({
-        query: `OPTIMIZE TABLE ${database}.${TABLE} FINAL`,
-      });
-
-      const result = await client.query({
-        query: `SELECT SpendUsd, PromptTokens, CompletionTokens FROM ${database}.${TABLE} WHERE TenantId = 't1' AND TraceId = 'trace-abc'`,
-        format: "JSONEachRow",
-      });
-      const rows = await result.json<{
-        SpendUsd: number;
-        PromptTokens: number;
-        CompletionTokens: number;
-      }>();
-
-      expect(rows).toHaveLength(1);
-      // With CreatedAt as version column, the second (later) write survives
-      expect(rows[0]!.SpendUsd).toBe(1.5);
-      expect(rows[0]!.PromptTokens).toBe(300);
-      expect(rows[0]!.CompletionTokens).toBe(150);
-    });
+async function versionColumnOf(table: string): Promise<string> {
+  const result = await ch.query({
+    query: `SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = {table:String}`,
+    query_params: { table },
+    format: "JSONEachRow",
   });
+  const [row] = await result.json<{ engine_full: string }>();
+  return row?.engine_full ?? "";
+}
 
-  describe("given version column is LastEventOccurredAt (the bug)", () => {
-    const BUG_TABLE = `${TABLE}_bug`;
+/**
+ * Puts `governance_kpis` back in the shape 00031 left it: the pre-upgrade
+ * engine, empty. The suite has to start from there because 00083 is what is
+ * under test, and the migrated container already has it applied.
+ */
+async function stageThePreUpgradeTable(): Promise<void> {
+  await ch.command({ query: "DROP TABLE IF EXISTS governance_kpis" });
+  await replayGooseMigrationUp({ client: ch, fileName: CREATE_MIGRATION });
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    // Later suites must see the head schema, not whichever intermediate state
+    // the last test left behind.
+    await stageThePreUpgradeTable();
+    await replayGooseMigrationUp({
+      client: ch,
+      fileName: VERSION_COLUMN_MIGRATION,
+    });
+  }
+  await stopTestContainers();
+}, 120_000);
+
+describe("governance_kpis version column migration", () => {
+  describe("given the pre-upgrade table holds rows and a write lands mid-migration", () => {
+    /**
+     * Whether the injected write actually happened. Without this the whole
+     * test passes vacuously if the copy statement is ever renamed or
+     * reordered — the hook would simply never fire and the assertion below
+     * would be checking a row nobody raced.
+     */
+    let injectedDuringCopy = false;
 
     beforeAll(async () => {
-      await client.command({
-        query: `DROP TABLE IF EXISTS ${database}.${BUG_TABLE}`,
-      });
+      injectedDuringCopy = false;
+      await stageThePreUpgradeTable();
 
-      // Same schema but with the BROKEN version column
-      await client.command({
-        query: `
-          CREATE TABLE ${database}.${BUG_TABLE} (
-            TenantId String,
-            SourceId String,
-            HourBucket DateTime,
-            TraceId String,
-            SourceType LowCardinality(String),
-            SpendUsd Float64,
-            PromptTokens UInt64,
-            CompletionTokens UInt64,
-            CreatedAt DateTime64(3),
-            LastEventOccurredAt DateTime64(3)
-          ) ENGINE = ReplacingMergeTree(LastEventOccurredAt)
-          PARTITION BY toYYYYMM(HourBucket)
-          ORDER BY (TenantId, SourceId, HourBucket, TraceId)
-        `,
+      await insertKpiRows([
+        {
+          TraceId: "trace-copied",
+          SpendUsd: 0.25,
+          PromptTokens: 100,
+          CompletionTokens: 50,
+          CreatedAt: "2026-08-01 10:00:01.000",
+          LastEventOccurredAt: "2026-08-01 10:05:00.000",
+        },
+      ]);
+
+      await replayGooseMigrationUp({
+        client: ch,
+        fileName: VERSION_COLUMN_MIGRATION,
+        afterStatement: async ({ statement }) => {
+          // The copy is the statement that opens the loss window: everything
+          // written from here until the swap lands only in the pre-swap table.
+          if (!/INSERT INTO\s+\S*governance_kpis_v2/i.test(statement)) return;
+          injectedDuringCopy = true;
+          await insertKpiRows([
+            {
+              TraceId: "trace-raced-the-copy",
+              SpendUsd: 0.75,
+              PromptTokens: 300,
+              CompletionTokens: 150,
+              CreatedAt: "2026-08-01 10:00:02.000",
+              LastEventOccurredAt: "2026-08-01 09:55:00.000",
+            },
+          ]);
+        },
       });
+    }, 120_000);
+
+    /** @scenario A trace written during the copy is not discarded by the swap */
+    it("keeps both the copied row and the one that raced the copy", async () => {
+      expect(injectedDuringCopy).toBe(true);
+
+      const rows = await readKpiRows();
+
+      expect(rows.map((row) => row.TraceId)).toEqual([
+        "trace-copied",
+        "trace-raced-the-copy",
+      ]);
+      expect(rows.map((row) => row.SpendUsd)).toEqual([0.25, 0.75]);
     });
 
-    afterAll(async () => {
-      await client.command({
-        query: `DROP TABLE IF EXISTS ${database}.${BUG_TABLE}`,
-      });
+    /** @scenario The rebuilt table versions rows by a clock that only moves forward */
+    it("versions the rebuilt table by CreatedAt", async () => {
+      expect(await versionColumnOf("governance_kpis")).toContain(
+        "ReplacingMergeTree(CreatedAt)",
+      );
     });
 
-    it("discards the correct row after merge — documenting the defect", async () => {
-      const hourBucket = "2026-08-01 10:00:00";
-
-      // First flush: lower spend, higher LastEventOccurredAt
-      await client.insert({
-        table: `${database}.${BUG_TABLE}`,
-        values: [
-          {
-            TenantId: "t1",
-            SourceId: "src1",
-            HourBucket: hourBucket,
-            TraceId: "trace-abc",
-            SourceType: "api_key",
-            SpendUsd: 0.5,
-            PromptTokens: 100,
-            CompletionTokens: 50,
-            CreatedAt: "2026-08-01 10:00:01.000",
-            LastEventOccurredAt: "2026-08-01 10:05:00.000",
-          },
-        ],
-        format: "JSONEachRow",
-      });
-
-      // Second flush: higher spend, LOWER LastEventOccurredAt
-      await client.insert({
-        table: `${database}.${BUG_TABLE}`,
-        values: [
-          {
-            TenantId: "t1",
-            SourceId: "src1",
-            HourBucket: hourBucket,
-            TraceId: "trace-abc",
-            SourceType: "api_key",
-            SpendUsd: 1.5,
-            PromptTokens: 300,
-            CompletionTokens: 150,
-            CreatedAt: "2026-08-01 10:00:02.000",
-            LastEventOccurredAt: "2026-08-01 09:55:00.000",
-          },
-        ],
-        format: "JSONEachRow",
-      });
-
-      await client.command({
-        query: `OPTIMIZE TABLE ${database}.${BUG_TABLE} FINAL`,
-      });
-
-      const result = await client.query({
-        query: `SELECT SpendUsd FROM ${database}.${BUG_TABLE} WHERE TenantId = 't1' AND TraceId = 'trace-abc'`,
-        format: "JSONEachRow",
-      });
-      const rows = await result.json<{ SpendUsd: number }>();
-
-      expect(rows).toHaveLength(1);
-      // BUG: merge keeps the row with higher LastEventOccurredAt (the stale one)
-      expect(rows[0]!.SpendUsd).toBe(0.5); // stale value survives, not 1.5
+    /** @scenario The scratch table does not outlive the migration */
+    it("leaves no scratch table behind", async () => {
+      expect(await versionColumnOf("governance_kpis_v2")).toBe("");
     });
   });
+
+  describe("given the migration is applied a second time", () => {
+    beforeAll(async () => {
+      await replayGooseMigrationUp({
+        client: ch,
+        fileName: VERSION_COLUMN_MIGRATION,
+      });
+    }, 120_000);
+
+    /** @scenario Re-applying a partially executed migration converges instead of wedging */
+    it("converges on the same rows rather than failing", async () => {
+      const rows = await readKpiRows();
+
+      expect(rows.map((row) => row.TraceId)).toEqual([
+        "trace-copied",
+        "trace-raced-the-copy",
+      ]);
+      expect(await versionColumnOf("governance_kpis")).toContain(
+        "ReplacingMergeTree(CreatedAt)",
+      );
+    });
+  });
+
+  describe("given a trace is re-folded with a LastEventOccurredAt that moved backward", () => {
+    beforeAll(async () => {
+      await insertKpiRows([
+        {
+          TraceId: "trace-refolded",
+          SpendUsd: 0.5,
+          PromptTokens: 100,
+          CompletionTokens: 50,
+          CreatedAt: "2026-08-01 10:00:01.000",
+          LastEventOccurredAt: "2026-08-01 10:05:00.000",
+        },
+      ]);
+      await insertKpiRows([
+        {
+          TraceId: "trace-refolded",
+          // Cumulative totals, written later, but carrying an EARLIER
+          // LastEventOccurredAt because an earlier-starting span folded in.
+          SpendUsd: 1.5,
+          PromptTokens: 300,
+          CompletionTokens: 150,
+          CreatedAt: "2026-08-01 10:00:02.000",
+          LastEventOccurredAt: "2026-08-01 09:55:00.000",
+        },
+      ]);
+      await ch.command({ query: "OPTIMIZE TABLE governance_kpis FINAL" });
+    }, 120_000);
+
+    /** @scenario A merge keeps the latest fold, not the one with the latest event */
+    it("keeps the cumulative totals after merge", async () => {
+      const rows = await readKpiRows();
+      const refolded = rows.filter((row) => row.TraceId === "trace-refolded");
+
+      expect(refolded).toHaveLength(1);
+      expect(refolded[0]!.SpendUsd).toBe(1.5);
+      expect(refolded[0]!.PromptTokens).toBe(300);
+    });
+  });
+  describe("given a previous run died after the swap", () => {
+    /**
+     * The state a `RENAME`-based swap cannot recover from: the pre-swap table
+     * still exists under the scratch name, so a re-apply that renamed onto an
+     * existing name would fail and need a human in the database.
+     */
+    let crashed = false;
+
+    beforeAll(async () => {
+      await stageThePreUpgradeTable();
+      await insertKpiRows([
+        {
+          TraceId: "trace-before-the-crash",
+          SpendUsd: 2,
+          PromptTokens: 10,
+          CompletionTokens: 5,
+          CreatedAt: "2026-08-01 10:00:03.000",
+          LastEventOccurredAt: "2026-08-01 10:06:00.000",
+        },
+      ]);
+
+      await replayGooseMigrationUp({
+        client: ch,
+        fileName: VERSION_COLUMN_MIGRATION,
+        afterStatement: async ({ statement }) => {
+          if (!/EXCHANGE TABLES/i.test(statement)) return;
+          crashed = true;
+          throw new Error("simulated runner crash after the swap");
+        },
+      }).catch(() => undefined);
+
+      await replayGooseMigrationUp({
+        client: ch,
+        fileName: VERSION_COLUMN_MIGRATION,
+      });
+    }, 120_000);
+
+    /** @scenario Re-applying after a crash mid-swap converges instead of wedging */
+    it("re-applies cleanly and keeps the rows", async () => {
+      expect(crashed).toBe(true);
+
+      const rows = await readKpiRows();
+
+      expect(rows.map((row) => row.TraceId)).toEqual([
+        "trace-before-the-crash",
+      ]);
+      expect(rows[0]!.SpendUsd).toBe(2);
+      expect(await versionColumnOf("governance_kpis")).toContain(
+        "ReplacingMergeTree(CreatedAt)",
+      );
+    });
+  });
+
 });

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -244,13 +244,21 @@ describe("governance_kpis version column migration", () => {
       expect(refolded[0]!.PromptTokens).toBe(300);
     });
   });
-  describe("given a previous run died after the swap", () => {
+  describe("given a previous run died after the swap, with a write that landed during the copy", () => {
     /**
-     * The state a `RENAME`-based swap cannot recover from: the pre-swap table
-     * still exists under the scratch name, so a re-apply that renamed onto an
-     * existing name would fail and need a human in the database.
+     * The loss window a naive re-apply reopens: a write that lands AFTER the
+     * snapshot copy exists only in the pre-swap table, which the exchange
+     * moves under the scratch name. If the runner then dies before
+     * reconciliation, the first draft's unconditional `DROP` at the top of the
+     * re-apply would discard that write for good. The `trace-before-the-crash`
+     * row (copied into the snapshot) survives either way; `trace-stranded-by-
+     * the-crash` (raced the copy, then stranded by the crash) is the one that
+     * only survives because the re-apply recovers the scratch before dropping
+     * it. Without both flags below the test could pass vacuously — the copy
+     * hook or the crash hook silently never firing.
      */
-    let crashed = false;
+    let crashedAfterExchange = false;
+    let racedAfterCopy = false;
 
     beforeAll(async () => {
       await stageThePreUpgradeTable();
@@ -269,9 +277,28 @@ describe("governance_kpis version column migration", () => {
         client: ch,
         fileName: VERSION_COLUMN_MIGRATION,
         afterStatement: async ({ statement }) => {
-          if (!/EXCHANGE TABLES/i.test(statement)) return;
-          crashed = true;
-          throw new Error("simulated runner crash after the swap");
+          // A write landing after the copy is absent from the rebuilt table
+          // and lives only in the pre-swap one.
+          if (/INSERT INTO\s+\S*governance_kpis_v2/i.test(statement)) {
+            racedAfterCopy = true;
+            await insertKpiRows([
+              {
+                TraceId: "trace-stranded-by-the-crash",
+                SpendUsd: 0.9,
+                PromptTokens: 40,
+                CompletionTokens: 20,
+                CreatedAt: "2026-08-01 10:00:04.000",
+                LastEventOccurredAt: "2026-08-01 10:07:00.000",
+              },
+            ]);
+            return;
+          }
+          // The runner then dies after the exchange but before step 7, the
+          // window where that write exists only under the scratch name.
+          if (/EXCHANGE TABLES/i.test(statement)) {
+            crashedAfterExchange = true;
+            throw new Error("simulated runner crash after the swap");
+          }
         },
       }).catch(() => undefined);
 
@@ -281,18 +308,83 @@ describe("governance_kpis version column migration", () => {
       });
     }, 120_000);
 
-    it("re-applies cleanly and keeps the rows", async () => {
-      expect(crashed).toBe(true);
+    it("recovers the stranded write on the rerun instead of dropping it", async () => {
+      expect(racedAfterCopy).toBe(true);
+      expect(crashedAfterExchange).toBe(true);
 
       const rows = await readKpiRows();
 
       expect(rows.map((row) => row.TraceId)).toEqual([
         "trace-before-the-crash",
+        "trace-stranded-by-the-crash",
       ]);
-      expect(rows[0]!.SpendUsd).toBe(2);
+      expect(rows.map((row) => row.SpendUsd)).toEqual([2, 0.9]);
       expect(await versionColumnOf("governance_kpis")).toContain(
         "ReplacingMergeTree(CreatedAt)",
       );
+    });
+  });
+
+  describe("given a later cumulative row for an already-copied trace races the copy", () => {
+    /**
+     * The accumulating-counter path: a trace already in the snapshot gets a
+     * newer cumulative row during the copy window. Reconciliation carries it
+     * over as a second part sharing the ORDER BY key, and the engine collapses
+     * it to the highest CreatedAt on merge — the same convergence a
+     * steady-state re-write of that trace produces. Reads are plain
+     * `sum(SpendUsd)` with no FINAL, so between merges the sum shows both
+     * parts; that transient is a property of the read path (identical with or
+     * without this migration), so the assertion is the merged result, taken
+     * after an explicit OPTIMIZE FINAL rather than racing a background merge.
+     */
+    let injectedDuringCopy = false;
+
+    beforeAll(async () => {
+      await stageThePreUpgradeTable();
+      await insertKpiRows([
+        {
+          TraceId: "trace-accumulating",
+          SpendUsd: 0.25,
+          PromptTokens: 100,
+          CompletionTokens: 50,
+          CreatedAt: "2026-08-01 10:00:01.000",
+          LastEventOccurredAt: "2026-08-01 10:05:00.000",
+        },
+      ]);
+
+      await replayGooseMigrationUp({
+        client: ch,
+        fileName: VERSION_COLUMN_MIGRATION,
+        afterStatement: async ({ statement }) => {
+          if (!/INSERT INTO\s+\S*governance_kpis_v2/i.test(statement)) return;
+          injectedDuringCopy = true;
+          // Same trace, a later cumulative total, higher CreatedAt.
+          await insertKpiRows([
+            {
+              TraceId: "trace-accumulating",
+              SpendUsd: 1.5,
+              PromptTokens: 300,
+              CompletionTokens: 150,
+              CreatedAt: "2026-08-01 10:00:02.000",
+              LastEventOccurredAt: "2026-08-01 09:55:00.000",
+            },
+          ]);
+        },
+      });
+    }, 120_000);
+
+    it("collapses to the latest cumulative total after merge", async () => {
+      expect(injectedDuringCopy).toBe(true);
+      await ch.command({ query: "OPTIMIZE TABLE governance_kpis FINAL" });
+
+      const rows = await readKpiRows();
+      const accumulating = rows.filter(
+        (row) => row.TraceId === "trace-accumulating",
+      );
+
+      expect(accumulating).toHaveLength(1);
+      expect(accumulating[0]!.SpendUsd).toBe(1.5);
+      expect(accumulating[0]!.PromptTokens).toBe(300);
     });
   });
 });

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -1,0 +1,224 @@
+import { type ClickHouseClient, createClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Regression: governance_kpis uses ReplacingMergeTree(LastEventOccurredAt),
+ * but LastEventOccurredAt moves backward as earlier-starting spans arrive
+ * (the fold takes min(occurredAt, span.startTimeUnixMs)). After background
+ * merge, ClickHouse keeps the row with the HIGHER version column — the
+ * stale, lower-spend row — and discards the correct cumulative one.
+ *
+ * Fix: migration 00083 swaps the version column to CreatedAt (wall-clock
+ * monotonic via DEFAULT now64(3)).
+ *
+ * @see https://github.com/langwatch/langwatch-saas/issues/1089
+ */
+describe("governance_kpis ReplacingMergeTree version column", () => {
+  let client: ClickHouseClient;
+  let database: string;
+  const TABLE = "test_governance_kpis_version_col";
+
+  beforeAll(async () => {
+    const connectionUrl =
+      process.env.CLICKHOUSE_URL ??
+      "http://default:langwatch@localhost:8123/langwatch";
+    const url = new URL(connectionUrl);
+    database = url.pathname.replace("/", "") || "langwatch";
+    client = createClient({ url: connectionUrl });
+  });
+
+  afterAll(async () => {
+    await client.command({
+      query: `DROP TABLE IF EXISTS ${database}.${TABLE}`,
+    });
+    await client.close();
+  });
+
+  describe("when version column is CreatedAt (the fix)", () => {
+    beforeAll(async () => {
+      await client.command({
+        query: `DROP TABLE IF EXISTS ${database}.${TABLE}`,
+      });
+
+      // Mirrors governance_kpis schema but with CreatedAt as version column
+      await client.command({
+        query: `
+          CREATE TABLE ${database}.${TABLE} (
+            TenantId String,
+            SourceId String,
+            HourBucket DateTime,
+            TraceId String,
+            SourceType LowCardinality(String),
+            SpendUsd Float64,
+            PromptTokens UInt64,
+            CompletionTokens UInt64,
+            CreatedAt DateTime64(3),
+            LastEventOccurredAt DateTime64(3)
+          ) ENGINE = ReplacingMergeTree(CreatedAt)
+          PARTITION BY toYYYYMM(HourBucket)
+          ORDER BY (TenantId, SourceId, HourBucket, TraceId)
+        `,
+      });
+    });
+
+    it("keeps the latest-written row after merge even when LastEventOccurredAt moves backward", async () => {
+      const hourBucket = "2026-08-01 10:00:00";
+
+      // First flush: lower spend, higher LastEventOccurredAt, earlier CreatedAt
+      await client.insert({
+        table: `${database}.${TABLE}`,
+        values: [
+          {
+            TenantId: "t1",
+            SourceId: "src1",
+            HourBucket: hourBucket,
+            TraceId: "trace-abc",
+            SourceType: "api_key",
+            SpendUsd: 0.5,
+            PromptTokens: 100,
+            CompletionTokens: 50,
+            CreatedAt: "2026-08-01 10:00:01.000",
+            LastEventOccurredAt: "2026-08-01 10:05:00.000", // higher (later event)
+          },
+        ],
+        format: "JSONEachRow",
+      });
+
+      // Second flush: higher spend (cumulative), LOWER LastEventOccurredAt
+      // (because an earlier-starting span arrived), HIGHER CreatedAt (wall clock)
+      await client.insert({
+        table: `${database}.${TABLE}`,
+        values: [
+          {
+            TenantId: "t1",
+            SourceId: "src1",
+            HourBucket: hourBucket,
+            TraceId: "trace-abc",
+            SourceType: "api_key",
+            SpendUsd: 1.5,
+            PromptTokens: 300,
+            CompletionTokens: 150,
+            CreatedAt: "2026-08-01 10:00:02.000",
+            LastEventOccurredAt: "2026-08-01 09:55:00.000", // lower (earlier event folded in)
+          },
+        ],
+        format: "JSONEachRow",
+      });
+
+      // Force merge — ReplacingMergeTree dedup fires
+      await client.command({
+        query: `OPTIMIZE TABLE ${database}.${TABLE} FINAL`,
+      });
+
+      const result = await client.query({
+        query: `SELECT SpendUsd, PromptTokens, CompletionTokens FROM ${database}.${TABLE} WHERE TenantId = 't1' AND TraceId = 'trace-abc'`,
+        format: "JSONEachRow",
+      });
+      const rows = await result.json<{
+        SpendUsd: number;
+        PromptTokens: number;
+        CompletionTokens: number;
+      }>();
+
+      expect(rows).toHaveLength(1);
+      // With CreatedAt as version column, the second (later) write survives
+      expect(rows[0]!.SpendUsd).toBe(1.5);
+      expect(rows[0]!.PromptTokens).toBe(300);
+      expect(rows[0]!.CompletionTokens).toBe(150);
+    });
+  });
+
+  describe("when version column is LastEventOccurredAt (the bug)", () => {
+    const BUG_TABLE = `${TABLE}_bug`;
+
+    beforeAll(async () => {
+      await client.command({
+        query: `DROP TABLE IF EXISTS ${database}.${BUG_TABLE}`,
+      });
+
+      // Same schema but with the BROKEN version column
+      await client.command({
+        query: `
+          CREATE TABLE ${database}.${BUG_TABLE} (
+            TenantId String,
+            SourceId String,
+            HourBucket DateTime,
+            TraceId String,
+            SourceType LowCardinality(String),
+            SpendUsd Float64,
+            PromptTokens UInt64,
+            CompletionTokens UInt64,
+            CreatedAt DateTime64(3),
+            LastEventOccurredAt DateTime64(3)
+          ) ENGINE = ReplacingMergeTree(LastEventOccurredAt)
+          PARTITION BY toYYYYMM(HourBucket)
+          ORDER BY (TenantId, SourceId, HourBucket, TraceId)
+        `,
+      });
+    });
+
+    afterAll(async () => {
+      await client.command({
+        query: `DROP TABLE IF EXISTS ${database}.${BUG_TABLE}`,
+      });
+    });
+
+    it("discards the correct row after merge — documenting the defect", async () => {
+      const hourBucket = "2026-08-01 10:00:00";
+
+      // First flush: lower spend, higher LastEventOccurredAt
+      await client.insert({
+        table: `${database}.${BUG_TABLE}`,
+        values: [
+          {
+            TenantId: "t1",
+            SourceId: "src1",
+            HourBucket: hourBucket,
+            TraceId: "trace-abc",
+            SourceType: "api_key",
+            SpendUsd: 0.5,
+            PromptTokens: 100,
+            CompletionTokens: 50,
+            CreatedAt: "2026-08-01 10:00:01.000",
+            LastEventOccurredAt: "2026-08-01 10:05:00.000",
+          },
+        ],
+        format: "JSONEachRow",
+      });
+
+      // Second flush: higher spend, LOWER LastEventOccurredAt
+      await client.insert({
+        table: `${database}.${BUG_TABLE}`,
+        values: [
+          {
+            TenantId: "t1",
+            SourceId: "src1",
+            HourBucket: hourBucket,
+            TraceId: "trace-abc",
+            SourceType: "api_key",
+            SpendUsd: 1.5,
+            PromptTokens: 300,
+            CompletionTokens: 150,
+            CreatedAt: "2026-08-01 10:00:02.000",
+            LastEventOccurredAt: "2026-08-01 09:55:00.000",
+          },
+        ],
+        format: "JSONEachRow",
+      });
+
+      await client.command({
+        query: `OPTIMIZE TABLE ${database}.${BUG_TABLE} FINAL`,
+      });
+
+      const result = await client.query({
+        query: `SELECT SpendUsd FROM ${database}.${BUG_TABLE} WHERE TenantId = 't1' AND TraceId = 'trace-abc'`,
+        format: "JSONEachRow",
+      });
+      const rows = await result.json<{ SpendUsd: number }>();
+
+      expect(rows).toHaveLength(1);
+      // BUG: merge keeps the row with higher LastEventOccurredAt (the stale one)
+      expect(rows[0]!.SpendUsd).toBe(0.5); // stale value survives, not 1.5
+    });
+  });
+});

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -34,7 +34,7 @@ describe("governance_kpis ReplacingMergeTree version column", () => {
     await client.close();
   });
 
-  describe("when version column is CreatedAt (the fix)", () => {
+  describe("given version column is CreatedAt (the fix)", () => {
     beforeAll(async () => {
       await client.command({
         query: `DROP TABLE IF EXISTS ${database}.${TABLE}`,
@@ -128,7 +128,7 @@ describe("governance_kpis ReplacingMergeTree version column", () => {
     });
   });
 
-  describe("when version column is LastEventOccurredAt (the bug)", () => {
+  describe("given version column is LastEventOccurredAt (the bug)", () => {
     const BUG_TABLE = `${TABLE}_bug`;
 
     beforeAll(async () => {

--- a/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/governanceKpis.versionColumn.integration.test.ts
@@ -10,23 +10,28 @@
  * are plain `sum(SpendUsd)` with no `FINAL` and no `argMax`, so nothing
  * compensated.
  *
- * These tests run the real migration file against the real table, staged into
- * its pre-upgrade state, because the two things that can actually break are
- * properties of the swap procedure and not of ClickHouse:
+ * These tests run the real migration file against a real `governance_kpis`,
+ * staged into its pre-upgrade state, because the two things that can actually
+ * break are properties of the swap procedure and not of ClickHouse:
  *   - the copy reads a snapshot, so a write arriving mid-migration must still
  *     survive (the reconciliation pass),
  *   - the runner may re-apply a partially executed file, so a second run must
  *     converge rather than wedge.
  *
+ * On its OWN endpoint, not the shared migrated one. Staging the pre-upgrade
+ * state means dropping and recreating `governance_kpis`, and the shared
+ * database is read by other suites — `spendSpikeAnomalyEvaluator` seeds and
+ * queries that exact table. `withReplayLock` orders replays against each
+ * other but not against plain readers, so on the shared endpoint a neighbour
+ * could read the table during the window where it does not exist. An isolated
+ * database removes the question rather than narrowing it.
+ *
  * @see https://github.com/langwatch/langwatch-saas/issues/1089
  */
-import type { ClickHouseClient } from "@clickhouse/client";
+import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import { generate } from "@langwatch/ksuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  startTestContainers,
-  stopTestContainers,
-} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoints";
 import { replayGooseMigrationUp } from "./migrationReplay";
 
 const CREATE_MIGRATION = "00031_create_governance_kpis.sql";
@@ -88,9 +93,10 @@ async function versionColumnOf(table: string): Promise<string> {
 }
 
 /**
- * Puts `governance_kpis` back in the shape 00031 left it: the pre-upgrade
- * engine, empty. The suite has to start from there because 00083 is what is
- * under test, and the migrated container already has it applied.
+ * Puts `governance_kpis` in the shape 00031 leaves it: the pre-upgrade engine,
+ * empty. 00083 is what is under test, so every case has to start from before
+ * it ran — and each one starts from a clean table so the cases cannot read each
+ * other's rows.
  */
 async function stageThePreUpgradeTable(): Promise<void> {
   await ch.command({ query: "DROP TABLE IF EXISTS governance_kpis" });
@@ -98,22 +104,18 @@ async function stageThePreUpgradeTable(): Promise<void> {
 }
 
 beforeAll(async () => {
-  const containers = await startTestContainers();
-  ch = containers.clickHouseClient;
+  const [endpoint] = await startTestClickHouseEndpoints({
+    suite: "governance-kpis-version-column",
+    names: ["migration"],
+  });
+  ch = createClient({ url: endpoint!.url });
 }, 120_000);
 
 afterAll(async () => {
-  if (ch) {
-    // Later suites must see the head schema, not whichever intermediate state
-    // the last test left behind.
-    await stageThePreUpgradeTable();
-    await replayGooseMigrationUp({
-      client: ch,
-      fileName: VERSION_COLUMN_MIGRATION,
-    });
-  }
-  await stopTestContainers();
-}, 120_000);
+  // Nothing to restore: the endpoint is this suite's own database, so the
+  // schema it is left in is nobody else's problem.
+  await ch?.close();
+});
 
 describe("governance_kpis version column migration", () => {
   describe("given the pre-upgrade table holds rows and a write lands mid-migration", () => {

--- a/platform/app/src/server/clickhouse/__tests__/migrationReplay.ts
+++ b/platform/app/src/server/clickhouse/__tests__/migrationReplay.ts
@@ -53,16 +53,33 @@ export async function replayRollupRebuild(
   }
 }
 
+/**
+ * Called after each Up statement, with its zero-based index and text.
+ *
+ * A migration that swaps a live table has to survive writes that arrive
+ * mid-run, and that is not something a test can provoke from outside: by the
+ * time `replayGooseMigrationUp` returns, the window has closed. This hook is
+ * the seam — a test writes into the table between the copy and the swap and
+ * then asserts the row survived, which is the only way to cover a
+ * reconciliation step rather than trust its comment.
+ */
+export type ReplayStatementHook = (step: {
+  index: number;
+  statement: string;
+}) => Promise<void>;
+
 export async function replayGooseMigrationUp({
   client,
   fileName,
+  afterStatement,
 }: {
   client: ClickHouseClient;
   fileName: string;
+  afterStatement?: ReplayStatementHook;
 }): Promise<void> {
   const release = await acquireClickHouseSchemaLock();
   try {
-    await runMigrationStatements({ client, fileName });
+    await runMigrationStatements({ client, fileName, afterStatement });
   } finally {
     release();
   }
@@ -71,9 +88,11 @@ export async function replayGooseMigrationUp({
 async function runMigrationStatements({
   client,
   fileName,
+  afterStatement,
 }: {
   client: ClickHouseClient;
   fileName: string;
+  afterStatement?: ReplayStatementHook;
 }): Promise<void> {
   const raw = await readFile(join(MIGRATIONS_DIR, fileName), "utf-8");
 
@@ -156,8 +175,9 @@ async function runMigrationStatements({
   await withReplayLock({
     database,
     run: async () => {
-      for (const query of queries) {
+      for (const [index, query] of queries.entries()) {
         await client.command({ query });
+        await afterStatement?.({ index, statement: query });
       }
     },
   });

--- a/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
+++ b/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
@@ -1,0 +1,80 @@
+-- +goose Up
+-- +goose ENVSUB ON
+--
+-- Fix: governance_kpis uses ReplacingMergeTree(LastEventOccurredAt) but
+-- LastEventOccurredAt moves backward (fold takes min(occurredAt,
+-- span.startTimeUnixMs)), so background merges keep the stale row and
+-- discard the correct cumulative one.
+--
+-- ClickHouse cannot ALTER the version column of a ReplacingMergeTree.
+-- Strategy: CREATE v2 with CreatedAt → INSERT SELECT → RENAME swap →
+-- DROP old. RENAME TABLE is atomic; write gap = INSERT duration only.
+--
+-- CreatedAt is a monotonic wall clock (DEFAULT now64(3)), set by the
+-- server at insert time. The writer does not set it explicitly, so
+-- later writes always have a higher CreatedAt than earlier ones.
+--
+-- @see https://github.com/langwatch/langwatch-saas/issues/1089
+
+-- 1. Create the replacement table with CreatedAt as the version column.
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2
+(
+    -- identity (per-trace contribution)
+    TenantId String CODEC(ZSTD(1)),
+    SourceId String CODEC(ZSTD(1)),
+    HourBucket DateTime CODEC(Delta(4), ZSTD(1)),
+    TraceId String CODEC(ZSTD(1)),
+
+    -- denormalised dimensions (filtered cheaply at read time)
+    SourceType LowCardinality(String),
+
+    -- per-trace contribution (sum at read time across the HourBucket
+    -- group to get the rollup; count(DISTINCT TraceId) for trace count)
+    SpendUsd Float64 CODEC(ZSTD(1)),
+    PromptTokens UInt64 CODEC(Delta(8), ZSTD(1)),
+    CompletionTokens UInt64 CODEC(Delta(8), ZSTD(1)),
+
+    -- timestamps
+    CreatedAt DateTime64(3) DEFAULT now64(3) CODEC(Delta(8), ZSTD(1)),
+    LastEventOccurredAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    -- indexes
+    INDEX idx_source_id SourceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_source_type SourceType TYPE set(64) GRANULARITY 4,
+    INDEX idx_hour_bucket HourBucket TYPE minmax GRANULARITY 1,
+    INDEX idx_tenant_source (TenantId, SourceId) TYPE bloom_filter(0.001) GRANULARITY 1
+)
+ENGINE = ${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}CreatedAt)
+PARTITION BY toYYYYMM(HourBucket)
+ORDER BY (TenantId, SourceId, HourBucket, TraceId)
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+-- +goose StatementEnd
+
+-- 2. Copy existing data. CreatedAt carries over from the source (it was
+--    already populated by the DEFAULT now64(3) at original insert time).
+-- +goose StatementBegin
+INSERT INTO ${CLICKHOUSE_DATABASE}.governance_kpis_v2
+SELECT * FROM ${CLICKHOUSE_DATABASE}.governance_kpis;
+-- +goose StatementEnd
+
+-- 3. Atomic swap — RENAME TABLE exchanges both names in a single
+--    metadata operation. No write gap apart from the INSERT above.
+-- +goose StatementBegin
+RENAME TABLE
+  ${CLICKHOUSE_DATABASE}.governance_kpis TO ${CLICKHOUSE_DATABASE}.governance_kpis_old,
+  ${CLICKHOUSE_DATABASE}.governance_kpis_v2 TO ${CLICKHOUSE_DATABASE}.governance_kpis;
+-- +goose StatementEnd
+
+-- 4. Drop the old table.
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_old;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- Down intentionally not provided. The version column fix is
+-- forward-only; rolling back would reintroduce the backward-moving
+-- version column bug. The table is derived data (rebuildable from
+-- event_log) so a manual rebuild is the rollback path if needed.

--- a/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
+++ b/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
@@ -30,14 +30,14 @@
 --      a RENAME whose destination already exists fails and wedges the
 --      migration until a human intervenes.
 --
---   2. Reconciliation: the copy at step 3 reads a snapshot, so a row
+--   2. Reconciliation: the copy at step 5 reads a snapshot, so a row
 --      written to governance_kpis after that SELECT begins is absent from
 --      the rebuilt table. The KPI writer is event-driven per trace, NOT a
 --      periodic re-emitter (governanceKpisSync.subscriber.ts: "a failure
 --      in a trace's final window is not retried at all"), and it inserts
 --      with async_insert = 1, wait_for_async_insert = 0, so buffered rows
 --      keep landing in the pre-swap table. Without a sweep those traces
---      would contribute nothing, permanently. Step 5 runs AFTER the
+--      would contribute nothing, permanently. Step 7 runs AFTER the
 --      exchange and inserts, from the pre-swap table, exactly the writes
 --      the snapshot missed — matched on
 --      (TenantId, SourceId, HourBucket, TraceId, CreatedAt), which
@@ -46,14 +46,33 @@
 --      aggregate states: the missed write is simply carried over, and the
 --      engine collapses it against its predecessor on the next merge.
 --
--- Residual, stated rather than hidden: (a) a row still sitting in an
--- async_insert buffer at the instant step 5's SELECT runs is missed —
--- bounded by async_insert_busy_timeout, not by the copy duration; (b) if
--- the runner crashes between the EXCHANGE (step 4) and the reconciliation
--- (step 5), the re-apply's step 1 drops the pre-swap table before it is
--- swept, losing that copy window. Both are bounded and this table is
--- derived data: it is rebuildable from event_log, which is the recovery
--- path if either fires.
+-- Crash-after-exchange recovery (the loss window 00064 sidesteps by reading
+-- its delta from a durable ledger, which this table does not have): if the
+-- runner dies between the EXCHANGE (step 6) and the reconciliation
+-- (step 7), every write from the copy window lives ONLY in the
+-- exchanged-out table, now sitting under the scratch name. A re-apply that
+-- dropped the scratch first — as the first draft of this file did — would
+-- discard those writes permanently. Steps 1-2 close that window: before
+-- anything is dropped, the re-apply reconciles whatever the scratch name
+-- currently holds back into the live table. It is the same anti-join as
+-- step 7 and a no-op in every state except the one it exists for:
+--   - fresh run: step 1 creates an empty scratch, step 2 sweeps nothing;
+--   - crashed mid-copy (pre-exchange): the scratch is a partial copy of the
+--     live table, so each of its rows already matches a live
+--     (key, CreatedAt) and the anti-join selects nothing;
+--   - crashed after the exchange: the scratch IS the old live table, and
+--     the anti-join carries exactly the copy-window writes the crash
+--     stranded there back into the new live table before step 3 drops it.
+-- CREATE TABLE IF NOT EXISTS at step 1 is what makes step 2 safe to run
+-- unconditionally: on a re-apply the scratch already exists (with whatever
+-- engine the crash left it), so the IF NOT EXISTS is a no-op and the sweep
+-- reads the real stranded table rather than a freshly-emptied one.
+--
+-- Residual, stated rather than hidden: a row still sitting in an
+-- async_insert buffer at the instant a reconciliation SELECT runs is
+-- missed — bounded by async_insert_busy_timeout, not by the copy duration.
+-- It is bounded and this table is derived data: it is rebuildable from
+-- event_log, which is the recovery path if it fires.
 --
 -- Replication: governance_kpis is already declared through
 -- CLICKHOUSE_ENGINE_REPLACING_PREFIX (00031), so on a cluster it is a
@@ -68,14 +87,86 @@
 -- @see https://github.com/langwatch/langwatch-saas/issues/1089
 -- ============================================================================
 
--- 1. Scratch is dropped, never reused: a previous partial run may have left
+-- 1. Ensure the scratch name exists so step 2 can read it unconditionally.
+--    On a fresh run this creates an empty table; on a re-apply the scratch
+--    already exists (a partial copy, or — after a crash past the exchange —
+--    the old live table itself), so IF NOT EXISTS is a no-op and preserves
+--    whatever the crash stranded there. The engine here is provisional:
+--    step 3 drops this table and step 4 recreates it, so a fresh run's
+--    engine is never swapped in. This CREATE mirrors step 4 exactly.
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2
+(
+    -- identity (per-trace contribution)
+    TenantId String CODEC(ZSTD(1)),
+    SourceId String CODEC(ZSTD(1)),
+    HourBucket DateTime CODEC(Delta(4), ZSTD(1)),
+    TraceId String CODEC(ZSTD(1)),
+
+    -- denormalised dimensions (filtered cheaply at read time)
+    SourceType LowCardinality(String),
+
+    -- per-trace contribution
+    SpendUsd Float64 CODEC(ZSTD(1)),
+    PromptTokens UInt64 CODEC(Delta(8), ZSTD(1)),
+    CompletionTokens UInt64 CODEC(Delta(8), ZSTD(1)),
+
+    -- timestamps
+    CreatedAt DateTime64(3) DEFAULT now64(3) CODEC(Delta(8), ZSTD(1)),
+    LastEventOccurredAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    -- indexes
+    INDEX idx_source_id SourceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_source_type SourceType TYPE set(64) GRANULARITY 4,
+    INDEX idx_hour_bucket HourBucket TYPE minmax GRANULARITY 1,
+    INDEX idx_tenant_source (TenantId, SourceId) TYPE bloom_filter(0.001) GRANULARITY 1
+)
+ENGINE = ${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}CreatedAt)
+PARTITION BY toYYYYMM(HourBucket)
+ORDER BY (TenantId, SourceId, HourBucket, TraceId)
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+-- +goose StatementEnd
+
+-- 2. Crash-after-exchange recovery. If a previous run died between the
+--    exchange (step 6) and the reconciliation (step 7), the copy-window
+--    writes are stranded in the exchanged-out table, now under the scratch
+--    name. Carry them back into the live table BEFORE step 3 drops it.
+--    Same anti-join as step 7, keyed on the full write identity
+--    (TenantId, SourceId, HourBucket, TraceId, CreatedAt): a no-op on a
+--    fresh run (empty scratch) and after a pre-exchange crash (the scratch
+--    is a subset of the live table), and the recovery in the one case it
+--    exists for.
+-- +goose StatementBegin
+INSERT INTO ${CLICKHOUSE_DATABASE}.governance_kpis
+    (TenantId, SourceId, HourBucket, TraceId, SourceType, SpendUsd, PromptTokens, CompletionTokens, CreatedAt, LastEventOccurredAt)
+SELECT
+    stranded.TenantId,
+    stranded.SourceId,
+    stranded.HourBucket,
+    stranded.TraceId,
+    stranded.SourceType,
+    stranded.SpendUsd,
+    stranded.PromptTokens,
+    stranded.CompletionTokens,
+    stranded.CreatedAt,
+    stranded.LastEventOccurredAt
+FROM ${CLICKHOUSE_DATABASE}.governance_kpis_v2 AS stranded
+LEFT ANTI JOIN (
+    SELECT TenantId, SourceId, HourBucket, TraceId, CreatedAt
+    FROM ${CLICKHOUSE_DATABASE}.governance_kpis
+) AS live
+USING (TenantId, SourceId, HourBucket, TraceId, CreatedAt);
+-- +goose StatementEnd
+
+-- 3. Scratch is dropped, never reused: a previous partial run may have left
 --    a table of the WRONG engine under this name, and rebuilding into it
---    would swap the backward-moving version column straight back in.
+--    would swap the backward-moving version column straight back in. Safe
+--    now that step 2 has recovered anything the scratch was holding.
 -- +goose StatementBegin
 DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd
 
--- 2. The replacement table — 00031's schema with CreatedAt as the version.
+-- 4. The replacement table — 00031's schema with CreatedAt as the version.
 -- +goose StatementBegin
 CREATE TABLE ${CLICKHOUSE_DATABASE}.governance_kpis_v2
 (
@@ -110,7 +201,7 @@ ORDER BY (TenantId, SourceId, HourBucket, TraceId)
 SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
 -- +goose StatementEnd
 
--- 3. Copy the existing rows. CreatedAt carries over from the source: it was
+-- 5. Copy the existing rows. CreatedAt carries over from the source: it was
 --    already populated by 00031's DEFAULT now64(3) at original insert time,
 --    so the copied rows keep their true write order.
 --    Columns are listed explicitly. `SELECT *` happens to be correct while
@@ -133,13 +224,13 @@ SELECT
 FROM ${CLICKHOUSE_DATABASE}.governance_kpis;
 -- +goose StatementEnd
 
--- 4. Atomic swap. Writes reach the rebuilt table from here on.
+-- 6. Atomic swap. Writes reach the rebuilt table from here on.
 -- +goose StatementBegin
 EXCHANGE TABLES ${CLICKHOUSE_DATABASE}.governance_kpis AND ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd
 
--- 5. Reconciliation. governance_kpis_v2 now holds the PRE-SWAP table, so
---    this sweeps the rows written to it during the copy at step 3.
+-- 7. Reconciliation. governance_kpis_v2 now holds the PRE-SWAP table, so
+--    this sweeps the rows written to it during the copy at step 5.
 --
 --    It is a DELTA pass, not a re-copy. Re-inserting the whole pre-swap
 --    table would be correct after a merge and wrong until one: reads are
@@ -172,7 +263,7 @@ LEFT ANTI JOIN (
 USING (TenantId, SourceId, HourBucket, TraceId, CreatedAt);
 -- +goose StatementEnd
 
--- 6. Drop the pre-swap table, now fully swept into the rebuilt one.
+-- 8. Drop the pre-swap table, now fully swept into the rebuilt one.
 -- +goose StatementBegin
 DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd

--- a/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
+++ b/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
@@ -1,24 +1,83 @@
 -- +goose Up
 -- +goose ENVSUB ON
+
+-- ============================================================================
+-- governance_kpis: swap the ReplacingMergeTree version column from
+-- LastEventOccurredAt to CreatedAt.
 --
--- Fix: governance_kpis uses ReplacingMergeTree(LastEventOccurredAt) but
--- LastEventOccurredAt moves backward (fold takes min(occurredAt,
--- span.startTimeUnixMs)), so background merges keep the stale row and
--- discard the correct cumulative one.
+-- LastEventOccurredAt moves BACKWARD: the fold takes
+-- min(occurredAt, span.startTimeUnixMs), so a later flush that folded in an
+-- earlier-starting span carries a LOWER value than the flush before it.
+-- ReplacingMergeTree keeps the row with the HIGHEST version at merge time,
+-- so background merges keep the stale, lower-spend row and discard the
+-- correct cumulative one. Reads are plain sum(SpendUsd) with no FINAL and
+-- no argMax (findSpendTotals), so nothing compensates: spend, prompt tokens
+-- and completion tokens all under-report after a merge.
 --
--- ClickHouse cannot ALTER the version column of a ReplacingMergeTree.
--- Strategy: CREATE v2 with CreatedAt → INSERT SELECT → RENAME swap →
--- DROP old. RENAME TABLE is atomic; write gap = INSERT duration only.
+-- CreatedAt (DEFAULT now64(3), never set by the writer) is a monotonic
+-- server wall clock, so a later write always carries a higher version.
 --
--- CreatedAt is a monotonic wall clock (DEFAULT now64(3)), set by the
--- server at insert time. The writer does not set it explicitly, so
--- later writes always have a higher CreatedAt than earlier ones.
+-- ClickHouse cannot ALTER the version column of a ReplacingMergeTree, so
+-- the table has to be rebuilt and swapped. The statement order below is
+-- 00064's (following 00058), and its two guarantees carry over:
+--
+--   1. Re-run safety (the runner may re-apply a partially executed file
+--      after a crash): the scratch table is DROPPED and recreated rather
+--      than reused, so it always has the CreatedAt engine rather than
+--      whatever a previous partial run left under that name. EXCHANGE
+--      TABLES is used rather than RENAME because EXCHANGE requires both
+--      names to exist and leaves both existing, so re-applying converges;
+--      a RENAME whose destination already exists fails and wedges the
+--      migration until a human intervenes.
+--
+--   2. Reconciliation: the copy at step 3 reads a snapshot, so a row
+--      written to governance_kpis after that SELECT begins is absent from
+--      the rebuilt table. The KPI writer is event-driven per trace, NOT a
+--      periodic re-emitter (governanceKpisSync.subscriber.ts: "a failure
+--      in a trace's final window is not retried at all"), and it inserts
+--      with async_insert = 1, wait_for_async_insert = 0, so buffered rows
+--      keep landing in the pre-swap table. Without a sweep those traces
+--      would contribute nothing, permanently. Step 5 runs AFTER the
+--      exchange and inserts, from the pre-swap table, exactly the writes
+--      the snapshot missed — matched on
+--      (TenantId, SourceId, HourBucket, TraceId, CreatedAt), which
+--      identifies a write rather than a key. Unlike 00064 the delta needs
+--      no arithmetic, because these are whole replacing rows rather than
+--      aggregate states: the missed write is simply carried over, and the
+--      engine collapses it against its predecessor on the next merge.
+--
+-- Residual, stated rather than hidden: (a) a row still sitting in an
+-- async_insert buffer at the instant step 5's SELECT runs is missed —
+-- bounded by async_insert_busy_timeout, not by the copy duration; (b) if
+-- the runner crashes between the EXCHANGE (step 4) and the reconciliation
+-- (step 5), the re-apply's step 1 drops the pre-swap table before it is
+-- swept, losing that copy window. Both are bounded and this table is
+-- derived data: it is rebuildable from event_log, which is the recovery
+-- path if either fires.
+--
+-- Replication: governance_kpis is already declared through
+-- CLICKHOUSE_ENGINE_REPLACING_PREFIX (00031), so on a cluster it is a
+-- ReplicatedReplacingMergeTree and its content is identical on every
+-- replica. That is why this file does not gate on
+-- CLICKHOUSE_IS_REPLICATED the way a migration carrying rows over from a
+-- plain-engine table must: there is no per-replica partial content to
+-- read. goose runs every statement on one connection, i.e. one replica;
+-- the DDL replicates through the database engine, and the INSERTs write
+-- into a Replicated engine so the rows replicate to every node.
 --
 -- @see https://github.com/langwatch/langwatch-saas/issues/1089
+-- ============================================================================
 
--- 1. Create the replacement table with CreatedAt as the version column.
+-- 1. Scratch is dropped, never reused: a previous partial run may have left
+--    a table of the WRONG engine under this name, and rebuilding into it
+--    would swap the backward-moving version column straight back in.
 -- +goose StatementBegin
-CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
+-- +goose StatementEnd
+
+-- 2. The replacement table — 00031's schema with CreatedAt as the version.
+-- +goose StatementBegin
+CREATE TABLE ${CLICKHOUSE_DATABASE}.governance_kpis_v2
 (
     -- identity (per-trace contribution)
     TenantId String CODEC(ZSTD(1)),
@@ -51,30 +110,78 @@ ORDER BY (TenantId, SourceId, HourBucket, TraceId)
 SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
 -- +goose StatementEnd
 
--- 2. Copy existing data. CreatedAt carries over from the source (it was
---    already populated by the DEFAULT now64(3) at original insert time).
+-- 3. Copy the existing rows. CreatedAt carries over from the source: it was
+--    already populated by 00031's DEFAULT now64(3) at original insert time,
+--    so the copied rows keep their true write order.
+--    Columns are listed explicitly. `SELECT *` happens to be correct while
+--    the two schemas are byte-identical, and silently stops being correct
+--    the moment somebody adds a column to one of them.
 -- +goose StatementBegin
 INSERT INTO ${CLICKHOUSE_DATABASE}.governance_kpis_v2
-SELECT * FROM ${CLICKHOUSE_DATABASE}.governance_kpis;
+    (TenantId, SourceId, HourBucket, TraceId, SourceType, SpendUsd, PromptTokens, CompletionTokens, CreatedAt, LastEventOccurredAt)
+SELECT
+    TenantId,
+    SourceId,
+    HourBucket,
+    TraceId,
+    SourceType,
+    SpendUsd,
+    PromptTokens,
+    CompletionTokens,
+    CreatedAt,
+    LastEventOccurredAt
+FROM ${CLICKHOUSE_DATABASE}.governance_kpis;
 -- +goose StatementEnd
 
--- 3. Atomic swap — RENAME TABLE exchanges both names in a single
---    metadata operation. No write gap apart from the INSERT above.
+-- 4. Atomic swap. Writes reach the rebuilt table from here on.
 -- +goose StatementBegin
-RENAME TABLE
-  ${CLICKHOUSE_DATABASE}.governance_kpis TO ${CLICKHOUSE_DATABASE}.governance_kpis_old,
-  ${CLICKHOUSE_DATABASE}.governance_kpis_v2 TO ${CLICKHOUSE_DATABASE}.governance_kpis;
+EXCHANGE TABLES ${CLICKHOUSE_DATABASE}.governance_kpis AND ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd
 
--- 4. Drop the old table.
+-- 5. Reconciliation. governance_kpis_v2 now holds the PRE-SWAP table, so
+--    this sweeps the rows written to it during the copy at step 3.
+--
+--    It is a DELTA pass, not a re-copy. Re-inserting the whole pre-swap
+--    table would be correct after a merge and wrong until one: reads are
+--    plain sum(SpendUsd) with no FINAL, so every duplicated row would
+--    double-count spend for as long as the duplicate parts survived.
+--    (TenantId, SourceId, HourBucket, TraceId, CreatedAt) identifies a
+--    write exactly — a row written during the window shares the ORDER BY
+--    key with its copied predecessor but carries a strictly higher
+--    CreatedAt — so the anti-join keeps precisely the writes the snapshot
+--    missed, and re-running it selects nothing.
 -- +goose StatementBegin
-DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_old;
+INSERT INTO ${CLICKHOUSE_DATABASE}.governance_kpis
+    (TenantId, SourceId, HourBucket, TraceId, SourceType, SpendUsd, PromptTokens, CompletionTokens, CreatedAt, LastEventOccurredAt)
+SELECT
+    missed.TenantId,
+    missed.SourceId,
+    missed.HourBucket,
+    missed.TraceId,
+    missed.SourceType,
+    missed.SpendUsd,
+    missed.PromptTokens,
+    missed.CompletionTokens,
+    missed.CreatedAt,
+    missed.LastEventOccurredAt
+FROM ${CLICKHOUSE_DATABASE}.governance_kpis_v2 AS missed
+LEFT ANTI JOIN (
+    SELECT TenantId, SourceId, HourBucket, TraceId, CreatedAt
+    FROM ${CLICKHOUSE_DATABASE}.governance_kpis
+) AS rebuilt
+USING (TenantId, SourceId, HourBucket, TraceId, CreatedAt);
+-- +goose StatementEnd
+
+-- 6. Drop the pre-swap table, now fully swept into the rebuilt one.
+-- +goose StatementBegin
+DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd
 
 -- +goose ENVSUB OFF
 
 -- +goose Down
--- IRREVERSIBLE: the version column swap discards the backward-moving
--- LastEventOccurredAt engine and there is no way to reconstruct it.
--- The table is derived data (rebuildable from event_log) so a manual
--- rebuild is the rollback path if needed.
+-- IRREVERSIBLE: the swap discards the LastEventOccurredAt-versioned table,
+-- and going back would restore a version column that moves backward and
+-- under-reports spend after every merge. Rollback statements stay commented
+-- out and must be applied manually if ever needed; the table is derived
+-- data and the supported recovery path is a rebuild from event_log.

--- a/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
+++ b/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
@@ -74,7 +74,7 @@ DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_old;
 -- +goose ENVSUB OFF
 
 -- +goose Down
--- Down intentionally not provided. The version column fix is
--- forward-only; rolling back would reintroduce the backward-moving
--- version column bug. The table is derived data (rebuildable from
--- event_log) so a manual rebuild is the rollback path if needed.
+-- IRREVERSIBLE: the version column swap discards the backward-moving
+-- LastEventOccurredAt engine and there is no way to reconstruct it.
+-- The table is derived data (rebuildable from event_log) so a manual
+-- rebuild is the rollback path if needed.

--- a/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
+++ b/platform/app/src/server/clickhouse/migrations/00083_governance_kpis_version_column_fix.sql
@@ -17,156 +17,89 @@
 -- CreatedAt (DEFAULT now64(3), never set by the writer) is a monotonic
 -- server wall clock, so a later write always carries a higher version.
 --
--- ClickHouse cannot ALTER the version column of a ReplacingMergeTree, so
--- the table has to be rebuilt and swapped. The statement order below is
--- 00064's (following 00058), and its two guarantees carry over:
+-- ClickHouse cannot ALTER the version column of a ReplacingMergeTree, so the
+-- table is rebuilt into a scratch copy and swapped in with EXCHANGE TABLES.
 --
---   1. Re-run safety (the runner may re-apply a partially executed file
---      after a crash): the scratch table is DROPPED and recreated rather
---      than reused, so it always has the CreatedAt engine rather than
---      whatever a previous partial run left under that name. EXCHANGE
---      TABLES is used rather than RENAME because EXCHANGE requires both
---      names to exist and leaves both existing, so re-applying converges;
---      a RENAME whose destination already exists fails and wedges the
---      migration until a human intervenes.
+-- ----------------------------------------------------------------------------
+-- PRECONDITION: the KPI writer MUST be quiesced before this runs.
+-- ----------------------------------------------------------------------------
+-- This is a copy-and-swap of a live table. The KPI writer
+-- (governanceKpisSync.subscriber.ts, in the `workers` deployment) inserts
+-- with async_insert = 1, wait_for_async_insert = 0 and is event-driven per
+-- trace: "a failure in a trace's final window is not retried at all". So a
+-- contribution written between the copy (step 3) and the drop (step 5)
+-- lands only in the pre-swap table and is discarded permanently when that
+-- table is dropped — there is no re-emit to heal it.
 --
---   2. Reconciliation: the copy at step 5 reads a snapshot, so a row
---      written to governance_kpis after that SELECT begins is absent from
---      the rebuilt table. The KPI writer is event-driven per trace, NOT a
---      periodic re-emitter (governanceKpisSync.subscriber.ts: "a failure
---      in a trace's final window is not retried at all"), and it inserts
---      with async_insert = 1, wait_for_async_insert = 0, so buffered rows
---      keep landing in the pre-swap table. Without a sweep those traces
---      would contribute nothing, permanently. Step 7 runs AFTER the
---      exchange and inserts, from the pre-swap table, exactly the writes
---      the snapshot missed — matched on
---      (TenantId, SourceId, HourBucket, TraceId, CreatedAt), which
---      identifies a write rather than a key. Unlike 00064 the delta needs
---      no arithmetic, because these are whole replacing rows rather than
---      aggregate states: the missed write is simply carried over, and the
---      engine collapses it against its predecessor on the next merge.
+-- Earlier drafts tried to reconcile that window from the exchanged-out table
+-- after the swap. That cannot be made lossless from inside a linear
+-- migration: an async_insert buffer accepted before the exchange can still
+-- flush into the pre-swap table AFTER the reconciliation read, and the drop
+-- then discards it. Every reconciliation attempt only narrowed the race; it
+-- never closed it. The correct fix is to remove the concurrency, not chase
+-- it — so this migration carries no reconciliation and instead REQUIRES the
+-- writer to be stopped.
 --
--- Crash-after-exchange recovery (the loss window 00064 sidesteps by reading
--- its delta from a durable ledger, which this table does not have): if the
--- runner dies between the EXCHANGE (step 6) and the reconciliation
--- (step 7), every write from the copy window lives ONLY in the
--- exchanged-out table, now sitting under the scratch name. A re-apply that
--- dropped the scratch first — as the first draft of this file did — would
--- discard those writes permanently. Steps 1-2 close that window: before
--- anything is dropped, the re-apply reconciles whatever the scratch name
--- currently holds back into the live table. It is the same anti-join as
--- step 7 and a no-op in every state except the one it exists for:
---   - fresh run: step 1 creates an empty scratch, step 2 sweeps nothing;
---   - crashed mid-copy (pre-exchange): the scratch is a partial copy of the
---     live table, so each of its rows already matches a live
---     (key, CreatedAt) and the anti-join selects nothing;
---   - crashed after the exchange: the scratch IS the old live table, and
---     the anti-join carries exactly the copy-window writes the crash
---     stranded there back into the new live table before step 3 drops it.
--- CREATE TABLE IF NOT EXISTS at step 1 is what makes step 2 safe to run
--- unconditionally: on a re-apply the scratch already exists (with whatever
--- engine the crash left it), so the IF NOT EXISTS is a no-op and the sweep
--- reads the real stranded table rather than a freshly-emptied one.
+-- Operational runbook for the deploy that applies this migration:
+--   1. Scale the `workers` deployment to 0 (stops the KPIs subscriber).
+--   2. Wait > 60s so any accepted async_insert buffer has flushed to the
+--      table (bounded by async_insert_busy_timeout, ~1s, with margin).
+--   3. Apply this migration.
+--   4. Scale `workers` back up. It resumes from event_log; governance_kpis is
+--      derived data, so the paused interval folds forward with no loss.
 --
--- Residual, stated rather than hidden: a row still sitting in an
--- async_insert buffer at the instant a reconciliation SELECT runs is
--- missed — bounded by async_insert_busy_timeout, not by the copy duration.
--- It is bounded and this table is derived data: it is rebuildable from
--- event_log, which is the recovery path if it fires.
+-- Step 0 GUARDS this precondition: it aborts the migration if governance_kpis
+-- shows a write in the last 60s, so an operator who forgets to quiesce gets a
+-- failed migration BEFORE any DDL rather than silent data loss. It is a
+-- heuristic backstop, not a substitute for the runbook: CreatedAt is server
+-- wall clock at insert, so "a fresh CreatedAt" means "a recent write", but a
+-- writer paused for under 60s, clock skew, or a write buffered on another
+-- replica can still slip past it. Quiesce first; do not lean on the guard.
+--
+-- Re-run safety (the runner may re-apply a partially executed file after a
+-- crash): the scratch table is DROPPED and recreated rather than reused, so
+-- it always carries the CreatedAt engine rather than whatever a previous
+-- partial run left under that name. EXCHANGE TABLES (not RENAME) requires
+-- both names to exist and leaves both existing, so re-applying converges; a
+-- RENAME whose destination already exists fails and wedges the migration.
+-- Because the writer is quiesced there are no concurrent writes, so a
+-- re-apply re-copies the same rows and converges on the same state.
 --
 -- Replication: governance_kpis is already declared through
 -- CLICKHOUSE_ENGINE_REPLACING_PREFIX (00031), so on a cluster it is a
--- ReplicatedReplacingMergeTree and its content is identical on every
--- replica. That is why this file does not gate on
--- CLICKHOUSE_IS_REPLICATED the way a migration carrying rows over from a
--- plain-engine table must: there is no per-replica partial content to
--- read. goose runs every statement on one connection, i.e. one replica;
--- the DDL replicates through the database engine, and the INSERTs write
--- into a Replicated engine so the rows replicate to every node.
+-- ReplicatedReplacingMergeTree with identical content on every replica. This
+-- file does not gate on CLICKHOUSE_IS_REPLICATED the way a migration carrying
+-- rows over from a plain-engine table must: there is no per-replica partial
+-- content to read. goose runs every statement on one connection (one
+-- replica); the DDL replicates through the database engine, and the INSERT
+-- writes into a Replicated engine so the rows replicate to every node.
 --
 -- @see https://github.com/langwatch/langwatch-saas/issues/1089
 -- ============================================================================
 
--- 1. Ensure the scratch name exists so step 2 can read it unconditionally.
---    On a fresh run this creates an empty table; on a re-apply the scratch
---    already exists (a partial copy, or — after a crash past the exchange —
---    the old live table itself), so IF NOT EXISTS is a no-op and preserves
---    whatever the crash stranded there. The engine here is provisional:
---    step 3 drops this table and step 4 recreates it, so a fresh run's
---    engine is never swapped in. This CREATE mirrors step 4 exactly.
+-- 0. Guard the quiesce precondition. throwIf aborts the migration (and marks
+--    it un-applied) if governance_kpis received a write in the last 60s,
+--    which means the writer is still running. This runs before any DDL, so a
+--    tripped guard leaves the table exactly as it was.
 -- +goose StatementBegin
-CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2
-(
-    -- identity (per-trace contribution)
-    TenantId String CODEC(ZSTD(1)),
-    SourceId String CODEC(ZSTD(1)),
-    HourBucket DateTime CODEC(Delta(4), ZSTD(1)),
-    TraceId String CODEC(ZSTD(1)),
-
-    -- denormalised dimensions (filtered cheaply at read time)
-    SourceType LowCardinality(String),
-
-    -- per-trace contribution
-    SpendUsd Float64 CODEC(ZSTD(1)),
-    PromptTokens UInt64 CODEC(Delta(8), ZSTD(1)),
-    CompletionTokens UInt64 CODEC(Delta(8), ZSTD(1)),
-
-    -- timestamps
-    CreatedAt DateTime64(3) DEFAULT now64(3) CODEC(Delta(8), ZSTD(1)),
-    LastEventOccurredAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
-
-    -- indexes
-    INDEX idx_source_id SourceId TYPE bloom_filter(0.001) GRANULARITY 1,
-    INDEX idx_source_type SourceType TYPE set(64) GRANULARITY 4,
-    INDEX idx_hour_bucket HourBucket TYPE minmax GRANULARITY 1,
-    INDEX idx_tenant_source (TenantId, SourceId) TYPE bloom_filter(0.001) GRANULARITY 1
-)
-ENGINE = ${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}CreatedAt)
-PARTITION BY toYYYYMM(HourBucket)
-ORDER BY (TenantId, SourceId, HourBucket, TraceId)
-SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+SELECT throwIf(
+    (
+        SELECT count()
+        FROM ${CLICKHOUSE_DATABASE}.governance_kpis
+        WHERE CreatedAt > now64(3) - INTERVAL 60 SECOND
+    ) > 0,
+    'governance_kpis received a write in the last 60s: the KPI writer is not quiesced. Scale the workers deployment to 0 and wait >60s before applying migration 00083 (see the header runbook).'
+);
 -- +goose StatementEnd
 
--- 2. Crash-after-exchange recovery. If a previous run died between the
---    exchange (step 6) and the reconciliation (step 7), the copy-window
---    writes are stranded in the exchanged-out table, now under the scratch
---    name. Carry them back into the live table BEFORE step 3 drops it.
---    Same anti-join as step 7, keyed on the full write identity
---    (TenantId, SourceId, HourBucket, TraceId, CreatedAt): a no-op on a
---    fresh run (empty scratch) and after a pre-exchange crash (the scratch
---    is a subset of the live table), and the recovery in the one case it
---    exists for.
--- +goose StatementBegin
-INSERT INTO ${CLICKHOUSE_DATABASE}.governance_kpis
-    (TenantId, SourceId, HourBucket, TraceId, SourceType, SpendUsd, PromptTokens, CompletionTokens, CreatedAt, LastEventOccurredAt)
-SELECT
-    stranded.TenantId,
-    stranded.SourceId,
-    stranded.HourBucket,
-    stranded.TraceId,
-    stranded.SourceType,
-    stranded.SpendUsd,
-    stranded.PromptTokens,
-    stranded.CompletionTokens,
-    stranded.CreatedAt,
-    stranded.LastEventOccurredAt
-FROM ${CLICKHOUSE_DATABASE}.governance_kpis_v2 AS stranded
-LEFT ANTI JOIN (
-    SELECT TenantId, SourceId, HourBucket, TraceId, CreatedAt
-    FROM ${CLICKHOUSE_DATABASE}.governance_kpis
-) AS live
-USING (TenantId, SourceId, HourBucket, TraceId, CreatedAt);
--- +goose StatementEnd
-
--- 3. Scratch is dropped, never reused: a previous partial run may have left
---    a table of the WRONG engine under this name, and rebuilding into it
---    would swap the backward-moving version column straight back in. Safe
---    now that step 2 has recovered anything the scratch was holding.
+-- 1. Scratch is dropped, never reused: a previous partial run may have left a
+--    table of the WRONG engine under this name, and rebuilding into it would
+--    swap the backward-moving version column straight back in.
 -- +goose StatementBegin
 DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd
 
--- 4. The replacement table — 00031's schema with CreatedAt as the version.
+-- 2. The replacement table — 00031's schema with CreatedAt as the version.
 -- +goose StatementBegin
 CREATE TABLE ${CLICKHOUSE_DATABASE}.governance_kpis_v2
 (
@@ -201,9 +134,10 @@ ORDER BY (TenantId, SourceId, HourBucket, TraceId)
 SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
 -- +goose StatementEnd
 
--- 5. Copy the existing rows. CreatedAt carries over from the source: it was
---    already populated by 00031's DEFAULT now64(3) at original insert time,
---    so the copied rows keep their true write order.
+-- 3. Copy the existing rows. With the writer quiesced this snapshot is the
+--    whole table — nothing is landing behind it. CreatedAt carries over from
+--    the source: it was already populated by 00031's DEFAULT now64(3) at
+--    original insert time, so the copied rows keep their true write order.
 --    Columns are listed explicitly. `SELECT *` happens to be correct while
 --    the two schemas are byte-identical, and silently stops being correct
 --    the moment somebody adds a column to one of them.
@@ -224,46 +158,13 @@ SELECT
 FROM ${CLICKHOUSE_DATABASE}.governance_kpis;
 -- +goose StatementEnd
 
--- 6. Atomic swap. Writes reach the rebuilt table from here on.
+-- 4. Atomic swap. governance_kpis is now the CreatedAt-versioned table.
 -- +goose StatementBegin
 EXCHANGE TABLES ${CLICKHOUSE_DATABASE}.governance_kpis AND ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd
 
--- 7. Reconciliation. governance_kpis_v2 now holds the PRE-SWAP table, so
---    this sweeps the rows written to it during the copy at step 5.
---
---    It is a DELTA pass, not a re-copy. Re-inserting the whole pre-swap
---    table would be correct after a merge and wrong until one: reads are
---    plain sum(SpendUsd) with no FINAL, so every duplicated row would
---    double-count spend for as long as the duplicate parts survived.
---    (TenantId, SourceId, HourBucket, TraceId, CreatedAt) identifies a
---    write exactly — a row written during the window shares the ORDER BY
---    key with its copied predecessor but carries a strictly higher
---    CreatedAt — so the anti-join keeps precisely the writes the snapshot
---    missed, and re-running it selects nothing.
--- +goose StatementBegin
-INSERT INTO ${CLICKHOUSE_DATABASE}.governance_kpis
-    (TenantId, SourceId, HourBucket, TraceId, SourceType, SpendUsd, PromptTokens, CompletionTokens, CreatedAt, LastEventOccurredAt)
-SELECT
-    missed.TenantId,
-    missed.SourceId,
-    missed.HourBucket,
-    missed.TraceId,
-    missed.SourceType,
-    missed.SpendUsd,
-    missed.PromptTokens,
-    missed.CompletionTokens,
-    missed.CreatedAt,
-    missed.LastEventOccurredAt
-FROM ${CLICKHOUSE_DATABASE}.governance_kpis_v2 AS missed
-LEFT ANTI JOIN (
-    SELECT TenantId, SourceId, HourBucket, TraceId, CreatedAt
-    FROM ${CLICKHOUSE_DATABASE}.governance_kpis
-) AS rebuilt
-USING (TenantId, SourceId, HourBucket, TraceId, CreatedAt);
--- +goose StatementEnd
-
--- 8. Drop the pre-swap table, now fully swept into the rebuilt one.
+-- 5. Drop the pre-swap table, now sitting under the scratch name. Safe: the
+--    writer is quiesced, so nothing landed in it after the copy.
 -- +goose StatementBegin
 DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.governance_kpis_v2;
 -- +goose StatementEnd

--- a/platform/app/src/server/clickhouse/migrations/00084_governance_kpis_version_column_fix.sql
+++ b/platform/app/src/server/clickhouse/migrations/00084_governance_kpis_version_column_fix.sql
@@ -88,7 +88,7 @@ SELECT throwIf(
         FROM ${CLICKHOUSE_DATABASE}.governance_kpis
         WHERE CreatedAt > now64(3) - INTERVAL 60 SECOND
     ) > 0,
-    'governance_kpis received a write in the last 60s: the KPI writer is not quiesced. Scale the workers deployment to 0 and wait >60s before applying migration 00083 (see the header runbook).'
+    'governance_kpis received a write in the last 60s: the KPI writer is not quiesced. Scale the workers deployment to 0 and wait >60s before applying migration 00084 (see the header runbook).'
 );
 -- +goose StatementEnd
 


### PR DESCRIPTION
# For humans

Governance spend numbers were quietly under-reporting. Each trace writes a running total into a rollup table, and the database was told to settle duplicates by keeping "the one with the latest event time" — but that time can move *backwards* as more of a trace arrives, so it kept the older, smaller number and threw the correct one away.

This changes the tie-breaker to the moment the row was written, which only ever moves forward, and rebuilds the table so existing rows follow the new rule. Spend, prompt tokens and completion tokens all stop under-reporting. The rebuild swaps the whole table, so it must run with the KPI writer briefly stopped — the migration refuses to run otherwise.

# Related Issue

- Resolves #1089

## Cause

`governance_kpis` is `ReplacingMergeTree(LastEventOccurredAt)`, but `LastEventOccurredAt` moves **backward**: the fold takes `min(occurredAt, span.startTimeUnixMs)`, so a later flush that folded in an earlier-starting span carries a *lower* value than the flush before it. The engine keeps the row with the highest version at merge time, so merges keep the stale, lower-spend row and discard the correct cumulative one.

`platform/app/src/server/clickhouse/migrations/00031_create_governance_kpis.sql:79`

Nothing compensates on the read side: `findSpendTotals` is a plain `sum(SpendUsd)` with no `FINAL` and no `argMax`.

## Fix

Migration `00084` swaps the version column to `CreatedAt` — `DEFAULT now64(3)`, never set by the writer, so it is a monotonic server clock. ClickHouse cannot `ALTER` a `ReplacingMergeTree` version column, so the table is rebuilt into a scratch copy and swapped in:

0. **Guard** — `throwIf` aborts the migration, before any DDL, if `governance_kpis` shows a write in the last 60s
1. **DROP** the scratch table — a partially executed run may have left one with the wrong engine, and rebuilding into it would swap the broken version column straight back in
2. **CREATE** `governance_kpis_v2` with `ReplacingMergeTree(CreatedAt)`
3. **INSERT SELECT** the existing rows, columns named explicitly (`CreatedAt` carries over from the original inserts, so write order is preserved)
4. **EXCHANGE TABLES** — not `RENAME`: a `RENAME` onto a name a crashed run left in place fails and wedges the migration, while `EXCHANGE` requires both names to exist and converges on re-apply
5. **DROP** the pre-swap table

No application code changes. The writer already relies on the `CreatedAt` server default, and the reader depends entirely on correct merge behaviour.

### Why there is no reconciliation (and why the writer must be quiesced)

This is a copy-and-swap of a live table, and earlier drafts tried to make it lossless *online* — reconciling, after the swap, the writes the copy's snapshot missed from the exchanged-out table. That can't be closed from inside a linear migration. The KPI writer (`governanceKpisSync.subscriber.ts`, in the `workers` deployment) is event-driven per trace and does not re-emit (*"a failure in a trace's final window is not retried at all"*), and it inserts with `async_insert = 1, wait_for_async_insert = 0`. So a block accepted before the `EXCHANGE` can flush into the pre-swap table **after** any reconciliation read and **before** the `DROP` — and the drop then discards it. Each successive fix (copy window → crash-after-exchange → async-buffer window) only narrowed the same race; none closed it.

The correct fix removes the concurrency instead of chasing it. The reconciliation is gone; the swap **requires the writer to be stopped**, and enforces it:

- **Runbook** (header): scale the `workers` deployment to 0, wait >60s for async buffers to flush, apply the migration, scale back up. `governance_kpis` is derived, so the paused interval folds forward from `event_log` with no loss on resume.
- **Step-0 guard**: `throwIf` aborts before any DDL if the table shows a write in the last 60s (`CreatedAt` is `DEFAULT now64(3)` = server wall-clock at insert), so forgetting to quiesce fails loudly and leaves the table untouched instead of silently under-counting. It is a heuristic backstop — a sub-60s pause, clock skew, or a buffer on another replica can slip past it — **not** a substitute for the runbook.

## Tests

`governanceKpis.versionColumn.integration.test.ts` runs the **real migration file against the real table**, staged back into the shape `00031` leaves it in, via `replayGooseMigrationUp`. It runs on its **own database** (`startTestClickHouseEndpoints`), not the shared migrated one: staging means dropping and recreating `governance_kpis`, and `spendSpikeAnomalyEvaluator` seeds and queries that exact table. `withReplayLock` orders replays against each other but not against plain readers, so on the shared endpoint a neighbouring suite could read the table during the window where it does not exist.

Seven tests: with the writer quiesced, every staged row survives the swap; the rebuilt engine is `ReplacingMergeTree(CreatedAt)`; no scratch table is left behind; a second clean application converges; a trace re-folded with a backward-moving `LastEventOccurredAt` keeps its cumulative totals after `OPTIMIZE FINAL` (the actual bug); and — the guard — a live write (default `CreatedAt`) makes the migration **abort** with the table left on `ReplacingMergeTree(LastEventOccurredAt)` and no scratch table created.

**Failing, against the pre-guard migration** — it swaps under the live writer instead of refusing:

```
 × aborts the migration instead of swapping under a live writer
   AssertionError: expected undefined to be an instance of Error
 × leaves the pre-upgrade table untouched
   Expected: "ReplacingMergeTree(LastEventOccurredAt)"
   Received: "ReplacingMergeTree(CreatedAt) …"
      Tests  2 failed | 5 passed (7)
```

**Passing:**

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Sweep

Checked all 20+ `ReplacingMergeTree` tables across 82 migration files. Every other version column (`UpdatedAt`, `EventTimestamp`, `IngestedAt`, `ProjectedAt`, `DedupVersion`, `inserted_at`, `AsOf`, `LastSeenAt`, `StartTime`, `OccurredAt`, `LastUpdatedAt`) is either a wall-clock timestamp set at write time or an immutable event timestamp. `governance_kpis` was the only table with a backward-moving one.

## Operational note, stated rather than hidden

This migration is **not** safe to apply while the KPI writer is running — that is the point of the change, and the step-0 guard enforces it. The guard is a heuristic (single-connection `now()` window), so the runbook, not the guard, is the guarantee: stop `workers`, wait for async buffers to flush, apply, restart. Because `governance_kpis` is derived data, the paused interval is recovered by the normal fold from `event_log` on restart — no manual rebuild in the happy path.

Not verified against a live replicated cluster. The migration does not gate on `CLICKHOUSE_IS_REPLICATED` because `governance_kpis` is already declared through `CLICKHOUSE_ENGINE_REPLACING_PREFIX`, so on a cluster its content is identical on every replica and the copy has nothing partial to read. The guard reads one connection (one replica), so a buffer held on another replica is the one case it cannot see — hence the wait-for-flush step in the runbook.

## Not fixed

- `LastEventOccurredAt` is kept as metadata rather than dropped. Removing it would mean changing the writer too, which is not worth the risk here.
- `00031`'s comments still describe `LastEventOccurredAt` as the version column. They are historical and accurate for that migration.

Closes langwatch/langwatch-saas#1089


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved governance KPI versioning to preserve the correct latest records when event timestamps change.
  * Migration now rebuilds the rollup table with a forward-only tie-breaker and refuses to run unless the KPI writer is stopped, avoiding data loss during the swap.
  * Prevented temporary migration artifacts from remaining after successful updates.

* **Tests**
  * Added coverage for data retention, cleanup, repeated migrations, the version-column fix, and the quiesce guard that aborts an unsafe migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
