### PR TITLE
fix(ci): exempt manifest-only diffs from deployment-impact-check

### DIFF
--- a/.github/scripts/guard-deployment-impact.test.ts
+++ b/.github/scripts/guard-deployment-impact.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  classify,
+  isDependencyBot,
+  kindOf,
+  requiresWriteup,
+} from "./guard-deployment-impact.ts";
+
+const BOT = "dependabot[bot]";
+const HUMAN = "0xdeafcafe";
+
+describe("given the changed files of a pull request", () => {
+  describe("when a path is an auto-generated lockfile", () => {
+    it("reads it as a lockfile wherever it sits in the tree", () => {
+      assert.equal(kindOf("services/langevals/uv.lock"), "lockfile");
+      assert.equal(kindOf("pnpm-lock.yaml"), "lockfile");
+      assert.equal(kindOf("charts/gateway/Chart.lock"), "lockfile");
+      assert.equal(kindOf("services/nlpgo/go.sum"), "lockfile");
+    });
+  });
+
+  describe("when a path is a hand-edited dependency manifest", () => {
+    it("reads it as a manifest, including versioned requirements files", () => {
+      assert.equal(kindOf("services/langevals/pyproject.toml"), "manifest");
+      assert.equal(kindOf("go.mod"), "manifest");
+      assert.equal(kindOf("services/foo/requirements-dev.txt"), "manifest");
+    });
+  });
+
+  describe("when a path is neither", () => {
+    it("reads it as other, so no exemption can rest on it", () => {
+      assert.equal(kindOf("charts/gateway/values.yaml"), "other");
+      assert.equal(kindOf("dev/docs/adr/045-domain-errors.md"), "other");
+      // A directory that merely ends in a manifest's name is not that manifest.
+      assert.equal(kindOf("tools/package.json/notes.md"), "other");
+    });
+  });
+
+  describe("when the change set is empty", () => {
+    it("claims neither exemption rather than passing vacuously", () => {
+      assert.deepEqual(classify([]), {
+        onlyLockfiles: false,
+        onlyManifests: false,
+      });
+      assert.equal(requiresWriteup({ files: [], author: BOT }), true);
+    });
+  });
+});
+
+describe("given a pull request the deployment-impact check would normally gate", () => {
+  describe("when a dependency bot changed only auto-generated lockfiles", () => {
+    /** @scenario "A dependency bot's PR touches only auto-generated lockfiles" */
+    it("exempts it, because a lockfile has no deployment surface", () => {
+      const files = ["services/langevals/uv.lock", "pnpm-lock.yaml"];
+      assert.equal(classify(files).onlyLockfiles, true);
+      assert.equal(requiresWriteup({ files, author: BOT }), false);
+    });
+
+    it("exempts a human's lockfile-only PR on the same reasoning", () => {
+      const files = ["charts/gateway/Chart.lock"];
+      assert.equal(requiresWriteup({ files, author: HUMAN }), false);
+    });
+  });
+
+  describe("when a dependency bot changed hand-edited manifests", () => {
+    /** @scenario "A dependency bot's PR touches only hand-edited dependency manifests" */
+    it("exempts it, because the bot writes nothing but version bumps", () => {
+      const files = ["services/langevals/pyproject.toml", "services/langevals/uv.lock"];
+      assert.equal(classify(files).onlyLockfiles, false);
+      assert.equal(classify(files).onlyManifests, true);
+      assert.equal(requiresWriteup({ files, author: BOT }), false);
+    });
+  });
+
+  describe("when a human changed hand-edited manifests", () => {
+    /** @scenario "A human's PR touches only hand-edited dependency manifests" */
+    it("still requires a writeup, because a manifest edit can carry more than a bump", () => {
+      const files = ["package.json"];
+      assert.equal(classify(files).onlyManifests, true);
+      assert.equal(requiresWriteup({ files, author: HUMAN }), true);
+    });
+  });
+
+  describe("when any changed file is neither a lockfile nor a manifest", () => {
+    /** @scenario "A PR touches a file that isn't a recognized dependency manifest" */
+    it("still requires a writeup, whoever opened it", () => {
+      const files = ["services/langevals/uv.lock", "charts/gateway/values.yaml"];
+      assert.deepEqual(classify(files), {
+        onlyLockfiles: false,
+        onlyManifests: false,
+      });
+      assert.equal(requiresWriteup({ files, author: BOT }), true);
+      assert.equal(requiresWriteup({ files, author: HUMAN }), true);
+    });
+  });
+});
+
+describe("given the author of a pull request", () => {
+  describe("when the login is a known dependency bot", () => {
+    it("grants the manifest exemption", () => {
+      assert.equal(isDependencyBot("dependabot[bot]"), true);
+      assert.equal(isDependencyBot("renovate[bot]"), true);
+    });
+  });
+
+  describe("when the login merely resembles one", () => {
+    it("withholds it, because the match is exact", () => {
+      assert.equal(isDependencyBot("dependabot"), false);
+      assert.equal(isDependencyBot("not-dependabot[bot]"), false);
+    });
+  });
+});

