### PR TITLE
fix(navigation): an admin keeps the project they picked, and the menu opens where they are

### DIFF
--- a/platform/app/src/components/sidebar/SideMenuLink.tsx
+++ b/platform/app/src/components/sidebar/SideMenuLink.tsx
@@ -182,6 +182,8 @@ export const SideMenuLink = ({
   // A page opened by its address can have its entry below the visible
   // part of a scrolled menu. "nearest" leaves the menu alone whenever
   // the entry is already visible, so click navigation never shifts it.
+  // Where the entry lands when a menu FIRST renders is the column's own
+  // call, not the entry's: useRevealActiveEntryOnLoad.
   useEffect(() => {
     if (isActive) {
       linkRef.current?.scrollIntoView?.({ block: "nearest" });

--- a/platform/app/src/components/sidebar/useRevealActiveEntryOnLoad.ts
+++ b/platform/app/src/components/sidebar/useRevealActiveEntryOnLoad.ts
@@ -1,0 +1,62 @@
+import { type RefObject, useEffect } from "react";
+
+/** The entry the menu marks as the page being shown. */
+const ACTIVE_ENTRY_SELECTOR = '[aria-current="page"]';
+
+/**
+ * Puts the active entry at the top of a scrolling menu when the menu first
+ * renders, as far as the menu can scroll.
+ *
+ * A page opened by its address, a bookmark or a shared link leaves its entry
+ * below the fold of a long menu. Revealing it is not enough on its own: the
+ * reader lands there to look through the pages around it, so the entry goes
+ * to the top and the rest of its group follows underneath.
+ *
+ * The menu grows after it first paints, because the gated groups arrive with
+ * the queries behind them, and entries added above the active one push it back
+ * down. So the reveal re-applies while the menu is still changing, and stops
+ * for good the moment the reader takes the menu over: a wheel, a touch, a
+ * pointer or a key inside it. Those are what tell a reader's scroll apart from
+ * the menu's own, which is why the scroll position itself is not the signal.
+ */
+export function useRevealActiveEntryOnLoad(
+  regionRef: RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    const region = regionRef.current;
+    if (!region) return;
+
+    const readerEvents = [
+      "wheel",
+      "touchstart",
+      "pointerdown",
+      "keydown",
+    ] as const;
+
+    const stop = () => {
+      observer.disconnect();
+      for (const event of readerEvents) {
+        region.removeEventListener(event, stop);
+      }
+    };
+
+    const reveal = () => {
+      const active = region.querySelector<HTMLElement>(ACTIVE_ENTRY_SELECTOR);
+      if (!active) return;
+      const offset =
+        active.getBoundingClientRect().top - region.getBoundingClientRect().top;
+      // The browser clamps this to the end of the menu, which is what
+      // "as far as the menu can scroll" means for the last entries.
+      region.scrollTop += offset;
+    };
+
+    const observer = new MutationObserver(reveal);
+    observer.observe(region, { childList: true, subtree: true });
+    for (const event of readerEvents) {
+      region.addEventListener(event, stop, { passive: true });
+    }
+    reveal();
+
+    return stop;
+  }, [regionRef]);
+}

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -150,6 +150,62 @@ import { MENU_WIDTH_EXPANDED } from "~/components/MainMenu";
 import { ProductSidebar } from "../shell/ProductSidebar";
 import { SHELL_SIDEBAR_WIDTH_EXPANDED } from "../shell/shellLayout";
 
+/**
+ * jsdom has no scrollIntoView at all, so the menu's own call is what the
+ * scroll assertions read: which entry it aimed at, and where in the
+ * column it asked to put it. Removed again in afterEach.
+ */
+function recordScrollIntoView(): {
+  element: HTMLElement;
+  options?: ScrollIntoViewOptions;
+}[] {
+  const scrolls: { element: HTMLElement; options?: ScrollIntoViewOptions }[] =
+    [];
+  (
+    window.HTMLElement.prototype as unknown as {
+      scrollIntoView: (options?: ScrollIntoViewOptions) => void;
+    }
+  ).scrollIntoView = function (
+    this: HTMLElement,
+    options?: ScrollIntoViewOptions,
+  ) {
+    scrolls.push({ element: this, options });
+  };
+  return scrolls;
+}
+
+/**
+ * jsdom reports every box at the origin, so the one measurement the reveal
+ * reads is stubbed: how far the active entry sits below the top of the
+ * menu it scrolls in.
+ */
+function stubEntryOffset({
+  entryLabel,
+  offset,
+}: {
+  entryLabel: string;
+  offset: number;
+}) {
+  const rectAt = (top: number) => ({ ...EMPTY_RECT, top, y: top });
+  window.HTMLElement.prototype.getBoundingClientRect = function (
+    this: HTMLElement,
+  ) {
+    if (this.dataset.testid === "sidebar-scroll-region") return rectAt(0);
+    if (this.getAttribute("aria-label") === entryLabel) return rectAt(offset);
+    return rectAt(0);
+  } as HTMLElement["getBoundingClientRect"];
+}
+
+const EMPTY_RECT = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  toJSON: () => ({}),
+  width: 0,
+  x: 0,
+} as const;
+
 function renderSidebar(surface: "me" | "llm-ops" | "gateway" | "governance") {
   return render(
     <ChakraProvider value={defaultSystem}>
@@ -166,11 +222,16 @@ beforeEach(() => {
   localStorage.clear();
 });
 
+const realGetBoundingClientRect =
+  window.HTMLElement.prototype.getBoundingClientRect;
+
 afterEach(() => {
   cleanup();
   // jsdom has no scrollIntoView; the deep-link test installs one.
   delete (window.HTMLElement.prototype as { scrollIntoView?: unknown })
     .scrollIntoView;
+  window.HTMLElement.prototype.getBoundingClientRect =
+    realGetBoundingClientRect;
 });
 
 describe("the product sidebar", () => {
@@ -259,23 +320,59 @@ describe("the product sidebar", () => {
   describe("when a page is opened by its address", () => {
     /** @scenario "Opening a page by its address reveals its sidebar entry" */
     it("brings that page's entry into view", async () => {
-      const scrolledInto: HTMLElement[] = [];
-      (
-        window.HTMLElement.prototype as unknown as {
-          scrollIntoView: (options?: ScrollIntoViewOptions) => void;
-        }
-      ).scrollIntoView = function (this: HTMLElement) {
-        scrolledInto.push(this);
-      };
+      const scrolls = recordScrollIntoView();
 
       mockPathname = "/gateway/virtual-keys";
       renderSidebar("gateway");
 
       await waitFor(() => {
         expect(
-          scrolledInto.some((el) => el.textContent?.includes("Virtual Keys")),
+          scrolls.some((scroll) =>
+            scroll.element.textContent?.includes("Virtual Keys"),
+          ),
         ).toBe(true);
       });
+      expect(
+        scrolls.every((scroll) => scroll.options?.block === "nearest"),
+      ).toBe(true);
+    });
+
+    /** @scenario "Opening a page by its address reveals its sidebar entry" */
+    it("scrolls the menu so that entry sits at the top of the column", async () => {
+      // jsdom lays nothing out, so the entry is placed by hand: 300px
+      // down a menu whose own box starts at the top of the viewport.
+      stubEntryOffset({ entryLabel: "Virtual Keys", offset: 300 });
+
+      mockPathname = "/gateway/virtual-keys";
+      renderSidebar("gateway");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("sidebar-scroll-region").scrollTop).toBe(300);
+      });
+    });
+
+    /** @scenario "Moving inside the menu leaves the scroll where it is" */
+    it("leaves the scroll alone once the reader takes over", async () => {
+      stubEntryOffset({ entryLabel: "Virtual Keys", offset: 300 });
+
+      mockPathname = "/gateway/virtual-keys";
+      renderSidebar("gateway");
+
+      const region = screen.getByTestId("sidebar-scroll-region");
+      await waitFor(() => {
+        expect(region.scrollTop).toBe(300);
+      });
+
+      // The reader scrolls the menu themselves, and it keeps changing
+      // under them: the gated groups are still arriving.
+      region.dispatchEvent(new Event("wheel"));
+      region.scrollTop = 40;
+      region.appendChild(document.createElement("div"));
+
+      await waitFor(() => {
+        expect(region.childElementCount).toBeGreaterThan(0);
+      });
+      expect(region.scrollTop).toBe(40);
     });
   });
 

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -176,24 +176,39 @@ function recordScrollIntoView(): {
 
 /**
  * jsdom reports every box at the origin, so the one measurement the reveal
- * reads is stubbed: how far the active entry sits below the top of the
- * menu it scrolls in.
+ * reads is stubbed: how far each named entry sits below the top of the menu
+ * it scrolls in.
  */
-function stubEntryOffset({
-  entryLabel,
-  offset,
-}: {
-  entryLabel: string;
-  offset: number;
-}) {
+function stubEntryOffsets(offsets: Record<string, number>) {
   const rectAt = (top: number) => ({ ...EMPTY_RECT, top, y: top });
   window.HTMLElement.prototype.getBoundingClientRect = function (
     this: HTMLElement,
   ) {
     if (this.dataset.testid === "sidebar-scroll-region") return rectAt(0);
-    if (this.getAttribute("aria-label") === entryLabel) return rectAt(offset);
-    return rectAt(0);
+    const label = this.getAttribute("aria-label");
+    return rectAt((label ? offsets[label] : undefined) ?? 0);
   } as HTMLElement["getBoundingClientRect"];
+}
+
+/**
+ * Appends a child to the menu and resolves once a MutationObserver has been
+ * handed that change.
+ *
+ * Waiting for the child to be in the DOM proves nothing: it is there the
+ * moment `appendChild` returns, while the observers run later in their own
+ * microtask. Observers are called in the order they were created, and the
+ * menu's own observer is created first, when the column mounts. So by the
+ * time this one runs, the menu has already had its chance to move.
+ */
+async function appendChildAndAwaitMutation(region: HTMLElement) {
+  await new Promise<void>((resolve) => {
+    const observer = new MutationObserver(() => {
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(region, { childList: true, subtree: true });
+    region.appendChild(document.createElement("div"));
+  });
 }
 
 const EMPTY_RECT = {
@@ -341,7 +356,7 @@ describe("the product sidebar", () => {
     it("scrolls the menu so that entry sits at the top of the column", async () => {
       // jsdom lays nothing out, so the entry is placed by hand: 300px
       // down a menu whose own box starts at the top of the viewport.
-      stubEntryOffset({ entryLabel: "Virtual Keys", offset: 300 });
+      stubEntryOffsets({ "Virtual Keys": 300 });
 
       mockPathname = "/gateway/virtual-keys";
       renderSidebar("gateway");
@@ -352,8 +367,41 @@ describe("the product sidebar", () => {
     });
 
     /** @scenario "Moving inside the menu leaves the scroll where it is" */
+    it("does not move the menu when another page in it is opened", async () => {
+      // Budgets sits further down than Virtual Keys, so a menu that
+      // revealed the newly opened page would land on a different number.
+      stubEntryOffsets({ "Virtual Keys": 300, Budgets: 520 });
+
+      mockPathname = "/gateway/virtual-keys";
+      const { rerender } = renderSidebar("gateway");
+
+      const region = screen.getByTestId("sidebar-scroll-region");
+      await waitFor(() => {
+        expect(region.scrollTop).toBe(300);
+      });
+
+      // Opening another page from the same menu. The column stays mounted
+      // and keeps its scroll; only the entry marked as the page being
+      // shown moves.
+      mockPathname = "/gateway/budgets";
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <ProductSidebar surface="gateway" isCompact={false} />
+        </ChakraProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("link", { name: "Budgets" })).toHaveAttribute(
+          "aria-current",
+          "page",
+        );
+      });
+      expect(region.scrollTop).toBe(300);
+    });
+
+    /** @scenario "A reader who scrolls the menu keeps the position they chose" */
     it("leaves the scroll alone once the reader takes over", async () => {
-      stubEntryOffset({ entryLabel: "Virtual Keys", offset: 300 });
+      stubEntryOffsets({ "Virtual Keys": 300 });
 
       mockPathname = "/gateway/virtual-keys";
       renderSidebar("gateway");
@@ -367,11 +415,8 @@ describe("the product sidebar", () => {
       // under them: the gated groups are still arriving.
       region.dispatchEvent(new Event("wheel"));
       region.scrollTop = 40;
-      region.appendChild(document.createElement("div"));
+      await appendChildAndAwaitMutation(region);
 
-      await waitFor(() => {
-        expect(region.childElementCount).toBeGreaterThan(0);
-      });
       expect(region.scrollTop).toBe(40);
     });
   });

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -364,6 +364,20 @@ describe("the settings shell in a new navigation mode", () => {
       });
     });
 
+    /** @scenario "The way back stays in place while the menu scrolls" */
+    it("keeps the way back out of the region the menu scrolls in", () => {
+      renderSettings();
+
+      const scrollRegion = screen.getByTestId("sidebar-scroll-region");
+      expect(scrollRegion).not.toContainElement(
+        screen.getByRole("link", { name: /^Back/ }),
+      );
+      // The pages themselves are what scrolls, so they stay inside it.
+      expect(scrollRegion).toContainElement(
+        screen.getByRole("link", { name: "Members" }),
+      );
+    });
+
     it("hides the enterprise entries outside an enterprise plan", () => {
       mockIsEnterprise = false;
       renderSettings();

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -1,6 +1,6 @@
 import { Badge, Box, Kbd, VStack } from "@chakra-ui/react";
 import { ArrowLeft, ExternalLink, Search } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { MainMenuSections } from "~/components/MainMenu";
 import { PersonalSidebarLinks } from "~/components/PersonalSidebar";
 import { SidebarSection } from "~/components/sidebar/SidebarSection";
@@ -9,6 +9,7 @@ import { SupportMenu } from "~/components/sidebar/SupportMenu";
 import { SideMenuDensityProvider } from "~/components/sidebar/sideMenuDensity";
 import { ThemeToggle } from "~/components/sidebar/ThemeToggle";
 import { UsageIndicator } from "~/components/sidebar/UsageIndicator";
+import { useRevealActiveEntryOnLoad } from "~/components/sidebar/useRevealActiveEntryOnLoad";
 import { useCommandBar } from "~/features/command-bar";
 import { getCommandBarShortcut } from "~/features/command-bar/utils/platform";
 import { APP_HEADER_HEIGHT } from "~/features/langy/logic/langyPanelLayout";
@@ -304,6 +305,9 @@ function SidebarContent({
   surface: SidebarSurface;
   showExpanded: boolean;
 }) {
+  const scrollRegionRef = useRef<HTMLDivElement>(null);
+  useRevealActiveEntryOnLoad(scrollRegionRef);
+
   return (
     <VStack
       paddingTop={2}
@@ -314,10 +318,20 @@ function SidebarContent({
       width={SHELL_SIDEBAR_WIDTH_EXPANDED}
       justifyContent="space-between"
     >
+      {/* The way back out of Settings sits above the scroll region, so a
+          long settings menu never scrolls it out of the column. */}
+      {surface === "settings" && (
+        <Box width="full" paddingX={3}>
+          <SettingsBackEntry showLabel={showExpanded} />
+        </Box>
+      )}
+
       {/* The scroll region spans the full column and carries the
           horizontal inset itself, so its scrollbar runs against the
           content panel instead of floating a padding away from it. */}
       <VStack
+        ref={scrollRegionRef}
+        data-testid="sidebar-scroll-region"
         width="full"
         paddingX={3}
         gap={0.5}
@@ -339,9 +353,6 @@ function SidebarContent({
           "&::-webkit-scrollbar-track": { background: "transparent" },
         }}
       >
-        {surface === "settings" && (
-          <SettingsBackEntry showLabel={showExpanded} />
-        )}
         <QuickSearchMenuItem showLabel={showExpanded} />
         <Box height={2} width="full" flexShrink={0} />
         <ProductSidebarBody surface={surface} showExpanded={showExpanded} />

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
@@ -99,7 +99,13 @@ const OWNING_TEAM = {
   projects: [{ id: "proj-data", name: "Data App", slug: "data-app" }],
 };
 
-function organizationWith(teams: unknown[], organizationRole = "MEMBER") {
+function organizationWith({
+  teams,
+  organizationRole = "MEMBER",
+}: {
+  teams: unknown[];
+  organizationRole?: string;
+}) {
   return {
     data: [
       {
@@ -134,11 +140,18 @@ function renderResolution() {
  * statement of that is what makes the assertion mean anything: calling the
  * hook's own exported predicate would let the two drift together and still
  * agree, which is exactly the failure this covers.
+ *
+ * Both inputs come from the hook under test, never from a literal in the
+ * test body. A literal role would make the admin assertions pass on their
+ * own, whatever role the hook resolved.
  */
-function chromeWouldRefuse(
-  team: { members?: { userId: string }[] } | undefined,
-  organizationRole = "MEMBER",
-) {
+function chromeWouldRefuse({
+  team,
+  organizationRole,
+}: {
+  team: { members?: { userId: string }[] } | undefined;
+  organizationRole: string | undefined;
+}) {
   // The page body renders for an organization admin on the role alone,
   // whatever team rows they hold.
   if (organizationRole === "ADMIN") return false;
@@ -158,7 +171,7 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
       mockLocalStorage[key] = "";
     }
     mockOrganizationsQuery.mockReturnValue(
-      organizationWith([OTHER_TEAM, OWNING_TEAM]),
+      organizationWith({ teams: [OTHER_TEAM, OWNING_TEAM] }),
     );
   });
 
@@ -173,7 +186,12 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
         const { result } = renderResolution();
 
         expect(result.current.team?.id).toBe("team-data");
-        expect(chromeWouldRefuse(result.current.team)).toBe(false);
+        expect(
+          chromeWouldRefuse({
+            team: result.current.team,
+            organizationRole: result.current.organizationRole,
+          }),
+        ).toBe(false);
       });
 
       /** @scenario The ambient project belongs to the team the member is on */
@@ -194,7 +212,12 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
 
         expect(result.current.team?.id).toBe("team-data");
         expect(result.current.project?.slug).toBe("data-app");
-        expect(chromeWouldRefuse(result.current.team)).toBe(false);
+        expect(
+          chromeWouldRefuse({
+            team: result.current.team,
+            organizationRole: result.current.organizationRole,
+          }),
+        ).toBe(false);
       });
 
       /** @scenario The remembered selection heals to the team the member is on */
@@ -213,7 +236,10 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
   describe("given an admin of the organization, on one of its teams", () => {
     beforeEach(() => {
       mockOrganizationsQuery.mockReturnValue(
-        organizationWith([OTHER_TEAM, OWNING_TEAM], "ADMIN"),
+        organizationWith({
+          teams: [OTHER_TEAM, OWNING_TEAM],
+          organizationRole: "ADMIN",
+        }),
       );
     });
 
@@ -227,7 +253,13 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
 
         expect(result.current.project?.slug).toBe("platform-app");
         expect(result.current.team?.id).toBe("team-platform");
-        expect(chromeWouldRefuse(result.current.team, "ADMIN")).toBe(false);
+        expect(result.current.organizationRole).toBe("ADMIN");
+        expect(
+          chromeWouldRefuse({
+            team: result.current.team,
+            organizationRole: result.current.organizationRole,
+          }),
+        ).toBe(false);
       });
 
       /** @scenario "The admin's remembered team survives" */
@@ -244,7 +276,9 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
   describe("given someone who belongs to no team in the organization", () => {
     beforeEach(() => {
       mockOrganizationsQuery.mockReturnValue(
-        organizationWith([OTHER_TEAM, { ...OWNING_TEAM, members: [] }]),
+        organizationWith({
+          teams: [OTHER_TEAM, { ...OWNING_TEAM, members: [] }],
+        }),
       );
     });
 
@@ -256,7 +290,12 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
         // A resolved context is what lets the chrome render the refusal at
         // all; leaving it undefined would hang the page on a loading screen.
         expect(result.current.team).toBeDefined();
-        expect(chromeWouldRefuse(result.current.team)).toBe(true);
+        expect(
+          chromeWouldRefuse({
+            team: result.current.team,
+            organizationRole: result.current.organizationRole,
+          }),
+        ).toBe(true);
       });
     });
   });
@@ -273,7 +312,12 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
         const { result } = renderResolution();
 
         expect(result.current.team?.id).toBe("team-platform");
-        expect(chromeWouldRefuse(result.current.team)).toBe(true);
+        expect(
+          chromeWouldRefuse({
+            team: result.current.team,
+            organizationRole: result.current.organizationRole,
+          }),
+        ).toBe(true);
       });
     });
   });

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.team-membership.integration.test.tsx
@@ -99,7 +99,7 @@ const OWNING_TEAM = {
   projects: [{ id: "proj-data", name: "Data App", slug: "data-app" }],
 };
 
-function organizationWith(teams: unknown[]) {
+function organizationWith(teams: unknown[], organizationRole = "MEMBER") {
   return {
     data: [
       {
@@ -107,7 +107,8 @@ function organizationWith(teams: unknown[]) {
         name: "ACME",
         slug: "acme",
         primaryIntent: null,
-        members: [{ role: "MEMBER" }],
+        // `organization.getAll` narrows the members to the caller's own row.
+        members: [{ role: organizationRole }],
         teams,
       },
     ],
@@ -136,7 +137,11 @@ function renderResolution() {
  */
 function chromeWouldRefuse(
   team: { members?: { userId: string }[] } | undefined,
+  organizationRole = "MEMBER",
 ) {
+  // The page body renders for an organization admin on the role alone,
+  // whatever team rows they hold.
+  if (organizationRole === "ADMIN") return false;
   return !(
     team?.members?.some((member) => member.userId === MEMBER_ID) ?? false
   );
@@ -201,6 +206,37 @@ describe("useOrganizationTeamProject team-membership resolution", () => {
 
         expect(mockLocalStorage.selectedTeamId).toBe("team-data");
         expect(mockLocalStorage.selectedProjectSlug).toBe("data-app");
+      });
+    });
+  });
+
+  describe("given an admin of the organization, on one of its teams", () => {
+    beforeEach(() => {
+      mockOrganizationsQuery.mockReturnValue(
+        organizationWith([OTHER_TEAM, OWNING_TEAM], "ADMIN"),
+      );
+    });
+
+    describe("when they open a settings page after working in another team's project", () => {
+      /** @scenario "The admin's picked project survives a page that names no project" */
+      it("keeps the project they picked, and its team", () => {
+        mockLocalStorage.selectedTeamId = "team-platform";
+        mockLocalStorage.selectedProjectSlug = "platform-app";
+
+        const { result } = renderResolution();
+
+        expect(result.current.project?.slug).toBe("platform-app");
+        expect(result.current.team?.id).toBe("team-platform");
+        expect(chromeWouldRefuse(result.current.team, "ADMIN")).toBe(false);
+      });
+
+      /** @scenario "The admin's remembered team survives" */
+      it("keeps the remembered team when only the team is remembered", () => {
+        mockLocalStorage.selectedTeamId = "team-platform";
+
+        const { result } = renderResolution();
+
+        expect(result.current.team?.id).toBe("team-platform");
       });
     });
   });

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -64,6 +64,42 @@ export function userBelongsToTeam<T extends { members?: { userId: string }[] }>(
 ): boolean {
   return team.members?.some((member) => member.userId === userId) ?? false;
 }
+
+/** The caller's own role in an organization, or undefined outside one. */
+export function organizationRoleOf(
+  organization: { members?: { role: OrganizationUserRole }[] } | undefined,
+): OrganizationUserRole | undefined {
+  // `organization.getAll` narrows `members` to the caller's own row.
+  return organization?.members?.[0]?.role;
+}
+
+/**
+ * Whether the caller can be shown a team's context.
+ *
+ * A membership row answers it, and so does the organization ADMIN role on its
+ * own: `organization.getAll` hands an admin every team of the organization
+ * with no membership row in most of them, and the server grants team
+ * permissions on the admin role alone (`resolveTeamPermission`). The page body
+ * applies the same two-part test, so a context this accepts is one the chrome
+ * renders rather than refuses.
+ *
+ * A caller with no user id yet is not held to the test: the session is still
+ * resolving, and refusing there would drop a selection that is about to be
+ * valid.
+ */
+export function userCanOpenTeam<T extends { members?: { userId: string }[] }>({
+  team,
+  userId,
+  organizationRole,
+}: {
+  team: T;
+  userId: string | undefined;
+  organizationRole: OrganizationUserRole | undefined;
+}): boolean {
+  if (organizationRole === OrganizationUserRole.ADMIN) return true;
+  if (!userId) return true;
+  return userBelongsToTeam(team, userId);
+}
 /**
  * Ambient team for organization-level work.
  *
@@ -331,18 +367,27 @@ export const useOrganizationTeamProject = (
   // /[some-slug]/* into every organization-scoped page that carries no project
   // of its own. Two kinds have to be dropped there. A personal workspace is a
   // private context the caller never asked to work in, and a team the caller
-  // does not belong to is one the chrome refuses outright. Both let the
-  // ambient resolution below pick again, which also re-persists what it picks
-  // so the stale selection heals itself.
+  // cannot be shown is one the chrome refuses outright. Both let the ambient
+  // resolution below pick again, which also re-persists what it picks so the
+  // stale selection heals itself.
+  //
+  // An organization admin passes the second test on their role, so the project
+  // they picked in a team they hold no membership row in stays picked. Dropping
+  // it there sent them back to another team's project on every page that names
+  // no project, the app root included.
   //
   // A slug named in the address bar keeps resolving exactly as before,
-  // including into a team the caller is not on: the refusal that follows is
-  // the honest answer to typing someone else's project into the URL.
+  // including into a team the caller cannot open: the refusal that follows is
+  // the plain answer to typing someone else's project into the URL.
   const stickySlugIsUnusable =
     !!slugMatch &&
     !isAddressedBySlug &&
     (!!slugMatch.team.isPersonal ||
-      (!!userId && !userBelongsToTeam(slugMatch.team, userId)));
+      !userCanOpenTeam({
+        team: slugMatch.team,
+        userId,
+        organizationRole: organizationRoleOf(slugMatch.organization),
+      }));
   const resolvedSlugMatch = stickySlugIsUnusable ? undefined : slugMatch;
 
   // For demo mode, find the organization that contains the demo project
@@ -389,16 +434,21 @@ export const useOrganizationTeamProject = (
       )
     : undefined;
 
-  // The remembered selection carries the same membership requirement as the
-  // ambient pick below. Without it a persisted team id keeps resolving a team
-  // the caller is not on, long after the resolution itself stopped producing
-  // one: the selection is written from whatever last resolved, so a bad pick
-  // outlives the page that made it.
+  // The remembered selection carries the same test as the ambient pick below.
+  // Without it a persisted team id keeps resolving a team the caller cannot be
+  // shown, long after the resolution itself stopped producing one: the
+  // selection is written from whatever last resolved, so a bad pick outlives
+  // the page that made it. An organization admin passes the test on their
+  // role, so their remembered team stays remembered.
   const rememberedTeam = organization?.teams.find(
     (team) =>
       team.id == localStorageTeamId &&
       !team.isPersonal &&
-      (!userId || userBelongsToTeam(team, userId)),
+      userCanOpenTeam({
+        team,
+        userId,
+        organizationRole: organizationRoleOf(organization),
+      }),
   );
 
   const team = isDemo
@@ -616,7 +666,7 @@ export const useOrganizationTeamProject = (
     };
   }
 
-  const organizationRole = organization?.members?.[0]?.role;
+  const organizationRole = organizationRoleOf(organization);
 
   // ============================================================================
   // NEW RBAC SYSTEM - Preferred API going forward

--- a/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+++ b/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
@@ -123,6 +123,41 @@ Feature: A personal workspace is never the ambient context for organization work
       # held to the membership test.
 
   # ============================================================================
+  # An organization admin reaches every team, so the test must not drop theirs
+  # ============================================================================
+
+  Rule: the membership test reads as "can the caller be shown this team"
+
+    An organization admin reaches every team of the organization, with or
+    without a membership row in it: the page body renders for them on the
+    admin role alone, and the picker offers them every project. A membership
+    test written as the team rows alone therefore throws away an admin's own
+    selection, and the project they picked reverts to another team's project
+    on every page that carries no project in its address, the app root
+    included. The test is the same one the page body applies: a membership
+    row, or the admin role.
+
+    Background:
+      Given ada is an admin of "ACME"
+      And ada belongs to the shared team holding "acme-app", and not to
+        "ACME Platform"
+
+    @integration
+    Scenario: The admin's picked project survives a page that names no project
+      Given ada has just opened "ACME Platform"'s project
+      When ada opens an organization-scoped settings page
+      Then the ambient project is still "ACME Platform"'s project
+      And the ambient team is "ACME Platform"
+
+    @integration
+    Scenario: The admin's remembered team survives
+      Given ada's remembered selection names "ACME Platform"
+      When ada opens an organization-scoped settings page
+      Then the ambient team is "ACME Platform"
+      # A member keeps healing to the team they are on, which the rule
+      # above still covers: only the admin role opens the other team.
+
+  # ============================================================================
   # The address bar still decides
   # ============================================================================
 

--- a/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+++ b/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
@@ -123,19 +123,17 @@ Feature: A personal workspace is never the ambient context for organization work
       # held to the membership test.
 
   # ============================================================================
-  # An organization admin reaches every team, so the test must not drop theirs
+  # An organization admin reaches every team of the organization
   # ============================================================================
 
-  Rule: the membership test reads as "can the caller be shown this team"
+  Rule: an admin keeps a selection in any team they are allowed to open
 
-    An organization admin reaches every team of the organization, with or
-    without a membership row in it: the page body renders for them on the
-    admin role alone, and the picker offers them every project. A membership
-    test written as the team rows alone therefore throws away an admin's own
-    selection, and the project they picked reverts to another team's project
-    on every page that carries no project in its address, the app root
-    included. The test is the same one the page body applies: a membership
-    row, or the admin role.
+    An organization admin can open every team of the organization and every
+    project in it, whether or not they were added to that team. So a project
+    an admin picks stays picked on the pages that follow, including the pages
+    that name no project in their address and the app root.
+
+    A member is unchanged: they keep only the teams they were added to.
 
     Background:
       Given ada is an admin of "ACME"
@@ -154,8 +152,8 @@ Feature: A personal workspace is never the ambient context for organization work
       Given ada's remembered selection names "ACME Platform"
       When ada opens an organization-scoped settings page
       Then the ambient team is "ACME Platform"
-      # A member keeps healing to the team they are on, which the rule
-      # above still covers: only the admin role opens the other team.
+      # A member still goes back to a team they were added to, which the
+      # rule above keeps covering.
 
   # ============================================================================
   # The address bar still decides

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -91,6 +91,13 @@ Feature: Product sidebars in the new navigation modes
   Scenario: Opening a page by its address reveals its sidebar entry
     Given I open a product page by its address
     Then the sidebar brings that page's entry into view
+    And the entry sits as near the top of the menu as the menu allows
+
+  @integration
+  Scenario: Moving inside the menu leaves the scroll where it is
+    Given a page is open and its entry is already in view
+    When I open another page from the same menu
+    Then the menu does not scroll
 
   @integration
   Scenario: Closing the Support menu with the pointer leaves no focus ring

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -100,6 +100,13 @@ Feature: Product sidebars in the new navigation modes
     Then the menu does not scroll
 
   @integration
+  Scenario: A reader who scrolls the menu keeps the position they chose
+    Given I open a product page by its address
+    When I scroll the menu myself
+    And the menu keeps growing while its remaining groups arrive
+    Then the menu stays where I put it
+
+  @integration
   Scenario: Closing the Support menu with the pointer leaves no focus ring
     Given the Support menu opened because the pointer moved over it
     When the pointer moves away and the menu closes

--- a/specs/navigation/settings-shell-v2.feature
+++ b/specs/navigation/settings-shell-v2.feature
@@ -13,7 +13,9 @@ Feature: Settings shell in the new navigation modes
   BACKOFFICE groups with their current gates. Enterprise-plan entries
   carry a quiet grey pill, since it marks a plan rather than asking to
   be read first. Every settings page keeps its address, and every
-  visibility gate keeps its current condition.
+  visibility gate keeps its current condition. The back entry and its
+  rule sit above the scroll region, so a long settings menu never
+  scrolls the way out of the column.
 
   Devices on the legacy mode keep the current settings chrome
   unchanged.
@@ -49,6 +51,13 @@ Feature: Settings shell in the new navigation modes
   Scenario: A rule separates the way back from the pages below it
     Given I open Settings in a new navigation mode
     Then a rule runs under the way back entry
+
+  @integration
+  Scenario: The way back stays in place while the menu scrolls
+    Given I open Settings in a new navigation mode
+    When the settings menu scrolls
+    Then the way back entry stays where it is
+    And only the pages under the rule move
 
   @integration
   Scenario: A lite member sees no restricted settings entries


### PR DESCRIPTION
Three follow-ups from using the new navigation: the project an admin picks stops reverting, a page opened by its address opens the menu where the reader is, and the way back out of Settings stays in place.

## 1. An organization admin keeps the project they picked

Reported from the product: picking a project in one team sticks, picking a project in another team does not. Opening the app root goes back to a different team's project, in the same organization.

The two behaviours split by team membership, not by anything the reader can see:

- `organization.getAll` returns **every** team of the organization to an admin or a member, and narrows `team.members` to the caller's own row. So an admin holds a membership row in a few teams and none in the rest.
- The page renders for an admin on the admin role alone (`DashboardPageBody`), and the server grants team permissions the same way (`resolveTeamPermission`). The picker offers them every project, and opening one by its address works.
- The ambient resolution, however, dropped a **persisted** selection whose team carried no membership row. That test was added for members, who really are refused in another team's project. Applied to an admin it threw away a project they can open, and the ambient pick then wrote its own choice over the stored one.

The result: every page that carries no project in its address, the app root included, sent the admin back to a project in a team they hold a row in.

The membership test now reads as "can the caller be shown this team": a membership row, or the organization admin role. That is the test the page body already applies, so the context the app resolves is one the chrome renders rather than refuses. A member is unchanged: their sticky selection still heals to a team they are on, which the existing scenarios keep pinning. Personal workspaces are still released, for admins too.

The resolution is shared with the current chrome, so this fix is not behind the navigation flag. The same reversion happened there.

**Measured in a browser** on a dev instance, with a team that holds zero membership rows and one project, in an organization where the reader is admin:

| | before | after |
|---|---|---|
| open the project by its address | renders, no refusal | renders, no refusal |
| then open `/` | lands on another team's project | stays on the picked project |
| stored `selectedProjectSlug` | overwritten with the other project | keeps the picked project |

## 2. A page opened by its address opens the menu at that page

The entry was revealed but sat at the bottom edge of the column, with its neighbours out of view below it. A reader who lands on `/ops` is there to look through the pages around it.

The active entry now goes to the **top** of the menu, as far as the menu can scroll, so the pages under it are in view. The menu that opened `/ops` scrolls to its end, which puts the active entry 107px down a 538px column with every entry below it visible.

Where the entry lands when a menu first renders is now the column's own call (`useRevealActiveEntryOnLoad`), not the entry's. The entry keeps `scrollIntoView({ block: "nearest" })` for later activations, which does nothing when the entry is visible, so a click never shifts the menu.

The reveal re-applies while the menu is still changing, because the gated groups arrive with the queries behind them and entries added above the active one push it back down. Without that the first scroll raced the menu's own growth and the entry drifted 292px down the column. It stops for good at the first wheel, touch, pointer or key inside the menu, so a reader who scrolls keeps the position they chose.

## 3. The way back out of Settings stays in place

"Back to Gateway" and friends scrolled away with the menu. The entry and its rule now sit above the scroll region, so the pages scroll under them and the way out is always there.

![Settings opened at /ops, with the way back pinned](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-scope-and-menu-scroll/settings-deeplink-and-pinned-back.png)

## Verification

- `pnpm typecheck` and `pnpm typecheck:tests`: clean.
- `pnpm test:component run src/features/navigation src/components/sidebar src/hooks`: 283 passed.
- `pnpm test:component run src/components/__tests__` (the legacy chrome pinning suites): 176 passed.
- Each new test was run against the code without its fix: the two admin scenarios fail on the membership test, and the two reveal scenarios fail without the column hook. The two menu scroll tests were each run against a broken hook as well: with the reveal reacting to the active entry changing, "does not move the menu when another page in it is opened" fails with `expected 820 to be 300`; with the reader events not disconnecting the observer, "leaves the scroll alone once the reader takes over" fails with `expected 340 to be 40`.
- `check:feature-parity`: personal-workspace-not-ambient-context 22/22, product-sidebars 16/16, settings-shell-v2 9/9, all bound.
- Biome on the touched files: no new violations. The eight complexity warnings on `useOrganizationTeamProject.ts` and `SideMenuLink.tsx` are the same eight the files carry on main.
- Browser QA on a dev instance at 1440x760: the table above, plus the settings menu opening at `/ops`, a click inside the menu leaving the scroll at its position, a reader scroll surviving the groups still arriving, and a menu that fits its column staying at the top.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deep-linked pages now bring their active sidebar entry near the top when possible.
  * Navigating between visible sidebar pages preserves the current scroll position.
  * The Settings back link remains fixed while menu pages scroll independently.
  * Organization admins retain selected or remembered team and project context on applicable settings pages.

* **Bug Fixes**
  * Improved sidebar scrolling behavior without overriding subsequent reader-controlled scrolling.

* **Tests**
  * Added coverage for sidebar positioning, Settings navigation layout, and administrator context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
