### PR TITLE
fix(ci): compare changed paths byte-exactly in the deployment-impact guard

### DIFF
--- a/.github/scripts/guard-deployment-impact.test.ts
+++ b/.github/scripts/guard-deployment-impact.test.ts
@@ -5,6 +5,7 @@ import {
   classify,
   isDependencyBot,
   kindOf,
+  parseChangedFiles,
   requiresWriteup,
 } from "./guard-deployment-impact.ts";
 
@@ -93,6 +94,62 @@ describe("given a pull request the deployment-impact check would normally gate",
       });
       assert.equal(requiresWriteup({ files, author: BOT }), true);
       assert.equal(requiresWriteup({ files, author: HUMAN }), true);
+    });
+  });
+});
+
+describe("given a path with unusual but legal whitespace", () => {
+  describe("when a name ends in a space", () => {
+    it("does not let it borrow a lockfile's exemption", () => {
+      // "Chart.lock " is a different file from "Chart.lock". Trimming the two
+      // together would exempt a PR that changed an unrecognised file.
+      assert.equal(kindOf("charts/gateway/Chart.lock "), "other");
+      assert.equal(
+        requiresWriteup({ files: ["charts/gateway/Chart.lock "], author: BOT }),
+        true,
+      );
+    });
+  });
+
+  describe("when a name contains a newline", () => {
+    it("classifies it whole rather than as two records", () => {
+      // Line-delimited transport would split this into "evil" and
+      // "uv.lock"; the second half alone would look exempt.
+      assert.equal(kindOf("services/evil\nuv.lock"), "other");
+      assert.equal(
+        requiresWriteup({ files: ["services/evil\nuv.lock"], author: BOT }),
+        true,
+      );
+    });
+  });
+});
+
+describe("given the JSON the workflow hands the guard", () => {
+  describe("when it is well-formed paginated output", () => {
+    it("flattens the pages and keeps every name byte-exact", () => {
+      const json = JSON.stringify([
+        [{ filename: "services/langevals/uv.lock" }],
+        [{ filename: "charts/gateway/Chart.lock " }],
+      ]);
+      assert.deepEqual(parseChangedFiles(json), [
+        "services/langevals/uv.lock",
+        "charts/gateway/Chart.lock ",
+      ]);
+    });
+  });
+
+  describe("when it is malformed", () => {
+    it("throws rather than waving the pull request through", () => {
+      assert.throws(() => parseChangedFiles("not json"), /did not parse/);
+      assert.throws(() => parseChangedFiles('{"files":[]}'), /not an array/);
+      assert.throws(
+        () => parseChangedFiles(JSON.stringify([[{ sha: "abc" }]])),
+        /no usable filename/,
+      );
+      assert.throws(
+        () => parseChangedFiles(JSON.stringify([[{ filename: "" }]])),
+        /no usable filename/,
+      );
     });
   });
 });