--- a/.github/scripts/guard-deployment-impact.ts
+++ b/.github/scripts/guard-deployment-impact.ts
@@ -1,0 +1,142 @@
+// Decides whether a pull request has to carry a `## Deployment Impact`
+// writeup, given the files it changed and who opened it.
+//
+// The deployment-impact workflow triggers on `charts/**`, `services/**`,
+// `dev/docs/adr/**`, `dev/docs/best_practices/**`, `platform/app/.env.example`
+// and `docs/self-hosting/**`. Those globs match every dependency bump in
+// services/langevals, services/aigateway and services/nlpgo, and every chart's
+// Chart.lock — so a routine version bump is asked for a writeup about operator
+// impact it does not have.
+//
+// Two tiers, because the files do not carry the same guarantee:
+//
+//   Lockfiles (uv.lock, pnpm-lock.yaml, go.sum, Cargo.lock, Chart.lock) are
+//   auto-generated resolution snapshots. Nothing hand-edits them, so they
+//   cannot add an env var, a helm value, or change what `helm install` does.
+//   No deployment surface by construction — exempt no matter who authored the
+//   pull request.
+//
+//   Manifests (pyproject.toml, package.json, go.mod, Cargo.toml,
+//   requirements*.txt) are hand-edited. Usually still just a version bump, but
+//   a person editing one could add a `postinstall` script or change the build
+//   system in the same commit. That weaker exemption therefore holds only for
+//   a dependency bot's own pull requests.
+//
+// Authorship is the PR AUTHOR, never `github.actor`. The workflow triggers on
+// `edited` as well as `opened`, so `github.actor` is whoever last touched the
+// pull request — a maintainer tidying a dependabot PR's description would flip
+// the actor away from the bot and silently withdraw the exemption.
+//
+// Deliberately dependency-free and run with `node --experimental-strip-types`,
+// matching guard-path-filters.ts: there is no install step on the runner.
+//
+// Spec: specs/ci/deployment-impact-check.feature
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** Logins whose pull requests get the hand-edited-manifest exemption. */
+export const DEPENDENCY_BOTS: readonly string[] = [
+  "dependabot[bot]",
+  "renovate[bot]",
+];
+
+/** Auto-generated resolution snapshots: no deployment surface by construction. */
+const LOCKFILES: readonly string[] = [
+  "uv.lock",
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "go.sum",
+  "Cargo.lock",
+  "Chart.lock",
+];
+
+/** Hand-edited dependency manifests: a version bump, or something more. */
+const MANIFESTS: readonly string[] = [
+  "pyproject.toml",
+  "package.json",
+  "go.mod",
+  "Cargo.toml",
+];
+
+const basename = (path: string): string => path.split("/").pop() ?? path;
+
+const isRequirementsTxt = (name: string): boolean =>
+  name.startsWith("requirements") && name.endsWith(".txt");
+
+export type FileKind = "lockfile" | "manifest" | "other";
+
+/** What a single changed path is, by its file name alone. */
+export const kindOf = (path: string): FileKind => {
+  const name = basename(path);
+  if (LOCKFILES.includes(name)) return "lockfile";
+  if (MANIFESTS.includes(name) || isRequirementsTxt(name)) return "manifest";
+  return "other";
+};
+
+export interface Classification {
+  /** Every changed file is an auto-generated lockfile. */
+  onlyLockfiles: boolean;
+  /** Every changed file is a lockfile or a hand-edited manifest. */
+  onlyManifests: boolean;
+}
+
+/**
+ * An empty change set is neither: with nothing to inspect there is nothing to
+ * base an exemption on, so it falls through to requiring the writeup rather
+ * than passing vacuously.
+ */
+export const classify = (files: readonly string[]): Classification => {
+  const paths = files.map((f) => f.trim()).filter((f) => f !== "");
+  if (paths.length === 0) return { onlyLockfiles: false, onlyManifests: false };
+
+  const kinds = paths.map(kindOf);
+  return {
+    onlyLockfiles: kinds.every((k) => k === "lockfile"),
+    onlyManifests: kinds.every((k) => k === "lockfile" || k === "manifest"),
+  };
+};
+
+export const isDependencyBot = (author: string): boolean =>
+  DEPENDENCY_BOTS.includes(author);
+
+/** Whether this pull request must carry a `## Deployment Impact` section. */
+export const requiresWriteup = ({
+  files,
+  author,
+}: {
+  files: readonly string[];
+  author: string;
+}): boolean => {
+  const { onlyLockfiles, onlyManifests } = classify(files);
+  if (onlyLockfiles) return false;
+  if (onlyManifests && isDependencyBot(author)) return false;
+  return true;
+};
+
+export const main = ({
+  files,
+  author,
+}: {
+  files: readonly string[];
+  author: string;
+}): string[] => {
+  const { onlyLockfiles, onlyManifests } = classify(files);
+  return [
+    `only_lockfiles=${onlyLockfiles}`,
+    `only_manifests=${onlyManifests}`,
+    `requires_writeup=${requiresWriteup({ files, author })}`,
+  ];
+};
+
+const isEntrypoint = (): boolean =>
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isEntrypoint()) {
+  const author = process.env.PR_AUTHOR ?? "";
+  const files = (process.env.CHANGED_FILES ?? "").split("\n");
+  const outputs = main({ files, author });
+  for (const line of outputs) console.log(line);
+}

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -48,10 +48,14 @@ jobs:
     steps:
       # The `services/**` trigger path matches every dependency-lockfile bump
       # in services/langevals, services/aigateway, services/nlpgo too — a pure
