### PR TITLE
fix(charts): serialize stored-objects PVC consumers across upgrades

### DIFF
--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -185,6 +185,15 @@ jobs:
         if: "!cancelled()"
         run: ./tests/workers-shutdown.sh
 
+      # In local-filesystem mode the app and the workers mount one ReadWriteOnce
+      # PVC, and a helm upgrade rolls both Deployments at once. The pre-upgrade
+      # hook that orders them is a template over several values, so which
+      # installs it renders for, how long it waits, and what it may touch are
+      # only visible in the rendered output.
+      - name: "assert stored-objects upgrades move one volume consumer at a time"
+        if: "!cancelled()"
+        run: ./tests/stored-objects-upgrade-ordering.sh
+
   # The render job above proves the chart PARSES; these vitest suites
   # assert on what it EMITS (env selection per provider, identity guards,
   # migration postures, validation failures). They normally run inside the

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -146,7 +146,16 @@ app:
 
 For an air-gapped install, mirror the hook image and point
 `app.storedObjects.localFilesystem.serializeUpgradesImage` at your copy. It
-needs `sh` and `kubectl`.
+needs `sh` and `kubectl`, and it accepts a digest reference. If your registry
+needs credentials, name the pull secrets in
+`app.storedObjects.localFilesystem.serializeUpgradesPullSecrets`: the hook
+Jobs run under their own ServiceAccount, so secrets you attached to the
+namespace's `default` ServiceAccount do not reach them.
+
+The image tag names the kubectl version. `kubectl` supports one minor version of
+skew either way, so change it if your cluster is far from 1.34. The hooks only
+call `get deployment`, `patch deployment --subresource=scale` and `wait
+--for=delete pod`, which have been stable for many releases.
 
 ### Secrets
 
@@ -335,7 +344,8 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `app.storedObjects.localFilesystem.size`                     | PVC size for the stored-objects volume.                                                                                                                                                                                                                                             | `10Gi`                       |
 | `app.storedObjects.localFilesystem.storageClassName`         | PVC storageClassName (cluster default if empty).                                                                                                                                                                                                                                    | `""`                         |
 | `app.storedObjects.localFilesystem.serializeUpgrades`        | Hold the workers at 0 replicas while the app rolls, so only one pod holds the shared RWO volume.                                                                                                                                                                                    | `true`                       |
