### PR TITLE
chore(dependabot): group langchain/arize families, drop dead mcp/typescript uv entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,6 +98,17 @@ updates:
         patterns:
           - "posthog-js"
           - "posthog-node"
+      langchain:
+        # Real coupled-release family (sdks/typescript depends on langchain +
+        # @langchain/core + @langchain/langgraph + @langchain/openai together).
+        # Bumping them independently is what produced #6804/#7207: two
+        # separate PRs each moved part of the family out of lockstep and each
+        # broke imports on its own. A group only opens once every member
+        # resolves together, which is the actual fix, not just fewer PRs.
+        applies-to: version-updates
+        patterns:
+          - "langchain"
+          - "@langchain/*"
       minor-and-patch:
         applies-to: version-updates
         patterns:
@@ -132,13 +143,21 @@ updates:
           - "minor"
           - "patch"
 
-  # The other two uv projects. Both were missing here, so neither got scheduled
-  # version updates and their locks only ever moved when an advisory-triggered
-  # security PR fired — which for services/langevals was never: it had accrued
-  # 47 open alerts, two of them critical, with zero dependabot PRs raised in the
+  # services/langevals was missing here, so it never got scheduled version
+  # updates and its lock only ever moved when an advisory-triggered security
+  # PR fired — which for services/langevals was never: it had accrued 47 open
+  # alerts, two of them critical, with zero dependabot PRs raised in the
   # project's history. A lock that never moves also drifts far enough that a
   # single security bump stops resolving cleanly, which is how the backlog
   # became self-sustaining. Same shape as /sdks/python above.
+  #
+  # Deliberately NOT covering /mcp/typescript. Its uv.lock exists only to
+  # typecheck Python fixture files under tests/fixtures/ for the MCP server's
+  # instrumentation-codegen — nothing in CI installs or executes it. A first
+  # scheduled sweep here on 2026-08-19 dumped 24 individual PRs (bump one dev
+  # fixture's transitive typing dep, repeat) for zero coverage gain and
+  # meaningfully added to the org's ~76-slot concurrent-job ceiling. If this
+  # directory starts being actually installed/run, re-add the entry then.
   - package-ecosystem: "uv"
     directory: "/services/langevals"
     schedule:
@@ -152,23 +171,13 @@ updates:
         applies-to: version-updates
         patterns:
           - "langchain*"
-      minor-and-patch:
+      arize:
+        # arize-phoenix today; grouped pre-emptively because upstream ships
+        # sibling packages (arize-phoenix-otel/-evals/-client) that release in
+        # step with it and would otherwise fragment the same way once used.
         applies-to: version-updates
         patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "uv"
-    directory: "/mcp/typescript"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 50
-    cooldown:
-      default-days: 8
-    groups:
+          - "arize*"
       minor-and-patch:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## Summary
- Adds a `langchain` group to the root npm entry (`langchain`, `@langchain/*`) — `sdks/typescript` genuinely depends on this family together, and bumping them independently is what produced #6804/#7207 as two separate PRs that each broke imports by moving part of the family out of lockstep.
- Adds an `arize` group to `/services/langevals` (pattern `arize*`) — grouped pre-emptively since upstream ships sibling packages (`arize-phoenix-otel`/`-evals`/`-client`) that release in step with `arize-phoenix`.
- **Drops the `/mcp/typescript` uv entry entirely.** Its `uv.lock` only typechecks Python fixture files under `tests/fixtures/` for the MCP server's instrumentation-codegen — nothing in CI installs or executes it. Its first scheduled sweep (2026-08-19) dumped 24 individual PRs for zero coverage gain, adding real load against the org's ~76-slot concurrent-job CI ceiling.

## Evidence
Pulled from the actual PR history (`gh pr list --search "label:dependencies"`) since the Aug-4 workspace consolidation (ADR-076): the root npm groups are working as designed, and the two `uv` entries added in the Aug-19 alert-backlog cleanup (`e5e64aa692`) account for nearly all current fragmentation — 39 distinct individually-bumped packages in `/mcp/typescript` alone in one sweep, vs. 0 real coverage since nothing executes that lockfile.

## What's NOT in this PR
- The ~20 still-open `/mcp/typescript` Dependabot PRs are now orphaned by this config change and need manual closing (Dependabot won't auto-close them) — happy to do that once this merges, or as a follow-up.
- No change to `/sdks/python`'s existing `langchain`/`opentelemetry` groups — already correctly configured.

## Deployment Impact
No deployment impact — this only changes `.github/dependabot.yml` (Dependabot config), not touching `charts/`, `services/` runtime code, ADRs, or self-hosting docs. No env vars, Helm values, or BYOC dataplane behavior affected.

## Test plan
- [x] Validated the YAML parses correctly and groups/entries match intent (`js-yaml`, checked in this session)
- [ ] Confirm next Monday's scheduled Dependabot run produces the expected grouped PRs (langchain family as one PR, arize as one PR, no new mcp/typescript PRs)