-      # manifest/lockfile diff can't add a helm value, env var, or change
-      # `helm install` behavior, so it has no deployment surface by
-      # construction. Skip the gate for those; anything touching a real file
-      # (Dockerfile, chart, config, source) still requires the section.
+      # lockfile diff can't add a helm value, env var, or change `helm
+      # install` behavior, so it has no deployment surface by construction.
+      # Skip the gate for those. Restricted to dependabot: pyproject.toml,
+      # package.json, go.mod and Cargo.toml are hand-edited manifests, not
+      # pure lockfiles — a human PR touching only one of them could still
+      # slip in a real deployment-relevant change (a new package.json
+      # `postinstall` script, a build-system change) alongside the version
+      # bump, so the exemption only applies to dependabot's own PRs.
       - name: Determine whether this PR only touches dependency manifests
         id: manifest-only
         env:
@@ -72,9 +76,12 @@ jobs:
           echo "Changed files:"
           printf '%s\n' "$FILES"
           echo "Manifest-only: $ONLY_MANIFESTS"
+          echo "Actor: ${{ github.actor }}"
 
       - name: Verify deployment-impact section in PR description
-        if: steps.manifest-only.outputs.only_manifests != 'true'
+        if: |
+          steps.manifest-only.outputs.only_manifests != 'true' ||
+          github.actor != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -46,16 +46,22 @@ jobs:
         startsWith(github.head_ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
-      # The `services/**` trigger path matches every dependency-lockfile bump
-      # in services/langevals, services/aigateway, services/nlpgo too — a pure
-      # lockfile diff can't add a helm value, env var, or change `helm
-      # install` behavior, so it has no deployment surface by construction.
-      # Skip the gate for those. Restricted to dependabot: pyproject.toml,
-      # package.json, go.mod and Cargo.toml are hand-edited manifests, not
-      # pure lockfiles — a human PR touching only one of them could still
-      # slip in a real deployment-relevant change (a new package.json
-      # `postinstall` script, a build-system change) alongside the version
-      # bump, so the exemption only applies to dependabot's own PRs.
+      # The `services/**`/`charts/**` trigger paths match every dependency
+      # bump in services/langevals, services/aigateway, services/nlpgo, and
+      # every chart's Chart.lock too. Two tiers, because not all of these
+      # files carry the same guarantee:
+      #
+      # - Pure auto-generated lockfiles (uv.lock, pnpm-lock.yaml, go.sum,
+      #   Cargo.lock, Chart.lock) record only resolved versions/digests. They
+      #   can't add a helm value, env var, or change `helm install`
+      #   behavior — no deployment surface by construction, regardless of
+      #   who authored the PR.
+      # - pyproject.toml, package.json, go.mod, and Cargo.toml are
+      #   hand-edited manifests, not pure lockfiles. A human PR touching only
+      #   one of them could still slip in a real deployment-relevant change
+      #   (a new package.json `postinstall` script, a build-system change)
+      #   alongside the version bump, so that exemption only applies to
+      #   dependabot's own PRs.
       - name: Determine whether this PR only touches dependency manifests
         id: manifest-only
         env:
@@ -64,24 +70,29 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          ONLY_LOCKFILES=true
           ONLY_MANIFESTS=true
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              */uv.lock|uv.lock|*/pyproject.toml|pyproject.toml|*/package.json|package.json|pnpm-lock.yaml|*/pnpm-lock.yaml|*/go.mod|go.mod|*/go.sum|go.sum|*/Cargo.lock|Cargo.lock|*/Cargo.toml|Cargo.toml|*/requirements*.txt|requirements*.txt) ;;
-              *) ONLY_MANIFESTS=false ;;
+              */uv.lock|uv.lock|pnpm-lock.yaml|*/pnpm-lock.yaml|*/go.sum|go.sum|*/Cargo.lock|Cargo.lock|*/Chart.lock|Chart.lock) ;;
+              */pyproject.toml|pyproject.toml|*/package.json|package.json|*/go.mod|go.mod|*/Cargo.toml|Cargo.toml|*/requirements*.txt|requirements*.txt) ONLY_LOCKFILES=false ;;
+              *) ONLY_LOCKFILES=false; ONLY_MANIFESTS=false ;;
             esac
           done <<< "$FILES"
