### PR TITLE
feat(authz): the Access surface lists from the head that decides (ADR-092 PR 3 follow-up)

### DIFF
--- a/platform/app/src/app/api/groups/[[...route]]/app.ts
+++ b/platform/app/src/app/api/groups/[[...route]]/app.ts
@@ -344,7 +344,10 @@ secured
       });
       if (!group) throw new GroupNotFoundError(id);
 
-      const bindings = await service.getBindings({ groupId: id });
+      const bindings = await service.getBindings({
+        organizationId: organization.id,
+        groupId: id,
+      });
       return c.json({
         data: bindings.map((b) => ({
           id: b.id,

--- a/platform/app/src/server/api-key/api-key.repository.ts
+++ b/platform/app/src/server/api-key/api-key.repository.ts
@@ -45,8 +45,6 @@ export class ApiKeyRepository {
      * rather than `prisma` above, which may be one.
      */
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-    // Listing reads go through the per-organization fork (ADR-092,
-    // delivery-plan PR 3 follow-up).
     private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
       prisma,
     ),

--- a/platform/app/src/server/api-key/api-key.repository.ts
+++ b/platform/app/src/server/api-key/api-key.repository.ts
@@ -37,10 +37,6 @@ export type ApiKeyWithBindings = ApiKey & {
 export type ApiKeyPrismaDelegate = PrismaClient | Prisma.TransactionClient;
 
 export class ApiKeyRepository {
-  // Listing reads go through the per-organization fork (ADR-092,
-  // delivery-plan PR 3 follow-up).
-  private readonly accessListing: AccessListingRepository;
-
   constructor(
     private readonly prisma: ApiKeyPrismaDelegate,
     /**
@@ -49,9 +45,12 @@ export class ApiKeyRepository {
      * rather than `prisma` above, which may be one.
      */
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-  ) {
-    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
-  }
+    // Listing reads go through the per-organization fork (ADR-092,
+    // delivery-plan PR 3 follow-up).
+    private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
+      prisma,
+    ),
+  ) {}
 
   static create(prisma: ApiKeyPrismaDelegate): ApiKeyRepository {
     return new ApiKeyRepository(prisma);

--- a/platform/app/src/server/api-key/api-key.repository.ts
+++ b/platform/app/src/server/api-key/api-key.repository.ts
@@ -11,6 +11,8 @@ import {
   type GrantsLedgerWriter,
   grantsLedgerWriter,
 } from "~/server/app-layer/authz/ledger";
+import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
+import type { AccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.repository";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { HIDDEN_SYSTEM_KEY_NAMES } from "./reserved-names";
 
@@ -35,6 +37,10 @@ export type ApiKeyWithBindings = ApiKey & {
 export type ApiKeyPrismaDelegate = PrismaClient | Prisma.TransactionClient;
 
 export class ApiKeyRepository {
+  // Listing reads go through the per-organization fork (ADR-092,
+  // delivery-plan PR 3 follow-up).
+  private readonly accessListing: AccessListingRepository;
+
   constructor(
     private readonly prisma: ApiKeyPrismaDelegate,
     /**
@@ -43,7 +49,9 @@ export class ApiKeyRepository {
      * rather than `prisma` above, which may be one.
      */
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-  ) {}
+  ) {
+    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
+  }
 
   static create(prisma: ApiKeyPrismaDelegate): ApiKeyRepository {
     return new ApiKeyRepository(prisma);
@@ -490,16 +498,20 @@ export class ApiKeyRepository {
     userId: string;
     organizationId: string;
   }) {
-    return this.prisma.roleBinding.findMany({
-      where: { userId, organizationId },
-      select: {
-        id: true,
-        role: true,
-        customRoleId: true,
-        scopeType: true,
-        scopeId: true,
-      },
+    // Through the per-organization fork (ADR-092, delivery-plan PR 3
+    // follow-up): a cut-over organization's key drawer is served from the
+    // ledger's own head.
+    const rows = await this.accessListing.findUserBindings({
+      organizationId,
+      userId,
     });
+    return rows.map((row) => ({
+      id: row.id,
+      role: row.role,
+      customRoleId: row.customRoleId,
+      scopeType: row.scopeType,
+      scopeId: row.scopeId,
+    }));
   }
 
   async findOrgsByIds(ids: string[]) {

--- a/platform/app/src/server/api/routers/project.ts
+++ b/platform/app/src/server/api/routers/project.ts
@@ -138,7 +138,7 @@ export const projectRouter = createTRPCRouter({
         // The team and the ADMIN binding that comes with it belong to the team
         // service: the binding is a grants-ledger fact, and a route is not
         // where the ledger is driven from.
-        const team = await new TeamService(prisma).createWithFoundingAdmin({
+        const team = await new TeamService({ prisma }).createWithFoundingAdmin({
           organizationId: input.organizationId,
           name: input.newTeamName ?? input.name,
           adminUserId: userId,

--- a/platform/app/src/server/api/routers/team.ts
+++ b/platform/app/src/server/api/routers/team.ts
@@ -58,7 +58,7 @@ export const teamRouter = createTRPCRouter({
     .input(z.object({ organizationId: z.string(), slug: z.string() }))
     .use(checkOrganizationPermission("organization:view"))
     .query(async ({ input, ctx }) => {
-      const service = new TeamService(ctx.prisma);
+      const service = new TeamService({ prisma: ctx.prisma });
       return service.getTeamBySlugForUser({
         slug: input.slug,
         organizationId: input.organizationId,
@@ -82,7 +82,7 @@ export const teamRouter = createTRPCRouter({
         "organization:manage",
       );
 
-      const service = new TeamService(ctx.prisma);
+      const service = new TeamService({ prisma: ctx.prisma });
       const teams = await service.getTeamsWithMembers({
         organizationId: input.organizationId,
         callerId,
@@ -119,7 +119,7 @@ export const teamRouter = createTRPCRouter({
     // settings/teams.tsx, an admin-only page.
     .use(checkOrganizationPermission("organization:manage"))
     .query(async ({ input, ctx }) => {
-      const service = new TeamService(ctx.prisma);
+      const service = new TeamService({ prisma: ctx.prisma });
       return service.getTeamsWithRoleBindings({
         organizationId: input.organizationId,
       });
@@ -141,7 +141,7 @@ export const teamRouter = createTRPCRouter({
         "organization:manage",
       );
 
-      const service = new TeamService(ctx.prisma);
+      const service = new TeamService({ prisma: ctx.prisma });
       const team = await service.getTeamWithMembers({
         slug: input.slug,
         organizationId: input.organizationId,
@@ -205,7 +205,7 @@ export const teamRouter = createTRPCRouter({
         });
       }
 
-      return new TeamService(ctx.prisma).updateWithMembers({
+      return new TeamService({ prisma: ctx.prisma }).updateWithMembers({
         teamId: input.teamId,
         name: input.name,
         members: input.members,
@@ -233,7 +233,7 @@ export const teamRouter = createTRPCRouter({
         });
       }
 
-      return new TeamService(ctx.prisma).createWithMembers({
+      return new TeamService({ prisma: ctx.prisma }).createWithMembers({
         organizationId: input.organizationId,
         name: input.name,
         members: input.members,
@@ -283,7 +283,7 @@ export const teamRouter = createTRPCRouter({
     )
     .use(checkTeamPermission("team:manage"))
     .mutation(async ({ input, ctx }) => {
-      const service = new TeamService(ctx.prisma);
+      const service = new TeamService({ prisma: ctx.prisma });
       return service.removeMember({
         teamId: input.teamId,
         userId: input.userId,

--- a/platform/app/src/server/app-layer/authz/cutover-gate.ts
+++ b/platform/app/src/server/app-layer/authz/cutover-gate.ts
@@ -41,12 +41,12 @@ import { perOrganizationCachedFlag } from "./per-organization-cached-gate";
  * constant rather than two: an organization mid-flip must converge in bounded
  * time whichever way it is moving.
  */
-const CACHE_TTL_MS = 60_000;
+export const CUTOVER_GATE_CACHE_TTL_MS = 60_000;
 
 const gate = perOrganizationCachedFlag({
   name: "cutover-gate",
-  positiveTtlMs: CACHE_TTL_MS,
-  negativeTtlMs: CACHE_TTL_MS,
+  positiveTtlMs: CUTOVER_GATE_CACHE_TTL_MS,
+  negativeTtlMs: CUTOVER_GATE_CACHE_TTL_MS,
 });
 
 /**

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Prisma } from "~/generated/prisma/client";
+import { resetCutoverGateForTesting } from "../../cutover-gate";
+import { CutoverAwareAccessListingRepository } from "../access-listing.cutover.repository";
+import type { AccessListingRepository } from "../access-listing.repository";
+
+/**
+ * The decorator answers one question per call - is THIS organization served
+ * by the engine - and delegates. What the tests pin is which head each
+ * listing reaches, because a listing that forked the wrong way would render
+ * an Access page from rows the organization is not being served from: access
+ * that does not exist shown, access that does hidden.
+ */
+const spyRepository = (name: string): AccessListingRepository =>
+  ({
+    findUserBindings: vi.fn().mockResolvedValue([]),
+    findOrganizationBindings: vi.fn().mockResolvedValue([]),
+    findUserAndGroupBindings: vi.fn().mockResolvedValue([]),
+    findScopeBindings: vi.fn().mockResolvedValue([]),
+    findGroupBindings: vi.fn().mockResolvedValue([]),
+    findTeamMemberBindings: vi.fn().mockResolvedValue(new Map()),
+    findBindingsForSynthesis: vi
+      .fn()
+      .mockImplementation(async ({ orgIds }: { orgIds: readonly string[] }) =>
+        orgIds.map((organizationId) => ({
+          organizationId,
+          scopeType: "TEAM",
+          scopeId: `team-of-${organizationId}`,
+          role: "MEMBER",
+          customRoleId: null,
+          customRole: null,
+          head: name,
+        })),
+      ),
+    findUserCreatedRoles: vi.fn().mockResolvedValue([]),
+  }) as unknown as AccessListingRepository;
+
+const repositoryFor = (onEngineByOrg: Record<string, boolean>) => {
+  const legacy = spyRepository("legacy");
+  const grants = spyRepository("grants");
+  const findUnique = vi.fn(
+    async ({ where }: { where: { organizationId: string } }) => ({
+      onEngine: onEngineByOrg[where.organizationId] === true,
+    }),
+  );
+  const prisma = {
+    authzCutoverProjection: { findUnique },
+  } as unknown as Prisma.TransactionClient;
+  return {
+    legacy,
+    grants,
+    findUnique,
+    repository: new CutoverAwareAccessListingRepository(prisma, {
+      legacy,
+      grants,
+    }),
+  };
+};
+
+describe("CutoverAwareAccessListingRepository", () => {
+  beforeEach(() => {
+    resetCutoverGateForTesting();
+  });
+  afterEach(() => {
+    resetCutoverGateForTesting();
+    vi.useRealTimers();
+  });
+
+  describe("given the organization is cut over", () => {
+    /** @scenario "A cut-over organization's access listings are served from the ledger's head" */
+    it("lists every binding surface from the grants head, leaving the legacy head untouched", async () => {
+      const { legacy, grants, repository } = repositoryFor({ "org-1": true });
+
+      await repository.findUserBindings({
+        organizationId: "org-1",
+        userId: "alice",
+      });
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      await repository.findUserAndGroupBindings({
+        organizationId: "org-1",
+        userId: "alice",
+        groupIds: ["group-1"],
+      });
+      await repository.findScopeBindings({
+        organizationId: "org-1",
+        scopeType: "TEAM",
+        scopeIds: ["team-1"],
+      });
+      await repository.findGroupBindings({
+        organizationId: "org-1",
+        groupId: "group-1",
+      });
+      await repository.findTeamMemberBindings({
+        organizationId: "org-1",
+        teamIds: ["team-1"],
+      });
+
+      expect(grants.findUserBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findUserAndGroupBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findScopeBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findGroupBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findTeamMemberBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findUserBindings).not.toHaveBeenCalled();
+      expect(legacy.findOrganizationBindings).not.toHaveBeenCalled();
+      expect(legacy.findUserAndGroupBindings).not.toHaveBeenCalled();
+      expect(legacy.findScopeBindings).not.toHaveBeenCalled();
+      expect(legacy.findGroupBindings).not.toHaveBeenCalled();
+      expect(legacy.findTeamMemberBindings).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "A cut-over organization's role editor lists roles from the ledger's head" */
+    it("lists the role editor's roles from the grants head", async () => {
+      const { legacy, grants, repository } = repositoryFor({ "org-1": true });
+
+      await repository.findUserCreatedRoles({ organizationId: "org-1" });
+
+      expect(grants.findUserCreatedRoles).toHaveBeenCalledWith({
+        organizationId: "org-1",
+      });
+      expect(legacy.findUserCreatedRoles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the organization has not cut over", () => {
+    /** @scenario "An organization that has not cut over keeps listing from the legacy tables" */
+    it("lists from the legacy head, leaving the grants head untouched", async () => {
+      const { legacy, grants, repository } = repositoryFor({ "org-1": false });
+
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      await repository.findUserCreatedRoles({ organizationId: "org-1" });
+
+      expect(legacy.findOrganizationBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findUserCreatedRoles).toHaveBeenCalledTimes(1);
+      expect(grants.findOrganizationBindings).not.toHaveBeenCalled();
+      expect(grants.findUserCreatedRoles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the synthesis read spans cut-over and legacy organizations", () => {
+    it("partitions the organizations across the heads and concatenates the rows", async () => {
+      const { legacy, grants, repository } = repositoryFor({
+        "org-engine": true,
+        "org-legacy": false,
+      });
+
+      const rows = await repository.findBindingsForSynthesis({
+        orgIds: ["org-engine", "org-legacy"],
+        userId: "alice",
+      });
+
+      expect(legacy.findBindingsForSynthesis).toHaveBeenCalledWith({
+        orgIds: ["org-legacy"],
+        userId: "alice",
+      });
+      expect(grants.findBindingsForSynthesis).toHaveBeenCalledWith({
+        orgIds: ["org-engine"],
+        userId: "alice",
+      });
+      expect(rows.map((row) => row.organizationId).sort()).toEqual([
+        "org-engine",
+        "org-legacy",
+      ]);
+    });
+
+    it("asks only the head that has organizations to answer for", async () => {
+      const { legacy, grants, repository } = repositoryFor({
+        "org-legacy": false,
+      });
+
+      await repository.findBindingsForSynthesis({
+        orgIds: ["org-legacy"],
+        userId: "alice",
+      });
+
+      expect(grants.findBindingsForSynthesis).not.toHaveBeenCalled();
+      expect(legacy.findBindingsForSynthesis).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the organization is rolled back after the gate cached a positive answer", () => {
+    /** @scenario "A rolled-back organization's listings return to the legacy head within the gate's cache window" */
+    it("stops reading the grant head once the cache window elapses, with no deploy", async () => {
+      vi.useFakeTimers();
+      const legacy = spyRepository("legacy");
+      const grants = spyRepository("grants");
+      const findUnique = vi
+        .fn()
+        .mockResolvedValueOnce({ onEngine: true })
+        .mockResolvedValueOnce({ onEngine: false });
+      const prisma = {
+        authzCutoverProjection: { findUnique },
+      } as unknown as Prisma.TransactionClient;
+      const repository = new CutoverAwareAccessListingRepository(prisma, {
+        legacy,
+        grants,
+      });
+
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(61_000);
+
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      expect(legacy.findOrganizationBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
@@ -17,7 +17,13 @@ import type { AccessListingRepository } from "../access-listing.repository";
 const spyRepository = (name: string): AccessListingRepository =>
   ({
     findUserBindings: vi.fn().mockResolvedValue([]),
-    findOrganizationBindings: vi.fn().mockResolvedValue([]),
+    // A row only this head could have produced, so the ROWS a listing returns
+    // name the head that served it - the proof style the spec section states.
+    // Spying on the call alone would not catch a delegator that asked the
+    // right head and then returned something else.
+    findOrganizationBindings: vi
+      .fn()
+      .mockResolvedValue([{ id: `row-from-${name}` }]),
     findUserAndGroupBindings: vi.fn().mockResolvedValue([]),
     findScopeBindings: vi.fn().mockResolvedValue([]),
     findGroupBindings: vi.fn().mockResolvedValue([]),
@@ -77,7 +83,9 @@ describe("CutoverAwareAccessListingRepository", () => {
         organizationId: "org-1",
         userId: "alice",
       });
-      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      const organizationRows = await repository.findOrganizationBindings({
+        organizationId: "org-1",
+      });
       await repository.findUserAndGroupBindings({
         organizationId: "org-1",
         userId: "alice",
@@ -97,6 +105,7 @@ describe("CutoverAwareAccessListingRepository", () => {
         teamIds: ["team-1"],
       });
 
+      expect(organizationRows).toEqual([{ id: "row-from-grants" }]);
       expect(grants.findUserBindings).toHaveBeenCalledTimes(1);
       expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
       expect(grants.findUserAndGroupBindings).toHaveBeenCalledTimes(1);
@@ -129,13 +138,62 @@ describe("CutoverAwareAccessListingRepository", () => {
     it("lists from the legacy head, leaving the grants head untouched", async () => {
       const { legacy, grants, repository } = repositoryFor({ "org-1": false });
 
-      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      const organizationRows = await repository.findOrganizationBindings({
+        organizationId: "org-1",
+      });
       await repository.findUserCreatedRoles({ organizationId: "org-1" });
 
+      expect(organizationRows).toEqual([{ id: "row-from-legacy" }]);
       expect(legacy.findOrganizationBindings).toHaveBeenCalledTimes(1);
       expect(legacy.findUserCreatedRoles).toHaveBeenCalledTimes(1);
       expect(grants.findOrganizationBindings).not.toHaveBeenCalled();
       expect(grants.findUserCreatedRoles).not.toHaveBeenCalled();
+    });
+
+    // The mirror of the cut-over case above. The delegator is eight near
+    // identical one-liners, so the defect to catch is one of them naming a
+    // head instead of asking: such a method passes the cut-over test and is
+    // never called again. A not-cut-over organization reaching the grant
+    // head would render an empty Access page - everyone's access hidden.
+    it("lists every binding surface from the legacy head, leaving the grants head untouched", async () => {
+      const { legacy, grants, repository } = repositoryFor({ "org-1": false });
+
+      await repository.findUserBindings({
+        organizationId: "org-1",
+        userId: "alice",
+      });
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      await repository.findUserAndGroupBindings({
+        organizationId: "org-1",
+        userId: "alice",
+        groupIds: ["group-1"],
+      });
+      await repository.findScopeBindings({
+        organizationId: "org-1",
+        scopeType: "TEAM",
+        scopeIds: ["team-1"],
+      });
+      await repository.findGroupBindings({
+        organizationId: "org-1",
+        groupId: "group-1",
+      });
+      await repository.findTeamMemberBindings({
+        organizationId: "org-1",
+        teamIds: ["team-1"],
+      });
+
+      expect(legacy.findUserBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findOrganizationBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findUserAndGroupBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findScopeBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findGroupBindings).toHaveBeenCalledTimes(1);
+      expect(legacy.findTeamMemberBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findUserBindings).not.toHaveBeenCalled();
+      expect(grants.findOrganizationBindings).not.toHaveBeenCalled();
+      expect(grants.findUserAndGroupBindings).not.toHaveBeenCalled();
+      expect(grants.findScopeBindings).not.toHaveBeenCalled();
+      expect(grants.findGroupBindings).not.toHaveBeenCalled();
+      expect(grants.findTeamMemberBindings).not.toHaveBeenCalled();
     });
   });
 
@@ -207,12 +265,72 @@ describe("CutoverAwareAccessListingRepository", () => {
 
       await repository.findOrganizationBindings({ organizationId: "org-1" });
       expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
+      expect(findUnique).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(CUTOVER_GATE_CACHE_TTL_MS + 1_000);
+      // Still inside the window: the rollback has happened in the projection
+      // but this pod is entitled to its cached answer, and must not have gone
+      // back to the projection to get it. Without this half, the assertion
+      // below would hold with no cache at all, or with the TTL widened to a
+      // day - it would prove "eventually", not "within one window".
+      vi.advanceTimersByTime(CUTOVER_GATE_CACHE_TTL_MS - 1);
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+      expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(2);
+      expect(legacy.findOrganizationBindings).not.toHaveBeenCalled();
+      expect(findUnique).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(2_000);
 
       await repository.findOrganizationBindings({ organizationId: "org-1" });
       expect(legacy.findOrganizationBindings).toHaveBeenCalledTimes(1);
-      expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
+      expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(2);
+      expect(findUnique).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // Every test above hands in its own pair of heads. No production call site
+  // does: they all construct the one-argument form and take the constructor's
+  // defaults. Those defaults are the only thing deciding which table a real
+  // Access page reads, and swapping them typechecks - same interface - and
+  // leaves every other test in this file green while the feature is inert.
+  describe("when the fork is composed the way every call site composes it", () => {
+    const prismaDouble = (onEngine: boolean) => {
+      const grantFindMany = vi.fn().mockResolvedValue([]);
+      const roleBindingFindMany = vi.fn().mockResolvedValue([]);
+      const prisma = {
+        authzCutoverProjection: {
+          findUnique: vi.fn().mockResolvedValue({ onEngine }),
+        },
+        grant: { findMany: grantFindMany },
+        roleBinding: { findMany: roleBindingFindMany },
+        user: { findMany: vi.fn().mockResolvedValue([]) },
+        group: { findMany: vi.fn().mockResolvedValue([]) },
+        apiKey: { findMany: vi.fn().mockResolvedValue([]) },
+        role: { findMany: vi.fn().mockResolvedValue([]) },
+      } as unknown as Prisma.TransactionClient;
+      return { prisma, grantFindMany, roleBindingFindMany };
+    };
+
+    it("reads the grant table for a cut-over organization", async () => {
+      const { prisma, grantFindMany, roleBindingFindMany } = prismaDouble(true);
+
+      await new CutoverAwareAccessListingRepository(
+        prisma,
+      ).findOrganizationBindings({ organizationId: "org-1" });
+
+      expect(grantFindMany).toHaveBeenCalledTimes(1);
+      expect(roleBindingFindMany).not.toHaveBeenCalled();
+    });
+
+    it("reads the binding table for an organization that has not cut over", async () => {
+      const { prisma, grantFindMany, roleBindingFindMany } =
+        prismaDouble(false);
+
+      await new CutoverAwareAccessListingRepository(
+        prisma,
+      ).findOrganizationBindings({ organizationId: "org-1" });
+
+      expect(roleBindingFindMany).toHaveBeenCalledTimes(1);
+      expect(grantFindMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Prisma } from "~/generated/prisma/client";
-import { resetCutoverGateForTesting } from "../../cutover-gate";
+import {
+  CUTOVER_GATE_CACHE_TTL_MS,
+  resetCutoverGateForTesting,
+} from "../../cutover-gate";
 import { CutoverAwareAccessListingRepository } from "../access-listing.cutover.repository";
 import type { AccessListingRepository } from "../access-listing.repository";
 
@@ -49,7 +52,6 @@ const repositoryFor = (onEngineByOrg: Record<string, boolean>) => {
   return {
     legacy,
     grants,
-    findUnique,
     repository: new CutoverAwareAccessListingRepository(prisma, {
       legacy,
       grants,
@@ -157,9 +159,15 @@ describe("CutoverAwareAccessListingRepository", () => {
         orgIds: ["org-engine"],
         userId: "alice",
       });
-      expect(rows.map((row) => row.organizationId).sort()).toEqual([
-        "org-engine",
-        "org-legacy",
+      const tagged = rows as unknown as Array<{
+        organizationId: string;
+        head: string;
+      }>;
+      expect(
+        tagged.map(({ organizationId, head }) => ({ organizationId, head })),
+      ).toEqual([
+        { organizationId: "org-legacy", head: "legacy" },
+        { organizationId: "org-engine", head: "grants" },
       ]);
     });
 
@@ -187,7 +195,8 @@ describe("CutoverAwareAccessListingRepository", () => {
       const findUnique = vi
         .fn()
         .mockResolvedValueOnce({ onEngine: true })
-        .mockResolvedValueOnce({ onEngine: false });
+        .mockResolvedValueOnce({ onEngine: false })
+        .mockResolvedValue({ onEngine: false });
       const prisma = {
         authzCutoverProjection: { findUnique },
       } as unknown as Prisma.TransactionClient;
@@ -199,7 +208,7 @@ describe("CutoverAwareAccessListingRepository", () => {
       await repository.findOrganizationBindings({ organizationId: "org-1" });
       expect(grants.findOrganizationBindings).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(61_000);
+      vi.advanceTimersByTime(CUTOVER_GATE_CACHE_TTL_MS + 1_000);
 
       await repository.findOrganizationBindings({ organizationId: "org-1" });
       expect(legacy.findOrganizationBindings).toHaveBeenCalledTimes(1);

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.grants.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.grants.repository.unit.test.ts
@@ -66,7 +66,7 @@ const prismaWith = (data: {
 describe("GrantsAccessListingRepository", () => {
   describe("when the grant rows carry facts the legacy vocabulary cannot express", () => {
     /** @scenario "Dormant facts never appear as bindings in a listing" */
-    it("skips lite-member and unknown role keys instead of defaulting them", async () => {
+    it("skips every fact the legacy vocabulary cannot carry instead of defaulting it", async () => {
       const { repository } = prismaWith({
         grants: [
           grantRow({
@@ -82,6 +82,26 @@ describe("GrantsAccessListingRepository", () => {
             principalType: "USER",
             principalId: "alice",
             roleKey: null,
+          }),
+          // The project-credential fact is the one the roleKey and scope
+          // filters do NOT catch: a listable PROJECT scope and a listable
+          // "admin" key, dormant only because its principal is collective.
+          // Listed, it would render as an ADMIN binding belonging to nobody.
+          grantRow({
+            id: "g-project-credential",
+            principalType: "PROJECT",
+            principalId: "project-1",
+            roleKey: "admin",
+            scopeType: "PROJECT",
+            scopeId: "project-1",
+          }),
+          grantRow({
+            id: "g-platform",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "admin",
+            scopeType: "PLATFORM",
+            scopeId: "platform",
           }),
           grantRow({
             id: "g-member",
@@ -104,13 +124,16 @@ describe("GrantsAccessListingRepository", () => {
       expect(rows.map((row) => row.id)).toEqual(["g-member"]);
     });
 
+    /** @scenario "Dormant facts never appear as bindings in a listing" */
     it("asks the query itself to exclude resource, platform and dormant rows", async () => {
       const { prisma, repository } = prismaWith({});
 
       await repository.findOrganizationBindings({ organizationId: ORG });
 
-      const where = prisma.grant.findMany.mock.calls[0]?.[0]?.where;
+      const call = prisma.grant.findMany.mock.calls[0]?.[0];
+      const where = call?.where;
       expect(where).toBeDefined();
+      expect(where.organizationId).toBe(ORG);
       expect(where.scopeType).toEqual({
         in: ["ORGANIZATION", "TEAM", "PROJECT"],
       });
@@ -121,6 +144,10 @@ describe("GrantsAccessListingRepository", () => {
           { roleKey: { startsWith: "custom:" } },
         ],
       });
+      // Business time, then id as the tiebreak: rows imported in one batch
+      // share an occurredAt, and without the second key they would reshuffle
+      // between reads of the same unchanged page.
+      expect(call?.orderBy).toEqual([{ occurredAt: "asc" }, { id: "asc" }]);
     });
   });
 
@@ -313,8 +340,14 @@ describe("GrantsAccessListingRepository", () => {
 
       expect(legacyRows[0]?.id).toBe(sharedId);
       expect(grantRows[0]?.id).toBe(sharedId);
-      expect(legacyRows[0]?.role).toBe(grantRows[0]?.role);
-      expect(legacyRows[0]?.scopeId).toBe(grantRows[0]?.scopeId);
+      // Not just the id: the whole rendered row. The two heads are read by
+      // one page, so any column that differs is a cell that changes on the
+      // day the organization cuts over. `createdAt` is the one to watch -
+      // legacy reports the binding's own createdAt, the grants head reports
+      // the fact's occurredAt, and they agree only because the import
+      // backdates it. Stamped at import time instead, every "since when" on
+      // the Access page would jump to cutover day.
+      expect(grantRows[0]).toEqual(legacyRows[0]);
     });
   });
 
@@ -472,6 +505,125 @@ describe("GrantsAccessListingRepository", () => {
           where: { organizationId: ORG, kind: "custom" },
         }),
       );
+    });
+  });
+
+  describe("when the listing is one group's own bindings", () => {
+    it("renders the row against the group and fences the name lookup to the organization", async () => {
+      const { prisma, repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-group",
+            principalType: "GROUP",
+            principalId: "group-1",
+            roleKey: "member",
+          }),
+        ],
+        groups: [{ id: "group-1", name: "SRE", scimSource: null }],
+      });
+
+      const rows = await repository.findGroupBindings({
+        organizationId: ORG,
+        groupId: "group-1",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.groupId).toBe("group-1");
+      expect(rows[0]?.group).toEqual({
+        id: "group-1",
+        name: "SRE",
+        scimSource: null,
+      });
+      expect(rows[0]?.userId).toBeNull();
+      expect(rows[0]?.apiKeyId).toBeNull();
+      // The fence that stops another organization's group name rendering on
+      // this page - the only thing bounding a lookup keyed by a bare id.
+      expect(prisma.group.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: { in: ["group-1"] }, organizationId: ORG },
+        }),
+      );
+    });
+  });
+
+  describe("when the listing is a scope's own bindings", () => {
+    it("asks nothing at all when there are no scopes to ask about", async () => {
+      const { prisma, repository } = prismaWith({});
+
+      const rows = await repository.findScopeBindings({
+        organizationId: ORG,
+        scopeType: "TEAM",
+        scopeIds: [],
+      });
+
+      expect(rows).toEqual([]);
+      expect(prisma.grant.findMany).not.toHaveBeenCalled();
+    });
+
+    it("drops a row whose principal no longer resolves in the organization", async () => {
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-present",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+          }),
+          grantRow({
+            id: "g-departed",
+            principalType: "USER",
+            principalId: "departed-dave",
+            roleKey: "admin",
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+      });
+
+      const rows = await repository.findScopeBindings({
+        organizationId: ORG,
+        scopeType: "TEAM",
+        scopeIds: ["team-1"],
+      });
+
+      expect(rows.map((row) => row.id)).toEqual(["g-present"]);
+    });
+  });
+
+  describe("when the listing is a member's own access breakdown", () => {
+    it("asks about the member's groups as well as the member", async () => {
+      const { prisma, repository } = prismaWith({});
+
+      await repository.findUserAndGroupBindings({
+        organizationId: ORG,
+        userId: "alice",
+        groupIds: ["group-1", "group-2"],
+      });
+
+      const where = prisma.grant.findMany.mock.calls[0]?.[0]?.where;
+      expect(where.AND).toContainEqual({
+        OR: [
+          { principalType: "USER", principalId: "alice" },
+          {
+            principalType: "GROUP",
+            principalId: { in: ["group-1", "group-2"] },
+          },
+        ],
+      });
+    });
+
+    it("asks only about the member when they belong to no group", async () => {
+      const { prisma, repository } = prismaWith({});
+
+      await repository.findUserAndGroupBindings({
+        organizationId: ORG,
+        userId: "alice",
+        groupIds: [],
+      });
+
+      const where = prisma.grant.findMany.mock.calls[0]?.[0]?.where;
+      expect(where.AND).toContainEqual({
+        OR: [{ principalType: "USER", principalId: "alice" }],
+      });
     });
   });
 });

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.grants.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.grants.repository.unit.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Prisma } from "~/generated/prisma/client";
+import { GrantsAccessListingRepository } from "../access-listing.grants.repository";
+import { PrismaAccessListingRepository } from "../access-listing.prisma.repository";
+
+/**
+ * The grants head speaks the ledger's vocabulary; the Access surface renders
+ * the legacy one. These tests pin the translation - the same one the fold
+ * writes onto the compat rows - and the decoration fences, because a row
+ * translated differently from how the compat head would have carried it is a
+ * listing that changes on the day an organization cuts over.
+ */
+
+const ORG = "org-1";
+
+type GrantRowSeed = {
+  id: string;
+  principalType: string;
+  principalId: string | null;
+  roleKey: string | null;
+  legacyRole?: string | null;
+  scopeType?: string;
+  scopeId?: string;
+  occurredAt?: Date;
+};
+
+const grantRow = (seed: GrantRowSeed) => ({
+  id: seed.id,
+  organizationId: ORG,
+  principalType: seed.principalType,
+  principalId: seed.principalId,
+  roleKey: seed.roleKey,
+  legacyRole: seed.legacyRole ?? null,
+  scopeType: seed.scopeType ?? "TEAM",
+  scopeId: seed.scopeId ?? "team-1",
+  occurredAt: seed.occurredAt ?? new Date("2026-01-05T00:00:00Z"),
+  updatedAt: new Date("2026-02-01T00:00:00Z"),
+});
+
+const prismaWith = (data: {
+  grants?: ReturnType<typeof grantRow>[];
+  users?: Array<Record<string, unknown>>;
+  groups?: Array<Record<string, unknown>>;
+  apiKeys?: Array<Record<string, unknown>>;
+  roles?: Array<Record<string, unknown>>;
+  groupMemberships?: Array<Record<string, unknown>>;
+}) => {
+  const prisma = {
+    grant: { findMany: vi.fn().mockResolvedValue(data.grants ?? []) },
+    user: { findMany: vi.fn().mockResolvedValue(data.users ?? []) },
+    group: { findMany: vi.fn().mockResolvedValue(data.groups ?? []) },
+    apiKey: { findMany: vi.fn().mockResolvedValue(data.apiKeys ?? []) },
+    role: { findMany: vi.fn().mockResolvedValue(data.roles ?? []) },
+    groupMembership: {
+      findMany: vi.fn().mockResolvedValue(data.groupMemberships ?? []),
+    },
+  };
+  return {
+    prisma,
+    repository: new GrantsAccessListingRepository(
+      prisma as unknown as Prisma.TransactionClient,
+    ),
+  };
+};
+
+describe("GrantsAccessListingRepository", () => {
+  describe("when the grant rows carry facts the legacy vocabulary cannot express", () => {
+    /** @scenario "Dormant facts never appear as bindings in a listing" */
+    it("skips lite-member and unknown role keys instead of defaulting them", async () => {
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-lite",
+            principalType: "USER",
+            principalId: "external-erin",
+            roleKey: "lite-member",
+            scopeType: "ORGANIZATION",
+            scopeId: ORG,
+          }),
+          grantRow({
+            id: "g-null",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: null,
+          }),
+          grantRow({
+            id: "g-member",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+          }),
+        ],
+        users: [
+          { id: "alice", name: "Alice", email: "a@x.io", image: null },
+          { id: "external-erin", name: "Erin", email: "e@x.io", image: null },
+        ],
+      });
+
+      const rows = await repository.findUserBindings({
+        organizationId: ORG,
+        userId: "alice",
+      });
+
+      expect(rows.map((row) => row.id)).toEqual(["g-member"]);
+    });
+
+    it("asks the query itself to exclude resource, platform and dormant rows", async () => {
+      const { prisma, repository } = prismaWith({});
+
+      await repository.findOrganizationBindings({ organizationId: ORG });
+
+      const where = prisma.grant.findMany.mock.calls[0]?.[0]?.where;
+      expect(where.scopeType).toEqual({
+        in: ["ORGANIZATION", "TEAM", "PROJECT"],
+      });
+      expect(where.principalType).toEqual({ in: ["USER", "GROUP", "API_KEY"] });
+      expect(where.AND[0]).toEqual({
+        OR: [
+          { roleKey: { in: ["admin", "member", "viewer"] } },
+          { roleKey: { startsWith: "custom:" } },
+        ],
+      });
+    });
+  });
+
+  describe("when a custom grant carries the built-in role its import preserved", () => {
+    it("lists the preserved role, exactly as the compat head reproduces it", async () => {
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-custom",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "custom:role-9",
+            legacyRole: "ADMIN",
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+        roles: [
+          {
+            id: "role-9",
+            organizationId: ORG,
+            name: "SRE",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+            occurredAt: new Date("2026-01-01T00:00:00Z"),
+            updatedAt: new Date("2026-01-02T00:00:00Z"),
+          },
+        ],
+      });
+
+      const rows = await repository.findUserBindings({
+        organizationId: ORG,
+        userId: "alice",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.role).toBe("ADMIN");
+      expect(rows[0]?.customRoleId).toBe("role-9");
+      expect(rows[0]?.customRole).toEqual({
+        id: "role-9",
+        name: "SRE",
+        permissions: ["traces:view"],
+      });
+    });
+  });
+
+  describe("when the listing is the organization's whole table", () => {
+    it("drops a row whose principal no longer resolves within the organization", async () => {
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-member",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+          }),
+          grantRow({
+            id: "g-departed",
+            principalType: "USER",
+            principalId: "departed-dave",
+            roleKey: "member",
+          }),
+          grantRow({
+            id: "g-foreign-key",
+            principalType: "API_KEY",
+            principalId: "key-foreign",
+            roleKey: "viewer",
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+      });
+
+      const rows = await repository.findOrganizationBindings({
+        organizationId: ORG,
+      });
+
+      expect(rows.map((row) => row.id)).toEqual(["g-member"]);
+    });
+
+    it("keeps a per-user row whose decoration is missing, like the legacy per-user read", async () => {
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-1",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+          }),
+        ],
+      });
+
+      const rows = await repository.findUserBindings({
+        organizationId: ORG,
+        userId: "alice",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.user).toBeNull();
+    });
+  });
+
+  describe("when a binding row is listed", () => {
+    it("carries the grant's own id and its business time", async () => {
+      const occurredAt = new Date("2023-04-05T00:00:00Z");
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "rb_adopted_id",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "admin",
+            occurredAt,
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+      });
+
+      const rows = await repository.findUserBindings({
+        organizationId: ORG,
+        userId: "alice",
+      });
+
+      expect(rows[0]?.id).toBe("rb_adopted_id");
+      expect(rows[0]?.createdAt).toEqual(occurredAt);
+    });
+  });
+
+  describe("when the two heads list the same imported binding", () => {
+    /** @scenario "A listing row keeps its identity across the cutover" */
+    it("lists it under the same id on both heads", async () => {
+      // The imported grant ADOPTS the binding's row id, so the two heads are
+      // the same row to a consumer holding its id.
+      const sharedId = "rb_1";
+      const legacyPrisma = {
+        roleBinding: {
+          findMany: vi.fn().mockResolvedValue([
+            {
+              id: sharedId,
+              organizationId: ORG,
+              userId: "alice",
+              groupId: null,
+              apiKeyId: null,
+              role: "MEMBER",
+              customRoleId: null,
+              scopeType: "TEAM",
+              scopeId: "team-1",
+              createdAt: new Date("2026-01-05T00:00:00Z"),
+              user: {
+                id: "alice",
+                name: "Alice",
+                email: "a@x.io",
+                image: null,
+              },
+              group: null,
+              apiKey: null,
+              customRole: null,
+            },
+          ]),
+        },
+      };
+      const legacy = new PrismaAccessListingRepository(
+        legacyPrisma as unknown as Prisma.TransactionClient,
+      );
+      const { repository: grants } = prismaWith({
+        grants: [
+          grantRow({
+            id: sharedId,
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+      });
+
+      const [legacyRows, grantRows] = await Promise.all([
+        legacy.findUserBindings({ organizationId: ORG, userId: "alice" }),
+        grants.findUserBindings({ organizationId: ORG, userId: "alice" }),
+      ]);
+
+      expect(legacyRows[0]?.id).toBe(sharedId);
+      expect(grantRows[0]?.id).toBe(sharedId);
+      expect(legacyRows[0]?.role).toBe(grantRows[0]?.role);
+      expect(legacyRows[0]?.scopeId).toBe(grantRows[0]?.scopeId);
+    });
+  });
+
+  describe("when role decoration points outside the organization", () => {
+    it("renders no role rather than another organization's", async () => {
+      const { prisma, repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-1",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "custom:foreign-role",
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+        roles: [],
+      });
+
+      const rows = await repository.findUserBindings({
+        organizationId: ORG,
+        userId: "alice",
+      });
+
+      expect(rows[0]?.customRole).toBeNull();
+      expect(prisma.role.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: ORG }),
+        }),
+      );
+    });
+  });
+
+  describe("when team member bindings are listed", () => {
+    it("pre-seeds every requested team and fences on current membership", async () => {
+      const { repository } = prismaWith({
+        grants: [
+          grantRow({
+            id: "g-1",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+            scopeType: "TEAM",
+            scopeId: "team-1",
+          }),
+          grantRow({
+            id: "g-2",
+            principalType: "USER",
+            principalId: "departed-dave",
+            roleKey: "member",
+            scopeType: "TEAM",
+            scopeId: "team-1",
+          }),
+        ],
+        users: [{ id: "alice", name: "Alice", email: "a@x.io", image: null }],
+      });
+
+      const byTeam = await repository.findTeamMemberBindings({
+        organizationId: ORG,
+        teamIds: ["team-1", "team-empty"],
+      });
+
+      expect([...byTeam.keys()].sort()).toEqual(["team-1", "team-empty"]);
+      expect(byTeam.get("team-empty")).toEqual([]);
+      expect(byTeam.get("team-1")?.map((member) => member.userId)).toEqual([
+        "alice",
+      ]);
+    });
+  });
+
+  describe("when the synthesis read expands the user's groups", () => {
+    it("keeps a group grant only when the user is in that group in the grant's own organization", async () => {
+      const { repository } = prismaWith({
+        groupMemberships: [
+          { groupId: "group-mine", group: { organizationId: ORG } },
+        ],
+        grants: [
+          grantRow({
+            id: "g-direct",
+            principalType: "USER",
+            principalId: "alice",
+            roleKey: "member",
+          }),
+          grantRow({
+            id: "g-via-group",
+            principalType: "GROUP",
+            principalId: "group-mine",
+            roleKey: "viewer",
+          }),
+          {
+            ...grantRow({
+              id: "g-foreign-group",
+              principalType: "GROUP",
+              principalId: "group-mine",
+              roleKey: "viewer",
+            }),
+            organizationId: "org-other",
+          },
+        ],
+      });
+
+      const rows = await repository.findBindingsForSynthesis({
+        orgIds: [ORG, "org-other"],
+        userId: "alice",
+      });
+
+      expect(
+        rows.map((row) => `${row.organizationId}:${row.scopeId}:${row.role}`),
+      ).toEqual([`${ORG}:team-1:MEMBER`, `${ORG}:team-1:VIEWER`]);
+    });
+  });
+
+  describe("when the role editor's roles are listed", () => {
+    /** @scenario "A cut-over organization's role editor lists roles from the ledger's head" */
+    it("serves the Role head's rows in the CustomRole column shape, business time first", async () => {
+      const { prisma, repository } = prismaWith({
+        roles: [
+          {
+            id: "role-1",
+            organizationId: ORG,
+            name: "SRE",
+            description: "on call",
+            permissions: ["traces:view"],
+            kind: "custom",
+            occurredAt: new Date("2026-01-01T00:00:00Z"),
+            updatedAt: new Date("2026-01-02T00:00:00Z"),
+          },
+        ],
+      });
+
+      const roles = await repository.findUserCreatedRoles({
+        organizationId: ORG,
+      });
+
+      expect(roles).toEqual([
+        {
+          id: "role-1",
+          organizationId: ORG,
+          name: "SRE",
+          description: "on call",
+          permissions: ["traces:view"],
+          kind: "custom",
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          updatedAt: new Date("2026-01-02T00:00:00Z"),
+        },
+      ]);
+      expect(prisma.role.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: ORG, kind: "custom" },
+        }),
+      );
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.grants.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.grants.repository.unit.test.ts
@@ -110,11 +110,12 @@ describe("GrantsAccessListingRepository", () => {
       await repository.findOrganizationBindings({ organizationId: ORG });
 
       const where = prisma.grant.findMany.mock.calls[0]?.[0]?.where;
+      expect(where).toBeDefined();
       expect(where.scopeType).toEqual({
         in: ["ORGANIZATION", "TEAM", "PROJECT"],
       });
       expect(where.principalType).toEqual({ in: ["USER", "GROUP", "API_KEY"] });
-      expect(where.AND[0]).toEqual({
+      expect(where.AND).toContainEqual({
         OR: [
           { roleKey: { in: ["admin", "member", "viewer"] } },
           { roleKey: { startsWith: "custom:" } },
@@ -168,7 +169,7 @@ describe("GrantsAccessListingRepository", () => {
 
   describe("when the listing is the organization's whole table", () => {
     it("drops a row whose principal no longer resolves within the organization", async () => {
-      const { repository } = prismaWith({
+      const { prisma, repository } = prismaWith({
         grants: [
           grantRow({
             id: "g-member",
@@ -197,6 +198,16 @@ describe("GrantsAccessListingRepository", () => {
       });
 
       expect(rows.map((row) => row.id)).toEqual(["g-member"]);
+      // In production a departed member's User row still exists and only the
+      // membership predicate excludes it, so pin the predicate itself — the
+      // row-drop above only proves drop-on-missing-decoration.
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            orgMemberships: { some: { organizationId: ORG } },
+          }),
+        }),
+      );
     });
 
     it("keeps a per-user row whose decoration is missing, like the legacy per-user read", async () => {
@@ -338,7 +349,7 @@ describe("GrantsAccessListingRepository", () => {
 
   describe("when team member bindings are listed", () => {
     it("pre-seeds every requested team and fences on current membership", async () => {
-      const { repository } = prismaWith({
+      const { prisma, repository } = prismaWith({
         grants: [
           grantRow({
             id: "g-1",
@@ -370,6 +381,13 @@ describe("GrantsAccessListingRepository", () => {
       expect(byTeam.get("team-1")?.map((member) => member.userId)).toEqual([
         "alice",
       ]);
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            orgMemberships: { some: { organizationId: ORG } },
+          }),
+        }),
+      );
     });
   });
 

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.prisma.repository.unit.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Prisma } from "~/generated/prisma/client";
+import { PrismaAccessListingRepository } from "../access-listing.prisma.repository";
+
+/**
+ * The legacy reader's queries were moved verbatim from the services'
+ * inline reads, and "byte-identical for a non-cut-over organization" is the
+ * claim the whole seam rests on. The services' own copies are gone, so these
+ * tests pin the moved WHERE / include / orderBy shapes directly — a drift
+ * here is a behaviour change for every organization that has not cut over.
+ *
+ * The expected shapes are written out literally on purpose: importing the
+ * module's own constants back would assert nothing.
+ */
+
+const PRINCIPAL_FENCE = {
+  OR: [
+    {
+      userId: { not: null },
+      user: { orgMemberships: { some: { organizationId: "org-1" } } },
+    },
+    { groupId: { not: null }, group: { organizationId: "org-1" } },
+    { apiKeyId: { not: null }, apiKey: { organizationId: "org-1" } },
+  ],
+};
+
+const DECORATION = {
+  user: { select: { id: true, name: true, email: true, image: true } },
+  group: { select: { id: true, name: true, scimSource: true } },
+  apiKey: { select: { id: true, name: true } },
+  customRole: { select: { id: true, name: true, permissions: true } },
+};
+
+const prismaWith = () => {
+  const prisma = {
+    roleBinding: { findMany: vi.fn().mockResolvedValue([]) },
+    customRole: { findMany: vi.fn().mockResolvedValue([]) },
+  };
+  return {
+    prisma,
+    repository: new PrismaAccessListingRepository(
+      prisma as unknown as Prisma.TransactionClient,
+    ),
+  };
+};
+
+describe("PrismaAccessListingRepository", () => {
+  describe("when one user's rows in one organization are listed", () => {
+    it("keeps the original where, decoration include and ascending order", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findUserBindings({
+        organizationId: "org-1",
+        userId: "alice",
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: { organizationId: "org-1", userId: "alice" },
+        include: DECORATION,
+        orderBy: { createdAt: "asc" },
+      });
+    });
+  });
+
+  describe("when the whole organization's rows are listed", () => {
+    it("carries the principal-membership fence the inline query carried", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findOrganizationBindings({ organizationId: "org-1" });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: { organizationId: "org-1", ...PRINCIPAL_FENCE },
+        include: DECORATION,
+        orderBy: { createdAt: "asc" },
+      });
+    });
+  });
+
+  describe("when a user's own and group-derived rows are listed together", () => {
+    it("ORs the user with the group memberships", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findUserAndGroupBindings({
+        organizationId: "org-1",
+        userId: "alice",
+        groupIds: ["group-1", "group-2"],
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: "org-1",
+          OR: [
+            { userId: "alice" },
+            { groupId: { in: ["group-1", "group-2"] } },
+          ],
+        },
+        include: DECORATION,
+        orderBy: { createdAt: "asc" },
+      });
+    });
+
+    it("asks only for the user's own rows when there are no groups", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findUserAndGroupBindings({
+        organizationId: "org-1",
+        userId: "alice",
+        groupIds: [],
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: "org-1", OR: [{ userId: "alice" }] },
+        }),
+      );
+    });
+  });
+
+  describe("when one scope's rows are listed", () => {
+    it("fences on the principal's membership and carries no ordering, like the team page's inline query", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findScopeBindings({
+        organizationId: "org-1",
+        scopeType: "TEAM",
+        scopeIds: ["team-1"],
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: "org-1",
+          scopeType: "TEAM",
+          scopeId: { in: ["team-1"] },
+          ...PRINCIPAL_FENCE,
+        },
+        include: DECORATION,
+      });
+    });
+
+    it("answers an empty scope list without a query", async () => {
+      const { prisma, repository } = prismaWith();
+
+      const rows = await repository.findScopeBindings({
+        organizationId: "org-1",
+        scopeType: "PROJECT",
+        scopeIds: [],
+      });
+
+      expect(rows).toEqual([]);
+      expect(prisma.roleBinding.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when one group's rows are listed", () => {
+    it("bounds the read to the organization", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findGroupBindings({
+        organizationId: "org-1",
+        groupId: "group-1",
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: { organizationId: "org-1", groupId: "group-1" },
+        include: DECORATION,
+      });
+    });
+  });
+
+  describe("when team member rows are listed for many teams", () => {
+    it("keeps the membership fence and pre-seeds every requested team", async () => {
+      const { prisma, repository } = prismaWith();
+
+      const byTeam = await repository.findTeamMemberBindings({
+        organizationId: "org-1",
+        teamIds: ["team-1", "team-empty"],
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: "org-1",
+          scopeType: "TEAM",
+          scopeId: { in: ["team-1", "team-empty"] },
+          userId: { not: null },
+          user: { orgMemberships: { some: { organizationId: "org-1" } } },
+        },
+        include: { user: true, customRole: true },
+      });
+      expect([...byTeam.keys()].sort()).toEqual(["team-1", "team-empty"]);
+      expect(byTeam.get("team-empty")).toEqual([]);
+    });
+
+    it("answers an empty team list without a query", async () => {
+      const { prisma, repository } = prismaWith();
+
+      const byTeam = await repository.findTeamMemberBindings({
+        organizationId: "org-1",
+        teamIds: [],
+      });
+
+      expect(byTeam.size).toBe(0);
+      expect(prisma.roleBinding.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the synthesis read spans organizations", () => {
+    it("keeps the original where and drops a group row tied to another organization", async () => {
+      const { prisma, repository } = prismaWith();
+      const row = {
+        organizationId: "org-1",
+        scopeType: "TEAM",
+        scopeId: "team-1",
+        role: "MEMBER",
+        customRoleId: null,
+        customRole: null,
+      };
+      prisma.roleBinding.findMany.mockResolvedValue([
+        { ...row, group: null },
+        { ...row, scopeId: "team-2", group: { organizationId: "org-1" } },
+        { ...row, scopeId: "team-3", group: { organizationId: "org-other" } },
+      ]);
+
+      const rows = await repository.findBindingsForSynthesis({
+        orgIds: ["org-1", "org-2"],
+        userId: "alice",
+      });
+
+      expect(prisma.roleBinding.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            organizationId: { in: ["org-1", "org-2"] },
+            OR: [
+              { userId: "alice" },
+              { group: { members: { some: { userId: "alice" } } } },
+            ],
+            scopeType: { in: ["TEAM", "ORGANIZATION", "PROJECT"] },
+          },
+        }),
+      );
+      expect(rows.map((r) => r.scopeId)).toEqual(["team-1", "team-2"]);
+      expect(rows[0]).not.toHaveProperty("group");
+    });
+
+    it("answers an empty organization list without a query", async () => {
+      const { prisma, repository } = prismaWith();
+
+      const rows = await repository.findBindingsForSynthesis({
+        orgIds: [],
+        userId: "alice",
+      });
+
+      expect(rows).toEqual([]);
+      expect(prisma.roleBinding.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the role editor's roles are listed", () => {
+    it("keeps the user-created kind filter and newest-first order", async () => {
+      const { prisma, repository } = prismaWith();
+
+      await repository.findUserCreatedRoles({ organizationId: "org-1" });
+
+      expect(prisma.customRole.findMany).toHaveBeenCalledWith({
+        where: { organizationId: "org-1", kind: "custom" },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.cutover.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.cutover.repository.ts
@@ -9,9 +9,14 @@
  *
  * Unlike the decision reader (`authz-read.cutover.repository.ts`), there is
  * no pass pinning here: every port method is one delegated call, and the
- * delegate finishes its own reads on the head it started on. The one
- * multi-organization method partitions its organizations by the gate's answer
- * and asks both heads, each only about its own organizations.
+ * delegate finishes its own reads on the head it started on. A caller that
+ * issues more than one call for a single page snapshot (the team detail view
+ * asks for TEAM and PROJECT scope bindings separately) can therefore straddle
+ * a gate flip — tolerated because the calls run concurrently inside the
+ * gate's 60-second coalescing window, row ids are stable across the heads,
+ * and a mixed render is a transient display artifact, never a decision. The
+ * one multi-organization method partitions its organizations by the gate's
+ * answer and asks both heads, each only about its own organizations.
  *
  * Browser-safety: like everything else under ./authz, this composes from a
  * caller-supplied Prisma handle and holds no module-scope storage.
@@ -26,12 +31,12 @@ import type {
   TeamScopedMemberBinding,
 } from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
 import { cutoverOnEngine } from "../cutover-gate";
+import { GrantsAccessListingRepository } from "./access-listing.grants.repository";
+import { PrismaAccessListingRepository } from "./access-listing.prisma.repository";
 import type {
   AccessListingBindingRow,
   AccessListingRepository,
 } from "./access-listing.repository";
-import { GrantsAccessListingRepository } from "./access-listing.grants.repository";
-import { PrismaAccessListingRepository } from "./access-listing.prisma.repository";
 
 export class CutoverAwareAccessListingRepository
   implements AccessListingRepository
@@ -107,12 +112,18 @@ export class CutoverAwareAccessListingRepository
     userId: string;
   }): Promise<RoleBindingForSynthesis[]> {
     if (orgIds.length === 0) return [];
-    const onEngine: string[] = [];
-    const onLegacy: string[] = [];
-    for (const organizationId of orgIds) {
-      if (await this.onEngine(organizationId)) onEngine.push(organizationId);
-      else onLegacy.push(organizationId);
-    }
+    const answers = await Promise.all(
+      orgIds.map(async (organizationId) => ({
+        organizationId,
+        onEngine: await this.onEngine(organizationId),
+      })),
+    );
+    const onEngine = answers
+      .filter((answer) => answer.onEngine)
+      .map((answer) => answer.organizationId);
+    const onLegacy = answers
+      .filter((answer) => !answer.onEngine)
+      .map((answer) => answer.organizationId);
     const [legacyRows, grantsRows] = await Promise.all([
       onLegacy.length > 0
         ? this.repositories.legacy.findBindingsForSynthesis({

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.cutover.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.cutover.repository.ts
@@ -1,0 +1,152 @@
+/**
+ * ADR-092 delivery-plan PR 3 follow-up — the Access surface's per-organization
+ * repoint. One `AccessListingRepository` in front of two: the legacy compat
+ * heads (`RoleBinding` / `CustomRole`) and the ledger's own projection
+ * (`Grant` / `Role`). Each call resolves the organization it is about, asks
+ * the SAME cutover gate the decision fork reads, and delegates - so the page
+ * a person looks at and the engine deciding what they may do on it can never
+ * be reading different heads for longer than the gate's cache window.
+ *
+ * Unlike the decision reader (`authz-read.cutover.repository.ts`), there is
+ * no pass pinning here: every port method is one delegated call, and the
+ * delegate finishes its own reads on the head it started on. The one
+ * multi-organization method partitions its organizations by the gate's answer
+ * and asks both heads, each only about its own organizations.
+ *
+ * Browser-safety: like everything else under ./authz, this composes from a
+ * caller-supplied Prisma handle and holds no module-scope storage.
+ */
+import type {
+  CustomRole,
+  Prisma,
+  RoleBindingScopeType,
+} from "~/generated/prisma/client";
+import type {
+  RoleBindingForSynthesis,
+  TeamScopedMemberBinding,
+} from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
+import { cutoverOnEngine } from "../cutover-gate";
+import type {
+  AccessListingBindingRow,
+  AccessListingRepository,
+} from "./access-listing.repository";
+import { GrantsAccessListingRepository } from "./access-listing.grants.repository";
+import { PrismaAccessListingRepository } from "./access-listing.prisma.repository";
+
+export class CutoverAwareAccessListingRepository
+  implements AccessListingRepository
+{
+  constructor(
+    private readonly prisma: Prisma.TransactionClient,
+    private readonly repositories: {
+      legacy: AccessListingRepository;
+      grants: AccessListingRepository;
+    } = {
+      legacy: new PrismaAccessListingRepository(prisma),
+      grants: new GrantsAccessListingRepository(prisma),
+    },
+  ) {}
+
+  async findUserBindings(args: {
+    organizationId: string;
+    userId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    return (await this.readerFor(args.organizationId)).findUserBindings(args);
+  }
+
+  async findOrganizationBindings(args: {
+    organizationId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    return (await this.readerFor(args.organizationId)).findOrganizationBindings(
+      args,
+    );
+  }
+
+  async findUserAndGroupBindings(args: {
+    organizationId: string;
+    userId: string;
+    groupIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]> {
+    return (await this.readerFor(args.organizationId)).findUserAndGroupBindings(
+      args,
+    );
+  }
+
+  async findScopeBindings(args: {
+    organizationId: string;
+    scopeType: RoleBindingScopeType;
+    scopeIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]> {
+    return (await this.readerFor(args.organizationId)).findScopeBindings(args);
+  }
+
+  async findGroupBindings(args: {
+    organizationId: string;
+    groupId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    return (await this.readerFor(args.organizationId)).findGroupBindings(args);
+  }
+
+  async findTeamMemberBindings(args: {
+    organizationId: string;
+    teamIds: readonly string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>> {
+    return (await this.readerFor(args.organizationId)).findTeamMemberBindings(
+      args,
+    );
+  }
+
+  /** Partitioned, not pinned: each organization is asked about on the head
+   *  the gate names for IT, and the answers concatenate - the rows carry
+   *  their organizationId, and the consumer's synthesis keys on it. */
+  async findBindingsForSynthesis({
+    orgIds,
+    userId,
+  }: {
+    orgIds: readonly string[];
+    userId: string;
+  }): Promise<RoleBindingForSynthesis[]> {
+    if (orgIds.length === 0) return [];
+    const onEngine: string[] = [];
+    const onLegacy: string[] = [];
+    for (const organizationId of orgIds) {
+      if (await this.onEngine(organizationId)) onEngine.push(organizationId);
+      else onLegacy.push(organizationId);
+    }
+    const [legacyRows, grantsRows] = await Promise.all([
+      onLegacy.length > 0
+        ? this.repositories.legacy.findBindingsForSynthesis({
+            orgIds: onLegacy,
+            userId,
+          })
+        : [],
+      onEngine.length > 0
+        ? this.repositories.grants.findBindingsForSynthesis({
+            orgIds: onEngine,
+            userId,
+          })
+        : [],
+    ]);
+    return [...legacyRows, ...grantsRows];
+  }
+
+  async findUserCreatedRoles(args: {
+    organizationId: string;
+  }): Promise<CustomRole[]> {
+    return (await this.readerFor(args.organizationId)).findUserCreatedRoles(
+      args,
+    );
+  }
+
+  private async readerFor(
+    organizationId: string,
+  ): Promise<AccessListingRepository> {
+    return (await this.onEngine(organizationId))
+      ? this.repositories.grants
+      : this.repositories.legacy;
+  }
+
+  private async onEngine(organizationId: string): Promise<boolean> {
+    return cutoverOnEngine({ prisma: this.prisma, organizationId });
+  }
+}

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.cutover.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.cutover.repository.ts
@@ -12,11 +12,12 @@
  * delegate finishes its own reads on the head it started on. A caller that
  * issues more than one call for a single page snapshot (the team detail view
  * asks for TEAM and PROJECT scope bindings separately) can therefore straddle
- * a gate flip — tolerated because the calls run concurrently inside the
- * gate's 60-second coalescing window, row ids are stable across the heads,
- * and a mixed render is a transient display artifact, never a decision. The
- * one multi-organization method partitions its organizations by the gate's
- * answer and asks both heads, each only about its own organizations.
+ * a gate flip — tolerated because the calls run concurrently and the gate's
+ * 60-second cache bounds how long a straddle lasts, row ids are stable across
+ * the heads, and a mixed render is a transient display artifact, never a
+ * decision. The one multi-organization method partitions its organizations by
+ * the gate's answer and asks both heads, each only about its own
+ * organizations.
  *
  * Browser-safety: like everything else under ./authz, this composes from a
  * caller-supplied Prisma handle and holds no module-scope storage.

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.grants.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.grants.repository.ts
@@ -125,6 +125,10 @@ function isBindingScope(scopeType: string): scopeType is RoleBindingScopeType {
   return (BINDING_SCOPE_TYPES as readonly string[]).includes(scopeType);
 }
 
+function isBindingPrincipal(principalType: string): boolean {
+  return (BINDING_PRINCIPAL_TYPES as readonly string[]).includes(principalType);
+}
+
 type ListableGrant = {
   row: GrantListRow;
   role: TeamUserRole;
@@ -136,6 +140,7 @@ function listableGrants(rows: readonly GrantListRow[]): ListableGrant[] {
   const listable: ListableGrant[] = [];
   for (const row of rows) {
     if (!isBindingScope(row.scopeType)) continue;
+    if (!isBindingPrincipal(row.principalType)) continue;
     const translated = compatRole(row);
     if (!translated) continue;
     listable.push({
@@ -347,6 +352,7 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
         ],
       },
       select: GRANT_ROW_SELECT,
+      orderBy: [{ occurredAt: "asc" }, { id: "asc" }],
     });
     const grants = listableGrants(rows).filter(
       ({ row }) =>

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.grants.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.grants.repository.ts
@@ -176,7 +176,7 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
     return this.decorate({
       organizationId,
       grants: listableGrants(rows),
-      dropUndecoratedPrincipals: true,
+      shouldDropUndecoratedPrincipals: true,
     });
   }
 
@@ -225,7 +225,7 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
     return this.decorate({
       organizationId,
       grants: listableGrants(rows),
-      dropUndecoratedPrincipals: true,
+      shouldDropUndecoratedPrincipals: true,
     });
   }
 
@@ -324,20 +324,10 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
   }): Promise<RoleBindingForSynthesis[]> {
     if (orgIds.length === 0) return [];
 
-    // The user's group memberships, resolved per organization so a grant
-    // naming a group can be tied back to "a group this user is in, in the
-    // grant's own organization" - the legacy relation predicate's shape.
-    const memberships = await this.prisma.groupMembership.findMany({
-      where: { userId, group: { organizationId: { in: [...orgIds] } } },
-      select: { groupId: true, group: { select: { organizationId: true } } },
+    const { groupIdsByOrg, allGroupIds } = await this.groupMembershipsFor({
+      userId,
+      orgIds,
     });
-    const groupIdsByOrg = new Map<string, Set<string>>();
-    for (const membership of memberships) {
-      const orgId = membership.group.organizationId;
-      if (!groupIdsByOrg.has(orgId)) groupIdsByOrg.set(orgId, new Set());
-      groupIdsByOrg.get(orgId)?.add(membership.groupId);
-    }
-    const allGroupIds = memberships.map((membership) => membership.groupId);
 
     const rows = await this.prisma.grant.findMany({
       where: {
@@ -365,27 +355,7 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
           groupIdsByOrg.get(row.organizationId)?.has(row.principalId) === true),
     );
 
-    // Role decoration carries the full role for the synthesized member shape.
-    // Per organization: `Role` is a projection with no relations, so the
-    // organization bound is the query's own predicate.
-    const roleIdsByOrg = new Map<string, Set<string>>();
-    for (const { row, customRoleId } of grants) {
-      if (!customRoleId) continue;
-      if (!roleIdsByOrg.has(row.organizationId)) {
-        roleIdsByOrg.set(row.organizationId, new Set());
-      }
-      roleIdsByOrg.get(row.organizationId)?.add(customRoleId);
-    }
-    const rolesByOrg = new Map<string, Map<string, CustomRole>>();
-    await Promise.all(
-      [...roleIdsByOrg.entries()].map(async ([orgId, roleIds]) => {
-        const roles = await this.findRolesAsCustomRoles({
-          organizationId: orgId,
-          roleIds: [...roleIds],
-        });
-        rolesByOrg.set(orgId, new Map(roles.map((role) => [role.id, role])));
-      }),
-    );
+    const rolesByOrg = await this.rolesByOrganizationFor(grants);
 
     return grants.map(({ row, role, customRoleId, scopeType }) => {
       const customRole = customRoleId
@@ -410,6 +380,60 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
           : null,
       };
     });
+  }
+
+  /** The user's group memberships, resolved per organization so a grant
+   *  naming a group can be tied back to "a group this user is in, in the
+   *  grant's own organization" - the legacy relation predicate's shape. */
+  private async groupMembershipsFor({
+    userId,
+    orgIds,
+  }: {
+    userId: string;
+    orgIds: readonly string[];
+  }): Promise<{
+    groupIdsByOrg: Map<string, Set<string>>;
+    allGroupIds: string[];
+  }> {
+    const memberships = await this.prisma.groupMembership.findMany({
+      where: { userId, group: { organizationId: { in: [...orgIds] } } },
+      select: { groupId: true, group: { select: { organizationId: true } } },
+    });
+    const groupIdsByOrg = new Map<string, Set<string>>();
+    for (const membership of memberships) {
+      const orgId = membership.group.organizationId;
+      if (!groupIdsByOrg.has(orgId)) groupIdsByOrg.set(orgId, new Set());
+      groupIdsByOrg.get(orgId)?.add(membership.groupId);
+    }
+    const allGroupIds = memberships.map((membership) => membership.groupId);
+    return { groupIdsByOrg, allGroupIds };
+  }
+
+  /** Role decoration carries the full role for the synthesized member shape.
+   *  Per organization: `Role` is a projection with no relations, so the
+   *  organization bound is the query's own predicate. */
+  private async rolesByOrganizationFor(
+    grants: readonly ListableGrant[],
+  ): Promise<Map<string, Map<string, CustomRole>>> {
+    const roleIdsByOrg = new Map<string, Set<string>>();
+    for (const { row, customRoleId } of grants) {
+      if (!customRoleId) continue;
+      if (!roleIdsByOrg.has(row.organizationId)) {
+        roleIdsByOrg.set(row.organizationId, new Set());
+      }
+      roleIdsByOrg.get(row.organizationId)?.add(customRoleId);
+    }
+    const rolesByOrg = new Map<string, Map<string, CustomRole>>();
+    await Promise.all(
+      [...roleIdsByOrg.entries()].map(async ([orgId, roleIds]) => {
+        const roles = await this.findRolesAsCustomRoles({
+          organizationId: orgId,
+          roleIds: [...roleIds],
+        });
+        rolesByOrg.set(orgId, new Map(roles.map((role) => [role.id, role])));
+      }),
+    );
+    return rolesByOrg;
   }
 
   async findUserCreatedRoles({
@@ -467,7 +491,7 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
 
   /** The principal and role decoration for `AccessListingBindingRow`s, read
    *  from the tables those things live in. With
-   *  `dropUndecoratedPrincipals` the row is dropped when its principal no
+   *  `shouldDropUndecoratedPrincipals` the row is dropped when its principal no
    *  longer resolves within the organization - the equivalent of the legacy
    *  whole-table query's relation predicates (a departed member, a foreign
    *  group or key). Without it a missing principal decorates to null and the
@@ -475,38 +499,50 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
   private async decorate({
     organizationId,
     grants,
-    dropUndecoratedPrincipals = false,
+    shouldDropUndecoratedPrincipals = false,
   }: {
     organizationId: string;
     grants: readonly ListableGrant[];
-    dropUndecoratedPrincipals?: boolean;
+    shouldDropUndecoratedPrincipals?: boolean;
   }): Promise<AccessListingBindingRow[]> {
-    const ids = {
-      user: new Set<string>(),
-      group: new Set<string>(),
-      apiKey: new Set<string>(),
-    };
-    const roleIds = new Set<string>();
+    const decoration = await this.fetchDecoration({
+      organizationId,
+      ids: collectDecorationIds(grants),
+      shouldDropUndecoratedPrincipals,
+    });
+    const listed: AccessListingBindingRow[] = [];
     for (const grant of grants) {
-      if (grant.customRoleId) roleIds.add(grant.customRoleId);
-      if (!grant.row.principalId) continue;
-      if (grant.row.principalType === "USER")
-        ids.user.add(grant.row.principalId);
-      else if (grant.row.principalType === "GROUP")
-        ids.group.add(grant.row.principalId);
-      else if (grant.row.principalType === "API_KEY")
-        ids.apiKey.add(grant.row.principalId);
+      const row = toListedRow({
+        grant,
+        decoration,
+        shouldDropUndecoratedPrincipals,
+      });
+      if (row) listed.push(row);
     }
+    return listed;
+  }
 
+  private async fetchDecoration({
+    organizationId,
+    ids,
+    shouldDropUndecoratedPrincipals,
+  }: {
+    organizationId: string;
+    ids: DecorationIds;
+    shouldDropUndecoratedPrincipals: boolean;
+  }): Promise<Decoration> {
     const [users, groups, apiKeys, roles] = await Promise.all([
       ids.user.size > 0
         ? this.prisma.user.findMany({
             where: {
               id: { in: [...ids.user] },
-              // The membership fence only matters where rows are dropped on
-              // it; for the per-user reads it is harmless and saves nothing
-              // to vary, so it is applied uniformly.
-              ...(dropUndecoratedPrincipals
+              // The membership fence applies only on the drop paths — the
+              // whole-table and scope listings, where the legacy queries
+              // exclude departed members via their relation predicates. The
+              // per-user reads stay unfenced on purpose: legacy decorates a
+              // departed member's own rows via an unfenced include, and the
+              // ids there always come from the caller, never from discovery.
+              ...(shouldDropUndecoratedPrincipals
                 ? { orgMemberships: { some: { organizationId } } }
                 : {}),
             },
@@ -525,58 +561,116 @@ export class GrantsAccessListingRepository implements AccessListingRepository {
             select: ACCESS_LISTING_API_KEY_SELECT,
           })
         : [],
-      this.findRolesAsCustomRoles({ organizationId, roleIds: [...roleIds] }),
+      this.findRolesAsCustomRoles({ organizationId, roleIds: [...ids.role] }),
     ]);
-    const userById = new Map(users.map((user) => [user.id, user]));
-    const groupById = new Map(groups.map((group) => [group.id, group]));
-    const apiKeyById = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
-    const roleById = new Map(roles.map((role) => [role.id, role]));
-
-    const listed: AccessListingBindingRow[] = [];
-    for (const grant of grants) {
-      const { row } = grant;
-      const user =
-        row.principalType === "USER" && row.principalId
-          ? (userById.get(row.principalId) ?? null)
-          : null;
-      const group =
-        row.principalType === "GROUP" && row.principalId
-          ? (groupById.get(row.principalId) ?? null)
-          : null;
-      const apiKey =
-        row.principalType === "API_KEY" && row.principalId
-          ? (apiKeyById.get(row.principalId) ?? null)
-          : null;
-      if (dropUndecoratedPrincipals && !user && !group && !apiKey) continue;
-
-      const customRole = grant.customRoleId
-        ? (roleById.get(grant.customRoleId) ?? null)
-        : null;
-      listed.push({
-        id: row.id,
-        organizationId: row.organizationId,
-        userId: row.principalType === "USER" ? row.principalId : null,
-        groupId: row.principalType === "GROUP" ? row.principalId : null,
-        apiKeyId: row.principalType === "API_KEY" ? row.principalId : null,
-        role: grant.role,
-        customRoleId: grant.customRoleId,
-        scopeType: grant.scopeType,
-        scopeId: row.scopeId,
-        createdAt: row.occurredAt,
-        user,
-        group,
-        apiKey,
-        customRole: customRole
-          ? {
-              id: customRole.id,
-              name: customRole.name,
-              permissions: customRole.permissions,
-            }
-          : null,
-      });
-    }
-    return listed;
+    return {
+      userById: new Map(users.map((user) => [user.id, user])),
+      groupById: new Map(groups.map((group) => [group.id, group])),
+      apiKeyById: new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey])),
+      roleById: new Map(roles.map((role) => [role.id, role])),
+    };
   }
+}
+
+type DecorationIds = {
+  user: Set<string>;
+  group: Set<string>;
+  apiKey: Set<string>;
+  role: Set<string>;
+};
+
+type Decoration = {
+  userById: Map<string, NonNullable<AccessListingBindingRow["user"]>>;
+  groupById: Map<string, NonNullable<AccessListingBindingRow["group"]>>;
+  apiKeyById: Map<string, NonNullable<AccessListingBindingRow["apiKey"]>>;
+  roleById: Map<string, CustomRole>;
+};
+
+function collectDecorationIds(grants: readonly ListableGrant[]): DecorationIds {
+  const ids: DecorationIds = {
+    user: new Set(),
+    group: new Set(),
+    apiKey: new Set(),
+    role: new Set(),
+  };
+  const byPrincipalType: Partial<Record<string, Set<string>>> = {
+    USER: ids.user,
+    GROUP: ids.group,
+    API_KEY: ids.apiKey,
+  };
+  for (const grant of grants) {
+    if (grant.customRoleId) ids.role.add(grant.customRoleId);
+    if (grant.row.principalId) {
+      byPrincipalType[grant.row.principalType]?.add(grant.row.principalId);
+    }
+  }
+  return ids;
+}
+
+function principalOf({
+  row,
+  decoration,
+}: {
+  row: ListableGrant["row"];
+  decoration: Decoration;
+}): Pick<AccessListingBindingRow, "user" | "group" | "apiKey"> {
+  const { principalId } = row;
+  if (!principalId) return { user: null, group: null, apiKey: null };
+  return {
+    user:
+      row.principalType === "USER"
+        ? (decoration.userById.get(principalId) ?? null)
+        : null,
+    group:
+      row.principalType === "GROUP"
+        ? (decoration.groupById.get(principalId) ?? null)
+        : null,
+    apiKey:
+      row.principalType === "API_KEY"
+        ? (decoration.apiKeyById.get(principalId) ?? null)
+        : null,
+  };
+}
+
+function toListedRow({
+  grant,
+  decoration,
+  shouldDropUndecoratedPrincipals,
+}: {
+  grant: ListableGrant;
+  decoration: Decoration;
+  shouldDropUndecoratedPrincipals: boolean;
+}): AccessListingBindingRow | null {
+  const { row } = grant;
+  const { user, group, apiKey } = principalOf({ row, decoration });
+  if (shouldDropUndecoratedPrincipals && !user && !group && !apiKey)
+    return null;
+
+  const customRole = grant.customRoleId
+    ? (decoration.roleById.get(grant.customRoleId) ?? null)
+    : null;
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    userId: row.principalType === "USER" ? row.principalId : null,
+    groupId: row.principalType === "GROUP" ? row.principalId : null,
+    apiKeyId: row.principalType === "API_KEY" ? row.principalId : null,
+    role: grant.role,
+    customRoleId: grant.customRoleId,
+    scopeType: grant.scopeType,
+    scopeId: row.scopeId,
+    createdAt: row.occurredAt,
+    user,
+    group,
+    apiKey,
+    customRole: customRole
+      ? {
+          id: customRole.id,
+          name: customRole.name,
+          permissions: customRole.permissions,
+        }
+      : null,
+  };
 }
 
 /** A `Role` head row in the `CustomRole` column shape. The two heads share

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.grants.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.grants.repository.ts
@@ -1,0 +1,605 @@
+/**
+ * ADR-092 delivery-plan PR 3 follow-up — the Access surface's reader for a
+ * CUT-OVER organization: the same port as
+ * `access-listing.prisma.repository.ts`, answered from the ledger's own
+ * projection (`Grant` / `Role`) instead of the compat
+ * `RoleBinding` / `CustomRole` heads.
+ *
+ * The translation into the legacy vocabulary is the one the fold itself
+ * performs onto the compat rows (`grantFactToCompatBinding`,
+ * packages/authz-server): admin→ADMIN, member→MEMBER, viewer→VIEWER,
+ * custom:<id>→(`legacyRole` ?? CUSTOM, id). A row the translation cannot
+ * express - `lite-member`, a RESOURCE or PLATFORM row, a collective
+ * principal - is SKIPPED, never defaulted: those are the dormant head-only
+ * facts (delivery-plan decision 13) the legacy pages never carried, and a
+ * listing that surfaced them would be a parity break in what people see.
+ *
+ * Decoration (user names, group names, key names) reads the tables those
+ * things actually live in - `User`, `Group`, `ApiKey` are not grants and are
+ * never projected - while role names and permissions come from the `Role`
+ * head, so a cut-over organization's listing never reads
+ * `RoleBinding`/`CustomRole` at all. Role decoration is bounded to the
+ * organization: a poisoned grant pointing at another organization's role
+ * renders as no role, exactly as the decision reader refuses to honour one.
+ *
+ * `createdAt` on a listed row is the grant's `occurredAt` - the fact's
+ * business time, which an imported grant backdates to the legacy row's
+ * `createdAt` - so "since when" reads the same across the heads.
+ *
+ * Deliberately independent of the legacy implementation, like the decision
+ * readers: each has to be readable on its own for a listing parity check to
+ * mean anything.
+ */
+import type {
+  CustomRole,
+  Prisma,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import type {
+  RoleBindingForSynthesis,
+  TeamScopedMemberBinding,
+} from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
+import { CUSTOM_ROLE_KIND } from "../../../role/role-kind";
+import type {
+  AccessListingBindingRow,
+  AccessListingRepository,
+} from "./access-listing.repository";
+import {
+  ACCESS_LISTING_API_KEY_SELECT,
+  ACCESS_LISTING_GROUP_SELECT,
+  ACCESS_LISTING_USER_SELECT,
+} from "./access-listing.repository";
+
+/** The three scope tiers a listed binding can carry - RESOURCE rows are the
+ *  share tier and PLATFORM rows are dormant facts; neither is a binding the
+ *  Access surface lists. */
+const BINDING_SCOPE_TYPES = ["ORGANIZATION", "TEAM", "PROJECT"] as const;
+
+/** The three principal kinds the legacy tables could express. Collective
+ *  principals (team / organization / project / anyone) are future-head-only
+ *  and never listed. */
+const BINDING_PRINCIPAL_TYPES = ["USER", "GROUP", "API_KEY"] as const;
+
+/** The roleKey shapes the legacy vocabulary can carry: the three built-ins
+ *  and `custom:<id>`. Everything else (`lite-member`, null) is dormant. */
+const LISTABLE_ROLE_KEY_WHERE: Prisma.GrantWhereInput = {
+  OR: [
+    { roleKey: { in: ["admin", "member", "viewer"] } },
+    { roleKey: { startsWith: "custom:" } },
+  ],
+};
+
+const GRANT_ROW_SELECT = {
+  id: true,
+  organizationId: true,
+  principalType: true,
+  principalId: true,
+  roleKey: true,
+  legacyRole: true,
+  scopeType: true,
+  scopeId: true,
+  occurredAt: true,
+  updatedAt: true,
+} as const satisfies Prisma.GrantSelect;
+
+type GrantListRow = Prisma.GrantGetPayload<{
+  select: typeof GRANT_ROW_SELECT;
+}>;
+
+/** roleKey → the compat (role, customRoleId) pair, the translation the fold
+ *  writes onto the compat head. Null for a key the legacy vocabulary cannot
+ *  carry - the caller skips the row. */
+function compatRole(row: {
+  roleKey: string | null;
+  legacyRole: string | null;
+}): { role: TeamUserRole; customRoleId: string | null } | null {
+  if (row.roleKey === "admin") return { role: "ADMIN", customRoleId: null };
+  if (row.roleKey === "member") return { role: "MEMBER", customRoleId: null };
+  if (row.roleKey === "viewer") return { role: "VIEWER", customRoleId: null };
+  if (row.roleKey?.startsWith("custom:")) {
+    return {
+      // `roleKey` alone cannot say which built-in role an imported custom
+      // binding ALSO carried, and the compat head reproduces it - so must the
+      // listing, or a cut-over Access page would show CUSTOM where the page
+      // showed ADMIN the day before. The column is a plain string on the
+      // projection row; a value the enum cannot carry reads as CUSTOM rather
+      // than inventing a role.
+      role: teamUserRoleFrom(row.legacyRole) ?? "CUSTOM",
+      customRoleId: row.roleKey.slice("custom:".length),
+    };
+  }
+  return null;
+}
+
+function teamUserRoleFrom(value: string | null): TeamUserRole | null {
+  return value === "ADMIN" ||
+    value === "MEMBER" ||
+    value === "VIEWER" ||
+    value === "CUSTOM"
+    ? value
+    : null;
+}
+
+function isBindingScope(scopeType: string): scopeType is RoleBindingScopeType {
+  return (BINDING_SCOPE_TYPES as readonly string[]).includes(scopeType);
+}
+
+type ListableGrant = {
+  row: GrantListRow;
+  role: TeamUserRole;
+  customRoleId: string | null;
+  scopeType: RoleBindingScopeType;
+};
+
+function listableGrants(rows: readonly GrantListRow[]): ListableGrant[] {
+  const listable: ListableGrant[] = [];
+  for (const row of rows) {
+    if (!isBindingScope(row.scopeType)) continue;
+    const translated = compatRole(row);
+    if (!translated) continue;
+    listable.push({
+      row,
+      role: translated.role,
+      customRoleId: translated.customRoleId,
+      scopeType: row.scopeType,
+    });
+  }
+  return listable;
+}
+
+export class GrantsAccessListingRepository implements AccessListingRepository {
+  constructor(private readonly prisma: Prisma.TransactionClient) {}
+
+  async findUserBindings({
+    organizationId,
+    userId,
+  }: {
+    organizationId: string;
+    userId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    const rows = await this.findGrantRows({
+      organizationId,
+      where: { principalType: "USER", principalId: userId },
+    });
+    // The legacy query carries no membership predicate on this read - the
+    // caller already scoped the ask to a member - so neither does this one.
+    return this.decorate({ organizationId, grants: listableGrants(rows) });
+  }
+
+  async findOrganizationBindings({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    const rows = await this.findGrantRows({ organizationId, where: {} });
+    return this.decorate({
+      organizationId,
+      grants: listableGrants(rows),
+      dropUndecoratedPrincipals: true,
+    });
+  }
+
+  async findUserAndGroupBindings({
+    organizationId,
+    userId,
+    groupIds,
+  }: {
+    organizationId: string;
+    userId: string;
+    groupIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]> {
+    const rows = await this.findGrantRows({
+      organizationId,
+      where: {
+        OR: [
+          { principalType: "USER", principalId: userId },
+          ...(groupIds.length > 0
+            ? [
+                {
+                  principalType: "GROUP" as const,
+                  principalId: { in: [...groupIds] },
+                },
+              ]
+            : []),
+        ],
+      },
+    });
+    return this.decorate({ organizationId, grants: listableGrants(rows) });
+  }
+
+  async findScopeBindings({
+    organizationId,
+    scopeType,
+    scopeIds,
+  }: {
+    organizationId: string;
+    scopeType: RoleBindingScopeType;
+    scopeIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]> {
+    if (scopeIds.length === 0) return [];
+    const rows = await this.findGrantRows({
+      organizationId,
+      where: { scopeType, scopeId: { in: [...scopeIds] } },
+    });
+    return this.decorate({
+      organizationId,
+      grants: listableGrants(rows),
+      dropUndecoratedPrincipals: true,
+    });
+  }
+
+  async findGroupBindings({
+    organizationId,
+    groupId,
+  }: {
+    organizationId: string;
+    groupId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    const rows = await this.findGrantRows({
+      organizationId,
+      where: { principalType: "GROUP", principalId: groupId },
+    });
+    return this.decorate({ organizationId, grants: listableGrants(rows) });
+  }
+
+  async findTeamMemberBindings({
+    organizationId,
+    teamIds,
+  }: {
+    organizationId: string;
+    teamIds: readonly string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>> {
+    const byTeam = new Map<string, TeamScopedMemberBinding[]>(
+      teamIds.map((teamId) => [teamId, []]),
+    );
+    if (teamIds.length === 0) return byTeam;
+
+    const rows = await this.findGrantRows({
+      organizationId,
+      where: {
+        principalType: "USER",
+        scopeType: "TEAM",
+        scopeId: { in: [...teamIds] },
+      },
+    });
+    const grants = listableGrants(rows);
+
+    // Full rows here, not the display selects: the member list's shape mirrors
+    // a legacy `TeamUser` join and carries the whole user and role. The user
+    // read keeps the legacy membership fence (a departed member is not
+    // listed); the role read is bounded to the organization.
+    const userIds = [
+      ...new Set(
+        grants.flatMap(({ row }) => (row.principalId ? [row.principalId] : [])),
+      ),
+    ];
+    const roleIds = [
+      ...new Set(
+        grants.flatMap(({ customRoleId }) =>
+          customRoleId ? [customRoleId] : [],
+        ),
+      ),
+    ];
+    const [users, roles] = await Promise.all([
+      userIds.length > 0
+        ? this.prisma.user.findMany({
+            where: {
+              id: { in: userIds },
+              orgMemberships: { some: { organizationId } },
+            },
+          })
+        : [],
+      this.findRolesAsCustomRoles({ organizationId, roleIds }),
+    ]);
+    const userById = new Map(users.map((user) => [user.id, user]));
+    const roleById = new Map(roles.map((role) => [role.id, role]));
+
+    for (const grant of grants) {
+      const user = grant.row.principalId
+        ? userById.get(grant.row.principalId)
+        : undefined;
+      if (!user) continue;
+      byTeam.get(grant.row.scopeId)?.push({
+        userId: user.id,
+        role: grant.role,
+        customRoleId: grant.customRoleId,
+        createdAt: grant.row.occurredAt,
+        updatedAt: grant.row.updatedAt,
+        user,
+        customRole: grant.customRoleId
+          ? (roleById.get(grant.customRoleId) ?? null)
+          : null,
+      });
+    }
+    return byTeam;
+  }
+
+  async findBindingsForSynthesis({
+    orgIds,
+    userId,
+  }: {
+    orgIds: readonly string[];
+    userId: string;
+  }): Promise<RoleBindingForSynthesis[]> {
+    if (orgIds.length === 0) return [];
+
+    // The user's group memberships, resolved per organization so a grant
+    // naming a group can be tied back to "a group this user is in, in the
+    // grant's own organization" - the legacy relation predicate's shape.
+    const memberships = await this.prisma.groupMembership.findMany({
+      where: { userId, group: { organizationId: { in: [...orgIds] } } },
+      select: { groupId: true, group: { select: { organizationId: true } } },
+    });
+    const groupIdsByOrg = new Map<string, Set<string>>();
+    for (const membership of memberships) {
+      const orgId = membership.group.organizationId;
+      if (!groupIdsByOrg.has(orgId)) groupIdsByOrg.set(orgId, new Set());
+      groupIdsByOrg.get(orgId)?.add(membership.groupId);
+    }
+    const allGroupIds = memberships.map((membership) => membership.groupId);
+
+    const rows = await this.prisma.grant.findMany({
+      where: {
+        organizationId: { in: [...orgIds] },
+        scopeType: { in: [...BINDING_SCOPE_TYPES] },
+        AND: [LISTABLE_ROLE_KEY_WHERE],
+        OR: [
+          { principalType: "USER", principalId: userId },
+          ...(allGroupIds.length > 0
+            ? [
+                {
+                  principalType: "GROUP" as const,
+                  principalId: { in: allGroupIds },
+                },
+              ]
+            : []),
+        ],
+      },
+      select: GRANT_ROW_SELECT,
+    });
+    const grants = listableGrants(rows).filter(
+      ({ row }) =>
+        row.principalType !== "GROUP" ||
+        (row.principalId != null &&
+          groupIdsByOrg.get(row.organizationId)?.has(row.principalId) === true),
+    );
+
+    // Role decoration carries the full role for the synthesized member shape.
+    // Per organization: `Role` is a projection with no relations, so the
+    // organization bound is the query's own predicate.
+    const roleIdsByOrg = new Map<string, Set<string>>();
+    for (const { row, customRoleId } of grants) {
+      if (!customRoleId) continue;
+      if (!roleIdsByOrg.has(row.organizationId)) {
+        roleIdsByOrg.set(row.organizationId, new Set());
+      }
+      roleIdsByOrg.get(row.organizationId)?.add(customRoleId);
+    }
+    const rolesByOrg = new Map<string, Map<string, CustomRole>>();
+    await Promise.all(
+      [...roleIdsByOrg.entries()].map(async ([orgId, roleIds]) => {
+        const roles = await this.findRolesAsCustomRoles({
+          organizationId: orgId,
+          roleIds: [...roleIds],
+        });
+        rolesByOrg.set(orgId, new Map(roles.map((role) => [role.id, role])));
+      }),
+    );
+
+    return grants.map(({ row, role, customRoleId, scopeType }) => {
+      const customRole = customRoleId
+        ? (rolesByOrg.get(row.organizationId)?.get(customRoleId) ?? null)
+        : null;
+      return {
+        organizationId: row.organizationId,
+        scopeType,
+        scopeId: row.scopeId,
+        role,
+        customRoleId,
+        customRole: customRole
+          ? {
+              id: customRole.id,
+              name: customRole.name,
+              description: customRole.description,
+              permissions: customRole.permissions,
+              organizationId: customRole.organizationId,
+              createdAt: customRole.createdAt,
+              updatedAt: customRole.updatedAt,
+            }
+          : null,
+      };
+    });
+  }
+
+  async findUserCreatedRoles({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<CustomRole[]> {
+    const roles = await this.prisma.role.findMany({
+      where: { organizationId, kind: CUSTOM_ROLE_KIND.CUSTOM },
+      orderBy: [{ occurredAt: "desc" }, { id: "desc" }],
+    });
+    return roles.map((role) => toCustomRoleShape(role));
+  }
+
+  /** One query shape for every binding listing: the organization, the
+   *  listable scope tiers, the listable principal kinds, a roleKey the legacy
+   *  vocabulary can carry, and the caller's own predicate on top. Ordered by
+   *  business time with the id as the tiebreak - batch-imported facts share
+   *  an `occurredAt`, and a listing must not reshuffle between reads. */
+  private async findGrantRows({
+    organizationId,
+    where,
+  }: {
+    organizationId: string;
+    where: Prisma.GrantWhereInput;
+  }): Promise<GrantListRow[]> {
+    return this.prisma.grant.findMany({
+      where: {
+        organizationId,
+        scopeType: { in: [...BINDING_SCOPE_TYPES] },
+        principalType: { in: [...BINDING_PRINCIPAL_TYPES] },
+        AND: [LISTABLE_ROLE_KEY_WHERE, where],
+      },
+      select: GRANT_ROW_SELECT,
+      orderBy: [{ occurredAt: "asc" }, { id: "asc" }],
+    });
+  }
+
+  /** The `Role` head's rows in the full `CustomRole` column shape the
+   *  consumers render. `createdAt` is the role fact's business time, matching
+   *  what the binding rows do with `occurredAt`. */
+  private async findRolesAsCustomRoles({
+    organizationId,
+    roleIds,
+  }: {
+    organizationId: string;
+    roleIds: readonly string[];
+  }): Promise<CustomRole[]> {
+    if (roleIds.length === 0) return [];
+    const roles = await this.prisma.role.findMany({
+      where: { id: { in: [...roleIds] }, organizationId },
+    });
+    return roles.map((role) => toCustomRoleShape(role));
+  }
+
+  /** The principal and role decoration for `AccessListingBindingRow`s, read
+   *  from the tables those things live in. With
+   *  `dropUndecoratedPrincipals` the row is dropped when its principal no
+   *  longer resolves within the organization - the equivalent of the legacy
+   *  whole-table query's relation predicates (a departed member, a foreign
+   *  group or key). Without it a missing principal decorates to null and the
+   *  row stays, exactly as the legacy per-user reads behave. */
+  private async decorate({
+    organizationId,
+    grants,
+    dropUndecoratedPrincipals = false,
+  }: {
+    organizationId: string;
+    grants: readonly ListableGrant[];
+    dropUndecoratedPrincipals?: boolean;
+  }): Promise<AccessListingBindingRow[]> {
+    const ids = {
+      user: new Set<string>(),
+      group: new Set<string>(),
+      apiKey: new Set<string>(),
+    };
+    const roleIds = new Set<string>();
+    for (const grant of grants) {
+      if (grant.customRoleId) roleIds.add(grant.customRoleId);
+      if (!grant.row.principalId) continue;
+      if (grant.row.principalType === "USER")
+        ids.user.add(grant.row.principalId);
+      else if (grant.row.principalType === "GROUP")
+        ids.group.add(grant.row.principalId);
+      else if (grant.row.principalType === "API_KEY")
+        ids.apiKey.add(grant.row.principalId);
+    }
+
+    const [users, groups, apiKeys, roles] = await Promise.all([
+      ids.user.size > 0
+        ? this.prisma.user.findMany({
+            where: {
+              id: { in: [...ids.user] },
+              // The membership fence only matters where rows are dropped on
+              // it; for the per-user reads it is harmless and saves nothing
+              // to vary, so it is applied uniformly.
+              ...(dropUndecoratedPrincipals
+                ? { orgMemberships: { some: { organizationId } } }
+                : {}),
+            },
+            select: ACCESS_LISTING_USER_SELECT,
+          })
+        : [],
+      ids.group.size > 0
+        ? this.prisma.group.findMany({
+            where: { id: { in: [...ids.group] }, organizationId },
+            select: ACCESS_LISTING_GROUP_SELECT,
+          })
+        : [],
+      ids.apiKey.size > 0
+        ? this.prisma.apiKey.findMany({
+            where: { id: { in: [...ids.apiKey] }, organizationId },
+            select: ACCESS_LISTING_API_KEY_SELECT,
+          })
+        : [],
+      this.findRolesAsCustomRoles({ organizationId, roleIds: [...roleIds] }),
+    ]);
+    const userById = new Map(users.map((user) => [user.id, user]));
+    const groupById = new Map(groups.map((group) => [group.id, group]));
+    const apiKeyById = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
+    const roleById = new Map(roles.map((role) => [role.id, role]));
+
+    const listed: AccessListingBindingRow[] = [];
+    for (const grant of grants) {
+      const { row } = grant;
+      const user =
+        row.principalType === "USER" && row.principalId
+          ? (userById.get(row.principalId) ?? null)
+          : null;
+      const group =
+        row.principalType === "GROUP" && row.principalId
+          ? (groupById.get(row.principalId) ?? null)
+          : null;
+      const apiKey =
+        row.principalType === "API_KEY" && row.principalId
+          ? (apiKeyById.get(row.principalId) ?? null)
+          : null;
+      if (dropUndecoratedPrincipals && !user && !group && !apiKey) continue;
+
+      const customRole = grant.customRoleId
+        ? (roleById.get(grant.customRoleId) ?? null)
+        : null;
+      listed.push({
+        id: row.id,
+        organizationId: row.organizationId,
+        userId: row.principalType === "USER" ? row.principalId : null,
+        groupId: row.principalType === "GROUP" ? row.principalId : null,
+        apiKeyId: row.principalType === "API_KEY" ? row.principalId : null,
+        role: grant.role,
+        customRoleId: grant.customRoleId,
+        scopeType: grant.scopeType,
+        scopeId: row.scopeId,
+        createdAt: row.occurredAt,
+        user,
+        group,
+        apiKey,
+        customRole: customRole
+          ? {
+              id: customRole.id,
+              name: customRole.name,
+              permissions: customRole.permissions,
+            }
+          : null,
+      });
+    }
+    return listed;
+  }
+}
+
+/** A `Role` head row in the `CustomRole` column shape. The two heads share
+ *  every column; `createdAt` carries the fact's business time
+ *  (`occurredAt`), consistent with what the binding rows report. */
+function toCustomRoleShape(role: {
+  id: string;
+  organizationId: string;
+  name: string;
+  description: string | null;
+  permissions: Prisma.JsonValue;
+  kind: string;
+  occurredAt: Date;
+  updatedAt: Date;
+}): CustomRole {
+  return {
+    id: role.id,
+    organizationId: role.organizationId,
+    name: role.name,
+    description: role.description,
+    permissions: role.permissions,
+    kind: role.kind,
+    createdAt: role.occurredAt,
+    updatedAt: role.updatedAt,
+  };
+}

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.prisma.repository.ts
@@ -12,9 +12,9 @@
  * different tables, and each has to be readable on its own for a listing
  * parity check to mean anything.
  */
-import type { Prisma } from "~/generated/prisma/client";
 import type {
   CustomRole,
+  Prisma,
   RoleBindingScopeType,
 } from "~/generated/prisma/client";
 import type {

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.prisma.repository.ts
@@ -1,0 +1,272 @@
+/**
+ * ADR-092 delivery-plan PR 3 follow-up — the Access surface's legacy reader.
+ *
+ * These are the exact queries the settings pages ran inline before the port
+ * existed (`RoleBindingService`, `TeamService`, the role-binding repository,
+ * the group and API-key repositories), moved here verbatim so the per-org
+ * fork has a legacy side to delegate to. Behaviour for a non-cut-over
+ * organization is therefore byte-identical to what shipped before this seam.
+ *
+ * Deliberately independent of `access-listing.grants.repository.ts`, for the
+ * same reason the decision readers are: the two answer the same questions of
+ * different tables, and each has to be readable on its own for a listing
+ * parity check to mean anything.
+ */
+import type { Prisma } from "~/generated/prisma/client";
+import type {
+  CustomRole,
+  RoleBindingScopeType,
+} from "~/generated/prisma/client";
+import type {
+  RoleBindingForSynthesis,
+  TeamScopedMemberBinding,
+} from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
+import { CUSTOM_ROLE_KIND } from "../../../role/role-kind";
+import type {
+  AccessListingBindingRow,
+  AccessListingRepository,
+} from "./access-listing.repository";
+import {
+  ACCESS_LISTING_API_KEY_SELECT,
+  ACCESS_LISTING_CUSTOM_ROLE_SELECT,
+  ACCESS_LISTING_GROUP_SELECT,
+  ACCESS_LISTING_USER_SELECT,
+} from "./access-listing.repository";
+
+/** The relation predicate the whole-table and scope listings carry: a row is
+ *  listed only while its principal is still of this organization. */
+const principalInOrganizationWhere = (
+  organizationId: string,
+): Prisma.RoleBindingWhereInput => ({
+  OR: [
+    {
+      userId: { not: null },
+      user: { orgMemberships: { some: { organizationId } } },
+    },
+    { groupId: { not: null }, group: { organizationId } },
+    { apiKeyId: { not: null }, apiKey: { organizationId } },
+  ],
+});
+
+const DECORATION_INCLUDE = {
+  user: { select: ACCESS_LISTING_USER_SELECT },
+  group: { select: ACCESS_LISTING_GROUP_SELECT },
+  apiKey: { select: ACCESS_LISTING_API_KEY_SELECT },
+  customRole: { select: ACCESS_LISTING_CUSTOM_ROLE_SELECT },
+} as const satisfies Prisma.RoleBindingInclude;
+
+type DecoratedRoleBinding = Prisma.RoleBindingGetPayload<{
+  include: typeof DECORATION_INCLUDE;
+}>;
+
+function toRow(binding: DecoratedRoleBinding): AccessListingBindingRow {
+  return {
+    id: binding.id,
+    organizationId: binding.organizationId,
+    userId: binding.userId,
+    groupId: binding.groupId,
+    apiKeyId: binding.apiKeyId,
+    role: binding.role,
+    customRoleId: binding.customRoleId,
+    scopeType: binding.scopeType,
+    scopeId: binding.scopeId,
+    createdAt: binding.createdAt,
+    user: binding.user,
+    group: binding.group,
+    apiKey: binding.apiKey,
+    customRole: binding.customRole,
+  };
+}
+
+export class PrismaAccessListingRepository implements AccessListingRepository {
+  constructor(private readonly prisma: Prisma.TransactionClient) {}
+
+  async findUserBindings({
+    organizationId,
+    userId,
+  }: {
+    organizationId: string;
+    userId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: { organizationId, userId },
+      include: DECORATION_INCLUDE,
+      orderBy: { createdAt: "asc" },
+    });
+    return bindings.map(toRow);
+  }
+
+  async findOrganizationBindings({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId,
+        ...principalInOrganizationWhere(organizationId),
+      },
+      include: DECORATION_INCLUDE,
+      orderBy: { createdAt: "asc" },
+    });
+    return bindings.map(toRow);
+  }
+
+  async findUserAndGroupBindings({
+    organizationId,
+    userId,
+    groupIds,
+  }: {
+    organizationId: string;
+    userId: string;
+    groupIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]> {
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId,
+        OR: [
+          { userId },
+          ...(groupIds.length > 0 ? [{ groupId: { in: [...groupIds] } }] : []),
+        ],
+      },
+      include: DECORATION_INCLUDE,
+      orderBy: { createdAt: "asc" },
+    });
+    return bindings.map(toRow);
+  }
+
+  async findScopeBindings({
+    organizationId,
+    scopeType,
+    scopeIds,
+  }: {
+    organizationId: string;
+    scopeType: RoleBindingScopeType;
+    scopeIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]> {
+    if (scopeIds.length === 0) return [];
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId,
+        scopeType,
+        scopeId: { in: [...scopeIds] },
+        ...principalInOrganizationWhere(organizationId),
+      },
+      include: DECORATION_INCLUDE,
+    });
+    return bindings.map(toRow);
+  }
+
+  async findGroupBindings({
+    organizationId,
+    groupId,
+  }: {
+    organizationId: string;
+    groupId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: { organizationId, groupId },
+      include: DECORATION_INCLUDE,
+    });
+    return bindings.map(toRow);
+  }
+
+  async findTeamMemberBindings({
+    organizationId,
+    teamIds,
+  }: {
+    organizationId: string;
+    teamIds: readonly string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>> {
+    // Pre-seed every requested teamId so the caller can rely on a hit even
+    // for teams with no members, and so a single query covers all teams.
+    const byTeam = new Map<string, TeamScopedMemberBinding[]>(
+      teamIds.map((teamId) => [teamId, []]),
+    );
+    if (teamIds.length === 0) return byTeam;
+
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId,
+        scopeType: "TEAM",
+        scopeId: { in: [...teamIds] },
+        userId: { not: null },
+        user: { orgMemberships: { some: { organizationId } } },
+      },
+      include: { user: true, customRole: true },
+    });
+
+    for (const binding of bindings) {
+      // The query filters userId non-null and includes user, but Prisma's
+      // types don't narrow — skip defensively rather than assert, so a future
+      // change to the where/include can't silently produce undefined fields.
+      if (!binding.userId || !binding.user) continue;
+      byTeam.get(binding.scopeId)?.push({
+        userId: binding.userId,
+        role: binding.role,
+        customRoleId: binding.customRoleId,
+        createdAt: binding.createdAt,
+        updatedAt: binding.updatedAt,
+        user: binding.user,
+        customRole: binding.customRole,
+      });
+    }
+
+    return byTeam;
+  }
+
+  async findBindingsForSynthesis({
+    orgIds,
+    userId,
+  }: {
+    orgIds: readonly string[];
+    userId: string;
+  }): Promise<RoleBindingForSynthesis[]> {
+    if (orgIds.length === 0) return [];
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId: { in: [...orgIds] },
+        OR: [{ userId }, { group: { members: { some: { userId } } } }],
+        scopeType: { in: ["TEAM", "ORGANIZATION", "PROJECT"] },
+      },
+      select: {
+        organizationId: true,
+        scopeType: true,
+        scopeId: true,
+        role: true,
+        customRoleId: true,
+        customRole: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            permissions: true,
+            organizationId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+        group: { select: { organizationId: true } },
+      },
+    });
+
+    return bindings
+      .filter(
+        (binding) =>
+          !binding.group ||
+          binding.group.organizationId === binding.organizationId,
+      )
+      .map(({ group: _group, ...binding }) => binding);
+  }
+
+  async findUserCreatedRoles({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<CustomRole[]> {
+    return this.prisma.customRole.findMany({
+      where: { organizationId, kind: CUSTOM_ROLE_KIND.CUSTOM },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+}

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.prisma.repository.ts
@@ -1,11 +1,16 @@
 /**
  * ADR-092 delivery-plan PR 3 follow-up — the Access surface's legacy reader.
  *
- * These are the exact queries the settings pages ran inline before the port
- * existed (`RoleBindingService`, `TeamService`, the role-binding repository,
- * the group and API-key repositories), moved here verbatim so the per-org
- * fork has a legacy side to delegate to. Behaviour for a non-cut-over
- * organization is therefore byte-identical to what shipped before this seam.
+ * These are the queries the settings pages ran inline before the port existed
+ * (`RoleBindingService`, `TeamService`, the role-binding repository, the group
+ * and API-key repositories), moved here so the per-org fork has a legacy side
+ * to delegate to. The WHERE predicates carry over unchanged, with one
+ * exception: the group listing gained the organization bound it never had.
+ * The row shapes did not - they were consolidated onto one row type and one
+ * decoration include, so three reads differ from their inline originals. The
+ * API-key read joins where it selected five scalars, `listForOrg`'s role
+ * select gained `permissions`, and the synthesis read drops the `group` key
+ * it only ever used to filter on.
  *
  * Deliberately independent of `access-listing.grants.repository.ts`, for the
  * same reason the decision readers are: the two answer the same questions of
@@ -248,6 +253,7 @@ export class PrismaAccessListingRepository implements AccessListingRepository {
         },
         group: { select: { organizationId: true } },
       },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     });
 
     return bindings

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.repository.ts
@@ -1,0 +1,162 @@
+/**
+ * ADR-092 delivery-plan PR 3 follow-up — the Access surface's read port.
+ *
+ * Decisions moved onto the ledger's head at cutover
+ * (`authz-read.cutover.repository.ts`); this port moves what people SEE. Every
+ * settings page that renders access - the bindings table, a member's own
+ * breakdown, team member lists, a group's bindings, the API key drawer, the
+ * role editor - lists through it, and the cutover-aware implementation serves
+ * a cut-over organization from `Grant`/`Role` and everyone else from the
+ * legacy `RoleBinding`/`CustomRole` heads, behind the same gate the decision
+ * fork reads. A page that renders one head while the engine decides from the
+ * other could show access that does not exist or hide access that does.
+ *
+ * The rows speak the LEGACY vocabulary (`TeamUserRole`,
+ * `RoleBindingScopeType`, a `customRole` object) on purpose: it is what every
+ * consumer renders today, and the grants head can always translate into it -
+ * the fold performs the identical translation onto the compat rows
+ * (`grantFactToCompatBinding` in @langwatch/authz-server). Row ids are stable
+ * across the heads by construction: an imported grant ADOPTS its binding's
+ * row id, and a ledger-born grant's id IS the compat row's id.
+ *
+ * Dormant facts (lite-member, project-credential, platform grants - delivery
+ * plan decision 13) never surface here: the legacy page never carried them,
+ * so a cut-over listing that showed them would be a parity break in what
+ * people see, not extra honesty.
+ */
+import type {
+  CustomRole,
+  Prisma,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import type {
+  RoleBindingForSynthesis,
+  TeamScopedMemberBinding,
+} from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
+
+/**
+ * One binding as the Access surface renders it: the fact columns plus the
+ * principal and role decoration every page needs. Decoration is nullable per
+ * principal kind; a consumer reads the arm matching the id that is set.
+ *
+ * `createdAt` carries the fact's business time. On the legacy head that is
+ * the row's own `createdAt`; on the grants head it is the fact's
+ * `occurredAt`, which an imported grant backdates to the legacy row's
+ * `createdAt` - so the two heads agree on what the column means even where
+ * the projection row was written later than the fact occurred.
+ */
+export type AccessListingBindingRow = {
+  id: string;
+  organizationId: string;
+  userId: string | null;
+  groupId: string | null;
+  apiKeyId: string | null;
+  role: TeamUserRole;
+  customRoleId: string | null;
+  scopeType: RoleBindingScopeType;
+  scopeId: string;
+  createdAt: Date;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  } | null;
+  group: { id: string; name: string; scimSource: string | null } | null;
+  apiKey: { id: string; name: string } | null;
+  customRole: {
+    id: string;
+    name: string;
+    permissions: Prisma.JsonValue;
+  } | null;
+};
+
+export interface AccessListingRepository {
+  /** Every binding naming this user directly, for the user's row on the
+   *  Access page. Unfiltered by membership, exactly as the legacy query: the
+   *  caller has already scoped the ask to a member. */
+  findUserBindings(args: {
+    organizationId: string;
+    userId: string;
+  }): Promise<AccessListingBindingRow[]>;
+
+  /** The organization's whole bindings table. Rows whose principal is no
+   *  longer of this organization (a departed member, a foreign group or key)
+   *  are dropped, exactly as the legacy query's relation predicates drop
+   *  them. */
+  findOrganizationBindings(args: {
+    organizationId: string;
+  }): Promise<AccessListingBindingRow[]>;
+
+  /** The user's own bindings plus the bindings of the groups they belong to,
+   *  for the "my access" breakdown. `groupIds` is the caller's resolved
+   *  membership - membership itself is not a grant and stays a caller-side
+   *  read. */
+  findUserAndGroupBindings(args: {
+    organizationId: string;
+    userId: string;
+    groupIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]>;
+
+  /** Every binding at the named scopes (a team page's team- and
+   *  project-scoped rows), principal-filtered like the whole table. */
+  findScopeBindings(args: {
+    organizationId: string;
+    scopeType: RoleBindingScopeType;
+    scopeIds: readonly string[];
+  }): Promise<AccessListingBindingRow[]>;
+
+  /** One group's bindings, for the group detail page. */
+  findGroupBindings(args: {
+    organizationId: string;
+    groupId: string;
+  }): Promise<AccessListingBindingRow[]>;
+
+  /** Direct user members of these teams, shaped for the team-settings member
+   *  list. Every requested teamId is present in the map (empty array if
+   *  none); a user may appear twice per team (a built-in plus a custom
+   *  binding) - callers dedupe. */
+  findTeamMemberBindings(args: {
+    organizationId: string;
+    teamIds: readonly string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>>;
+
+  /** The user's team- and org-relevant bindings across organizations, direct
+   *  or via group, for organization.getAll's team-membership synthesis. */
+  findBindingsForSynthesis(args: {
+    orgIds: readonly string[];
+    userId: string;
+  }): Promise<RoleBindingForSynthesis[]>;
+
+  /** The user-created roles of one organization, newest first - the role
+   *  editor's list. */
+  findUserCreatedRoles(args: { organizationId: string }): Promise<CustomRole[]>;
+}
+
+/** Shared select shapes, so the legacy implementation and the grants
+ *  implementation's decoration lookups can never drift on which columns the
+ *  surface renders. */
+export const ACCESS_LISTING_USER_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+  image: true,
+} as const satisfies Prisma.UserSelect;
+
+export const ACCESS_LISTING_GROUP_SELECT = {
+  id: true,
+  name: true,
+  scimSource: true,
+} as const satisfies Prisma.GroupSelect;
+
+export const ACCESS_LISTING_API_KEY_SELECT = {
+  id: true,
+  name: true,
+} as const satisfies Prisma.ApiKeySelect;
+
+export const ACCESS_LISTING_CUSTOM_ROLE_SELECT = {
+  id: true,
+  name: true,
+  permissions: true,
+} as const satisfies Prisma.CustomRoleSelect;

--- a/platform/app/src/server/app-layer/authz/repositories/access-listing.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/access-listing.repository.ts
@@ -134,9 +134,11 @@ export interface AccessListingRepository {
   findUserCreatedRoles(args: { organizationId: string }): Promise<CustomRole[]>;
 }
 
-/** Shared select shapes, so the legacy implementation and the grants
- *  implementation's decoration lookups can never drift on which columns the
- *  surface renders. */
+/** Shared select shapes for the principal decoration lookups (user, group,
+ *  API key), so the legacy and grants implementations can never drift on
+ *  which columns the surface renders. The custom-role select is used by the
+ *  legacy side only — the grants side builds the same shape by hand from the
+ *  `Role` model, and the paired listing tests are what hold them together. */
 export const ACCESS_LISTING_USER_SELECT = {
   id: true,
   name: true,

--- a/platform/app/src/server/app-layer/groups/group.service.ts
+++ b/platform/app/src/server/app-layer/groups/group.service.ts
@@ -342,8 +342,14 @@ export class GroupRestService {
     await this.repo.removeMember({ groupId, userId });
   }
 
-  async getBindings({ groupId }: { groupId: string }) {
-    return this.repo.findBindings({ groupId });
+  async getBindings({
+    organizationId,
+    groupId,
+  }: {
+    organizationId: string;
+    groupId: string;
+  }) {
+    return this.repo.findBindings({ organizationId, groupId });
   }
 
   async addBinding({

--- a/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -42,8 +42,6 @@ export class PrismaGroupRepository implements GroupRepository {
   constructor(
     private readonly prisma: PrismaClient,
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-    // Listing reads go through the per-organization fork (ADR-092,
-    // delivery-plan PR 3 follow-up).
     private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
       prisma,
     ),

--- a/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -39,16 +39,15 @@ function attachFor(binding: CreateBindingInput) {
 }
 
 export class PrismaGroupRepository implements GroupRepository {
-  // Listing reads go through the per-organization fork (ADR-092,
-  // delivery-plan PR 3 follow-up).
-  private readonly accessListing: AccessListingRepository;
-
   constructor(
     private readonly prisma: PrismaClient,
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-  ) {
-    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
-  }
+    // Listing reads go through the per-organization fork (ADR-092,
+    // delivery-plan PR 3 follow-up).
+    private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
+      prisma,
+    ),
+  ) {}
 
   async findAllByOrganization({
     organizationId,

--- a/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -10,6 +10,11 @@ import {
   type GrantsLedgerWriter,
   grantsLedgerWriter,
 } from "~/server/app-layer/authz/ledger";
+import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
+import type {
+  AccessListingBindingRow,
+  AccessListingRepository,
+} from "~/server/app-layer/authz/repositories/access-listing.repository";
 import { scopesTouchPersonalTeam } from "~/server/role-bindings/personal-team-scope";
 import type {
   CreateBindingInput,
@@ -34,10 +39,16 @@ function attachFor(binding: CreateBindingInput) {
 }
 
 export class PrismaGroupRepository implements GroupRepository {
+  // Listing reads go through the per-organization fork (ADR-092,
+  // delivery-plan PR 3 follow-up).
+  private readonly accessListing: AccessListingRepository;
+
   constructor(
     private readonly prisma: PrismaClient,
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-  ) {}
+  ) {
+    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
+  }
 
   async findAllByOrganization({
     organizationId,
@@ -224,11 +235,18 @@ export class PrismaGroupRepository implements GroupRepository {
     });
   }
 
-  async findBindings({ groupId }: { groupId: string }) {
-    return this.prisma.roleBinding.findMany({
-      where: { groupId },
-      include: { customRole: { select: { id: true, name: true } } },
-    });
+  async findBindings({
+    organizationId,
+    groupId,
+  }: {
+    organizationId: string;
+    groupId: string;
+  }): Promise<AccessListingBindingRow[]> {
+    // Through the per-organization fork (ADR-092, delivery-plan PR 3
+    // follow-up): a cut-over organization's group page is served from the
+    // ledger's own head. The organization now bounds the read, too - the
+    // route has already proven the group belongs to it.
+    return this.accessListing.findGroupBindings({ organizationId, groupId });
   }
 
   async createBinding({

--- a/platform/app/src/server/app-layer/groups/repositories/group.repository.ts
+++ b/platform/app/src/server/app-layer/groups/repositories/group.repository.ts
@@ -6,6 +6,7 @@ import type {
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import type { AccessListingBindingRow } from "~/server/app-layer/authz/repositories/access-listing.repository";
 
 export interface GroupWithDetails extends Group {
   _count: { members: number };
@@ -106,10 +107,9 @@ export interface GroupRepository {
   removeMember(params: { groupId: string; userId: string }): Promise<void>;
 
   findBindings(params: {
+    organizationId: string;
     groupId: string;
-  }): Promise<
-    Array<RoleBinding & { customRole: { id: string; name: string } | null }>
-  >;
+  }): Promise<AccessListingBindingRow[]>;
 
   createBinding(params: {
     data: CreateBindingInput;

--- a/platform/app/src/server/app-layer/role-bindings/__tests__/role-binding.prisma.repository.tenant.unit.test.ts
+++ b/platform/app/src/server/app-layer/role-bindings/__tests__/role-binding.prisma.repository.tenant.unit.test.ts
@@ -1,12 +1,29 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type PrismaClient,
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import { resetCutoverGateForTesting } from "~/server/app-layer/authz/cutover-gate";
 import { PrismaRoleBindingRepository } from "../repositories/role-binding.prisma.repository";
 
+/** These reads now go through the per-organization fork, so the double has to
+ *  answer the gate. Without it the gate's read throws, the gate fail-safes to
+ *  the legacy head, and the assertions below pass on a swallowed exception
+ *  rather than on a head this test chose. */
+const legacyPrisma = (roleBindingFindMany: ReturnType<typeof vi.fn>) =>
+  ({
+    roleBinding: { findMany: roleBindingFindMany },
+    authzCutoverProjection: {
+      findUnique: vi.fn().mockResolvedValue({ onEngine: false }),
+    },
+  }) as unknown as PrismaClient;
+
 describe("PrismaRoleBindingRepository tenant references", () => {
+  afterEach(() => {
+    resetCutoverGateForTesting();
+  });
+
   it("drops a group binding whose group belongs to another organization", async () => {
     const findMany = vi.fn().mockResolvedValue([
       {
@@ -19,9 +36,7 @@ describe("PrismaRoleBindingRepository tenant references", () => {
         group: { organizationId: "org_2" },
       },
     ]);
-    const repository = new PrismaRoleBindingRepository({
-      roleBinding: { findMany },
-    } as unknown as PrismaClient);
+    const repository = new PrismaRoleBindingRepository(legacyPrisma(findMany));
 
     const bindings = await repository.listForOrganizationsAndUser({
       orgIds: ["org_1", "org_2"],
@@ -33,9 +48,7 @@ describe("PrismaRoleBindingRepository tenant references", () => {
 
   it("requires team binding users to belong to the organization", async () => {
     const findMany = vi.fn().mockResolvedValue([]);
-    const repository = new PrismaRoleBindingRepository({
-      roleBinding: { findMany },
-    } as unknown as PrismaClient);
+    const repository = new PrismaRoleBindingRepository(legacyPrisma(findMany));
 
     await repository.listTeamScopedUserBindingsByTeamIds({
       organizationId: "org_1",

--- a/platform/app/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
@@ -2,6 +2,8 @@ import {
   type PrismaClient,
   RoleBindingScopeType,
 } from "~/generated/prisma/client";
+import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
+import type { AccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.repository";
 import { ScopeNotInOrganizationError } from "~/server/role-bindings/errors";
 import type {
   RoleBindingForSynthesis,
@@ -10,7 +12,15 @@ import type {
 } from "./role-binding.repository";
 
 export class PrismaRoleBindingRepository implements RoleBindingRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+  // The listing reads go through the per-organization fork (ADR-092,
+  // delivery-plan PR 3 follow-up): a cut-over organization's member lists are
+  // served from the ledger's own head, everyone else's from the legacy
+  // tables, behind the same gate the decision fork reads.
+  private readonly accessListing: AccessListingRepository;
+
+  constructor(private readonly prisma: PrismaClient) {
+    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
+  }
 
   async listForOrganizationsAndUser({
     orgIds,
@@ -19,44 +29,7 @@ export class PrismaRoleBindingRepository implements RoleBindingRepository {
     orgIds: string[];
     userId: string;
   }): Promise<RoleBindingForSynthesis[]> {
-    const bindings = await this.prisma.roleBinding.findMany({
-      where: {
-        organizationId: { in: orgIds },
-        OR: [{ userId }, { group: { members: { some: { userId } } } }],
-        scopeType: {
-          in: [
-            RoleBindingScopeType.TEAM,
-            RoleBindingScopeType.ORGANIZATION,
-            RoleBindingScopeType.PROJECT,
-          ],
-        },
-      },
-      select: {
-        organizationId: true,
-        scopeType: true,
-        scopeId: true,
-        role: true,
-        customRoleId: true,
-        customRole: {
-          select: {
-            id: true,
-            name: true,
-            description: true,
-            permissions: true,
-            organizationId: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        },
-        group: { select: { organizationId: true } },
-      },
-    });
-
-    return bindings.filter(
-      (binding) =>
-        !binding.group ||
-        binding.group.organizationId === binding.organizationId,
-    );
+    return this.accessListing.findBindingsForSynthesis({ orgIds, userId });
   }
 
   async listTeamScopedUserBindingsByTeamIds({
@@ -66,41 +39,10 @@ export class PrismaRoleBindingRepository implements RoleBindingRepository {
     organizationId: string;
     teamIds: string[];
   }): Promise<Map<string, TeamScopedMemberBinding[]>> {
-    // Pre-seed every requested teamId so the caller can rely on a hit even for
-    // teams with no members, and so a single query covers all teams (no N+1).
-    const byTeam = new Map<string, TeamScopedMemberBinding[]>(
-      teamIds.map((teamId) => [teamId, []]),
-    );
-    if (teamIds.length === 0) return byTeam;
-
-    const bindings = await this.prisma.roleBinding.findMany({
-      where: {
-        organizationId,
-        scopeType: RoleBindingScopeType.TEAM,
-        scopeId: { in: teamIds },
-        userId: { not: null },
-        user: { orgMemberships: { some: { organizationId } } },
-      },
-      include: { user: true, customRole: true },
+    return this.accessListing.findTeamMemberBindings({
+      organizationId,
+      teamIds,
     });
-
-    for (const binding of bindings) {
-      // The query filters userId non-null and includes user, but Prisma's types
-      // don't narrow — skip defensively rather than assert, so a future change
-      // to the where/include can't silently produce undefined fields.
-      if (!binding.userId || !binding.user) continue;
-      byTeam.get(binding.scopeId)?.push({
-        userId: binding.userId,
-        role: binding.role,
-        customRoleId: binding.customRoleId,
-        createdAt: binding.createdAt,
-        updatedAt: binding.updatedAt,
-        user: binding.user,
-        customRole: binding.customRole,
-      });
-    }
-
-    return byTeam;
   }
 
   async validateScopeInOrg({

--- a/platform/app/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
@@ -12,15 +12,16 @@ import type {
 } from "./role-binding.repository";
 
 export class PrismaRoleBindingRepository implements RoleBindingRepository {
-  // The listing reads go through the per-organization fork (ADR-092,
-  // delivery-plan PR 3 follow-up): a cut-over organization's member lists are
-  // served from the ledger's own head, everyone else's from the legacy
-  // tables, behind the same gate the decision fork reads.
-  private readonly accessListing: AccessListingRepository;
-
-  constructor(private readonly prisma: PrismaClient) {
-    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
-  }
+  constructor(
+    private readonly prisma: PrismaClient,
+    // The listing reads go through the per-organization fork (ADR-092,
+    // delivery-plan PR 3 follow-up): a cut-over organization's member lists
+    // are served from the ledger's own head, everyone else's from the legacy
+    // tables, behind the same gate the decision fork reads.
+    private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
+      prisma,
+    ),
+  ) {}
 
   async listForOrganizationsAndUser({
     orgIds,

--- a/platform/app/src/server/role-bindings/__tests__/role-binding.service.tenant.unit.test.ts
+++ b/platform/app/src/server/role-bindings/__tests__/role-binding.service.tenant.unit.test.ts
@@ -4,6 +4,7 @@ import {
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import { resetCutoverGateForTesting } from "~/server/app-layer/authz/cutover-gate";
 import type { GrantsLedgerWriter } from "~/server/app-layer/authz/ledger";
 import type { RoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
 import type { RoleService } from "~/server/role/role.service";
@@ -26,6 +27,12 @@ const prisma = {
     findMany: bindingFindMany,
   },
   groupMembership: { findMany: groupMembershipFindMany },
+  // The listing reads go through the per-organization fork, which asks the
+  // gate first. Answering it keeps these tests on the legacy head by choice;
+  // without it the gate's read throws and they pass on the fail-safe.
+  authzCutoverProjection: {
+    findUnique: vi.fn().mockResolvedValue({ onEngine: false }),
+  },
   $transaction: vi.fn(),
 } as unknown as PrismaClient;
 
@@ -47,6 +54,7 @@ let service: RoleBindingService;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetCutoverGateForTesting();
   validateScopeInOrg.mockResolvedValue(undefined);
   validateRolesAssignable.mockResolvedValue(undefined);
   organizationUserFindFirst.mockResolvedValue({ role: "MEMBER" });

--- a/platform/app/src/server/role-bindings/role-binding.service.ts
+++ b/platform/app/src/server/role-bindings/role-binding.service.ts
@@ -17,6 +17,8 @@ import {
   type LedgerBindingAttach,
   ledgerPrincipal,
 } from "~/server/app-layer/authz/ledger";
+import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
+import type { AccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.repository";
 import type { RoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
 import { LiteMemberViewerOnlyError } from "~/server/app-layer/teams/team.service";
 import type { RoleService } from "~/server/role/role.service";
@@ -103,22 +105,30 @@ export class RoleBindingService {
   // Every binding write on this service is a grants-ledger command; the
   // RoleBinding table is a projection fed by the fold, never written here.
   private readonly writer: GrantsLedgerWriter;
+  // Listing reads go through the per-organization fork: a cut-over
+  // organization's Access pages are served from the ledger's own head, so
+  // what people see and what the engine decides from can never be different
+  // heads (ADR-092, delivery-plan PR 3 follow-up).
+  private readonly accessListing: AccessListingRepository;
 
   constructor({
     prisma,
     repo,
     roleService,
     writer = grantsLedgerWriter(),
+    accessListing = new CutoverAwareAccessListingRepository(prisma),
   }: {
     prisma: PrismaClient;
     repo: RoleBindingRepository;
     roleService: RoleService;
     writer?: GrantsLedgerWriter;
+    accessListing?: AccessListingRepository;
   }) {
     this.prisma = prisma;
     this.repo = repo;
     this.roleService = roleService;
     this.writer = writer;
+    this.accessListing = accessListing;
   }
 
   /**
@@ -399,12 +409,9 @@ export class RoleBindingService {
     organizationId: string;
     userId: string;
   }) {
-    const bindings = await this.prisma.roleBinding.findMany({
-      where: { organizationId, userId },
-      include: {
-        customRole: { select: { id: true, name: true } },
-      },
-      orderBy: { createdAt: "asc" },
+    const bindings = await this.accessListing.findUserBindings({
+      organizationId,
+      userId,
     });
 
     const { scopeNames, personalScopeIds } = await this.resolveScopes({
@@ -428,25 +435,8 @@ export class RoleBindingService {
   }
 
   async listForOrg({ organizationId }: { organizationId: string }) {
-    const bindings = await this.prisma.roleBinding.findMany({
-      where: {
-        organizationId,
-        OR: [
-          {
-            userId: { not: null },
-            user: { orgMemberships: { some: { organizationId } } },
-          },
-          { groupId: { not: null }, group: { organizationId } },
-          { apiKeyId: { not: null }, apiKey: { organizationId } },
-        ],
-      },
-      include: {
-        user: { select: { id: true, name: true, email: true, image: true } },
-        group: { select: { id: true, name: true, scimSource: true } },
-        apiKey: { select: { id: true, name: true } },
-        customRole: { select: { id: true, name: true } },
-      },
-      orderBy: { createdAt: "asc" },
+    const bindings = await this.accessListing.findOrganizationBindings({
+      organizationId,
     });
 
     const { scopeNames, personalScopeIds } = await this.resolveScopes({
@@ -527,19 +517,10 @@ export class RoleBindingService {
 
     const groupIds = groupMemberships.map((gm) => gm.groupId);
 
-    const allBindings = await this.prisma.roleBinding.findMany({
-      where: {
-        organizationId,
-        OR: [
-          { userId },
-          ...(groupIds.length > 0 ? [{ groupId: { in: groupIds } }] : []),
-        ],
-      },
-      include: {
-        customRole: { select: { id: true, name: true, permissions: true } },
-        group: { select: { id: true, name: true } },
-      },
-      orderBy: { createdAt: "asc" },
+    const allBindings = await this.accessListing.findUserAndGroupBindings({
+      organizationId,
+      userId,
+      groupIds,
     });
 
     const orgScopeIds = allBindings

--- a/platform/app/src/server/role-bindings/role-binding.service.ts
+++ b/platform/app/src/server/role-bindings/role-binding.service.ts
@@ -376,7 +376,7 @@ export class RoleBindingService {
     const [orgs, teams, projects] = await Promise.all([
       orgIds.length > 0
         ? this.prisma.organization.findMany({
-            where: { id: { in: orgIds } },
+            where: { id: { in: orgIds.filter((id) => id === organizationId) } },
             select: { id: true, name: true },
           })
         : [],

--- a/platform/app/src/server/role/repositories/role.repository.ts
+++ b/platform/app/src/server/role/repositories/role.repository.ts
@@ -12,6 +12,8 @@ import {
   type GrantsLedgerWriter,
   grantsLedgerWriter,
 } from "~/server/app-layer/authz/ledger";
+import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
+import type { AccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.repository";
 import { isRootPrismaClient } from "~/server/db";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { RoleDuplicateNameError, RoleNotFoundError } from "../errors";
@@ -39,6 +41,11 @@ export type UpdateRoleParams = Partial<
  * Single Responsibility: Handle all database operations for CustomRole
  */
 export class RoleRepository {
+  // Listing reads go through the per-organization fork (ADR-092,
+  // delivery-plan PR 3 follow-up): a cut-over organization's role editor
+  // lists from the ledger's own Role head.
+  private readonly accessListing: AccessListingRepository;
+
   constructor(
     private readonly prisma: RolePrismaDelegate,
     /**
@@ -49,7 +56,9 @@ export class RoleRepository {
      * transaction client.
      */
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-  ) {}
+  ) {
+    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
+  }
 
   async findAllByOrganization(organizationId: string) {
     return this.prisma.customRole.findMany({
@@ -59,13 +68,10 @@ export class RoleRepository {
   }
 
   async findUserCreatedByOrganization(organizationId: string) {
-    return this.prisma.customRole.findMany({
-      where: {
-        organizationId,
-        kind: CUSTOM_ROLE_KIND.CUSTOM,
-      },
-      orderBy: { createdAt: "desc" },
-    });
+    // Through the per-organization fork (ADR-092, delivery-plan PR 3
+    // follow-up): a cut-over organization's role editor is served from the
+    // ledger's own Role head.
+    return this.accessListing.findUserCreatedRoles({ organizationId });
   }
 
   async findById(roleId: string) {

--- a/platform/app/src/server/role/repositories/role.repository.ts
+++ b/platform/app/src/server/role/repositories/role.repository.ts
@@ -41,11 +41,6 @@ export type UpdateRoleParams = Partial<
  * Single Responsibility: Handle all database operations for CustomRole
  */
 export class RoleRepository {
-  // Listing reads go through the per-organization fork (ADR-092,
-  // delivery-plan PR 3 follow-up): a cut-over organization's role editor
-  // lists from the ledger's own Role head.
-  private readonly accessListing: AccessListingRepository;
-
   constructor(
     private readonly prisma: RolePrismaDelegate,
     /**
@@ -56,9 +51,13 @@ export class RoleRepository {
      * transaction client.
      */
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-  ) {
-    this.accessListing = new CutoverAwareAccessListingRepository(prisma);
-  }
+    // Listing reads go through the per-organization fork (ADR-092,
+    // delivery-plan PR 3 follow-up): a cut-over organization's role editor
+    // lists from the ledger's own Role head.
+    private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
+      prisma,
+    ),
+  ) {}
 
   async findAllByOrganization(organizationId: string) {
     return this.prisma.customRole.findMany({

--- a/platform/app/src/server/teams/__tests__/team.service.last-admin-concurrency.integration.test.ts
+++ b/platform/app/src/server/teams/__tests__/team.service.last-admin-concurrency.integration.test.ts
@@ -25,7 +25,7 @@ import { TeamService } from "../team.service";
 
 describe("TeamService.removeMember", () => {
   const ns = `team-last-admin-${nanoid(8)}`;
-  const service = new TeamService(prisma);
+  const service = new TeamService({ prisma });
 
   let organizationId: string;
   let teamId: string;

--- a/platform/app/src/server/teams/__tests__/team.service.removeMember.unit.test.ts
+++ b/platform/app/src/server/teams/__tests__/team.service.removeMember.unit.test.ts
@@ -74,11 +74,11 @@ beforeEach(() => {
   groupMembershipFindMany.mockResolvedValue([]);
   teamUserDeleteMany.mockResolvedValue({ count: 1 });
   revokeBindings.mockResolvedValue(undefined);
-  service = new TeamService(
+  service = new TeamService({
     prisma,
-    {} as never,
-    { revokeBindings } as unknown as GrantsLedgerWriter,
-  );
+    roleBindingRepo: {} as never,
+    writer: { revokeBindings } as unknown as GrantsLedgerWriter,
+  });
 });
 
 describe("given a team with two admins", () => {

--- a/platform/app/src/server/teams/team.service.ts
+++ b/platform/app/src/server/teams/team.service.ts
@@ -15,7 +15,10 @@ import {
   grantsLedgerWriter,
 } from "~/server/app-layer/authz/ledger";
 import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
-import type { AccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.repository";
+import {
+  ACCESS_LISTING_USER_SELECT,
+  type AccessListingRepository,
+} from "~/server/app-layer/authz/repositories/access-listing.repository";
 import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.prisma.repository";
 import type {
   RoleBindingRepository,
@@ -51,15 +54,6 @@ export const TEAM_ROLE_PRIORITY: Record<TeamUserRole, number> = {
   [TeamUserRole.VIEWER]: 2,
   [TeamUserRole.CUSTOM]: 3,
 };
-
-/** The user fields every team-member projection selects (kept in one place so
- * the shape can't drift across the three role-binding include sites). */
-const MEMBER_USER_SELECT = {
-  id: true,
-  name: true,
-  email: true,
-  image: true,
-} as const satisfies Prisma.UserSelect;
 
 // Ascending, nulls last — matches Postgres `ORDER BY col ASC` (the ordering the
 // previous Prisma `orderBy` produced before members were resolved in memory).
@@ -226,21 +220,30 @@ function directAdminUserIdsAfterPlan({
 }
 
 export class TeamService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    // Constructed once and reused across reads; the default keeps existing
-    // `new TeamService(prisma)` call sites working while allowing injection.
-    private readonly roleBindingRepo: RoleBindingRepository = new PrismaRoleBindingRepository(
-      prisma,
-    ),
-    private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
-    // Listing reads go through the per-organization fork (ADR-092,
-    // delivery-plan PR 3 follow-up): a cut-over organization's team pages are
-    // served from the ledger's own head.
-    private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
-      prisma,
-    ),
-  ) {}
+  private readonly prisma: PrismaClient;
+  private readonly roleBindingRepo: RoleBindingRepository;
+  private readonly writer: GrantsLedgerWriter;
+  // Listing reads go through the per-organization fork (ADR-092,
+  // delivery-plan PR 3 follow-up): a cut-over organization's team pages are
+  // served from the ledger's own head.
+  private readonly accessListing: AccessListingRepository;
+
+  constructor({
+    prisma,
+    roleBindingRepo = new PrismaRoleBindingRepository(prisma),
+    writer = grantsLedgerWriter(),
+    accessListing = new CutoverAwareAccessListingRepository(prisma),
+  }: {
+    prisma: PrismaClient;
+    roleBindingRepo?: RoleBindingRepository;
+    writer?: GrantsLedgerWriter;
+    accessListing?: AccessListingRepository;
+  }) {
+    this.prisma = prisma;
+    this.roleBindingRepo = roleBindingRepo;
+    this.writer = writer;
+    this.accessListing = accessListing;
+  }
 
   /**
    * Shape TEAM-scoped RoleBindings into the legacy `team.members` (TeamUser)
@@ -466,7 +469,7 @@ export class TeamService {
                   group: { organizationId },
                   user: { orgMemberships: { some: { organizationId } } },
                 },
-                include: { user: { select: MEMBER_USER_SELECT } },
+                include: { user: { select: ACCESS_LISTING_USER_SELECT } },
               })
             : [];
 

--- a/platform/app/src/server/teams/team.service.ts
+++ b/platform/app/src/server/teams/team.service.ts
@@ -14,6 +14,8 @@ import {
   type GrantsLedgerWriter,
   grantsLedgerWriter,
 } from "~/server/app-layer/authz/ledger";
+import { CutoverAwareAccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.cutover.repository";
+import type { AccessListingRepository } from "~/server/app-layer/authz/repositories/access-listing.repository";
 import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.prisma.repository";
 import type {
   RoleBindingRepository,
@@ -58,19 +60,6 @@ const MEMBER_USER_SELECT = {
   email: true,
   image: true,
 } as const satisfies Prisma.UserSelect;
-
-const principalInOrganizationWhere = (
-  organizationId: string,
-): Prisma.RoleBindingWhereInput => ({
-  OR: [
-    {
-      userId: { not: null },
-      user: { orgMemberships: { some: { organizationId } } },
-    },
-    { groupId: { not: null }, group: { organizationId } },
-    { apiKeyId: { not: null }, apiKey: { organizationId } },
-  ],
-});
 
 // Ascending, nulls last — matches Postgres `ORDER BY col ASC` (the ordering the
 // previous Prisma `orderBy` produced before members were resolved in memory).
@@ -245,6 +234,12 @@ export class TeamService {
       prisma,
     ),
     private readonly writer: GrantsLedgerWriter = grantsLedgerWriter(),
+    // Listing reads go through the per-organization fork (ADR-092,
+    // delivery-plan PR 3 follow-up): a cut-over organization's team pages are
+    // served from the ledger's own head.
+    private readonly accessListing: AccessListingRepository = new CutoverAwareAccessListingRepository(
+      prisma,
+    ),
   ) {}
 
   /**
@@ -438,36 +433,16 @@ export class TeamService {
 
         // ── Fetch all RoleBindings touching this team (team-level + project-level) ──
         const [teamBindings, projectBindings] = await Promise.all([
-          this.prisma.roleBinding.findMany({
-            where: {
-              organizationId,
-              scopeType: RoleBindingScopeType.TEAM,
-              scopeId: team.id,
-              ...principalInOrganizationWhere(organizationId),
-            },
-            include: {
-              user: { select: MEMBER_USER_SELECT },
-              group: { select: { id: true, name: true, scimSource: true } },
-              apiKey: { select: { id: true, name: true } },
-              customRole: { select: { id: true, name: true } },
-            },
+          this.accessListing.findScopeBindings({
+            organizationId,
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeIds: [team.id],
           }),
-          projectIds.length > 0
-            ? this.prisma.roleBinding.findMany({
-                where: {
-                  organizationId,
-                  scopeType: RoleBindingScopeType.PROJECT,
-                  scopeId: { in: projectIds },
-                  ...principalInOrganizationWhere(organizationId),
-                },
-                include: {
-                  user: { select: MEMBER_USER_SELECT },
-                  group: { select: { id: true, name: true, scimSource: true } },
-                  apiKey: { select: { id: true, name: true } },
-                  customRole: { select: { id: true, name: true } },
-                },
-              })
-            : [],
+          this.accessListing.findScopeBindings({
+            organizationId,
+            scopeType: RoleBindingScopeType.PROJECT,
+            scopeIds: projectIds,
+          }),
         ]);
 
         // ── Expand group memberships for every group referenced by any

--- a/specs/rbac/unified-authorization-engine.feature
+++ b/specs/rbac/unified-authorization-engine.feature
@@ -365,8 +365,8 @@ Feature: Unified authorization engine
   @unit
   Scenario: A listing row keeps its identity across the cutover
     Given "acme" has a binding imported into the ledger
-    When the organization's bindings are listed before and after the cutover
-    Then the same row is listed under the same id on both sides
+    When the organization's bindings are listed from each head
+    Then both heads list the row under the same id
     # The imported grant ADOPTS the binding's row id, so a bookmarked or
     # cached row reference survives the head swap.
 

--- a/specs/rbac/unified-authorization-engine.feature
+++ b/specs/rbac/unified-authorization-engine.feature
@@ -332,6 +332,70 @@ Feature: Unified authorization engine
     And the legacy binding tables are not read
 
   # ============================================================================
+  # The Access surface reads the head that decides (delivery plan PR 3 follow-up)
+  # ============================================================================
+  # Decisions moved onto the ledger's head at cutover; this section moves what
+  # people SEE. Every settings page that renders access - the bindings table,
+  # a member's own breakdown, team member lists, a group's bindings, the API
+  # key drawer, the role editor - lists from the same head the engine decides
+  # from, per organization, behind the same gate. A page that renders one head
+  # while the engine decides from the other could show access that does not
+  # exist or hide access that does.
+  #
+  # Same proof style as the fork above: the listed access exists as a grant
+  # and as nothing else (or the reverse), so which rows come back proves which
+  # head served the listing rather than both happening to agree.
+
+  @unit
+  Scenario: A cut-over organization's access listings are served from the ledger's head
+    Given "acme" has been cut over to the engine
+    And user "alice" holds a grant at project "chatbot" that no binding row records
+    When the organization's bindings are listed for the Access page
+    Then alice's grant appears in the listing
+    And the legacy binding tables are not read
+
+  @unit
+  Scenario: An organization that has not cut over keeps listing from the legacy tables
+    Given "acme" has not been cut over
+    And a grant head row exists that no legacy binding records
+    When the organization's bindings are listed for the Access page
+    Then the listing shows exactly the legacy binding rows
+    And the grant head is not read
+
+  @unit
+  Scenario: A listing row keeps its identity across the cutover
+    Given "acme" has a binding imported into the ledger
+    When the organization's bindings are listed before and after the cutover
+    Then the same row is listed under the same id on both sides
+    # The imported grant ADOPTS the binding's row id, so a bookmarked or
+    # cached row reference survives the head swap.
+
+  @unit
+  Scenario: A rolled-back organization's listings return to the legacy head within the gate's cache window
+    Given "acme" is being served by the engine
+    When "acme" is rolled back onto the legacy path
+    Then access listings in "acme" stop reading the grant head within the gate's cache window
+    And nothing is deployed or restarted for that to hold
+
+  @unit
+  Scenario: A cut-over organization's role editor lists roles from the ledger's head
+    Given "acme" has been cut over to the engine
+    And a custom role exists in the ledger's role head
+    When the organization's roles are listed
+    Then the role appears with its name, description and permissions
+    And the legacy custom-role table is not read
+
+  @unit
+  Scenario: Dormant facts never appear as bindings in a listing
+    Given "acme" has been cut over to the engine
+    And the cutover imported lite-member, project-credential and platform facts
+    When the organization's bindings are listed for the Access page
+    Then none of those facts appear as binding rows
+    # The listing shows what the legacy page showed: the compat head never
+    # carried these facts, so a cut-over listing that surfaced them would be
+    # a parity break in what people see, not extra honesty.
+
+  # ============================================================================
   # The resource tier (ADR-092 §8) — sharing is a grant on the tree
   # ============================================================================
   #


### PR DESCRIPTION
Follow-up to #7151, the slice the delivery plan left trailing PR 3: *"effectivePermissions / useCan / Access-surface reads can ride here or trail as a small follow-up."* effectivePermissions and useCan already ride the engine; this moves the last piece — what people SEE.

## What this delivers

**The listing port** — `AccessListingRepository`, one port in front of two independent implementations, delegated per organization by the SAME cutover gate the decision fork reads (`cutover-gate.ts`), so the page a person looks at and the engine deciding what they may do on it can never read different heads for longer than the gate's 60s window:

- `access-listing.prisma.repository.ts` — the queries the settings pages ran inline before the seam existed, moved here. The WHERE predicates carry over unchanged (the one exception is the group listing, which gained the organization bound it never had — flag 3 below); the row shapes were consolidated onto one type and one decoration include, so three reads differ from their inline originals: the API-key read joins where it selected five scalars, `listForOrg`'s role select gained `permissions`, and the synthesis read drops the `group` key it only ever used to filter on.
- `access-listing.grants.repository.ts` — the same questions answered from `Grant`/`Role`, translated into the legacy vocabulary with the fold's own mapping (`grantFactToCompatBinding`'s arms): built-ins map straight, `custom:<id>` lists under the built-in role its import preserved (`legacyRole ?? CUSTOM`) — a cut-over Access page never shows CUSTOM where it showed ADMIN the day before. Role decoration is organization-bounded, like the decision reader; principal decoration (user/group/key names) reads the tables those things actually live in — they are not grants and were never projected.

**The repointed surfaces** — the bindings table and per-user listing plus the my-access breakdown (`RoleBindingService`), team member lists and the team detail view (`TeamService` + the role-binding repository), the group page's bindings (now organization-bounded — the query previously carried no tenancy predicate at all; the route had already proven the group's organization), the API key drawer's user bindings, `organization.getAll`'s team-membership synthesis (multi-organization: partitioned per organization across the heads), and the role editor's list (served from the `Role` head, which carries every `CustomRole` column).

**What never surfaces** — dormant facts (delivery-plan decision 13): `lite-member`, project-credential and platform rows are excluded in the query AND skipped by the translation, never defaulted. The legacy pages never carried them; a cut-over listing that showed them would be a parity break in what people see, not extra honesty.

**Row identity holds across the heads** — an imported grant ADOPTS its binding's row id and a ledger-born grant's id IS the compat row's id, so a listing row keeps its id through cutover and rollback (pinned by a paired test through both implementations).

`createdAt` on a grants-head row is the fact's `occurredAt` — the business time an import backdates to the legacy row's own `createdAt` — so "since when" reads the same across the heads.

## Deliberately out of scope (the PR 4 remainder)

Decision-shaped reads that still hit legacy tables directly (`api/utils.ts` content-visibility roles, `isOrgAdmin`/`isOrgAdminApiKey`, `resolveKeyPermissions`, the effective-team-admins last-admin guards), write-path validation and transaction diff reads, delete-guard counts, and the relation includes that still render bindings from the compat head — the ApiKey one, and the Group list and detail reads (`findAllByOrganization` / `findById`), whose `GET /:id/bindings` sibling DID move. All of them are correct on the compat head (the fold authors it for cut-over organizations, parity-proved) and retire with the tables at contract.

## Review flags (honest ones)

1. **The legacy per-user reads gained joins**: `findUserBindings` now carries the shared decoration include (user/group/apiKey) where the old inline query joined only `customRole`. Same rows, one shared select shape so the two implementations cannot drift on which columns the surface renders.
2. **The synthesis partition is per organization, sequential gate reads** — orgIds counts are small (a user's organizations), and the gate is cached per organization.
3. **The group bindings read is now organization-bounded** — a cross-organization binding row pointing at the group (impossible via the writers, possible via corruption) is no longer listed. Behaviour change in a pathological case only, in the safe direction.
4. **Datastore-lane validation is CI-only here** (same posture as #7151): the local environment has no container runtime strategy for testcontainers. The role-bindings REST integration suite is the one to watch on the first CI run.

Spec: six new scenarios in `specs/rbac/unified-authorization-engine.feature` ("The Access surface reads the head that decides"), all `@unit`-tagged and bound (`check:feature-parity`: 33/33 for the file, exit 0).

## Review round 1 (second commit)

The follow-up commit folds in the review feedback: every constructor takes the listing repository as an injectable optional-with-default parameter (`TeamService` moves to an options-object constructor), the per-organization gate reads in `findBindingsForSynthesis` resolve in parallel, the legacy implementation gains its own query-shape tests (the moved queries had lost their inline pin), the fence tests now pin the membership predicate itself, the gate exports `CUTOVER_GATE_CACHE_TTL_MS` and the rollback test is driven off it, `decorate()` and the synthesis read are split into helpers to meet the complexity budget, the drop flag is `shouldDropUndecoratedPrincipals`, and the row-identity scenario wording matches exactly what its bound test proves.

Green locally: 29 seam tests across the three listing test files; 828 unit tests across the authz repositories, role-bindings, roles, groups, api-key, teams and router surfaces; the component lane over `src/features` (1466); scoped `tsc` over every changed file plus the tests against the tests config, both with a control run; the CI biome delta gate script run against `origin/main` reports **no new violations** (net −1); `pnpm format` applied.

## Review round 2 — a five-lens audit (third commit)

An independent audit across security, feature-logic, test-quality, design and spec, over the whole diff. **No P0 or P1 security findings**: every one of the eleven new queries carries an organization predicate, and the group-bindings tenancy fix in flag 3 was confirmed to close a real (if latent) gap. What came out of it, in `52b0f56`:

1. **A collective principal is now skipped by the translation**, not only by the query — which the module header already claimed. It matters because a project-credential fact carries a listable `PROJECT` scope *and* `roleKey: "admin"`, so neither the scope filter nor the role-key filter touches it and the SQL `principalType` predicate was the only thing keeping it out. Two reviewers reached this independently from opposite directions. Verified by mutation: remove the guard and the added test lists it as an ADMIN binding belonging to nobody.
2. **`findBindingsForSynthesis` is ordered on both heads.** It was unordered on *both* while its consumer (`enrichTeamWithRoleBindings`) resolves a team role by first match — so a user holding both a direct TEAM binding and a group-derived one could be shown a different team role after cutover than before, and back again on rollback. Both heads now order on business time then id, which the import backdates into agreement.
3. **The ORGANIZATION scope-name lookup is bounded to the organization** — the one arm its own defence-in-depth docblock did not actually cover.
4. The legacy reader's header no longer claims byte-identical, and names the three reads that differ instead (mirrored above).
5. The cutover header no longer calls the gate's 60-second TTL a "coalescing window" — coalescing is the in-flight read, a different mechanism.

The test gaps that mattered:

- **The default composition is now pinned.** Every production call site constructs the one-argument form and takes the constructor defaults; no test ever did. Swapping those two defaults typechecks and leaves the feature inert. Verified by mutation — with them swapped, only the two new tests fail and the other seven pass.
- **The not-cut-over direction covers all eight port methods**, not two. In a delegator that is eight near-identical one-liners, the live defect class is one of them naming a head instead of asking.
- **The rollback test asserts the answer is still cached *before* the window elapses**, so it can no longer pass with no cache at all, or with the TTL widened.
- **The cross-head identity test compares the whole rendered row**, not just its id — that is what pins "since when" agreeing across the heads.
- `findGroupBindings`, `findScopeBindings` and `findUserAndGroupBindings` gain coverage they had none of, including the group decoration fence.
- The two tenant suites answer the gate rather than reaching their assertions through its swallowed exception — they were passing green for the wrong reason, twice per run, and populating the module-level gate cache under `isolate: false`.

Green: 498 unit tests across the authz, role-bindings, teams, role, api-key and groups suites; `check:feature-parity` exit 0 (33/33 bound for this file); biome reports no diagnostics on any changed file; scoped `tsc` over every changed file against the tests config, with a control run proving it was not false-passing.

The two review comments that could not be posted inline — both on the spec section — were assessed and declined, with the reasoning in a comment below.

**Deliberately not folded in**, surfaced by the audit and left for a decision rather than changed quietly: the roleKey to compat-role translation now exists in four expressions across three files and two of them already disagree on the custom-role case; `TeamService` holds two independent forks, so injecting one fakes only half the service; `RoleRepository` is forked on its list read but legacy on its by-id reads, so a dropped compat write would give a cut-over organization a role that lists but will not open (the API-key drawer has the same split for role names); the teams settings page's per-team fan-out grows on the grants head; and there is still no datastore-level parity test reading one seeded organization through both implementations and comparing.

## Deployment Impact

None: no migrations, no environment variables, no chart changes. Reads fork per organization behind the existing cutover gate; nothing changes for any organization until it is cut over, and a rollback returns its listings to the legacy head within the gate's existing 60-second window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access and role-binding listings now use organization-aware data sources, supporting seamless transitions between legacy and ledger-backed records.
  * Group binding lookups are scoped to the selected organization.
  * Listings preserve consistent binding and role details while excluding inactive records.

* **Bug Fixes**
  * Improved organization isolation and filtering across group, team, user, and scope listings.

* **Tests**
  * Added comprehensive coverage for legacy/ledger transitions, filtering, ordering, organization isolation, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