-| `app.storedObjects.localFilesystem.serializeUpgradesImage`   | Image the upgrade hooks run. Needs sh and kubectl.                                                                                                                                                                                                                                  | `alpine/k8s:1.30.0`          |
+| `app.storedObjects.localFilesystem.serializeUpgradesImage`   | Image the upgrade hooks run. Needs sh and kubectl. A digest reference works too.                                                                                                                                                                                                    | `alpine/k8s:1.34.9`          |
+| `app.storedObjects.localFilesystem.serializeUpgradesPullSecrets` | Pull secrets for that image. The hook Jobs use their own ServiceAccount, so secrets on the namespace default ServiceAccount do not reach them.                                                                                                                                      | `[]`                         |
 | `app.email`                                                  | Email provider configuration.                                                                                                                                                                                                                                                       |                              |
 | `app.email.defaultFrom`                                      | Default "from" address.                                                                                                                                                                                                                                                             | `""`                         |
 | `app.email.provider`                                         | Email provider. Empty sends no email.                                                                                                                                                                                                                                               | `""`                         |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -94,6 +94,46 @@ helm upgrade lw . -f examples/overlays/size-dev.yaml -f examples/overlays/access
 helm uninstall lw
 ```
 
+#### Upgrades with local-filesystem stored objects
+
+This is the default mode, where the app and the workers mount one
+`ReadWriteOnce` PVC. A `ReadWriteOnce` volume attaches to one node, so every
+pod that mounts it has to run on that node. Both Deployments already use a
+kill-then-start rollout for this reason, but a `helm upgrade` rolls both at the
+same time. On a cluster with more than one node, the new pod of one Deployment
+can be scheduled on a fresh node while the old pod of the other still holds the
+attachment on the old node, and both then wedge in `ContainerCreating` with a
+multi-attach error.
+
+The chart orders them for you. A pre-upgrade hook Job scales the workers to 0
+and waits for their pods to go away, so the app rolls as the only holder of the
+volume. The workers come back at `workers.replicaCount` when Helm applies the
+release, and the new workers pod follows the new app pod through the affinity
+the chart already sets. Expect a brief worker outage per upgrade, on top of the
+brief app outage the kill-then-start rollout already carries.
+
+The hook needs a ServiceAccount token and a namespaced Role: `get` on the
+workers Deployment, `patch` on its scale subresource, and read access to the
+pods of the release namespace. It renders only in this mode. With
+`app.dataplane` (S3 / Azure) there is no shared volume, so it never renders.
+
+If the hook fails, the upgrade stops and the workers stay at 0. That is
+deliberate: it is safer than a wedged rollout. Read the Job logs, fix the cause,
+then run the upgrade again, which scales the workers back up.
+
+To order the rollout yourself, or on a cluster that forbids that RBAC:
+
+```yaml
+app:
+  storedObjects:
+    localFilesystem:
+      serializeUpgrades: false
+```
+
+For an air-gapped install, mirror the hook image and point
+`app.storedObjects.localFilesystem.serializeUpgradesImage` at your copy. It
+needs `sh` and `kubectl`.
+
 ### Secrets
 
 Use `secretKeyRef` to reference existing Kubernetes Secrets instead of inlining values:
@@ -279,6 +319,8 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `app.storedObjects.localFilesystem.path`                     | Mount point that the LocalFilesystemDriver writes under.                                                                                                                                                                                                                            | `/var/lib/langwatch/objects` |
 | `app.storedObjects.localFilesystem.size`                     | PVC size for the stored-objects volume.                                                                                                                                                                                                                                             | `10Gi`                       |
 | `app.storedObjects.localFilesystem.storageClassName`         | PVC storageClassName (cluster default if empty).                                                                                                                                                                                                                                    | `""`                         |
+| `app.storedObjects.localFilesystem.serializeUpgrades`        | Scale the workers to 0 in a pre-upgrade hook, so only one pod holds the shared RWO volume while the app rolls.                                                                                                                                                                      | `true`                       |
+| `app.storedObjects.localFilesystem.serializeUpgradesImage`   | Image the pre-upgrade hook runs. Needs sh and kubectl.                                                                                                                                                                                                                              | `alpine/k8s:1.30.0`          |
 | `app.email`                                                  | Email provider configuration.                                                                                                                                                                                                                                                       |                              |
 | `app.email.defaultFrom`                                      | Default "from" address.                                                                                                                                                                                                                                                             | `""`                         |
 | `app.email.provider`                                         | Email provider. Empty sends no email.                                                                                                                                                                                                                                               | `""`                         |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -191,7 +191,7 @@ A default install does **not** clear Pod Security Admission `restricted` on its
 own: four bundled components can't comply. On clusters that enforce it, add
 `examples/overlays/strict-admission.yaml`, which turns off the upstream
 Prometheus subchart, the Langy assistant (whose manager must run as root to
-give each worker its own UID — never force it non-root), the ClickHouse
+give each worker its own UID, never force it non-root), the ClickHouse
 preflight Job and the stored-objects upgrade hooks (both run kubectl, so they
 need a token and a writable root), plus the custom-metrics gateway HPA. Full
 details in

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -188,12 +188,13 @@ dropped capabilities, `RuntimeDefault` seccomp, no mounted SA token, and
 resource requests/limits on every container.
 
 A default install does **not** clear Pod Security Admission `restricted` on its
-own: three bundled components can't comply. On clusters that enforce it, add
+own: four bundled components can't comply. On clusters that enforce it, add
 `examples/overlays/strict-admission.yaml`, which turns off the upstream
 Prometheus subchart, the Langy assistant (whose manager must run as root to
-give each worker its own UID — never force it non-root), and the ClickHouse
-preflight Job (it runs kubectl, so it needs a token and a writable root), plus
-the custom-metrics gateway HPA. Full details in
+give each worker its own UID — never force it non-root), the ClickHouse
+preflight Job and the stored-objects upgrade hooks (both run kubectl, so they
+need a token and a writable root), plus the custom-metrics gateway HPA. Full
+details in
 [Security → Pod Security](https://docs.langwatch.ai/self-hosting/security#pod-security).
 
 ### Regenerate this table

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -105,21 +105,35 @@ can be scheduled on a fresh node while the old pod of the other still holds the
 attachment on the old node, and both then wedge in `ContainerCreating` with a
 multi-attach error.
 
-The chart orders them for you. A pre-upgrade hook Job scales the workers to 0
-and waits for their pods to go away, so the app rolls as the only holder of the
-volume. The workers come back at `workers.replicaCount` when Helm applies the
-release, and the new workers pod follows the new app pod through the affinity
-the chart already sets. Expect a brief worker outage per upgrade, on top of the
-brief app outage the kill-then-start rollout already carries.
+The chart orders them for you, with two hook Jobs:
 
-The hook needs a ServiceAccount token and a namespaced Role: `get` on the
-workers Deployment, `patch` on its scale subresource, and read access to the
-pods of the release namespace. It renders only in this mode. With
-`app.dataplane` (S3 / Azure) there is no shared volume, so it never renders.
+1. A **pre-upgrade** Job scales the workers to 0 and waits for their pods to go
+   away, so the old workers pod cannot hold the volume on the old node while
+   Helm rolls the app.
+2. A **post-upgrade** Job scales the workers to 0 again, waits for the app
+   rollout to finish, and then scales them back to `workers.replicaCount`.
 
-If the hook fails, the upgrade stops and the workers stay at 0. That is
-deliberate: it is safer than a wedged rollout. Read the Job logs, fix the cause,
-then run the upgrade again, which scales the workers back up.
+The second step is not redundant. Helm's apply restores the replica count from
+the manifest, so a new workers pod is created at the same instant as the new app
+pod. Its required `podAffinity` matches the old app pod, which is still
+terminating on the old node, so the scheduler puts the workers back on the node
+the app is leaving, where they take over the attachment and wedge the new app
+pod for good. Holding the workers at 0 until the app rollout finishes is what
+makes them follow the new app pod.
+
+Expect a worker outage that covers the app rollout, on top of the brief app
+outage the kill-then-start rollout already carries.
+
+The hooks need a ServiceAccount token and a namespaced Role: `get` on the app
+and the workers Deployments, `patch` on the workers' scale subresource, and read
+access to the pods of the release namespace. They render only in this mode. With
+`app.dataplane` (S3 / Azure) there is no shared volume, so they never render.
+
+If the pre-upgrade Job fails, the upgrade stops and the workers stay at 0. That
+is deliberate: it is safer than a wedged rollout. Read the Job logs, fix the
+cause, then run the upgrade again, which scales the workers back up. The
+post-upgrade Job never fails the release over a slow or broken app: if the
+rollout does not finish in time it says so and brings the workers back anyway.
 
 To order the rollout yourself, or on a cluster that forbids that RBAC:
 
@@ -319,8 +333,8 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `app.storedObjects.localFilesystem.path`                     | Mount point that the LocalFilesystemDriver writes under.                                                                                                                                                                                                                            | `/var/lib/langwatch/objects` |
 | `app.storedObjects.localFilesystem.size`                     | PVC size for the stored-objects volume.                                                                                                                                                                                                                                             | `10Gi`                       |
 | `app.storedObjects.localFilesystem.storageClassName`         | PVC storageClassName (cluster default if empty).                                                                                                                                                                                                                                    | `""`                         |
-| `app.storedObjects.localFilesystem.serializeUpgrades`        | Scale the workers to 0 in a pre-upgrade hook, so only one pod holds the shared RWO volume while the app rolls.                                                                                                                                                                      | `true`                       |
-| `app.storedObjects.localFilesystem.serializeUpgradesImage`   | Image the pre-upgrade hook runs. Needs sh and kubectl.                                                                                                                                                                                                                              | `alpine/k8s:1.30.0`          |
+| `app.storedObjects.localFilesystem.serializeUpgrades`        | Hold the workers at 0 replicas while the app rolls, so only one pod holds the shared RWO volume.                                                                                                                                                                                    | `true`                       |
+| `app.storedObjects.localFilesystem.serializeUpgradesImage`   | Image the upgrade hooks run. Needs sh and kubectl.                                                                                                                                                                                                                                  | `alpine/k8s:1.30.0`          |
 | `app.email`                                                  | Email provider configuration.                                                                                                                                                                                                                                                       |                              |
 | `app.email.defaultFrom`                                      | Default "from" address.                                                                                                                                                                                                                                                             | `""`                         |
 | `app.email.provider`                                         | Email provider. Empty sends no email.                                                                                                                                                                                                                                               | `""`                         |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -107,11 +107,12 @@ multi-attach error.
 
 The chart orders them for you, with two hook Jobs:
 
-1. A **pre-upgrade** Job scales the workers to 0 and waits for their pods to go
-   away, so the old workers pod cannot hold the volume on the old node while
-   Helm rolls the app.
-2. A **post-upgrade** Job scales the workers to 0 again, waits for the app
-   rollout to finish, and then scales them back to `workers.replicaCount`.
+1. A **drain** Job (`pre-upgrade`, `pre-rollback`) scales the workers to 0 and
+   waits for their pods to go away, so the old workers pod cannot hold the
+   volume on the old node while Helm rolls the app.
+2. A **restore** Job (`post-upgrade`, `post-rollback`) scales the workers to 0
+   again, waits for the app rollout to finish, and then scales them back to
+   `workers.replicaCount`.
 
 The second step is not redundant. Helm's apply restores the replica count from
 the manifest, so a new workers pod is created at the same instant as the new app
@@ -129,11 +130,25 @@ and the workers Deployments, `patch` on the workers' scale subresource, and read
 access to the pods of the release namespace. They render only in this mode. With
 `app.dataplane` (S3 / Azure) there is no shared volume, so they never render.
 
-If the pre-upgrade Job fails, the upgrade stops and the workers stay at 0. That
-is deliberate: it is safer than a wedged rollout. Read the Job logs, fix the
-cause, then run the upgrade again, which scales the workers back up. The
-post-upgrade Job never fails the release over a slow or broken app: if the
-rollout does not finish in time it says so and brings the workers back anyway.
+If the drain Job fails, the upgrade stops and the workers stay at 0. That is
+deliberate: it is safer than a wedged rollout. Read the Job logs, fix the cause,
+then run the upgrade again, which scales the workers back up. The restore Job
+never fails the release over a slow or broken app: if the rollout does not
+finish in time it says so and brings the workers back anyway.
+
+**Rollbacks.** `helm rollback` moves both Deployments the same way an upgrade
+does, so both Jobs are registered for the rollback events too and a rollback is
+ordered the same way. One case the chart cannot cover: on a rollback Helm runs
+the hooks stored in the **target** revision, so a rollback to a chart version
+from before these Jobs existed runs no Jobs at all. Before such a downgrade,
+scale the workers down by hand and bring them back after it:
+
+```bash
+kubectl -n <namespace> scale deployment <release>-workers --replicas=0
+kubectl -n <namespace> rollout status deployment <release>-workers --timeout=2m
+helm rollback <release> <old-revision>
+kubectl -n <namespace> scale deployment <release>-workers --replicas=1
+```
 
 To order the rollout yourself, or on a cluster that forbids that RBAC:
 

--- a/charts/langwatch/examples/overlays/strict-admission.yaml
+++ b/charts/langwatch/examples/overlays/strict-admission.yaml
@@ -71,6 +71,18 @@ gateway:
   replicaCount: 2
 
 app:
+  # The stored-objects upgrade hooks scale the workers Deployment through the
+  # Kubernetes API while the app rolls, so their pods need an automounted
+  # ServiceAccount token and a writable root for kubectl's discovery cache.
+  # They render only in local-filesystem stored-objects mode, where the app and
+  # the workers share one ReadWriteOnce volume. That mode is the documented
+  # hobby tier and is not what a locked-down cluster should run: enable
+  # app.dataplane (S3 / MinIO / Azure) instead, and the hooks never render at
+  # all. Pinned off here so the overlay is self-contained.
+  storedObjects:
+    localFilesystem:
+      serializeUpgrades: false
+
   telemetry:
     # Prometheus is off above, so don't expose app metrics either - nothing
     # would scrape them. This is already the default; pinned here so the two

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -186,6 +186,7 @@ backend for you:
         clusters). Expect a brief downtime per upgrade; set app/workers
         deployment.strategy explicitly to override. Zero-downtime
         upgrades require S3-backed stored objects instead of local-FS.
+{{- if and .Values.workers.enabled .Values.app.storedObjects.localFilesystem.serializeUpgrades }}
       • That rollout is per Deployment, and a helm upgrade rolls both at
         once. So two hook Jobs keep the workers off the volume while the
         app rolls: a pre-upgrade Job scales the workers to 0 and waits
@@ -202,6 +203,14 @@ backend for you:
         the pre-upgrade Job fails, the upgrade stops and the workers stay
         at 0: read the Job logs, then run the upgrade again to bring them
         back.
+{{- else if .Values.workers.enabled }}
+      • Upgrade ordering is OFF
+        (app.storedObjects.localFilesystem.serializeUpgrades=false), and
+        the app and the workers both mount this volume. Scale the workers
+        to 0 yourself before every upgrade and back up after it, or the
+        two rollouts can wedge each other on an RWO multi-attach error on
+        a cluster with more than one node.
+{{- end }}
       • GitOps (ArgoCD / Flux): the dataset-migration hook maps to a
         PostSync hook, which already waits for the rollout to be healthy;
         plain Helm should upgrade with --wait when crossing the ADR-032

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -203,6 +203,11 @@ backend for you:
         the pre-upgrade Job fails, the upgrade stops and the workers stay
         at 0: read the Job logs, then run the upgrade again to bring them
         back.
+      • Both Jobs run on `helm rollback` too. They cannot cover a
+        rollback to a chart version from before they existed, because
+        helm runs the TARGET revision's hooks: scale
+        {{ .Release.Name }}-workers to 0 by hand before such a downgrade
+        and back up after it.
 {{- else if .Values.workers.enabled }}
       • Upgrade ordering is OFF
         (app.storedObjects.localFilesystem.serializeUpgrades=false), and

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -186,6 +186,18 @@ backend for you:
         clusters). Expect a brief downtime per upgrade; set app/workers
         deployment.strategy explicitly to override. Zero-downtime
         upgrades require S3-backed stored objects instead of local-FS.
+      • That rollout is per Deployment, and a helm upgrade rolls both at
+        once. So a pre-upgrade hook Job scales the workers to 0 and waits
+        for their pods to go away first, and the app then rolls as the
+        only holder of the volume. The workers come back at
+        workers.replicaCount when helm applies the release. The hook
+        needs a ServiceAccount token and a small namespaced Role (get on
+        the workers Deployment, patch on its scale, read on pods). Turn
+        it off with
+        app.storedObjects.localFilesystem.serializeUpgrades=false if you
+        order the rollout yourself or your cluster forbids that RBAC. If
+        the hook fails, the upgrade stops and the workers stay at 0: read
+        the Job logs, then run the upgrade again to bring them back.
       • GitOps (ArgoCD / Flux): the dataset-migration hook maps to a
         PostSync hook, which already waits for the rollout to be healthy;
         plain Helm should upgrade with --wait when crossing the ADR-032

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -187,17 +187,21 @@ backend for you:
         deployment.strategy explicitly to override. Zero-downtime
         upgrades require S3-backed stored objects instead of local-FS.
       • That rollout is per Deployment, and a helm upgrade rolls both at
-        once. So a pre-upgrade hook Job scales the workers to 0 and waits
-        for their pods to go away first, and the app then rolls as the
-        only holder of the volume. The workers come back at
-        workers.replicaCount when helm applies the release. The hook
-        needs a ServiceAccount token and a small namespaced Role (get on
-        the workers Deployment, patch on its scale, read on pods). Turn
-        it off with
+        once. So two hook Jobs keep the workers off the volume while the
+        app rolls: a pre-upgrade Job scales the workers to 0 and waits
+        for their pods to go away, and a post-upgrade Job holds them at 0
+        until the app rollout finishes, then scales them back to
+        workers.replicaCount. Without the second Job the new workers pod
+        follows the still-terminating old app pod back to the old node
+        and wedges the new app pod there. The Jobs need a ServiceAccount
+        token and a small namespaced Role (get on the app and the workers
+        Deployments, patch on the workers' scale, read on pods). Turn
+        them off with
         app.storedObjects.localFilesystem.serializeUpgrades=false if you
         order the rollout yourself or your cluster forbids that RBAC. If
-        the hook fails, the upgrade stops and the workers stay at 0: read
-        the Job logs, then run the upgrade again to bring them back.
+        the pre-upgrade Job fails, the upgrade stops and the workers stay
+        at 0: read the Job logs, then run the upgrade again to bring them
+        back.
       • GitOps (ArgoCD / Flux): the dataset-migration hook maps to a
         PostSync hook, which already waits for the rollout to be healthy;
         plain Helm should upgrade with --wait when crossing the ADR-032

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -1238,6 +1238,100 @@ podAffinity:
       topologyKey: kubernetes.io/hostname
 {{- end -}}
 
+{{/*
+  Shared pod spec for the stored-objects upgrade hook Jobs, up to and including
+  the `containers:` key. Both the pre-upgrade and the post-upgrade Job run the
+  same image with the same identity, so the parts that are not the script live
+  here rather than being written twice.
+
+  automountServiceAccountToken is true on purpose. These Jobs are the only
+  workloads in the release that call the Kubernetes API, so they need the token
+  global.automountServiceAccountToken withholds from the rest.
+
+  The scheduling keys come from global.scheduling so the Jobs land where the
+  rest of the release lands. On a cluster whose nodes are tainted, a hook that
+  ignored them would sit Pending and stall every upgrade.
+
+  See templates/app/stored-objects-serialize-upgrade.yaml.
+*/}}
+{{- define "langwatch.storedObjects.upgradeHookPodSpec" -}}
+restartPolicy: Never
+serviceAccountName: {{ .Release.Name }}-stored-objects-upgrade
+automountServiceAccountToken: true
+{{- with .Values.global.scheduling.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.global.scheduling.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.global.scheduling.priorityClassName }}
+priorityClassName: {{ . | quote }}
+{{- end }}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  seccompProfile:
+    type: RuntimeDefault
+containers:
+{{- end -}}
+
+{{/*
+  Shell functions both stored-objects upgrade hook Jobs use. They read the
+  `ns`, `deploy` and `selector` variables the Job's script sets above them.
+*/}}
+{{- define "langwatch.storedObjects.upgradeHookShellHelpers" -}}
+deployment_exists() {
+  kubectl -n "$ns" get deployment "$deploy" >/dev/null 2>&1
+}
+
+scale_workers() {
+  kubectl -n "$ns" patch deployment "$deploy" --subresource=scale --type=merge -p "{\"spec\":{\"replicas\":${1}}}"
+}
+
+wait_for_workers_gone() {
+  printf 'serialize-upgrade: waiting up to %ss for the %s pods to go away\n' "${1}" "$deploy"
+  out=$(kubectl -n "$ns" wait --for=delete pod --selector="$selector" --timeout="${1}s" 2>&1)
+  status=$?
+  printf '%s\n' "$out"
+  [ "$status" -eq 0 ] && return 0
+  # kubectl below 1.31 reports an empty selector result as an error. No pods
+  # left IS the state this waits for, so it must not read as a failure.
+  case "$out" in
+    *'no matching resources found'*) return 0 ;;
+  esac
+  return 1
+}
+{{- end -}}
+
+{{/*
+  The post-upgrade hook's wait for the app rollout. Reads `ns` and `app`.
+
+  It polls rather than calling `kubectl rollout status`, which LISTs
+  Deployments. Kubernetes ignores resourceNames on `list`, so `rollout status`
+  cannot run under a Role restricted to two Deployments by name, and using it
+  would mean granting read access to every Deployment in the namespace.
+
+  Done means the Deployment has observed its current generation and every
+  replica it asks for is ready, which is what proves the NEW app pod, not the
+  one it replaced, is the pod holding the volume.
+*/}}
+{{- define "langwatch.storedObjects.upgradeHookAppRolloutHelper" -}}
+wait_for_app_rollout() {
+  deadline=$(( $(date +%s) + ${1} ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    state=$(kubectl -n "$ns" get deployment "$app" -o jsonpath='{.metadata.generation} {.status.observedGeneration} {.spec.replicas} {.status.readyReplicas}' 2>/dev/null)
+    set -- $state
+    if [ -n "${1:-}" ] && [ "${1:-}" = "${2:-}" ] && [ -n "${3:-}" ] && [ "${4:-0}" = "${3:-}" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+{{- end -}}
+
 {{/* ClickHouse: Cluster name for the app (only when replicas > 1 or external.cluster set) */}}
 {{- define "langwatch.clickhouse.clusterName" -}}
   {{- if .Values.clickhouse.chartManaged -}}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -1369,7 +1369,13 @@ app_rollout_done() {
   IFS='|'
   set -- $state
   IFS=$old_ifs
-  generation="${1:-}"; observed="${2:-}"; want="${3:-}"; updated="${4:-}"; current="${5:-}"; available="${6:-}"
+  # The three status counters default to 0, because the API omits a zero-valued
+  # one and an app parked at replicaCount 0 is a finished rollout, not one that
+  # never starts. The desired count stays mandatory: with it missing there is
+  # nothing to compare against. Defaulting the counters does not weaken the
+  # check, since a rollout that has not produced its pods yet reports 0 against
+  # a desired count above 0 and still reads as unfinished.
+  generation="${1:-}"; observed="${2:-}"; want="${3:-}"; updated="${4:-0}"; current="${5:-0}"; available="${6:-0}"
   is_number "$generation" || return 1
   is_number "$observed" || return 1
   is_number "$want" || return 1

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -1248,9 +1248,22 @@ podAffinity:
   workloads in the release that call the Kubernetes API, so they need the token
   global.automountServiceAccountToken withholds from the rest.
 
-  The scheduling keys come from global.scheduling so the Jobs land where the
-  rest of the release lands. On a cluster whose nodes are tainted, a hook that
-  ignored them would sit Pending and stall every upgrade.
+  nodeSelector, tolerations, affinity and priorityClassName come from
+  global.scheduling so the Jobs land where the rest of the release lands. On a
+  cluster whose nodes are tainted or whose workloads carry a required node
+  affinity, a hook that ignored them would sit Pending and stall every upgrade.
+
+  global.scheduling.topologySpreadConstraints is deliberately NOT copied. A
+  spread constraint describes how the replicas of a service should be
+  distributed; on a single-run Job it can only make the pod unschedulable when
+  whenUnsatisfiable is DoNotSchedule, which for a fail-closed pre-upgrade hook
+  means a blocked upgrade.
+
+  imagePullSecrets are their own value rather than a chart-wide one, because
+  these Jobs run under their OWN ServiceAccount. Pull secrets an operator
+  attached to the namespace's `default` ServiceAccount, which is what the rest
+  of the release uses when global.serviceAccount.create is false, do not reach
+  them.
 
   See templates/app/stored-objects-serialize-upgrade.yaml.
 */}}
@@ -1258,12 +1271,20 @@ podAffinity:
 restartPolicy: Never
 serviceAccountName: {{ .Release.Name }}-stored-objects-upgrade
 automountServiceAccountToken: true
+{{- with .Values.app.storedObjects.localFilesystem.serializeUpgradesPullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.global.scheduling.nodeSelector }}
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.global.scheduling.tolerations }}
 tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.global.scheduling.affinity }}
+affinity:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.global.scheduling.priorityClassName }}
@@ -1311,19 +1332,61 @@ wait_for_workers_gone() {
   It polls rather than calling `kubectl rollout status`, which LISTs
   Deployments. Kubernetes ignores resourceNames on `list`, so `rollout status`
   cannot run under a Role restricted to two Deployments by name, and using it
-  would mean granting read access to every Deployment in the namespace.
+  would mean granting read access to every Deployment in the namespace. The
+  condition below is the one `rollout status` itself applies.
 
-  Done means the Deployment has observed its current generation and every
-  replica it asks for is ready, which is what proves the NEW app pod, not the
-  one it replaced, is the pod holding the volume.
+  All four parts are needed to prove the NEW app pod, not the one it replaced,
+  is the pod holding the volume:
+
+    observedGeneration >= generation   the controller has seen the new spec
+    updatedReplicas    == replicas     every pod asked for is from the new spec
+    statusReplicas     == updated      no pod from the old spec is left
+    available          >= updated      the new pods are ready
+
+  readyReplicas alone is not enough, and getting that wrong would reintroduce
+  the wedge this hook exists to prevent: it counts ready pods across EVERY
+  ReplicaSet, so during a kill-then-start rollout there is a window where the
+  controller has already recorded the new generation while the still-Ready OLD
+  pod satisfies the count. The workers would then come back against the node
+  the app is leaving.
 */}}
 {{- define "langwatch.storedObjects.upgradeHookAppRolloutHelper" -}}
+is_number() {
+  case "${1:-}" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  return 0
+}
+
+app_rollout_done() {
+  # Pipe-separated, not space-separated. A status field that is absent (which
+  # is how the API reports zero) renders as nothing, so on whitespace splitting
+  # every later field shifts left and is read as the wrong one. With an
+  # explicit separator the empty field keeps its place, and an empty field
+  # fails is_number below, which reads as "not done yet" and keeps waiting.
+  state=$(kubectl -n "$ns" get deployment "$app" -o jsonpath='{.metadata.generation}|{.status.observedGeneration}|{.spec.replicas}|{.status.updatedReplicas}|{.status.replicas}|{.status.availableReplicas}|' 2>/dev/null)
+  old_ifs=$IFS
+  IFS='|'
+  set -- $state
+  IFS=$old_ifs
+  generation="${1:-}"; observed="${2:-}"; want="${3:-}"; updated="${4:-}"; current="${5:-}"; available="${6:-}"
+  is_number "$generation" || return 1
+  is_number "$observed" || return 1
+  is_number "$want" || return 1
+  is_number "$updated" || return 1
+  is_number "$current" || return 1
+  is_number "$available" || return 1
+  [ "$observed" -ge "$generation" ] || return 1
+  [ "$updated" -eq "$want" ] || return 1
+  [ "$current" -eq "$updated" ] || return 1
+  [ "$available" -ge "$updated" ] || return 1
+  return 0
+}
+
 wait_for_app_rollout() {
   deadline=$(( $(date +%s) + ${1} ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    state=$(kubectl -n "$ns" get deployment "$app" -o jsonpath='{.metadata.generation} {.status.observedGeneration} {.spec.replicas} {.status.readyReplicas}' 2>/dev/null)
-    set -- $state
-    if [ -n "${1:-}" ] && [ "${1:-}" = "${2:-}" ] && [ -n "${3:-}" ] && [ "${4:-0}" = "${3:-}" ]; then
+    if app_rollout_done; then
       return 0
     fi
     sleep 5

--- a/charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml
+++ b/charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml
@@ -1,0 +1,215 @@
+{{/*
+  Pre-upgrade hook that stands the workers down before helm rolls the app, for
+  installs where the app and the workers share one ReadWriteOnce
+  stored-objects PVC.
+
+  Why. In local-filesystem mode both Deployments mount
+  `<release>-stored-objects`. A ReadWriteOnce volume attaches to ONE node, so
+  every consumer has to sit on that node. Each Deployment already defends this
+  on its own: a kill-then-start rollout (maxSurge=0/maxUnavailable=1) and, for
+  the workers, a required podAffinity to the app pod. A helm upgrade rolls both
+  Deployments at the same time and nothing orders them, so the new pod of one
+  can be scheduled on a fresh node while the old pod of the other still holds
+  the attachment on the old node. Both then wedge in ContainerCreating with a
+  multi-attach error, and the attach-detach controller can hold that state for
+  many minutes. Issue #7191.
+
+  What this does. It makes the manual recovery part of the upgrade: scale the
+  workers to 0, wait until their pods are gone, and only then let helm apply
+  the new manifests. The app is the single remaining consumer of the volume at
+  that point, which maxSurge=0 handles correctly, and the workers Deployment
+  comes back with the release because its manifest names `replicas` (helm's
+  three-way merge sees the live 0, the manifest's count, and patches the count
+  back). The new workers pod then follows the new app pod through the affinity
+  that is already there.
+
+  Scope. Renders only when local-filesystem is the ACTIVE stored-objects
+  backend (the same helper the PVC uses), the workers are deployed, and
+  `app.storedObjects.localFilesystem.serializeUpgrades` is on. With
+  app.dataplane enabled there is no shared volume and nothing to order.
+
+  Hook contract. pre-upgrade only: a first install has no old pod holding the
+  volume, so there is nothing to serialize. The Job is still defensive about a
+  missing Deployment, because ArgoCD and Flux map pre-upgrade to PreSync and
+  run it on the first sync too. hook-delete-policy keeps a FAILED Job for the
+  operator to read, and `before-hook-creation` removes it at the start of the
+  next attempt, so a failure never blocks the next upgrade.
+
+  Failure is fail-closed: the upgrade stops rather than risking the wedge. The
+  workers stay at 0 in that case; `helm rollback`, a repeat upgrade, or a
+  manual scale brings them back. Operators who order the rollout themselves
+  (or whose RBAC forbids the patch) set serializeUpgrades=false.
+*/}}
+{{- if and (eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true") .Values.workers.enabled .Values.app.storedObjects.localFilesystem.serializeUpgrades }}
+{{- $name := printf "%s-stored-objects-upgrade" .Release.Name }}
+{{- $workersDeployment := printf "%s-workers" .Release.Name }}
+{{- /* The wait has to outlast the workers' own shutdown budget. A terminating
+       pod keeps its volume attached to its node until it is fully gone, so a
+       wait shorter than terminationGracePeriodSeconds would report success
+       while the old pod still holds the attachment, which is the state this
+       hook exists to prevent. The helper is the same one the workers
+       Deployment renders its grace period from, so an operator who raises the
+       grace period raises this with it. */}}
+{{- $graceSeconds := int (include "langwatch.terminationGracePeriod" (dict "component" .Values.workers "name" "workers")) }}
+{{- $waitSeconds := add $graceSeconds 60 }}
+{{- $deadlineSeconds := add $waitSeconds 60 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "langwatch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "langwatch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  # Read the workers Deployment by name, so "not installed yet" is
+  # distinguishable from a real failure.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: [{{ $workersDeployment | quote }}]
+    verbs: ["get"]
+  # Change the replica count and nothing else. A patch on the scale
+  # subresource cannot touch the image, the environment, or any other field of
+  # the pod spec.
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    resourceNames: [{{ $workersDeployment | quote }}]
+    verbs: ["get", "patch"]
+  # Watch the workers pods go away. Kubernetes ignores resourceNames on list
+  # and watch, so this covers the pods of this namespace, read only. The Role
+  # is namespaced, so it reaches no other namespace and nothing cluster-wide.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "langwatch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $name }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "langwatch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ $deadlineSeconds }}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "langwatch.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $name }}
+      # This pod is the one workload in the release that DOES call the
+      # Kubernetes API, so it needs the token global.automountServiceAccountToken
+      # withholds from the rest.
+      automountServiceAccountToken: true
+      {{- with .Values.global.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: serialize-upgrade
+          image: {{ .Values.app.storedObjects.localFilesystem.serializeUpgradesImage | quote }}
+          imagePullPolicy: IfNotPresent
+          # readOnlyRootFilesystem is omitted, the same way the ClickHouse
+          # preflight Job omits it: kubectl writes a discovery cache under
+          # $HOME and warns or fails on a read-only root.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -u
+              ns={{ .Release.Namespace | quote }}
+              deploy={{ $workersDeployment | quote }}
+              selector={{ printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s" $workersDeployment .Release.Name | quote }}
+              timeout={{ $waitSeconds }}
+
+              if ! kubectl -n "$ns" get deployment "$deploy" >/dev/null 2>&1; then
+                printf 'serialize-upgrade: no Deployment %s in namespace %s, nothing to stand down\n' "$deploy" "$ns"
+                exit 0
+              fi
+
+              printf 'serialize-upgrade: scaling %s to 0 so the app is the only holder of the stored-objects volume\n' "$deploy"
+              if ! kubectl -n "$ns" patch deployment "$deploy" --subresource=scale --type=merge -p '{"spec":{"replicas":0}}'; then
+                printf 'serialize-upgrade: could not scale %s to 0. Scale it yourself and retry, or set app.storedObjects.localFilesystem.serializeUpgrades=false to order the rollout on your own.\n' "$deploy" >&2
+                exit 1
+              fi
+
+              printf 'serialize-upgrade: waiting up to %ss for the %s pods to go away\n' "$timeout" "$deploy"
+              out=$(kubectl -n "$ns" wait --for=delete pod --selector="$selector" --timeout="${timeout}s" 2>&1)
+              status=$?
+              printf '%s\n' "$out"
+              if [ "$status" -ne 0 ]; then
+                # kubectl below 1.31 reports an empty selector result as an
+                # error. No pods left IS the state this step waits for, so it
+                # must not read as a failure.
+                case "$out" in
+                  *'no matching resources found'*)
+                    printf 'serialize-upgrade: no %s pods left, the app can roll alone\n' "$deploy"
+                    exit 0
+                    ;;
+                esac
+                printf 'serialize-upgrade: %s pods were still present after %ss. The upgrade is stopped so it cannot wedge on a multi-attach error. Check why the pods do not terminate, then run the upgrade again (it scales the workers back up).\n' "$deploy" "$timeout" >&2
+                exit 1
+              fi
+              printf 'serialize-upgrade: the %s pods are gone, the app can roll alone\n' "$deploy"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+{{- end }}

--- a/charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml
+++ b/charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml
@@ -17,13 +17,13 @@
   the whole upgrade, and give the workers back after the app pod that owns the
   volume is running:
 
-    pre-upgrade   scale the workers to 0 and wait for their pods to go away, so
-                  the OLD workers pod cannot hold the volume on the old node
-                  while helm rolls the app.
+    the drain Job     scale the workers to 0 and wait for their pods to go
+    (pre-upgrade,     away, so the OLD workers pod cannot hold the volume on
+     pre-rollback)    the old node while helm rolls the app.
 
-    post-upgrade  scale the workers to 0 again, wait, then wait for the app
-                  rollout to finish and scale the workers back to
-                  workers.replicaCount.
+    the restore Job   scale the workers to 0 again, wait, then wait for the app
+    (post-upgrade,    rollout to finish and scale the workers back to
+     post-rollback)   workers.replicaCount.
 
   The second scale-to-0 is not redundant. Helm's apply restores the replica
   count from the manifest, so a NEW workers pod is created at the same instant
@@ -31,22 +31,37 @@
   is still terminating on the old node, so the scheduler puts the workers back
   on the node the app is leaving, where it takes over the attachment and wedges
   the new app pod for good. Measured on a 4 node EKS cluster: with the
-  pre-upgrade hook alone, an upgrade that moved the app to another node left
-  the app in ContainerCreating with "Multi-Attach error ... Volume is already
-  used by pod(s) <release>-app-<old>". Standing the workers down until the app
-  rollout completes is what makes the workers follow the NEW app pod.
+  drain Job alone, an upgrade that moved the app to another node left the app
+  in ContainerCreating with "Multi-Attach error ... Volume is already used by
+  pod(s) <release>-app-<old>". Standing the workers down until the app rollout
+  completes is what makes the workers follow the NEW app pod.
 
   Scope. Renders only when local-filesystem is the ACTIVE stored-objects
   backend (the same helper the PVC uses), the workers are deployed, and
   `app.storedObjects.localFilesystem.serializeUpgrades` is on. With
   app.dataplane enabled there is no shared volume and nothing to order.
 
-  Hook contract. Upgrade phases only: a first install has no old pod holding
-  the volume. Both Jobs are still defensive about a missing Deployment, because
-  ArgoCD and Flux map these phases to PreSync and PostSync and run them on the
-  first sync too. hook-delete-policy keeps a FAILED Job for the operator to
-  read, and `before-hook-creation` removes it at the start of the next attempt,
-  so a failure never blocks the next upgrade.
+  Hook contract. Upgrade AND rollback phases, never install: a first install
+  has no old pod holding the volume, but a rollback moves both Deployments the
+  same way an upgrade does, and is most likely to be run while recovering from
+  a rollout that already went wrong. Helm fires pre-rollback / post-rollback
+  there, not the upgrade pair, so a Job registered for the upgrade events alone
+  would not run and the race would be back.
+
+  One limit worth knowing, because the chart cannot close it: on a rollback
+  Helm runs the hooks stored in the TARGET revision's manifests, not the
+  current one. So these annotations protect a rollback to any revision that
+  already carries these hooks. A downgrade to a chart version from before them
+  runs no hooks at all. Scale the workers Deployment to 0 by hand before such a
+  downgrade. The same rule decides the replica count the post-rollback Job
+  restores: it renders from the target revision's workers.replicaCount, which
+  is the count that revision asks for and therefore the right one.
+
+  Both Jobs are defensive about a missing Deployment, because ArgoCD and Flux
+  map these phases to PreSync and PostSync and run them on the first sync too.
+  hook-delete-policy keeps a FAILED Job for the operator to read, and
+  `before-hook-creation` removes it at the start of the next attempt, so a
+  failure never blocks the next upgrade or rollback.
 
   Failure posture differs per phase, on purpose. The pre-upgrade Job is
   fail-closed: it stops the upgrade before anything is applied rather than risk
@@ -91,7 +106,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade,post-upgrade
+    helm.sh/hook: pre-upgrade,pre-rollback,post-upgrade,post-rollback
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
@@ -102,7 +117,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade,post-upgrade
+    helm.sh/hook: pre-upgrade,pre-rollback,post-upgrade,post-rollback
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
@@ -133,7 +148,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade,post-upgrade
+    helm.sh/hook: pre-upgrade,pre-rollback,post-upgrade,post-rollback
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
@@ -152,7 +167,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade
+    helm.sh/hook: pre-upgrade,pre-rollback
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
@@ -217,7 +232,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-upgrade
+    helm.sh/hook: post-upgrade,post-rollback
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:

--- a/charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml
+++ b/charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml
@@ -1,58 +1,88 @@
 {{/*
-  Pre-upgrade hook that stands the workers down before helm rolls the app, for
-  installs where the app and the workers share one ReadWriteOnce
-  stored-objects PVC.
+  Upgrade hooks that keep the workers off the shared stored-objects volume
+  while the app rolls, for installs where both mount one ReadWriteOnce PVC.
 
-  Why. In local-filesystem mode both Deployments mount
-  `<release>-stored-objects`. A ReadWriteOnce volume attaches to ONE node, so
-  every consumer has to sit on that node. Each Deployment already defends this
-  on its own: a kill-then-start rollout (maxSurge=0/maxUnavailable=1) and, for
-  the workers, a required podAffinity to the app pod. A helm upgrade rolls both
-  Deployments at the same time and nothing orders them, so the new pod of one
-  can be scheduled on a fresh node while the old pod of the other still holds
-  the attachment on the old node. Both then wedge in ContainerCreating with a
-  multi-attach error, and the attach-detach controller can hold that state for
-  many minutes. Issue #7191.
+  Why. In local-filesystem mode the app Deployment and the workers Deployment
+  both mount `<release>-stored-objects`. A ReadWriteOnce volume attaches to ONE
+  node, so every consumer has to sit on that node. Each Deployment already
+  defends this on its own: a kill-then-start rollout (maxSurge=0/
+  maxUnavailable=1) and, for the workers, a required podAffinity to the app
+  pod. A helm upgrade rolls both Deployments at the same time and nothing
+  orders them, so the new pod of one can be scheduled on a fresh node while the
+  old pod of the other still holds the attachment on the old node. Both then
+  wedge in ContainerCreating with a multi-attach error, and the attach-detach
+  controller can hold that state for many minutes. Issue #7191.
 
-  What this does. It makes the manual recovery part of the upgrade: scale the
-  workers to 0, wait until their pods are gone, and only then let helm apply
-  the new manifests. The app is the single remaining consumer of the volume at
-  that point, which maxSurge=0 handles correctly, and the workers Deployment
-  comes back with the release because its manifest names `replicas` (helm's
-  three-way merge sees the live 0, the manifest's count, and patches the count
-  back). The new workers pod then follows the new app pod through the affinity
-  that is already there.
+  What these hooks do. They keep the app as the only consumer of the volume for
+  the whole upgrade, and give the workers back after the app pod that owns the
+  volume is running:
+
+    pre-upgrade   scale the workers to 0 and wait for their pods to go away, so
+                  the OLD workers pod cannot hold the volume on the old node
+                  while helm rolls the app.
+
+    post-upgrade  scale the workers to 0 again, wait, then wait for the app
+                  rollout to finish and scale the workers back to
+                  workers.replicaCount.
+
+  The second scale-to-0 is not redundant. Helm's apply restores the replica
+  count from the manifest, so a NEW workers pod is created at the same instant
+  as the new app pod. Its required podAffinity matches the OLD app pod, which
+  is still terminating on the old node, so the scheduler puts the workers back
+  on the node the app is leaving, where it takes over the attachment and wedges
+  the new app pod for good. Measured on a 4 node EKS cluster: with the
+  pre-upgrade hook alone, an upgrade that moved the app to another node left
+  the app in ContainerCreating with "Multi-Attach error ... Volume is already
+  used by pod(s) <release>-app-<old>". Standing the workers down until the app
+  rollout completes is what makes the workers follow the NEW app pod.
 
   Scope. Renders only when local-filesystem is the ACTIVE stored-objects
   backend (the same helper the PVC uses), the workers are deployed, and
   `app.storedObjects.localFilesystem.serializeUpgrades` is on. With
   app.dataplane enabled there is no shared volume and nothing to order.
 
-  Hook contract. pre-upgrade only: a first install has no old pod holding the
-  volume, so there is nothing to serialize. The Job is still defensive about a
-  missing Deployment, because ArgoCD and Flux map pre-upgrade to PreSync and
-  run it on the first sync too. hook-delete-policy keeps a FAILED Job for the
-  operator to read, and `before-hook-creation` removes it at the start of the
-  next attempt, so a failure never blocks the next upgrade.
+  Hook contract. Upgrade phases only: a first install has no old pod holding
+  the volume. Both Jobs are still defensive about a missing Deployment, because
+  ArgoCD and Flux map these phases to PreSync and PostSync and run them on the
+  first sync too. hook-delete-policy keeps a FAILED Job for the operator to
+  read, and `before-hook-creation` removes it at the start of the next attempt,
+  so a failure never blocks the next upgrade.
 
-  Failure is fail-closed: the upgrade stops rather than risking the wedge. The
-  workers stay at 0 in that case; `helm rollback`, a repeat upgrade, or a
-  manual scale brings them back. Operators who order the rollout themselves
-  (or whose RBAC forbids the patch) set serializeUpgrades=false.
+  Failure posture differs per phase, on purpose. The pre-upgrade Job is
+  fail-closed: it stops the upgrade before anything is applied rather than risk
+  the wedge. The post-upgrade Job runs after the manifests are already applied,
+  so it never fails the release over an app that is slow or broken: if the app
+  rollout does not finish in time it warns, scales the workers back up anyway,
+  and exits 0. It fails only when it cannot reach the Kubernetes API, which
+  would leave the workers at 0 and has to be visible.
+
+  Operators who order the rollout themselves, or whose cluster forbids this
+  RBAC, set serializeUpgrades=false.
 */}}
 {{- if and (eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true") .Values.workers.enabled .Values.app.storedObjects.localFilesystem.serializeUpgrades }}
 {{- $name := printf "%s-stored-objects-upgrade" .Release.Name }}
 {{- $workersDeployment := printf "%s-workers" .Release.Name }}
-{{- /* The wait has to outlast the workers' own shutdown budget. A terminating
-       pod keeps its volume attached to its node until it is fully gone, so a
-       wait shorter than terminationGracePeriodSeconds would report success
-       while the old pod still holds the attachment, which is the state this
-       hook exists to prevent. The helper is the same one the workers
-       Deployment renders its grace period from, so an operator who raises the
-       grace period raises this with it. */}}
-{{- $graceSeconds := int (include "langwatch.terminationGracePeriod" (dict "component" .Values.workers "name" "workers")) }}
-{{- $waitSeconds := add $graceSeconds 60 }}
-{{- $deadlineSeconds := add $waitSeconds 60 }}
+{{- $appDeployment := printf "%s-app" .Release.Name }}
+{{- $workersSelector := printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s" $workersDeployment .Release.Name }}
+{{- $workersReplicas := .Values.workers.replicaCount | int }}
+{{- /* The wait for the workers to go away has to outlast their own shutdown
+       budget. A terminating pod keeps its volume attached to its node until it
+       is fully gone, so a shorter wait would report success while the old pod
+       still holds the attachment, which is the state these hooks exist to
+       prevent. The helper is the same one the workers Deployment renders its
+       grace period from, so an operator who raises the grace period raises
+       this with it. */}}
+{{- $workersGrace := int (include "langwatch.terminationGracePeriod" (dict "component" .Values.workers "name" "workers")) }}
+{{- $workersWait := add $workersGrace 60 }}
+{{- /* The wait for the app rollout covers three things in series: the old app
+       pod finishing its own grace period, the volume detaching from that node
+       and attaching to the new one (the attach-detach controller retries with
+       a backoff of minutes), and the app booting. Ten minutes on top of the
+       app's grace period covers all three with room to spare, and the Job
+       warns and gives the workers back rather than failing when it does
+       not. */}}
+{{- $appGrace := int (include "langwatch.terminationGracePeriod" (dict "component" .Values.app "name" "app")) }}
+{{- $appWait := add $appGrace 600 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -61,7 +91,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade
+    helm.sh/hook: pre-upgrade,post-upgrade
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
@@ -72,19 +102,19 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade
+    helm.sh/hook: pre-upgrade,post-upgrade
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
-  # Read the workers Deployment by name, so "not installed yet" is
-  # distinguishable from a real failure.
+  # Read the two Deployments by name: the workers, so "not installed yet" is
+  # distinguishable from a real failure, and the app, to follow its rollout.
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    resourceNames: [{{ $workersDeployment | quote }}]
+    resourceNames: [{{ $workersDeployment | quote }}, {{ $appDeployment | quote }}]
     verbs: ["get"]
-  # Change the replica count and nothing else. A patch on the scale
+  # Change the workers' replica count and nothing else. A patch on the scale
   # subresource cannot touch the image, the environment, or any other field of
-  # the pod spec.
+  # the pod spec, and the app Deployment is not in this rule at all.
   - apiGroups: ["apps"]
     resources: ["deployments/scale"]
     resourceNames: [{{ $workersDeployment | quote }}]
@@ -103,7 +133,7 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade
+    helm.sh/hook: pre-upgrade,post-upgrade
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
@@ -118,7 +148,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $name }}
+  name: {{ $name }}-pre
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
   annotations:
@@ -127,36 +157,14 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: {{ $deadlineSeconds }}
+  activeDeadlineSeconds: {{ add $workersWait 60 }}
   ttlSecondsAfterFinished: 600
   template:
     metadata:
       labels:
         {{- include "langwatch.labels" . | nindent 8 }}
     spec:
-      restartPolicy: Never
-      serviceAccountName: {{ $name }}
-      # This pod is the one workload in the release that DOES call the
-      # Kubernetes API, so it needs the token global.automountServiceAccountToken
-      # withholds from the rest.
-      automountServiceAccountToken: true
-      {{- with .Values.global.scheduling.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.global.scheduling.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.global.scheduling.priorityClassName }}
-      priorityClassName: {{ . | quote }}
-      {{- end }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      containers:
+      {{- include "langwatch.storedObjects.upgradeHookPodSpec" . | nindent 6 }}
         - name: serialize-upgrade
           image: {{ .Values.app.storedObjects.localFilesystem.serializeUpgradesImage | quote }}
           imagePullPolicy: IfNotPresent
@@ -173,38 +181,111 @@ spec:
               set -u
               ns={{ .Release.Namespace | quote }}
               deploy={{ $workersDeployment | quote }}
-              selector={{ printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s" $workersDeployment .Release.Name | quote }}
-              timeout={{ $waitSeconds }}
+              selector={{ $workersSelector | quote }}
+              timeout={{ $workersWait }}
 
-              if ! kubectl -n "$ns" get deployment "$deploy" >/dev/null 2>&1; then
-                printf 'serialize-upgrade: no Deployment %s in namespace %s, nothing to stand down\n' "$deploy" "$ns"
+              {{ include "langwatch.storedObjects.upgradeHookShellHelpers" . | nindent 14 | trim }}
+
+              if ! deployment_exists; then
+                printf 'serialize-upgrade[pre]: no Deployment %s in namespace %s, nothing to stand down\n' "$deploy" "$ns"
                 exit 0
               fi
 
-              printf 'serialize-upgrade: scaling %s to 0 so the app is the only holder of the stored-objects volume\n' "$deploy"
-              if ! kubectl -n "$ns" patch deployment "$deploy" --subresource=scale --type=merge -p '{"spec":{"replicas":0}}'; then
-                printf 'serialize-upgrade: could not scale %s to 0. Scale it yourself and retry, or set app.storedObjects.localFilesystem.serializeUpgrades=false to order the rollout on your own.\n' "$deploy" >&2
+              printf 'serialize-upgrade[pre]: scaling %s to 0 so the app is the only holder of the stored-objects volume\n' "$deploy"
+              if ! scale_workers 0; then
+                printf 'serialize-upgrade[pre]: could not scale %s to 0. Scale it yourself and retry, or set app.storedObjects.localFilesystem.serializeUpgrades=false to order the rollout on your own.\n' "$deploy" >&2
                 exit 1
               fi
 
-              printf 'serialize-upgrade: waiting up to %ss for the %s pods to go away\n' "$timeout" "$deploy"
-              out=$(kubectl -n "$ns" wait --for=delete pod --selector="$selector" --timeout="${timeout}s" 2>&1)
-              status=$?
-              printf '%s\n' "$out"
-              if [ "$status" -ne 0 ]; then
-                # kubectl below 1.31 reports an empty selector result as an
-                # error. No pods left IS the state this step waits for, so it
-                # must not read as a failure.
-                case "$out" in
-                  *'no matching resources found'*)
-                    printf 'serialize-upgrade: no %s pods left, the app can roll alone\n' "$deploy"
-                    exit 0
-                    ;;
-                esac
-                printf 'serialize-upgrade: %s pods were still present after %ss. The upgrade is stopped so it cannot wedge on a multi-attach error. Check why the pods do not terminate, then run the upgrade again (it scales the workers back up).\n' "$deploy" "$timeout" >&2
+              if ! wait_for_workers_gone "$timeout"; then
+                printf 'serialize-upgrade[pre]: %s pods were still present after %ss. The upgrade is stopped so it cannot wedge on a multi-attach error. Check why the pods do not terminate, then run the upgrade again (it scales the workers back up).\n' "$deploy" "$timeout" >&2
                 exit 1
               fi
-              printf 'serialize-upgrade: the %s pods are gone, the app can roll alone\n' "$deploy"
+              printf 'serialize-upgrade[pre]: the %s pods are gone, the app can roll alone\n' "$deploy"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}-post
+  labels:
+    {{- include "langwatch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ add (add $workersWait $appWait) 120 }}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "langwatch.labels" . | nindent 8 }}
+    spec:
+      {{- include "langwatch.storedObjects.upgradeHookPodSpec" . | nindent 6 }}
+        - name: serialize-upgrade
+          image: {{ .Values.app.storedObjects.localFilesystem.serializeUpgradesImage | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -u
+              ns={{ .Release.Namespace | quote }}
+              deploy={{ $workersDeployment | quote }}
+              app={{ $appDeployment | quote }}
+              selector={{ $workersSelector | quote }}
+              timeout={{ $workersWait }}
+              app_timeout={{ $appWait }}
+              replicas={{ $workersReplicas }}
+
+              {{ include "langwatch.storedObjects.upgradeHookShellHelpers" . | nindent 14 | trim }}
+
+              {{ include "langwatch.storedObjects.upgradeHookAppRolloutHelper" . | nindent 14 | trim }}
+
+              if ! deployment_exists; then
+                printf 'serialize-upgrade[post]: no Deployment %s in namespace %s, nothing to bring back\n' "$deploy" "$ns"
+                exit 0
+              fi
+
+              # Helm restored the replica count when it applied the release, so
+              # a new workers pod may already be running on the node the old app
+              # pod is leaving. Stand it down until the app owns the volume.
+              printf 'serialize-upgrade[post]: scaling %s to 0 until the app rollout finishes\n' "$deploy"
+              if ! scale_workers 0; then
+                printf 'serialize-upgrade[post]: could not scale %s to 0. Scale it to %s yourself once the app pod is running.\n' "$deploy" "$replicas" >&2
+                exit 1
+              fi
+              if ! wait_for_workers_gone "$timeout"; then
+                printf 'serialize-upgrade[post]: %s pods were still present after %ss, bringing the workers back anyway\n' "$deploy" "$timeout" >&2
+              fi
+
+              printf 'serialize-upgrade[post]: waiting up to %ss for the %s rollout to finish\n' "$app_timeout" "$app"
+              if wait_for_app_rollout "$app_timeout"; then
+                printf 'serialize-upgrade[post]: %s is running, the workers can follow it\n' "$app"
+              else
+                # Never fail the release over a slow or broken app: the
+                # manifests are already applied, and leaving the workers at 0
+                # would be a silent capacity loss on top of whatever is wrong.
+                printf 'serialize-upgrade[post]: %s did not finish its rollout in %ss. Bringing the workers back anyway. Check the app pod: while it is not running, the workers may hold the stored-objects volume on another node.\n' "$app" "$app_timeout" >&2
+              fi
+
+              printf 'serialize-upgrade[post]: scaling %s back to %s\n' "$deploy" "$replicas"
+              if ! scale_workers "$replicas"; then
+                printf 'serialize-upgrade[post]: could not scale %s back to %s. Scale it yourself.\n' "$deploy" "$replicas" >&2
+                exit 1
+              fi
+              printf 'serialize-upgrade[post]: %s is back at %s\n' "$deploy" "$replicas"
           resources:
             requests:
               cpu: 10m

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -699,7 +699,7 @@ EXEMPT_WORKLOADS=(
   # Same shape: the upgrade hooks scale the workers Deployment through the
   # Kubernetes API, so they need their token and a writable root. Only render
   # in local-filesystem stored-objects mode, which a strict cluster should not
-  # be running anyway — that mode shares one ReadWriteOnce volume between the
+  # be running anyway: that mode shares one ReadWriteOnce volume between the
   # app and the workers and is the documented hobby tier. Use app.dataplane.
   "templates/app/stored-objects-serialize-upgrade.yaml:app.storedObjects.localFilesystem.serializeUpgrades"
 )

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -696,6 +696,12 @@ EXEMPT_WORKLOADS=(
   # Runs kubectl against Secrets, so it needs its token and a writable root for
   # kubectl's discovery cache. Only renders on the operator-owned-Secret path.
   "charts/clickhouse/templates/preflight-secrets-job.yaml:clickhouse.preflight.enabled"
+  # Same shape: the upgrade hooks scale the workers Deployment through the
+  # Kubernetes API, so they need their token and a writable root. Only render
+  # in local-filesystem stored-objects mode, which a strict cluster should not
+  # be running anyway — that mode shares one ReadWriteOnce volume between the
+  # app and the workers and is the documented hobby tier. Use app.dataplane.
+  "templates/app/stored-objects-serialize-upgrade.yaml:app.storedObjects.localFilesystem.serializeUpgrades"
 )
 
 # Every emptyDir in the rendered manifest must declare a sizeLimit: they are

--- a/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
+++ b/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+#
+# Renders the chart and asserts that an upgrade of a local-filesystem install
+# moves ONE consumer of the stored-objects volume at a time.
+#
+# Why this matters. In local-filesystem mode the app Deployment and the workers
+# Deployment mount the same ReadWriteOnce PVC. A ReadWriteOnce volume attaches
+# to one node, so every consumer has to sit on that node. A helm upgrade rolls
+# both Deployments at once and nothing orders them, so on a cluster with more
+# than one node the new pod of one Deployment can be scheduled on a fresh node
+# while the old pod of the other still holds the attachment on the old node.
+# Both wedge in ContainerCreating with a multi-attach error (issue #7191).
+#
+# The chart answers with a pre-upgrade hook Job that scales the workers to 0 and
+# waits for their pods to go away. Everything about that hook is a Go template
+# over several values: which installs it renders for, how long it waits, what it
+# is allowed to touch. A gate written the wrong way round, a wait shorter than
+# the workers' own shutdown budget, or an RBAC rule that grew wider are all
+# invisible in the template source and visible only in the rendered output.
+# See specs/setup/helm-stored-objects-upgrade-ordering.feature.
+#
+# Scenario bindings use the same `@scenario` token as the bats suites,
+# expressed as a hash-comment above the test function it verifies. The next
+# line that is neither blank nor a comment must be that function.
+#
+# Usage (from charts/langwatch):
+#   helm dependency build .
+#   ./tests/stored-objects-upgrade-ordering.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+readonly HOOK_TEMPLATE="langwatch/templates/app/stored-objects-serialize-upgrade.yaml"
+readonly STORED_OBJECTS_PVC_TEMPLATE="langwatch/templates/app/stored-objects-pvc.yaml"
+readonly WORKERS_DEPLOYMENT="lw-workers"
+
+# The workers' default grace period. The wait has to outlast it, because a
+# terminating pod keeps its volume attached to its node until it is fully gone.
+readonly DEFAULT_GRACE_SECONDS=55
+
+# Secret autogen, so the chart's own secret validation lets a bare render
+# through. Matches the other suites in this directory.
+readonly BASE="--set autogen.enabled=true"
+
+# Minimum flags that make S3 the active stored-objects backend.
+readonly DATAPLANE="--set app.dataplane.enabled=true --set app.dataplane.s3.bucket=b --set app.dataplane.s3.region=eu-central-1"
+
+failures=0
+
+fail() {
+  echo "FAIL [$1]: $2"
+  failures=$((failures + 1))
+}
+
+# Renders a profile, aborting on a render error rather than letting an empty
+# result satisfy a "renders nothing" assertion.
+render() {
+  local out
+  # shellcheck disable=SC2086
+  if ! out=$(helm template lw . $BASE $1 2>&1); then
+    echo "RENDER ERROR for flags '$1':" >&2
+    printf '%s\n' "$out" | head -n 20 >&2
+    exit 2
+  fi
+  printf '%s\n' "$out"
+}
+
+# Prints only the documents the hook template produced, so a value from another
+# template can never satisfy an assertion.
+hook_block() {
+  render "$1" | awk -v want="$HOOK_TEMPLATE" '
+    /^# Source: / { grab = ($3 == want) }
+    grab { print }
+  '
+}
+
+# Prints the one document of a given kind out of a hook block on stdin.
+hook_doc() {
+  awk -v want="$1" '
+    /^# Source: / {
+      if (kind == want) { printf "%s", buf }
+      buf = ""; kind = ""; next
+    }
+    /^kind: / { kind = $2 }
+    { buf = buf $0 "\n" }
+    END { if (kind == want) printf "%s", buf }
+  '
+}
+
+# Prints one component Deployment, the same way workers-shutdown.sh does.
+render_component() {
+  render "$2" | awk -v want="langwatch/templates/$1/deployment.yaml" '
+    /^# Source: / { grab = ($3 == want) }
+    grab { print }
+  '
+}
+
+# Asserts a profile renders no hook at all, and says which profile.
+expect_no_hook() {
+  local label="$1" flags="$2" block
+  block=$(hook_block "$flags")
+  if [ -n "$block" ]; then
+    fail "$label" "the pre-upgrade hook rendered where no volume is shared"
+    return
+  fi
+  echo "ok   [$label] no pre-upgrade hook rendered"
+}
+
+expect_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*) return 0 ;;
+  esac
+  fail "$label" "expected to find: ${needle}"
+  return 1
+}
+
+expect_absent() {
+  local label="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*)
+      fail "$label" "must not contain: ${needle}"
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+# @scenario "A local-filesystem install gets a pre-upgrade step"
+test_default_install_renders_the_hook() {
+  local block job app_block workers_block
+  block=$(hook_block "")
+  if [ -z "$block" ]; then
+    fail "default hook" "the default local-filesystem install rendered no pre-upgrade hook"
+    return
+  fi
+
+  job=$(printf '%s\n' "$block" | hook_doc Job)
+  if [ -z "$job" ]; then
+    fail "default hook" "the hook rendered no Job"
+    return
+  fi
+  expect_contains "default hook" "$job" "helm.sh/hook: pre-upgrade" || return 0
+
+  # The ordering claim, stated as the two facts a render can show: the Job is a
+  # pre-upgrade hook (helm runs those before it applies anything), and neither
+  # Deployment is a hook, so both are ordinary release resources that helm only
+  # touches afterwards. The RBAC carries a lower weight than the Job, so the
+  # ServiceAccount exists before the Job needs it.
+  app_block=$(render_component "app" "")
+  workers_block=$(render_component "workers" "")
+  expect_absent "default hook" "$app_block" "helm.sh/hook" || return 0
+  expect_absent "default hook" "$workers_block" "helm.sh/hook" || return 0
+
+  local job_weight rbac_weight
+  job_weight=$(printf '%s\n' "$job" | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
+  rbac_weight=$(printf '%s\n' "$block" | hook_doc Role | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
+  case "${job_weight}${rbac_weight}" in
+    '' | *[!0-9-]*)
+      fail "default hook" "hook weights did not render as numbers (Job '${job_weight:-<absent>}', Role '${rbac_weight:-<absent>}')"
+      return
+      ;;
+  esac
+  if [ "$rbac_weight" -ge "$job_weight" ]; then
+    fail "default hook" \
+      "the Role's weight (${rbac_weight}) must be below the Job's (${job_weight}), or the Job can start without its permissions"
+    return
+  fi
+  echo "ok   [default hook] pre-upgrade Job at weight ${job_weight}, RBAC at ${rbac_weight}, Deployments are not hooks"
+}
+
+# @scenario "The pre-upgrade step scales the workers to zero and waits for the pods"
+test_hook_scales_workers_to_zero_and_waits() {
+  local job
+  job=$(hook_block "" | hook_doc Job)
+
+  # The scale target, the count, and the wait all have to name the workers.
+  # Asserting only that the script says "replicas":0 would pass just as happily
+  # if it scaled the app.
+  expect_contains "scale and wait" "$job" "deploy=\"${WORKERS_DEPLOYMENT}\"" || return 0
+  expect_contains "scale and wait" "$job" '--subresource=scale' || return 0
+  expect_contains "scale and wait" "$job" '{"spec":{"replicas":0}}' || return 0
+  expect_contains "scale and wait" "$job" '--for=delete pod' || return 0
+  expect_contains "scale and wait" "$job" \
+    "selector=\"app.kubernetes.io/name=${WORKERS_DEPLOYMENT},app.kubernetes.io/instance=lw\"" || return 0
+  echo "ok   [scale and wait] the hook scales ${WORKERS_DEPLOYMENT} to 0 and waits for its pods to be deleted"
+}
+
+wait_seconds_of() {
+  printf '%s' "$1" | awk -F'=' '/^ *timeout=/ { gsub(/ /, "", $2); print $2; exit }'
+}
+
+deadline_seconds_of() {
+  printf '%s' "$1" | awk '/activeDeadlineSeconds:/ { print $2; exit }'
+}
+
+# Asserts one profile's wait outlasts the grace period that profile grants.
+expect_wait_outlasts_grace() {
+  local label="$1" flags="$2" grace="$3" job wait deadline
+  job=$(hook_block "$flags" | hook_doc Job)
+  if [ -z "$job" ]; then
+    fail "$label" "rendered no hook Job"
+    return
+  fi
+  wait=$(wait_seconds_of "$job")
+  deadline=$(deadline_seconds_of "$job")
+  case "${wait}" in
+    '' | *[!0-9]*)
+      fail "$label" "the wait did not render as a number (got '${wait:-<absent>}')"
+      return
+      ;;
+  esac
+  case "${deadline}" in
+    '' | *[!0-9]*)
+      fail "$label" "activeDeadlineSeconds did not render as a number (got '${deadline:-<absent>}')"
+      return
+      ;;
+  esac
+  if [ "$wait" -le "$grace" ]; then
+    fail "$label" \
+      "the hook waits ${wait}s, which does not outlast the ${grace}s the workers may take to exit"
+    return
+  fi
+  # A deadline at or below the wait would kill the Job while the wait it was
+  # sized for is still running, which reads as "the pods never went away".
+  if [ "$deadline" -le "$wait" ]; then
+    fail "$label" \
+      "activeDeadlineSeconds is ${deadline}s, which cuts the ${wait}s wait short"
+    return
+  fi
+  echo "ok   [$label] waits ${wait}s for a ${grace}s grace period, with a ${deadline}s Job deadline"
+}
+
+# @scenario "The wait outlasts the time the workers may take to shut down"
+test_wait_outlasts_the_grace_period() {
+  expect_wait_outlasts_grace "wait vs grace" "" "$DEFAULT_GRACE_SECONDS"
+  # An operator who gives the workers a slower drain must not be left with a
+  # wait sized for the old one.
+  expect_wait_outlasts_grace "wait vs raised grace" \
+    "--set workers.shutdownDrainSeconds=60 --set workers.terminationGracePeriodSeconds=120" \
+    120
+}
+
+# @scenario "The workers come back at the replica count the release names"
+test_workers_replicas_are_in_the_manifest() {
+  local block replicas
+  block=$(render_component "workers" "")
+  replicas=$(printf '%s\n' "$block" | awk '/^  replicas:/ { print $2; exit }')
+  case "$replicas" in
+    '' | *[!0-9]*)
+      fail "workers replicas" \
+        "the workers Deployment does not name replicas (got '${replicas:-<absent>}'). The hook scales them to 0, and only a rendered replica count brings them back when helm applies the release."
+      return
+      ;;
+  esac
+  if [ "$replicas" -lt 1 ]; then
+    fail "workers replicas" "the workers Deployment renders replicas: ${replicas}"
+    return
+  fi
+  echo "ok   [workers replicas] the manifest names replicas: ${replicas}, so applying the release restores the count"
+}
+
+# @scenario "An install with object storage gets no pre-upgrade step"
+test_dataplane_renders_no_hook() {
+  expect_no_hook "dataplane" "$DATAPLANE"
+  # Anchor the reason: with S3 active there is no stored-objects PVC either, so
+  # nothing is shared and nothing needs ordering. Matched by template source,
+  # because the bundled datastores render PersistentVolumeClaims of their own.
+  local out
+  out=$(render "$DATAPLANE")
+  expect_absent "dataplane" "$out" "$STORED_OBJECTS_PVC_TEMPLATE" || return 0
+  echo "ok   [dataplane] no stored-objects PVC and no hook"
+}
+
+# @scenario "An install without workers gets no pre-upgrade step"
+test_no_workers_renders_no_hook() {
+  expect_no_hook "workers off" "--set workers.enabled=false"
+}
+
+# @scenario "An operator can turn the pre-upgrade step off"
+test_knob_off_renders_no_hook() {
+  local flags="--set app.storedObjects.localFilesystem.serializeUpgrades=false"
+  expect_no_hook "knob off" "$flags"
+  # The knob orders the rollout, it does not change the storage mode: the PVC
+  # and the workers' mount of it have to survive.
+  local out workers_block
+  out=$(render "$flags")
+  expect_contains "knob off" "$out" "$STORED_OBJECTS_PVC_TEMPLATE" || return 0
+  workers_block=$(render_component "workers" "$flags")
+  expect_contains "knob off" "$workers_block" "claimName: lw-stored-objects" || return 0
+  echo "ok   [knob off] the PVC and the workers' mount of it are unchanged"
+}
+
+# @scenario "The step may touch only the workers Deployment and the pods beside it"
+test_hook_rbac_is_scoped() {
+  local block role
+  block=$(hook_block "")
+  role=$(printf '%s\n' "$block" | hook_doc Role)
+  if [ -z "$role" ]; then
+    fail "rbac scope" "the hook rendered no Role"
+    return
+  fi
+
+  # Namespaced only. A ClusterRole here would hand the hook every namespace.
+  expect_absent "rbac scope" "$block" "kind: ClusterRole" || return 0
+  expect_absent "rbac scope" "$block" "kind: ClusterRoleBinding" || return 0
+
+  # Named target. Without resourceNames the hook could scale any Deployment in
+  # the namespace, including the app it is supposed to leave alone.
+  expect_contains "rbac scope" "$role" "resourceNames: [\"${WORKERS_DEPLOYMENT}\"]" || return 0
+  local named_rules
+  named_rules=$(printf '%s\n' "$role" | grep -c 'resourceNames:' || true)
+  if [ "$named_rules" -ne 2 ]; then
+    fail "rbac scope" "expected both Deployment rules to name ${WORKERS_DEPLOYMENT}, found ${named_rules} resourceNames"
+    return
+  fi
+
+  # Write access is the scale subresource only. A patch on `deployments` itself
+  # could rewrite the image or the environment.
+  expect_contains "rbac scope" "$role" 'resources: ["deployments"]' || return 0
+  expect_contains "rbac scope" "$role" 'resources: ["deployments/scale"]' || return 0
+  local deployment_verbs scale_verbs pod_verbs
+  deployment_verbs=$(printf '%s\n' "$role" | awk '/resources: \["deployments"\]/ { want=1 } want && /verbs:/ { print; exit }')
+  scale_verbs=$(printf '%s\n' "$role" | awk '/resources: \["deployments\/scale"\]/ { want=1 } want && /verbs:/ { print; exit }')
+  pod_verbs=$(printf '%s\n' "$role" | awk '/resources: \["pods"\]/ { want=1 } want && /verbs:/ { print; exit }')
+
+  expect_contains "rbac scope" "$deployment_verbs" 'verbs: ["get"]' || return 0
+  expect_contains "rbac scope" "$scale_verbs" 'verbs: ["get", "patch"]' || return 0
+  expect_contains "rbac scope" "$pod_verbs" 'verbs: ["get", "list", "watch"]' || return 0
+
+  # Nothing that can destroy or create work.
+  local verb
+  for verb in create delete deletecollection update; do
+    expect_absent "rbac scope" "$role" "\"${verb}\"" || return 0
+  done
+  echo "ok   [rbac scope] a namespaced Role: get on ${WORKERS_DEPLOYMENT}, patch on its scale, read on pods"
+}
+
+# @scenario "A first install is not blocked by the step"
+test_hook_is_upgrade_only_and_tolerates_a_missing_deployment() {
+  local block job
+  block=$(hook_block "")
+  job=$(printf '%s\n' "$block" | hook_doc Job)
+
+  # pre-install would run this on a fresh install, where there is no old pod
+  # holding the volume and no Deployment to scale.
+  expect_absent "first install" "$block" "pre-install" || return 0
+
+  # ArgoCD and Flux map pre-upgrade to PreSync and run it on the first sync
+  # anyway, so the script itself has to leave without an error.
+  expect_contains "first install" "$job" 'if ! kubectl -n "$ns" get deployment "$deploy"' || return 0
+  expect_contains "first install" "$job" 'nothing to stand down' || return 0
+  local guard_exit
+  guard_exit=$(printf '%s\n' "$job" | awk '/nothing to stand down/ { want=1 } want && /exit / { print $2; exit }')
+  if [ "$guard_exit" != "0" ]; then
+    fail "first install" "a missing Deployment must exit 0, the script exits '${guard_exit:-<absent>}'"
+    return
+  fi
+  echo "ok   [first install] pre-upgrade only, and a missing Deployment exits 0"
+}
+
+# @scenario "A failed step does not block the next upgrade"
+test_failed_hook_does_not_block_the_next_upgrade() {
+  local block policies
+  block=$(hook_block "")
+  policies=$(printf '%s\n' "$block" | grep 'helm.sh/hook-delete-policy' | sort -u)
+  if [ -z "$policies" ]; then
+    fail "delete policy" "the hook declares no hook-delete-policy, so a failed Job blocks the next upgrade with AlreadyExists"
+    return
+  fi
+  # Every document needs it, not just one of the four.
+  local policy_count doc_count
+  policy_count=$(printf '%s\n' "$block" | grep -c 'helm.sh/hook-delete-policy' || true)
+  doc_count=$(printf '%s\n' "$block" | grep -c '^# Source: ' || true)
+  if [ "$policy_count" -ne "$doc_count" ]; then
+    fail "delete policy" "${doc_count} hook documents but only ${policy_count} carry a hook-delete-policy"
+    return
+  fi
+  expect_contains "delete policy" "$policies" "before-hook-creation" || return 0
+  # hook-failed would delete the evidence the operator needs to read.
+  expect_absent "delete policy" "$policies" "hook-failed" || return 0
+  echo "ok   [delete policy] all ${doc_count} hook documents replace themselves before the next attempt and keep a failed Job"
+}
+
+test_default_install_renders_the_hook
+test_hook_scales_workers_to_zero_and_waits
+test_wait_outlasts_the_grace_period
+test_workers_replicas_are_in_the_manifest
+test_dataplane_renders_no_hook
+test_no_workers_renders_no_hook
+test_knob_off_renders_no_hook
+test_hook_rbac_is_scoped
+test_hook_is_upgrade_only_and_tolerates_a_missing_deployment
+test_failed_hook_does_not_block_the_next_upgrade
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+
+echo "all stored-objects-upgrade-ordering assertions passed"

--- a/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
+++ b/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Renders the chart and asserts that an upgrade of a local-filesystem install
-# moves ONE consumer of the stored-objects volume at a time.
+# keeps the workers off the shared stored-objects volume while the app rolls.
 #
 # Why this matters. In local-filesystem mode the app Deployment and the workers
 # Deployment mount the same ReadWriteOnce PVC. A ReadWriteOnce volume attaches
@@ -11,12 +11,14 @@
 # while the old pod of the other still holds the attachment on the old node.
 # Both wedge in ContainerCreating with a multi-attach error (issue #7191).
 #
-# The chart answers with a pre-upgrade hook Job that scales the workers to 0 and
-# waits for their pods to go away. Everything about that hook is a Go template
-# over several values: which installs it renders for, how long it waits, what it
-# is allowed to touch. A gate written the wrong way round, a wait shorter than
-# the workers' own shutdown budget, or an RBAC rule that grew wider are all
-# invisible in the template source and visible only in the rendered output.
+# The chart answers with two hooks: a pre-upgrade Job that scales the workers to
+# 0 and waits for their pods to go away, and a post-upgrade Job that stands them
+# down again (helm's apply restores the count) until the app rollout finishes.
+# Everything about them is a Go template over several values: which installs
+# they render for, how long they wait, what they are allowed to touch. A gate
+# written the wrong way round, a wait shorter than the workers' own shutdown
+# budget, or an RBAC rule that grew wider are all invisible in the template
+# source and visible only in the rendered output.
 # See specs/setup/helm-stored-objects-upgrade-ordering.feature.
 #
 # Scenario bindings use the same `@scenario` token as the bats suites,
@@ -34,8 +36,11 @@ cd "$(dirname "$0")/.."
 readonly HOOK_TEMPLATE="langwatch/templates/app/stored-objects-serialize-upgrade.yaml"
 readonly STORED_OBJECTS_PVC_TEMPLATE="langwatch/templates/app/stored-objects-pvc.yaml"
 readonly WORKERS_DEPLOYMENT="lw-workers"
+readonly APP_DEPLOYMENT="lw-app"
+readonly PRE_JOB="lw-stored-objects-upgrade-pre"
+readonly POST_JOB="lw-stored-objects-upgrade-post"
 
-# The workers' default grace period. The wait has to outlast it, because a
+# The workers' default grace period. The waits have to outlast it, because a
 # terminating pod keeps its volume attached to its node until it is fully gone.
 readonly DEFAULT_GRACE_SECONDS=55
 
@@ -88,6 +93,20 @@ hook_doc() {
   '
 }
 
+# Prints the one document with a given metadata.name out of a hook block on
+# stdin. The two Jobs share a kind, so the name is what tells them apart.
+hook_doc_named() {
+  awk -v want="$1" '
+    /^# Source: / {
+      if (name == want) { printf "%s", buf }
+      buf = ""; name = ""; next
+    }
+    /^  name: / && name == "" { name = $2 }
+    { buf = buf $0 "\n" }
+    END { if (name == want) printf "%s", buf }
+  '
+}
+
 # Prints one component Deployment, the same way workers-shutdown.sh does.
 render_component() {
   render "$2" | awk -v want="langwatch/templates/$1/deployment.yaml" '
@@ -101,10 +120,10 @@ expect_no_hook() {
   local label="$1" flags="$2" block
   block=$(hook_block "$flags")
   if [ -n "$block" ]; then
-    fail "$label" "the pre-upgrade hook rendered where no volume is shared"
+    fail "$label" "the upgrade hooks rendered where no volume is shared"
     return
   fi
-  echo "ok   [$label] no pre-upgrade hook rendered"
+  echo "ok   [$label] no upgrade hooks rendered"
 }
 
 expect_contains() {
@@ -129,19 +148,19 @@ expect_absent() {
 
 # @scenario "A local-filesystem install gets a pre-upgrade step"
 test_default_install_renders_the_hook() {
-  local block job app_block workers_block
+  local block pre app_block workers_block
   block=$(hook_block "")
   if [ -z "$block" ]; then
-    fail "default hook" "the default local-filesystem install rendered no pre-upgrade hook"
+    fail "default hook" "the default local-filesystem install rendered no upgrade hooks"
     return
   fi
 
-  job=$(printf '%s\n' "$block" | hook_doc Job)
-  if [ -z "$job" ]; then
-    fail "default hook" "the hook rendered no Job"
+  pre=$(printf '%s\n' "$block" | hook_doc_named "$PRE_JOB")
+  if [ -z "$pre" ]; then
+    fail "default hook" "the hooks rendered no ${PRE_JOB} Job"
     return
   fi
-  expect_contains "default hook" "$job" "helm.sh/hook: pre-upgrade" || return 0
+  expect_contains "default hook" "$pre" "helm.sh/hook: pre-upgrade" || return 0
 
   # The ordering claim, stated as the two facts a render can show: the Job is a
   # pre-upgrade hook (helm runs those before it applies anything), and neither
@@ -154,7 +173,7 @@ test_default_install_renders_the_hook() {
   expect_absent "default hook" "$workers_block" "helm.sh/hook" || return 0
 
   local job_weight rbac_weight
-  job_weight=$(printf '%s\n' "$job" | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
+  job_weight=$(printf '%s\n' "$pre" | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
   rbac_weight=$(printf '%s\n' "$block" | hook_doc Role | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
   case "${job_weight}${rbac_weight}" in
     '' | *[!0-9-]*)
@@ -172,19 +191,19 @@ test_default_install_renders_the_hook() {
 
 # @scenario "The pre-upgrade step scales the workers to zero and waits for the pods"
 test_hook_scales_workers_to_zero_and_waits() {
-  local job
-  job=$(hook_block "" | hook_doc Job)
+  local pre
+  pre=$(hook_block "" | hook_doc_named "$PRE_JOB")
 
   # The scale target, the count, and the wait all have to name the workers.
   # Asserting only that the script says "replicas":0 would pass just as happily
   # if it scaled the app.
-  expect_contains "scale and wait" "$job" "deploy=\"${WORKERS_DEPLOYMENT}\"" || return 0
-  expect_contains "scale and wait" "$job" '--subresource=scale' || return 0
-  expect_contains "scale and wait" "$job" '{"spec":{"replicas":0}}' || return 0
-  expect_contains "scale and wait" "$job" '--for=delete pod' || return 0
-  expect_contains "scale and wait" "$job" \
+  expect_contains "scale and wait" "$pre" "deploy=\"${WORKERS_DEPLOYMENT}\"" || return 0
+  expect_contains "scale and wait" "$pre" '--subresource=scale' || return 0
+  expect_contains "scale and wait" "$pre" 'scale_workers 0' || return 0
+  expect_contains "scale and wait" "$pre" '--for=delete pod' || return 0
+  expect_contains "scale and wait" "$pre" \
     "selector=\"app.kubernetes.io/name=${WORKERS_DEPLOYMENT},app.kubernetes.io/instance=lw\"" || return 0
-  echo "ok   [scale and wait] the hook scales ${WORKERS_DEPLOYMENT} to 0 and waits for its pods to be deleted"
+  echo "ok   [scale and wait] the pre-upgrade Job scales ${WORKERS_DEPLOYMENT} to 0 and waits for its pods to be deleted"
 }
 
 wait_seconds_of() {
@@ -198,9 +217,9 @@ deadline_seconds_of() {
 # Asserts one profile's wait outlasts the grace period that profile grants.
 expect_wait_outlasts_grace() {
   local label="$1" flags="$2" grace="$3" job wait deadline
-  job=$(hook_block "$flags" | hook_doc Job)
+  job=$(hook_block "$flags" | hook_doc_named "$PRE_JOB")
   if [ -z "$job" ]; then
-    fail "$label" "rendered no hook Job"
+    fail "$label" "rendered no ${PRE_JOB} Job"
     return
   fi
   wait=$(wait_seconds_of "$job")
@@ -242,26 +261,53 @@ test_wait_outlasts_the_grace_period() {
     120
 }
 
-# @scenario "The workers come back at the replica count the release names"
-test_workers_replicas_are_in_the_manifest() {
-  local block replicas
-  block=$(render_component "workers" "")
-  replicas=$(printf '%s\n' "$block" | awk '/^  replicas:/ { print $2; exit }')
-  case "$replicas" in
+# @scenario "The workers come back only after the app pod that holds the volume is running"
+test_workers_come_back_after_the_app_rollout() {
+  local block post replicas app_wait deadline
+  block=$(hook_block "")
+  post=$(printf '%s\n' "$block" | hook_doc_named "$POST_JOB")
+  if [ -z "$post" ]; then
+    fail "post hook" "the hooks rendered no ${POST_JOB} Job"
+    return
+  fi
+  expect_contains "post hook" "$post" "helm.sh/hook: post-upgrade" || return 0
+
+  # Stand the workers down again: helm's apply restored the count, and the new
+  # workers pod can follow the still-terminating old app pod back to the node
+  # the app is leaving.
+  expect_contains "post hook" "$post" 'scale_workers 0' || return 0
+  expect_contains "post hook" "$post" '--for=delete pod' || return 0
+
+  # Wait for the app, by name, before giving the workers back.
+  expect_contains "post hook" "$post" "app=\"${APP_DEPLOYMENT}\"" || return 0
+  expect_contains "post hook" "$post" 'wait_for_app_rollout "$app_timeout"' || return 0
+
+  # And then restore the count the release names, not a hardcoded 1.
+  replicas=$(printf '%s' "$post" | awk -F'=' '/^ *replicas=/ { gsub(/ /, "", $2); print $2; exit }')
+  if [ "$replicas" != "1" ]; then
+    fail "post hook" "the post-upgrade Job restores '${replicas:-<absent>}' replicas, expected the chart's workers.replicaCount of 1"
+    return
+  fi
+  expect_contains "post hook" "$post" 'scale_workers "$replicas"' || return 0
+
+  # The Job deadline has to cover both waits, or it kills itself before it can
+  # bring the workers back.
+  app_wait=$(printf '%s' "$post" | awk -F'=' '/^ *app_timeout=/ { gsub(/ /, "", $2); print $2; exit }')
+  deadline=$(deadline_seconds_of "$post")
+  case "${app_wait}${deadline}" in
     '' | *[!0-9]*)
-      fail "workers replicas" \
-        "the workers Deployment does not name replicas (got '${replicas:-<absent>}'). The hook scales them to 0, and only a rendered replica count brings them back when helm applies the release."
+      fail "post hook" "the app wait or the deadline did not render as numbers (app '${app_wait:-<absent>}', deadline '${deadline:-<absent>}')"
       return
       ;;
   esac
-  if [ "$replicas" -lt 1 ]; then
-    fail "workers replicas" "the workers Deployment renders replicas: ${replicas}"
+  if [ "$deadline" -le "$app_wait" ]; then
+    fail "post hook" "activeDeadlineSeconds is ${deadline}s, which cuts the ${app_wait}s app wait short"
     return
   fi
-  echo "ok   [workers replicas] the manifest names replicas: ${replicas}, so applying the release restores the count"
+  echo "ok   [post hook] stands the workers down, waits up to ${app_wait}s for ${APP_DEPLOYMENT}, then restores ${replicas}"
 }
 
-# @scenario "An install with object storage gets no pre-upgrade step"
+# @scenario "An install with object storage gets no upgrade steps"
 test_dataplane_renders_no_hook() {
   expect_no_hook "dataplane" "$DATAPLANE"
   # Anchor the reason: with S3 active there is no stored-objects PVC either, so
@@ -270,15 +316,15 @@ test_dataplane_renders_no_hook() {
   local out
   out=$(render "$DATAPLANE")
   expect_absent "dataplane" "$out" "$STORED_OBJECTS_PVC_TEMPLATE" || return 0
-  echo "ok   [dataplane] no stored-objects PVC and no hook"
+  echo "ok   [dataplane] no stored-objects PVC and no hooks"
 }
 
-# @scenario "An install without workers gets no pre-upgrade step"
+# @scenario "An install without workers gets no upgrade steps"
 test_no_workers_renders_no_hook() {
   expect_no_hook "workers off" "--set workers.enabled=false"
 }
 
-# @scenario "An operator can turn the pre-upgrade step off"
+# @scenario "An operator can turn the upgrade steps off"
 test_knob_off_renders_no_hook() {
   local flags="--set app.storedObjects.localFilesystem.serializeUpgrades=false"
   expect_no_hook "knob off" "$flags"
@@ -292,32 +338,34 @@ test_knob_off_renders_no_hook() {
   echo "ok   [knob off] the PVC and the workers' mount of it are unchanged"
 }
 
-# @scenario "The step may touch only the workers Deployment and the pods beside it"
+# @scenario "The steps may touch only the two Deployments and the pods beside them"
 test_hook_rbac_is_scoped() {
   local block role
   block=$(hook_block "")
   role=$(printf '%s\n' "$block" | hook_doc Role)
   if [ -z "$role" ]; then
-    fail "rbac scope" "the hook rendered no Role"
+    fail "rbac scope" "the hooks rendered no Role"
     return
   fi
 
-  # Namespaced only. A ClusterRole here would hand the hook every namespace.
+  # Namespaced only. A ClusterRole here would hand the hooks every namespace.
   expect_absent "rbac scope" "$block" "kind: ClusterRole" || return 0
   expect_absent "rbac scope" "$block" "kind: ClusterRoleBinding" || return 0
 
-  # Named target. Without resourceNames the hook could scale any Deployment in
-  # the namespace, including the app it is supposed to leave alone.
+  # Named targets. Without resourceNames the hooks could scale any Deployment
+  # in the namespace.
+  expect_contains "rbac scope" "$role" "resourceNames: [\"${WORKERS_DEPLOYMENT}\", \"${APP_DEPLOYMENT}\"]" || return 0
   expect_contains "rbac scope" "$role" "resourceNames: [\"${WORKERS_DEPLOYMENT}\"]" || return 0
   local named_rules
   named_rules=$(printf '%s\n' "$role" | grep -c 'resourceNames:' || true)
   if [ "$named_rules" -ne 2 ]; then
-    fail "rbac scope" "expected both Deployment rules to name ${WORKERS_DEPLOYMENT}, found ${named_rules} resourceNames"
+    fail "rbac scope" "expected both Deployment rules to name their targets, found ${named_rules} resourceNames"
     return
   fi
 
-  # Write access is the scale subresource only. A patch on `deployments` itself
-  # could rewrite the image or the environment.
+  # Write access is the workers' scale subresource only. A patch on
+  # `deployments` itself could rewrite the image or the environment, and the app
+  # Deployment must not be writable at all.
   expect_contains "rbac scope" "$role" 'resources: ["deployments"]' || return 0
   expect_contains "rbac scope" "$role" 'resources: ["deployments/scale"]' || return 0
   local deployment_verbs scale_verbs pod_verbs
@@ -334,30 +382,55 @@ test_hook_rbac_is_scoped() {
   for verb in create delete deletecollection update; do
     expect_absent "rbac scope" "$role" "\"${verb}\"" || return 0
   done
-  echo "ok   [rbac scope] a namespaced Role: get on ${WORKERS_DEPLOYMENT}, patch on its scale, read on pods"
+  echo "ok   [rbac scope] a namespaced Role: get on both Deployments, patch on the workers' scale, read on pods"
 }
 
-# @scenario "A first install is not blocked by the step"
+# @scenario "A first install is not blocked by the steps"
 test_hook_is_upgrade_only_and_tolerates_a_missing_deployment() {
-  local block job
+  local block pre post guard_exit
   block=$(hook_block "")
-  job=$(printf '%s\n' "$block" | hook_doc Job)
+  pre=$(printf '%s\n' "$block" | hook_doc_named "$PRE_JOB")
+  post=$(printf '%s\n' "$block" | hook_doc_named "$POST_JOB")
 
-  # pre-install would run this on a fresh install, where there is no old pod
+  # pre-install would run these on a fresh install, where there is no old pod
   # holding the volume and no Deployment to scale.
   expect_absent "first install" "$block" "pre-install" || return 0
+  expect_absent "first install" "$block" "post-install" || return 0
 
-  # ArgoCD and Flux map pre-upgrade to PreSync and run it on the first sync
-  # anyway, so the script itself has to leave without an error.
-  expect_contains "first install" "$job" 'if ! kubectl -n "$ns" get deployment "$deploy"' || return 0
-  expect_contains "first install" "$job" 'nothing to stand down' || return 0
-  local guard_exit
-  guard_exit=$(printf '%s\n' "$job" | awk '/nothing to stand down/ { want=1 } want && /exit / { print $2; exit }')
-  if [ "$guard_exit" != "0" ]; then
-    fail "first install" "a missing Deployment must exit 0, the script exits '${guard_exit:-<absent>}'"
+  # ArgoCD and Flux map these phases to PreSync and PostSync and run them on the
+  # first sync anyway, so both scripts have to leave without an error.
+  local job label
+  for label in pre post; do
+    if [ "$label" = "pre" ]; then job="$pre"; else job="$post"; fi
+    expect_contains "first install" "$job" 'if ! deployment_exists; then' || return 0
+    guard_exit=$(printf '%s\n' "$job" | awk '/deployment_exists; then/ { want=1 } want && /^ *exit / { print $2; exit }')
+    if [ "$guard_exit" != "0" ]; then
+      fail "first install" "the ${label} Job must exit 0 when the Deployment is missing, it exits '${guard_exit:-<absent>}'"
+      return
+    fi
+  done
+  echo "ok   [first install] upgrade phases only, and both Jobs exit 0 when the Deployment is missing"
+}
+
+# @scenario "A slow or broken app never leaves the workers switched off"
+test_post_hook_restores_workers_even_when_the_app_is_slow() {
+  local post tail_of_script
+  post=$(hook_block "" | hook_doc_named "$POST_JOB")
+
+  # The wait is wrapped in an if/else that reports the problem and carries on,
+  # rather than exiting. The scale back up therefore runs on both branches.
+  expect_contains "post hook resilience" "$post" 'if wait_for_app_rollout "$app_timeout"; then' || return 0
+  expect_contains "post hook resilience" "$post" 'Bringing the workers back anyway' || return 0
+
+  # Nothing between the wait and the scale-up may exit, or a slow app would
+  # leave the workers at 0.
+  tail_of_script=$(printf '%s\n' "$post" | awk '/waiting up to %ss for the %s rollout/ { want=1 } want && /scale_workers "\$replicas"/ { exit } want { print }')
+  if [ -z "$tail_of_script" ]; then
+    fail "post hook resilience" "could not find the rollout wait ahead of the scale back up"
     return
   fi
-  echo "ok   [first install] pre-upgrade only, and a missing Deployment exits 0"
+  expect_absent "post hook resilience" "$tail_of_script" "exit 1" || return 0
+  echo "ok   [post hook resilience] a rollout that does not finish warns and still brings the workers back"
 }
 
 # @scenario "A failed step does not block the next upgrade"
@@ -366,10 +439,10 @@ test_failed_hook_does_not_block_the_next_upgrade() {
   block=$(hook_block "")
   policies=$(printf '%s\n' "$block" | grep 'helm.sh/hook-delete-policy' | sort -u)
   if [ -z "$policies" ]; then
-    fail "delete policy" "the hook declares no hook-delete-policy, so a failed Job blocks the next upgrade with AlreadyExists"
+    fail "delete policy" "the hooks declare no hook-delete-policy, so a failed Job blocks the next upgrade with AlreadyExists"
     return
   fi
-  # Every document needs it, not just one of the four.
+  # Every document needs it, not just one of the five.
   local policy_count doc_count
   policy_count=$(printf '%s\n' "$block" | grep -c 'helm.sh/hook-delete-policy' || true)
   doc_count=$(printf '%s\n' "$block" | grep -c '^# Source: ' || true)
@@ -386,12 +459,13 @@ test_failed_hook_does_not_block_the_next_upgrade() {
 test_default_install_renders_the_hook
 test_hook_scales_workers_to_zero_and_waits
 test_wait_outlasts_the_grace_period
-test_workers_replicas_are_in_the_manifest
+test_workers_come_back_after_the_app_rollout
 test_dataplane_renders_no_hook
 test_no_workers_renders_no_hook
 test_knob_off_renders_no_hook
 test_hook_rbac_is_scoped
 test_hook_is_upgrade_only_and_tolerates_a_missing_deployment
+test_post_hook_restores_workers_even_when_the_app_is_slow
 test_failed_hook_does_not_block_the_next_upgrade
 
 if [ "$failures" -gt 0 ]; then

--- a/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
+++ b/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
@@ -109,6 +109,14 @@ hook_doc_named() {
   '
 }
 
+# Prints the exact `helm.sh/hook` value of a rendered document. Matched whole,
+# because a substring test for "pre-upgrade" passes just as happily against
+# "pre-upgrade,pre-rollback" and against "pre-upgrade" alone, and the whole
+# point of these assertions is which lifecycle events are covered.
+hook_events_of() {
+  printf '%s\n' "$1" | awk -F': ' '/helm.sh\/hook:/ { gsub(/ /, "", $2); print $2; exit }'
+}
+
 # Prints one component Deployment, the same way workers-shutdown.sh does.
 render_component() {
   render "$2" | awk -v want="langwatch/templates/$1/deployment.yaml" '
@@ -183,7 +191,12 @@ test_default_install_renders_the_hook() {
     fail "default hook" "the hooks rendered no ${PRE_JOB} Job"
     return
   fi
-  expect_contains "default hook" "$pre" "helm.sh/hook: pre-upgrade" || return 0
+  local pre_events
+  pre_events=$(hook_events_of "$pre")
+  if [ "$pre_events" != "pre-upgrade,pre-rollback" ]; then
+    fail "default hook" "the drain Job runs on '${pre_events:-<absent>}', expected pre-upgrade,pre-rollback"
+    return
+  fi
 
   # The ordering claim, stated as the two facts a render can show: the Job is a
   # pre-upgrade hook (helm runs those before it applies anything), and neither
@@ -277,7 +290,12 @@ test_workers_come_back_after_the_app_rollout() {
     fail "post hook" "the hooks rendered no ${POST_JOB} Job"
     return
   fi
-  expect_contains "post hook" "$post" "helm.sh/hook: post-upgrade" || return 0
+  local post_events
+  post_events=$(hook_events_of "$post")
+  if [ "$post_events" != "post-upgrade,post-rollback" ]; then
+    fail "post hook" "the restore Job runs on '${post_events:-<absent>}', expected post-upgrade,post-rollback"
+    return
+  fi
 
   # Stand the workers down again: helm's apply restored the count, and the new
   # workers pod can follow the still-terminating old app pod back to the node
@@ -500,7 +518,64 @@ test_hook_is_upgrade_only_and_tolerates_a_missing_deployment() {
       return
     fi
   done
-  echo "ok   [first install] upgrade phases only, and both Jobs exit 0 when the Deployment is missing"
+  echo "ok   [first install] never an install phase, and both Jobs exit 0 when the Deployment is missing"
+}
+
+# A rollback moves both Deployments the same way an upgrade does, and helm
+# fires its own pair of events for it. A Job registered for the upgrade events
+# alone simply does not run there, silently, which is the worst shape this bug
+# can take: the operator is already recovering from a bad rollout.
+#
+# @scenario "A rollback is ordered the same way an upgrade is"
+test_rollback_runs_the_same_steps() {
+  local block doc name events want
+  block=$(hook_block "")
+  if [ -z "$block" ]; then
+    fail "rollback" "the default local-filesystem install rendered no upgrade hooks"
+    return
+  fi
+
+  # The two Jobs each need their own half of the rollback lifecycle.
+  doc=$(printf '%s\n' "$block" | hook_doc_named "$PRE_JOB")
+  events=$(hook_events_of "$doc")
+  if [ "$events" != "pre-upgrade,pre-rollback" ]; then
+    fail "rollback" "the drain Job runs on '${events:-<absent>}', expected pre-upgrade,pre-rollback"
+    return
+  fi
+  doc=$(printf '%s\n' "$block" | hook_doc_named "$POST_JOB")
+  events=$(hook_events_of "$doc")
+  if [ "$events" != "post-upgrade,post-rollback" ]; then
+    fail "rollback" "the restore Job runs on '${events:-<absent>}', expected post-upgrade,post-rollback"
+    return
+  fi
+
+  # The ServiceAccount, the Role and the RoleBinding need all four events, or a
+  # Job runs during a rollback with no identity and no permissions.
+  local kind
+  for kind in ServiceAccount Role RoleBinding; do
+    doc=$(printf '%s\n' "$block" | hook_doc "$kind")
+    if [ -z "$doc" ]; then
+      fail "rollback" "rendered no ${kind}"
+      return
+    fi
+    events=$(hook_events_of "$doc")
+    want="pre-upgrade,pre-rollback,post-upgrade,post-rollback"
+    if [ "$events" != "$want" ]; then
+      fail "rollback" "the ${kind} runs on '${events:-<absent>}', expected ${want}"
+      return
+    fi
+  done
+
+  # Count as well as sample, so a document added later cannot quietly skip the
+  # rollback events.
+  local rollback_docs doc_count
+  rollback_docs=$(printf '%s\n' "$block" | grep -c 'helm.sh/hook: .*rollback' || true)
+  doc_count=$(printf '%s\n' "$block" | grep -c '^# Source: ' || true)
+  if [ "$rollback_docs" -ne "$doc_count" ]; then
+    fail "rollback" "${doc_count} hook documents but only ${rollback_docs} cover a rollback"
+    return
+  fi
+  echo "ok   [rollback] all ${doc_count} hook documents cover the rollback events too"
 }
 
 # @scenario "A slow or broken app never leaves the workers switched off"
@@ -557,6 +632,7 @@ test_no_workers_renders_no_hook
 test_knob_off_renders_no_hook
 test_hook_rbac_is_scoped
 test_hook_is_upgrade_only_and_tolerates_a_missing_deployment
+test_rollback_runs_the_same_steps
 test_post_hook_restores_workers_even_when_the_app_is_slow
 test_failed_hook_does_not_block_the_next_upgrade
 

--- a/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
+++ b/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
@@ -48,8 +48,10 @@ readonly DEFAULT_GRACE_SECONDS=55
 # through. Matches the other suites in this directory.
 readonly BASE="--set autogen.enabled=true"
 
-# Minimum flags that make S3 the active stored-objects backend.
-readonly DATAPLANE="--set app.dataplane.enabled=true --set app.dataplane.s3.bucket=b --set app.dataplane.s3.region=eu-central-1"
+# Minimum flags that make S3 the active stored-objects backend. The chart
+# already defaults app.dataplane.provider to awsS3 and names a bucket, so the
+# switch is the only thing to set. There is no app.dataplane.s3 key.
+readonly DATAPLANE="--set app.dataplane.enabled=true --set app.dataplane.provider=awsS3 --set app.dataplane.bucket=langwatch-dataset"
 
 failures=0
 
@@ -146,6 +148,27 @@ expect_absent() {
   return 0
 }
 
+# Fails unless EVERY named value is a whole number. Validating them one by one
+# matters: concatenating two values and testing the result would let an empty
+# one hide behind a numeric one, and the arithmetic comparison that follows
+# would then error out, which `if` reads as false and the suite reports as ok.
+# Call as: expect_numbers <label> name=value name=value ...
+expect_numbers() {
+  local label="$1" pair name value
+  shift
+  for pair in "$@"; do
+    name=${pair%%=*}
+    value=${pair#*=}
+    case "$value" in
+      '' | *[!0-9-]* | -*-* | -)
+        fail "$label" "${name} did not render as a number (got '${value:-<absent>}')"
+        return 1
+        ;;
+    esac
+  done
+  return 0
+}
+
 # @scenario "A local-filesystem install gets a pre-upgrade step"
 test_default_install_renders_the_hook() {
   local block pre app_block workers_block
@@ -175,12 +198,7 @@ test_default_install_renders_the_hook() {
   local job_weight rbac_weight
   job_weight=$(printf '%s\n' "$pre" | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
   rbac_weight=$(printf '%s\n' "$block" | hook_doc Role | awk -F'"' '/helm.sh\/hook-weight/ { print $2; exit }')
-  case "${job_weight}${rbac_weight}" in
-    '' | *[!0-9-]*)
-      fail "default hook" "hook weights did not render as numbers (Job '${job_weight:-<absent>}', Role '${rbac_weight:-<absent>}')"
-      return
-      ;;
-  esac
+  expect_numbers "default hook" "the Job's weight=${job_weight}" "the Role's weight=${rbac_weight}" || return 0
   if [ "$rbac_weight" -ge "$job_weight" ]; then
     fail "default hook" \
       "the Role's weight (${rbac_weight}) must be below the Job's (${job_weight}), or the Job can start without its permissions"
@@ -224,18 +242,7 @@ expect_wait_outlasts_grace() {
   fi
   wait=$(wait_seconds_of "$job")
   deadline=$(deadline_seconds_of "$job")
-  case "${wait}" in
-    '' | *[!0-9]*)
-      fail "$label" "the wait did not render as a number (got '${wait:-<absent>}')"
-      return
-      ;;
-  esac
-  case "${deadline}" in
-    '' | *[!0-9]*)
-      fail "$label" "activeDeadlineSeconds did not render as a number (got '${deadline:-<absent>}')"
-      return
-      ;;
-  esac
+  expect_numbers "$label" "the wait=${wait}" "activeDeadlineSeconds=${deadline}" || return 0
   if [ "$wait" -le "$grace" ]; then
     fail "$label" \
       "the hook waits ${wait}s, which does not outlast the ${grace}s the workers may take to exit"
@@ -282,6 +289,20 @@ test_workers_come_back_after_the_app_rollout() {
   expect_contains "post hook" "$post" "app=\"${APP_DEPLOYMENT}\"" || return 0
   expect_contains "post hook" "$post" 'wait_for_app_rollout "$app_timeout"' || return 0
 
+  # "Rolled out" has to mean the NEW pod. readyReplicas counts ready pods
+  # across every ReplicaSet, so a check built on it alone passes while the old
+  # pod is still the ready one, and the workers come back against the node the
+  # app is leaving. That is the wedge this hook exists to prevent, so assert on
+  # the fields that distinguish the generations.
+  local field
+  for field in updatedReplicas observedGeneration availableReplicas; do
+    expect_contains "post hook" "$post" ".status.${field}" || return 0
+  done
+  expect_absent "post hook" "$post" ".status.readyReplicas" || return 0
+  # No old pod may be left: status.replicas has to equal updatedReplicas.
+  expect_contains "post hook" "$post" '[ "$current" -eq "$updated" ]' || return 0
+  expect_contains "post hook" "$post" '[ "$available" -ge "$updated" ]' || return 0
+
   # And then restore the count the release names, not a hardcoded 1.
   replicas=$(printf '%s' "$post" | awk -F'=' '/^ *replicas=/ { gsub(/ /, "", $2); print $2; exit }')
   if [ "$replicas" != "1" ]; then
@@ -294,17 +315,85 @@ test_workers_come_back_after_the_app_rollout() {
   # bring the workers back.
   app_wait=$(printf '%s' "$post" | awk -F'=' '/^ *app_timeout=/ { gsub(/ /, "", $2); print $2; exit }')
   deadline=$(deadline_seconds_of "$post")
-  case "${app_wait}${deadline}" in
-    '' | *[!0-9]*)
-      fail "post hook" "the app wait or the deadline did not render as numbers (app '${app_wait:-<absent>}', deadline '${deadline:-<absent>}')"
-      return
-      ;;
-  esac
+  expect_numbers "post hook" "app_timeout=${app_wait}" "activeDeadlineSeconds=${deadline}" || return 0
   if [ "$deadline" -le "$app_wait" ]; then
     fail "post hook" "activeDeadlineSeconds is ${deadline}s, which cuts the ${app_wait}s app wait short"
     return
   fi
   echo "ok   [post hook] stands the workers down, waits up to ${app_wait}s for ${APP_DEPLOYMENT}, then restores ${replicas}"
+}
+
+# Prints the shell script a hook Job runs, dedented out of the rendered YAML
+# literal block and cut before the body, so the variables and the function
+# definitions can be sourced and driven directly.
+hook_script_prelude() {
+  printf '%s\n' "$1" | awk '
+    /^            - \|$/ { grab = 1; next }
+    !grab { next }
+    /^$/ { print ""; next }
+    /^              / {
+      line = substr($0, 15)
+      if (line ~ /^if ! deployment_exists/) { exit }
+      print line
+      next
+    }
+    { exit }
+  '
+}
+
+# The rollout check decides when the workers may come back, and getting it
+# wrong reintroduces the wedge silently. Asserting that the script mentions
+# `updatedReplicas` would pass just as happily if the comparison were
+# backwards, so this one runs the function against a fake kubectl and reads its
+# answer. See specs/setup/helm-stored-objects-upgrade-ordering.feature.
+#
+# @scenario "The workers come back only after the app pod that holds the volume is running"
+test_rollout_check_waits_for_the_new_pod() {
+  local post prelude workdir got
+  post=$(hook_block "" | hook_doc_named "$POST_JOB")
+  prelude=$(hook_script_prelude "$post")
+  if ! printf '%s\n' "$prelude" | grep -q 'app_rollout_done()'; then
+    fail "rollout check" "could not extract app_rollout_done from the rendered ${POST_JOB} Job"
+    return
+  fi
+
+  workdir=$(mktemp -d)
+  printf '%s\n' "$prelude" > "$workdir/lib.sh"
+  # A kubectl that answers with whatever the case under test holds.
+  printf '#!/bin/sh\nprintf %%s "$FAKE_STATE"\n' > "$workdir/kubectl"
+  chmod +x "$workdir/kubectl"
+
+  # generation|observedGeneration|spec.replicas|updatedReplicas|status.replicas|availableReplicas|
+  local label state want bad=0
+  local cases='settled on the new spec;5|5|1|1|1|1|;done
+controller has not seen the new spec;5|4|1|1|1|1|;waiting
+old pod still ready, new one not created;5|5|1||1|1|;waiting
+old pod still present beside the new one;5|5|1|1|2|2|;waiting
+new pod created but not yet available;5|5|1|1|1||;waiting
+nothing reported at all;||||||;waiting
+kubectl returned nothing;;waiting
+two replicas, only one updated;5|5|2|1|2|2|;waiting
+two replicas, both updated and available;5|5|2|2|2|2|;done'
+
+  while IFS=';' read -r label state want; do
+    [ -z "$label" ] && continue
+    if PATH="$workdir:$PATH" FAKE_STATE="$state" \
+       bash -c ". '$workdir/lib.sh' >/dev/null 2>&1; app_rollout_done"; then
+      got=done
+    else
+      got=waiting
+    fi
+    if [ "$got" != "$want" ]; then
+      fail "rollout check" "'${label}' reported ${got}, expected ${want} (state '${state}')"
+      bad=1
+    fi
+  done <<EOF
+$cases
+EOF
+
+  rm -rf "$workdir"
+  [ "$bad" -eq 0 ] || return 0
+  echo "ok   [rollout check] the rollout is only done once every replica is from the new spec and available"
 }
 
 # @scenario "An install with object storage gets no upgrade steps"
@@ -460,6 +549,7 @@ test_default_install_renders_the_hook
 test_hook_scales_workers_to_zero_and_waits
 test_wait_outlasts_the_grace_period
 test_workers_come_back_after_the_app_rollout
+test_rollout_check_waits_for_the_new_pod
 test_dataplane_renders_no_hook
 test_no_workers_renders_no_hook
 test_knob_off_renders_no_hook

--- a/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
+++ b/charts/langwatch/tests/stored-objects-upgrade-ordering.sh
@@ -373,7 +373,9 @@ new pod created but not yet available;5|5|1|1|1||;waiting
 nothing reported at all;||||||;waiting
 kubectl returned nothing;;waiting
 two replicas, only one updated;5|5|2|1|2|2|;waiting
-two replicas, both updated and available;5|5|2|2|2|2|;done'
+two replicas, one updated and no old pod left;5|5|2|1|1|1|;waiting
+two replicas, both updated and available;5|5|2|2|2|2|;done
+an app parked at zero replicas;5|5|0|||;done'
 
   while IFS=';' read -r label state want; do
     [ -z "$label" ] && continue

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -469,8 +469,8 @@ app:
   ## @param app.storedObjects.localFilesystem.path [string, default: /var/lib/langwatch/objects] Mount point that the LocalFilesystemDriver writes under.
   ## @param app.storedObjects.localFilesystem.size [string, default: 10Gi] PVC size for the stored-objects volume.
   ## @param app.storedObjects.localFilesystem.storageClassName [string] PVC storageClassName (cluster default if empty).
-  ## @param app.storedObjects.localFilesystem.serializeUpgrades [default: true] Scale the workers to 0 in a pre-upgrade hook, so only one pod holds the shared RWO volume while the app rolls.
-  ## @param app.storedObjects.localFilesystem.serializeUpgradesImage [string, default: alpine/k8s:1.30.0] Image the pre-upgrade hook runs. Needs sh and kubectl.
+  ## @param app.storedObjects.localFilesystem.serializeUpgrades [default: true] Hold the workers at 0 replicas while the app rolls, so only one pod holds the shared RWO volume.
+  ## @param app.storedObjects.localFilesystem.serializeUpgradesImage [string, default: alpine/k8s:1.30.0] Image the upgrade hooks run. Needs sh and kubectl.
   storedObjects:
     localFilesystem:
       enabled: true
@@ -486,15 +486,16 @@ app:
       # multi-attach error (issue #7191).
       #
       # With this on, a pre-upgrade hook Job scales the workers to 0 and waits
-      # for their pods to go away before helm applies the new manifests. The
-      # app then rolls as the only holder of the volume, and the workers come
-      # back at workers.replicaCount with the release.
+      # for their pods to go away before helm applies the new manifests, and a
+      # post-upgrade hook Job holds them at 0 until the app rollout finishes
+      # and then scales them back to workers.replicaCount. The app rolls as the
+      # only holder of the volume, and the workers follow the NEW app pod.
       #
-      # The hook needs a ServiceAccount token and a small Role (get on the
-      # workers Deployment, patch on its scale, read on the namespace's pods).
-      # Turn it off if you order the rollout yourself, if your cluster forbids
-      # that RBAC, or if you moved to app.dataplane (where it never renders
-      # anyway, because no volume is shared).
+      # The hooks need a ServiceAccount token and a small Role (get on the app
+      # and the workers Deployments, patch on the workers' scale, read on the
+      # namespace's pods). Turn them off if you order the rollout yourself, if
+      # your cluster forbids that RBAC, or if you moved to app.dataplane (where
+      # they never render anyway, because no volume is shared).
       serializeUpgrades: true
       # Needs sh + kubectl. registry.k8s.io/kubectl is distroless and has no
       # /bin/sh. Mirror this image into your own registry for an air-gapped

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -486,11 +486,17 @@ app:
       # attachment on the old node, and both wedge in ContainerCreating with a
       # multi-attach error (issue #7191).
       #
-      # With this on, a pre-upgrade hook Job scales the workers to 0 and waits
-      # for their pods to go away before helm applies the new manifests, and a
-      # post-upgrade hook Job holds them at 0 until the app rollout finishes
-      # and then scales them back to workers.replicaCount. The app rolls as the
-      # only holder of the volume, and the workers follow the NEW app pod.
+      # With this on, a hook Job scales the workers to 0 and waits for their
+      # pods to go away before helm applies the new manifests, and a second
+      # hook Job holds them at 0 until the app rollout finishes and then scales
+      # them back to workers.replicaCount. The app rolls as the only holder of
+      # the volume, and the workers follow the NEW app pod. Both Jobs run on
+      # rollback as well as upgrade.
+      #
+      # One case the chart cannot cover: on a rollback helm runs the hooks
+      # stored in the TARGET revision, so rolling back to a chart version from
+      # before these Jobs existed runs no Jobs at all. Scale the workers
+      # Deployment to 0 by hand before such a downgrade, and back up after it.
       #
       # The hooks need a ServiceAccount token and a small Role (get on the app
       # and the workers Deployments, patch on the workers' scale, read on the

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -470,7 +470,8 @@ app:
   ## @param app.storedObjects.localFilesystem.size [string, default: 10Gi] PVC size for the stored-objects volume.
   ## @param app.storedObjects.localFilesystem.storageClassName [string] PVC storageClassName (cluster default if empty).
   ## @param app.storedObjects.localFilesystem.serializeUpgrades [default: true] Hold the workers at 0 replicas while the app rolls, so only one pod holds the shared RWO volume.
-  ## @param app.storedObjects.localFilesystem.serializeUpgradesImage [string, default: alpine/k8s:1.30.0] Image the upgrade hooks run. Needs sh and kubectl.
+  ## @param app.storedObjects.localFilesystem.serializeUpgradesImage [string, default: alpine/k8s:1.34.9] Image the upgrade hooks run. Needs sh and kubectl. A digest reference works too.
+  ## @param app.storedObjects.localFilesystem.serializeUpgradesPullSecrets [array] Pull secrets for that image. The hook Jobs use their own ServiceAccount, so secrets on the namespace default ServiceAccount do not reach them.
   storedObjects:
     localFilesystem:
       enabled: true
@@ -498,9 +499,23 @@ app:
       # they never render anyway, because no volume is shared).
       serializeUpgrades: true
       # Needs sh + kubectl. registry.k8s.io/kubectl is distroless and has no
-      # /bin/sh. Mirror this image into your own registry for an air-gapped
-      # install.
-      serializeUpgradesImage: alpine/k8s:1.30.0
+      # /bin/sh.
+      #
+      # The tag names the kubectl version. kubectl supports one minor version
+      # of skew either way, so change this to match your cluster if it is far
+      # from 1.34. The hook only calls `get deployment`, `patch
+      # deployment --subresource=scale` and `wait --for=delete pod`, which are
+      # long-stable, so a wider skew works in practice.
+      #
+      # Mirror the image into your own registry for an air-gapped install and
+      # point this at your copy. A digest works here too
+      # (`myregistry.example.com/alpine/k8s@sha256:...`) if you pin by digest.
+      serializeUpgradesImage: alpine/k8s:1.34.9
+      # Pull secrets for that image. The hook Jobs run under their own
+      # ServiceAccount, so secrets attached to the namespace's `default`
+      # ServiceAccount, which the rest of the release uses, do not reach them.
+      # Example: [{ name: my-registry }]
+      serializeUpgradesPullSecrets: []
 
   # Email notification configuration
   # Naming a provider is what turns email on, so there is one switch rather

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -469,12 +469,37 @@ app:
   ## @param app.storedObjects.localFilesystem.path [string, default: /var/lib/langwatch/objects] Mount point that the LocalFilesystemDriver writes under.
   ## @param app.storedObjects.localFilesystem.size [string, default: 10Gi] PVC size for the stored-objects volume.
   ## @param app.storedObjects.localFilesystem.storageClassName [string] PVC storageClassName (cluster default if empty).
