### PR TITLE
fix(governance): anthropic_admin cost_report 400 — default too recent + log error body

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -124,7 +124,7 @@ function IngestionSourceDetailPage() {
     { enabled: !!orgId && !!sourceId, refetchOnWindowFocus: false },
   );
   const eventsQuery = api.activityMonitor.eventsForSource.useQuery(
-    { organizationId: orgId, sourceId: sourceId ?? "", limit: 50 },
+    { organizationId: orgId, sourceId: sourceId ?? "", limit: 20 },
     { enabled: !!orgId && !!sourceId, refetchOnWindowFocus: false },
   );
   const utils = api.useUtils();

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -1252,7 +1252,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       key: "startingAt",
       label: "Backfill start (optional)",
       placeholder: "2026-08-01",
-      hint: "The date the first run reads from: `2026-08-01`, or an instant carrying a timezone (`2026-08-01T00:00:00Z`). A time without a timezone is rejected rather than read as yours. Empty = 3 days back for cost, 24 hours for usage.",
+      hint: "The date the first run reads from: `2026-08-01`, or an instant carrying a timezone (`2026-08-01T00:00:00Z`). A time without a timezone is rejected rather than read as yours. Empty = 3 calendar days back at midnight UTC for cost, 1 calendar day back at midnight UTC for usage.",
     },
   ],
   databricks_genie: [

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -1252,7 +1252,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       key: "startingAt",
       label: "Backfill start (optional)",
       placeholder: "2026-08-01",
-      hint: "The date the first run reads from: `2026-08-01`, or an instant carrying a timezone (`2026-08-01T00:00:00Z`). A time without a timezone is rejected rather than read as yours. Empty = 24 hours back.",
+      hint: "The date the first run reads from: `2026-08-01`, or an instant carrying a timezone (`2026-08-01T00:00:00Z`). A time without a timezone is rejected rather than read as yours. Empty = 3 days back for cost, 24 hours for usage.",
     },
   ],
   databricks_genie: [

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -135,6 +135,32 @@ function defaultStartingAt(report: "usage" | "cost"): string {
   return d.toISOString();
 }
 
+/** Cap on how much of an error response body we log. */
+const MAX_ERROR_BODY_BYTES = 4_096;
+
+/**
+ * Best-effort read of a non-OK response body, bounded so an unexpectedly
+ * large payload doesn't blow up logs or memory.
+ */
+async function safeResponseText(response: Response): Promise<string> {
+  try {
+    const raw = await response.text();
+    if (raw.length <= MAX_ERROR_BODY_BYTES) return raw;
+    return `${raw.slice(0, MAX_ERROR_BODY_BYTES)}… [truncated]`;
+  } catch {
+    return "";
+  }
+}
+
+async function fetchPageError(
+  response: Response,
+  report: string,
+): Promise<Error> {
+  const detail = await safeResponseText(response);
+  const suffix = detail ? `: ${detail}` : "";
+  return new Error(`HTTP ${response.status} (anthropic ${report}_report)${suffix}`);
+}
+
 /** One group-by row inside a usage bucket. Unknown fields are tolerated. */
 const usageResultSchema = z
   .object({
@@ -383,17 +409,7 @@ export class AnthropicAdminPuller
       signal,
     });
     if (!response.ok) {
-      // Read the body so the actual API error message reaches the logs —
-      // HTTP/2 has no statusText, and without this the 400 is opaque.
-      let detail = "";
-      try {
-        detail = await response.text();
-      } catch {
-        // Best-effort; some responses have no body.
-      }
-      throw new Error(
-        `HTTP ${response.status} (anthropic ${config.report}_report)${detail ? `: ${detail}` : ""}`,
-      );
+      throw await fetchPageError(response, config.report);
     }
     return await response.json();
   }

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -108,7 +108,7 @@ function parseCursor(
     }
   }
   return {
-    startingAt: config.startingAt ?? defaultStartingAt(),
+    startingAt: config.startingAt ?? defaultStartingAt(config.report),
     page: null,
   };
 }
@@ -117,9 +117,22 @@ function encodeCursor(startingAt: string, page: string | null): string {
   return JSON.stringify({ startingAt, page });
 }
 
