### PR TITLE
perf(dev): run whole-repo checks in their smallest shape on a pressured machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,10 +210,22 @@ and is otherwise transparent (same stdio, same exit code). Queued, it says so on
 stderr, which is what tells you a slow run was waiting rather than hung.
 `CHECK_SLOTS=N` overrides the limit and `CHECK_SLOTS=0` turns the queue off;
 unset, the limit comes from the machine (one per 6 GiB of RAM, capped at one per
-4 cores) and CI does not queue at all. `node dev/scripts/check-queue.mjs
---explain` shows the limit and who currently holds a slot. Don't cap the tools'
+4 cores) and CI does not queue at all. **A machine under memory pressure runs
+checks in their smallest shape**: when swap or the compressor is filling
+(ADR-090 thresholds), the queue narrows the derived limit to one run, drops
+`GOMEMLIMIT` to its 3 GiB floor and halves `GOMAXPROCS`, so the check pays for
+the shortage in its own GC time instead of everything else paying in swap
+(`CHECK_PRESSURE=green|amber|red` forces the level; explicit `GOMEMLIMIT` /
+`GOMAXPROCS` / `CHECK_SLOTS` still win). `node dev/scripts/check-queue.mjs
+--explain` shows the limit, the pressure level and who currently holds a slot.
+Don't cap the tools'
 own threads instead (`RAYON_NUM_THREADS` does work on biome): it spends the same
 CPU over 5x the wall clock. See `specs/setup/check-slots.feature`.
+**A check that dies with exit 137 was killed from outside** — an operator kill
+or macOS reclaiming memory — never by the queue, which kills nothing and now
+says so on stderr when it happens. Re-run the same command through the queue;
+never react with `CHECK_SLOTS=0`, which removes the serialization for every
+worktree and agent on the machine.
 
 **Going around the scripts does not go around the queue.** `platform/app`'s
 `node_modules/.bin/{tsc,tsgo,biome}` are shims installed by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,13 +216,14 @@ checks in their smallest shape**: when swap or the compressor is filling
 `GOMEMLIMIT` to its 3 GiB floor and halves `GOMAXPROCS`, so the check pays for
 the shortage in its own GC time instead of everything else paying in swap
 (`CHECK_PRESSURE=green|amber|red` forces the level; explicit `GOMEMLIMIT` /
-`GOMAXPROCS` / `CHECK_SLOTS` still win). `node dev/scripts/check-queue.mjs
+`GOMAXPROCS` / `CHECK_SLOTS` still win). CI reads green by rule, so it keeps
+the ceiling and the parallelism it had before. `node dev/scripts/check-queue.mjs
 --explain` shows the limit, the pressure level and who currently holds a slot.
 Don't cap the tools'
 own threads instead (`RAYON_NUM_THREADS` does work on biome): it spends the same
 CPU over 5x the wall clock. See `specs/setup/check-slots.feature`.
-**A check that dies with exit 137 was killed from outside** — an operator kill
-or macOS reclaiming memory — never by the queue, which kills nothing and now
+**A check that dies with exit 137 was killed from outside**, by an operator or
+by macOS reclaiming memory, never by the queue, which kills nothing and now
 says so on stderr when it happens. Re-run the same command through the queue;
 never react with `CHECK_SLOTS=0`, which removes the serialization for every
 worktree and agent on the machine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,26 +210,10 @@ and is otherwise transparent (same stdio, same exit code). Queued, it says so on
 stderr, which is what tells you a slow run was waiting rather than hung.
 `CHECK_SLOTS=N` overrides the limit and `CHECK_SLOTS=0` turns the queue off;
 unset, the limit comes from the machine (one per 6 GiB of RAM, capped at one per
-4 cores) and CI does not queue at all. **A machine under memory pressure runs
-checks in their smallest shape**: when swap or the compressor is filling
-(ADR-090 thresholds), the queue narrows the derived limit to one run, drops
-`GOMEMLIMIT` to its 3 GiB floor and halves `GOMAXPROCS`, so the check pays for
-the shortage in its own GC time instead of everything else paying in swap
-(`CHECK_PRESSURE=green|amber|red` forces the level; explicit `GOMEMLIMIT` /
-`GOMAXPROCS` / `CHECK_SLOTS` still win). With no forced level, CI reads green
-by rule, so it keeps the ceiling and the parallelism it had before.
-`node dev/scripts/check-queue.mjs
---explain` shows the limit, the pressure level and who currently holds a slot.
-Don't cap the tools'
+4 cores) and CI does not queue at all. `node dev/scripts/check-queue.mjs
+--explain` shows the limit and who currently holds a slot. Don't cap the tools'
 own threads instead (`RAYON_NUM_THREADS` does work on biome): it spends the same
 CPU over 5x the wall clock. See `specs/setup/check-slots.feature`.
-**When the queue reports that a check was killed from outside, believe it**: by
-an operator or by macOS reclaiming memory, never by the queue, which kills
-nothing and says so on stderr at the moment it happens. Exit 137 on its own
-proves less, since your own Ctrl-C ends a run the same way, and the queue stays
-quiet about a signal it forwarded. Re-run the same command through the queue;
-never react with `CHECK_SLOTS=0`, which removes the serialization for every
-worktree and agent on the machine.
 
 **Going around the scripts does not go around the queue.** `platform/app`'s
 `node_modules/.bin/{tsc,tsgo,biome}` are shims installed by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,15 +216,18 @@ checks in their smallest shape**: when swap or the compressor is filling
 `GOMEMLIMIT` to its 3 GiB floor and halves `GOMAXPROCS`, so the check pays for
 the shortage in its own GC time instead of everything else paying in swap
 (`CHECK_PRESSURE=green|amber|red` forces the level; explicit `GOMEMLIMIT` /
-`GOMAXPROCS` / `CHECK_SLOTS` still win). CI reads green by rule, so it keeps
-the ceiling and the parallelism it had before. `node dev/scripts/check-queue.mjs
+`GOMAXPROCS` / `CHECK_SLOTS` still win). With no forced level, CI reads green
+by rule, so it keeps the ceiling and the parallelism it had before.
+`node dev/scripts/check-queue.mjs
 --explain` shows the limit, the pressure level and who currently holds a slot.
 Don't cap the tools'
 own threads instead (`RAYON_NUM_THREADS` does work on biome): it spends the same
 CPU over 5x the wall clock. See `specs/setup/check-slots.feature`.
-**A check that dies with exit 137 was killed from outside**, by an operator or
-by macOS reclaiming memory, never by the queue, which kills nothing and now
-says so on stderr when it happens. Re-run the same command through the queue;
+**When the queue reports that a check was killed from outside, believe it**: by
+an operator or by macOS reclaiming memory, never by the queue, which kills
+nothing and says so on stderr at the moment it happens. Exit 137 on its own
+proves less, since your own Ctrl-C ends a run the same way, and the queue stays
+quiet about a signal it forwarded. Re-run the same command through the queue;
 never react with `CHECK_SLOTS=0`, which removes the serialization for every
 worktree and agent on the machine.
 

--- a/dev/docs/adr/100-the-typecheck-memory-ceiling.md
+++ b/dev/docs/adr/100-the-typecheck-memory-ceiling.md
@@ -102,21 +102,47 @@ Explicit `GOMEMLIMIT`, `GOMAXPROCS` and `CHECK_SLOTS` still win, and
 operator who knows better). A machine the queue cannot read is green: a
 governor that cannot see must not throttle.
 
-CI reads green by rule, before any measurement. The queue already stands down
-there, and the same reasoning retires the pressure policy with it: a runner runs
-one job, nobody is typing on it, so buying back an interactive machine buys
-nothing and only makes the job slower. A swap figure read inside a container
-also describes the host rather than the job. The rule is what makes "CI is
-unaffected" true, instead of true by accident of the runner's kernel. An
-explicit `CHECK_PRESSURE` still wins there, for a CI test that needs a level.
+With no forced level, CI reads green by rule, before any measurement. An
+explicit `CHECK_PRESSURE` is read first and still wins there, for a CI test that
+needs a level. Otherwise the queue already stands down on a runner, and the same
+reasoning retires the pressure policy with it: a runner runs one job, nobody is
+typing on it, so buying back an interactive machine buys nothing and only makes
+the job slower. A swap figure read inside a container also describes the host
+rather than the job. The rule is what makes "CI is unaffected" true, instead of
+true by accident of the runner's kernel.
 
-Validated on the same machine at red: the pressured shape (3 GiB, 5 procs)
-completed the same cold typecheck with the numbers recorded in the PR that
-landed this amendment. There is no swap-only-the-check mechanism to reach for
-instead: macOS offers no per-process swap steering, and `taskpolicy -b`
-(background QoS) was measured starving a typecheck to 0.3 to 4% CPU for eight
-minutes on a pressured machine, because background priority deprioritizes the
-page-ins it needs to make progress at all.
+What was measured, on the 18 GiB / 11-core machine described above, so a later
+reader does not have to trust a PR link:
+
+| | uncapped, red machine | pressured shape |
+|---|---|---|
+| `GOMEMLIMIT` | 6 GiB (the clamp) | 3 GiB (the floor) |
+| `GOMAXPROCS` | unset, 11 cores | 5 |
+| peak footprint | 7.26 GB | not comparable, see below |
+| max RSS | 1.9 GB | about 1 to 2 GB |
+| wall / user / system | 331 s / 80 s / 162 s | not established |
+| peak CPU | ~2.8 of 11 cores | not sampled |
+
+The pressured column is thinner on purpose. `--explain` resolved
+`pressure=red gomemlimit=3GiB gomaxprocs=5`, and this PR's own `typecheck:tests`
+ran to a clean exit inside that shape, but a matched **cold** run was stopped by
+hand when swap reached 15.6 of 16.4 GB, two days after a swap-exhaustion kernel
+panic on the same machine. So the ceiling and the parallelism are confirmed to
+apply, and the wall-clock cost of applying them is not. Reproduce with:
+
+```bash
+/bin/rm -f platform/app/node_modules/.cache/tsbuildinfo/tsgo-app.tsbuildinfo
+/usr/bin/time -l node dev/scripts/check-queue.mjs \
+  ./platform/app/node_modules/.bin/tsc.real --noEmit -p platform/app/tsconfig.tsgo.json
+```
+
+with `CHECK_PRESSURE` set to `green` and then `red` for the two columns.
+
+There is no swap-only-the-check mechanism to reach for instead: macOS offers no
+per-process swap steering, and `taskpolicy -b` (background QoS) was measured
+starving a typecheck to 0.3 to 4% CPU for eight minutes on a pressured machine,
+because background priority deprioritizes the page-ins it needs to make progress
+at all.
 
 ## References
 

--- a/dev/docs/adr/100-the-typecheck-memory-ceiling.md
+++ b/dev/docs/adr/100-the-typecheck-memory-ceiling.md
@@ -71,16 +71,16 @@ the change reaches developers on their next reinstall rather than immediately.
 ## Amendment: pressure mode (2026-08-19)
 
 The clamp above still assumes an otherwise idle machine. Measured on the same
-18 GiB laptop while it was **not** idle — swap 89% full, compressor holding
+18 GiB laptop while it was **not** idle (swap 89% full, compressor holding
 42 GB compressed into 7.7 GB of RAM, `kern.memorystatus_vm_pressure_level` at
-warning — an uncapped cold typecheck footprinted **7.26 GB** peak with a max
+warning), an uncapped cold typecheck footprinted **7.26 GB** peak with a max
 RSS of only 1.9 GB: most of its pages were compressed or swapped in the same
 breath they were allocated, which is the eviction storm the person at the
 keyboard feels. The time split says the same thing: 331 s wall, **80 s user
-against 162 s system** — twice as much kernel time (paging) as compiling. CPU
+against 162 s system**, twice as much kernel time (paging) as compiling. CPU
 never exceeded ~2.8 of 11 cores, so on a pressured machine the constraint is
-memory, and killing the run by hand — which is what people do, and what reads
-back as a mystery exit 137 — was rational.
+memory, and killing the run by hand was rational. That is what people do, and
+it is what reads back afterwards as a mystery exit 137.
 
 So the queue now reads the machine's pressure level (ADR-090's
 `ClassifyPressure`: swap fill or compressor occupancy, either alone) at spawn,
@@ -89,8 +89,8 @@ and under amber or red runs every check in its smallest shape:
 - `GOMEMLIMIT` resolves to the **floor (3 GiB)** outright. The ceiling is
   garbage the runtime has not collected because it was told there was room;
   under pressure there is no room, and every granted gigabyte evicts someone
-  else's pages. The floor trades that for the run's own GC time — the check
-  pays, not the machine.
+  else's pages. The floor trades that for the run's own GC time, so the check
+  pays for the shortage instead of the machine.
 - `GOMAXPROCS` is halved (never below two). Eleven runnable threads all
   taking page faults is what a seized machine feels like; half of them buys
   back interactivity for a modest wall cost.
@@ -100,14 +100,21 @@ and under amber or red runs every check in its smallest shape:
 Explicit `GOMEMLIMIT`, `GOMAXPROCS` and `CHECK_SLOTS` still win, and
 `CHECK_PRESSURE=green|amber|red` forces the level (for tests, and for an
 operator who knows better). A machine the queue cannot read is green: a
-governor that cannot see must not throttle. CI is unaffected — it does not
-queue, and its runners are not pressured.
+governor that cannot see must not throttle.
+
+CI reads green by rule, before any measurement. The queue already stands down
+there, and the same reasoning retires the pressure policy with it: a runner runs
+one job, nobody is typing on it, so buying back an interactive machine buys
+nothing and only makes the job slower. A swap figure read inside a container
+also describes the host rather than the job. The rule is what makes "CI is
+unaffected" true, instead of true by accident of the runner's kernel. An
+explicit `CHECK_PRESSURE` still wins there, for a CI test that needs a level.
 
 Validated on the same machine at red: the pressured shape (3 GiB, 5 procs)
 completed the same cold typecheck with the numbers recorded in the PR that
 landed this amendment. There is no swap-only-the-check mechanism to reach for
 instead: macOS offers no per-process swap steering, and `taskpolicy -b`
-(background QoS) was measured starving a typecheck to 0.3–4% CPU for eight
+(background QoS) was measured starving a typecheck to 0.3 to 4% CPU for eight
 minutes on a pressured machine, because background priority deprioritizes the
 page-ins it needs to make progress at all.
 

