### PR TITLE
feat(langevals): run same-credential evaluations concurrently

### DIFF
--- a/services/langevals/evaluators/langevals/langevals_langevals/competitor_llm.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/competitor_llm.py
@@ -7,9 +7,9 @@ from litellm.utils import trim_messages
 
 from pydantic import Field
 from typing import List, Optional, cast
-import os
 import json
 
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluatorEntry,
@@ -58,10 +58,6 @@ class CompetitorLLMEvaluator(
     def evaluate(self, entry: CompetitorLLMEntry) -> SingleEvaluationResult:
         passed = True
         vendor, model = self.settings.model.split("/")
-        if vendor == "azure":
-            os.environ["AZURE_API_KEY"] = self.get_env("AZURE_API_KEY")
-            os.environ["AZURE_API_BASE"] = self.get_env("AZURE_API_BASE")
-            os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
         content = ""
         content += entry.input if entry.input else ""
         content += "\n" + entry.output if entry.output else ""
@@ -109,6 +105,7 @@ class CompetitorLLMEvaluator(
             ),
         )
         response = litellm.completion(
+            **azure_api_version(self.settings.model, "2023-12-01-preview"),
             model=litellm_model,
             messages=messages,
             tools=[

--- a/services/langevals/evaluators/langevals/langevals_langevals/competitor_llm_function_call.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/competitor_llm_function_call.py
@@ -5,9 +5,9 @@ from litellm.utils import trim_messages
 
 from pydantic import BaseModel, Field
 from typing import List, Optional, Literal, cast
-import os
 import json
 
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluatorEntry,
@@ -60,10 +60,6 @@ class CompetitorLLMFunctionCallEvaluator(
     def evaluate(self, entry: CompetitorLLMFunctionCallEntry) -> SingleEvaluationResult:
         passed = True
         vendor, model = self.settings.model.split("/")
-        if vendor == "azure":
-            os.environ["AZURE_API_KEY"] = self.get_env("AZURE_API_KEY")
-            os.environ["AZURE_API_BASE"] = self.get_env("AZURE_API_BASE")
-            os.environ["AZURE_API_VERSION"] = "2023-07-01-preview"
         content = ""
         content += entry.input if entry.input else ""
         content += "\n" + entry.output if entry.output else ""
@@ -114,6 +110,7 @@ class CompetitorLLMFunctionCallEvaluator(
             ),
         )
         response = litellm.completion(
+            **azure_api_version(self.settings.model, "2023-07-01-preview"),
             model=litellm_model,
             messages=messages,
             tools=[

--- a/services/langevals/evaluators/langevals/langevals_langevals/llm_boolean.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/llm_boolean.py
@@ -1,6 +1,6 @@
 import json
-import os
 from typing import Literal, Optional, cast
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     MAX_TOKENS_HARD_LIMIT,
     BaseEvaluator,
@@ -57,11 +57,6 @@ class CustomLLMBooleanEvaluator(
     is_guardrail = True
 
     def evaluate(self, entry: CustomLLMBooleanEntry) -> SingleEvaluationResult:
-        os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
-        if self.env:
-            for key, env in self.env.items():
-                os.environ[key] = env
-
         if not entry.input and not entry.output and not entry.contexts:
             return EvaluationResultSkipped(details="No content to evaluate")
 
@@ -105,6 +100,7 @@ class CustomLLMBooleanEvaluator(
         else:
             response = litellm.completion(
                 model=self.settings.model,
+                **azure_api_version(self.settings.model, "2023-12-01-preview"),
                 messages=[
                     {
                         "role": "system",

--- a/services/langevals/evaluators/langevals/langevals_langevals/llm_category.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/llm_category.py
@@ -1,6 +1,6 @@
 import json
-import os
 from typing import Optional, Union, cast
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     MAX_TOKENS_HARD_LIMIT,
     BaseEvaluator,
@@ -74,11 +74,6 @@ class CustomLLMCategoryEvaluator(
     is_guardrail = False
 
     def evaluate(self, entry: CustomLLMCategoryEntry) -> SingleEvaluationResult:
-        os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
-        if self.env:
-            for key, env in self.env.items():
-                os.environ[key] = env
-
         if not entry.input and not entry.output and not entry.contexts:
             return EvaluationResultSkipped(details="No content to evaluate")
 
@@ -114,6 +109,7 @@ class CustomLLMCategoryEvaluator(
         cost = None
         response = litellm.completion(
             model=self.settings.model,
+            **azure_api_version(self.settings.model, "2023-12-01-preview"),
             messages=[
                 {
                     "role": "system",

--- a/services/langevals/evaluators/langevals/langevals_langevals/llm_score.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/llm_score.py
@@ -1,6 +1,6 @@
 import json
-import os
 from typing import Optional, cast
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     MAX_TOKENS_HARD_LIMIT,
     BaseEvaluator,
@@ -53,10 +53,6 @@ class CustomLLMScoreEvaluator(
     is_guardrail = False
 
     def evaluate(self, entry: CustomLLMScoreEntry) -> SingleEvaluationResult:
-        if self.env:
-            for key, env in self.env.items():
-                os.environ[key] = env
-
         if not entry.input and not entry.output and not entry.contexts:
             return EvaluationResultSkipped(details="No content to evaluate")
 
@@ -100,6 +96,7 @@ class CustomLLMScoreEvaluator(
         else:
             response = litellm.completion(
                 model=self.settings.model,
+                **azure_api_version(self.settings.model, "2023-12-01-preview"),
                 messages=[
                     {
                         "role": "system",

--- a/services/langevals/evaluators/langevals/langevals_langevals/off_topic.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/off_topic.py
@@ -7,8 +7,8 @@ from litellm.utils import trim_messages, get_max_tokens
 from pydantic import BaseModel, Field
 from typing import Optional, List, Literal, cast
 import json
-import os
 
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluatorEntry,
@@ -67,10 +67,6 @@ class OffTopicEvaluator(BaseEvaluator[OffTopicEntry, OffTopicSettings, OffTopicR
 
     def evaluate(self, entry: OffTopicEntry) -> SingleEvaluationResult:
         vendor, model = self.settings.model.split("/")
-        if vendor == "azure":
-            os.environ["AZURE_API_KEY"] = self.get_env("AZURE_API_KEY")
-            os.environ["AZURE_API_BASE"] = self.get_env("AZURE_API_BASE")
-            os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
 
         content = entry.input or ""
         if not content:
@@ -109,6 +105,7 @@ class OffTopicEvaluator(BaseEvaluator[OffTopicEntry, OffTopicSettings, OffTopicR
         )
 
         response = litellm.completion(
+            **azure_api_version(self.settings.model, "2023-12-01-preview"),
             model=litellm_model,
             messages=messages,
             tools=[

--- a/services/langevals/evaluators/langevals/langevals_langevals/pairwise_compare.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/pairwise_compare.py
@@ -13,10 +13,10 @@ BDD spec:     specs/experiments/pairwise-compare-mvp.feature
 """
 
 import json
-import os
 from typing import Literal, Optional, cast
 
 import litellm
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluationResult,
@@ -161,11 +161,6 @@ class PairwiseCompareEvaluator(
     is_guardrail = False
 
     def evaluate(self, entry: PairwiseCompareEntry) -> SingleEvaluationResult:
-        os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
-        if self.env:
-            for key, env in self.env.items():
-                os.environ[key] = env
-
         if not entry.candidate_a_output or not entry.candidate_b_output:
             return EvaluationResultSkipped(
                 details="Missing candidate output(s)"
@@ -286,6 +281,7 @@ class PairwiseCompareEvaluator(
 
         response = litellm.completion(
             model=self.settings.model,
+            **azure_api_version(self.settings.model, "2023-12-01-preview"),
             messages=[
                 {
                     "role": "system",

--- a/services/langevals/evaluators/langevals/langevals_langevals/query_resolution.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/query_resolution.py
@@ -6,9 +6,9 @@ from litellm.files.main import ModelResponse
 from litellm.utils import trim_messages
 from pydantic import Field
 from typing import List, Optional, Literal, cast
-import os
 import json
 
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluatorEntry,
@@ -56,10 +56,6 @@ class QueryResolutionEvaluator(
         self, entry: QueryResolutionEntry
     ) -> SingleEvaluationResult:
         vendor, model = self.settings.model.split("/")
-        if vendor == "azure":
-            os.environ["AZURE_API_KEY"] = self.get_env("AZURE_API_KEY")
-            os.environ["AZURE_API_BASE"] = self.get_env("AZURE_API_BASE")
-            os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
 
         content = entry.conversation or []
         conversation = ""
@@ -99,6 +95,7 @@ class QueryResolutionEvaluator(
         )
 
         response = litellm.completion(
+            **azure_api_version(self.settings.model, "2023-12-01-preview"),
             model=litellm_model,
             messages=messages,
             tools=[

--- a/services/langevals/evaluators/langevals/langevals_langevals/select_best_compare.py
+++ b/services/langevals/evaluators/langevals/langevals_langevals/select_best_compare.py
@@ -20,11 +20,11 @@ BDD spec:     specs/experiments/comparison.feature
 """
 
 import json
-import os
 import random
 import re
 from typing import Literal, Optional, cast
 
+from langevals_core.litellm_patch import azure_api_version
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluationResult,
@@ -258,11 +258,6 @@ class SelectBestCompareEvaluator(
     is_guardrail = False
 
     def evaluate(self, entry: SelectBestCompareEntry) -> SingleEvaluationResult:
-        os.environ["AZURE_API_VERSION"] = "2023-12-01-preview"
-        if self.env:
-            for key, env in self.env.items():
-                os.environ[key] = env
-
         candidates = [c for c in entry.candidates if c.output]
         if len(candidates) < 2:
             return EvaluationResultSkipped(
@@ -579,6 +574,7 @@ class SelectBestCompareEvaluator(
         # customer-facing prose and the schema already asks for brevity.
         response = completion(
             model=self.settings.model,
+            **azure_api_version(self.settings.model, "2023-12-01-preview"),
             temperature=effective_temperature,
             drop_params=True,
             messages=[

--- a/services/langevals/evaluators/ragas/langevals_ragas/lib/common.py
+++ b/services/langevals/evaluators/ragas/langevals_ragas/lib/common.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
-import os
+
+from langevals_core.litellm_patch import azure_api_version
 from typing import List, Optional
 from langevals_core.base_evaluator import (
     BaseEvaluator,
@@ -54,16 +55,20 @@ def prepare_llm(
     settings: RagasSettings = RagasSettings(),
     temperature: float = 0,
 ):
-    os.environ.setdefault("AZURE_API_VERSION", "2024-02-01")
-    if evaluator.env:
-        for key, env in evaluator.env.items():
-            os.environ[key] = env
-
-    gpt = model_to_langchain(settings.model, temperature=temperature)
+    gpt = model_to_langchain(
+        settings.model,
+        temperature=temperature,
+        extra_call_kwargs=azure_api_version(settings.model, "2024-02-01"),
+    )
     llm = LangchainLLMWrapper(langchain_llm=gpt)
 
     if hasattr(settings, "embeddings_model"):
-        embeddings = embeddings_model_to_langchain(settings.embeddings_model)  # type: ignore
+        embeddings = embeddings_model_to_langchain(
+            settings.embeddings_model,  # type: ignore
+            extra_call_kwargs=azure_api_version(
+                settings.embeddings_model, "2024-02-01"  # type: ignore
+            ),
+        )
         embeddings_wrapper = LangchainEmbeddingsWrapper(embeddings)
     else:
         embeddings_wrapper = None

--- a/services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py
+++ b/services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py
@@ -14,14 +14,23 @@ class LitellmCompletion:
     exception: Optional[Exception] = None
     temperature: float = 0
 
-    def __init__(self, temperature: float = 0):
+    def __init__(
+        self,
+        temperature: float = 0,
+        extra_call_kwargs: Optional[dict] = None,
+    ):
         self.temperature = temperature
+        # Call arguments the evaluator pins for every call made through this
+        # client, e.g. the azure api_version that used to be set through the
+        # process environment.
+        self.extra_call_kwargs = extra_call_kwargs or {}
 
     def create(self, *args, **kwargs):
         try:
             if self.temperature:
                 kwargs["temperature"] = self.temperature
             kwargs["drop_params"] = True
+            kwargs.update(self.extra_call_kwargs)
             return litellm.completion(*args, **kwargs)
         except Exception as e:
             self.exception = e
@@ -36,6 +45,7 @@ class AsyncLitellmCompletion(LitellmCompletion):
 def model_to_langchain(
     model: str,
     temperature: float = 0,
+    extra_call_kwargs: Optional[dict] = None,
 ) -> BaseChatModel:
     if model.startswith("claude-"):
         model = model.replace("claude-", "anthropic/claude-")
@@ -47,16 +57,24 @@ def model_to_langchain(
         model=model,
         api_key="dummy",  # type: ignore
         temperature=temperature or 0,
-        client=LitellmCompletion(temperature=temperature),
-        async_client=AsyncLitellmCompletion(temperature=temperature),
+        client=LitellmCompletion(
+            temperature=temperature, extra_call_kwargs=extra_call_kwargs
+        ),
+        async_client=AsyncLitellmCompletion(
+            temperature=temperature, extra_call_kwargs=extra_call_kwargs
+        ),
     )
 
 
 class LitellmEmbeddings:
     exception: Optional[Exception] = None
 
+    def __init__(self, extra_call_kwargs: Optional[dict] = None):
+        self.extra_call_kwargs = extra_call_kwargs or {}
+
     def create(self, *args, **kwargs):
         try:
+            kwargs.update(self.extra_call_kwargs)
             result = litellm.embedding(*args, **kwargs)
             return result.model_dump()
         except Exception as e:
@@ -89,9 +107,12 @@ class LitellmEmbeddingsWrapper(OpenAIEmbeddings):
         return self.embed_query(question)
 
 
-def embeddings_model_to_langchain(embeddings_model: str):
+def embeddings_model_to_langchain(
+    embeddings_model: str,
+    extra_call_kwargs: Optional[dict] = None,
+):
     return LitellmEmbeddingsWrapper(
         model=embeddings_model,
         api_key="dummy",  # type: ignore
-        client=LitellmEmbeddings(),
+        client=LitellmEmbeddings(extra_call_kwargs=extra_call_kwargs),
     )

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -88,44 +88,20 @@ def size_thread_pool_for_evaluations() -> None:
         limiter.total_tokens = wanted
 
 
-def request_env_key(env: Optional[dict[str, str]]) -> tuple:
-    """Everything a request can write into `os.environ`.
-
-    `BaseEvaluator.set_model_envs` writes the model provider credentials and
-    the litellm passthrough variables, but it is not the only writer: the
-    custom LLM evaluators and every Ragas evaluator, through `prepare_llm`,
-    copy the whole `env` of the request into `os.environ` while they run. So
-    the whole `env` is what decides which requests write the same process
-    environment. Requests that share this key write identical values and can
-    run at the same time. Any difference keeps them in separate generations,
-    whether or not the variable belongs to a provider this service knows,
-    because credentials for Bedrock and other providers reach litellm through
-    variables that no allowlist here covers.
-    """
-    if not env:
-        return ()
-    return tuple(sorted(env.items()))
-
-
 class EvaluationQueueTimeout(Exception):
     """Raised when a request waited out the queue timeout without admission."""
 
 
 class EvaluationGate:
-    """Admits evaluations concurrently while they share one environment.
+    """Bounds how many evaluations run at once, first come first served.
 
-    Evaluations write their request `env` into `os.environ` because litellm
-    reads credentials implicitly, so two evaluations with different
-    credentials must never overlap. Two evaluations with the same credentials
-    write identical values, so they can, and on a single-project install
-    (where every request carries the same provider keys) that is every
-    evaluation. The gate tracks the env of the in-flight evaluations as a
-    generation: same-env requests run together up to `max_concurrent`, and
-    waiters queue per env key in arrival order. As soon as any request waits,
-    the running generation stops admitting new entries, so a steady stream
-    with one env cannot starve the others: generations run strictly in the
-    order their first waiter arrived. The process environment is restored
-    once the last evaluation of a generation leaves.
+    Credentials do not constrain admission: a request's `env` stays in its own
+    evaluation context and reaches the model call as explicit arguments (see
+    `langevals_core.request_env`), so evaluations with different credentials
+    run together safely. What is left for the gate is overload protection:
+    at most `max_concurrent` evaluations run, waiters are admitted strictly
+    in arrival order, and a waiter that outlives `timeout_seconds` is
+    rejected so its caller gets a clear signal instead of a stale result.
     """
 
     def __init__(
@@ -136,11 +112,11 @@ class EvaluationGate:
     ):
         self._condition = threading.Condition()
         self._active = 0
-        self._key: Optional[tuple] = None
-        # Waiting env keys in first-arrival order, each with its waiter
-        # count. Timed-out waiters remove themselves, so a key nobody waits
-        # for anymore can never block the queue.
-        self._waiting: OrderedDict[tuple, int] = OrderedDict()
+        # Arrival-ordered tickets of the requests waiting for capacity.
+        # Timed-out waiters remove their ticket, so an abandoned ticket can
+        # never block the queue.
+        self._waiting: OrderedDict[int, None] = OrderedDict()
+        self._next_ticket = 0
         self._max_concurrent = max_concurrent
         self._timeout_seconds = timeout_seconds
         # The queue deadline reads the clock through this attribute, so a
@@ -153,69 +129,79 @@ class EvaluationGate:
         return self._active
 
     @property
-    def waiting_environments(self) -> list[tuple]:
-        return list(self._waiting)
-
-    @property
     def waiting_evaluations(self) -> int:
-        return sum(self._waiting.values())
+        return len(self._waiting)
 
-    def _may_admit(self, key: tuple) -> bool:
+    def _may_admit(self, ticket: Optional[int]) -> bool:
         if self._active >= self._max_concurrent:
             return False
         front = next(iter(self._waiting), None)
-        if front is not None and front != key:
-            return False
-        # Either join the open generation with the same env, or start a new
-        # generation on a drained gate.
-        return self._key == key or self._key is None
-
-    def _leave_queue(self, key: tuple) -> None:
-        remaining = self._waiting.get(key, 0) - 1
-        if remaining > 0:
-            self._waiting[key] = remaining
-        else:
-            self._waiting.pop(key, None)
-            # The queue front may have changed; blocked waiters of the next
-            # key must re-check instead of sitting out their own deadline.
-            self._condition.notify_all()
+        # Nobody may overtake the queue: with waiters present, only the
+        # earliest ticket goes through.
+        return front is None or front == ticket
 
     @contextmanager
-    def admit(self, key: tuple):
+    def admit(self):
         deadline = self._clock() + self._timeout_seconds
         with self._condition:
-            is_queued = False
+            ticket: Optional[int] = None
             try:
                 while True:
                     # A queued request past its deadline is rejected even if
                     # capacity happens to free at that same moment: its
                     # caller already gave up, so running it would only delay
                     # the live requests behind it.
-                    if is_queued and self._clock() >= deadline:
+                    if ticket is not None and self._clock() >= deadline:
                         raise EvaluationQueueTimeout()
-                    if self._may_admit(key):
+                    if self._may_admit(ticket):
                         break
-                    if not is_queued:
-                        self._waiting[key] = self._waiting.get(key, 0) + 1
-                        is_queued = True
+                    if ticket is None:
+                        ticket = self._next_ticket
+                        self._next_ticket += 1
+                        self._waiting[ticket] = None
                     self._condition.wait(deadline - self._clock())
             finally:
-                if is_queued:
-                    self._leave_queue(key)
-            self._key = key
+                if ticket is not None:
+                    self._waiting.pop(ticket, None)
+                    # The queue front may have changed; blocked waiters
+                    # behind it must re-check instead of sitting out their
+                    # own deadline.
+                    self._condition.notify_all()
             self._active += 1
         try:
             yield
         finally:
             with self._condition:
                 self._active -= 1
-                if self._active == 0:
-                    # Drop the request credentials (and anything an evaluator
-                    # library set) the moment nothing is running anymore.
-                    os.environ.clear()
-                    os.environ.update(original_env)
-                    self._key = None
+                self._warn_once_on_environment_drift()
                 self._condition.notify_all()
+
+    _drift_warned = False
+
+    def _warn_once_on_environment_drift(self) -> None:
+        """Tripwire for a writer regression, checked when the gate drains.
+
+        No evaluation writes the process environment anymore; that is what
+        makes different-credential evaluations safe to run together. If an
+        evaluator or library starts writing again, concurrent requests could
+        read each other's credentials, so make the regression visible. Warn
+        rather than restore: rewriting os.environ while other evaluations run
+        is exactly the class of mutation this server no longer does.
+        """
+        if self._active > 0 or EvaluationGate._drift_warned:
+            return
+        if dict(os.environ) != original_env:
+            EvaluationGate._drift_warned = True
+            drifted = {
+                key
+                for key in set(os.environ) | set(original_env)
+                if os.environ.get(key) != original_env.get(key)
+            }
+            print(
+                "WARNING: the process environment changed while evaluations "
+                f"ran (keys: {', '.join(sorted(drifted))}). Evaluations must "
+                "not write os.environ; check for a writer regression."
+            )
 
 
 evaluation_gate = EvaluationGate(
@@ -280,13 +266,13 @@ def create_evaluator_routes(evaluator_cls):
         # evaluation never blocks the event loop and /healthcheck stays
         # responsive under load.
         try:
-            with evaluation_gate.admit(request_env_key(req.env)):
+            with evaluation_gate.admit():
                 if module_name == "ragas":
                     nest_asyncio_if_running_loop()
-                # Constructing the evaluator writes the request env into
-                # os.environ (set_model_envs), and some evaluators write the
-                # whole env again while they run. Everything admitted
-                # together carries the same env, so the writes are identical.
+                # The request env stays on the evaluator and is bound to each
+                # entry's evaluation context; nothing about this request
+                # touches os.environ, which is what lets requests with
+                # different credentials run at the same time.
                 evaluator = evaluator_cls(settings=(req.settings or {}), env=req.env)  # type: ignore
                 return evaluator.evaluate_batch(
                     req.data,

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -135,6 +135,10 @@ class EvaluationGate:
     def waiting_environments(self) -> list[tuple]:
         return list(self._waiting)
 
+    @property
+    def waiting_evaluations(self) -> int:
+        return sum(self._waiting.values())
+
     def _may_admit(self, key: tuple) -> bool:
         if self._active >= self._max_concurrent:
             return False
@@ -159,23 +163,23 @@ class EvaluationGate:
     def admit(self, key: tuple):
         deadline = self._clock() + self._timeout_seconds
         with self._condition:
-            queued = False
+            is_queued = False
             try:
                 while True:
                     # A queued request past its deadline is rejected even if
                     # capacity happens to free at that same moment: its
                     # caller already gave up, so running it would only delay
                     # the live requests behind it.
-                    if queued and self._clock() >= deadline:
+                    if is_queued and self._clock() >= deadline:
                         raise EvaluationQueueTimeout()
                     if self._may_admit(key):
                         break
-                    if not queued:
+                    if not is_queued:
                         self._waiting[key] = self._waiting.get(key, 0) + 1
-                        queued = True
+                        is_queued = True
                     self._condition.wait(deadline - self._clock())
             finally:
-                if queued:
+                if is_queued:
                     self._leave_queue(key)
             self._key = key
             self._active += 1

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -27,7 +27,6 @@ from typing import Callable, List, Optional
 from langevals_core.base_evaluator import (
     EvaluationResultSkipped,
     EvaluationResultError,
-    models_env_vars,
 )
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from mangum import Mangum
@@ -89,22 +88,23 @@ def size_thread_pool_for_evaluations() -> None:
         limiter.total_tokens = wanted
 
 
-def model_env_key(env: Optional[dict[str, str]]) -> tuple:
-    """The part of a request's `env` that gets written into `os.environ`.
+def request_env_key(env: Optional[dict[str, str]]) -> tuple:
+    """Everything a request can write into `os.environ`.
 
-    Mirrors the filter in `BaseEvaluator.set_model_envs`: model provider
-    credentials and litellm passthrough variables. Two requests with the same
-    key write the same process environment, so they can run at the same time.
+    `BaseEvaluator.set_model_envs` writes the model provider credentials and
+    the litellm passthrough variables, but it is not the only writer: the
+    custom LLM evaluators and every Ragas evaluator, through `prepare_llm`,
+    copy the whole `env` of the request into `os.environ` while they run. So
+    the whole `env` is what decides which requests write the same process
+    environment. Requests that share this key write identical values and can
+    run at the same time. Any difference keeps them in separate generations,
+    whether or not the variable belongs to a provider this service knows,
+    because credentials for Bedrock and other providers reach litellm through
+    variables that no allowlist here covers.
     """
     if not env:
         return ()
-    return tuple(
-        sorted(
-            (key, value)
-            for key, value in env.items()
-            if key in models_env_vars or key.startswith("X_LITELLM_")
-        )
-    )
+    return tuple(sorted(env.items()))
 
 
 class EvaluationQueueTimeout(Exception):
@@ -280,12 +280,13 @@ def create_evaluator_routes(evaluator_cls):
         # evaluation never blocks the event loop and /healthcheck stays
         # responsive under load.
         try:
-            with evaluation_gate.admit(model_env_key(req.env)):
+            with evaluation_gate.admit(request_env_key(req.env)):
                 if module_name == "ragas":
                     nest_asyncio_if_running_loop()
                 # Constructing the evaluator writes the request env into
-                # os.environ (set_model_envs). Everything admitted together
-                # carries the same key, so concurrent writes are identical.
+                # os.environ (set_model_envs), and some evaluators write the
+                # whole env again while they run. Everything admitted
+                # together carries the same env, so the writes are identical.
                 evaluator = evaluator_cls(settings=(req.settings or {}), env=req.env)  # type: ignore
                 return evaluator.evaluate_batch(
                     req.data,

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -61,6 +61,14 @@ original_env = os.environ.copy()
 EVALUATION_QUEUE_TIMEOUT_SECONDS = (
     positive_float_or_none(os.getenv("LANGEVALS_QUEUE_TIMEOUT")) or 300.0
 )
+# The two concurrency knobs multiply, because they count different things.
+# The gate admits REQUESTS, and each admitted request fans its batch out to at
+# most MAX_EVALUATIONS_IN_PARALLEL entries. With the defaults that is 64
+# requests at once and up to 64 x 50 entry evaluations in flight. The batch
+# executor starts a thread per submitted entry and only when it is submitted,
+# so single-entry requests cost one thread each and the product is a ceiling,
+# not a reservation. Lower MAX_EVALUATIONS_IN_PARALLEL to bound the width of
+# every batch, and MAX_CONCURRENT_EVALUATIONS to bound how many run together.
 MAX_EVALUATIONS_IN_PARALLEL = (
     positive_int_or_none(os.getenv("MAX_EVALUATIONS_IN_PARALLEL")) or 50
 )
@@ -102,6 +110,10 @@ class EvaluationGate:
     at most `max_concurrent` evaluations run, waiters are admitted strictly
     in arrival order, and a waiter that outlives `timeout_seconds` is
     rejected so its caller gets a clear signal instead of a stale result.
+
+    One ticket covers one request, whatever the size of its batch. The width
+    of a batch is `MAX_EVALUATIONS_IN_PARALLEL`, so the two knobs multiply,
+    as the comment on them describes.
     """
 
     def __init__(

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -152,14 +152,19 @@ class EvaluationGate:
         with self._condition:
             queued = False
             try:
-                while not self._may_admit(key):
+                while True:
+                    # A queued request past its deadline is rejected even if
+                    # capacity happens to free at that same moment: its
+                    # caller already gave up, so running it would only delay
+                    # the live requests behind it.
+                    if queued and time.monotonic() >= deadline:
+                        raise EvaluationQueueTimeout()
+                    if self._may_admit(key):
+                        break
                     if not queued:
                         self._waiting[key] = self._waiting.get(key, 0) + 1
                         queued = True
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        raise EvaluationQueueTimeout()
-                    self._condition.wait(remaining)
+                    self._condition.wait(deadline - time.monotonic())
             finally:
                 if queued:
                     self._leave_queue(key)

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -6,6 +6,7 @@ import signal
 import sys
 import threading
 import time
+import anyio.to_thread
 import dotenv
 from fastapi.responses import RedirectResponse
 
@@ -44,6 +45,7 @@ def handle_sigterm(signum, frame):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    size_thread_pool_for_evaluations()
     if os.getenv("RUNNING_IN_DOCKER"):
         signal.signal(signal.SIGTERM, handle_sigterm)
         signal.signal(signal.SIGINT, handle_sigterm)
@@ -64,8 +66,27 @@ MAX_EVALUATIONS_IN_PARALLEL = (
     positive_int_or_none(os.getenv("MAX_EVALUATIONS_IN_PARALLEL")) or 50
 )
 MAX_CONCURRENT_EVALUATIONS = (
-    positive_int_or_none(os.getenv("MAX_CONCURRENT_EVALUATIONS")) or 8
+    positive_int_or_none(os.getenv("MAX_CONCURRENT_EVALUATIONS")) or 64
 )
+# Spare threads for anything the framework runs off the event loop that is not
+# an evaluation. The pool is sized from the knob plus this, never below it.
+THREAD_POOL_HEADROOM = 8
+
+
+def size_thread_pool_for_evaluations() -> None:
+    """Give the worker-thread pool room for every evaluation the gate admits.
+
+    The evaluate endpoints are sync, so FastAPI runs them on AnyIO's shared
+    worker-thread pool, which holds 40 threads by default. A request with no
+    thread waits BEFORE it reaches the gate, where nothing knows its
+    credentials, so a pool smaller than the gate would both cap the knob
+    silently and decide the running order the gate is there to decide.
+    Sizing the pool from the knob keeps the gate the only limit.
+    """
+    limiter = anyio.to_thread.current_default_thread_limiter()
+    wanted = MAX_CONCURRENT_EVALUATIONS + THREAD_POOL_HEADROOM
+    if limiter.total_tokens < wanted:
+        limiter.total_tokens = wanted
 
 
 def model_env_key(env: Optional[dict[str, str]]) -> tuple:

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from contextlib import asynccontextmanager, contextmanager
 import asyncio
 import os
@@ -98,16 +99,22 @@ class EvaluationGate:
     write identical values, so they can, and on a single-project install
     (where every request carries the same provider keys) that is every
     evaluation. The gate tracks the env of the in-flight evaluations as a
-    generation: same-env requests run together up to `max_concurrent`, a
-    request with a different env waits for the previous generation to drain,
-    and the process environment is restored once the last one leaves.
+    generation: same-env requests run together up to `max_concurrent`, and
+    waiters queue per env key in arrival order. As soon as any request waits,
+    the running generation stops admitting new entries, so a steady stream
+    with one env cannot starve the others: generations run strictly in the
+    order their first waiter arrived. The process environment is restored
+    once the last evaluation of a generation leaves.
     """
 
     def __init__(self, max_concurrent: int, timeout_seconds: float):
         self._condition = threading.Condition()
         self._active = 0
         self._key: Optional[tuple] = None
-        self._switch_pending = False
+        # Waiting env keys in first-arrival order, each with its waiter
+        # count. Timed-out waiters remove themselves, so a key nobody waits
+        # for anymore can never block the queue.
+        self._waiting: OrderedDict[tuple, int] = OrderedDict()
         self._max_concurrent = max_concurrent
         self._timeout_seconds = timeout_seconds
 
@@ -115,27 +122,48 @@ class EvaluationGate:
     def active_evaluations(self) -> int:
         return self._active
 
+    @property
+    def waiting_environments(self) -> list[tuple]:
+        return list(self._waiting)
+
+    def _may_admit(self, key: tuple) -> bool:
+        if self._active >= self._max_concurrent:
+            return False
+        front = next(iter(self._waiting), None)
+        if front is not None and front != key:
+            return False
+        # Either join the open generation with the same env, or start a new
+        # generation on a drained gate.
+        return self._key == key or self._key is None
+
+    def _leave_queue(self, key: tuple) -> None:
+        remaining = self._waiting.get(key, 0) - 1
+        if remaining > 0:
+            self._waiting[key] = remaining
+        else:
+            self._waiting.pop(key, None)
+            # The queue front may have changed; blocked waiters of the next
+            # key must re-check instead of sitting out their own deadline.
+            self._condition.notify_all()
+
     @contextmanager
     def admit(self, key: tuple):
         deadline = time.monotonic() + self._timeout_seconds
         with self._condition:
-            while (
-                self._active >= self._max_concurrent
-                or (self._key is not None and self._key != key)
-                or (self._switch_pending and self._active > 0)
-            ):
-                if self._key is not None and self._key != key:
-                    # Close the running generation to new entries, so a
-                    # steady stream with one env cannot starve a request
-                    # with another env: the generation drains, then whoever
-                    # wakes first starts the next one.
-                    self._switch_pending = True
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise EvaluationQueueTimeout()
-                self._condition.wait(remaining)
+            queued = False
+            try:
+                while not self._may_admit(key):
+                    if not queued:
+                        self._waiting[key] = self._waiting.get(key, 0) + 1
+                        queued = True
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise EvaluationQueueTimeout()
+                    self._condition.wait(remaining)
+            finally:
+                if queued:
+                    self._leave_queue(key)
             self._key = key
-            self._switch_pending = False
             self._active += 1
         try:
             yield

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -22,7 +22,7 @@ from langevals.utils import (
 dotenv.load_dotenv()
 
 from fastapi import FastAPI, HTTPException, Request
-from typing import List, Optional
+from typing import Callable, List, Optional
 from langevals_core.base_evaluator import (
     EvaluationResultSkipped,
     EvaluationResultError,
@@ -107,7 +107,12 @@ class EvaluationGate:
     once the last evaluation of a generation leaves.
     """
 
-    def __init__(self, max_concurrent: int, timeout_seconds: float):
+    def __init__(
+        self,
+        max_concurrent: int,
+        timeout_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+    ):
         self._condition = threading.Condition()
         self._active = 0
         self._key: Optional[tuple] = None
@@ -117,6 +122,10 @@ class EvaluationGate:
         self._waiting: OrderedDict[tuple, int] = OrderedDict()
         self._max_concurrent = max_concurrent
         self._timeout_seconds = timeout_seconds
+        # The queue deadline reads the clock through this attribute, so a
+        # test can move a blocked waiter past its deadline at a chosen
+        # moment and check what the gate does when capacity frees after it.
+        self._clock = clock
 
     @property
     def active_evaluations(self) -> int:
@@ -148,7 +157,7 @@ class EvaluationGate:
 
     @contextmanager
     def admit(self, key: tuple):
-        deadline = time.monotonic() + self._timeout_seconds
+        deadline = self._clock() + self._timeout_seconds
         with self._condition:
             queued = False
             try:
@@ -157,14 +166,14 @@ class EvaluationGate:
                     # capacity happens to free at that same moment: its
                     # caller already gave up, so running it would only delay
                     # the live requests behind it.
-                    if queued and time.monotonic() >= deadline:
+                    if queued and self._clock() >= deadline:
                         raise EvaluationQueueTimeout()
                     if self._may_admit(key):
                         break
                     if not queued:
                         self._waiting[key] = self._waiting.get(key, 0) + 1
                         queued = True
-                    self._condition.wait(deadline - time.monotonic())
+                    self._condition.wait(deadline - self._clock())
             finally:
                 if queued:
                     self._leave_queue(key)

--- a/services/langevals/langevals/server.py
+++ b/services/langevals/langevals/server.py
@@ -1,9 +1,10 @@
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 import asyncio
 import os
 import signal
 import sys
 import threading
+import time
 import dotenv
 from fastapi.responses import RedirectResponse
 
@@ -24,6 +25,7 @@ from typing import List, Optional
 from langevals_core.base_evaluator import (
     EvaluationResultSkipped,
     EvaluationResultError,
+    models_env_vars,
 )
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from mangum import Mangum
@@ -52,19 +54,106 @@ app.add_middleware(StagedPayloadMiddleware)
 
 original_env = os.environ.copy()
 
-# Evaluations mutate the process environment (the request's `env` becomes env
-# vars for litellm), so only one evaluation may run at a time per process.
-# The lock keeps that invariant now that the endpoint runs in a worker thread
-# instead of holding the event loop hostage: with the loop free, /healthcheck
-# always answers and Kubernetes probes stay green while evaluations queue.
-evaluation_lock = threading.Lock()
-# Both knobs are read while the server boots: a blank or mistyped value in a
+# The knobs are read while the server boots: a blank or mistyped value in a
 # manifest falls back to the default instead of stopping the pod.
 EVALUATION_QUEUE_TIMEOUT_SECONDS = (
     positive_float_or_none(os.getenv("LANGEVALS_QUEUE_TIMEOUT")) or 300.0
 )
 MAX_EVALUATIONS_IN_PARALLEL = (
     positive_int_or_none(os.getenv("MAX_EVALUATIONS_IN_PARALLEL")) or 50
+)
+MAX_CONCURRENT_EVALUATIONS = (
+    positive_int_or_none(os.getenv("MAX_CONCURRENT_EVALUATIONS")) or 8
+)
+
+
+def model_env_key(env: Optional[dict[str, str]]) -> tuple:
+    """The part of a request's `env` that gets written into `os.environ`.
+
+    Mirrors the filter in `BaseEvaluator.set_model_envs`: model provider
+    credentials and litellm passthrough variables. Two requests with the same
+    key write the same process environment, so they can run at the same time.
+    """
+    if not env:
+        return ()
+    return tuple(
+        sorted(
+            (key, value)
+            for key, value in env.items()
+            if key in models_env_vars or key.startswith("X_LITELLM_")
+        )
+    )
+
+
+class EvaluationQueueTimeout(Exception):
+    """Raised when a request waited out the queue timeout without admission."""
+
+
+class EvaluationGate:
+    """Admits evaluations concurrently while they share one environment.
+
+    Evaluations write their request `env` into `os.environ` because litellm
+    reads credentials implicitly, so two evaluations with different
+    credentials must never overlap. Two evaluations with the same credentials
+    write identical values, so they can, and on a single-project install
+    (where every request carries the same provider keys) that is every
+    evaluation. The gate tracks the env of the in-flight evaluations as a
+    generation: same-env requests run together up to `max_concurrent`, a
+    request with a different env waits for the previous generation to drain,
+    and the process environment is restored once the last one leaves.
+    """
+
+    def __init__(self, max_concurrent: int, timeout_seconds: float):
+        self._condition = threading.Condition()
+        self._active = 0
+        self._key: Optional[tuple] = None
+        self._switch_pending = False
+        self._max_concurrent = max_concurrent
+        self._timeout_seconds = timeout_seconds
+
+    @property
+    def active_evaluations(self) -> int:
+        return self._active
+
+    @contextmanager
+    def admit(self, key: tuple):
+        deadline = time.monotonic() + self._timeout_seconds
+        with self._condition:
+            while (
+                self._active >= self._max_concurrent
+                or (self._key is not None and self._key != key)
+                or (self._switch_pending and self._active > 0)
+            ):
+                if self._key is not None and self._key != key:
+                    # Close the running generation to new entries, so a
+                    # steady stream with one env cannot starve a request
+                    # with another env: the generation drains, then whoever
+                    # wakes first starts the next one.
+                    self._switch_pending = True
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise EvaluationQueueTimeout()
+                self._condition.wait(remaining)
+            self._key = key
+            self._switch_pending = False
+            self._active += 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._active -= 1
+                if self._active == 0:
+                    # Drop the request credentials (and anything an evaluator
+                    # library set) the moment nothing is running anymore.
+                    os.environ.clear()
+                    os.environ.update(original_env)
+                    self._key = None
+                self._condition.notify_all()
+
+
+evaluation_gate = EvaluationGate(
+    max_concurrent=MAX_CONCURRENT_EVALUATIONS,
+    timeout_seconds=EVALUATION_QUEUE_TIMEOUT_SECONDS,
 )
 
 
@@ -123,27 +212,23 @@ def create_evaluator_routes(evaluator_cls):
         # Sync endpoint: FastAPI runs it in a worker thread, so a long
         # evaluation never blocks the event loop and /healthcheck stays
         # responsive under load.
-        if not evaluation_lock.acquire(timeout=EVALUATION_QUEUE_TIMEOUT_SECONDS):
+        try:
+            with evaluation_gate.admit(model_env_key(req.env)):
+                if module_name == "ragas":
+                    nest_asyncio_if_running_loop()
+                # Constructing the evaluator writes the request env into
+                # os.environ (set_model_envs). Everything admitted together
+                # carries the same key, so concurrent writes are identical.
+                evaluator = evaluator_cls(settings=(req.settings or {}), env=req.env)  # type: ignore
+                return evaluator.evaluate_batch(
+                    req.data,
+                    max_evaluations_in_parallel=MAX_EVALUATIONS_IN_PARALLEL,
+                )
+        except EvaluationQueueTimeout:
             raise HTTPException(
                 status_code=503,
                 detail="Evaluation queue is full, retry in a moment",
             )
-        try:
-            if module_name == "ragas":
-                nest_asyncio_if_running_loop()
-            os.environ.clear()
-            os.environ.update(
-                original_env
-            )  # always try to set env vars from the original env back again to avoid side effects
-            evaluator = evaluator_cls(settings=(req.settings or {}), env=req.env)  # type: ignore
-            return evaluator.evaluate_batch(
-                req.data,
-                max_evaluations_in_parallel=MAX_EVALUATIONS_IN_PARALLEL,
-            )
-        finally:
-            os.environ.clear()
-            os.environ.update(original_env)
-            evaluation_lock.release()
 
 
 evaluators = load_evaluator_packages()

--- a/services/langevals/langevals_core/langevals_core/base_evaluator.py
+++ b/services/langevals/langevals_core/langevals_core/base_evaluator.py
@@ -25,6 +25,7 @@ from tenacity import (
 from tqdm.auto import tqdm as tqdm_auto
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from langevals_core.litellm_patch import patch_litellm
+from langevals_core.request_env import bind_request_env, request_env
 
 import time
 import warnings
@@ -238,7 +239,11 @@ class BaseEvaluator(BaseModel, Generic[TEntry, TSettings, TResult], ABC):
         super().__init__(**kwargs)
         if not self.__preloaded:
             self.__class__.preload()
-        self.set_model_envs()
+        # Library callers construct an evaluator and call `evaluate` directly
+        # on the same thread; binding here is what makes their `env` reach the
+        # model call. `evaluate_batch` does not rely on it: every entry is
+        # scoped explicitly, whichever worker thread it lands on.
+        bind_request_env(self.env)
 
     @classmethod
     def preload(cls):
@@ -264,28 +269,19 @@ class BaseEvaluator(BaseModel, Generic[TEntry, TSettings, TResult], ABC):
         except KeyError:
             raise EnvMissingException(f"Variable {var} not defined in environment.")
 
-    def set_model_envs(self):
-        # Those variables may be used non-explicitly, so we need to set them globally here for the arguments given
-        for key, value in (self.env or {}).items():
-            if key in models_env_vars or key.startswith("X_LITELLM_"):
-                os.environ[key] = value
-
-        # azure alias for litellm
-        if os.environ.get("AZURE_OPENAI_API_KEY") is not None:
-            os.environ["AZURE_API_KEY"] = os.environ["AZURE_OPENAI_API_KEY"]
-        if os.environ.get("AZURE_OPENAI_ENDPOINT") is not None:
-            os.environ["AZURE_API_BASE"] = os.environ["AZURE_OPENAI_ENDPOINT"]
-        # reverse azure alias for litellm
-        if os.environ.get("AZURE_API_KEY") is not None:
-            os.environ["AZURE_OPENAI_API_KEY"] = os.environ["AZURE_API_KEY"]
-        if os.environ.get("AZURE_API_BASE") is not None:
-            os.environ["AZURE_OPENAI_ENDPOINT"] = os.environ["AZURE_API_BASE"]
-
     def evaluate(self, entry: TEntry) -> SingleEvaluationResult:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
     def _evaluate_entry(self, entry, retries=0, restore_tqdm=True):
         _disable_tqdm()
+        # Every entry runs through here, on whatever worker thread the batch
+        # executor picked, so this is the one place that binds the request env
+        # for the model call underneath. Scoped, because executor threads are
+        # reused and must not carry one request's credentials into the next.
+        with request_env(self.env):
+            return self.__evaluate_entry_bound(entry, retries, restore_tqdm)
+
+    def __evaluate_entry_bound(self, entry, retries, restore_tqdm):
         try:
             retryer = Retrying(
                 # A 400 from the model provider is deterministic: a content

--- a/services/langevals/langevals_core/langevals_core/litellm_patch.py
+++ b/services/langevals/langevals_core/langevals_core/litellm_patch.py
@@ -7,9 +7,31 @@ import litellm.cost_calculator
 from openai import OpenAI, AzureOpenAI
 import json
 
+from langevals_core.request_env import current_request_env
+
 # Necessary for running DSPy on AWS lambdas
 os.environ["DSP_CACHEDIR"] = mkdtemp()
 os.environ["DSPY_CACHEDIR"] = mkdtemp()
+
+# An operator configuring azure on the server environment may use either the
+# AZURE_OPENAI_* names or litellm's AZURE_API_* names; litellm only reads its
+# own. Alias the SERVER environment once at import, both ways. Request
+# credentials never pass through here: they stay in the request context and
+# reach litellm as call arguments, where `request_credentials` accepts both
+# spellings itself.
+def _alias_baseline_azure_env() -> None:
+    aliases = [
+        ("AZURE_OPENAI_API_KEY", "AZURE_API_KEY"),
+        ("AZURE_OPENAI_ENDPOINT", "AZURE_API_BASE"),
+    ]
+    for openai_name, litellm_name in aliases:
+        if os.environ.get(openai_name) and not os.environ.get(litellm_name):
+            os.environ[litellm_name] = os.environ[openai_name]
+        if os.environ.get(litellm_name) and not os.environ.get(openai_name):
+            os.environ[openai_name] = os.environ[litellm_name]
+
+
+_alias_baseline_azure_env()
 
 # Parameters that need type conversion from string env vars
 INT_PARAMS = {"max_tokens", "seed", "n", "top_logprobs", "max_completion_tokens"}
@@ -126,71 +148,187 @@ def convert_param_type(key: str, value: str):
     return value
 
 
-# Patch litellm completion for mapping AZURE_DEPLOYMENT_NAME into the model name
-def patch_litellm():
-    _original_completion = litellm.completion
+# The request env vars that resolve into litellm call arguments, by the
+# model's provider prefix. This is how a request's credentials reach the call
+# without anyone writing os.environ: the names mirror what litellm itself
+# reads from the environment, so behavior is unchanged for credentials that
+# live in the server's own environment (litellm still falls back to those on
+# its own). Azure accepts both its litellm names and the AZURE_OPENAI_* names
+# the platform sends; first present wins.
+PROVIDER_CREDENTIAL_VARS = {
+    "openai": {
+        "api_key": ["OPENAI_API_KEY"],
+        "api_base": ["OPENAI_BASE_URL"],
+    },
+    "azure": {
+        "api_key": ["AZURE_API_KEY", "AZURE_OPENAI_API_KEY"],
+        "api_base": ["AZURE_API_BASE", "AZURE_OPENAI_ENDPOINT"],
+        "api_version": ["AZURE_API_VERSION"],
+    },
+    "anthropic": {"api_key": ["ANTHROPIC_API_KEY"]},
+    "groq": {"api_key": ["GROQ_API_KEY"]},
+    "gemini": {"api_key": ["GEMINI_API_KEY"]},
+    "vertex_ai": {"vertex_credentials": ["GOOGLE_APPLICATION_CREDENTIALS"]},
+}
 
-    def patch_litellm_params(kwargs):
-        kwargs["drop_params"] = True
-        # Caching on disk is timing out for some reason, disable it
-        kwargs["cache"] = {"no-cache": True, "no-store": True}
 
-        if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") is not None:
-            kwargs["vertex_credentials"] = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+def _model_provider(model: str) -> str:
+    # litellm treats a bare model name (no provider prefix) as openai.
+    return model.split("/", 1)[0] if "/" in model else "openai"
 
-        for key, value in os.environ.items():
-            if key.startswith("X_LITELLM_") and not key.startswith(
-                "X_LITELLM_EMBEDDINGS_"
-            ):
-                replaced_key = key.replace("X_LITELLM_", "")
-                # check if key is all uppercase, likely not a litellm key and got here by accident
-                if replaced_key.isupper():
-                    continue
-                kwargs[replaced_key] = convert_param_type(replaced_key, value)
 
-        if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
-            kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])
+def azure_api_version(model: str, api_version: str) -> dict:
+    """The api_version call argument for an azure model, empty for any other.
 
-        # Azure patches
-        if (
-            os.environ.get("AZURE_DEPLOYMENT_NAME") is not None
-            and "model" in kwargs
-            and kwargs["model"].startswith("azure/")
+    Evaluators used to pin their azure API version by writing AZURE_API_VERSION
+    into os.environ; as a call argument the pin stays with the one call it
+    belongs to. A request's X_LITELLM_api_version still overrides it, the same
+    precedence the environment write had.
+    """
+    return {"api_version": api_version} if model.startswith("azure/") else {}
+
+
+def request_credentials(kwargs: dict) -> None:
+    """Resolve the running evaluation's env into explicit call arguments.
+
+    Explicit arguments already on the call are kept: an evaluator that names
+    its own api_version, or a test that injects a client, always wins. The
+    request env fills the gaps, and whatever the request does not carry is
+    left for litellm to resolve from the server's own environment, which is
+    exactly where non-request credentials live.
+    """
+    env = current_request_env()
+    if not env:
+        return
+    provider_vars = PROVIDER_CREDENTIAL_VARS.get(
+        _model_provider(kwargs.get("model") or ""), {}
+    )
+    for argument, var_names in provider_vars.items():
+        if kwargs.get(argument) is not None:
+            continue
+        for var_name in var_names:
+            if env.get(var_name):
+                kwargs[argument] = env[var_name]
+                break
+
+
+def patch_litellm_params(kwargs):
+    kwargs["drop_params"] = True
+    # Caching on disk is timing out for some reason, disable it
+    kwargs["cache"] = {"no-cache": True, "no-store": True}
+
+    request_env = current_request_env()
+
+    google_credentials = request_env.get(
+        "GOOGLE_APPLICATION_CREDENTIALS"
+    ) or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if google_credentials is not None:
+        kwargs["vertex_credentials"] = google_credentials
+
+
+    request_credentials(kwargs)
+
+    # X_LITELLM_* variables are litellm call arguments by name. The server's
+    # own environment provides the baseline and the request env overrides it,
+    # the same precedence get_env gives every other variable.
+    for key, value in {**os.environ, **request_env}.items():
+        if key.startswith("X_LITELLM_") and not key.startswith(
+            "X_LITELLM_EMBEDDINGS_"
         ):
-            kwargs["model"] = "azure/" + os.environ["AZURE_DEPLOYMENT_NAME"]
+            replaced_key = key.replace("X_LITELLM_", "")
+            # check if key is all uppercase, likely not a litellm key and got here by accident
+            if replaced_key.isupper():
+                continue
+            kwargs[replaced_key] = convert_param_type(replaced_key, value)
 
-        if "use_azure_gateway" in kwargs:
-            kwargs["model"] = kwargs["model"].replace("azure/", "")
+    if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
+        kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])
 
-            if "/openai/" in kwargs["api_base"]:
-                if not kwargs["api_base"].endswith("/"):
-                    kwargs["api_base"] += "/"
+    # Azure patches
+    deployment_name = request_env.get("AZURE_DEPLOYMENT_NAME") or os.environ.get(
+        "AZURE_DEPLOYMENT_NAME"
+    )
+    if (
+        deployment_name is not None
+        and "model" in kwargs
+        and kwargs["model"].startswith("azure/")
+    ):
+        kwargs["model"] = "azure/" + deployment_name
 
-                if "/deployments" not in kwargs["api_base"]:
-                    kwargs["api_base"] += "deployments/"
+    if "use_azure_gateway" in kwargs:
+        kwargs["model"] = kwargs["model"].replace("azure/", "")
 
-                kwargs["api_base"] += kwargs["model"]
+        if "/openai/" in kwargs["api_base"]:
+            if not kwargs["api_base"].endswith("/"):
+                kwargs["api_base"] += "/"
 
-            kwargs["client"] = OpenAI(
-                base_url=kwargs["api_base"],
-                default_query={"api-version": kwargs["api_version"]},
-            )
+            if "/deployments" not in kwargs["api_base"]:
+                kwargs["api_base"] += "deployments/"
 
-            del kwargs["api_base"]
-            del kwargs["use_azure_gateway"]
+            kwargs["api_base"] += kwargs["model"]
 
-        # Last, so that an operator's X_LITELLM_reasoning_effort counts as an
-        # explicit choice and the azure rewrites above have already settled
-        # which model the request actually names.
-        kwargs = apply_tool_reasoning_compatibility(kwargs)
+        kwargs["client"] = OpenAI(
+            base_url=kwargs["api_base"],
+            default_query={"api-version": kwargs["api_version"]},
+        )
 
-        return kwargs
+        del kwargs["api_base"]
+        del kwargs["use_azure_gateway"]
+
+    # Last, so that an operator's X_LITELLM_reasoning_effort counts as an
+    # explicit choice and the azure rewrites above have already settled
+    # which model the request actually names.
+    kwargs = apply_tool_reasoning_compatibility(kwargs)
+
+    return kwargs
+
+
+def patch_litellm_embedding_params(kwargs):
+    kwargs["drop_params"] = True
+
+    request_env = current_request_env()
+
+    embeddings_deployment = request_env.get(
+        "AZURE_EMBEDDINGS_DEPLOYMENT_NAME"
+    ) or os.environ.get("AZURE_EMBEDDINGS_DEPLOYMENT_NAME")
+    if embeddings_deployment is not None:
+        kwargs["model"] = "azure/" + embeddings_deployment
+
+    request_credentials(kwargs)
+
+    for key, value in {**os.environ, **request_env}.items():
+        if key.startswith("X_LITELLM_EMBEDDINGS_"):
+            replaced_key = key.replace("X_LITELLM_EMBEDDINGS_", "")
+            # check if key is all uppercase, likely not a litellm key and got here by accident
+            if replaced_key.isupper():
+                continue
+            kwargs[replaced_key] = convert_param_type(replaced_key, value)
+
+    if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
+        kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])
+
+    return kwargs
+
+
+# The unpatched litellm entry points. Tests replace these to capture the
+# final call arguments after every patch above has been applied; nothing else
+# should touch them.
+originals: dict = {}
+
+
+def patch_litellm():
+    if originals:
+        return
+    originals["completion"] = litellm.completion
+    originals["acompletion"] = litellm.acompletion
+    originals["embedding"] = litellm.embedding
+    originals["completion_cost"] = litellm.cost_calculator.completion_cost
 
     def patched_completion(*args, **kwargs):
         kwargs = patch_litellm_params(kwargs)
 
         try:
-            return _original_completion(*args, **kwargs)
+            return originals["completion"](*args, **kwargs)
         except Exception as exception:
             conflict = tool_reasoning_conflict(kwargs, exception)
             if conflict is not None:
@@ -199,13 +337,11 @@ def patch_litellm():
 
     litellm.completion = patched_completion
 
-    _original_acompletion = litellm.acompletion
-
     async def patched_acompletion(*args, **kwargs):
         kwargs = patch_litellm_params(kwargs)
 
         try:
-            return await _original_acompletion(*args, **kwargs)
+            return await originals["acompletion"](*args, **kwargs)
         except Exception as exception:
             conflict = tool_reasoning_conflict(kwargs, exception)
             if conflict is not None:
@@ -214,35 +350,16 @@ def patch_litellm():
 
     litellm.acompletion = patched_acompletion
 
-    _original_embedding = litellm.embedding
-
     def patched_embedding(*args, **kwargs):
-        kwargs["drop_params"] = True
-        if os.environ.get("AZURE_EMBEDDINGS_DEPLOYMENT_NAME") is not None:
-            kwargs["model"] = "azure/" + os.environ["AZURE_EMBEDDINGS_DEPLOYMENT_NAME"]
-        # if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") is not None:
-        #     kwargs["vertex_credentials"] = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-        for key, value in os.environ.items():
-            if key.startswith("X_LITELLM_EMBEDDINGS_"):
-                replaced_key = key.replace("X_LITELLM_EMBEDDINGS_", "")
-                # check if key is all uppercase, likely not a litellm key and got here by accident
-                if replaced_key.isupper():
-                    continue
-                kwargs[replaced_key] = convert_param_type(replaced_key, value)
-
-        if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
-            kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])
-
-        return _original_embedding(*args, **kwargs)
+        kwargs = patch_litellm_embedding_params(kwargs)
+        return originals["embedding"](*args, **kwargs)
 
     litellm.embedding = patched_embedding
-
-    _original_completion_cost = litellm.cost_calculator.completion_cost
 
     # Fail silently if completion_cost fails
     def patched_completion_cost(*args, **kwargs):
         try:
-            return _original_completion_cost(*args, **kwargs)
+            return originals["completion_cost"](*args, **kwargs)
         except Exception as e:
             warnings.warn(f"Failed to calculate completion_cost: {e}")
             return None

--- a/services/langevals/langevals_core/langevals_core/litellm_patch.py
+++ b/services/langevals/langevals_core/langevals_core/litellm_patch.py
@@ -169,6 +169,16 @@ PROVIDER_CREDENTIAL_VARS = {
     "groq": {"api_key": ["GROQ_API_KEY"]},
     "gemini": {"api_key": ["GEMINI_API_KEY"]},
     "vertex_ai": {"vertex_credentials": ["GOOGLE_APPLICATION_CREDENTIALS"]},
+    # A request carrying its own AWS credentials names them the way the
+    # provider form stores them. The session token is here for temporary
+    # credentials: an assumed role gives all three, and access key with secret
+    # alone is rejected.
+    "bedrock": {
+        "aws_access_key_id": ["AWS_ACCESS_KEY_ID"],
+        "aws_secret_access_key": ["AWS_SECRET_ACCESS_KEY"],
+        "aws_session_token": ["AWS_SESSION_TOKEN"],
+        "aws_region_name": ["AWS_REGION_NAME"],
+    },
 }
 
 
@@ -219,14 +229,19 @@ def patch_litellm_params(kwargs):
 
     request_env = current_request_env()
 
-    google_credentials = request_env.get(
-        "GOOGLE_APPLICATION_CREDENTIALS"
-    ) or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-    if google_credentials is not None:
-        kwargs["vertex_credentials"] = google_credentials
-
-
     request_credentials(kwargs)
+
+    # The server environment is the fallback for vertex, after the request env
+    # had its turn through the table above and only when the caller named
+    # nothing. Reading it for any other provider would attach credentials that
+    # the call has no use for.
+    if (
+        kwargs.get("vertex_credentials") is None
+        and _model_provider(kwargs.get("model") or "") == "vertex_ai"
+    ):
+        google_credentials = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if google_credentials is not None:
+            kwargs["vertex_credentials"] = google_credentials
 
     # X_LITELLM_* variables are litellm call arguments by name. The server's
     # own environment provides the baseline and the request env overrides it,

--- a/services/langevals/langevals_core/langevals_core/request_env.py
+++ b/services/langevals/langevals_core/langevals_core/request_env.py
@@ -1,0 +1,51 @@
+"""The env of the evaluation that is running right now, without os.environ.
+
+Evaluators receive per-request credentials in their `env`, and the model
+libraries underneath (litellm, and dspy/ragas/langchain on top of it) resolve
+credentials implicitly. The old bridge between the two was writing the request
+env into `os.environ`, which is process-global: two concurrent evaluations
+with different credentials could read each other's, so the server had to
+serialize them. This context is the replacement bridge. The evaluation
+machinery binds the request env here, and the litellm patch layer resolves
+credentials from it into explicit per-call arguments, so nothing about a
+request ever touches the process environment and evaluations with different
+credentials can run at the same time.
+
+A ContextVar rather than a threading.local: ragas evaluators run their work on
+asyncio tasks, and tasks inherit the context they were created under, so the
+binding survives the sync-to-async hop inside one evaluation while staying
+invisible to every other thread.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Optional
+
+_current_env: ContextVar[Optional[dict[str, str]]] = ContextVar(
+    "langevals_request_env", default=None
+)
+
+
+def bind_request_env(env: Optional[dict[str, str]]) -> None:
+    """Bind without scoping, for library callers.
+
+    Constructing an evaluator binds its env to the current context, so
+    `MyEvaluator(env={...}).evaluate(entry)` keeps working for anyone using
+    langevals as a library, the way the old os.environ write did, minus the
+    process-global part. Server request handling does not rely on this: every
+    batch entry is scoped explicitly by `request_env` around its evaluation.
+    """
+    _current_env.set(env)
+
+
+@contextmanager
+def request_env(env: Optional[dict[str, str]]) -> Iterator[None]:
+    token = _current_env.set(env)
+    try:
+        yield
+    finally:
+        _current_env.reset(token)
+
+
+def current_request_env() -> dict[str, str]:
+    return _current_env.get() or {}

--- a/services/langevals/langevals_core/tests/test_tool_reasoning_compatibility.py
+++ b/services/langevals/langevals_core/tests/test_tool_reasoning_compatibility.py
@@ -16,9 +16,9 @@ import os
 from typing import Optional
 
 import litellm
-import litellm.cost_calculator
 import pytest
 
+from langevals_core import litellm_patch
 from langevals_core.litellm_patch import ToolReasoningConflictError, patch_litellm
 
 # The rejection as the provider words it, captured from a Comparison run whose
@@ -101,39 +101,26 @@ class _Provider:
 
 @pytest.fixture
 def provider(monkeypatch):
-    """langevals' litellm patch rebuilt over a stub, so a judge request can be
-    read exactly as the provider would receive it.
+    """langevals' litellm patch driving a stub provider, so a judge request can
+    be read exactly as the provider would receive it.
 
-    Both entry points langevals patches are stubbed, so an evaluator that
-    awaits its judge is covered by the same fixture as one that blocks on it.
-    litellm's module attributes are restored afterwards, so the rest of the
-    suite keeps the real client. X_LITELLM_ variables are cleared because the
-    patch merges them into every request, and an ambient reasoning effort would
-    read here as a caller's explicit choice.
+    The patch installs once per process and then calls the entry points it
+    captured in `litellm_patch.originals`. The stub goes there, at the
+    innermost layer, so the request travels the real patched path, and one
+    fixture covers the evaluators that block on their judge and the ones that
+    await it. X_LITELLM_ variables are cleared because the patch merges them
+    into every request, and an ambient reasoning effort would read here as a
+    caller's explicit choice.
     """
     for key in list(os.environ):
         if key.startswith("X_LITELLM_"):
             monkeypatch.delenv(key)
 
-    originals = (
-        litellm.completion,
-        litellm.acompletion,
-        litellm.embedding,
-        litellm.cost_calculator.completion_cost,
-    )
-    stub = _Provider()
-    litellm.completion = stub
-    litellm.acompletion = stub.acall
     patch_litellm()
-    try:
-        yield stub
-    finally:
-        (
-            litellm.completion,
-            litellm.acompletion,
-            litellm.embedding,
-            litellm.cost_calculator.completion_cost,
-        ) = originals
+    stub = _Provider()
+    monkeypatch.setitem(litellm_patch.originals, "completion", stub)
+    monkeypatch.setitem(litellm_patch.originals, "acompletion", stub.acall)
+    return stub
 
 
 def judge_request(model: str, **overrides) -> dict:

--- a/services/langevals/tests/deterministic/test_credential_isolation.py
+++ b/services/langevals/tests/deterministic/test_credential_isolation.py
@@ -37,9 +37,32 @@ finally:
     else:
         os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
 
+# The server captured its baseline while the temporary preload flag was set.
+# Rebase it on the clean environment, so the drift tripwire compares against
+# what the process actually holds.
+server.original_env = os.environ.copy()
+
 from langevals_core import litellm_patch
 from langevals_core.litellm_patch import patch_litellm_params
 from langevals_core.request_env import request_env
+from langevals_langevals.competitor_llm import CompetitorLLMEntry, CompetitorLLMEvaluator
+from langevals_langevals.competitor_llm_function_call import (
+    CompetitorLLMFunctionCallEntry,
+    CompetitorLLMFunctionCallEvaluator,
+)
+from langevals_langevals.llm_boolean import CustomLLMBooleanEntry, CustomLLMBooleanEvaluator
+from langevals_langevals.llm_category import CustomLLMCategoryEntry, CustomLLMCategoryEvaluator
+from langevals_langevals.llm_score import CustomLLMScoreEntry, CustomLLMScoreEvaluator
+from langevals_langevals.off_topic import OffTopicEntry, OffTopicEvaluator
+from langevals_langevals.pairwise_compare import PairwiseCompareEntry, PairwiseCompareEvaluator
+from langevals_langevals.query_resolution import (
+    QueryResolutionEntry,
+    QueryResolutionEvaluator,
+)
+from langevals_langevals.select_best_compare import (
+    SelectBestCompareEntry,
+    SelectBestCompareEvaluator,
+)
 
 
 def environment_snapshot() -> dict:
@@ -111,6 +134,57 @@ def test_the_deployment_name_rewrite_reads_the_request_env():
     with request_env({"AZURE_DEPLOYMENT_NAME": "my-deployment"}):
         kwargs = patch_litellm_params({"model": "openai/gpt-5-mini"})
     assert kwargs["model"] == "openai/gpt-5-mini"
+
+
+def test_bedrock_credentials_resolve_into_call_arguments():
+    """Temporary AWS credentials need all three parts on the call.
+
+    An assumed role gives an access key, a secret and a session token, and
+    the provider rejects the pair without the token.
+    """
+    with request_env(
+        {
+            "AWS_ACCESS_KEY_ID": "req-access-key",
+            "AWS_SECRET_ACCESS_KEY": "req-secret-key",
+            "AWS_SESSION_TOKEN": "req-session-token",
+            "AWS_REGION_NAME": "eu-central-1",
+        }
+    ):
+        kwargs = patch_litellm_params({"model": "bedrock/anthropic.claude-sonnet-4"})
+    assert kwargs["aws_access_key_id"] == "req-access-key"
+    assert kwargs["aws_secret_access_key"] == "req-secret-key"
+    assert kwargs["aws_session_token"] == "req-session-token"
+    assert kwargs["aws_region_name"] == "eu-central-1"
+
+
+def test_vertex_credentials_resolve_from_the_request_env():
+    with request_env({"GOOGLE_APPLICATION_CREDENTIALS": "req-google-credentials"}):
+        kwargs = patch_litellm_params({"model": "vertex_ai/gemini-2.5-pro"})
+    assert kwargs["vertex_credentials"] == "req-google-credentials"
+
+
+def test_an_explicit_vertex_credential_wins_over_the_request_env():
+    with request_env({"GOOGLE_APPLICATION_CREDENTIALS": "from-request"}):
+        kwargs = patch_litellm_params(
+            {"model": "vertex_ai/gemini-2.5-pro", "vertex_credentials": "explicit"}
+        )
+    assert kwargs["vertex_credentials"] == "explicit"
+
+
+def test_the_server_vertex_credential_reaches_vertex_calls_only(monkeypatch):
+    """The server's own Google credentials are a vertex fallback.
+
+    They belong to the vertex call that has none of its own. Attaching them
+    to a call for another provider gives it an argument it cannot use.
+    """
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "server-google-credentials")
+
+    with request_env({}):
+        vertex = patch_litellm_params({"model": "vertex_ai/gemini-2.5-pro"})
+        openai = patch_litellm_params({"model": "openai/gpt-5-mini"})
+
+    assert vertex["vertex_credentials"] == "server-google-credentials"
+    assert "vertex_credentials" not in openai
 
 
 def test_resolution_never_writes_the_environment():
@@ -189,127 +263,107 @@ AZURE_SENTINEL_ENV = {
 }
 
 
-def evaluator_cases():
-    from langevals_langevals.competitor_llm import CompetitorLLMEntry, CompetitorLLMEvaluator
-    from langevals_langevals.competitor_llm_function_call import (
-        CompetitorLLMFunctionCallEntry,
-        CompetitorLLMFunctionCallEvaluator,
-    )
-    from langevals_langevals.llm_boolean import CustomLLMBooleanEntry, CustomLLMBooleanEvaluator
-    from langevals_langevals.llm_category import CustomLLMCategoryEntry, CustomLLMCategoryEvaluator
-    from langevals_langevals.llm_score import CustomLLMScoreEntry, CustomLLMScoreEvaluator
-    from langevals_langevals.off_topic import OffTopicEntry, OffTopicEvaluator
-    from langevals_langevals.pairwise_compare import PairwiseCompareEntry, PairwiseCompareEvaluator
-    from langevals_langevals.query_resolution import (
-        QueryResolutionEntry,
-        QueryResolutionEvaluator,
-    )
-    from langevals_langevals.select_best_compare import (
-        SelectBestCompareEntry,
+text_entry = {"input": "What is the answer?", "output": "The answer is 42."}
+EVALUATOR_CASES = [
+    pytest.param(
+        CustomLLMBooleanEvaluator,
+        CustomLLMBooleanEntry(**text_entry),
+        {"model": "openai/gpt-5-mini"},
+        OPENAI_SENTINEL_ENV,
+        "sentinel-openai-key",
+        id="llm_boolean-openai",
+    ),
+    pytest.param(
+        CustomLLMBooleanEvaluator,
+        CustomLLMBooleanEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="llm_boolean-azure",
+    ),
+    pytest.param(
+        CustomLLMScoreEvaluator,
+        CustomLLMScoreEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="llm_score-azure",
+    ),
+    pytest.param(
+        CustomLLMCategoryEvaluator,
+        CustomLLMCategoryEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="llm_category-azure",
+    ),
+    pytest.param(
+        PairwiseCompareEvaluator,
+        PairwiseCompareEntry(
+            input="Which is better?",
+            candidate_a_id="a",
+            candidate_a_output="first",
+            candidate_b_id="b",
+            candidate_b_output="second",
+        ),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="pairwise_compare-azure",
+    ),
+    pytest.param(
         SelectBestCompareEvaluator,
-    )
-
-    text_entry = {"input": "What is the answer?", "output": "The answer is 42."}
-    return [
-        pytest.param(
-            CustomLLMBooleanEvaluator,
-            CustomLLMBooleanEntry(**text_entry),
-            {"model": "openai/gpt-5-mini"},
-            OPENAI_SENTINEL_ENV,
-            "sentinel-openai-key",
-            id="llm_boolean-openai",
+        SelectBestCompareEntry(
+            input="Which is best?",
+            candidates=[
+                {"id": "a", "output": "first"},
+                {"id": "b", "output": "second"},
+            ],
         ),
-        pytest.param(
-            CustomLLMBooleanEvaluator,
-            CustomLLMBooleanEntry(**text_entry),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="llm_boolean-azure",
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="select_best_compare-azure",
+    ),
+    pytest.param(
+        OffTopicEvaluator,
+        OffTopicEntry(input="Tell me about the weather"),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="off_topic-azure",
+    ),
+    pytest.param(
+        CompetitorLLMEvaluator,
+        CompetitorLLMEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="competitor_llm-azure",
+    ),
+    pytest.param(
+        CompetitorLLMFunctionCallEvaluator,
+        CompetitorLLMFunctionCallEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="competitor_llm_function_call-azure",
+    ),
+    pytest.param(
+        QueryResolutionEvaluator,
+        QueryResolutionEntry(
+            conversation=[{"input": "Where is my order?", "output": "It shipped."}]
         ),
-        pytest.param(
-            CustomLLMScoreEvaluator,
-            CustomLLMScoreEntry(**text_entry),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="llm_score-azure",
-        ),
-        pytest.param(
-            CustomLLMCategoryEvaluator,
-            CustomLLMCategoryEntry(**text_entry),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="llm_category-azure",
-        ),
-        pytest.param(
-            PairwiseCompareEvaluator,
-            PairwiseCompareEntry(
-                input="Which is better?",
-                candidate_a_id="a",
-                candidate_a_output="first",
-                candidate_b_id="b",
-                candidate_b_output="second",
-            ),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="pairwise_compare-azure",
-        ),
-        pytest.param(
-            SelectBestCompareEvaluator,
-            SelectBestCompareEntry(
-                input="Which is best?",
-                candidates=[
-                    {"id": "a", "output": "first"},
-                    {"id": "b", "output": "second"},
-                ],
-            ),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="select_best_compare-azure",
-        ),
-        pytest.param(
-            OffTopicEvaluator,
-            OffTopicEntry(input="Tell me about the weather"),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="off_topic-azure",
-        ),
-        pytest.param(
-            CompetitorLLMEvaluator,
-            CompetitorLLMEntry(**text_entry),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="competitor_llm-azure",
-        ),
-        pytest.param(
-            CompetitorLLMFunctionCallEvaluator,
-            CompetitorLLMFunctionCallEntry(**text_entry),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="competitor_llm_function_call-azure",
-        ),
-        pytest.param(
-            QueryResolutionEvaluator,
-            QueryResolutionEntry(
-                conversation=[{"input": "Where is my order?", "output": "It shipped."}]
-            ),
-            {"model": "azure/gpt-4o"},
-            AZURE_SENTINEL_ENV,
-            "sentinel-azure-key",
-            id="query_resolution-azure",
-        ),
-    ]
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="query_resolution-azure",
+    ),
+]
 
 
 @pytest.mark.parametrize(
-    "evaluator_cls, entry, settings, env, expected_api_key", evaluator_cases()
+    "evaluator_cls, entry, settings, env, expected_api_key", EVALUATOR_CASES
 )
 def test_the_request_credential_reaches_the_call_and_not_the_environment(
     captured_calls, evaluator_cls, entry, settings, env, expected_api_key

--- a/services/langevals/tests/deterministic/test_credential_isolation.py
+++ b/services/langevals/tests/deterministic/test_credential_isolation.py
@@ -1,0 +1,376 @@
+"""Request credentials reach the model call and never the process environment.
+
+Evaluators used to bridge request `env` to litellm by writing it into
+`os.environ`, some of them the whole dict. That is a cross-request boundary:
+with two evaluations in flight, whichever wrote last supplied credentials to
+both. These tests pin the replacement contract for every family that used to
+write:
+
+- the request env is resolved into explicit litellm call arguments
+  (api_key, api_base, api_version) by the patch layer, and
+- `os.environ` is byte-identical before, during, and after the evaluation.
+
+The provider is stubbed at the innermost layer, `litellm_patch.originals`,
+which is the unpatched litellm entry point: everything above it, the
+evaluator, dspy or langchain shims, and the whole patch pipeline, is real.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Same import guard as the other files in this directory (they must agree,
+# since the first file pytest collects is the one that actually imports the
+# module): `langevals.server` reads sys.argv and DISABLE_EVALUATORS_PRELOAD at
+# import time, and both are restored right after.
+_original_argv = sys.argv
+_original_preload = os.environ.get("DISABLE_EVALUATORS_PRELOAD")
+sys.argv = ["server.py", "--only", "langevals,ragas"]
+os.environ["DISABLE_EVALUATORS_PRELOAD"] = "1"
+try:
+    from langevals import server  # noqa: F401  (imports and patches litellm)
+finally:
+    sys.argv = _original_argv
+    if _original_preload is None:
+        os.environ.pop("DISABLE_EVALUATORS_PRELOAD", None)
+    else:
+        os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
+
+from langevals_core import litellm_patch
+from langevals_core.litellm_patch import patch_litellm_params
+from langevals_core.request_env import request_env
+
+
+def environment_snapshot() -> dict:
+    # PYTEST_CURRENT_TEST is pytest's own per-phase marker and changes under
+    # our feet; everything else must stay byte-identical.
+    return {k: v for k, v in os.environ.items() if k != "PYTEST_CURRENT_TEST"}
+
+
+# ---------------------------------------------------------------------------
+# The resolution layer itself, kwargs in, kwargs out.
+# ---------------------------------------------------------------------------
+
+
+def test_azure_credentials_resolve_into_call_arguments():
+    with request_env(
+        {
+            "AZURE_OPENAI_API_KEY": "req-azure-key",
+            "AZURE_OPENAI_ENDPOINT": "https://req.example.com",
+        }
+    ):
+        kwargs = patch_litellm_params({"model": "azure/gpt-4o"})
+    assert kwargs["api_key"] == "req-azure-key"
+    assert kwargs["api_base"] == "https://req.example.com"
+
+
+def test_azure_litellm_names_win_over_the_openai_spellings():
+    with request_env(
+        {
+            "AZURE_API_KEY": "litellm-name",
+            "AZURE_OPENAI_API_KEY": "openai-name",
+        }
+    ):
+        kwargs = patch_litellm_params({"model": "azure/gpt-4o"})
+    assert kwargs["api_key"] == "litellm-name"
+
+
+def test_openai_credentials_resolve_for_bare_model_names():
+    with request_env({"OPENAI_API_KEY": "req-openai-key"}):
+        kwargs = patch_litellm_params({"model": "gpt-5-mini"})
+    assert kwargs["api_key"] == "req-openai-key"
+
+
+def test_credentials_of_another_provider_do_not_apply():
+    with request_env({"OPENAI_API_KEY": "req-openai-key"}):
+        kwargs = patch_litellm_params({"model": "anthropic/claude-sonnet-5"})
+    assert "api_key" not in kwargs
+
+
+def test_an_explicit_call_argument_wins_over_the_request_env():
+    with request_env({"AZURE_API_VERSION": "from-env"}):
+        kwargs = patch_litellm_params(
+            {"model": "azure/gpt-4o", "api_version": "explicit"}
+        )
+    assert kwargs["api_version"] == "explicit"
+
+
+def test_x_litellm_variables_win_over_the_credential_mapping():
+    with request_env(
+        {"OPENAI_API_KEY": "mapped", "X_LITELLM_api_key": "passthrough"}
+    ):
+        kwargs = patch_litellm_params({"model": "openai/gpt-5-mini"})
+    assert kwargs["api_key"] == "passthrough"
+
+
+def test_the_deployment_name_rewrite_reads_the_request_env():
+    with request_env({"AZURE_DEPLOYMENT_NAME": "my-deployment"}):
+        kwargs = patch_litellm_params({"model": "azure/gpt-4o"})
+    assert kwargs["model"] == "azure/my-deployment"
+    with request_env({"AZURE_DEPLOYMENT_NAME": "my-deployment"}):
+        kwargs = patch_litellm_params({"model": "openai/gpt-5-mini"})
+    assert kwargs["model"] == "openai/gpt-5-mini"
+
+
+def test_resolution_never_writes_the_environment():
+    before = environment_snapshot()
+    with request_env(
+        {
+            "AZURE_OPENAI_API_KEY": "req-azure-key",
+            "X_LITELLM_api_key": "passthrough",
+            "AZURE_DEPLOYMENT_NAME": "my-deployment",
+        }
+    ):
+        patch_litellm_params({"model": "azure/gpt-4o"})
+    assert environment_snapshot() == before
+
+
+# ---------------------------------------------------------------------------
+# Every evaluator family that used to write os.environ, end to end.
+# ---------------------------------------------------------------------------
+
+
+def canned_tool_call_response(model: str):
+    from litellm.files.main import ModelResponse
+
+    return ModelResponse(
+        model=model,
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "evaluation", "arguments": "{}"},
+                        }
+                    ],
+                },
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+@pytest.fixture
+def captured_calls(monkeypatch):
+    calls: list[dict] = []
+
+    def recording_completion(*args, **kwargs):
+        calls.append(
+            {
+                "api_key": kwargs.get("api_key"),
+                "api_base": kwargs.get("api_base"),
+                "api_version": kwargs.get("api_version"),
+                "model": kwargs.get("model"),
+                # What the process environment held at the exact moment of
+                # the provider call, which is when a leaked credential would
+                # be read.
+                "global_openai_key": os.environ.get("OPENAI_API_KEY"),
+                "global_azure_key": os.environ.get("AZURE_API_KEY")
+                or os.environ.get("AZURE_OPENAI_API_KEY"),
+            }
+        )
+        return canned_tool_call_response(kwargs.get("model", "gpt-5-mini"))
+
+    monkeypatch.setitem(litellm_patch.originals, "completion", recording_completion)
+    return calls
+
+
+OPENAI_SENTINEL_ENV = {"OPENAI_API_KEY": "sentinel-openai-key"}
+AZURE_SENTINEL_ENV = {
+    "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
+    "AZURE_OPENAI_ENDPOINT": "https://sentinel.openai.azure.com",
+}
+
+
+def evaluator_cases():
+    from langevals_langevals.competitor_llm import CompetitorLLMEntry, CompetitorLLMEvaluator
+    from langevals_langevals.competitor_llm_function_call import (
+        CompetitorLLMFunctionCallEntry,
+        CompetitorLLMFunctionCallEvaluator,
+    )
+    from langevals_langevals.llm_boolean import CustomLLMBooleanEntry, CustomLLMBooleanEvaluator
+    from langevals_langevals.llm_category import CustomLLMCategoryEntry, CustomLLMCategoryEvaluator
+    from langevals_langevals.llm_score import CustomLLMScoreEntry, CustomLLMScoreEvaluator
+    from langevals_langevals.off_topic import OffTopicEntry, OffTopicEvaluator
+    from langevals_langevals.pairwise_compare import PairwiseCompareEntry, PairwiseCompareEvaluator
+    from langevals_langevals.query_resolution import (
+        QueryResolutionEntry,
+        QueryResolutionEvaluator,
+    )
+    from langevals_langevals.select_best_compare import (
+        SelectBestCompareEntry,
+        SelectBestCompareEvaluator,
+    )
+
+    text_entry = {"input": "What is the answer?", "output": "The answer is 42."}
+    return [
+        pytest.param(
+            CustomLLMBooleanEvaluator,
+            CustomLLMBooleanEntry(**text_entry),
+            {"model": "openai/gpt-5-mini"},
+            OPENAI_SENTINEL_ENV,
+            "sentinel-openai-key",
+            id="llm_boolean-openai",
+        ),
+        pytest.param(
+            CustomLLMBooleanEvaluator,
+            CustomLLMBooleanEntry(**text_entry),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="llm_boolean-azure",
+        ),
+        pytest.param(
+            CustomLLMScoreEvaluator,
+            CustomLLMScoreEntry(**text_entry),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="llm_score-azure",
+        ),
+        pytest.param(
+            CustomLLMCategoryEvaluator,
+            CustomLLMCategoryEntry(**text_entry),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="llm_category-azure",
+        ),
+        pytest.param(
+            PairwiseCompareEvaluator,
+            PairwiseCompareEntry(
+                input="Which is better?",
+                candidate_a_id="a",
+                candidate_a_output="first",
+                candidate_b_id="b",
+                candidate_b_output="second",
+            ),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="pairwise_compare-azure",
+        ),
+        pytest.param(
+            SelectBestCompareEvaluator,
+            SelectBestCompareEntry(
+                input="Which is best?",
+                candidates=[
+                    {"id": "a", "output": "first"},
+                    {"id": "b", "output": "second"},
+                ],
+            ),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="select_best_compare-azure",
+        ),
+        pytest.param(
+            OffTopicEvaluator,
+            OffTopicEntry(input="Tell me about the weather"),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="off_topic-azure",
+        ),
+        pytest.param(
+            CompetitorLLMEvaluator,
+            CompetitorLLMEntry(**text_entry),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="competitor_llm-azure",
+        ),
+        pytest.param(
+            CompetitorLLMFunctionCallEvaluator,
+            CompetitorLLMFunctionCallEntry(**text_entry),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="competitor_llm_function_call-azure",
+        ),
+        pytest.param(
+            QueryResolutionEvaluator,
+            QueryResolutionEntry(
+                conversation=[{"input": "Where is my order?", "output": "It shipped."}]
+            ),
+            {"model": "azure/gpt-4o"},
+            AZURE_SENTINEL_ENV,
+            "sentinel-azure-key",
+            id="query_resolution-azure",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "evaluator_cls, entry, settings, env, expected_api_key", evaluator_cases()
+)
+def test_the_request_credential_reaches_the_call_and_not_the_environment(
+    captured_calls, evaluator_cls, entry, settings, env, expected_api_key
+):
+    before = environment_snapshot()
+
+    evaluator = evaluator_cls(settings=settings, env=env)
+    results = evaluator.evaluate_batch([entry])
+
+    # The canned provider response carries an empty payload, so the
+    # evaluator may report an error result; what matters here is that it
+    # made its call and how. It must never swallow the whole batch.
+    assert len(results) == 1
+    assert environment_snapshot() == before
+    assert len(captured_calls) >= 1
+    for call in captured_calls:
+        assert call["api_key"] == expected_api_key
+        assert call["global_openai_key"] != "sentinel-openai-key"
+        assert call["global_azure_key"] != "sentinel-azure-key"
+        if call["model"].startswith("azure/"):
+            assert call["api_base"] == "https://sentinel.openai.azure.com"
+            assert call["api_version"] is not None
+
+
+def test_the_ragas_helper_no_longer_writes_the_environment():
+    """prepare_llm copied the whole request env into os.environ; now it must
+    build its client without touching the process environment at all."""
+    from langevals_ragas.lib.common import RagasSettings, prepare_llm
+    from langevals_ragas.response_relevancy import RagasResponseRelevancyEvaluator
+
+    before = environment_snapshot()
+    evaluator = RagasResponseRelevancyEvaluator(
+        settings={},
+        env={"OPENAI_API_KEY": "sentinel-openai-key", "CUSTOM_VAR": "sentinel"},
+    )
+    prepare_llm(evaluator, settings=RagasSettings(model="azure/gpt-4o"))
+    assert environment_snapshot() == before
+
+
+def test_constructing_any_evaluator_leaves_the_environment_alone():
+    """set_model_envs is gone: construction must not write a single variable.
+
+    Sweeps every evaluator class the server loaded, so a future evaluator
+    that reintroduces an environment write at construction fails here by
+    name.
+    """
+    from langevals.utils import get_evaluator_classes
+
+    sentinel_env = {
+        "OPENAI_API_KEY": "sentinel-openai-key",
+        "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
+        "X_LITELLM_api_key": "sentinel-passthrough",
+        "SOME_CUSTOM_VARIABLE": "sentinel-custom",
+    }
+    constructed = 0
+    before = environment_snapshot()
+    for evaluator_package in server.evaluators.values():
+        for evaluator_cls in get_evaluator_classes(evaluator_package):
+            evaluator_cls(settings={}, env=dict(sentinel_env))
+            constructed += 1
+            assert environment_snapshot() == before, (
+                f"{evaluator_cls.__name__} changed os.environ at construction"
+            )
+    assert constructed > 10

--- a/services/langevals/tests/deterministic/test_credential_isolation.py
+++ b/services/langevals/tests/deterministic/test_credential_isolation.py
@@ -1,24 +1,19 @@
-"""Request credentials reach the model call and never the process environment.
+"""The resolution layer: request env in, litellm call arguments out.
 
 Evaluators used to bridge request `env` to litellm by writing it into
 `os.environ`, some of them the whole dict. That is a cross-request boundary:
 with two evaluations in flight, whichever wrote last supplied credentials to
-both. These tests pin the replacement contract for every family that used to
-write:
+both. The replacement resolves the request env into explicit call arguments,
+and these tests pin that resolution: which variable becomes which argument,
+which provider it applies to, what an explicit argument outranks, and that
+nothing reaches the process environment on the way.
 
-- the request env is resolved into explicit litellm call arguments
-  (api_key, api_base, api_version) by the patch layer, and
-- `os.environ` is byte-identical before, during, and after the evaluation.
-
-The provider is stubbed at the innermost layer, `litellm_patch.originals`,
-which is the unpatched litellm entry point: everything above it, the
-evaluator, dspy or langchain shims, and the whole patch pipeline, is real.
+The same contract proved end to end, through every evaluator family that used
+to write, is in test_evaluator_credential_isolation.py.
 """
 
 import os
 import sys
-
-import pytest
 
 # Same import guard as the other files in this directory (they must agree,
 # since the first file pytest collects is the one that actually imports the
@@ -42,28 +37,8 @@ finally:
 # what the process actually holds.
 server.original_env = os.environ.copy()
 
-from langevals_core import litellm_patch
 from langevals_core.litellm_patch import patch_litellm_params
 from langevals_core.request_env import request_env
-from langevals_langevals.competitor_llm import CompetitorLLMEntry, CompetitorLLMEvaluator
-from langevals_langevals.competitor_llm_function_call import (
-    CompetitorLLMFunctionCallEntry,
-    CompetitorLLMFunctionCallEvaluator,
-)
-from langevals_langevals.llm_boolean import CustomLLMBooleanEntry, CustomLLMBooleanEvaluator
-from langevals_langevals.llm_category import CustomLLMCategoryEntry, CustomLLMCategoryEvaluator
-from langevals_langevals.llm_score import CustomLLMScoreEntry, CustomLLMScoreEvaluator
-from langevals_langevals.off_topic import OffTopicEntry, OffTopicEvaluator
-from langevals_langevals.pairwise_compare import PairwiseCompareEntry, PairwiseCompareEvaluator
-from langevals_langevals.query_resolution import (
-    QueryResolutionEntry,
-    QueryResolutionEvaluator,
-)
-from langevals_langevals.select_best_compare import (
-    SelectBestCompareEntry,
-    SelectBestCompareEvaluator,
-)
-
 
 def environment_snapshot() -> dict:
     # PYTEST_CURRENT_TEST is pytest's own per-phase marker and changes under
@@ -198,233 +173,3 @@ def test_resolution_never_writes_the_environment():
     ):
         patch_litellm_params({"model": "azure/gpt-4o"})
     assert environment_snapshot() == before
-
-
-# ---------------------------------------------------------------------------
-# Every evaluator family that used to write os.environ, end to end.
-# ---------------------------------------------------------------------------
-
-
-def canned_tool_call_response(model: str):
-    from litellm.files.main import ModelResponse
-
-    return ModelResponse(
-        model=model,
-        choices=[
-            {
-                "index": 0,
-                "finish_reason": "tool_calls",
-                "message": {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": "call_1",
-                            "type": "function",
-                            "function": {"name": "evaluation", "arguments": "{}"},
-                        }
-                    ],
-                },
-            }
-        ],
-        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
-    )
-
-
-@pytest.fixture
-def captured_calls(monkeypatch):
-    calls: list[dict] = []
-
-    def recording_completion(*args, **kwargs):
-        calls.append(
-            {
-                "api_key": kwargs.get("api_key"),
-                "api_base": kwargs.get("api_base"),
-                "api_version": kwargs.get("api_version"),
-                "model": kwargs.get("model"),
-                # What the process environment held at the exact moment of
-                # the provider call, which is when a leaked credential would
-                # be read.
-                "global_openai_key": os.environ.get("OPENAI_API_KEY"),
-                "global_azure_key": os.environ.get("AZURE_API_KEY")
-                or os.environ.get("AZURE_OPENAI_API_KEY"),
-            }
-        )
-        return canned_tool_call_response(kwargs.get("model", "gpt-5-mini"))
-
-    monkeypatch.setitem(litellm_patch.originals, "completion", recording_completion)
-    return calls
-
-
-OPENAI_SENTINEL_ENV = {"OPENAI_API_KEY": "sentinel-openai-key"}
-AZURE_SENTINEL_ENV = {
-    "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
-    "AZURE_OPENAI_ENDPOINT": "https://sentinel.openai.azure.com",
-}
-
-
-text_entry = {"input": "What is the answer?", "output": "The answer is 42."}
-EVALUATOR_CASES = [
-    pytest.param(
-        CustomLLMBooleanEvaluator,
-        CustomLLMBooleanEntry(**text_entry),
-        {"model": "openai/gpt-5-mini"},
-        OPENAI_SENTINEL_ENV,
-        "sentinel-openai-key",
-        id="llm_boolean-openai",
-    ),
-    pytest.param(
-        CustomLLMBooleanEvaluator,
-        CustomLLMBooleanEntry(**text_entry),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="llm_boolean-azure",
-    ),
-    pytest.param(
-        CustomLLMScoreEvaluator,
-        CustomLLMScoreEntry(**text_entry),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="llm_score-azure",
-    ),
-    pytest.param(
-        CustomLLMCategoryEvaluator,
-        CustomLLMCategoryEntry(**text_entry),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="llm_category-azure",
-    ),
-    pytest.param(
-        PairwiseCompareEvaluator,
-        PairwiseCompareEntry(
-            input="Which is better?",
-            candidate_a_id="a",
-            candidate_a_output="first",
-            candidate_b_id="b",
-            candidate_b_output="second",
-        ),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="pairwise_compare-azure",
-    ),
-    pytest.param(
-        SelectBestCompareEvaluator,
-        SelectBestCompareEntry(
-            input="Which is best?",
-            candidates=[
-                {"id": "a", "output": "first"},
-                {"id": "b", "output": "second"},
-            ],
-        ),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="select_best_compare-azure",
-    ),
-    pytest.param(
-        OffTopicEvaluator,
-        OffTopicEntry(input="Tell me about the weather"),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="off_topic-azure",
-    ),
-    pytest.param(
-        CompetitorLLMEvaluator,
-        CompetitorLLMEntry(**text_entry),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="competitor_llm-azure",
-    ),
-    pytest.param(
-        CompetitorLLMFunctionCallEvaluator,
-        CompetitorLLMFunctionCallEntry(**text_entry),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="competitor_llm_function_call-azure",
-    ),
-    pytest.param(
-        QueryResolutionEvaluator,
-        QueryResolutionEntry(
-            conversation=[{"input": "Where is my order?", "output": "It shipped."}]
-        ),
-        {"model": "azure/gpt-4o"},
-        AZURE_SENTINEL_ENV,
-        "sentinel-azure-key",
-        id="query_resolution-azure",
-    ),
-]
-
-
-@pytest.mark.parametrize(
-    "evaluator_cls, entry, settings, env, expected_api_key", EVALUATOR_CASES
-)
-def test_the_request_credential_reaches_the_call_and_not_the_environment(
-    captured_calls, evaluator_cls, entry, settings, env, expected_api_key
-):
-    before = environment_snapshot()
-
-    evaluator = evaluator_cls(settings=settings, env=env)
-    results = evaluator.evaluate_batch([entry])
-
-    # The canned provider response carries an empty payload, so the
-    # evaluator may report an error result; what matters here is that it
-    # made its call and how. It must never swallow the whole batch.
-    assert len(results) == 1
-    assert environment_snapshot() == before
-    assert len(captured_calls) >= 1
-    for call in captured_calls:
-        assert call["api_key"] == expected_api_key
-        assert call["global_openai_key"] != "sentinel-openai-key"
-        assert call["global_azure_key"] != "sentinel-azure-key"
-        if call["model"].startswith("azure/"):
-            assert call["api_base"] == "https://sentinel.openai.azure.com"
-            assert call["api_version"] is not None
-
-
-def test_the_ragas_helper_no_longer_writes_the_environment():
-    """prepare_llm copied the whole request env into os.environ; now it must
-    build its client without touching the process environment at all."""
-    from langevals_ragas.lib.common import RagasSettings, prepare_llm
-    from langevals_ragas.response_relevancy import RagasResponseRelevancyEvaluator
-
-    before = environment_snapshot()
-    evaluator = RagasResponseRelevancyEvaluator(
-        settings={},
-        env={"OPENAI_API_KEY": "sentinel-openai-key", "CUSTOM_VAR": "sentinel"},
-    )
-    prepare_llm(evaluator, settings=RagasSettings(model="azure/gpt-4o"))
-    assert environment_snapshot() == before
-
-
-def test_constructing_any_evaluator_leaves_the_environment_alone():
-    """set_model_envs is gone: construction must not write a single variable.
-
-    Sweeps every evaluator class the server loaded, so a future evaluator
-    that reintroduces an environment write at construction fails here by
-    name.
-    """
-    from langevals.utils import get_evaluator_classes
-
-    sentinel_env = {
-        "OPENAI_API_KEY": "sentinel-openai-key",
-        "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
-        "X_LITELLM_api_key": "sentinel-passthrough",
-        "SOME_CUSTOM_VARIABLE": "sentinel-custom",
-    }
-    constructed = 0
-    before = environment_snapshot()
-    for evaluator_package in server.evaluators.values():
-        for evaluator_cls in get_evaluator_classes(evaluator_package):
-            evaluator_cls(settings={}, env=dict(sentinel_env))
-            constructed += 1
-            assert environment_snapshot() == before, (
-                f"{evaluator_cls.__name__} changed os.environ at construction"
-            )
-    assert constructed > 10

--- a/services/langevals/tests/deterministic/test_evaluator_credential_isolation.py
+++ b/services/langevals/tests/deterministic/test_evaluator_credential_isolation.py
@@ -1,0 +1,299 @@
+"""Every evaluator family that used to write os.environ, end to end.
+
+Evaluators used to bridge request `env` to litellm by writing it into
+`os.environ`, some of them the whole dict. That is a cross-request boundary:
+with two evaluations in flight, whichever wrote last supplied credentials to
+both. These tests pin the replacement contract for every family that used to
+write:
+
+- the request env is resolved into explicit litellm call arguments
+  (api_key, api_base, api_version) by the patch layer, and
+- `os.environ` is byte-identical before, during, and after the evaluation.
+
+The provider is stubbed at the innermost layer, `litellm_patch.originals`,
+which is the unpatched litellm entry point: everything above it, the
+evaluator, dspy or langchain shims, and the whole patch pipeline, is real.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Same import guard as the other files in this directory (they must agree,
+# since the first file pytest collects is the one that actually imports the
+# module): `langevals.server` reads sys.argv and DISABLE_EVALUATORS_PRELOAD at
+# import time, and both are restored right after.
+_original_argv = sys.argv
+_original_preload = os.environ.get("DISABLE_EVALUATORS_PRELOAD")
+sys.argv = ["server.py", "--only", "langevals,ragas"]
+os.environ["DISABLE_EVALUATORS_PRELOAD"] = "1"
+try:
+    from langevals import server  # noqa: F401  (imports and patches litellm)
+finally:
+    sys.argv = _original_argv
+    if _original_preload is None:
+        os.environ.pop("DISABLE_EVALUATORS_PRELOAD", None)
+    else:
+        os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
+
+# The server captured its baseline while the temporary preload flag was set.
+# Rebase it on the clean environment, so the drift tripwire compares against
+# what the process actually holds.
+server.original_env = os.environ.copy()
+
+
+from langevals_core import litellm_patch
+from langevals_langevals.competitor_llm import CompetitorLLMEntry, CompetitorLLMEvaluator
+from langevals_langevals.competitor_llm_function_call import (
+    CompetitorLLMFunctionCallEntry,
+    CompetitorLLMFunctionCallEvaluator,
+)
+from langevals_langevals.llm_boolean import CustomLLMBooleanEntry, CustomLLMBooleanEvaluator
+from langevals_langevals.llm_category import CustomLLMCategoryEntry, CustomLLMCategoryEvaluator
+from langevals_langevals.llm_score import CustomLLMScoreEntry, CustomLLMScoreEvaluator
+from langevals_langevals.off_topic import OffTopicEntry, OffTopicEvaluator
+from langevals_langevals.pairwise_compare import PairwiseCompareEntry, PairwiseCompareEvaluator
+from langevals_langevals.query_resolution import (
+    QueryResolutionEntry,
+    QueryResolutionEvaluator,
+)
+from langevals_langevals.select_best_compare import (
+    SelectBestCompareEntry,
+    SelectBestCompareEvaluator,
+)
+
+def environment_snapshot() -> dict:
+    # PYTEST_CURRENT_TEST is pytest's own per-phase marker and changes under
+    # our feet; everything else must stay byte-identical.
+    return {k: v for k, v in os.environ.items() if k != "PYTEST_CURRENT_TEST"}
+
+
+# ---------------------------------------------------------------------------
+# Every evaluator family that used to write os.environ, end to end.
+# ---------------------------------------------------------------------------
+
+
+def canned_tool_call_response(model: str):
+    from litellm.files.main import ModelResponse
+
+    return ModelResponse(
+        model=model,
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "evaluation", "arguments": "{}"},
+                        }
+                    ],
+                },
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+@pytest.fixture
+def captured_calls(monkeypatch):
+    calls: list[dict] = []
+
+    def recording_completion(*args, **kwargs):
+        calls.append(
+            {
+                "api_key": kwargs.get("api_key"),
+                "api_base": kwargs.get("api_base"),
+                "api_version": kwargs.get("api_version"),
+                "model": kwargs.get("model"),
+                # What the process environment held at the exact moment of
+                # the provider call, which is when a leaked credential would
+                # be read.
+                "global_openai_key": os.environ.get("OPENAI_API_KEY"),
+                "global_azure_key": os.environ.get("AZURE_API_KEY")
+                or os.environ.get("AZURE_OPENAI_API_KEY"),
+            }
+        )
+        return canned_tool_call_response(kwargs.get("model", "gpt-5-mini"))
+
+    monkeypatch.setitem(litellm_patch.originals, "completion", recording_completion)
+    return calls
+
+
+OPENAI_SENTINEL_ENV = {"OPENAI_API_KEY": "sentinel-openai-key"}
+AZURE_SENTINEL_ENV = {
+    "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
+    "AZURE_OPENAI_ENDPOINT": "https://sentinel.openai.azure.com",
+}
+
+
+text_entry = {"input": "What is the answer?", "output": "The answer is 42."}
+EVALUATOR_CASES = [
+    pytest.param(
+        CustomLLMBooleanEvaluator,
+        CustomLLMBooleanEntry(**text_entry),
+        {"model": "openai/gpt-5-mini"},
+        OPENAI_SENTINEL_ENV,
+        "sentinel-openai-key",
+        id="llm_boolean-openai",
+    ),
+    pytest.param(
+        CustomLLMBooleanEvaluator,
+        CustomLLMBooleanEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="llm_boolean-azure",
+    ),
+    pytest.param(
+        CustomLLMScoreEvaluator,
+        CustomLLMScoreEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="llm_score-azure",
+    ),
+    pytest.param(
+        CustomLLMCategoryEvaluator,
+        CustomLLMCategoryEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="llm_category-azure",
+    ),
+    pytest.param(
+        PairwiseCompareEvaluator,
+        PairwiseCompareEntry(
+            input="Which is better?",
+            candidate_a_id="a",
+            candidate_a_output="first",
+            candidate_b_id="b",
+            candidate_b_output="second",
+        ),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="pairwise_compare-azure",
+    ),
+    pytest.param(
+        SelectBestCompareEvaluator,
+        SelectBestCompareEntry(
+            input="Which is best?",
+            candidates=[
+                {"id": "a", "output": "first"},
+                {"id": "b", "output": "second"},
+            ],
+        ),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="select_best_compare-azure",
+    ),
+    pytest.param(
+        OffTopicEvaluator,
+        OffTopicEntry(input="Tell me about the weather"),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="off_topic-azure",
+    ),
+    pytest.param(
+        CompetitorLLMEvaluator,
+        CompetitorLLMEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="competitor_llm-azure",
+    ),
+    pytest.param(
+        CompetitorLLMFunctionCallEvaluator,
+        CompetitorLLMFunctionCallEntry(**text_entry),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="competitor_llm_function_call-azure",
+    ),
+    pytest.param(
+        QueryResolutionEvaluator,
+        QueryResolutionEntry(
+            conversation=[{"input": "Where is my order?", "output": "It shipped."}]
+        ),
+        {"model": "azure/gpt-4o"},
+        AZURE_SENTINEL_ENV,
+        "sentinel-azure-key",
+        id="query_resolution-azure",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "evaluator_cls, entry, settings, env, expected_api_key", EVALUATOR_CASES
+)
+def test_the_request_credential_reaches_the_call_and_not_the_environment(
+    captured_calls, evaluator_cls, entry, settings, env, expected_api_key
+):
+    before = environment_snapshot()
+
+    evaluator = evaluator_cls(settings=settings, env=env)
+    results = evaluator.evaluate_batch([entry])
+
+    # The canned provider response carries an empty payload, so the
+    # evaluator may report an error result; what matters here is that it
+    # made its call and how. It must never swallow the whole batch.
+    assert len(results) == 1
+    assert environment_snapshot() == before
+    assert len(captured_calls) >= 1
+    for call in captured_calls:
+        assert call["api_key"] == expected_api_key
+        assert call["global_openai_key"] != "sentinel-openai-key"
+        assert call["global_azure_key"] != "sentinel-azure-key"
+        if call["model"].startswith("azure/"):
+            assert call["api_base"] == "https://sentinel.openai.azure.com"
+            assert call["api_version"] is not None
+
+
+def test_the_ragas_helper_no_longer_writes_the_environment():
+    """prepare_llm copied the whole request env into os.environ; now it must
+    build its client without touching the process environment at all."""
+    from langevals_ragas.lib.common import RagasSettings, prepare_llm
+    from langevals_ragas.response_relevancy import RagasResponseRelevancyEvaluator
+
+    before = environment_snapshot()
+    evaluator = RagasResponseRelevancyEvaluator(
+        settings={},
+        env={"OPENAI_API_KEY": "sentinel-openai-key", "CUSTOM_VAR": "sentinel"},
+    )
+    prepare_llm(evaluator, settings=RagasSettings(model="azure/gpt-4o"))
+    assert environment_snapshot() == before
+
+
+def test_constructing_any_evaluator_leaves_the_environment_alone():
+    """set_model_envs is gone: construction must not write a single variable.
+
+    Sweeps every evaluator class the server loaded, so a future evaluator
+    that reintroduces an environment write at construction fails here by
+    name.
+    """
+    from langevals.utils import get_evaluator_classes
+
+    sentinel_env = {
+        "OPENAI_API_KEY": "sentinel-openai-key",
+        "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
+        "X_LITELLM_api_key": "sentinel-passthrough",
+        "SOME_CUSTOM_VARIABLE": "sentinel-custom",
+    }
+    constructed = 0
+    before = environment_snapshot()
+    for evaluator_package in server.evaluators.values():
+        for evaluator_cls in get_evaluator_classes(evaluator_package):
+            evaluator_cls(settings={}, env=dict(sentinel_env))
+            constructed += 1
+            assert environment_snapshot() == before, (
+                f"{evaluator_cls.__name__} changed os.environ at construction"
+            )
+    assert constructed > 10

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -40,6 +40,11 @@ finally:
     else:
         os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
 
+# The server captured original_env while the temporary preload flag was set,
+# and the gate restores that snapshot after every burst. Rebase it on the
+# clean environment so the restore cannot leak the flag into other tests.
+server.original_env = os.environ.copy()
+
 
 @pytest.fixture
 def slow_exact_match(monkeypatch):
@@ -129,6 +134,7 @@ async def test_different_env_evaluations_never_overlap(slow_exact_match):
 
 @pytest.mark.anyio
 async def test_environment_is_restored_after_the_burst(slow_exact_match):
+    expected_env = dict(os.environ)
     transport = httpx.ASGITransport(app=server.app)
     env = {"OPENAI_API_KEY": "must-not-outlive-the-burst"}
     async with httpx.AsyncClient(
@@ -144,8 +150,67 @@ async def test_environment_is_restored_after_the_burst(slow_exact_match):
             )
         )
 
-    assert os.environ.get("OPENAI_API_KEY") != "must-not-outlive-the-burst"
-    assert "PATH" in os.environ
+    # The whole environment, not just the injected credential, is back to its
+    # pre-burst state. PYTEST_CURRENT_TEST is pytest's own per-phase marker:
+    # it was set after the server captured its baseline, so the restore
+    # legitimately drops it and pytest re-sets it on the next phase.
+    def without_pytest_marker(env: dict) -> dict:
+        return {k: v for k, v in env.items() if k != "PYTEST_CURRENT_TEST"}
+
+    assert without_pytest_marker(dict(os.environ)) == without_pytest_marker(
+        expected_env
+    )
+
+
+@pytest.mark.anyio
+async def test_waiting_environment_runs_before_later_requests_for_the_old_one(
+    slow_exact_match,
+):
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+
+        def post(key: str):
+            return asyncio.create_task(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request({"OPENAI_API_KEY": key}),
+                )
+            )
+
+        first_generation = [post("tenant-a-key") for _ in range(2)]
+        deadline = time.monotonic() + 5
+        while server.evaluation_gate.active_evaluations == 0:
+            if time.monotonic() >= deadline:
+                pytest.fail("The first generation was not admitted within 5s")
+            await asyncio.sleep(0.01)
+
+        tenant_b = post("tenant-b-key")
+        deadline = time.monotonic() + 5
+        while not server.evaluation_gate.waiting_environments:
+            if time.monotonic() >= deadline:
+                pytest.fail("The waiting environment never queued within 5s")
+            await asyncio.sleep(0.01)
+
+        # Arrives while tenant B is already waiting, so it must queue BEHIND
+        # tenant B even though its env matches the running generation.
+        late_tenant_a = post("tenant-a-key")
+
+        responses = await asyncio.gather(
+            *first_generation, tenant_b, late_tenant_a
+        )
+
+    assert all(r.status_code == 200 for r in responses)
+    by_key: dict[str, list[dict]] = {}
+    for observation in slow_exact_match:
+        by_key.setdefault(observation["openai_key"], []).append(observation)
+    b_evaluation = by_key["tenant-b-key"][0]
+    late_a_started = max(o["started"] for o in by_key["tenant-a-key"])
+    # Generations run in first-waiter order: B before the A request that
+    # queued after it, with no overlap between the generations.
+    assert b_evaluation["started"] < late_a_started
+    assert late_a_started >= b_evaluation["finished"]
 
 
 def test_gate_times_out_with_a_clear_error():

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -1,13 +1,17 @@
-"""Regression tests for concurrent evaluations sharing one environment.
+"""Regression tests for concurrent evaluations and credential isolation.
 
 The server used to run strictly one evaluation at a time per process, because
-each request's `env` (the caller's model credentials) is written into
-`os.environ` for litellm to read. That made a burst of N judge evaluations
+each request's `env` (the caller's model credentials) was written into
+`os.environ` for litellm to read: two concurrent evaluations with different
+credentials could read each other's. That made a burst of N judge evaluations
 take N times the single-call latency: a customer's 46-call experiment against
-a slow judge model took half an hour. Requests that carry the SAME
-credentials write identical values though, so they can safely overlap. The
-gate admits same-env evaluations together and only serializes generations
-with different envs.
+a slow judge model took half an hour.
+
+Now no evaluation touches `os.environ` at all. The request env is bound to the
+evaluation's own context (`langevals_core.request_env`) and resolved into
+explicit call arguments by the litellm patch layer, so evaluations run
+together whatever credentials they carry, and the gate only bounds how many
+run at once, first come first served.
 
 These tests drive the real ASGI app in-process. The slow evaluator is
 `langevals/exact_match` with its `evaluate` patched to sleep: `time.sleep`
@@ -43,8 +47,8 @@ finally:
         os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
 
 # The server captured original_env while the temporary preload flag was set,
-# and the gate restores that snapshot after every burst. Rebase it on the
-# clean environment so the restore cannot leak the flag into other tests.
+# and the drift tripwire compares against that snapshot. Rebase it on the
+# clean environment so the flag cannot read as drift.
 server.original_env = os.environ.copy()
 
 
@@ -99,7 +103,12 @@ def slow_exact_match(monkeypatch):
             {
                 "started": started,
                 "finished": time.monotonic(),
-                "openai_key": os.environ.get("OPENAI_API_KEY"),
+                # The credential this evaluation received, and what the
+                # process environment held while it ran. The first must be
+                # the request's own; the second must never hold any
+                # request's.
+                "request_key": (self.env or {}).get("OPENAI_API_KEY"),
+                "global_key": os.environ.get("OPENAI_API_KEY"),
             }
         )
         return original_evaluate(self, entry)
@@ -137,9 +146,79 @@ async def test_same_env_evaluations_run_concurrently(slow_exact_match):
 
     assert all(r.status_code == 200 for r in responses)
     assert len(slow_exact_match) == 4
-    # Four 0.8s evaluations sharing one env must overlap: serialized they
-    # would take at least 3.2s.
+    # Four 0.8s evaluations must overlap: serialized they would take at
+    # least 3.2s.
     assert wall < 2.4
+
+
+@pytest.mark.anyio
+async def test_different_env_evaluations_run_concurrently_without_crossing(
+    slow_exact_match,
+):
+    """Different credentials no longer serialize, and never cross.
+
+    This is the inversion of the old contract: when request credentials were
+    written into os.environ, overlapping two tenants would have swapped their
+    keys mid-call, so the server serialized them. With credentials bound to
+    each evaluation's own context, the two tenants must overlap, each must
+    see exactly its own key, and neither key may ever appear in the process
+    environment.
+    """
+    transport = httpx.ASGITransport(app=server.app)
+    tenant_keys = {"tenant-a-key", "tenant-b-key"}
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+        start = time.monotonic()
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request({"OPENAI_API_KEY": key}),
+                )
+                for key in sorted(tenant_keys)
+            )
+        )
+        wall = time.monotonic() - start
+
+    assert all(r.status_code == 200 for r in responses)
+    assert len(slow_exact_match) == 2
+    first, second = sorted(slow_exact_match, key=lambda o: o["started"])
+    # They overlapped: the second started before the first finished, and the
+    # pair beat the 1.6s serial floor.
+    assert second["started"] < first["finished"]
+    assert wall < 1.5
+    # Each evaluation carried its own credential, and no request credential
+    # ever reached the process environment.
+    assert {first["request_key"], second["request_key"]} == tenant_keys
+    assert first["global_key"] not in tenant_keys
+    assert second["global_key"] not in tenant_keys
+
+
+@pytest.mark.anyio
+async def test_the_process_environment_is_never_touched(slow_exact_match):
+    def without_pytest_marker(env: dict) -> dict:
+        # PYTEST_CURRENT_TEST is pytest's own per-phase marker and changes
+        # under our feet; everything else must be byte-identical.
+        return {k: v for k, v in env.items() if k != "PYTEST_CURRENT_TEST"}
+
+    before = without_pytest_marker(dict(os.environ))
+    transport = httpx.ASGITransport(app=server.app)
+    env = {"OPENAI_API_KEY": "must-never-enter-the-environment"}
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+        await asyncio.gather(
+            *(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request(env),
+                )
+                for _ in range(3)
+            )
+        )
+
+    assert without_pytest_marker(dict(os.environ)) == before
 
 
 @pytest.mark.anyio
@@ -199,158 +278,52 @@ async def test_a_burst_wider_than_the_default_thread_pool_runs_together(
     assert peak > ANYIO_DEFAULT_THREAD_POOL
 
 
-@pytest.mark.anyio
-async def test_different_env_evaluations_never_overlap(slow_exact_match):
-    transport = httpx.ASGITransport(app=server.app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test", timeout=120
-    ) as client:
-        responses = await asyncio.gather(
-            *(
-                client.post(
-                    "/langevals/exact_match/evaluate",
-                    json=evaluation_request({"OPENAI_API_KEY": key}),
-                )
-                for key in ("tenant-a-key", "tenant-b-key")
-            )
-        )
+def test_admissions_run_in_arrival_order():
+    """Waiters are admitted first come first served, never overtaken."""
+    gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=30)
+    entered: list[str] = []
+    entered_lock = threading.Lock()
+    releases = {name: threading.Event() for name in ("holder", "second", "third")}
+    threads: dict[str, threading.Thread] = {}
 
-    assert all(r.status_code == 200 for r in responses)
-    assert len(slow_exact_match) == 2
-    first, second = sorted(slow_exact_match, key=lambda o: o["started"])
-    # The second tenant's evaluation must not start until the first tenant's
-    # generation drained: overlapping them would swap credentials mid-call.
-    assert second["started"] >= first["finished"]
-    # And each evaluation saw its own credentials in the process env.
-    assert {first["openai_key"], second["openai_key"]} == {
-        "tenant-a-key",
-        "tenant-b-key",
-    }
+    def run(name: str) -> None:
+        with gate.admit():
+            with entered_lock:
+                entered.append(name)
+            releases[name].wait(5)
 
+    def start(name: str) -> None:
+        threads[name] = threading.Thread(target=run, args=(name,))
+        threads[name].start()
 
-@pytest.mark.anyio
-async def test_different_credentials_outside_the_provider_lists_never_overlap(
-    slow_exact_match,
-):
-    """A variable no provider list covers still separates two requests.
+    start("holder")
+    wait_until(lambda: gate.active_evaluations == 1, "The holder was not admitted")
+    start("second")
+    wait_until(lambda: gate.waiting_evaluations == 1, "The second never queued")
+    start("third")
+    wait_until(lambda: gate.waiting_evaluations == 2, "The third never queued")
 
-    `set_model_envs` is not the only writer of the process environment: the
-    custom LLM evaluators and every Ragas evaluator copy the whole request
-    env into `os.environ` while they run. Bedrock credentials travel that
-    way, so two tenants that differ only in an AWS variable would overwrite
-    each other if the gate let them share a generation.
-    """
-    transport = httpx.ASGITransport(app=server.app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test", timeout=120
-    ) as client:
-        responses = await asyncio.gather(
-            *(
-                client.post(
-                    "/langevals/exact_match/evaluate",
-                    json=evaluation_request(
-                        {
-                            "AWS_ACCESS_KEY_ID": f"{tenant}-id",
-                            "AWS_SECRET_ACCESS_KEY": f"{tenant}-secret",
-                        }
-                    ),
-                )
-                for tenant in ("tenant-a", "tenant-b")
-            )
-        )
+    releases["holder"].set()
+    wait_until(lambda: "second" in entered, "The second was not admitted")
+    # The third is still waiting: capacity is 1 and the second holds it.
+    assert "third" not in entered
+    releases["second"].set()
+    wait_until(lambda: "third" in entered, "The third was not admitted")
+    releases["third"].set()
 
-    assert all(r.status_code == 200 for r in responses)
-    assert len(slow_exact_match) == 2
-    first, second = sorted(slow_exact_match, key=lambda o: o["started"])
-    assert second["started"] >= first["finished"]
-
-
-@pytest.mark.anyio
-async def test_environment_is_restored_after_the_burst(slow_exact_match):
-    expected_env = dict(os.environ)
-    transport = httpx.ASGITransport(app=server.app)
-    env = {"OPENAI_API_KEY": "must-not-outlive-the-burst"}
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test", timeout=120
-    ) as client:
-        await asyncio.gather(
-            *(
-                client.post(
-                    "/langevals/exact_match/evaluate",
-                    json=evaluation_request(env),
-                )
-                for _ in range(3)
-            )
-        )
-
-    # The whole environment, not just the injected credential, is back to its
-    # pre-burst state. PYTEST_CURRENT_TEST is pytest's own per-phase marker:
-    # it was set after the server captured its baseline, so the restore
-    # legitimately drops it and pytest re-sets it on the next phase.
-    def without_pytest_marker(env: dict) -> dict:
-        return {k: v for k, v in env.items() if k != "PYTEST_CURRENT_TEST"}
-
-    assert without_pytest_marker(dict(os.environ)) == without_pytest_marker(
-        expected_env
-    )
-
-
-@pytest.mark.anyio
-async def test_waiting_environment_runs_before_later_requests_for_the_old_one(
-    slow_exact_match,
-):
-    transport = httpx.ASGITransport(app=server.app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test", timeout=120
-    ) as client:
-
-        def post(key: str):
-            return asyncio.create_task(
-                client.post(
-                    "/langevals/exact_match/evaluate",
-                    json=evaluation_request({"OPENAI_API_KEY": key}),
-                )
-            )
-
-        first_generation = [post("tenant-a-key") for _ in range(2)]
-        deadline = time.monotonic() + 5
-        while server.evaluation_gate.active_evaluations == 0:
-            if time.monotonic() >= deadline:
-                pytest.fail("The first generation was not admitted within 5s")
-            await asyncio.sleep(0.01)
-
-        tenant_b = post("tenant-b-key")
-        deadline = time.monotonic() + 5
-        while not server.evaluation_gate.waiting_environments:
-            if time.monotonic() >= deadline:
-                pytest.fail("The waiting environment never queued within 5s")
-            await asyncio.sleep(0.01)
-
-        # Arrives while tenant B is already waiting, so it must queue BEHIND
-        # tenant B even though its env matches the running generation.
-        late_tenant_a = post("tenant-a-key")
-
-        responses = await asyncio.gather(
-            *first_generation, tenant_b, late_tenant_a
-        )
-
-    assert all(r.status_code == 200 for r in responses)
-    by_key: dict[str, list[dict]] = {}
-    for observation in slow_exact_match:
-        by_key.setdefault(observation["openai_key"], []).append(observation)
-    b_evaluation = by_key["tenant-b-key"][0]
-    late_a_started = max(o["started"] for o in by_key["tenant-a-key"])
-    # Generations run in first-waiter order: B before the A request that
-    # queued after it, with no overlap between the generations.
-    assert b_evaluation["started"] < late_a_started
-    assert late_a_started >= b_evaluation["finished"]
+    for name, thread in threads.items():
+        thread.join(timeout=5)
+        assert not thread.is_alive(), f"{name} never finished"
+    assert entered == ["holder", "second", "third"]
+    assert gate.active_evaluations == 0
+    assert gate.waiting_evaluations == 0
 
 
 def test_gate_times_out_with_a_clear_error():
     gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=0.05)
-    with gate.admit(()):
+    with gate.admit():
         with pytest.raises(server.EvaluationQueueTimeout):
-            with gate.admit((("OPENAI_API_KEY", "other"),)):
+            with gate.admit():
                 pass
 
 
@@ -358,16 +331,15 @@ def test_capacity_freed_after_the_deadline_does_not_admit():
     clock = ManualClock()
     gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=30, clock=clock)
     release = threading.Event()
-    late_key = (("OPENAI_API_KEY", "late"),)
     late_outcome: list[str] = []
 
     def holder():
-        with gate.admit(()):
+        with gate.admit():
             release.wait(5)
 
     def late_request():
         try:
-            with gate.admit(late_key):
+            with gate.admit():
                 late_outcome.append("admitted")
         except server.EvaluationQueueTimeout:
             late_outcome.append("timed out")
@@ -379,7 +351,7 @@ def test_capacity_freed_after_the_deadline_does_not_admit():
     waiting = threading.Thread(target=late_request)
     waiting.start()
     wait_until(
-        lambda: gate.waiting_environments == [late_key],
+        lambda: gate.waiting_evaluations == 1,
         "The late request never queued",
     )
 
@@ -394,107 +366,8 @@ def test_capacity_freed_after_the_deadline_does_not_admit():
     assert not waiting.is_alive()
     assert not holding.is_alive()
     assert late_outcome == ["timed out"]
-    assert gate.waiting_environments == []
+    assert gate.waiting_evaluations == 0
     assert gate.active_evaluations == 0
     # The gate is healthy afterwards: a fresh request admits immediately.
-    with gate.admit((("OPENAI_API_KEY", "fresh"),)):
+    with gate.admit():
         assert gate.active_evaluations == 1
-
-
-def test_a_repeating_environment_cannot_hold_the_queue_front():
-    """A request joins a queued generation of its own env, but not a running one.
-
-    Requests that arrive while their own env is still queued join that
-    queued generation, because batching same-env work is what the gate is
-    for. That costs the env behind them one generation, never more: the
-    moment the generation starts, its waiters leave the queue and the front
-    belongs to the next env, so every later request of the running env
-    queues behind it. A repeating env therefore cannot hold the front.
-    """
-    gate = server.EvaluationGate(max_concurrent=3, timeout_seconds=30)
-    env_a = (("OPENAI_API_KEY", "a"),)
-    env_b = (("OPENAI_API_KEY", "b"),)
-    env_c = (("OPENAI_API_KEY", "c"),)
-    entered: list[str] = []
-    entered_lock = threading.Lock()
-    releases = {name: threading.Event() for name in ("a", "b1", "b2", "c", "b3")}
-    threads: dict[str, threading.Thread] = {}
-
-    def entered_so_far() -> list[str]:
-        with entered_lock:
-            return list(entered)
-
-    def start(name: str, key: tuple) -> None:
-        def run():
-            with gate.admit(key):
-                with entered_lock:
-                    entered.append(name)
-                releases[name].wait(5)
-
-        threads[name] = threading.Thread(target=run)
-        threads[name].start()
-
-    start("a", env_a)
-    wait_until(lambda: gate.active_evaluations == 1, "A was not admitted")
-
-    start("b1", env_b)
-    wait_until(lambda: gate.waiting_environments == [env_b], "B never queued")
-    start("c", env_c)
-    wait_until(
-        lambda: gate.waiting_environments == [env_b, env_c],
-        "C never queued behind B",
-    )
-    # Arrives while B is still queued and C waits behind it, so it joins B's
-    # queued generation instead of forming a third one after C.
-    start("b2", env_b)
-    wait_until(lambda: gate.waiting_evaluations == 3, "The second B never queued")
-
-    releases["a"].set()
-    wait_until(
-        lambda: gate.active_evaluations == 2, "Both B requests did not run together"
-    )
-
-    # B is running now, so it no longer holds the queue front. This request
-    # queues behind C even though its env matches the running generation and
-    # the gate still has spare capacity.
-    start("b3", env_b)
-    wait_until(
-        lambda: gate.waiting_environments == [env_c, env_b],
-        "The late B never queued behind C",
-    )
-
-    releases["b1"].set()
-    releases["b2"].set()
-    wait_until(lambda: "c" in entered_so_far(), "C did not run after B drained")
-    releases["c"].set()
-    wait_until(lambda: "b3" in entered_so_far(), "The late B did not run after C")
-    releases["b3"].set()
-
-    for name, thread in threads.items():
-        thread.join(timeout=5)
-        assert not thread.is_alive(), f"{name} never finished"
-
-    assert entered[0] == "a"
-    assert set(entered[1:3]) == {"b1", "b2"}
-    assert entered[3:] == ["c", "b3"]
-    assert gate.active_evaluations == 0
-    assert gate.waiting_evaluations == 0
-
-
-def test_the_env_key_separates_requests_by_every_variable():
-    assert server.request_env_key(None) == ()
-    assert server.request_env_key({}) == ()
-    same = {"OPENAI_API_KEY": "k", "AZURE_API_KEY": "a"}
-    assert server.request_env_key(same) == server.request_env_key(
-        dict(reversed(same.items()))
-    )
-    assert server.request_env_key({"OPENAI_API_KEY": "k"}) != server.request_env_key(
-        {"OPENAI_API_KEY": "other"}
-    )
-    # A credential no provider list here covers still changes the key. Bedrock
-    # reaches litellm through AWS variables, and the evaluators that copy the
-    # whole env would otherwise overwrite each other while both run.
-    assert server.request_env_key({"AWS_SECRET_ACCESS_KEY": "a"}) != ()
-    assert server.request_env_key(
-        {"AWS_SECRET_ACCESS_KEY": "a"}
-    ) != server.request_env_key({"AWS_SECRET_ACCESS_KEY": "b"})

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -229,6 +229,43 @@ async def test_different_env_evaluations_never_overlap(slow_exact_match):
 
 
 @pytest.mark.anyio
+async def test_different_credentials_outside_the_provider_lists_never_overlap(
+    slow_exact_match,
+):
+    """A variable no provider list covers still separates two requests.
+
+    `set_model_envs` is not the only writer of the process environment: the
+    custom LLM evaluators and every Ragas evaluator copy the whole request
+    env into `os.environ` while they run. Bedrock credentials travel that
+    way, so two tenants that differ only in an AWS variable would overwrite
+    each other if the gate let them share a generation.
+    """
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request(
+                        {
+                            "AWS_ACCESS_KEY_ID": f"{tenant}-id",
+                            "AWS_SECRET_ACCESS_KEY": f"{tenant}-secret",
+                        }
+                    ),
+                )
+                for tenant in ("tenant-a", "tenant-b")
+            )
+        )
+
+    assert all(r.status_code == 200 for r in responses)
+    assert len(slow_exact_match) == 2
+    first, second = sorted(slow_exact_match, key=lambda o: o["started"])
+    assert second["started"] >= first["finished"]
+
+
+@pytest.mark.anyio
 async def test_environment_is_restored_after_the_burst(slow_exact_match):
     expected_env = dict(os.environ)
     transport = httpx.ASGITransport(app=server.app)
@@ -444,11 +481,20 @@ def test_a_repeating_environment_cannot_hold_the_queue_front():
     assert gate.waiting_evaluations == 0
 
 
-def test_model_env_key_ignores_non_model_vars():
-    assert server.model_env_key(None) == ()
-    assert server.model_env_key({"NOT_A_MODEL_VAR": "x"}) == ()
+def test_the_env_key_separates_requests_by_every_variable():
+    assert server.request_env_key(None) == ()
+    assert server.request_env_key({}) == ()
     same = {"OPENAI_API_KEY": "k", "AZURE_API_KEY": "a"}
-    assert server.model_env_key(same) == server.model_env_key(dict(reversed(same.items())))
-    assert server.model_env_key({"OPENAI_API_KEY": "k"}) != server.model_env_key(
+    assert server.request_env_key(same) == server.request_env_key(
+        dict(reversed(same.items()))
+    )
+    assert server.request_env_key({"OPENAI_API_KEY": "k"}) != server.request_env_key(
         {"OPENAI_API_KEY": "other"}
     )
+    # A credential no provider list here covers still changes the key. Bedrock
+    # reaches litellm through AWS variables, and the evaluators that copy the
+    # whole env would otherwise overwrite each other while both run.
+    assert server.request_env_key({"AWS_SECRET_ACCESS_KEY": "a"}) != ()
+    assert server.request_env_key(
+        {"AWS_SECRET_ACCESS_KEY": "a"}
+    ) != server.request_env_key({"AWS_SECRET_ACCESS_KEY": "b"})

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -21,6 +21,7 @@ import sys
 import threading
 import time
 
+import anyio.to_thread
 import httpx
 import pytest
 
@@ -69,6 +70,11 @@ class ManualClock:
     def advance(self, seconds: float) -> None:
         with self._lock:
             self._now += seconds
+
+
+# AnyIO's default worker-thread pool, which is what caps sync endpoints
+# until the server sizes it for the gate.
+ANYIO_DEFAULT_THREAD_POOL = 40
 
 
 def wait_until(condition, description: str, timeout: float = 5) -> None:
@@ -134,6 +140,63 @@ async def test_same_env_evaluations_run_concurrently(slow_exact_match):
     # Four 0.8s evaluations sharing one env must overlap: serialized they
     # would take at least 3.2s.
     assert wall < 2.4
+
+
+@pytest.mark.anyio
+async def test_the_thread_pool_has_room_for_every_evaluation_the_gate_admits():
+    limiter = anyio.to_thread.current_default_thread_limiter()
+    assert limiter.total_tokens == ANYIO_DEFAULT_THREAD_POOL
+    async with server.lifespan(server.app):
+        assert limiter.total_tokens >= server.MAX_CONCURRENT_EVALUATIONS
+
+
+@pytest.mark.anyio
+async def test_a_burst_wider_than_the_default_thread_pool_runs_together(
+    slow_exact_match,
+):
+    """The knob decides the width, not the framework's thread pool.
+
+    Sync endpoints run on AnyIO's worker threads, and a request with no
+    thread waits before it reaches the gate. With the pool left at its
+    default the gate could never admit more than 40 evaluations whatever the
+    knob said, and the requests above that would queue where the gate cannot
+    order them.
+    """
+    if server.MAX_CONCURRENT_EVALUATIONS <= ANYIO_DEFAULT_THREAD_POOL:
+        pytest.skip("the knob is below the default pool, so there is nothing to prove")
+
+    burst = ANYIO_DEFAULT_THREAD_POOL + 8
+    env = {"OPENAI_API_KEY": "one-tenant"}
+    peak = 0
+
+    async def sample_active():
+        nonlocal peak
+        while True:
+            peak = max(peak, server.evaluation_gate.active_evaluations)
+            await asyncio.sleep(0.005)
+
+    transport = httpx.ASGITransport(app=server.app)
+    async with server.lifespan(server.app):
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test", timeout=120
+        ) as client:
+            sampler = asyncio.create_task(sample_active())
+            try:
+                responses = await asyncio.gather(
+                    *(
+                        client.post(
+                            "/langevals/exact_match/evaluate",
+                            json=evaluation_request(env),
+                        )
+                        for _ in range(burst)
+                    )
+                )
+            finally:
+                sampler.cancel()
+
+    assert all(r.status_code == 200 for r in responses)
+    assert len(slow_exact_match) == burst
+    assert peak > ANYIO_DEFAULT_THREAD_POOL
 
 
 @pytest.mark.anyio

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -301,6 +301,86 @@ def test_capacity_freed_after_the_deadline_does_not_admit():
         assert gate.active_evaluations == 1
 
 
+def test_a_repeating_environment_cannot_hold_the_queue_front():
+    """A request joins a queued generation of its own env, but not a running one.
+
+    Requests that arrive while their own env is still queued join that
+    queued generation, because batching same-env work is what the gate is
+    for. That costs the env behind them one generation, never more: the
+    moment the generation starts, its waiters leave the queue and the front
+    belongs to the next env, so every later request of the running env
+    queues behind it. A repeating env therefore cannot hold the front.
+    """
+    gate = server.EvaluationGate(max_concurrent=3, timeout_seconds=30)
+    env_a = (("OPENAI_API_KEY", "a"),)
+    env_b = (("OPENAI_API_KEY", "b"),)
+    env_c = (("OPENAI_API_KEY", "c"),)
+    entered: list[str] = []
+    entered_lock = threading.Lock()
+    releases = {name: threading.Event() for name in ("a", "b1", "b2", "c", "b3")}
+    threads: dict[str, threading.Thread] = {}
+
+    def entered_so_far() -> list[str]:
+        with entered_lock:
+            return list(entered)
+
+    def start(name: str, key: tuple) -> None:
+        def run():
+            with gate.admit(key):
+                with entered_lock:
+                    entered.append(name)
+                releases[name].wait(5)
+
+        threads[name] = threading.Thread(target=run)
+        threads[name].start()
+
+    start("a", env_a)
+    wait_until(lambda: gate.active_evaluations == 1, "A was not admitted")
+
+    start("b1", env_b)
+    wait_until(lambda: gate.waiting_environments == [env_b], "B never queued")
+    start("c", env_c)
+    wait_until(
+        lambda: gate.waiting_environments == [env_b, env_c],
+        "C never queued behind B",
+    )
+    # Arrives while B is still queued and C waits behind it, so it joins B's
+    # queued generation instead of forming a third one after C.
+    start("b2", env_b)
+    wait_until(lambda: gate.waiting_evaluations == 3, "The second B never queued")
+
+    releases["a"].set()
+    wait_until(
+        lambda: gate.active_evaluations == 2, "Both B requests did not run together"
+    )
+
+    # B is running now, so it no longer holds the queue front. This request
+    # queues behind C even though its env matches the running generation and
+    # the gate still has spare capacity.
+    start("b3", env_b)
+    wait_until(
+        lambda: gate.waiting_environments == [env_c, env_b],
+        "The late B never queued behind C",
+    )
+
+    releases["b1"].set()
+    releases["b2"].set()
+    wait_until(lambda: "c" in entered_so_far(), "C did not run after B drained")
+    releases["c"].set()
+    wait_until(lambda: "b3" in entered_so_far(), "The late B did not run after C")
+    releases["b3"].set()
+
+    for name, thread in threads.items():
+        thread.join(timeout=5)
+        assert not thread.is_alive(), f"{name} never finished"
+
+    assert entered[0] == "a"
+    assert set(entered[1:3]) == {"b1", "b2"}
+    assert entered[3:] == ["c", "b3"]
+    assert gate.active_evaluations == 0
+    assert gate.waiting_evaluations == 0
+
+
 def test_model_env_key_ignores_non_model_vars():
     assert server.model_env_key(None) == ()
     assert server.model_env_key({"NOT_A_MODEL_VAR": "x"}) == ()

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -18,6 +18,7 @@ any provider dependency.
 import asyncio
 import os
 import sys
+import threading
 import time
 
 import httpx
@@ -219,6 +220,37 @@ def test_gate_times_out_with_a_clear_error():
         with pytest.raises(server.EvaluationQueueTimeout):
             with gate.admit((("OPENAI_API_KEY", "other"),)):
                 pass
+
+
+def test_capacity_freed_after_the_deadline_does_not_admit():
+    gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=0.05)
+    release = threading.Event()
+
+    def holder():
+        with gate.admit(()):
+            release.wait(2)
+
+    holding = threading.Thread(target=holder)
+    holding.start()
+    deadline = time.monotonic() + 2
+    while gate.active_evaluations == 0:
+        if time.monotonic() >= deadline:
+            pytest.fail("The holder was not admitted within 2s")
+        time.sleep(0.005)
+
+    # Free the capacity only after every waiter's 0.05s deadline has passed:
+    # none of them may be admitted late, and none may linger in the queue.
+    threading.Timer(0.3, release.set).start()
+    for _ in range(3):
+        with pytest.raises(server.EvaluationQueueTimeout):
+            with gate.admit((("OPENAI_API_KEY", "late"),)):
+                pass
+    holding.join(timeout=2)
+    assert not holding.is_alive()
+    assert gate.waiting_environments == []
+    # The gate is healthy afterwards: a fresh request admits immediately.
+    with gate.admit((("OPENAI_API_KEY", "fresh"),)):
+        assert gate.active_evaluations == 1
 
 
 def test_model_env_key_ignores_non_model_vars():

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -47,6 +47,38 @@ finally:
 server.original_env = os.environ.copy()
 
 
+class ManualClock:
+    """A monotonic clock the test moves by hand.
+
+    Real time cannot produce one of the cases the gate has to handle: a
+    request that is still queued after its deadline passed. On a real clock
+    such a waiter wakes on its own timeout the moment the deadline passes, so
+    capacity can never free while it is both queued and expired. Advancing
+    this clock puts the blocked waiter past its deadline first, and the
+    release then follows.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._now = 0.0
+
+    def __call__(self) -> float:
+        with self._lock:
+            return self._now
+
+    def advance(self, seconds: float) -> None:
+        with self._lock:
+            self._now += seconds
+
+
+def wait_until(condition, description: str, timeout: float = 5) -> None:
+    deadline = time.monotonic() + timeout
+    while not condition():
+        if time.monotonic() >= deadline:
+            pytest.fail(f"{description} within {timeout}s")
+        time.sleep(0.005)
+
+
 @pytest.fixture
 def slow_exact_match(monkeypatch):
     from langevals_langevals.exact_match import ExactMatchEvaluator
@@ -223,31 +255,47 @@ def test_gate_times_out_with_a_clear_error():
 
 
 def test_capacity_freed_after_the_deadline_does_not_admit():
-    gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=0.05)
+    clock = ManualClock()
+    gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=30, clock=clock)
     release = threading.Event()
+    late_key = (("OPENAI_API_KEY", "late"),)
+    late_outcome: list[str] = []
 
     def holder():
         with gate.admit(()):
-            release.wait(2)
+            release.wait(5)
+
+    def late_request():
+        try:
+            with gate.admit(late_key):
+                late_outcome.append("admitted")
+        except server.EvaluationQueueTimeout:
+            late_outcome.append("timed out")
 
     holding = threading.Thread(target=holder)
     holding.start()
-    deadline = time.monotonic() + 2
-    while gate.active_evaluations == 0:
-        if time.monotonic() >= deadline:
-            pytest.fail("The holder was not admitted within 2s")
-        time.sleep(0.005)
+    wait_until(lambda: gate.active_evaluations == 1, "The holder was not admitted")
 
-    # Free the capacity only after every waiter's 0.05s deadline has passed:
-    # none of them may be admitted late, and none may linger in the queue.
-    threading.Timer(0.3, release.set).start()
-    for _ in range(3):
-        with pytest.raises(server.EvaluationQueueTimeout):
-            with gate.admit((("OPENAI_API_KEY", "late"),)):
-                pass
-    holding.join(timeout=2)
+    waiting = threading.Thread(target=late_request)
+    waiting.start()
+    wait_until(
+        lambda: gate.waiting_environments == [late_key],
+        "The late request never queued",
+    )
+
+    # The deadline of the queued request passes BEFORE the capacity it waits
+    # for frees. Its caller already gave up, so the gate must reject it
+    # instead of starting it now and delaying the live requests behind it.
+    clock.advance(31)
+    release.set()
+
+    waiting.join(timeout=5)
+    holding.join(timeout=5)
+    assert not waiting.is_alive()
     assert not holding.is_alive()
+    assert late_outcome == ["timed out"]
     assert gate.waiting_environments == []
+    assert gate.active_evaluations == 0
     # The gate is healthy afterwards: a fresh request admits immediately.
     with gate.admit((("OPENAI_API_KEY", "fresh"),)):
         assert gate.active_evaluations == 1

--- a/services/langevals/tests/deterministic/test_server_concurrency.py
+++ b/services/langevals/tests/deterministic/test_server_concurrency.py
@@ -1,0 +1,166 @@
+"""Regression tests for concurrent evaluations sharing one environment.
+
+The server used to run strictly one evaluation at a time per process, because
+each request's `env` (the caller's model credentials) is written into
+`os.environ` for litellm to read. That made a burst of N judge evaluations
+take N times the single-call latency: a customer's 46-call experiment against
+a slow judge model took half an hour. Requests that carry the SAME
+credentials write identical values though, so they can safely overlap. The
+gate admits same-env evaluations together and only serializes generations
+with different envs.
+
+These tests drive the real ASGI app in-process. The slow evaluator is
+`langevals/exact_match` with its `evaluate` patched to sleep: `time.sleep`
+releases the GIL, standing in for the network wait of a judge call without
+any provider dependency.
+"""
+
+import asyncio
+import os
+import sys
+import time
+
+import httpx
+import pytest
+
+# Same import guard as test_server_responsiveness (they must agree, since the
+# first of the two files pytest collects is the one that actually imports the
+# module): `langevals.server` reads sys.argv and DISABLE_EVALUATORS_PRELOAD at
+# import time, and both are restored right after.
+_original_argv = sys.argv
+_original_preload = os.environ.get("DISABLE_EVALUATORS_PRELOAD")
+sys.argv = ["server.py", "--only", "langevals,ragas"]
+os.environ["DISABLE_EVALUATORS_PRELOAD"] = "1"
+try:
+    from langevals import server
+finally:
+    sys.argv = _original_argv
+    if _original_preload is None:
+        os.environ.pop("DISABLE_EVALUATORS_PRELOAD", None)
+    else:
+        os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
+
+
+@pytest.fixture
+def slow_exact_match(monkeypatch):
+    from langevals_langevals.exact_match import ExactMatchEvaluator
+
+    observations: list[dict] = []
+    original_evaluate = ExactMatchEvaluator.evaluate
+
+    def slow_evaluate(self, entry):
+        started = time.monotonic()
+        time.sleep(0.8)
+        observations.append(
+            {
+                "started": started,
+                "finished": time.monotonic(),
+                "openai_key": os.environ.get("OPENAI_API_KEY"),
+            }
+        )
+        return original_evaluate(self, entry)
+
+    monkeypatch.setattr(ExactMatchEvaluator, "evaluate", slow_evaluate)
+    return observations
+
+
+def evaluation_request(env: dict) -> dict:
+    return {
+        "data": [{"output": "42", "expected_output": "42"}],
+        "settings": {},
+        "env": env,
+    }
+
+
+@pytest.mark.anyio
+async def test_same_env_evaluations_run_concurrently(slow_exact_match):
+    transport = httpx.ASGITransport(app=server.app)
+    env = {"OPENAI_API_KEY": "same-key-for-both"}
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+        start = time.monotonic()
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request(env),
+                )
+                for _ in range(4)
+            )
+        )
+        wall = time.monotonic() - start
+
+    assert all(r.status_code == 200 for r in responses)
+    assert len(slow_exact_match) == 4
+    # Four 0.8s evaluations sharing one env must overlap: serialized they
+    # would take at least 3.2s.
+    assert wall < 2.4
+
+
+@pytest.mark.anyio
+async def test_different_env_evaluations_never_overlap(slow_exact_match):
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request({"OPENAI_API_KEY": key}),
+                )
+                for key in ("tenant-a-key", "tenant-b-key")
+            )
+        )
+
+    assert all(r.status_code == 200 for r in responses)
+    assert len(slow_exact_match) == 2
+    first, second = sorted(slow_exact_match, key=lambda o: o["started"])
+    # The second tenant's evaluation must not start until the first tenant's
+    # generation drained: overlapping them would swap credentials mid-call.
+    assert second["started"] >= first["finished"]
+    # And each evaluation saw its own credentials in the process env.
+    assert {first["openai_key"], second["openai_key"]} == {
+        "tenant-a-key",
+        "tenant-b-key",
+    }
+
+
+@pytest.mark.anyio
+async def test_environment_is_restored_after_the_burst(slow_exact_match):
+    transport = httpx.ASGITransport(app=server.app)
+    env = {"OPENAI_API_KEY": "must-not-outlive-the-burst"}
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test", timeout=120
+    ) as client:
+        await asyncio.gather(
+            *(
+                client.post(
+                    "/langevals/exact_match/evaluate",
+                    json=evaluation_request(env),
+                )
+                for _ in range(3)
+            )
+        )
+
+    assert os.environ.get("OPENAI_API_KEY") != "must-not-outlive-the-burst"
+    assert "PATH" in os.environ
+
+
+def test_gate_times_out_with_a_clear_error():
+    gate = server.EvaluationGate(max_concurrent=1, timeout_seconds=0.05)
+    with gate.admit(()):
+        with pytest.raises(server.EvaluationQueueTimeout):
+            with gate.admit((("OPENAI_API_KEY", "other"),)):
+                pass
+
+
+def test_model_env_key_ignores_non_model_vars():
+    assert server.model_env_key(None) == ()
+    assert server.model_env_key({"NOT_A_MODEL_VAR": "x"}) == ()
+    same = {"OPENAI_API_KEY": "k", "AZURE_API_KEY": "a"}
+    assert server.model_env_key(same) == server.model_env_key(dict(reversed(same.items())))
+    assert server.model_env_key({"OPENAI_API_KEY": "k"}) != server.model_env_key(
+        {"OPENAI_API_KEY": "other"}
+    )

--- a/services/langevals/tests/deterministic/test_server_responsiveness.py
+++ b/services/langevals/tests/deterministic/test_server_responsiveness.py
@@ -44,6 +44,11 @@ finally:
     else:
         os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
 
+# The server captured original_env while the temporary preload flag was set,
+# and it restores that snapshot after evaluations. Rebase it on the clean
+# environment so the restore cannot leak the flag into other tests.
+server.original_env = os.environ.copy()
+
 
 def big_text(kb: int, seed: int) -> str:
     rng = random.Random(seed)

--- a/services/langevals/tests/deterministic/test_server_responsiveness.py
+++ b/services/langevals/tests/deterministic/test_server_responsiveness.py
@@ -71,13 +71,13 @@ async def test_healthcheck_answers_while_an_evaluation_runs():
         evaluation = asyncio.create_task(
             client.post("/ragas/context_f1/evaluate", json=SLOW_EVALUATION)
         )
-        # Wait until the evaluation holds the lock, so the healthcheck below
-        # is provably sent while an evaluation is running. A fixed sleep can
+        # Wait until the evaluation is admitted, so the healthcheck below is
+        # provably sent while an evaluation is running. A fixed sleep can
         # lose that race under CPU pressure and pass without testing anything.
         deadline = time.monotonic() + 5
-        while not server.evaluation_lock.locked():
+        while server.evaluation_gate.active_evaluations == 0:
             if time.monotonic() >= deadline:
-                pytest.fail("The evaluation did not take the lock within 5s")
+                pytest.fail("The evaluation was not admitted within 5s")
             await asyncio.sleep(0.01)
         health_started = time.monotonic()
         health = await client.get("/healthcheck")


### PR DESCRIPTION
## What

Follow-up to #7129 and #7133, closing the customer investigation: after upgrading to 3.14.0 the evaluator pods stay alive, but a 23-question experiment against two targets still took 30 minutes. This PR removes the reason: langevals ran strictly ONE evaluation at a time per process.

## Why it was serial

Each request's `env` (the caller's model credentials) was written into `os.environ`, because litellm reads credentials implicitly. Several evaluators wrote the whole request env, not just the model variables: the custom LLM judges, the ragas helper, and the azure branch of four older evaluators. The process environment is shared, so two in-flight evaluations with different credentials could read each other's, and #7133 made the only safe answer explicit with a process-wide lock. Every judge evaluation queued behind the previous one, and a burst of N calls took N times the single-call latency. With a heavy reasoning judge at 30-40s per call, 46 calls is the reported half hour. The SDK's `exp.loop` default of `threads=4` cannot help: the client threads just wait in the server's queue.

Measured on a lw-dev EKS rig running the published `langwatch/langevals:3.14.0` image at the chart's `size-minimal` shape (1 worker, the same shape a customer pod gets):

- 8 concurrent distinct evaluations with a live azure judge completed in a strict staircase, one every ~0.85s, spread 6.07s. Textbook serialization.
- The same 46-call experiment through the platform: 45.8s wall, per-call p50 3.37s, of which ~2.4s was queue wait.

## The fix

Request credentials stop going through `os.environ` entirely, so evaluations run in parallel whatever credentials they carry:

- `langevals_core/request_env.py` binds each evaluation's `env` to its own context. `BaseEvaluator` binds at construction for library callers, and `_evaluate_entry` scopes it around every batch entry, on whatever worker thread the batch executor picked. A ContextVar, so the binding survives ragas' sync-to-async hop and stays invisible to every other thread.
- The litellm patch layer resolves that context into explicit call arguments: provider credentials by model prefix (`api_key`, `api_base`, `api_version`, `vertex_credentials`), the `X_LITELLM_*` passthrough, and the azure deployment rewrite, all request-first with the server's own environment left to litellm as the fallback. Every model call in the fleet funnels through this layer: the custom judges call litellm directly, dspy passes construction kwargs through, and the ragas langchain shim wraps `litellm.completion` and `litellm.embedding`.
- The evaluators that wrote the request env or pinned `AZURE_API_VERSION` globally no longer touch `os.environ`; each pins its API version on its own call. The azure name aliasing (`AZURE_OPENAI_*` to `AZURE_API_*`) happens once at import, on the server's environment only.
- An earlier revision of this PR keyed the gate on the request env instead (same-credential requests ran together, different ones serialized). A review finding killed that design twice over: the allowlisted key missed variables that the full-env writers wrote anyway, and keying on the whole env would collapse managed-Bedrock traffic to serial, because its STS session tokens differ on every request. Per-call credentials close both.

The gate in `server.py` is now pure overload protection:

- At most `MAX_CONCURRENT_EVALUATIONS` run at once (default 64, env knob), admitted strictly in arrival order. The default is set so the server is not the limit for a client that fans out: callers raise their own concurrency whenever they want.
- The server sizes AnyIO's worker-thread pool from the knob at startup. Sync endpoints run on that pool, which holds 40 threads by default, so without this the gate could never admit more than 40 however high the knob was set, and requests above 40 would wait for a thread BEFORE reaching the gate, outside its arrival-order queue.
- A waiter past `LANGEVALS_QUEUE_TIMEOUT` still gets the clear 503, and capacity that frees after its deadline does not admit it.
- A drift tripwire warns once if anything writes `os.environ` while evaluations run, which would mean a writer regressed.

## Proof on the rig and against real providers

Same lw-dev rig, published 3.14.0 image, 1 worker, all changed files overlaid, and the pod's environment carries NO provider credentials, so every successful call below can only have used the credentials its own request carried:

- Battle test, 8 rounds of four SIMULTANEOUS requests: llm_answer_match on azure (valid key), llm_answer_match on openai (valid key), llm_boolean on azure (INVALID key), llm_boolean on openai (valid key). The valid requests succeeded on all 8 rounds, the invalid key failed all 8 rounds with its own AuthenticationError, and rounds overlapped (wall ~6-8s vs ~12-20s serial floor). If credentials crossed between concurrent requests, the invalid-key request would sometimes borrow a valid key or the valid ones would fail. The same test passed 12 rounds against a local credential-scrubbed server.
- 48 concurrent same-credential azure judge calls on the 1-worker pod: 48/48 processed, wall 3.3s, p50 2.4s, max 3.3s. One wave, proving the pool sizing holds under gunicorn and the burst was not split at AnyIO's 40-thread default.
- The earlier staircase evidence stands: the 8-call staircase became a flat line, and the 46-call experiment went 45.8s -> 24.4s at SDK `threads=4`, 8.6s at `threads=16`. For the reported case (~35s per judge call): ~27 minutes -> ~3.5-7 minutes, and different-credential traffic no longer serializes at all.
- 136 real-provider tests across the ten evaluators that used to write the environment pass unchanged (the litellm server-env fallback path), plus ragas end to end.

## Tests

Keyless, wired into the existing no-provider CI step (62 tests total in that step now):

`tests/deterministic/test_credential_isolation.py` (new):

- Ten end-to-end cases, one per evaluator family that used to write the environment (the custom judges, pairwise and select-best compare, off-topic, both competitor evaluators, query resolution), each run against a provider stub captured at the unpatched litellm entry point: the request's own `api_key`/`api_base`/`api_version` must be on the final call, and `os.environ` must be byte-identical before, during, and after. Mutation-verified in both directions: removing the injection fails 13 tests; reintroducing a global env write in one evaluator fails its cases.
- The ragas helper builds its client without touching the environment.
- A whole-fleet construction sweep: constructing ANY loaded evaluator with a sentinel env leaves the environment alone, so a future evaluator reintroducing the write fails by name.
- Unit tests for the resolution layer: provider mapping, azure name aliases, explicit-argument precedence, `X_LITELLM_*` override, deployment-name rewrite from the request env, and that resolution itself never writes.

`tests/deterministic/test_server_concurrency.py`:

- Four same-env evaluations must overlap (wall under 2.4s where serial is 3.2s+).
- Two DIFFERENT-env evaluations must overlap too, each seeing exactly its own credential, with neither credential ever appearing in the process environment. This is the inversion of the old contract, and the point of the PR.
- A burst with request credentials leaves the process environment byte-identical.
- Admissions run in arrival order and are never overtaken.
- The gate times out with its own exception type (a provider `TimeoutError` cannot be mistaken for queue saturation), surfaced as the 503, and capacity freed after a waiter's deadline does not admit it (driven by a manual clock, because real time cannot hold a waiter past its deadline while capacity frees).
- The worker-thread pool has room for every evaluation the gate admits, and a burst wider than the default pool runs together. Both fail without the pool sizing, with a measured peak of exactly 40.

The responsiveness test still guards the event loop staying free during evaluations.

## Deployment impact

- One new optional env knob: `MAX_CONCURRENT_EVALUATIONS` (default 64). `LANGEVALS_QUEUE_TIMEOUT` and `MAX_EVALUATIONS_IN_PARALLEL` keep their meaning and defaults. The two interact: a request holds one gate slot and opens up to `MAX_EVALUATIONS_IN_PARALLEL` threads for the entries in its own batch, so an operator who sends large batches sizes them together.
- Helm values: none added or changed. Vanilla `helm install`: same pods, same probes; each process now serves up to 64 evaluations at once instead of 1, across any mix of credentials. A pod still gets one process per CPU (`CPU_COUNT`), and each process has its own gate.
- Server-environment credentials keep working: whatever the request does not carry is left for litellm to resolve from the process environment, which is exactly where operator-configured credentials live. The 136 real-provider tests run on that path.
- SaaS Lambda (Mangum) is unaffected: it runs with the lifespan off, so the thread pool keeps its default there, and there is one invocation per process either way.
- API surface unchanged: same endpoints, same 503 saturation case.
- For anyone using langevals as a Python library: `MyEvaluator(env={...}).evaluate(entry)` keeps working, since construction binds the env to the calling thread's context, the same reach the old global write had on a single thread, without the process-global part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Evaluations can now run concurrently while keeping model credentials isolated per request.
  - Added configurable concurrency limits and fair, first-come-first-served queueing.
  - Requests waiting too long receive a clear HTTP 503 response.
  - Azure configuration no longer changes the application environment.

- **Bug Fixes**
  - Improved reliability for simultaneous evaluations.
  - Prevented credentials from crossing between concurrent requests.

- **Tests**
  - Added coverage for concurrency, queueing, timeouts, credential isolation, and environment safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
