### PR TITLE
chore(release): pin the platform at 3.15.0

### DIFF
--- a/.release-please-shim
+++ b/.release-please-shim
@@ -1,1 +1,1 @@
-release-please shadow marker (v7), next: 3.13.0
+release-please shadow marker (v7), next: 3.15.0


### PR DESCRIPTION
Release pull request #7171 proposes 4.0.0. The major comes from the BREAKING CHANGE footer on the lwql rename (#7183). That footer states a deploy-ordering constraint for the rename's own rollout: the migration and the image must ship in the same release, because a pod on the previous image raises 42703 against the migrated schema. It does not change any API or operator-facing behavior, so it is not a major for the platform. The constraint itself stays visible: the changelog keeps the note under 3.15.0.

Same cure as #6918: this pull request touches one shim and carries one footer, so a squash cannot collapse it into anything else. When it merges, release-please retargets #7171 from 4.0.0 to 3.15.0.

Release-As: 3.15.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the upcoming release version to 3.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->