### PR TITLE
fix(sdks/python): migrate haystack examples to the 3.x chat API

### DIFF
--- a/sdks/python/examples/haystack_bot.py
+++ b/sdks/python/examples/haystack_bot.py
@@ -11,8 +11,9 @@ from haystack import Pipeline, Document, component
 from haystack.utils import Secret
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
-from haystack.components.generators import OpenAIGenerator
-from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.dataclasses import ChatMessage
 
 import os
 import langwatch
@@ -66,39 +67,43 @@ class TrackedInMemoryBM25Retriever(InMemoryBM25Retriever):
 retriever = TrackedInMemoryBM25Retriever(document_store=document_store)
 
 
-class TrackedPromptBuilder(PromptBuilder):
+class TrackedChatPromptBuilder(ChatPromptBuilder):
     @langwatch.span()
-    @component.output_types(prompt=str)
+    @component.output_types(prompt=List[ChatMessage])
     def run(self, template=None, template_variables=None, **kwargs):
         return super().run(template, template_variables, **kwargs)
 
-    @component.output_types(prompt=str)
+    @component.output_types(prompt=List[ChatMessage])
     async def run_async(self, template=None, template_variables=None, **kwargs):
         return self.run(template, template_variables, **kwargs)
 
 
-prompt_builder = TrackedPromptBuilder(template=prompt_template)
+prompt_builder = TrackedChatPromptBuilder(
+    template=[ChatMessage.from_user(prompt_template)]
+)
 
 
-class TrackedOpenAIGenerator(OpenAIGenerator):
+class TrackedOpenAIChatGenerator(OpenAIChatGenerator):
     @langwatch.span(type="llm")
-    def run(self, prompt: str, **kwargs):
-        result = super().run(prompt, **kwargs)
+    def run(self, messages: List[ChatMessage], **kwargs):
+        result = super().run(messages, **kwargs)
+        reply = result["replies"][0]
+        usage = reply.meta.get("usage", {})
         langwatch.get_current_span().update(
             model=self.model,
-            output=result["replies"][0],
+            output=reply.text,
             metrics={
-                "prompt_tokens": result["meta"][0]["usage"]["prompt_tokens"],
-                "completion_tokens": result["meta"][0]["usage"]["completion_tokens"],
+                "prompt_tokens": usage.get("prompt_tokens"),
+                "completion_tokens": usage.get("completion_tokens"),
             },
         )
         return result
 
-    async def run_async(self, prompt: str, **kwargs):
-        return self.run(prompt, **kwargs)
+    async def run_async(self, messages: List[ChatMessage], **kwargs):
+        return self.run(messages, **kwargs)
 
 
-llm = TrackedOpenAIGenerator(
+llm = TrackedOpenAIChatGenerator(
     api_key=Secret.from_token(os.environ["OPENAI_API_KEY"]), model="gpt-5-mini"
 )
 
@@ -107,7 +112,7 @@ rag_pipeline.add_component("retriever", retriever)
 rag_pipeline.add_component("prompt_builder", prompt_builder)
 rag_pipeline.add_component("llm", llm)
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 
 @cl.on_message
@@ -137,5 +142,5 @@ async def main(message: cl.Message):
         }
     )
 
-    msg.content = results["llm"]["replies"][0]
+    msg.content = results["llm"]["replies"][0].text
     await msg.send()

--- a/sdks/python/examples/opentelemetry/openinference_haystack.py
+++ b/sdks/python/examples/opentelemetry/openinference_haystack.py
@@ -12,9 +12,9 @@ from haystack import Pipeline, Document
 from haystack.utils import Secret
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
-from haystack.components.generators import OpenAIGenerator
-from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.dataclasses import ChatMessage
 
 import os
 from openinference.instrumentation.haystack import HaystackInstrumentor
@@ -46,8 +46,8 @@ Answer:
 """
 
 retriever = InMemoryBM25Retriever(document_store=document_store)
-prompt_builder = PromptBuilder(template=prompt_template)
-llm = OpenAIGenerator(
+prompt_builder = ChatPromptBuilder(template=[ChatMessage.from_user(prompt_template)])
+llm = OpenAIChatGenerator(
     api_key=Secret.from_token(os.environ["OPENAI_API_KEY"]), model="gpt-5-mini"
 )
 
@@ -56,7 +56,7 @@ rag_pipeline.add_component("retriever", retriever)
 rag_pipeline.add_component("prompt_builder", prompt_builder)
 rag_pipeline.add_component("llm", llm)
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 
 @cl.on_message
@@ -78,5 +78,5 @@ async def main(message: cl.Message):
             }
         )
 
-    msg.content = results["llm"]["replies"][0]
+    msg.content = results["llm"]["replies"][0].text
     await msg.send()


### PR DESCRIPTION
Fixes main, which is red on `sdks/python` — `test_examples.py::test_example[examples/haystack_bot.py]`:

```
ImportError: cannot import name 'OpenAIGenerator'
from 'haystack.components.generators'
```

#7248 moved `haystack-ai` from `>=2.13.2,<4.0.0` to `>=3.0.0,<4.0.0`. Haystack 3.0 removed the non-chat `OpenAIGenerator` — `haystack.components.generators` now exposes only `OpenAIImageGenerator`, and the text path is `OpenAIChatGenerator` under `.generators.chat`.

Worth noting the bump was titled `in /mcp/typescript` but landed in `sdks/python/pyproject.toml`. That mislabelling is the same dead-manifest problem #7280 was cleaning up, and it is why this broke a directory nobody was watching.

## What changed

The new generator takes `messages: list[ChatMessage]` rather than `prompt: str`, so the migration reaches past the import:

- `PromptBuilder` → `ChatPromptBuilder`. Its `prompt` socket emits `list[ChatMessage]`, so the pipeline edge becomes `prompt_builder.prompt → llm.messages` (the old bare `connect("prompt_builder", "llm")` no longer type-matches).
- A reply is a `ChatMessage`, so content is `reply.text`, and token counts move from `result["meta"][0]["usage"]` to `reply.meta["usage"]`.
- Haystack 3 rejects any component whose `run` and `run_async` signatures differ, so the `@langwatch.span`-tracked subclasses override both in step. This one is easy to miss — it fails at component construction, not at import.

Also drops an `AnswerBuilder` import `openinference_haystack.py` never used.

## Verification

Both examples import cleanly against the real `sdks/python` env with `haystack-ai 3.0.0`:

```
IMPORT OK: examples.haystack_bot
IMPORT OK: examples.opentelemetry.openinference_haystack
```

Both files construct and `connect()` their pipelines at module scope, so a wiring or socket-type error surfaces at import — that import passing is the wiring check, not just a syntax check. The socket shapes were confirmed directly against haystack 3.0.0 (`ChatPromptBuilder.run` → `prompt=list[ChatMessage]`, `OpenAIChatGenerator.run(messages=...)`, `usage` keys unchanged).

Not exercised locally: the live `main()` call, which needs a real OpenAI key. CI covers that.

## Deployment Impact

No deployment impact — this changes two example scripts under `sdks/python/examples/`, which are not shipped in the published package and are not part of any deployed service. No env vars, helm values, default `helm install` behaviour, or BYOC dataplane surface is touched.