+  ## @param app.storedObjects.localFilesystem.serializeUpgrades [default: true] Scale the workers to 0 in a pre-upgrade hook, so only one pod holds the shared RWO volume while the app rolls.
+  ## @param app.storedObjects.localFilesystem.serializeUpgradesImage [string, default: alpine/k8s:1.30.0] Image the pre-upgrade hook runs. Needs sh and kubectl.
   storedObjects:
     localFilesystem:
       enabled: true
       path: /var/lib/langwatch/objects
       size: 10Gi
       storageClassName: ""
+
+      # The app and the workers mount the same ReadWriteOnce PVC in this mode,
+      # and a helm upgrade rolls both Deployments at once. On a cluster with
+      # more than one node the new pod of one Deployment can be scheduled on a
+      # fresh node while the old pod of the other still holds the volume
+      # attachment on the old node, and both wedge in ContainerCreating with a
+      # multi-attach error (issue #7191).
+      #
+      # With this on, a pre-upgrade hook Job scales the workers to 0 and waits
+      # for their pods to go away before helm applies the new manifests. The
+      # app then rolls as the only holder of the volume, and the workers come
+      # back at workers.replicaCount with the release.
+      #
+      # The hook needs a ServiceAccount token and a small Role (get on the
+      # workers Deployment, patch on its scale, read on the namespace's pods).
+      # Turn it off if you order the rollout yourself, if your cluster forbids
+      # that RBAC, or if you moved to app.dataplane (where it never renders
+      # anyway, because no volume is shared).
+      serializeUpgrades: true
+      # Needs sh + kubectl. registry.k8s.io/kubectl is distroless and has no
+      # /bin/sh. Mirror this image into your own registry for an air-gapped
+      # install.
+      serializeUpgradesImage: alpine/k8s:1.30.0
 
   # Email notification configuration
   # Naming a provider is what turns email on, so there is one switch rather

