### PR TITLE
ci: refresh and snapshot the boxd golden machine on merge to main

### DIFF
--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -140,10 +140,27 @@ port_holders() {
   done
   echo "$held"
 }
+# Ask the kernel who holds the port and kill that tree, rather than guessing at
+# process names. Name patterns cannot cover a stack this script did not start —
+# a vite server from an older stack held 5560 and matched nothing.
+free_ports() {
+  local p pid pids
+  for p in $APP_PORTS; do
+    pids="$(ss -lntpH "sport = :$p" 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)"
+    for pid in $pids; do
+      [ "$pid" = "1" ] && continue # never the init process
+      echo "port $p held by pid $pid ($(ps -o cmd= -p "$pid" 2>/dev/null | cut -c1-60)) — stopping it"
+      kill_tree "$pid"
+    done
+  done
+}
+free_ports
+
 for _ in $(seq 1 15); do
   BUSY="$(port_holders)"
   [ -z "${BUSY// /}" ] && break
   echo "waiting for ports to free up:$BUSY"
+  free_ports
   sleep 2
 done
 BUSY="$(port_holders)"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -74,13 +74,38 @@ else
   pnpm prisma migrate deploy
 fi
 
-# restart the dev stack (patterns exclude this script itself; SIGKILL because
-# concurrently's --restart-tries -1 stack survives plain TERM)
+# Stop the previous dev stack by process group. Name patterns are not enough:
+# the API server runs as `tsx src/server.mts`, which matches none of the
+# patterns below, so pattern-only kills left an old server alive holding the
+# app port. A stale server answering the health and collector gates would make
+# a refresh look verified while serving the previous commit — the gates check
+# git HEAD, which the reset already moved.
+DEV_PGID_FILE="$WORKDIR/dev-stack.pgid"
+if [ -s "$DEV_PGID_FILE" ]; then
+  OLD_PGID="$(cat "$DEV_PGID_FILE")"
+  kill -9 -"$OLD_PGID" 2>/dev/null || true
+fi
+
+# Patterns still run, for stacks started before the pgid file existed and for
+# anything started outside a refresh. SIGKILL because concurrently's
+# --restart-tries -1 stack survives plain TERM; bracket escapes so the patterns
+# cannot match this script itself.
 pkill -9 -f "dev-superviso[r]" 2>/dev/null || true
 pkill -9 -f "bin/pnpm de[v]" 2>/dev/null || true
 pkill -9 -f "concurrentl[y]" 2>/dev/null || true
 pkill -9 -f "start:ap[p]" 2>/dev/null || true
+pkill -9 -f "tsx/dist/cli.mjs src/server.mt[s]" 2>/dev/null || true
+pkill -9 -f "loader.mjs src/server.mt[s]" 2>/dev/null || true
 sleep 3
+
+# Nothing may still hold the app port, or the new stack's check-ports step
+# blocks and the refresh reports done while the app never boots.
+for _ in $(seq 1 10); do
+  HOLDERS="$(pgrep -f "src/server.mt[s]" | tr '\n' ' ')"
+  [ -z "$HOLDERS" ] && break
+  echo "waiting for old API server(s) to exit: $HOLDERS"
+  sleep 2
+done
 # Two deliberate details here:
 #   9>&-  the dev stack outlives this script, and an inherited lock fd would
 #         keep the flock held for the life of the machine.
@@ -88,5 +113,13 @@ sleep 3
 #         refresh by killing the refresh's process group does not take staging
 #         down with it.
 setsid nohup pnpm dev > "$DEV_LOG" 2>&1 9>&- &
+DEV_PID=$!
+
+# Record the new stack's process group so the next refresh can stop all of it,
+# including the API server that no name pattern matches. Read from the kernel:
+# $! is only the group id when setsid does not fork.
+sleep 1
+ps -o pgid= -p "$DEV_PID" 2>/dev/null | tr -d '[:space:]' > "$DEV_PGID_FILE" || true
+echo "dev stack pgid: $(cat "$DEV_PGID_FILE" 2>/dev/null || echo unknown)"
 
 echo done > "$STATUS"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -82,17 +82,30 @@ fi
 # app port. A stale server answering the health and collector gates would make
 # a refresh look verified while serving the previous commit — the gates check
 # git HEAD, which the reset already moved.
-DEV_PGID_FILE="$WORKDIR/dev-stack.pgid"
-if [ -s "$DEV_PGID_FILE" ]; then
-  OLD_PGID="$(cat "$DEV_PGID_FILE")"
-  # Process ids are recycled, so a pgid recorded before a reboot can name an
-  # unrelated group by the time we read it. Kill it only if its leader still
-  # looks like a dev stack.
-  LEADER_CMD="$(ps -o cmd= -p "$OLD_PGID" 2>/dev/null || true)"
-  case "$LEADER_CMD" in
+DEV_ROOT_FILE="$WORKDIR/dev-stack.pid"
+
+# Kill children before parents: `pnpm start` puts the workers (vite, the Go
+# gateway, the API) in their own session, so a process-group kill rooted at the
+# stack's leader misses exactly the processes that hold the ports. Parentage
+# still connects them, so walk the tree instead of trusting the group.
+kill_tree() {
+  local pid="$1" kid
+  for kid in $(pgrep -P "$pid" 2>/dev/null || true); do
+    kill_tree "$kid"
+  done
+  kill -9 "$pid" 2>/dev/null || true
+}
+
+if [ -s "$DEV_ROOT_FILE" ]; then
+  OLD_ROOT="$(cat "$DEV_ROOT_FILE")"
+  # Process ids are recycled, so a pid recorded before a reboot can name an
+  # unrelated process by the time we read it. Kill it only if it still looks
+  # like a dev stack.
+  ROOT_CMD="$(ps -o cmd= -p "$OLD_ROOT" 2>/dev/null || true)"
+  case "$ROOT_CMD" in
     "") : ;; # already gone
-    *pnpm*dev*) kill -9 -"$OLD_PGID" 2>/dev/null || true ;;
-    *) echo "pgid $OLD_PGID is not a dev stack ($LEADER_CMD) — refusing to kill it" ;;
+    *pnpm*dev*) echo "stopping previous dev stack (pid $OLD_ROOT)"; kill_tree "$OLD_ROOT" ;;
+    *) echo "pid $OLD_ROOT is not a dev stack ($ROOT_CMD) — refusing to kill it" ;;
   esac
 fi
 
@@ -106,19 +119,30 @@ pkill -9 -f "concurrentl[y]" 2>/dev/null || true
 pkill -9 -f "start:ap[p]" 2>/dev/null || true
 pkill -9 -f "tsx/dist/cli.mjs src/server.mt[s]" 2>/dev/null || true
 pkill -9 -f "loader.mjs src/server.mt[s]" 2>/dev/null || true
+# The Go services outlive their parents and hold ports of their own — an
+# nlpgo binary from an earlier stack was found still holding 5561 a day later.
+pkill -9 -f "go run ./cmd/servic[e]" 2>/dev/null || true
+pkill -9 -f "exe/service nlpg[o]" 2>/dev/null || true
+pkill -9 -f "exe/service aigatewa[y]" 2>/dev/null || true
+pkill -9 -f "make -C ../.. servic[e]" 2>/dev/null || true
 sleep 3
 
-# Nothing may still hold the app port, or the new stack's check-ports step
+# Nothing may still hold the app ports, or the new stack's check-ports step
 # blocks and the refresh reports done while the app never boots.
-for _ in $(seq 1 10); do
+for _ in $(seq 1 15); do
   # `|| true` inside the substitution: pgrep exits 1 when nothing matches, and
   # under `set -o pipefail` that failure would abort the whole refresh at the
   # exact moment the loop has succeeded.
-  HOLDERS="$( { pgrep -f "src/server.mt[s]" || true; } | tr '\n' ' ')"
+  HOLDERS="$( { pgrep -f "src/server.mt[s]|exe/servic[e]|vite/bin/vite.j[s]" || true; } | tr '\n' ' ')"
   [ -z "${HOLDERS// /}" ] && break
-  echo "waiting for old API server(s) to exit: $HOLDERS"
+  echo "waiting for old stack processes to exit: $HOLDERS"
   sleep 2
 done
+LEFTOVER="$( { pgrep -f "src/server.mt[s]|exe/servic[e]" || true; } | tr '\n' ' ')"
+if [ -n "${LEFTOVER// /}" ]; then
+  echo "refusing to start: previous stack still holds ports (pids $LEFTOVER)"
+  exit 1
+fi
 # Two deliberate details here:
 #   9>&-  the dev stack outlives this script, and an inherited lock fd would
 #         keep the flock held for the life of the machine.