-/** A first run with no configured watermark reads the last full day. */
-function defaultStartingAt(): string {
-  return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+/**
+ * A first run with no configured watermark.
+ *
+ * Cost reports use daily buckets with a ~1-day processing lag, so the most
+ * recent *completed* bucket is ≥2 days ago.  Going back 3 days guarantees at
+ * least one full bucket and avoids the 400 Anthropic returns when there is no
+ * valid ending date after `starting_at`.
+ *
+ * Usage reports can have sub-day granularity, so 24 h is fine.
+ */
+function defaultStartingAt(report: "usage" | "cost"): string {
+  const daysBack = report === "cost" ? 3 : 1;
+  const d = new Date(Date.now() - daysBack * 24 * 60 * 60 * 1000);
+  // Snap to midnight UTC so the timestamp aligns with daily bucket boundaries.
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString();
 }
 
 /** One group-by row inside a usage bucket. Unknown fields are tolerated. */
@@ -370,8 +383,16 @@ export class AnthropicAdminPuller
       signal,
     });
     if (!response.ok) {
+      // Read the body so the actual API error message reaches the logs —
+      // HTTP/2 has no statusText, and without this the 400 is opaque.
+      let detail = "";
+      try {
+        detail = await response.text();
+      } catch {
+        // Best-effort; some responses have no body.
+      }
       throw new Error(
-        `HTTP ${response.status} ${response.statusText} (anthropic ${config.report}_report)`,
+        `HTTP ${response.status} (anthropic ${config.report}_report)${detail ? `: ${detail}` : ""}`,
       );
     }
     return await response.json();

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -142,7 +142,9 @@ const MAX_ERROR_BODY_BYTES = 4_096;
  * Best-effort read of a non-OK response body, bounded so an unexpectedly
  * large payload doesn't blow up logs or memory.
  */
-async function safeResponseText(response: Response): Promise<string> {
+async function safeResponseText(response: {
+  text(): Promise<string>;
+}): Promise<string> {
   try {
     const raw = await response.text();
     if (raw.length <= MAX_ERROR_BODY_BYTES) return raw;
@@ -153,12 +155,14 @@ async function safeResponseText(response: Response): Promise<string> {
 }
 
 async function fetchPageError(
-  response: Response,
+  response: { status: number; text(): Promise<string> },
   report: string,
 ): Promise<Error> {
   const detail = await safeResponseText(response);
   const suffix = detail ? `: ${detail}` : "";
-  return new Error(`HTTP ${response.status} (anthropic ${report}_report)${suffix}`);
+  return new Error(
+    `HTTP ${response.status} (anthropic ${report}_report)${suffix}`,
+  );
 }
 
 /** One group-by row inside a usage bucket. Unknown fields are tolerated. */


### PR DESCRIPTION
## Summary

Fixes the `anthropic_admin` cost_report ingestion source always failing with HTTP 400, and caps the event list on the ingestion source detail page.

## Changes

### 1. `defaultStartingAt()` now report-aware (`anthropicAdmin.puller.ts`)

Cost reports use daily buckets with a ~1-day processing lag. The old default of 24h ago has no completed bucket — Anthropic returns `"Invalid date range: ending date must be after starting date"`.

- Cost reports: 3 calendar days back at midnight UTC (guarantees ≥1 complete daily bucket)
- Usage reports: 1 calendar day back at midnight UTC (unchanged effective behavior)

### 2. HTTP error body now logged and bounded (`anthropicAdmin.puller.ts`)

The error handler discarded the response body. HTTP/2 has no `statusText`, so logs showed `"HTTP 400 "` with no explanation. Now reads `response.text()` via `safeResponseText()` (capped at 4 KiB) and includes it in the thrown error. Error construction extracted into `fetchPageError()` to keep `fetchPage()` under the cognitive-complexity lint threshold.

### 3. Form hint updated (`ingestion-sources.tsx`)

"Empty = 24 hours back" → "Empty = 3 calendar days back at midnight UTC for cost, 1 calendar day back at midnight UTC for usage"

### 4. Ingestion source detail events capped at 20 (`ingestion-source-detail.tsx`)

The event list query limit was 50, which made the page unwieldy. Reduced to 20.

## Verification

Confirmed via direct API call:
- `starting_at` = 24h ago → 400 `"Invalid date range: ending date must be after starting date"`
- `starting_at` = `2026-08-01T00:00:00Z` → 200 with real cost data

Closes #7177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic Admin backfills now use report-specific default ranges: three calendar days for cost reports and one calendar day for usage reports.
  * Backfills begin at midnight UTC for consistent reporting.

* **Bug Fixes**
  * Error messages now include service-provided details when available.
  * Recent activity views now display up to 20 events, improving focus on the most recent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->