--- a/specs/setup/helm-stored-objects-upgrade-ordering.feature
+++ b/specs/setup/helm-stored-objects-upgrade-ordering.feature
@@ -1,20 +1,20 @@
 Feature: A chart upgrade moves one stored-objects volume consumer at a time
   As someone who runs LangWatch on their own cluster with local-filesystem
   stored objects,
-  I want the upgrade to stand the workers down before it rolls the app,
+  I want the workers to stay off the shared volume while the app rolls,
   so that my pods do not wedge in ContainerCreating on a multi-attach error.
 
   # Cross-references:
   #   charts/langwatch/templates/app/stored-objects-pvc.yaml — the ReadWriteOnce
   #     volume, rendered only when local-filesystem is the active backend.
   #   charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml — the
-  #     pre-upgrade hook this feature describes.
+  #     pre-upgrade and post-upgrade hooks this feature describes.
   #   charts/langwatch/templates/workers/deployment.yaml — the second consumer of
-  #     that volume, and the replicas the release restores.
+  #     that volume, and the podAffinity that ties it to the app pod.
   #   charts/langwatch/templates/_helpers.tpl —
-  #     langwatch.storedObjects.localFilesystemIsActive (the gate this hook shares
-  #     with the PVC) and langwatch.terminationGracePeriod (the shutdown budget the
-  #     wait must cover).
+  #     langwatch.storedObjects.localFilesystemIsActive (the gate these hooks
+  #     share with the PVC), langwatch.storedObjects.colocationAffinity, and
+  #     langwatch.terminationGracePeriod (the shutdown budget the waits cover).
   #   charts/langwatch/tests/stored-objects-upgrade-ordering.sh — the suite that
   #     renders the chart and asserts what this feature describes.
   #   specs/event-sourcing/worker-graceful-shutdown.feature — where the 55 second