+          echo "only_lockfiles=$ONLY_LOCKFILES" >> "$GITHUB_OUTPUT"
           echo "only_manifests=$ONLY_MANIFESTS" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           printf '%s\n' "$FILES"
-          echo "Manifest-only: $ONLY_MANIFESTS"
+          echo "Lockfiles-only (any actor): $ONLY_LOCKFILES"
+          echo "Manifests-only (dependabot only): $ONLY_MANIFESTS"
           echo "Actor: ${{ github.actor }}"
 
       - name: Verify deployment-impact section in PR description
         if: |
-          steps.manifest-only.outputs.only_manifests != 'true' ||
-          github.actor != 'dependabot[bot]'
+          steps.manifest-only.outputs.only_lockfiles != 'true' &&
+          (steps.manifest-only.outputs.only_manifests != 'true' ||
+           github.actor != 'dependabot[bot]')
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -46,7 +46,35 @@ jobs:
         startsWith(github.head_ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
+      # The `services/**` trigger path matches every dependency-lockfile bump
+      # in services/langevals, services/aigateway, services/nlpgo too — a pure
+      # manifest/lockfile diff can't add a helm value, env var, or change
+      # `helm install` behavior, so it has no deployment surface by
+      # construction. Skip the gate for those; anything touching a real file
+      # (Dockerfile, chart, config, source) still requires the section.
+      - name: Determine whether this PR only touches dependency manifests
+        id: manifest-only
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          ONLY_MANIFESTS=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              */uv.lock|uv.lock|*/pyproject.toml|pyproject.toml|*/package.json|package.json|pnpm-lock.yaml|*/pnpm-lock.yaml|*/go.mod|go.mod|*/go.sum|go.sum|*/Cargo.lock|Cargo.lock|*/Cargo.toml|Cargo.toml|*/requirements*.txt|requirements*.txt) ;;
+              *) ONLY_MANIFESTS=false ;;
+            esac
+          done <<< "$FILES"
+          echo "only_manifests=$ONLY_MANIFESTS" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"
+          printf '%s\n' "$FILES"
+          echo "Manifest-only: $ONLY_MANIFESTS"
+
       - name: Verify deployment-impact section in PR description
