### PR TITLE
fix(governance): anthropic cost report amount is cents, not USD (was 100x) + four adjacent puller defects

### DIFF
--- a/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/services/pulled-usage-pricing.service.ts
+++ b/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/services/pulled-usage-pricing.service.ts
@@ -36,9 +36,10 @@ export interface PulledUsageQuantities {
 
 /**
  * A provider that hands us a cost. `costStatus` is the adapter's call and not
- * derivable from the basis: an Anthropic cost report is the invoice figure,
- * while a metered-unit charge reported by another provider is still an
- * approximation of one.
+ * derivable from the basis: only the adapter knows whether the provider's
+ * figure is the invoice or an approximation of one (Anthropic's cost report,
+ * for instance, excludes Priority Tier usage, so it is provider-reported yet
+ * still an estimate).
  */
 interface ProviderReportedPrice {
   basis: typeof PULLED_USAGE_COST_BASIS.PROVIDER_REPORTED;

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -128,7 +128,7 @@ export const SOURCE_TYPE_OPTIONS = [
     label: "Anthropic Admin API (usage & cost)",
     mode: "pull",
     blurb:
-      "Polls Anthropic's organization usage/cost reports with an Admin API key (sk-ant-admin-...). Pick ONE report per source: usage (token counts, we price them) or cost (invoice amounts, carried verbatim). Never create both for the same org — the same spend would be counted twice.",
+      "Polls Anthropic's organization usage/cost reports with an Admin API key (sk-ant-admin-...). Pick ONE report per source: usage (token counts, we price them) or cost (Anthropic's reported spend, excludes Priority Tier). Never create both for the same org — the same spend would be counted twice.",
     icon: <Anthropic />,
   },
   {

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -1210,7 +1210,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       key: "report",
       label: "Report (usage or cost)",
       placeholder: "cost",
-      hint: "Exactly one per source. `cost` carries Anthropic's invoice amounts verbatim; `usage` pulls token counts that we price ourselves. Never create both reports for the same organization — the same spend would be counted twice.",
+      hint: "Exactly one per source. `cost` carries Anthropic's own reported spend (Priority Tier usage is excluded, so it is close to but not the invoice); `usage` pulls token counts that we price ourselves. Never create both reports for the same organization — the same spend would be counted twice.",
       required: true,
     },
     {

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -597,6 +597,34 @@ describe("the Anthropic Admin puller", () => {
       );
     });
 
+    it("falls back to the configured start when a kept usage watermark is not a date", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(USAGE_PAGE));
+
+      await new AnthropicAdminPuller().runOnce(
+        {
+          ...RUN_OPTIONS,
+          // A corrupt watermark certifies no history, so falling back
+          // duplicates nothing — while passing it through as `starting_at`
+          // would 400 on every retry forever (the cursor holds still on
+          // failure).
+          cursor: '{"startingAt":"not-a-date","page":"page_stale"}',
+        },
+        {
+          adapter: "anthropic_admin",
+          report: "usage",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+          startingAt: "2026-07-01T00:00:00.000Z",
+        },
+      );
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).not.toContain("page=");
+      expect(url).toContain(
+        `starting_at=${encodeURIComponent("2026-07-01T00:00:00.000Z")}`,
+      );
+    });
+
     it("never rewinds a cost source FORWARD: a backlogged watermark older than the configured start survives", async () => {
       fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
 

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -547,7 +547,7 @@ describe("the Anthropic Admin puller", () => {
       expect(String(fetchMock.mock.calls[0]?.[0])).toContain("page=page_2");
     });
 
-    it("drops the page token but keeps the watermark on a config edit", async () => {
+    it("discards the cursor and re-reads from the configured start on a config edit", async () => {
       const puller = new AnthropicAdminPuller();
       const cursor = await midWindowCursor(puller);
 
@@ -558,7 +558,8 @@ describe("the Anthropic Admin puller", () => {
 
       const url = String(fetchMock.mock.calls[0]?.[0]);
       expect(url).not.toContain("page=");
-      // The watermark survives: the window is re-read, not skipped.
+      // The whole window is re-read from the configured start: the watermark
+      // only certifies data pulled under the query it was minted with.
       expect(url).toContain(
         `starting_at=${encodeURIComponent("2026-08-01T00:00:00.000Z")}`,
       );
@@ -572,7 +573,8 @@ describe("the Anthropic Admin puller", () => {
           ...RUN_OPTIONS,
           // A cursor persisted by the previous version: no query identity.
           // This fix itself changes the group_by set, so replaying its page
-          // token would 400 on the first post-deploy run.
+          // token would 400 on the first post-deploy run — and everything
+          // behind its watermark was mapped by the old code.
           cursor: '{"startingAt":"2026-08-01T00:00:00Z","page":"page_stale"}',
         },
         {
@@ -580,14 +582,54 @@ describe("the Anthropic Admin puller", () => {
           report: "usage",
           bucketWidth: "1d",
           schedule: "0 * * * *",
+          startingAt: "2026-07-01T00:00:00.000Z",
         },
       );
 
       const url = String(fetchMock.mock.calls[0]?.[0]);
       expect(url).not.toContain("page=");
+      // Rewound to the configured start, not the legacy watermark.
       expect(url).toContain(
-        `starting_at=${encodeURIComponent("2026-08-01T00:00:00Z")}`,
+        `starting_at=${encodeURIComponent("2026-07-01T00:00:00.000Z")}`,
       );
+    });
+
+    it("rewinds a drained cost cursor from the 100x era so restatement can repair it", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
+
+      const result = await new AnthropicAdminPuller().runOnce(
+        {
+          ...RUN_OPTIONS,
+          // A mature source: drained (no page token), watermark well past the
+          // buckets whose costs were stored 100x. Keeping the watermark would
+          // strand those rows forever — no scheduled run ever re-reads them.
+          cursor:
+            '{"startingAt":"2026-08-05T00:00:00Z","page":null,"query":null}',
+        },
+        {
+          adapter: "anthropic_admin",
+          report: "cost",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+          startingAt: "2026-07-01T00:00:00.000Z",
+        },
+      );
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).toContain(
+        `starting_at=${encodeURIComponent("2026-07-01T00:00:00.000Z")}`,
+      );
+      // The re-pulled bucket keeps its stable identity, so the corrected
+      // figure supersedes the 100x row instead of sitting beside it.
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+      expect(record?.costNanoUsd).toBe(412_800_000_000);
+      // And the rewind runs once: the freshly minted cursor carries the
+      // current query identity.
+      expect(JSON.parse(result.cursor ?? "{}").query).toContain("cost:");
     });
   });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -49,13 +49,19 @@ const USAGE_PAGE = {
       results: [
         {
           uncached_input_tokens: 120_000,
-          cache_creation_input_tokens: 1_000,
+          // The API's real shape: cache creation is NESTED, split by TTL.
+          // There is no flat `cache_creation_input_tokens` field.
+          cache_creation: {
+            ephemeral_1h_input_tokens: 1_000,
+            ephemeral_5m_input_tokens: 500,
+          },
           cache_read_input_tokens: 4_000,
           output_tokens: 8_000,
           model: "anthropic/claude-sonnet-5",
           workspace_id: "ws_1",
           api_key_id: "key_1",
           service_tier: "standard",
+          context_window: "0-200k",
         },
       ],
     },
@@ -64,13 +70,15 @@ const USAGE_PAGE = {
   next_page: null,
 };
 
+// `amount` is denominated in CENTS ("lowest currency units"), per the docs:
+// "41280.000000" in USD is $412.80.
 const COST_PAGE = {
   data: [
     {
       starting_at: "2026-08-01T00:00:00Z",
       results: [
         {
-          amount: "1234.567890123",
+          amount: "41280.000000",
           currency: "USD",
           workspace_id: "ws_1",
           description: "Claude usage",
@@ -116,7 +124,10 @@ describe("the Anthropic Admin puller", () => {
       expect(record?.costNanoUsd).toBeGreaterThan(0);
       expect(record?.tokensInput).toBe(120_000);
       expect(record?.tokensCacheRead).toBe(4_000);
-      expect(record?.tokensCacheWrite).toBe(1_000);
+      // Both TTL variants of the nested `cache_creation` object count as
+      // cache-write tokens. The old flat-field schema read this as 0 and the
+      // `.default(0)` masked the shape mismatch.
+      expect(record?.tokensCacheWrite).toBe(1_500);
       expect(record?.occurredAtMs).toBe(Date.parse("2026-08-01T00:00:00Z"));
     });
 
@@ -135,11 +146,46 @@ describe("the Anthropic Admin puller", () => {
       expect(url).toContain("bucket_width=1d");
       expect(url).toContain("group_by%5B%5D=model");
       expect(url).toContain("group_by%5B%5D=workspace_id");
+      // The API returns null for any field not in group_by, so a dimension
+      // that rides the key MUST also be asked for — otherwise serviceTier and
+      // contextWindow are always "", and batch / long-context usage collapses
+      // onto standard usage under one key.
+      expect(url).toContain("group_by%5B%5D=service_tier");
+      expect(url).toContain("group_by%5B%5D=context_window");
+    });
+
+    it("keys rows differing only by context window apart", async () => {
+      const row = USAGE_PAGE.data[0]!.results[0]!;
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          ...USAGE_PAGE,
+          data: [
+            {
+              ...USAGE_PAGE.data[0]!,
+              results: [row, { ...row, context_window: "200k-1M" }],
+            },
+          ],
+        }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "usage",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+
+      // Long-context usage is priced differently, so the two rows must not
+      // collapse onto one identity (source_event_id is the OCSF dedup key).
+      expect(result.events).toHaveLength(2);
+      expect(result.events[0]!.source_event_id).not.toBe(
+        result.events[1]!.source_event_id,
+      );
     });
   });
 
   describe("when the source pulls the cost report", () => {
-    it("carries Anthropic's invoiced figure as an exact provider cost", async () => {
+    it("converts Anthropic's cents figure to USD at the boundary", async () => {
       fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
 
       const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
@@ -155,11 +201,45 @@ describe("the Anthropic Admin puller", () => {
         observedAt: OBSERVED_AT,
       });
       expect(record?.costBasis).toBe("provider_reported");
-      expect(record?.costStatus).toBe("exact");
+      // Not "exact": the cost report excludes Priority Tier usage, so it is
+      // Anthropic's own figure but not the full invoice.
+      expect(record?.costStatus).toBe("estimate");
       expect(record?.rateVersion).toBeNull();
-      // Every digit Anthropic published survives to the integer, which is the
-      // whole reason the exact string rides the hint next to the float.
-      expect(record?.costNanoUsd).toBe(1_234_567_890_123);
+      // The documented worked example: `amount` is denominated in cents, so
+      // "41280.000000" is $412.80 — not $41,280. Stored verbatim it was 100x.
+      expect(record?.costNanoUsd).toBe(412_800_000_000);
+    });
+
+    it("shifts the decimal point without passing through a float", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          ...COST_PAGE,
+          data: [
+            {
+              starting_at: "2026-08-01T00:00:00Z",
+              results: [
+                { ...COST_PAGE.data[0]!.results[0], amount: "1234.567890123" },
+              ],
+            },
+          ],
+        }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "cost",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+      // 1234.567890123 cents = $12.34567890123; every digit nano-USD can hold
+      // survives, the sub-nano tail rounds half away from zero.
+      expect(record?.costNanoUsd).toBe(12_345_678_901);
     });
 
     it("drops a non-USD row rather than inventing a rate, and keeps the rest", async () => {
@@ -195,7 +275,7 @@ describe("the Anthropic Admin puller", () => {
         source: SOURCE,
         observedAt: OBSERVED_AT,
       });
-      expect(record?.costNanoUsd).toBe(1_234_567_890_123);
+      expect(record?.costNanoUsd).toBe(412_800_000_000);
     });
 
     it("asks for the daily bucket the cost report actually supports", async () => {
@@ -280,8 +360,100 @@ describe("the Anthropic Admin puller", () => {
         observedAt: new Date("2026-08-07T09:00:00.000Z"),
       });
 
+      // 999.5 cents = $9.995.
       expect(after?.restatementKey).toBe(before?.restatementKey);
-      expect(after?.costNanoUsd).toBe(999_500_000_000);
+      expect(after?.costNanoUsd).toBe(9_995_000_000);
+    });
+  });
+
+  describe("when the query the cursor was minted under changes", () => {
+    // Anthropic returns 400 when a page token is replayed with changed query
+    // params, and the puller holds the cursor still on failure — so a config
+    // edit would wedge the source: every retry replays the same dead token.
+    const config = {
+      adapter: "anthropic_admin" as const,
+      report: "usage" as const,
+      schedule: "0 * * * *",
+      startingAt: "2026-08-01T00:00:00.000Z",
+    };
+
+    /**
+     * A cursor persisted mid-window, holding a live page token: every page
+     * claims another, so the run exhausts MAX_PAGES_PER_RUN and returns with
+     * the token still in hand.
+     */
+    async function midWindowCursor(puller: AnthropicAdminPuller) {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ ...USAGE_PAGE, has_more: true, next_page: "page_2" }),
+      );
+      const run = await puller.runOnce(RUN_OPTIONS, {
+        ...config,
+        bucketWidth: "1d",
+      });
+      if (!run.cursor?.includes("page_2")) {
+        throw new Error(
+          `expected a mid-window cursor holding page_2, got ${String(run.cursor)}`,
+        );
+      }
+      fetchMock.mockClear();
+      fetchMock.mockResolvedValue(jsonResponse(USAGE_PAGE));
+      return run.cursor;
+    }
+
+    it("keeps replaying Anthropic's page token while the query is unchanged", async () => {
+      const puller = new AnthropicAdminPuller();
+      const cursor = await midWindowCursor(puller);
+
+      await puller.runOnce(
+        { ...RUN_OPTIONS, cursor },
+        { ...config, bucketWidth: "1d" },
+      );
+
+      // Same config → the mid-window token is safe to replay.
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain("page=page_2");
+    });
+
+    it("drops the page token but keeps the watermark on a config edit", async () => {
+      const puller = new AnthropicAdminPuller();
+      const cursor = await midWindowCursor(puller);
+
+      await puller.runOnce(
+        { ...RUN_OPTIONS, cursor },
+        { ...config, bucketWidth: "1h" },
+      );
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).not.toContain("page=");
+      // The watermark survives: the window is re-read, not skipped.
+      expect(url).toContain(
+        `starting_at=${encodeURIComponent("2026-08-01T00:00:00.000Z")}`,
+      );
+    });
+
+    it("treats a cursor from before query-binding as unsafe to replay", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(USAGE_PAGE));
+
+      await new AnthropicAdminPuller().runOnce(
+        {
+          ...RUN_OPTIONS,
+          // A cursor persisted by the previous version: no query identity.
+          // This fix itself changes the group_by set, so replaying its page
+          // token would 400 on the first post-deploy run.
+          cursor: '{"startingAt":"2026-08-01T00:00:00Z","page":"page_stale"}',
+        },
+        {
+          adapter: "anthropic_admin",
+          report: "usage",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+        },
+      );
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).not.toContain("page=");
+      expect(url).toContain(
+        `starting_at=${encodeURIComponent("2026-08-01T00:00:00Z")}`,
+      );
     });
   });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -594,6 +594,31 @@ describe("the Anthropic Admin puller", () => {
       );
     });
 