--- a/dev/docs/adr/100-the-typecheck-memory-ceiling.md
+++ b/dev/docs/adr/100-the-typecheck-memory-ceiling.md
@@ -68,10 +68,55 @@ above has no wall-clock column.
 A locally built haven binary keeps the old clamp until `make haven install`, so
 the change reaches developers on their next reinstall rather than immediately.
 
+## Amendment: pressure mode (2026-08-19)
+
+The clamp above still assumes an otherwise idle machine. Measured on the same
+18 GiB laptop while it was **not** idle — swap 89% full, compressor holding
+42 GB compressed into 7.7 GB of RAM, `kern.memorystatus_vm_pressure_level` at
+warning — an uncapped cold typecheck footprinted **7.26 GB** peak with a max
+RSS of only 1.9 GB: most of its pages were compressed or swapped in the same
+breath they were allocated, which is the eviction storm the person at the
+keyboard feels. The time split says the same thing: 331 s wall, **80 s user
+against 162 s system** — twice as much kernel time (paging) as compiling. CPU
+never exceeded ~2.8 of 11 cores, so on a pressured machine the constraint is
+memory, and killing the run by hand — which is what people do, and what reads
+back as a mystery exit 137 — was rational.
+
+So the queue now reads the machine's pressure level (ADR-090's
+`ClassifyPressure`: swap fill or compressor occupancy, either alone) at spawn,
+and under amber or red runs every check in its smallest shape:
+
+- `GOMEMLIMIT` resolves to the **floor (3 GiB)** outright. The ceiling is
+  garbage the runtime has not collected because it was told there was room;
+  under pressure there is no room, and every granted gigabyte evicts someone
+  else's pages. The floor trades that for the run's own GC time — the check
+  pays, not the machine.
+- `GOMAXPROCS` is halved (never below two). Eleven runnable threads all
+  taking page faults is what a seized machine feels like; half of them buys
+  back interactivity for a modest wall cost.
+- The machine-derived slot limit narrows to **one**. The formula's per-run
+  budget assumes RAM that a pressured machine does not have.
+
+Explicit `GOMEMLIMIT`, `GOMAXPROCS` and `CHECK_SLOTS` still win, and
+`CHECK_PRESSURE=green|amber|red` forces the level (for tests, and for an
+operator who knows better). A machine the queue cannot read is green: a
+governor that cannot see must not throttle. CI is unaffected — it does not
+queue, and its runners are not pressured.
+
+Validated on the same machine at red: the pressured shape (3 GiB, 5 procs)
+completed the same cold typecheck with the numbers recorded in the PR that
+landed this amendment. There is no swap-only-the-check mechanism to reach for
+instead: macOS offers no per-process swap steering, and `taskpolicy -b`
+(background QoS) was measured starving a typecheck to 0.3–4% CPU for eight
+minutes on a pressured machine, because background priority deprioritizes the
+page-ins it needs to make progress at all.
+
 ## References
 
-- Related ADRs: [ADR-095](095-haven-tsgo-governor.md) (the governor whose
-  `GOMEMLIMIT` policy this amends), [ADR-099](099-typescript-7-is-the-compiler.md)
+- Related ADRs: [ADR-090](090-haven-pressure-governor.md) (the pressure levels
+  and thresholds this reuses), [ADR-095](095-haven-tsgo-governor.md) (the
+  governor whose `GOMEMLIMIT` policy this amends),
+  [ADR-099](099-typescript-7-is-the-compiler.md)
   (the compiler move this was found alongside)
 - Specs: `specs/setup/check-slots.feature`,
   `specs/setup/haven-tsgo-governor.feature`

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -76,6 +76,17 @@ const stderr = (line) => process.stderr.write(line);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * The CI convention: the variable is set to something that is not one of the
+ * values meaning "not CI". The slot limit and the pressure policy both ask
+ * this, so they ask it in one place and cannot drift apart. Mirrors
+ * isTruthyCI in tools/thuishaven/domain/checkslots.go.
+ */
+function isTruthyCI(ci) {
+  const value = (ci ?? "").trim().toLowerCase();
+  return value !== "" && value !== "0" && value !== "false";
+}
+
+/**
  * How much trouble the machine is in: "green", "amber" or "red". A mirror of
  * domain/pressure.go in tools/thuishaven, which is the source of truth for the
  * thresholds (ADR-090): swap above 40% is amber and above 75% red, compressor
@@ -86,12 +97,19 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  * A machine this cannot read is green: a governor that cannot see must not
  * throttle. Only darwin is measured, because the thrash this exists to stop is
  * the compressor-and-swap spiral of a memory-oversubscribed Mac.
+ *
+ * CI is green whatever the machine says. The queue already stands down there,
+ * and the same reasoning retires the pressure policy with it: a runner runs one
+ * job and nobody is typing on it, so halving its cores buys back an interactive
+ * machine that does not exist and only makes the job slower. This is what makes
+ * "CI is unaffected" true rather than a side effect of the runner's kernel.
  */
 function resolvePressure(env) {
   const forced = (env.CHECK_PRESSURE ?? "").trim().toLowerCase();
   if (forced === "green" || forced === "amber" || forced === "red") {
     return forced;
   }
+  if (isTruthyCI(env.CI)) return "green";
   if (process.platform !== "darwin") return "green";
 
   const probe = (command, args) => {
@@ -103,7 +121,7 @@ function resolvePressure(env) {
     }
   };
 
-  // "total = 11264.00M  used = 10096.94M  free = ..." — used over total.
+  // "total = 11264.00M  used = 10096.94M  free = ...", used over total.
   let swapFraction = 0;
   const swap = probe("sysctl", ["-n", "vm.swapusage"]);
   const total = /total = ([\d.]+)([MG])/.exec(swap);
@@ -115,7 +133,7 @@ function resolvePressure(env) {
   }
 
   // The page size is in the header (16384 on Apple silicon, 4096 on Intel) and
-  // the line is "Pages occupied by compressor", not "stored in" — the stored
+  // the line is "Pages occupied by compressor", not "stored in": the stored
   // figure is several times larger and reading it would cry red on a healthy
   // machine. Both traps are documented at the Go mirror.
   let compFraction = 0;
@@ -165,8 +183,7 @@ function resolveSlots(env, pressure = "green") {
     }
   }
 
