### PR TITLE
fix(governance): route claude_compliance API key to credentials.token

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/__tests__/claudeCompliancePullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/claudeCompliancePullConfig.unit.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Same contract as `anthropicAdminPullConfig.unit.test.ts`: whatever
+ * `buildClaudeCompliancePullConfig` saves must route the workspace API
+ * key into `pullConfig.credentials.token`, because the frozen puller
+ * config (`CLAUDE_COMPLIANCE_PULL_CONFIG`) templates that path into the
+ * `x-api-key` header. A missing credential means a literal
+ * `${{credentials.token}}` hits Anthropic → 401 on every run.
+ *
+ * Regression test for #7168.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildClaudeCompliancePullConfig,
+  buildParserConfig,
+  type ComposerState,
+} from "../ingestion-sources";
+
+function composer(
+  parserConfig: Record<string, string>,
+  pullSchedule = "",
+): ComposerState {
+  return {
+    sourceType: "claude_compliance",
+    name: "Anthropic compliance",
+    description: "",
+    parserConfig,
+    ottlStatements: [],
+    pullSchedule,
+  };
+}
+
+describe("buildClaudeCompliancePullConfig", () => {
+  it("given a valid workspace API key, routes it to credentials.token", () => {
+    const config = buildClaudeCompliancePullConfig(
+      composer({ workspaceApiKey: "sk-ant-admin-test" }),
+    );
+
+    expect(config).not.toBeNull();
+    expect(config).toMatchObject({
+      adapter: "claude_compliance",
+      credentials: { token: "sk-ant-admin-test" },
+    });
+  });
+
+  it("given no workspace API key, refuses to build", () => {
+    expect(buildClaudeCompliancePullConfig(composer({}))).toBeNull();
+    expect(
+      buildClaudeCompliancePullConfig(composer({ workspaceApiKey: "" })),
+    ).toBeNull();
+    expect(
+      buildClaudeCompliancePullConfig(composer({ workspaceApiKey: "   " })),
+    ).toBeNull();
+  });
+
+  it("keeps the secret out of the persisted parserConfig", () => {
+    const state = composer({ workspaceApiKey: "sk-ant-admin-test" });
+    const parser = buildParserConfig(state);
+    expect(parser).not.toHaveProperty("workspaceApiKey");
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -290,6 +290,11 @@ function resolvePullConfig(
       "Missing or invalid Anthropic fields",
       "Admin API key is required, report must be `usage` or `cost`, bucket width is usage-only and must be 1m/1h/1d, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z).",
     ],
+    claude_compliance: [
+      () => buildClaudeCompliancePullConfig(composer),
+      "Missing Anthropic compliance fields",
+      "Workspace API key is required.",
+    ],
   };
 
   const builder = builders[composer.sourceType];
@@ -1502,6 +1507,19 @@ export function buildAnthropicAdminPullConfig(
       "0 * * * *",
     credentials: { token },
   };
+}
+
+/**
+ * Claude Compliance builder — the frozen puller config
+ * (`CLAUDE_COMPLIANCE_PULL_CONFIG`) only needs the workspace API key
+ * routed into `credentials.token` for the `x-api-key` header template.
+ */
+export function buildClaudeCompliancePullConfig(
+  c: ComposerState,
+): Record<string, unknown> | null {
+  const token = trimmedField(c.parserConfig, "workspaceApiKey");
+  if (!token) return null;
+  return { adapter: "claude_compliance", credentials: { token } };
 }
 
 /** One composer field, trimmed, with an absent key reading as empty. */


### PR DESCRIPTION
## Problem

`claude_compliance` ingestion sources stay stuck on "Awaiting first event" because the API key never reaches the HTTP request.

`resolvePullConfig()` had builders for `http_custom`, `databricks_genie`, and `anthropic_admin` — but not `claude_compliance`. The fallthrough returned `{ adapter: "claude_compliance" }` with no `credentials` subtree. At dispatch time, `decryptCredentials(undefined)` → `{}`. The puller header template `${{credentials.token}}` stayed literal → Anthropic 401 on every run.

## Cause

`ingestion-sources.tsx:293` — missing builder in `resolvePullConfig()`.

## Fix

- Add `buildClaudeCompliancePullConfig()` that reads `workspaceApiKey` from the composer and routes it to `pullConfig.credentials.token`
- Register it in the `builders` map

## Test evidence

### Before fix (test fails)
```
FAIL  buildClaudeCompliancePullConfig > given a valid workspace API key, routes it to credentials.token
TypeError: buildClaudeCompliancePullConfig is not a function

Tests  2 failed | 1 passed (3)
```

### After fix (test passes)
```
✓ given a valid workspace API key, routes it to credentials.token  1ms
✓ given no workspace API key, refuses to build  0ms
✓ keeps the secret out of the persisted parserConfig  0ms

Test Files  3 passed (3)
Tests  15 passed (15)
```

## Sweep findings

- `copilot_studio` has the same bug class: `clientSecret` (secret: true) with no builder, `${{credentials.token}}` in frozen config. Different fix needed (OAuth2 with 3 fields) — separate issue.
- `openai_compliance` — no credential template, uses IAM role assumption. Safe.

## Not fixed

- P1 from #7168: existing rows may have `workspaceApiKey` stored in plaintext JSONB. Migration to re-encrypt is a separate change.
- `copilot_studio` missing builder (different fix shape).

Closes #7168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Compliance as a supported pull-based ingestion source.
  * Workspace API keys are validated and securely stored for configured pulls.

* **Bug Fixes**
  * Prevented missing or whitespace-only API keys from creating invalid configurations.
  * Ensured API secrets are excluded from persisted parser configuration.

* **Tests**
  * Added regression coverage for valid, missing, and whitespace-only API key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->