+    it("never rewinds FORWARD: a backlogged watermark older than the configured start survives", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(USAGE_PAGE));
+
+      await new AnthropicAdminPuller().runOnce(
+        {
+          ...RUN_OPTIONS,
+          // A source that fell behind: legacy cursor, watermark months old.
+          // No configured startingAt, so the rewind target would default to
+          // ~24h ago — snapping forward would silently skip the backlog.
+          cursor: '{"startingAt":"2026-06-01T00:00:00Z","page":null}',
+        },
+        {
+          adapter: "anthropic_admin",
+          report: "usage",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+        },
+      );
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).toContain(
+        `starting_at=${encodeURIComponent("2026-06-01T00:00:00Z")}`,
+      );
+    });
+
     it("rewinds a drained cost cursor from the 100x era so restatement can repair it", async () => {
       fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
 

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -183,6 +183,35 @@ describe("the Anthropic Admin puller", () => {
       );
     });
 
+    it("keys rows differing only by service tier apart", async () => {
+      const row = USAGE_PAGE.data[0]!.results[0]!;
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          ...USAGE_PAGE,
+          data: [
+            {
+              ...USAGE_PAGE.data[0]!,
+              results: [row, { ...row, service_tier: "batch" }],
+            },
+          ],
+        }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "usage",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+
+      // Batch usage is priced differently from standard, so service tier must
+      // participate in identity the same way context window does.
+      expect(result.events).toHaveLength(2);
+      expect(result.events[0]!.source_event_id).not.toBe(
+        result.events[1]!.source_event_id,
+      );
+    });
+
     it("falls back to the legacy flat cache-creation field when the nested object is absent", async () => {
       const { cache_creation: _nested, ...row } =
         USAGE_PAGE.data[0]!.results[0]!;
@@ -331,6 +360,42 @@ describe("the Anthropic Admin puller", () => {
       // The unsupported row is gone and the USD row beside it survived. A
       // throw here would have unwound the whole run — and since the row is
       // non-USD on every retry, it would have wedged the source permanently.
+      expect(result.events).toHaveLength(1);
+      expect(result.errorCount).toBe(0);
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+      expect(record?.costNanoUsd).toBe(412_800_000_000);
+    });
+
+    it("drops a malformed amount row rather than aborting the pull", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          ...COST_PAGE,
+          data: [
+            {
+              starting_at: "2026-08-01T00:00:00Z",
+              results: [
+                { ...COST_PAGE.data[0]!.results[0], amount: "not-a-number" },
+                COST_PAGE.data[0]!.results[0],
+              ],
+            },
+          ],
+        }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "cost",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+
+      // Same blast-radius call as the non-USD row: the malformed row would be
+      // malformed again on every retry, so a throw would wedge the source
+      // permanently. One bad row costs one row.
       expect(result.events).toHaveLength(1);
       expect(result.errorCount).toBe(0);
       const record = buildPulledUsageRecord({

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -242,6 +242,39 @@ describe("the Anthropic Admin puller", () => {
       expect(record?.costNanoUsd).toBe(12_345_678_901);
     });
 
+    it("survives an exponent-form amount from the schema's number branch", async () => {
+      // JSON.stringify never emits this, but the amount schema accepts raw
+      // numbers, and String(1e-7) is "1e-7" — the one input class the digit
+      // shift can't handle by slicing. It must convert, not throw: a throw
+      // here holds the cursor and replays forever.
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          ...COST_PAGE,
+          data: [
+            {
+              starting_at: "2026-08-01T00:00:00Z",
+              results: [{ ...COST_PAGE.data[0]!.results[0], amount: 1e-7 }],
+            },
+          ],
+        }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "cost",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+      // 1e-7 cents = 1e-9 USD = exactly one nano-USD.
+      expect(record?.costNanoUsd).toBe(1);
+    });
+
     it("drops a non-USD row rather than inventing a rate, and keeps the rest", async () => {
       fetchMock.mockResolvedValue(
         jsonResponse({

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -547,7 +547,7 @@ describe("the Anthropic Admin puller", () => {
       expect(String(fetchMock.mock.calls[0]?.[0])).toContain("page=page_2");
     });
 
-    it("discards the cursor and re-reads from the configured start on a config edit", async () => {
+    it("keeps the usage watermark on a config edit, dropping only the page token", async () => {
       const puller = new AnthropicAdminPuller();
       const cursor = await midWindowCursor(puller);
 
@@ -558,23 +558,26 @@ describe("the Anthropic Admin puller", () => {
 
       const url = String(fetchMock.mock.calls[0]?.[0]);
       expect(url).not.toContain("page=");
-      // The whole window is re-read from the configured start: the watermark
-      // only certifies data pulled under the query it was minted with.
+      // Usage identity embeds the config bucket width, so a historical
+      // re-read under the new query would emit rows under NEW keys beside
+      // the old ones — duplicated spend, not restatement. The watermark
+      // survives; only the dead page token goes.
       expect(url).toContain(
         `starting_at=${encodeURIComponent("2026-08-01T00:00:00.000Z")}`,
       );
     });
 
-    it("treats a cursor from before query-binding as unsafe to replay", async () => {
+    it("keeps a pre-query-binding usage watermark rather than rewinding into duplicates", async () => {
       fetchMock.mockResolvedValue(jsonResponse(USAGE_PAGE));
 
       await new AnthropicAdminPuller().runOnce(
         {
           ...RUN_OPTIONS,
           // A cursor persisted by the previous version: no query identity.
-          // This fix itself changes the group_by set, so replaying its page
-          // token would 400 on the first post-deploy run — and everything
-          // behind its watermark was mapped by the old code.
+          // Its page token would 400 against the widened group_by, so it
+          // goes — but the watermark stays: this PR changed the usage
+          // identity (serviceTier, contextWindow), so re-reading history
+          // would double-count every bucket instead of restating it.
           cursor: '{"startingAt":"2026-08-01T00:00:00Z","page":"page_stale"}',
         },
         {
@@ -588,26 +591,26 @@ describe("the Anthropic Admin puller", () => {
 
       const url = String(fetchMock.mock.calls[0]?.[0]);
       expect(url).not.toContain("page=");
-      // Rewound to the configured start, not the legacy watermark.
+      // NOT rewound to the configured start — the watermark is kept.
       expect(url).toContain(
-        `starting_at=${encodeURIComponent("2026-07-01T00:00:00.000Z")}`,
+        `starting_at=${encodeURIComponent("2026-08-01T00:00:00Z")}`,
       );
     });
 
-    it("never rewinds FORWARD: a backlogged watermark older than the configured start survives", async () => {
-      fetchMock.mockResolvedValue(jsonResponse(USAGE_PAGE));
+    it("never rewinds a cost source FORWARD: a backlogged watermark older than the configured start survives", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
 
       await new AnthropicAdminPuller().runOnce(
         {
           ...RUN_OPTIONS,
-          // A source that fell behind: legacy cursor, watermark months old.
-          // No configured startingAt, so the rewind target would default to
-          // ~24h ago — snapping forward would silently skip the backlog.
+          // A cost source that fell behind: legacy cursor, watermark months
+          // old. No configured startingAt, so the rewind target would default
+          // to ~3 days ago — snapping forward would silently skip the backlog.
           cursor: '{"startingAt":"2026-06-01T00:00:00Z","page":null}',
         },
         {
           adapter: "anthropic_admin",
-          report: "usage",
+          report: "cost",
           bucketWidth: "1d",
           schedule: "0 * * * *",
         },

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -182,6 +182,36 @@ describe("the Anthropic Admin puller", () => {
         result.events[1]!.source_event_id,
       );
     });
+
+    it("falls back to the legacy flat cache-creation field when the nested object is absent", async () => {
+      const { cache_creation: _nested, ...row } =
+        USAGE_PAGE.data[0]!.results[0]!;
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          ...USAGE_PAGE,
+          data: [
+            {
+              ...USAGE_PAGE.data[0]!,
+              results: [{ ...row, cache_creation_input_tokens: 2_345 }],
+            },
+          ],
+        }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "usage",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+      expect(record?.tokensCacheWrite).toBe(2_345);
+    });
   });
 
   describe("when the source pulls the cost report", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -687,6 +687,75 @@ describe("the Anthropic Admin puller", () => {
       // current query identity.
       expect(JSON.parse(result.cursor ?? "{}").query).toContain("cost:");
     });
+
+    it("rewinds a cost source again when startingAt is widened after its first run", async () => {
+      // The legacy-source remediation: a source with no configured
+      // `startingAt` first repairs only the default window, THEN the operator
+      // sets a deeper start. The configured start is part of the cost cursor
+      // identity, so the edit mints a mismatch and the rewind fires once more
+      // — without this, the cursor would match forever and the deeper 100x
+      // rows would be unreachable short of deleting the cursor by hand.
+      fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
+      const puller = new AnthropicAdminPuller();
+
+      const firstRun = await puller.runOnce(RUN_OPTIONS, {
+        adapter: "anthropic_admin",
+        report: "cost",
+        bucketWidth: "1d",
+        schedule: "0 * * * *",
+      });
+      fetchMock.mockClear();
+      fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
+
+      await puller.runOnce(
+        { ...RUN_OPTIONS, cursor: firstRun.cursor },
+        {
+          adapter: "anthropic_admin",
+          report: "cost",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+          startingAt: "2026-01-01T00:00:00.000Z",
+        },
+      );
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).toContain(
+        `starting_at=${encodeURIComponent("2026-01-01T00:00:00.000Z")}`,
+      );
+    });
+
+    it("keeps replaying a cost page token while the config is unchanged", async () => {
+      // Guards the identity's stability: what `runOnce` mints must be what
+      // `parseCursor` computes for the same config, or every scheduled run
+      // would discard its cursor and re-read from the start.
+      fetchMock.mockResolvedValue(
+        jsonResponse({ ...COST_PAGE, has_more: true, next_page: "page_2" }),
+      );
+      const puller = new AnthropicAdminPuller();
+      const costConfig = {
+        adapter: "anthropic_admin" as const,
+        report: "cost" as const,
+        bucketWidth: "1d" as const,
+        schedule: "0 * * * *",
+        startingAt: "2026-08-01T00:00:00.000Z",
+      };
+
+      const firstRun = await puller.runOnce(RUN_OPTIONS, costConfig);
+      if (!firstRun.cursor?.includes("page_2")) {
+        throw new Error(
+          `expected a mid-window cursor holding page_2, got ${String(firstRun.cursor)}`,
+        );
+      }
+      fetchMock.mockClear();
+      fetchMock.mockResolvedValue(jsonResponse(COST_PAGE));
+
+      await puller.runOnce(
+        { ...RUN_OPTIONS, cursor: firstRun.cursor },
+        costConfig,
+      );
+
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain("page=page_2");
+    });
   });
 
   describe("when a page claims more pages but names none", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -379,6 +379,12 @@ describe("the Anthropic Admin puller", () => {
               starting_at: "2026-08-01T00:00:00Z",
               results: [
                 { ...COST_PAGE.data[0]!.results[0], amount: "not-a-number" },
+                // An exponent past Number's safe-integer range would collapse
+                // to Infinity and emit "eInfinity" — malformed, not money.
+                {
+                  ...COST_PAGE.data[0]!.results[0],
+                  amount: `1e${"9".repeat(309)}`,
+                },
                 COST_PAGE.data[0]!.results[0],
               ],
             },

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -547,7 +547,7 @@ describe("the Anthropic Admin puller", () => {
       expect(String(fetchMock.mock.calls[0]?.[0])).toContain("page=page_2");
     });
 
-    it("keeps the usage watermark on a config edit, dropping only the page token", async () => {
+    it("resumes a config-edited usage source from the newest bucket it emitted, not the window start", async () => {
       const puller = new AnthropicAdminPuller();
       const cursor = await midWindowCursor(puller);
 
@@ -558,13 +558,48 @@ describe("the Anthropic Admin puller", () => {
 
       const url = String(fetchMock.mock.calls[0]?.[0]);
       expect(url).not.toContain("page=");
-      // Usage identity embeds the config bucket width, so a historical
-      // re-read under the new query would emit rows under NEW keys beside
-      // the old ones — duplicated spend, not restatement. The watermark
-      // survives; only the dead page token goes.
+      // Usage identity embeds the config bucket width, so everything re-read
+      // under the new query is emitted under NEW keys beside the old rows —
+      // duplicated spend, not restatement. Restarting the window at its
+      // start would re-read every page already emitted, so the resume point
+      // is the in-window watermark the cut-off run recorded (the bucket's
+      // `starting_at`, not the window's `2026-08-01T00:00:00.000Z` start):
+      // at most one bucket is re-read.
       expect(url).toContain(
-        `starting_at=${encodeURIComponent("2026-08-01T00:00:00.000Z")}`,
+        `starting_at=${encodeURIComponent("2026-08-01T00:00:00Z")}`,
       );
+    });
+
+    it("records the newest bucket emitted beside the page token when a run is cut off", async () => {
+      const puller = new AnthropicAdminPuller();
+
+      const cursor = await midWindowCursor(puller);
+
+      // The window start alone says where the window BEGAN, not how far the
+      // run got — resuming a stale cursor from it re-reads the whole window.
+      expect(JSON.parse(cursor)).toMatchObject({
+        startingAt: "2026-08-01T00:00:00.000Z",
+        page: "page_2",
+        watermark: "2026-08-01T00:00:00Z",
+      });
+    });
+
+    it("carries the recorded watermark through a resumed run cut off before its first page", async () => {
+      const puller = new AnthropicAdminPuller();
+      const cursor = await midWindowCursor(puller);
+
+      const run = await puller.runOnce(
+        { ...RUN_OPTIONS, cursor, deadlineMs: Date.now() - 1 },
+        { ...config, bucketWidth: "1d" },
+      );
+
+      // A deadline that fires before any page is read must not blank the
+      // watermark the previous run recorded — that would silently widen the
+      // stale-cursor re-read back to the whole window.
+      expect(JSON.parse(run.cursor!)).toMatchObject({
+        page: "page_2",
+        watermark: "2026-08-01T00:00:00Z",
+      });
     });
 
     it("keeps a pre-query-binding usage watermark rather than rewinding into duplicates", async () => {
@@ -573,11 +608,15 @@ describe("the Anthropic Admin puller", () => {
       await new AnthropicAdminPuller().runOnce(
         {
           ...RUN_OPTIONS,
-          // A cursor persisted by the previous version: no query identity.
-          // Its page token would 400 against the widened group_by, so it
-          // goes — but the watermark stays: this PR changed the usage
-          // identity (serviceTier, contextWindow), so re-reading history
-          // would double-count every bucket instead of restating it.
+          // A cursor persisted by the previous version: no query identity
+          // and no in-window watermark. Its page token would 400 against the
+          // widened group_by, so it goes — and with no record of how far the
+          // cut-off run got, the resume point falls back to the window
+          // start. That re-reads the in-flight window (bounded by
+          // MAX_PAGES_PER_RUN) under the new usage identity, duplicating
+          // those buckets ONCE — accepted over skipping the rest of the
+          // window. It must not reach further back than that: rewinding to
+          // the configured start would double-count all history.
           cursor: '{"startingAt":"2026-08-01T00:00:00Z","page":"page_stale"}',
         },
         {

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -16,9 +16,13 @@
  *   usage_report/messages — token counts per bucket, no cost. We price it
  *                           ourselves, so every record is `computed` /
  *                           `estimate`.
- *   cost_report           — the amount Anthropic will invoice, per bucket,
- *                           as a decimal string. Carried verbatim, so every
- *                           record is `provider_reported` / `exact`.
+ *   cost_report           — Anthropic's own cost figure, per bucket, as a
+ *                           decimal string denominated in CENTS. Converted to
+ *                           USD at this boundary and recorded as
+ *                           `provider_reported` / `estimate` — estimate
+ *                           because the report excludes Priority Tier usage,
+ *                           so it is the provider's figure but not the full
+ *                           invoice.
  *
  * Never both. The same spend arriving down both paths would be counted twice,
  * and the supersede rule that would let them coexist is named and deferred in
@@ -63,6 +67,25 @@ const MAX_PAGES_PER_RUN = 20;
  */
 const COST_REPORT_BUCKET_WIDTH = "1d" as const;
 
+/**
+ * The group-by sets, named once because they are load-bearing twice: they are
+ * the request parameters AND part of the cursor's query identity below.
+ *
+ * Usage asks for every dimension its restatement key is built from —
+ * `service_tier` and `context_window` included, because the API returns null
+ * for any field not in `group_by`, and a dimension that is always "" collapses
+ * batch and long-context usage onto standard usage under one key.
+ */
+const USAGE_GROUP_BY = [
+  "model",
+  "workspace_id",
+  "api_key_id",
+  "service_tier",
+  "context_window",
+] as const;
+/** The cost report only supports these two. */
+const COST_GROUP_BY = ["workspace_id", "description"] as const;
+
 export const ANTHROPIC_ADMIN_ADAPTER_ID = "anthropic_admin" as const;
 
 export const anthropicAdminPullConfigSchema = z.object({
@@ -87,19 +110,48 @@ export type AnthropicAdminPullConfig = z.infer<
  * The durable cursor. `startingAt` is the watermark a fresh run resumes from
  * and `page` is Anthropic's own token inside that window, so a run cut off
  * mid-window resumes mid-window instead of re-reading it.
+ *
+ * `query` is the identity of the request the page token was minted under.
+ * Anthropic returns 400 when a page token is replayed with changed query
+ * params, and this adapter holds the cursor still on failure — so without the
+ * binding, one config edit mid-window would wedge the source permanently:
+ * every retry replays the same dead token. A mismatch drops only the token;
+ * the watermark survives, so the window is re-read rather than skipped.
  */
 const cursorSchema = z.object({
   startingAt: z.string(),
   page: z.string().nullable().default(null),
+  query: z.string().nullable().default(null),
 });
+
+/**
+ * What Anthropic would reject a replayed page token over: the endpoint and
+ * every query parameter that rides beside `page`.
+ */
+function queryIdentity(config: AnthropicAdminPullConfig): string {
+  return config.report === "usage"
+    ? `usage:${config.bucketWidth}:${USAGE_GROUP_BY.join(",")}`
+    : `cost:${COST_REPORT_BUCKET_WIDTH}:${COST_GROUP_BY.join(",")}`;
+}
 
 function parseCursor(
   cursor: string | null,
   config: AnthropicAdminPullConfig,
-): z.infer<typeof cursorSchema> {
+): { startingAt: string; page: string | null } {
   if (cursor) {
     try {
-      return cursorSchema.parse(JSON.parse(cursor));
+      const parsed = cursorSchema.parse(JSON.parse(cursor));
+      if (parsed.page !== null && parsed.query !== queryIdentity(config)) {
+        // Also covers cursors minted before query-binding existed (`query`
+        // null): this change itself widened the group_by set, so their page
+        // tokens are exactly the ones that would 400 on the first replay.
+        logger.warn(
+          { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
+          "anthropic admin cursor was minted under a different query; dropping the page token and re-reading the window from the watermark",
+        );
+        return { startingAt: parsed.startingAt, page: null };
+      }
+      return { startingAt: parsed.startingAt, page: parsed.page };
     } catch {
       logger.warn(
         { cursor },
@@ -113,8 +165,12 @@ function parseCursor(
   };
 }
 
-function encodeCursor(startingAt: string, page: string | null): string {
-  return JSON.stringify({ startingAt, page });
+function encodeCursor(
+  startingAt: string,
+  page: string | null,
+  query: string,
+): string {
+  return JSON.stringify({ startingAt, page, query });
 }
 
 /**
@@ -169,6 +225,18 @@ async function fetchPageError(
 const usageResultSchema = z
   .object({
     uncached_input_tokens: z.number().nonnegative().default(0),
+    /**
+     * The API nests cache creation, split by cache TTL. The flat
+     * `cache_creation_input_tokens` fallback below is tolerance for a shape
+     * the docs no longer show — the nested object wins whenever present.
+     */
+    cache_creation: z
+      .object({
+        ephemeral_1h_input_tokens: z.number().nonnegative().default(0),
+        ephemeral_5m_input_tokens: z.number().nonnegative().default(0),
+      })
+      .passthrough()
+      .nullish(),
     cache_creation_input_tokens: z.number().nonnegative().default(0),
     cache_read_input_tokens: z.number().nonnegative().default(0),
     output_tokens: z.number().nonnegative().default(0),
@@ -176,8 +244,23 @@ const usageResultSchema = z
     workspace_id: z.string().nullable().default(null),
     api_key_id: z.string().nullable().default(null),
     service_tier: z.string().nullable().default(null),
+    context_window: z.string().nullable().default(null),
   })
   .passthrough();
+
+/**
+ * Every cache-write token in a usage row, whichever shape carried it. The old
+ * flat-only schema read the nested shape as 0 and the `.default(0)` masked it.
+ */
+function cacheWriteTokens(result: z.infer<typeof usageResultSchema>): number {
+  if (result.cache_creation) {
+    return (
+      result.cache_creation.ephemeral_1h_input_tokens +
+      result.cache_creation.ephemeral_5m_input_tokens
+    );
+  }
+  return result.cache_creation_input_tokens;
+}
 
 /** One group-by row inside a cost bucket. `amount` is a decimal string. */
 const costResultSchema = z
@@ -190,6 +273,28 @@ const costResultSchema = z
     model: z.string().nullable().default(null),
   })
   .passthrough();
+
+/**
+ * Anthropic's `amount` is denominated in the currency's LOWEST unit — cents
+ * for USD — as a decimal string: the docs' worked example is `"123.45"` in
+ * USD meaning $1.23. The shift to dollars is index arithmetic on the string,
+ * so no digit ever passes through a float on the way to the ledger.
+ *
+ * An amount that is not a plain decimal throws rather than guesses: same
+ * class as a malformed page — a contract that moved, not a row to retry.
+ */
+function centsToUsd(amount: string): string {
+  const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());
+  if (!match) {
+    throw new Error(
+      `anthropic cost amount is not a decimal string: ${JSON.stringify(amount)}`,
+    );
+  }
+  const [, sign = "", wholeRaw = "0", fraction = ""] = match;
+  // Three digits guarantee a whole part survives the two-digit shift.
+  const whole = wholeRaw.padStart(3, "0");
+  return `${sign}${whole.slice(0, -2)}.${whole.slice(-2)}${fraction}`;
+}
 
 const bucketSchema = z.object({
   starting_at: z.string(),
@@ -231,6 +336,45 @@ function dimensionPath(dimensions: Record<string, string>): string {
   return Object.values(dimensions).map(encodeURIComponent).join(":");
 }
 
+/**
+ * The request URL for one page of one report. Everything here except `page`
+ * is what `queryIdentity` binds the cursor to — change one, change both.
+ */
+function reportUrl({
+  config,
+  startingAt,
+  page,
+}: {
+  config: AnthropicAdminPullConfig;
+  startingAt: string;
+  page: string | null;
+}): URL {
+  const url = new URL(
+    config.report === "usage"
+      ? `${API_BASE}/usage_report/messages`
+      : `${API_BASE}/cost_report`,
+  );
+  url.searchParams.set("starting_at", startingAt);
+  if (config.report === "usage") {
+    url.searchParams.set("bucket_width", config.bucketWidth);
+    for (const dim of USAGE_GROUP_BY) {
+      url.searchParams.append("group_by[]", dim);
+    }
+  } else {
+    // The cost report is daily-only, so the width is pinned here rather than
+    // taken from config. It has to match `COST_REPORT_BUCKET_WIDTH`, which
+    // rides the restatement key: a width that could vary with config would
+    // re-key unchanged cost buckets the moment an operator edited it, and
+    // the same spend would be recorded twice.
+    url.searchParams.set("bucket_width", COST_REPORT_BUCKET_WIDTH);
+    for (const dim of COST_GROUP_BY) {
+      url.searchParams.append("group_by[]", dim);
+    }
+  }
+  if (page) url.searchParams.set("page", page);
+  return url;
+}
+
 export class AnthropicAdminPuller
   implements PullerAdapter<AnthropicAdminPullConfig>
 {
@@ -250,6 +394,7 @@ export class AnthropicAdminPuller
     // mid-run can never quietly carry a different `startingAt` with it.
     const cursor = parseCursor(options.cursor, config);
     const startingAt = cursor.startingAt;
+    const query = queryIdentity(config);
     let page = cursor.page;
 
     for (let pageCount = 0; pageCount < MAX_PAGES_PER_RUN; pageCount += 1) {
@@ -258,7 +403,7 @@ export class AnthropicAdminPuller
         // so a deadline costs latency rather than a window.
         return {
           events,
-          cursor: encodeCursor(startingAt, page),
+          cursor: encodeCursor(startingAt, page, query),
           errorCount: 0,
         };
       }
@@ -276,7 +421,7 @@ export class AnthropicAdminPuller
         // watermark only ever moves forward.
         return {
           events,
-          cursor: encodeCursor(read.watermark ?? startingAt, null),
+          cursor: encodeCursor(read.watermark ?? startingAt, null, query),
           errorCount: 0,
         };
       }
@@ -287,7 +432,11 @@ export class AnthropicAdminPuller
       { adapter: this.id, report: config.report },
       "anthropic admin hit MAX_PAGES_PER_RUN; the next run resumes from the cursor",
     );
-    return { events, cursor: encodeCursor(startingAt, page), errorCount: 0 };
+    return {
+      events,
+      cursor: encodeCursor(startingAt, page, query),
+      errorCount: 0,
+    };
   }
 
   /**
@@ -373,29 +522,7 @@ export class AnthropicAdminPuller
       );
     }
 
-    const url = new URL(
-      config.report === "usage"
-        ? `${API_BASE}/usage_report/messages`
-        : `${API_BASE}/cost_report`,
-    );
-    url.searchParams.set("starting_at", startingAt);
-    if (config.report === "usage") {
-      url.searchParams.set("bucket_width", config.bucketWidth);
-      for (const dim of ["model", "workspace_id", "api_key_id"]) {
-        url.searchParams.append("group_by[]", dim);
-      }
-    } else {
-      // The cost report is daily-only, so the width is pinned here rather than
-      // taken from config. It has to match `COST_REPORT_BUCKET_WIDTH`, which
-      // rides the restatement key: a width that could vary with config would
-      // re-key unchanged cost buckets the moment an operator edited it, and
-      // the same spend would be recorded twice.
-      url.searchParams.set("bucket_width", COST_REPORT_BUCKET_WIDTH);
-      url.searchParams.append("group_by[]", "workspace_id");
-      url.searchParams.append("group_by[]", "description");
-    }
-    if (page) url.searchParams.set("page", page);
-
+    const url = reportUrl({ config, startingAt, page });
     const signal = options.signal
       ? AbortSignal.any([
           options.signal,
@@ -464,6 +591,7 @@ export class AnthropicAdminPuller
       workspaceId: dimension(result.workspace_id),
       apiKeyId: dimension(result.api_key_id),
       serviceTier: dimension(result.service_tier),
+      contextWindow: dimension(result.context_window),
     };
     return {
       source_event_id: `usage:${startingAt}:${dimensionPath(dimensions)}`,
@@ -482,7 +610,7 @@ export class AnthropicAdminPuller
           dimensions,
           model: dimension(result.model),
           tokensCacheRead: result.cache_read_input_tokens,
-          tokensCacheWrite: result.cache_creation_input_tokens,
+          tokensCacheWrite: cacheWriteTokens(result),
         },
       },
     };
@@ -522,7 +650,7 @@ export class AnthropicAdminPuller
       );
       return null;
     }
-    const amount = result.amount;
+    const amountUsd = centsToUsd(result.amount);
     return {
       source_event_id: `cost:${startingAt}:${dimensionPath(dimensions)}`,
       event_timestamp: startingAt,
@@ -531,16 +659,17 @@ export class AnthropicAdminPuller
       target: dimension(result.model),
       // Decimal string — no Number() coercion. The exact value rides through
       // to the pricing service via the hint below.
-      cost_usd: amount,
+      cost_usd: amountUsd,
       tokens_input: 0,
       tokens_output: 0,
       raw_payload: JSON.stringify(result),
       extra: {
         [PULLED_USAGE_HINT_KEY]: {
           costBasis: "provider_reported",
-          // Anthropic's cost report IS the invoiced figure.
-          costStatus: "exact",
-          costUsd: amount,
+          // Anthropic's own figure, but NOT the invoice: the cost report
+          // excludes Priority Tier usage, so "exact" would overclaim.
+          costStatus: "estimate",
+          costUsd: amountUsd,
           dimensions,
           model: dimension(result.model),
         },

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -172,9 +172,9 @@ function encodeCursor({
   startingAt,
   page,
   query,
-}: {
-  startingAt: string;
-  page: string | null;
+}: Omit<z.infer<typeof cursorSchema>, "query"> & {
+  // Refined non-null: every cursor minted after query-binding carries the
+  // query identity; only cursors READ from storage can lack it.
   query: string;
 }): string {
   return JSON.stringify({ startingAt, page, query });
@@ -287,23 +287,24 @@ const costResultSchema = z
  * USD meaning $1.23. The shift to dollars is index arithmetic on the string,
  * so no digit ever passes through a float on the way to the ledger.
  *
- * An amount that is not a plain decimal throws rather than guesses: same
- * class as a malformed page — a contract that moved, not a row to retry.
+ * An amount that is not a decimal returns null rather than guessing — and
+ * rather than throwing: a throw here escapes `runOnce`'s fetch-only error
+ * handling, discards every event already read, and holds the cursor on a row
+ * that would be malformed again on every retry, wedging the source
+ * permanently. Same blast-radius call as the non-USD skip in `costEvent`.
  */
-function centsToUsd(amount: string): string {
+function centsToUsd(amount: string): string | null {
   const match = /^([+-]?)(\d+)(?:\.(\d*))?(?:[eE]([+-]?\d+))?$/.exec(
     amount.trim(),
   );
   if (!match) {
-    throw new Error(
-      `anthropic cost amount is not a decimal string: ${JSON.stringify(amount)}`,
-    );
+    return null;
   }
   const [, sign = "", wholeRaw = "0", fraction = "", exponent] = match;
   if (exponent !== undefined) {
-    // Exponent form ("1e-7") can only reach here via the schema's number
-    // branch stringifying a float. Shift the exponent instead of the digits —
-    // the money parser downstream reads exponents exactly.
+    // Exponent form ("1e-7") — from the schema's number branch stringifying a
+    // float, or sent as a string outright. Shift the exponent instead of the
+    // digits — the money parser downstream reads exponents exactly.
     return `${sign}${wholeRaw}${fraction ? `.${fraction}` : ""}e${
       Number(exponent) - 2
     }`;
@@ -672,6 +673,16 @@ export class AnthropicAdminPuller
       return null;
     }
     const amountUsd = centsToUsd(result.amount);
+    if (amountUsd === null) {
+      // Same reasoning as the non-USD skip above: one permanently malformed
+      // row must cost one row, not the whole source. No raw amount in the
+      // log — dimensions identify the row without echoing unparseable input.
+      logger.error(
+        { adapter: this.id, startingAt, dimensions },
+        "anthropic cost report amount is not a decimal; skipping the row",
+      );
+      return null;
+    }
     return {
       source_event_id: `cost:${startingAt}:${dimensionPath(dimensions)}`,
       event_timestamp: startingAt,

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -126,7 +126,11 @@ export type AnthropicAdminPullConfig = z.infer<
  * old rows in place. That is what repairs the 100x figures — mature sources
  * resume from their watermark, so the wrong rows behind it would otherwise
  * never be re-read. After the first re-pull the cursor carries the current
- * identity and the rewind never fires again.
+ * identity and the rewind never fires again — until the configuration itself
+ * changes: the configured `startingAt` is part of the cost identity, so
+ * WIDENING it later mints a mismatch and the rewind fires once more, reaching
+ * the deeper window. That is the operator's repair lever for sources whose
+ * first post-deploy run only covered the default window.
  *
  * USAGE sources drop only the unsafe page token and KEEP the watermark.
  * Usage identity is NOT stable across a query change — it embeds the config
@@ -144,13 +148,23 @@ const cursorSchema = z.object({
 });
 
 /**
- * What Anthropic would reject a replayed page token over: the endpoint and
- * every query parameter that rides beside `page`.
+ * The configuration a cursor is bound to. Two concerns share it:
+ *
+ * 1. What Anthropic would reject a replayed page token over: the endpoint and
+ *    every query parameter that rides beside `page`.
+ * 2. For COST sources only, the repair window. The configured `startingAt`
+ *    decides how far back a stale-cursor rewind reaches, so widening it on a
+ *    source that has already run must mint a new identity — otherwise the
+ *    cursor matches forever, the watermark replays, and the deeper history
+ *    stays wrong with no way to reach it short of deleting the cursor by
+ *    hand. Usage deliberately excludes it: usage never rewinds (see
+ *    `cursorSchema`), so binding it there would only drop a live page token
+ *    over an edit that changes nothing.
  */
 function queryIdentity(config: AnthropicAdminPullConfig): string {
   return config.report === "usage"
     ? `usage:${config.bucketWidth}:${USAGE_GROUP_BY.join(",")}`
-    : `cost:${COST_REPORT_BUCKET_WIDTH}:${COST_GROUP_BY.join(",")}`;
+    : `cost:${COST_REPORT_BUCKET_WIDTH}:${COST_GROUP_BY.join(",")}:${config.startingAt ?? ""}`;
 }
 
 function parseCursor({
@@ -214,7 +228,7 @@ function staleCursorRestart({
   }
   logger.warn(
     { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
-    "anthropic admin cost cursor was minted under a different query; discarding it and re-reading from the start",
+    "anthropic admin cost cursor was minted under a different query or repair window; discarding it and re-reading from the start",
   );
   const configuredStart = config.startingAt ?? defaultStartingAt(config.report);
   // The EARLIER of the stored watermark and the configured start: the

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -117,15 +117,25 @@ export type AnthropicAdminPullConfig = z.infer<
  * binding, one config edit mid-window would wedge the source permanently:
  * every retry replays the same dead token.
  *
- * A mismatch discards the WHOLE cursor, watermark included, and re-reads from
- * the configured start. The watermark only certifies data pulled under the
- * query it was minted with: everything behind it was fetched, mapped, and
- * priced by the old code, and keeping it would strand those rows as written.
- * That is exactly how the 100x cost figures survived — mature sources resume
- * from their watermark, so the wrong rows behind it were never re-read.
- * Re-reading is idempotent: identities are stable, so restatement supersedes
- * the old rows, and after the first re-pull the cursor carries the current
+ * What a mismatch does depends on whether re-reading can SUPERSEDE:
+ *
+ * COST sources discard the whole cursor, watermark included, and re-read from
+ * the configured start. Cost identity (`costEvent`'s dimensions plus the
+ * pinned bucket width) is independent of config and unchanged by this fix, so
+ * a re-read emits the same `source_event_id`s and restatement replaces the
+ * old rows in place. That is what repairs the 100x figures — mature sources
+ * resume from their watermark, so the wrong rows behind it would otherwise
+ * never be re-read. After the first re-pull the cursor carries the current
  * identity and the rewind never fires again.
+ *
+ * USAGE sources drop only the unsafe page token and KEEP the watermark.
+ * Usage identity is NOT stable across a query change — it embeds the config
+ * bucket width, and this fix itself added `serviceTier` and `contextWindow`
+ * to it — so a historical re-read would emit rows under new keys BESIDE the
+ * old ones rather than superseding them: every re-read bucket would be
+ * double-counted spend. History stays as written (the flat-cache zeros and
+ * collapsed tiers are a documented, bounded wrong); correctness applies from
+ * the watermark forward.
  */
 const cursorSchema = z.object({
   startingAt: z.string(),
@@ -159,25 +169,8 @@ function parseCursor({
       // Also covers cursors minted before query-binding existed (`query`
       // null): this change itself widened the group_by set and fixed the
       // cents→USD conversion, so everything those cursors certify was
-      // written by the old code. Rewind — see the cursorSchema doc for why
-      // the watermark must not survive.
-      logger.warn(
-        { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
-        "anthropic admin cursor was minted under a different query; discarding it and re-reading from the start",
-      );
-      const configuredStart =
-        config.startingAt ?? defaultStartingAt(config.report);
-      // The EARLIER of the stored watermark and the configured start: the
-      // rewind must never move the watermark FORWARD. A source that fell
-      // behind (paused, erroring) holds a watermark older than the default
-      // window, and snapping it to `configuredStart` would silently skip
-      // everything in between.
-      const watermarkMs = Date.parse(parsed.startingAt);
-      const rewoundStart =
-        Number.isNaN(watermarkMs) || Date.parse(configuredStart) <= watermarkMs
-          ? configuredStart
-          : parsed.startingAt;
-      return { startingAt: rewoundStart, page: null };
+      // written by the old code.
+      return staleCursorRestart({ parsed, config });
     } catch {
       logger.warn(
         { cursor },
@@ -189,6 +182,47 @@ function parseCursor({
     startingAt: config.startingAt ?? defaultStartingAt(config.report),
     page: null,
   };
+}
+
+/**
+ * Where a run resumes after its cursor failed the query-identity check.
+ * The split between reports is the cursorSchema doc's supersede-vs-duplicate
+ * distinction: cost re-reads restate, usage re-reads double-count.
+ */
+function staleCursorRestart({
+  parsed,
+  config,
+}: {
+  parsed: z.infer<typeof cursorSchema>;
+  config: AnthropicAdminPullConfig;
+}): Pick<z.infer<typeof cursorSchema>, "startingAt" | "page"> {
+  if (config.report === "usage") {
+    // No rewind: usage identity is not stable across a query change, so
+    // re-reading history would duplicate spend rather than restate it.
+    // The page token still has to go — it would 400 against the new
+    // query params.
+    logger.warn(
+      { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
+      "anthropic admin usage cursor was minted under a different query; dropping the page token and keeping the watermark",
+    );
+    return { startingAt: parsed.startingAt, page: null };
+  }
+  logger.warn(
+    { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
+    "anthropic admin cost cursor was minted under a different query; discarding it and re-reading from the start",
+  );
+  const configuredStart = config.startingAt ?? defaultStartingAt(config.report);
+  // The EARLIER of the stored watermark and the configured start: the
+  // rewind must never move the watermark FORWARD. A source that fell
+  // behind (paused, erroring) holds a watermark older than the default
+  // window, and snapping it to `configuredStart` would silently skip
+  // everything in between.
+  const watermarkMs = Date.parse(parsed.startingAt);
+  const rewoundStart =
+    Number.isNaN(watermarkMs) || Date.parse(configuredStart) <= watermarkMs
+      ? configuredStart
+      : parsed.startingAt;
+  return { startingAt: rewoundStart, page: null };
 }
 
 function encodeCursor({

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -111,12 +111,21 @@ export type AnthropicAdminPullConfig = z.infer<
  * and `page` is Anthropic's own token inside that window, so a run cut off
  * mid-window resumes mid-window instead of re-reading it.
  *
- * `query` is the identity of the request the page token was minted under.
+ * `query` is the identity of the request the cursor was minted under.
  * Anthropic returns 400 when a page token is replayed with changed query
  * params, and this adapter holds the cursor still on failure — so without the
  * binding, one config edit mid-window would wedge the source permanently:
- * every retry replays the same dead token. A mismatch drops only the token;
- * the watermark survives, so the window is re-read rather than skipped.
+ * every retry replays the same dead token.
+ *
+ * A mismatch discards the WHOLE cursor, watermark included, and re-reads from
+ * the configured start. The watermark only certifies data pulled under the
+ * query it was minted with: everything behind it was fetched, mapped, and
+ * priced by the old code, and keeping it would strand those rows as written.
+ * That is exactly how the 100x cost figures survived — mature sources resume
+ * from their watermark, so the wrong rows behind it were never re-read.
+ * Re-reading is idempotent: identities are stable, so restatement supersedes
+ * the old rows, and after the first re-pull the cursor carries the current
+ * identity and the rewind never fires again.
  */
 const cursorSchema = z.object({
   startingAt: z.string(),
@@ -144,17 +153,18 @@ function parseCursor({
   if (cursor) {
     try {
       const parsed = cursorSchema.parse(JSON.parse(cursor));
-      if (parsed.page !== null && parsed.query !== queryIdentity(config)) {
-        // Also covers cursors minted before query-binding existed (`query`
-        // null): this change itself widened the group_by set, so their page
-        // tokens are exactly the ones that would 400 on the first replay.
-        logger.warn(
-          { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
-          "anthropic admin cursor was minted under a different query; dropping the page token and re-reading the window from the watermark",
-        );
-        return { startingAt: parsed.startingAt, page: null };
+      if (parsed.query === queryIdentity(config)) {
+        return { startingAt: parsed.startingAt, page: parsed.page };
       }
-      return { startingAt: parsed.startingAt, page: parsed.page };
+      // Also covers cursors minted before query-binding existed (`query`
+      // null): this change itself widened the group_by set and fixed the
+      // cents→USD conversion, so everything those cursors certify was
+      // written by the old code. Fall through to the configured start —
+      // see the cursorSchema doc for why the watermark must not survive.
+      logger.warn(
+        { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
+        "anthropic admin cursor was minted under a different query; discarding it and re-reading from the configured start",
+      );
     } catch {
       logger.warn(
         { cursor },

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -284,13 +284,23 @@ const costResultSchema = z
  * class as a malformed page — a contract that moved, not a row to retry.
  */
 function centsToUsd(amount: string): string {
-  const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());
+  const match = /^([+-]?)(\d+)(?:\.(\d*))?(?:[eE]([+-]?\d+))?$/.exec(
+    amount.trim(),
+  );
   if (!match) {
     throw new Error(
       `anthropic cost amount is not a decimal string: ${JSON.stringify(amount)}`,
     );
   }
-  const [, sign = "", wholeRaw = "0", fraction = ""] = match;
+  const [, sign = "", wholeRaw = "0", fraction = "", exponent] = match;
+  if (exponent !== undefined) {
+    // Exponent form ("1e-7") can only reach here via the schema's number
+    // branch stringifying a float. Shift the exponent instead of the digits —
+    // the money parser downstream reads exponents exactly.
+    return `${sign}${wholeRaw}${fraction ? `.${fraction}` : ""}e${
+      Number(exponent) - 2
+    }`;
+  }
   // Three digits guarantee a whole part survives the two-digit shift.
   const whole = wholeRaw.padStart(3, "0");
   return `${sign}${whole.slice(0, -2)}.${whole.slice(-2)}${fraction}`;

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -159,12 +159,25 @@ function parseCursor({
       // Also covers cursors minted before query-binding existed (`query`
       // null): this change itself widened the group_by set and fixed the
       // cents→USD conversion, so everything those cursors certify was
-      // written by the old code. Fall through to the configured start —
-      // see the cursorSchema doc for why the watermark must not survive.
+      // written by the old code. Rewind — see the cursorSchema doc for why
+      // the watermark must not survive.
       logger.warn(
         { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
-        "anthropic admin cursor was minted under a different query; discarding it and re-reading from the configured start",
+        "anthropic admin cursor was minted under a different query; discarding it and re-reading from the start",
       );
+      const configuredStart =
+        config.startingAt ?? defaultStartingAt(config.report);
+      // The EARLIER of the stored watermark and the configured start: the
+      // rewind must never move the watermark FORWARD. A source that fell
+      // behind (paused, erroring) holds a watermark older than the default
+      // window, and snapping it to `configuredStart` would silently skip
+      // everything in between.
+      const watermarkMs = Date.parse(parsed.startingAt);
+      const rewoundStart =
+        Number.isNaN(watermarkMs) || Date.parse(configuredStart) <= watermarkMs
+          ? configuredStart
+          : parsed.startingAt;
+      return { startingAt: rewoundStart, page: null };
     } catch {
       logger.warn(
         { cursor },

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -305,8 +305,15 @@ function centsToUsd(amount: string): string | null {
     // Exponent form ("1e-7") — from the schema's number branch stringifying a
     // float, or sent as a string outright. Shift the exponent instead of the
     // digits — the money parser downstream reads exponents exactly.
+    const exponentValue = Number(exponent);
+    if (!Number.isSafeInteger(exponentValue)) {
+      // An exponent too large for exact arithmetic would collapse to
+      // Infinity and emit "eInfinity". No real money amount lives out
+      // there — treat it as malformed.
+      return null;
+    }
     return `${sign}${wholeRaw}${fraction ? `.${fraction}` : ""}e${
-      Number(exponent) - 2
+      exponentValue - 2
     }`;
   }
   // Three digits guarantee a whole part survives the two-digit shift.

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -140,7 +140,7 @@ function parseCursor({
 }: {
   cursor: string | null;
   config: AnthropicAdminPullConfig;
-}): { startingAt: string; page: string | null } {
+}): Pick<z.infer<typeof cursorSchema>, "startingAt" | "page"> {
   if (cursor) {
     try {
       const parsed = cursorSchema.parse(JSON.parse(cursor));

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -200,12 +200,17 @@ function staleCursorRestart({
     // No rewind: usage identity is not stable across a query change, so
     // re-reading history would duplicate spend rather than restate it.
     // The page token still has to go — it would 400 against the new
-    // query params.
+    // query params. A watermark that doesn't parse as a date certifies no
+    // history at all, so falling back to the configured start duplicates
+    // nothing — and passing it through would 400 on every retry forever.
     logger.warn(
       { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
       "anthropic admin usage cursor was minted under a different query; dropping the page token and keeping the watermark",
     );
-    return { startingAt: parsed.startingAt, page: null };
+    const keptWatermark = Number.isNaN(Date.parse(parsed.startingAt))
+      ? (config.startingAt ?? defaultStartingAt(config.report))
+      : parsed.startingAt;
+    return { startingAt: keptWatermark, page: null };
   }
   logger.warn(
     { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -134,10 +134,13 @@ function queryIdentity(config: AnthropicAdminPullConfig): string {
     : `cost:${COST_REPORT_BUCKET_WIDTH}:${COST_GROUP_BY.join(",")}`;
 }
 
-function parseCursor(
-  cursor: string | null,
-  config: AnthropicAdminPullConfig,
-): { startingAt: string; page: string | null } {
+function parseCursor({
+  cursor,
+  config,
+}: {
+  cursor: string | null;
+  config: AnthropicAdminPullConfig;
+}): { startingAt: string; page: string | null } {
   if (cursor) {
     try {
       const parsed = cursorSchema.parse(JSON.parse(cursor));
@@ -165,11 +168,15 @@ function parseCursor(
   };
 }
 
-function encodeCursor(
-  startingAt: string,
-  page: string | null,
-  query: string,
-): string {
+function encodeCursor({
+  startingAt,
+  page,
+  query,
+}: {
+  startingAt: string;
+  page: string | null;
+  query: string;
+}): string {
   return JSON.stringify({ startingAt, page, query });
 }
 
@@ -402,7 +409,7 @@ export class AnthropicAdminPuller
     // The window's watermark does not move within a run; only the page token
     // does. Two variables rather than one reassigned object, so a page advance
     // mid-run can never quietly carry a different `startingAt` with it.
-    const cursor = parseCursor(options.cursor, config);
+    const cursor = parseCursor({ cursor: options.cursor, config });
     const startingAt = cursor.startingAt;
     const query = queryIdentity(config);
     let page = cursor.page;
@@ -413,7 +420,7 @@ export class AnthropicAdminPuller
         // so a deadline costs latency rather than a window.
         return {
           events,
-          cursor: encodeCursor(startingAt, page, query),
+          cursor: encodeCursor({ startingAt, page, query }),
           errorCount: 0,
         };
       }
@@ -431,7 +438,11 @@ export class AnthropicAdminPuller
         // watermark only ever moves forward.
         return {
           events,
-          cursor: encodeCursor(read.watermark ?? startingAt, null, query),
+          cursor: encodeCursor({
+            startingAt: read.watermark ?? startingAt,
+            page: null,
+            query,
+          }),
           errorCount: 0,
         };
       }
@@ -444,7 +455,7 @@ export class AnthropicAdminPuller
     );
     return {
       events,
-      cursor: encodeCursor(startingAt, page, query),
+      cursor: encodeCursor({ startingAt, page, query }),
       errorCount: 0,
     };
   }

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -132,19 +132,33 @@ export type AnthropicAdminPullConfig = z.infer<
  * the deeper window. That is the operator's repair lever for sources whose
  * first post-deploy run only covered the default window.
  *
- * USAGE sources drop only the unsafe page token and KEEP the watermark.
- * Usage identity is NOT stable across a query change — it embeds the config
- * bucket width, and this fix itself added `serviceTier` and `contextWindow`
- * to it — so a historical re-read would emit rows under new keys BESIDE the
- * old ones rather than superseding them: every re-read bucket would be
- * double-counted spend. History stays as written (the flat-cache zeros and
- * collapsed tiers are a documented, bounded wrong); correctness applies from
- * the watermark forward.
+ * USAGE sources drop only the unsafe page token and resume as close to where
+ * the token pointed as the cursor can certify. Usage identity is NOT stable
+ * across a query change — it embeds the config bucket width, and this fix
+ * itself added `serviceTier` and `contextWindow` to it — so anything re-read
+ * under the new query is emitted under new keys BESIDE the old rows rather
+ * than superseding them: every re-read bucket is double-counted spend.
+ * That is why `watermark` exists: a run cut off mid-window (deadline or
+ * MAX_PAGES_PER_RUN) records the newest bucket it actually emitted, and a
+ * usage mismatch resumes from there — re-reading at most the one bucket the
+ * token was sitting inside. Cursors minted before `watermark` existed carry
+ * only the window start, so their in-flight window (bounded by
+ * MAX_PAGES_PER_RUN) is re-read ONCE under the new keys — a bounded,
+ * one-shot duplication, accepted over skipping the rest of the window.
+ * History behind the window stays as written (the flat-cache zeros and
+ * collapsed tiers are a documented, bounded wrong).
  */
 const cursorSchema = z.object({
   startingAt: z.string(),
   page: z.string().nullable().default(null),
   query: z.string().nullable().default(null),
+  /**
+   * Newest bucket `starting_at` already emitted from the in-flight window,
+   * recorded only while a page token is in hand. Null once the window drains
+   * (`startingAt` itself becomes the resume point) and on cursors minted
+   * before this field existed.
+   */
+  watermark: z.string().nullable().default(null),
 });
 
 /**
@@ -173,12 +187,16 @@ function parseCursor({
 }: {
   cursor: string | null;
   config: AnthropicAdminPullConfig;
-}): Pick<z.infer<typeof cursorSchema>, "startingAt" | "page"> {
+}): Pick<z.infer<typeof cursorSchema>, "startingAt" | "page" | "watermark"> {
   if (cursor) {
     try {
       const parsed = cursorSchema.parse(JSON.parse(cursor));
       if (parsed.query === queryIdentity(config)) {
-        return { startingAt: parsed.startingAt, page: parsed.page };
+        return {
+          startingAt: parsed.startingAt,
+          page: parsed.page,
+          watermark: parsed.watermark,
+        };
       }
       // Also covers cursors minted before query-binding existed (`query`
       // null): this change itself widened the group_by set and fixed the
@@ -195,6 +213,7 @@ function parseCursor({
   return {
     startingAt: config.startingAt ?? defaultStartingAt(config.report),
     page: null,
+    watermark: null,
   };
 }
 
@@ -209,22 +228,31 @@ function staleCursorRestart({
 }: {
   parsed: z.infer<typeof cursorSchema>;
   config: AnthropicAdminPullConfig;
-}): Pick<z.infer<typeof cursorSchema>, "startingAt" | "page"> {
+}): Pick<z.infer<typeof cursorSchema>, "startingAt" | "page" | "watermark"> {
   if (config.report === "usage") {
     // No rewind: usage identity is not stable across a query change, so
     // re-reading history would duplicate spend rather than restate it.
     // The page token still has to go — it would 400 against the new
-    // query params. A watermark that doesn't parse as a date certifies no
-    // history at all, so falling back to the configured start duplicates
-    // nothing — and passing it through would 400 on every retry forever.
+    // query params. Resume from the in-window watermark when the cursor
+    // recorded one: that re-reads at most the bucket the token sat inside,
+    // instead of every page of the window already emitted under the old
+    // keys. Cursors without one (minted pre-`watermark`, or drained)
+    // resume from the window start. A date that doesn't parse certifies no
+    // history at all, so the configured start duplicates nothing — and
+    // passing it through would 400 on every retry forever.
     logger.warn(
       { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
-      "anthropic admin usage cursor was minted under a different query; dropping the page token and keeping the watermark",
+      "anthropic admin usage cursor was minted under a different query; dropping the page token and resuming from the newest bucket it certifies",
     );
-    const keptWatermark = Number.isNaN(Date.parse(parsed.startingAt))
-      ? (config.startingAt ?? defaultStartingAt(config.report))
-      : parsed.startingAt;
-    return { startingAt: keptWatermark, page: null };
+    const resumeFrom = [parsed.watermark, parsed.startingAt].find(
+      (candidate) => candidate !== null && !Number.isNaN(Date.parse(candidate)),
+    );
+    return {
+      startingAt:
+        resumeFrom ?? config.startingAt ?? defaultStartingAt(config.report),
+      page: null,
+      watermark: null,
+    };
   }
   logger.warn(
     { adapter: ANTHROPIC_ADMIN_ADAPTER_ID, report: config.report },
@@ -241,19 +269,20 @@ function staleCursorRestart({
     Number.isNaN(watermarkMs) || Date.parse(configuredStart) <= watermarkMs
       ? configuredStart
       : parsed.startingAt;
-  return { startingAt: rewoundStart, page: null };
+  return { startingAt: rewoundStart, page: null, watermark: null };
 }
 
 function encodeCursor({
   startingAt,
   page,
   query,
+  watermark,
 }: Omit<z.infer<typeof cursorSchema>, "query"> & {
   // Refined non-null: every cursor minted after query-binding carries the
   // query identity; only cursors READ from storage can lack it.
   query: string;
 }): string {
-  return JSON.stringify({ startingAt, page, query });
+  return JSON.stringify({ startingAt, page, query, watermark });
 }
 
 /**
@@ -490,13 +519,18 @@ export class AnthropicAdminPuller
     config: AnthropicAdminPullConfig,
   ): Promise<PullResult> {
     const events: NormalizedPullEvent[] = [];
-    // The window's watermark does not move within a run; only the page token
-    // does. Two variables rather than one reassigned object, so a page advance
-    // mid-run can never quietly carry a different `startingAt` with it.
+    // The window start does not move within a run; only the page token and
+    // the in-window watermark do. Separate variables rather than one
+    // reassigned object, so a page advance mid-run can never quietly carry a
+    // different `startingAt` with it. The watermark tracks the newest bucket
+    // actually emitted, so a cut-off run records how far it really got —
+    // that record is what lets a later identity mismatch resume near the
+    // token instead of re-reading the window (see `cursorSchema`).
     const cursor = parseCursor({ cursor: options.cursor, config });
     const startingAt = cursor.startingAt;
     const query = queryIdentity(config);
     let page = cursor.page;
+    let watermark = cursor.watermark;
 
     for (let pageCount = 0; pageCount < MAX_PAGES_PER_RUN; pageCount += 1) {
       if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
@@ -504,7 +538,7 @@ export class AnthropicAdminPuller
         // so a deadline costs latency rather than a window.
         return {
           events,
-          cursor: encodeCursor({ startingAt, page, query }),
+          cursor: encodeCursor({ startingAt, page, query, watermark }),
           errorCount: 0,
         };
       }
@@ -516,16 +550,19 @@ export class AnthropicAdminPuller
         return { events, cursor: options.cursor, errorCount: 1 };
       }
       events.push(...read.events);
+      watermark = read.watermark ?? watermark;
 
       if (read.nextPage === null) {
         // Drained. The next run starts from the newest bucket read, so the
-        // watermark only ever moves forward.
+        // watermark only ever moves forward — and the in-window watermark is
+        // retired: `startingAt` itself is now the resume point.
         return {
           events,
           cursor: encodeCursor({
-            startingAt: read.watermark ?? startingAt,
+            startingAt: watermark ?? startingAt,
             page: null,
             query,
+            watermark: null,
           }),
           errorCount: 0,
         };
@@ -539,7 +576,7 @@ export class AnthropicAdminPuller
     );
     return {
       events,
-      cursor: encodeCursor({ startingAt, page, query }),
+      cursor: encodeCursor({ startingAt, page, query, watermark }),
       errorCount: 0,
     };
   }


### PR DESCRIPTION
# Related Issue

- Resolves #6977

## For humans

The Anthropic cost puller was recording every dollar figure 100 times too big: Anthropic reports cost in **cents**, and we stored the number as if it were dollars. This fixes that, plus four smaller defects in the same puller that made cache-token counts read as zero, blurred batch/long-context usage together, overclaimed the figure as "the invoice", and could permanently wedge a source after a config edit.

## Why

Closes #6977.

The cost report's `amount` field is a decimal string denominated in the currency's **lowest unit** — cents for USD. The docs' worked example: `"41280.000000"` in USD is **$412.80**. The puller stored it verbatim as `costUsd` and marked it `costStatus: "exact"`, so every cost figure in the ledger was 100x. Verified against the [cost report API docs](https://platform.claude.com/docs/en/api/admin-api/usage-cost/get-cost-report) ("Cost amount in lowest currency units (e.g. cents) as a decimal string. For example, `"123.45"` in `"USD"` represents `$1.23`."), which also confirmed the four adjacent defects the issue lists.

## What changed

All in `anthropicAdmin.puller.ts` (+ two dashboard copy strings):

1. **Cents → USD at the boundary.** `centsToUsd()` shifts the decimal point by string index arithmetic — no digit ever passes through a float on its way to `usdToNanoUsd`'s bigint scaling. A non-decimal amount (or an exponent outside safe-integer range) drops that row with a log instead of throwing: a throw would unwind the run, hold the cursor, and wedge the source on a row that would be malformed again on every retry.
2. **Nested `cache_creation`.** The API nests cache-write tokens by TTL (`ephemeral_1h_input_tokens` + `ephemeral_5m_input_tokens`); the old flat-field schema read the real shape as 0 and `.default(0)` masked it. Nested wins; the flat field stays as fallback.
3. **`service_tier` + `context_window` grouped and keyed.** The API returns null for any field not in `group_by`, so both dimensions were always `""` — batch and long-context usage collapsed onto standard usage under one restatement key. Both are now requested, and `contextWindow` rides the usage dimensions.
4. **`costStatus` downgraded `exact` → `estimate`.** The cost report excludes Priority Tier usage, so it is Anthropic's own figure but not the full invoice. Dashboard copy ("invoice amounts, carried verbatim") updated to match.
5. **Cursor bound to its query — and the 100x cost rows self-repair through it.** Anthropic returns 400 when a page token is replayed with changed query params, and this adapter holds the cursor still on failure — one config edit mid-window would wedge the source permanently. The cursor now carries a query identity, and what a mismatch does depends on whether re-reading can supersede. **Cost** sources discard the whole cursor (watermark included) and re-read from the configured start: cost identities are config-independent and unchanged here, so restatement supersedes the 100x records in place, and the fresh cursor means the rewind fires exactly once per source. **Usage** sources drop only the dead page token and resume as close to it as the cursor can certify: this PR changes the usage identity (`serviceTier`, `contextWindow`), so anything re-read under the new query writes rows under new keys *beside* the old ones — duplicated spend, not repair. The cursor therefore records an in-window `watermark` (the newest bucket a cut-off run actually emitted), and a usage mismatch resumes from it — re-reading at most the one bucket the token sat inside. Cursors minted before this PR carry no such record, so a usage source that was mid-window at deploy re-reads its in-flight window (bounded by `MAX_PAGES_PER_RUN` = 20 pages) **once** under the new keys — a bounded, one-shot duplication accepted over skipping the rest of the window. History behind the window stays as written.

## Test plan

Regression tests written first and watched fail (9 failing before the fix, including the 100x on record):

```
× converts Anthropic's cents figure to USD at the boundary
  AssertionError: expected 41280000000000 to be 412800000000
× turns each bucket row into a self-priced estimate
  AssertionError: expected +0 to be 1500
× asks Anthropic to group by the dimensions the key is built from
  AssertionError: expected '…' to contain 'group_by%5B%5D=service_tier'
× drops the page token but keeps the watermark on a config edit
  AssertionError: expected '…' not to contain 'page='
(+5 more)
```

After the fix: `anthropicAdminPuller.unit.test.ts` 28/28 (each review-round fix added its own fail-first regression tests), full `ee/governance` suite green, `pnpm typecheck` and `typecheck:tests` clean, biome new-violations gate clean against the merge base.

Key assertions: the documented example `"41280.000000"` → `412_800_000_000` nano-USD; `"1234.567890123"` cents → `12_345_678_901` (string shift, no float); nested cache tokens sum to 1,500 with the legacy flat field as fallback; rows differing only by `context_window` — or only by `service_tier` — get distinct identities; malformed and out-of-range amounts drop their row while the rest of the page survives; a same-query cursor still replays its page token; a changed-query or pre-binding **cost** cursor is discarded entirely and the window re-read from the configured start (including a drained 100x-era cursor, whose re-pulled bucket supersedes the wrong figure) but never rewound *forward* past a backlogged watermark; a changed-query **usage** cursor drops its page token and resumes from the in-window watermark the cut-off run recorded (not the window start), so at most one bucket is re-read under the new keys; a cut-off run persists that watermark beside the token and a resumed run cut off before its first page carries it through; a pre-binding usage cursor (no watermark recorded) falls back to the window start — the documented one-shot re-read — but never rewinds to the configured start.

## Anything surprising?

- **Existing 100x records repair themselves — no operator step.** Every pre-fix cursor lacks a query identity, so the first post-deploy scheduled run discards it and re-reads from the configured start; cost restatement keys are unchanged, so the corrected figures supersede the 100x rows in place. One bounded caveat: a source with no configured `startingAt` rewinds only to the 3-day default window. Repairing deeper history there means setting `startingAt` on the source (one config field) — and that works **after** the first post-deploy run too, because the configured start is part of the cost cursor identity: widening it mints a mismatch and fires the rewind again, still guarded against ever moving the watermark forward. Usage identity deliberately excludes the start (usage never rewinds).
- **Usage history is deliberately NOT re-read — with one bounded exception.** Adding `contextWindow` to the dimensions (and asking for `service_tier`, which was always `""` before) changes the usage restatement keys, so a historical re-read would *join* old rows rather than supersede them — every re-read bucket double-counted. The puller therefore never rewinds usage on a query change. The exception: a usage source that was **mid-window at deploy** (a run cut off at the deadline or the 20-page cap) holds a pre-binding cursor recording only where the window *started*, not how far the run got — so its first post-deploy run re-reads that in-flight window once, duplicating those buckets under the new keys. Bounded to ≤20 pages per source, fires once. Going forward the cursor records an in-window watermark, narrowing the same event to ≤1 bucket for any future identity change. Old usage rows keep their old (flat-cache-zero, tier-collapsed) values; anyone who needs history restated must first remove the old-key rows for the window, then rewind. Cost keys are untouched.
- The issue asked for one real API call against a test org before shipping the divide; no admin key was available here. The docs' field description and worked example are unambiguous, and the fixture bakes the documented example in — flagging rather than silently claiming it was live-verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic usage and cost reporting accuracy, including cache-creation tokens, context-window details, and service tiers.
  * Converted reported costs from cents to USD while preserving precision and rejecting invalid amounts.
  * Improved pagination handling when report queries change.

* **Documentation**
  * Clarified that provider-reported costs may be estimates.
  * Noted that Anthropic cost reports exclude Priority Tier usage and may differ from invoice totals.
  * Clarified that usage reports are priced by LangWatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