@@ -37,21 +37,30 @@ Feature: A chart upgrade moves one stored-objects volume consumer at a time
   # this on a 3.14.0 upgrade and recovered by scaling the workers to 0, redoing
   # the rollout, and scaling the workers back up.
   #
-  # The fix makes that recovery part of the upgrade. A pre-upgrade hook Job scales
-  # the workers Deployment to 0 and waits until its pods are gone. Helm then
-  # applies the new manifests with the app as the only consumer of the volume,
-  # which the kill-then-start rollout already handles, and the workers Deployment
-  # comes back at the replica count its manifest names and follows the new app pod
-  # through the affinity that is already there.
+  # The fix makes that recovery part of the upgrade, in two steps. A pre-upgrade
+  # hook scales the workers to 0 and waits for their pods to go away, so the old
+  # workers pod cannot hold the volume while helm rolls the app. A post-upgrade
+  # hook scales them to 0 again, waits for the app rollout to finish, and only
+  # then gives the workers back.
   #
-  # These scenarios are verified by rendering the chart. The hook is a Go template
-  # over several values, so a gate that is written the wrong way round, a wait that
-  # is shorter than the shutdown budget, or an RBAC rule that grew wider is only
-  # visible in the rendered output. Each scenario binds to a test function in
-  # charts/langwatch/tests/stored-objects-upgrade-ordering.sh, which the parity
-  # checker discovers through its shell-test root.
+  # The second step is not redundant. Helm's apply restores the replica count
+  # from the manifest, so a new workers pod is created at the same instant as the
+  # new app pod. Its required podAffinity matches the old app pod, which is still
+  # terminating on the old node, so the scheduler puts the workers back on the
+  # node the app is leaving, where they take over the attachment and wedge the
+  # new app pod for good. This was measured on a four node EKS cluster: with the
+  # pre-upgrade step alone, an upgrade that moved the app to another node left it
+  # in ContainerCreating with "Multi-Attach error ... Volume is already used by
+  # pod(s) <release>-app-<old>".
+  #
+  # These scenarios are verified by rendering the chart. The hooks are Go
+  # templates over several values, so a gate that is written the wrong way round,
+  # a wait that is shorter than the shutdown budget, or an RBAC rule that grew
+  # wider is only visible in the rendered output. Each scenario binds to a test
+  # function in charts/langwatch/tests/stored-objects-upgrade-ordering.sh, which
+  # the parity checker discovers through its shell-test root.
 
