### PR TITLE
fix(haven): make PORTLESS=0 actually bypass the proxy

### DIFF
--- a/tools/thuishaven/app/config.go
+++ b/tools/thuishaven/app/config.go
@@ -55,12 +55,13 @@ type Config struct {
 	// terminal is quiet and the full detail lives in Grafana. "" opts out and leaves
 	// the console to .env. Resolved from LW_OBS_CONSOLE_LEVEL.
 	ObservabilityConsoleLevel string
-	// ShouldUsePortless routes a worktree's stack through the portless proxy
-	// (hostname URLs, shared TLS port). PORTLESS=0 disables it: `up` never
-	// starts, trusts, or registers with the proxy, and every service's own
-	// loopback port is served plain over HTTP instead — the documented escape
-	// hatch for a machine where the portless proxy's TLS won't come up.
-	ShouldUsePortless bool
+	// PortlessDisabled is PORTLESS=0: `up` never starts, trusts, or registers
+	// with the portless proxy, and every service's own loopback port is served
+	// plain HTTP instead of routing through the proxy's shared hostname+TLS
+	// port — the documented escape hatch for a machine where the proxy's TLS
+	// won't come up. The zero value is false (portless enabled), matching every
+	// stack provisioned before this knob existed — see domain.Stack.PortlessDisabled.
+	PortlessDisabled bool
 }
 
 // PlanOptions decide which services `up` runs and how.

--- a/tools/thuishaven/app/config.go
+++ b/tools/thuishaven/app/config.go
@@ -55,6 +55,12 @@ type Config struct {
 	// terminal is quiet and the full detail lives in Grafana. "" opts out and leaves
 	// the console to .env. Resolved from LW_OBS_CONSOLE_LEVEL.
 	ObservabilityConsoleLevel string
+	// ShouldUsePortless routes a worktree's stack through the portless proxy
+	// (hostname URLs, shared TLS port). PORTLESS=0 disables it: `up` never
+	// starts, trusts, or registers with the proxy, and every service's own
+	// loopback port is served plain over HTTP instead — the documented escape
+	// hatch for a machine where the portless proxy's TLS won't come up.
+	ShouldUsePortless bool
 }
 
 // PlanOptions decide which services `up` runs and how.

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -300,7 +300,7 @@ func (o *Orchestrator) serviceEndpoint(proxyScheme string, proxyPort, ownPort in
 	return proxyScheme, proxyPort
 }
 
