### PR TITLE
fix(ops): the tenancy guard lets the enrollment rollout read itself again

### DIFF
--- a/platform/app/src/utils/__tests__/dbOrganizationIdProtection.unit.test.ts
+++ b/platform/app/src/utils/__tests__/dbOrganizationIdProtection.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "~/generated/prisma/client";
 
 import { reapExpiredLangySessionApiKeys } from "~/server/app-layer/langy/langyApiKey";
+import { PrismaSystemMigrationEnrollmentRepository } from "~/server/app-layer/system-migrations/repositories/system-migration-enrollment.prisma.repository";
 import { parsePrismaDatamodel } from "~/test-utils/prismaDatamodel";
 import type { GuardParams } from "../dbGuardMiddleware";
 import {
@@ -637,6 +638,102 @@ describe("guardOrganizationId — platform-owned API-key sweeps", () => {
           args: {
             where: { name: { contains: "Langy session" } },
             data: { revokedAt: new Date() },
+          },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});
+
+describe("guardOrganizationId — the migration rollout's enrollment rows", () => {
+  /**
+   * A Prisma stand-in that installs the SAME middleware the real client does
+   * (`db.ts` → `prisma.$use(guardOrganizationId)`), so every call the real
+   * repository makes is subject to the guard exactly as it is in production.
+   * No database: the guard is a pure function of the query arguments.
+   *
+   * The repository's reads are what this exists to drive. They were admitted
+   * only alongside a `stage` predicate; enrollment then went per-migration and
+   * dropped that column, and nothing failed, because no test put the repository
+   * and the guard in the same room. The ops page and every migration pass threw
+   * in production instead. Driving the ACTUAL repository through the ACTUAL
+   * middleware means drift on either side fails here.
+   */
+  function guardedEnrollmentRepository() {
+    const calls: Array<{ action: string; args: unknown }> = [];
+    const through = (action: string) => async (args: unknown) => {
+      calls.push({ action, args });
+      return guardOrganizationId(
+        { model: "SystemMigrationEnrollment", action, args },
+        async () => [],
+      );
+    };
+    const prisma = {
+      systemMigrationEnrollment: {
+        findMany: through("findMany"),
+        findUnique: through("findUnique"),
+        groupBy: through("groupBy"),
+        create: through("create"),
+        delete: through("delete"),
+      },
+      organization: { findMany: async () => [], findUnique: async () => null },
+      user: { findMany: async () => [] },
+    };
+    return {
+      repository: new PrismaSystemMigrationEnrollmentRepository(
+        prisma as unknown as PrismaClient,
+      ),
+      calls,
+    };
+  }
+
+  describe("when the ops page lists every enrollment", () => {
+    it("passes the guard — the listing is platform-scope by design", async () => {
+      const { repository, calls } = guardedEnrollmentRepository();
+
+      await expect(repository.findAll()).resolves.toEqual([]);
+
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  describe("when a migration pass reads the organizations it processes", () => {
+    it("passes the guard — one read covers every tenant and every migration", async () => {
+      const { repository } = guardedEnrollmentRepository();
+
+      await expect(
+        repository.findEnrolledOrganizationIdsByMigration(),
+      ).resolves.toEqual(new Map());
+    });
+  });
+
+  describe("when the rollout gauge counts enrollments per migration", () => {
+    it("passes the guard — the groupBy reads across organizations", async () => {
+      const { repository } = guardedEnrollmentRepository();
+
+      await expect(repository.countEnrolledByMigration()).resolves.toEqual(
+        new Map(),
+      );
+    });
+  });
+
+  describe("when a bulk write names a migration but no organization", () => {
+    it("THROWS — the hatch is granted to reads, never to a fleet-wide withdrawal", async () => {
+      await expect(
+        runGuard({
+          model: "SystemMigrationEnrollment",
+          action: "deleteMany",
+          args: { where: { migrationName: "authz-cutover" } },
+        }),
+      ).rejects.toThrow();
+
+      await expect(
+        runGuard({
+          model: "SystemMigrationEnrollment",
+          action: "updateMany",
+          args: {
+            where: { migrationName: "authz-cutover" },
+            data: { migrationName: "authz-team-user-backfill" },
           },
         }),
       ).rejects.toThrow();

--- a/platform/app/src/utils/dbOrganizationIdProtection.ts
+++ b/platform/app/src/utils/dbOrganizationIdProtection.ts
@@ -22,6 +22,22 @@ import type { GuardMiddleware, GuardParams } from "./dbGuardMiddleware";
 
 type OrgScopedModelConfig = {
   /**
+   * Actions admitted with NO single-organization predicate at all — the narrow
+   * case of a table whose rows are platform bookkeeping rather than tenant
+   * data, and whose reads are across-organizations by design.
+   *
+   * This is deliberately separate from `extraBound`, which can only ever
+   * narrow a WHERE clause that exists: the guard rejects a missing or
+   * non-object `where` before any bound is consulted, so a bare `findMany()`
+   * is unreachable from there no matter what the bound says. A model that
+   * genuinely has no predicate to offer has to say so here, by action, where
+   * it reads as the exemption it is.
+   *
+   * Grant this to READ actions only, and only to a model carrying no customer
+   * data. It is the widest thing in this file.
+   */
+  platformScopeActions?: readonly string[];
+  /**
    * Extra single-org-bounding predicates beyond organizationId / row id /
    * composite-org key. Used for parent foreign keys and globally-unique
    * secret columns that each resolve to exactly one organization.
@@ -286,15 +302,27 @@ const ORG_SCOPED_MODELS: Record<string, OrgScopedModelConfig> = {
   // Which organizations the in-place migration runner processes on cloud
   // (specs/rbac/in-place-authz-migration.feature, the enrollment scenarios).
   // The runner's per-pass read and the ops listing are platform-scope by
-  // design - they list one STAGE across organizations, the same posture as
-  // the ops rollup over SystemMigrationTenantState - so a stage-string
-  // predicate is admitted for reads only. Writes stay bounded to one
-  // organization: enroll carries organizationId in its data, withdraw names
-  // the compound (organizationId, stage) key, and a stage-wide bulk write
-  // (which would withdraw every organization at once) has no admitted shape.
+  // design - the same posture as the ops rollup over
+  // SystemMigrationTenantState - so READS are admitted unbounded.
+  //
+  // They used to be admitted only alongside a `stage` string, back when
+  // enrollment was one row per (organization, stage) and every read named the
+  // stage it was about. Enrollment is now per MIGRATION, and all three reads
+  // span migrations as well as organizations: the ops listing shows every
+  // enrollment, the pass reads the whole table once to probe per (tenant,
+  // migration) in memory, and the rollout gauge groups by migration name.
+  // There is no narrowing predicate left to require, and going on requiring
+  // the departed column meant the guard refused every one of them.
+  //
+  // Reads only, and the action gate is what keeps that honest. Writes stay
+  // bounded to one organization: enroll carries organizationId in its data,
+  // withdraw names the compound (organizationId, migrationName) key, the
+  // organization purge deletes by organizationId, and a migration-wide bulk
+  // write - which would withdraw every organization at once - has no admitted
+  // shape. The rows themselves are operator bookkeeping: an organization id, a
+  // migration name, and who enrolled it.
   SystemMigrationEnrollment: {
-    extraBound: ({ clause, action }) =>
-      action === "findMany" && typeof clauseField(clause, "stage") === "string",
+    platformScopeActions: ["findMany", "groupBy"],
   },
   AuthzProjectionCursor: {},
   AuthzCutoverProjection: {},
@@ -475,6 +503,12 @@ const _guardOrganizationId = ({ params }: { params: GuardParams }) => {
     }
     return;
   }
+
+  // The platform-scope exemption, granted per action and read before any
+  // predicate is looked at — which is the whole point of it, since the reads it
+  // covers carry no predicate to look at. Placed after the create branch so it
+  // can never admit a write that declares no owner.
+  if (config.platformScopeActions?.includes(action)) return;
 
   const where = params.args?.where;
   if (!where || typeof where !== "object") {


### PR DESCRIPTION
Follow-up to #7304, which is live in production and inert.

## What is broken right now

Grafana, on the rolled-out image:

```
The findMany action on the SystemMigrationEnrollment model requires an
'organizationId' or row id in the where clause      ops.listMigrationEnrollments
The groupBy action ... same                         ops.listSystemMigrations
```

and the same `findMany` refusal on `langwatch-service-worker` under logger
`langwatch:system-migrations:boot`. It is not only the ops page: **every
worker's migration pass dies at boot** reading the organizations it processes,
so nothing has migrated since the deploy.

## Why

Enrollment went per-migration and dropped `SystemMigrationEnrollment.stage`,
but the organization-tenancy guard still admitted reads on that model only
alongside a `stage` string. All three reads the feature performs — the ops
listing, the pass's whole-table read, the rollout gauge's `groupBy` — lost
their only admitted shape.

Fixing the bound alone would not have worked. `_guardOrganizationId` throws on
a missing or non-object `where` **before** it consults `extraBound`, so a bare
`findMany()` is unreachable from there whatever the bound returns.

## The change

Reads that legitimately span organizations now declare themselves as
`platformScopeActions`, granted per action and checked after the create branch
so it can never admit a write. Writes are untouched and still bounded: enroll
declares its organization in the data, withdraw names the compound
`(organizationId, migrationName)` key, the organization purge deletes by
`organizationId`, and a migration-wide bulk write has no admitted shape.

The tests drive the real repository through the real middleware, the way the
API-key reaper's do. Nothing did before, which is exactly why a rename on one
side and a predicate on the other could disagree all the way to production.

## Checks

- `dbOrganizationIdProtection.unit.test.ts` 40/40; `system-migrations` + `utils`
  880/880
- biome: same three pre-existing complexity warnings as main, no new delta
- scoped typecheck clean, with a control run proving it checked both files

Prod stays inert until this deploys — there is no config-side workaround, the
guard is code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization data protection for system migration enrollment records.
  * Allowed approved platform-wide read operations while continuing to block unscoped bulk updates and deletes.
  * Added validation coverage for organization-tenancy safeguards across lookups, grouping, updates, and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->