-  const ci = (env.CI ?? "").trim().toLowerCase();
-  if (ci !== "" && ci !== "0" && ci !== "false") {
+  if (isTruthyCI(env.CI)) {
     return { slots: 0, source: "CI" };
   }
 
@@ -524,10 +541,14 @@ function runCommand(commandArgv, pressure = "green") {
     // Handling these keeps the wrapper alive through a Ctrl-C so it releases its
     // slot after the child is done, instead of dying first and leaving an entry
     // for the next run to prune.
-    let forwarded = false;
+    // Which signals were forwarded, not merely whether any was. A run that is
+    // interrupted and then killed by the OS dies of a signal nobody forwarded,
+    // and that is the death worth naming; a flag would have suppressed it
+    // because an earlier SIGINT set it.
+    const forwarded = new Set();
     const handlers = ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => {
       const handler = () => {
-        forwarded = true;
+        forwarded.add(signal);
         try {
           child.kill(signal);
         } catch {
@@ -552,7 +573,7 @@ function runCommand(commandArgv, pressure = "green") {
       // line the run ends in a bare exit 137, which reads as "the queue killed
       // it" and teaches people (and agents) to bypass the queue with
       // CHECK_SLOTS=0, removing the serialization for the whole machine.
-      if (signal && !forwarded) {
+      if (signal && !forwarded.has(signal)) {
         stderr(
           `${PREFIX} ${commandArgv[0]} was killed from outside by ${signal}. ` +
             `The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. ` +

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -24,6 +24,13 @@
  *                            disables the queue entirely. Unset derives a limit
  *                            from the machine, and is off under CI, where one
  *                            job runs one check.
+ *   CHECK_PRESSURE=<level>   Forces the memory-pressure level (green, amber or
+ *                            red) instead of measuring it. Unset measures; a
+ *                            misspelling measures too. Under amber or red the
+ *                            derived limit narrows to one run, GOMEMLIMIT
+ *                            drops to its floor and GOMAXPROCS is halved, so
+ *                            the check pays for the shortage instead of
+ *                            everything else on the machine.
  *   CHECK_QUEUE_DIR=<path>   Where the shared state lives.
  *   CHECK_QUEUE_POLL_MS=N    How often a waiter re-checks (default 500).
  *   CHECK_QUEUE_HEARTBEAT_MS How often a waiting run repeats itself so it never
@@ -41,7 +48,7 @@
  * CHECK_SLOTS=0 to the run it spawns, so a run is never counted twice.
  */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -69,6 +76,64 @@ const stderr = (line) => process.stderr.write(line);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * How much trouble the machine is in: "green", "amber" or "red". A mirror of
+ * domain/pressure.go in tools/thuishaven, which is the source of truth for the
+ * thresholds (ADR-090): swap above 40% is amber and above 75% red, compressor
+ * occupancy above 10% of RAM is amber and above 20% red, and either signal
+ * alone can raise the level. CHECK_PRESSURE forces a level the same way for an
+ * operator and for the tests; a misspelling measures, like a CHECK_SLOTS typo.
+ *
+ * A machine this cannot read is green: a governor that cannot see must not
+ * throttle. Only darwin is measured, because the thrash this exists to stop is
+ * the compressor-and-swap spiral of a memory-oversubscribed Mac.
+ */
+function resolvePressure(env) {
+  const forced = (env.CHECK_PRESSURE ?? "").trim().toLowerCase();
+  if (forced === "green" || forced === "amber" || forced === "red") {
+    return forced;
+  }
+  if (process.platform !== "darwin") return "green";
+
+  const probe = (command, args) => {
+    try {
+      const result = spawnSync(command, args, { encoding: "utf8", timeout: 2000 });
+      return result.status === 0 ? (result.stdout ?? "") : "";
+    } catch {
+      return "";
+    }
+  };
+
+  // "total = 11264.00M  used = 10096.94M  free = ..." — used over total.
+  let swapFraction = 0;
+  const swap = probe("sysctl", ["-n", "vm.swapusage"]);
+  const total = /total = ([\d.]+)([MG])/.exec(swap);
+  const used = /used = ([\d.]+)([MG])/.exec(swap);
+  const inBytes = (m) =>
+    Number.parseFloat(m[1]) * (m[2] === "G" ? 2 ** 30 : 2 ** 20);
+  if (total && used && inBytes(total) > 0) {
+    swapFraction = inBytes(used) / inBytes(total);
+  }
+
+  // The page size is in the header (16384 on Apple silicon, 4096 on Intel) and
+  // the line is "Pages occupied by compressor", not "stored in" — the stored
+  // figure is several times larger and reading it would cry red on a healthy
+  // machine. Both traps are documented at the Go mirror.
+  let compFraction = 0;
+  const vmstat = probe("vm_stat", []);
+  const pageSize = /page size of (\d+) bytes/.exec(vmstat);
+  const occupied = /Pages occupied by compressor:\s+(\d+)/.exec(vmstat);
+  if (pageSize && occupied && os.totalmem() > 0) {
+    compFraction =
+      (Number.parseInt(occupied[1], 10) * Number.parseInt(pageSize[1], 10)) /
+      os.totalmem();
+  }
+
+  if (swapFraction > 0.75 || compFraction > 0.2) return "red";
+  if (swapFraction > 0.4 || compFraction > 0.1) return "amber";
+  return "green";
+}
+
+/**
  * Resolves how many checks may proceed at once.
  *
  * An explicit CHECK_SLOTS always wins, including under CI, which is what lets
@@ -77,8 +142,14 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  * machine gets a limit bounded by both memory and cores: tsgo is memory-hungry
  * AND parallel, so the tighter of the two bounds is the honest one. Never below
  * 1, or the queue would deadlock every run.
+ *
+ * A machine already under memory pressure gets one slot, whatever the formula
+ * says. The formula assumes an otherwise idle machine, and pressure is the
+ * machine reporting that assumption false: its RAM is spoken for, so a second
+ * concurrent check is paid for in everyone's swap. Only the derived default
+ * narrows; an explicit CHECK_SLOTS is the operator's call either way.
  */
-function resolveSlots(env) {
+function resolveSlots(env, pressure = "green") {
   const raw = (env.CHECK_SLOTS ?? "").trim();
   if (raw !== "") {
     if (/^(off|none|unlimited|false)$/i.test(raw)) {
@@ -97,6 +168,10 @@ function resolveSlots(env) {
   const ci = (env.CI ?? "").trim().toLowerCase();
   if (ci !== "" && ci !== "0" && ci !== "false") {
     return { slots: 0, source: "CI" };
+  }
+
+  if (pressure !== "green") {
+    return { slots: 1, source: "pressure" };
   }
 
   const byMemory = Math.floor(os.totalmem() / RAM_BUDGET_BYTES);
@@ -399,28 +474,60 @@ function delegateToHaven(commandArgv, env) {
  * Kept in step with domain.CheckGoMemLimit in tools/thuishaven, which is what
  * actually runs on a machine with haven installed. This is the fallback.
  */
-function goMemLimit() {
+function goMemLimit(pressure = "green") {
   if (process.env.GOMEMLIMIT) return process.env.GOMEMLIMIT;
+  // Under pressure the floor, outright: the ceiling is garbage the runtime
+  // has not collected because it was told there was room, and on a machine
+  // that is already compressing and swapping every granted gigabyte is paid
+  // by evicting someone else's pages. The floor trades that for the run's own
+  // GC time, which is the trade a pressured machine wants.
+  if (pressure !== "green") return "3GiB";
   const gib = Math.max(3, Math.min(6, Math.floor(os.totalmem() / 2 ** 31)));
   return `${gib}GiB`;
 }
 
+/**
+ * The parallelism the queue grants the Go-runtime tools it wraps. Green sets
+ * nothing (every core is the right spend for one run on an idle machine);
+ * under pressure half the cores, never below two, so the run stops being
+ * eleven threads all taking page faults while somebody tries to type. An
+ * operator's explicit GOMAXPROCS always wins.
+ */
+function goMaxProcs(pressure = "green") {
+  if (process.env.GOMAXPROCS) return process.env.GOMAXPROCS;
+  if (pressure === "green") return null;
+  const cpus =
+    typeof os.availableParallelism === "function"
+      ? os.availableParallelism()
+      : os.cpus().length;
+  return String(Math.max(2, Math.floor(cpus / 2)));
+}
+
 /** Runs the command with stdio inherited, forwarding signals, resolving its exit code. */
-function runCommand(commandArgv) {
+function runCommand(commandArgv, pressure = "green") {
   return new Promise((resolve) => {
-    const child = spawn(commandArgv[0], commandArgv.slice(1), {
-      stdio: "inherit",
+    const childEnv = {
+      ...process.env,
       // We are the slot for everything below us. Without this, a run holding
       // the only slot queues behind itself the moment it reaches a bin shim
       // (`pnpm typecheck` spawns .bin/tsgo, which is one) or a nested package
       // script, and waits out the whole maximum wait before starting.
-      env: { ...process.env, CHECK_SLOTS: "0", GOMEMLIMIT: goMemLimit() },
+      CHECK_SLOTS: "0",
+      GOMEMLIMIT: goMemLimit(pressure),
+    };
+    const procs = goMaxProcs(pressure);
+    if (procs !== null) childEnv.GOMAXPROCS = procs;
+    const child = spawn(commandArgv[0], commandArgv.slice(1), {
+      stdio: "inherit",
+      env: childEnv,
     });
     // Handling these keeps the wrapper alive through a Ctrl-C so it releases its
     // slot after the child is done, instead of dying first and leaving an entry
     // for the next run to prune.
+    let forwarded = false;
     const handlers = ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => {
       const handler = () => {
+        forwarded = true;
         try {
           child.kill(signal);
         } catch {
@@ -440,6 +547,18 @@ function runCommand(commandArgv) {
     });
     child.on("exit", (code, signal) => {
       detach();
+      // A child that dies by a signal this wrapper never forwarded was killed
+      // from outside: an operator, or the OS reclaiming memory. Without this
+      // line the run ends in a bare exit 137, which reads as "the queue killed
+      // it" and teaches people (and agents) to bypass the queue with
+      // CHECK_SLOTS=0, removing the serialization for the whole machine.
+      if (signal && !forwarded) {
+        stderr(
+          `${PREFIX} ${commandArgv[0]} was killed from outside by ${signal}. ` +
+            `The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. ` +
+            `Re-run the same command. Do not set CHECK_SLOTS=0.\n`,
+        );
+      }
       resolve(signal ? 128 + (os.constants.signals[signal] ?? 0) : (code ?? 0));
     });
   });
@@ -447,9 +566,14 @@ function runCommand(commandArgv) {
 
 /** `--explain` output: the resolved limit, where it came from, and who holds what. */
 async function explain(env) {
-  const { slots, source } = resolveSlots(env);
+  const pressure = resolvePressure(env);
+  const { slots, source } = resolveSlots(env, pressure);
   const dir = resolveQueueDir(env);
-  stderr(`slots=${slots} source=${source}\ndir=${dir}\n`);
+  stderr(`slots=${slots} source=${source}\npressure=${pressure}\n`);
+  stderr(`gomemlimit=${goMemLimit(pressure)}\n`);
+  const procs = goMaxProcs(pressure);
+  if (procs !== null) stderr(`gomaxprocs=${procs}\n`);
+  stderr(`dir=${dir}\n`);
   if (slots <= 0) {
     stderr("queue=off\n");
     return 0;
@@ -486,8 +610,11 @@ async function main(argv, env) {
     return 2;
   }
 
-  const { slots } = resolveSlots(env);
-  if (slots <= 0) return runCommand(commandArgv);
+  // Measured once: the level shapes the slot count and the child's
+  // environment together, and two measurements could disagree.
+  const pressure = resolvePressure(env);
+  const { slots } = resolveSlots(env, pressure);
+  if (slots <= 0) return runCommand(commandArgv, pressure);
 
   const delegated = await delegateToHaven(commandArgv, env);
   if (delegated !== null) return delegated;
@@ -543,7 +670,7 @@ async function main(argv, env) {
   }
 
   try {
-    return await runCommand(commandArgv);
+    return await runCommand(commandArgv, pressure);
   } finally {
     release();
   }

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -567,20 +567,27 @@ function runCommand(commandArgv, pressure = "green") {
       resolve(127);
     });
     child.on("exit", (code, signal) => {
-      detach();
-      // A child that dies by a signal this wrapper never forwarded was killed
-      // from outside: an operator, or the OS reclaiming memory. Without this
-      // line the run ends in a bare exit 137, which reads as "the queue killed
-      // it" and teaches people (and agents) to bypass the queue with
-      // CHECK_SLOTS=0, removing the serialization for the whole machine.
-      if (signal && !forwarded.has(signal)) {
-        stderr(
-          `${PREFIX} ${commandArgv[0]} was killed from outside by ${signal}. ` +
-            `The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. ` +
-            `Re-run the same command. Do not set CHECK_SLOTS=0.\n`,
-        );
-      }
-      resolve(signal ? 128 + (os.constants.signals[signal] ?? 0) : (code ?? 0));
+      // One turn later, so that a signal delivered to the whole process group
+      // is in the record before it is read. A Ctrl-C at a terminal reaches the
+      // wrapper and the child together, and the child's exit can be handled
+      // first, with our own handler for the same signal still pending.
+      // Detaching here rather than there would drop that handler outright.
+      setImmediate(() => {
+        detach();
+        // A child that dies by a signal this wrapper never forwarded was killed
+        // from outside: an operator, or the OS reclaiming memory. Without this
+        // line the run ends in a bare exit 137, which reads as "the queue killed
+        // it" and teaches people (and agents) to bypass the queue with
+        // CHECK_SLOTS=0, removing the serialization for the whole machine.
+        if (signal && !forwarded.has(signal)) {
+          stderr(
+            `${PREFIX} ${commandArgv[0]} was killed from outside by ${signal}. ` +
+              `The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. ` +
+              `Re-run the same command. Do not set CHECK_SLOTS=0.\n`,
+          );
+        }
+        resolve(signal ? 128 + (os.constants.signals[signal] ?? 0) : (code ?? 0));
+      });
     });
   });
 }

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -113,6 +113,11 @@ function startRun(tag: string, options: RunOptions = {}): Run {
     // suite would be testing haven instead (see the delegation tests below,
     // which exercise that path deliberately).
     CHECK_QUEUE_IMPL: "js",
+    // And they pin the pressure level, because the queue measures the real
+    // machine: on a laptop that is genuinely swapping, every derived-limit
+    // assertion would flake red. The pressure tests below force their own
+    // levels the same way.
+    CHECK_PRESSURE: "green",
     ...options.env,
   })) {
     if (value !== undefined) env[key] = value;
@@ -496,6 +501,26 @@ describe("check queue", () => {
       expect(expected).toBeGreaterThanOrEqual(1);
     });
 
+    /** @scenario "Memory pressure narrows the queue to one run" */
+    it("narrows the derived limit to one under pressure", async () => {
+      const result = await startRun("explain", {
+        argv: ["--explain"],
+        env: { CHECK_SLOTS: undefined, CI: undefined, CHECK_PRESSURE: "red" },
+      }).done;
+
+      expect(result.stderr).toContain("slots=1 source=pressure");
+      expect(result.stderr).toContain("pressure=red");
+    });
+
+    it("lets an explicit CHECK_SLOTS win over pressure", async () => {
+      const result = await startRun("explain", {
+        argv: ["--explain"],
+        env: { CHECK_SLOTS: "3", CI: undefined, CHECK_PRESSURE: "red" },
+      }).done;
+
+      expect(result.stderr).toContain("slots=3 source=CHECK_SLOTS");
+    });
+
     /** @scenario "CI does not queue by default" */
     it("does not queue under CI", async () => {
       const explained = await startRun("explain", {
@@ -513,6 +538,111 @@ describe("check queue", () => {
       );
       await Promise.all(runs.map((run) => run.done));
       expect(maxOverlap(readEvents())).toBe(2);
+    });
+  });
+
+  describe("given the machine is under memory pressure", () => {
+    /** Dumps the environment the wrapper hands the command it runs. */
+    function envDumper(): { script: string; out: string } {
+      const out = path.join(scratch, "child-env.json");
+      const script = path.join(scratch, "dump-env.cjs");
+      writeFileSync(
+        script,
+        [
+          'const fs = require("node:fs");',
+          "const [target] = process.argv.slice(2);",
+          "fs.writeFileSync(target, JSON.stringify({",
+          "  GOMEMLIMIT: process.env.GOMEMLIMIT ?? null,",
+          "  GOMAXPROCS: process.env.GOMAXPROCS ?? null,",
+          "}));",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      return { script, out };
+    }
+
+    /** @scenario "Memory pressure lowers the memory ceiling to the floor" */
+    /** @scenario "Memory pressure halves the compiler's parallelism" */
+    it("hands the command the floor and half the cores", async () => {
+      const { script, out } = envDumper();
+      const result = await startRun("pressured", {
+        argv: ["node", script, out],
+        env: {
+          CHECK_PRESSURE: "red",
+          GOMEMLIMIT: undefined,
+          GOMAXPROCS: undefined,
+        },
+      }).done;
+
+      expect(result.code).toBe(0);
+      const child = JSON.parse(readFileSync(out, "utf8"));
+      expect(child.GOMEMLIMIT).toBe("3GiB");
+      const cpus = os.availableParallelism();
+      expect(child.GOMAXPROCS).toBe(String(Math.max(2, Math.floor(cpus / 2))));
+    });
+
+    it("leaves the parallelism alone on a green machine", async () => {
+      const { script, out } = envDumper();
+      const result = await startRun("green", {
+        argv: ["node", script, out],
+        env: {
+          CHECK_PRESSURE: "green",
+          GOMEMLIMIT: undefined,
+          GOMAXPROCS: undefined,
+        },
+      }).done;
+
+      expect(result.code).toBe(0);
+      const child = JSON.parse(readFileSync(out, "utf8"));
+      expect(child.GOMEMLIMIT).toMatch(/GiB$/);
+      expect(child.GOMEMLIMIT).not.toBe(null);
+      expect(child.GOMAXPROCS).toBe(null);
+    });
+
+    it("lets an operator's explicit settings through unchanged", async () => {
+      const { script, out } = envDumper();
+      const result = await startRun("operator", {
+        argv: ["node", script, out],
+        env: { CHECK_PRESSURE: "red", GOMEMLIMIT: "8GiB", GOMAXPROCS: "9" },
+      }).done;
+
+      expect(result.code).toBe(0);
+      const child = JSON.parse(readFileSync(out, "utf8"));
+      expect(child.GOMEMLIMIT).toBe("8GiB");
+      expect(child.GOMAXPROCS).toBe("9");
+    });
+  });
+
+  describe("given a run is killed from outside the queue", () => {
+    /** @scenario "A run killed from outside is reported as not the queue's doing" */
+    it("says the queue never kills and names the wrong fix", async () => {
+      const result = await startRun("killed", {
+        argv: ["sh", "-c", "kill -KILL $$"],
+      }).done;
+
+      expect(result.code).toBe(137);
+      expect(result.stderr).toContain("killed from outside by SIGKILL");
+      expect(result.stderr).toContain("never kills");
+      expect(result.stderr).toContain("Do not set CHECK_SLOTS=0");
+    });
+
+    it("says nothing about a signal the wrapper itself forwarded", async () => {
+      const run = startRun("interrupted", { holdMs: 5000 });
+      await waitForHolder();
+      run.child.kill("SIGTERM");
+      const result = await run.done;
+
+      expect(result.stderr).not.toContain("killed from outside");
+    });
+
+    it("says nothing about a clean failure", async () => {
+      const result = await startRun("failing", {
+        argv: ["sh", "-c", "exit 7"],
+      }).done;
+
+      expect(result.code).toBe(7);
+      expect(result.stderr).not.toContain("killed from outside");
     });
   });
 

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -84,6 +84,8 @@ type RunOptions = {
   env?: Record<string, string | undefined>;
   /** Everything after the script path, replacing the fake command. */
   argv?: string[];
+  /** Give the run its own process group, so a test can signal the group. */
+  detached?: boolean;
 };
 
 type Run = {
@@ -126,6 +128,7 @@ function startRun(tag: string, options: RunOptions = {}): Run {
   const child = spawn(process.execPath, [QUEUE_SCRIPT, ...argv], {
     env,
     stdio: ["ignore", "pipe", "pipe"],
+    detached: options.detached ?? false,
   });
   running.add(child);
 
@@ -650,6 +653,20 @@ describe("check queue", () => {
       expect(result.stderr).toContain("Do not set CHECK_SLOTS=0");
     });
 
+    /** @scenario "A signal delivered to the whole process group still counts as forwarded" */
+    it("says nothing when the whole process group is signalled", async () => {
+      // What a Ctrl-C at a terminal does: the wrapper and the command receive
+      // the signal together, so the command can be gone before the wrapper has
+      // handled its own copy. Reading the record too early accuses the operator
+      // of an outside kill for their own interrupt.
+      const run = startRun("group", { holdMs: 5000, detached: true });
+      await waitForHolder();
+      process.kill(-(run.child.pid ?? 0), "SIGTERM");
+      const result = await run.done;
+
+      expect(result.stderr).not.toContain("killed from outside");
+    });
+
     it("says nothing about a signal the wrapper itself forwarded", async () => {
       const run = startRun("interrupted", { holdMs: 5000 });
       await waitForHolder();
@@ -673,8 +690,12 @@ describe("check queue", () => {
         try {
           pid = readFileSync(pidFile, "utf8").trim();
         } catch {
-          await sleep(25);
+          // Not created yet.
         }
+        // The redirection creates the file before the shell writes the pid into
+        // it, so an empty read is as much "not ready" as a missing file. Waiting
+        // on both is what keeps the attempts from burning off in microseconds.
+        if (pid === "") await sleep(25);
       }
       expect(pid).not.toBe("");
 

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -79,13 +79,15 @@ afterEach(() => {
 });
 
 type RunOptions = {
+  /** Names the run in the shared event log. */
+  tag: string;
   /** How long the fake command holds the slot once it starts. */
   holdMs?: number;
   env?: Record<string, string | undefined>;
   /** Everything after the script path, replacing the fake command. */
   argv?: string[];
   /** Give the run its own process group, so a test can signal the group. */
-  detached?: boolean;
+  isDetached?: boolean;
 };
 
 type Run = {
@@ -93,13 +95,19 @@ type Run = {
   done: Promise<{ code: number | null; stdout: string; stderr: string }>;
 };
 
-function startRun(tag: string, options: RunOptions = {}): Run {
-  const argv = options.argv ?? [
+function startRun({
+  tag,
+  holdMs = 0,
+  env: envOverrides,
+  argv: argvOverride,
+  isDetached = false,
+}: RunOptions): Run {
+  const argv = argvOverride ?? [
     "node",
     fakeCommand,
     logFile,
     tag,
-    String(options.holdMs ?? 0),
+    String(holdMs),
   ];
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries({
@@ -120,7 +128,7 @@ function startRun(tag: string, options: RunOptions = {}): Run {
     // assertion would flake red. The pressure tests below force their own
     // levels the same way.
     CHECK_PRESSURE: "green",
-    ...options.env,
+    ...envOverrides,
   })) {
     if (value !== undefined) env[key] = value;
   }
@@ -128,7 +136,7 @@ function startRun(tag: string, options: RunOptions = {}): Run {
   const child = spawn(process.execPath, [QUEUE_SCRIPT, ...argv], {
     env,
     stdio: ["ignore", "pipe", "pipe"],
-    detached: options.detached ?? false,
+    detached: isDetached,
   });
   running.add(child);
 
@@ -204,7 +212,7 @@ describe("check queue", () => {
   describe("given a free slot", () => {
     /** @scenario "A run that finds a free slot is silent" */
     it("runs immediately and says nothing of its own", async () => {
-      const run = startRun("solo", { env: { CHECK_SLOTS: "2" } });
+      const run = startRun({ tag: "solo", env: { CHECK_SLOTS: "2" } });
       const result = await run.done;
 
       expect(result.code).toBe(0);
@@ -217,7 +225,8 @@ describe("check queue", () => {
       // The bin shims mean a queued `pnpm typecheck` spawns another gated
       // entry point. Without this, it queues behind the slot it is holding and
       // waits out the entire maximum wait before starting.
-      const run = startRun("nested", {
+      const run = startRun({
+        tag: "nested",
         argv: ["node", "-e", "process.stdout.write(process.env.CHECK_SLOTS)"],
         env: { CHECK_SLOTS: "3" },
       });
@@ -228,7 +237,8 @@ describe("check queue", () => {
 
     /** @scenario "The wrapper is transparent to the command it runs" */
     it("passes the command's exit code and output straight through", async () => {
-      const run = startRun("passthrough", {
+      const run = startRun({
+        tag: "passthrough",
         argv: [
           "node",
           "-e",
@@ -247,9 +257,9 @@ describe("check queue", () => {
     /** @scenario "A run past the limit waits and names what it is waiting for" */
     /** @scenario "A run that waited says how long it waited" */
     it("waits, reports what it is queued behind, and reports the wait", async () => {
-      const holder = startRun("holder", { holdMs: 700 });
+      const holder = startRun({ tag: "holder", holdMs: 700 });
       await waitForHolder();
-      const queued = startRun("queued");
+      const queued = startRun({ tag: "queued" });
 
       const [, second] = await Promise.all([holder.done, queued.done]);
 
@@ -268,12 +278,13 @@ describe("check queue", () => {
         npm_package_name: "@langwatch/web",
         npm_lifecycle_event: script,
       });
-      const typecheck = startRun("typecheck", {
+      const typecheck = startRun({
+        tag: "typecheck",
         holdMs: 700,
         env: scriptEnv("typecheck"),
       });
       await waitForHolder();
-      const lint = startRun("lint", { env: scriptEnv("lint") });
+      const lint = startRun({ tag: "lint", env: scriptEnv("lint") });
 
       const [, second] = await Promise.all([typecheck.done, lint.done]);
 
@@ -313,7 +324,8 @@ describe("check queue", () => {
 
     /** @scenario "A long wait repeats itself so it never looks hung" */
     it("repeats its position and names the holder while it waits", async () => {
-      const holder = startRun("holder", {
+      const holder = startRun({
+        tag: "holder",
         holdMs: 900,
         // A run's label is the package and script pnpm is running, which is
         // what makes one worktree's typecheck distinguishable from another's.
@@ -323,7 +335,8 @@ describe("check queue", () => {
         },
       });
       await waitForHolder();
-      const queued = startRun("queued", {
+      const queued = startRun({
+        tag: "queued",
         env: { CHECK_QUEUE_HEARTBEAT_MS: "150" },
       });
 
@@ -339,11 +352,11 @@ describe("check queue", () => {
 
     /** @scenario "Waiters are served in arrival order" */
     it("serves the run that queued first", async () => {
-      const holder = startRun("holder", { holdMs: 900 });
+      const holder = startRun({ tag: "holder", holdMs: 900 });
       await waitForHolder();
-      const first = startRun("first");
+      const first = startRun({ tag: "first" });
       await sleep(200);
-      const second = startRun("second");
+      const second = startRun({ tag: "second" });
 
       await Promise.all([holder.done, first.done, second.done]);
 
@@ -352,7 +365,7 @@ describe("check queue", () => {
 
     /** @scenario "An explicit limit is honored" */
     it("never runs more than the limit at once", async () => {
-      const runs = ["a", "b", "c"].map((tag) => startRun(tag, { holdMs: 150 }));
+      const runs = ["a", "b", "c"].map((tag) => startRun({ tag, holdMs: 150 }));
       await Promise.all(runs.map((run) => run.done));
 
       expect(startOrder(readEvents())).toHaveLength(3);
@@ -363,13 +376,13 @@ describe("check queue", () => {
   describe("given a slot cannot be released normally", () => {
     /** @scenario "A slot held by a dead process is reclaimed" */
     it("reclaims a slot whose owner was killed", async () => {
-      const holder = startRun("killed", { holdMs: 3000 });
+      const holder = startRun({ tag: "killed", holdMs: 3000 });
       await waitForHolder();
       expect(queueEntries()).toHaveLength(1);
       holder.child.kill("SIGKILL");
       await holder.done;
 
-      const next = startRun("after-kill");
+      const next = startRun({ tag: "after-kill" });
       const result = await next.done;
 
       expect(result.code).toBe(0);
@@ -386,13 +399,14 @@ describe("check queue", () => {
       // overlap has been read, so holding far longer than that costs the suite
       // nothing and keeps a loaded machine from ending the holder first, which
       // reads as the queue having serialized the two runs.
-      const holder = startRun("holder", { holdMs: 60_000 });
+      const holder = startRun({ tag: "holder", holdMs: 60_000 });
       await waitForHolder();
       // The hold must be wide enough that the run's start and end cannot
       // share a Date.now() millisecond: maxOverlap breaks ties end-first
       // (which "never runs more than the limit" needs), and a same-instant
       // start/end pair would collapse this run's occupancy to nothing.
-      const impatient = startRun("impatient", {
+      const impatient = startRun({
+        tag: "impatient",
         holdMs: 150,
         env: { CHECK_QUEUE_MAX_WAIT_MS: "200" },
       });
@@ -477,7 +491,7 @@ describe("check queue", () => {
     /** @scenario "The limit can be turned off" */
     it("runs everything at once and keeps no state", async () => {
       const runs = ["a", "b", "c"].map((tag) =>
-        startRun(tag, { holdMs: 300, env: { CHECK_SLOTS: "0" } }),
+        startRun({ tag, holdMs: 300, env: { CHECK_SLOTS: "0" } }),
       );
       const results = await Promise.all(runs.map((run) => run.done));
 
@@ -490,7 +504,8 @@ describe("check queue", () => {
   describe("given no explicit limit", () => {
     /** @scenario "The default limit is derived from the machine" */
     it("bounds the default by both memory and cores, never below one", async () => {
-      const run = startRun("explain", {
+      const run = startRun({
+        tag: "explain",
         argv: ["--explain"],
         env: { CHECK_SLOTS: undefined, CI: undefined },
       });
@@ -506,7 +521,8 @@ describe("check queue", () => {
 
     /** @scenario "Memory pressure narrows the queue to one run" */
     it("narrows the derived limit to one under pressure", async () => {
-      const result = await startRun("explain", {
+      const result = await startRun({
+        tag: "explain",
         argv: ["--explain"],
         env: { CHECK_SLOTS: undefined, CI: undefined, CHECK_PRESSURE: "red" },
       }).done;
@@ -516,7 +532,8 @@ describe("check queue", () => {
     });
 
     it("lets an explicit CHECK_SLOTS win over pressure", async () => {
-      const result = await startRun("explain", {
+      const result = await startRun({
+        tag: "explain",
         argv: ["--explain"],
         env: { CHECK_SLOTS: "3", CI: undefined, CHECK_PRESSURE: "red" },
       }).done;
@@ -526,7 +543,8 @@ describe("check queue", () => {
 
     /** @scenario "CI does not queue by default" */
     it("does not queue under CI", async () => {
-      const explained = await startRun("explain", {
+      const explained = await startRun({
+        tag: "explain",
         argv: ["--explain"],
         env: { CHECK_SLOTS: undefined, CI: "true" },
       }).done;
@@ -534,7 +552,8 @@ describe("check queue", () => {
       expect(explained.stderr).toContain("queue=off");
 
       const runs = ["a", "b"].map((tag) =>
-        startRun(tag, {
+        startRun({
+          tag,
           holdMs: 300,
           env: { CHECK_SLOTS: undefined, CI: "true" },
         }),
@@ -545,7 +564,8 @@ describe("check queue", () => {
 
     /** @scenario "CI keeps the runtime limits it had before the pressure policy" */
     it("reads green under CI whatever the machine measures", async () => {
-      const explained = await startRun("ci-pressure", {
+      const explained = await startRun({
+        tag: "ci-pressure",
         argv: ["--explain"],
         // No forced level: this is the measured path, which CI short-circuits.
         env: { CHECK_SLOTS: undefined, CI: "true", CHECK_PRESSURE: undefined },
@@ -557,7 +577,8 @@ describe("check queue", () => {
     });
 
     it("still lets an explicit level through under CI", async () => {
-      const explained = await startRun("ci-forced", {
+      const explained = await startRun({
+        tag: "ci-forced",
         argv: ["--explain"],
         env: { CHECK_SLOTS: undefined, CI: "true", CHECK_PRESSURE: "red" },
       }).done;
@@ -592,7 +613,8 @@ describe("check queue", () => {
     /** @scenario "Memory pressure halves the compiler's parallelism" */
     it("hands the command the floor and half the cores", async () => {
       const { script, out } = envDumper();
-      const result = await startRun("pressured", {
+      const result = await startRun({
+        tag: "pressured",
         argv: ["node", script, out],
         env: {
           CHECK_PRESSURE: "red",
@@ -610,7 +632,8 @@ describe("check queue", () => {
 
     it("leaves the parallelism alone on a green machine", async () => {
       const { script, out } = envDumper();
-      const result = await startRun("green", {
+      const result = await startRun({
+        tag: "green",
         argv: ["node", script, out],
         env: {
           CHECK_PRESSURE: "green",
@@ -628,7 +651,8 @@ describe("check queue", () => {
 
     it("lets an operator's explicit settings through unchanged", async () => {
       const { script, out } = envDumper();
-      const result = await startRun("operator", {
+      const result = await startRun({
+        tag: "operator",
         argv: ["node", script, out],
         env: { CHECK_PRESSURE: "red", GOMEMLIMIT: "8GiB", GOMAXPROCS: "9" },
       }).done;
@@ -643,7 +667,8 @@ describe("check queue", () => {
   describe("given a run is killed from outside the queue", () => {
     /** @scenario "A run killed from outside is reported as not the queue's doing" */
     it("says the queue never kills and names the wrong fix", async () => {
-      const result = await startRun("killed", {
+      const result = await startRun({
+        tag: "killed",
         argv: ["sh", "-c", "kill -KILL $$"],
       }).done;
 
@@ -659,16 +684,20 @@ describe("check queue", () => {
       // the signal together, so the command can be gone before the wrapper has
       // handled its own copy. Reading the record too early accuses the operator
       // of an outside kill for their own interrupt.
-      const run = startRun("group", { holdMs: 5000, detached: true });
+      const run = startRun({ tag: "group", holdMs: 5000, isDetached: true });
       await waitForHolder();
-      process.kill(-(run.child.pid ?? 0), "SIGTERM");
+      // Never negate a missing pid: -0 reaches process.kill as 0, which signals
+      // the caller's own process group, and the caller here is the test runner.
+      const group = run.child.pid;
+      if (!group) throw new Error("the detached run reported no pid to signal");
+      process.kill(-group, "SIGTERM");
       const result = await run.done;
 
       expect(result.stderr).not.toContain("killed from outside");
     });
 
     it("says nothing about a signal the wrapper itself forwarded", async () => {
-      const run = startRun("interrupted", { holdMs: 5000 });
+      const run = startRun({ tag: "interrupted", holdMs: 5000 });
       await waitForHolder();
       run.child.kill("SIGTERM");
       const result = await run.done;
@@ -681,7 +710,8 @@ describe("check queue", () => {
       const pidFile = path.join(scratch, "escalated.pid");
       // The command ignores the forwarded SIGTERM (the disposition survives the
       // exec), so the signal that finally ends it is one nobody forwarded.
-      const run = startRun("escalated", {
+      const run = startRun({
+        tag: "escalated",
         argv: ["sh", "-c", `trap '' TERM; echo $$ > ${pidFile}; exec sleep 5`],
       });
 
@@ -709,7 +739,8 @@ describe("check queue", () => {
     });
 
     it("says nothing about a clean failure", async () => {
-      const result = await startRun("failing", {
+      const result = await startRun({
+        tag: "failing",
         argv: ["sh", "-c", "exit 7"],
       }).done;
 
@@ -734,7 +765,8 @@ describe("check queue", () => {
     /** @scenario "With haven installed the queue runs inside haven" */
     it("hands the run to `haven slot run` and passes its exit code through", async () => {
       const { bin, argvFile } = fakeHaven(7);
-      const result = await startRun("delegated", {
+      const result = await startRun({
+        tag: "delegated",
         env: { CHECK_QUEUE_IMPL: undefined, HAVEN_BIN: bin },
       }).done;
 
@@ -748,7 +780,8 @@ describe("check queue", () => {
 
     /** @scenario "Without haven the JavaScript queue still gates" */
     it("falls back to the JS queue when the haven binary does not exist", async () => {
-      const result = await startRun("fallback", {
+      const result = await startRun({
+        tag: "fallback",
         env: {
           CHECK_QUEUE_IMPL: undefined,
           HAVEN_BIN: path.join(scratch, "no-such-haven"),
@@ -764,7 +797,8 @@ describe("check queue", () => {
     /** @scenario "The operator can force the JavaScript queue" */
     it("never delegates when CHECK_QUEUE_IMPL is js", async () => {
       const { bin, argvFile } = fakeHaven(7);
-      const result = await startRun("forced-js", {
+      const result = await startRun({
+        tag: "forced-js",
         env: { CHECK_QUEUE_IMPL: "js", HAVEN_BIN: bin },
       }).done;
 

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -539,6 +539,29 @@ describe("check queue", () => {
       await Promise.all(runs.map((run) => run.done));
       expect(maxOverlap(readEvents())).toBe(2);
     });
+
+    /** @scenario "CI keeps the runtime limits it had before the pressure policy" */
+    it("reads green under CI whatever the machine measures", async () => {
+      const explained = await startRun("ci-pressure", {
+        argv: ["--explain"],
+        // No forced level: this is the measured path, which CI short-circuits.
+        env: { CHECK_SLOTS: undefined, CI: "true", CHECK_PRESSURE: undefined },
+      }).done;
+
+      expect(explained.stderr).toContain("pressure=green");
+      // Green sets no GOMAXPROCS at all, so the line is absent entirely.
+      expect(explained.stderr).not.toContain("gomaxprocs=");
+    });
+
+    it("still lets an explicit level through under CI", async () => {
+      const explained = await startRun("ci-forced", {
+        argv: ["--explain"],
+        env: { CHECK_SLOTS: undefined, CI: "true", CHECK_PRESSURE: "red" },
+      }).done;
+
+      expect(explained.stderr).toContain("pressure=red");
+      expect(explained.stderr).toContain("slots=0 source=CI");
+    });
   });
 
   describe("given the machine is under memory pressure", () => {
@@ -634,6 +657,34 @@ describe("check queue", () => {
       const result = await run.done;
 
       expect(result.stderr).not.toContain("killed from outside");
+    });
+
+    /** @scenario "An interrupted run killed from outside is still reported" */
+    it("still names the kill when an interrupt came first", async () => {
+      const pidFile = path.join(scratch, "escalated.pid");
+      // The command ignores the forwarded SIGTERM (the disposition survives the
+      // exec), so the signal that finally ends it is one nobody forwarded.
+      const run = startRun("escalated", {
+        argv: ["sh", "-c", `trap '' TERM; echo $$ > ${pidFile}; exec sleep 5`],
+      });
+
+      let pid = "";
+      for (let attempt = 0; attempt < 200 && pid === ""; attempt++) {
+        try {
+          pid = readFileSync(pidFile, "utf8").trim();
+        } catch {
+          await sleep(25);
+        }
+      }
+      expect(pid).not.toBe("");
+
+      run.child.kill("SIGTERM");
+      await sleep(100);
+      process.kill(Number(pid), "SIGKILL");
+      const result = await run.done;
+
+      expect(result.code).toBe(137);
+      expect(result.stderr).toContain("killed from outside by SIGKILL");
     });
 
     it("says nothing about a clean failure", async () => {

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -226,6 +226,19 @@ Feature: Machine-wide slots for whole-repo checks
     Then the wrapper still reports the kill, because the earlier interrupt did not cause it
     And a run the wrapper itself canceled is not reported
 
+  # A Ctrl-C at a terminal reaches the wrapper and the command together, so the
+  # command can be gone before the wrapper has handled its own copy of the
+  # signal. Reading the record at that moment would accuse the operator of a
+  # kill from outside for their own interrupt, which is the exact mistake the
+  # report exists to prevent.
+
+  @unit
+  Scenario: A signal delivered to the whole process group still counts as forwarded
+    Given a check is running through the queue
+    When the whole process group is signalled at once
+    Then the wrapper counts the signal as one it forwarded
+    And it reports no kill from outside
+
   # --- The bin shims: the package scripts are not the only way in ---
 
   # Wrapping the scripts left every other route to the binary uncounted, and

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -187,6 +187,20 @@ Feature: Machine-wide slots for whole-repo checks
     Then the forced level is used instead of measuring the machine
     And a misspelled level falls back to the measurement, like a CHECK_SLOTS typo
 
+  # CI already runs one check per job on a machine of its own, which is why it
+  # gets no queue. The same reasoning retires the pressure policy there: nobody
+  # is typing on a runner, so buying back an interactive machine buys nothing
+  # and only makes the job slower, and a swap figure read inside a container
+  # describes the host rather than the job.
+
+  @unit
+  Scenario: CI keeps the runtime limits it had before the pressure policy
+    Given the run is under CI
+    When the level is resolved
+    Then it is green whatever the machine measures
+    And the check runs with the same memory ceiling and parallelism it had before
+    And an explicitly forced level still wins, for a test that needs one
+
   # --- A killed run must not read as the queue's doing ---
 
   # Observed in the wild: a whole-tree typecheck ended in a bare exit 137, and
@@ -204,6 +218,13 @@ Feature: Machine-wide slots for whole-repo checks
     And it says to re-run the same command rather than set CHECK_SLOTS=0
     And a signal the wrapper itself forwarded, like Ctrl-C, is not reported
     And a command that fails on its own is not reported
+
+  @unit
+  Scenario: An interrupted run killed from outside is still reported
+    Given a check was interrupted and the command ignored the forwarded signal
+    When the command is then killed by a signal the wrapper did not forward
+    Then the wrapper still reports the kill, because the earlier interrupt did not cause it
+    And a run the wrapper itself canceled is not reported
 
   # --- The bin shims: the package scripts are not the only way in ---
 

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -28,6 +28,7 @@ Feature: Machine-wide slots for whole-repo checks
   #
   # Knobs, all optional:
   #   CHECK_SLOTS=N            how many may run at once (0 disables the gate)
+  #   CHECK_PRESSURE=<level>   force the memory-pressure level (green/amber/red)
   #   CHECK_QUEUE_DIR=<path>   where the shared state lives
   #   CHECK_QUEUE_POLL_MS=N    how often a waiter re-checks
   #   CHECK_QUEUE_HEARTBEAT_MS how often a waiting run repeats itself
@@ -143,6 +144,66 @@ Feature: Machine-wide slots for whole-repo checks
     Given CI is set and CHECK_SLOTS is not
     When a check runs
     Then the gate is off, because a CI runner runs one check at a time anyway
+
+  # --- Memory pressure: the machine says the formula's assumption is false ---
+
+  # The derived limit and the 6 GiB memory ceiling both assume an otherwise
+  # idle machine. A machine that is already compressing and swapping is the
+  # machine saying that assumption is false: its RAM is spoken for, and every
+  # gigabyte a check takes is paid by evicting someone else's pages. Under
+  # pressure the check runs in its smallest shape, so the check pays for the
+  # shortage in its own time instead of everything else paying in swap.
+  # The level and its thresholds are ADR-090's (domain/pressure.go): either
+  # swap fill or compressor occupancy alone can raise it. A machine the queue
+  # cannot read is green, because a governor that cannot see must not throttle.
+
+  @unit
+  Scenario: Memory pressure narrows the queue to one run
+    Given the machine reports amber or red memory pressure
+    And CHECK_SLOTS is not set
+    When the limit is resolved
+    Then it is one, whatever the formula would have said
+    And an explicit CHECK_SLOTS still wins, because it is the operator's call
+
+  @unit
+  Scenario: Memory pressure lowers the memory ceiling to the floor
+    Given the machine reports amber or red memory pressure
+    When a check runs through the queue
+    Then its GOMEMLIMIT is the 3 GiB floor, whatever the machine's size
+    And an operator's explicit GOMEMLIMIT still reaches it unchanged
+
+  @unit
+  Scenario: Memory pressure halves the compiler's parallelism
+    Given the machine reports amber or red memory pressure
+    When a check runs through the queue
+    Then its GOMAXPROCS is half the cores, never below two
+    And a green machine sets no GOMAXPROCS at all
+    And an operator's explicit GOMAXPROCS still wins
+
+  @unit
+  Scenario: A forced pressure level overrides the measurement
+    Given CHECK_PRESSURE is set to green, amber or red
+    When the level is resolved
+    Then the forced level is used instead of measuring the machine
+    And a misspelled level falls back to the measurement, like a CHECK_SLOTS typo
+
+  # --- A killed run must not read as the queue's doing ---
+
+  # Observed in the wild: a whole-tree typecheck ended in a bare exit 137, and
+  # the agent driving it concluded the queue had killed it and re-ran with
+  # CHECK_SLOTS=0, removing the machine-wide serialization for everyone. The
+  # queue never kills runs; a signal death it did not forward is an operator
+  # kill or the OS reclaiming memory, and the wrapper now says so at the
+  # moment it happens, where the next reader of the transcript will see it.
+
+  @unit
+  Scenario: A run killed from outside is reported as not the queue's doing
+    Given a check is running through the queue
+    When the command dies by a signal the wrapper did not forward
+    Then the wrapper says the queue never kills runs and names the likely causes
+    And it says to re-run the same command rather than set CHECK_SLOTS=0
+    And a signal the wrapper itself forwarded, like Ctrl-C, is not reported
+    And a command that fails on its own is not reported
 
   # --- The bin shims: the package scripts are not the only way in ---
 

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -274,7 +274,12 @@ registry, and dashboard stay the same.
   until the rest fits. The check queue also sets `GOMEMLIMIT` on the runs it
   spawns — half the machine, clamped to `[3, 6]` GiB — so the common case
   degrades to "slower" rather than expanding into whatever room the machine
-  happens to have (`dev/docs/adr/100-the-typecheck-memory-ceiling.md`). The
+  happens to have (`dev/docs/adr/100-the-typecheck-memory-ceiling.md`). On a
+  machine already under memory pressure (ADR-090's levels) the queue goes
+  further: the derived slot limit narrows to one, `GOMEMLIMIT` drops to its
+  3 GiB floor and `GOMAXPROCS` is halved, so the check pays for the shortage
+  instead of everything else swapping. `CHECK_PRESSURE=green|amber|red`
+  forces the level; explicit `GOMEMLIMIT`/`GOMAXPROCS`/`CHECK_SLOTS` win. The
   same watch observes gopls, biome, vitest workers, node, bun and claude
   agents (never touched — observed only) and ships every class's footprint to
   the local Grafana as `haven_proc_*` metrics. See

--- a/tools/thuishaven/cmd/slot.go
+++ b/tools/thuishaven/cmd/slot.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"os/signal"
 	"runtime"
-	"sync/atomic"
+	"sync"
 	"syscall"
 	"time"
 
@@ -95,6 +96,7 @@ func resolveSlotPressure() domain.Pressure {
 	return domain.ResolveCheckPressure(
 		os.Getenv("CHECK_PRESSURE"),
 		domain.ClassifyPressure(system.New().MemStat()),
+		os.Getenv("CI"),
 	)
 }
 
@@ -235,26 +237,72 @@ func slotExec(ctx context.Context, argv []string, pressure domain.Pressure) int 
 		fmt.Fprintf(os.Stderr, "checks: could not run %s: %v\n", argv[0], err)
 		return 127
 	}
+	relay := startSignalRelay(cmd.Process)
+	err := cmd.Wait()
+	death := slotDeath{forwarded: relay.close(), canceled: ctx.Err() != nil}
+	reportOutsideKill(err, argv[0], death)
+	return slotExitCode(err, argv[0])
+}
+
+// slotDeath is what the wrapper knows about how the child ended beyond the
+// Wait error: which signals it forwarded, and whether it ended the run itself
+// through the context. exec.CommandContext kills with SIGKILL on cancellation,
+// which no forwarded-signal record can account for, so the cancellation is
+// tracked next to them.
+type slotDeath struct {
+	forwarded map[syscall.Signal]bool
+	canceled  bool
+}
+
+// signalRelay passes the wrapper's terminating signals down to the child and
+// records which ones it sent. Which signals, not merely whether any: a run
+// that is interrupted and then killed by the OS dies of a signal nobody
+// forwarded, and that is the death worth naming, which a boolean would have
+// suppressed because an earlier SIGINT set it.
+type signalRelay struct {
+	mu        sync.Mutex
+	forwarded map[syscall.Signal]bool
+	stop      chan struct{}
+}
+
+func startSignalRelay(proc *os.Process) *signalRelay {
+	relay := &signalRelay{
+		forwarded: map[syscall.Signal]bool{},
+		stop:      make(chan struct{}),
+	}
 	signals := make(chan os.Signal, 4)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-	done := make(chan struct{})
-	var forwarded atomic.Bool
 	go func() {
+		defer signal.Stop(signals)
 		for {
 			select {
 			case sig := <-signals:
-				forwarded.Store(true)
-				_ = cmd.Process.Signal(sig)
-			case <-done:
+				relay.record(sig)
+				_ = proc.Signal(sig)
+			case <-relay.stop:
 				return
 			}
 		}
 	}()
-	err := cmd.Wait()
-	close(done)
-	signal.Stop(signals)
-	reportOutsideKill(err, argv[0], forwarded.Load())
-	return slotExitCode(err, argv[0])
+	return relay
+}
+
+func (r *signalRelay) record(sig os.Signal) {
+	number, ok := sig.(syscall.Signal)
+	if !ok {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.forwarded[number] = true
+}
+
+// close ends the relay and reports the signals it forwarded.
+func (r *signalRelay) close() map[syscall.Signal]bool {
+	close(r.stop)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return maps.Clone(r.forwarded)
 }
 
 // reportOutsideKill names the one death this wrapper is reliably blamed for
@@ -263,8 +311,12 @@ func slotExec(ctx context.Context, argv []string, pressure domain.Pressure) int 
 // this line the run ends in a bare exit 137, which reads as "the queue killed
 // it" and teaches people (and agents) to bypass the queue with CHECK_SLOTS=0,
 // removing the machine-wide serialization for everyone.
-func reportOutsideKill(err error, argv0 string, forwarded bool) {
-	if err == nil || forwarded {
+//
+// The test is the signal that ended the child, not whether any signal was
+// forwarded before it. Ctrl-C on a child that ignores SIGINT and is then
+// reclaimed by the OS is an outside kill and says so.
+func reportOutsideKill(err error, argv0 string, death slotDeath) {
+	if err == nil || death.canceled {
 		return
 	}
 	exitErr, ok := errors.AsType[*exec.ExitError](err)
@@ -276,6 +328,9 @@ func reportOutsideKill(err error, argv0 string, forwarded bool) {
 		return
 	}
 	sig := status.Signal()
+	if death.forwarded[sig] {
+		return
+	}
 	fmt.Fprintf(os.Stderr,
 		"checks: %s was killed from outside by signal %d (%s). The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. Re-run the same command. Do not set CHECK_SLOTS=0.\n",
 		argv0, int(sig), sig.String())

--- a/tools/thuishaven/cmd/slot.go
+++ b/tools/thuishaven/cmd/slot.go
@@ -262,29 +262,60 @@ type slotDeath struct {
 type signalRelay struct {
 	mu        sync.Mutex
 	forwarded map[syscall.Signal]bool
+	signals   chan os.Signal
 	stop      chan struct{}
+	done      chan struct{}
 }
 
 func startSignalRelay(proc *os.Process) *signalRelay {
-	relay := &signalRelay{
-		forwarded: map[syscall.Signal]bool{},
-		stop:      make(chan struct{}),
-	}
 	signals := make(chan os.Signal, 4)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-	go func() {
-		defer signal.Stop(signals)
-		for {
-			select {
-			case sig := <-signals:
-				relay.record(sig)
-				_ = proc.Signal(sig)
-			case <-relay.stop:
-				return
-			}
-		}
-	}()
+	relay := newSignalRelay(signals)
+	go relay.pump(proc)
 	return relay
+}
+
+// newSignalRelay builds the relay over a channel the caller owns, so a test
+// can deliver a signal without raising one at the whole test binary.
+func newSignalRelay(signals chan os.Signal) *signalRelay {
+	return &signalRelay{
+		forwarded: map[syscall.Signal]bool{},
+		signals:   signals,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+}
+
+func (r *signalRelay) pump(proc *os.Process) {
+	defer close(r.done)
+	defer signal.Stop(r.signals)
+	for {
+		select {
+		case sig := <-r.signals:
+			r.record(sig)
+			_ = proc.Signal(sig)
+		case <-r.stop:
+			r.drain()
+			return
+		}
+	}
+}
+
+// drain records the signals still queued when the child died. A Ctrl-C at a
+// terminal reaches the whole process group, so the child can die of the signal
+// while the wrapper's own copy of it is still in the channel. Without this the
+// select can take the stop branch, discard that copy, and report the operator's
+// own interrupt as a kill from outside, which is the mistake this whole report
+// exists to prevent.
+func (r *signalRelay) drain() {
+	for {
+		select {
+		case sig := <-r.signals:
+			r.record(sig)
+		default:
+			return
+		}
+	}
 }
 
 func (r *signalRelay) record(sig os.Signal) {
@@ -297,9 +328,12 @@ func (r *signalRelay) record(sig os.Signal) {
 	r.forwarded[number] = true
 }
 
-// close ends the relay and reports the signals it forwarded.
+// close ends the relay and reports the signals it forwarded. It waits for the
+// pump to drain what is still queued, so a signal delivered to the process
+// group is in the record before the caller reads it.
 func (r *signalRelay) close() map[syscall.Signal]bool {
 	close(r.stop)
+	<-r.done
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return maps.Clone(r.forwarded)

--- a/tools/thuishaven/cmd/slot.go
+++ b/tools/thuishaven/cmd/slot.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -46,9 +47,14 @@ func runSlot(ctx context.Context, _ deps, inv invocation) error {
 	}
 	switch inv.raw[0] {
 	case "explain":
-		slots, source := resolveSlotLimit()
+		pressure := resolveSlotPressure()
+		slots, source := resolveSlotLimit(pressure)
 		fmt.Printf("slots=%d source=%s\n", slots, source)
-		fmt.Printf("gomemlimit=%s\n", domain.CheckGoMemLimit(system.New().TotalMemory(), os.Getenv("GOMEMLIMIT")))
+		fmt.Printf("pressure=%s\n", pressure)
+		fmt.Printf("gomemlimit=%s\n", domain.CheckGoMemLimit(system.New().TotalMemory(), os.Getenv("GOMEMLIMIT"), pressure))
+		if procs := domain.CheckGoMaxProcs(runtime.NumCPU(), os.Getenv("GOMAXPROCS"), pressure); procs != "" {
+			fmt.Printf("gomaxprocs=%s\n", procs)
+		}
 		return nil
 	case "run":
 		label, argv, err := parseSlotRun(inv.raw[1:])
@@ -60,6 +66,7 @@ func runSlot(ctx context.Context, _ deps, inv invocation) error {
 			label:    label,
 			argv:     argv,
 			progress: os.Stderr,
+			pressure: resolveSlotPressure(),
 		}
 		if code := job.run(ctx); code != 0 {
 			os.Exit(code)
@@ -70,10 +77,24 @@ func runSlot(ctx context.Context, _ deps, inv invocation) error {
 	}
 }
 
-func resolveSlotLimit() (int, string) {
+func resolveSlotLimit(pressure domain.Pressure) (int, string) {
 	return domain.ResolveCheckSlots(
-		system.New().TotalMemory(), runtime.NumCPU(),
+		domain.CheckMachine{
+			TotalRAMBytes: system.New().TotalMemory(),
+			NumCPU:        runtime.NumCPU(),
+			Pressure:      pressure,
+		},
 		domain.CheckEnv{CheckSlots: os.Getenv("CHECK_SLOTS"), CI: os.Getenv("CI")},
+	)
+}
+
+// resolveSlotPressure measures once per invocation: the level shapes the
+// slot count and the child's environment together, and two measurements
+// could disagree across their few milliseconds.
+func resolveSlotPressure() domain.Pressure {
+	return domain.ResolveCheckPressure(
+		os.Getenv("CHECK_PRESSURE"),
+		domain.ClassifyPressure(system.New().MemStat()),
 	)
 }
 
@@ -110,6 +131,7 @@ type slotJob struct {
 	label    string
 	argv     []string
 	progress io.Writer
+	pressure domain.Pressure
 
 	slots     int
 	queuedAt  time.Time
@@ -122,9 +144,9 @@ type slotJob struct {
 // a semaphore error and the maximum wait both degrade to running anyway, with
 // a line on stderr saying so.
 func (j *slotJob) run(ctx context.Context) int {
-	j.slots, _ = resolveSlotLimit()
+	j.slots, _ = resolveSlotLimit(j.pressure)
 	if j.slots <= 0 {
-		return slotExec(ctx, j.argv)
+		return slotExec(ctx, j.argv, j.pressure)
 	}
 	j.queuedAt = time.Now()
 	release, canceled := j.wait(ctx)
@@ -134,7 +156,7 @@ func (j *slotJob) run(ctx context.Context) int {
 	if j.announced && release != nil {
 		fmt.Fprintf(j.progress, "checks: slot free after %s in the queue, starting now.\n", formatSlotWait(time.Since(j.queuedAt)))
 	}
-	code := slotExec(ctx, j.argv)
+	code := slotExec(ctx, j.argv, j.pressure)
 	if release != nil {
 		release()
 	}
@@ -194,17 +216,21 @@ func (j *slotJob) report(waited time.Duration) {
 // slotExec runs argv with stdio inherited, CHECK_SLOTS=0 so nothing below the
 // slot queues behind it, and GOMEMLIMIT (unless the operator set one) so the
 // Go-runtime tools this queue wraps degrade to slower instead of resident
-// (ADR-095). Signals are forwarded so Ctrl-C reaches the child and the slot is
-// still released afterwards.
-func slotExec(ctx context.Context, argv []string) int {
+// (ADR-095); under memory pressure GOMAXPROCS is capped too, so the run leaves
+// cores for the person at the keyboard. Signals are forwarded so Ctrl-C
+// reaches the child and the slot is still released afterwards.
+func slotExec(ctx context.Context, argv []string, pressure domain.Pressure) int {
 	// The whole command is the caller's own argv — this is a process wrapper,
 	// running exactly what it was asked to run, as the same user.
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // G204: wrapper runs the caller's own command
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Env = append(os.Environ(),
 		"CHECK_SLOTS=0",
-		"GOMEMLIMIT="+domain.CheckGoMemLimit(system.New().TotalMemory(), os.Getenv("GOMEMLIMIT")),
+		"GOMEMLIMIT="+domain.CheckGoMemLimit(system.New().TotalMemory(), os.Getenv("GOMEMLIMIT"), pressure),
 	)
+	if procs := domain.CheckGoMaxProcs(runtime.NumCPU(), os.Getenv("GOMAXPROCS"), pressure); procs != "" {
+		cmd.Env = append(cmd.Env, "GOMAXPROCS="+procs)
+	}
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "checks: could not run %s: %v\n", argv[0], err)
 		return 127
@@ -212,10 +238,12 @@ func slotExec(ctx context.Context, argv []string) int {
 	signals := make(chan os.Signal, 4)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	done := make(chan struct{})
+	var forwarded atomic.Bool
 	go func() {
 		for {
 			select {
 			case sig := <-signals:
+				forwarded.Store(true)
 				_ = cmd.Process.Signal(sig)
 			case <-done:
 				return
@@ -225,7 +253,32 @@ func slotExec(ctx context.Context, argv []string) int {
 	err := cmd.Wait()
 	close(done)
 	signal.Stop(signals)
+	reportOutsideKill(err, argv[0], forwarded.Load())
 	return slotExitCode(err, argv[0])
+}
+
+// reportOutsideKill names the one death this wrapper is reliably blamed for
+// and did not cause. A child that dies by a signal the wrapper never forwarded
+// was killed from outside: an operator, or macOS reclaiming memory. Without
+// this line the run ends in a bare exit 137, which reads as "the queue killed
+// it" and teaches people (and agents) to bypass the queue with CHECK_SLOTS=0,
+// removing the machine-wide serialization for everyone.
+func reportOutsideKill(err error, argv0 string, forwarded bool) {
+	if err == nil || forwarded {
+		return
+	}
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
+	if !ok {
+		return
+	}
+	status, isStatus := exitErr.Sys().(syscall.WaitStatus)
+	if !isStatus || !status.Signaled() {
+		return
+	}
+	sig := status.Signal()
+	fmt.Fprintf(os.Stderr,
+		"checks: %s was killed from outside by signal %d (%s). The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. Re-run the same command. Do not set CHECK_SLOTS=0.\n",
+		argv0, int(sig), sig.String())
 }
 
 // slotExitCode maps a Wait error to the exit code the wrapper passes through:

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/adapters/semaphore"
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
 
 func TestParseSlotRun(t *testing.T) {
@@ -94,6 +95,124 @@ func TestSlotRunIsTransparentToTheCommand(t *testing.T) {
 			t.Fatalf("child GOMEMLIMIT = %q, want the operator's 2GiB", string(env))
 		}
 	})
+}
+
+// @scenario "Memory pressure lowers the memory ceiling to the floor"
+// @scenario "Memory pressure halves the compiler's parallelism"
+func TestSlotRunUnderPressure(t *testing.T) {
+	sem := semaphore.New(t.TempDir())
+	t.Setenv("CHECK_SLOTS", "1")
+	t.Setenv("CI", "")
+	t.Setenv("GOMEMLIMIT", "")
+	t.Setenv("GOMAXPROCS", "")
+
+	t.Run("a pressured run gets the floor and half the cores", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "env.txt")
+		job := &slotJob{sem: sem, label: "pressured", argv: []string{
+			"sh", "-c", `printf '%s %s' "$GOMEMLIMIT" "$GOMAXPROCS" > ` + out,
+		}, progress: &bytes.Buffer{}, pressure: domain.Red}
+		if code := job.run(context.Background()); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		env, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("reading the child's env dump: %v", err)
+		}
+		fields := strings.Fields(string(env))
+		if len(fields) != 2 || fields[0] != "3GiB" || fields[1] == "" {
+			t.Fatalf("child env = %q, want the 3GiB floor and a GOMAXPROCS cap", string(env))
+		}
+	})
+
+	t.Run("a green run leaves GOMAXPROCS alone", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "env.txt")
+		job := &slotJob{sem: sem, label: "green", argv: []string{
+			"sh", "-c", `printf '%s' "${GOMAXPROCS:-unset}" > ` + out,
+		}, progress: &bytes.Buffer{}, pressure: domain.Green}
+		if code := job.run(context.Background()); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		env, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("reading the child's env dump: %v", err)
+		}
+		if string(env) != "unset" {
+			t.Fatalf("child GOMAXPROCS = %q, want unset on a green machine", string(env))
+		}
+	})
+}
+
+// @scenario "A run killed from outside is reported as not the queue's doing"
+func TestSlotRunReportsAnOutsideKill(t *testing.T) {
+	sem := semaphore.New(t.TempDir())
+	t.Setenv("CHECK_SLOTS", "1")
+	t.Setenv("CI", "")
+
+	t.Run("a child killed by a signal nobody forwarded is named", func(t *testing.T) {
+		var progress bytes.Buffer
+		job := &slotJob{sem: sem, label: "killed", argv: []string{
+			"sh", "-c", "kill -KILL $$",
+		}, progress: &progress}
+		code := job.run(context.Background())
+		if code != 137 {
+			t.Fatalf("exit code = %d, want 137", code)
+		}
+		// The message goes to the process stderr rather than the job's progress
+		// writer, so capture it around the run.
+		// (job.progress carries only queueing chatter, asserted silent here.)
+		if progress.Len() != 0 {
+			t.Fatalf("queue chatter on a free slot: %q", progress.String())
+		}
+	})
+
+	t.Run("a child that exits on its own says nothing", func(t *testing.T) {
+		stderr := captureStderr(t, func() {
+			job := &slotJob{sem: sem, label: "clean", argv: []string{"sh", "-c", "exit 3"}, progress: &bytes.Buffer{}}
+			if code := job.run(context.Background()); code != 3 {
+				t.Fatalf("exit code = %d, want 3", code)
+			}
+		})
+		if strings.Contains(stderr, "killed from outside") {
+			t.Fatalf("a clean exit must not be reported as a kill: %q", stderr)
+		}
+	})
+
+	t.Run("the kill message names the cause and the wrong fix", func(t *testing.T) {
+		stderr := captureStderr(t, func() {
+			job := &slotJob{sem: sem, label: "killed", argv: []string{"sh", "-c", "kill -KILL $$"}, progress: &bytes.Buffer{}}
+			if code := job.run(context.Background()); code != 137 {
+				t.Fatalf("exit code = %d, want 137", code)
+			}
+		})
+		for _, want := range []string{"killed from outside", "signal 9", "never kills", "Do not set CHECK_SLOTS=0"} {
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("kill report %q is missing %q", stderr, want)
+			}
+		}
+	})
+}
+
+// captureStderr runs body with os.Stderr swapped for a pipe and returns what
+// was written. slotExec writes the outside-kill report to the real stderr (it
+// belongs to the terminal, not the progress writer), so the test reads it the
+// same way a person would.
+func captureStderr(t *testing.T, body func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+	body()
+	_ = w.Close()
+	os.Stderr = orig
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	return buf.String()
 }
 
 // @scenario "A run queued inside haven says so"

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -316,3 +316,27 @@ func TestSlotRunQueuesAndSaysSo(t *testing.T) {
 		t.Fatalf("a run that waited must report it, got %q", report)
 	}
 }
+
+// @scenario "A signal delivered to the whole process group still counts as forwarded"
+func TestSignalRelayRecordsAQueuedSignal(t *testing.T) {
+	child := exec.Command("sleep", "10")
+	if err := child.Start(); err != nil {
+		t.Fatalf("starting the stand-in child: %v", err)
+	}
+	defer func() {
+		_ = child.Process.Kill()
+		_ = child.Wait()
+	}()
+
+	// A Ctrl-C at a terminal reaches the wrapper and the child together, so the
+	// wrapper's own copy of the signal can still be queued at the moment the
+	// child is already gone and the relay closes.
+	signals := make(chan os.Signal, 4)
+	relay := newSignalRelay(signals)
+	signals <- syscall.SIGINT
+	go relay.pump(child.Process)
+
+	if forwarded := relay.close(); !forwarded[syscall.SIGINT] {
+		t.Fatal("a signal queued when the child died must still count as forwarded, or the wrapper reports the operator's own interrupt as a kill from outside")
+	}
+}

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -119,8 +123,9 @@ func TestSlotRunUnderPressure(t *testing.T) {
 			t.Fatalf("reading the child's env dump: %v", err)
 		}
 		fields := strings.Fields(string(env))
-		if len(fields) != 2 || fields[0] != "3GiB" || fields[1] == "" {
-			t.Fatalf("child env = %q, want the 3GiB floor and a GOMAXPROCS cap", string(env))
+		wantProcs := strconv.Itoa(max(2, runtime.NumCPU()/2))
+		if len(fields) != 2 || fields[0] != "3GiB" || fields[1] != wantProcs {
+			t.Fatalf("child env = %q, want the 3GiB floor and GOMAXPROCS=%s", string(env), wantProcs)
 		}
 	})
 
@@ -188,6 +193,64 @@ func TestSlotRunReportsAnOutsideKill(t *testing.T) {
 			if !strings.Contains(stderr, want) {
 				t.Fatalf("kill report %q is missing %q", stderr, want)
 			}
+		}
+	})
+}
+
+// @scenario "An interrupted run killed from outside is still reported"
+func TestReportOutsideKillReadsTheSignalThatKilled(t *testing.T) {
+	// A real SIGKILL death, so the Wait error carries the wait status the
+	// wrapper reads rather than a synthetic one.
+	killed := exec.Command("sh", "-c", "kill -KILL $$").Run()
+	if killed == nil {
+		t.Fatal("the probe command was supposed to die by SIGKILL")
+	}
+
+	t.Run("a forwarded SIGINT does not excuse a SIGKILL", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			reportOutsideKill(killed, "sh", slotDeath{
+				forwarded: map[syscall.Signal]bool{syscall.SIGINT: true},
+			})
+		})
+		if !strings.Contains(out, "killed from outside") {
+			t.Fatalf("an escalation after an interrupt must still be named, got %q", out)
+		}
+	})
+
+	t.Run("the signal the wrapper forwarded is not reported", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			reportOutsideKill(killed, "sh", slotDeath{
+				forwarded: map[syscall.Signal]bool{syscall.SIGKILL: true},
+			})
+		})
+		if strings.Contains(out, "killed from outside") {
+			t.Fatalf("the wrapper must not blame a kill it sent: %q", out)
+		}
+	})
+
+	t.Run("a run the wrapper canceled is not an outside kill", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			reportOutsideKill(killed, "sh", slotDeath{canceled: true})
+		})
+		if strings.Contains(out, "killed from outside") {
+			t.Fatalf("cancellation is the wrapper's own doing: %q", out)
+		}
+	})
+
+	// exec.CommandContext kills with SIGKILL on cancellation, which no
+	// forwarded-signal record accounts for, so this path needs the real thing.
+	t.Run("a canceled context stays quiet end to end", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := captureStderr(t, func() {
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				cancel()
+			}()
+			slotExec(ctx, []string{"sh", "-c", "sleep 5"}, domain.Green)
+		})
+		if strings.Contains(out, "killed from outside") {
+			t.Fatalf("a canceled run must not be reported as an outside kill: %q", out)
 		}
 	})
 }

--- a/tools/thuishaven/domain/checkslots.go
+++ b/tools/thuishaven/domain/checkslots.go
@@ -42,7 +42,16 @@ type CheckMachine struct {
 // disabled for a good reason) needs the same lever. A value that is not one of
 // the three level names falls back to the measurement, exactly like a
 // CHECK_SLOTS typo: a misspelling must not change the policy.
-func ResolveCheckPressure(override string, measured Pressure) Pressure {
+//
+// CI reads green whatever the machine says. The queue already stands down
+// there, and the same reasoning retires the pressure policy with it: a runner
+// runs one job and nobody is typing on it, so halving its cores buys back an
+// interactive machine that does not exist and only makes the job slower. A
+// swap figure read inside a container describes the host, not this job. The
+// level is measured on macOS only, so today CI is green by accident of the
+// runner's kernel on a Linux runner and by this rule everywhere; the rule is
+// what makes "CI is unaffected" true rather than lucky.
+func ResolveCheckPressure(override string, measured Pressure, ci string) Pressure {
 	switch strings.ToLower(strings.TrimSpace(override)) {
 	case "green":
 		return Green
@@ -50,9 +59,19 @@ func ResolveCheckPressure(override string, measured Pressure) Pressure {
 		return Amber
 	case "red":
 		return Red
-	default:
-		return measured
 	}
+	if isTruthyCI(ci) {
+		return Green
+	}
+	return measured
+}
+
+// isTruthyCI reads the CI convention: the variable is set to something that is
+// not one of the values meaning "not CI". The slot limit and the pressure
+// policy both ask this, so they ask it in one place and cannot drift apart.
+func isTruthyCI(ci string) bool {
+	value := strings.ToLower(strings.TrimSpace(ci))
+	return value != "" && value != "0" && value != "false"
 }
 
 // ResolveCheckSlots resolves how many whole-repo checks may run at once, and
@@ -70,7 +89,7 @@ func ResolveCheckPressure(override string, measured Pressure) Pressure {
 // says. The formula assumes an otherwise idle machine, and pressure is the
 // machine reporting that assumption false: its RAM is spoken for, so a second
 // concurrent check is paid for in everyone's swap. Only the derived default
-// narrows — an explicit CHECK_SLOTS is the operator's call either way.
+// narrows. An explicit CHECK_SLOTS is the operator's call either way.
 func ResolveCheckSlots(machine CheckMachine, env CheckEnv) (int, string) {
 	raw := strings.TrimSpace(env.CheckSlots)
 	if raw != "" {
@@ -84,8 +103,7 @@ func ResolveCheckSlots(machine CheckMachine, env CheckEnv) (int, string) {
 		// An unparseable value falls through to the derived default, exactly
 		// like the JS wrapper: a typo must not turn the gate off.
 	}
-	ci := strings.ToLower(strings.TrimSpace(env.CI))
-	if ci != "" && ci != "0" && ci != "false" {
+	if isTruthyCI(env.CI) {
 		return 0, "CI"
 	}
 	if machine.Pressure > Green {
@@ -130,7 +148,7 @@ func CheckGoMemLimit(totalRAMBytes uint64, existing string, pressure Pressure) s
 }
 
 // CheckGoMaxProcs is the parallelism the queue grants the Go-runtime tools it
-// wraps. On a green machine it grants nothing — an empty string means "do not
+// wraps. On a green machine it grants nothing: an empty string means "do not
 // set it" and the tool uses every core, which is the right spend for one run
 // on an idle machine. Under pressure it halves the cores, never below two:
 // eleven runnable threads on a machine that has to page every allocation in

--- a/tools/thuishaven/domain/checkslots.go
+++ b/tools/thuishaven/domain/checkslots.go
@@ -28,8 +28,36 @@ type CheckEnv struct {
 	CI         string // CI
 }
 
+// CheckMachine carries the machine facts the limit is resolved from.
+type CheckMachine struct {
+	TotalRAMBytes uint64
+	NumCPU        int
+	Pressure      Pressure
+}
+
+// ResolveCheckPressure reads the CHECK_PRESSURE override, falling back to what
+// the machine measured. The override exists for two reasons that are really
+// one: tests need a deterministic level, and an operator who knows better than
+// the heuristic (a machine that is about to get busy, or one whose swap is
+// disabled for a good reason) needs the same lever. A value that is not one of
+// the three level names falls back to the measurement, exactly like a
+// CHECK_SLOTS typo: a misspelling must not change the policy.
+func ResolveCheckPressure(override string, measured Pressure) Pressure {
+	switch strings.ToLower(strings.TrimSpace(override)) {
+	case "green":
+		return Green
+	case "amber":
+		return Amber
+	case "red":
+		return Red
+	default:
+		return measured
+	}
+}
+
 // ResolveCheckSlots resolves how many whole-repo checks may run at once, and
-// names where the answer came from ("CHECK_SLOTS", "CI" or "machine").
+// names where the answer came from ("CHECK_SLOTS", "CI", "machine" or
+// "pressure").
 //
 // An explicit CHECK_SLOTS always wins, including under CI — that is what lets
 // tests exercise the queue on a CI runner. "0" (or off/none/unlimited/false)
@@ -37,7 +65,13 @@ type CheckEnv struct {
 // and a developer machine gets a limit bounded by both memory and cores —
 // tsgo is memory-hungry AND parallel, so the tighter bound is the honest one —
 // never below 1, or the queue would deadlock every run.
-func ResolveCheckSlots(totalRAMBytes uint64, numCPU int, env CheckEnv) (int, string) {
+//
+// A machine already under memory pressure gets one slot, whatever the formula
+// says. The formula assumes an otherwise idle machine, and pressure is the
+// machine reporting that assumption false: its RAM is spoken for, so a second
+// concurrent check is paid for in everyone's swap. Only the derived default
+// narrows — an explicit CHECK_SLOTS is the operator's call either way.
+func ResolveCheckSlots(machine CheckMachine, env CheckEnv) (int, string) {
 	raw := strings.TrimSpace(env.CheckSlots)
 	if raw != "" {
 		switch strings.ToLower(raw) {
@@ -54,8 +88,11 @@ func ResolveCheckSlots(totalRAMBytes uint64, numCPU int, env CheckEnv) (int, str
 	if ci != "" && ci != "0" && ci != "false" {
 		return 0, "CI"
 	}
-	byMemory := int(totalRAMBytes / checkRAMPerRun)
-	byCPU := numCPU / checkCPUsPerRun
+	if machine.Pressure > Green {
+		return 1, "pressure"
+	}
+	byMemory := int(machine.TotalRAMBytes / checkRAMPerRun)
+	byCPU := machine.NumCPU / checkCPUsPerRun
 	return max(1, min(byMemory, byCPU)), "machine"
 }
 
@@ -74,10 +111,38 @@ func ResolveCheckSlots(totalRAMBytes uint64, numCPU int, env CheckEnv) (int, str
 // the price of collecting continuously to miss it. 6 itself is a judgement
 // between measured points and wants a re-measure on an unloaded machine; see
 // ADR-100, which records what the samples do and do not establish.
-func CheckGoMemLimit(totalRAMBytes uint64, existing string) string {
+//
+// A machine under memory pressure gets the floor outright. The ceiling is
+// garbage the runtime has not collected because it was told there was room;
+// on a machine that is already compressing and swapping there is no room, and
+// every gigabyte the ceiling grants is paid by evicting someone else's pages.
+// The floor trades that for the run's own GC time, which is the trade a
+// pressured machine wants: the check pays, not everything else.
+func CheckGoMemLimit(totalRAMBytes uint64, existing string, pressure Pressure) string {
 	if existing != "" {
 		return existing
 	}
+	if pressure > Green {
+		return "3GiB"
+	}
 	gib := int(totalRAMBytes / (2 << 30))
 	return fmt.Sprintf("%dGiB", clampInt(gib, 3, 6))
+}
+
+// CheckGoMaxProcs is the parallelism the queue grants the Go-runtime tools it
+// wraps. On a green machine it grants nothing — an empty string means "do not
+// set it" and the tool uses every core, which is the right spend for one run
+// on an idle machine. Under pressure it halves the cores, never below two:
+// eleven runnable threads on a machine that has to page every allocation in
+// is eleven threads taking page faults, and half of them buys back an
+// interactive machine for a modest wall-clock cost. An operator's explicit
+// GOMAXPROCS always wins, whatever the level.
+func CheckGoMaxProcs(numCPU int, existing string, pressure Pressure) string {
+	if existing != "" {
+		return existing
+	}
+	if pressure == Green {
+		return ""
+	}
+	return strconv.Itoa(max(2, numCPU/2))
 }

--- a/tools/thuishaven/domain/checkslots_test.go
+++ b/tools/thuishaven/domain/checkslots_test.go
@@ -19,7 +19,7 @@ func TestResolveCheckSlots(t *testing.T) {
 		}
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
-				slots, source := ResolveCheckSlots(c.ram, c.cpus, CheckEnv{})
+				slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: c.ram, NumCPU: c.cpus, Pressure: Green}, CheckEnv{})
 				if slots != c.want || source != "machine" {
 					t.Fatalf("got %d from %q, want %d from machine", slots, source, c.want)
 				}
@@ -28,23 +28,62 @@ func TestResolveCheckSlots(t *testing.T) {
 	})
 
 	t.Run("given an explicit CHECK_SLOTS", func(t *testing.T) {
-		if slots, source := ResolveCheckSlots(18*checkGiB, 11, CheckEnv{CheckSlots: "5", CI: "true"}); slots != 5 || source != "CHECK_SLOTS" {
+		if slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 18 * checkGiB, NumCPU: 11, Pressure: Green}, CheckEnv{CheckSlots: "5", CI: "true"}); slots != 5 || source != "CHECK_SLOTS" {
 			t.Fatalf("an explicit limit must win, even under CI: got %d from %q", slots, source)
 		}
-		if slots, _ := ResolveCheckSlots(18*checkGiB, 11, CheckEnv{CheckSlots: "off", CI: ""}); slots != 0 {
+		if slots, _ := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 18 * checkGiB, NumCPU: 11, Pressure: Green}, CheckEnv{CheckSlots: "off", CI: ""}); slots != 0 {
 			t.Fatalf("off must disable the gate, got %d", slots)
 		}
-		if slots, source := ResolveCheckSlots(18*checkGiB, 11, CheckEnv{CheckSlots: "bananas", CI: ""}); slots != 2 || source != "machine" {
+		if slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 18 * checkGiB, NumCPU: 11, Pressure: Green}, CheckEnv{CheckSlots: "bananas", CI: ""}); slots != 2 || source != "machine" {
 			t.Fatalf("a typo must fall back to the derived limit, got %d from %q", slots, source)
 		}
 	})
 
 	t.Run("given CI without an explicit limit", func(t *testing.T) {
-		if slots, source := ResolveCheckSlots(18*checkGiB, 11, CheckEnv{CheckSlots: "", CI: "true"}); slots != 0 || source != "CI" {
+		if slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 18 * checkGiB, NumCPU: 11, Pressure: Green}, CheckEnv{CheckSlots: "", CI: "true"}); slots != 0 || source != "CI" {
 			t.Fatalf("CI must not queue, got %d from %q", slots, source)
 		}
-		if slots, _ := ResolveCheckSlots(18*checkGiB, 11, CheckEnv{CheckSlots: "", CI: "false"}); slots != 2 {
+		if slots, _ := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 18 * checkGiB, NumCPU: 11, Pressure: Green}, CheckEnv{CheckSlots: "", CI: "false"}); slots != 2 {
 			t.Fatalf("CI=false is not CI, got %d", slots)
+		}
+	})
+
+	// @scenario "Memory pressure narrows the queue to one run"
+	t.Run("given a machine under memory pressure", func(t *testing.T) {
+		for _, level := range []Pressure{Amber, Red} {
+			if slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 64 * checkGiB, NumCPU: 16, Pressure: level}, CheckEnv{}); slots != 1 || source != "pressure" {
+				t.Fatalf("under %s the derived limit must narrow to 1, got %d from %q", level, slots, source)
+			}
+		}
+		if slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 64 * checkGiB, NumCPU: 16, Pressure: Red}, CheckEnv{CheckSlots: "3"}); slots != 3 || source != "CHECK_SLOTS" {
+			t.Fatalf("an explicit limit must still win under pressure, got %d from %q", slots, source)
+		}
+		if slots, source := ResolveCheckSlots(CheckMachine{TotalRAMBytes: 64 * checkGiB, NumCPU: 16, Pressure: Red}, CheckEnv{CI: "true"}); slots != 0 || source != "CI" {
+			t.Fatalf("CI must stay unqueued under pressure, got %d from %q", slots, source)
+		}
+	})
+}
+
+// @scenario "A forced pressure level overrides the measurement"
+func TestResolveCheckPressure(t *testing.T) {
+	t.Run("given an explicit CHECK_PRESSURE", func(t *testing.T) {
+		if got := ResolveCheckPressure("green", Red); got != Green {
+			t.Fatalf("green must override a red measurement, got %s", got)
+		}
+		if got := ResolveCheckPressure("RED", Green); got != Red {
+			t.Fatalf("red must override in any case, got %s", got)
+		}
+		if got := ResolveCheckPressure(" amber ", Green); got != Amber {
+			t.Fatalf("surrounding spaces must not matter, got %s", got)
+		}
+	})
+
+	t.Run("given no or a misspelled override", func(t *testing.T) {
+		if got := ResolveCheckPressure("", Amber); got != Amber {
+			t.Fatalf("empty must fall back to the measurement, got %s", got)
+		}
+		if got := ResolveCheckPressure("bananas", Red); got != Red {
+			t.Fatalf("a typo must fall back to the measurement, got %s", got)
 		}
 	})
 }
@@ -58,15 +97,53 @@ func TestCheckGoMemLimit(t *testing.T) {
 			18 * checkGiB: "6GiB",
 			64 * checkGiB: "6GiB",
 		} {
-			if got := CheckGoMemLimit(ram, ""); got != want {
+			if got := CheckGoMemLimit(ram, "", Green); got != want {
 				t.Fatalf("CheckGoMemLimit(%d) = %q, want %q", ram, got, want)
 			}
 		}
 	})
 
 	t.Run("an operator's explicit limit always wins", func(t *testing.T) {
-		if got := CheckGoMemLimit(18*checkGiB, "2GiB"); got != "2GiB" {
+		if got := CheckGoMemLimit(18*checkGiB, "2GiB", Green); got != "2GiB" {
 			t.Fatalf("got %q, want the operator's 2GiB", got)
+		}
+		if got := CheckGoMemLimit(18*checkGiB, "8GiB", Red); got != "8GiB" {
+			t.Fatalf("got %q, want the operator's 8GiB even under pressure", got)
+		}
+	})
+
+	// @scenario "Memory pressure lowers the memory ceiling to the floor"
+	t.Run("a pressured machine gets the floor whatever its size", func(t *testing.T) {
+		for _, level := range []Pressure{Amber, Red} {
+			if got := CheckGoMemLimit(64*checkGiB, "", level); got != "3GiB" {
+				t.Fatalf("under %s a 64 GiB machine must still resolve the floor, got %q", level, got)
+			}
+		}
+	})
+}
+
+// @scenario "Memory pressure halves the compiler's parallelism"
+func TestCheckGoMaxProcs(t *testing.T) {
+	t.Run("a green machine sets nothing", func(t *testing.T) {
+		if got := CheckGoMaxProcs(11, "", Green); got != "" {
+			t.Fatalf("green must leave GOMAXPROCS unset, got %q", got)
+		}
+	})
+
+	t.Run("a pressured machine halves the cores, never below two", func(t *testing.T) {
+		for cpus, want := range map[int]string{11: "5", 4: "2", 2: "2", 1: "2"} {
+			if got := CheckGoMaxProcs(cpus, "", Red); got != want {
+				t.Fatalf("CheckGoMaxProcs(%d, red) = %q, want %q", cpus, got, want)
+			}
+		}
+		if got := CheckGoMaxProcs(11, "", Amber); got != "5" {
+			t.Fatalf("amber caps too, got %q", got)
+		}
+	})
+
+	t.Run("an operator's explicit setting always wins", func(t *testing.T) {
+		if got := CheckGoMaxProcs(11, "8", Red); got != "8" {
+			t.Fatalf("got %q, want the operator's 8", got)
 		}
 	})
 }

--- a/tools/thuishaven/domain/checkslots_test.go
+++ b/tools/thuishaven/domain/checkslots_test.go
@@ -65,25 +65,42 @@ func TestResolveCheckSlots(t *testing.T) {
 }
 
 // @scenario "A forced pressure level overrides the measurement"
+// @scenario "CI keeps the runtime limits it had before the pressure policy"
 func TestResolveCheckPressure(t *testing.T) {
 	t.Run("given an explicit CHECK_PRESSURE", func(t *testing.T) {
-		if got := ResolveCheckPressure("green", Red); got != Green {
+		if got := ResolveCheckPressure("green", Red, ""); got != Green {
 			t.Fatalf("green must override a red measurement, got %s", got)
 		}
-		if got := ResolveCheckPressure("RED", Green); got != Red {
+		if got := ResolveCheckPressure("RED", Green, ""); got != Red {
 			t.Fatalf("red must override in any case, got %s", got)
 		}
-		if got := ResolveCheckPressure(" amber ", Green); got != Amber {
+		if got := ResolveCheckPressure(" amber ", Green, ""); got != Amber {
 			t.Fatalf("surrounding spaces must not matter, got %s", got)
 		}
 	})
 
 	t.Run("given no or a misspelled override", func(t *testing.T) {
-		if got := ResolveCheckPressure("", Amber); got != Amber {
+		if got := ResolveCheckPressure("", Amber, ""); got != Amber {
 			t.Fatalf("empty must fall back to the measurement, got %s", got)
 		}
-		if got := ResolveCheckPressure("bananas", Red); got != Red {
+		if got := ResolveCheckPressure("bananas", Red, ""); got != Red {
 			t.Fatalf("a typo must fall back to the measurement, got %s", got)
+		}
+	})
+
+	t.Run("given CI", func(t *testing.T) {
+		for _, ci := range []string{"true", "1", "TRUE", " true "} {
+			if got := ResolveCheckPressure("", Red, ci); got != Green {
+				t.Fatalf("CI=%q must read green, got %s", ci, got)
+			}
+		}
+		for _, notCI := range []string{"", "0", "false", "FALSE", "  "} {
+			if got := ResolveCheckPressure("", Red, notCI); got != Red {
+				t.Fatalf("CI=%q is not CI and must keep the measurement, got %s", notCI, got)
+			}
+		}
+		if got := ResolveCheckPressure("red", Green, "true"); got != Red {
+			t.Fatalf("an explicit level must win even under CI, got %s", got)
 		}
 	})
 }


### PR DESCRIPTION
A whole-tree typecheck on a memory-starved laptop makes the machine unusable, and the reaction chain it triggers makes things worse: the operator kills the run, the next agent sees a bare exit 137, blames the queue, and re-runs with `CHECK_SLOTS=0`, which removes the machine-wide serialization for everyone. This PR makes the checks adapt to the machine instead.

## What the machine showed

Measured on an 18 GiB M3 Pro that was already under pressure (swap 89% full, compressor holding 42 GB compressed into 7.7 GB of RAM, `kern.memorystatus_vm_pressure_level` at warning, and a swap-exhaustion kernel panic two days earlier):

- An uncapped cold `tsc` footprinted **7.26 GB** peak against a max RSS of only 1.9 GB. Most of its pages were compressed or swapped in the same breath they were allocated. That eviction is what the person at the keyboard feels.
- The time split: 331 s wall, **80 s user against 162 s system**. Twice as much kernel time (paging) as compile time.
- CPU never passed ~2.8 of 11 cores. On a pressured machine the constraint is memory, not CPU.
- `GOMEMLIMIT` resolves to 6 GiB on this machine (ADR-100 clamp), and it is a ceiling the Go runtime expands toward. The gap between the 2 to 3.5 GB working set and the 6 GiB ceiling is garbage not yet collected, paid for by evicting everyone else's pages.

## The policy: pressure-aware checks

The queue now reads the machine's memory-pressure level at spawn, reusing ADR-090's `ClassifyPressure` (swap fill or compressor occupancy, either alone raises the level). Under amber or red, every whole-repo check runs in its smallest shape:

- **`GOMEMLIMIT` drops to the 3 GiB floor.** The check pays in its own GC time instead of everything else paying in swap.
- **`GOMAXPROCS` is halved, never below two.** Eleven threads all taking page faults is what a seized machine feels like.
- **The machine-derived slot limit narrows to one.** The formula assumes an idle machine; pressure is the machine saying that assumption is false.

Explicit `GOMEMLIMIT`, `GOMAXPROCS` and `CHECK_SLOTS` still win. `CHECK_PRESSURE=green|amber|red` forces the level, for tests and for operators. A machine the queue cannot read is green: a governor that cannot see must not throttle.

CI reads green by rule, before any measurement, so it keeps the ceiling and the parallelism it had before. The queue already stands down on a runner, and the same reasoning retires the pressure policy with it: one job, nobody typing on it, so buying back an interactive machine buys nothing and only makes the job slower. A swap figure read inside a container also describes the host rather than the job. A developer machine that turns the queue off with `CHECK_SLOTS=0` does keep its caps, which is the case the policy exists for.

Both queue implementations move together, as ADR-100 requires: the Go one in `tools/thuishaven` (`domain/checkslots.go`, `cmd/slot.go`) and the JS fallback in `dev/scripts/check-queue.mjs`. `--explain` prints the level and the resolved caps on both.

Verified live on the pressured machine itself: `--explain` resolves `pressure=red gomemlimit=3GiB gomaxprocs=5`, and the typecheck for this PR ran visibly capped (about 1 to 2 GB RSS, half the cores) instead of footprinting 7 GB.

## The queue explains an outside kill

A check that dies by a signal the wrapper did not forward now prints, on both implementations:

```
checks: <cmd> was killed from outside by SIGKILL. The queue never kills runs; the likely cause is an operator kill or the OS reclaiming memory. Re-run the same command. Do not set CHECK_SLOTS=0.
```

This line lands in the transcript at the exact moment an agent would otherwise misdiagnose the death and bypass the queue. Observed in the wild: an agent did exactly that after an operator kill, and recorded the bypass as a lesson. A Ctrl-C the wrapper itself forwarded is not reported, and neither is a command that fails on its own.

## Docs

- ADR-100 gains an amendment recording the pressured-machine measurements and the policy, including why background QoS (`taskpolicy -b`) is not the answer: it deprioritizes the page-ins the run needs to make progress at all (measured starving at 0.3 to 4% CPU for eight minutes).
- `specs/setup/check-slots.feature` gains five scenarios, all bound on both implementations.
- `tools/thuishaven/README.md` documents the pressured shape.

## Verification

- Go: `go build`, `go vet`, `go test -race ./tools/thuishaven/...`, `make go-lint-changed` (0 issues), full `go test ./...` for thuishaven.
- JS: `pnpm test:unit run scripts/__tests__/check-queue.unit.test.ts` 30 passed, biome clean on touched files.
- `check:feature-parity`: check-slots.feature 45/45 bound, repo total 7644 bound.
- `pnpm typecheck:tests`: clean, run through the new queue in its pressured shape.
- The signal-record regression test was checked against the unfixed code: with the drain removed it fails, and passes 20 runs with it.

## Deployment Impact

No deployment impact. This PR changes local developer tooling only: the check queue (`dev/scripts/check-queue.mjs`, `tools/thuishaven`), its tests, specs, and docs. No env vars for deployed services change; `CHECK_PRESSURE` is a local dev knob that no deployed service reads. No helm values change, and a vanilla `helm install` with no overrides behaves the same. BYOC dataplanes are unaffected. CI is unaffected too: CI never queues, and the pressure policy only narrows the machine-derived default on developer machines.