@@ -128,11 +152,9 @@ done
 setsid nohup pnpm dev > "$DEV_LOG" 2>&1 9>&- &
 DEV_PID=$!
 
-# Record the new stack's process group so the next refresh can stop all of it,
-# including the API server that no name pattern matches. Read from the kernel:
-# $! is only the group id when setsid does not fork.
-sleep 1
-ps -o pgid= -p "$DEV_PID" 2>/dev/null | tr -d '[:space:]' > "$DEV_PGID_FILE" || true
-echo "dev stack pgid: $(cat "$DEV_PGID_FILE" 2>/dev/null || echo unknown)"
+# Record the new stack's root pid so the next refresh can walk and kill the
+# whole tree, including the workers that move into their own session.
+echo "$DEV_PID" > "$DEV_ROOT_FILE"
+echo "dev stack root pid: $DEV_PID"
 
 echo done > "$STATUS"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -36,6 +36,13 @@ if ! flock -n 9; then
 fi
 echo "$EXPECTED_SHA $$" >&9
 
+# Record our own process group so the workflow can kill the whole tree — pnpm,
+# prisma and their children — if the run fails or is cancelled. Read from the
+# kernel rather than assumed from the launcher's $!, which is only the process
+# group id when setsid happens not to fork.
+PGID_FILE="${STATUS%.status}.pgid"
+ps -o pgid= -p $$ | tr -d '[:space:]' > "$PGID_FILE"
+
 trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
 
 # no TTY here: pnpm refuses destructive steps without CI=true
@@ -74,8 +81,12 @@ pkill -9 -f "bin/pnpm de[v]" 2>/dev/null || true
 pkill -9 -f "concurrentl[y]" 2>/dev/null || true
 pkill -9 -f "start:ap[p]" 2>/dev/null || true
 sleep 3
-# 9>&- matters: the dev stack outlives this script, and an inherited lock fd
-# would keep the flock held for the life of the machine.
-nohup pnpm dev > "$DEV_LOG" 2>&1 9>&- &
+# Two deliberate details here:
+#   9>&-  the dev stack outlives this script, and an inherited lock fd would
+#         keep the flock held for the life of the machine.
+#   setsid  puts the dev stack in its own session, so that cleaning up a failed
+#         refresh by killing the refresh's process group does not take staging
+#         down with it.
+setsid nohup pnpm dev > "$DEV_LOG" 2>&1 9>&- &
 
 echo done > "$STATUS"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -20,11 +20,24 @@ git fetch -q origin main
 git checkout -qf main
 git reset -q --hard origin/main
 
-cd langwatch
+# app package location: platform/app since the repo restructure, langwatch/ before
+if [ -d platform/app ]; then APP_DIR=platform/app; else APP_DIR=langwatch; fi
+
+# carry the machine's .env across the restructure (it is not in the image repo)
+if [ ! -f "$APP_DIR/.env" ] && [ -f langwatch/.env ]; then
+  cp langwatch/.env "$APP_DIR/.env"
+fi
+
+cd "$APP_DIR"
 pnpm install
-pnpm prisma migrate deploy
+if grep -q '"prisma:migrate"' package.json; then
+  pnpm run prisma:migrate
+else
+  pnpm prisma migrate deploy
+fi
 
 # restart the dev stack (patterns exclude this script itself)
+pkill -f "dev-superviso[r]" 2>/dev/null || true
 pkill -f "bin/pnpm de[v]" 2>/dev/null || true
 pkill -f "concurrentl[y]" 2>/dev/null || true
 sleep 3

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -127,20 +127,29 @@ pkill -9 -f "exe/service aigatewa[y]" 2>/dev/null || true
 pkill -9 -f "make -C ../.. servic[e]" 2>/dev/null || true
 sleep 3
 
-# Nothing may still hold the app ports, or the new stack's check-ports step
-# blocks and the refresh reports done while the app never boots.
+# The new stack's check-ports step blocks if anything still holds its ports, and
+# the refresh would report done while the app never boots. Ask about the ports
+# themselves rather than about process names: a name pattern broad enough to
+# catch the Go services also matches the Go linker, whose -o argument contains
+# the binary path, and that is a compile step which exits on its own.
+APP_PORTS="5560 5561"
+port_holders() {
+  local p held=""
+  for p in $APP_PORTS; do
+    if ss -lnt "sport = :$p" 2>/dev/null | grep -q LISTEN; then held="$held $p"; fi
+  done
+  echo "$held"
+}
 for _ in $(seq 1 15); do
-  # `|| true` inside the substitution: pgrep exits 1 when nothing matches, and
-  # under `set -o pipefail` that failure would abort the whole refresh at the
-  # exact moment the loop has succeeded.
-  HOLDERS="$( { pgrep -f "src/server.mt[s]|exe/servic[e]|vite/bin/vite.j[s]" || true; } | tr '\n' ' ')"
-  [ -z "${HOLDERS// /}" ] && break
-  echo "waiting for old stack processes to exit: $HOLDERS"
+  BUSY="$(port_holders)"
+  [ -z "${BUSY// /}" ] && break
+  echo "waiting for ports to free up:$BUSY"
   sleep 2
 done
-LEFTOVER="$( { pgrep -f "src/server.mt[s]|exe/servic[e]" || true; } | tr '\n' ' ')"
-if [ -n "${LEFTOVER// /}" ]; then
-  echo "refusing to start: previous stack still holds ports (pids $LEFTOVER)"
+BUSY="$(port_holders)"
+if [ -n "${BUSY// /}" ]; then
+  echo "refusing to start: previous stack still holds port(s)$BUSY"
+  ss -lntp 2>/dev/null | grep -E ":(${APP_PORTS// /|}) " || true
   exit 1
 fi
 # Two deliberate details here:

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -1,12 +1,35 @@
 #!/bin/bash
 # Runs ON the boxd golden machine (launched detached by the boxd-golden-refresh
-# workflow). Writes done/failed to /tmp/golden-refresh.status for the workflow
-# to poll — `boxd machine exec` wedges on long foreground commands, so all the
-# slow work happens here, detached.
+# workflow). Usage: boxd-golden-refresh.sh <commit-sha> <status-file>
+# Writes done/failed to the status file for the workflow to poll — `boxd machine
+# exec` wedges on long foreground commands, so all the slow work happens here,
+# detached.
 set -euo pipefail
 
-STATUS=/tmp/golden-refresh.status
-trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
+# Deploy the exact commit that triggered the workflow run, not whatever
+# origin/main points at by the time this detached script starts — the job is
+# serialized, so main can move while a run waits its turn.
+EXPECTED_SHA="${1:?expected commit SHA is required}"
+# Per-run status file, so a run cancelled by the job timeout cannot leave a
+# status behind for the next run to read.
+STATUS="${2:?status file path is required}"
+LOCK=/tmp/golden-refresh.lock
+
+# Single-flight on the machine itself. GitHub's concurrency group serializes
+# the jobs, but a cancelled job leaves this script running detached, and two
+# refreshes sharing one checkout and one dev stack corrupt each other.
+if ! mkdir "$LOCK" 2>/dev/null; then
+  if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +90 2>/dev/null)" ]; then
+    echo "lock older than 90 min — assuming abandoned, taking over"
+  else
+    echo "another refresh is in flight — refusing to start"
+    echo failed > "$STATUS"
+    exit 1
+  fi
+fi
+echo "$EXPECTED_SHA" > "$LOCK/sha"
+
+trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi; rm -rf "$LOCK"' EXIT
 
 # no TTY here: pnpm refuses destructive steps without CI=true
 export CI=true
@@ -14,11 +37,6 @@ export CI=true
 # nvm-installed node is only on the interactive PATH
 NODE_BIN="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
 export PATH="$NODE_BIN:$HOME/bin:$HOME/go/bin:/usr/local/bin:$PATH"
-
-# Deploy the exact commit that triggered the workflow run, not whatever
-# origin/main points at by the time this detached script starts — the job is
-# serialized, so main can move while a run waits its turn.
-EXPECTED_SHA="${1:?expected commit SHA is required}"
 
 cd "$HOME/langwatch"
 git fetch -q origin main

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -36,10 +36,12 @@ else
   pnpm prisma migrate deploy
 fi
 
-# restart the dev stack (patterns exclude this script itself)
-pkill -f "dev-superviso[r]" 2>/dev/null || true
-pkill -f "bin/pnpm de[v]" 2>/dev/null || true
-pkill -f "concurrentl[y]" 2>/dev/null || true
+# restart the dev stack (patterns exclude this script itself; SIGKILL because
+# concurrently's --restart-tries -1 stack survives plain TERM)
+pkill -9 -f "dev-superviso[r]" 2>/dev/null || true
+pkill -9 -f "bin/pnpm de[v]" 2>/dev/null || true
+pkill -9 -f "concurrentl[y]" 2>/dev/null || true
+pkill -9 -f "start:ap[p]" 2>/dev/null || true
 sleep 3
 nohup pnpm dev > /tmp/pnpm-dev.log 2>&1 &
 

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -18,18 +18,20 @@ LOCK=/tmp/golden-refresh.lock
 # Single-flight on the machine itself. GitHub's concurrency group serializes
 # the jobs, but a cancelled job leaves this script running detached, and two
 # refreshes sharing one checkout and one dev stack corrupt each other.