-  Rule: Local-filesystem installs stand the workers down before the app rolls
+  Rule: The workers stay off the shared volume for the whole upgrade
 
     @e2e
     Scenario: A local-filesystem install gets a pre-upgrade step
@@ -75,48 +84,57 @@ Feature: A chart upgrade moves one stored-objects volume consumer at a time
       And raising the grace period raises the wait with it
 
     @e2e
-    Scenario: The workers come back at the replica count the release names
-      Given a release that names a worker replica count
-      When the chart renders the workers Deployment
-      Then the count is part of the manifest, so applying the release restores it
-      after the step scaled it to zero
+    Scenario: The workers come back only after the app pod that holds the volume is running
+      Given helm restores the replica count as soon as it applies the release
+      When the chart renders
+      Then a post-upgrade step stands the workers down again
+      And it waits for the app rollout to finish
+      And it then scales the workers back to the count the release names
 
-  Rule: The step renders only where the shared volume exists
+  Rule: The steps render only where the shared volume exists
 
     @e2e
-    Scenario: An install with object storage gets no pre-upgrade step
+    Scenario: An install with object storage gets no upgrade steps
       Given an install that keeps stored objects in S3 or Azure Blob
       When the chart renders
-      Then there is no pre-upgrade step, because no volume is shared
+      Then there are no upgrade steps, because no volume is shared
 
     @e2e