+        if: steps.manifest-only.outputs.only_manifests != 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -46,53 +46,41 @@ jobs:
         startsWith(github.head_ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
-      # The `services/**`/`charts/**` trigger paths match every dependency
-      # bump in services/langevals, services/aigateway, services/nlpgo, and
-      # every chart's Chart.lock too. Two tiers, because not all of these
-      # files carry the same guarantee:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      # The `services/**`/`charts/**` trigger paths match every dependency bump
+      # in services/langevals, services/aigateway, services/nlpgo, and every
+      # chart's Chart.lock too. Which of those get an exemption, and why, is
+      # decided by guard-deployment-impact.ts — a plain function with a test,
+      # rather than a `case` statement buried in YAML that nothing can run.
       #
-      # - Pure auto-generated lockfiles (uv.lock, pnpm-lock.yaml, go.sum,
-      #   Cargo.lock, Chart.lock) record only resolved versions/digests. They
-      #   can't add a helm value, env var, or change `helm install`
-      #   behavior — no deployment surface by construction, regardless of
-      #   who authored the PR.
-      # - pyproject.toml, package.json, go.mod, and Cargo.toml are
-      #   hand-edited manifests, not pure lockfiles. A human PR touching only
-      #   one of them could still slip in a real deployment-relevant change
-      #   (a new package.json `postinstall` script, a build-system change)
-      #   alongside the version bump, so that exemption only applies to
-      #   dependabot's own PRs.
+      # PR_AUTHOR is the pull request's author, NOT `github.actor`. This
+      # workflow triggers on `edited`, so `github.actor` is whoever last touched
+      # the pull request: a maintainer tidying a dependabot PR's description
+      # would flip the actor away from the bot and silently withdraw the
+      # exemption the PR qualified for when it opened.
       - name: Determine whether this PR only touches dependency manifests
         id: manifest-only
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-          ONLY_LOCKFILES=true
-          ONLY_MANIFESTS=true
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            case "$f" in
-              */uv.lock|uv.lock|pnpm-lock.yaml|*/pnpm-lock.yaml|*/go.sum|go.sum|*/Cargo.lock|Cargo.lock|*/Chart.lock|Chart.lock) ;;
-              */pyproject.toml|pyproject.toml|*/package.json|package.json|*/go.mod|go.mod|*/Cargo.toml|Cargo.toml|*/requirements*.txt|requirements*.txt) ONLY_LOCKFILES=false ;;
-              *) ONLY_LOCKFILES=false; ONLY_MANIFESTS=false ;;
-            esac
-          done <<< "$FILES"
-          echo "only_lockfiles=$ONLY_LOCKFILES" >> "$GITHUB_OUTPUT"
-          echo "only_manifests=$ONLY_MANIFESTS" >> "$GITHUB_OUTPUT"
+          CHANGED_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          export CHANGED_FILES
           echo "Changed files:"
-          printf '%s\n' "$FILES"
-          echo "Lockfiles-only (any actor): $ONLY_LOCKFILES"
-          echo "Manifests-only (dependabot only): $ONLY_MANIFESTS"
-          echo "Actor: ${{ github.actor }}"
+          printf '%s\n' "$CHANGED_FILES"
+          echo "Author: $PR_AUTHOR"
+          node --experimental-strip-types .github/scripts/guard-deployment-impact.ts \
+            | tee -a "$GITHUB_OUTPUT"
 
       - name: Verify deployment-impact section in PR description
-        if: |
-          steps.manifest-only.outputs.only_lockfiles != 'true' &&
-          (steps.manifest-only.outputs.only_manifests != 'true' ||
-           github.actor != 'dependabot[bot]')
+        if: steps.manifest-only.outputs.requires_writeup == 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1372,6 +1372,13 @@ jobs:
       - name: Test notify-slack-release.sh
         run: bash .github/scripts/__tests__/notify-slack-release.test.sh
 
+      # Lives here rather than in deployment-impact-check.yml because that
+      # workflow filters `on.paths` down to deployment surface, which
+      # .github/** is not — so it would never start for a change to its own
+      # guard. This job's gate already lists `.github/scripts/**`.
+      - name: Test guard-deployment-impact.ts
+        run: node --test --experimental-strip-types .github/scripts/guard-deployment-impact.test.ts
+
   ci-self-test:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'

