### PR TITLE
fix(ops): record the queue operator actions that were recorded nowhere (#7134)

### DIFF
--- a/platform/app/src/server/api/routers/ops.ts
+++ b/platform/app/src/server/api/routers/ops.ts
@@ -347,9 +347,14 @@ export const opsRouter = createTRPCRouter({
         groupId: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const ops = requireOps();
-      return ops.queues.unblockGroup(input);
+      return ops.queues.unblockGroup({
+        ...input,
+        // Opaque id, not email: the audit trail must trace the actor without
+        // carrying PII into the log stream.
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   unblockAll: protectedProcedure
@@ -359,9 +364,14 @@ export const opsRouter = createTRPCRouter({
         queueName: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const ops = requireOps();
-      return ops.queues.unblockAll(input);
+      return ops.queues.unblockAll({
+        ...input,
+        // Opaque id, not email: the audit trail must trace the actor without
+        // carrying PII into the log stream.
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   drainGroup: protectedProcedure
@@ -372,9 +382,14 @@ export const opsRouter = createTRPCRouter({
         groupId: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const ops = requireOps();
-      return ops.queues.drainGroup(input);
+      return ops.queues.drainGroup({
+        ...input,
+        // Opaque id, not email: the audit trail must trace the actor without
+        // carrying PII into the log stream.
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   pausePipeline: protectedProcedure
@@ -448,9 +463,14 @@ export const opsRouter = createTRPCRouter({
         groupIdContains: z.string().optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const ops = requireOps();
-      return ops.queues.drainTenant(input);
+      return ops.queues.drainTenant({
+        ...input,
+        // Opaque id, not email: the audit trail must trace the actor without
+        // carrying PII into the log stream.
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   retryBlocked: protectedProcedure
@@ -937,9 +957,14 @@ export const opsRouter = createTRPCRouter({
         groupId: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const ops = requireOps();
-      return ops.queues.moveToDlq(input);
+      return ops.queues.moveToDlq({
+        ...input,
+        // Opaque id, not email: the audit trail must trace the actor without
+        // carrying PII into the log stream.
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   moveAllBlockedToDlq: protectedProcedure
@@ -951,9 +976,14 @@ export const opsRouter = createTRPCRouter({
         errorFilter: z.string().optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const ops = requireOps();
-      return ops.queues.moveAllBlockedToDlq(input);
+      return ops.queues.moveAllBlockedToDlq({
+        ...input,
+        // Opaque id, not email: the audit trail must trace the actor without
+        // carrying PII into the log stream.
+        requestedBy: ctx.session.user.id,
+      });
     }),
 
   replayFromDlq: protectedProcedure

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -90,6 +90,255 @@ function createMockRepo(
 }
 
 describe("QueueService", () => {
+  describe("operator-action audit", () => {
+    /**
+     * These six acts wrote no audit row at all before this suite existed, and
+     * `QueueControlAction` had no name for any of them, so the gap could not
+     * be closed by accident. Each pair below is the same shape: the act is
+     * recorded when it changed something, and not recorded when it did not.
+     */
+    const auditedService = (overrides: Record<string, unknown>) => {
+      const repo = createMockRepo(overrides);
+      const append = vi.fn().mockResolvedValue(undefined);
+      return {
+        repo,
+        append,
+        service: new QueueService({ repo, audit: { append } }),
+      };
+    };
+
+    describe("given a drain that removed jobs", () => {
+      describe("when the group is drained", () => {
+        /** @scenario "A drain records who emptied the group" */
+        it("records the actor, the group and the job count", async () => {
+          const { append, service } = auditedService({
+            drainGroup: vi.fn().mockResolvedValue({ jobsRemoved: 5 }),
+          });
+
+          await service.drainGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          });
+
+          expect(append).toHaveBeenCalledWith({
+            actorUserId: "user_1",
+            action: "queue_drain_group",
+            queueName: "q1",
+            metadata: { groupId: "g1", jobsRemoved: 5 },
+          });
+        });
+      });
+    });
+
+    describe("given a drain that removed nothing", () => {
+      describe("when the group is already empty", () => {
+        it("writes no row, so the log carries acts and not clicks", async () => {
+          const { append, service } = auditedService({
+            drainGroup: vi.fn().mockResolvedValue({ jobsRemoved: 0 }),
+          });
+
+          await service.drainGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          });
+
+          expect(append).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("given a tenant drain", () => {
+      describe("when groups were drained", () => {
+        /** @scenario "A tenant drain records the filter that selected the groups" */
+        it("records the filter, because which groups is unrecoverable afterwards", async () => {
+          const { append, service } = auditedService({
+            drainTenant: vi
+              .fn()
+              .mockResolvedValue({ groupsDrained: 3, jobsDrained: 12 }),
+          });
+
+          await service.drainTenant({
+            queueName: "q1",
+            tenantId: "t1",
+            groupIdContains: "ingest",
+            requestedBy: "user_1",
+          });
+
+          expect(append).toHaveBeenCalledWith({
+            actorUserId: "user_1",
+            action: "queue_drain_tenant",
+            queueName: "q1",
+            metadata: {
+              tenantId: "t1",
+              groupIdContains: "ingest",
+              groupsDrained: 3,
+              jobsDrained: 12,
+            },
+          });
+        });
+
+        it("records an absent filter as null rather than omitting it", async () => {
+          // An omitted key and "no filter was set" read the same in a JSON
+          // column, and they mean different things: one is a drain of
+          // everything, the other is a row written by an older build.
+          const { append, service } = auditedService({
+            drainTenant: vi
+              .fn()
+              .mockResolvedValue({ groupsDrained: 1, jobsDrained: 2 }),
+          });
+
+          await service.drainTenant({
+            queueName: "q1",
+            tenantId: "t1",
+            requestedBy: "user_1",
+          });
+
+          expect(append.mock.calls[0]?.[0].metadata).toMatchObject({
+            groupIdContains: null,
+          });
+        });
+      });
+    });
+
+    describe("given a move to the dead-letter queue", () => {
+      describe("when jobs moved", () => {
+        /** @scenario "Moving a group to the dead-letter queue is recorded" */
+        it("records the actor and the group", async () => {
+          const { append, service } = auditedService({
+            moveToDlq: vi.fn().mockResolvedValue({ jobsMoved: 3 }),
+          });
+
+          await service.moveToDlq({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          });
+
+          expect(append).toHaveBeenCalledWith({
+            actorUserId: "user_1",
+            action: "queue_move_group_to_dlq",
+            queueName: "q1",
+            metadata: { groupId: "g1", jobsMoved: 3 },
+          });
+        });
+      });
+    });
+
+    describe("given a bulk move of blocked groups", () => {
+      describe("when groups moved", () => {
+        it("records both filters that selected them", async () => {
+          const { append, service } = auditedService({
+            moveAllBlockedToDlq: vi
+              .fn()
+              .mockResolvedValue({ movedCount: 2, jobsMoved: 9 }),
+          });
+
+          await service.moveAllBlockedToDlq({
+            queueName: "q1",
+            pipelineFilter: "ingest",
+            errorFilter: "Timeout",
+            requestedBy: "user_1",
+          });
+
+          expect(append).toHaveBeenCalledWith({
+            actorUserId: "user_1",
+            action: "queue_move_all_blocked_to_dlq",
+            queueName: "q1",
+            metadata: {
+              pipelineFilter: "ingest",
+              errorFilter: "Timeout",
+              movedCount: 2,
+              jobsMoved: 9,
+            },
+          });
+        });
+      });
+    });
+
+    describe("given an unblock", () => {
+      describe("when the group was blocked", () => {
+        /** @scenario "An unblock is recorded only when it changed something" */
+        it("records the act", async () => {
+          const { append, service } = auditedService({
+            unblockGroup: vi.fn().mockResolvedValue({ wasBlocked: true }),
+          });
+
+          await service.unblockGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          });
+
+          expect(append).toHaveBeenCalledWith({
+            actorUserId: "user_1",
+            action: "queue_unblock_group",
+            queueName: "q1",
+            metadata: { groupId: "g1", wasBlocked: true },
+          });
+        });
+      });
+
+      describe("when the group was not blocked", () => {
+        it("writes no row", async () => {
+          const { append, service } = auditedService({
+            unblockGroup: vi.fn().mockResolvedValue({ wasBlocked: false }),
+          });
+
+          await service.unblockGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          });
+
+          expect(append).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("when unblocking every group", () => {
+        it("records the count", async () => {
+          const { append, service } = auditedService({
+            unblockAll: vi.fn().mockResolvedValue({ unblockedCount: 7 }),
+          });
+
+          await service.unblockAll({ queueName: "q1", requestedBy: "user_1" });
+
+          expect(append).toHaveBeenCalledWith({
+            actorUserId: "user_1",
+            action: "queue_unblock_all",
+            queueName: "q1",
+            metadata: { unblockedCount: 7 },
+          });
+        });
+      });
+    });
+
+    describe("given the repository contract", () => {
+      describe("when an audited act runs", () => {
+        it("does not leak the actor into the repository call", async () => {
+          // requestedBy is an audit concern. The repository takes the same
+          // arguments it always did, so nothing downstream has to learn about
+          // it and the Redis layer stays unaware of who asked.
+          const { repo, service } = auditedService({
+            drainGroup: vi.fn().mockResolvedValue({ jobsRemoved: 1 }),
+          });
+
+          await service.drainGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          });
+
+          expect(repo.drainGroup).toHaveBeenCalledWith({
+            queueName: "q1",
+            groupId: "g1",
+          });
+        });
+      });
+    });
+  });
+
   describe("dead-letter recovery audit", () => {
     /** @scenario Discarding a DLQ group removes it and remembers the act */
     it("records the queue, the groups and the job count on a discard", async () => {
@@ -457,6 +706,7 @@ describe("QueueService", () => {
         const result = await service.unblockGroup({
           queueName: "q1",
           groupId: "g1",
+          requestedBy: "user_1",
         });
 
         expect(result).toEqual({ wasBlocked: true });
@@ -477,6 +727,7 @@ describe("QueueService", () => {
         const result = await service.unblockGroup({
           queueName: "q1",
           groupId: "g1",
+          requestedBy: "user_1",
         });
 
         expect(result.wasBlocked).toBe(false);
@@ -495,6 +746,7 @@ describe("QueueService", () => {
         const result = await service.drainGroup({
           queueName: "q1",
           groupId: "g1",
+          requestedBy: "user_1",
         });
 
         expect(result).toEqual({ jobsRemoved: 5 });
@@ -517,6 +769,7 @@ describe("QueueService", () => {
         const result = await service.moveToDlq({
           queueName: "q1",
           groupId: "g1",
+          requestedBy: "user_1",
         });
 
         expect(result).toEqual({ jobsMoved: 3 });
@@ -536,7 +789,10 @@ describe("QueueService", () => {
         });
         const service = new QueueService({ repo });
 
-        const result = await service.unblockAll({ queueName: "q1" });
+        const result = await service.unblockAll({
+          queueName: "q1",
+          requestedBy: "user_1",
+        });
 
         expect(result).toEqual({ unblockedCount: 7 });
         expect(repo.unblockAll).toHaveBeenCalledWith({ queueName: "q1" });
@@ -657,6 +913,7 @@ describe("QueueService", () => {
         const result = await service.drainTenant({
           queueName: "q1",
           tenantId: "project_X",
+          requestedBy: "user_1",
         });
 
         expect(result).toEqual({ groupsDrained: 1234, jobsDrained: 5678 });
@@ -682,6 +939,7 @@ describe("QueueService", () => {
         const result = await service.drainTenant({
           queueName: "q1",
           tenantId: "project_X",
+          requestedBy: "user_1",
         });
 
         expect(result).toEqual({ groupsDrained: 3, jobsDrained: 12 });
@@ -696,6 +954,7 @@ describe("QueueService", () => {
           queueName: "q1",
           tenantId: "project_X",
           groupIdContains: "/fold/traceSummary/",
+          requestedBy: "user_1",
         });
 
         expect(repo.drainTenant).toHaveBeenCalledWith({

--- a/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -94,8 +94,9 @@ describe("QueueService", () => {
     /**
      * These six acts wrote no audit row at all before this suite existed, and
      * `QueueControlAction` had no name for any of them, so the gap could not
-     * be closed by accident. Each pair below is the same shape: the act is
-     * recorded when it changed something, and not recorded when it did not.
+     * be closed by accident. Each act is recorded when it changed something,
+     * with the metadata that is unrecoverable afterwards; the table at the end
+     * of this block covers the other half, that none of them records a no-op.
      */
     const auditedService = (overrides: Record<string, unknown>) => {
       const repo = createMockRepo(overrides);
@@ -127,24 +128,6 @@ describe("QueueService", () => {
             queueName: "q1",
             metadata: { groupId: "g1", jobsRemoved: 5 },
           });
-        });
-      });
-    });
-
-    describe("given a drain that removed nothing", () => {
-      describe("when the group is already empty", () => {
-        it("writes no row, so the log carries acts and not clicks", async () => {
-          const { append, service } = auditedService({
-            drainGroup: vi.fn().mockResolvedValue({ jobsRemoved: 0 }),
-          });
-
-          await service.drainGroup({
-            queueName: "q1",
-            groupId: "g1",
-            requestedBy: "user_1",
-          });
-
-          expect(append).not.toHaveBeenCalled();
         });
       });
     });
@@ -280,22 +263,6 @@ describe("QueueService", () => {
         });
       });
 
-      describe("when the group was not blocked", () => {
-        it("writes no row", async () => {
-          const { append, service } = auditedService({
-            unblockGroup: vi.fn().mockResolvedValue({ wasBlocked: false }),
-          });
-
-          await service.unblockGroup({
-            queueName: "q1",
-            groupId: "g1",
-            requestedBy: "user_1",
-          });
-
-          expect(append).not.toHaveBeenCalled();
-        });
-      });
-
       describe("when unblocking every group", () => {
         it("records the count", async () => {
           const { append, service } = auditedService({
@@ -310,6 +277,93 @@ describe("QueueService", () => {
             queueName: "q1",
             metadata: { unblockedCount: 7 },
           });
+        });
+      });
+    });
+
+    /**
+     * One case per gate. Each act is gated on its own "did anything change"
+     * field, so making any single one of them append unconditionally fills the
+     * log with clicks while every other test in this file stays green. A
+     * seventh audited act arriving without its no-op case shows up here as a
+     * missing row rather than as an audit log nobody trusts.
+     */
+    const noOpActs: {
+      name: string;
+      unchanged: Record<string, unknown>;
+      act: (service: QueueService) => Promise<unknown>;
+    }[] = [
+      {
+        name: "drainGroup",
+        unchanged: { jobsRemoved: 0 },
+        act: (service) =>
+          service.drainGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          }),
+      },
+      {
+        name: "drainTenant",
+        unchanged: { groupsDrained: 0, jobsDrained: 0 },
+        act: (service) =>
+          service.drainTenant({
+            queueName: "q1",
+            tenantId: "t1",
+            requestedBy: "user_1",
+          }),
+      },
+      {
+        name: "moveToDlq",
+        unchanged: { jobsMoved: 0 },
+        act: (service) =>
+          service.moveToDlq({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          }),
+      },
+      {
+        name: "moveAllBlockedToDlq",
+        unchanged: { movedCount: 0, jobsMoved: 0 },
+        act: (service) =>
+          service.moveAllBlockedToDlq({
+            queueName: "q1",
+            requestedBy: "user_1",
+          }),
+      },
+      {
+        name: "unblockGroup",
+        unchanged: { wasBlocked: false },
+        act: (service) =>
+          service.unblockGroup({
+            queueName: "q1",
+            groupId: "g1",
+            requestedBy: "user_1",
+          }),
+      },
+      {
+        name: "unblockAll",
+        unchanged: { unblockedCount: 0 },
+        act: (service) =>
+          service.unblockAll({ queueName: "q1", requestedBy: "user_1" }),
+      },
+    ];
+
+    describe.each(noOpActs)("given $name changed nothing", ({
+      name,
+      unchanged,
+      act,
+    }) => {
+      describe("when the act runs", () => {
+        it("writes no row, so the log carries acts and not clicks", async () => {
+          const { append, service } = auditedService({
+            [name]: vi.fn().mockResolvedValue(unchanged),
+          });
+
+          await act(service);
+
+          expect(append).not.toHaveBeenCalled();
         });
       });
     });

--- a/platform/app/src/server/app-layer/ops/queue-audit.repository.ts
+++ b/platform/app/src/server/app-layer/ops/queue-audit.repository.ts
@@ -2,14 +2,25 @@ import type { Prisma, PrismaClient } from "~/generated/prisma/client";
 
 export type QueueControlAction =
   | "queue_redrive_dlq_groups"
-  | "queue_discard_dlq_groups";
+  | "queue_discard_dlq_groups"
+  | "queue_drain_group"
+  | "queue_drain_tenant"
+  | "queue_move_group_to_dlq"
+  | "queue_move_all_blocked_to_dlq"
+  | "queue_unblock_group"
+  | "queue_unblock_all";
 
 /**
- * Audit sink for GroupQueue dead-letter recovery
+ * Audit sink for GroupQueue operator actions
  * (specs/ops/dead-letter-recovery.feature). The Redis substrate forgets DLQ
  * entries at their TTL, so for a discard THIS row is the retained mark: the
  * queue, the groups, how many jobs they held, and their last errors survive
  * here after the entries themselves are gone.
+ *
+ * The same holds for a drain, which removes jobs outright. Every act that
+ * removes or relocates work carries a name here, because an act the log
+ * cannot name is an act that did not happen as far as anyone reading it
+ * later is concerned.
  */
 export interface QueueAuditSink {
   append(entry: {
@@ -20,7 +31,26 @@ export interface QueueAuditSink {
   }): Promise<void>;
 }
 
-const TARGET_KIND = "queue_dlq";
+/**
+ * The audit log's target kinds for these acts, keyed by action.
+ *
+ * A drain or an unblock operates on the live queue, not on its dead-letter
+ * side, so filing them under `queue_dlq` would put them in front of an
+ * operator filtering for dead-letter activity and hide them from one
+ * filtering for the queue. Derived from the action rather than fixed, so the
+ * two dead-letter acts keep the kind they have always written and nothing
+ * already filtering on it is reclassified underneath.
+ */
+const TARGET_KIND_BY_ACTION: Record<QueueControlAction, string> = {
+  queue_redrive_dlq_groups: "queue_dlq",
+  queue_discard_dlq_groups: "queue_dlq",
+  queue_drain_group: "queue",
+  queue_drain_tenant: "queue",
+  queue_move_group_to_dlq: "queue",
+  queue_move_all_blocked_to_dlq: "queue",
+  queue_unblock_group: "queue",
+  queue_unblock_all: "queue",
+};
 
 /** For app presets that run without Postgres. */
 export class NullQueueAuditSink implements QueueAuditSink {
@@ -47,7 +77,7 @@ export class QueueAuditRepository implements QueueAuditSink {
         projectId: null,
         organizationId: null,
         action: entry.action,
-        targetKind: TARGET_KIND,
+        targetKind: TARGET_KIND_BY_ACTION[entry.action],
         targetId: entry.queueName,
         metadata: (entry.metadata ?? {}) as Prisma.InputJsonValue,
       },

--- a/platform/app/src/server/app-layer/ops/queue.service.ts
+++ b/platform/app/src/server/app-layer/ops/queue.service.ts
@@ -184,21 +184,59 @@ export class QueueService {
   async unblockGroup(params: {
     queueName: string;
     groupId: string;
+    requestedBy: string;
   }): Promise<{ wasBlocked: boolean }> {
-    return this.repo.unblockGroup(params);
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.unblockGroup(rest);
+    // Only when it changed something. A no-op unblock on a group that was not
+    // blocked is a misread of the dashboard, not an act, and auditing it would
+    // bury the acts that did happen.
+    if (result.wasBlocked) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_unblock_group",
+        queueName: params.queueName,
+        metadata: { groupId: params.groupId, ...result },
+      });
+    }
+    return result;
   }
 
   async unblockAll(params: {
     queueName: string;
+    requestedBy: string;
   }): Promise<{ unblockedCount: number }> {
-    return this.repo.unblockAll(params);
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.unblockAll(rest);
+    if (result.unblockedCount > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_unblock_all",
+        queueName: params.queueName,
+        metadata: { ...result },
+      });
+    }
+    return result;
   }
 
   async drainGroup(params: {
     queueName: string;
     groupId: string;
+    requestedBy: string;
   }): Promise<{ jobsRemoved: number }> {
-    return this.repo.drainGroup(params);
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.drainGroup(rest);
+    // A drain removes the jobs outright, so this row is the only thing that
+    // survives to say the group was emptied and by whom.
+    if (result.jobsRemoved > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_drain_group",
+        queueName: params.queueName,
+        metadata: { groupId: params.groupId, ...result },
+      });
+    }
+    return result;
   }
 
   async pausePipeline(params: {
@@ -249,23 +287,67 @@ export class QueueService {
     queueName: string;
     tenantId: string;
     groupIdContains?: string;
+    requestedBy: string;
   }): Promise<{ groupsDrained: number; jobsDrained: number }> {
-    return this.repo.drainTenant(params);
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.drainTenant(rest);
+    // The widest act on this surface: every group for one tenant. The filter
+    // that selected them is recorded too, because "which groups" is not
+    // recoverable from the counts once the jobs are gone.
+    if (result.groupsDrained > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_drain_tenant",
+        queueName: params.queueName,
+        metadata: {
+          tenantId: params.tenantId,
+          groupIdContains: params.groupIdContains ?? null,
+          ...result,
+        },
+      });
+    }
+    return result;
   }
 
   async moveToDlq(params: {
     queueName: string;
     groupId: string;
+    requestedBy: string;
   }): Promise<{ jobsMoved: number }> {
-    return this.repo.moveToDlq(params);
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.moveToDlq(rest);
+    if (result.jobsMoved > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_move_group_to_dlq",
+        queueName: params.queueName,
+        metadata: { groupId: params.groupId, ...result },
+      });
+    }
+    return result;
   }
 
   async moveAllBlockedToDlq(params: {
     queueName: string;
     pipelineFilter?: string;
     errorFilter?: string;
+    requestedBy: string;
   }): Promise<{ movedCount: number; jobsMoved: number }> {
-    return this.repo.moveAllBlockedToDlq(params);
+    const { requestedBy, ...rest } = params;
+    const result = await this.repo.moveAllBlockedToDlq(rest);
+    if (result.movedCount > 0) {
+      await this.audit.append({
+        actorUserId: requestedBy,
+        action: "queue_move_all_blocked_to_dlq",
+        queueName: params.queueName,
+        metadata: {
+          pipelineFilter: params.pipelineFilter ?? null,
+          errorFilter: params.errorFilter ?? null,
+          ...result,
+        },
+      });
+    }
+    return result;
   }
 
   async replayFromDlq(params: {

--- a/specs/ops/dead-letter-recovery.feature
+++ b/specs/ops/dead-letter-recovery.feature
@@ -144,6 +144,39 @@ Feature: Dead-letter recovery
     And marking one as never-to-be-sent is called discard everywhere
     And replay stays reserved for projection rebuilds
 
+  # ── Recording the acts themselves ─────────────────────────────────────
+
+  # The controls doc says operator actions are audited, and the dead-letter
+  # verbs are. The queue-level verbs next to them were not: a drain removed
+  # every job in a group and nothing anywhere said who did it, because
+  # `QueueControlAction` had no name for the act. These pin the parity.
+
+  @unit
+  Scenario: A drain records who emptied the group
+    Given a queue group holding jobs
+    When the operator drains it
+    Then the audit trail records the operator, the queue, the group and how many jobs went
+
+  @unit
+  Scenario: A tenant drain records the filter that selected the groups
+    Given an operator draining one tenant's groups behind a name filter
+    When the drain runs
+    Then the audit trail records the filter as well as the counts
+    And an absent filter is recorded as absent rather than left out
+
+  @unit
+  Scenario: Moving a group to the dead-letter queue is recorded
+    Given a queue group the operator moves to the dead-letter queue
+    When the move runs
+    Then the audit trail records the operator, the queue and the group
+
+  @unit
+  Scenario: An unblock is recorded only when it changed something
+    Given a group the operator unblocks
+    When the group was blocked
+    Then the audit trail records the act
+    But when the group was not blocked nothing is recorded
+
   # ── The headline number ───────────────────────────────────────────────
 
   @unit


### PR DESCRIPTION
## Ticket

Refs #7134. Deliberately **Refs** and not **Closes**: this delivers the prerequisite that issue's design assumes exists, and leaves the issue's own subject open. Reasoning below, and on the issue.

## The premise, corrected

#7134 says the crash window in `discardManyFromDlq` also applies to its neighbours, "which have the same ordering". They do not. On `main` at `876222bf30` all six are pass-throughs with no audit call:

```ts
async drainGroup(params: { queueName: string; groupId: string }): Promise<{ jobsRemoved: number }> {
  return this.repo.drainGroup(params);
}
```

There are exactly two `this.audit.append` calls in `queue.service.ts` and both belong to `redriveManyFromDlq` / `discardManyFromDlq`. The routers do not compensate: each of the six is `return ops.queues.<op>(input)`, no actor, no audit. And the vocabulary had no word for them:

```ts
export type QueueControlAction =
  | "queue_redrive_dlq_groups"
  | "queue_discard_dlq_groups";
```

So the gap is not that these six record late. It is that `drainTenant` removes every job for a tenant and nothing anywhere says who did it.

That reorders the work. The issue's remedy is a write-ahead intent plus a reconciler across every destructive act; for six of the seven that would be a durability guarantee wrapped around a record that is never written.

## Change

Each of the six takes a `requestedBy` and appends on the same terms the two dead-letter acts already use, with the actor threaded from `ctx.session.user.id` exactly as `runCleanup` and `deleteBlob` already do.

Two decisions worth naming:

**Guarded on having changed something.** An unblock of a group that was not blocked is a misread of the dashboard, not an act. Auditing it would bury the acts that did happen. Same rule `redrive` and `discard` already apply.

**Target kind derived from the action.** `TARGET_KIND` was the constant `"queue_dlq"`. A drain or an unblock operates on the live queue, so filing them there would put them in front of an operator filtering for dead-letter activity and hide them from one filtering for the queue. The two dead-letter acts keep the kind they have always written, so nothing already filtering on it is reclassified underneath.

`requestedBy` is stripped before the repository call, so the repository contract is unchanged and the Redis layer stays unaware of who asked. That is pinned by a test, and by the pre-existing delegation tests which still assert the exact old argument shape.

## Evidence

**Six mutations, six caught**, each applied to the shipped tree and reverted between runs:

| # | Mutation | Fails |
|---|---|---|
| M1 | `drainGroup` stops auditing | the drain-records test, only |
| M2 | `drainGroup` audits unconditionally | the no-op test, only |
| M3 | the actor leaks into the repository call | the leak test **and** the pre-existing delegation test |
| M4 | tenant drain omits `groupIdContains` | both tenant-drain tests |
| M5 | `moveToDlq` writes the wrong action name | the move test, only |
| M6 | one `@scenario` annotation removed | the parity gate, `19/20 scenarios bound` |

M3 failing an older test as well is the useful signal: the repository contract was already pinned, and this change does not move it.

M2 is there because the easy version of this fix audits everything, which produces a log where a click and an act look the same.

**Tests.** 192 pass across `src/server/app-layer/ops` (18 files), 36 in the queue-service suite.

**Types.** `pnpm typecheck` and `pnpm typecheck:tests` both 0 errors, run separately.

**Specs.** Four new bound scenarios in `specs/ops/dead-letter-recovery.feature`; `check:feature-parity` exits 0 at `20/20 scenarios bound`.

**Lint.** Zero error-level Biome diagnostics on the changed files, and the new-violations gate run locally the way CI runs it reports `base 3478 / head 3478, no new Biome violations`.

## What this does not do

The write-ahead intent and the reconciler from #7134 are still outstanding, and are better work once every act has a row to be durable about. The crash window between act and record remains, now on eight operations rather than two. That is a wider surface by count and a strictly smaller gap in practice, because the alternative for six of them was no record at all.

## Deployment impact

None. No migration, no config, no API shape change. New rows appear in the existing `auditLog` table for acts that previously wrote nothing.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added audit logging for queue control actions, including unblocking, draining, and moving work to the dead-letter queue.
  - Audit records now identify the operator and capture the queue, affected groups or jobs, filters, and operation counts.
  - Actions that do not change queue state no longer create audit records.

- **Tests**
  - Added coverage for group and tenant operations, filtering, conditional logging, actor attribution, and sensitive error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->