-    Scenario: An install without workers gets no pre-upgrade step
+    Scenario: An install without workers gets no upgrade steps
       Given an install that does not deploy the workers
       When the chart renders
-      Then there is no pre-upgrade step, because only the app holds the volume
+      Then there are no upgrade steps, because only the app holds the volume
 
     @e2e
-    Scenario: An operator can turn the pre-upgrade step off
+    Scenario: An operator can turn the upgrade steps off
       Given an operator who orders the rollout themselves
       When they turn the serialize-upgrades knob off and the chart renders
-      Then there is no pre-upgrade step
+      Then there are no upgrade steps
       And the rest of the local-filesystem install is unchanged
 
-  Rule: The step is safe to run and safe to fail
+  Rule: The steps are safe to run and safe to fail
 
     @e2e
-    Scenario: The step may touch only the workers Deployment and the pods beside it
-      Given the step needs the Kubernetes API to scale a Deployment
-      When the chart renders its permissions
-      Then it may read and change the scale of the workers Deployment by name
-      And it may read the pods in its own namespace and nothing else
-      And it holds no permission that reaches outside its namespace
+    Scenario: The steps may touch only the two Deployments and the pods beside them
+      Given the steps need the Kubernetes API to scale a Deployment
+      When the chart renders their permissions
+      Then they may read the app and the workers Deployments by name
+      And they may change the scale of the workers Deployment and nothing else
+      And they may read the pods in their own namespace
+      And they hold no permission that reaches outside their namespace
 
     @e2e
-    Scenario: A first install is not blocked by the step
+    Scenario: A first install is not blocked by the steps
       Given a cluster where the workers Deployment does not exist yet
-      When the step runs
+      When a step runs
       Then it reports success and changes nothing
+
+    @e2e
+    Scenario: A slow or broken app never leaves the workers switched off
+      Given an app that does not finish its rollout in time
+      When the post-upgrade step gives up waiting
+      Then it warns, scales the workers back up, and reports success
+      So that a problem with the app is never also a silent loss of workers
 
     @e2e
     Scenario: A failed step does not block the next upgrade

--- a/specs/setup/helm-stored-objects-upgrade-ordering.feature
+++ b/specs/setup/helm-stored-objects-upgrade-ordering.feature
@@ -1,0 +1,125 @@
+Feature: A chart upgrade moves one stored-objects volume consumer at a time
+  As someone who runs LangWatch on their own cluster with local-filesystem
+  stored objects,
+  I want the upgrade to stand the workers down before it rolls the app,
+  so that my pods do not wedge in ContainerCreating on a multi-attach error.
+
+  # Cross-references:
+  #   charts/langwatch/templates/app/stored-objects-pvc.yaml — the ReadWriteOnce
+  #     volume, rendered only when local-filesystem is the active backend.
+  #   charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml — the
+  #     pre-upgrade hook this feature describes.
+  #   charts/langwatch/templates/workers/deployment.yaml — the second consumer of
+  #     that volume, and the replicas the release restores.
+  #   charts/langwatch/templates/_helpers.tpl —
+  #     langwatch.storedObjects.localFilesystemIsActive (the gate this hook shares
+  #     with the PVC) and langwatch.terminationGracePeriod (the shutdown budget the
+  #     wait must cover).
+  #   charts/langwatch/tests/stored-objects-upgrade-ordering.sh — the suite that
+  #     renders the chart and asserts what this feature describes.
+  #   specs/event-sourcing/worker-graceful-shutdown.feature — where the 55 second
+  #     grace period comes from.
+  #
+  # Context. In local-filesystem mode the app Deployment and the workers
+  # Deployment mount the same ReadWriteOnce PersistentVolumeClaim. A
+  # ReadWriteOnce volume attaches to one node, so every consumer must sit on
+  # that node. The chart already defends this inside each Deployment: both use a
+  # kill-then-start rollout (maxSurge=0, maxUnavailable=1), the workers carry a
+  # required podAffinity to the app pod, and the chart refuses more than one
+  # replica of either.
+  #
+  # Those defenses are per Deployment. A helm upgrade rolls both Deployments at
+  # the same time and nothing orders them, so on a cluster with more than one
+  # node the new pod of one Deployment can be scheduled on a fresh node while the
+  # old pod of the other still holds the volume attachment on the old node. Both
+  # pods then wedge in ContainerCreating with a multi-attach error, and the
+  # attach-detach controller can hold that state for many minutes. A customer hit
+  # this on a 3.14.0 upgrade and recovered by scaling the workers to 0, redoing
+  # the rollout, and scaling the workers back up.
+  #
+  # The fix makes that recovery part of the upgrade. A pre-upgrade hook Job scales
+  # the workers Deployment to 0 and waits until its pods are gone. Helm then
+  # applies the new manifests with the app as the only consumer of the volume,
+  # which the kill-then-start rollout already handles, and the workers Deployment
+  # comes back at the replica count its manifest names and follows the new app pod
+  # through the affinity that is already there.
+  #
+  # These scenarios are verified by rendering the chart. The hook is a Go template
+  # over several values, so a gate that is written the wrong way round, a wait that
+  # is shorter than the shutdown budget, or an RBAC rule that grew wider is only
+  # visible in the rendered output. Each scenario binds to a test function in
+  # charts/langwatch/tests/stored-objects-upgrade-ordering.sh, which the parity
+  # checker discovers through its shell-test root.
+
+  Rule: Local-filesystem installs stand the workers down before the app rolls
+
+    @e2e
+    Scenario: A local-filesystem install gets a pre-upgrade step
+      Given the default install, which keeps stored objects on a local filesystem
+      When the chart renders
+      Then the release carries a pre-upgrade step that stands the workers down
+      And that step runs before helm changes any Deployment
+
+    @e2e
+    Scenario: The pre-upgrade step scales the workers to zero and waits for the pods
+      Given the default install
+      When the chart renders
+      Then the step scales the workers Deployment to zero replicas
+      And it waits for the workers pods to be gone before it reports success
+
+    @e2e
+    Scenario: The wait outlasts the time the workers may take to shut down
+      Given the workers may take their whole grace period to exit
+      When the chart renders
+      Then the step waits longer than that grace period
+      And raising the grace period raises the wait with it
+
+    @e2e
+    Scenario: The workers come back at the replica count the release names
+      Given a release that names a worker replica count
+      When the chart renders the workers Deployment
+      Then the count is part of the manifest, so applying the release restores it
+      after the step scaled it to zero
+
+  Rule: The step renders only where the shared volume exists
+
+    @e2e
+    Scenario: An install with object storage gets no pre-upgrade step
+      Given an install that keeps stored objects in S3 or Azure Blob
+      When the chart renders
+      Then there is no pre-upgrade step, because no volume is shared
+
+    @e2e
+    Scenario: An install without workers gets no pre-upgrade step
+      Given an install that does not deploy the workers
+      When the chart renders
+      Then there is no pre-upgrade step, because only the app holds the volume
+
+    @e2e
+    Scenario: An operator can turn the pre-upgrade step off
+      Given an operator who orders the rollout themselves
+      When they turn the serialize-upgrades knob off and the chart renders
+      Then there is no pre-upgrade step
+      And the rest of the local-filesystem install is unchanged
+
+  Rule: The step is safe to run and safe to fail
+
+    @e2e
+    Scenario: The step may touch only the workers Deployment and the pods beside it
+      Given the step needs the Kubernetes API to scale a Deployment
+      When the chart renders its permissions
+      Then it may read and change the scale of the workers Deployment by name
+      And it may read the pods in its own namespace and nothing else
+      And it holds no permission that reaches outside its namespace
+
+    @e2e
+    Scenario: A first install is not blocked by the step
+      Given a cluster where the workers Deployment does not exist yet
+      When the step runs
+      Then it reports success and changes nothing
+
+    @e2e
+    Scenario: A failed step does not block the next upgrade
+      Given a step that failed and was left behind for the operator to read
+      When the operator starts the next upgrade
+      Then the old Job is removed first, so the new one can be created

--- a/specs/setup/helm-stored-objects-upgrade-ordering.feature
+++ b/specs/setup/helm-stored-objects-upgrade-ordering.feature
@@ -5,19 +5,19 @@ Feature: A chart upgrade moves one stored-objects volume consumer at a time
   so that my pods do not wedge in ContainerCreating on a multi-attach error.
 
   # Cross-references:
-  #   charts/langwatch/templates/app/stored-objects-pvc.yaml — the ReadWriteOnce
+  #   charts/langwatch/templates/app/stored-objects-pvc.yaml: the ReadWriteOnce
   #     volume, rendered only when local-filesystem is the active backend.
-  #   charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml — the
+  #   charts/langwatch/templates/app/stored-objects-serialize-upgrade.yaml: the
   #     pre-upgrade and post-upgrade hooks this feature describes.
-  #   charts/langwatch/templates/workers/deployment.yaml — the second consumer of
+  #   charts/langwatch/templates/workers/deployment.yaml: the second consumer of
   #     that volume, and the podAffinity that ties it to the app pod.
-  #   charts/langwatch/templates/_helpers.tpl —
+  #   charts/langwatch/templates/_helpers.tpl:
   #     langwatch.storedObjects.localFilesystemIsActive (the gate these hooks
   #     share with the PVC), langwatch.storedObjects.colocationAffinity, and
   #     langwatch.terminationGracePeriod (the shutdown budget the waits cover).
-  #   charts/langwatch/tests/stored-objects-upgrade-ordering.sh — the suite that
+  #   charts/langwatch/tests/stored-objects-upgrade-ordering.sh: the suite that
   #     renders the chart and asserts what this feature describes.
-  #   specs/event-sourcing/worker-graceful-shutdown.feature — where the 55 second
+  #   specs/event-sourcing/worker-graceful-shutdown.feature: where the 55 second
   #     grace period comes from.
   #
   # Context. In local-filesystem mode the app Deployment and the workers

--- a/specs/setup/helm-stored-objects-upgrade-ordering.feature
+++ b/specs/setup/helm-stored-objects-upgrade-ordering.feature
@@ -131,6 +131,20 @@ Feature: A chart upgrade moves one stored-objects volume consumer at a time
       Then it reports success and changes nothing
 
     @e2e
+    Scenario: A rollback is ordered the same way an upgrade is
+      Given an operator rolling the release back after a bad rollout
+      When helm runs its rollback steps
+      Then the same two steps run, because they are registered for the rollback
+      events as well as the upgrade events
+      And the workers come back at the count the target release names
+      # A rollback moves both Deployments the same way an upgrade does, and it
+      # is most likely to be run while recovering from a rollout that already
+      # went wrong. Helm fires pre-rollback and post-rollback there, not the
+      # upgrade pair. The chart cannot protect a downgrade to a version from
+      # before these steps existed, because helm runs the target revision's
+      # hooks: that case needs a manual worker scale-down and is documented.
+
+    @e2e
     Scenario: A slow or broken app never leaves the workers switched off
       Given an app that does not finish its rollout in time
       When the post-upgrade step gives up waiting

--- a/specs/setup/helm-stored-objects-upgrade-ordering.feature
+++ b/specs/setup/helm-stored-objects-upgrade-ordering.feature
@@ -89,6 +89,7 @@ Feature: A chart upgrade moves one stored-objects volume consumer at a time
       When the chart renders
       Then a post-upgrade step stands the workers down again
       And it waits for the app rollout to finish