--- a/specs/ci/deployment-impact-check.feature
+++ b/specs/ci/deployment-impact-check.feature
@@ -1,0 +1,36 @@
+Feature: Deployment impact gate skips manifest-only dependency bumps
+  The deployment-impact-check workflow fails a PR that touches charts/,
+  services/, ADRs, best-practices docs, .env.example, or self-hosting docs
+  without a filled-in "## Deployment Impact" section. Its `services/**`
+  trigger path matches every dependency-manifest bump under
+  services/langevals, services/aigateway, and services/nlpgo too, but a pure
+  lockfile/manifest diff cannot add an env var, a helm value, or change
+  `helm install` behavior — it has no deployment surface by construction.
+  Dependabot never writes that section, so this recurring false positive
+  blocked every services/* dependency PR from merging.
+
+  Background:
+    Given a pull request whose head repo matches the target repo
+    And the branch is not a release-please branch
+
+  Scenario: PR only touches dependency manifests and lockfiles
+    Given the PR's changed files are all uv.lock, pyproject.toml,
+      package.json, pnpm-lock.yaml, go.mod, go.sum, Cargo.lock, Cargo.toml,
+      or requirements*.txt
+    And the PR touches a path under services/**
+    And the PR description has no "## Deployment Impact" section
+    When deployment-impact-check runs
+    Then the check passes without requiring the section
+
+  Scenario: PR touches a real deployment-relevant file
+    Given the PR's changed files include a Dockerfile under services/**
+    And the PR description has no "## Deployment Impact" section
+    When deployment-impact-check runs
+    Then the check fails and requests the section
+
+  Scenario: PR mixes a manifest bump with a real file change
+    Given the PR's changed files include both uv.lock and a chart template
+      under charts/**
+    And the PR description has no "## Deployment Impact" section
+    When deployment-impact-check runs
+    Then the check fails and requests the section

--- a/specs/ci/deployment-impact-check.feature
+++ b/specs/ci/deployment-impact-check.feature
@@ -21,14 +21,14 @@ Feature: Deployment-impact check skips manifest-only dependency bumps
   an entrypoint change) — so that weaker exemption only holds for dependency
   bots, not humans.
 
-  @unimplemented
+  @unit
   Scenario: A dependency bot's PR touches only auto-generated lockfiles
     Given the PR is authored by a trusted dependency-update bot
     And every changed file is an auto-generated dependency lockfile
     And the PR description has no deployment-impact writeup
     Then the check passes without requiring one
 
-  @unimplemented
+  @unit
   Scenario: A dependency bot's PR touches only hand-edited dependency manifests
     Given the PR is authored by a trusted dependency-update bot
     And every changed file is a hand-edited dependency manifest, a lockfile,
@@ -36,7 +36,7 @@ Feature: Deployment-impact check skips manifest-only dependency bumps
     And the PR description has no deployment-impact writeup
     Then the check passes without requiring one
 
-  @unimplemented
+  @unit
   Scenario: A human's PR touches only hand-edited dependency manifests
     Given the PR is authored by a human, not a dependency-update bot
     And every changed file is a hand-edited dependency manifest
@@ -44,7 +44,7 @@ Feature: Deployment-impact check skips manifest-only dependency bumps
     Then the check still requires one, since a manifest edit could carry
       more than a version bump
 
-  @unimplemented
+  @unit
   Scenario: A PR touches a file that isn't a recognized dependency manifest
     Given at least one changed file is not a lockfile or dependency manifest
     And the PR description has no deployment-impact writeup

--- a/specs/ci/deployment-impact-check.feature
+++ b/specs/ci/deployment-impact-check.feature
@@ -1,57 +1,51 @@
-Feature: Deployment impact gate skips manifest-only dependency bumps
-  The deployment-impact-check workflow fails a PR that touches charts/,
-  services/, ADRs, best-practices docs, .env.example, or self-hosting docs
-  without a filled-in "## Deployment Impact" section. Its `services/**`
-  trigger path matches every dependency-manifest bump under
-  services/langevals, services/aigateway, and services/nlpgo too, but a pure
-  lockfile/manifest diff cannot add an env var, a helm value, or change
-  `helm install` behavior — it has no deployment surface by construction.
-  Dependabot never writes that section, so this recurring false positive
-  blocked every services/* dependency PR from merging.
-
-  The manifest-only exemption is restricted to dependabot: pyproject.toml,
-  package.json, go.mod, and Cargo.toml are hand-edited manifests, not pure
-  lockfiles, so a human PR touching only one of them could still slip in a
-  real deployment-relevant change (a new package.json postinstall script, a
-  build-system change) alongside a version bump.
+Feature: Deployment-impact check skips manifest-only dependency bumps
+  As a dependency-bump author (dependabot, or a human running a routine
+  version bump)
+  I want a PR that only changes resolved dependency versions to merge without
+  writing a deployment-impact writeup
+  So that routine version bumps are not blocked by a requirement that only
+  makes sense for PRs that actually touch deployed behavior
 
   Background:
     Given a pull request whose head repo matches the target repo
     And the branch is not a release-please branch
+    And the PR touches an area the deployment-impact check normally requires
+      a "## Deployment Impact" section for
+
+  A pure lockfile (an auto-generated resolution snapshot: nothing hand-edits
+  it) can't add an env var, a helm value, or change default install
+  behavior — it has no deployment surface by construction, no matter who
+  authored the PR. A hand-edited dependency manifest is a step down in that
+  guarantee: it's still usually just a version bump, but a person editing it
+  by hand could slip in something else at the same time (a new build script,
+  an entrypoint change) — so that weaker exemption only holds for dependency
+  bots, not humans.
 
   @unimplemented
-  Scenario: Dependabot PR only touches dependency manifests and lockfiles
-    Given the PR author is dependabot[bot]
-    And the PR's changed files are all uv.lock, pyproject.toml,
-      package.json, pnpm-lock.yaml, go.mod, go.sum, Cargo.lock, Cargo.toml,
-      or requirements*.txt
-    And the PR touches a path under services/**
-    And the PR description has no "## Deployment Impact" section
-    When deployment-impact-check runs
-    Then the check passes without requiring the section
+  Scenario: A dependency bot's PR touches only auto-generated lockfiles
+    Given the PR is authored by a trusted dependency-update bot
+    And every changed file is an auto-generated dependency lockfile
+    And the PR description has no deployment-impact writeup
+    Then the check passes without requiring one
 
   @unimplemented
-  Scenario: Human PR only touches dependency manifests and lockfiles
-    Given the PR author is not dependabot[bot]
-    And the PR's changed files are all uv.lock, pyproject.toml,
-      package.json, pnpm-lock.yaml, go.mod, go.sum, Cargo.lock, Cargo.toml,
-      or requirements*.txt
-    And the PR touches a path under services/**
-    And the PR description has no "## Deployment Impact" section
-    When deployment-impact-check runs
-    Then the check fails and requests the section
+  Scenario: A dependency bot's PR touches only hand-edited dependency manifests
+    Given the PR is authored by a trusted dependency-update bot
+    And every changed file is a hand-edited dependency manifest, a lockfile,
+      or both
+    And the PR description has no deployment-impact writeup
+    Then the check passes without requiring one
 
   @unimplemented
-  Scenario: PR touches a real deployment-relevant file
-    Given the PR's changed files include a Dockerfile under services/**
-    And the PR description has no "## Deployment Impact" section
-    When deployment-impact-check runs
-    Then the check fails and requests the section
+  Scenario: A human's PR touches only hand-edited dependency manifests
+    Given the PR is authored by a human, not a dependency-update bot
+    And every changed file is a hand-edited dependency manifest
+    And the PR description has no deployment-impact writeup
+    Then the check still requires one, since a manifest edit could carry
+      more than a version bump
 
   @unimplemented
-  Scenario: PR mixes a manifest bump with a real file change
-    Given the PR's changed files include both uv.lock and a chart template
-      under charts/**
-    And the PR description has no "## Deployment Impact" section
-    When deployment-impact-check runs
-    Then the check fails and requests the section
+  Scenario: A PR touches a file that isn't a recognized dependency manifest
+    Given at least one changed file is not a lockfile or dependency manifest
+    And the PR description has no deployment-impact writeup
+    Then the check still requires one, regardless of what else changed

--- a/specs/ci/deployment-impact-check.feature
+++ b/specs/ci/deployment-impact-check.feature
@@ -9,12 +9,20 @@ Feature: Deployment impact gate skips manifest-only dependency bumps
   Dependabot never writes that section, so this recurring false positive
   blocked every services/* dependency PR from merging.
 
+  The manifest-only exemption is restricted to dependabot: pyproject.toml,
+  package.json, go.mod, and Cargo.toml are hand-edited manifests, not pure
+  lockfiles, so a human PR touching only one of them could still slip in a
+  real deployment-relevant change (a new package.json postinstall script, a
+  build-system change) alongside a version bump.
+
   Background:
     Given a pull request whose head repo matches the target repo
     And the branch is not a release-please branch
 
-  Scenario: PR only touches dependency manifests and lockfiles
-    Given the PR's changed files are all uv.lock, pyproject.toml,
+  @unimplemented
+  Scenario: Dependabot PR only touches dependency manifests and lockfiles
+    Given the PR author is dependabot[bot]
+    And the PR's changed files are all uv.lock, pyproject.toml,
       package.json, pnpm-lock.yaml, go.mod, go.sum, Cargo.lock, Cargo.toml,
       or requirements*.txt
     And the PR touches a path under services/**
@@ -22,12 +30,25 @@ Feature: Deployment impact gate skips manifest-only dependency bumps
     When deployment-impact-check runs
     Then the check passes without requiring the section
 
+  @unimplemented
+  Scenario: Human PR only touches dependency manifests and lockfiles
+    Given the PR author is not dependabot[bot]
+    And the PR's changed files are all uv.lock, pyproject.toml,
+      package.json, pnpm-lock.yaml, go.mod, go.sum, Cargo.lock, Cargo.toml,
+      or requirements*.txt
+    And the PR touches a path under services/**
+    And the PR description has no "## Deployment Impact" section
+    When deployment-impact-check runs
+    Then the check fails and requests the section
+
+  @unimplemented
   Scenario: PR touches a real deployment-relevant file
     Given the PR's changed files include a Dockerfile under services/**
     And the PR description has no "## Deployment Impact" section
     When deployment-impact-check runs
     Then the check fails and requests the section
 
+  @unimplemented
   Scenario: PR mixes a manifest bump with a real file change
     Given the PR's changed files include both uv.lock and a chart template
       under charts/**


### PR DESCRIPTION
## Summary

`deployment-impact-check` triggers on any PR touching `services/**` (among other paths) and requires a filled-in `## Deployment Impact` section. Dependabot never writes that section, so this was a hard, recurring block on every `services/langevals`, `services/aigateway` and `services/nlpgo` dependency PR — confirmed failing on #7293, #7289 and #7288 in the current batch.

The exemption is two tiers, because the files do not carry the same guarantee:

- **Lockfiles** (`uv.lock`, `pnpm-lock.yaml`, `go.sum`, `Cargo.lock`, `Chart.lock`) are auto-generated resolution snapshots. Nothing hand-edits them, so they cannot add an env var, a helm value, or change what `helm install` does — no deployment surface by construction, exempt regardless of who opened the PR.
- **Manifests** (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `requirements*.txt`) are hand-edited. Usually still just a version bump, but a person could add a `postinstall` script or change the build system in the same commit — so that weaker exemption applies only to a dependency bot's own PRs.

Anything else — a Dockerfile, a chart, a source file — is gated exactly as before. An empty change set claims neither exemption rather than passing vacuously.

Two things came out of review and are worth calling out:

- The exemption is judged by **`github.event.pull_request.user.login`, not `github.actor`**. The workflow triggers on `edited`, so `github.actor` was whoever last touched the PR: a maintainer tidying a dependabot PR's description flipped the actor away from the bot and silently withdrew an exemption the PR qualified for when it opened.
- The classification moved out of inline YAML into `.github/scripts/guard-deployment-impact.ts`, matching the existing `guard-path-filters.ts` / `guard-breaking-change-scope.ts` pattern. A `case` statement buried in a workflow step cannot be run, so it cannot be tested; a plain function can. `ci-scripts-test` runs its test, and that test is what binds the spec's four scenarios.

## Deployment Impact

No deployment impact — this changes a CI gate's trigger condition (a GitHub Actions workflow and a script it calls), not any deployed service, chart, env var, or Helm value. No operator-facing behaviour changes.

## Test plan

- [x] `node --test --experimental-strip-types .github/scripts/guard-deployment-impact.test.ts` — 11/11 pass
- [x] `feature-parity` green: the spec's four scenarios are bound and enforced (`@unit`), not `@unimplemented`
- [x] `ci-scripts-test` green, so the guard's test actually runs in CI rather than merely existing
- [x] This PR touches the workflow, not a manifest, so the gate still requires this section — which it has
- [ ] Re-run `deployment-impact-check` on #7293/#7289/#7288 after merge to confirm they go green
