### PR TITLE
fix(dev): listen for signals before the check queue starts the command

### DIFF
--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -534,10 +534,6 @@ function runCommand(commandArgv, pressure = "green") {
     };
     const procs = goMaxProcs(pressure);
     if (procs !== null) childEnv.GOMAXPROCS = procs;
-    const child = spawn(commandArgv[0], commandArgv.slice(1), {
-      stdio: "inherit",
-      env: childEnv,
-    });
     // Handling these keeps the wrapper alive through a Ctrl-C so it releases its
     // slot after the child is done, instead of dying first and leaving an entry
     // for the next run to prune.
@@ -545,12 +541,21 @@ function runCommand(commandArgv, pressure = "green") {
     // interrupted and then killed by the OS dies of a signal nobody forwarded,
     // and that is the death worth naming; a flag would have suppressed it
     // because an earlier SIGINT set it.
+    // They go on before the spawn, not after. A signal keeps its default
+    // disposition until the first listener exists, so one arriving between the
+    // two ends the wrapper in the kernel: the interrupt reaches nobody and the
+    // command runs on with no parent. Occupancy follows the wrapper's pid, so
+    // the queue then counts that slot free and can start another check on top
+    // of a run that is still using the machine, which is the oversubscription
+    // the queue exists to prevent. No handler can see a null child, because a
+    // signal raised during this synchronous block only reaches JS a turn later.
+    let child = null;
     const forwarded = new Set();
     const handlers = ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => {
       const handler = () => {
         forwarded.add(signal);
         try {
-          child.kill(signal);
+          child?.kill(signal);
         } catch {
           // The child is already gone; its exit event is what resolves us.
         }
@@ -561,6 +566,10 @@ function runCommand(commandArgv, pressure = "green") {
     const detach = () => {
       for (const { signal, handler } of handlers) process.off(signal, handler);
     };
+    child = spawn(commandArgv[0], commandArgv.slice(1), {
+      stdio: "inherit",
+      env: childEnv,
+    });
     child.on("error", (err) => {
       detach();
       stderr(`${PREFIX} could not run ${commandArgv[0]}: ${err.message}\n`);

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -88,6 +88,8 @@ type RunOptions = {
   argv?: string[];
   /** Give the run its own process group, so a test can signal the group. */
   isDetached?: boolean;
+  /** The queue to run, for the tests that need one stalled at a known point. */
+  script?: string;
 };
 
 type Run = {
@@ -101,6 +103,7 @@ function startRun({
   env: envOverrides,
   argv: argvOverride,
   isDetached = false,
+  script = QUEUE_SCRIPT,
 }: RunOptions): Run {
   const argv = argvOverride ?? [
     "node",
@@ -133,7 +136,7 @@ function startRun({
     if (value !== undefined) env[key] = value;
   }
 
-  const child = spawn(process.execPath, [QUEUE_SCRIPT, ...argv], {
+  const child = spawn(process.execPath, [script, ...argv], {
     env,
     stdio: ["ignore", "pipe", "pipe"],
     detached: isDetached,
@@ -705,16 +708,16 @@ describe("check queue", () => {
       expect(result.stderr).not.toContain("killed from outside");
     });
 
-    /** @scenario "An interrupted run killed from outside is still reported" */
-    it("still names the kill when an interrupt came first", async () => {
-      const pidFile = path.join(scratch, "escalated.pid");
-      // The command ignores the forwarded SIGTERM (the disposition survives the
-      // exec), so the signal that finally ends it is one nobody forwarded.
-      const run = startRun({
-        tag: "escalated",
-        argv: ["sh", "-c", `trap '' TERM; echo $$ > ${pidFile}; exec sleep 5`],
-      });
+    /**
+     * The command that ignores a forwarded SIGTERM, so the signal that finally
+     * ends it is one nobody forwarded. It publishes its own pid, because the
+     * test has to reach past the wrapper to kill it.
+     */
+    function ignoresTermArgv(pidFile: string): string[] {
+      return ["sh", "-c", `trap '' TERM; echo $$ > ${pidFile}; exec sleep 5`];
+    }
 
+    async function waitForPid(pidFile: string): Promise<string> {
       let pid = "";
       for (let attempt = 0; attempt < 200 && pid === ""; attempt++) {
         try {
@@ -727,13 +730,75 @@ describe("check queue", () => {
         // on both is what keeps the attempts from burning off in microseconds.
         if (pid === "") await sleep(25);
       }
-      expect(pid).not.toBe("");
+      if (pid === "") throw new Error("the command never published its pid");
+      return pid;
+    }
+
+    /** @scenario "An interrupted run killed from outside is still reported" */
+    it("still names the kill when an interrupt came first", async () => {
+      const pidFile = path.join(scratch, "escalated.pid");
+      const run = startRun({
+        tag: "escalated",
+        argv: ignoresTermArgv(pidFile),
+      });
+      const pid = await waitForPid(pidFile);
 
       run.child.kill("SIGTERM");
       await sleep(100);
       process.kill(Number(pid), "SIGKILL");
       const result = await run.done;
 
+      expect(result.code).toBe(137);
+      expect(result.stderr).toContain("killed from outside by SIGKILL");
+    });
+
+    /**
+     * A copy of the queue that stops for `stallMs` at one exact point: the
+     * moment the child exists.
+     *
+     * The interrupt this pins is a scheduling race, so no arrangement of real
+     * timing reproduces it on demand. A delay is the one edit that cannot
+     * change what a program does, only when it does it, so injecting one is
+     * what turns the race into a decision the test can make.
+     */
+    function queueStalledAsCommandAppears(stallMs: number): string {
+      const source = readFileSync(QUEUE_SCRIPT, "utf8");
+      const call = source.indexOf("spawn(commandArgv[0]");
+      const end = source.indexOf("});", call);
+      if (call === -1 || end === -1) {
+        throw new Error(
+          "the queue no longer spawns the command the way this test stalls it",
+        );
+      }
+      const at = end + "});".length;
+      const copy = path.join(scratch, "check-queue-stalled.mjs");
+      writeFileSync(
+        copy,
+        `${source.slice(0, at)}\n{ const until = Date.now() + ${stallMs}; while (Date.now() < until) {} }\n${source.slice(at)}`,
+        "utf8",
+      );
+      return copy;
+    }
+
+    /** @scenario "An interrupt that arrives as the command starts is forwarded" */
+    it("forwards an interrupt that lands in the instant the command appears", async () => {
+      const pidFile = path.join(scratch, "stalled.pid");
+      const run = startRun({
+        tag: "stalled",
+        script: queueStalledAsCommandAppears(400),
+        argv: ignoresTermArgv(pidFile),
+      });
+      // Published from inside the stall, so the interrupt below is delivered
+      // while the wrapper is still held there.
+      const pid = await waitForPid(pidFile);
+
+      run.child.kill("SIGTERM");
+      await sleep(100);
+      process.kill(Number(pid), "SIGKILL");
+      const result = await run.done;
+
+      // A wrapper that took the interrupt on its default disposition would be
+      // dead by now, reporting no code and leaving the command behind.
       expect(result.code).toBe(137);
       expect(result.stderr).toContain("killed from outside by SIGKILL");
     });

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -239,6 +239,20 @@ Feature: Machine-wide slots for whole-repo checks
     Then the wrapper counts the signal as one it forwarded
     And it reports no kill from outside
 
+  # A signal keeps its default disposition until the wrapper is listening for
+  # it, so the order of starting the command and listening decides what a
+  # Ctrl-C at that instant does. In the wrong order the machine kills the
+  # wrapper outright: the interrupt reaches nobody and the command keeps
+  # running with no parent. A slot is counted for as long as its wrapper
+  # lives, so the queue then makes that slot free and can start another check
+  # on top of a run that is still using the machine.
+
+  @unit
+  Scenario: An interrupt that arrives as the command starts is forwarded
+    Given a contributor interrupts a check in the instant its command starts
+    Then the interrupt reaches the command
+    And the wrapper stays alive to report how the command ended
+
   # --- The bin shims: the package scripts are not the only way in ---
 
   # Wrapping the scripts left every other route to the binary uncounted, and

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -251,7 +251,7 @@ Feature: Machine-wide slots for whole-repo checks
   Scenario: An interrupt that arrives as the command starts is forwarded
     Given a contributor interrupts a check in the instant its command starts
     Then the interrupt reaches the command
-    And the wrapper stays alive to report how the command ended
+    And the check still reports how the command ended
 
   # --- The bin shims: the package scripts are not the only way in ---
 

--- a/tools/thuishaven/cmd/slot.go
+++ b/tools/thuishaven/cmd/slot.go
@@ -233,11 +233,13 @@ func slotExec(ctx context.Context, argv []string, pressure domain.Pressure) int 
 	if procs := domain.CheckGoMaxProcs(runtime.NumCPU(), os.Getenv("GOMAXPROCS"), pressure); procs != "" {
 		cmd.Env = append(cmd.Env, "GOMAXPROCS="+procs)
 	}
+	relay := notifySignalRelay()
 	if err := cmd.Start(); err != nil {
+		relay.stopNotify()
 		fmt.Fprintf(os.Stderr, "checks: could not run %s: %v\n", argv[0], err)
 		return 127
 	}
-	relay := startSignalRelay(cmd.Process)
+	relay.forwardTo(cmd.Process)
 	err := cmd.Wait()
 	death := slotDeath{forwarded: relay.close(), canceled: ctx.Err() != nil}
 	reportOutsideKill(err, argv[0], death)
@@ -267,12 +269,30 @@ type signalRelay struct {
 	done      chan struct{}
 }
 
-func startSignalRelay(proc *os.Process) *signalRelay {
+// notifySignalRelay starts listening before there is a child to forward to.
+// Until signal.Notify runs, a terminating signal keeps its default disposition
+// and ends the wrapper where it stands: the interrupt reaches nobody and the
+// command runs on with no parent. The OS drops the slot's flock with the
+// wrapper, so the queue counts that slot free and can start another check on
+// top of a run that is still using the machine, which is the oversubscription
+// the queue exists to prevent. The channel is buffered, so a signal that
+// arrives before the child exists waits in it for forwardTo.
+func notifySignalRelay() *signalRelay {
 	signals := make(chan os.Signal, 4)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-	relay := newSignalRelay(signals)
-	go relay.pump(proc)
-	return relay
+	return newSignalRelay(signals)
+}
+
+// forwardTo starts passing signals to the child, including any that arrived
+// while it was starting.
+func (r *signalRelay) forwardTo(proc *os.Process) {
+	go r.pump(proc)
+}
+
+// stopNotify gives up the listening for a run that never started, where there
+// is no pump for close to wait on.
+func (r *signalRelay) stopNotify() {
+	signal.Stop(r.signals)
 }
 
 // newSignalRelay builds the relay over a channel the caller owns, so a test

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -338,5 +339,33 @@ func TestSignalRelayRecordsAQueuedSignal(t *testing.T) {
 
 	if forwarded := relay.close(); !forwarded[syscall.SIGINT] {
 		t.Fatal("a signal queued when the child died must still count as forwarded, or the wrapper reports the operator's own interrupt as a kill from outside")
+	}
+}
+
+// @scenario "An interrupt that arrives as the command starts is forwarded"
+func TestSignalRelayForwardsASignalThatArrivedBeforeTheChild(t *testing.T) {
+	child := exec.Command("sleep", "10")
+	if err := child.Start(); err != nil {
+		t.Fatalf("starting the stand-in child: %v", err)
+	}
+
+	// The wrapper listens before it starts the command, so an interrupt in
+	// between is already waiting when forwarding begins. Dropping it there
+	// would leave the operator's Ctrl-C unanswered and the command running.
+	signals := make(chan os.Signal, 4)
+	relay := newSignalRelay(signals)
+	signals <- syscall.SIGTERM
+	relay.forwardTo(child.Process)
+
+	err := child.Wait()
+	relay.close()
+
+	exit := &exec.ExitError{}
+	if !errors.As(err, &exit) {
+		t.Fatalf("the child must end by the forwarded signal, got %v", err)
+	}
+	status, ok := exit.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGTERM {
+		t.Fatalf("the child must be ended by SIGTERM, got %v", exit)
 	}
 }


### PR DESCRIPTION
The check queue started the command first and began listening for signals second. A signal keeps its default disposition until the first listener exists, so an interrupt that lands between the two ends the wrapper in the kernel.

Found from a CI failure on an unrelated PR's merge run: `check-queue.unit.test.ts > still names the kill when an interrupt came first` failed with `expected null to be 137`. A null exit code is what a process killed by a signal reports, so the wrapper was dying instead of forwarding. It reproduces on a loaded runner because the wrapper only has to lose the CPU for a moment in that window while the command it just started races ahead.

## What the window costs

It is not only a flaky test. In that instant a Ctrl-C reaches nobody, and the command runs on with no parent.

The slot does not stay held. Both queues count a slot for as long as its wrapper lives: the JavaScript queue counts entries whose pid is alive, and haven's semaphore is an flock the OS drops when the holder dies. So the slot frees immediately, while the orphaned command is still using the cores and the memory it was given. The queue can then start another check on top of it, which is the oversubscription the queue exists to prevent.

## The change

Both implementations listen before they start the command:

- `dev/scripts/check-queue.mjs`: the handlers go on before `spawn`. A signal raised during that synchronous block reaches JavaScript a turn later, so no handler can see a command that does not exist yet.
- `tools/thuishaven/cmd/slot.go`: `signal.Notify` moves before `cmd.Start`, split into `notifySignalRelay` (listen) and `forwardTo` (pump to the child). The channel is buffered, so a signal that arrives while the command starts waits there and is still delivered. A start that fails gives up the listening through `stopNotify`, since there is no pump for `close` to wait on.

The Go path is the one that runs on a machine with haven installed, so it mattered more there.

## Verification

The new test `forwards an interrupt that lands in the instant the command appears` runs the real queue with a 400ms stall injected at one exact point, the moment the child exists. A delay is the one edit that cannot change what a program does, only when it does it, which is what turns the race into something a test can decide rather than hope for.

- Against the old ordering it fails with `expected null to be 137`, the exact CI symptom.
- Against the new ordering it passes.
- Full suite 31/31, `make go-lint-changed` 0 issues, `check:feature-parity` 46/46 bound on `check-slots.feature`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of interrupts and termination signals during command startup.
  - Ensured signals received before a command starts are forwarded correctly.
  - Improved reporting when commands terminate due to external signals.

- **Tests**
  - Added coverage for signal forwarding during startup and termination scenarios.
  - Added validation for wrapper behavior when commands ignore termination requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->