### PR TITLE
fix(clickhouse): a tenant is a project or an organization, and the grants ledger's is the latter

### DIFF
--- a/platform/app/scripts/dogfood/audio/probeSpendReads.ts
+++ b/platform/app/scripts/dogfood/audio/probeSpendReads.ts
@@ -8,7 +8,7 @@
  * included, for rows this run created seconds ago.
  */
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 
@@ -47,7 +47,7 @@ export interface LedgerDebit {
 }
 
 export async function clickhouse(projectId: string) {
-  const client = await getClickHouseClientForProject(projectId);
+  const client = await getClickHouseClientForTenant(projectId);
   if (!client) throw new Error("no ClickHouse client available");
   return client;
 }

--- a/platform/app/scripts/dogfood/gateway/seed-vk-table-polish.ts
+++ b/platform/app/scripts/dogfood/gateway/seed-vk-table-polish.ts
@@ -23,7 +23,7 @@
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import { nextResetAt } from "~/server/gateway/budgetWindow";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
@@ -103,7 +103,7 @@ async function purgePrevious(target: SeedTarget) {
   });
 
   if (previous.length > 0) {
-    const client = await getClickHouseClientForProject(target.projectId);
+    const client = await getClickHouseClientForTenant(target.projectId);
     if (!client) {
       throw new Error(
         `refusing to delete ${previous.length} previous fixture key(s): no ClickHouse client for ${target.projectId}, so their ledger and rollup rows would be stranded`,

--- a/platform/app/scripts/dogfood/governance/seed-bird-eye.ts
+++ b/platform/app/scripts/dogfood/governance/seed-bird-eye.ts
@@ -41,7 +41,7 @@
  *        --org <organizationId> [--days 30] [--rows 240]'
  */
 import { randomBytes } from "crypto";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import { ensureHiddenGovernanceProject } from "../../../ee/governance/services/governanceProject.service";
 
@@ -324,7 +324,7 @@ async function seedTraceSummaries({
   sources: { id: string; teamId: string | null; teamName: string }[];
   args: Args;
 }): Promise<{ totalCostUsd: number; rowsInserted: number }> {
-  const ch = await getClickHouseClientForProject(govProjectId);
+  const ch = await getClickHouseClientForTenant(govProjectId);
   if (!ch)
     throw new Error("ClickHouse client unavailable for governance tenant");
 

--- a/platform/app/scripts/dogfood/governance/seed-heavy-usage.ts
+++ b/platform/app/scripts/dogfood/governance/seed-heavy-usage.ts
@@ -22,7 +22,7 @@
  */
 import { randomBytes } from "crypto";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 
 export interface Args {
   personalProject: string;
@@ -239,7 +239,7 @@ export async function runSeedHeavyUsage(
   const traces: SyntheticTrace[] = [];
   for (let i = 0; i < args.rows; i++) traces.push(synthTrace(args));
 
-  const client = await getClickHouseClientForProject(args.personalProject);
+  const client = await getClickHouseClientForTenant(args.personalProject);
   if (!client) throw new Error("ClickHouse client unavailable for tenant");
 
   const traceRows = traces.map((t) => ({

--- a/platform/app/scripts/seed-mass.ts
+++ b/platform/app/scripts/seed-mass.ts
@@ -29,7 +29,7 @@ import { seedDemoPlatform } from "../prisma/seed-demo-platform";
 import { PrismaClient } from "../src/generated/prisma/client";
 import { resetApp } from "../src/server/app-layer/app";
 import { initializeDefaultApp } from "../src/server/app-layer/presets";
-import { getClickHouseClientForProject } from "../src/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "../src/server/clickhouse/clickhouseClient";
 import { DEFAULT_PII_REDACTION_LEVEL } from "../src/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import { createPrismaPgAdapter } from "../src/server/prismaPgAdapter";
 import { getSuiteSetId } from "../src/server/suites/suite-set-id";
@@ -290,7 +290,7 @@ interface SeedWindow {
  * cold ones on S3) — this runs every 2s for up to ten minutes.
  */
 async function projectionCounts(window: SeedWindow): Promise<ProjectionCounts> {
-  const client = await getClickHouseClientForProject(PROJECT_ID);
+  const client = await getClickHouseClientForTenant(PROJECT_ID);
   if (!client) throw new Error("ClickHouse client is unavailable");
   const result = await client.query({
     query: `

--- a/platform/app/scripts/seed-realistic-platform-data.ts
+++ b/platform/app/scripts/seed-realistic-platform-data.ts
@@ -12,7 +12,7 @@ import { seedDemoPlatform } from "../prisma/seed-demo-platform";
 import { PrismaClient } from "../src/generated/prisma/client";
 import { resetApp } from "../src/server/app-layer/app";
 import { initializeDefaultApp } from "../src/server/app-layer/presets";
-import { getClickHouseClientForProject } from "../src/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "../src/server/clickhouse/clickhouseClient";
 import { createPrismaPgAdapter } from "../src/server/prismaPgAdapter";
 import { getSuiteSetId } from "../src/server/suites/suite-set-id";
 import {
@@ -393,7 +393,7 @@ interface ProjectionCounts {
 }
 
 async function projectionCounts(): Promise<ProjectionCounts> {
-  const client = await getClickHouseClientForProject(PROJECT_ID);
+  const client = await getClickHouseClientForTenant(PROJECT_ID);
   if (!client) throw new Error("ClickHouse client is unavailable");
   const result = await client.query({
     query: `

--- a/platform/app/scripts/seed-trace-evals.ts
+++ b/platform/app/scripts/seed-trace-evals.ts
@@ -10,7 +10,7 @@
  *     npx tsx scripts/seed-trace-evals.ts
  */
 import { EvaluationRunClickHouseRepository } from "../src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository";
-import { getClickHouseClientForProject } from "../src/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "../src/server/clickhouse/clickhouseClient";
 
 async function main() {
   const projectId = process.env.PROJECT_ID;
@@ -21,7 +21,7 @@ async function main() {
 
   const repo = new EvaluationRunClickHouseRepository({
     resolveClient: async (tenantId: string) => {
-      const client = await getClickHouseClientForProject(tenantId);
+      const client = await getClickHouseClientForTenant(tenantId);
       if (!client)
         throw new Error(`No ClickHouse client for project ${tenantId}`);
       return client;

--- a/platform/app/src/app/api/gateway-spend/__tests__/gateway-spend-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/gateway-spend/__tests__/gateway-spend-rest-api.integration.test.ts
@@ -73,7 +73,7 @@ vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
     >();
   return {
     ...original,
-    getClickHouseClientForProject: resolveTestClickHouseClient,
+    getClickHouseClientForTenant: resolveTestClickHouseClient,
   };
 });
 

--- a/platform/app/src/app/api/webhooks/__tests__/webhooks-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/webhooks/__tests__/webhooks-rest-api.integration.test.ts
@@ -18,7 +18,7 @@ import {
   TeamUserRole,
 } from "~/generated/prisma/client";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   verifyWebhookSignature,
@@ -45,7 +45,7 @@ vi.mock("~/server/app-layer/app", () => ({
     },
     gateway: {
       webhookEvents: new WebhookEventsClickHouseRepository(async (tenantId) => {
-        const client = await getClickHouseClientForProject(tenantId);
+        const client = await getClickHouseClientForTenant(tenantId);
         if (!client) throw new Error("ClickHouse is not configured");
         return client;
       }),

--- a/platform/app/src/server/__tests__/end-user-spend-routing.integration.test.ts
+++ b/platform/app/src/server/__tests__/end-user-spend-routing.integration.test.ts
@@ -63,7 +63,7 @@ vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
     >();
   return {
     ...original,
-    getClickHouseClientForProject: async () => chClient,
+    getClickHouseClientForTenant: async () => chClient,
   };
 });
 

--- a/platform/app/src/server/analytics/clickhouse/__tests__/memory-safety.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/memory-safety.test.ts
@@ -331,7 +331,7 @@ describe("memory-safety", () => {
         }
       });
 
-      it("clickhouse-trace.service.ts uses getClickHouseClientForProject which wraps with default settings", () => {
+      it("clickhouse-trace.service.ts uses getClickHouseClientForTenant which wraps with default settings", () => {
         const traceServicePath = path.resolve(
           __dirname,
           "..",
@@ -342,11 +342,11 @@ describe("memory-safety", () => {
         );
         const source = fs.readFileSync(traceServicePath, "utf-8");
 
-        // The trace service must use getClickHouseClientForProject, which
+        // The trace service must use getClickHouseClientForTenant, which
         // internally wraps clients with wrapWithDefaultSettings. This ensures
         // memory-safety defaults are automatically injected on every query.
         // The wrapper's merge behavior is tested in safeClickhouseClient.unit.test.ts.
-        expect(source).toContain("getClickHouseClientForProject");
+        expect(source).toContain("getClickHouseClientForTenant");
       });
     });
   });

--- a/platform/app/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
@@ -370,16 +370,16 @@ describe("experiments.deleteExperiment", () => {
   // The most reliable proof is a source-level check: with the imports gone
   // there is no path by which the archive procedure can reach those
   // services. Runtime fail-on-call mocks were considered but rejected
-  // because getClickHouseClientForProject is still used by sibling
+  // because getClickHouseClientForTenant is still used by sibling
   // list/enrichment procedures in the same router and globally mocking it
   // would break unrelated tests.
   describe("the router source file", () => {
     /** @scenario The delete-experiment code path does NOT contact ClickHouse */
-    it("does not import getClickHouseClientForProject", async () => {
+    it("does not import getClickHouseClientForTenant", async () => {
       const src = await import("node:fs/promises").then((fs) =>
         fs.readFile(require.resolve("../experiments.ts"), "utf8"),
       );
-      expect(src).not.toMatch(/getClickHouseClientForProject/);
+      expect(src).not.toMatch(/getClickHouseClientForTenant/);
     });
 
     /** @scenario The delete-experiment code path does NOT call the DSpy step cleanup */

--- a/platform/app/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
@@ -370,10 +370,9 @@ describe("experiments.deleteExperiment", () => {
   // The most reliable proof is a source-level check: with the imports gone
   // there is no path by which the archive procedure can reach those
   // services. Runtime fail-on-call mocks were considered but rejected
-  // because getClickHouseClientForTenant is still used by sibling
-  // list/enrichment procedures in the same router and globally mocking it
-  // would break unrelated tests.
-  describe("the router source file", () => {
+  // because the resolver is reached from sibling list/enrichment paths and
+  // globally mocking it would break unrelated tests.
+  describe("when checking the router source file", () => {
     /** @scenario The delete-experiment code path does NOT contact ClickHouse */
     it("does not import getClickHouseClientForTenant", async () => {
       const src = await import("node:fs/promises").then((fs) =>

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-payload-offload.integration.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-payload-offload.integration.test.ts
@@ -7,7 +7,7 @@
  * or the CI service container), a real StoredObjectsService backed by a
  * LocalFilesystemDriver on a per-test temp dir, the real event_log repository,
  * and the real evaluation_runs repository. No boundary under test is mocked -
- * only `getClickHouseClientForProject` is wired to the test client so the
+ * only `getClickHouseClientForTenant` is wired to the test client so the
  * stored-objects repository routes to the same database.
  *
  * Covers the feature-file scenarios:
@@ -69,7 +69,7 @@ vi.mock("~/server/clickhouse/clickhouseClient", async () => {
   );
   return {
     ...actual,
-    getClickHouseClientForProject: vi.fn(),
+    getClickHouseClientForTenant: vi.fn(),
   };
 });
 
@@ -166,7 +166,7 @@ beforeAll(async () => {
   // than resolving a client, so the fixture has to provide one.
   installClickHouseTestApp({ resolveClient: async () => ch });
   vi.mocked(
-    clickhouseClientModule.getClickHouseClientForProject,
+    clickhouseClientModule.getClickHouseClientForTenant,
   ).mockResolvedValue(ch);
 
   evalRepo = new EvaluationRunClickHouseRepository({
@@ -324,7 +324,7 @@ describe("evaluation inputs offload (integration)", () => {
 
       // The v1 read service resolves the marker at the read boundary. Inject
       // the same stored-objects service the write used (its client is the test
-      // client via the getClickHouseClientForProject mock).
+      // client via the getClickHouseClientForTenant mock).
       // The repository is injected so the read goes through the same test
       // client the write used. The fixture App resolves one too, but the
       // injected dependency path is the one this asserts on.

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -33,7 +33,7 @@ import {
   clearCustomClientCache,
   getAllClickHouseInstances,
   getClickHouseClientForOrganization,
-  getClickHouseClientForProject,
+  getClickHouseClientForTenant,
   getSharedClickHouseClient,
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
@@ -385,7 +385,7 @@ export function initializeDefaultApp(options?: {
   const resolveClickHouseClient: ClickHouseClientResolver = async (
     tenantId: string,
   ): Promise<ClickHouseClient> => {
-    const client = await getClickHouseClientForProject(tenantId);
+    const client = await getClickHouseClientForTenant(tenantId);
     if (!client)
       throw new Error(`ClickHouse not available for tenant ${tenantId}`);
     return client;

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
@@ -65,15 +65,15 @@ const hasTestcontainers = !!(
 );
 
 // Mock the ClickHouse routing module so BOTH the read path
-// (ClickHouseTraceService.resolveClient -> getClickHouseClientForProject) AND the
+// (ClickHouseTraceService.resolveClient -> getClickHouseClientForTenant) AND the
 // blob resolver (buildTraceBlobResolutionDeps -> defaultResolveClickHouseClient ->
-// getClickHouseClientForProject, wired only when isClickHouseEnabled()) resolve to
+// getClickHouseClientForTenant, wired only when isClickHouseEnabled()) resolve to
 // the testcontainer client. importOriginal keeps every other export intact.
 vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => ({
   ...(await importOriginal<
     typeof import("~/server/clickhouse/clickhouseClient")
   >()),
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
   // Must be true so buildTraceBlobResolutionDeps wires the CH resolver onto the
   // BlobStore — otherwise getFromEventLog throws and every read degrades to the
   // preview, which would mask the very fix this test proves.
@@ -337,7 +337,7 @@ describe.skipIf(!hasTestcontainers)(
       // Wire the mocked routing module to the testcontainer client, so both the
       // read path and the blob resolver dial the real `ch`.
       vi.mocked(
-        clickhouseClientModule.getClickHouseClientForProject,
+        clickhouseClientModule.getClickHouseClientForTenant,
       ).mockResolvedValue(client);
 
       // buildTraceBlobResolutionDeps()'s no-arg call — the exact shape the
@@ -347,7 +347,7 @@ describe.skipIf(!hasTestcontainers)(
       await resetApp();
       installClickHouseTestApp({
         resolveClient: (tenantId) =>
-          clickhouseClientModule.getClickHouseClientForProject(tenantId),
+          clickhouseClientModule.getClickHouseClientForTenant(tenantId),
       });
     }, 60_000);
 

--- a/platform/app/src/server/app-layer/usage/__tests__/usage-service-getResolvedUsageUnit.unit.test.ts
+++ b/platform/app/src/server/app-layer/usage/__tests__/usage-service-getResolvedUsageUnit.unit.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../tracing", () => ({
 
 vi.mock("../../../clickhouse/clickhouseClient", () => ({
   isClickHouseEnabled: () => false,
-  getClickHouseClientForProject: () => Promise.resolve(null),
+  getClickHouseClientForTenant: () => Promise.resolve(null),
 }));
 
 const PAID_TIERED_PLAN: PlanInfo = {

--- a/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -83,7 +83,7 @@ vi.mock("../../tracing", () => ({
 
 vi.mock("../../../clickhouse/clickhouseClient", () => ({
   isClickHouseEnabled: () => false,
-  getClickHouseClientForProject: () => Promise.resolve(null),
+  getClickHouseClientForTenant: () => Promise.resolve(null),
 }));
 
 const { mockEnv } = vi.hoisted(() => {

--- a/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -24,6 +24,9 @@ let privateClient: ClickHouseClient;
 // The org IDs we'll use — set the env var BEFORE importing clickhouseClient
 const PRIVATE_ORG_ID = `test-private-org-${nanoid(6)}`;
 const SHARED_ORG_ID = `test-shared-org-${nanoid(6)}`;
+// An organization that owns no project, because it is the tenant itself: the
+// grants ledger's aggregate is one organization (ADR-092 §13).
+const PRIVATE_ORG_ID_WITHOUT_PROJECTS = `test-private-org-tenant-${nanoid(6)}`;
 
 // Table names stay unqualified throughout: each endpoint's client carries its
 // own database in the connection URL, and that is precisely the separation
@@ -134,6 +137,9 @@ describe("ClickHouse routing via env vars", () => {
 
     // Set the private CH env var BEFORE importing clickhouseClient
     process.env[`CLICKHOUSE_URL__testcustomer__${PRIVATE_ORG_ID}`] = privateUrl;
+    process.env[
+      `CLICKHOUSE_URL__grantsledger__${PRIVATE_ORG_ID_WITHOUT_PROJECTS}`
+    ] = privateUrl;
 
     sharedClient = createClient({
       url: sharedUrl,
@@ -152,11 +158,11 @@ describe("ClickHouse routing via env vars", () => {
   }, 300_000);
 
   afterAll(async () => {
-    const { clearCustomClientCache, clearProjectOrgCache } = await import(
+    const { clearCustomClientCache, clearTenantOrgCache } = await import(
       "../clickhouseClient"
     );
     await clearCustomClientCache();
-    clearProjectOrgCache();
+    clearTenantOrgCache();
 
     if (createdProjectIds.length > 0) {
       await prisma.project.deleteMany({
@@ -176,6 +182,9 @@ describe("ClickHouse routing via env vars", () => {
 
     // Clean up env var
     delete process.env[`CLICKHOUSE_URL__testcustomer__${PRIVATE_ORG_ID}`];
+    delete process.env[
+      `CLICKHOUSE_URL__grantsledger__${PRIVATE_ORG_ID_WITHOUT_PROJECTS}`
+    ];
   }, 60_000);
 
   describe("when org has no private ClickHouse env var", () => {
@@ -184,7 +193,7 @@ describe("ClickHouse routing via env vars", () => {
     /** @scenario Project in a standard org routes to the shared instance */
     /** @scenario Data written for a standard org does not appear in private */
     it("returns the shared (default) client", async () => {
-      const { getClickHouseClientForProject } = await import(
+      const { getClickHouseClientForTenant } = await import(
         "../clickhouseClient"
       );
 
@@ -197,7 +206,7 @@ describe("ClickHouse routing via env vars", () => {
       createdTeamIds.push(teamId);
       createdOrgIds.push(organizationId);
 
-      const client = await getClickHouseClientForProject(projectId);
+      const client = await getClickHouseClientForTenant(projectId);
       expect(client).toBe(sharedClient);
 
       const rowId = `shared-${nanoid(8)}`;
@@ -226,7 +235,7 @@ describe("ClickHouse routing via env vars", () => {
     /** @scenario Project in a private-CH org routes to the private instance */
     /** @scenario Data written for a private-CH org does not appear in shared */
     it("returns a client connected to the private instance", async () => {
-      const { getClickHouseClientForProject } = await import(
+      const { getClickHouseClientForTenant } = await import(
         "../clickhouseClient"
       );
 
@@ -239,7 +248,7 @@ describe("ClickHouse routing via env vars", () => {
       createdTeamIds.push(teamId);
       createdOrgIds.push(organizationId);
 
-      const client = await getClickHouseClientForProject(projectId);
+      const client = await getClickHouseClientForTenant(projectId);
       expect(client).not.toBe(sharedClient);
 
       const rowId = `private-${nanoid(8)}`;
@@ -261,6 +270,64 @@ describe("ClickHouse routing via env vars", () => {
         projectId,
       });
       expect(sharedRows).toHaveLength(0);
+    });
+  });
+
+  describe("when the tenant is an organization rather than a project", () => {
+    /** @scenario An organization is a tenant in its own right */
+    it("routes by that organization, with no project of that id", async () => {
+      const { getClickHouseClientForTenant } = await import(
+        "../clickhouseClient"
+      );
+
+      // The grants ledger's aggregate is an organization, so this is the id
+      // its event-store writes arrive with — no project carries it, and the
+      // resolver used to refuse it and park the tenant.
+      const privateOrganization = await prisma.organization.create({
+        data: {
+          id: PRIVATE_ORG_ID_WITHOUT_PROJECTS,
+          name: "Test CH Routing Org grants-ledger",
+          slug: `--test-ch-routing-orgtenant-${nanoid(6)}`,
+        },
+      });
+      createdOrgIds.push(privateOrganization.id);
+
+      const client = await getClickHouseClientForTenant(privateOrganization.id);
+      expect(client).not.toBeNull();
+
+      const rowId = `org-tenant-${nanoid(8)}`;
+      await insertTestRow(client!, {
+        id: rowId,
+        projectId: privateOrganization.id,
+        data: "org-tenant-data",
+      });
+
+      const privateRows = await queryTestRow(privateClient, {
+        id: rowId,
+        projectId: privateOrganization.id,
+      });
+      expect(privateRows).toHaveLength(1);
+
+      const sharedRows = await queryTestRow(sharedClient, {
+        id: rowId,
+        projectId: privateOrganization.id,
+      });
+      expect(sharedRows).toHaveLength(0);
+    });
+  });
+
+  describe("when the tenant names neither a project nor an organization", () => {
+    /** @scenario A tenant that names neither a project nor an organization is refused */
+    it("refuses rather than falling back to the shared client", async () => {
+      const { getClickHouseClientForTenant } = await import(
+        "../clickhouseClient"
+      );
+
+      const strangerId = `not-a-tenant-${nanoid(8)}`;
+
+      await expect(getClickHouseClientForTenant(strangerId)).rejects.toThrow(
+        strangerId,
+      );
     });
   });
 

--- a/platform/app/src/server/clickhouse/__tests__/clientAccessBoundary.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/clientAccessBoundary.unit.test.ts
@@ -44,7 +44,7 @@ const DRIVER_MODULE = /from\s+["']@clickhouse\/client(?:\/[^"']+)?["']/;
 
 /** The functions that hand out a live client. */
 const RESOLVES_CLIENT =
-  /\b(getClickHouseClientForProject|getClickHouseClientForOrganization|getSharedClickHouseClient|getAllClickHouseInstances)\b/;
+  /\b(getClickHouseClientForTenant|getClickHouseClientForOrganization|getSharedClickHouseClient|getAllClickHouseInstances)\b/;
 
 /**
  * A shared exported resolver is the same escape hatch again, one import away
@@ -65,14 +65,14 @@ const RESOLVES_CLIENT =
 const CLIENT_MODULE = "src/server/clickhouse/clickhouseClient.ts";
 
 const CLIENT_MODULE_VALUE_EXPORTS = new Set([
-  "getClickHouseClientForProject",
+  "getClickHouseClientForTenant",
   "getClickHouseClientForOrganization",
   "getAllClickHouseInstances",
   "getSharedClickHouseClient",
   "isClickHouseEnabled",
   "clearCustomClientCache",
   "getCustomClientCacheSize",
-  "clearProjectOrgCache",
+  "clearTenantOrgCache",
   "getPrivateClickHouseUrls",
 ]);
 
@@ -279,7 +279,7 @@ const EVERY_EXPORT_FORM = [
   '  export * from "./more-resolvers";',
   '\texport * as clients from "./clients";',
   "  export const inferredResolver = async (tenantId: string) => tenantId;",
-  "export async function getClickHouseClientForProject(id: string) {}",
+  "export async function getClickHouseClientForTenant(id: string) {}",
   'export { _shared as getSharedClickHouseClient } from "./client";',
   "export type ClickHouseClientResolver = (id: string) => Promise<Client>;",
   "export interface Unrelated { a: string }",
@@ -295,7 +295,7 @@ describe("the ClickHouse client access boundary", () => {
         '* from "./more-resolvers"',
         '* from "./clients"',
         "inferredResolver",
-        "getClickHouseClientForProject",
+        "getClickHouseClientForTenant",
         "getSharedClickHouseClient",
       ]);
     });

--- a/platform/app/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
@@ -294,11 +294,11 @@ describe("Private ClickHouse data isolation through event-sourcing repositories"
 
   afterAll(async () => {
     // Clean up clickhouseClient caches
-    const { clearCustomClientCache, clearProjectOrgCache } = await import(
+    const { clearCustomClientCache, clearTenantOrgCache } = await import(
       "../clickhouseClient"
     );
     await clearCustomClientCache();
-    clearProjectOrgCache();
+    clearTenantOrgCache();
 
     // Clean up Prisma data
     if (createdProjectIds.length > 0) {
@@ -323,15 +323,15 @@ describe("Private ClickHouse data isolation through event-sourcing repositories"
   }, 60_000);
 
   /**
-   * Builds a ClickHouseClientResolver that uses getClickHouseClientForProject
+   * Builds a ClickHouseClientResolver that uses getClickHouseClientForTenant
    * and throws if the client is null (mirrors production wiring).
    */
   async function buildResolver(): Promise<ClickHouseClientResolver> {
-    const { getClickHouseClientForProject } = await import(
+    const { getClickHouseClientForTenant } = await import(
       "../clickhouseClient"
     );
     return async (tenantId: string) => {
-      const client = await getClickHouseClientForProject(tenantId);
+      const client = await getClickHouseClientForTenant(tenantId);
       if (!client) {
         throw new Error(
           `No ClickHouse client resolved for tenantId: ${tenantId}`,

--- a/platform/app/src/server/clickhouse/clickhouseClient.ts
+++ b/platform/app/src/server/clickhouse/clickhouseClient.ts
@@ -14,7 +14,8 @@ const logger = createLogger("langwatch:clickhouse:routing");
 
 /**
  * Resolver function that returns the appropriate ClickHouseClient for a given
- * tenant (projectId). Repositories use this instead of holding a fixed client,
+ * tenant — a project for most callers, an organization for the ones whose
+ * aggregate is one. Repositories use this instead of holding a fixed client,
  * enabling per-tenant routing to private ClickHouse instances.
  *
  * The type is exported; a resolver is not. One is built in the composition
@@ -79,32 +80,51 @@ function parsePrivateEnvVars(
 /** Cache of custom ClickHouse clients keyed by organizationId. */
 const customClientCache = new Map<string, ClickHouseClient>();
 
-/** Cache of projectId → organizationId to avoid repeated DB lookups. */
-const projectOrgCache = new Map<string, string>();
+/** Cache of tenantId → organizationId to avoid repeated DB lookups. */
+const tenantOrgCache = new Map<string, string>();
 
 /**
- * Returns the appropriate ClickHouse client for a given project.
+ * Returns the appropriate ClickHouse client for a given tenant.
  *
- * Resolves the project's organization (cached), then checks for a private
- * ClickHouse env var for that org. Falls back to the shared client.
+ * A tenant is usually a project, and was only ever a project until the grants
+ * ledger (ADR-092 §13) put an aggregate per ORGANIZATION into the same event
+ * store. Both kinds resolve here because routing is per-organization either
+ * way: a project contributes the organization that owns it, and an
+ * organization contributes itself.
+ *
+ * Resolves that organization (cached), then checks for a private ClickHouse
+ * env var for it. Falls back to the shared client.
+ *
+ * An id that names neither is still an error rather than the shared client:
+ * a tenant we cannot place is exactly the one whose data must not land on
+ * somebody else's instance.
  */
-export async function getClickHouseClientForProject(
-  projectId: string,
+export async function getClickHouseClientForTenant(
+  tenantId: string,
 ): Promise<ClickHouseClient | null> {
-  let orgId = projectOrgCache.get(projectId);
+  let orgId = tenantOrgCache.get(tenantId);
 
   if (!orgId) {
     const project = await prisma.project.findUnique({
-      where: { id: projectId },
+      where: { id: tenantId },
       select: { team: { select: { organizationId: true } } },
     });
-    if (!project) {
-      throw new Error(
-        `Cannot resolve ClickHouse client: project "${projectId}" not found. Refusing to fall back to shared client to prevent data leakage.`,
-      );
+    orgId = project?.team.organizationId;
+
+    if (!orgId) {
+      const organization = await prisma.organization.findUnique({
+        where: { id: tenantId },
+        select: { id: true },
+      });
+      if (!organization) {
+        throw new Error(
+          `Cannot resolve ClickHouse client: tenant "${tenantId}" is neither a project nor an organization. Refusing to fall back to shared client to prevent data leakage.`,
+        );
+      }
+      orgId = organization.id;
     }
-    orgId = project.team.organizationId;
-    projectOrgCache.set(projectId, orgId);
+
+    tenantOrgCache.set(tenantId, orgId);
   }
 
   return getClickHouseClientForOrganization(orgId);
@@ -240,10 +260,10 @@ export function getCustomClientCacheSize(): number {
 }
 
 /**
- * Clears the project → org cache. Useful for testing.
+ * Clears the tenant → org cache. Useful for testing.
  */
-export function clearProjectOrgCache(): void {
-  projectOrgCache.clear();
+export function clearTenantOrgCache(): void {
+  tenantOrgCache.clear();
 }
 
 /**

--- a/platform/app/src/server/experiments-v3/services/__tests__/clickhouse-experiment-run.getRun.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/services/__tests__/clickhouse-experiment-run.getRun.integration.test.ts
@@ -6,7 +6,7 @@ import {
   stopTestContainers,
 } from "../../../event-sourcing/__tests__/integration/testContainers";
 
-// getRun resolves its ClickHouse client through getClickHouseClientForProject;
+// getRun resolves its ClickHouse client through getClickHouseClientForTenant;
 // point that at the testcontainer client so the real query path runs.
 let testClient: ClickHouseClient;
 vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
@@ -16,7 +16,7 @@ vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
     >();
   return {
     ...actual,
-    getClickHouseClientForProject: async () => testClient,
+    getClickHouseClientForTenant: async () => testClient,
   };
 });
 

--- a/platform/app/src/server/experiments-v3/services/__tests__/experiment-run.service.getRun-null.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/services/__tests__/experiment-run.service.getRun-null.unit.test.ts
@@ -23,10 +23,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getClickHouseClientForProjectMock = vi.fn();
+const getClickHouseClientForTenantMock = vi.fn();
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: (...args: unknown[]) =>
-    getClickHouseClientForProjectMock(...args),
+  getClickHouseClientForTenant: (...args: unknown[]) =>
+    getClickHouseClientForTenantMock(...args),
 }));
 
 import { ExperimentRunService } from "../experiment-run.service";
@@ -37,12 +37,12 @@ function makeService() {
 
 describe("ExperimentRunService.getRun", () => {
   beforeEach(() => {
-    getClickHouseClientForProjectMock.mockReset();
+    getClickHouseClientForTenantMock.mockReset();
   });
 
   describe("when the ClickHouse client is unavailable", () => {
     it("returns null instead of throwing so the UI can poll without 500-cascade", async () => {
-      getClickHouseClientForProjectMock.mockResolvedValue(null);
+      getClickHouseClientForTenantMock.mockResolvedValue(null);
 
       const result = await makeService().getRun({
         projectId: "project_x",
@@ -56,7 +56,7 @@ describe("ExperimentRunService.getRun", () => {
 
   describe("when the run row has not been folded into ClickHouse yet", () => {
     it("returns null so the UI can poll until the projection lands", async () => {
-      getClickHouseClientForProjectMock.mockResolvedValue({
+      getClickHouseClientForTenantMock.mockResolvedValue({
         query: vi.fn().mockResolvedValue({
           json: vi.fn().mockResolvedValue([]),
         }),

--- a/platform/app/src/server/experiments-v3/services/experiment-run.service.ts
+++ b/platform/app/src/server/experiments-v3/services/experiment-run.service.ts
@@ -2,7 +2,7 @@ import { TupleParam } from "@clickhouse/client";
 import { createLogger } from "@langwatch/observability";
 import { getLangWatchTracer } from "langwatch";
 import type { PrismaClient } from "~/generated/prisma/client";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma as defaultPrisma } from "~/server/db";
 import { ExperimentService } from "~/server/experiments/experiment.service";
 import {
@@ -39,7 +39,7 @@ interface ClickHouseCountRow {
 }
 
 type ProjectClickHouseClient = NonNullable<
-  Awaited<ReturnType<typeof getClickHouseClientForProject>>
+  Awaited<ReturnType<typeof getClickHouseClientForTenant>>
 >;
 
 /**
@@ -122,7 +122,7 @@ export class ExperimentRunService {
         },
       },
       async () => {
-        const clickHouseClient = await getClickHouseClientForProject(projectId);
+        const clickHouseClient = await getClickHouseClientForTenant(projectId);
         if (!clickHouseClient) {
           throw new Error(
             `ClickHouse client unavailable for project ${projectId}`,
@@ -225,7 +225,7 @@ export class ExperimentRunService {
         },
       },
       async () => {
-        const clickHouseClient = await getClickHouseClientForProject(projectId);
+        const clickHouseClient = await getClickHouseClientForTenant(projectId);
         if (!clickHouseClient) {
           throw new Error(
             `ClickHouse client unavailable for project ${projectId}`,
@@ -300,7 +300,7 @@ export class ExperimentRunService {
         },
       },
       async () => {
-        const clickHouseClient = await getClickHouseClientForProject(projectId);
+        const clickHouseClient = await getClickHouseClientForTenant(projectId);
         if (!clickHouseClient) {
           throw new Error(
             `ClickHouse client unavailable for project ${projectId}`,
@@ -430,7 +430,7 @@ export class ExperimentRunService {
         attributes: { "tenant.id": projectId, "run.id": runId },
       },
       async () => {
-        const clickHouseClient = await getClickHouseClientForProject(projectId);
+        const clickHouseClient = await getClickHouseClientForTenant(projectId);
         if (!clickHouseClient) {
           // Deliberately `null`, not `throw` — see method JSDoc above for
           // why this method diverges from the rest of the class.

--- a/platform/app/src/server/export/__tests__/export-summary-blob-resolution.integration.test.ts
+++ b/platform/app/src/server/export/__tests__/export-summary-blob-resolution.integration.test.ts
@@ -89,7 +89,7 @@ vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
     await importOriginal<
       typeof import("~/server/clickhouse/clickhouseClient")
     >();
-  return { ...actual, getClickHouseClientForProject: vi.fn() };
+  return { ...actual, getClickHouseClientForTenant: vi.fn() };
 });
 
 vi.mock("~/server/db", () => ({
@@ -248,11 +248,11 @@ beforeAll(async () => {
   ch = containers.clickHouseClient;
 
   const chModule = await import("~/server/clickhouse/clickhouseClient");
-  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(chModule.getClickHouseClientForTenant).mockResolvedValue(ch);
 
   // ExportService reaches buildTraceBlobResolutionDeps() with no override,
   // which now takes its default resolver from getApp().clickhouse rather
-  // than isClickHouseEnabled()/getClickHouseClientForProject directly — so
+  // than isClickHouseEnabled()/getClickHouseClientForTenant directly — so
   // the production wiring this test wants to exercise needs a real App
   // singleton whose resolver dials the same (mocked) testcontainer client.
   await resetApp();
@@ -260,7 +260,7 @@ beforeAll(async () => {
     clickhouse: {
       enabled: true,
       resolveClient: async (tenantId: string) => {
-        const resolved = await chModule.getClickHouseClientForProject(tenantId);
+        const resolved = await chModule.getClickHouseClientForTenant(tenantId);
         if (!resolved) {
           throw new Error(`ClickHouse not available for tenant ${tenantId}`);
         }

--- a/platform/app/src/server/gateway/__tests__/budget.clickhouse.repository.periodStart.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budget.clickhouse.repository.periodStart.integration.test.ts
@@ -30,7 +30,7 @@ import {
   replayGooseMigrationUp,
   replayRollupRebuild,
 } from "~/server/clickhouse/__tests__/migrationReplay";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -120,7 +120,7 @@ describe("given a debit recorded against a budget in ClickHouse", () => {
     });
 
     repo = new GatewayBudgetClickHouseRepository(async (tenantId) => {
-      const client = await getClickHouseClientForProject(tenantId);
+      const client = await getClickHouseClientForTenant(tenantId);
       if (!client) throw new Error("no ClickHouse client in test environment");
       return client;
     });
@@ -214,7 +214,7 @@ describe("given a debit recorded against a budget in ClickHouse", () => {
     const tzOccurredAt = new Date();
 
     beforeAll(async () => {
-      const client = await getClickHouseClientForProject(TENANT_ID);
+      const client = await getClickHouseClientForTenant(TENANT_ID);
       const occurredAt = tzOccurredAt.getTime();
       await client!.insert({
         table: "gateway_budget_ledger_events",
@@ -291,7 +291,7 @@ describe("given a debit recorded against a budget in ClickHouse", () => {
     // them. UpdatedAt is bookkeeping the rebuild re-stamps by design, so
     // it stays out of the comparison.
     const captureUtcRows = async () => {
-      const client = await getClickHouseClientForProject(TENANT_ID);
+      const client = await getClickHouseClientForTenant(TENANT_ID);
       const result = await client!.query({
         query: `
           SELECT
@@ -318,7 +318,7 @@ describe("given a debit recorded against a budget in ClickHouse", () => {
     };
 
     beforeAll(async () => {
-      const client = await getClickHouseClientForProject(TENANT_ID);
+      const client = await getClickHouseClientForTenant(TENANT_ID);
 
       utcRowsBeforeRebuild = await captureUtcRows();
 
@@ -384,7 +384,7 @@ describe("given a debit recorded against a budget in ClickHouse", () => {
       // Re-apply the current migration unconditionally so a failure
       // anywhere in this describe can never leave later suites running
       // against the 00055 view. Idempotent by the migration's own design.
-      const client = await getClickHouseClientForProject(TENANT_ID);
+      const client = await getClickHouseClientForTenant(TENANT_ID);
       await replayRollupRebuild(client!);
     }, 120_000);
 
@@ -425,7 +425,7 @@ describe("given a debit recorded against a budget in ClickHouse", () => {
 
   describe("when comparing the periods the two sides use", () => {
     it("buckets every window into a period the read path asks for", async () => {
-      const client = await getClickHouseClientForProject(TENANT_ID);
+      const client = await getClickHouseClientForTenant(TENANT_ID);
       const result = await client!.query({
         query: `
           SELECT Window, count() AS buckets

--- a/platform/app/src/server/gateway/__tests__/budgetBucketBreakdown.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budgetBucketBreakdown.integration.test.ts
@@ -24,7 +24,7 @@ import type {
 } from "~/generated/prisma/client";
 import { Prisma } from "~/generated/prisma/client";
 import { holdClickHouseSchemaLockForFile } from "~/server/clickhouse/__tests__/holdSchemaLock";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -154,7 +154,7 @@ describe("given per-user buckets recorded against attributed-user templates", ()
     });
 
     repo = new GatewayBudgetClickHouseRepository(async (tenantId) => {
-      const client = await getClickHouseClientForProject(tenantId);
+      const client = await getClickHouseClientForTenant(tenantId);
       if (!client) throw new Error("no ClickHouse client in test environment");
       return client;
     });

--- a/platform/app/src/server/gateway/__tests__/budgetEnforcement.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budgetEnforcement.integration.test.ts
@@ -24,7 +24,7 @@ import {
   replayGooseMigrationUp,
   replayRollupRebuild,
 } from "~/server/clickhouse/__tests__/migrationReplay";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -184,7 +184,7 @@ describe("given a blocking budget on traffic the gateway is serving", () => {
     });
 
     const resolveClient = async (tenantId: string) => {
-      const client = await getClickHouseClientForProject(tenantId);
+      const client = await getClickHouseClientForTenant(tenantId);
       if (!client) throw new Error("no ClickHouse client in test environment");
       return client;
     };
@@ -384,7 +384,7 @@ describe("given a blocking budget on traffic the gateway is serving", () => {
         },
       });
 
-      const client = await getClickHouseClientForProject(PRE_PROJECT_ID);
+      const client = await getClickHouseClientForTenant(PRE_PROJECT_ID);
       if (!client) throw new Error("no ClickHouse client in test environment");
 
       // Pre-rebuild state: the 00055 view truncates periods in the server
@@ -446,7 +446,7 @@ describe("given a blocking budget on traffic the gateway is serving", () => {
       // Re-apply the current migration unconditionally so a failure
       // anywhere in this describe can never leave later suites running
       // against the 00055 view. Idempotent by the migration's own design.
-      const client = await getClickHouseClientForProject(PRE_PROJECT_ID);
+      const client = await getClickHouseClientForTenant(PRE_PROJECT_ID);
       await replayRollupRebuild(client!);
     }, 120_000);
 

--- a/platform/app/src/server/gateway/__tests__/budgetNanoExactSpend.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budgetNanoExactSpend.integration.test.ts
@@ -28,7 +28,7 @@ import {
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { holdClickHouseSchemaLockForFile } from "~/server/clickhouse/__tests__/holdSchemaLock";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -166,7 +166,7 @@ async function wireRowFor(budgetId: string) {
 
 /** The nano sum the ledger itself holds, read straight out of ClickHouse. */
 async function ledgerNanoFor(budgetId: string): Promise<number> {
-  const client = await getClickHouseClientForProject(PROJECT_ID);
+  const client = await getClickHouseClientForTenant(PROJECT_ID);
   if (!client) throw new Error("no ClickHouse client in test environment");
   const result = await client.query({
     query: `
@@ -247,7 +247,7 @@ beforeAll(async () => {
   });
 
   chRepo = new GatewayBudgetClickHouseRepository(async (tenantId) => {
-    const client = await getClickHouseClientForProject(tenantId);
+    const client = await getClickHouseClientForTenant(tenantId);
     if (!client) throw new Error("no ClickHouse client in test environment");
     return client;
   });

--- a/platform/app/src/server/gateway/__tests__/budgetSiblingSpend.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budgetSiblingSpend.integration.test.ts
@@ -26,7 +26,7 @@ import {
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { holdClickHouseSchemaLockForFile } from "~/server/clickhouse/__tests__/holdSchemaLock";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -317,7 +317,7 @@ beforeAll(async () => {
   });
 
   chRepo = new GatewayBudgetClickHouseRepository(async (tenantId) => {
-    const client = await getClickHouseClientForProject(tenantId);
+    const client = await getClickHouseClientForTenant(tenantId);
     if (!client) throw new Error("no ClickHouse client in test environment");
     return client;
   });

--- a/platform/app/src/server/gateway/__tests__/characterPricedSpend.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/characterPricedSpend.integration.test.ts
@@ -20,7 +20,7 @@ import {
 } from "@ee/governance/process-manager/gatewayDebits.process";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -145,7 +145,7 @@ beforeAll(async () => {
   });
 
   chRepo = new GatewayBudgetClickHouseRepository(async (tenantId) => {
-    const client = await getClickHouseClientForProject(tenantId);
+    const client = await getClickHouseClientForTenant(tenantId);
     if (!client) throw new Error("no ClickHouse client in test environment");
     return client;
   });

--- a/platform/app/src/server/gateway/__tests__/pulledUsageLedger.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/pulledUsageLedger.integration.test.ts
@@ -21,7 +21,7 @@ import {
 } from "@ee/governance/process-manager/pulledUsageLedger.process";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -197,7 +197,7 @@ beforeAll(async () => {
   });
 
   const resolveClient = async (tenantId: string) => {
-    const client = await getClickHouseClientForProject(tenantId);
+    const client = await getClickHouseClientForTenant(tenantId);
     if (!client) throw new Error("no ClickHouse client in test environment");
     return client;
   };
@@ -246,7 +246,7 @@ describe("given a connected provider source that pulls usage on a schedule", () 
         }),
       );
 
-      const client = await getClickHouseClientForProject(GOV_PROJECT_ID);
+      const client = await getClickHouseClientForTenant(GOV_PROJECT_ID);
       const result = await client!.query({
         query: `SELECT Scope, ScopeId, BudgetId FROM gateway_budget_ledger_events
                 WHERE TenantId = {tenantId:String}
@@ -497,7 +497,7 @@ async function rollupRows(): Promise<
     SpendNanoUSD: string;
   }>
 > {
-  const client = await getClickHouseClientForProject(APP_PROJECT_ID);
+  const client = await getClickHouseClientForTenant(APP_PROJECT_ID);
   const result = await client!.query({
     query: `SELECT Scope,
                    BudgetId,
@@ -519,7 +519,7 @@ async function rollupRows(): Promise<
 
 /** How many physical rows the ledger holds for one restatement key. */
 async function rawRowsFor(restatementKey: string): Promise<number> {
-  const client = await getClickHouseClientForProject(GOV_PROJECT_ID);
+  const client = await getClickHouseClientForTenant(GOV_PROJECT_ID);
   const result = await client!.query({
     query: `SELECT count() AS n FROM gateway_budget_ledger_events
             WHERE TenantId = {tenantId:String} AND GatewayRequestId = {requestId:String}`,

--- a/platform/app/src/server/routes/__tests__/gateway-internal.config-route.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/gateway-internal.config-route.integration.test.ts
@@ -13,7 +13,7 @@
  *
  * The route takes its budget repository from `getApp()`; standing in for
  * the store means standing in for `getApp()`, wired to the same
- * `getClickHouseClientForProject` resolver the route used to build inline
+ * `getClickHouseClientForTenant` resolver the route used to build inline
  * — this test asserts on aliases/policy rules, not spend, so it does not
  * need to control which ClickHouse client that resolves to.
  *
@@ -24,7 +24,7 @@
 import { createHash, createHmac } from "crypto";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -39,7 +39,7 @@ vi.mock("~/server/app-layer/app", () => ({
   getApp: () => ({
     gateway: {
       budgets: new GatewayBudgetClickHouseRepository(async (projectId) => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) throw new Error("ClickHouse is not configured");
         return client;
       }),

--- a/platform/app/src/server/scenarios/execution/__tests__/ingest-lag.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/ingest-lag.service.unit.test.ts
@@ -36,7 +36,7 @@ vi.mock("@langwatch/observability", () => ({
 // module; the tests always inject their own resolver, so stub the module out
 // of the import graph entirely.
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 function clientReturning(

--- a/platform/app/src/server/scenarios/repositories/ingest-lag.repository.ts
+++ b/platform/app/src/server/scenarios/repositories/ingest-lag.repository.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ClickHouseClient } from "@clickhouse/client";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 
 /** Resolves the ClickHouse client for a project. Injectable for tests. */
 export type IngestLagClientResolver = (
@@ -32,7 +32,7 @@ interface IngestLagRow {
  */
 export async function findIngestLagP95({
   projectId,
-  clientResolver = getClickHouseClientForProject,
+  clientResolver = getClickHouseClientForTenant,
 }: {
   projectId: string;
   clientResolver?: IngestLagClientResolver;

--- a/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/azure-blob-driver.integration.test.ts
@@ -55,7 +55,7 @@ vi.mock("~/env.mjs", () => ({
 }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
   getSharedClickHouseClient: vi.fn(),
 }));
 
@@ -130,7 +130,7 @@ beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
   vi.mocked(
-    clickhouseClientModule.getClickHouseClientForProject,
+    clickhouseClientModule.getClickHouseClientForTenant,
   ).mockResolvedValue(ch);
   vi.mocked(clickhouseClientModule.getSharedClickHouseClient).mockReturnValue(
     ch,

--- a/platform/app/src/server/stored-objects/__tests__/files-route.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/files-route.integration.test.ts
@@ -16,7 +16,7 @@
  *
  * Strategy:
  *  - The files route calls `createStoredObjectsService` which calls
- *    `StoredObjectsRepository` → `getClickHouseClientForProject`.
+ *    `StoredObjectsRepository` → `getClickHouseClientForTenant`.
  *  - We mock `createStoredObjectsService` so individual service methods can
  *    be stubbed per case without needing a live ClickHouse.
  *  - Real Prisma projects are created so the authMiddleware resolves API keys.

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
@@ -16,7 +16,7 @@
  * Uses:
  *  - testcontainers ClickHouse (via startTestContainers) for real SQL
  *  - LocalFilesystemDriver pointed at a per-test temp dir for real byte storage
- *  - vi.mock to wire getClickHouseClientForProject to the test container client
+ *  - vi.mock to wire getClickHouseClientForTenant to the test container client
  */
 
 import crypto from "node:crypto";
@@ -51,10 +51,10 @@ import { mintFileUri } from "../uri";
 // Hoisted mocks — must be declared before any imports that trigger module load
 // ---------------------------------------------------------------------------
 
-// Wire getClickHouseClientForProject to return the test container client.
+// Wire getClickHouseClientForTenant to return the test container client.
 // The actual client reference is replaced in beforeAll once the container starts.
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
   getSharedClickHouseClient: vi.fn(),
 }));
 
@@ -171,7 +171,7 @@ beforeAll(async () => {
   // replaced these exports with mock fns at module-load; we only need
   // to set their return values here, not re-import.
   vi.mocked(
-    clickhouseClientModule.getClickHouseClientForProject,
+    clickhouseClientModule.getClickHouseClientForTenant,
   ).mockResolvedValue(ch);
   vi.mocked(clickhouseClientModule.getSharedClickHouseClient).mockReturnValue(
     ch,

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects.repository.unit.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects.repository.unit.test.ts
@@ -23,7 +23,7 @@ const { mockInsert, mockQuery, mockQueryResult } = vi.hoisted(() => {
 });
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ insert: mockInsert, query: mockQuery }),
 }));
 

--- a/platform/app/src/server/stored-objects/__tests__/stored-objects.storage-usage.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/stored-objects.storage-usage.integration.test.ts
@@ -6,7 +6,7 @@
  * StoredObjectsService.getStorageUsageByProject sums size_bytes of a project's
  * live objects, deduped across ReplacingMergeTree versions and optionally
  * scoped to one purpose. Real ClickHouse + LocalFilesystemDriver; only
- * getClickHouseClientForProject is wired to the test client.
+ * getClickHouseClientForTenant is wired to the test client.
  */
 
 import fs from "node:fs/promises";
@@ -30,7 +30,7 @@ vi.mock("~/server/clickhouse/clickhouseClient", async () => {
   );
   return {
     ...actual,
-    getClickHouseClientForProject: vi.fn(),
+    getClickHouseClientForTenant: vi.fn(),
   };
 });
 
@@ -67,7 +67,7 @@ beforeAll(async () => {
   if (!client) throw new Error("ClickHouse test container not available");
   ch = client;
   vi.mocked(
-    clickhouseClientModule.getClickHouseClientForProject,
+    clickhouseClientModule.getClickHouseClientForTenant,
   ).mockResolvedValue(ch);
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "so-usage-int-"));
 }, 120_000);

--- a/platform/app/src/server/stored-objects/__tests__/trace-media-extraction.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/trace-media-extraction.integration.test.ts
@@ -61,7 +61,7 @@ import { mintFileUri } from "../uri";
 // ---------------------------------------------------------------------------
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
   getSharedClickHouseClient: vi.fn(),
 }));
 
@@ -279,7 +279,7 @@ beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
   vi.mocked(
-    clickhouseClientModule.getClickHouseClientForProject,
+    clickhouseClientModule.getClickHouseClientForTenant,
   ).mockResolvedValue(ch);
   vi.mocked(clickhouseClientModule.getSharedClickHouseClient).mockReturnValue(
     ch,

--- a/platform/app/src/server/stored-objects/stored-objects.repository.ts
+++ b/platform/app/src/server/stored-objects/stored-objects.repository.ts
@@ -6,7 +6,7 @@
  */
 import { SpanKind } from "@opentelemetry/api";
 import { getLangWatchTracer } from "langwatch";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import type { StoredObject } from "./stored-object";
 import { storedObjectSchema } from "./stored-object";
 
@@ -17,7 +17,7 @@ const tracer = getLangWatchTracer("langwatch.stored-objects.repository");
 /**
  * ClickHouse repository for stored_objects rows.
  *
- * Clients are resolved at call time via `getClickHouseClientForProject` so
+ * Clients are resolved at call time via `getClickHouseClientForTenant` so
  * per-tenant private ClickHouse routing is always respected.
  */
 export class StoredObjectsRepository {
@@ -46,7 +46,7 @@ export class StoredObjectsRepository {
         },
       },
       async () => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) {
           throw new Error(
             "ClickHouse is not configured — cannot insert stored object",
@@ -110,7 +110,7 @@ export class StoredObjectsRepository {
         },
       },
       async (span) => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) {
           throw new Error(
             "ClickHouse is not configured — cannot find stored object by id",
@@ -199,7 +199,7 @@ export class StoredObjectsRepository {
         },
       },
       async (span) => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) {
           throw new Error(
             "ClickHouse is not configured — cannot enumerate stored objects",
@@ -263,7 +263,7 @@ export class StoredObjectsRepository {
     afterId?: string;
     limit: number;
   }): Promise<StoredObject[]> {
-    const client = await getClickHouseClientForProject(projectId);
+    const client = await getClickHouseClientForTenant(projectId);
     if (!client) {
       throw new Error(
         "ClickHouse is not configured — cannot enumerate stored objects",
@@ -340,7 +340,7 @@ export class StoredObjectsRepository {
         },
       },
       async (span) => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) {
           throw new Error(
             "ClickHouse is not configured - cannot sum stored object sizes",
@@ -417,7 +417,7 @@ export class StoredObjectsRepository {
         },
       },
       async () => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) {
           throw new Error(
             "ClickHouse is not configured — cannot delete stored objects",
@@ -477,7 +477,7 @@ export class StoredObjectsRepository {
         },
       },
       async () => {
-        const client = await getClickHouseClientForProject(projectId);
+        const client = await getClickHouseClientForTenant(projectId);
         if (!client) {
           throw new Error(
             "ClickHouse is not configured — cannot delete stored objects",

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-cursor-mid-scroll-mutation.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-cursor-mid-scroll-mutation.integration.test.ts
@@ -28,7 +28,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -42,7 +42,7 @@ import type {
 import { openProtections } from "./open-protections";
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -205,7 +205,7 @@ async function drain({
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(getClickHouseClientForTenant).mockResolvedValue(ch);
   service = new ClickHouseTraceService({
     prisma: prisma as unknown as ConstructorParameters<
       typeof ClickHouseTraceService

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
@@ -146,9 +146,9 @@ function makeQueryInput(
 let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
-// Mock getClickHouseClientForProject to return the test container client
+// Mock getClickHouseClientForTenant to return the test container client
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 // Mock prisma
@@ -161,7 +161,7 @@ vi.mock("~/server/db", () => ({
 }));
 
 // Lazy import so the mock is in place before the module loads
-let getClickHouseClientForProject: ReturnType<typeof vi.fn>;
+let getClickHouseClientForTenant: ReturnType<typeof vi.fn>;
 
 beforeAll(async () => {
   const containers = await startTestContainers();
@@ -169,10 +169,10 @@ beforeAll(async () => {
 
   // Wire up the mock to return the test container's client
   const chModule = await import("~/server/clickhouse/clickhouseClient");
-  getClickHouseClientForProject = vi.mocked(
-    chModule.getClickHouseClientForProject,
+  getClickHouseClientForTenant = vi.mocked(
+    chModule.getClickHouseClientForTenant,
   );
-  getClickHouseClientForProject.mockResolvedValue(ch);
+  getClickHouseClientForTenant.mockResolvedValue(ch);
 
   // Import the mocked prisma and build the shared service instance
   const { prisma } = await import("~/server/db");
@@ -524,7 +524,7 @@ describe("ClickHouse trace dedup (integration)", () => {
 
         it("resolves the OccurredAt span and bounds the heavy summary read", async () => {
           const { client, queries } = recordingClient();
-          getClickHouseClientForProject.mockResolvedValue(client);
+          getClickHouseClientForTenant.mockResolvedValue(client);
           try {
             const traces = await service.getTracesWithSpans(
               tenantId,
@@ -536,7 +536,7 @@ describe("ClickHouse trace dedup (integration)", () => {
             expect(traces![0]!.trace_id).toBe(traceId);
             expect(traces![0]!.metrics?.total_time_ms).toBe(300);
           } finally {
-            getClickHouseClientForProject.mockResolvedValue(ch);
+            getClickHouseClientForTenant.mockResolvedValue(ch);
           }
 
           // A cheap resolve (min/max OccurredAt) runs, then the heavy summary
@@ -555,7 +555,7 @@ describe("ClickHouse trace dedup (integration)", () => {
 
         it("stays unbounded when the trace ids resolve to no rows", async () => {
           const { client, queries } = recordingClient();
-          getClickHouseClientForProject.mockResolvedValue(client);
+          getClickHouseClientForTenant.mockResolvedValue(client);
           try {
             const traces = await service.getTracesWithSpans(
               tenantId,
@@ -564,7 +564,7 @@ describe("ClickHouse trace dedup (integration)", () => {
             );
             expect(traces ?? []).toHaveLength(0);
           } finally {
-            getClickHouseClientForProject.mockResolvedValue(ch);
+            getClickHouseClientForTenant.mockResolvedValue(ch);
           }
 
           // Resolve found nothing (epoch default), so the heavy summary read

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-existence.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-existence.integration.test.ts
@@ -63,7 +63,7 @@ let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -79,7 +79,7 @@ beforeAll(async () => {
   ch = containers.clickHouseClient;
 
   const chModule = await import("~/server/clickhouse/clickhouseClient");
-  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(chModule.getClickHouseClientForTenant).mockResolvedValue(ch);
 
   const { prisma } = await import("~/server/db");
   service = new ClickHouseTraceService({

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
@@ -162,7 +162,7 @@ let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -178,7 +178,7 @@ beforeAll(async () => {
   ch = containers.clickHouseClient;
 
   const chModule = await import("~/server/clickhouse/clickhouseClient");
-  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(chModule.getClickHouseClientForTenant).mockResolvedValue(ch);
 
   const { prisma } = await import("~/server/db");
   service = new ClickHouseTraceService({

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-occurred-axis-pagination.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-occurred-axis-pagination.integration.test.ts
@@ -11,7 +11,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -25,7 +25,7 @@ import type {
 import { openProtections } from "./open-protections";
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -142,7 +142,7 @@ async function drainPages(): Promise<string[][]> {
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(getClickHouseClientForTenant).mockResolvedValue(ch);
   service = new ClickHouseTraceService({
     prisma: prisma as unknown as ConstructorParameters<
       typeof ClickHouseTraceService

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-prefix.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-prefix.integration.test.ts
@@ -78,7 +78,7 @@ let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -94,10 +94,10 @@ beforeAll(async () => {
   ch = containers.clickHouseClient;
 
   const chModule = await import("~/server/clickhouse/clickhouseClient");
-  const getClickHouseClientForProject = vi.mocked(
-    chModule.getClickHouseClientForProject,
+  const getClickHouseClientForTenant = vi.mocked(
+    chModule.getClickHouseClientForTenant,
   );
-  getClickHouseClientForProject.mockResolvedValue(ch);
+  getClickHouseClientForTenant.mockResolvedValue(ch);
 
   const { prisma } = await import("~/server/db");
   service = new ClickHouseTraceService({

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
@@ -141,7 +141,7 @@ let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -157,7 +157,7 @@ beforeAll(async () => {
   ch = containers.clickHouseClient;
 
   const chModule = await import("~/server/clickhouse/clickhouseClient");
-  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(chModule.getClickHouseClientForTenant).mockResolvedValue(ch);
 
   const { prisma } = await import("~/server/db");
   service = new ClickHouseTraceService({

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
@@ -20,7 +20,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -34,7 +34,7 @@ import type {
 import { openProtections } from "./open-protections";
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -161,7 +161,7 @@ function traceIdsOf(result: TracesForProjectResult): string[] {
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(getClickHouseClientForTenant).mockResolvedValue(ch);
   service = new ClickHouseTraceService({
     prisma: prisma as unknown as ConstructorParameters<
       typeof ClickHouseTraceService

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.joined-fallback-cap.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.joined-fallback-cap.unit.test.ts
@@ -19,7 +19,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockClickHouseQuery = vi.hoisted(() => vi.fn());
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ query: mockClickHouseQuery }),
 }));
 

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -40,7 +40,7 @@ const { mockClickHouseQuery } = vi.hoisted(() => ({
 }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ query: mockClickHouseQuery }),
 }));
 

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service-resolution.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service-resolution.unit.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the ClickHouseTraceService → blob-resolution seam (ADR-022).
  *
- * Mocks only the lowest-level CH driver (getClickHouseClientForProject) and
+ * Mocks only the lowest-level CH driver (getClickHouseClientForTenant) and
  * wires a real BlobStore (via getFromEventLog stub) + real TraceIOExtractionService
  * so the full resolution + recomputed-IO pipeline fires end-to-end.
  *
@@ -26,7 +26,7 @@ const { mockClickHouseQuery } = vi.hoisted(() => ({
 }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ query: mockClickHouseQuery }),
 }));
 

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -11,7 +11,7 @@ const { mockClickHouseQuery, mockPrismaFindUnique } = vi.hoisted(() => ({
 }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ query: mockClickHouseQuery }),
 }));
 

--- a/platform/app/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/free-text-span-name-search.integration.test.ts
@@ -22,7 +22,7 @@ import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -118,7 +118,7 @@ let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -180,7 +180,7 @@ async function searchViaLegacyList(query: string): Promise<string[]> {
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(getClickHouseClientForTenant).mockResolvedValue(ch);
   service = new ClickHouseTraceService({
     prisma: prisma as ConstructorParameters<
       typeof ClickHouseTraceService

--- a/platform/app/src/server/traces/__tests__/projection-search.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/projection-search.integration.test.ts
@@ -19,7 +19,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -191,7 +191,7 @@ let annotationScoreFindMany: ReturnType<typeof vi.fn>;
 const QUALITY_SCORE_ID = "annscore-quality-id";
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -240,7 +240,7 @@ beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
 
-  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(getClickHouseClientForTenant).mockResolvedValue(ch);
 
   annotationFindMany = vi.mocked(prisma.annotation.findMany);
   annotationScoreFindMany = vi.mocked(prisma.annotationScore.findMany);

--- a/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-search-spans-not-hydrated.integration.test.ts
@@ -25,7 +25,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 import {
   startTestContainers,
@@ -136,7 +136,7 @@ let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
@@ -171,7 +171,7 @@ async function readPage(options: Record<string, unknown>) {
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  vi.mocked(getClickHouseClientForTenant).mockResolvedValue(ch);
   service = new ClickHouseTraceService({
     prisma: prisma as ConstructorParameters<
       typeof ClickHouseTraceService

--- a/platform/app/src/server/traces/__tests__/trace-service-4888-full-flag.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-service-4888-full-flag.unit.test.ts
@@ -56,7 +56,7 @@ const { mockClickHouseQuery } = vi.hoisted(() => ({
 }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ query: mockClickHouseQuery }),
 }));
 

--- a/platform/app/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-service-claude-enrichment.unit.test.ts
@@ -49,7 +49,7 @@ vi.mock("~/server/evaluations/evaluation.service", () => ({
 vi.mock("~/server/db", () => ({ prisma: {} }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
   isClickHouseEnabled: () => false,
 }));
 

--- a/platform/app/src/server/traces/__tests__/trace-service-edit-overlay.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-service-edit-overlay.unit.test.ts
@@ -63,7 +63,7 @@ vi.mock("~/server/evaluations/evaluation.service", () => ({
 vi.mock("~/server/db", () => ({ prisma: {} }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: vi.fn(),
+  getClickHouseClientForTenant: vi.fn(),
   isClickHouseEnabled: () => false,
 }));
 

--- a/platform/app/src/server/traces/__tests__/trace-summary-anchored-span-window.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/trace-summary-anchored-span-window.unit.test.ts
@@ -22,7 +22,7 @@ const { mockClickHouseQuery } = vi.hoisted(() => ({
 }));
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
-  getClickHouseClientForProject: () =>
+  getClickHouseClientForTenant: () =>
     Promise.resolve({ query: mockClickHouseQuery }),
 }));
 

--- a/platform/app/src/server/traces/clickhouse-trace.service.ts
+++ b/platform/app/src/server/traces/clickhouse-trace.service.ts
@@ -17,7 +17,7 @@ import {
 } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
 import type { ExtractedIO } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForTenant } from "~/server/clickhouse/clickhouseClient";
 import { DataRetentionPolicyRepository } from "~/server/data-retention/policy/dataRetentionPolicy.repository";
 import { RetentionPolicyCache } from "~/server/data-retention/retentionPolicyCache";
 import type { RetentionPolicyResolver } from "~/server/data-retention/retentionPolicyResolver";
@@ -437,7 +437,7 @@ export class ClickHouseTraceService {
    * Resolve the ClickHouse client for a given project.
    *
    * The returned client is already wrapped with wrapWithDefaultSettings
-   * by getClickHouseClientForProject, so every query automatically receives
+   * by getClickHouseClientForTenant, so every query automatically receives
    * memory-safety limits (max_memory_usage, max_bytes_before_external_group_by).
    *
    * @throws ClickHouseClientUnavailableError when no client resolves —
@@ -445,7 +445,7 @@ export class ClickHouseTraceService {
    *   configuration error, never a signal to fall back.
    */
   private async resolveClient(projectId: string): Promise<ClickHouseClient> {
-    const client = await getClickHouseClientForProject(projectId);
+    const client = await getClickHouseClientForTenant(projectId);
     if (!client) {
       throw new ClickHouseClientUnavailableError(projectId);
     }

--- a/specs/private-dataplane/clickhouse-routing.feature
+++ b/specs/private-dataplane/clickhouse-routing.feature
@@ -79,6 +79,31 @@ Feature: Private ClickHouse Routing
     Then the returned client connects to the shared ClickHouse
 
   # ---------------------------------------------------------------------------
+  # Tenant-level routing
+  #
+  # A tenant was a project and nothing else until the grants ledger put an
+  # aggregate per organization into the same event store, at which point every
+  # one of its writes asked to be routed by an id no project carries. Routing
+  # is per-organization either way, so both kinds resolve — and an id that is
+  # neither still refuses, because a tenant nobody can place is exactly the one
+  # whose data must not land on another customer's instance.
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: An organization is a tenant in its own right
+    Given org "org123" has a private ClickHouse configured
+    When a client is resolved for the tenant "org123"
+    Then the returned client connects to the private ClickHouse
+    And no project needs to exist for that id
+
+  @integration
+  Scenario: A tenant that names neither a project nor an organization is refused
+    Given an id that matches no project and no organization
+    When a client is resolved for that tenant
+    Then resolution fails with an error naming the tenant
+    And the shared client is not returned
+
+  # ---------------------------------------------------------------------------
   # Admin / migration operations
   # ---------------------------------------------------------------------------
 

--- a/specs/private-dataplane/clickhouse-routing.feature
+++ b/specs/private-dataplane/clickhouse-routing.feature
@@ -68,14 +68,14 @@ Feature: Private ClickHouse Routing
   Scenario: Project in a private-CH org routes to the private instance
     Given org "org123" has a private ClickHouse configured
     And a project exists under org "org123"
-    When getClickHouseClientForProject(projectId) is called
+    When getClickHouseClientForTenant(projectId) is called
     Then the returned client connects to the private ClickHouse
 
   @integration
   Scenario: Project in a standard org routes to the shared instance
     Given org "org456" has no private ClickHouse configured
     And a project exists under org "org456"
-    When getClickHouseClientForProject(projectId) is called
+    When getClickHouseClientForTenant(projectId) is called
     Then the returned client connects to the shared ClickHouse
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The first production enrollment of the grants ledger parked, blaming the projection:

```
{ "kind": "error", "message": "grants projection did not land the genesis import
  for organization_sxNrUOMicGEDG_HKUHRrV within 120000ms; tenant parked for retry" }
```

The projection was innocent. **No event ever appended.** On the workers, every
`authz_grants` command was failing at the event store and re-staging with backoff:

```
EventStoreClickHouse.storeEvents — Cannot resolve ClickHouse client:
project "organization_sxNrUOMicGEDG_HKUHRrV" not found.
Refusing to fall back to shared client to prevent data leakage.
```

`authz_grants` keeps one aggregate per organization (ADR-092 §13), so its
event-store tenant is an organization id. The resolver looked every tenant up in
`Project`, found nothing, and refused — correctly, on its own terms: a tenant it
cannot place is exactly the one whose data must not land on another customer's
instance. But the tenant was placeable; the resolver just did not know the second
way to place one.

Three job groups — `attachGrants`, `proveMigrationParity`,
`recordMigrationTenantState` — sat retrying while `awaitConvergence` counted down
to 120s and parked the organization.

It stayed invisible until an organization was actually enrolled because this is
the first pipeline in production that both appends events **and** has an
organization tenant. `billing_report` passes an organization id as its tenant too,
but its handler always returns `[]`, so it never reaches the event store. The
integration tests inject a resolver that ignores the id.

## What changed

`getClickHouseClientForProject` is now `getClickHouseClientForTenant`, and resolves
both kinds of tenant: a project contributes the organization that owns it, an
organization contributes itself. Routing is per-organization either way, so there
is one lookup order and one refusal, not a second parallel resolver for the callers
that happen to hold an organization id.

The refusal is unchanged in substance for an id that names neither, which is the
only case that was ever meant to fail.

## How it works

The added lookup only runs where the old code threw: the project lookup comes
first and short-circuits, so the hot path (every trace read and write) is exactly
the query it was, and the tenant to organization cache still absorbs the second
call onwards.

Nothing else in the append path assumes a project. Retention resolves to the
platform default for an id it cannot place rather than throwing, and `event_log`
carries no TTL, so the ledger's own events are not on a clock.

`packages/clickhouse-client/src/tenancy.ts` already models this properly —
`TenantDirectory`, `createTenantRouter`, fail-closed with a bounded cache — and is
wired into nothing. Moving app routing onto it is the right end state and is not
this PR; this one is the smallest change that unparks production.

## Test plan

- [x] New scenario: an organization is a tenant in its own right — an organization
      with a private ClickHouse route and **no project of that id** resolves to its
      own instance, and the row written through it is absent from the shared one.
- [x] New scenario: an id naming neither a project nor an organization is still
      refused rather than handed the shared client.
- [x] **Control run** — with the old function body restored, the first new test
      fails and the rest pass. The regression test observes the failure, it does
      not assert on a string.
- [x] `clickhouseClient.integration.test.ts` + `privateClickhouseDataIsolation.integration.test.ts`: 11 pass.
- [x] `clientAccessBoundary.unit.test.ts`: 11 pass — its export allowlist is
      exhaustive over this module, so the rename had to be declared there.
- [x] 80 unit tests across the files that mock the module (traces, stored objects).
- [x] `biome check ./src ./ee ./scripts ./e2e ./prisma ./vite --diagnostic-level=error`: clean.
- [x] tslsp diagnostics clean on the six touched source files.

Both scenarios are tagged and bound with `@scenario` annotations in
`specs/private-dataplane/clickhouse-routing.feature`.

Second commit, from review: the file's two existing project-routing scenarios
still named `getClickHouseClientForProject`, so the specification described a
contract this branch removes — both now name the resolver that exists, with
scenario titles untouched so every binding holds. `pnpm check:feature-parity`
passes. The archive test's rationale comment claimed the resolver is still
referenced by sibling procedures in the same router; the router names it
nowhere, which is what the assertion under that comment proves.

## Anything surprising?

**The parked organization recovers on its own if this lands soon.** The three job
groups retry 25 times over about 2h27m, then `handleExhaustedRetries` blocks the
group — it is visible on /ops, and nothing is dropped. After that, unblock the
group or re-run the tenant; the genesis import is idempotent on content-hashed
command ids either way.

**Step 1 reported a clean finish it had not earned.** The team-user backfill
finalized while its `migration_parity_proved` command was failing in the same
queue. Ledger sends are fire-and-forget, so only the genesis import waits on
convergence — a migration can pass on facts that never landed. Worth its own
change; not this one.

The rename touches 64 files. Sixty of them are one identifier each, in tests that
mock the module by name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ClickHouse routing now supports tenant-level resolution, including organizations without projects.
  * Invalid tenant identifiers are rejected instead of falling back to the shared ClickHouse instance.
  * Private data routing and isolation are strengthened for organization-level tenants.

* **Bug Fixes**
  * Updated spend, trace, usage, evaluation, and stored-object operations to resolve data through the correct tenant context.

* **Tests**
  * Added and updated coverage for tenant routing, private instances, isolation, and invalid-tenant handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->