-if ! mkdir "$LOCK" 2>/dev/null; then
-  if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +90 2>/dev/null)" ]; then
-    echo "lock older than 90 min — assuming abandoned, taking over"
-  else
-    echo "another refresh is in flight — refusing to start"
-    echo failed > "$STATUS"
-    exit 1
-  fi
+#
+# The lock is kernel-held: flock is bound to this process through fd 9 and the
+# kernel drops it when the process dies, however it dies. Nothing times a lock
+# out or reclaims one, so a refresh that runs long is never overtaken, and a
+# refresh that is killed never leaves a lock behind.
+exec 9> "$LOCK"
+if ! flock -n 9; then
+  echo "another refresh holds $LOCK — refusing to start"
+  echo failed > "$STATUS"
+  exit 1
 fi
-echo "$EXPECTED_SHA" > "$LOCK/sha"
+echo "$EXPECTED_SHA $$" >&9
 
-trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi; rm -rf "$LOCK"' EXIT
+trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
 
 # no TTY here: pnpm refuses destructive steps without CI=true
 export CI=true
@@ -67,6 +69,8 @@ pkill -9 -f "bin/pnpm de[v]" 2>/dev/null || true
 pkill -9 -f "concurrentl[y]" 2>/dev/null || true
 pkill -9 -f "start:ap[p]" 2>/dev/null || true
 sleep 3
-nohup pnpm dev > /tmp/pnpm-dev.log 2>&1 &
+# 9>&- matters: the dev stack outlives this script, and an inherited lock fd
+# would keep the flock held for the life of the machine.
+nohup pnpm dev > /tmp/pnpm-dev.log 2>&1 9>&- &
 
 echo done > "$STATUS"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -49,7 +49,9 @@ trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
 export CI=true
 
 # nvm-installed node is only on the interactive PATH
-NODE_BIN="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
+# `|| true`: under `set -o pipefail` an unmatched glob would abort the refresh
+# here with no message at all, rather than failing later where the log says why.
+NODE_BIN="$( { ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null || true; } | sort -V | tail -1)"
 export PATH="$NODE_BIN:$HOME/bin:$HOME/go/bin:/usr/local/bin:$PATH"
 
 cd "$HOME/langwatch"
@@ -101,8 +103,11 @@ sleep 3
 # Nothing may still hold the app port, or the new stack's check-ports step
 # blocks and the refresh reports done while the app never boots.
 for _ in $(seq 1 10); do
-  HOLDERS="$(pgrep -f "src/server.mt[s]" | tr '\n' ' ')"
-  [ -z "$HOLDERS" ] && break
+  # `|| true` inside the substitution: pgrep exits 1 when nothing matches, and
+  # under `set -o pipefail` that failure would abort the whole refresh at the
+  # exact moment the loop has succeeded.
+  HOLDERS="$( { pgrep -f "src/server.mt[s]" || true; } | tr '\n' ' ')"
+  [ -z "${HOLDERS// /}" ] && break
   echo "waiting for old API server(s) to exit: $HOLDERS"
   sleep 2
 done

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -15,10 +15,16 @@ export CI=true
 NODE_BIN="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
 export PATH="$NODE_BIN:$HOME/bin:$HOME/go/bin:/usr/local/bin:$PATH"
 
+# Deploy the exact commit that triggered the workflow run, not whatever
+# origin/main points at by the time this detached script starts — the job is
+# serialized, so main can move while a run waits its turn.
+EXPECTED_SHA="${1:?expected commit SHA is required}"
+
 cd "$HOME/langwatch"
 git fetch -q origin main
 git checkout -qf main
-git reset -q --hard origin/main
+git rev-parse -q --verify "${EXPECTED_SHA}^{commit}" > /dev/null
+git reset -q --hard "$EXPECTED_SHA"
 
 # app package location: platform/app since the repo restructure, langwatch/ before
 if [ -d platform/app ]; then APP_DIR=platform/app; else APP_DIR=langwatch; fi

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -85,7 +85,15 @@ fi
 DEV_PGID_FILE="$WORKDIR/dev-stack.pgid"
 if [ -s "$DEV_PGID_FILE" ]; then
   OLD_PGID="$(cat "$DEV_PGID_FILE")"
-  kill -9 -"$OLD_PGID" 2>/dev/null || true
+  # Process ids are recycled, so a pgid recorded before a reboot can name an
+  # unrelated group by the time we read it. Kill it only if its leader still
+  # looks like a dev stack.
+  LEADER_CMD="$(ps -o cmd= -p "$OLD_PGID" 2>/dev/null || true)"
+  case "$LEADER_CMD" in
+    "") : ;; # already gone
+    *pnpm*dev*) kill -9 -"$OLD_PGID" 2>/dev/null || true ;;
+    *) echo "pgid $OLD_PGID is not a dev stack ($LEADER_CMD) — refusing to kill it" ;;
+  esac
 fi
 
 # Patterns still run, for stacks started before the pgid file existed and for

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -132,7 +132,10 @@ sleep 3
 # themselves rather than about process names: a name pattern broad enough to
 # catch the Go services also matches the Go linker, whose -o argument contains
 # the binary path, and that is a compile step which exits on its own.
