### PR TITLE
test(python-sdk): pin traceparent adoption across tracing styles

### DIFF
--- a/sdks/python/specs/telemetry/traceparent-adoption.feature
+++ b/sdks/python/specs/telemetry/traceparent-adoption.feature
@@ -1,0 +1,36 @@
+Feature: Remote traceparent adoption across tracing styles
+  As a developer whose agent endpoint is called by LangWatch simulations
+  I want every tracing style the SDK proposes to join the caller's trace
+  So that the judge finds the agent's spans under the trace id it propagated
+
+  # LangWatch sends a W3C traceparent header on every scenario call. The
+  # extracted context must be attached BEFORE any tracing starts, because a
+  # handler decorated with @langwatch.trace() opens its root span before the
+  # handler body runs. Middleware-level attach() covers every style; a
+  # with-block around the handler body only covers traces started inside it.
+
+  Scenario: Attach before a decorated handler joins the remote trace
+    Given the remote context is attached before the handler runs
+    When a handler decorated with @langwatch.trace() executes
+    Then its root span carries the remote trace id
+    And its root span's parent is the remote caller's span
+
+  Scenario: A decorated handler without early extraction starts its own trace
+    Given no remote context is attached before the handler runs
+    When a handler decorated with @langwatch.trace() executes
+    Then its root span carries a fresh trace id
+
+  Scenario: Attach covers plain OpenTelemetry spans
+    Given the remote context is attached
+    When the handler opens a plain OpenTelemetry span
+    Then the span carries the remote trace id
+
+  Scenario: Attach covers a context-manager trace and its nested spans
+    Given the remote context is attached
+    When the handler runs inside "with langwatch.trace()" and opens a nested span
+    Then every span carries the remote trace id
+
+  Scenario: A with-block covers a trace started inside it
+    Given the handler wraps its body in a span opened with the extracted context
+    When a langwatch trace starts inside that block
+    Then every span carries the remote trace id

--- a/sdks/python/specs/telemetry/traceparent-adoption.feature
+++ b/sdks/python/specs/telemetry/traceparent-adoption.feature
@@ -33,4 +33,5 @@ Feature: Remote traceparent adoption across tracing styles
   Scenario: A with-block covers a trace started inside it
     Given the handler wraps its body in a span opened with the extracted context
     When a langwatch trace starts inside that block
-    Then every span carries the remote trace id
+    Then every span inside the block carries the remote trace id
+    And a span opened before the block keeps a different trace id

--- a/sdks/python/tests/telemetry/test_traceparent_adoption.py
+++ b/sdks/python/tests/telemetry/test_traceparent_adoption.py
@@ -12,7 +12,7 @@
 from typing import Sequence
 
 from opentelemetry import propagate
-from opentelemetry.context import attach, detach
+from opentelemetry.context import Context, attach, detach
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
@@ -84,7 +84,14 @@ def test_decorated_handler_without_early_extraction_starts_its_own_trace():
     def handler():
         pass
 
-    handler()
+    # Run under an empty context. The scenario is "nothing attached", and
+    # whatever span happens to be current when this test starts would
+    # otherwise parent the handler and decide the assertion below.
+    token = attach(Context())
+    try:
+        handler()
+    finally:
+        detach(token)
 
     assert REMOTE_TRACE_ID not in _trace_ids(exporter)
     assert exporter.spans[0].parent is None
