### PR TITLE
fix(lwql): derive tenant capabilities with bcrypt

### DIFF
--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -909,8 +909,11 @@ model Project {
   name                String
   slug                String                    @unique
   apiKey              String                    @unique
-  /// Random per-project secret whose SHA-256 digest is this project's LangWatchQL
-  /// SQL tenant capability in ClickHouse. Deliberately NOT the API key: the
+  /// Random per-project secret whose bcrypt digest, under a salt derived from
+  /// the secret with HKDF, is this project's LangWatchQL SQL tenant capability
+  /// in ClickHouse — see `server/analytics/lwql/capability.ts`, which is the
+  /// only implementation of that derivation and must stay the only one.
+  /// Deliberately NOT the API key: the
   /// credential a caller authenticates with and the capability the database
   /// resolves a tenant from stay decoupled, so rotating one never invalidates
   /// the other, and a leak of the ClickHouse key map's input discloses nothing

--- a/platform/app/src/app/api/query/__tests__/queryRestAnswerableQuestions.integration.test.ts
+++ b/platform/app/src/app/api/query/__tests__/queryRestAnswerableQuestions.integration.test.ts
@@ -831,10 +831,12 @@ describe("given the /api/v1/query REST door and a seed with known answers", () =
     await harness.admin.insert({
       table: `${database}.${harness.names.keyMapTable}`,
       format: "JSONEachRow",
-      values: [asking, other].map((project) => ({
-        KeyHash: lwqlTenantCapability({ secret: project.lwqlKey }),
-        TenantId: project.id,
-      })),
+      values: await Promise.all(
+        [asking, other].map(async (project) => ({
+          KeyHash: await lwqlTenantCapability({ secret: project.lwqlKey }),
+          TenantId: project.id,
+        })),
+      ),
     });
 
     await seedTenant({

--- a/platform/app/src/app/api/query/__tests__/queryRestApi.integration.test.ts
+++ b/platform/app/src/app/api/query/__tests__/queryRestApi.integration.test.ts
@@ -313,10 +313,12 @@ describe("given the /api/v1/query REST family", () => {
     await harness.admin.insert({
       table: `${database}.${harness.names.keyMapTable}`,
       format: "JSONEachRow",
-      values: [projectA, projectB].map((project) => ({
-        KeyHash: lwqlTenantCapability({ secret: project.lwqlKey }),
-        TenantId: project.id,
-      })),
+      values: await Promise.all(
+        [projectA, projectB].map(async (project) => ({
+          KeyHash: await lwqlTenantCapability({ secret: project.lwqlKey }),
+          TenantId: project.id,
+        })),
+      ),
     });
 
     for (const project of [projectA, projectB]) {

--- a/platform/app/src/app/api/query/__tests__/queryRestServiceProofs.integration.test.ts
+++ b/platform/app/src/app/api/query/__tests__/queryRestServiceProofs.integration.test.ts
@@ -634,10 +634,12 @@ describe("given the /api/v1/query REST family's service, isolation and policy pr
     await harness.admin.insert({
       table: `${database}.${harness.names.keyMapTable}`,
       format: "JSONEachRow",
-      values: [openProject, gatedProject].map((project) => ({
-        KeyHash: lwqlTenantCapability({ secret: project.lwqlKey }),
-        TenantId: project.id,
-      })),
+      values: await Promise.all(
+        [openProject, gatedProject].map(async (project) => ({
+          KeyHash: await lwqlTenantCapability({ secret: project.lwqlKey }),
+          TenantId: project.id,
+        })),
+      ),
     });
 
     for (const project of [openProject, gatedProject]) {
@@ -1601,7 +1603,7 @@ describe("given the /api/v1/query REST family's service, isolation and policy pr
       // Every request below is made as the gated project, so the *open*
       // project is the other tenant, and its very existence is one of the
       // things an error must not disclose.
-      const capability = lwqlTenantCapability({
+      const capability = await lwqlTenantCapability({
         secret: gatedProject.lwqlKey,
       });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/capability-cache.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/capability-cache.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The capability cache's two load-bearing properties, both of which need a
+ * boundary moved to observe and so cannot live in `capability.unit.test.ts`.
+ *
+ * The cache is the one structure in the module shared by every tenant in the
+ * process, and a deterministic function's *results* look identical whether it
+ * is cached or not — so a test written against the returned values proves
+ * determinism and would stay green if the cache were deleted outright. These
+ * two are written against what the cache actually changes: how many times
+ * bcrypt runs, and which entry a colliding key is allowed to answer with.
+ *
+ * `node:crypto` is stubbed to hand every secret the *same* cache key while
+ * leaving the salt derivation real, which is the collision the `cached.salt`
+ * check exists for and which no amount of real input can be made to produce.
+ */
+
+import { hkdfSync } from "node:crypto";
+
+import { compare } from "bcrypt";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const CACHE_KEY_INFO = "langwatchql.tenant-capability.cache-key.v1";
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return {
+    ...actual,
+    hkdfSync: vi.fn(
+      (
+        digest: string,
+        key: string,
+        salt: string,
+        info: string,
+        keylen: number,
+      ) =>
+        info === CACHE_KEY_INFO
+          ? new Uint8Array(keylen).fill(7).buffer
+          : actual.hkdfSync(digest, key, salt, info, keylen),
+    ),
+  };
+});
+
+const hashSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("bcrypt", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("bcrypt")>();
+  hashSpy.mockImplementation(actual.hash);
+  return { ...actual, hash: hashSpy };
+});
+
+import { lwqlTenantCapability } from "../capability";
+
+describe("given the process-wide capability cache", () => {
+  beforeEach(() => {
+    hashSpy.mockClear();
+  });
+
+  /**
+   * The failure this guards is the only way one project could be handed
+   * another's capability in-process, and it is the reason the cache stores its
+   * salt rather than just the digest. With the cache key forced to collide, a
+   * lookup that trusted the key alone would answer the second project with the
+   * first project's capability — a capability that names the wrong tenant in
+   * the key map. The salt check has to turn that into a recomputation.
+   */
+  describe("when two projects' cache keys collide", () => {
+    it("never answers one project with the other's capability", async () => {
+      const mine = "collision-tenant-a-secret";
+      const theirs = "collision-tenant-b-secret";
+
+      const first = await lwqlTenantCapability({ secret: mine });
+      const second = await lwqlTenantCapability({ secret: theirs });
+
+      expect(second).not.toBe(first);
+      // Asserted with bcrypt's own verifier: the capability handed to the
+      // second project must be one only that project's secret produces.
+      expect(await compare(theirs, second)).toBe(true);
+      expect(await compare(mine, second)).toBe(false);
+      // And the collision cost a recomputation rather than a wrong answer.
+      expect(hashSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  /**
+   * The memoisation is the sole reason a ~200ms KDF is affordable on the query
+   * path. Nothing about the returned value reveals whether it happened, so it
+   * is asserted where it is visible: bcrypt runs once per project, not once
+   * per query.
+   */
+  describe("when one project derives its capability more than once", () => {
+    it("runs bcrypt once and serves the rest from the cache", async () => {
+      const secret = "memoised-tenant-secret";
+
+      const cold = await lwqlTenantCapability({ secret });
+      const warm = await lwqlTenantCapability({ secret });
+
+      expect(warm).toBe(cold);
+      expect(hashSpy).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * The cache holds the in-flight promise rather than the finished digest,
+     * so the several queries a dashboard opens at once share one derivation.
+     * Storing the resolved value instead would leave every concurrent caller
+     * to start its own hash and occupy the whole libuv thread pool.
+     */
+    it("coalesces derivations that start before the first one finishes", async () => {
+      const secret = "coalesced-tenant-secret";
+
+      const capabilities = await Promise.all([
+        lwqlTenantCapability({ secret }),
+        lwqlTenantCapability({ secret }),
+        lwqlTenantCapability({ secret }),
+      ]);
+
+      expect(new Set(capabilities).size).toBe(1);
+      expect(hashSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /**
+   * The stub is only trustworthy if it is actually installed — a `vi.mock`
+   * factory that silently failed to apply would make every assertion above
+   * pass for the wrong reason, because real cache keys never collide.
+   */
+  describe("when the collision stub is checked", () => {
+    it("hands every secret the same cache key", () => {
+      const keyFor = (secret: string) =>
+        Buffer.from(
+          hkdfSync("sha256", secret, "namespace", CACHE_KEY_INFO, 32),
+        ).toString("hex");
+
+      expect(keyFor("one")).toBe(keyFor("two"));
+    });
+  });
+});

--- a/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The tenant capability's derivation, pinned.
+ *
+ * The service-level test in `lwql.service.unit.test.ts` proves the service
+ * sends *this* value; these prove the value itself is the one the key map is
+ * provisioned against, and that the two ways it could quietly stop naming one
+ * tenant — an unset secret, and bcrypt's silent truncation — are refusals
+ * rather than wrong answers.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { lwqlTenantCapability } from "../capability";
+
+const SECRET = "sk-lw-lwql-capability-unit-test-key";
+
+describe("given a project's LangWatchQL secret", () => {
+  describe("when the capability is derived", () => {
+    /**
+     * The known answer, and the only assertion here that can catch a change of
+     * algorithm, salt derivation or work factor. It is written out rather than
+     * recomputed: an expectation derived through the same function would agree
+     * with it after any change, including a change that stopped hashing.
+     *
+     * It is also what proves the derivation is deterministic *across
+     * processes*, which asserting one call against another cannot — this
+     * constant was computed in a different process from the one running it.
+     * That determinism is load-bearing: the key map resolves a tenant by
+     * equality on this string, so a derivation that varied per call would make
+     * every LangWatchQL read return zero rows.
+     */
+    it("matches the digest the key map is provisioned with", async () => {
+      expect(await lwqlTenantCapability({ secret: SECRET })).toBe(
+        "$2b$10$RnlZxIxlVQ4VDkYPOwjbouOPphk4TCJBsv1EWY.ldRkqHjcPBZx5C",
+      );
+    });
+
+    it("never carries the raw secret it was derived from", async () => {
+      expect(await lwqlTenantCapability({ secret: SECRET })).not.toContain(
+        SECRET,
+      );
+    });
+
+    it("gives two projects unrelated capabilities", async () => {
+      const [first, second] = await Promise.all([
+        lwqlTenantCapability({ secret: `${SECRET}-a` }),
+        lwqlTenantCapability({ secret: `${SECRET}-b` }),
+      ]);
+
+      expect(first).not.toBe(second);
+      // Distinct salts, not merely distinct digests: a shared salt would make
+      // one precomputation serve every project in the key map.
+      expect(first.slice(0, 29)).not.toBe(second.slice(0, 29));
+    });
+  });
+
+  describe("when the secret was never selected", () => {
+    /**
+     * `undefined` hashes to a perfectly valid digest that matches no key-map
+     * row, so the query succeeds and returns nothing — indistinguishable from a
+     * tenant with no data. Throwing is what makes the wiring bug loud.
+     */
+    it("refuses to derive a capability rather than hashing nothing", async () => {
+      await expect(lwqlTenantCapability({ secret: "" })).rejects.toThrow(
+        /non-empty secret/,
+      );
+    });
+  });
+
+  describe("when the secret is longer than bcrypt reads", () => {
+    /**
+     * bcrypt stops at 72 bytes. Two secrets sharing a 72-byte prefix therefore
+     * derive the *same* capability, and two projects holding one capability
+     * read each other's rows — the one failure this whole module exists to
+     * prevent. `lwqlKey` is far shorter today, which is exactly why the refusal
+     * has to be in the code: it is the day someone lengthens the secret that it
+     * has to fire.
+     */
+    it("refuses the secret rather than silently truncating it", async () => {
+      const atLimit = "x".repeat(72);
+
+      await expect(
+        lwqlTenantCapability({ secret: `${atLimit}-overflow` }),
+      ).rejects.toThrow(/at most 72 bytes/);
+    });
+
+    /** Bytes, not characters — the limit bcrypt actually applies. */
+    it("counts multi-byte characters against the limit", async () => {
+      await expect(
+        lwqlTenantCapability({ secret: "é".repeat(37) }),
+      ).rejects.toThrow(/at most 72 bytes/);
+    });
+  });
+});

--- a/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
@@ -36,10 +36,18 @@ describe("given a project's LangWatchQL secret", () => {
       );
     });
 
-    it("never carries the raw secret it was derived from", async () => {
-      expect(await lwqlTenantCapability({ secret: SECRET })).not.toContain(
-        SECRET,
-      );
+    /**
+     * The shape, not merely "it is not the secret" — a bcrypt digest could not
+     * contain this secret whatever went wrong, so that assertion can never
+     * fail on its own. This one pins what the key map has to store: the
+     * `$2b$10$` prefix is how the work factor stays readable off the data, and
+     * it is what would change silently if the cost were ever raised.
+     */
+    it("is a cost-10 bcrypt digest and never carries the raw secret", async () => {
+      const capability = await lwqlTenantCapability({ secret: SECRET });
+
+      expect(capability).toMatch(/^\$2b\$10\$[./A-Za-z0-9]{53}$/);
+      expect(capability).not.toContain(SECRET);
     });
 
     it("gives two projects unrelated capabilities", async () => {
@@ -63,6 +71,7 @@ describe("given a project's LangWatchQL secret", () => {
    * itself, which would agree with any mistake made in both places.
    */
   describe("when a capability is checked against the secrets it could name", () => {
+    /** @scenario "Two projects never derive the same tenant capability" */
     it("verifies against its own project's secret and no other", async () => {
       const mine = `${SECRET}-tenant-a`;
       const theirs = `${SECRET}-tenant-b`;
@@ -74,13 +83,16 @@ describe("given a project's LangWatchQL secret", () => {
   });
 
   /**
-   * The cache is one map shared by every tenant in the process, which is the
-   * one place a capability could be handed to the wrong project. Derive several
-   * tenants, then derive them all again in a different order so every second
-   * call is a cache hit, and require each to still be its own.
+   * Determinism across calls and across interleavings — deliberately not a
+   * cache test. A pure function of the secret returns these same values
+   * whether the memoisation is present or absent, which is why the cache's own
+   * properties are pinned in `capability-cache.unit.test.ts`, where a stubbed
+   * boundary can observe them. What this block is for is the key map's
+   * requirement: a project's capability is stable, and no two share one.
    */
-  describe("when several projects derive capabilities through the shared cache", () => {
-    it("never serves one project the capability of another", async () => {
+  describe("when several projects derive capabilities in different orders", () => {
+    /** @scenario "A project's tenant capability is the same every time it is derived" */
+    it("gives each project the same capability every time, and never another's", async () => {
       const secrets = ["alpha", "beta", "gamma"].map(
         (name) => `${SECRET}-${name}`,
       );
@@ -94,7 +106,7 @@ describe("given a project's LangWatchQL secret", () => {
           .map((secret) => lwqlTenantCapability({ secret })),
       );
 
-      // Every cache hit answered with the same capability as the cold call.
+      // The second pass, taken in reverse, answered with the same capabilities.
       expect(warm).toEqual([...cold].reverse());
       // And no two projects share one, which is what the key map would need to
       // resolve two tenants to a single row.
@@ -108,6 +120,7 @@ describe("given a project's LangWatchQL secret", () => {
      * row, so the query succeeds and returns nothing — indistinguishable from a
      * tenant with no data. Throwing is what makes the wiring bug loud.
      */
+    /** @scenario "An unset secret is refused rather than hashed" */
     it("refuses to derive a capability rather than hashing nothing", async () => {
       await expect(lwqlTenantCapability({ secret: "" })).rejects.toThrow(
         /non-empty secret/,
@@ -124,11 +137,22 @@ describe("given a project's LangWatchQL secret", () => {
      * has to be in the code: it is the day someone lengthens the secret that it
      * has to fire.
      */
-    it("refuses the secret rather than silently truncating it", async () => {
-      const atLimit = "x".repeat(72);
+    /**
+     * Pinned on both sides, because only one side is a security bug and the
+     * other is an outage. Testing the refusal alone leaves `>` free to drift to
+     * `>=`, which refuses every 72-byte secret — swallowed by the key-map sync
+     * into a log line, so the project silently never gets a row.
+     */
+    it("accepts a secret of exactly 72 bytes", async () => {
+      expect(await lwqlTenantCapability({ secret: "x".repeat(72) })).toMatch(
+        /^\$2b\$10\$/,
+      );
+    });
 
+    /** @scenario "A secret the derivation cannot represent is refused, never truncated" */
+    it("refuses the first byte past the limit rather than truncating to it", async () => {
       await expect(
-        lwqlTenantCapability({ secret: `${atLimit}-overflow` }),
+        lwqlTenantCapability({ secret: "x".repeat(73) }),
       ).rejects.toThrow(/at most 72 bytes/);
     });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
@@ -8,6 +8,7 @@
  * rather than wrong answers.
  */
 
+import { compare } from "bcrypt";
 import { describe, expect, it } from "vitest";
 
 import { lwqlTenantCapability } from "../capability";
@@ -51,6 +52,53 @@ describe("given a project's LangWatchQL secret", () => {
       // Distinct salts, not merely distinct digests: a shared salt would make
       // one precomputation serve every project in the key map.
       expect(first.slice(0, 29)).not.toBe(second.slice(0, 29));
+    });
+  });
+
+  /**
+   * The capability is the tenant's name in the key map, so the property that
+   * matters is not just that two projects get different strings — it is that a
+   * capability can only ever have come from its own project's secret. Asserted
+   * with bcrypt's own verifier rather than by comparing our derivation against
+   * itself, which would agree with any mistake made in both places.
+   */
+  describe("when a capability is checked against the secrets it could name", () => {
+    it("verifies against its own project's secret and no other", async () => {
+      const mine = `${SECRET}-tenant-a`;
+      const theirs = `${SECRET}-tenant-b`;
+      const capability = await lwqlTenantCapability({ secret: mine });
+
+      expect(await compare(mine, capability)).toBe(true);
+      expect(await compare(theirs, capability)).toBe(false);
+    });
+  });
+
+  /**
+   * The cache is one map shared by every tenant in the process, which is the
+   * one place a capability could be handed to the wrong project. Derive several
+   * tenants, then derive them all again in a different order so every second
+   * call is a cache hit, and require each to still be its own.
+   */
+  describe("when several projects derive capabilities through the shared cache", () => {
+    it("never serves one project the capability of another", async () => {
+      const secrets = ["alpha", "beta", "gamma"].map(
+        (name) => `${SECRET}-${name}`,
+      );
+
+      const cold = await Promise.all(
+        secrets.map((secret) => lwqlTenantCapability({ secret })),
+      );
+      const warm = await Promise.all(
+        [...secrets]
+          .reverse()
+          .map((secret) => lwqlTenantCapability({ secret })),
+      );
+
+      // Every cache hit answered with the same capability as the cold call.
+      expect(warm).toEqual([...cold].reverse());
+      // And no two projects share one, which is what the key map would need to
+      // resolve two tenants to a single row.
+      expect(new Set(cold).size).toBe(secrets.length);
     });
   });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/capability.unit.test.ts
@@ -106,7 +106,6 @@ describe("given a project's LangWatchQL secret", () => {
           .map((secret) => lwqlTenantCapability({ secret })),
       );
 
-      // The second pass, taken in reverse, answered with the same capabilities.
       expect(warm).toEqual([...cold].reverse());
       // And no two projects share one, which is what the key map would need to
       // resolve two tenants to a single row.

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -171,7 +171,7 @@ describe("given the LangWatchQL service", () => {
       // any change to that algorithm, so the digest the key map is provisioned
       // against is stated as a constant instead.
       expect(executor.calls[0]!.tenantCapability).toBe(
-        "4c99f991d0fce515d9326788c6c85359c26cf1536dd1ae0dbb23e806ea05eda2",
+        "3b39a279643e25b0dc08d6ef2f4c6bec873da8fa96a1c7c0b46821c25c9ca0b6e93943bb883b397d76ab896d07b9c7764f0ee8cc2cf9b815cb4e17d320d197a0",
       );
       // The raw key is the secret the digest exists to keep out of the
       // database; a capability that merely contained it would be a leak.
@@ -198,12 +198,12 @@ describe("given the LangWatchQL service", () => {
       });
 
       expect(executor.calls[0]!.tenantCapability).toBe(
-        "4c99f991d0fce515d9326788c6c85359c26cf1536dd1ae0dbb23e806ea05eda2",
+        "3b39a279643e25b0dc08d6ef2f4c6bec873da8fa96a1c7c0b46821c25c9ca0b6e93943bb883b397d76ab896d07b9c7764f0ee8cc2cf9b815cb4e17d320d197a0",
       );
-      // sha256 of PROJECT_WITH_API_KEY.apiKey — what the key map would have to
+      // SHA-512 of PROJECT_WITH_API_KEY.apiKey — what the key map would have to
       // hold instead, and what no LangWatchQL query may ever present.
       expect(executor.calls[0]!.tenantCapability).not.toBe(
-        "725346695d40d416f268694ccc9481c4dc7285693e36226bca84c1b5dade1bd6",
+        "95a41ba91b26b8c5d6143c96a071fe6309f1e5fdb464fe2e10e2e0ae464089bf0f1fc253c0bab6f6530581dfb268f511a53a9fc49cf87caf0ed2f1531e8be690",
       );
       expect(executor.calls[0]!.tenantCapability).not.toContain(
         PROJECT_WITH_API_KEY.apiKey,

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -142,7 +142,7 @@ describe("given the LangWatchQL service", () => {
       // any change to that algorithm, so the digest the key map is provisioned
       // against is stated as a constant instead.
       expect(executor.calls[0]!.tenantCapability).toBe(
-        "3b39a279643e25b0dc08d6ef2f4c6bec873da8fa96a1c7c0b46821c25c9ca0b6e93943bb883b397d76ab896d07b9c7764f0ee8cc2cf9b815cb4e17d320d197a0",
+        "$2b$10$QIF0tEPWE8jC7LFk0/WjYuv9Zo0bbNsHsOGS5rZY5C0OQ6WyBWD9q",
       );
       // The raw key is the secret the digest exists to keep out of the
       // database; a capability that merely contained it would be a leak.
@@ -169,12 +169,13 @@ describe("given the LangWatchQL service", () => {
       });
 
       expect(executor.calls[0]!.tenantCapability).toBe(
-        "3b39a279643e25b0dc08d6ef2f4c6bec873da8fa96a1c7c0b46821c25c9ca0b6e93943bb883b397d76ab896d07b9c7764f0ee8cc2cf9b815cb4e17d320d197a0",
+        "$2b$10$QIF0tEPWE8jC7LFk0/WjYuv9Zo0bbNsHsOGS5rZY5C0OQ6WyBWD9q",
       );
-      // SHA-512 of PROJECT_WITH_API_KEY.apiKey — what the key map would have to
-      // hold instead, and what no LangWatchQL query may ever present.
+      // The same derivation over PROJECT_WITH_API_KEY.apiKey — what the key map
+      // would have to hold instead, and what no LangWatchQL query may ever
+      // present.
       expect(executor.calls[0]!.tenantCapability).not.toBe(
-        "95a41ba91b26b8c5d6143c96a071fe6309f1e5fdb464fe2e10e2e0ae464089bf0f1fc253c0bab6f6530581dfb268f511a53a9fc49cf87caf0ed2f1531e8be690",
+        "$2b$10$G9AJgeBrTpRaf52Bh0T/BuQ32i9XeCHzW3t4PYxSnM6JbiLjm7/Uu",
       );
       expect(executor.calls[0]!.tenantCapability).not.toContain(
         PROJECT_WITH_API_KEY.apiKey,

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -142,7 +142,7 @@ describe("given the LangWatchQL service", () => {
       // any change to that algorithm, so the digest the key map is provisioned
       // against is stated as a constant instead.
       expect(executor.calls[0]!.tenantCapability).toBe(
-        "4c99f991d0fce515d9326788c6c85359c26cf1536dd1ae0dbb23e806ea05eda2",
+        "3b39a279643e25b0dc08d6ef2f4c6bec873da8fa96a1c7c0b46821c25c9ca0b6e93943bb883b397d76ab896d07b9c7764f0ee8cc2cf9b815cb4e17d320d197a0",
       );
       // The raw key is the secret the digest exists to keep out of the
       // database; a capability that merely contained it would be a leak.
@@ -169,12 +169,12 @@ describe("given the LangWatchQL service", () => {
       });
 
       expect(executor.calls[0]!.tenantCapability).toBe(
-        "4c99f991d0fce515d9326788c6c85359c26cf1536dd1ae0dbb23e806ea05eda2",
+        "3b39a279643e25b0dc08d6ef2f4c6bec873da8fa96a1c7c0b46821c25c9ca0b6e93943bb883b397d76ab896d07b9c7764f0ee8cc2cf9b815cb4e17d320d197a0",
       );
-      // sha256 of PROJECT_WITH_API_KEY.apiKey — what the key map would have to
+      // SHA-512 of PROJECT_WITH_API_KEY.apiKey — what the key map would have to
       // hold instead, and what no LangWatchQL query may ever present.
       expect(executor.calls[0]!.tenantCapability).not.toBe(
-        "725346695d40d416f268694ccc9481c4dc7285693e36226bca84c1b5dade1bd6",
+        "95a41ba91b26b8c5d6143c96a071fe6309f1e5fdb464fe2e10e2e0ae464089bf0f1fc253c0bab6f6530581dfb268f511a53a9fc49cf87caf0ed2f1531e8be690",
       );
       expect(executor.calls[0]!.tenantCapability).not.toContain(
         PROJECT_WITH_API_KEY.apiKey,

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Protections } from "../../../traces/protections";
 import { LWQL_VIEW_CATALOG } from "../catalog/lwqlViews";
+import { LangWatchQLUnavailableError } from "../errors";
 import {
   applyLangWatchQLResultLimits,
   type LangWatchQLExecutor,
@@ -842,24 +843,64 @@ describe("given the LangWatchQL service", () => {
      * indistinguishable from a tenant with no data, and stays that way until
      * someone asks why the numbers are missing.
      *
-     * A plain `Error`, not a handled one: nothing the caller of the API did
-     * causes it and nothing they can do fixes it (ADR-045).
+     * The derivation itself throws a plain `Error`, correctly: nothing the
+     * caller did causes it and nothing they can do fixes it (ADR-045). The
+     * service maps it onto `lwql_unavailable` before it reaches the boundary,
+     * because a plain `Error` escaping here reads to the customer as a generic
+     * unknown failure, and this one has a name: the project cannot be resolved
+     * to a tenant, so there is no identity to run its SQL as. Asserted on the
+     * `code`, never on the prose, which is copy and will change.
      */
-    it("fails loudly instead of hashing an empty secret into a digest that matches nothing", async () => {
+    it("refuses as lwql_unavailable rather than hashing an empty secret into a digest that matches nothing", async () => {
       const executor = recordingExecutor();
 
-      await expect(
-        serviceWith(executor).execute({
+      const refusal = await serviceWith(executor)
+        .execute({
           project: PROJECT_WITHOUT_LWQL_KEY,
           protections: FULLY_PERMITTED,
           sql: "SELECT count() FROM analytics.traces",
-        }),
-      ).rejects.toThrow(
-        "LangWatchQL tenant capability requires a non-empty secret",
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+
+      expect(refusal).toBeInstanceOf(LangWatchQLUnavailableError);
+      expect((refusal as LangWatchQLUnavailableError).code).toBe(
+        "lwql_unavailable",
       );
+      // The cause is kept rather than swallowed, so the log line still says
+      // which of the derivation's two refusals fired.
+      expect(
+        (refusal as LangWatchQLUnavailableError).reasons?.[0]?.message,
+      ).toMatch(/non-empty secret/);
 
       // Nothing reached the database: the refusal is before execution, not a
       // query that ran and quietly answered nothing.
+      expect(executor.calls).toHaveLength(0);
+    });
+
+    /**
+     * bcrypt's other refusal, reaching the caller through the same door. A
+     * project cannot have a key this long today — the column is a UUID default
+     * — which is why the mapping has to be tested rather than assumed: the day
+     * the key gets longer is the day this fires in production.
+     */
+    it("maps an underivable over-long key onto the same refusal", async () => {
+      const executor = recordingExecutor();
+
+      const refusal = await serviceWith(executor)
+        .execute({
+          project: { ...PROJECT, lwqlKey: "x".repeat(73) },
+          protections: FULLY_PERMITTED,
+          sql: "SELECT count() FROM analytics.traces",
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+
+      expect(refusal).toBeInstanceOf(LangWatchQLUnavailableError);
       expect(executor.calls).toHaveLength(0);
     });
   });

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlClickHouseHarness.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlClickHouseHarness.ts
@@ -161,7 +161,7 @@ export interface LangWatchQLTenantFixture {
    * substring.
    */
   rawSecret: string;
-  /** `sha256(rawSecret)`, the only form that travels to ClickHouse. */
+  /** `sha512(rawSecret)`, the only form that travels to ClickHouse. */
   keyHash: string;
 }
 
@@ -177,7 +177,7 @@ function tenantFixture(
     // own copy of the algorithm would drift into seeding a digest production
     // never computes — surfacing as every LangWatchQL read returning zero rows,
     // which is indistinguishable from a tenant that simply has no data. What
-    // pins the digest to SHA-256 is a known-answer assertion, in
+    // pins the digest to SHA-512 is a known-answer assertion, in
     // `tenantIsolation.integration.test.ts`.
     keyHash: lwqlTenantCapability({ secret: rawSecret }),
   };

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlClickHouseHarness.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlClickHouseHarness.ts
@@ -161,14 +161,17 @@ export interface LangWatchQLTenantFixture {
    * substring.
    */
   rawSecret: string;
-  /** `sha512(rawSecret)`, the only form that travels to ClickHouse. */
+  /**
+   * The bcrypt capability for `rawSecret` — the only form that travels to
+   * ClickHouse.
+   */
   keyHash: string;
 }
 
-function tenantFixture(
+async function tenantFixture(
   tenantId: string,
   rawSecret: string,
-): LangWatchQLTenantFixture {
+): Promise<LangWatchQLTenantFixture> {
   return {
     tenantId,
     rawSecret,
@@ -177,17 +180,21 @@ function tenantFixture(
     // own copy of the algorithm would drift into seeding a digest production
     // never computes — surfacing as every LangWatchQL read returning zero rows,
     // which is indistinguishable from a tenant that simply has no data. What
-    // pins the digest to SHA-512 is a known-answer assertion, in
+    // pins the digest to one algorithm is a known-answer assertion, in
     // `tenantIsolation.integration.test.ts`.
-    keyHash: lwqlTenantCapability({ secret: rawSecret }),
+    keyHash: await lwqlTenantCapability({ secret: rawSecret }),
   };
 }
 
-export const TENANT_A = tenantFixture(
+// Awaited at module scope because the capability is a KDF: every consumer below
+// reads `keyHash` synchronously, and a fixture holding a pending promise would
+// seed the key map with `[object Promise]` — a digest that matches nothing, and
+// so a whole isolation suite passing for the wrong reason.
+export const TENANT_A = await tenantFixture(
   "tenant-a",
   "raw-lwql-key-DO-NOT-LOG-abcdef123456",
 );
-export const TENANT_B = tenantFixture(
+export const TENANT_B = await tenantFixture(
   "tenant-b",
   "raw-lwql-key-VICTIM-DO-NOT-LOG-fedcba654321",
 );

--- a/platform/app/src/server/analytics/lwql/__tests__/productionProvisioning.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/productionProvisioning.unit.test.ts
@@ -23,6 +23,7 @@ import type { LangWatchQLViewDefinition } from "../catalog/types";
 import { lwqlPostgresViews } from "../catalog/types";
 import type { LangWatchQLConnection } from "../executor";
 import {
+  isCurrentGenerationCapability,
   LWQL_KEY_MAP_TABLE,
   lwqlKeyMapTableQualifiedName,
   lwqlPostgresSchemaFromDatabaseUrl,
@@ -227,7 +228,104 @@ describe("given planLwqlKeyMapBackfill", () => {
           projects: [{ id: "project-blank", lwqlKey: "" }],
           existingHashes: new Set(),
         }),
-      ).resolves.toBeDefined();
+      ).resolves.toEqual({
+        rowsToInsert: [],
+        blankKeyProjectIds: ["project-blank"],
+        unhashableProjectIds: [],
+      });
+    });
+  });
+
+  /**
+   * The capability's second refusal, and the one that arrived with bcrypt: a
+   * key past 72 bytes cannot be hashed without silently truncating it. The
+   * contract is the same as for a blank key — collect the project, keep going —
+   * and the reason is the blast radius. Propagating the rejection would fail
+   * the whole deploy-time backfill, insert nothing for anyone, and never name
+   * the project at fault.
+   */
+  /**
+   * The backfill runs on every pod's boot path, before the listener starts and
+   * inside the startup probe's budget, so what it does on the *second* deploy
+   * matters more than what it does on the first. Deriving a capability costs
+   * roughly 200ms; doing it for every project on every deploy is a KDF per
+   * project of boot latency forever, and at enough projects it outruns the
+   * probe and the pod never converges.
+   */
+  describe("when a project already holds a current-generation row", () => {
+    /** @scenario "A deploy re-derives only the projects whose key-map row is out of date" */
+    it("derives nothing for it, so a steady-state deploy does no bcrypt work", async () => {
+      const plan = await planLwqlKeyMapBackfill({
+        projects: [{ id: "project-mapped", lwqlKey: "a-perfectly-normal-key" }],
+        existingHashes: new Set(),
+        tenantsHoldingCurrentCapability: new Set(["project-mapped"]),
+      });
+
+      expect(plan.rowsToInsert).toEqual([]);
+      expect(plan.blankKeyProjectIds).toEqual([]);
+      expect(plan.unhashableProjectIds).toEqual([]);
+    });
+
+    /**
+     * The skip keys on the *current* generation, not on "has any row at all".
+     * Every project holds a previous-generation row on the deploy that changes
+     * the derivation, and skipping those would leave the key map permanently
+     * stale — the migration would silently never happen.
+     */
+    /** @scenario "A deploy re-derives only the projects whose key-map row is out of date" */
+    it("still derives for a project whose only row is a previous generation", async () => {
+      const plan = await planLwqlKeyMapBackfill({
+        projects: [{ id: "project-stale", lwqlKey: "a-perfectly-normal-key" }],
+        existingHashes: new Set(["a".repeat(64)]),
+        tenantsHoldingCurrentCapability: new Set(),
+      });
+
+      expect(plan.rowsToInsert).toEqual([
+        {
+          KeyHash: expect.stringMatching(/^\$2b\$10\$/),
+          TenantId: "project-stale",
+        },
+      ]);
+    });
+  });
+
+  /**
+   * The prefix test is what separates those two cases, and it reads the cost
+   * factor out of the stored value — so it has to move if the cost ever does.
+   */
+  describe("when a stored hash is checked for its generation", () => {
+    it("accepts this derivation's digests and rejects a bare sha256 hex", async () => {
+      const current = await lwqlTenantCapability({
+        secret: "generation-check",
+      });
+
+      expect(isCurrentGenerationCapability(current)).toBe(true);
+      expect(isCurrentGenerationCapability("a".repeat(64))).toBe(false);
+      // A different cost factor is a different generation, not a variant.
+      expect(isCurrentGenerationCapability(`$2b$12$${"a".repeat(53)}`)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("when a project's lwqlKey is longer than bcrypt reads", () => {
+    /** @scenario "One project's unusable secret never costs the other projects their key-map rows" */
+    it("reports that project and still plans rows for the others", async () => {
+      const plan = await planLwqlKeyMapBackfill({
+        projects: [
+          { id: "project-overlong", lwqlKey: "x".repeat(73) },
+          { id: "project-healthy", lwqlKey: "a-perfectly-normal-key" },
+        ],
+        existingHashes: new Set(),
+      });
+
+      expect(plan.unhashableProjectIds).toEqual(["project-overlong"]);
+      expect(plan.rowsToInsert).toEqual([
+        {
+          KeyHash: expect.stringMatching(/^\$2b\$10\$/),
+          TenantId: "project-healthy",
+        },
+      ]);
     });
   });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/productionProvisioning.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/productionProvisioning.unit.test.ts
@@ -211,8 +211,8 @@ describe("given lwqlPostgresSchemaFromDatabaseUrl", () => {
 
 describe("given planLwqlKeyMapBackfill", () => {
   describe("when a project has a blank lwqlKey", () => {
-    it("surfaces it in blankKeyProjectIds instead of inserting a row", () => {
-      const plan = planLwqlKeyMapBackfill({
+    it("surfaces it in blankKeyProjectIds instead of inserting a row", async () => {
+      const plan = await planLwqlKeyMapBackfill({
         projects: [{ id: "project-blank", lwqlKey: "" }],
         existingHashes: new Set(),
       });
@@ -221,20 +221,20 @@ describe("given planLwqlKeyMapBackfill", () => {
       expect(plan.rowsToInsert).toEqual([]);
     });
 
-    it("does not throw, even though lwqlTenantCapability throws on an empty secret", () => {
-      expect(() =>
+    it("does not reject, even though lwqlTenantCapability rejects on an empty secret", async () => {
+      await expect(
         planLwqlKeyMapBackfill({
           projects: [{ id: "project-blank", lwqlKey: "" }],
           existingHashes: new Set(),
         }),
-      ).not.toThrow();
+      ).resolves.toBeDefined();
     });
   });
 
   describe("when a project's key hash is already in existingHashes", () => {
-    it("excludes it from rowsToInsert", () => {
-      const hash = lwqlTenantCapability({ secret: "already-mapped-key" });
-      const plan = planLwqlKeyMapBackfill({
+    it("excludes it from rowsToInsert", async () => {
+      const hash = await lwqlTenantCapability({ secret: "already-mapped-key" });
+      const plan = await planLwqlKeyMapBackfill({
         projects: [{ id: "project-existing", lwqlKey: "already-mapped-key" }],
         existingHashes: new Set([hash]),
       });
@@ -248,8 +248,8 @@ describe("given planLwqlKeyMapBackfill", () => {
     // Contrived — a unique key is the invariant this table exists to record —
     // but the plan still must not depend on that invariant holding, so it
     // dedupes within a single run rather than inserting both.
-    it("inserts only the first occurrence", () => {
-      const plan = planLwqlKeyMapBackfill({
+    it("inserts only the first occurrence", async () => {
+      const plan = await planLwqlKeyMapBackfill({
         projects: [
           { id: "project-a", lwqlKey: "shared-key" },
           { id: "project-b", lwqlKey: "shared-key" },
@@ -263,15 +263,15 @@ describe("given planLwqlKeyMapBackfill", () => {
   });
 
   describe("when a project has a new, non-blank, not-yet-mapped key", () => {
-    it("includes it in rowsToInsert with its real hash", () => {
-      const plan = planLwqlKeyMapBackfill({
+    it("includes it in rowsToInsert with its real hash", async () => {
+      const plan = await planLwqlKeyMapBackfill({
         projects: [{ id: "project-new", lwqlKey: "brand-new-key" }],
         existingHashes: new Set(),
       });
 
       expect(plan.rowsToInsert).toEqual([
         {
-          KeyHash: lwqlTenantCapability({ secret: "brand-new-key" }),
+          KeyHash: await lwqlTenantCapability({ secret: "brand-new-key" }),
           TenantId: "project-new",
         },
       ]);
@@ -280,9 +280,11 @@ describe("given planLwqlKeyMapBackfill", () => {
   });
 
   describe("when projects mix blank, already-mapped, and new keys", () => {
-    it("handles each independently in a single pass", () => {
-      const existingHash = lwqlTenantCapability({ secret: "existing-key" });
-      const plan = planLwqlKeyMapBackfill({
+    it("handles each independently in a single pass", async () => {
+      const existingHash = await lwqlTenantCapability({
+        secret: "existing-key",
+      });
+      const plan = await planLwqlKeyMapBackfill({
         projects: [
           { id: "project-blank", lwqlKey: "" },
           { id: "project-existing", lwqlKey: "existing-key" },
@@ -294,7 +296,7 @@ describe("given planLwqlKeyMapBackfill", () => {
       expect(plan.blankKeyProjectIds).toEqual(["project-blank"]);
       expect(plan.rowsToInsert).toEqual([
         {
-          KeyHash: lwqlTenantCapability({ secret: "new-key" }),
+          KeyHash: await lwqlTenantCapability({ secret: "new-key" }),
           TenantId: "project-new",
         },
       ]);

--- a/platform/app/src/server/analytics/lwql/__tests__/tenantIsolation.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/tenantIsolation.integration.test.ts
@@ -480,7 +480,7 @@ describe("given the LangWatchQL analytics setup applied to a ClickHouse 25.10 se
       // `lwqlTenantCapability` does and would agree with it after any
       // change, including a change that stopped hashing at all.
       expect(harness.tenantA.keyHash).toBe(
-        "baff4cf64716a3750285c79ce2be7cf6732b7c2d2e61e2dda5d59fa3fe575f0f6334f9f8f2393e06df347bcbd950e7b66c6158e0efb1318c1b6420a9dd4ea3db",
+        "$2b$10$Ku/1VKftbfUmpfpZBWxm0uh08g/T6qUyNUt/cDUNtn2jE699E2EAW",
       );
       expect(harness.tenantA.rawSecret.length).toBeGreaterThanOrEqual(24);
 

--- a/platform/app/src/server/analytics/lwql/__tests__/tenantIsolation.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/tenantIsolation.integration.test.ts
@@ -480,7 +480,7 @@ describe("given the LangWatchQL analytics setup applied to a ClickHouse 25.10 se
       // `lwqlTenantCapability` does and would agree with it after any
       // change, including a change that stopped hashing at all.
       expect(harness.tenantA.keyHash).toBe(
-        "80e5fb77f0eed9c68e4b32c0cd2f0b10be340dc6da29142c2c84c51fff50dda1",
+        "baff4cf64716a3750285c79ce2be7cf6732b7c2d2e61e2dda5d59fa3fe575f0f6334f9f8f2393e06df347bcbd950e7b66c6158e0efb1318c1b6420a9dd4ea3db",
       );
       expect(harness.tenantA.rawSecret.length).toBeGreaterThanOrEqual(24);
 

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -23,29 +23,105 @@
  * The raw secret never leaves the control plane: only the digest is sent, which
  * is what makes the value safe to appear in `system.query_log` for auditing.
  *
- * ## Why a fast hash, and why a slow KDF would be wrong here
+ * ## Why bcrypt, and how it stays a usable join key
  *
- * Static analysis reads `sha512` over a secret as password storage and asks
- * for bcrypt or Argon2 (CodeQL `js/insufficient-password-hash`). Neither
- * applies. This is not a verifier for a human-chosen secret; it is the
- * join key ClickHouse looks up in the key map, so it has to be deterministic —
- * a per-call salt, which is the property that makes a password KDF worth
- * having, would make every lookup miss. And the input it protects is not
- * guessable: the secret is a database-generated UUID, so the work factor a KDF
- * buys against a dictionary attack is defending a keyspace nothing is going to
- * search. The cost, meanwhile, would be real and per-query.
+ * bcrypt is the digest because the value is a hash of a secret, and a hash of a
+ * secret should be a KDF whatever we believe about the keyspace behind it
+ * (CodeQL `js/insufficient-password-hash`). The two properties that normally
+ * make a password KDF unusable as a lookup key are dealt with here rather than
+ * argued away:
  *
- * What actually keeps the digest safe is that it is useless without a session
- * only the control plane can open: the restricted identity cannot read
- * `system.*`, and the validator refuses a `SETTINGS` clause, so a caller cannot
- * present someone else's digest as its own.
+ * **A per-call random salt would make every lookup miss.** The key map is an
+ * equality join on `KeyHash`, not a `bcrypt.compare` loop — the restricted
+ * identity cannot run a verifier, it can only match the setting it was handed
+ * against a row. So the salt is *derived from the secret* with HKDF instead of
+ * drawn from the RNG, which keeps this a pure function of its input while still
+ * giving every project a distinct salt. Deriving the salt from the secret is
+ * the wrong move when the input is a human-chosen password, because it hands a
+ * precomputation attack the one thing a salt is meant to deny it; it is the
+ * right move when the input is a database-minted secret, where there is no
+ * dictionary to precompute against and the salt's remaining job is to keep two
+ * projects' digests unrelated.
+ *
+ * **The work factor would otherwise be paid per query.** It is paid per
+ * *project*, once per process: the secret is stable, so the digest is memoised
+ * under the derived salt. That also keeps the raw secret out of the cache —
+ * the key is the salt, which the secret cannot be recovered from. A cold call
+ * costs roughly 200ms, which is why it is awaited off the event loop rather
+ * than hashed synchronously; every later query for that project reads the map.
+ *
+ * None of this is what makes the digest safe to hold, and the work factor
+ * should not be mistaken for the control. What keeps it safe is that it is
+ * useless without a session only the control plane can open: the restricted
+ * identity cannot read `system.*`, and the validator refuses a `SETTINGS`
+ * clause, so a caller cannot present someone else's digest as its own.
+ *
+ * ## Why the length guard is not paranoia
+ *
+ * bcrypt silently truncates its input at 72 bytes. Under a fast digest that is
+ * nothing; here it means two projects whose secrets share a 72-byte prefix
+ * would compute the *same capability* and read each other's rows. `lwqlKey` is
+ * far shorter than that and the collision cannot happen today, which is exactly
+ * why the guard has to be in the code rather than in the reader's memory: the
+ * day someone lengthens the secret, this throws instead of quietly merging two
+ * tenants.
  *
  * @see ./provisioning.ts — the key map this value is looked up in
- * @see ./validation/validate.ts — the `SETTINGS` refusal that clause depends on
+ * @see ./validation/validate.ts — the `SETTINGS` refusal this design depends on
  * @see specs/analytics/lwql-api.feature
  */
 
-import { createHash } from "node:crypto";
+import { hkdfSync } from "node:crypto";
+import { hash } from "bcrypt";
+
+/**
+ * bcrypt's work factor, and part of the digest's wire format — a change here
+ * changes every capability, so it is a re-provisioning of the key map.
+ */
+const CAPABILITY_COST = 10;
+
+/** Domain separation, so this derivation can never collide with another. */
+const SALT_NAMESPACE = "langwatchql.tenant-capability.salt.v1";
+const SALT_INFO = "langwatchql.tenant-capability.v1";
+
+/** bcrypt's salt is 16 bytes, written as 22 characters of its own base64. */
+const SALT_BYTES = 16;
+const SALT_CHARS = 22;
+
+/** The input length past which bcrypt stops reading. See the guard above. */
+const BCRYPT_MAX_SECRET_BYTES = 72;
+
+/**
+ * Derived capabilities, keyed by the derived salt rather than by the secret so
+ * that nothing in this map can be turned back into a credential.
+ *
+ * Bounded, and evicted oldest-first: the cost of evicting a project that is
+ * still active is one re-hash, so the simplest policy that cannot grow without
+ * limit is the right one.
+ */
+const CAPABILITY_CACHE_LIMIT = 10_000;
+const capabilityCache = new Map<string, string>();
+
+/**
+ * The bcrypt salt for a secret, in the modular-crypt form bcrypt parses.
+ *
+ * HKDF rather than a bare digest because deriving a salt is what a KDF is for,
+ * and the 16 bytes are written in bcrypt's alphabet — which is `./A-Za-z0-9`,
+ * so the one character standard base64 produces that bcrypt would reject (`+`)
+ * is mapped onto `.`. The trailing bits of the 22nd character are unused, and
+ * bcrypt canonicalises them in its output; that is deterministic too, so the
+ * digest still round-trips.
+ */
+function capabilitySalt(secret: string): string {
+  const derived = Buffer.from(
+    hkdfSync("sha256", secret, SALT_NAMESPACE, SALT_INFO, SALT_BYTES),
+  );
+  const encoded = derived
+    .toString("base64")
+    .slice(0, SALT_CHARS)
+    .replace(/\+/g, ".");
+  return `$2b$${String(CAPABILITY_COST).padStart(2, "0")}$${encoded}`;
+}
 
 /**
  * The tenant capability for a project, as the key map stores it.
@@ -61,11 +137,35 @@ import { createHash } from "node:crypto";
  *   in its raw form. Never logged, never sent to the database, and never
  *   returned to a caller.
  */
-export function lwqlTenantCapability({ secret }: { secret: string }): string {
+export async function lwqlTenantCapability({
+  secret,
+}: {
+  secret: string;
+}): Promise<string> {
   if (!secret) {
     throw new Error(
       "LangWatchQL tenant capability requires a non-empty secret",
     );
   }
-  return createHash("sha512").update(secret).digest("hex");
+  if (Buffer.byteLength(secret, "utf8") > BCRYPT_MAX_SECRET_BYTES) {
+    throw new Error(
+      `LangWatchQL tenant capability requires a secret of at most ${BCRYPT_MAX_SECRET_BYTES} bytes`,
+    );
+  }
+
+  const salt = capabilitySalt(secret);
+  const cached = capabilityCache.get(salt);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const capability = await hash(secret, salt);
+  if (capabilityCache.size >= CAPABILITY_CACHE_LIMIT) {
+    const oldest = capabilityCache.keys().next();
+    if (!oldest.done) {
+      capabilityCache.delete(oldest.value);
+    }
+  }
+  capabilityCache.set(salt, capability);
+  return capability;
 }

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -95,12 +95,18 @@ const BCRYPT_MAX_SECRET_BYTES = 72;
  * Derived capabilities, keyed by the derived salt rather than by the secret so
  * that nothing in this map can be turned back into a credential.
  *
+ * It holds the in-flight hash, not the finished digest, so that concurrent
+ * first queries for one project share a single hash instead of each starting
+ * their own. A dashboard opening several LangWatchQL queries at once is the
+ * normal case, not a rare one, and bcrypt runs on the libuv thread pool — four
+ * copies of the same cold derivation would occupy all of it.
+ *
  * Bounded, and evicted oldest-first: the cost of evicting a project that is
  * still active is one re-hash, so the simplest policy that cannot grow without
  * limit is the right one.
  */
 const CAPABILITY_CACHE_LIMIT = 10_000;
-const capabilityCache = new Map<string, string>();
+const capabilityCache = new Map<string, Promise<string>>();
 
 /**
  * The bcrypt salt for a secret, in the modular-crypt form bcrypt parses.
@@ -159,7 +165,7 @@ export async function lwqlTenantCapability({
     return cached;
   }
 
-  const capability = await hash(secret, salt);
+  const capability = hash(secret, salt);
   if (capabilityCache.size >= CAPABILITY_CACHE_LIMIT) {
     const oldest = capabilityCache.keys().next();
     if (!oldest.done) {
@@ -167,5 +173,9 @@ export async function lwqlTenantCapability({
     }
   }
   capabilityCache.set(salt, capability);
+  // A failed hash must not be remembered as this project's answer: drop it so
+  // the next query derives again rather than replaying the failure forever.
+  // The rejection still reaches this call's caller through the returned promise.
+  capability.catch(() => capabilityCache.delete(salt));
   return capability;
 }

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -83,17 +83,37 @@ const CAPABILITY_COST = 10;
 /** Domain separation, so this derivation can never collide with another. */
 const SALT_NAMESPACE = "langwatchql.tenant-capability.salt.v1";
 const SALT_INFO = "langwatchql.tenant-capability.v1";
+const CACHE_KEY_INFO = "langwatchql.tenant-capability.cache-key.v1";
 
 /** bcrypt's salt is 16 bytes, written as 22 characters of its own base64. */
 const SALT_BYTES = 16;
 const SALT_CHARS = 22;
 
+/**
+ * The cache key is its own full-width derivation, not the salt.
+ *
+ * bcrypt fixes the salt at 16 bytes, and keying the cache by it would put a
+ * cross-tenant leak behind a 128-bit birthday bound: two projects deriving one
+ * salt would mean the second is served the first's capability, and reads the
+ * first's rows. 32 bytes here costs nothing and is not the value bcrypt
+ * constrains, so the key does not inherit that limit.
+ */
+const CACHE_KEY_BYTES = 32;
+
 /** The input length past which bcrypt stops reading. See the guard above. */
 const BCRYPT_MAX_SECRET_BYTES = 72;
 
 /**
- * Derived capabilities, keyed by the derived salt rather than by the secret so
- * that nothing in this map can be turned back into a credential.
+ * Derived capabilities, keyed by a one-way derivation of the secret rather than
+ * by the secret itself, so that nothing in this map can be turned back into a
+ * credential.
+ *
+ * Every entry carries the salt it was derived under and a hit is only accepted
+ * when that salt matches the one this call derived. A cache is shared by every
+ * tenant in the process, so "the key matched" is not on its own a good enough
+ * reason to hand back someone's capability; the salt check makes a mistaken hit
+ * a recomputation rather than a cross-tenant read, and it costs one string
+ * comparison.
  *
  * It holds the in-flight hash, not the finished digest, so that concurrent
  * first queries for one project share a single hash instead of each starting
@@ -106,7 +126,10 @@ const BCRYPT_MAX_SECRET_BYTES = 72;
  * limit is the right one.
  */
 const CAPABILITY_CACHE_LIMIT = 10_000;
-const capabilityCache = new Map<string, Promise<string>>();
+const capabilityCache = new Map<
+  string,
+  { readonly salt: string; readonly capability: Promise<string> }
+>();
 
 /**
  * The bcrypt salt for a secret, in the modular-crypt form bcrypt parses.
@@ -127,6 +150,16 @@ function capabilitySalt(secret: string): string {
     .slice(0, SALT_CHARS)
     .replace(/\+/g, ".");
   return `$2b$${String(CAPABILITY_COST).padStart(2, "0")}$${encoded}`;
+}
+
+/**
+ * The cache key for a secret: one-way, full width, and separated from the salt
+ * by its own `info` so the two derivations cannot be confused for each other.
+ */
+function capabilityCacheKey(secret: string): string {
+  return Buffer.from(
+    hkdfSync("sha256", secret, SALT_NAMESPACE, CACHE_KEY_INFO, CACHE_KEY_BYTES),
+  ).toString("hex");
 }
 
 /**
@@ -160,9 +193,14 @@ export async function lwqlTenantCapability({
   }
 
   const salt = capabilitySalt(secret);
-  const cached = capabilityCache.get(salt);
-  if (cached !== undefined) {
-    return cached;
+  const cacheKey = capabilityCacheKey(secret);
+
+  // Only a hit whose salt was derived from *this* secret is this caller's
+  // answer. Anything else is treated as a miss and recomputed, so the worst a
+  // key collision could cost is one hash rather than another tenant's rows.
+  const cached = capabilityCache.get(cacheKey);
+  if (cached !== undefined && cached.salt === salt) {
+    return cached.capability;
   }
 
   const capability = hash(secret, salt);
@@ -172,10 +210,14 @@ export async function lwqlTenantCapability({
       capabilityCache.delete(oldest.value);
     }
   }
-  capabilityCache.set(salt, capability);
+  capabilityCache.set(cacheKey, { salt, capability });
   // A failed hash must not be remembered as this project's answer: drop it so
   // the next query derives again rather than replaying the failure forever.
   // The rejection still reaches this call's caller through the returned promise.
-  capability.catch(() => capabilityCache.delete(salt));
+  capability.catch(() => {
+    if (capabilityCache.get(cacheKey)?.capability === capability) {
+      capabilityCache.delete(cacheKey);
+    }
+  });
   return capability;
 }

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -54,6 +54,19 @@
  * process, so it is written to fail towards a wasted hash rather than towards
  * the wrong tenant: see {@link capabilityCache}.
  *
+ * Be exact about what the work factor buys, because the encoding above gives
+ * some of it back. The first 29 characters of every capability are the salt,
+ * and the salt is `HKDF-SHA256(secret)` — so anyone holding a capability can
+ * test a candidate secret with two HMACs instead of a cost-10 bcrypt. Against
+ * a guessable secret that would matter, and the honest reading is that bcrypt
+ * is here to satisfy the rule that a hash of a secret is a KDF, not to make
+ * this digest expensive to attack. What actually makes guessing hopeless is
+ * the input: `lwqlKey` is a database-minted UUID, so there is no dictionary
+ * and no shortcut to 122 bits. Closing the gap properly would mean mixing in a
+ * value that never leaves the control plane — a pepper, or a salt derived from
+ * the project id rather than the secret — and either is a re-provisioning of
+ * the key map, so it is a deliberate decision rather than a tidy-up.
+ *
  * None of this is what makes the digest safe to hold, and the work factor
  * should not be mistaken for the control. What keeps it safe is that it is
  * useless without a session only the control plane can open: the restricted
@@ -85,21 +98,27 @@ import { hash } from "bcrypt";
 const CAPABILITY_COST = 10;
 
 /**
- * HKDF inputs. The namespace separates this feature's derivations from any
- * other use of the same secret; the two `info` values separate the bcrypt salt
- * from the cache key, so neither can ever be mistaken for the other.
+ * HKDF inputs, named for the parameter each one is passed as.
  *
- * The namespace string still reads `…salt.v1` because it is the value that was
- * mixed into every capability already derived. Renaming it would change every
- * digest, which is a re-provisioning of the key map, not a tidy-up.
+ * {@link CAPABILITY_HKDF_SALT} is HKDF's *salt*: it separates this feature's
+ * derivations from any other use of the same secret. The two `info` values
+ * separate the bcrypt salt from the cache key, so a derivation for one can
+ * never be mistaken for the other.
+ *
+ * All three strings are part of the wire format. Changing any of them changes
+ * every capability, which is a re-provisioning of the key map rather than a
+ * tidy-up — so they carry a version suffix and are not edited in place. The
+ * historical `…salt.v1` in the first value is a name, not a description of
+ * which parameter it feeds; it is left alone for that reason.
  */
-const CAPABILITY_NAMESPACE = "langwatchql.tenant-capability.salt.v1";
-const SALT_INFO = "langwatchql.tenant-capability.v1";
+const CAPABILITY_HKDF_SALT = "langwatchql.tenant-capability.salt.v1";
+const BCRYPT_SALT_INFO = "langwatchql.tenant-capability.v1";
 const CACHE_KEY_INFO = "langwatchql.tenant-capability.cache-key.v1";
 
-/** bcrypt's salt is 16 bytes, written as 22 characters of its own base64. */
+/** bcrypt reads exactly 16 salt bytes, written as 22 base64 characters. */
 const SALT_BYTES = 16;
-const SALT_CHARS = 22;
+/** Derived, never stated: base64 carries 6 bits a character. */
+const SALT_CHARS = Math.ceil((SALT_BYTES * 8) / 6);
 
 /**
  * The cache key is its own full-width derivation, not the salt.
@@ -114,6 +133,17 @@ const CACHE_KEY_BYTES = 32;
 
 /** The input length past which bcrypt stops reading. See the guard above. */
 const BCRYPT_MAX_SECRET_BYTES = 72;
+
+/**
+ * The modular-crypt prefix every capability this module derives begins with.
+ *
+ * Exported because the cost factor is part of the wire format: a stored digest
+ * that does not start with this was derived by an older generation of this
+ * function and no longer names its tenant. The backfill uses it to tell a row
+ * it can trust from one it has to replace, which is the only way to know that
+ * without re-deriving every project's capability on every deploy.
+ */
+export const CAPABILITY_PREFIX = `$2b$${String(CAPABILITY_COST).padStart(2, "0")}$`;
 
 /**
  * Derived capabilities, keyed by a one-way derivation of the secret rather than
@@ -146,22 +176,36 @@ const capabilityCache = new Map<
 /**
  * The bcrypt salt for a secret, in the modular-crypt form bcrypt parses.
  *
- * HKDF rather than a bare digest because deriving a salt is what a KDF is for,
- * and the 16 bytes are written in bcrypt's alphabet — which is `./A-Za-z0-9`,
- * so the one character standard base64 produces that bcrypt would reject (`+`)
- * is mapped onto `.`. The trailing bits of the 22nd character are unused, and
- * bcrypt canonicalises them in its output; that is deterministic too, so the
- * digest still round-trips.
+ * HKDF rather than a bare digest because deriving a salt is what a KDF is for.
+ * The 16 bytes are then written as *standard* base64 with `+` remapped to `.`,
+ * which lands them in the alphabet bcrypt accepts (`./A-Za-z0-9`) — the only
+ * character standard base64 emits that bcrypt would reject.
+ *
+ * This is deliberately not bcrypt's own base64, whose ordering differs, so the
+ * salt bcrypt decodes is a permutation of the HKDF output rather than the
+ * output itself. That costs nothing here: the mapping is injective (`.` never
+ * occurs in standard base64) and deterministic, so distinct secrets still get
+ * distinct salts. It matters only to a reimplementation — a second
+ * implementation in another language must copy *this* encoding, not bcrypt's,
+ * or it will derive different capabilities and silently match no key-map row.
+ * The trailing bits of the 22nd character are unused; bcrypt canonicalises
+ * them in its output, deterministically, so the digest still round-trips.
  */
 function capabilitySalt(secret: string): string {
   const derived = Buffer.from(
-    hkdfSync("sha256", secret, CAPABILITY_NAMESPACE, SALT_INFO, SALT_BYTES),
+    hkdfSync(
+      "sha256",
+      secret,
+      CAPABILITY_HKDF_SALT,
+      BCRYPT_SALT_INFO,
+      SALT_BYTES,
+    ),
   );
   const encoded = derived
     .toString("base64")
     .slice(0, SALT_CHARS)
     .replace(/\+/g, ".");
-  return `$2b$${String(CAPABILITY_COST).padStart(2, "0")}$${encoded}`;
+  return `${CAPABILITY_PREFIX}${encoded}`;
 }
 
 /**
@@ -173,7 +217,7 @@ function capabilityCacheKey(secret: string): string {
     hkdfSync(
       "sha256",
       secret,
-      CAPABILITY_NAMESPACE,
+      CAPABILITY_HKDF_SALT,
       CACHE_KEY_INFO,
       CACHE_KEY_BYTES,
     ),
@@ -189,6 +233,17 @@ function capabilityCacheKey(secret: string): string {
  * zero rows, and is indistinguishable from a tenant with no data. Throwing is
  * what turns a silent wrong answer into a loud wiring failure; a plain `Error`
  * because nothing a caller does fixes it (ADR-045).
+ *
+ * Refuses a secret over 72 bytes for the same reason, and it is the more
+ * dangerous of the two: bcrypt stops reading there, so two secrets sharing a
+ * 72-byte prefix would derive one capability and the two projects holding it
+ * would read each other's rows. Callers that hash a set of projects should
+ * expect this per project rather than letting one bad key take the batch down.
+ *
+ * The result is memoised process-wide per secret, so only the first call for a
+ * project pays the work factor — roughly 200ms — and later calls are a map
+ * lookup. That is why this is async and must never be made synchronous: a
+ * 200ms blocking hash on a shared API process stalls every in-flight request.
  *
  * @param secret - the project's LangWatchQL secret (`Project.lwqlKey`),
  *   in its raw form. Never logged, never sent to the database, and never
@@ -218,10 +273,32 @@ export async function lwqlTenantCapability({
   // key collision could cost is one hash rather than another tenant's rows.
   const cached = capabilityCache.get(cacheKey);
   if (cached !== undefined && cached.salt === salt) {
+    // Re-inserted so the map orders by last use rather than by first: eviction
+    // walks insertion order, and without this a project queried on every
+    // request is dropped as readily as one queried once at boot.
+    capabilityCache.delete(cacheKey);
+    capabilityCache.set(cacheKey, cached);
     return cached.capability;
   }
 
-  const capability = hash(secret, salt);
+  // bcrypt validates a salt's *shape* but not its alphabet: a character
+  // outside `./A-Za-z0-9` stops its base64 decoder early and leaves the rest
+  // of the salt buffer as uninitialised memory, so it answers with a digest
+  // under a salt nobody chose instead of refusing. Today's encoder cannot emit
+  // one — but switching it to `base64url` would, and the symptom would be a
+  // capability that matches no key-map row, which reads exactly like a tenant
+  // with no data. Checking the digest carries the salt it was asked for turns
+  // that into the loud failure this module's header insists on. The final salt
+  // character is excluded because bcrypt canonicalises its unused trailing
+  // bits.
+  const capability = hash(secret, salt).then((digest) => {
+    if (!digest.startsWith(salt.slice(0, -1))) {
+      throw new Error(
+        "LangWatchQL tenant capability: bcrypt returned a digest under a different salt than it was given",
+      );
+    }
+    return digest;
+  });
   if (capabilityCache.size >= CAPABILITY_CACHE_LIMIT) {
     const oldest = capabilityCache.keys().next();
     if (!oldest.done) {

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -67,5 +67,5 @@ export function lwqlTenantCapability({ secret }: { secret: string }): string {
       "LangWatchQL tenant capability requires a non-empty secret",
     );
   }
-  return createHash("sha256").update(secret).digest("hex");
+  return createHash("sha512").update(secret).digest("hex");
 }

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -25,7 +25,7 @@
  *
  * ## Why a fast hash, and why a slow KDF would be wrong here
  *
- * Static analysis reads `sha256` over a secret as password storage and asks
+ * Static analysis reads `sha512` over a secret as password storage and asks
  * for bcrypt or Argon2 (CodeQL `js/insufficient-password-hash`). Neither
  * applies. This is not a verifier for a human-chosen secret; it is the
  * join key ClickHouse looks up in the key map, so it has to be deterministic —

--- a/platform/app/src/server/analytics/lwql/capability.ts
+++ b/platform/app/src/server/analytics/lwql/capability.ts
@@ -45,10 +45,14 @@
  *
  * **The work factor would otherwise be paid per query.** It is paid per
  * *project*, once per process: the secret is stable, so the digest is memoised
- * under the derived salt. That also keeps the raw secret out of the cache —
- * the key is the salt, which the secret cannot be recovered from. A cold call
- * costs roughly 200ms, which is why it is awaited off the event loop rather
- * than hashed synchronously; every later query for that project reads the map.
+ * under a one-way derivation of it, which keeps the raw secret out of the cache
+ * because nothing there can be turned back into a credential. A cold call costs
+ * roughly 200ms, which is why it is awaited off the event loop rather than
+ * hashed synchronously; every later query for that project reads the map.
+ *
+ * That cache is the one structure in this file shared by every tenant in the
+ * process, so it is written to fail towards a wasted hash rather than towards
+ * the wrong tenant: see {@link capabilityCache}.
  *
  * None of this is what makes the digest safe to hold, and the work factor
  * should not be mistaken for the control. What keeps it safe is that it is
@@ -80,8 +84,16 @@ import { hash } from "bcrypt";
  */
 const CAPABILITY_COST = 10;
 
-/** Domain separation, so this derivation can never collide with another. */
-const SALT_NAMESPACE = "langwatchql.tenant-capability.salt.v1";
+/**
+ * HKDF inputs. The namespace separates this feature's derivations from any
+ * other use of the same secret; the two `info` values separate the bcrypt salt
+ * from the cache key, so neither can ever be mistaken for the other.
+ *
+ * The namespace string still reads `…salt.v1` because it is the value that was
+ * mixed into every capability already derived. Renaming it would change every
+ * digest, which is a re-provisioning of the key map, not a tidy-up.
+ */
+const CAPABILITY_NAMESPACE = "langwatchql.tenant-capability.salt.v1";
 const SALT_INFO = "langwatchql.tenant-capability.v1";
 const CACHE_KEY_INFO = "langwatchql.tenant-capability.cache-key.v1";
 
@@ -143,7 +155,7 @@ const capabilityCache = new Map<
  */
 function capabilitySalt(secret: string): string {
   const derived = Buffer.from(
-    hkdfSync("sha256", secret, SALT_NAMESPACE, SALT_INFO, SALT_BYTES),
+    hkdfSync("sha256", secret, CAPABILITY_NAMESPACE, SALT_INFO, SALT_BYTES),
   );
   const encoded = derived
     .toString("base64")
@@ -158,7 +170,13 @@ function capabilitySalt(secret: string): string {
  */
 function capabilityCacheKey(secret: string): string {
   return Buffer.from(
-    hkdfSync("sha256", secret, SALT_NAMESPACE, CACHE_KEY_INFO, CACHE_KEY_BYTES),
+    hkdfSync(
+      "sha256",
+      secret,
+      CAPABILITY_NAMESPACE,
+      CACHE_KEY_INFO,
+      CACHE_KEY_BYTES,
+    ),
   ).toString("hex");
 }
 

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -555,6 +555,36 @@ export class LangWatchQLService {
    * more decisions to make — only the database call, the advisory diagnostics
    * over its answer, and the result both of them describe.
    */
+  /**
+   * The project's tenant capability, with a derivation failure mapped onto the
+   * API's own vocabulary.
+   *
+   * The derivation refuses two things — an unselected secret and one longer
+   * than bcrypt reads — and both throw a plain `Error`, correctly, because
+   * neither is anything a caller did. But a plain `Error` escaping here reaches
+   * the boundary as a generic "unknown error" plus a trace id, for a failure we
+   * can name precisely: this project cannot be resolved to a tenant, so there
+   * is no identity to run its SQL as. That is the same condition as a missing
+   * restricted identity and gets the same answer, with the original kept as a
+   * `reason` so the log line still says which of the two refusals fired.
+   */
+  private async tenantCapabilityFor(project: {
+    id: string;
+    lwqlKey: string;
+  }): Promise<string> {
+    try {
+      return await lwqlTenantCapability({ secret: project.lwqlKey });
+    } catch (error) {
+      logger.error(
+        { projectId: project.id, error },
+        "LangWatchQL query refused: this project's key cannot be derived into a tenant capability",
+      );
+      throw new LangWatchQLUnavailableError({
+        reasons: error instanceof Error ? [error] : [],
+      });
+    }
+  }
+
   private async executeValidated({
     executor,
     project,
@@ -585,9 +615,7 @@ export class LangWatchQLService {
       ...(Object.keys(executionParameters).length > 0
         ? { parameters: executionParameters }
         : {}),
-      tenantCapability: await lwqlTenantCapability({
-        secret: project.lwqlKey,
-      }),
+      tenantCapability: await this.tenantCapabilityFor(project),
       limits: this.limits,
     });
 

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -585,7 +585,7 @@ export class LangWatchQLService {
       ...(Object.keys(executionParameters).length > 0
         ? { parameters: executionParameters }
         : {}),
-      tenantCapability: lwqlTenantCapability({
+      tenantCapability: await lwqlTenantCapability({
         secret: project.lwqlKey,
       }),
       limits: this.limits,

--- a/platform/app/src/server/analytics/lwql/productionProvisioning.ts
+++ b/platform/app/src/server/analytics/lwql/productionProvisioning.ts
@@ -251,31 +251,50 @@ export interface LwqlKeyMapBackfillPlan {
 
 /**
  * Diffs every project's key hash against the key-map table's current rows and
- * returns only what is missing. Pure: takes the already-read existing hash
- * set, computes no I/O.
+ * returns only what is missing. Reads nothing: it takes the already-read
+ * existing hash set, and the only work it does is deriving each project's
+ * capability.
+ *
+ * That derivation is a KDF (`../capability.ts`), which is why this is `async`
+ * and why the hashes are derived up front rather than inside the loop — one
+ * costs roughly 200ms, so a serial loop would put the whole backfill on the
+ * critical path at 200ms a project.
  *
  * Duplicate `(hash, tenant)` pairs are harmless at read time (row filters use
  * `HAVING uniqExact(TenantId) = 1`), but this still de-duplicates within one
  * run — inserting a row already covered by `existingHashes`, or repeated
  * inside `projects` itself, buys nothing and only grows the table.
  */
-export function planLwqlKeyMapBackfill({
+export async function planLwqlKeyMapBackfill({
   projects,
   existingHashes,
 }: {
   projects: readonly { id: string; lwqlKey: string }[];
   existingHashes: ReadonlySet<string>;
-}): LwqlKeyMapBackfillPlan {
+}): Promise<LwqlKeyMapBackfillPlan> {
   const rowsToInsert: LwqlKeyMapRow[] = [];
   const blankKeyProjectIds: string[] = [];
   const plannedHashes = new Set<string>();
 
-  for (const project of projects) {
-    if (!project.lwqlKey) {
+  // A blank key is reported, never hashed: the capability refuses an empty
+  // secret, and this function's contract is to collect those projects rather
+  // than throw on the first one.
+  const derived = await Promise.all(
+    projects.map(async (project) =>
+      project.lwqlKey
+        ? {
+            project,
+            hash: await lwqlTenantCapability({ secret: project.lwqlKey }),
+          }
+        : { project, hash: undefined },
+    ),
+  );
+
+  for (const { project, hash } of derived) {
+    if (hash === undefined) {
       blankKeyProjectIds.push(project.id);
       continue;
     }
-    const hash = lwqlTenantCapability({ secret: project.lwqlKey });
     if (existingHashes.has(hash) || plannedHashes.has(hash)) continue;
     plannedHashes.add(hash);
     rowsToInsert.push({

--- a/platform/app/src/server/analytics/lwql/productionProvisioning.ts
+++ b/platform/app/src/server/analytics/lwql/productionProvisioning.ts
@@ -23,7 +23,7 @@
  * @see specs/analytics/lwql-api.feature
  */
 
-import { lwqlTenantCapability } from "./capability";
+import { CAPABILITY_PREFIX, lwqlTenantCapability } from "./capability";
 import { LWQL_VIEW_CATALOG } from "./catalog/lwqlViews";
 import type { LangWatchQLViewDefinition } from "./catalog/types";
 import { isPostgresResident } from "./catalog/types";
@@ -231,6 +231,17 @@ export function productionPostgresReaderGrantStatements({
   ];
 }
 
+/**
+ * Whether a stored key-map hash was written by the current derivation.
+ *
+ * The cost factor is in the stored value, so a row that does not carry this
+ * prefix was derived by an older generation of `lwqlTenantCapability` and no
+ * longer resolves for its tenant — it has to be re-derived, not trusted.
+ */
+export function isCurrentGenerationCapability(hash: string): boolean {
+  return hash.startsWith(CAPABILITY_PREFIX);
+}
+
 /** One project's key-map row candidate. */
 export interface LwqlKeyMapRow {
   KeyHash: string;
@@ -247,6 +258,17 @@ export interface LwqlKeyMapBackfillPlan {
    * log these loudly rather than skip them quietly.
    */
   blankKeyProjectIds: string[];
+  /**
+   * Project ids whose `lwqlKey` was present but could not be hashed — today
+   * that means a key over bcrypt's 72-byte limit, which the capability refuses
+   * rather than silently truncating.
+   *
+   * Reported per project for the same reason blanks are, and it is why this
+   * plan does not simply propagate the rejection: one unusable key must not
+   * cost every other project its row. Same consequence as a blank key for the
+   * project it names, so the caller logs it just as loudly.
+   */
+  unhashableProjectIds: string[];
 }
 
 /**
@@ -256,9 +278,13 @@ export interface LwqlKeyMapBackfillPlan {
  * capability.
  *
  * That derivation is a KDF (`../capability.ts`), which is why this is `async`
- * and why the hashes are derived up front rather than inside the loop — one
- * costs roughly 200ms, so a serial loop would put the whole backfill on the
- * critical path at 200ms a project.
+ * and why the hashes are derived in batches rather than one at a time. Be
+ * precise about what that buys: bcrypt's async `hash` occupies a libuv thread,
+ * and the pool is four threads by default, so concurrency divides the cost by
+ * about four — measured, 4 hashes take as long as 1, and 64 take sixteen times
+ * as long. It is a constant factor, not an amortisation. The backfill is still
+ * O(projects) in bcrypt time on every deploy, where it used to be
+ * microseconds; on a large deployment that is the cost to watch.
  *
  * Duplicate `(hash, tenant)` pairs are harmless at read time (row filters use
  * `HAVING uniqExact(TenantId) = 1`), but this still de-duplicates within one
@@ -268,42 +294,101 @@ export interface LwqlKeyMapBackfillPlan {
 export async function planLwqlKeyMapBackfill({
   projects,
   existingHashes,
+  tenantsHoldingCurrentCapability = new Set<string>(),
 }: {
   projects: readonly { id: string; lwqlKey: string }[];
   existingHashes: ReadonlySet<string>;
+  /**
+   * Tenants whose key-map row was already written by *this* generation of the
+   * derivation — see {@link CAPABILITY_PREFIX}. Their capability is not
+   * re-derived, which is what keeps a steady-state deploy free of bcrypt work
+   * entirely instead of paying it per project forever.
+   *
+   * Deliberately not "every tenant with any row": on the deploy that changes
+   * the derivation, every project holds a row from the previous generation and
+   * every one of them has to be re-derived. Matching on the current prefix is
+   * what makes this an optimisation rather than a way to skip the migration.
+   *
+   * The assumption it rests on is that a project's `lwqlKey` never changes
+   * after it is minted — it is `@unique @default(dbgenerated(...))` with no
+   * update path. If a rotation path is ever added it must write the key-map
+   * row itself, the way project creation does, because this backfill will no
+   * longer notice.
+   */
+  tenantsHoldingCurrentCapability?: ReadonlySet<string>;
 }): Promise<LwqlKeyMapBackfillPlan> {
   const rowsToInsert: LwqlKeyMapRow[] = [];
-  const blankKeyProjectIds: string[] = [];
+  const unhashableProjectIds: string[] = [];
   const plannedHashes = new Set<string>();
 
   // A blank key is reported, never hashed: the capability refuses an empty
   // secret, and this function's contract is to collect those projects rather
-  // than throw on the first one.
-  const derived = await Promise.all(
-    projects.map(async (project) =>
-      project.lwqlKey
-        ? {
+  // than throw on the first one. Partitioned before the fan-out so the blank
+  // case never has to be re-derived from a missing hash afterwards.
+  const keyed = projects.filter(
+    (project) =>
+      project.lwqlKey && !tenantsHoldingCurrentCapability.has(project.id),
+  );
+  const blankKeyProjectIds = projects
+    .filter((project) => !project.lwqlKey)
+    .map((project) => project.id);
+
+  // Batch by batch, awaited in turn: the concurrency bound only exists if the
+  // batches are sequential — mapping them all into one `Promise.all` would
+  // start every project at once and be exactly the fan-out it is meant to
+  // replace. Each project's refusal is caught rather than propagated, because
+  // `Promise.all` rejecting on the first one would fail the deploy, insert
+  // nothing for anybody, and never name the project at fault; collecting it
+  // keeps this function's documented contract for both refusals, not just for
+  // blanks.
+  for (const batch of chunk(keyed, CAPABILITY_DERIVATION_CONCURRENCY)) {
+    const derived = await Promise.all(
+      batch.map(async (project) => {
+        try {
+          return {
             project,
             hash: await lwqlTenantCapability({ secret: project.lwqlKey }),
-          }
-        : { project, hash: undefined },
-    ),
-  );
+          };
+        } catch {
+          return { project, hash: undefined };
+        }
+      }),
+    );
 
-  for (const { project, hash } of derived) {
-    if (hash === undefined) {
-      blankKeyProjectIds.push(project.id);
-      continue;
+    for (const { project, hash } of derived) {
+      if (hash === undefined) {
+        unhashableProjectIds.push(project.id);
+        continue;
+      }
+      if (existingHashes.has(hash) || plannedHashes.has(hash)) continue;
+      plannedHashes.add(hash);
+      rowsToInsert.push({
+        [KEY_MAP_COLUMNS.keyHash]: hash,
+        [KEY_MAP_COLUMNS.tenantId]: project.id,
+      });
     }
-    if (existingHashes.has(hash) || plannedHashes.has(hash)) continue;
-    plannedHashes.add(hash);
-    rowsToInsert.push({
-      [KEY_MAP_COLUMNS.keyHash]: hash,
-      [KEY_MAP_COLUMNS.tenantId]: project.id,
-    });
   }
 
-  return { rowsToInsert, blankKeyProjectIds };
+  return { rowsToInsert, blankKeyProjectIds, unhashableProjectIds };
+}
+
+/**
+ * How many capabilities are derived at once.
+ *
+ * bcrypt's async `hash` runs on the libuv thread pool, which is four threads
+ * unless `UV_THREADPOOL_SIZE` says otherwise, so mapping every project at once
+ * buys nothing past the fourth and starves the same pool that serves
+ * `dns.lookup` — which the ClickHouse and Postgres clients need mid-backfill.
+ * Deriving in bounded batches keeps the win and leaves the pool breathing.
+ */
+const CAPABILITY_DERIVATION_CONCURRENCY = 4;
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
 }
 
 /**

--- a/platform/app/src/server/analytics/lwql/provisioning.ts
+++ b/platform/app/src/server/analytics/lwql/provisioning.ts
@@ -604,8 +604,10 @@ export function lwqlPolicyCoverageQuery({
  * audit that compares those columns against the raw hash silently never
  * matches, and reads as "the hash was not recorded".
  *
- * Correct for the hex digests this model uses; a value containing a quote or a
- * backslash would additionally be escaped by the dump.
+ * Correct for the capabilities this model audits: bcrypt writes its digests in
+ * `$`, `.`, `/` and the alphanumerics, so none of them carries a quote or a
+ * backslash. A value that did would additionally be escaped by the dump, and
+ * this would have to escape it too.
  */
 export function auditedSettingValue(value: string): string {
   return `'${value}'`;

--- a/platform/app/src/server/app-layer/projects/project.service.ts
+++ b/platform/app/src/server/app-layer/projects/project.service.ts
@@ -313,7 +313,7 @@ export class ProjectService {
       // comment.
       const { database: sourceDatabase } = parseConnectionUrl();
       const row: LwqlKeyMapRow = {
-        KeyHash: lwqlTenantCapability({ secret: project.lwqlKey }),
+        KeyHash: await lwqlTenantCapability({ secret: project.lwqlKey }),
         TenantId: project.id,
       };
       if (!this.lwqlKeyMap) {

--- a/platform/app/src/tasks/provisionLwql.ts
+++ b/platform/app/src/tasks/provisionLwql.ts
@@ -24,6 +24,7 @@ import { createLogger } from "@langwatch/observability";
 import { lwqlConnectionFromEnv } from "../server/analytics/lwql/executor";
 import { LWQL_KEY_MAP_INSERT_SETTINGS } from "../server/analytics/lwql/lwqlKeyMap.repository";
 import {
+  isCurrentGenerationCapability,
   type LwqlKeyMapBackfillPlan,
   lwqlKeyMapTableQualifiedName,
   lwqlPostgresSchemaFromDatabaseUrl,
@@ -89,24 +90,41 @@ async function planBackfillFromCurrentState({
   // "every ClickHouse query MUST filter on TenantId" rule cannot apply to.
   // `qualified()` (via lwqlKeyMapTableQualifiedName) validates the
   // interpolated database and table identifiers.
+  // The tenant id comes back alongside the hash so the planner can tell a
+  // project that already holds a current-generation row from one that needs
+  // deriving. Without it every deploy re-derives every project's capability —
+  // a KDF per project on the pod's boot path, before the listener starts.
   const existingResult = await client.query({
-    query: `SELECT DISTINCT ${KEY_MAP_COLUMNS.keyHash} FROM ${table}`,
+    query: `SELECT DISTINCT ${KEY_MAP_COLUMNS.keyHash}, ${KEY_MAP_COLUMNS.tenantId} FROM ${table}`,
     format: "JSONEachRow",
   });
   const existingRows = (await existingResult.json()) as Array<
     Record<string, string>
   >;
   // `noUncheckedIndexedAccess` types the lookup as `string | undefined` even
-  // though every row genuinely carries this column (it is the only thing the
-  // query selects) — filtered, not defaulted, so a row that somehow lacked it
-  // is dropped rather than coerced into a bogus "" entry in the set.
+  // though every row genuinely carries these columns (they are the only thing
+  // the query selects) — filtered, not defaulted, so a row that somehow lacked
+  // one is dropped rather than coerced into a bogus "" entry in the set.
   const existingHashes = new Set(
     existingRows
       .map((row) => row[KEY_MAP_COLUMNS.keyHash])
       .filter((hash): hash is string => hash !== undefined),
   );
+  const tenantsHoldingCurrentCapability = new Set(
+    existingRows
+      .filter((row) => {
+        const hash = row[KEY_MAP_COLUMNS.keyHash];
+        return hash !== undefined && isCurrentGenerationCapability(hash);
+      })
+      .map((row) => row[KEY_MAP_COLUMNS.tenantId])
+      .filter((tenantId): tenantId is string => tenantId !== undefined),
+  );
 
-  return planLwqlKeyMapBackfill({ projects, existingHashes });
+  return planLwqlKeyMapBackfill({
+    projects,
+    existingHashes,
+    tenantsHoldingCurrentCapability,
+  });
 }
 
 async function backfillKeyMap({
@@ -134,6 +152,19 @@ async function backfillKeyMap({
         projectIds: plan.blankKeyProjectIds,
       },
       "lwql key-map backfill found projects with an empty lwqlKey — these projects cannot authenticate to LangWatchQL until their key is regenerated",
+    );
+  }
+
+  // Same consequence as a blank key — no key-map row, so no LangWatchQL access
+  // — and the same reason to be loud about it. Reported per project rather than
+  // aborting the run, so one unusable key never costs the rest their rows.
+  if (plan.unhashableProjectIds.length > 0) {
+    logger.error(
+      {
+        count: plan.unhashableProjectIds.length,
+        projectIds: plan.unhashableProjectIds,
+      },
+      "lwql key-map backfill could not derive a capability for these projects — their lwqlKey is unusable (over bcrypt's 72-byte limit) and they cannot authenticate to LangWatchQL until it is regenerated",
     );
   }
 

--- a/specs/analytics/lwql-api.feature
+++ b/specs/analytics/lwql-api.feature
@@ -160,6 +160,56 @@ Feature: LangWatchQL analytics SQL API — read-only native ClickHouse SQL over 
     Then the log entry carries the key hash
     And the raw API key appears nowhere in the log entry
 
+  # ---------------------------------------------------------------------------
+  # How the capability is derived from the project's secret. The capability IS
+  # the tenant's name in the key map, so anything that lets two projects derive
+  # the same one lets each read the other's rows — and anything that makes a
+  # project derive a capability the map does not hold reads as a tenant with no
+  # data rather than as a failure.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Two projects never derive the same tenant capability
+    Given two projects with different LangWatchQL secrets
+    When each project's tenant capability is derived
+    Then the two capabilities differ
+    And each verifies against only its own project's secret
+
+  @unit
+  Scenario: A project's tenant capability is the same every time it is derived
+    Given a project's LangWatchQL secret
+    When its tenant capability is derived more than once, in any order
+    Then every derivation returns the same capability
+    And the capability is a work-factored digest that never contains the raw secret
+
+  @unit
+  Scenario: A secret the derivation cannot represent is refused, never truncated
+    Given a project whose LangWatchQL secret is longer than the derivation reads
+    When its tenant capability is derived
+    Then the derivation is refused with an error naming the limit
+    And no capability is produced that a shorter secret could also produce
+
+  @unit
+  Scenario: An unset secret is refused rather than hashed
+    Given a caller that did not select the project's LangWatchQL secret
+    When it asks for that project's tenant capability
+    Then the derivation is refused
+    And no capability is produced that would match no key-map row and read as an empty tenant
+
+  @unit
+  Scenario: One project's unusable secret never costs the other projects their key-map rows
+    Given a set of projects of which one has a secret the derivation refuses
+    When the key-map backfill is planned for all of them
+    Then the plan reports the refused project by id
+    And the plan still contains a row for every other project
+
+  @unit
+  Scenario: A deploy re-derives only the projects whose key-map row is out of date
+    Given projects whose key-map rows were written by the current derivation
+    And a project whose only key-map row was written by a previous derivation
+    When the key-map backfill is planned
+    Then only the out-of-date project's capability is derived
+
   @integration
   Scenario: Revoking a key hash from the key map takes effect within the stated revocation bound
     Given the restricted identity carries tenant-a's valid key-hash context


### PR DESCRIPTION
## Why

CodeQL `js/insufficient-password-hash` on `lwql/capability.ts` — alert 281 on
this pull request's ref, 279 on `main`, and the check that is red on this
branch. It is the only open instance of that rule in the repository; every other
one is dismissed.

The first round of this PR widened the digest from SHA-256 to SHA-512 and argued
the rule was inapplicable: the value is a deterministic join key for the
ClickHouse key map, not password storage. That argument is still true, and
CodeQL is still unmoved — the rule wants a KDF, and digest width is not one. The
check stayed red.

Dismissing it was the other option, and it is worth saying why we are not
reaching for it a second time: this finding was already dismissed once, as alert
269, when the file lived at `server/analytics/governed-sql/capability.ts`.
Renaming the directory raised it again against the same code. A false positive
that comes back every time the file moves costs more over time than the fix, and
the fix turned out to be smaller than the rationale block defending it.

## What changed

`lwqlTenantCapability` derives the capability with bcrypt rather than a bare
digest, and is now `async`. The known-answer constants in the service unit test
and the tenant-isolation integration test move with it, and a new
`capability.unit.test.ts` pins the derivation and its two refusals.

The branch has also been brought level with `main`, which it was 323 commits
behind. That was not housekeeping: GitHub could not compute a merge ref for a
conflicting PR, so **none** of the `pull_request` workflows had run against any
commit here since 2026-08-21 — including the CodeQL job whose alert this PR
exists to clear. Merging main also surfaced three call sites written after this
branch was cut (the key-map backfill planner, the per-project key-map sync, and
the `/api/v1/query` tests), each of which had to be awaited; left synchronous
they would have written a `Promise` into the `KeyHash` column.

## How it works

Two properties normally make a password KDF unusable as a lookup key. Both are
dealt with here rather than argued away.

**A per-call random salt would make every lookup miss.** The key map is an
equality join on `KeyHash` — the restricted identity cannot run
`bcrypt.compare`, it can only match the setting it was handed against a row. So
the salt is derived from the secret with HKDF rather than drawn from the RNG,
which keeps `lwqlTenantCapability` a pure function of its input while still
giving every project a distinct salt.

Deriving a salt from the secret is the wrong move for a human-chosen password,
because it hands a precomputation attack the one thing a salt exists to deny it.
It is the right move for a database-minted secret, where there is no dictionary
to precompute against and the salt's remaining job is to keep two projects'
digests unrelated.

**The work factor would otherwise be paid per query** — roughly 200ms per hash
at cost 10, measured. It is paid per *project*, once per process: the derivation
is memoised under a one-way derivation of the secret, so nothing in the cache can
be turned back into a credential. The cache holds the in-flight hash rather than
the finished digest, so the several queries a dashboard opens at once share one
cold derivation instead of each starting its own — bcrypt runs on the libuv
thread pool, which is four threads, and four copies of one derivation would
occupy all of it. The hash is awaited off the event loop rather than run through
`hashSync`; a 200ms synchronous hash on a shared API process stalls every other
in-flight request.

**What the work factor does not buy, stated plainly.** The first 29 characters of
every capability are the salt, and the salt is `HKDF-SHA256(secret)` — so anyone
holding a capability can test a candidate secret with two HMACs rather than a
cost-10 bcrypt. Against a guessable secret that would matter. bcrypt is here
because a hash of a secret should be a KDF, not because it makes this digest
expensive to attack; what makes guessing hopeless is that `lwqlKey` is a
database-minted UUID with no dictionary behind it. Closing the gap properly means
mixing in a value that never leaves the control plane — a pepper, or a salt
derived from the project id instead of the secret — and either is a
re-provisioning of the key map, so it is a decision rather than a tidy-up. Worth
noting this is strictly better than `main`, where the stored value was
`sha256(secret)` and a guess cost one hash.

None of this is what makes the digest safe to hold, and the work factor should
not be mistaken for the control. What keeps it safe is unchanged: it is useless
without a session only the control plane can open — the restricted identity
cannot read `system.*`, and the validator refuses a `SETTINGS` clause.

**bcrypt truncates at 72 bytes**, which a fast digest never did. Two secrets
sharing a 72-byte prefix derive the *same* capability, and two projects holding
one capability read each other's rows — the one failure this module exists to
prevent. `lwqlKey` is far shorter than that today, which is exactly why the
refusal is in the code rather than in the reader's memory. Confirmed rather than
assumed: bcrypt over `"A".repeat(72)` and `"A".repeat(73)` returns the same
digest.

## When the derivation refuses

It refuses two things — an unset secret and one past bcrypt's 72 bytes — and
both are plain `Error`s, because neither is anything a caller did and nothing
they do fixes it (ADR-045). Awaited inline on the query path, though, a plain
`Error` reaches the boundary as a generic unknown failure plus a trace id, for a
condition we can name exactly: the project does not resolve to a tenant, so
there is no identity to run its SQL as. That is the same condition as a missing
restricted identity, so it gets the same answer — `lwql_unavailable`, 503,
`platform` fault — with the original kept as a `reason` so the log line still
says which of the two refusals fired.

Not solved with a `CHECK (octet_length(lwqlKey) BETWEEN 1 AND 72)`: the column
is database-generated with no update path, so there are no invalid rows to
backfill, and a constraint would move the failure to insert time on a value the
application never chooses. The guard belongs in the derivation, where it fires
for every caller however the value got there.

## Why one tenant can never hold another's capability

The capability *is* the tenant's name in the key map, so "two projects derive
the same one" is the failure that matters, not a performance note. Five paths
could produce it, and each is closed by something checkable rather than by
argument:

| Path | What closes it |
| --- | --- |
| Two projects presenting the same input | `Project.lwqlKey` is `@unique` in Postgres, database-generated |
| Two inputs deriving one digest | Distinct secrets give distinct HKDF salts *and* distinct digests; asserted with bcrypt's own verifier, not by re-running our derivation |
| bcrypt truncating the input | Refused past 72 bytes. Confirmed 72 and 73 collide, 71 and 72 do not, and a NUL byte does **not** truncate — so 72 is the only boundary |
| The process-wide cache serving the wrong entry | Full-width 32-byte key, and a hit is accepted only when its stored salt matches the one derived from the presented secret. Proved by forcing a cache-key collision, not argued: `capability-cache.unit.test.ts` stubs the key derivation so two projects collide, and asserts the second is still handed only its own capability. Dropping the salt check makes that test fail with the two capabilities identical |
| The capability leaking into a log or an error | Nothing logs it; `queryRestServiceProofs.integration.test.ts` already asserts it never reaches a caller, volunteered or asked for |

The cache is the one that needed fixing rather than documenting. Keying it by
the derived salt put a cross-tenant read behind a 128-bit birthday bound,
because bcrypt fixes the salt at 16 bytes. The key is now its own 32-byte
derivation under a separate `info`, and the salt check downgrades any mistaken
hit from "another tenant's rows" to "one wasted hash".

## Test plan

- `pnpm test:unit run src/server/analytics/lwql/ src/server/app-layer/projects/ src/tasks/` — 534 pass across 31 files.
- The cache tests were checked by mutation, because a test that cannot fail is worse than no test: deleting the cache leaves the derivation tests green and fails the new ones, and dropping the salt check fails them with one project holding another's capability.
- `pnpm check:feature-parity` — `specs/analytics/lwql-api.feature` is 102/102 bound, including six new scenarios for the derivation's refusals and the backfill's contract. Tagged and annotated, so they enforce rather than describe.
- `pnpm typecheck` — clean. That is what proves no call site was left synchronous: a missed `await` is a `Promise<string>` where a `string` belongs.
- The new known-answer constants were computed in a separate process from the
  one asserting them, which is what makes them a determinism check and not a
  value echoed back at itself.
- The harness's tenant fixtures were loaded under vitest and observed to resolve
  to the digests `tenantIsolation.integration.test.ts` asserts — the integration
  lane itself needs ClickHouse and runs in CI.

## Anything surprising?

**This is a breaking change for any already-provisioned key map, and main has
raised the stakes since this branch was cut.** The digest is the contract
between this function and whatever populates the ClickHouse key map; rows
provisioned with the old digest stop resolving the moment this deploys, and
every LangWatchQL read for those tenants returns an auth refusal.

When this branch was written there was no production writer of those rows.
There is now — `productionProvisioning.ts` and `project.service.ts` arrived in
#7194, and this branch has been brought level with main to pick them up. So the
re-provisioning is a real, runnable step rather than a hand-edit: the backfill
in `tasks/provisionLwql.ts` diffs every project's capability against the table
and inserts what is missing, so running it after deploy repopulates the map with
the new digests. **The stale rows are not removed by it** — the backfill only
inserts — so the old ones linger until something deletes them. They match
nothing and grant nothing, but they are worth cleaning up.

One cost worth stating plainly, because it lands on the boot path: that backfill
runs in `start:prepare:db`, before the pod starts listening and inside the
startup probe's 300s budget. Deriving a bcrypt digest for every project on every
deploy would be minutes of boot latency at any real size, and at enough projects
the probe kills the container mid-backfill and it never converges. So the
backfill re-derives only the projects whose key-map row was not written by the
current derivation — it can tell, because the cost factor is in the stored value.
The deploy that lands this change still pays it for every project, once; every
deploy after it derives nothing. The fan-out is bounded to four at a time and
sequential between batches, because that is the size of the libuv pool it shares
with `dns.lookup` for the ClickHouse and Postgres clients running alongside it.

A project whose key cannot be hashed is collected and reported by id rather than
throwing, the way a blank key already was. Left as `Promise.all`, one unusable
key would have failed the deploy, inserted nothing for anybody, and named no
project.

The cost factor is part of the wire format — raising it later is another
re-provisioning, not a config tweak. The `$2b$10$` prefix in the stored digest
is what makes the current factor readable off the data.

`capability.unit.test.ts` costs about four bcrypt hashes, so it is a second or
two slower than a normal unit test file. That is the work factor doing its job
rather than something to tune away.