-APP_PORTS="5560 5561"
+# 5560 vite (what the boxd proxy serves), 5561 the nlpgo service, 6560 the API
+# the gateway probes at /api/internal/gateway/health. A stale holder of any of
+# them stops the new stack from serving.
+APP_PORTS="5560 5561 6560"
 port_holders() {
   local p held=""
   for p in $APP_PORTS; do

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -34,7 +34,6 @@ if ! flock -n 9; then
   echo failed > "$STATUS"
   exit 1
 fi
-echo "$EXPECTED_SHA $$" >&9
 
 # Record our own process group so the workflow can kill the whole tree — pnpm,
 # prisma and their children — if the run fails or is cancelled. Read from the
@@ -43,6 +42,7 @@ echo "$EXPECTED_SHA $$" >&9
 PGID_FILE="${STATUS%.status}.pgid"
 ps -o pgid= -p $$ | tr -d '[:space:]' > "$PGID_FILE"
 
+# shellcheck disable=SC2154  # `code` is assigned by the first statement of this trap
 trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
 
 # no TTY here: pnpm refuses destructive steps without CI=true
@@ -52,6 +52,14 @@ export CI=true
 # `|| true`: under `set -o pipefail` an unmatched glob would abort the refresh
 # here with no message at all, rather than failing later where the log says why.
 NODE_BIN="$( { ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null || true; } | sort -V | tail -1)"
+# An empty NODE_BIN must not be interpolated into PATH: a leading empty element
+# means the current directory, which at this point is the checkout we just reset
+# to whatever main contains, so a repo-tracked file named `node` or `pnpm` would
+# be executed. Fail loudly instead — without nvm's node nothing below can work.
+if [ -z "$NODE_BIN" ]; then
+  echo "no nvm node found under $HOME/.nvm/versions/node/*/bin"
+  exit 1
+fi
 export PATH="$NODE_BIN:$HOME/bin:$HOME/go/bin:/usr/local/bin:$PATH"
 
 cd "$HOME/langwatch"
@@ -186,4 +194,8 @@ DEV_PID=$!
 echo "$DEV_PID" > "$DEV_ROOT_FILE"
 echo "dev stack root pid: $DEV_PID"
 
-echo done > "$STATUS"
+# Stamp the commit into the status. The workflow compares the whole line against
+# `done <its own sha>`, so a status left by some other run — or the word "done"
+# appearing anywhere in the exec channel's own output — cannot be read as this
+# run finishing.
+echo "done $EXPECTED_SHA" > "$STATUS"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -8,14 +8,17 @@ set -euo pipefail
 STATUS=/tmp/golden-refresh.status
 trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
 
+# no TTY here: pnpm refuses destructive steps without CI=true
+export CI=true
+
 # nvm-installed node is only on the interactive PATH
 NODE_BIN="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
 export PATH="$NODE_BIN:$HOME/bin:$HOME/go/bin:/usr/local/bin:$PATH"
 
 cd "$HOME/langwatch"
-git fetch origin main
-git checkout -f main
-git reset --hard origin/main
+git fetch -q origin main
+git checkout -qf main
+git reset -q --hard origin/main
 
 cd langwatch
 pnpm install

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -13,7 +13,12 @@ EXPECTED_SHA="${1:?expected commit SHA is required}"
 # Per-run status file, so a run cancelled by the job timeout cannot leave a
 # status behind for the next run to read.
 STATUS="${2:?status file path is required}"
-LOCK=/tmp/golden-refresh.lock
+# Everything this refresh writes lives beside the status file, in the private
+# 0700 directory the workflow creates. Nothing goes to a world-writable path,
+# so no other local user can pre-create or symlink what we open.
+WORKDIR="$(dirname "$STATUS")"
+LOCK="$WORKDIR/golden-refresh.lock"
+DEV_LOG="$WORKDIR/pnpm-dev.log"
 
 # Single-flight on the machine itself. GitHub's concurrency group serializes
 # the jobs, but a cancelled job leaves this script running detached, and two
@@ -71,6 +76,6 @@ pkill -9 -f "start:ap[p]" 2>/dev/null || true
 sleep 3
 # 9>&- matters: the dev stack outlives this script, and an inherited lock fd
 # would keep the flock held for the life of the machine.
-nohup pnpm dev > /tmp/pnpm-dev.log 2>&1 9>&- &
+nohup pnpm dev > "$DEV_LOG" 2>&1 9>&- &
 
 echo done > "$STATUS"

--- a/.github/scripts/boxd-golden-refresh.sh
+++ b/.github/scripts/boxd-golden-refresh.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Runs ON the boxd golden machine (launched detached by the boxd-golden-refresh
+# workflow). Writes done/failed to /tmp/golden-refresh.status for the workflow
+# to poll — `boxd machine exec` wedges on long foreground commands, so all the
+# slow work happens here, detached.
+set -euo pipefail
+
+STATUS=/tmp/golden-refresh.status
+trap 'code=$?; if [ "$code" -ne 0 ]; then echo failed > "$STATUS"; fi' EXIT
+
+# nvm-installed node is only on the interactive PATH
+NODE_BIN="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
+export PATH="$NODE_BIN:$HOME/bin:$HOME/go/bin:/usr/local/bin:$PATH"
+
+cd "$HOME/langwatch"
+git fetch origin main
+git checkout -f main
+git reset --hard origin/main
+
+cd langwatch
+pnpm install
+pnpm prisma migrate deploy
+
+# restart the dev stack (patterns exclude this script itself)
+pkill -f "bin/pnpm de[v]" 2>/dev/null || true
+pkill -f "concurrentl[y]" 2>/dev/null || true
+sleep 3
+nohup pnpm dev > /tmp/pnpm-dev.log 2>&1 &
+
+echo done > "$STATUS"

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   refresh-golden:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +68,7 @@ jobs:
 
       - name: Wait for /api/health 204
         run: |
-          for i in $(seq 1 40); do
+          for i in $(seq 1 120); do
             CODE=$(curl -sk -o /dev/null -w '%{http_code}' "$GOLDEN_URL/api/health" || true)
             echo "health: $CODE"
             [ "$CODE" = "204" ] && exit 0

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -1,0 +1,95 @@
+name: Boxd Golden Refresh
+
+# On every merge to main: fast-forward the boxd golden machine to main,
+# verify it is actually up and serving, then save the verified state as a
+# snapshot. The golden stays running as the standing staging environment;
+# the snapshot is the durable fork source for preview boxes.
+#
+# A red run of this workflow on main means staging is broken.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: boxd-golden-refresh
+  cancel-in-progress: false
+
+env:
+  BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
+  GOLDEN: langwatch-golden-v3
+  SNAPSHOT: langwatch-main
+  GOLDEN_URL: https://langwatch-golden-v3.boxd.sh
+
+jobs:
+  refresh-golden:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Install boxd CLI
+        run: |
+          curl -fsSL https://boxd.sh/downloads/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Golden is running and exec channel works
+        run: |
+          boxd machine get "$GOLDEN" --json
+          boxd machine exec --timeout 30 "$GOLDEN" -- echo exec-ok | grep -q exec-ok
+
+      - name: Launch refresh on golden (detached)
+        run: |
+          B64=$(base64 -w0 .github/scripts/boxd-golden-refresh.sh)
+          boxd machine exec --timeout 60 "$GOLDEN" -- bash -c \
+            "echo $B64 | base64 -d > /tmp/golden-refresh.sh && chmod +x /tmp/golden-refresh.sh && rm -f /tmp/golden-refresh.status"
+          boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
+            "nohup /tmp/golden-refresh.sh > /tmp/golden-refresh.log 2>&1 & echo launched"
+
+      - name: Wait for refresh to finish
+        run: |
+          for i in $(seq 1 60); do
+            S=$(boxd machine exec --timeout 30 "$GOLDEN" -- cat /tmp/golden-refresh.status 2>/dev/null || true)
+            case "$S" in
+              *done*) echo "refresh done"; exit 0 ;;
+              *failed*)
+                echo "refresh FAILED — log tail:"
+                boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 /tmp/golden-refresh.log || true
+                exit 1 ;;
+            esac
+            sleep 20
+          done
+          echo "refresh timed out — log tail:"
+          boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 /tmp/golden-refresh.log || true
+          exit 1
+
+      - name: Wait for /api/health 204
+        run: |
+          for i in $(seq 1 40); do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}' "$GOLDEN_URL/api/health" || true)
+            echo "health: $CODE"
+            [ "$CODE" = "204" ] && exit 0
+            sleep 15
+          done
+          echo "app never became healthy"
+          exit 1
+
+      - name: Verify golden serves this exact commit
+        run: |
+          DEPLOYED=$(boxd machine exec --timeout 30 "$GOLDEN" -- git -C /home/boxd/langwatch rev-parse HEAD | tr -d '[:space:]')
+          echo "deployed=$DEPLOYED expected=$GITHUB_SHA"
+          [ "$DEPLOYED" = "$GITHUB_SHA" ]
+
+      - name: Verify API auth layer is up (collector rejects unauthenticated)
+        run: |
+          CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST "$GOLDEN_URL/api/collector" -H 'Content-Type: application/json' -d '{}')
+          echo "collector unauthenticated: $CODE"
+          [ "$CODE" = "401" ]
+
+      - name: Save verified snapshot
+        run: |
+          boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json
+          boxd snapshots list

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -22,7 +22,6 @@ permissions:
 env:
   GOLDEN: langwatch-golden-v3
   SNAPSHOT: langwatch-main
-  GOLDEN_URL: https://langwatch-golden-v3.boxd.sh
   # Re-pin when boxd ships a new installer:
   #   curl -fsSL https://boxd.sh/downloads/cli/install.sh | sha256sum
   BOXD_INSTALLER_SHA256: 935d59706c090a6ed8276c6a8635b1e24b5d9748cf14625365bccd445ee16343
@@ -39,9 +38,21 @@ env:
 
 jobs:
   refresh-golden:
-    # BOXD_API_KEY can exec on the shared golden, so it is never exposed to a
-    # ref other than main. Without this, a write-access user could point
-    # workflow_dispatch at a modified branch and run arbitrary code with it.
+    # BOXD_API_KEY can exec on the shared golden, so reaching it must not be
+    # something a branch can grant itself.
+    #
+    # The `if:` below is defence in depth ONLY. It cannot be the control on its
+    # own: workflow_dispatch runs the workflow definition from the ref you pick,
+    # so whoever dispatches a modified branch also gets to delete this line in
+    # the same commit. The credential has to be gated by something outside the
+    # file it protects.
+    #
+    # That gate is the environment: a repo admin must configure `boxd-golden`
+    # with a deployment branch rule of `main` only (and required reviewers), and
+    # hold BOXD_API_KEY as an environment secret rather than a repo secret. Then
+    # a dispatch from any other ref cannot read the credential at all, whatever
+    # the workflow file on that ref says.
+    environment: boxd-golden
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # 45 + 45 + 15 minutes of polling, plus room for the CLI install, the two
@@ -81,13 +92,17 @@ jobs:
             echo "REMOTE_SCRIPT=$DIR/refresh.$RUN.sh"
             echo "REMOTE_STATUS=$DIR/refresh.$RUN.status"
             echo "REMOTE_LOG=$DIR/refresh.$RUN.log"
+            # Derived, so renaming the machine is a one-line change.
+            echo "GOLDEN_URL=https://${GOLDEN}.boxd.sh"
           } >> "$GITHUB_ENV"
 
+      # No `boxd machine get --json` here: the machine record carries env and
+      # config that does not belong in a job log. The exec probe below proves
+      # both things this step needs — the machine is up and the channel works.
       - name: Golden is running and exec channel works
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
-          boxd machine get "$GOLDEN" --json
           boxd machine exec --timeout 30 "$GOLDEN" -- echo exec-ok | grep -q exec-ok
 
       - name: Launch refresh on golden (detached)