@@ -130,13 +137,21 @@ def test_attach_covers_a_context_manager_trace_and_nested_spans():
 
 def test_a_with_block_covers_a_trace_started_inside_it():
     """The narrower pattern stays valid: a span opened with the extracted
-    context parents everything started inside its block."""
+    context parents everything started inside its block, and only that. Work
+    the handler does before the block stays outside the remote trace, which
+    is the limit that makes middleware the better placement."""
     provider, exporter = _make_provider_and_exporter()
     tracer = provider.get_tracer("agent")
+
+    with tracer.start_as_current_span("before-block"):
+        pass
 
     ctx = propagate.extract(HEADERS)
     with tracer.start_as_current_span("chat", context=ctx):
         with LangWatchTrace(name="inner", tracer_provider=provider):
             pass
 
-    assert _trace_ids(exporter) == {REMOTE_TRACE_ID}
+    by_name = {s.name: s for s in exporter.spans}
+    assert f"{by_name['chat'].context.trace_id:032x}" == REMOTE_TRACE_ID
+    assert f"{by_name['inner'].context.trace_id:032x}" == REMOTE_TRACE_ID
+    assert f"{by_name['before-block'].context.trace_id:032x}" != REMOTE_TRACE_ID

--- a/sdks/python/tests/telemetry/test_traceparent_adoption.py
+++ b/sdks/python/tests/telemetry/test_traceparent_adoption.py
@@ -1,0 +1,142 @@
+# Remote traceparent adoption across the tracing styles the SDK proposes.
+#
+# LangWatch simulations send a W3C traceparent header on every scenario call,
+# and the judge fetches the agent's spans by that trace id. These tests pin
+# which extraction pattern makes each style join the caller's trace:
+# attach() before any tracing starts covers everything, including handlers
+# decorated with @langwatch.trace(), whose root span opens before the handler
+# body runs. That ordering is why the docs put the extraction in middleware.
+#
+# See specs/telemetry/traceparent-adoption.feature
+
+from typing import Sequence
+
+from opentelemetry import propagate
+from opentelemetry.context import attach, detach
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+import langwatch
+from langwatch.telemetry.tracing import LangWatchTrace
+
+REMOTE_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+REMOTE_SPAN_ID = "00f067aa0ba902b7"
+HEADERS = {"traceparent": f"00-{REMOTE_TRACE_ID}-{REMOTE_SPAN_ID}-01"}
+
+
+class _InMemoryExporter(SpanExporter):
+    """Minimal in-memory exporter for test assertions."""
+
+    def __init__(self):
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        pass
+
+
+def _make_provider_and_exporter():
+    exporter = _InMemoryExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def _trace_ids(exporter: _InMemoryExporter) -> set:
+    return {f"{s.context.trace_id:032x}" for s in exporter.spans}
+
+
+def test_attach_before_decorated_handler_joins_the_remote_trace():
+    """attach() before the handler runs puts a @langwatch.trace() root span
+    inside the remote trace, parented under the caller's span."""
+    provider, exporter = _make_provider_and_exporter()
+
+    @langwatch.trace(name="handler", tracer_provider=provider)
+    def handler():
+        pass
+
+    token = attach(propagate.extract(HEADERS))
+    try:
+        handler()
+    finally:
+        detach(token)
+
+    assert _trace_ids(exporter) == {REMOTE_TRACE_ID}
+    root = exporter.spans[0]
+    assert root.parent is not None
+    assert f"{root.parent.span_id:016x}" == REMOTE_SPAN_ID
+
+
+def test_decorated_handler_without_early_extraction_starts_its_own_trace():
+    """Without an attached remote context, the decorator opens a fresh trace.
+    The handler body cannot fix this: the root span already exists by the
+    time the body runs, which is why extraction belongs in middleware."""
+    provider, exporter = _make_provider_and_exporter()
+
+    @langwatch.trace(name="handler", tracer_provider=provider)
+    def handler():
+        pass
+
+    handler()
+
+    assert REMOTE_TRACE_ID not in _trace_ids(exporter)
+    assert exporter.spans[0].parent is None
+
+
+def test_attach_covers_plain_opentelemetry_spans():
+    """A handler that only uses plain OpenTelemetry spans joins the remote
+    trace the same way."""
+    provider, exporter = _make_provider_and_exporter()
+    tracer = provider.get_tracer("agent")
+
+    token = attach(propagate.extract(HEADERS))
+    try:
+        with tracer.start_as_current_span("llm-call"):
+            pass
+    finally:
+        detach(token)
+
+    assert _trace_ids(exporter) == {REMOTE_TRACE_ID}
+
+
+def test_attach_covers_a_context_manager_trace_and_nested_spans():
+    """with langwatch.trace() plus nested langwatch spans all land in the
+    remote trace, with the root span parented under the caller's span."""
+    provider, exporter = _make_provider_and_exporter()
+
+    token = attach(propagate.extract(HEADERS))
+    try:
+        with LangWatchTrace(name="handler", tracer_provider=provider) as t:
+            with t.span(name="tool-call"):
+                pass
+    finally:
+        detach(token)
+
+    assert _trace_ids(exporter) == {REMOTE_TRACE_ID}
+    by_name = {s.name: s for s in exporter.spans}
+    root = by_name["handler"]
+    assert root.parent is not None
+    assert f"{root.parent.span_id:016x}" == REMOTE_SPAN_ID
+    assert by_name["tool-call"].parent is not None
+    assert by_name["tool-call"].parent.span_id == root.context.span_id
+
+
+def test_a_with_block_covers_a_trace_started_inside_it():
+    """The narrower pattern stays valid: a span opened with the extracted
+    context parents everything started inside its block."""
+    provider, exporter = _make_provider_and_exporter()
+    tracer = provider.get_tracer("agent")
+
+    ctx = propagate.extract(HEADERS)
+    with tracer.start_as_current_span("chat", context=ctx):
+        with LangWatchTrace(name="inner", tracer_provider=provider):
+            pass
+
+    assert _trace_ids(exporter) == {REMOTE_TRACE_ID}


### PR DESCRIPTION
## What

Regression tests that pin which traceparent extraction pattern makes each python-sdk tracing style join the remote caller's trace. Motivated by a review of the connect-agent guidance: the documented per-handler `with tracer.start_as_current_span("chat", context=ctx)` snippet cannot cover a handler decorated with `@langwatch.trace()`, because the decorator opens the root span before the handler body runs.

## Verified behavior (all tested against the SDK)

| Style | `attach()` before the handler | `with` block inside the handler |
|---|---|---|
| `@langwatch.trace()` decorated handler | joins the remote trace, root parented under the caller's span | cannot apply, fresh trace id |
| `with langwatch.trace()` + nested `span()` | joins | joins when started inside the block |
| Plain OpenTelemetry spans | joins | joins when started inside the block |

The conclusion for the docs: extraction belongs in middleware (`attach(propagate.extract(headers))` before routing, `detach` after), which is also what the old langwatch_nlp event consumer did. The docs and connect-agent skill guidance change ships separately on langwatch#7155.

## Tests

`sdks/python/tests/telemetry/test_traceparent_adoption.py`, 5 tests, in-memory exporter, no network. Spec: `sdks/python/specs/telemetry/traceparent-adoption.feature`. The file survives the `make test-unit` `-k` exclusions (verified with `--collect-only`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry trace propagation for incoming W3C `traceparent` headers.
  * Preserved caller trace IDs and parent-child relationships across decorated handlers, OpenTelemetry spans, context-managed traces, nested spans, and extracted contexts.
  * Ensured traces started without timely context extraction correctly receive a new trace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->