### PR TITLE
feat(navigation): product switcher becomes the default, and the sidebar matches the design

### DIFF
--- a/platform/app/src/components/AppHeaderUserMenu.tsx
+++ b/platform/app/src/components/AppHeaderUserMenu.tsx
@@ -1,6 +1,7 @@
 import { Button, Portal } from "@chakra-ui/react";
 import { Monitor, PanelsTopLeft } from "lucide-react";
 import {
+  DEFAULT_NAVIGATION_MODE,
   type NavigationMode,
   useNavigationModeStore,
 } from "~/features/navigation/navigationModeStore";
@@ -88,6 +89,9 @@ export function AppHeaderUserMenu({
   const setStoredNavigationMode = useNavigationModeStore(
     (s) => s.setStoredMode,
   );
+  // The picker only shows with the flag on, where a device that never
+  // picked runs the default mode. It reports that, not the old chrome.
+  const currentNavigationMode = storedNavigationMode ?? DEFAULT_NAVIGATION_MODE;
 
   const graphicsQualityOverride = useGraphicsQualityOverrideStore(
     (s) => s.override,
@@ -169,11 +173,11 @@ export function AppHeaderUserMenu({
                 >
                   <Menu.TriggerItem value="navigation-mode">
                     <PanelsTopLeft size={14} />
-                    Navigation ({NAVIGATION_MODE_LABELS[storedNavigationMode]})
+                    Navigation ({NAVIGATION_MODE_LABELS[currentNavigationMode]})
                   </Menu.TriggerItem>
                   <Menu.Content>
                     <Menu.RadioItemGroup
-                      value={storedNavigationMode}
+                      value={currentNavigationMode}
                       onValueChange={(e) => {
                         const mode = e.value as NavigationMode;
                         setStoredNavigationMode(mode);

--- a/platform/app/src/components/sidebar/CollapsibleMenuGroup.tsx
+++ b/platform/app/src/components/sidebar/CollapsibleMenuGroup.tsx
@@ -12,7 +12,8 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import type { Project } from "~/generated/prisma/client";
 import { trackEvent } from "../../utils/tracking";
-import { ICON_SIZE, MENU_ITEM_HEIGHT, SideMenuLink } from "./SideMenuLink";
+import { SideMenuLink } from "./SideMenuLink";
+import { useSideMenuDensity } from "./sideMenuDensity";
 
 export type CollapsibleMenuChild = {
   icon: React.ComponentType<{ size?: string | number; color?: string }>;
@@ -44,6 +45,7 @@ export const CollapsibleMenuGroup = ({
   beta,
   betaLabel,
 }: CollapsibleMenuGroupProps) => {
+  const density = useSideMenuDensity();
   const isAnyChildActive = children.some((child) => child.isActive);
   const [isExpanded, setIsExpanded] = useState(
     defaultExpanded || isAnyChildActive,
@@ -84,9 +86,9 @@ export const CollapsibleMenuGroup = ({
           >
             <HStack
               width={showLabel ? "full" : "auto"}
-              height={MENU_ITEM_HEIGHT}
-              gap={3}
-              paddingX={3}
+              height={density.height}
+              gap={density.gap}
+              paddingX={density.paddingX}
               borderRadius="lg"
               backgroundColor="transparent"
               _hover={{
@@ -99,18 +101,18 @@ export const CollapsibleMenuGroup = ({
                 display="flex"
                 alignItems="center"
                 justifyContent="center"
-                width={`${ICON_SIZE}px`}
-                height={`${ICON_SIZE}px`}
+                width={`${density.iconSize}px`}
+                height={`${density.iconSize}px`}
               >
                 <Icon
-                  size={ICON_SIZE}
+                  size={density.iconSize}
                   color="var(--chakra-colors-nav-fg-muted)"
                 />
               </Box>
               {showLabel && (
                 <>
                   <Text
-                    fontSize="14px"
+                    fontSize={density.fontSize}
                     fontWeight="normal"
                     color="nav.fg"
                     whiteSpace="nowrap"

--- a/platform/app/src/components/sidebar/SideMenuLink.tsx
+++ b/platform/app/src/components/sidebar/SideMenuLink.tsx
@@ -6,9 +6,9 @@ import { BetaPill } from "../ui/BetaPill";
 import { LegacyPill } from "../ui/LegacyPill";
 import { Link } from "../ui/link";
 import { Tooltip } from "../ui/tooltip";
+import { SIDE_MENU_DENSITIES, useSideMenuDensity } from "./sideMenuDensity";
 
-export const MENU_ITEM_HEIGHT = "32px";
-export const ICON_SIZE = 16;
+export const MENU_ITEM_HEIGHT = SIDE_MENU_DENSITIES.comfortable.height;
 
 // Base props for the visual menu item styling
 export type SideMenuItemProps = {
@@ -76,6 +76,7 @@ export const SideMenuItem = ({
       </Badge>
     ) : null;
 
+  const density = useSideMenuDensity();
   const IconElem = icon as React.ComponentType<{
     size?: string | number;
     color?: string;
@@ -84,7 +85,10 @@ export const SideMenuItem = ({
   const iconNode =
     typeof IconElem === "function" ||
     (IconElem as unknown as { render?: unknown }).render ? (
-      <IconElem size={ICON_SIZE} color="var(--chakra-colors-nav-fg-muted)" />
+      <IconElem
+        size={density.iconSize}
+        color="var(--chakra-colors-nav-fg-muted)"
+      />
     ) : (
       (icon as React.ReactNode)
     );
@@ -92,9 +96,9 @@ export const SideMenuItem = ({
   return (
     <HStack
       width={showLabel ? "full" : "auto"}
-      height={MENU_ITEM_HEIGHT}
-      gap={3}
-      paddingX={3}
+      height={density.height}
+      gap={density.gap}
+      paddingX={density.paddingX}
       borderRadius="lg"
       backgroundColor={isActive ? "nav.bgActive" : "transparent"}
       _hover={{
@@ -108,8 +112,8 @@ export const SideMenuItem = ({
         display="flex"
         alignItems="center"
         justifyContent="center"
-        width={`${ICON_SIZE}px`}
-        height={`${ICON_SIZE}px`}
+        width={`${density.iconSize}px`}
+        height={`${density.iconSize}px`}
       >
         {iconNode}
         {badge && !showLabel && (
@@ -121,7 +125,7 @@ export const SideMenuItem = ({
       {showLabel && (
         <>
           <Text
-            fontSize="14px"
+            fontSize={density.fontSize}
             fontWeight="normal"
             color="nav.fg"
             whiteSpace="nowrap"

--- a/platform/app/src/components/sidebar/SideMenuLink.tsx
+++ b/platform/app/src/components/sidebar/SideMenuLink.tsx
@@ -1,5 +1,6 @@
 import { Badge, Box, HStack, Text } from "@chakra-ui/react";
 import type React from "react";
+import { useEffect, useRef } from "react";
 import type { Project } from "~/generated/prisma/client";
 import { trackEvent } from "../../utils/tracking";
 import { BetaPill } from "../ui/BetaPill";
@@ -177,6 +178,16 @@ export const SideMenuLink = ({
   isExternal,
   unavailableReason,
 }: SideMenuLinkProps) => {
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  // A page opened by its address can have its entry below the visible
+  // part of a scrolled menu. "nearest" leaves the menu alone whenever
+  // the entry is already visible, so click navigation never shifts it.
+  useEffect(() => {
+    if (isActive) {
+      linkRef.current?.scrollIntoView?.({ block: "nearest" });
+    }
+  }, [isActive]);
+
   if (unavailableReason) {
     return (
       <Tooltip
@@ -210,6 +221,7 @@ export const SideMenuLink = ({
 
   return (
     <Link
+      ref={linkRef}
       variant="plain"
       width="full"
       href={href}

--- a/platform/app/src/components/sidebar/SideMenuSectionLabel.tsx
+++ b/platform/app/src/components/sidebar/SideMenuSectionLabel.tsx
@@ -1,0 +1,24 @@
+import { Text } from "@chakra-ui/react";
+import { useSideMenuDensity } from "./sideMenuDensity";
+
+/**
+ * The heading above a group of sidebar menu items ("OBSERVE",
+ * "ORGANIZATION"). One component for the current chrome and the
+ * navigation-v2 sidebars, so the two cannot drift; it reads its size
+ * from the menu density in context.
+ */
+export function SideMenuSectionLabel({ label }: { label: string }) {
+  const { sectionLabel } = useSideMenuDensity();
+
+  return (
+    <Text
+      fontSize={sectionLabel.fontSize}
+      fontWeight={sectionLabel.fontWeight}
+      letterSpacing={sectionLabel.letterSpacing}
+      textTransform="uppercase"
+      whiteSpace="nowrap"
+    >
+      {label}
+    </Text>
+  );
+}

--- a/platform/app/src/components/sidebar/SidebarSection.tsx
+++ b/platform/app/src/components/sidebar/SidebarSection.tsx
@@ -1,7 +1,8 @@
-import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, VStack } from "@chakra-ui/react";
 import { ChevronRight } from "lucide-react";
 import type React from "react";
 
+import { SideMenuSectionLabel } from "./SideMenuSectionLabel";
 import { useSidebarSectionState } from "./useSidebarSectionState";
 
 export { getSidebarSectionStorageKey } from "./useSidebarSectionState";
@@ -78,16 +79,7 @@ const SidebarSectionToggle = ({
         color="gray.500"
         _hover={{ color: "nav.fg" }}
       >
-        {showExpanded && (
-          <Text
-            fontSize="11px"
-            fontWeight="medium"
-            textTransform="uppercase"
-            whiteSpace="nowrap"
-          >
-            {label}
-          </Text>
-        )}
+        {showExpanded && <SideMenuSectionLabel label={label} />}
         {!isExpanded && (
           <Box opacity={0.5} display="flex">
             <ChevronRight size={13} aria-hidden="true" />

--- a/platform/app/src/components/sidebar/SupportMenu.tsx
+++ b/platform/app/src/components/sidebar/SupportMenu.tsx
@@ -1,4 +1,5 @@
 import { Box, MenuSeparator, Portal, VStack } from "@chakra-ui/react";
+import type { FocusEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   LuActivity,
@@ -41,6 +42,12 @@ export const SupportMenu = ({
   // cursor past the trigger to a sidebar item below leaves the menu
   // stuck open with no cursor over it.
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The menu machine gives focus back to the trigger on every close.
+  // After a keyboard close that is correct; after a pointer-out close it
+  // paints the keyboard focus ring on an entry the reader only hovered,
+  // and the ring stays until the next click. The timestamp marks the
+  // pointer closes so the trigger can drop that one focus when it lands.
+  const pointerCloseAtRef = useRef(Number.NEGATIVE_INFINITY);
   const cancelClose = useCallback(() => {
     if (closeTimerRef.current) {
       clearTimeout(closeTimerRef.current);
@@ -49,7 +56,10 @@ export const SupportMenu = ({
   }, []);
   const scheduleClose = useCallback(() => {
     cancelClose();
-    closeTimerRef.current = setTimeout(() => setIsOpen(false), 120);
+    closeTimerRef.current = setTimeout(() => {
+      pointerCloseAtRef.current = performance.now();
+      setIsOpen(false);
+    }, 120);
   }, [cancelClose]);
   useEffect(() => cancelClose, [cancelClose]);
 
@@ -101,6 +111,12 @@ export const SupportMenu = ({
               setIsOpen(true);
             }}
             onMouseLeave={scheduleClose}
+            onFocus={(e: FocusEvent<HTMLElement>) => {
+              if (performance.now() - pointerCloseAtRef.current < 300) {
+                pointerCloseAtRef.current = Number.NEGATIVE_INFINITY;
+                e.currentTarget.blur();
+              }
+            }}
           >
             <SideMenuItem
               icon={LuLifeBuoy}

--- a/platform/app/src/components/sidebar/__tests__/SupportMenu.chatPlacement.integration.test.tsx
+++ b/platform/app/src/components/sidebar/__tests__/SupportMenu.chatPlacement.integration.test.tsx
@@ -64,6 +64,48 @@ describe("the support menu chat placement", () => {
     });
   });
 
+  describe("when the pointer opens the menu and moves away", () => {
+    /** @scenario Closing the Support menu with the pointer leaves no focus ring */
+    it("closes the menu without leaving focus on the Support entry", async () => {
+      renderMenu({ chatPlacement: "in-menu" });
+      const trigger = screen.getByRole("button", { name: "Support" });
+
+      const user = await openSupportMenu();
+      await user.unhover(trigger);
+
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute("aria-expanded", "false");
+      });
+      // The machine focuses the trigger in a microtask after the close;
+      // give that focus time to land before asserting it was dropped.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(trigger).not.toHaveFocus();
+    });
+
+    /** @scenario Closing the Support menu with the pointer leaves no focus ring */
+    it("keeps focus on the Support entry after a keyboard close", async () => {
+      renderMenu({ chatPlacement: "in-menu" });
+      const trigger = screen.getByRole("button", { name: "Support" });
+      const user = userEvent.setup();
+
+      trigger.focus();
+      await user.keyboard("{Enter}");
+      // The machine moves focus into the menu a frame after it opens;
+      // Escape only closes the menu once it carries the focus.
+      await waitFor(() => {
+        expect(screen.getByRole("menu")).toHaveFocus();
+      });
+
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute("aria-expanded", "false");
+      });
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    });
+  });
+
   describe("when rendered for a navigation-v2 sidebar", () => {
     /** @scenario Chat moves inside the Support menu in the new modes */
     it("folds the chat into the Support menu and drops the standalone entry", async () => {

--- a/platform/app/src/components/sidebar/__tests__/sideMenuDensity.integration.test.tsx
+++ b/platform/app/src/components/sidebar/__tests__/sideMenuDensity.integration.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The two sidebar menu densities. The current chrome renders its menu
+ * components outside any provider, so the comfortable size is the
+ * default and cannot change under it; the navigation-v2 sidebars opt
+ * into the compact size for their subtree.
+ *
+ * Spec: specs/navigation/product-sidebars.feature
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { House } from "lucide-react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/tracking", () => ({ trackEvent: vi.fn() }));
+
+import { SideMenuLink } from "../SideMenuLink";
+import { SideMenuSectionLabel } from "../SideMenuSectionLabel";
+import { SideMenuDensityProvider } from "../sideMenuDensity";
+
+function renderMenu({ isCompact }: { isCompact: boolean }) {
+  const menu = (
+    <>
+      <SideMenuLink icon={House} label="Home" href="/home" />
+      <SideMenuSectionLabel label="Observe" />
+    </>
+  );
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      {isCompact ? (
+        <SideMenuDensityProvider density="compact">
+          {menu}
+        </SideMenuDensityProvider>
+      ) : (
+        menu
+      )}
+    </ChakraProvider>,
+  );
+}
+
+/** The item row carries the height, gap and padding; the label the type. */
+function itemRow() {
+  return screen.getByRole("link", { name: "Home" }).firstElementChild;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("sidebar menu density", () => {
+  describe("when a sidebar asks for the compact density", () => {
+    /** @scenario "The sidebar draws its menu one step smaller" */
+    it("draws the item and its heading one step smaller", () => {
+      renderMenu({ isCompact: true });
+
+      expect(screen.getByText("Home")).toHaveStyle({ fontSize: "13px" });
+      expect(itemRow()).toHaveStyle({
+        height: "29px",
+        gap: "var(--chakra-spacing-2\\.5)",
+        paddingInline: "var(--chakra-spacing-2)",
+      });
+      expect(screen.getByText("Observe")).toHaveStyle({
+        fontSize: "10px",
+        fontWeight: "var(--chakra-font-weights-semibold)",
+        // 0.09em of the 10px heading
+        letterSpacing: "0.9px",
+      });
+    });
+  });
+
+  describe("when no density is asked for", () => {
+    /** @scenario "The current chrome keeps its own menu size" */
+    it("keeps the comfortable item and heading of the current chrome", () => {
+      renderMenu({ isCompact: false });
+
+      expect(screen.getByText("Home")).toHaveStyle({ fontSize: "14px" });
+      expect(itemRow()).toHaveStyle({
+        height: "32px",
+        gap: "var(--chakra-spacing-3)",
+        paddingInline: "var(--chakra-spacing-3)",
+      });
+      expect(screen.getByText("Observe")).toHaveStyle({
+        fontSize: "11px",
+        fontWeight: "var(--chakra-font-weights-medium)",
+        letterSpacing: "normal",
+      });
+    });
+  });
+});

--- a/platform/app/src/components/sidebar/sideMenuDensity.tsx
+++ b/platform/app/src/components/sidebar/sideMenuDensity.tsx
@@ -1,0 +1,86 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+/**
+ * How tight the sidebar menu items are drawn.
+ *
+ * The current chrome uses "comfortable". The navigation-v2 shells use
+ * "compact", which fits page names the wider type truncated, and the
+ * two share every menu component, so the size travels in context rather
+ * than as a prop through each of them.
+ *
+ * Specs: specs/navigation/product-sidebars.feature,
+ *        specs/navigation/settings-shell-v2.feature
+ */
+export type SideMenuDensity = "comfortable" | "compact";
+
+export interface SideMenuSectionLabelTokens {
+  fontSize: string;
+  fontWeight: string;
+  letterSpacing: string;
+}
+
+export interface SideMenuDensityTokens {
+  /** Menu item label size. */
+  fontSize: string;
+  /** Space between the icon and the label, in Chakra spacing units. */
+  gap: number;
+  /** Horizontal padding inside a menu item, in Chakra spacing units. */
+  paddingX: number;
+  /** Menu item height. */
+  height: string;
+  /** Icon edge length, in pixels. */
+  iconSize: number;
+  /** The heading above a group of menu items. */
+  sectionLabel: SideMenuSectionLabelTokens;
+}
+
+export const SIDE_MENU_DENSITIES: Record<
+  SideMenuDensity,
+  SideMenuDensityTokens
+> = {
+  comfortable: {
+    fontSize: "14px",
+    gap: 3,
+    paddingX: 3,
+    height: "32px",
+    iconSize: 16,
+    sectionLabel: {
+      fontSize: "11px",
+      fontWeight: "medium",
+      letterSpacing: "normal",
+    },
+  },
+  compact: {
+    fontSize: "13px",
+    gap: 2.5,
+    paddingX: 2,
+    height: "29px",
+    iconSize: 15,
+    sectionLabel: {
+      fontSize: "10px",
+      fontWeight: "semibold",
+      letterSpacing: "0.09em",
+    },
+  },
+};
+
+const SideMenuDensityContext = createContext<SideMenuDensity>("comfortable");
+
+export function SideMenuDensityProvider({
+  density,
+  children,
+}: {
+  density: SideMenuDensity;
+  children: ReactNode;
+}) {
+  return (
+    <SideMenuDensityContext.Provider value={density}>
+      {children}
+    </SideMenuDensityContext.Provider>
+  );
+}
+
+/** The sizes to draw a sidebar menu item with, at the current density. */
+export function useSideMenuDensity(): SideMenuDensityTokens {
+  return SIDE_MENU_DENSITIES[useContext(SideMenuDensityContext)];
+}

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -146,7 +146,9 @@ vi.mock("~/utils/tracking", () => ({
   trackEvent: (...args: unknown[]) => trackEventMock(...args),
 }));
 
+import { MENU_WIDTH_EXPANDED } from "~/components/MainMenu";
 import { ProductSidebar } from "../shell/ProductSidebar";
+import { SHELL_SIDEBAR_WIDTH_EXPANDED } from "../shell/shellLayout";
 
 function renderSidebar(surface: "me" | "llm-ops" | "gateway" | "governance") {
   return render(
@@ -266,6 +268,44 @@ describe("the product sidebar", () => {
       expect(
         screen.getByRole("radiogroup", { name: "Theme" }),
       ).toBeInTheDocument();
+    });
+
+    /** @scenario "A rule separates the bottom block from the pages above it" */
+    it("draws a rule above the block", () => {
+      renderSidebar("governance");
+
+      const block = screen.getByTestId("sidebar-bottom-block");
+      expect(block).toContainElement(
+        screen.getByRole("radiogroup", { name: "Theme" }),
+      );
+      expect(block).toHaveStyle({ borderTopWidth: "1px" });
+    });
+  });
+
+  describe("when the sidebar column renders", () => {
+    /** @scenario "The sidebar draws its menu one step smaller" */
+    it("is wider than the current chrome's menu", () => {
+      renderSidebar("llm-ops");
+
+      expect(Number.parseInt(SHELL_SIDEBAR_WIDTH_EXPANDED, 10)).toBeGreaterThan(
+        Number.parseInt(MENU_WIDTH_EXPANDED, 10),
+      );
+      expect(screen.getByTestId("product-sidebar")).toHaveStyle({
+        width: SHELL_SIDEBAR_WIDTH_EXPANDED,
+      });
+    });
+
+    /** @scenario "The search key cap reads as a quiet hint" */
+    it("gives the Quick Search key cap grey type and a hairline border", () => {
+      renderSidebar("llm-ops");
+
+      const cap = screen
+        .getByRole("button", { name: "Quick Search" })
+        .querySelector("kbd");
+      // The hairline border is pinned on the shared chip style itself,
+      // which jsdom can read where a CSS variable it cannot resolve is
+      // out of reach: quietChipStyle.unit.test.ts.
+      expect(cap).toHaveStyle({ color: "var(--chakra-colors-gray-400)" });
     });
   });
 });

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -168,6 +168,9 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  // jsdom has no scrollIntoView; the deep-link test installs one.
+  delete (window.HTMLElement.prototype as { scrollIntoView?: unknown })
+    .scrollIntoView;
 });
 
 describe("the product sidebar", () => {
@@ -250,6 +253,29 @@ describe("the product sidebar", () => {
       expect(screen.getByText("Anomaly Rules")).toBeInTheDocument();
       expect(screen.getByText("Tool Catalog")).toBeInTheDocument();
       expect(screen.getByText("Departments")).toBeInTheDocument();
+    });
+  });
+
+  describe("when a page is opened by its address", () => {
+    /** @scenario "Opening a page by its address reveals its sidebar entry" */
+    it("brings that page's entry into view", async () => {
+      const scrolledInto: HTMLElement[] = [];
+      (
+        window.HTMLElement.prototype as unknown as {
+          scrollIntoView: (options?: ScrollIntoViewOptions) => void;
+        }
+      ).scrollIntoView = function (this: HTMLElement) {
+        scrolledInto.push(this);
+      };
+
+      mockPathname = "/gateway/virtual-keys";
+      renderSidebar("gateway");
+
+      await waitFor(() => {
+        expect(
+          scrolledInto.some((el) => el.textContent?.includes("Virtual Keys")),
+        ).toBe(true);
+      });
     });
   });
 

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -253,12 +253,12 @@ vi.mock("~/components/sidebar/PresenceMenuItem", () => ({
   PresenceMenuItem: () => null,
 }));
 
-import { MENU_WIDTH_EXPANDED } from "~/components/MainMenu";
 import { useNavigationModeStore } from "~/features/navigation/navigationModeStore";
 import {
   DashboardLayout,
   type DashboardLayoutProps,
 } from "../../../components/DashboardLayout";
+import { SHELL_SIDEBAR_WIDTH_EXPANDED } from "../shell/shellLayout";
 
 function renderShell(props: Partial<DashboardLayoutProps> = {}) {
   return render(
@@ -362,13 +362,13 @@ describe("the product-switcher top bar", () => {
       renderShell();
 
       expect(screen.getByTestId("shell-product-cluster")).toHaveStyle({
-        width: MENU_WIDTH_EXPANDED,
-        minWidth: MENU_WIDTH_EXPANDED,
+        width: SHELL_SIDEBAR_WIDTH_EXPANDED,
+        minWidth: SHELL_SIDEBAR_WIDTH_EXPANDED,
       });
       // The content column caps itself at the viewport minus that same
       // width, so the two cannot drift apart.
       expect(screen.getByTestId("shell-content-column")).toHaveStyle({
-        maxWidth: `${window.innerWidth - Number.parseInt(MENU_WIDTH_EXPANDED, 10)}px`,
+        maxWidth: `${window.innerWidth - Number.parseInt(SHELL_SIDEBAR_WIDTH_EXPANDED, 10)}px`,
       });
     });
   });

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -321,23 +321,36 @@ describe("the settings shell in a new navigation mode", () => {
     });
 
     /** @scenario "The settings groups fold, and start open" */
-    it("opens every group, and folds one away when its heading is pressed", async () => {
+    it("opens every group, folds one away, and keeps it folded next time", async () => {
       const user = userEvent.setup();
-      renderSettings();
+      const { unmount } = renderSettings();
 
+      // A folded group reads "Expand <name>", so none of them means all open.
+      expect(screen.queryAllByRole("button", { name: /^Expand / })).toEqual([]);
+      expect(
+        screen.getAllByRole("button", { name: /^Collapse / }).length,
+      ).toBeGreaterThan(1);
       expect(screen.getByRole("link", { name: "Members" })).toBeInTheDocument();
 
-      const accessHeading = screen.getByRole("button", {
-        name: "Collapse Access",
-      });
-      expect(accessHeading).toHaveAttribute("aria-expanded", "true");
-
-      await user.click(accessHeading);
+      await user.click(screen.getByRole("button", { name: "Collapse Access" }));
 
       expect(
         screen.queryByRole("link", { name: "Members" }),
       ).not.toBeInTheDocument();
-      // Folding one group leaves its neighbours alone.
+      expect(
+        screen.getByRole("button", { name: "Collapse Organization" }),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("link", { name: "General" })).toBeInTheDocument();
+
+      unmount();
+      renderSettings();
+
+      expect(
+        screen.getByRole("button", { name: "Expand Access" }),
+      ).toHaveAttribute("aria-expanded", "false");
+      expect(
+        screen.queryByRole("link", { name: "Members" }),
+      ).not.toBeInTheDocument();
       expect(screen.getByRole("link", { name: "General" })).toBeInTheDocument();
     });
 

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -17,6 +17,7 @@
 
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -317,6 +318,27 @@ describe("the settings shell in a new navigation mode", () => {
       expect(pills[0]).toHaveStyle({
         color: "var(--chakra-colors-gray-400)",
       });
+    });
+
+    /** @scenario "The settings groups fold, and start open" */
+    it("opens every group, and folds one away when its heading is pressed", async () => {
+      const user = userEvent.setup();
+      renderSettings();
+
+      expect(screen.getByRole("link", { name: "Members" })).toBeInTheDocument();
+
+      const accessHeading = screen.getByRole("button", {
+        name: "Collapse Access",
+      });
+      expect(accessHeading).toHaveAttribute("aria-expanded", "true");
+
+      await user.click(accessHeading);
+
+      expect(
+        screen.queryByRole("link", { name: "Members" }),
+      ).not.toBeInTheDocument();
+      // Folding one group leaves its neighbours alone.
+      expect(screen.getByRole("link", { name: "General" })).toBeInTheDocument();
     });
 
     /** @scenario "A rule separates the way back from the pages below it" */

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -305,12 +305,28 @@ describe("the settings shell in a new navigation mode", () => {
       expect(screen.getByTestId("settings-page-content")).toBeInTheDocument();
     });
 
-    /** @scenario Enterprise entries carry a violet pill */
-    it("marks the enterprise entries with the pill", () => {
+    /** @scenario "Enterprise entries carry a quiet grey pill" */
+    it("marks the enterprise entries with a grey pill in a hairline border", () => {
       renderSettings();
 
       expect(screen.getByRole("link", { name: "Groups" })).toBeInTheDocument();
-      expect(screen.getAllByText("ENT").length).toBeGreaterThanOrEqual(1);
+      const pills = screen.getAllByText("ENT");
+      expect(pills.length).toBeGreaterThanOrEqual(1);
+      // The hairline border is pinned on the shared chip style itself:
+      // shell/__tests__/quietChipStyle.unit.test.ts.
+      expect(pills[0]).toHaveStyle({
+        color: "var(--chakra-colors-gray-400)",
+      });
+    });
+
+    /** @scenario "A rule separates the way back from the pages below it" */
+    it("draws a rule under the way back entry", () => {
+      renderSettings();
+
+      const backEntry = screen.getByRole("link", { name: /^Back/ });
+      expect(backEntry.parentElement).toHaveStyle({
+        borderBottomWidth: "1px",
+      });
     });
 
     it("hides the enterprise entries outside an enterprise plan", () => {

--- a/platform/app/src/features/navigation/__tests__/useNavigationMode.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/useNavigationMode.integration.test.tsx
@@ -48,7 +48,10 @@ beforeEach(() => {
     organization: { id: "org_1" },
     isLoading: false,
   });
-  useNavigationModeStore.setState({ storedMode: null, lastKnownFlag: null });
+  useNavigationModeStore.setState({
+    storedMode: null,
+    isLastKnownFlagEnabled: null,
+  });
 });
 
 describe("useNavigationMode", () => {
@@ -67,7 +70,7 @@ describe("useNavigationMode", () => {
   });
 
   describe("when the device picked nothing and the flag has not answered", () => {
-    /** @scenario "A device with no stored preference and the flag off keeps the old navigation" */
+    /** @scenario "A device with no stored preference keeps the old navigation until the flag answers" */
     it("resolves to legacy without a loading screen", () => {
       useFeatureFlagMock.mockReturnValue({ enabled: false, isLoading: true });
 
@@ -78,7 +81,7 @@ describe("useNavigationMode", () => {
 
     /** @scenario "A device that saw the flag on paints the new navigation first" */
     it("resolves to the product switcher when the flag was on last time", () => {
-      useNavigationModeStore.setState({ lastKnownFlag: true });
+      useNavigationModeStore.setState({ isLastKnownFlagEnabled: true });
       useFeatureFlagMock.mockReturnValue({ enabled: false, isLoading: true });
 
       const { result } = renderHook(() => useNavigationMode());
@@ -97,7 +100,9 @@ describe("useNavigationMode", () => {
       renderHook(() => useNavigationMode());
 
       expect(localStorage.getItem(FLAG_STORAGE_KEY)).toBe("on");
-      expect(useNavigationModeStore.getState().lastKnownFlag).toBe(true);
+      expect(useNavigationModeStore.getState().isLastKnownFlagEnabled).toBe(
+        true,
+      );
     });
   });
 

--- a/platform/app/src/features/navigation/__tests__/useNavigationMode.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/useNavigationMode.integration.test.tsx
@@ -1,10 +1,11 @@
 /**
  * @vitest-environment jsdom
  *
- * The navigation-mode resolution contract: legacy resolves synchronously
- * with no flag check, a stored v2 mode waits for the flag instead of
- * flashing the old chrome, and flag off falls back to legacy without
- * erasing the device preference.
+ * The navigation-mode resolution contract: a picked legacy resolves
+ * synchronously with no flag check, a picked v2 mode waits for the flag
+ * instead of flashing the old chrome, a device that picked nothing
+ * follows the flag without ever waiting, and flag off falls back to
+ * legacy without erasing the device preference.
  *
  * Spec: specs/navigation/navigation-modes.feature
  */
@@ -30,6 +31,7 @@ import {
 import { useNavigationMode } from "../useNavigationMode";
 
 const STORAGE_KEY = "langwatch:navigation-mode:v1";
+const FLAG_STORAGE_KEY = "langwatch:navigation-mode-flag:v1";
 
 function flagQueryRan(): boolean {
   return useFeatureFlagMock.mock.calls.some(
@@ -46,17 +48,56 @@ beforeEach(() => {
     organization: { id: "org_1" },
     isLoading: false,
   });
-  useNavigationModeStore.setState({ storedMode: "legacy" });
+  useNavigationModeStore.setState({ storedMode: null, lastKnownFlag: null });
 });
 
 describe("useNavigationMode", () => {
-  describe("when the device has no stored preference", () => {
-    /** @scenario A device with no stored preference stays on the old navigation */
-    it("resolves to legacy immediately without a flag check", () => {
+  describe("when the device picked nothing and the flag is on", () => {
+    /** @scenario "A device with no stored preference runs the product switcher" */
+    it("resolves to the product switcher", () => {
+      useFeatureFlagMock.mockReturnValue({ enabled: true, isLoading: false });
+
+      const { result } = renderHook(() => useNavigationMode());
+
+      expect(result.current).toEqual({
+        status: "ready",
+        mode: "product-switcher",
+      });
+    });
+  });
+
+  describe("when the device picked nothing and the flag has not answered", () => {
+    /** @scenario "A device with no stored preference and the flag off keeps the old navigation" */
+    it("resolves to legacy without a loading screen", () => {
+      useFeatureFlagMock.mockReturnValue({ enabled: false, isLoading: true });
+
       const { result } = renderHook(() => useNavigationMode());
 
       expect(result.current).toEqual({ status: "ready", mode: "legacy" });
-      expect(flagQueryRan()).toBe(false);
+    });
+
+    /** @scenario "A device that saw the flag on paints the new navigation first" */
+    it("resolves to the product switcher when the flag was on last time", () => {
+      useNavigationModeStore.setState({ lastKnownFlag: true });
+      useFeatureFlagMock.mockReturnValue({ enabled: false, isLoading: true });
+
+      const { result } = renderHook(() => useNavigationMode());
+
+      expect(result.current).toEqual({
+        status: "ready",
+        mode: "product-switcher",
+      });
+    });
+  });
+
+  describe("when the flag answers", () => {
+    it("remembers the answer for the next visit", () => {
+      useFeatureFlagMock.mockReturnValue({ enabled: true, isLoading: false });
+
+      renderHook(() => useNavigationMode());
+
+      expect(localStorage.getItem(FLAG_STORAGE_KEY)).toBe("on");
+      expect(useNavigationModeStore.getState().lastKnownFlag).toBe(true);
     });
   });
 
@@ -130,10 +171,10 @@ describe("useNavigationMode", () => {
 
 describe("navigationModeStore", () => {
   describe("when storage holds garbage", () => {
-    /** @scenario Garbage in storage counts as legacy */
-    it("loads as legacy", () => {
+    /** @scenario "Garbage in storage counts as no stored choice" */
+    it("loads as no pick at all", () => {
       localStorage.setItem(STORAGE_KEY, "banana");
-      expect(loadStoredNavigationMode()).toBe("legacy");
+      expect(loadStoredNavigationMode()).toBeNull();
     });
   });
 

--- a/platform/app/src/features/navigation/logic/__tests__/resolveNavigationMode.unit.test.ts
+++ b/platform/app/src/features/navigation/logic/__tests__/resolveNavigationMode.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The full resolution table for the navigation mode, away from React:
+ * which of the three modes a device paints for every combination of a
+ * stored pick, the last flag answer this device saw, and the current
+ * flag answer.
+ *
+ * Spec: specs/navigation/navigation-modes.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isLegacyNavigationDevice,
+  resolveNavigationMode,
+} from "../resolveNavigationMode";
+
+const pending = { status: "pending" } as const;
+const on = { status: "answered", isEnabled: true } as const;
+const off = { status: "answered", isEnabled: false } as const;
+
+describe("resolveNavigationMode", () => {
+  describe("given the reader picked the old navigation", () => {
+    describe("when the flag has not answered", () => {
+      it("resolves to legacy without waiting", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: "legacy",
+            lastKnownFlag: true,
+            flag: pending,
+          }),
+        ).toEqual({ status: "ready", mode: "legacy" });
+      });
+    });
+
+    describe("when the flag is on", () => {
+      it("keeps legacy, since the pick is an opt-out", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: "legacy",
+            lastKnownFlag: true,
+            flag: on,
+          }),
+        ).toEqual({ status: "ready", mode: "legacy" });
+      });
+    });
+  });
+
+  describe("given the reader picked a new mode", () => {
+    describe("when the flag has not answered", () => {
+      it("waits rather than flashing the old chrome", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: "icon-rail",
+            lastKnownFlag: true,
+            flag: pending,
+          }),
+        ).toEqual({ status: "loading" });
+      });
+    });
+
+    describe("when the flag is on", () => {
+      it("resolves to the picked mode", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: "icon-rail",
+            lastKnownFlag: null,
+            flag: on,
+          }),
+        ).toEqual({ status: "ready", mode: "icon-rail" });
+      });
+    });
+
+    describe("when the flag is off", () => {
+      it("resolves to legacy", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: "icon-rail",
+            lastKnownFlag: true,
+            flag: off,
+          }),
+        ).toEqual({ status: "ready", mode: "legacy" });
+      });
+    });
+  });
+
+  describe("given the reader picked nothing", () => {
+    describe("when the flag is on", () => {
+      it("resolves to the default mode", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: null,
+            lastKnownFlag: null,
+            flag: on,
+          }),
+        ).toEqual({ status: "ready", mode: "product-switcher" });
+      });
+    });
+
+    describe("when the flag is off", () => {
+      it("resolves to legacy", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: null,
+            lastKnownFlag: true,
+            flag: off,
+          }),
+        ).toEqual({ status: "ready", mode: "legacy" });
+      });
+    });
+
+    describe("when the flag has not answered and never answered before", () => {
+      it("resolves to legacy without waiting", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: null,
+            lastKnownFlag: null,
+            flag: pending,
+          }),
+        ).toEqual({ status: "ready", mode: "legacy" });
+      });
+    });
+
+    describe("when the flag has not answered but was on last time", () => {
+      it("resolves to the default mode without waiting", () => {
+        expect(
+          resolveNavigationMode({
+            storedMode: null,
+            lastKnownFlag: true,
+            flag: pending,
+          }),
+        ).toEqual({ status: "ready", mode: "product-switcher" });
+      });
+    });
+  });
+});
+
+describe("isLegacyNavigationDevice", () => {
+  describe("when the reader picked nothing and the flag never answered on", () => {
+    it("counts the device as legacy", () => {
+      expect(
+        isLegacyNavigationDevice({ storedMode: null, lastKnownFlag: null }),
+      ).toBe(true);
+      expect(
+        isLegacyNavigationDevice({ storedMode: null, lastKnownFlag: false }),
+      ).toBe(true);
+    });
+  });
+
+  describe("when the device runs a new mode", () => {
+    it("does not count the device as legacy", () => {
+      expect(
+        isLegacyNavigationDevice({ storedMode: null, lastKnownFlag: true }),
+      ).toBe(false);
+      expect(
+        isLegacyNavigationDevice({
+          storedMode: "product-switcher",
+          lastKnownFlag: null,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/features/navigation/logic/__tests__/resolveNavigationMode.unit.test.ts
+++ b/platform/app/src/features/navigation/logic/__tests__/resolveNavigationMode.unit.test.ts
@@ -24,7 +24,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: "legacy",
-            lastKnownFlag: true,
+            isLastKnownFlagEnabled: true,
             flag: pending,
           }),
         ).toEqual({ status: "ready", mode: "legacy" });
@@ -36,7 +36,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: "legacy",
-            lastKnownFlag: true,
+            isLastKnownFlagEnabled: true,
             flag: on,
           }),
         ).toEqual({ status: "ready", mode: "legacy" });
@@ -50,7 +50,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: "icon-rail",
-            lastKnownFlag: true,
+            isLastKnownFlagEnabled: true,
             flag: pending,
           }),
         ).toEqual({ status: "loading" });
@@ -62,7 +62,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: "icon-rail",
-            lastKnownFlag: null,
+            isLastKnownFlagEnabled: null,
             flag: on,
           }),
         ).toEqual({ status: "ready", mode: "icon-rail" });
@@ -74,7 +74,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: "icon-rail",
-            lastKnownFlag: true,
+            isLastKnownFlagEnabled: true,
             flag: off,
           }),
         ).toEqual({ status: "ready", mode: "legacy" });
@@ -88,7 +88,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: null,
-            lastKnownFlag: null,
+            isLastKnownFlagEnabled: null,
             flag: on,
           }),
         ).toEqual({ status: "ready", mode: "product-switcher" });
@@ -100,7 +100,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: null,
-            lastKnownFlag: true,
+            isLastKnownFlagEnabled: true,
             flag: off,
           }),
         ).toEqual({ status: "ready", mode: "legacy" });
@@ -112,7 +112,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: null,
-            lastKnownFlag: null,
+            isLastKnownFlagEnabled: null,
             flag: pending,
           }),
         ).toEqual({ status: "ready", mode: "legacy" });
@@ -124,7 +124,7 @@ describe("resolveNavigationMode", () => {
         expect(
           resolveNavigationMode({
             storedMode: null,
-            lastKnownFlag: true,
+            isLastKnownFlagEnabled: true,
             flag: pending,
           }),
         ).toEqual({ status: "ready", mode: "product-switcher" });
@@ -137,10 +137,16 @@ describe("isLegacyNavigationDevice", () => {
   describe("when the reader picked nothing and the flag never answered on", () => {
     it("counts the device as legacy", () => {
       expect(
-        isLegacyNavigationDevice({ storedMode: null, lastKnownFlag: null }),
+        isLegacyNavigationDevice({
+          storedMode: null,
+          isLastKnownFlagEnabled: null,
+        }),
       ).toBe(true);
       expect(
-        isLegacyNavigationDevice({ storedMode: null, lastKnownFlag: false }),
+        isLegacyNavigationDevice({
+          storedMode: null,
+          isLastKnownFlagEnabled: false,
+        }),
       ).toBe(true);
     });
   });
@@ -148,12 +154,15 @@ describe("isLegacyNavigationDevice", () => {
   describe("when the device runs a new mode", () => {
     it("does not count the device as legacy", () => {
       expect(
-        isLegacyNavigationDevice({ storedMode: null, lastKnownFlag: true }),
+        isLegacyNavigationDevice({
+          storedMode: null,
+          isLastKnownFlagEnabled: true,
+        }),
       ).toBe(false);
       expect(
         isLegacyNavigationDevice({
           storedMode: "product-switcher",
-          lastKnownFlag: null,
+          isLastKnownFlagEnabled: null,
         }),
       ).toBe(false);
     });

--- a/platform/app/src/features/navigation/logic/resolveNavigationMode.ts
+++ b/platform/app/src/features/navigation/logic/resolveNavigationMode.ts
@@ -15,7 +15,7 @@ export interface NavigationModeInputs {
   /** The mode the reader picked, null when they never picked one. */
   storedMode: NavigationMode | null;
   /** The last release_ui_navigation_v2_enabled answer on this device. */
-  lastKnownFlag: boolean | null;
+  isLastKnownFlagEnabled: boolean | null;
   flag: NavigationFlagAnswer;
 }
 
@@ -36,7 +36,7 @@ export interface NavigationModeInputs {
  */
 export function resolveNavigationMode({
   storedMode,
-  lastKnownFlag,
+  isLastKnownFlagEnabled,
   flag,
 }: NavigationModeInputs): NavigationModeResolution {
   if (storedMode === "legacy") return { status: "ready", mode: "legacy" };
@@ -50,7 +50,7 @@ export function resolveNavigationMode({
 
   return {
     status: "ready",
-    mode: lastKnownFlag ? DEFAULT_NAVIGATION_MODE : "legacy",
+    mode: isLastKnownFlagEnabled ? DEFAULT_NAVIGATION_MODE : "legacy",
   };
 }
 
@@ -61,11 +61,14 @@ export function resolveNavigationMode({
  */
 export function isLegacyNavigationDevice({
   storedMode,
-  lastKnownFlag,
-}: Pick<NavigationModeInputs, "storedMode" | "lastKnownFlag">): boolean {
+  isLastKnownFlagEnabled,
+}: Pick<
+  NavigationModeInputs,
+  "storedMode" | "isLastKnownFlagEnabled"
+>): boolean {
   const resolution = resolveNavigationMode({
     storedMode,
-    lastKnownFlag,
+    isLastKnownFlagEnabled,
     flag: { status: "pending" },
   });
   return resolution.status === "ready" && resolution.mode === "legacy";

--- a/platform/app/src/features/navigation/logic/resolveNavigationMode.ts
+++ b/platform/app/src/features/navigation/logic/resolveNavigationMode.ts
@@ -1,0 +1,72 @@
+import {
+  DEFAULT_NAVIGATION_MODE,
+  type NavigationMode,
+} from "../navigationModeStore";
+
+export type NavigationModeResolution =
+  | { status: "ready"; mode: NavigationMode }
+  | { status: "loading" };
+
+export type NavigationFlagAnswer =
+  | { status: "pending" }
+  | { status: "answered"; isEnabled: boolean };
+
+export interface NavigationModeInputs {
+  /** The mode the reader picked, null when they never picked one. */
+  storedMode: NavigationMode | null;
+  /** The last release_ui_navigation_v2_enabled answer on this device. */
+  lastKnownFlag: boolean | null;
+  flag: NavigationFlagAnswer;
+}
+
+/**
+ * Which navigation shell to render, resolved in three steps so no reader
+ * waits for an answer that cannot change what they see:
+ *
+ * 1. A picked `legacy` is an opt-out and never consults the flag. It
+ *    resolves on the first frame with no extra request.
+ * 2. With the flag answered, the flag decides: off is legacy, on is the
+ *    picked mode, or the default mode when there is no pick.
+ * 3. While the flag is pending, a picked v2 mode waits, so the old
+ *    chrome never flashes in front of it. A device with no pick paints
+ *    the answer the flag last gave it here, so it never waits either:
+ *    legacy until the flag has answered on at least once.
+ *
+ * Spec: specs/navigation/navigation-modes.feature
+ */
+export function resolveNavigationMode({
+  storedMode,
+  lastKnownFlag,
+  flag,
+}: NavigationModeInputs): NavigationModeResolution {
+  if (storedMode === "legacy") return { status: "ready", mode: "legacy" };
+
+  if (flag.status === "answered") {
+    if (!flag.isEnabled) return { status: "ready", mode: "legacy" };
+    return { status: "ready", mode: storedMode ?? DEFAULT_NAVIGATION_MODE };
+  }
+
+  if (storedMode !== null) return { status: "loading" };
+
+  return {
+    status: "ready",
+    mode: lastKnownFlag ? DEFAULT_NAVIGATION_MODE : "legacy",
+  };
+}
+
+/**
+ * Whether this device paints the legacy chrome before the flag answers.
+ * For the few call sites that read the mode outside a render, where
+ * subscribing to the flag query is not possible.
+ */
+export function isLegacyNavigationDevice({
+  storedMode,
+  lastKnownFlag,
+}: Pick<NavigationModeInputs, "storedMode" | "lastKnownFlag">): boolean {
+  const resolution = resolveNavigationMode({
+    storedMode,
+    lastKnownFlag,
+    flag: { status: "pending" },
+  });
+  return resolution.status === "ready" && resolution.mode === "legacy";
+}

--- a/platform/app/src/features/navigation/navigationModeStore.ts
+++ b/platform/app/src/features/navigation/navigationModeStore.ts
@@ -8,8 +8,15 @@ export const NAVIGATION_MODES: readonly NavigationMode[] = [
   "icon-rail",
 ];
 
+/**
+ * The mode a device renders when the reader never picked one and the
+ * release_ui_navigation_v2_enabled flag is on. With the flag off the
+ * mode is always legacy, whatever this says.
+ */
+export const DEFAULT_NAVIGATION_MODE: NavigationMode = "product-switcher";
+
 const STORAGE_KEY = "langwatch:navigation-mode:v1";
-const DEFAULT_MODE: NavigationMode = "legacy";
+const FLAG_STORAGE_KEY = "langwatch:navigation-mode-flag:v1";
 
 /**
  * Which navigation shell this device renders: the current chrome
@@ -20,41 +27,74 @@ const DEFAULT_MODE: NavigationMode = "legacy";
  * a non-legacy value takes effect; the preference itself survives the flag
  * turning off.
  *
+ * The store keeps two values. `storedMode` is the reader's own pick and
+ * is null until they make one, so "never picked" and "picked the old
+ * navigation" stay different answers. `lastKnownFlag` is the last answer
+ * the flag gave on this device, which lets a device with no pick paint
+ * its mode on the first frame instead of waiting for the flag query. It
+ * is a device-wide hint, so a reader who belongs to one organization with
+ * the flag on and one with it off may paint the previous organization's
+ * answer for the one frame before the query lands.
+ *
  * Spec: specs/navigation/navigation-modes.feature
  */
 function isNavigationMode(value: unknown): value is NavigationMode {
   return NAVIGATION_MODES.includes(value as NavigationMode);
 }
 
-export function loadStoredNavigationMode(): NavigationMode {
-  if (typeof window === "undefined") return DEFAULT_MODE;
+/** The reader's own pick, or null when they never made one. */
+export function loadStoredNavigationMode(): NavigationMode | null {
+  if (typeof window === "undefined") return null;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (isNavigationMode(raw)) return raw;
   } catch {
     // storage may be disabled
   }
-  return DEFAULT_MODE;
+  return null;
 }
 
-function persist(value: NavigationMode): void {
+/** The last flag answer this device saw, or null before the first one. */
+export function loadLastKnownNavigationFlag(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(FLAG_STORAGE_KEY);
+    if (raw === "on") return true;
+    if (raw === "off") return false;
+  } catch {
+    // storage may be disabled
+  }
+  return null;
+}
+
+function persist(key: string, value: string): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(STORAGE_KEY, value);
+    localStorage.setItem(key, value);
   } catch {
     // storage may be full / disabled
   }
 }
 
 interface NavigationModeState {
-  storedMode: NavigationMode;
+  storedMode: NavigationMode | null;
+  lastKnownFlag: boolean | null;
   setStoredMode: (mode: NavigationMode) => void;
+  rememberFlag: (isEnabled: boolean) => void;
 }
 
-export const useNavigationModeStore = create<NavigationModeState>((set) => ({
-  storedMode: loadStoredNavigationMode(),
-  setStoredMode: (mode) => {
-    persist(mode);
-    set({ storedMode: mode });
-  },
-}));
+export const useNavigationModeStore = create<NavigationModeState>(
+  (set, get) => ({
+    storedMode: loadStoredNavigationMode(),
+    lastKnownFlag: loadLastKnownNavigationFlag(),
+    setStoredMode: (mode) => {
+      persist(STORAGE_KEY, mode);
+      set({ storedMode: mode });
+    },
+    rememberFlag: (isEnabled) => {
+      if (get().lastKnownFlag === isEnabled) return;
+      persist(FLAG_STORAGE_KEY, isEnabled ? "on" : "off");
+      set({ lastKnownFlag: isEnabled });
+    },
+  }),
+);

--- a/platform/app/src/features/navigation/navigationModeStore.ts
+++ b/platform/app/src/features/navigation/navigationModeStore.ts
@@ -29,12 +29,15 @@ const FLAG_STORAGE_KEY = "langwatch:navigation-mode-flag:v1";
  *
  * The store keeps two values. `storedMode` is the reader's own pick and
  * is null until they make one, so "never picked" and "picked the old
- * navigation" stay different answers. `lastKnownFlag` is the last answer
- * the flag gave on this device, which lets a device with no pick paint
- * its mode on the first frame instead of waiting for the flag query. It
- * is a device-wide hint, so a reader who belongs to one organization with
- * the flag on and one with it off may paint the previous organization's
- * answer for the one frame before the query lands.
+ * navigation" stay different answers. `isLastKnownFlagEnabled` is the
+ * last answer the flag gave on this device, which lets a device with no
+ * pick paint its mode on the first frame instead of waiting for the flag
+ * query. It is a device-wide hint, so a reader who belongs to one
+ * organization with the flag on and one with it off may paint the
+ * previous organization's answer for the one frame before the query
+ * lands. Subscribe to the store to read it, never read it once: the
+ * query answer lands in the store, and a device the flag turns off for
+ * must follow it.
  *
  * Spec: specs/navigation/navigation-modes.feature
  */
@@ -67,7 +70,7 @@ export function loadLastKnownNavigationFlag(): boolean | null {
   return null;
 }
 
-function persist(key: string, value: string): void {
+function persist({ key, value }: { key: string; value: string }): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(key, value);
@@ -78,7 +81,7 @@ function persist(key: string, value: string): void {
 
 interface NavigationModeState {
   storedMode: NavigationMode | null;
-  lastKnownFlag: boolean | null;
+  isLastKnownFlagEnabled: boolean | null;
   setStoredMode: (mode: NavigationMode) => void;
   rememberFlag: (isEnabled: boolean) => void;
 }
@@ -86,15 +89,15 @@ interface NavigationModeState {
 export const useNavigationModeStore = create<NavigationModeState>(
   (set, get) => ({
     storedMode: loadStoredNavigationMode(),
-    lastKnownFlag: loadLastKnownNavigationFlag(),
+    isLastKnownFlagEnabled: loadLastKnownNavigationFlag(),
     setStoredMode: (mode) => {
-      persist(STORAGE_KEY, mode);
+      persist({ key: STORAGE_KEY, value: mode });
       set({ storedMode: mode });
     },
     rememberFlag: (isEnabled) => {
-      if (get().lastKnownFlag === isEnabled) return;
-      persist(FLAG_STORAGE_KEY, isEnabled ? "on" : "off");
-      set({ lastKnownFlag: isEnabled });
+      if (get().isLastKnownFlagEnabled === isEnabled) return;
+      persist({ key: FLAG_STORAGE_KEY, value: isEnabled ? "on" : "off" });
+      set({ isLastKnownFlagEnabled: isEnabled });
     },
   }),
 );

--- a/platform/app/src/features/navigation/shell/NavigationV2Shell.tsx
+++ b/platform/app/src/features/navigation/shell/NavigationV2Shell.tsx
@@ -165,10 +165,16 @@ function ShellContentRow({
           borderTopWidth="1px"
           borderLeftWidth="1px"
           borderStyle="solid"
-          borderColor="border.muted"
+          // In light mode `border.muted` is the same grey as `bg.page`, so the
+          // panel edge needs the stronger token to read at all. Dark keeps the
+          // muted one, which already contrasts against the page there.
+          borderColor="border"
           borderTopRightRadius={langyDockInset > 0 ? "xl" : 0}
           borderRightWidth={langyDockInset > 0 ? "1px" : 0}
-          _dark={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.07)" }}
+          _dark={{
+            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.07)",
+            borderColor: "border.muted",
+          }}
           overflow="auto"
           display="flex"
           minHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -1,14 +1,12 @@
-import { Badge, Box, Kbd, Text, VStack } from "@chakra-ui/react";
+import { Badge, Box, Kbd, VStack } from "@chakra-ui/react";
 import { ArrowLeft, ExternalLink, Search } from "lucide-react";
 import { useState } from "react";
-import {
-  MainMenuSections,
-  MENU_WIDTH_COMPACT,
-  MENU_WIDTH_EXPANDED,
-} from "~/components/MainMenu";
+import { MainMenuSections } from "~/components/MainMenu";
 import { PersonalSidebarLinks } from "~/components/PersonalSidebar";
 import { SideMenuItem, SideMenuLink } from "~/components/sidebar/SideMenuLink";
+import { SideMenuSectionLabel } from "~/components/sidebar/SideMenuSectionLabel";
 import { SupportMenu } from "~/components/sidebar/SupportMenu";
+import { SideMenuDensityProvider } from "~/components/sidebar/sideMenuDensity";
 import { ThemeToggle } from "~/components/sidebar/ThemeToggle";
 import { UsageIndicator } from "~/components/sidebar/UsageIndicator";
 import { useCommandBar } from "~/features/command-bar";
@@ -27,6 +25,11 @@ import {
 } from "../sectionNavItems";
 import { useReachableProducts } from "../useReachableProducts";
 import { useSettingsMenu } from "../useSettingsMenu";
+import { QUIET_SIDEBAR_CHIP } from "./quietChipStyle";
+import {
+  SHELL_SIDEBAR_WIDTH_COMPACT,
+  SHELL_SIDEBAR_WIDTH_EXPANDED,
+} from "./shellLayout";
 
 export type SidebarSurface = ProductId | "settings";
 
@@ -51,7 +54,17 @@ function QuickSearchMenuItem({ showLabel }: { showLabel: boolean }) {
         icon={Search}
         label="Quick Search"
         showLabel={showLabel}
-        rightElement={<Kbd size="sm">{getCommandBarShortcut()}</Kbd>}
+        rightElement={
+          <Kbd
+            variant="outline"
+            fontSize="10px"
+            fontWeight="normal"
+            background="bg.muted"
+            {...QUIET_SIDEBAR_CHIP}
+          >
+            {getCommandBarShortcut()}
+          </Kbd>
+        }
       />
     </Box>
   );
@@ -77,7 +90,20 @@ function SidebarBottomBlock({
   });
 
   return (
-    <VStack width="full" gap={0.5} align="start">
+    <VStack
+      data-testid="sidebar-bottom-block"
+      width="full"
+      gap={0.5}
+      align="start"
+      borderTopWidth="1px"
+      borderTopColor="border"
+      paddingTop={2}
+      marginTop={2}
+      // The rule reads as the edge of the block, so it runs a little
+      // wider than the items it separates.
+      marginX="-4px"
+      paddingX="4px"
+    >
       <UsageIndicator showLabel={showExpanded} />
       {shouldIncludeSettingsLink && hasPermission("organization:view") && (
         <SideMenuLink
@@ -123,9 +149,9 @@ function SettingsBackEntry({ showLabel }: { showLabel: boolean }) {
     <Box
       width="full"
       borderBottomWidth="1px"
-      borderBottomColor="border.muted"
-      paddingBottom={1.5}
-      marginBottom={1}
+      borderBottomColor="border"
+      paddingBottom={2.5}
+      marginBottom={1.5}
     >
       <SideMenuLink
         icon={ArrowLeft}
@@ -140,7 +166,7 @@ function SettingsBackEntry({ showLabel }: { showLabel: boolean }) {
 /**
  * The Settings sidebar body: the regrouped, iconed settings menu with
  * the same gates the legacy settings navigation applies. Enterprise
- * entries carry the violet pill.
+ * entries carry the quiet grey pill.
  */
 function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
   const router = useRouter();
@@ -151,18 +177,14 @@ function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
       {groups.map((group) => (
         <VStack key={group.label} width="full" gap={0.5} align="start">
           {showExpanded && (
-            <Text
-              fontSize="11px"
-              fontWeight="medium"
-              textTransform="uppercase"
-              whiteSpace="nowrap"
+            <Box
               color="gray.500"
               paddingX={2}
               paddingTop={2.5}
               paddingBottom={0.5}
             >
-              {group.label}
-            </Text>
+              <SideMenuSectionLabel label={group.label} />
+            </Box>
           )}
           {group.items.map((item) => (
             <SideMenuLink
@@ -181,10 +203,12 @@ function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
                 item.isEnterprise ? (
                   <Badge
                     title="Enterprise plan feature"
-                    colorPalette="purple"
                     variant="outline"
-                    fontSize="9px"
-                    borderRadius="sm"
+                    fontSize="8.5px"
+                    fontWeight="semibold"
+                    letterSpacing="0.06em"
+                    textTransform="uppercase"
+                    {...QUIET_SIDEBAR_CHIP}
                   >
                     ENT
                   </Badge>
@@ -272,12 +296,70 @@ function ProductSidebarBody({
 }
 
 /**
+ * Everything inside the sidebar column: the way back on Settings, Quick
+ * Search, the surface's own pages, and the bottom block pinned under
+ * them. Laid out at the expanded width whatever the column is showing,
+ * so a collapsing column slides the same content out of view instead of
+ * reflowing it.
+ */
+function SidebarContent({
+  surface,
+  showExpanded,
+}: {
+  surface: SidebarSurface;
+  showExpanded: boolean;
+}) {
+  return (
+    <VStack
+      paddingX={3}
+      paddingTop={2}
+      paddingBottom={2}
+      gap={0}
+      height="100%"
+      align="start"
+      width={SHELL_SIDEBAR_WIDTH_EXPANDED}
+      justifyContent="space-between"
+    >
+      <VStack
+        width="full"
+        gap={0.5}
+        align="start"
+        flex={1}
+        minHeight={0}
+        overflowY="auto"
+        overflowX="hidden"
+        css={{
+          scrollbarWidth: "thin",
+          "&::-webkit-scrollbar": { width: "4px" },
+          "&::-webkit-scrollbar-thumb": {
+            background: "var(--chakra-colors-border-emphasized)",
+            borderRadius: "2px",
+          },
+          "&::-webkit-scrollbar-track": { background: "transparent" },
+        }}
+      >
+        {surface === "settings" && (
+          <SettingsBackEntry showLabel={showExpanded} />
+        )}
+        <QuickSearchMenuItem showLabel={showExpanded} />
+        <Box height={2} width="full" flexShrink={0} />
+        <ProductSidebarBody surface={surface} showExpanded={showExpanded} />
+      </VStack>
+
+      <SidebarBottomBlock
+        showExpanded={showExpanded}
+        shouldIncludeSettingsLink={surface !== "settings"}
+      />
+    </VStack>
+  );
+}
+
+/**
  * The navigation-v2 sidebar frame, shared by the product-switcher and
- * icon-rail shells: Quick Search first, the active surface's own pages,
- * and the pinned bottom block. The Settings surface opens with the way
- * back to the product the user came from. It never auto-hides; only
- * small screens keep the hover-expanded responsive collapse the legacy
- * chrome has.
+ * icon-rail shells: a wider column than the current chrome's, drawn one
+ * step tighter so the longer page names hold one line. It never
+ * auto-hides; only small screens keep the hover-expanded responsive
+ * collapse the legacy chrome has.
  *
  * Specs: specs/navigation/product-sidebars.feature,
  *        specs/navigation/settings-shell-v2.feature
@@ -291,71 +373,41 @@ export function ProductSidebar({
 }) {
   const [isHovered, setIsHovered] = useState(false);
   const showExpanded = !isCompact || isHovered;
-  const currentWidth = showExpanded ? MENU_WIDTH_EXPANDED : MENU_WIDTH_COMPACT;
+  const columnWidth = isCompact
+    ? SHELL_SIDEBAR_WIDTH_COMPACT
+    : SHELL_SIDEBAR_WIDTH_EXPANDED;
+  const fullHeight = `calc(100vh - ${APP_HEADER_HEIGHT}px)`;
 
   return (
-    <Box
-      background="bg.page"
-      width={isCompact ? MENU_WIDTH_COMPACT : MENU_WIDTH_EXPANDED}
-      minWidth={isCompact ? MENU_WIDTH_COMPACT : MENU_WIDTH_EXPANDED}
-      height={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
-      position="relative"
-      onMouseEnter={() => isCompact && setIsHovered(true)}
-      onMouseLeave={() => isCompact && setIsHovered(false)}
-    >
+    <SideMenuDensityProvider density="compact">
       <Box
-        position={isCompact ? "absolute" : "relative"}
-        zIndex={isCompact ? 100 : "auto"}
-        top={0}
-        left={0}
-        width={currentWidth}
-        height={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
+        data-testid="product-sidebar"
         background="bg.page"
-        transition="width 0.15s ease-in-out"
-        overflow="hidden"
+        width={columnWidth}
+        minWidth={columnWidth}
+        height={fullHeight}
+        position="relative"
+        onMouseEnter={() => isCompact && setIsHovered(true)}
+        onMouseLeave={() => isCompact && setIsHovered(false)}
       >
-        <VStack
-          paddingX={2}
-          paddingTop={2}
-          paddingBottom={2}
-          gap={0}
-          height="100%"
-          align="start"
-          width={MENU_WIDTH_EXPANDED}
-          justifyContent="space-between"
+        <Box
+          position={isCompact ? "absolute" : "relative"}
+          zIndex={isCompact ? 100 : "auto"}
+          top={0}
+          left={0}
+          width={
+            showExpanded
+              ? SHELL_SIDEBAR_WIDTH_EXPANDED
+              : SHELL_SIDEBAR_WIDTH_COMPACT
+          }
+          height={fullHeight}
+          background="bg.page"
+          transition="width 0.15s ease-in-out"
+          overflow="hidden"
         >
-          <VStack
-            width="full"
-            gap={0.5}
-            align="start"
-            flex={1}
-            minHeight={0}
-            overflowY="auto"
-            overflowX="hidden"
-            css={{
-              scrollbarWidth: "thin",
-              "&::-webkit-scrollbar": { width: "4px" },
-              "&::-webkit-scrollbar-thumb": {
-                background: "var(--chakra-colors-border-emphasized)",
-                borderRadius: "2px",
-              },
-              "&::-webkit-scrollbar-track": { background: "transparent" },
-            }}
-          >
-            {surface === "settings" && (
-              <SettingsBackEntry showLabel={showExpanded} />
-            )}
-            <QuickSearchMenuItem showLabel={showExpanded} />
-            <Box height={2} width="full" flexShrink={0} />
-            <ProductSidebarBody surface={surface} showExpanded={showExpanded} />
-          </VStack>
-
-          <SidebarBottomBlock
-            showExpanded={showExpanded}
-            shouldIncludeSettingsLink={surface !== "settings"}
-          />
-        </VStack>
+          <SidebarContent surface={surface} showExpanded={showExpanded} />
+        </Box>
       </Box>
-    </Box>
+    </SideMenuDensityProvider>
   );
 }

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -3,8 +3,8 @@ import { ArrowLeft, ExternalLink, Search } from "lucide-react";
 import { useState } from "react";
 import { MainMenuSections } from "~/components/MainMenu";
 import { PersonalSidebarLinks } from "~/components/PersonalSidebar";
+import { SidebarSection } from "~/components/sidebar/SidebarSection";
 import { SideMenuItem, SideMenuLink } from "~/components/sidebar/SideMenuLink";
-import { SideMenuSectionLabel } from "~/components/sidebar/SideMenuSectionLabel";
 import { SupportMenu } from "~/components/sidebar/SupportMenu";
 import { SideMenuDensityProvider } from "~/components/sidebar/sideMenuDensity";
 import { ThemeToggle } from "~/components/sidebar/ThemeToggle";
@@ -175,17 +175,12 @@ function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
   return (
     <>
       {groups.map((group) => (
-        <VStack key={group.label} width="full" gap={0.5} align="start">
-          {showExpanded && (
-            <Box
-              color="gray.500"
-              paddingX={2}
-              paddingTop={2.5}
-              paddingBottom={0.5}
-            >
-              <SideMenuSectionLabel label={group.label} />
-            </Box>
-          )}
+        <SidebarSection
+          key={group.id}
+          id={group.id}
+          label={group.label}
+          showExpanded={showExpanded}
+        >
           {group.items.map((item) => (
             <SideMenuLink
               key={item.href}
@@ -216,7 +211,7 @@ function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
               }
             />
           ))}
-        </VStack>
+        </SidebarSection>
       ))}
     </>
   );
@@ -311,7 +306,6 @@ function SidebarContent({
 }) {
   return (
     <VStack
-      paddingX={3}
       paddingTop={2}
       paddingBottom={2}
       gap={0}
@@ -320,8 +314,12 @@ function SidebarContent({
       width={SHELL_SIDEBAR_WIDTH_EXPANDED}
       justifyContent="space-between"
     >
+      {/* The scroll region spans the full column and carries the
+          horizontal inset itself, so its scrollbar runs against the
+          content panel instead of floating a padding away from it. */}
       <VStack
         width="full"
+        paddingX={3}
         gap={0.5}
         align="start"
         flex={1}
@@ -329,7 +327,10 @@ function SidebarContent({
         overflowY="auto"
         overflowX="hidden"
         css={{
-          scrollbarWidth: "thin",
+          // No standard scrollbar-width here: Chromium treats it as an
+          // opt out of the ::-webkit-scrollbar styling below, and the
+          // native bar it falls back to is a wide one with a track.
+          // Firefox takes its default scrollbar instead.
           "&::-webkit-scrollbar": { width: "4px" },
           "&::-webkit-scrollbar-thumb": {
             background: "var(--chakra-colors-border-emphasized)",
@@ -346,10 +347,12 @@ function SidebarContent({
         <ProductSidebarBody surface={surface} showExpanded={showExpanded} />
       </VStack>
 
-      <SidebarBottomBlock
-        showExpanded={showExpanded}
-        shouldIncludeSettingsLink={surface !== "settings"}
-      />
+      <Box width="full" paddingX={3}>
+        <SidebarBottomBlock
+          showExpanded={showExpanded}
+          shouldIncludeSettingsLink={surface !== "settings"}
+        />
+      </Box>
     </VStack>
   );
 }

--- a/platform/app/src/features/navigation/shell/ShellTopBar.tsx
+++ b/platform/app/src/features/navigation/shell/ShellTopBar.tsx
@@ -75,7 +75,9 @@ export function ShellTopBar({
           gap={3}
           alignItems="center"
           minWidth={0}
-          paddingLeft={shouldShowProductCluster ? 3 : 0}
+          // The cluster ends at the sidebar edge, so this inset is the
+          // gap the organization control keeps from the content column.
+          paddingLeft={shouldShowProductCluster ? "22px" : 0}
         >
           <OrganizationSelect activeProductId={activeProductId} />
           <ProductScopeControl activeProductId={activeProductId} />
@@ -117,8 +119,9 @@ function ProductCluster({
         <ProductSwitcherMenu activeProductId={activeProductId} />
       ) : (
         // Settings is a detour, not a product to switch between; the way
-        // out is the sidebar's back entry.
-        <HStack gap={2} paddingX={2}>
+        // out is the sidebar's back entry. It keeps the switcher pill's
+        // inset, so the icon sits where a product icon sits.
+        <HStack gap={2} paddingX={2.5} height="28px">
           <SettingsIcon size={14} color="var(--chakra-colors-fg-muted)" />
           <Text fontSize="13px" fontWeight="medium">
             Settings

--- a/platform/app/src/features/navigation/shell/__tests__/quietChipStyle.unit.test.ts
+++ b/platform/app/src/features/navigation/shell/__tests__/quietChipStyle.unit.test.ts
@@ -1,0 +1,20 @@
+/**
+ * The enterprise pill and the Quick Search key cap share one chip
+ * style, so neither can drift back to a colour of its own.
+ *
+ * Specs: specs/navigation/product-sidebars.feature,
+ *        specs/navigation/settings-shell-v2.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import { QUIET_SIDEBAR_CHIP } from "../quietChipStyle";
+
+describe("the quiet sidebar chip", () => {
+  describe("when a sidebar marks an item with it", () => {
+    it("uses grey type inside a hairline border", () => {
+      expect(QUIET_SIDEBAR_CHIP.color).toBe("gray.400");
+      expect(QUIET_SIDEBAR_CHIP.borderWidth).toBe("1px");
+      expect(QUIET_SIDEBAR_CHIP.borderColor).toBe("border");
+    });
+  });
+});

--- a/platform/app/src/features/navigation/shell/quietChipStyle.ts
+++ b/platform/app/src/features/navigation/shell/quietChipStyle.ts
@@ -1,0 +1,18 @@
+/**
+ * The quiet chip the sidebar marks an item with: grey type inside a
+ * hairline border, no colour of its own. The enterprise pill and the
+ * Quick Search key cap both wear it, so a mark never competes with the
+ * page name it sits next to.
+ *
+ * Specs: specs/navigation/product-sidebars.feature,
+ *        specs/navigation/settings-shell-v2.feature
+ */
+export const QUIET_SIDEBAR_CHIP = {
+  color: "gray.400",
+  borderWidth: "1px",
+  borderColor: "border",
+  borderRadius: "sm",
+  paddingX: 1,
+  paddingY: "1px",
+  lineHeight: "1.3",
+} as const;

--- a/platform/app/src/features/navigation/shell/shellLayout.ts
+++ b/platform/app/src/features/navigation/shell/shellLayout.ts
@@ -1,0 +1,14 @@
+import { MENU_WIDTH_COMPACT } from "~/components/MainMenu";
+
+/**
+ * The sidebar column in the navigation-v2 shells. Wider than the
+ * current chrome's menu, which is what lets the compact menu type hold
+ * the longer product page names on one line.
+ *
+ * The top bar's product cluster and the content column's width cap both
+ * read these, so the three cannot drift apart.
+ */
+export const SHELL_SIDEBAR_WIDTH_EXPANDED = "212px";
+
+/** Small screens keep the same collapsed width the current chrome has. */
+export const SHELL_SIDEBAR_WIDTH_COMPACT = MENU_WIDTH_COMPACT;

--- a/platform/app/src/features/navigation/shell/useNavigationV2ShellState.ts
+++ b/platform/app/src/features/navigation/shell/useNavigationV2ShellState.ts
@@ -1,6 +1,5 @@
 import { useBreakpointValue } from "@chakra-ui/react";
 import { useLayoutEffect } from "react";
-import { MENU_WIDTH_COMPACT, MENU_WIDTH_EXPANDED } from "~/components/MainMenu";
 import {
   LANGY_DOCK_GAP,
   LANGY_DOCKED_OFFSET,
@@ -16,6 +15,10 @@ import { useRouter } from "~/utils/compat/next-router";
 import { findCurrentRoute } from "~/utils/routes";
 import { resolveShellRoute, type ShellRoute } from "../logic/resolveShellRoute";
 import type { ProductId } from "../products";
+import {
+  SHELL_SIDEBAR_WIDTH_COMPACT,
+  SHELL_SIDEBAR_WIDTH_EXPANDED,
+} from "./shellLayout";
 
 type OrganizationTeamProject = ReturnType<typeof useOrganizationTeamProject>;
 type AppSession = ReturnType<typeof useRequiredSession>["data"];
@@ -144,7 +147,9 @@ function toReadyState({
     isSettingsRoute: route.isSettingsRoute,
     isDevelopment,
     isCompactSidebar,
-    menuWidth: isCompactSidebar ? MENU_WIDTH_COMPACT : MENU_WIDTH_EXPANDED,
+    menuWidth: isCompactSidebar
+      ? SHELL_SIDEBAR_WIDTH_COMPACT
+      : SHELL_SIDEBAR_WIDTH_EXPANDED,
     showPresenceMenuItem: pathname.startsWith("/[project]/traces"),
     langyDockInset,
   };

--- a/platform/app/src/features/navigation/useNavigationMode.ts
+++ b/platform/app/src/features/navigation/useNavigationMode.ts
@@ -34,7 +34,9 @@ export type { NavigationModeResolution };
  */
 export function useNavigationMode(): NavigationModeResolution {
   const storedMode = useNavigationModeStore((state) => state.storedMode);
-  const lastKnownFlag = useNavigationModeStore((state) => state.lastKnownFlag);
+  const isLastKnownFlagEnabled = useNavigationModeStore(
+    (state) => state.isLastKnownFlagEnabled,
+  );
   const rememberFlag = useNavigationModeStore((state) => state.rememberFlag);
   const isFlagNeeded = storedMode !== "legacy";
 
@@ -68,7 +70,7 @@ export function useNavigationMode(): NavigationModeResolution {
 
   return resolveNavigationMode({
     storedMode,
-    lastKnownFlag,
+    isLastKnownFlagEnabled,
     flag: isFlagAnswered
       ? { status: "answered", isEnabled: isFlagEnabled }
       : { status: "pending" },

--- a/platform/app/src/features/navigation/useNavigationMode.ts
+++ b/platform/app/src/features/navigation/useNavigationMode.ts
@@ -1,26 +1,32 @@
+import { useEffect } from "react";
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import {
-  type NavigationMode,
-  useNavigationModeStore,
-} from "./navigationModeStore";
+  type NavigationModeResolution,
+  resolveNavigationMode,
+} from "./logic/resolveNavigationMode";
+import { useNavigationModeStore } from "./navigationModeStore";
 
-export type NavigationModeResolution =
-  | { status: "ready"; mode: NavigationMode }
-  | { status: "loading" };
+export type { NavigationModeResolution };
 
 /**
  * Resolve which navigation shell this device renders, without flicker in
  * either direction:
  *
- * - Stored mode `legacy` (the default, including garbage in storage)
- *   resolves synchronously. The flag query never runs, so the current
- *   chrome renders with zero extra requests, the fast path every
- *   flag-off customer takes.
- * - A stored v2 mode stays `loading` until the organization and the
+ * - A picked `legacy` resolves synchronously. The flag query never runs,
+ *   so the current chrome renders with zero extra requests, the fast
+ *   path every reader who opted out takes.
+ * - A picked v2 mode stays `loading` until the organization and the
  *   release_ui_navigation_v2_enabled flag resolve, so the old chrome
  *   never flashes before the new shell. Flag off resolves to `legacy`
  *   without erasing the stored preference.
+ * - A device with no pick never waits: it paints the answer the flag
+ *   last gave it, then follows the flag. That is legacy on a device the
+ *   flag has never been on for, so a flag-off reader sees the current
+ *   chrome on the first frame and it never changes under them.
+ *
+ * The flag query shares its key with the one the avatar menu already
+ * runs on every page, so react-query answers both with one request.
  *
  * Layout seams key off `mode !== "legacy"`, never off the raw flag.
  *
@@ -28,28 +34,43 @@ export type NavigationModeResolution =
  */
 export function useNavigationMode(): NavigationModeResolution {
   const storedMode = useNavigationModeStore((state) => state.storedMode);
-  const isV2Requested = storedMode !== "legacy";
+  const lastKnownFlag = useNavigationModeStore((state) => state.lastKnownFlag);
+  const rememberFlag = useNavigationModeStore((state) => state.rememberFlag);
+  const isFlagNeeded = storedMode !== "legacy";
 
   // The same organization queries the dashboard layout itself runs; react-query
-  // dedupes them, so the legacy path stays at zero extra requests.
+  // dedupes them, so the opted-out path stays at zero extra requests.
   const { organization, isLoading: isOrganizationLoading } =
     useOrganizationTeamProject({
       redirectToOnboarding: false,
       redirectToProjectOnboarding: false,
     });
 
-  const { enabled: flagEnabled, isLoading: isFlagLoading } = useFeatureFlag(
+  const { enabled: isFlagEnabled, isLoading: isFlagLoading } = useFeatureFlag(
     "release_ui_navigation_v2_enabled",
     {
       organizationId: organization?.id,
-      // Only a device that opted into a v2 mode pays for the flag check, and
-      // only once the organization is known (an org-less user still resolves
-      // user-level).
-      enabled: isV2Requested && !isOrganizationLoading,
+      // A reader who opted out of the new navigation pays for no flag
+      // check, and the check waits until the organization is known (an
+      // org-less user still resolves user-level).
+      enabled: isFlagNeeded && !isOrganizationLoading,
     },
   );
 
-  if (!isV2Requested) return { status: "ready", mode: "legacy" };
-  if (isOrganizationLoading || isFlagLoading) return { status: "loading" };
-  return { status: "ready", mode: flagEnabled ? storedMode : "legacy" };
+  const isFlagAnswered =
+    isFlagNeeded && !isOrganizationLoading && !isFlagLoading;
+
+  // Remembering the answer is what lets the next visit paint the right
+  // shell on its first frame instead of starting on the other one.
+  useEffect(() => {
+    if (isFlagAnswered) rememberFlag(isFlagEnabled);
+  }, [isFlagAnswered, isFlagEnabled, rememberFlag]);
+
+  return resolveNavigationMode({
+    storedMode,
+    lastKnownFlag,
+    flag: isFlagAnswered
+      ? { status: "answered", isEnabled: isFlagEnabled }
+      : { status: "pending" },
+  });
 }

--- a/platform/app/src/features/navigation/useSettingsMenu.ts
+++ b/platform/app/src/features/navigation/useSettingsMenu.ts
@@ -58,7 +58,7 @@ export interface SettingsMenuItem {
    */
   alsoActiveAt?: string[];
   icon: LucideIcon;
-  /** Enterprise-plan entry; renders the violet pill. */
+  /** Enterprise-plan entry; renders the quiet grey pill. */
   isEnterprise?: boolean;
 }
 

--- a/platform/app/src/features/navigation/useSettingsMenu.ts
+++ b/platform/app/src/features/navigation/useSettingsMenu.ts
@@ -63,6 +63,13 @@ export interface SettingsMenuItem {
 }
 
 export interface SettingsMenuGroup {
+  /**
+   * Identifies the group in the collapse-state storage key, so a copy edit to
+   * `label` never drops a reader's open and closed sections. The `settings-`
+   * prefix keeps it clear of the product sidebar sections, which share that
+   * key space and already claim plain names like `ops`.
+   */
+  id: string;
   label: string;
   items: SettingsMenuItem[];
 }
@@ -82,6 +89,7 @@ function organizationGroup({
   isLiteMember,
 }: SettingsMenuGates): SettingsMenuGroup {
   return {
+    id: "settings-organization",
     label: "Organization",
     items: [
       {
@@ -129,6 +137,7 @@ function accessGroup({
   isLiteMember,
 }: SettingsMenuGates): SettingsMenuGroup {
   return {
+    id: "settings-access",
     label: "Access",
     items: [
       {
@@ -183,6 +192,7 @@ function aiInfrastructureGroup({
   isLiteMember,
 }: SettingsMenuGates): SettingsMenuGroup {
   return {
+    id: "settings-ai-infrastructure",
     label: "AI Infrastructure",
     items: [
       {
@@ -202,6 +212,7 @@ function dataControlsGroup({
   hasPermission,
 }: SettingsMenuGates): SettingsMenuGroup {
   return {
+    id: "settings-data-controls",
     label: "Data Controls",
     items: [
       {
@@ -225,6 +236,7 @@ function dataControlsGroup({
 
 function projectGroup({ isLiteMember }: SettingsMenuGates): SettingsMenuGroup {
   return {
+    id: "settings-project",
     label: "Project",
     items: [
       {
@@ -256,6 +268,7 @@ function projectGroup({ isLiteMember }: SettingsMenuGates): SettingsMenuGroup {
  */
 export function opsGroup(): SettingsMenuGroup {
   return {
+    id: "settings-ops",
     label: "Ops",
     items: [
       {
@@ -291,6 +304,7 @@ export function opsGroup(): SettingsMenuGroup {
 
 export function backofficeGroup(): SettingsMenuGroup {
   return {
+    id: "settings-backoffice",
     label: "Backoffice",
     items: [
       {

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.navigationV2Teleport.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.navigationV2Teleport.integration.test.tsx
@@ -5,11 +5,12 @@
  * another org does, so the hook pushes the user to that project) is
  * suppressed on devices in a navigation-v2 mode: the v2 org switch and
  * landing resolver own cross-org destinations. Legacy devices keep the
- * teleport bit-for-bit.
+ * teleport bit-for-bit, and a device the flag answers off for gets it
+ * back on that answer.
  *
  * Spec: specs/navigation/navigation-v2-landing.feature
  */
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockOrganizationsQuery, mockRouter, idleQuery } = vi.hoisted(() => ({
@@ -97,7 +98,10 @@ function seedStorage(key: string, value: string) {
 beforeEach(() => {
   window.localStorage.clear();
   mockRouter.push.mockClear();
-  useNavigationModeStore.setState({ storedMode: "legacy" });
+  useNavigationModeStore.setState({
+    storedMode: "legacy",
+    isLastKnownFlagEnabled: null,
+  });
   mockOrganizationsQuery.mockReturnValue({
     data: [EMPTY_ORG, OTHER_ORG],
     isLoading: false,
@@ -145,6 +149,33 @@ describe("cross-organization project teleport", () => {
         expect(result.current.organization?.id).toBe("org-empty");
       });
       expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the flag answers off for the current organization", () => {
+    /** @scenario An organization with the new navigation off gets the teleport back */
+    it("pushes the user to the other organization's project", async () => {
+      // No pick of their own, and the last answer this device saw was on,
+      // which is the state of a reader who came from an organization the
+      // new navigation is on for.
+      useNavigationModeStore.setState({
+        storedMode: null,
+        isLastKnownFlagEnabled: true,
+      });
+      const { result } = renderWithRedirects();
+
+      await waitFor(() => {
+        expect(result.current.organization?.id).toBe("org-empty");
+      });
+      expect(mockRouter.push).not.toHaveBeenCalled();
+
+      act(() => {
+        useNavigationModeStore.getState().rememberFlag(false);
+      });
+
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith("/other-app");
+      });
     });
   });
 });

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -475,6 +475,14 @@ export const useOrganizationTeamProject = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDemo, organization, project, team, router.query.project]);
 
+  // Subscribed, not read once. The store holds the last flag answer this
+  // device saw, which is device-wide: a reader who leaves an organization
+  // with the new navigation on for one with it off starts as a v2 device
+  // and becomes a legacy one when the flag answers. The redirect effect
+  // below must run again on that answer, so it reads a subscribed value.
+  // Spec: specs/navigation/navigation-v2-landing.feature
+  const isLegacyNavigation = useNavigationModeStore(isLegacyNavigationDevice);
+
   useEffect(() => {
     if (
       projectQueryParam &&
@@ -543,10 +551,9 @@ export const useOrganizationTeamProject = (
       teamsWithProjectsOnAnyOrg.length > 0 &&
       // In the navigation-v2 modes the org switch and the landing resolver
       // own cross-organization destinations; this teleport to another
-      // org's project would fight them mid-navigation. Read fresh from the
-      // store (not subscribed) so legacy devices stay on the exact current
-      // code path. Spec: specs/navigation/navigation-v2-landing.feature
-      isLegacyNavigationDevice(useNavigationModeStore.getState())
+      // org's project would fight them mid-navigation.
+      // Spec: specs/navigation/navigation-v2-landing.feature
+      isLegacyNavigation
     ) {
       // Personal workspaces are never a valid project-home target — only
       // redirect when a shared team's project exists (ADR-038 v6).
@@ -584,6 +591,7 @@ export const useOrganizationTeamProject = (
     }
   }, [
     isDemo,
+    isLegacyNavigation,
     organization,
     organizations.data,
     finalProject,

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useLocalStorage } from "usehooks-ts";
+import { isLegacyNavigationDevice } from "~/features/navigation/logic/resolveNavigationMode";
 import { useNavigationModeStore } from "~/features/navigation/navigationModeStore";
 import { OrganizationUserRole, type Project } from "~/generated/prisma/client";
 import { useRouter } from "~/utils/compat/next-router";
@@ -545,7 +546,7 @@ export const useOrganizationTeamProject = (
       // org's project would fight them mid-navigation. Read fresh from the
       // store (not subscribed) so legacy devices stay on the exact current
       // code path. Spec: specs/navigation/navigation-v2-landing.feature
-      useNavigationModeStore.getState().storedMode === "legacy"
+      isLegacyNavigationDevice(useNavigationModeStore.getState())
     ) {
       // Personal workspaces are never a valid project-home target — only
       // redirect when a shared team's project exists (ADR-038 v6).

--- a/specs/navigation/navigation-modes.feature
+++ b/specs/navigation/navigation-modes.feature
@@ -31,7 +31,7 @@ Feature: Navigation modes behind one flag
     Then the mode is "product-switcher"
 
   @integration
-  Scenario: A device with no stored preference and the flag off keeps the old navigation
+  Scenario: A device with no stored preference keeps the old navigation until the flag answers
     Given my device has no stored navigation mode
     And the navigation flag check has not answered yet
     When the app shell resolves the navigation mode

--- a/specs/navigation/navigation-modes.feature
+++ b/specs/navigation/navigation-modes.feature
@@ -8,21 +8,43 @@ Feature: Navigation modes behind one flag
   as today), product-switcher (a top-bar dropdown switches products) and
   icon-rail (a left rail switches products). The mode is a device
   preference in localStorage, never synced to the account. With the flag
-  off, or the mode legacy, the current chrome renders unchanged.
+  off the current chrome renders unchanged, whatever the stored mode.
 
-  The mode resolves without flicker: a device on legacy must never wait
-  for a flag check, and a device on a new mode must never flash the old
-  chrome while the flag check runs.
+  With the flag on, a device that never picked a mode runs the product
+  switcher. Picking "Old navigation" is an opt-out and keeps the current
+  chrome.
+
+  The mode resolves without flicker. A device that picked legacy never
+  waits for a flag check. A device that picked a new mode never flashes
+  the old chrome while the check runs. A device that picked nothing never
+  waits either: it paints the answer the flag last gave it, which is the
+  current chrome until the flag has answered on at least once.
 
   Background:
     Given I am signed in
 
   @integration
-  Scenario: A device with no stored preference stays on the old navigation
+  Scenario: A device with no stored preference runs the product switcher
     Given my device has no stored navigation mode
+    And the navigation flag is on for me
+    When the app shell resolves the navigation mode
+    Then the mode is "product-switcher"
+
+  @integration
+  Scenario: A device with no stored preference and the flag off keeps the old navigation
+    Given my device has no stored navigation mode
+    And the navigation flag check has not answered yet
     When the app shell resolves the navigation mode
     Then the mode is "legacy" immediately
-    And no feature flag check runs
+    And no loading screen is shown
+
+  @integration
+  Scenario: A device that saw the flag on paints the new navigation first
+    Given my device has no stored navigation mode
+    And the flag was on the last time this device asked
+    And the navigation flag check has not answered yet
+    When the app shell resolves the navigation mode
+    Then the mode is "product-switcher" immediately
 
   @integration
   Scenario: A device set to legacy never waits for the flag
@@ -55,10 +77,10 @@ Feature: Navigation modes behind one flag
     And the stored preference is still "product-switcher"
 
   @integration
-  Scenario: Garbage in storage counts as legacy
+  Scenario: Garbage in storage counts as no stored choice
     Given my device stored "banana" as the navigation mode
-    When the app shell resolves the navigation mode
-    Then the mode is "legacy" immediately
+    When the app shell reads the stored navigation mode
+    Then the device counts as having picked no mode
 
   @integration
   Scenario: Picking a mode persists on the device

--- a/specs/navigation/navigation-v2-landing.feature
+++ b/specs/navigation/navigation-v2-landing.feature
@@ -105,6 +105,14 @@ Feature: Landing in the new navigation modes
     When the app resolves my context in legacy mode
     Then I am sent to the other organization's project as today
 
+  @integration
+  Scenario: An organization with the new navigation off gets the teleport back
+    Given my current organization has no project
+    And another organization of mine has one
+    And my device painted a new navigation mode from the last flag answer
+    When the navigation flag answers off for my current organization
+    Then I am sent to the other organization's project
+
   @unit
   Scenario: Switching organization stays in the same product when possible
     Given I am in the Gateway product

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -11,6 +11,11 @@ Feature: Product sidebars in the new navigation modes
   Govern group (the product switcher replaces it), and Gateway and
   Governance promote their section pages from the shared registry.
 
+  The column is wider than the current chrome's and its type is one step
+  smaller, which is what lets the longer page names hold one line. The
+  size is a property of the sidebar, not of the menu components, so the
+  current chrome keeps its own size unchanged.
+
   @integration
   Scenario: Quick Search sits first and opens the command bar
     Given a product sidebar in a new navigation mode
@@ -56,3 +61,26 @@ Feature: Product sidebars in the new navigation modes
     Given the current chrome on the cloud version
     Then the sidebar shows the standalone "Chat" entry
     And the Support menu has no chat entry
+
+  @integration
+  Scenario: The sidebar draws its menu one step smaller
+    Given a product sidebar in a new navigation mode
+    Then the menu items use the compact type and spacing
+    And the group headings use the compact heading style
+    And the column is wider than the current chrome's menu
+
+  @integration
+  Scenario: The current chrome keeps its own menu size
+    Given the current chrome
+    Then the menu items keep the comfortable type and spacing
+    And the group headings keep the comfortable heading style
+
+  @integration
+  Scenario: The search key cap reads as a quiet hint
+    Given a product sidebar in a new navigation mode
+    Then the key cap next to Quick Search is grey with a hairline border
+
+  @integration
+  Scenario: A rule separates the bottom block from the pages above it
+    Given a product sidebar in a new navigation mode
+    Then a rule runs above the bottom block

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -91,3 +91,10 @@ Feature: Product sidebars in the new navigation modes
   Scenario: Opening a page by its address reveals its sidebar entry
     Given I open a product page by its address
     Then the sidebar brings that page's entry into view
+
+  @integration
+  Scenario: Closing the Support menu with the pointer leaves no focus ring
+    Given the Support menu opened because the pointer moved over it
+    When the pointer moves away and the menu closes
+    Then the Support entry does not keep focus
+    But a keyboard close keeps focus on the Support entry

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -14,7 +14,9 @@ Feature: Product sidebars in the new navigation modes
   The column is wider than the current chrome's and its type is one step
   smaller, which is what lets the longer page names hold one line. The
   size is a property of the sidebar, not of the menu components, so the
-  current chrome keeps its own size unchanged.
+  current chrome keeps its own size unchanged. The pages scroll inside
+  the column, and the scrollbar sits against the content panel with no
+  gap.
 
   @integration
   Scenario: Quick Search sits first and opens the command bar
@@ -84,3 +86,8 @@ Feature: Product sidebars in the new navigation modes
   Scenario: A rule separates the bottom block from the pages above it
     Given a product sidebar in a new navigation mode
     Then a rule runs above the bottom block
+
+  @integration
+  Scenario: Opening a page by its address reveals its sidebar entry
+    Given I open a product page by its address
+    Then the sidebar brings that page's entry into view

--- a/specs/navigation/settings-shell-v2.feature
+++ b/specs/navigation/settings-shell-v2.feature
@@ -38,6 +38,14 @@ Feature: Settings shell in the new navigation modes
     And the pill is grey with a hairline border, not a coloured one
 
   @integration
+  Scenario: The settings groups fold, and start open
+    Given I open Settings in a new navigation mode
+    Then every settings group is open
+    When I press a group heading
+    Then that group folds away and the other groups stay as they are
+    And my choice is kept for the next time I open Settings
+
+  @integration
   Scenario: A rule separates the way back from the pages below it
     Given I open Settings in a new navigation mode
     Then a rule runs under the way back entry

--- a/specs/navigation/settings-shell-v2.feature
+++ b/specs/navigation/settings-shell-v2.feature
@@ -11,7 +11,8 @@ Feature: Settings shell in the new navigation modes
   then the settings menu regrouped with icons: ORGANIZATION, ACCESS,
   AI INFRASTRUCTURE, DATA CONTROLS, PROJECT, and the internal OPS and
   BACKOFFICE groups with their current gates. Enterprise-plan entries
-  carry a violet pill. Every settings page keeps its address, and every
+  carry a quiet grey pill, since it marks a plan rather than asking to
+  be read first. Every settings page keeps its address, and every
   visibility gate keeps its current condition.
 
   Devices on the legacy mode keep the current settings chrome
@@ -30,10 +31,16 @@ Feature: Settings shell in the new navigation modes
     And General and Members keep their current addresses
 
   @integration
-  Scenario: Enterprise entries carry a violet pill
+  Scenario: Enterprise entries carry a quiet grey pill
     Given my plan shows the enterprise settings entries
     When the settings sidebar renders in a new navigation mode
     Then the enterprise entries carry an "ENT" pill
+    And the pill is grey with a hairline border, not a coloured one
+
+  @integration
+  Scenario: A rule separates the way back from the pages below it
+    Given I open Settings in a new navigation mode
+    Then a rule runs under the way back entry
 
   @integration
   Scenario: A lite member sees no restricted settings entries


### PR DESCRIPTION
Follow-up polish on the navigation-v2 chrome that shipped in #7076. Eleven changes, all behind `release_ui_navigation_v2_enabled`. With the flag off the current chrome is unchanged, to the pixel.

## 1. The product switcher is the default

With the flag on, a device that never picked a mode now runs the product switcher instead of the old navigation. Picking "Old navigation" in the avatar menu stays an opt-out and is remembered.

The store now tells "never picked" apart from "picked the old navigation": `storedMode` is `null` until the reader picks. It also keeps `isLastKnownFlagEnabled`, the last answer the flag gave on this device. The cross-organization teleport follows the live flag answer as it lands, not the first cached one, so a device the flag sends back to the current chrome keeps the teleport.

Resolution order (`logic/resolveNavigationMode.ts`, a pure function with its own unit table):

1. A picked `legacy` resolves on the first frame and never runs the flag query. That is the path of every reader who opted out.
2. With the flag answered, the flag decides: off is legacy, on is the picked mode, or the product switcher when there is no pick.
3. While the flag is pending, a picked v2 mode waits, so the old chrome never flashes in front of it. A device with no pick never waits either: it paints what the flag last answered on this device.

**First-paint cost.** A device with no pick, on the very first load after the flag turns on, paints the current chrome for the length of one flag query and then swaps to the product switcher. That answer is then remembered, so every later load paints the product switcher on the first frame. A reader with the flag off never sees a swap and never sees a new loading screen, since the remembered answer for them is the current chrome. The flag query itself costs no extra request: it shares a react-query key with the one the avatar menu already runs on every page.

## 2. Menu type and spacing

The sidebar menu components are shared with the current chrome, so the size travels in React context (`SideMenuDensityProvider`) rather than as a prop through each of them. The navigation-v2 sidebar asks for `compact`; everything else keeps `comfortable`, which is the default and is what the current chrome renders.

| | current chrome | navigation-v2 |
|---|---|---|
| item type | 14px | 13px |
| item gap | 12px | 10px |
| item padding | 12px | 8px |
| item height | 32px | 29px |
| icon | 16px | 15px |
| group heading | 11px, medium | 10px, semibold, 0.09em |

Longer page names now hold one line: "Roles & Permissions" needed 133px in the old column against 132px of room, and "Coding Agent Sessions" needed 154px. Both fit in the 147px the new column gives them. Two enterprise entries with a long name and a pill, "Roles & Permissions" and "SCIM Provisioning", still ellipsize, because the pill takes the room back.

## 3. A wider column

`SHELL_SIDEBAR_WIDTH_EXPANDED` is 212px, in its own module so the current chrome's `MENU_WIDTH_EXPANDED` stays 200px. The top bar's product cluster and the content column's width cap both read the new constant, so the three cannot drift.

## 4. Quiet marks

The enterprise pill was violet type in a violet border. It and the Quick Search key cap now share one style, grey type inside a hairline border, so a mark never competes with the page name next to it.

## 5. Rules in the sidebar

A rule under the way back entry in Settings, and a rule above the bottom block in every sidebar.

## 6. Settings header alignment

The Settings title in the top bar now keeps the product pill's own inset, so its icon sits exactly where a product icon sits. The organization control starts 22px into the content column. Measured against the design: logo at 16px, icon at 55px, title at 77px, organization at 234px.

## 7. The content panel hairline

The main panel already asked for a 1px top and left border with a 12px top-left radius, but it drew them with `border.muted`. In light mode that token resolves to the same grey as `bg.page`, so the border painted in the colour of the background behind it and the panel edge never showed. Sampling a pixel column across the top edge went straight from `#F1F5F9` to `#FFFFFF` with nothing between.

It now uses the default border token, which resolves to `#E2E8F0`, the value the design uses. The same sample now reads `#F1F5F9`, one row of `#E2E8F0`, then `#FFFFFF`. Dark mode keeps the muted token, which already contrasts against the page there, so dark is unchanged.

![Settings with the panel hairline](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-settings-border.png)

## 8. The settings groups fold

The settings menu groups collapse and expand like the sections of the LLM Ops sidebar, through the same `SidebarSection` control, and they all start open. Folding one group leaves the others alone, and the choice is kept on the device. The stored state keys on a stable group id with a `settings-` prefix, so a copy edit to a group label never drops a reader's open and closed sections, and the ids never collide with the product sidebar sections that share the key space.

![Settings with a folded group](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-settings-foldable.png)

## 9. The scrollbar sits against the content panel

The sidebar carried its horizontal padding outside the scroll region, so the scrollbar floated 12px away from the content panel. The scroll region now spans the full column and carries the inset itself, and the scrollbar runs against the panel edge. Measured in the browser: the scroll region's right edge and the sidebar's right edge are both at 212px.

The slim scrollbar came back with it. The region set the standard `scrollbar-width` property next to the `::-webkit-scrollbar` styling, and Chromium treats the standard property as an opt out of the custom styling, so it painted a wide native bar with a track instead of the 4px thumb. The standard property is gone; Firefox takes its default scrollbar.

## 10. A page opened by its address reveals its sidebar entry

Opening a page from the address bar, a bookmark or a shared link left the menu scrolled to the top, with the active entry out of view below it. The active entry now scrolls into view when it renders. It scrolls with `block: "nearest"`, so a click inside an already visible menu never shifts the scroll, and back and forward navigation reveal the entry they activate.

/ops opened from the address bar at a short window, with the menu scrolled to the active Dashboard entry:

![Ops by deep link](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-ops-deeplink.png)

## 11. Closing the Support menu with the pointer leaves no focus ring

The Support menu opens when the pointer moves over it. The menu component moves focus into the menu on open and gives it back to the Support entry on close, and focus given by script paints the browser keyboard focus ring. So a pointer that crossed Support and left again put a blue ring on the entry, and the ring stayed until the next click.

A close that came from the pointer now drops that focus the moment it lands. A keyboard close keeps it: Escape after opening with Enter returns focus to the Support entry with the ring showing, which keyboard readers need. Verified in the browser both ways, and pinned by a test that fails without the fix.

## Verification

- `pnpm typecheck:all`: clean.
- `pnpm test:component run src/features/navigation src/components/sidebar`: 74 passed.
- `pnpm test:unit run src/features/navigation`: 66 passed.
- Legacy pinning suites (`DashboardLayout.legacyChrome`, the four `MainMenu` suites): 34 passed. Measured in a browser as well: with the mode on legacy the menu is still a 200px column with 32px items, 14px labels, 16px icons and 11px headings.
- `check:feature-parity`: navigation-modes 15/15, product-sidebars 14/14, settings-shell-v2 8/8, all bound.
- The Biome new-violations gate against the merge base: no new violations.
- `src/components/__tests__/GlobalUpgradeModal.integration.test.tsx` fails when the whole directory runs. It fails the same way on a clean checkout of main, so it is not from this branch.

## Browser QA

Signed in on a real dev instance with the flag on, at 1440x900, light and dark.

Settings, with the enterprise entries shown:

![settings](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-settings-after.png)

LLM Ops in the product-switcher mode:

![llm ops](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-llmops-after.png)

The icon rail, on a Gateway page:

![icon rail](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-iconrail-after.png)

The current chrome, unchanged:

![legacy](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-v2-polish/nav-v2-legacy-unchanged.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact and comfortable sidebar density options.
  * Added expandable settings groups with persisted collapsed state.
  * Active sidebar entries now scroll into view automatically.
  * Improved navigation-mode selection using feature flags, saved preferences, and cached device state.

* **Visual Updates**
  * Refined sidebar widths, spacing, typography, and alignment.
  * Updated Quick Search and enterprise badges with subtle grey styling and borders.
  * Improved section separators and content panel borders.

* **Bug Fixes**
  * Improved fallback behavior for missing or invalid navigation preferences.
  * Improved navigation when opening pages directly or switching organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