@@ -108,20 +123,40 @@ jobs:
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
+          # The remote log carries pnpm, prisma and dev-stack output from a
+          # machine that has real staging credentials in its .env — prisma
+          # prints DATABASE_URL, password included, in connection errors. Runner
+          # log masking only covers registered secrets, so strip inline URL
+          # credentials before any of it reaches this job's log.
+          tail_remote_log() {
+            boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 "$REMOTE_LOG" 2>/dev/null \
+              | sed -E 's#([a-zA-Z][a-zA-Z0-9+.-]*://[^:/@[:space:]]+:)[^@[:space:]]+@#\1***@#g' \
+              || true
+          }
+          # The status is matched EXACTLY against this run's own sha. `S` is
+          # whatever the exec channel emitted, not just the file: a substring
+          # match would let the word "done" in a CLI banner end the wait while
+          # the refresh was still mid-flight, and the health gate would then run
+          # against the previous stack, which the script has not killed yet.
           DEADLINE=$(( $(date +%s) + REFRESH_WAIT_SECONDS ))
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
             S=$(boxd machine exec --timeout 30 "$GOLDEN" -- cat "$REMOTE_STATUS" 2>/dev/null || true)
+            S=$(printf '%s' "$S" | tr -d '\r' | tr '\n' ' ' | sed -E 's/^ +| +$//g')
             case "$S" in
-              *done*) echo "refresh done"; exit 0 ;;
-              *failed*)
+              "done $GITHUB_SHA") echo "refresh done"; exit 0 ;;
+              "done "*)
+                echo "status names a different commit: [$S] — expected [done $GITHUB_SHA]"
+                tail_remote_log
+                exit 1 ;;
+              failed)
                 echo "refresh FAILED — log tail:"
-                boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 "$REMOTE_LOG" || true
+                tail_remote_log
                 exit 1 ;;
             esac
             sleep 20
           done
           echo "refresh timed out after ${REFRESH_WAIT_SECONDS}s — log tail:"
-          boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 "$REMOTE_LOG" || true
+          tail_remote_log
           exit 1
 
       - name: Wait for /api/health 204
@@ -136,7 +171,15 @@ jobs:
           echo "app never became healthy within ${HEALTH_WAIT_SECONDS}s"
           exit 1
 
-      - name: Verify golden serves this exact commit
+      # Scope of this gate, stated plainly: it proves the CHECKOUT on the golden
+      # is this commit. It does not prove the running process is serving bytes
+      # built from it — `pnpm dev` compiles lazily, so a stale build can answer
+      # while the working tree is current. What binds the serving process to the
+      # refresh is the port reclaim in the script (nothing from an older stack
+      # is left holding the app ports) plus the health and collector gates
+      # above. Asserting the sha back over HTTP would need the app to expose it;
+      # it does not today.
+      - name: Verify the golden's checkout is this exact commit
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
@@ -159,7 +202,13 @@ jobs:
           # six minutes after the CLI returned an error. Treat the save as a
           # request and poll for the result, so a slow snapshot is not reported
           # as a failed refresh.
-          BEFORE=$(boxd snapshots list | awk -v n="$SNAPSHOT" '$1==n {print $2}')
+          # The version/state columns are read positionally. Confirm the command
+          # works and its output still has the shape we parse before betting the
+          # 15-minute poll on it — otherwise a changed column layout shows up as
+          # a slow "did not become ready" instead of an obvious parse failure.
+          LIST=$(boxd snapshots list) || { echo "boxd snapshots list failed"; exit 1; }
+          printf '%s\n' "$LIST" | head -5
+          BEFORE=$(printf '%s\n' "$LIST" | awk -v n="$SNAPSHOT" '$1==n {print $2}')
           echo "version before save: ${BEFORE:-none}"
           boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json \
             || echo "save returned non-zero — polling for the snapshot to become ready"

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -29,8 +29,12 @@ env:
   # Poll budgets, in seconds. They must sum to less than timeout-minutes below,
   # with headroom for the gates and the snapshot save, so that a stuck refresh
   # ends in this workflow's own diagnostics instead of a bare job cancellation.
-  REFRESH_WAIT_SECONDS: "2700" # 45 min (a full cold refresh was observed at ~31)
-  HEALTH_WAIT_SECONDS: "1200" # 20 min
+  # The numbers come from timing the real thing on the golden, not from guesses:
+  # a cold refresh (pnpm install + migrations) took ~31 min, and because that
+  # install replaces node_modules, the dev stack then rebuilds every SDK and
+  # bundle before it serves — a clean boot to /api/health 204 measured 27m28s.
+  REFRESH_WAIT_SECONDS: "2700" # 45 min
+  HEALTH_WAIT_SECONDS: "2700" # 45 min
   SNAPSHOT_WAIT_SECONDS: "900" # 15 min
 
 jobs:
@@ -40,7 +44,9 @@ jobs:
     # workflow_dispatch at a modified branch and run arbitrary code with it.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # 45 + 45 + 15 minutes of polling, plus room for the CLI install, the two
+    # HTTP gates and the SHA check.
+    timeout-minutes: 120
     permissions:
       contents: read
     steps:

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -53,7 +53,11 @@ jobs:
     # a dispatch from any other ref cannot read the credential at all, whatever
     # the workflow file on that ref says.
     environment: boxd-golden
-    if: github.ref == 'refs/heads/main'
+    # The repository check keeps this off forks. A fork pushing to its own main
+    # has neither the environment nor the credential, so the job could only ever
+    # fail there — and this workflow's whole contract is that a red run means
+    # staging is broken.
+    if: github.ref == 'refs/heads/main' && github.repository == 'langwatch/langwatch'
     runs-on: ubuntu-latest
     # 45 + 45 + 15 minutes of polling, plus room for the CLI install, the two
     # HTTP gates and the SHA check.

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -29,8 +29,9 @@ env:
   # Poll budgets, in seconds. They must sum to less than timeout-minutes below,
   # with headroom for the gates and the snapshot save, so that a stuck refresh
   # ends in this workflow's own diagnostics instead of a bare job cancellation.
-  REFRESH_WAIT_SECONDS: "3300" # 55 min
+  REFRESH_WAIT_SECONDS: "2700" # 45 min (a full cold refresh was observed at ~31)
   HEALTH_WAIT_SECONDS: "1200" # 20 min
+  SNAPSHOT_WAIT_SECONDS: "900" # 15 min
 
 jobs:
   refresh-golden:
@@ -146,8 +147,31 @@ jobs:
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
-          boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json
+          # `boxd snapshots save` gives up on its own client-side timeout while
+          # the snapshot is still being written — observed becoming ready about
+          # six minutes after the CLI returned an error. Treat the save as a
+          # request and poll for the result, so a slow snapshot is not reported
+          # as a failed refresh.
+          BEFORE=$(boxd snapshots list | awk -v n="$SNAPSHOT" '$1==n {print $2}')
+          echo "version before save: ${BEFORE:-none}"
+          boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json \
+            || echo "save returned non-zero — polling for the snapshot to become ready"
+          DEADLINE=$(( $(date +%s) + SNAPSHOT_WAIT_SECONDS ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            ROW=$(boxd snapshots list | awk -v n="$SNAPSHOT" '$1==n {print $2, $3}')
+            echo "snapshot: ${ROW:-absent}"
+            # A new version in ready state is the only success: without the
+            # version check, an older ready snapshot would pass this gate while
+            # today's save was still pending.
+            case "$ROW" in
+              "$BEFORE "*) : ;;
+              *" ready") echo "snapshot ready"; boxd snapshots list; exit 0 ;;
+            esac
+            sleep 30
+          done
+          echo "snapshot did not become ready within ${SNAPSHOT_WAIT_SECONDS}s"
           boxd snapshots list
+          exit 1
 
       # Best effort: on cancellation the runner kills the steps above, but the
       # detached refresh keeps running on the golden. Kill only this run's own

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -67,9 +67,11 @@ jobs:
       - name: Per-run remote paths
         run: |
           RUN="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "REMOTE_SCRIPT=/tmp/golden-refresh.$RUN.sh" >> "$GITHUB_ENV"
-          echo "REMOTE_STATUS=/tmp/golden-refresh.$RUN.status" >> "$GITHUB_ENV"
-          echo "REMOTE_LOG=/tmp/golden-refresh.$RUN.log" >> "$GITHUB_ENV"
+          {
+            echo "REMOTE_SCRIPT=/tmp/golden-refresh.$RUN.sh"
+            echo "REMOTE_STATUS=/tmp/golden-refresh.$RUN.status"
+            echo "REMOTE_LOG=/tmp/golden-refresh.$RUN.log"
+          } >> "$GITHUB_ENV"
 
       - name: Golden is running and exec channel works
         env:
@@ -141,13 +143,15 @@ jobs:
           boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json
           boxd snapshots list
 
-      # Best effort: on cancellation the runner kills the steps above but the
-      # detached refresh keeps running on the golden and keeps its lock. The
-      # script's own stale-lock takeover is the backstop if this never runs.
-      - name: Release remote lock if this run was cancelled
+      # Best effort: on cancellation the runner kills the steps above, but the
+      # detached refresh keeps running on the golden. Kill only this run's own
+      # process — never the lock file. The lock is kernel-held, so killing the
+      # owner releases it; deleting it by hand would free it while another
+      # run's refresh was still live.
+      - name: Stop this run's remote refresh if cancelled
         if: cancelled()
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
-          boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
-            "pkill -9 -f 'golden-refresh.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.s[h]' || true; rm -rf /tmp/golden-refresh.lock" || true
+          boxd machine exec --timeout 30 "$GOLDEN" -- \
+            pkill -9 -f "golden-refresh.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.s[h]" || true

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   refresh-golden:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Wait for refresh to finish
         run: |
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             S=$(boxd machine exec --timeout 30 "$GOLDEN" -- cat /tmp/golden-refresh.status 2>/dev/null || true)
             case "$S" in
               *done*) echo "refresh done"; exit 0 ;;

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -64,13 +64,19 @@ jobs:
       # Per-run paths: a run cancelled by the job timeout can leave its detached
       # refresh alive on the golden, and shared file names would let the next
       # run read the dead run's status.
+      # Everything the refresh writes goes in a private 0700 directory owned by
+      # the refresh user, not a world-writable path — a local user on the golden
+      # must not be able to pre-create or symlink a file we open. The names are
+      # run-scoped so an abandoned run's status can never be read as this run's.
       - name: Per-run remote paths
         run: |
           RUN="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          DIR=/home/boxd/.golden-refresh
           {
-            echo "REMOTE_SCRIPT=/tmp/golden-refresh.$RUN.sh"
-            echo "REMOTE_STATUS=/tmp/golden-refresh.$RUN.status"
-            echo "REMOTE_LOG=/tmp/golden-refresh.$RUN.log"
+            echo "REMOTE_DIR=$DIR"
+            echo "REMOTE_SCRIPT=$DIR/refresh.$RUN.sh"
+            echo "REMOTE_STATUS=$DIR/refresh.$RUN.status"
+            echo "REMOTE_LOG=$DIR/refresh.$RUN.log"
           } >> "$GITHUB_ENV"
 
       - name: Golden is running and exec channel works
@@ -86,7 +92,7 @@ jobs:
         run: |
           B64=$(base64 -w0 .github/scripts/boxd-golden-refresh.sh)
           boxd machine exec --timeout 60 "$GOLDEN" -- bash -c \
-            "echo $B64 | base64 -d > $REMOTE_SCRIPT && chmod +x $REMOTE_SCRIPT && rm -f $REMOTE_STATUS"
+            "mkdir -p $REMOTE_DIR && chmod 700 $REMOTE_DIR && echo $B64 | base64 -d > $REMOTE_SCRIPT && chmod +x $REMOTE_SCRIPT && rm -f $REMOTE_STATUS"
           boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
             "nohup $REMOTE_SCRIPT '$GITHUB_SHA' '$REMOTE_STATUS' > $REMOTE_LOG 2>&1 & echo launched"
 
@@ -154,4 +160,4 @@ jobs:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
           boxd machine exec --timeout 30 "$GOLDEN" -- \
-            pkill -9 -f "golden-refresh.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.s[h]" || true
+            pkill -9 -f "refresh.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.s[h]" || true

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -16,40 +16,62 @@ concurrency:
   group: boxd-golden-refresh
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
-  BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
   GOLDEN: langwatch-golden-v3
   SNAPSHOT: langwatch-main
   GOLDEN_URL: https://langwatch-golden-v3.boxd.sh
+  # Re-pin when boxd ships a new installer:
+  #   curl -fsSL https://boxd.sh/downloads/cli/install.sh | sha256sum
+  BOXD_INSTALLER_SHA256: 935d59706c090a6ed8276c6a8635b1e24b5d9748cf14625365bccd445ee16343
 
 jobs:
   refresh-golden:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      # persist-credentials: false — nothing here talks to git after checkout,
+      # and the default would leave the workflow token in .git/config.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           sparse-checkout: .github
+          persist-credentials: false
 
+      # No BOXD_TOKEN in this step's environment: the installer is third-party
+      # code and must never run with the control-plane credential in scope.
+      # The downloaded script is checksum-verified before it executes.
       - name: Install boxd CLI
         run: |
-          curl -fsSL https://boxd.sh/downloads/install.sh | sh
+          set -euo pipefail
+          curl -fsSL --max-time 60 https://boxd.sh/downloads/cli/install.sh -o /tmp/boxd-install.sh
+          echo "$BOXD_INSTALLER_SHA256  /tmp/boxd-install.sh" | sha256sum -c -
+          sh /tmp/boxd-install.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Golden is running and exec channel works
+        env:
+          BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
           boxd machine get "$GOLDEN" --json
           boxd machine exec --timeout 30 "$GOLDEN" -- echo exec-ok | grep -q exec-ok
 
       - name: Launch refresh on golden (detached)
+        env:
+          BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
           B64=$(base64 -w0 .github/scripts/boxd-golden-refresh.sh)
           boxd machine exec --timeout 60 "$GOLDEN" -- bash -c \
             "echo $B64 | base64 -d > /tmp/golden-refresh.sh && chmod +x /tmp/golden-refresh.sh && rm -f /tmp/golden-refresh.status"
           boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
-            "nohup /tmp/golden-refresh.sh > /tmp/golden-refresh.log 2>&1 & echo launched"
+            "nohup /tmp/golden-refresh.sh '$GITHUB_SHA' > /tmp/golden-refresh.log 2>&1 & echo launched"
 
       - name: Wait for refresh to finish
+        env:
+          BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
           for i in $(seq 1 120); do
             S=$(boxd machine exec --timeout 30 "$GOLDEN" -- cat /tmp/golden-refresh.status 2>/dev/null || true)
@@ -69,7 +91,7 @@ jobs:
       - name: Wait for /api/health 204
         run: |
           for i in $(seq 1 120); do
-            CODE=$(curl -sk -o /dev/null -w '%{http_code}' "$GOLDEN_URL/api/health" || true)
+            CODE=$(curl -sS --max-time 15 -o /dev/null -w '%{http_code}' "$GOLDEN_URL/api/health" || true)
             echo "health: $CODE"
             [ "$CODE" = "204" ] && exit 0
             sleep 15
@@ -78,6 +100,8 @@ jobs:
           exit 1
 
       - name: Verify golden serves this exact commit
+        env:
+          BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
           DEPLOYED=$(boxd machine exec --timeout 30 "$GOLDEN" -- git -C /home/boxd/langwatch rev-parse HEAD | tr -d '[:space:]')
           echo "deployed=$DEPLOYED expected=$GITHUB_SHA"
@@ -85,11 +109,13 @@ jobs:
 
       - name: Verify API auth layer is up (collector rejects unauthenticated)
         run: |
-          CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST "$GOLDEN_URL/api/collector" -H 'Content-Type: application/json' -d '{}')
+          CODE=$(curl -sS --max-time 15 -o /dev/null -w '%{http_code}' -X POST "$GOLDEN_URL/api/collector" -H 'Content-Type: application/json' -d '{}')
           echo "collector unauthenticated: $CODE"
           [ "$CODE" = "401" ]
 
       - name: Save verified snapshot
+        env:
+          BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
           boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json
           boxd snapshots list

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -26,9 +26,18 @@ env:
   # Re-pin when boxd ships a new installer:
   #   curl -fsSL https://boxd.sh/downloads/cli/install.sh | sha256sum
   BOXD_INSTALLER_SHA256: 935d59706c090a6ed8276c6a8635b1e24b5d9748cf14625365bccd445ee16343
+  # Poll budgets, in seconds. They must sum to less than timeout-minutes below,
+  # with headroom for the gates and the snapshot save, so that a stuck refresh
+  # ends in this workflow's own diagnostics instead of a bare job cancellation.
+  REFRESH_WAIT_SECONDS: "3300" # 55 min
+  HEALTH_WAIT_SECONDS: "1200" # 20 min
 
 jobs:
   refresh-golden:
