### PR TITLE
feat(cli): create the HTTP agent on the spot when agent dev finds none

### DIFF
--- a/sdks/typescript/src/cli/commands/agents/__tests__/agent-dev-resolve.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/agents/__tests__/agent-dev-resolve.unit.test.ts
@@ -1,6 +1,7 @@
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentsApiService } from "@/client-sdk/services/agents/agents-api.service";
-import { resolveTargetAgent } from "../dev/resolve";
+import { resolveLocalUrl, resolveTargetAgent } from "../dev/resolve";
 
 /**
  * Agent selection for `langwatch agent dev` when `--agent` is omitted.
@@ -64,6 +65,15 @@ function makeService({
 	return { service, create };
 }
 
+// Vitest recycles worker processes across files, so forcing a value into
+// process.stdin.isTTY would leak into whatever file runs next in the same
+// worker. Capture the original descriptors once and restore them after each
+// test.
+const originalTTY = {
+	stdin: Object.getOwnPropertyDescriptor(process.stdin, "isTTY"),
+	stdout: Object.getOwnPropertyDescriptor(process.stdout, "isTTY"),
+};
+
 function setTTY(isTTY: boolean) {
 	Object.defineProperty(process.stdin, "isTTY", {
 		value: isTTY,
@@ -73,6 +83,19 @@ function setTTY(isTTY: boolean) {
 		value: isTTY,
 		configurable: true,
 	});
+}
+
+function restoreTTY() {
+	for (const [stream, descriptor] of [
+		[process.stdin, originalTTY.stdin],
+		[process.stdout, originalTTY.stdout],
+	] as const) {
+		if (descriptor) {
+			Object.defineProperty(stream, "isTTY", descriptor);
+		} else {
+			delete (stream as { isTTY?: boolean }).isTTY;
+		}
+	}
 }
 
 describe("agent dev target resolution", () => {
@@ -88,7 +111,7 @@ describe("agent dev target resolution", () => {
 	});
 
 	afterEach(() => {
-		setTTY(false);
+		restoreTTY();
 		vi.restoreAllMocks();
 	});
 
@@ -112,6 +135,11 @@ describe("agent dev target resolution", () => {
 				});
 				expect(agent.id).toBe("agent_new");
 				expect(agent.name).toBe("My Local Agent");
+				expect(mockPrompts).toHaveBeenCalledWith(
+					expect.objectContaining({
+						initial: path.basename(process.cwd()),
+					}),
+				);
 			});
 
 			/** @scenario "Declining the offered agent name ends the session with instructions" */
@@ -181,6 +209,21 @@ describe("agent dev target resolution", () => {
 					"--agent <id|name>",
 				);
 			});
+		});
+	});
+
+	describe("given a --url value carrying embedded credentials", () => {
+		/** @scenario "A local URL carrying credentials is refused" */
+		it("fails and says to pass the URL without credentials", () => {
+			// The URL lands in the agent's platform config and in terminal
+			// output, so userinfo in it would leak both ways.
+			expect(() =>
+				resolveLocalUrl({ url: "http://user:secret@localhost:3000" }),
+			).toThrow(ProcessExitError);
+
+			expect(String(consoleError.mock.calls.flat())).toContain(
+				"without credentials",
+			);
 		});
 	});
 

--- a/sdks/typescript/src/cli/commands/agents/__tests__/agent-dev-resolve.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/agents/__tests__/agent-dev-resolve.unit.test.ts
@@ -137,8 +137,24 @@ describe("agent dev target resolution", () => {
 				expect(agent.name).toBe("My Local Agent");
 				expect(mockPrompts).toHaveBeenCalledWith(
 					expect.objectContaining({
-						initial: path.basename(process.cwd()),
+						initial: path.basename(process.cwd()) || "my-agent",
 					}),
+				);
+			});
+
+			it("offers my-agent when the directory has no basename", async () => {
+				setTTY(true);
+				vi.spyOn(process, "cwd").mockReturnValue("/");
+				mockPrompts.mockResolvedValue({ name: "my-agent" });
+				const { service } = makeService({ agents: [] });
+
+				await resolveTargetAgent({
+					service,
+					localUrl: "http://localhost:8010/agent/chat",
+				});
+
+				expect(mockPrompts).toHaveBeenCalledWith(
+					expect.objectContaining({ initial: "my-agent" }),
 				);
 			});
 

