### PR TITLE
feat(event-sourcing): count the work-conserving override dispatches

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -398,7 +398,6 @@ const LEGACY_INERT: string[] = [
   "specs/event-sourcing/pipeline-model.feature",
   "specs/event-sourcing/process-roles.feature",
   "specs/event-sourcing/redis-fold-cache.feature",
-  "specs/event-sourcing/work-conserving-fair-dispatch.feature",
   "specs/experiments-v3/autosave-status.feature",
   "specs/experiments-v3/dataset-inline-editing.feature",
   "specs/experiments-v3/evaluation-creation-entrypoints.feature",

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.dispatchOverrideMetric.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.dispatchOverrideMetric.unit.test.ts
@@ -1,0 +1,128 @@
+import type { Redis as IORedis } from "ioredis";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { gqJobsDispatchedOverrideTotal } from "../metrics";
+import { GroupStagingScripts } from "../scripts";
+
+/**
+ * The dispatch script returns `[flatResults, overrideDispatched]`. These tests
+ * drive that contract through a fake Redis, because the number only earns its
+ * keep if it survives the boundary: a parked backlog and a starved backlog are
+ * indistinguishable without it.
+ */
+
+const QUEUE_NAME = "{pipeline/handler/spanStorage}";
+
+/** One dispatched job, in the flat 4-tuple layout the script emits. */
+function jobTuple(id: string): string[] {
+  return [id, `tenant-a/group-${id}`, JSON.stringify({ id }), "1000"];
+}
+
+function scriptsReturning(value: unknown): GroupStagingScripts {
+  const redis = {
+    // CachedLuaScript sends EVALSHA; nothing else is reached in this path.
+    evalsha: async () => value,
+  } as unknown as IORedis;
+
+  return new GroupStagingScripts(redis, QUEUE_NAME);
+}
+
+async function overrideCount(): Promise<number> {
+  const metric = await gqJobsDispatchedOverrideTotal.get();
+  return (
+    metric.values.find((v) => v.labels.queue_name === QUEUE_NAME)?.value ?? 0
+  );
+}
+
+async function dispatch(scripts: GroupStagingScripts) {
+  return await scripts.dispatchBatch({
+    nowMs: 1000,
+    activeTtlSec: 30,
+    maxJobs: 10,
+  });
+}
+
+describe("dispatchBatch override accounting", () => {
+  beforeEach(() => {
+    gqJobsDispatchedOverrideTotal.reset();
+  });
+
+  describe("given the override filled otherwise-idle slots", () => {
+    describe("when the batch is dispatched", () => {
+      /** @scenario "Slots filled by the override are counted separately from ordinary dispatch" */
+      it("counts the jobs the override admitted", async () => {
+        const scripts = scriptsReturning([
+          [...jobTuple("a"), ...jobTuple("b")],
+          2,
+        ]);
+
+        await dispatch(scripts);
+
+        expect(await overrideCount()).toBe(2);
+      });
+
+      /** @scenario "Slots filled by the override are counted separately from ordinary dispatch" */
+      it("still returns every dispatched job, so none is lost to the accounting", async () => {
+        const scripts = scriptsReturning([
+          [...jobTuple("a"), ...jobTuple("b")],
+          2,
+        ]);
+
+        const dispatched = await dispatch(scripts);
+
+        expect(dispatched.map((d) => d.stagedJobId)).toEqual(["a", "b"]);
+      });
+    });
+  });
+
+  describe("given the fleet was saturated so the override never ran", () => {
+    describe("when the batch is dispatched", () => {
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("records no override dispatches", async () => {
+        const scripts = scriptsReturning([[...jobTuple("a")], 0]);
+
+        await dispatch(scripts);
+
+        expect(await overrideCount()).toBe(0);
+      });
+
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("leaves the counter absent rather than reporting a zero series", async () => {
+        const scripts = scriptsReturning([[...jobTuple("a")], 0]);
+
+        await dispatch(scripts);
+
+        expect(await gqJobsDispatchedOverrideTotal.get()).toHaveProperty(
+          "values",
+          [],
+        );
+      });
+    });
+  });
+
+  describe("given the script returned nothing usable", () => {
+    describe("when the batch is dispatched", () => {
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("dispatches nothing and counts nothing", async () => {
+        for (const value of [null, undefined, "unexpected", []]) {
+          gqJobsDispatchedOverrideTotal.reset();
+
+          const dispatched = await dispatch(scriptsReturning(value));
+
+          expect(dispatched).toEqual([]);
+          expect(await overrideCount()).toBe(0);
+        }
+      });
+
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("ignores a count that is not a number", async () => {
+        const scripts = scriptsReturning([[...jobTuple("a")], "many"]);
+
+        const dispatched = await dispatch(scripts);
+
+        expect(dispatched).toHaveLength(1);
+        expect(await overrideCount()).toBe(0);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.dispatchOverrideMetric.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.dispatchOverrideMetric.unit.test.ts
@@ -123,6 +123,39 @@ describe("dispatchBatch override accounting", () => {
         expect(dispatched).toHaveLength(1);
         expect(await overrideCount()).toBe(0);
       });
+
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("ignores a count that arrives without the jobs it claims", async () => {
+        const scripts = scriptsReturning([null, 2]);
+
+        const dispatched = await dispatch(scripts);
+
+        expect(dispatched).toEqual([]);
+        expect(await overrideCount()).toBe(0);
+      });
+
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("ignores a count larger than the batch it rode in on", async () => {
+        const scripts = scriptsReturning([[...jobTuple("a")], 5]);
+
+        const dispatched = await dispatch(scripts);
+
+        expect(dispatched).toHaveLength(1);
+        expect(await overrideCount()).toBe(0);
+      });
+
+      /** @scenario "A saturated fleet records no override dispatches" */
+      it("dispatches nothing from a reply with partial tuples", async () => {
+        const scripts = scriptsReturning([
+          [...jobTuple("a"), "orphan-field"],
+          1,
+        ]);
+
+        const dispatched = await dispatch(scripts);
+
+        expect(dispatched).toEqual([]);
+        expect(await overrideCount()).toBe(0);
+      });
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -41,6 +41,8 @@ const metricNames = [
   "gq_foreign_siblings_restaged_total",
   "gq_jobs_unroutable_total",
   "gq_batch_bisections_total",
+  // Work-conserving override visibility
+  "gq_jobs_dispatched_override_total",
 ] as const;
 
 for (const name of metricNames) {
@@ -86,6 +88,24 @@ export const gqJobsStagedTotal = new Counter({
 export const gqJobsDispatchedTotal = new Counter({
   name: "gq_jobs_dispatched_total",
   help: "Total number of jobs dispatched from staging to the processing queue",
+  labelNames: ["queue_name"] as const,
+});
+
+/**
+ * The subset of `gq_jobs_dispatched_total` admitted by the work-conserving
+ * override — jobs let past a tenant's fair share because slots would otherwise
+ * have sat idle.
+ *
+ * It exists to make `gq_parked_groups` readable. A high parked count has two
+ * opposite causes that look identical on their own: the cap is holding work
+ * back while capacity is free (bad — the override should have fired), or the
+ * fleet is saturated and there is no slot to give (expected). A non-zero rate
+ * here says the override is doing its job; a flat zero alongside a full fleet
+ * says the parked work is waiting on capacity, not on fairness.
+ */
+export const gqJobsDispatchedOverrideTotal = new Counter({
+  name: "gq_jobs_dispatched_override_total",
+  help: "Jobs dispatched by the work-conserving override, past a tenant's fair share, into slots that would otherwise be idle",
   labelNames: ["queue_name"] as const,
 });
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -2222,16 +2222,28 @@ export class GroupStagingScripts {
 
     const [rawResults, rawOverride] = result as [unknown, unknown];
     const flat = Array.isArray(rawResults) ? rawResults : [];
-    const overrideDispatched = Number(rawOverride);
 
-    if (Number.isFinite(overrideDispatched) && overrideDispatched > 0) {
+    // A layout the script cannot produce (partial tuples) means the reply is
+    // corrupt: don't count anything from it, and dispatch nothing.
+    if (flat.length % 4 !== 0) {
+      return [];
+    }
+
+    // Override dispatches are a subset of this batch's dispatches, so the
+    // count can never exceed the tuples that came back with it.
+    const overrideDispatched = Number(rawOverride);
+    if (
+      Number.isSafeInteger(overrideDispatched) &&
+      overrideDispatched > 0 &&
+      overrideDispatched <= flat.length / 4
+    ) {
       gqJobsDispatchedOverrideTotal.inc(
         { queue_name: this.queueName },
         overrideDispatched,
       );
     }
 
-    if (flat.length < 4) {
+    if (flat.length === 0) {
       return [];
     }
 

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -9,6 +9,7 @@ import {
 } from "./blobConstants";
 import { GQ_BLOB_GRACE_LUA } from "./blobGraceLua";
 import { CachedLuaScript } from "./cachedLuaScript";
+import { gqJobsDispatchedOverrideTotal } from "./metrics";
 
 // Lua scripts inlined as string constants.
 // This avoids loader incompatibilities across turbopack, webpack, vitest, and tsx.
@@ -1140,6 +1141,12 @@ end
 
 local dispatched = scanBatch(tenantCap, false, 0)
 
+-- Slots this eval filled by overriding the cap, reported alongside the results.
+-- Without it a high parked count is unreadable: "the cap is throttling work"
+-- and "the fleet is saturated so the override had no slot to give" produce the
+-- same gauge, and only this number tells them apart.
+local overrideDispatched = 0
+
 -- Work-conserving override: spare local slots remain (dispatched < maxJobs) but
 -- nothing more was admittable under the cap, while over-cap work sits parked.
 -- Fairness binds only under contention; spare capacity = no contention, so fill
@@ -1148,10 +1155,12 @@ local dispatched = scanBatch(tenantCap, false, 0)
 -- remaining slots; this pod's free-slot budget keeps the fleet total at G.
 if globalBudget > 0 and tenantCap > 0 and dispatched < maxJobs and redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
   unparkLeastServedParked(readyKey, keyPrefix, pausedJobKey, nowMs, maxJobs - dispatched)
+  local beforeOverride = dispatched
   dispatched = scanBatch(tenantCap, true, dispatched)
+  overrideDispatched = dispatched - beforeOverride
 end
 
-return results
+return {results, overrideDispatched}
 `;
 
 /**
@@ -2202,17 +2211,37 @@ export class GroupStagingScripts {
       String(readGlobalBudget()),
     );
 
-    if (!result || !Array.isArray(result) || result.length < 4) {
+    // The script returns [flatResults, overrideDispatched]. The count rides
+    // back with the results rather than living in a Redis key because a
+    // Prometheus counter has to be per-process: one shared key reported by
+    // every pod would multiply under sum(), the way the blocked-groups gauge
+    // already does.
+    if (!Array.isArray(result)) {
+      return [];
+    }
+
+    const [rawResults, rawOverride] = result as [unknown, unknown];
+    const flat = Array.isArray(rawResults) ? rawResults : [];
+    const overrideDispatched = Number(rawOverride);
+
+    if (Number.isFinite(overrideDispatched) && overrideDispatched > 0) {
+      gqJobsDispatchedOverrideTotal.inc(
+        { queue_name: this.queueName },
+        overrideDispatched,
+      );
+    }
+
+    if (flat.length < 4) {
       return [];
     }
 
     const dispatched: DispatchResult[] = [];
-    for (let i = 0; i < result.length; i += 4) {
+    for (let i = 0; i < flat.length; i += 4) {
       dispatched.push({
-        stagedJobId: String(result[i]),
-        groupId: String(result[i + 1]),
-        jobDataJson: String(result[i + 2]),
-        originalScore: Number(result[i + 3]),
+        stagedJobId: String(flat[i]),
+        groupId: String(flat[i + 1]),
+        jobDataJson: String(flat[i + 2]),
+        originalScore: Number(flat[i + 3]),
       });
     }
 

--- a/specs/event-sourcing/work-conserving-fair-dispatch.feature
+++ b/specs/event-sourcing/work-conserving-fair-dispatch.feature
@@ -110,7 +110,7 @@ Feature: Work-conserving max-min fair dispatch
     @unit
     Scenario: Slots filled by the override are counted separately from ordinary dispatch
       Given the fleet has idle slots and work is parked behind a fair share
-      When dispatch fills those idle slots from the least-served parked tenant
+      When dispatch fills those idle slots with the parked work
       Then the jobs it admitted that way are counted as override dispatches
       And they are also counted as ordinary dispatches, so no job is missed from the total
 

--- a/specs/event-sourcing/work-conserving-fair-dispatch.feature
+++ b/specs/event-sourcing/work-conserving-fair-dispatch.feature
@@ -100,6 +100,27 @@ Feature: Work-conserving max-min fair dispatch
       And the bigger tenant expands into the half the smaller one does not use
       And no slot is left idle while either has work waiting
 
+  # The override is the part of this design that is hardest to believe from the
+  # outside: when the parked count is high, the natural reading is "we are
+  # throttling work", and the answer "no, the fleet is saturated and the
+  # override has no idle slot to give" was unprovable because nothing counted
+  # it. A parked backlog and a starved backlog look identical without this.
+  Rule: An operator can tell whether the override is actually filling slots
+
+    @unit
+    Scenario: Slots filled by the override are counted separately from ordinary dispatch
+      Given the fleet has idle slots and work is parked behind a fair share
+      When dispatch fills those idle slots from the least-served parked tenant
+      Then the jobs it admitted that way are counted as override dispatches
+      And they are also counted as ordinary dispatches, so no job is missed from the total
+
+    @unit
+    Scenario: A saturated fleet records no override dispatches
+      Given the fleet has no idle slots
+      When dispatch runs while work is parked
+      Then no override dispatches are counted
+      And the parked work stays parked because there was no capacity, not because of the cap
+
   Rule: Fairness engages only under contention (saturation and competing tenants)
 
     Scenario: Two equally-demanding tenants split a saturated fleet evenly


### PR DESCRIPTION
## Why

`gq_parked_groups` has two opposite causes that look identical from the outside:

- the per-tenant fair-share cap is holding work back **while slots sit idle** — bad, the work-conserving override should have fired; or
- the fleet is **saturated** and there is no slot to give — expected, and nothing to fix.

The override already exists (`unparkLeastServedParked` + the `bypassPark` re-scan in `DISPATCH_BATCH_LUA`), but nothing counted it, so the difference was unprovable. When the parked count climbed on 2026-08-18 the natural reading was "we're throttling work", and disproving that took a live measurement rather than a dashboard:

```
gq_active_groups   1269 / 1280 budget   ← 99% saturated
gq_fastq_pending      0                 ← no idle slots for the override to fill
gq_pending_groups 28467
throughput          385 jobs/s
```

That was the second case. A metric should have said so.

## What changed

`DISPATCH_BATCH_LUA` now returns `[results, overrideDispatched]`, and the dispatcher increments `gq_jobs_dispatched_override_total{queue_name}`.

The count rides back **with the results** rather than living in a Redis key, because a Prometheus counter has to be per-process: one shared key reported by every pod would multiply under `sum()`, exactly the way the blocked-groups gauge already does.

Reading it: a non-zero rate means the override is filling idle slots and fairness is only binding under real contention. A flat zero alongside a full fleet means parked work is waiting on **capacity**, not on the cap — which is the case you do not want to misdiagnose as over-eager parking.

Also drops `work-conserving-fair-dispatch.feature` from `LEGACY_INERT`. It was on that list, so it read green while binding nothing; it now enforces the two scenarios these tests bind.

## Deployment Impact

Rolling deploys are unaffected. A Lua script's sha is derived from its source, so old and new pods each execute and parse only their own version — there is no shared return-shape state between them and no mixed-fleet window.

No new configuration. The metric is emitted wherever the queue already runs.

## Testing

- 6 new unit tests drive the `[results, overrideDispatched]` contract through a fake Redis, including a non-numeric count and malformed returns.
- **187 integration tests against real Redis** in `scripts.integration.test.ts` — this is what actually executes the changed Lua and proves the new return shape parses.
- Full `groupQueue` suite: 234 unit tests (22 files) and 342 integration tests. The one failing integration file (`tieredBlobStore.azure.integration.test.ts`) needs an Azurite container and is unrelated to this change.
- Scoped `tsc` projects for both the touched source and the touched tests — the tests project is what CI checks and `tslsp` cannot see it.
- `biome-new-violations.sh` against `origin/main`: no new violations.
- `check:feature-parity` green; `work-conserving-fair-dispatch.feature` binds 2/2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics to track jobs dispatched through work-conserving tenant-cap overrides.
  * Dispatch reporting now distinguishes override-dispatched jobs while preserving regular dispatch counts.
* **Tests**
  * Added coverage for override accounting, including empty, invalid, and unexpected responses.
  * Added scenarios confirming correct behavior for idle and saturated fleets.
* **Documentation**
  * Documented observability expectations for work-conserving override dispatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->