### PR TITLE
docs: point FEATURE_MAP at the SKILL.mdx sources

### DIFF
--- a/FEATURE_MAP.md
+++ b/FEATURE_MAP.md
@@ -145,9 +145,9 @@ Legend: ✅ present · — absent · `—` no SDK/CLI/skill/MCP by design
 - **Scenario SDK** — separate: `@langwatch/scenario` / `langwatch-scenario`
 
 ### Skills
-- **Feature skills** — `skills/{tracing,evaluations,scenarios,prompts}/SKILL.md`
-- **Cross-cutting** — `skills/{analytics,datasets}/SKILL.md`
-- **Meta** — `skills/level-up/SKILL.md` (orchestrates the feature skills)
+- **Feature skills** — `skills/{tracing,evaluations,scenarios,prompts}/SKILL.mdx`
+- **Cross-cutting** — `skills/{analytics,datasets}/SKILL.mdx`
+- **Meta** — `skills/level-up/SKILL.mdx` (orchestrates the feature skills)
 - **Recipes** — `skills/recipes/{debug-instrumentation,improve-setup,test-cli-usability,evaluate-multimodal,generate-rag-dataset,test-compliance}`
 
 ### Documentation
@@ -162,7 +162,7 @@ Validation checklist:
 
 - Every `api` value corresponds to a route in `platform/app/src/app/api/` or `platform/app/src/pages/api/`
 - Every `mcp` tool name appears in `mcp/typescript/src/index.ts`
-- Every `skill` name has a `skills/{name}/SKILL.md`
+- Every `skill` name has a `skills/{name}/SKILL.mdx`
 - Every `cli` command exists in `sdks/typescript/src/cli/`
 - Every `ui` route exists in `platform/app/src/utils/routes.ts`
 - No aspirational entries — use `plannedSync` for future intent


### PR DESCRIPTION
`3141eb856` (*refactor(skills): real MDX with imports + JSX, retire link-as-partial
sleight of hand*, #3432) renamed the skill sources to `SKILL.mdx`. `FEATURE_MAP.md`
still names `SKILL.md` in four places, including the invariant list at the bottom
that says every skill name has one.

Checked against `git ls-tree -r HEAD` rather than a working tree:

| skill | `SKILL.md` in HEAD | `SKILL.mdx` in HEAD |
|---|---|---|
| `level-up` | 0 | 1 |
| `tracing` | 0 | 1 |
| `evaluations` | 0 | 1 |
| `scenarios` | 0 | 1 |
| `prompts` | 0 | 1 |
| `datasets` | 0 | 1 |

Under `skills/`, HEAD records **21 `SKILL.mdx` and 21 `SKILL.md`** - but every one of
the `.md` is under `skills/_compiled/native/`, which are generated outputs rather than
the sources this section is describing.

## One line deliberately left alone

Line 159 points at `.claude/skills/feature-map/SKILL.md`. That one really is a `.md`
file in HEAD, so a blanket replace across the document would have broken a correct
reference. It is unchanged.

## One thing I did not fix, because it is your call

Line 149 reads:

```
- **Cross-cutting** - `skills/{analytics,datasets}/SKILL.mdx`
```

`skills/analytics/` is not in HEAD at all - neither `SKILL.md` nor `SKILL.mdx`, no
directory. `feature-map.json` does mention analytics, so I could not tell whether the
skill is planned and not yet written, or whether the reference should come out. Either
is a one-word change and both are yours to pick, so I left the name in place and only
corrected the extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Skills documentation references to use the `.SKILL.mdx` file extension.
  * Updated the validation checklist to reflect the new file extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Found with [docproof](https://github.com/melbinjp/docproof), which checks what documentation claims against what the repository actually contains.