--- a/.github/scripts/guard-deployment-impact.ts
+++ b/.github/scripts/guard-deployment-impact.ts
@@ -32,6 +32,7 @@
 //
 // Spec: specs/ci/deployment-impact-check.feature
 
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -83,19 +84,55 @@ export interface Classification {
 }
 
 /**
+ * Names arrive exactly as the API reported them — no trimming. A path may end
+ * in a space, and `"charts/x/Chart.lock "` is a DIFFERENT file from
+ * `"charts/x/Chart.lock"`; normalising the two together would let an
+ * unrecognised file borrow a lockfile's exemption.
+ *
  * An empty change set is neither: with nothing to inspect there is nothing to
  * base an exemption on, so it falls through to requiring the writeup rather
  * than passing vacuously.
  */
 export const classify = (files: readonly string[]): Classification => {
-  const paths = files.map((f) => f.trim()).filter((f) => f !== "");
-  if (paths.length === 0) return { onlyLockfiles: false, onlyManifests: false };
+  if (files.length === 0) return { onlyLockfiles: false, onlyManifests: false };
 
-  const kinds = paths.map(kindOf);
+  const kinds = files.map(kindOf);
   return {
     onlyLockfiles: kinds.every((k) => k === "lockfile"),
     onlyManifests: kinds.every((k) => k === "lockfile" || k === "manifest"),
   };
+};
+
+/**
+ * Filenames out of `gh api --paginate --slurp`: an array of pages, each an
+ * array of file objects. JSON rather than newline-delimited text because a
+ * path may legally contain a newline, and line-splitting would turn one such
+ * path into two records that classify independently.
+ *
+ * Fails closed. A guard that cannot read its input must say so rather than
+ * wave the pull request through, matching rule R3 in guard-path-filters.ts.
+ */
+export const parseChangedFiles = (json: string): string[] => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (cause) {
+    throw new Error(`changed-files JSON did not parse: ${String(cause)}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("changed-files JSON is not an array of pages");
+  }
+
+  const entries = parsed.flatMap((page) => (Array.isArray(page) ? page : [page]));
+  return entries.map((entry) => {
+    const filename = (entry as { filename?: unknown } | null)?.filename;
+    if (typeof filename !== "string" || filename === "") {
+      throw new Error(
+        `changed-files entry has no usable filename: ${JSON.stringify(entry)}`,
+      );
+    }
+    return filename;
+  });
 };
 
 export const isDependencyBot = (author: string): boolean =>
@@ -135,8 +172,13 @@ const isEntrypoint = (): boolean =>
   import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 
 if (isEntrypoint()) {
-  const author = process.env.PR_AUTHOR ?? "";
-  const files = (process.env.CHANGED_FILES ?? "").split("\n");
-  const outputs = main({ files, author });
+  const path = process.argv[2];
+  if (path === undefined) {
+    throw new Error(
+      "usage: guard-deployment-impact.ts <changed-files.json>  (PR_AUTHOR in env)",
+    );
+  }
+  const files = parseChangedFiles(readFileSync(path, "utf8"));
+  const outputs = main({ files, author: process.env.PR_AUTHOR ?? "" });
   for (const line of outputs) console.log(line);
 }

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -71,13 +71,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          CHANGED_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-          export CHANGED_FILES
-          echo "Changed files:"
-          printf '%s\n' "$CHANGED_FILES"
+          # JSON, not newline-delimited names. A path may legally contain a
+          # newline, and splitting on lines would turn one such path into two
+          # records that classify independently — so the file list never
+          # crosses a line-delimited boundary at all.
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --slurp \
+            > "${RUNNER_TEMP}/changed-files.json"
           echo "Author: $PR_AUTHOR"
           node --experimental-strip-types .github/scripts/guard-deployment-impact.ts \
-            | tee -a "$GITHUB_OUTPUT"
+            "${RUNNER_TEMP}/changed-files.json" | tee -a "$GITHUB_OUTPUT"
 
       - name: Verify deployment-impact section in PR description
         if: steps.manifest-only.outputs.requires_writeup == 'true'


### PR DESCRIPTION
Follow-up to #7294. CodeRabbit posted this finding a minute before that PR merged, so it never got addressed there.

Two ways an unrecognised file could borrow a lockfile's exemption from `deployment-impact-check`:

**1. Trimming laundered whitespace.** `classify()` did `files.map(f => f.trim())`. A path may legally end in a space, and `charts/gateway/Chart.lock ` is a *different* file from `charts/gateway/Chart.lock` — trimming collapsed the two together, so a PR touching only the former was exempted as if it had touched a lockfile. Paths are now compared byte-exact.

**2. Newline-delimited transport could split a path.** The file list crossed the workflow → script boundary as newline-delimited text. A path containing a newline split into two independent records, and the tail alone could look exempt. The list now travels as `gh api --paginate --slurp` JSON through a temp file and is never line-split, so the name the API reported is the name the guard classifies.

Parsing fails closed on malformed input — unparseable JSON, a non-array, or an entry with no usable `filename` all throw rather than waving the PR through. That matches rule R3 in `guard-path-filters.ts`: a guard that cannot read its input has to say so, because silently returning "not gated" reproduces the exact failure the guard exists to prevent.

Practical severity is low — you need a file whose name, after trimming, basenames to a lockfile — but the fix is small and strictly safer, so it is worth having.

## Test plan

- [x] `node --test --experimental-strip-types .github/scripts/guard-deployment-impact.test.ts` — 15/15 pass (up from 11; new cases cover trailing-space names, newline-containing names, and all four malformed-JSON paths)
- [x] End-to-end against real API output: `gh api repos/langwatch/langwatch/pulls/7294/files --paginate --slurp` confirmed to be an array-of-pages, and the guard read it and returned `requires_writeup=true` for that PR's file set
- [x] Exemption still fires where it should: a `uv.lock` + `pyproject.toml` change returns `requires_writeup=false` for `dependabot[bot]` and `true` for a human — the two tiers still behave as #7294 intended

## Deployment Impact

No deployment impact — this changes a CI gate's classification logic (a GitHub Actions workflow and the script it calls), not any deployed service, chart, env var, or Helm value. No operator-facing behaviour changes.