-// Up is the launcher hook `make haven up` runs in portless mode.
+// Up is the launcher hook `make haven up` runs, in either routing mode.
 func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) error {
 	if err := o.ensurePortlessProxy(); err != nil {
 		return err
@@ -533,7 +533,8 @@ func (o *Orchestrator) Down(ctx context.Context, p UpParams, force bool) error {
 	if err != nil {
 		return err
 	}
-	if st, ok := o.stackBySlug(slug); ok && st.LauncherPID != o.sys.Getpid() && o.sys.ProcessAlive(st.LauncherPID) {
+	st, ok := o.stackBySlug(slug)
+	if ok && st.LauncherPID != o.sys.Getpid() && o.sys.ProcessAlive(st.LauncherPID) {
 		if force {
 			// -f: no grace — SIGKILL the launcher's whole process group at once,
 			// for the stack that is wedged or just needs to be gone NOW.
@@ -545,7 +546,17 @@ func (o *Orchestrator) Down(ctx context.Context, p UpParams, force bool) error {
 			fmt.Printf("stopped launcher (pid %d)\n", st.LauncherPID)
 		}
 	}
-	if !o.cfg.PortlessDisabled {
+	// Use the mode the stack was actually provisioned under, not this run's
+	// PORTLESS — `PORTLESS=0 haven down` on a stack that registered its aliases
+	// under portless must still remove them, or they leak (dangling routes that
+	// can later point at a reused loopback port). No registry entry (already
+	// torn down, or never registered) leaves nothing to go on but this run's
+	// setting.
+	portlessDisabled := o.cfg.PortlessDisabled
+	if ok {
+		portlessDisabled = st.PortlessDisabled
+	}
+	if !portlessDisabled {
 		for _, r := range domain.PerWorktreeServices {
 			o.proxy.Remove(r.Name, slug)
 		}

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -146,7 +146,10 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 	if err != nil {
 		return domain.Stack{}, nil, err
 	}
-	scheme, pport := o.proxy.Endpoint()
+	proxyScheme, proxyPort := "", 0
+	if o.cfg.ShouldUsePortless {
+		proxyScheme, proxyPort = o.proxy.Endpoint()
+	}
 	// ports[0..nSvc-1] back the routed services (app/gateway/nlp/langyagent, in
 	// PerWorktreeServices order); ports[nSvc] is the API backend behind app's /api,
 	// ports[nSvc+1] the worker metrics endpoint.
@@ -176,7 +179,6 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 		svc := domain.Service{
 			Name: r.Name, Role: r.Role, Port: ports[i],
 			Hostname: o.cfg.Naming.Hostname(r.Name, slug),
-			URL:      o.cfg.Naming.URL(r.Name, slug, scheme, pport),
 		}
 		// A service this worktree opts out of (gateway/nlp/langyagent) resolves to a
 		// live baseline stack's copy when one exists, so its URL stays defined. With
@@ -191,8 +193,19 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 				svc.Port = 0
 			}
 		}
+		if o.cfg.ShouldUsePortless {
+			// The proxy routes every service through one shared scheme+port by
+			// hostname, so the URL is defined even for a dead route (a 502, by
+			// design — see above).
+			svc.URL = o.cfg.Naming.URL(r.Name, slug, proxyScheme, proxyPort)
+		} else if svc.Port != 0 {
+			// No proxy: each service is reached directly on its own loopback port,
+			// plain HTTP. A genuinely unavailable service has no port to reach it
+			// on, so it gets no URL either.
+			svc.URL = o.cfg.Naming.URL(r.Name, slug, "http", svc.Port)
+		}
 		st.Services = append(st.Services, svc)
-		if svc.Port != 0 {
+		if svc.Port != 0 && o.cfg.ShouldUsePortless {
 			if err := o.proxy.Register(svc.Name, slug, svc.Port); err != nil {
 				o.log.Warn("alias registration failed", zap.String("host", svc.Hostname), zap.Error(err))
 			}
@@ -212,8 +225,10 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 		return domain.Stack{}, nil, err
 	}
 	cleanup := func() {
-		for _, s := range st.Services {
-			o.proxy.Remove(s.Name, slug)
+		if o.cfg.ShouldUsePortless {
+			for _, s := range st.Services {
+				o.proxy.Remove(s.Name, slug)
+			}
 		}
 		o.store.RemoveStack(slug)
 	}
@@ -250,10 +265,17 @@ func (o *Orchestrator) heartbeat(ctx context.Context, st domain.Stack) {
 	}
 }
 
-// Up is the launcher hook `make haven up` runs in portless mode.
-func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) error {
-	// Bootstrap is part of up, not a command: a fresh machine installs portless,
-	// trusts the CA, and starts the proxy right here (each step idempotent).
+// ensurePortlessProxy installs, trusts, and starts the portless proxy — part of
+// `up`'s bootstrap, not a separate command, so a fresh machine self-configures
+// on the first `haven up` (each step idempotent). PORTLESS=0 skips all of it:
+// the escape hatch for a machine where the proxy's TLS handshake won't come up
+// (#7117). Callers must then serve every service plain HTTP on its own loopback
+// port instead, with no proxy involved — see provision's use of
+// Config.ShouldUsePortless.
+func (o *Orchestrator) ensurePortlessProxy() error {
+	if !o.cfg.ShouldUsePortless {
+		return nil
+	}
 	if !o.proxy.Installed() {
 		fmt.Println("portless is not installed — installing it (one time)…")
 		if err := o.proxy.Install(); err != nil {
@@ -262,6 +284,14 @@ func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) err
 	}
 	if err := o.proxy.EnsureReady(); err != nil {
 		return fmt.Errorf("could not start the portless proxy: %w", err)
+	}
+	return nil
+}
+
+// Up is the launcher hook `make haven up` runs in portless mode.
+func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) error {
+	if err := o.ensurePortlessProxy(); err != nil {
+		return err
 	}
 	slug, err := o.resolveSlug(p)
 	if err != nil {
@@ -495,11 +525,13 @@ func (o *Orchestrator) Down(ctx context.Context, p UpParams, force bool) error {
 			fmt.Printf("stopped launcher (pid %d)\n", st.LauncherPID)
 		}
 	}
-	for _, r := range domain.PerWorktreeServices {
-		o.proxy.Remove(r.Name, slug)
+	if o.cfg.ShouldUsePortless {
+		for _, r := range domain.PerWorktreeServices {
+			o.proxy.Remove(r.Name, slug)
+		}
+		o.proxy.Remove(domain.ClickHouseService, slug)
+		o.proxy.Remove(domain.PostgresService, slug)
 	}
-	o.proxy.Remove(domain.ClickHouseService, slug)
-	o.proxy.Remove(domain.PostgresService, slug)
 	o.store.RemoveStack(slug)
 	fmt.Printf("stack %q torn down (databases kept — `haven db reset` for fresh ones)\n", slug)
 	return nil
@@ -526,14 +558,19 @@ func (o *Orchestrator) ensureClickHouse(ctx context.Context, st *domain.Stack) {
 	}
 	st.ClickHouseHTTPPort = port
 	st.ClickHouseDatabase = db
-	scheme, pport := o.proxy.Endpoint()
+	scheme, epPort := "http", port
+	if o.cfg.ShouldUsePortless {
+		scheme, epPort = o.proxy.Endpoint()
+	}
 	st.Services = append(st.Services, domain.Service{
 		Name: domain.ClickHouseService, Role: "ClickHouse (this stack's DB)", Port: port,
 		Hostname: o.cfg.Naming.Hostname(domain.ClickHouseService, st.Slug),
-		URL:      o.cfg.Naming.URL(domain.ClickHouseService, st.Slug, scheme, pport),
+		URL:      o.cfg.Naming.URL(domain.ClickHouseService, st.Slug, scheme, epPort),
 	})
-	if err := o.proxy.Register(domain.ClickHouseService, st.Slug, port); err != nil {
-		o.log.Warn("clickhouse alias registration failed", zap.Error(err))
+	if o.cfg.ShouldUsePortless {
+		if err := o.proxy.Register(domain.ClickHouseService, st.Slug, port); err != nil {
+			o.log.Warn("clickhouse alias registration failed", zap.Error(err))
+		}
 	}
 }
 

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -146,10 +146,10 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 	if err != nil {
 		return domain.Stack{}, nil, err
 	}
-	proxyScheme, proxyPort := "", 0
-	if o.cfg.ShouldUsePortless {
-		proxyScheme, proxyPort = o.proxy.Endpoint()
-	}
+	// Endpoint just reads portless's own local state files (proxy.port/proxy.tls);
+	// it never invokes the binary, so it is always safe to call, even under
+	// PORTLESS=0 with no proxy installed.
+	proxyScheme, proxyPort := o.proxy.Endpoint()
 	// ports[0..nSvc-1] back the routed services (app/gateway/nlp/langyagent, in
 	// PerWorktreeServices order); ports[nSvc] is the API backend behind app's /api,
 	// ports[nSvc+1] the worker metrics endpoint.
@@ -174,6 +174,7 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 		LangyTier:            opts.LangyTier,
 		LangyImage:           opts.langyImageTag,
 		DisableGoogleDLP:     o.cfg.ShouldDisableGoogleDLP,
+		PortlessDisabled:     o.cfg.PortlessDisabled,
 	}
 	for i, r := range domain.PerWorktreeServices {
 		svc := domain.Service{
@@ -193,19 +194,17 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 				svc.Port = 0
 			}
 		}
-		if o.cfg.ShouldUsePortless {
-			// The proxy routes every service through one shared scheme+port by
-			// hostname, so the URL is defined even for a dead route (a 502, by
-			// design — see above).
-			svc.URL = o.cfg.Naming.URL(r.Name, slug, proxyScheme, proxyPort)
-		} else if svc.Port != 0 {
-			// No proxy: each service is reached directly on its own loopback port,
-			// plain HTTP. A genuinely unavailable service has no port to reach it
-			// on, so it gets no URL either.
-			svc.URL = o.cfg.Naming.URL(r.Name, slug, "http", svc.Port)
+		// Portless enabled: the proxy routes every service through one shared
+		// scheme+port by hostname, so the URL is defined even for a dead route (a
+		// 502, by design — see above). Disabled: each service is reached directly
+		// on its own loopback port; a genuinely unavailable one has no port to
+		// reach it on, so it gets no URL either.
+		if !o.cfg.PortlessDisabled || svc.Port != 0 {
+			scheme, port := o.serviceEndpoint(proxyScheme, proxyPort, svc.Port)
+			svc.URL = o.cfg.Naming.URL(r.Name, slug, scheme, port)
 		}
 		st.Services = append(st.Services, svc)
-		if svc.Port != 0 && o.cfg.ShouldUsePortless {
+		if svc.Port != 0 && !o.cfg.PortlessDisabled {
 			if err := o.proxy.Register(svc.Name, slug, svc.Port); err != nil {
 				o.log.Warn("alias registration failed", zap.String("host", svc.Hostname), zap.Error(err))
 			}
@@ -225,7 +224,7 @@ func (o *Orchestrator) provision(ctx context.Context, p UpParams, opts PlanOptio
 		return domain.Stack{}, nil, err
 	}
 	cleanup := func() {
-		if o.cfg.ShouldUsePortless {
+		if !o.cfg.PortlessDisabled {
 			for _, s := range st.Services {
 				o.proxy.Remove(s.Name, slug)
 			}
@@ -271,9 +270,9 @@ func (o *Orchestrator) heartbeat(ctx context.Context, st domain.Stack) {
 // the escape hatch for a machine where the proxy's TLS handshake won't come up
 // (#7117). Callers must then serve every service plain HTTP on its own loopback
 // port instead, with no proxy involved — see provision's use of
-// Config.ShouldUsePortless.
+// Config.PortlessDisabled.
 func (o *Orchestrator) ensurePortlessProxy() error {
-	if !o.cfg.ShouldUsePortless {
+	if o.cfg.PortlessDisabled {
 		return nil
 	}
 	if !o.proxy.Installed() {
@@ -286,6 +285,19 @@ func (o *Orchestrator) ensurePortlessProxy() error {
 		return fmt.Errorf("could not start the portless proxy: %w", err)
 	}
 	return nil
+}
+
+// serviceEndpoint resolves how one routed service is actually reachable.
+// Portless enabled: every service shares the proxy's own scheme+port —
+// hostname routing (not the port) is what tells them apart. PORTLESS=0: there
+// is no proxy, so a service is reached directly on its own loopback port over
+// plain HTTP. The single decision point provision and ensureClickHouse both
+// resolve their service URL through.
+func (o *Orchestrator) serviceEndpoint(proxyScheme string, proxyPort, ownPort int) (scheme string, port int) {
+	if o.cfg.PortlessDisabled {
+		return "http", ownPort
+	}
+	return proxyScheme, proxyPort
 }
 
 // Up is the launcher hook `make haven up` runs in portless mode.
@@ -480,7 +492,13 @@ func (o *Orchestrator) reconcileRunningStack(p UpParams, opts PlanOptions) (proc
 	// re-running `up` after unsetting LANGY_UNSAFE_CONTAINER must actually put
 	// the UID sandbox back, not report a match.
 	tierMatches := st.LangyTier == opts.LangyTier
-	if !opts.ShouldForce && !opts.ShouldRebuildImages && selectionMatches && imageMatches && tierMatches {
+	// PORTLESS is a machine/run-level knob (Config, not PlanOptions), so it isn't
+	// covered by selectionMatches — compare it explicitly, or flipping PORTLESS=0
+	// on a stack that is already up silently keeps serving the old mode (through
+	// a proxy the operator just asked to bypass, defeating the whole escape
+	// hatch — see #7117).
+	portlessMatches := st.PortlessDisabled == o.cfg.PortlessDisabled
+	if !opts.ShouldForce && !opts.ShouldRebuildImages && selectionMatches && imageMatches && tierMatches && portlessMatches {
 		fmt.Printf("stack %q is already running (launcher pid %d) and matches the selection — nothing to do\n", slug, st.LauncherPID)
 		fmt.Printf("  bounce a service: haven restart [service] · restart everything: haven up -f · stop: haven down\n")
 		return false, nil
@@ -490,6 +508,8 @@ func (o *Orchestrator) reconcileRunningStack(p UpParams, opts PlanOptions) (proc
 		fmt.Printf("stack %q is running — replacing it (-f)\n", slug)
 	case opts.ShouldRebuildImages:
 		fmt.Printf("stack %q is running — replacing it to rebuild its images (--rebuild)\n", slug)
+	case !portlessMatches:
+		fmt.Printf("stack %q is running with a different PORTLESS setting — restarting it to match\n", slug)
 	case !tierMatches:
 		fmt.Printf("stack %q is running under a different langy isolation tier — restarting it with the requested one\n", slug)
 	case !imageMatches:
@@ -525,7 +545,7 @@ func (o *Orchestrator) Down(ctx context.Context, p UpParams, force bool) error {
 			fmt.Printf("stopped launcher (pid %d)\n", st.LauncherPID)
 		}
 	}
-	if o.cfg.ShouldUsePortless {
+	if !o.cfg.PortlessDisabled {
 		for _, r := range domain.PerWorktreeServices {
 			o.proxy.Remove(r.Name, slug)
 		}
@@ -558,16 +578,14 @@ func (o *Orchestrator) ensureClickHouse(ctx context.Context, st *domain.Stack) {
 	}
 	st.ClickHouseHTTPPort = port
 	st.ClickHouseDatabase = db
-	scheme, epPort := "http", port
-	if o.cfg.ShouldUsePortless {
-		scheme, epPort = o.proxy.Endpoint()
-	}
+	proxyScheme, proxyPort := o.proxy.Endpoint()
+	scheme, epPort := o.serviceEndpoint(proxyScheme, proxyPort, port)
 	st.Services = append(st.Services, domain.Service{
 		Name: domain.ClickHouseService, Role: "ClickHouse (this stack's DB)", Port: port,
 		Hostname: o.cfg.Naming.Hostname(domain.ClickHouseService, st.Slug),
 		URL:      o.cfg.Naming.URL(domain.ClickHouseService, st.Slug, scheme, epPort),
 	})
-	if o.cfg.ShouldUsePortless {
+	if !o.cfg.PortlessDisabled {
 		if err := o.proxy.Register(domain.ClickHouseService, st.Slug, port); err != nil {
 			o.log.Warn("clickhouse alias registration failed", zap.Error(err))
 		}

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -312,14 +312,7 @@ func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) err
 	// Resolve the langy image tag before anything else: it is pure file hashing,
 	// and the reconcile guard needs it to notice a source edit under an
 	// unchanged selection (same services, new bytes — still a restart).
-	if opts.Selection.Langy && opts.LangyTier.RunsInContainer() {
-		if tag, err := langyImageTag(opts.RepoRoot); err == nil {
-			opts.langyImageTag = tag
-		} else {
-			o.log.Warn("could not derive the langy image tag — using the plain dev tag", zap.Error(err))
-			opts.langyImageTag = langyImage
-		}
-	}
+	o.resolveLangyImageTag(&opts)
 	// Serialize `up` per slug: two concurrent runs could both pass the
 	// already-running guard and then both register the same slug. The lock is
 	// held only through guard + registration — holding it across supervision
@@ -354,6 +347,32 @@ func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) err
 	endRegistration()
 	fmt.Printf("  %s\n\n", opts.Selection.Describe())
 
+	if err := o.prepareWorktree(ctx, p, st); err != nil {
+		return err
+	}
+	langyDockerHost := o.langyContainerHost(ctx, st, &opts)
+	o.sup.Supervise(ctx, o.planChildren(st, opts, p.LwDir, langyDockerHost))
+	return nil
+}
+
+// resolveLangyImageTag derives the content-addressed langy image tag for a
+// container-tier selection, falling back to the plain dev tag when the hash
+// cannot be computed. No-op when langy is deselected or running on the host.
+func (o *Orchestrator) resolveLangyImageTag(opts *PlanOptions) {
+	if !opts.Selection.Langy || !opts.LangyTier.RunsInContainer() {
+		return
+	}
+	if tag, err := langyImageTag(opts.RepoRoot); err == nil {
+		opts.langyImageTag = tag
+	} else {
+		o.log.Warn("could not derive the langy image tag — using the plain dev tag", zap.Error(err))
+		opts.langyImageTag = langyImage
+	}
+}
+
+// prepareWorktree runs the pre-boot lanes: dependency install, codegen,
+// migrations and the seed. Only a migration failure stops the up.
+func (o *Orchestrator) prepareWorktree(ctx context.Context, p UpParams, st domain.Stack) error {
 	// Stale dependencies install themselves before anything needs them. Lifecycle
 	// scripts (the repo's postinstall) run for the developer's own worktree and
 	// are suppressed for an untrusted one — `haven pr` sanitises the fork install
@@ -377,44 +396,51 @@ func (o *Orchestrator) Up(ctx context.Context, p UpParams, opts PlanOptions) err
 	if err := o.sup.RunOnce(ctx, "prepare", p.LwDir, "pnpm -s run start:prepare:db", env); err != nil {
 		return fmt.Errorf("migrations failed — nothing was dropped; fix the migration, or run `haven db reset` for a fresh database: %w", err)
 	}
-	// Always seed. The seed is idempotent (a no-op once the stable local project +
-	// API key exist), so every `up` guarantees the same migrations AND the same
-	// seeded credential are in place — a freshly-provisioned DB is immediately
-	// usable with the well-known LANGWATCH_API_KEY, no manual sign-up.
-	//
-	// When haven manages Postgres the overlay carries a per-slug loopback
-	// DATABASE_URL (provably local) and the seed uses it. When it does not — DB
-	// management disabled, or Postgres failed to come up — the seed would inherit
-	// whatever DATABASE_URL is in .env, so guard that inherited URL exactly as
-	// `haven seed` does and skip (never seed a non-local database) rather than
-	// abort the up.
-	if hasEnvKey(env, "DATABASE_URL") {
-		if err := o.sup.RunOnce(ctx, "seed", p.LwDir, seedShell("pnpm -s run prisma:seed", env), env); err != nil {
-			o.log.Warn("seed failed (continuing)", zap.Error(err))
+	o.runSeed(ctx, p, env)
+	return nil
+}
+
+// runSeed always seeds. The seed is idempotent (a no-op once the stable local
+// project + API key exist), so every `up` guarantees the same migrations AND
+// the same seeded credential are in place — a freshly-provisioned DB is
+// immediately usable with the well-known LANGWATCH_API_KEY, no manual sign-up.
+//
+// When haven manages Postgres the overlay carries a per-slug loopback
+// DATABASE_URL (provably local) and the seed uses it. When it does not — DB
+// management disabled, or Postgres failed to come up — the seed would inherit
+// whatever DATABASE_URL is in .env, so guard that inherited URL exactly as
+// `haven seed` does and skip (never seed a non-local database) rather than
+// abort the up.
+func (o *Orchestrator) runSeed(ctx context.Context, p UpParams, env []string) {
+	if !hasEnvKey(env, "DATABASE_URL") {
+		if err := o.guardInheritedSeedEnv(p.LwDir); err != nil {
+			o.log.Warn("skipping seed — inherited database URL is not local", zap.Error(err))
+			fmt.Printf("haven: %v — skipping seed\n", err)
+			return
 		}
-	} else if err := o.guardInheritedSeedEnv(p.LwDir); err != nil {
-		o.log.Warn("skipping seed — inherited database URL is not local", zap.Error(err))
-		fmt.Printf("haven: %v — skipping seed\n", err)
-	} else if err := o.sup.RunOnce(ctx, "seed", p.LwDir, seedShell("pnpm -s run prisma:seed", env), env); err != nil {
+	}
+	if err := o.sup.RunOnce(ctx, "seed", p.LwDir, seedShell("pnpm -s run prisma:seed", env), env); err != nil {
 		o.log.Warn("seed failed (continuing)", zap.Error(err))
 	}
-	// In the container tiers (the sandboxed default and container-unsafe), the
-	// langyagent worker runs on colima rather than the host. Bring the VM up and
-	// ensure its image before planning; on failure, fail closed — skip langy rather
-	// than silently dropping to the unsafe host runner — and tell the user the
-	// explicit opt-in for host mode.
-	langyDockerHost := ""
-	if opts.Selection.Langy && st.LangyTier.RunsInContainer() {
-		if dh, err := o.prepareLangyContainer(ctx, opts.RepoRoot, st.LangyImage, opts.ShouldRebuildImages); err != nil {
-			o.log.Warn("langyagent container unavailable — skipping it (set LANGY_UNSAFE_HOST_ACCESS=1 to run the worker on the host instead)",
-				zap.String("tier", st.LangyTier.String()), zap.Error(err))
-			opts.Selection.Langy = false
-		} else {
-			langyDockerHost = dh
-		}
+}
+
+// langyContainerHost prepares the colima-backed langy runtime for the
+// container tiers (the sandboxed default and container-unsafe), returning the
+// docker socket the worker container should run against. On failure it fails
+// closed — langy is deselected rather than silently dropped to the unsafe
+// host runner — and tells the user the explicit opt-in for host mode.
+func (o *Orchestrator) langyContainerHost(ctx context.Context, st domain.Stack, opts *PlanOptions) string {
+	if !opts.Selection.Langy || !st.LangyTier.RunsInContainer() {
+		return ""
 	}
-	o.sup.Supervise(ctx, o.planChildren(st, opts, p.LwDir, langyDockerHost))
-	return nil
+	dh, err := o.prepareLangyContainer(ctx, opts.RepoRoot, st.LangyImage, opts.ShouldRebuildImages)
+	if err != nil {
+		o.log.Warn("langyagent container unavailable — skipping it (set LANGY_UNSAFE_HOST_ACCESS=1 to run the worker on the host instead)",
+			zap.String("tier", st.LangyTier.String()), zap.Error(err))
+		opts.Selection.Langy = false
+		return ""
+	}
+	return dh
 }
 
 // prepareLangyContainer brings colima up and ensures the stack's

--- a/tools/thuishaven/app/portless_bypass_test.go
+++ b/tools/thuishaven/app/portless_bypass_test.go
@@ -56,7 +56,7 @@ func serviceByName(services []domain.Service, name string) (domain.Service, bool
 // @scenario "PORTLESS=0 bypasses the proxy bootstrap on up"
 func TestPortlessBypassSkipsProxyBootstrap(t *testing.T) {
 	proxy := &recordingProxy{}
-	o := &Orchestrator{cfg: Config{ShouldUsePortless: false}, proxy: proxy}
+	o := &Orchestrator{cfg: Config{PortlessDisabled: true}, proxy: proxy}
 
 	if err := o.ensurePortlessProxy(); err != nil {
 		t.Fatalf("ensurePortlessProxy: %v", err)
@@ -72,7 +72,7 @@ func TestPortlessBypassSkipsProxyBootstrap(t *testing.T) {
 // @scenario "Portless enabled still bootstraps the proxy on up"
 func TestPortlessEnabledStillBootstrapsProxy(t *testing.T) {
 	proxy := &recordingProxy{}
-	o := &Orchestrator{cfg: Config{ShouldUsePortless: true}, proxy: proxy}
+	o := &Orchestrator{cfg: Config{PortlessDisabled: false}, proxy: proxy}
 
 	if err := o.ensurePortlessProxy(); err != nil {
 		t.Fatalf("ensurePortlessProxy: %v", err)
@@ -92,7 +92,7 @@ func TestPortlessBypassProvisionsDirectHTTP(t *testing.T) {
 	sys := &playPortSystem{}
 	proxy := &recordingProxy{}
 	o := &Orchestrator{
-		cfg:   Config{Naming: domain.DefaultNaming(""), ShouldUsePortless: false},
+		cfg:   Config{Naming: domain.DefaultNaming(""), PortlessDisabled: true},
 		store: store, sys: sys, proxy: proxy, log: zap.NewNop(),
 	}
 	p := UpParams{WorktreeDir: "/wt/x", IsLinkedWorktree: true, Branch: "x"}
@@ -133,7 +133,7 @@ func TestPortlessEnabledProvisionsThroughProxy(t *testing.T) {
 	sys := &playPortSystem{}
 	proxy := &recordingProxy{}
 	o := &Orchestrator{
-		cfg:   Config{Naming: domain.DefaultNaming(""), ShouldUsePortless: true},
+		cfg:   Config{Naming: domain.DefaultNaming(""), PortlessDisabled: false},
 		store: store, sys: sys, proxy: proxy, log: zap.NewNop(),
 	}
 	p := UpParams{WorktreeDir: "/wt/x", IsLinkedWorktree: true, Branch: "x"}
@@ -155,5 +155,87 @@ func TestPortlessEnabledProvisionsThroughProxy(t *testing.T) {
 	}
 	if len(proxy.registered) == 0 {
 		t.Error("services must be registered with the proxy when portless is enabled")
+	}
+}
+
+// PORTLESS is a machine/run-level knob (Config), not part of the per-stack
+// Selection reconcileRunningStack otherwise compares — flipping it on an
+// already-running stack must still trigger a restart, or the escape hatch is a
+// no-op for the most likely real journey: a stack is already up under a broken
+// proxy, the operator sets PORTLESS=0, and `haven up` reports "nothing to do".
+//
+// @scenario "A stack provisioned under one PORTLESS setting restarts when the setting flips"
+func TestReconcileDetectsPortlessSettingChange(t *testing.T) {
+	store := &fakeStore{
+		stacks:    []domain.Stack{{Slug: "feat-x", WorktreeDir: "/wt/feat-x", LauncherPID: 42, PortlessDisabled: false}},
+		slugCache: map[string]string{"/wt/feat-x": "feat-x"},
+	}
+	sys := &fakeSystem{alive: map[int]bool{42: true}}
+	o := &Orchestrator{
+		cfg:   Config{Naming: domain.DefaultNaming(""), PortlessDisabled: true},
+		store: store, sys: sys, proxy: &fakeProxy{}, log: zap.NewNop(),
+	}
+	p := UpParams{WorktreeDir: "/wt/feat-x", IsLinkedWorktree: true}
+
+	proceed, err := o.reconcileRunningStack(p, PlanOptions{Selection: domain.SelectionFromStack(store.stacks[0])})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !proceed {
+		t.Error("a PORTLESS setting change must re-provision, not report a no-op")
+	}
+	if len(sys.terminated) != 1 || sys.terminated[0] != 42 {
+		t.Errorf("the old launcher must be terminated, got %v", sys.terminated)
+	}
+}
+
+// @scenario "PORTLESS=0 serves ClickHouse directly over HTTP on its own port"
+func TestPortlessBypassEnsureClickHouseServesDirectHTTP(t *testing.T) {
+	proxy := &recordingProxy{}
+	o := &Orchestrator{
+		cfg:   Config{Naming: domain.DefaultNaming(""), PortlessDisabled: true, ShouldManageClickHouse: true},
+		ch:    &fakeDBServer{},
+		proxy: proxy, log: zap.NewNop(),
+	}
+	st := &domain.Stack{Slug: "x"}
+
+	o.ensureClickHouse(context.Background(), st)
+
+	ch, ok := serviceByName(st.Services, domain.ClickHouseService)
+	if !ok {
+		t.Fatal("no clickhouse service recorded")
+	}
+	wantURL := o.cfg.Naming.URL(domain.ClickHouseService, "x", "http", ch.Port)
+	if ch.URL != wantURL {
+		t.Errorf("clickhouse URL = %q, want %q — plain http on its own port, no shared proxy port", ch.URL, wantURL)
+	}
+	if len(proxy.registered) != 0 {
+		t.Errorf("clickhouse must not be registered with the proxy under PORTLESS=0, got %v", proxy.registered)
+	}
+}
+
+// @scenario "Portless enabled routes ClickHouse through the shared proxy endpoint"
+func TestPortlessEnabledEnsureClickHouseRoutesThroughProxy(t *testing.T) {
+	proxy := &recordingProxy{}
+	o := &Orchestrator{
+		cfg:   Config{Naming: domain.DefaultNaming(""), PortlessDisabled: false, ShouldManageClickHouse: true},
+		ch:    &fakeDBServer{},
+		proxy: proxy, log: zap.NewNop(),
+	}
+	st := &domain.Stack{Slug: "x"}
+
+	o.ensureClickHouse(context.Background(), st)
+
+	ch, ok := serviceByName(st.Services, domain.ClickHouseService)
+	if !ok {
+		t.Fatal("no clickhouse service recorded")
+	}
+	wantScheme, wantPort := proxy.Endpoint()
+	wantURL := o.cfg.Naming.URL(domain.ClickHouseService, "x", wantScheme, wantPort)
+	if ch.URL != wantURL {
+		t.Errorf("clickhouse URL = %q, want %q — the shared proxy endpoint, not its own port", ch.URL, wantURL)
+	}
+	if len(proxy.registered) == 0 {
+		t.Error("clickhouse must be registered with the proxy when portless is enabled")
 	}
 }

--- a/tools/thuishaven/app/portless_bypass_test.go
+++ b/tools/thuishaven/app/portless_bypass_test.go
@@ -52,8 +52,6 @@ func serviceByName(services []domain.Service, name string) (domain.Service, bool
 // portless proxy's TLS handshake won't come up (#7117): before this, the flag
 // was documented in `haven help env` but nothing read it, so `up` always
 // bootstrapped and routed through the proxy regardless.
-//
-// @scenario "PORTLESS=0 bypasses the proxy bootstrap on up"
 func TestPortlessBypassSkipsProxyBootstrap(t *testing.T) {
 	proxy := &recordingProxy{}
 	o := &Orchestrator{cfg: Config{PortlessDisabled: true}, proxy: proxy}
@@ -69,7 +67,6 @@ func TestPortlessBypassSkipsProxyBootstrap(t *testing.T) {
 	}
 }
 
-// @scenario "Portless enabled still bootstraps the proxy on up"
 func TestPortlessEnabledStillBootstrapsProxy(t *testing.T) {
 	proxy := &recordingProxy{}
 	o := &Orchestrator{cfg: Config{PortlessDisabled: false}, proxy: proxy}
@@ -85,8 +82,6 @@ func TestPortlessEnabledStillBootstrapsProxy(t *testing.T) {
 	}
 }
 
-// @scenario "PORTLESS=0 serves the app directly over HTTP on its own port"
-// @scenario "PORTLESS=0 never registers a hostname with the proxy"
 func TestPortlessBypassProvisionsDirectHTTP(t *testing.T) {
 	store := &fakeStore{slugCache: map[string]string{"/wt/x": "x"}}
 	sys := &playPortSystem{}
@@ -126,8 +121,6 @@ func TestPortlessBypassProvisionsDirectHTTP(t *testing.T) {
 
 // Portless enabled is the existing, unchanged behavior: every routed service
 // shares the proxy's own scheme+port, addressed by hostname.
-//
-// @scenario "Portless enabled routes services through the shared proxy endpoint"
 func TestPortlessEnabledProvisionsThroughProxy(t *testing.T) {
 	store := &fakeStore{slugCache: map[string]string{"/wt/x": "x"}}
 	sys := &playPortSystem{}
@@ -163,8 +156,6 @@ func TestPortlessEnabledProvisionsThroughProxy(t *testing.T) {
 // already-running stack must still trigger a restart, or the escape hatch is a
 // no-op for the most likely real journey: a stack is already up under a broken
 // proxy, the operator sets PORTLESS=0, and `haven up` reports "nothing to do".
-//
-// @scenario "A stack provisioned under one PORTLESS setting restarts when the setting flips"
 func TestReconcileDetectsPortlessSettingChange(t *testing.T) {
 	store := &fakeStore{
 		stacks:    []domain.Stack{{Slug: "feat-x", WorktreeDir: "/wt/feat-x", LauncherPID: 42, PortlessDisabled: false}},
@@ -189,7 +180,35 @@ func TestReconcileDetectsPortlessSettingChange(t *testing.T) {
 	}
 }
 
-// @scenario "PORTLESS=0 serves ClickHouse directly over HTTP on its own port"
+// Down must remove aliases for the mode the stack actually registered them
+// under, not this run's PORTLESS setting — `PORTLESS=0 haven down` tearing
+// down a stack that came up with portless enabled must still remove its
+// aliases, or they leak as dangling routes that can later point at a reused
+// loopback port.
+func TestDownUsesTheStacksOwnPortlessMode(t *testing.T) {
+	ctx := context.Background()
+	params := UpParams{WorktreeDir: "/wt/feat-x", IsLinkedWorktree: true}
+	store := &fakeStore{
+		stacks:    []domain.Stack{{Slug: "feat-x", WorktreeDir: "/wt/feat-x", LauncherPID: 42, PortlessDisabled: false}},
+		slugCache: map[string]string{"/wt/feat-x": "feat-x"},
+	}
+	sys := &fakeSystem{alive: map[int]bool{42: true}}
+	proxy := &fakeProxy{}
+	o := &Orchestrator{
+		// This run asks to bypass the proxy, but the stack was provisioned with
+		// it enabled — Down must still clean up under the mode it registered.
+		cfg:   Config{Naming: domain.DefaultNaming(""), PortlessDisabled: true},
+		store: store, sys: sys, proxy: proxy, log: zap.NewNop(),
+	}
+
+	if err := o.Down(ctx, params, false); err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+	if len(proxy.removed) == 0 {
+		t.Error("down must remove the aliases the stack actually registered, even when this run's PORTLESS differs")
+	}
+}
+
 func TestPortlessBypassEnsureClickHouseServesDirectHTTP(t *testing.T) {
 	proxy := &recordingProxy{}
 	o := &Orchestrator{
@@ -214,7 +233,6 @@ func TestPortlessBypassEnsureClickHouseServesDirectHTTP(t *testing.T) {
 	}
 }
 
-// @scenario "Portless enabled routes ClickHouse through the shared proxy endpoint"
 func TestPortlessEnabledEnsureClickHouseRoutesThroughProxy(t *testing.T) {
 	proxy := &recordingProxy{}
 	o := &Orchestrator{

--- a/tools/thuishaven/app/portless_bypass_test.go
+++ b/tools/thuishaven/app/portless_bypass_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
+)
+
+// recordingProxy wraps fakeProxy and records every call a test needs to assert
+// never happened under PORTLESS=0.
+type recordingProxy struct {
+	fakeProxy
+	registered   []string
+	installCalls int
+	ensureCalls  int
+}
+
+func (p *recordingProxy) Installed() bool {
+	p.installCalls++
+	return false // force ensurePortlessProxy down the Install() branch too
+}
+
+func (p *recordingProxy) Install() error {
+	p.installCalls++
+	return nil
+}
+
+func (p *recordingProxy) EnsureReady() error {
+	p.ensureCalls++
+	return nil
+}
+
+func (p *recordingProxy) Register(service, slug string, port int) error {
+	p.registered = append(p.registered, service+"."+slug)
+	return nil
+}
+
+func serviceByName(services []domain.Service, name string) (domain.Service, bool) {
+	for _, s := range services {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return domain.Service{}, false
+}
+
+// PORTLESS=0 is haven's documented escape hatch for a machine where the
+// portless proxy's TLS handshake won't come up (#7117): before this, the flag
+// was documented in `haven help env` but nothing read it, so `up` always
+// bootstrapped and routed through the proxy regardless.
+//
+// @scenario "PORTLESS=0 bypasses the proxy bootstrap on up"
+func TestPortlessBypassSkipsProxyBootstrap(t *testing.T) {
+	proxy := &recordingProxy{}
+	o := &Orchestrator{cfg: Config{ShouldUsePortless: false}, proxy: proxy}
+
+	if err := o.ensurePortlessProxy(); err != nil {
+		t.Fatalf("ensurePortlessProxy: %v", err)
+	}
+	if proxy.installCalls != 0 {
+		t.Errorf("PORTLESS=0 must never check/install portless, got %d calls", proxy.installCalls)
+	}
+	if proxy.ensureCalls != 0 {
+		t.Errorf("PORTLESS=0 must never start/trust the proxy, got %d calls", proxy.ensureCalls)
+	}
+}
+
+// @scenario "Portless enabled still bootstraps the proxy on up"
+func TestPortlessEnabledStillBootstrapsProxy(t *testing.T) {
+	proxy := &recordingProxy{}
+	o := &Orchestrator{cfg: Config{ShouldUsePortless: true}, proxy: proxy}
+
+	if err := o.ensurePortlessProxy(); err != nil {
+		t.Fatalf("ensurePortlessProxy: %v", err)
+	}
+	if proxy.installCalls == 0 {
+		t.Error("portless enabled must still check/install the proxy")
+	}
+	if proxy.ensureCalls != 1 {
+		t.Errorf("portless enabled must start/trust the proxy exactly once, got %d", proxy.ensureCalls)
+	}
+}
+
+// @scenario "PORTLESS=0 serves the app directly over HTTP on its own port"
+// @scenario "PORTLESS=0 never registers a hostname with the proxy"
+func TestPortlessBypassProvisionsDirectHTTP(t *testing.T) {
+	store := &fakeStore{slugCache: map[string]string{"/wt/x": "x"}}
+	sys := &playPortSystem{}
+	proxy := &recordingProxy{}
+	o := &Orchestrator{
+		cfg:   Config{Naming: domain.DefaultNaming(""), ShouldUsePortless: false},
+		store: store, sys: sys, proxy: proxy, log: zap.NewNop(),
+	}
+	p := UpParams{WorktreeDir: "/wt/x", IsLinkedWorktree: true, Branch: "x"}
+
+	st, cleanup, err := o.provision(context.Background(), p, PlanOptions{Selection: domain.DefaultSelection()}, false)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	defer cleanup()
+
+	app, ok := serviceByName(st.Services, "app")
+	if !ok {
+		t.Fatal("no app service in the provisioned stack")
+	}
+	if app.Port == 0 {
+		t.Fatal("app service was provisioned with no port")
+	}
+	wantURL := fmt.Sprintf("http://app.%s.langwatch.localhost:%d", st.Slug, app.Port)
+	if app.URL != wantURL {
+		t.Errorf("app URL = %q, want %q — plain http on its own loopback port, no shared proxy port", app.URL, wantURL)
+	}
+	if len(proxy.registered) != 0 {
+		t.Errorf("no service should be registered with the proxy under PORTLESS=0, got %v", proxy.registered)
+	}
+
+	cleanup()
+	if len(proxy.registered) != 0 {
+		t.Errorf("teardown must not touch the proxy under PORTLESS=0 either, got %v", proxy.registered)
+	}
+}
+
+// Portless enabled is the existing, unchanged behavior: every routed service
+// shares the proxy's own scheme+port, addressed by hostname.
+//
+// @scenario "Portless enabled routes services through the shared proxy endpoint"
+func TestPortlessEnabledProvisionsThroughProxy(t *testing.T) {
+	store := &fakeStore{slugCache: map[string]string{"/wt/x": "x"}}
+	sys := &playPortSystem{}
+	proxy := &recordingProxy{}
+	o := &Orchestrator{
+		cfg:   Config{Naming: domain.DefaultNaming(""), ShouldUsePortless: true},
+		store: store, sys: sys, proxy: proxy, log: zap.NewNop(),
+	}
+	p := UpParams{WorktreeDir: "/wt/x", IsLinkedWorktree: true, Branch: "x"}
+
+	st, cleanup, err := o.provision(context.Background(), p, PlanOptions{Selection: domain.DefaultSelection()}, false)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	defer cleanup()
+
+	app, ok := serviceByName(st.Services, "app")
+	if !ok {
+		t.Fatal("no app service in the provisioned stack")
+	}
+	wantScheme, wantPort := proxy.Endpoint()
+	wantURL := o.cfg.Naming.URL("app", st.Slug, wantScheme, wantPort)
+	if app.URL != wantURL {
+		t.Errorf("app URL = %q, want %q — the shared proxy endpoint, not the app's own port", app.URL, wantURL)
+	}
+	if len(proxy.registered) == 0 {
+		t.Error("services must be registered with the proxy when portless is enabled")
+	}
+}

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -98,7 +98,14 @@ var envHelpText = `Environment variables.
     LANGWATCH_LOCAL_TLD=test     Use a different TLD (default: localhost).
     HAVEN_BASELINE=1             Mark this stack as the shared default others fall
                                  back to for services they don't run themselves.
-    PORTLESS=0                   Bypass portless entirely (legacy PORT scheme).
+    PORTLESS=0                   Bypass the portless proxy entirely — no proxy
+                                 install/start/trust, no hostname routing. Each
+                                 service is served plain HTTP on its own
+                                 loopback port instead (still at its usual
+                                 app.<slug>.langwatch.localhost hostname, which
+                                 resolves to loopback with no proxy needed).
+                                 The escape hatch for a machine where the
+                                 proxy's TLS handshake won't come up.
     HAVEN_AGENT=1                Plain, colorless, redraw-free output (also on
                                  with --agent, NO_COLOR, or a non-terminal stdout)
                                  — zero token waste when an AI agent drives haven.

--- a/tools/thuishaven/cmd/root.go
+++ b/tools/thuishaven/cmd/root.go
@@ -204,7 +204,7 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 		HeartbeatEvery:          30 * time.Second,
 		DaemonArgv:              selfArgv(trustedRepoRoot(), "daemon"),
 		IsAgent:                 isAgent,
-		ShouldUsePortless:       devEnv("PORTLESS") != "0",
+		PortlessDisabled:        devEnv("PORTLESS") == "0",
 		ShouldManageClickHouse:  devEnv("LANGWATCH_HAVEN_CH") != "0",
 		// Opt-in on purpose: "no stack registered" does not mean nobody is
 		// querying — the documented native test mode (LANGWATCH_TEST_CLICKHOUSE_URL)

--- a/tools/thuishaven/cmd/root.go
+++ b/tools/thuishaven/cmd/root.go
@@ -204,6 +204,7 @@ func wire(logger *zap.Logger, isAgent bool) deps {
 		HeartbeatEvery:          30 * time.Second,
 		DaemonArgv:              selfArgv(trustedRepoRoot(), "daemon"),
 		IsAgent:                 isAgent,
+		ShouldUsePortless:       devEnv("PORTLESS") != "0",
 		ShouldManageClickHouse:  devEnv("LANGWATCH_HAVEN_CH") != "0",
 		// Opt-in on purpose: "no stack registered" does not mean nobody is
 		// querying — the documented native test mode (LANGWATCH_TEST_CLICKHOUSE_URL)

--- a/tools/thuishaven/domain/stack.go
+++ b/tools/thuishaven/domain/stack.go
@@ -92,7 +92,15 @@ type Stack struct {
 	// sandboxed. It decides whether the worker runs in colima or on the host and
 	// which callback URLs the overlay hands the control plane.
 	LangyTier LangyTier `json:"langyTier,omitempty"`
-	Services  []Service `json:"services"`
+	// PortlessDisabled marks a stack provisioned with PORTLESS=0: every service
+	// serves plain HTTP on its own loopback port instead of routing through the
+	// portless proxy. The zero value is false (portless enabled, the historical
+	// behavior), so a stack persisted before this field existed reads back as it
+	// always behaved. `up` compares it against the requested run so flipping
+	// PORTLESS between runs restarts the stack onto the requested mode instead of
+	// silently keeping the old one (see reconcileRunningStack).
+	PortlessDisabled bool      `json:"portlessDisabled,omitempty"`
+	Services         []Service `json:"services"`
 	// UpdatedAt is refreshed by the launcher's heartbeat; the daemon reaps a
 	// stack whose launcher has died or whose heartbeat has gone stale.
 	UpdatedAt time.Time `json:"updatedAt"`


### PR DESCRIPTION
## Summary

`haven help env` has always documented `PORTLESS=0` as bypassing portless entirely, but nothing in the code ever read a bare `PORTLESS` variable — `haven up` unconditionally installed, trusted, and routed through the portless proxy regardless. On a machine where the proxy's TLS handshake won't complete (`ERR_CONNECTION_CLOSED` / `SSL_ERROR_SYSCALL`, as reported), there was no supported way to reach the app short of hand-patching `.env.portless` and killing the API process to force a re-read — exactly the workaround described in the issue.

This implements the documented behavior: `PORTLESS=0` now actually bypasses the proxy for a worktree's stack.

- `Config.PortlessDisabled` (resolved from `PORTLESS=0`, same precedence as the other `LANGWATCH_HAVEN_*` knobs; zero value `false` matches the historical default) gates every portless touchpoint in the per-worktree lifecycle:
  - `up` skips installing/trusting/starting the proxy entirely (`ensurePortlessProxy`)
  - `provision` / `ensureClickHouse` skip proxy registration and build each service's URL as plain `http://` on its **own loopback port**, instead of the shared proxy scheme+port — both resolve the decision through one shared `Orchestrator.serviceEndpoint` method
  - `down` / provisioning cleanup skip proxy teardown too, so bypass mode never has to invoke the (possibly broken) portless binary at all
- `domain.Stack.PortlessDisabled` records which mode a stack was actually provisioned under, and `reconcileRunningStack` now compares it explicitly (same treatment as the langy isolation tier). Without this, the primary real-world journey — a stack is already up under the broken proxy, the operator sets `PORTLESS=0` and reruns `haven up` — reported "nothing to do" and silently kept serving the old proxy URLs, defeating the whole escape hatch.
- Hostnames are unchanged — `app.<slug>.langwatch.localhost` still resolves to loopback natively, no proxy required — only the scheme and port differ.
- Updated `haven help env` to describe what `PORTLESS=0` actually does now (it previously said "legacy PORT scheme", which was never implemented).

Out of scope: the underlying portless TLS handshake failure itself (external `portless` npm package/proxy daemon — not reproducible or fixable from this Go code), and the shared machine-wide daemon's own hub/dashboard/observability routing (`daemon.go`, `hub.go`, `session.go`, `report.go`), which is a separate concern from "is my worktree's app reachable."

Fixes #7117

## Test plan

- `go test ./tools/thuishaven/...` — all packages pass
- `tools/thuishaven/app/portless_bypass_test.go`:
  - `PORTLESS=0` never calls `Installed`/`Install`/`EnsureReady` on the proxy; portless enabled still bootstraps it
  - `PORTLESS=0` provisions the app service with a direct `http://app.<slug>.langwatch.localhost:<port>` URL and never registers with the proxy (including on teardown); portless enabled still routes through the shared proxy endpoint
  - `ensureClickHouse` under both modes (previously uncovered — `ch` is nil in the pre-existing provision fixtures)
  - flipping `PORTLESS` on an already-running stack triggers a restart instead of a no-op
- `golangci-lint run --new-from-rev=HEAD ./tools/thuishaven/...` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to bypass the Portless proxy and access services directly over local HTTP ports.
  * Portless remains enabled by default and can be disabled with `PORTLESS=0`.
  * Services, including managed ClickHouse, use proxy routing when enabled and direct loopback URLs when disabled.
  * Running stacks now restart automatically when the Portless setting changes.

* **Documentation**
  * Updated command-line help with Portless bypass behavior and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->