### PR TITLE
fix(governance): replace hardcoded white backgrounds with theme tokens in ingestion sources drawers

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -8,6 +8,7 @@ import {
   Heading,
   HStack,
   Input,
+  NativeSelect,
   Spacer,
   Spinner,
   Text,
@@ -843,30 +844,26 @@ function SourceComposerDrawer({
                 <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
                   Source type
                 </Text>
-                <select
-                  value={composer.sourceType}
-                  onChange={(e) =>
-                    setComposer({
-                      ...composer,
-                      sourceType: e.target.value as SourceType,
-                      parserConfig: {},
-                      ottlStatements: [],
-                    })
-                  }
-                  style={{
-                    padding: "8px",
-                    border: "1px solid var(--chakra-colors-border-muted)",
-                    borderRadius: "var(--chakra-radii-sm)",
-                    background: "white",
-                    fontSize: "14px",
-                  }}
-                >
-                  {sourceTypeOptions.map((o) => (
-                    <option key={o.value} value={o.value}>
-                      {o.label} · {o.mode}
-                    </option>
-                  ))}
-                </select>
+                <NativeSelect.Root size="sm">
+                  <NativeSelect.Field
+                    value={composer.sourceType}
+                    onChange={(e) =>
+                      setComposer({
+                        ...composer,
+                        sourceType: e.target.value as SourceType,
+                        parserConfig: {},
+                        ottlStatements: [],
+                      })
+                    }
+                  >
+                    {sourceTypeOptions.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label} · {o.mode}
+                      </option>
+                    ))}
+                  </NativeSelect.Field>
+                  <NativeSelect.Indicator />
+                </NativeSelect.Root>
                 {!isEnterprise && (
                   <Text fontSize="xs" color="fg.muted">
                     Other source types are available on Enterprise plans.
@@ -879,7 +876,6 @@ function SourceComposerDrawer({
                 </Text>
                 <Input
                   size="sm"
-                  backgroundColor="white"
                   value={composer.name}
                   onChange={(e) =>
                     setComposer({ ...composer, name: e.target.value })
@@ -899,7 +895,6 @@ function SourceComposerDrawer({
               </Text>
               <Textarea
                 size="sm"
-                backgroundColor="white"
                 rows={2}
                 value={composer.description}
                 onChange={(e) =>
@@ -1061,7 +1056,6 @@ function SourceEditDrawer({
               </Text>
               <Input
                 size="sm"
-                backgroundColor="white"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
               />
@@ -1072,7 +1066,6 @@ function SourceEditDrawer({
               </Text>
               <Textarea
                 size="sm"
-                backgroundColor="white"
                 rows={2}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -1644,7 +1637,6 @@ function ParserConfigFields({
           {f.key === "parserDsl" || f.key === "eventMappingDsl" ? (
             <Textarea
               size="sm"
-              backgroundColor="white"
               rows={6}
               value={values[f.key] ?? ""}
               onChange={(e) => onChange({ ...values, [f.key]: e.target.value })}
@@ -1654,7 +1646,6 @@ function ParserConfigFields({
           ) : (
             <Input
               size="sm"
-              backgroundColor="white"
               type={isSecretFieldKey(f.key) ? "password" : "text"}
               value={values[f.key] ?? ""}
               onChange={(e) => onChange({ ...values, [f.key]: e.target.value })}
@@ -1691,7 +1682,6 @@ function PullScheduleField({
       </Text>
       <Input
         size="sm"
-        backgroundColor="white"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={defaultSchedule}


### PR DESCRIPTION
Fixes #7160

## What

The ingestion sources drawers (`SourceComposerDrawer`, `SourceEditDrawer`, `ParserConfigFields`, `PullScheduleField`) hardcoded `backgroundColor="white"` on all form inputs and used a raw HTML `<select>` with inline white background. This broke dark mode and bypassed the design system.

## Changes

- **Raw `<select>` → `NativeSelect.Root`/`.Field`/`.Indicator`** — Chakra's themed native select, inherits dark-mode colors and border tokens
- **Removed 8× `backgroundColor="white"`** from `Input` and `Textarea` components — inputs now inherit the theme's `bg` token

## Not addressed (separate concern)

The drawers use `useState`-driven open/close instead of URL-routed drawers per `dev/docs/best_practices/drawers.md`. That's a larger refactor tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated source-type selection controls for a more consistent interface.
  * Removed fixed white backgrounds from several ingestion configuration fields, allowing them to better match the surrounding theme and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->