+    # BOXD_API_KEY can exec on the shared golden, so it is never exposed to a
+    # ref other than main. Without this, a write-access user could point
+    # workflow_dispatch at a modified branch and run arbitrary code with it.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -52,6 +61,16 @@ jobs:
           sh /tmp/boxd-install.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      # Per-run paths: a run cancelled by the job timeout can leave its detached
+      # refresh alive on the golden, and shared file names would let the next
+      # run read the dead run's status.
+      - name: Per-run remote paths
+        run: |
+          RUN="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "REMOTE_SCRIPT=/tmp/golden-refresh.$RUN.sh" >> "$GITHUB_ENV"
+          echo "REMOTE_STATUS=/tmp/golden-refresh.$RUN.status" >> "$GITHUB_ENV"
+          echo "REMOTE_LOG=/tmp/golden-refresh.$RUN.log" >> "$GITHUB_ENV"
+
       - name: Golden is running and exec channel works
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
@@ -65,38 +84,40 @@ jobs:
         run: |
           B64=$(base64 -w0 .github/scripts/boxd-golden-refresh.sh)
           boxd machine exec --timeout 60 "$GOLDEN" -- bash -c \
-            "echo $B64 | base64 -d > /tmp/golden-refresh.sh && chmod +x /tmp/golden-refresh.sh && rm -f /tmp/golden-refresh.status"
+            "echo $B64 | base64 -d > $REMOTE_SCRIPT && chmod +x $REMOTE_SCRIPT && rm -f $REMOTE_STATUS"
           boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
-            "nohup /tmp/golden-refresh.sh '$GITHUB_SHA' > /tmp/golden-refresh.log 2>&1 & echo launched"
+            "nohup $REMOTE_SCRIPT '$GITHUB_SHA' '$REMOTE_STATUS' > $REMOTE_LOG 2>&1 & echo launched"
 
       - name: Wait for refresh to finish
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
-          for i in $(seq 1 120); do
-            S=$(boxd machine exec --timeout 30 "$GOLDEN" -- cat /tmp/golden-refresh.status 2>/dev/null || true)
+          DEADLINE=$(( $(date +%s) + REFRESH_WAIT_SECONDS ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            S=$(boxd machine exec --timeout 30 "$GOLDEN" -- cat "$REMOTE_STATUS" 2>/dev/null || true)
             case "$S" in
               *done*) echo "refresh done"; exit 0 ;;
               *failed*)
                 echo "refresh FAILED — log tail:"
-                boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 /tmp/golden-refresh.log || true
+                boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 "$REMOTE_LOG" || true
                 exit 1 ;;
             esac
             sleep 20
           done
-          echo "refresh timed out — log tail:"
-          boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 /tmp/golden-refresh.log || true
+          echo "refresh timed out after ${REFRESH_WAIT_SECONDS}s — log tail:"
+          boxd machine exec --timeout 60 "$GOLDEN" -- tail -50 "$REMOTE_LOG" || true
           exit 1
 
       - name: Wait for /api/health 204
         run: |