+      And it reads that from the new pod, never from the one it replaced
       And it then scales the workers back to the count the release names
 
   Rule: The steps render only where the shared volume exists
@@ -134,7 +135,7 @@ Feature: A chart upgrade moves one stored-objects volume consumer at a time
       Given an app that does not finish its rollout in time
       When the post-upgrade step gives up waiting
       Then it warns, scales the workers back up, and reports success
-      So that a problem with the app is never also a silent loss of workers
+      # A problem with the app must never also be a silent loss of workers.
 
     @e2e
     Scenario: A failed step does not block the next upgrade


### PR DESCRIPTION
Closes #7191

## The bug

In the default stored-objects mode (local filesystem, no S3 or Azure) the app
Deployment and the workers Deployment mount the same `ReadWriteOnce` PVC,
`<release>-stored-objects`. A `ReadWriteOnce` volume attaches to one node, so
every pod that mounts it has to run on that node.

The chart already defends this inside each Deployment:

- both use a kill-then-start rollout (`RollingUpdate` with
  `maxSurge=0`/`maxUnavailable=1`),
- the workers carry a required `podAffinity` to the app pod,
- the chart refuses more than one replica of either.

Those defenses are per Deployment. A `helm upgrade` rolls both Deployments at
the same time and nothing orders them, so on a cluster with more than one node
the new pod of one Deployment can be scheduled on a fresh node while the old pod
of the other still holds the volume attachment on the old node. Both pods then
wedge in `ContainerCreating` with a multi-attach error, and the attach-detach
controller can hold that state for minutes.

A customer hit this on a 3.14.0 upgrade of a multi-node cluster. They recovered
by scaling the workers to 0, redoing the rollout, and scaling the workers back
up.

#6825 made the window wider. Before it, neither pod set
`terminationGracePeriodSeconds` and the entrypoint force-exited after about 5
seconds. Now the grace period is 55 seconds, and a terminating pod keeps its
volume attached to its node until it is fully gone.

## The fix

The customer workaround is now part of the upgrade, in two steps:

1. A **pre-upgrade** hook Job scales the workers Deployment to 0 and waits until
   its pods are gone, so the old workers pod cannot hold the volume on the old
   node while Helm rolls the app.
2. A **post-upgrade** hook Job scales the workers to 0 again, waits for the app
   rollout to finish, and then scales them back to `workers.replicaCount`.

The second step is not redundant, and the EKS run below is what proved it. Helm's
apply restores the replica count from the manifest, so a new workers pod is
created at the same instant as the new app pod. Its required `podAffinity`
matches the **old** app pod, which is still terminating on the old node, so the
scheduler puts the workers back on the node the app is leaving, where they take
over the attachment and wedge the new app pod for good. Holding the workers at 0
until the app rollout finishes is what makes them follow the new app pod.

Details:

- **Gate.** The hooks render only when local-filesystem is the ACTIVE backend
  (the same `langwatch.storedObjects.localFilesystemIsActive` helper the PVC
  uses), the workers are enabled, and the new
  `app.storedObjects.localFilesystem.serializeUpgrades` knob is on (default
  `true`). With `app.dataplane` enabled there is no shared volume, so nothing
  renders.
- **Waits.** The wait for the workers to go away is derived from their own
  `langwatch.terminationGracePeriod`, plus 60 seconds. With the defaults that is
  115 seconds against a 55 second grace period, and it rises when an operator
  raises the grace period. The wait for the app rollout is the app's grace
  period plus 10 minutes, which covers the old pod terminating, the volume
  detaching and attaching, and the app booting. Each Job's
  `activeDeadlineSeconds` sits above its waits so the deadline cannot cut them
  short.
- **RBAC.** A namespaced `Role`: `get` on the app and the workers Deployments by
  name, `patch` on the workers' `scale` subresource by name, and
  `get`/`list`/`watch` on the pods of the release namespace. A patch on the
  scale subresource cannot change the image or the environment, and the app
  Deployment is not writable at all. Kubernetes ignores `resourceNames` on
  `list` and `watch`, so the pod read covers the namespace, which the code
  comment states. The rollout wait polls the app Deployment rather than calling
  `kubectl rollout status`, which LISTs Deployments and so cannot run under a
  Role restricted by `resourceNames`.
- **Prior art.** Image, ServiceAccount, hook weights, delete policy, security
  context and resource limits follow the ClickHouse preflight hook from #4423
  (`charts/clickhouse-serverless/templates/preflight-secrets-job.yaml`).
- **Hook lifecycle.** The drain Job runs on `pre-upgrade,pre-rollback` and the
  restore Job on `post-upgrade,post-rollback`; the ServiceAccount and the RBAC
  carry all four. Never an install phase: a first install has no old pod
  holding the volume. `hook-delete-policy:
  before-hook-creation,hook-succeeded` keeps a failed Job for the operator to
  read and removes it at the start of the next attempt, so a failure never
  blocks the next upgrade. Both scripts exit 0 when the workers Deployment does
  not exist, because ArgoCD and Flux map these phases to PreSync and PostSync
  and run them on the first sync too.
- **Failure posture.** The pre-upgrade Job is fail-closed: it stops the upgrade
  before anything is applied rather than risk the wedge. The post-upgrade Job
  runs after the manifests are applied, so it never fails the release over a
  slow or broken app: it warns, brings the workers back anyway, and exits 0.
  Leaving the workers at 0 would be a silent capacity loss on top of whatever is
  already wrong.
- **Pod security.** The Jobs call the Kubernetes API, so they need an
  automounted token and a writable root, which the chart's hardening gate
  forbids. They join the ClickHouse preflight Job in `EXEMPT_WORKLOADS`, and
  `examples/overlays/strict-admission.yaml` turns them off, which the gate
  requires of every exemption. A locked-down cluster should be on
  `app.dataplane` anyway, where the hooks never render.

## Deployment Impact

Chart only. No application code changes.

- **Who is affected:** self-hosted installs on the default local-filesystem
  stored-objects mode with the workers enabled. Installs on `app.dataplane` (S3,
  MinIO, Azure) render nothing new and are unaffected.
- **What changes at upgrade time:** two short-lived hook Jobs, a ServiceAccount,
  a Role and a RoleBinding are created and deleted around each `helm upgrade`.
  The workers are at 0 replicas for the length of the app rollout, then come
  back at `workers.replicaCount`. On the runs below that was 37 to 55 seconds.
  The app outage is the one the kill-then-start rollout already carried.
- **New permissions:** the release namespace gains a Role for the duration of
  the upgrade (`get` on two Deployments by name, `patch` on the workers' scale,
  read on pods). An installer whose RBAC cannot create a Role or bind it must
  set `app.storedObjects.localFilesystem.serializeUpgrades: false`.
- **New image pulled at upgrade time:** `alpine/k8s:1.34.9`, the same image the
  ClickHouse preflight Job uses at a newer tag. Air-gapped installs mirror it
  and set `app.storedObjects.localFilesystem.serializeUpgradesImage`, plus
  `serializeUpgradesPullSecrets` if the registry needs credentials.
- **Rollback:** a rollback to a revision that carries these hooks is serialized
  the same way an upgrade is, because both Jobs are registered for the rollback
  events as well. A rollback to an older chart that predates them is **not**:
  Helm runs the target revision's hooks, so nothing runs. Scale the workers
  Deployment to 0 by hand before such a downgrade and back up after it, as the
  chart README, values comment and NOTES.txt all now say.
- **Interrupted upgrade:** if one is aborted between the two Jobs, the workers
  stay at 0 and the next upgrade or a manual `kubectl scale` brings them back.
- **No migrations, no schema changes, no new env vars on any long-lived pod.**

## Spec and tests

- `specs/setup/helm-stored-objects-upgrade-ordering.feature`: 12 scenarios,
  12/12 bound (`pnpm check:feature-parity`).
- `charts/langwatch/tests/stored-objects-upgrade-ordering.sh`: render-based
  assertions in the style of `workers-shutdown.sh`. It checks the hooks render
  in local-filesystem mode and not with a dataplane, with the workers off, or
  with the knob off; the pre-upgrade Job scales the workers by name and waits
  for their pods; the wait outlasts the grace period at the default and at a
  raised one; the post-upgrade Job stands the workers down, waits for the app by
  name, and restores `workers.replicaCount`; the Role is namespaced and scoped;
  the Deployments are not hooks themselves; a rollout that does not finish still
  brings the workers back; and every hook document carries
  `before-hook-creation`.
- Wired into `.github/workflows/langwatch-chart.yml` beside the other assertion
  steps.

The suite was mutation checked: shortening the wait below the grace period,
widening the pod verbs to include `delete`, dropping either half of the rollout
condition, and dropping `pre-rollback` from the drain Job all fail it.

The rollback lifecycle is covered by render assertions rather than a live
`helm rollback`. The suite reads each document's `helm.sh/hook` value whole
(a substring test for `pre-upgrade` passes against `pre-upgrade` alone, which is
the bug) and counts the documents, so one added later cannot quietly skip the
rollback events. The shared dev cluster was released after the upgrade proof
below, so the live rollback was not run.

## EKS proof

Cluster `langwatch-dev-ekscluster-runtime` (eu-central-1, Kubernetes 1.34, four
nodes across two availability zones), namespace `langwatch-pvc-test`, EBS `gp2`
storage class. Values: `autogen.enabled=true`, `size-minimal` and
`langy-disabled` overlays, default local-filesystem stored objects.

Note on the topology: an EBS volume is bound to one availability zone, so the
"other node" for a node flip has to be the second node in the same zone.

### 1. Baseline on the published 3.14.0 chart

```
$ helm upgrade --install langwatch langwatch --repo https://langwatch.github.io/langwatch --version 3.14.0 ...
Release "langwatch" does not exist. Installing it now.
STATUS: deployed
REVISION: 1

$ kubectl -n langwatch-pvc-test get pods -o wide
langwatch-app-55789c47ff-4pqrf       1/1  Running  ip-10-0-3-133.eu-central-1.compute.internal
langwatch-workers-76cc4d89c6-xk25k   1/1  Running  ip-10-0-3-133.eu-central-1.compute.internal

$ kubectl get volumeattachment ...   # for pvc-25d79e53-c989-4fb8-92cc-91135d4d4575
csi-7897d...  ip-10-0-3-133.eu-central-1.compute.internal  True
```

### 2. The race, reproduced on the published chart

Upgraded to the same published 3.14.0 chart with the app pinned to the other
node in the same zone. The old app pod went away, the workers were untouched and
kept the volume on `ip-10-0-3-133`, and the new app pod landed on
`ip-10-0-3-108`:

```
$ kubectl -n langwatch-pvc-test describe pod langwatch-app-bf9bfddf6-xbr44
Events:
  Normal   Scheduled           6s  Successfully assigned .../langwatch-app-bf9bfddf6-xbr44
                                   to ip-10-0-3-108.eu-central-1.compute.internal
  Warning  FailedAttachVolume  6s  attachdetach-controller
        Multi-Attach error for volume "pvc-25d79e53-c989-4fb8-92cc-91135d4d4575"
        Volume is already used by pod(s) langwatch-workers-76cc4d89c6-xk25k
```

It did not clear. Four minutes later:

```
$ kubectl wait --for=condition=Ready pod/langwatch-app-bf9bfddf6-xbr44 --timeout=240s
error: timed out waiting for the condition on pods/langwatch-app-bf9bfddf6-xbr44

$ kubectl -n langwatch-pvc-test get pods -o wide
langwatch-app-bf9bfddf6-xbr44        0/1  ContainerCreating  4m17s  ip-10-0-3-108...
langwatch-workers-76cc4d89c6-xk25k   1/1  Running            9m28s  ip-10-0-3-133...
```

### 3. Why the pre-upgrade hook alone is not enough

An early version of this PR had only the pre-upgrade hook. On a node flip it
left the release wedged again, with the actors swapped: the new workers pod that
Helm's apply created followed the still-terminating old app pod back to the old
node and took the volume there.

```
07:35:13  ScalingReplicaSet   langwatch-workers  Scaled up replica set ... from 0 to 1
07:35:13  ScalingReplicaSet   langwatch-app      Scaled up replica set langwatch-app-bf9bfddf6 from 0 to 1
07:35:13  FailedAttachVolume  langwatch-app-bf9bfddf6-svbfz
          Multi-Attach error ... Volume is already used by pod(s) langwatch-app-55789c47ff-9bhpj
07:35:14  Started             langwatch-workers-76cc4d89c6-pkl28   # on the OLD node

$ kubectl -n langwatch-pvc-test get pods -o wide     # 2m27s later
langwatch-app-bf9bfddf6-svbfz        0/1  ContainerCreating  2m27s  ip-10-0-3-108...
langwatch-workers-76cc4d89c6-pkl28   1/1  Running            2m27s  ip-10-0-3-133...
```

That is what the post-upgrade hook exists for.

### 4. The branch chart recovers the wedge and places the pods correctly

`helm upgrade langwatch ./charts/langwatch` from the wedged state, same values:

```
$ kubectl logs job/langwatch-stored-objects-upgrade-pre
07:46:29.570  serialize-upgrade[pre]: scaling langwatch-workers to 0 so the app is the only holder of the stored-objects volume
07:46:29.977  scale.autoscaling/langwatch-workers patched
07:46:29.979  serialize-upgrade: waiting up to 115s for the langwatch-workers pods to go away
07:46:32.749  pod/langwatch-workers-76cc4d89c6-pkl28 condition met
07:46:32.749  serialize-upgrade[pre]: the langwatch-workers pods are gone, the app can roll alone

$ kubectl logs job/langwatch-stored-objects-upgrade-post
07:46:44.927  serialize-upgrade[post]: scaling langwatch-workers to 0 until the app rollout finishes
07:46:45.347  scale.autoscaling/langwatch-workers patched
07:46:45.349  serialize-upgrade: waiting up to 115s for the langwatch-workers pods to go away
07:46:45.799  serialize-upgrade[post]: waiting up to 655s for the langwatch-app rollout to finish
07:47:07.747  serialize-upgrade[post]: langwatch-app is running, the workers can follow it
07:47:07.747  serialize-upgrade[post]: scaling langwatch-workers back to 1
07:47:08.235  scale.autoscaling/langwatch-workers patched
07:47:08.237  serialize-upgrade[post]: langwatch-workers is back at 1
```

The event trail shows the pre-upgrade Job completing before any Deployment
changed, the apply recreating the workers pod, and the post-upgrade Job removing
it again so the app could attach:

```
07:46:28  SuccessfulCreate        langwatch-stored-objects-upgrade-pre    Created pod: ...-thclc
07:46:30  SuccessfulDelete        langwatch-workers-76cc4d89c6            Deleted pod: ...-pkl28
07:46:35  Completed               langwatch-stored-objects-upgrade-pre    Job completed
07:46:38  SuccessfulCreate        langwatch-workers-76cc4d89c6            Created pod: ...-hqvhm   # helm's apply
07:46:43  SuccessfulCreate        langwatch-stored-objects-upgrade-post   Created pod: ...-2tpzv
07:46:45  ScalingReplicaSet       langwatch-workers                       Scaled down ... from 1 to 0
07:46:53  SuccessfulAttachVolume  langwatch-app-bf9bfddf6-svbfz           AttachVolume.Attach succeeded
07:46:54  Started                 langwatch-app-bf9bfddf6-svbfz           Started container langwatch-app
07:47:08  ScalingReplicaSet       langwatch-workers                       Scaled up ... from 0 to 1
07:47:10  Completed               langwatch-stored-objects-upgrade-post   Job completed
```

The app that had been stuck since 07:35 attached its volume and started.

### 5. Node flip on the branch chart: 55 seconds, no wedge

Same upgrade, app pinned back to `ip-10-0-3-133`, so the app changes node while
holding the volume:

```
07:47:54  helm upgrade langwatch ./charts/langwatch ...
07:48:00  SuccessfulCreate        langwatch-stored-objects-upgrade-pre    Created pod: ...-fhngq
07:48:02  SuccessfulDelete        langwatch-workers-76cc4d89c6            Deleted pod: ...-22f8n
07:48:04  Completed               langwatch-stored-objects-upgrade-pre    Job completed
07:48:07  Killing                 langwatch-app-bf9bfddf6-svbfz           Stopping container langwatch-app
07:48:07  SuccessfulCreate        langwatch-app-bcdfb7c8                  Created pod: ...-lvlmv
07:48:07  SuccessfulCreate        langwatch-workers-76cc4d89c6            Created pod: ...-sk5vp   # helm's apply
07:48:07  FailedAttachVolume      langwatch-app-bcdfb7c8-lvlmv
          Multi-Attach error ... Volume is already used by pod(s) langwatch-app-bf9bfddf6-svbfz
07:48:11  ScalingReplicaSet       langwatch-workers                       Scaled down ... from 1 to 0
07:48:33  SuccessfulAttachVolume  langwatch-app-bcdfb7c8-lvlmv            AttachVolume.Attach succeeded
07:48:46  ScalingReplicaSet       langwatch-workers                       Scaled up ... from 0 to 1
07:48:48  Completed               langwatch-stored-objects-upgrade-post   Job completed
07:48:49  helm upgrade returned, REVISION: 7

$ kubectl -n langwatch-pvc-test get pods -o wide
langwatch-app-bcdfb7c8-lvlmv         1/1  Running  ip-10-0-3-133...
langwatch-workers-76cc4d89c6-hp8xp   1/1  Running  ip-10-0-3-133...
```

There is still one attach retry at 07:48:07, and it is a different thing from
the bug: it names the **old app pod**, not the workers, so it clears as soon as
that pod finishes its own grace period. It did, 26 seconds later. Nothing was
left holding the volume on the old node, which is what the post-upgrade hook
guarantees.

### 6. Ordinary same-node upgrade: 37 seconds, no attach errors at all

```
07:49:34  helm upgrade ... --set app.pod.annotations.proof=run8 --set workers.pod.annotations.proof=run8
07:49:43  serialize-upgrade[pre]:  scaling langwatch-workers to 0 ...
07:49:47  serialize-upgrade[pre]:  the langwatch-workers pods are gone, the app can roll alone
07:49:53  ScalingReplicaSet        langwatch-app       Scaled up replica set langwatch-app-78c97db566 from 0 to 1
07:49:58  serialize-upgrade[post]: scaling langwatch-workers to 0 until the app rollout finishes
07:50:07  serialize-upgrade[post]: langwatch-app is running, the workers can follow it
07:50:07  serialize-upgrade[post]: langwatch-workers is back at 1
07:50:11  helm upgrade returned, REVISION: 8

$ kubectl -n langwatch-pvc-test get deploy langwatch-workers -o jsonpath='{.spec.replicas} {.status.readyReplicas}'
1 1

$ kubectl -n langwatch-pvc-test get pods
langwatch-app-78c97db566-2qkmx       1/1  Running
langwatch-clickhouse-0               1/1  Running
langwatch-gateway-775558fb4b-dkpsf   1/1  Running
langwatch-gateway-775558fb4b-kqj59   1/1  Running
langwatch-langevals-657f456747-kph2k 1/1  Running
langwatch-langwatch-nlp-84c59768f6-7fc5k 1/1 Running
langwatch-postgresql-0               1/1  Running
langwatch-redis-master-0             1/1  Running
langwatch-workers-864cc8c5f6-ckhpj   1/1  Running
```

Every `FailedAttachVolume` event the namespace ever produced, in full:

```
07:48:07  langwatch-app-bcdfb7c8-lvlmv   ... used by pod(s) langwatch-app-55789c47ff-9bhpj   # step 5, cleared in 26s
07:35:13  langwatch-app-bf9bfddf6-svbfz  ... used by pod(s) langwatch-app-55789c47ff-9bhpj   # step 3, pre-hook only
07:28:43  langwatch-app-bf9bfddf6-xbr44  ... used by pod(s) langwatch-workers-...-xk25k      # step 2, the bug
```

The namespace, its release and its PVCs were removed afterwards.