--- a/sdks/typescript/src/cli/commands/agents/__tests__/agent-dev-resolve.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/agents/__tests__/agent-dev-resolve.unit.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentsApiService } from "@/client-sdk/services/agents/agents-api.service";
+import { resolveTargetAgent } from "../dev/resolve";
+
+/**
+ * Agent selection for `langwatch agent dev` when `--agent` is omitted.
+ *
+ * The selection order (flag, remembered agent, lone agent, picker) mostly
+ * needs no test double beyond a fake service, but the edges do: with no HTTP
+ * agents a terminal session offers to create one on the spot, and a session
+ * without a terminal must fail with the exact command that skips the
+ * interactivity.
+ *
+ * @see specs/agents/agent-dev-tunnel.feature
+ */
+
+const { mockPrompts } = vi.hoisted(() => ({ mockPrompts: vi.fn() }));
+vi.mock("prompts", () => ({ default: mockPrompts }));
+
+// Keep the per-directory memory inert: these tests drive the picker, not the
+// remembered-agent shortcut.
+vi.mock("../../../utils/governance/config", () => ({
+	loadConfig: vi.fn(() => ({})),
+	saveConfig: vi.fn(),
+}));
+
+class ProcessExitError extends Error {
+	constructor(public code: number) {
+		super(`process.exit(${code})`);
+	}
+}
+
+const noop = () => {
+	// intentionally empty, suppresses output during tests
+};
+
+const makeAgent = (overrides: Record<string, unknown> = {}) => ({
+	id: "agent_abc123",
+	name: "Bid Companion",
+	type: "http",
+	config: { url: "https://staging.example.com/agent" },
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+	platformUrl: "https://app.langwatch.test/proj/agents",
+	...overrides,
+});
+
+function makeService({
+	agents,
+}: {
+	agents: ReturnType<typeof makeAgent>[];
+}): { service: AgentsApiService; create: ReturnType<typeof vi.fn> } {
+	const create = vi
+		.fn()
+		.mockImplementation((params: { name: string; config: unknown }) =>
+			Promise.resolve(
+				makeAgent({ id: "agent_new", name: params.name, config: params.config }),
+			),
+		);
+	const service = {
+		list: vi.fn().mockResolvedValue({ data: agents }),
+		create,
+	} as unknown as AgentsApiService;
+	return { service, create };
+}
+
+function setTTY(isTTY: boolean) {
+	Object.defineProperty(process.stdin, "isTTY", {
+		value: isTTY,
+		configurable: true,
+	});
+	Object.defineProperty(process.stdout, "isTTY", {
+		value: isTTY,
+		configurable: true,
+	});
+}
+
+describe("agent dev target resolution", () => {
+	let consoleError: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		mockPrompts.mockReset();
+		vi.spyOn(console, "log").mockImplementation(noop);
+		consoleError = vi.spyOn(console, "error").mockImplementation(noop);
+		vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code as number);
+		});
+	});
+
+	afterEach(() => {
+		setTTY(false);
+		vi.restoreAllMocks();
+	});
+
+	describe("given the project has no HTTP agents", () => {
+		describe("when the session runs in a terminal", () => {
+			/** @scenario "With no HTTP agents, an interactive session creates one on the spot" */
+			it("creates the agent it offered and returns it as the target", async () => {
+				setTTY(true);
+				mockPrompts.mockResolvedValue({ name: "My Local Agent" });
+				const { service, create } = makeService({ agents: [] });
+
+				const agent = await resolveTargetAgent({
+					service,
+					localUrl: "http://localhost:8010/agent/chat",
+				});
+
+				expect(create).toHaveBeenCalledWith({
+					name: "My Local Agent",
+					type: "http",
+					config: { url: "http://localhost:8010/agent/chat", method: "POST" },
+				});
+				expect(agent.id).toBe("agent_new");
+				expect(agent.name).toBe("My Local Agent");
+			});
+
+			/** @scenario "Declining the offered agent name ends the session with instructions" */
+			it("fails with the create command when the name prompt is cancelled", async () => {
+				setTTY(true);
+				// prompts resolves with an empty object when the user hits Esc.
+				mockPrompts.mockResolvedValue({});
+				const { service, create } = makeService({ agents: [] });
+
+				await expect(
+					resolveTargetAgent({
+						service,
+						localUrl: "http://localhost:8010/agent/chat",
+					}),
+				).rejects.toThrow(ProcessExitError);
+
+				expect(create).not.toHaveBeenCalled();
+				expect(String(consoleError.mock.calls.flat())).toContain(
+					"langwatch agent create",
+				);
+			});
+		});
+
+		describe("when the session runs without a terminal", () => {
+			/** @scenario "With no HTTP agents and no terminal, the session names the create command" */
+			it("fails with the create command instead of prompting", async () => {
+				setTTY(false);
+				const { service, create } = makeService({ agents: [] });
+
+				await expect(
+					resolveTargetAgent({
+						service,
+						localUrl: "http://localhost:8010/agent/chat",
+					}),
+				).rejects.toThrow(ProcessExitError);
+
+				expect(mockPrompts).not.toHaveBeenCalled();
+				expect(create).not.toHaveBeenCalled();
+				expect(String(consoleError.mock.calls.flat())).toContain(
+					"langwatch agent create",
+				);
+			});
+		});
+	});
+
+	describe("given the project has several HTTP agents", () => {
+		describe("when the session runs without a terminal and no --agent flag", () => {
+			/** @scenario "With several HTTP agents and no terminal, the session names the agent flag" */
+			it("fails and says to pass --agent", async () => {
+				setTTY(false);
+				const { service } = makeService({
+					agents: [
+						makeAgent({ id: "agent_a", name: "A" }),
+						makeAgent({ id: "agent_b", name: "B" }),
+					],
+				});
+
+				await expect(
+					resolveTargetAgent({
+						service,
+						localUrl: "http://localhost:8010/agent/chat",
+					}),
+				).rejects.toThrow(ProcessExitError);
+
+				expect(mockPrompts).not.toHaveBeenCalled();
+				expect(String(consoleError.mock.calls.flat())).toContain(
+					"--agent <id|name>",
+				);
+			});
+		});
+	});
+
+	describe("given the project has exactly one HTTP agent", () => {
+		it("picks it without prompting, even without a terminal", async () => {
+			setTTY(false);
+			const only = makeAgent({ id: "agent_only", name: "Only" });
+			const { service } = makeService({ agents: [only] });
+
+			const agent = await resolveTargetAgent({
+				service,
+				localUrl: "http://localhost:8010/agent/chat",
+			});
+
+			expect(agent.id).toBe("agent_only");
+			expect(mockPrompts).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/sdks/typescript/src/cli/commands/agents/dev.ts
+++ b/sdks/typescript/src/cli/commands/agents/dev.ts
@@ -106,7 +106,11 @@ export async function startAgentDevSession(
   await resolveCredentials({ apiKey: options.apiKey });
 
   const service = new AgentsApiService();
-  const agent = await resolveTargetAgent({ service, agentFlag: options.agent });
+  const agent = await resolveTargetAgent({
+    service,
+    agentFlag: options.agent,
+    localUrl,
+  });
   rememberAgentForDirectory(agent.id);
 
   // A bring-your-own tunnel forwards straight to the user's own server, so

--- a/sdks/typescript/src/cli/commands/agents/dev/resolve.ts
+++ b/sdks/typescript/src/cli/commands/agents/dev/resolve.ts
@@ -46,6 +46,13 @@ export function resolveLocalUrl(options: {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       fail("--url must be an http or https URL");
     }
+    // The URL is stored in the agent's platform config and printed by the
+    // session, so credentials embedded in it would leak both ways.
+    if (parsed.username || parsed.password) {
+      fail(
+        "--url must not carry a username or password. Pass the URL without credentials.",
+      );
+    }
     return options.url;
   }
   fail(
@@ -178,7 +185,7 @@ async function createHttpAgentInteractively({
     type: "text",
     name: "name",
     message: `This project has no HTTP agents. Name a new one (will point at ${localUrl}):`,
-    initial: path.basename(process.cwd()),
+    initial: path.basename(process.cwd()) || "my-agent",
   });
   const name = typeof answer.name === "string" ? answer.name.trim() : "";
   if (!name) {

--- a/sdks/typescript/src/cli/commands/agents/dev/resolve.ts
+++ b/sdks/typescript/src/cli/commands/agents/dev/resolve.ts
@@ -3,6 +3,7 @@
  * which registered HTTP agent to repoint.
  */
 
+import * as path from "node:path";
 import chalk from "chalk";
 import prompts from "prompts";
 import {
@@ -79,14 +80,17 @@ function rememberedAgentForDirectory(): string | undefined {
  *
  *   1. `--agent <id|name>`: an exact id, else a name match over HTTP agents.
  *   2. The agent remembered for this directory from a previous run.
- *   3. An interactive picker over the project's HTTP agents (TTY only).
+ *   3. An interactive picker over the project's HTTP agents (TTY only), which
+ *      offers to create one when the project has none yet.
  */
 export async function resolveTargetAgent({
   service,
   agentFlag,
+  localUrl,
 }: {
   service: AgentsApiService;
   agentFlag?: string;
+  localUrl: string;
 }): Promise<AgentResponse> {
   const listing = await service.list({ limit: 100 });
   const httpAgents = listing.data.filter((agent) => agent.type === "http");
@@ -98,7 +102,7 @@ export async function resolveTargetAgent({
   const remembered = agentFromMemory(httpAgents);
   if (remembered) return remembered;
 
-  return pickHttpAgent(httpAgents);
+  return pickHttpAgent({ service, httpAgents, localUrl });
 }
 
 /** `--agent <id|name>`: an exact id, else a name match over HTTP agents. */
@@ -154,14 +158,56 @@ function agentFromMemory(httpAgents: AgentResponse[]): AgentResponse | undefined
   return match;
 }
 
+const CREATE_INSTRUCTIONS =
+  "This project has no HTTP agents. Create one first: langwatch agent create \"My Agent\" --type http --config '{\"url\":\"https://...\"}'";
+
+/**
+ * The project has no HTTP agents yet: offer to create one on the spot (TTY
+ * only). The created agent points at the local server, so after the session
+ * restores it, its URL states what it targeted; edit it in the UI when the
+ * agent gets a deployed address.
+ */
+async function createHttpAgentInteractively({
+  service,
+  localUrl,
+}: {
+  service: AgentsApiService;
+  localUrl: string;
+}): Promise<AgentResponse> {
+  const answer = await prompts({
+    type: "text",
+    name: "name",
+    message: `This project has no HTTP agents. Name a new one (will point at ${localUrl}):`,
+    initial: path.basename(process.cwd()),
+  });
+  const name = typeof answer.name === "string" ? answer.name.trim() : "";
+  if (!name) {
+    fail(CREATE_INSTRUCTIONS);
+  }
+  const created = await service.create({
+    name,
+    type: "http",
+    config: { url: localUrl, method: "POST" },
+  });
+  console.log(chalk.green(`Created HTTP agent "${created.name}".`));
+  return created;
+}
+
 /** The only HTTP agent, else an interactive picker over them (TTY only). */
-async function pickHttpAgent(
-  httpAgents: AgentResponse[],
-): Promise<AgentResponse> {
+async function pickHttpAgent({
+  service,
+  httpAgents,
+  localUrl,
+}: {
+  service: AgentsApiService;
+  httpAgents: AgentResponse[];
+  localUrl: string;
+}): Promise<AgentResponse> {
   if (httpAgents.length === 0) {
-    fail(
-      "This project has no HTTP agents. Create one first: langwatch agent create \"My Agent\" --type http --config '{\"url\":\"https://...\"}'",
-    );
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      fail(CREATE_INSTRUCTIONS);
+    }
+    return createHttpAgentInteractively({ service, localUrl });
   }
   if (httpAgents.length === 1) {
     return httpAgents[0]!;

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -1618,7 +1618,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     .description("Expose a local agent server through a public tunnel and point a registered HTTP agent at it (Ctrl-C restores the previous URL)")
     .option("--port <number>", "Local port to expose (tunnels http://localhost:<number>)")
     .option("--url <url>", "Local URL to expose (mutually exclusive with --port)")
-    .option("--agent <idOrName>", "Which registered HTTP agent to point at the tunnel (picker when omitted)")
+    .option("--agent <idOrName>", "Which registered HTTP agent to point at the tunnel (when omitted: picker, created on the spot if the project has none)")
     .option("--tunnel-url <url>", "Bring your own tunnel URL and skip tunnel provisioning")
     .option("--no-update-url", "Print the tunnel URL without changing the agent")
     .option("--no-auth", "Skip the local auth proxy (for servers that already authenticate requests)")

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -1618,7 +1618,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     .description("Expose a local agent server through a public tunnel and point a registered HTTP agent at it (Ctrl-C restores the previous URL)")
     .option("--port <number>", "Local port to expose (tunnels http://localhost:<number>)")
     .option("--url <url>", "Local URL to expose (mutually exclusive with --port)")
-    .option("--agent <idOrName>", "Which registered HTTP agent to point at the tunnel (when omitted: picker, created on the spot if the project has none)")
+    .option("--agent <idOrName>", "Which registered HTTP agent to point at the tunnel (when omitted: picker, and in an interactive terminal it creates one if the project has none)")
     .option("--tunnel-url <url>", "Bring your own tunnel URL and skip tunnel provisioning")
     .option("--no-update-url", "Print the tunnel URL without changing the agent")
     .option("--no-auth", "Skip the local auth proxy (for servers that already authenticate requests)")

--- a/specs/agents/agent-dev-tunnel.feature
+++ b/specs/agents/agent-dev-tunnel.feature
@@ -81,7 +81,13 @@ Feature: Agent dev tunnel
     And the session runs in a terminal
     When the developer confirms the offered agent name
     Then the session registers a new HTTP agent pointing at the local server
+    And the offered name defaults to the current directory's name
     And the new agent is the session's target
+
+  Scenario: A local URL carrying credentials is refused
+    Given a --url value with a username and password embedded in it
+    When the session resolves the local server to expose
+    Then the session fails and says to pass the URL without credentials
 
   Scenario: Declining the offered agent name ends the session with instructions
     Given the project has no HTTP agents

--- a/specs/agents/agent-dev-tunnel.feature
+++ b/specs/agents/agent-dev-tunnel.feature
@@ -71,3 +71,30 @@ Feature: Agent dev tunnel
     When I pick a target for a simulation
     Then that agent shows a local tunnel badge
     And agents without the marker show no badge
+
+  # `--agent` is optional: the session reuses the agent remembered for the
+  # directory, auto-picks a lone HTTP agent, and offers an interactive picker
+  # over several. The scenarios below pin the edges of that selection.
+
+  Scenario: With no HTTP agents, an interactive session creates one on the spot
+    Given the project has no HTTP agents
+    And the session runs in a terminal
+    When the developer confirms the offered agent name
+    Then the session registers a new HTTP agent pointing at the local server
+    And the new agent is the session's target
+
+  Scenario: Declining the offered agent name ends the session with instructions
+    Given the project has no HTTP agents
+    And the session runs in a terminal
+    When the developer cancels the name prompt
+    Then the session fails and names the agent create command
+
+  Scenario: With no HTTP agents and no terminal, the session names the create command
+    Given the project has no HTTP agents
+    And the session runs without a terminal
+    Then the session fails and names the agent create command
+
+  Scenario: With several HTTP agents and no terminal, the session names the agent flag
+    Given the project has several HTTP agents and no --agent flag
+    And the session runs without a terminal
+    Then the session fails and says to pass --agent to skip the picker


### PR DESCRIPTION
## What

`langwatch agent dev` no longer needs a separate `agent create` step on a project with no HTTP agents yet. An interactive session offers a name (defaulting to the directory name) and registers the agent pointing at the local server, then the session repoints it at the tunnel as usual.

## Why

`--agent` was already optional: the session reuses the agent remembered for the directory, auto-picks a lone HTTP agent, and shows a picker over several. The one edge that still pushed work back at the user was the empty project, which failed with create instructions even in a terminal. That is the first-run path, so it should be the smoothest one.

## Behavior

- Terminal, no HTTP agents: one prompt for the agent name, then `create` with `{url: <local url>, method: "POST"}`. Cancelling the prompt fails with the `agent create` command.
- No terminal, no HTTP agents: unchanged fail naming the `agent create` command, so coding agents get a copy-paste path instead of a hang.
- No terminal, several HTTP agents: unchanged fail naming `--agent <id|name>` to skip the picker.
- The created agent's URL stays the local URL after Ctrl-C restore, which states what it targeted; edit it in the UI when the agent gets a deployed address.

## Tests

Four new scenarios in `specs/agents/agent-dev-tunnel.feature` (15/15 bound), covered by the new `agent-dev-resolve.unit.test.ts`, which drives `resolveTargetAgent` with a fake service and pinned TTY state. SDK typecheck and the CLI boot-graph pin test are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `agent dev` can automatically create an HTTP agent during interactive sessions when none exists.
  - The new agent targets the local development URL and defaults to the current directory name.
  - Users can select an agent interactively or specify `--agent` when multiple agents are available.
  - The sole available HTTP agent is selected automatically.

- **Bug Fixes**
  - Local URLs containing embedded credentials are now rejected.
  - Clear guidance is provided for cancellation and non-interactive agent selection or creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->