-          for i in $(seq 1 120); do
+          DEADLINE=$(( $(date +%s) + HEALTH_WAIT_SECONDS ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
             CODE=$(curl -sS --max-time 15 -o /dev/null -w '%{http_code}' "$GOLDEN_URL/api/health" || true)
             echo "health: $CODE"
             [ "$CODE" = "204" ] && exit 0
             sleep 15
           done
-          echo "app never became healthy"
+          echo "app never became healthy within ${HEALTH_WAIT_SECONDS}s"
           exit 1
 
       - name: Verify golden serves this exact commit
@@ -119,3 +140,14 @@ jobs:
         run: |
           boxd snapshots save "$GOLDEN" "$SNAPSHOT" --json
           boxd snapshots list
+
+      # Best effort: on cancellation the runner kills the steps above but the
+      # detached refresh keeps running on the golden and keeps its lock. The
+      # script's own stale-lock takeover is the backstop if this never runs.
+      - name: Release remote lock if this run was cancelled
+        if: cancelled()
+        env:
+          BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
+        run: |
+          boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
+            "pkill -9 -f 'golden-refresh.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.s[h]' || true; rm -rf /tmp/golden-refresh.lock" || true

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -94,8 +94,12 @@ jobs:
           B64=$(base64 -w0 .github/scripts/boxd-golden-refresh.sh)
           boxd machine exec --timeout 60 "$GOLDEN" -- bash -c \
             "mkdir -p $REMOTE_DIR && chmod 700 $REMOTE_DIR && echo $B64 | base64 -d > $REMOTE_SCRIPT && chmod +x $REMOTE_SCRIPT && rm -f $REMOTE_STATUS"
+          # setsid gives the refresh its own process group, so cleanup can kill
+          # the whole tree — pnpm, prisma and their children — rather than just
+          # the script. Those children inherit the lock fd, so leaving them
+          # alive would also leave the golden locked against the next run.
           boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
-            "nohup $REMOTE_SCRIPT '$GITHUB_SHA' '$REMOTE_STATUS' > $REMOTE_LOG 2>&1 & echo launched"
+            "setsid nohup $REMOTE_SCRIPT '$GITHUB_SHA' '$REMOTE_STATUS' > $REMOTE_LOG 2>&1 & echo launched"
 
       - name: Wait for refresh to finish
         env:
@@ -173,15 +177,19 @@ jobs:
           boxd snapshots list
           exit 1
 
-      # Best effort: on cancellation the runner kills the steps above, but the
-      # detached refresh keeps running on the golden. Kill only this run's own
-      # process — never the lock file. The lock is kernel-held, so killing the
-      # owner releases it; deleting it by hand would free it while another
-      # run's refresh was still live.
-      - name: Stop this run's remote refresh if cancelled
-        if: cancelled()
+      # A failed or cancelled run leaves the detached refresh — and everything
+      # pnpm and prisma started under it — running on the golden, holding the
+      # lock through the inherited fd. Kill this run's whole process group.
+      #
+      # Never delete the lock file: it is kernel-held, so killing the owner
+      # releases it, while removing it by hand would free it out from under a
+      # different run that was still working. The dev stack is in its own
+      # session (setsid in the script), so staging survives this cleanup.
+      - name: Stop this run's remote refresh on failure or cancellation
+        if: failure() || cancelled()
         env:
           BOXD_TOKEN: ${{ secrets.BOXD_API_KEY }}
         run: |
-          boxd machine exec --timeout 30 "$GOLDEN" -- \
-            pkill -9 -f "refresh.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.s[h]" || true
+          PGID_FILE="${REMOTE_STATUS%.status}.pgid"
+          boxd machine exec --timeout 30 "$GOLDEN" -- bash -c \
+            "PGID=\$(cat $PGID_FILE 2>/dev/null); if [ -n \"\$PGID\" ]; then kill -9 -\"\$PGID\" 2>/dev/null && echo killed group \$PGID || echo 'group \$PGID already gone'; else echo 'no pgid recorded — refresh never started'; fi" || true

--- a/.github/workflows/boxd-golden-refresh.yml
+++ b/.github/workflows/boxd-golden-refresh.yml
@@ -68,9 +68,6 @@ jobs:
           sh /tmp/boxd-install.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      # Per-run paths: a run cancelled by the job timeout can leave its detached
-      # refresh alive on the golden, and shared file names would let the next
-      # run read the dead run's status.
       # Everything the refresh writes goes in a private 0700 directory owned by
       # the refresh user, not a world-writable path — a local user on the golden
       # must not be able to pre-create or symlink a file we open. The names are


### PR DESCRIPTION
## Reviewer cockpit
- Scariest thing: the workflow hard-resets the golden machine's checkout (`git reset --hard origin/main`) and kills/restarts its dev stack on every merge to main. If the verify gates were wrong, a broken snapshot could silently become the fork source for preview boxes — that's why the snapshot only saves after all gates pass.
- Start here: `.github/workflows/boxd-golden-refresh.yml` (the gates), then `.github/scripts/boxd-golden-refresh.sh` (what runs on the machine).

## Why
The boxd golden machine (`langwatch-golden-v3`, the standing staging env and fork source for preview boxes) goes stale between manual refreshes — it was sitting on a commit from Aug 4. This wires the refresh into CI so every merge to main updates it, verifies it's actually serving, and saves a verified snapshot (`langwatch-main`) as the durable fork baseline.

## What changed
- Added `.github/workflows/boxd-golden-refresh.yml`: on push to main (or manual dispatch), refresh → verify → snapshot. Decision: verify BEFORE snapshot, so a broken build never becomes the fork source; consequence: a red run on main = staging is broken, and the last good snapshot stays intact.
- Added `.github/scripts/boxd-golden-refresh.sh`: runs on the machine itself, detached. Decision: detached with a status file instead of foreground `boxd machine exec`, because exec wedges on long commands (~60s); alternative (foreground exec) was rejected for that reason.
- Created a Langwatch-org-fenced boxd API key (`refresh-golden gh-actions langwatch/langwatch`) and stored it as the `BOXD_API_KEY` repo secret. The key is fenced to the Langwatch org only.

## How it works
1. Install boxd CLI on the runner; auth via `BOXD_TOKEN` env from the secret.
2. Gate: machine is running and exec channel answers.
3. Ship the refresh script (base64 through exec), launch it detached. It fast-forwards `/home/boxd/langwatch` to `origin/main`, runs `pnpm install` + `prisma migrate deploy`, restarts `pnpm dev`, writes `done`/`failed` to `/tmp/golden-refresh.status`.
4. Poll the status file (short execs), then poll `https://langwatch-golden-v3.boxd.sh/api/health` until 204 — never `/`, which nginx answers even with the app dead.
5. Gate: deployed `git rev-parse HEAD` must equal the merge commit SHA.
6. Gate: unauthenticated POST to `/api/collector` returns 401 (proves the API/auth layer is really up, not just the health route).
7. Only then: `boxd snapshots save langwatch-golden-v3 langwatch-main` (re-saving the same name versions it; new forks always get latest).

## Review round 2 (commits 78ec931a8d, 17684a861f)
Seven findings from `langwatch-agent` and CodeRabbit, all accepted and fixed:
- `BOXD_TOKEN` is no longer job-wide — it is set per-step on the steps that call `boxd`, so the third-party installer never runs with the control-plane credential in scope. The installer is downloaded and `sha256sum`-verified against a pinned digest before it executes, and now uses the same URL as `boxd-pr-preview.yml`.
- Added `permissions: contents: read`; checkout is SHA-pinned with `persist-credentials: false`.
- The script deploys the triggering `GITHUB_SHA` rather than whatever `origin/main` points at when it starts — the job is serialized, so main can move while a run queues.
- Removed `curl -k` from both gates (the golden's certificate chains to a public root, so it was only masking failures) and added explicit `--max-time`.
- All poll loops are wall-clock bounded and sized from measured times (45 min refresh + 45 min health + 15 min snapshot inside a 120-minute job), so a stuck refresh ends in this workflow's diagnostics rather than a bare cancellation.
- Run-scoped status/log/script paths in a private 0700 directory, plus a kernel-held `flock` on the machine, so an abandoned detached refresh cannot collide with the next run and no lock is ever reclaimed from a live owner.
- `workflow_dispatch` is restricted to main via `if: github.ref == 'refs/heads/main'`, so a modified branch cannot be dispatched with the golden's key.

## Re-verification found four more bugs (see the full-cycle proof comment)
Running the whole cycle again against the live golden with the fixed files turned up four defects that review alone had not:
- **Stale API servers survived every refresh.** The API runs as `tsx src/server.mts` and matched no kill pattern; six were found alive, the oldest 27 hours. Since the port holder answers the health and collector gates while the SHA gate reads `git HEAD`, a refresh could have reported verified while a day-old server served the traffic.
- **A process-group kill cannot stop the dev stack** — `pnpm start` moves the workers into their own session. The script now walks the process tree.
- **`set -o pipefail` aborted the refresh silently** when `pgrep` matched nothing, ending the log after the migrations with no error. The same trap was latent in the existing `NODE_BIN` glob.
- **`boxd snapshots save` exits non-zero on its own client timeout** while the snapshot is still being written, so the final step would have failed runs that fully succeeded. It now polls for a new version in `ready` state.

Snapshot `langwatch-main` is at v3 ready, saved from the verified state. The golden itself is **not serving right now** — load climbed after the ~60 GB snapshot and stayed high, and a rescue refresh hung on `prisma migrate deploy` behind hour-old `lwtest` sessions that are `idle in transaction`. That is machine state, not a defect in this diff; it needs an operator decision (clear those sessions, or reboot the VM). See https://github.com/langwatch/langwatch/pull/7200#issuecomment-5361625139

**Follow-up for a repo admin (not in this PR), filed as https://github.com/langwatch/langwatch/issues/7354:** `BOXD_API_KEY` needs a protected GitHub environment. This PR declares `environment: boxd-golden` on the job, so the platform gate activates as soon as an admin creates that environment with a main-only deployment branch rule and moves the secret into it. Until then the in-file ref guard is defence in depth only — it cannot protect the credential by itself, because `workflow_dispatch` runs the workflow definition from the selected ref and that guard is editable in the same commit that abuses it.

**Blocking decision for the owner, filed as https://github.com/langwatch/langwatch/issues/7355:** previews fork `langwatch-main-golden-image` (`boxd-pr-preview.yml:24,99`) while this workflow refreshes `langwatch-golden-v3`. Nothing forks the snapshot this workflow saves. Someone has to say which machine is canonical before this lands.

## Human verification

<!-- no-ui-surface -->
**Backend-only, no UI surface.** This PR adds a GitHub Actions workflow and a bash script. It renders nothing and changes no application code, so there is no screenshot or recording to embed. The observable output is a workflow run, a `/api/health` status code, and a boxd snapshot version — all captured as text in the proof section below and in https://github.com/langwatch/langwatch/pull/7200#issuecomment-5360608661

**Deferred to post-merge, and named here rather than left implicit: the trigger has never been observed firing.** `on: push` to `main` cannot fire while this sits on a branch, so no pre-merge evidence of arming is obtainable. Everything downstream of the trigger IS proven — the refresh, verify and snapshot cycle ran end-to-end on the live golden with the exact committed script (run `final-1787251128`, below). What remains unproven is only that GitHub starts it.

Whoever merges owns this check, on the first merge to main after this lands:
- Confirm a "Boxd Golden Refresh" run appears in https://github.com/langwatch/langwatch/actions and that it is the one this push triggered.
- Confirm the job did not skip: the fork guard is `github.ref == 'refs/heads/main' && github.repository == 'langwatch/langwatch'`, and `environment: boxd-golden` must resolve or the job cannot read the credential (see https://github.com/langwatch/langwatch/issues/7354).
- Check https://langwatch-golden-v3.boxd.sh/api/health returns 204 and `boxd snapshots list` shows a new `langwatch-main` version in `ready`.

If the run does not appear at all, the workflow file is on main but the trigger is wrong; that is a one-line fix, not a redesign.

## How I can prove I was successful
- proven: `/api/health` → 204 and unauthenticated `/api/collector` → 401 against the live golden (probed before writing the gates; both matched).
- proven: exec channel, `--timeout` flag, `boxd snapshots save`, `boxd auth keys create --org` all confirmed against the live CLI/machine, not docs.
- proven: `BOXD_API_KEY` secret is set on this repo (`gh secret set` succeeded).
- **proven: the full refresh→verify→snapshot cycle ran end-to-end on the live golden using the exact committed script** (shipped to the machine and launched the same way the workflow launches it). Run `final-1787251128`, commit `b741ffd646cfb1fe154d552de92bb392f86f88f1`:
  - status file: `done`
  - `/api/health`: **204**, reached 27m28s after launch on the first proven clean single-stack boot
  - deployed `git rev-parse HEAD` == `$GITHUB_SHA` → **SHA-GATE: PASS**
  - unauthenticated `POST /api/collector`: **401** → **AUTH-GATE: PASS**
  - lock released after the run (`LOCK-FREE`), refresh process group drained (`refresh_group_members=0`)
  - snapshot step as written: save errored client-side, gate polled `v2 pending` ×7 → **`v3 ready` 60.3G** → **SNAPSHOT-GATE: PASS**
  - full output: https://github.com/langwatch/langwatch/pull/7200#issuecomment-5360608661 (supersedes the two earlier proof comments)
- proven: the timeout budgets are measured, not guessed — 105 min of polling inside `timeout-minutes: 120` (15 min headroom). The earlier 20-min health budget would have failed the measured 27m28s boot.
- proven: each behavioural fix has its own falsifiable test — lock ownership (5 cases, including a 5-hour-backdated lock that must still be refused), fd-9 inheritance (reproduced the leak, then fixed), tree-kill vs group-kill (group reached 2 of 3 processes, tree reached all), `pipefail` abort on empty `pgrep`, recycled-pgid refusal, snapshot decision table (6 cases), port reclaim against a listener no name pattern matches.
- **missing: a run of the workflow itself.** `on: push: branches: [main]` cannot fire before this merges, so no one has watched the trigger fire. That is the one remaining piece of evidence and it can only be collected after merge — first run on main is the final proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated refresh and deployment verification for the golden environment.
  * Added support for manually triggered refreshes and automatic refreshes after changes reach the main branch.
  * Added verified environment snapshots after health, commit, and authentication checks pass.
  * Added safeguards against concurrent refreshes, failed runs, and canceled operations, along with diagnostic reporting to support troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




