### PR TITLE
fix(navigation): open LLM Ops from Me, and line up the sidebar rules

### DIFF
--- a/platform/app/src/components/__tests__/DashboardLayout.legacyChrome.integration.test.tsx
+++ b/platform/app/src/components/__tests__/DashboardLayout.legacyChrome.integration.test.tsx
@@ -43,8 +43,10 @@ vi.mock("~/hooks/useRequiredSession", () => ({
   }),
 }));
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  userBelongsToTeam: () => true,
+// Only the hook is stubbed. The access helpers beside it are pure, and the
+// organization admin the fixture signs in as passes them on their role.
+vi.mock("~/hooks/useOrganizationTeamProject", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   useOrganizationTeamProject: () => ({
     isLoading: false,
     organization: { id: "org_1", name: "ACME", members: [] },

--- a/platform/app/src/features/command-bar/CommandPalette.tsx
+++ b/platform/app/src/features/command-bar/CommandPalette.tsx
@@ -568,6 +568,10 @@ export function CommandPalette({
       easterEggItem={easterEggItem}
       askLangyItem={askLangyItem}
       isLoading={searchLoading}
+      // The dialog holds the field and the list in one card, so the list
+      // draws the line between them. The inline panel is its own box under
+      // the field, and already has an edge there.
+      showTopDivider={!inline}
     />
   );
 

--- a/platform/app/src/features/command-bar/__tests__/CommandPaletteInlinePanel.integration.test.tsx
+++ b/platform/app/src/features/command-bar/__tests__/CommandPaletteInlinePanel.integration.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The edges of the results list on each surface. The raised bar keeps the
+ * field and the list in one card, where a line marks the boundary between
+ * them. The home mounts the same palette with the list as its own panel, and
+ * there the line drew a second edge a few pixels inside the panel's own.
+ *
+ * Spec: specs/home/langy-home.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/features/langy/hooks/useCanAskLangy", () => ({
+  useCanAskLangy: () => false,
+}));
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn() }),
+}));
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project_1", slug: "demo" },
+    organizations: [],
+  }),
+}));
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: { IS_SAAS: false, NODE_ENV: "test" } }),
+}));
+vi.mock("~/hooks/useOpsPermission", () => ({
+  useOpsPermission: () => ({ hasAccess: false }),
+}));
+vi.mock("~/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+vi.mock("~/utils/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "user_1" } } }),
+}));
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    pathname: "/[project]",
+    query: {},
+    asPath: "/demo",
+    push: vi.fn(),
+  }),
+}));
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ setTheme: vi.fn() }),
+}));
+vi.mock("../useCommandSearch", () => ({
+  useCommandSearch: () => ({
+    idResult: null,
+    searchResults: [],
+    isLoading: false,
+  }),
+}));
+vi.mock("../effects/useEasterEggEffects", () => ({
+  useEasterEggEffects: () => ({ triggerEffect: vi.fn() }),
+}));
+
+import { CommandPalette, type CommandPaletteSurface } from "../CommandPalette";
+
+function renderPalette(surface: CommandPaletteSurface) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <CommandPalette
+        surface={surface}
+        active={true}
+        query="analytics"
+        setQuery={vi.fn()}
+        onDone={vi.fn()}
+      />
+    </ChakraProvider>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("the command palette results", () => {
+  describe("when the home mounts the palette inline", () => {
+    /** @scenario The results panel draws one edge, not two */
+    it("draws no line above the first group", () => {
+      renderPalette("inline");
+
+      expect(screen.getByTestId("command-bar-results")).not.toHaveStyle({
+        borderTopWidth: "1px",
+      });
+    });
+  });
+
+  describe("when the raised bar mounts the palette", () => {
+    /** @scenario The results panel draws one edge, not two */
+    it("keeps the line that separates the list from the field above it", () => {
+      renderPalette("dialog");
+
+      expect(screen.getByTestId("command-bar-results")).toHaveStyle({
+        borderTopWidth: "1px",
+      });
+    });
+  });
+});

--- a/platform/app/src/features/command-bar/components/CommandBarResults.tsx
+++ b/platform/app/src/features/command-bar/components/CommandBarResults.tsx
@@ -27,6 +27,12 @@ interface CommandBarResultsProps {
   easterEggItem: ListItem | null;
   askLangyItem: ListItem | null;
   isLoading: boolean;
+  /**
+   * Whether a line marks the boundary with the field above the list. True
+   * where the field and the list share one card, false where the list is its
+   * own panel and already carries an edge of its own.
+   */
+  showTopDivider: boolean;
 }
 
 interface GroupConfig {
@@ -62,6 +68,7 @@ export const CommandBarResults = forwardRef<
     easterEggItem,
     askLangyItem,
     isLoading,
+    showTopDivider,
   },
   ref,
 ) {
@@ -244,11 +251,13 @@ export const CommandBarResults = forwardRef<
   return (
     <Box
       ref={ref}
+      data-testid="command-bar-results"
       maxHeight={COMMAND_BAR_MAX_HEIGHT}
       overflowY="auto"
       paddingBottom={2.5}
-      borderTop="1px solid"
-      borderColor="border.subtle"
+      {...(showTopDivider
+        ? { borderTop: "1px solid", borderColor: "border.subtle" }
+        : {})}
     >
       <VStack align="stretch" gap={0}>
         {renderGroups()}

--- a/platform/app/src/features/navigation/__tests__/IconRailShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/IconRailShell.integration.test.tsx
@@ -96,8 +96,10 @@ vi.mock("~/hooks/useRequiredSession", () => ({
   }),
 }));
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  userBelongsToTeam: () => true,
+// Only the hook is stubbed. The access helpers beside it are pure, and the
+// fixture holds the membership rows they read, so the real ones answer.
+vi.mock("~/hooks/useOrganizationTeamProject", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   useOrganizationTeamProject: () => ({
     isLoading: false,
     organization: mockOrganizations[0],

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -448,6 +448,56 @@ describe("the product sidebar", () => {
       );
       expect(block).toHaveStyle({ borderTopWidth: "1px" });
     });
+
+    /** @scenario "The rule keeps the same distance from both edges of the column" */
+    it("draws the rule from a box that fills the column", () => {
+      renderSidebar("governance");
+
+      // A box already at the full width of its parent cannot be widened by a
+      // negative margin: only its left edge moves, which is what put the rule
+      // 8px from the left of the column and 16px from the right. The inset
+      // belongs to the wrapper, where both edges get it. An unset logical
+      // margin reads as "" here, where a set one reads as its length.
+      expect(
+        getComputedStyle(screen.getByTestId("sidebar-bottom-block"))
+          .marginInline,
+      ).toBe("");
+    });
+
+    /** @scenario "The rule keeps the same distance from both edges of the column" */
+    it("lines the block's entries up with the entries above them", () => {
+      renderSidebar("governance");
+
+      const block = screen.getByTestId("sidebar-bottom-block");
+      const inset = (element: HTMLElement) =>
+        getComputedStyle(element).paddingInline;
+
+      // Two steps of the spacing scale to the rule and one more to the
+      // entries under it, which is the one step the entries above them take.
+      expect(inset(block.parentElement!)).toBe("var(--chakra-spacing-2)");
+      expect(inset(block)).toBe("var(--chakra-spacing-1)");
+      expect(inset(screen.getByTestId("sidebar-scroll-region"))).toBe(
+        "var(--chakra-spacing-3)",
+      );
+    });
+
+    /** @scenario "The entries are cut at the rule as they scroll under it" */
+    it("ends the scrolling part at the rule and keeps the gap inside it", () => {
+      renderSidebar("governance");
+
+      const block = screen.getByTestId("sidebar-bottom-block");
+      const region = screen.getByTestId("sidebar-scroll-region");
+      // A margin between the two is a strip the entries disappear in before
+      // they reach the line. As padding inside the scrolling part, the same
+      // space holds the last entry off the rule at rest and the entries
+      // travel through it as the menu moves.
+      // An unset margin reads as "0" here; a spacing step would read as the
+      // variable the scale is written with, as the region's padding does.
+      expect(getComputedStyle(block).marginTop).toBe("0");
+      expect(getComputedStyle(region).paddingBottom).toBe(
+        "var(--chakra-spacing-2)",
+      );
+    });
   });
 
   describe("when the sidebar column renders", () => {

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -36,12 +36,31 @@ const teamA = {
     },
   ],
 };
+/** The reader's own workspace, which is what the Me pages resolve. */
+const personalTeam = {
+  id: "team_personal",
+  name: "Ada's Workspace",
+  slug: "personal-ada",
+  isPersonal: true,
+  ownerUserId: "user_1",
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  projects: [
+    {
+      id: "project_personal",
+      slug: "personal-ada-abc123",
+      name: "Personal Workspace",
+      isPersonal: true,
+    },
+  ],
+};
 const orgA = {
   id: "org_1",
   name: "ACME",
   members: [{ userId: "user_1", role: "ADMIN" }],
-  teams: [teamA],
+  teams: [teamA, personalTeam],
 };
+/** The team the page being rendered resolves to. */
+let mockAmbientTeam: typeof teamA | typeof personalTeam = teamA;
 const orgB = {
   id: "org_2",
   name: "Beta Corp",
@@ -90,14 +109,16 @@ vi.mock("~/hooks/useRequiredSession", () => ({
   }),
 }));
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  userBelongsToTeam: () => true,
+// Only the hook is stubbed. The access helpers beside it are pure, and the
+// fixture holds the membership rows they read, so the real ones answer.
+vi.mock("~/hooks/useOrganizationTeamProject", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   useOrganizationTeamProject: () => ({
     isLoading: false,
     organization: mockOrganizations[0],
     organizations: mockOrganizations,
-    team: teamA,
-    project: teamA.projects[0],
+    team: mockAmbientTeam,
+    project: mockAmbientTeam.projects[0],
     organizationRole: "ADMIN",
     hasPermission: () => true,
   }),
@@ -270,6 +291,11 @@ function renderShell(props: Partial<DashboardLayoutProps> = {}) {
   );
 }
 
+/** The switcher row for a product, which is what carries its state. */
+function productMenuItem(label: string) {
+  return screen.getByText(label).closest("[role='menuitem']");
+}
+
 async function openProductSwitcher() {
   const user = userEvent.setup();
   await user.click(screen.getByRole("button", { name: "Switch product" }));
@@ -285,6 +311,7 @@ beforeEach(() => {
   mockPathname = "/[project]";
   mockGovernanceFlagEnabled = true;
   mockOrganizations = [orgA];
+  mockAmbientTeam = teamA;
   pushMock.mockClear();
   trackEventMock.mockReset();
   commandBarOpenMock.mockReset();
@@ -429,9 +456,15 @@ describe("the product-switcher top bar", () => {
   });
 
   describe("when on a Me page", () => {
+    beforeEach(() => {
+      mockPathname = "/me";
+      // The Me pages resolve the personal workspace, so the project the
+      // chrome carries there is a private one LLM Ops can never open.
+      mockAmbientTeam = personalTeam;
+    });
+
     /** @scenario The Me scope shows my name with a Personal badge */
     it("shows the user name with a Personal badge", () => {
-      mockPathname = "/me";
       renderShell({ personalScope: true });
 
       expect(screen.getByText("Ada")).toBeInTheDocument();
@@ -439,6 +472,47 @@ describe("the product-switcher top bar", () => {
       expect(
         screen.queryByRole("button", { name: "Switch project" }),
       ).not.toBeInTheDocument();
+    });
+
+    /** @scenario LLM Ops opens from the personal workspace */
+    it("offers LLM Ops and opens the project last worked in", async () => {
+      localStorage.setItem(
+        "selectedProjectSlug",
+        JSON.stringify("support-bot"),
+      );
+      renderShell({ personalScope: true });
+      const user = await openProductSwitcher();
+
+      expect(productMenuItem("LLM Ops")).not.toHaveAttribute("data-disabled");
+
+      await user.click(screen.getByText("LLM Ops"));
+
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/support-bot");
+      });
+    });
+
+    /** @scenario LLM Ops opens a project I can reach when I have opened none yet */
+    it("opens a project of a team it can open when nothing is remembered", async () => {
+      renderShell({ personalScope: true });
+      const user = await openProductSwitcher();
+
+      await user.click(screen.getByText("LLM Ops"));
+
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/demo");
+      });
+    });
+
+    /** @scenario LLM Ops stays closed when the organization holds no project for me */
+    it("greys LLM Ops out when no team it can open holds a project", async () => {
+      mockOrganizations = [
+        { ...orgA, teams: [{ ...teamA, projects: [] }, personalTeam] },
+      ];
+      renderShell({ personalScope: true });
+      await openProductSwitcher();
+
+      expect(productMenuItem("LLM Ops")).toHaveAttribute("data-disabled");
     });
   });
 

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -405,6 +405,9 @@ describe("the settings shell in a new navigation mode", () => {
         .getAllByRole("link")
         .map((link) => link.textContent?.trim());
 
+      // It moved out of ACCESS rather than gaining a second home there, which
+      // an index lookup on its own would read as the move having worked.
+      expect(entries.filter((entry) => entry === "API Keys")).toHaveLength(1);
       expect(entries.indexOf("API Keys")).toBe(entries.indexOf("General") + 1);
       // Members opens ACCESS, so an entry before it is in ORGANIZATION.
       expect(entries.indexOf("API Keys")).toBeLessThan(

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -73,8 +73,10 @@ vi.mock("~/hooks/useRequiredSession", () => ({
   }),
 }));
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  userBelongsToTeam: () => true,
+// Only the hook is stubbed. The access helpers beside it are pure, and the
+// fixture holds the membership rows they read, so the real ones answer.
+vi.mock("~/hooks/useOrganizationTeamProject", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   useOrganizationTeamProject: () => ({
     isLoading: false,
     organization,
@@ -375,6 +377,38 @@ describe("the settings shell in a new navigation mode", () => {
       // The pages themselves are what scrolls, so they stay inside it.
       expect(scrollRegion).toContainElement(
         screen.getByRole("link", { name: "Members" }),
+      );
+    });
+
+    /** @scenario "The pages are cut at the rule as they scroll under the way back" */
+    it("starts the scrolling part at the rule and keeps the gap inside it", () => {
+      renderSettings();
+
+      const backEntry = screen.getByRole("link", { name: /^Back/ });
+      // A margin under the rule is a strip the pages disappear in before they
+      // reach the line. As padding inside the scrolling part, the same space
+      // holds the first page off the rule and the pages travel through it.
+      // An unset margin reads as "0" here, where a spacing step would read as
+      // the variable the scale is written with.
+      expect(getComputedStyle(backEntry.parentElement!).marginBottom).toBe("0");
+      expect(
+        getComputedStyle(screen.getByTestId("sidebar-scroll-region"))
+          .paddingTop,
+      ).toBe("var(--chakra-spacing-1\\.5)");
+    });
+
+    /** @scenario "API Keys sits under General" */
+    it("puts API Keys under General, above the ACCESS group", () => {
+      renderSettings();
+
+      const entries = within(screen.getByTestId("sidebar-scroll-region"))
+        .getAllByRole("link")
+        .map((link) => link.textContent?.trim());
+
+      expect(entries.indexOf("API Keys")).toBe(entries.indexOf("General") + 1);
+      // Members opens ACCESS, so an entry before it is in ORGANIZATION.
+      expect(entries.indexOf("API Keys")).toBeLessThan(
+        entries.indexOf("Members"),
       );
     });
 

--- a/platform/app/src/features/navigation/__tests__/resolveLlmOpsProjectSlug.unit.test.ts
+++ b/platform/app/src/features/navigation/__tests__/resolveLlmOpsProjectSlug.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Which project LLM Ops opens when the ambient one cannot be it: the Me
+ * pages resolve the personal workspace, and a reader who has just switched
+ * organization has nothing remembered at all.
+ *
+ * Spec: specs/navigation/product-switcher-navigation.feature
+ */
+import { describe, expect, it } from "vitest";
+import { OrganizationUserRole } from "~/generated/prisma/client";
+import { resolveLlmOpsProjectSlug } from "../useLlmOpsProjectSlug";
+
+const USER_ID = "user-mia";
+
+const OWN_TEAM = {
+  isPersonal: false,
+  members: [{ userId: USER_ID }],
+  projects: [{ slug: "acme-app" }, { slug: "acme-labs" }],
+};
+
+const OTHER_TEAM = {
+  isPersonal: false,
+  members: [{ userId: "user-someone-else" }],
+  projects: [{ slug: "platform-app" }],
+};
+
+const PERSONAL_TEAM = {
+  isPersonal: true,
+  members: [{ userId: USER_ID }],
+  projects: [{ slug: "personal-mia-abc123" }],
+};
+
+function resolve({
+  ambientProject,
+  rememberedProjectSlug = "",
+  teams = [OTHER_TEAM, OWN_TEAM, PERSONAL_TEAM],
+  organizationRole = OrganizationUserRole.MEMBER,
+}: {
+  ambientProject?: { slug: string; isPersonal?: boolean };
+  rememberedProjectSlug?: string;
+  teams?: {
+    isPersonal: boolean;
+    members: { userId: string }[];
+    projects: { slug: string }[];
+  }[];
+  organizationRole?: OrganizationUserRole;
+}) {
+  return resolveLlmOpsProjectSlug({
+    ambientProject,
+    rememberedProjectSlug,
+    teams,
+    userId: USER_ID,
+    organizationRole,
+  });
+}
+
+describe("resolveLlmOpsProjectSlug", () => {
+  describe("given the reader is on an LLM Ops page", () => {
+    it("opens the project that page is about", () => {
+      expect(resolve({ ambientProject: { slug: "acme-labs" } })).toBe(
+        "acme-labs",
+      );
+    });
+  });
+
+  describe("given the ambient project is the personal workspace", () => {
+    it("opens the project the reader last had open", () => {
+      expect(
+        resolve({
+          ambientProject: { slug: "personal-mia-abc123", isPersonal: true },
+          rememberedProjectSlug: "acme-labs",
+        }),
+      ).toBe("acme-labs");
+    });
+
+    it("opens a project of a team the reader is on when nothing is remembered", () => {
+      expect(
+        resolve({
+          ambientProject: { slug: "personal-mia-abc123", isPersonal: true },
+        }),
+      ).toBe("acme-app");
+    });
+  });
+
+  describe("given the remembered project is one the reader cannot open", () => {
+    it("ignores it and opens a team they are on", () => {
+      expect(resolve({ rememberedProjectSlug: "platform-app" })).toBe(
+        "acme-app",
+      );
+    });
+
+    it("keeps it for an organization admin, who can open every team", () => {
+      expect(
+        resolve({
+          rememberedProjectSlug: "platform-app",
+          organizationRole: OrganizationUserRole.ADMIN,
+        }),
+      ).toBe("platform-app");
+    });
+  });
+
+  describe("given the remembered project is the personal one", () => {
+    it("opens a project of the organization instead", () => {
+      expect(resolve({ rememberedProjectSlug: "personal-mia-abc123" })).toBe(
+        "acme-app",
+      );
+    });
+  });
+
+  describe("given no team the reader can open holds a project", () => {
+    it("reports no home, so the product can be greyed out", () => {
+      expect(
+        resolve({ teams: [OTHER_TEAM, { ...OWN_TEAM, projects: [] }] }),
+      ).toBeNull();
+    });
+
+    it("reports no home when the organization has no team at all", () => {
+      expect(resolve({ teams: [] })).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/features/navigation/shell/IconRail.tsx
+++ b/platform/app/src/features/navigation/shell/IconRail.tsx
@@ -3,10 +3,10 @@ import type { LucideIcon } from "lucide-react";
 import { Settings as SettingsIcon } from "lucide-react";
 import { LogoIcon } from "~/components/icons/LogoIcon";
 import { Link } from "~/components/ui/link";
-import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRouter } from "~/utils/compat/next-router";
 import { trackEvent } from "~/utils/tracking";
 import { PRODUCTS, type ProductDefinition, type ProductId } from "../products";
+import { useLlmOpsProjectSlug } from "../useLlmOpsProjectSlug";
 import { useReachableProducts } from "../useReachableProducts";
 
 export const ICON_RAIL_WIDTH = "64px";
@@ -93,11 +93,7 @@ export function IconRail({
 }) {
   const router = useRouter();
   const { reachableProducts } = useReachableProducts();
-  const { project } = useOrganizationTeamProject({
-    redirectToOnboarding: false,
-    redirectToProjectOnboarding: false,
-  });
-  const projectSlug = project && !project.isPersonal ? project.slug : null;
+  const projectSlug = useLlmOpsProjectSlug();
 
   const options = PRODUCTS.filter(
     (product) =>

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -24,6 +24,7 @@ import {
   governanceNavItems,
   type SectionNavItemData,
 } from "../sectionNavItems";
+import { useLlmOpsProjectSlug } from "../useLlmOpsProjectSlug";
 import { useReachableProducts } from "../useReachableProducts";
 import { useSettingsMenu } from "../useSettingsMenu";
 import { QUIET_SIDEBAR_CHIP } from "./quietChipStyle";
@@ -99,11 +100,11 @@ function SidebarBottomBlock({
       borderTopWidth="1px"
       borderTopColor="border"
       paddingTop={2}
-      marginTop={2}
-      // The rule reads as the edge of the block, so it runs a little
-      // wider than the items it separates.
-      marginX="-4px"
-      paddingX="4px"
+      // The rule is the block's top edge, so it runs a step wider than the
+      // entries it separates. That step is padding, not a negative margin:
+      // the box already fills the column, so a negative margin would move
+      // its left edge and leave the right one where it was.
+      paddingX={1}
     >
       <UsageIndicator showLabel={showExpanded} />
       {shouldIncludeSettingsLink && hasPermission("organization:view") && (
@@ -132,27 +133,28 @@ function SidebarBottomBlock({
  * Spec: specs/navigation/settings-shell-v2.feature
  */
 function SettingsBackEntry({ showLabel }: { showLabel: boolean }) {
-  const { organization, project } = useOrganizationTeamProject({
+  const { organization } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
   const { reachableProducts } = useReachableProducts();
+  const projectSlug = useLlmOpsProjectSlug();
   const target = resolveSettingsBackTarget({
     organizationId: organization?.id ?? null,
     rememberedProduct: organization
       ? readLastVisitedProduct({ organizationId: organization.id })
       : null,
     reachableProducts,
-    projectSlug: project && !project.isPersonal ? project.slug : null,
+    projectSlug,
   });
 
   return (
     <Box
       width="full"
+      paddingX={1}
       borderBottomWidth="1px"
       borderBottomColor="border"
       paddingBottom={2.5}
-      marginBottom={1.5}
     >
       <SideMenuLink
         icon={ArrowLeft}
@@ -321,19 +323,26 @@ function SidebarContent({
       {/* The way back out of Settings sits above the scroll region, so a
           long settings menu never scrolls it out of the column. */}
       {surface === "settings" && (
-        <Box width="full" paddingX={3}>
+        <Box width="full" paddingX={2}>
           <SettingsBackEntry showLabel={showExpanded} />
         </Box>
       )}
 
       {/* The scroll region spans the full column and carries the
           horizontal inset itself, so its scrollbar runs against the
-          content panel instead of floating a padding away from it. */}
+          content panel instead of floating a padding away from it.
+
+          Its edges meet the rules above and below it, so the entries are
+          cut exactly at a line rather than a few pixels before it. The
+          space that holds them off those lines is padding in here, which
+          the entries travel through as the menu moves. */}
       <VStack
         ref={scrollRegionRef}
         data-testid="sidebar-scroll-region"
         width="full"
         paddingX={3}
+        paddingTop={surface === "settings" ? 1.5 : 0}
+        paddingBottom={2}
         gap={0.5}
         align="start"
         flex={1}
@@ -358,7 +367,7 @@ function SidebarContent({
         <ProductSidebarBody surface={surface} showExpanded={showExpanded} />
       </VStack>
 
-      <Box width="full" paddingX={3}>
+      <Box width="full" paddingX={2}>
         <SidebarBottomBlock
           showExpanded={showExpanded}
           shouldIncludeSettingsLink={surface !== "settings"}

--- a/platform/app/src/features/navigation/shell/ProductSwitcherMenu.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSwitcherMenu.tsx
@@ -2,7 +2,6 @@ import type { ButtonProps } from "@chakra-ui/react";
 import { Box, Button, HStack, Portal, Text, VStack } from "@chakra-ui/react";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { Menu } from "~/components/ui/menu";
-import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRouter } from "~/utils/compat/next-router";
 import { trackEvent } from "~/utils/tracking";
 import {
@@ -11,6 +10,7 @@ import {
   type ProductId,
   productById,
 } from "../products";
+import { useLlmOpsProjectSlug } from "../useLlmOpsProjectSlug";
 import { useReachableProducts } from "../useReachableProducts";
 
 /** The trigger reads as a raised pill on the top bar's gray. */
@@ -47,11 +47,7 @@ export function ProductSwitcherMenu({
 }) {
   const router = useRouter();
   const { reachableProducts } = useReachableProducts();
-  const { project } = useOrganizationTeamProject({
-    redirectToOnboarding: false,
-    redirectToProjectOnboarding: false,
-  });
-  const projectSlug = project && !project.isPersonal ? project.slug : null;
+  const projectSlug = useLlmOpsProjectSlug();
 
   const active = productById(activeProductId);
   const ActiveIcon = active.icon;

--- a/platform/app/src/features/navigation/useLandingRedirect.ts
+++ b/platform/app/src/features/navigation/useLandingRedirect.ts
@@ -10,6 +10,7 @@ import {
 import { readLastVisitedProduct } from "./logic/productMemory";
 import { resolveLandingDestination } from "./logic/resolveLandingDestination";
 import type { ProductId } from "./products";
+import { useLlmOpsProjectSlug } from "./useLlmOpsProjectSlug";
 import { useNavigationMode } from "./useNavigationMode";
 import { useReachableProducts } from "./useReachableProducts";
 
@@ -203,6 +204,7 @@ export function useLandingRedirect(): void {
   // flag queries behind it.
   const { reachableProducts, isLoading: isReachableLoading } =
     useReachableProducts({ enabled: isV2 });
+  const llmOpsProjectSlug = useLlmOpsProjectSlug();
   const replaceOnce = useReplaceOnce();
 
   useEffect(() => {
@@ -217,7 +219,7 @@ export function useLandingRedirect(): void {
           ? readLastVisitedProduct({ organizationId: organization.id })
           : null,
         projectSlug: project?.slug ?? null,
-        projectHomeSlug: project && !project.isPersonal ? project.slug : null,
+        projectHomeSlug: llmOpsProjectSlug,
         isOrgless:
           !isLoading && !organization && (organizations?.length ?? 0) === 0,
         lastVisitedHomeKind,
@@ -236,5 +238,6 @@ export function useLandingRedirect(): void {
     isV2,
     isReachableLoading,
     reachableProducts,
+    llmOpsProjectSlug,
   ]);
 }

--- a/platform/app/src/features/navigation/useLlmOpsProjectSlug.ts
+++ b/platform/app/src/features/navigation/useLlmOpsProjectSlug.ts
@@ -55,7 +55,7 @@ export function resolveLlmOpsProjectSlug({
 
   // The same preference the ambient context resolves with, so the product
   // opens where an organization-scoped page would have put the reader.
-  const preferredTeam = selectAmbientTeam(openableTeams, userId);
+  const preferredTeam = selectAmbientTeam({ teams: openableTeams, userId });
   return preferredTeam?.projects[0]?.slug ?? null;
 }
 

--- a/platform/app/src/features/navigation/useLlmOpsProjectSlug.ts
+++ b/platform/app/src/features/navigation/useLlmOpsProjectSlug.ts
@@ -1,0 +1,81 @@
+import { useLocalStorage } from "usehooks-ts";
+import type { OrganizationUserRole } from "~/generated/prisma/client";
+import {
+  organizationRoleOf,
+  selectAmbientTeam,
+  useOrganizationTeamProject,
+  userCanOpenTeam,
+} from "~/hooks/useOrganizationTeamProject";
+import { useRequiredSession } from "~/hooks/useRequiredSession";
+
+interface CandidateTeam {
+  isPersonal?: boolean | null;
+  members?: { userId: string }[];
+  projects: { slug: string }[];
+}
+
+/**
+ * Which project the LLM Ops product opens, from anywhere in the app.
+ *
+ * On an LLM Ops page that is the project being shown. Everywhere else the
+ * ambient project can be private (the Me pages resolve the personal
+ * workspace) or absent, and LLM Ops still has somewhere to go: the project
+ * the reader last had open, else the first one of a team they are allowed to
+ * open. Null only when no team they can open holds a project, which is the
+ * one case where the product has no home and the switcher greys it out.
+ *
+ * Spec: specs/navigation/product-switcher-navigation.feature
+ */
+export function resolveLlmOpsProjectSlug({
+  ambientProject,
+  rememberedProjectSlug,
+  teams,
+  userId,
+  organizationRole,
+}: {
+  ambientProject: { slug: string; isPersonal?: boolean | null } | undefined;
+  rememberedProjectSlug: string;
+  teams: CandidateTeam[];
+  userId: string | undefined;
+  organizationRole: OrganizationUserRole | undefined;
+}): string | null {
+  if (ambientProject && !ambientProject.isPersonal) return ambientProject.slug;
+
+  const openableTeams = teams.filter(
+    (team) =>
+      !team.isPersonal &&
+      userCanOpenTeam({ team, userId, organizationRole }) &&
+      team.projects.length > 0,
+  );
+
+  const remembered = openableTeams
+    .flatMap((team) => team.projects)
+    .find((project) => project.slug === rememberedProjectSlug);
+  if (remembered) return remembered.slug;
+
+  // The same preference the ambient context resolves with, so the product
+  // opens where an organization-scoped page would have put the reader.
+  const preferredTeam = selectAmbientTeam(openableTeams, userId);
+  return preferredTeam?.projects[0]?.slug ?? null;
+}
+
+/** `resolveLlmOpsProjectSlug` against the live workspace and this device. */
+export function useLlmOpsProjectSlug(): string | null {
+  const { organization, project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const { data: session } = useRequiredSession();
+  const [rememberedProjectSlug] = useLocalStorage<string>(
+    "selectedProjectSlug",
+    "",
+  );
+
+  return resolveLlmOpsProjectSlug({
+    ambientProject: project,
+    rememberedProjectSlug,
+    teams: organization?.teams ?? [],
+    userId: session?.user?.id,
+    organizationRole: organizationRoleOf(organization),
+  });
+}

--- a/platform/app/src/features/navigation/useSettingsMenu.ts
+++ b/platform/app/src/features/navigation/useSettingsMenu.ts
@@ -98,6 +98,12 @@ function organizationGroup({
         isExactMatch: true,
         icon: Settings2,
       },
+      // Keys sit here rather than in Access, where four enterprise entries
+      // came first and left a page most readers use at the bottom of a group
+      // they cannot open.
+      ...(!isLiteMember
+        ? [{ label: "API Keys", href: "/settings/api-keys", icon: KeyRound }]
+        : []),
       {
         label: "Authentication",
         href: "/settings/authentication",
@@ -152,9 +158,6 @@ function accessGroup({
         icon: FolderKanban,
       },
       ...(showEnterpriseNav && !isLiteMember ? enterpriseAccessItems() : []),
-      ...(!isLiteMember
-        ? [{ label: "API Keys", href: "/settings/api-keys", icon: KeyRound }]
-        : []),
     ],
   };
 }

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
@@ -377,6 +377,51 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
     });
   });
 
+  describe("given /me and a stale project remembered from an earlier organization-scoped visit", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me";
+      mockRouter.pathname = "/me";
+      mockRouter.asPath = "/me";
+      mockLocalStorage.selectedTeamId = "team-shared";
+      mockLocalStorage.selectedProjectSlug = "acme-app";
+    });
+
+    // The remembered slug resolved before any personal-workspace preference
+    // could apply, so /me ran Langy and every other personal feature against
+    // the shared project.
+    /** @scenario A project remembered from an earlier organization-scoped visit does not follow jane onto the personal-workspace page */
+    it("resolves the personal team and project, not the remembered shared ones", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.team?.id).toBe("team-personal");
+      expect(result.current.project?.id).toBe("proj-personal");
+    });
+
+    /** @scenario The personal-workspace page leaves the remembered selection alone */
+    it("leaves the remembered team and project where they were", () => {
+      renderResolution();
+
+      expect(mockLocalStorage.selectedTeamId).toBe("team-shared");
+      expect(mockLocalStorage.selectedProjectSlug).toBe("acme-app");
+    });
+  });
+
+  describe("given /me and nothing remembered yet", () => {
+    beforeEach(() => {
+      mockRouter.route = "/me";
+      mockRouter.pathname = "/me";
+      mockRouter.asPath = "/me";
+    });
+
+    /** @scenario The personal-workspace page leaves the remembered selection alone */
+    it("writes no personal selection for the pages that follow to read", () => {
+      renderResolution();
+
+      expect(mockLocalStorage.selectedTeamId).toBe("");
+      expect(mockLocalStorage.selectedProjectSlug).toBe("");
+    });
+  });
+
   describe("given /me but the organization has no personal team at all", () => {
     beforeEach(() => {
       mockRouter.route = "/me";

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.personal-workspace.integration.test.tsx
@@ -89,6 +89,19 @@ function renderResolution() {
   );
 }
 
+/**
+ * The next organization-scoped page, resolved after the one on screen is
+ * gone. What the first page left behind is all this one has to go on, which
+ * is what makes the return trip observable rather than a read of storage.
+ */
+function renderAfterReturningToOrganizationWork() {
+  cleanup();
+  mockRouter.route = "/settings/model-providers";
+  mockRouter.pathname = "/settings/model-providers";
+  mockRouter.asPath = "/settings/model-providers";
+  return renderResolution();
+}
+
 describe("useOrganizationTeamProject personal-workspace resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -382,6 +395,21 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       mockRouter.route = "/me";
       mockRouter.pathname = "/me";
       mockRouter.asPath = "/me";
+      // Two projects, and the one jane left is the second: with a single
+      // project, coming back to the first and coming back to the one she left
+      // are the same page, and the test would hold whatever the code did.
+      mockOrganizationsQuery.mockReturnValue(
+        loadedOrganizationsQuery([
+          PERSONAL_TEAM,
+          {
+            ...SHARED_TEAM,
+            projects: [
+              { id: "proj-other", name: "ACME Other", slug: "acme-other" },
+              ...SHARED_TEAM.projects,
+            ],
+          },
+        ]),
+      );
       mockLocalStorage.selectedTeamId = "team-shared";
       mockLocalStorage.selectedProjectSlug = "acme-app";
     });
@@ -397,12 +425,14 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       expect(result.current.project?.id).toBe("proj-personal");
     });
 
-    /** @scenario The personal-workspace page leaves the remembered selection alone */
-    it("leaves the remembered team and project where they were", () => {
+    /** @scenario Organization-scoped work goes on in the project jane left, after a visit to the personal-workspace page */
+    it("opens the project she left when she goes back to organization-scoped work", () => {
       renderResolution();
 
-      expect(mockLocalStorage.selectedTeamId).toBe("team-shared");
-      expect(mockLocalStorage.selectedProjectSlug).toBe("acme-app");
+      const { result } = renderAfterReturningToOrganizationWork();
+
+      expect(result.current.team?.id).toBe("team-shared");
+      expect(result.current.project?.slug).toBe("acme-app");
     });
   });
 
@@ -413,12 +443,14 @@ describe("useOrganizationTeamProject personal-workspace resolution", () => {
       mockRouter.asPath = "/me";
     });
 
-    /** @scenario The personal-workspace page leaves the remembered selection alone */
-    it("writes no personal selection for the pages that follow to read", () => {
+    /** @scenario The personal workspace is not what the next organization-scoped page is about */
+    it("opens the shared team on the next organization-scoped page", () => {
       renderResolution();
 
-      expect(mockLocalStorage.selectedTeamId).toBe("");
-      expect(mockLocalStorage.selectedProjectSlug).toBe("");
+      const { result } = renderAfterReturningToOrganizationWork();
+
+      expect(result.current.team?.id).toBe("team-shared");
+      expect(result.current.project?.id).toBe("proj-app");
     });
   });
 

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -362,14 +362,21 @@ export const useOrganizationTeamProject = (
       ? slugMatches.find((match) => userBelongsToTeam(match.team, userId))
       : undefined) ?? slugMatches[0];
 
+  // `/me` and its sub-routes ARE the personal workspace, which is the one
+  // place a project of the organization must never resolve unless the address
+  // bar names it. Read before the slug is resolved, so the whole chain below
+  // can hold the persisted selection to it.
+  const isPersonalScopeRoute = router.pathname.startsWith("/me");
+
   // A slug that resolved off the persisted selection rather than off the URL
   // is stickiness, not intent: it survives from the last visit to
   // /[some-slug]/* into every organization-scoped page that carries no project
-  // of its own. Two kinds have to be dropped there. A personal workspace is a
-  // private context the caller never asked to work in, and a team the caller
-  // cannot be shown is one the chrome refuses outright. Both let the ambient
-  // resolution below pick again, which also re-persists what it picks so the
-  // stale selection heals itself.
+  // of its own. Three kinds have to be dropped there. A personal workspace is
+  // a private context the caller never asked to work in, a team the caller
+  // cannot be shown is one the chrome refuses outright, and any project at all
+  // is the wrong answer on the personal-workspace pages. All three let the
+  // ambient resolution below pick again, which also re-persists what it picks
+  // on the pages that write, so the stale selection heals itself.
   //
   // An organization admin passes the second test on their role, so the project
   // they picked in a team they hold no membership row in stays picked. Dropping
@@ -382,7 +389,8 @@ export const useOrganizationTeamProject = (
   const stickySlugIsUnusable =
     !!slugMatch &&
     !isAddressedBySlug &&
-    (!!slugMatch.team.isPersonal ||
+    (isPersonalScopeRoute ||
+      !!slugMatch.team.isPersonal ||
       !userCanOpenTeam({
         team: slugMatch.team,
         userId,
@@ -410,24 +418,21 @@ export const useOrganizationTeamProject = (
             ) ?? organizations.data[0])
           : undefined;
 
-  // `/me` and its sub-routes are the one place "no project slug in the URL"
-  // does NOT mean "organization-level work", it means the user's own
-  // personal workspace, the opposite of the ambient/shared team `selectAmbientTeam`
-  // exists to prefer. Checked BEFORE the localStorage-remembered-team lookup,
-  // not just added as a further fallback after it: a member who visited any
-  // organization-scoped page earlier in the session has a non-personal team
-  // id already persisted there, and that stale selection legitimately wins
-  // on THOSE pages (see the stickiness handling above) but must never win on
-  // /me itself, which is unambiguously about the personal workspace and
-  // cannot mean anything else. Left as a fallback-only check, that persisted
-  // selection matched before this was ever reached, and /me resolved to the
-  // shared team's first (or, if it holds no project yet, undefined) project,
-  // which then read every personal-scope feature (Langy chief among them) as
-  // running in a context that either belonged to someone else or did not
-  // exist. Gated on the same `/me` prefix DashboardLayout already uses for
-  // `isPersonalScopeRoute`, so every other caller (settings pages,
-  // project-slug pages, demo mode) is unaffected.
-  const isPersonalScopeRoute = router.pathname.startsWith("/me");
+  // The personal workspace itself, on the pages that are about it. Checked
+  // BEFORE the localStorage-remembered-team lookup, not just added as a
+  // further fallback after it: a member who visited any organization-scoped
+  // page earlier in the session has a non-personal team id already persisted
+  // there, and that stale selection legitimately wins on THOSE pages (see the
+  // stickiness handling above) but must never win on /me itself, which is
+  // unambiguously about the personal workspace and cannot mean anything else.
+  // Left as a fallback-only check, that persisted selection matched before
+  // this was ever reached, and /me resolved to the shared team's first (or, if
+  // it holds no project yet, undefined) project, which then read every
+  // personal-scope feature (Langy chief among them) as running in a context
+  // that either belonged to someone else or did not exist. Gated on the same
+  // `/me` prefix DashboardLayout already uses for `isPersonalScopeRoute`, so
+  // every other caller (settings pages, project-slug pages, demo mode) is
+  // unaffected.
   const ownPersonalTeam = isPersonalScopeRoute
     ? organization?.teams.find(
         (team) => team.isPersonal && team.ownerUserId === userId,
@@ -498,11 +503,20 @@ export const useOrganizationTeamProject = (
     if (organization && organization.id !== localStorageOrganizationId) {
       setLocalStorageOrganizationId(organization.id);
     }
-    if (team && team.id !== localStorageTeamId) {
-      setLocalStorageTeamId(team.id);
-    }
-    if (project && project.slug !== localStorageProjectSlug) {
-      setLocalStorageProjectSlug(project.slug);
+    // The remembered selection answers "where was I working", which is a
+    // question about the organization's teams and projects. A personal
+    // workspace is not one of them: written here it replaced the project the
+    // reader had open, so the app root sent them to another team's project
+    // afterwards and the product switcher had no project to open LLM Ops
+    // with. The private context is resolved from the /me address every time,
+    // so it needs nothing remembered.
+    if (!team?.isPersonal) {
+      if (team && team.id !== localStorageTeamId) {
+        setLocalStorageTeamId(team.id);
+      }
+      if (project && project.slug !== localStorageProjectSlug) {
+        setLocalStorageProjectSlug(project.slug);
+      }
     }
     // Visiting an actual /[project]/* page marks the implicit home preference
     // as "project". Pairs with MyLayout's "personal" marker so the `/` index

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -138,7 +138,7 @@ export function selectAmbientTeam<
     projects: unknown[];
     members?: { userId: string }[];
   },
->(teams: T[], userId?: string): T | undefined {
+>({ teams, userId }: { teams: T[]; userId?: string }): T | undefined {
   const byPreference = (candidates: T[]) =>
     candidates.find((team) => !team.isPersonal && team.projects.length > 0) ??
     candidates.find((team) => !team.isPersonal) ??
@@ -461,13 +461,14 @@ export const useOrganizationTeamProject = (
         t.projects.some(
           (project) => project.slug === publicEnv.data?.DEMO_PROJECT_SLUG,
         ),
-      ) ?? selectAmbientTeam(organization?.teams ?? [], userId)) // The team holding the demo project, else the ambient one
+      ) ?? selectAmbientTeam({ teams: organization?.teams ?? [], userId })) // The team holding the demo project, else the ambient one
     : resolvedSlugMatch
       ? resolvedSlugMatch.team
       : ownPersonalTeam
         ? ownPersonalTeam
         : organization
-          ? (rememberedTeam ?? selectAmbientTeam(organization.teams, userId))
+          ? (rememberedTeam ??
+            selectAmbientTeam({ teams: organization.teams, userId }))
           : undefined;
 
   // For demo mode, find the project with the demo slug

--- a/platform/app/src/pages/__tests__/index.landing.integration.test.tsx
+++ b/platform/app/src/pages/__tests__/index.landing.integration.test.tsx
@@ -39,7 +39,10 @@ vi.mock("~/features/navigation/useReachableProducts", () => ({
   }),
 }));
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+// Only the hook is stubbed. The access helpers beside it are pure, and the
+// project this fixture resolves is the organization's, so they answer with it.
+vi.mock("~/hooks/useOrganizationTeamProject", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   useOrganizationTeamProject: () => ({
     isLoading: false,
     organization: { id: "org_1" },

--- a/platform/app/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
@@ -163,7 +163,7 @@ describe("AGENT_GOVERNANCE signup then adding a model provider (real DB)", () =>
 
       // Exactly what the hook does with no localStorage team and no
       // project slug in the URL, which is the case on /settings/*.
-      const ambientTeam = selectAmbientTeam(teams);
+      const ambientTeam = selectAmbientTeam({ teams });
       const ambientProject = ambientTeam ? ambientTeam.projects[0] : undefined;
 
       expect(ambientTeam?.isPersonal).toBe(false);
@@ -176,7 +176,7 @@ describe("AGENT_GOVERNANCE signup then adding a model provider (real DB)", () =>
         include: { projects: true },
       });
 
-      expect(selectAmbientTeam(teams)?.id).toBe(
+      expect(selectAmbientTeam({ teams })?.id).toBe(
         teams.find((t) => !t.isPersonal)!.id,
       );
     });

--- a/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+++ b/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
@@ -232,13 +232,13 @@ Feature: A personal workspace is never the ambient context for organization work
     not exist, even though nothing in the address bar or the remembered
     selection asked for that.
 
-    The remembered selection is held to this from both sides. A remembered
-    team OR project carried in from an earlier organization-scoped page never
-    decides `/me`, and `/me` never writes its own team and project back over
-    that selection. The write is what made the personal workspace the last
-    thing the reader worked on, so leaving it sent them to another team's
-    project on the app root and greyed out LLM Ops in the product switcher,
-    which has no project to open while the remembered one is private.
+    The personal workspace is held apart from organization-scoped work on both
+    sides. Work carried in from an earlier organization-scoped page never
+    decides `/me`, and a visit to `/me` never becomes the organization-scoped
+    work the reader returns to. When it did, the reader came back to another
+    team's project on the app root, and LLM Ops was greyed out in the product
+    switcher, which had no project to open while the private one was the last
+    one open.
 
     @integration
     Scenario: Visiting the personal-workspace page resolves the personal team
@@ -288,10 +288,21 @@ Feature: A personal workspace is never the ambient context for organization work
       # shared project.
 
     @integration
-    Scenario: The personal-workspace page leaves the remembered selection alone
-      Given jane's remembered selection names the shared team and "acme-app"
+    Scenario: Organization-scoped work goes on in the project jane left, after a visit to the personal-workspace page
+      Given jane was last working in "acme-app", the second project of the
+        shared team
       When jane opens her personal-workspace page
-      Then the remembered team and project are still the shared ones
+      And she opens an organization-scoped page again
+      Then that page is about "acme-app", the project she left
+      # With one project in the team, coming back to the first one and coming
+      # back to the one she left look the same, so the team holds two here.
+
+    @integration
+    Scenario: The personal workspace is not what the next organization-scoped page is about
+      Given jane has not opened any project yet
+      When jane opens her personal-workspace page
+      And she opens an organization-scoped page again
+      Then that page is about the shared team, not her personal workspace
 
     @integration
     Scenario: A member with no personal workspace of their own falls back to the ambient team

--- a/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
+++ b/specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature
@@ -232,6 +232,14 @@ Feature: A personal workspace is never the ambient context for organization work
     not exist, even though nothing in the address bar or the remembered
     selection asked for that.
 
+    The remembered selection is held to this from both sides. A remembered
+    team OR project carried in from an earlier organization-scoped page never
+    decides `/me`, and `/me` never writes its own team and project back over
+    that selection. The write is what made the personal workspace the last
+    thing the reader worked on, so leaving it sent them to another team's
+    project on the app root and greyed out LLM Ops in the product switcher,
+    which has no project to open while the remembered one is private.
+
     @integration
     Scenario: Visiting the personal-workspace page resolves the personal team
       Given jane's personal team is listed before the shared team
@@ -267,6 +275,23 @@ Feature: A personal workspace is never the ambient context for organization work
       # selection must not follow her onto the personal-workspace page
       # either, because that page can never mean anything but her own
       # workspace.
+
+    @integration
+    Scenario: A project remembered from an earlier organization-scoped visit does not follow jane onto the personal-workspace page
+      Given jane's last remembered project selection is "acme-app", from an
+        earlier organization-scoped page
+      When jane opens her personal-workspace page
+      Then the ambient team is her personal team
+      And the ambient project is her personal project
+      # The remembered project resolved before any personal-workspace
+      # preference could apply, so /me ran every personal feature against the
+      # shared project.
+
+    @integration
+    Scenario: The personal-workspace page leaves the remembered selection alone
+      Given jane's remembered selection names the shared team and "acme-app"
+      When jane opens her personal-workspace page
+      Then the remembered team and project are still the shared ones
 
     @integration
     Scenario: A member with no personal workspace of their own falls back to the ambient team

--- a/specs/home/langy-home.feature
+++ b/specs/home/langy-home.feature
@@ -56,6 +56,16 @@ Feature: The Langy home
     And exactly one such canvas is on the page
     And the current announcement reads as a single line across the block's top
 
+  # The results carry a line above them in the raised Cmd+K bar, where the
+  # field and the list share one card and the line is the boundary between
+  # them. Here the results are their own panel under the field, so that line
+  # became a second edge a few pixels inside the panel's own.
+  Scenario: The results panel draws one edge, not two
+    Given the Langy home renders
+    When I type into the field
+    Then the results hang under it as one panel with one border
+    And no further line runs above the first group
+
   Scenario: The example asks are the ones Langy actually offers
     Given the Langy home renders
     Then the row beneath the composer offers three example asks

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -18,6 +18,12 @@ Feature: Product sidebars in the new navigation modes
   the column, and the scrollbar sits against the content panel with no
   gap.
 
+  The rule above the bottom block is the bottom edge of the part that
+  scrolls: it keeps the same distance from both edges of the column, and
+  the entries pass under it and are cut there. The space between the
+  last entry and the rule belongs to the scrolling part, so it is there
+  when the menu rests and the entries travel through it as it moves.
+
   @integration
   Scenario: Quick Search sits first and opens the command bar
     Given a product sidebar in a new navigation mode
@@ -86,6 +92,18 @@ Feature: Product sidebars in the new navigation modes
   Scenario: A rule separates the bottom block from the pages above it
     Given a product sidebar in a new navigation mode
     Then a rule runs above the bottom block
+
+  @integration
+  Scenario: The rule keeps the same distance from both edges of the column
+    Given a product sidebar in a new navigation mode
+    Then the rule starts as far from the left edge as it ends from the right
+    And the entries of the bottom block line up with the entries above it
+
+  @integration
+  Scenario: The entries are cut at the rule as they scroll under it
+    Given a product sidebar in a new navigation mode
+    Then the part that scrolls ends at the rule
+    And the space above the rule scrolls with the entries
 
   @integration
   Scenario: Opening a page by its address reveals its sidebar entry

--- a/specs/navigation/product-switcher-navigation.feature
+++ b/specs/navigation/product-switcher-navigation.feature
@@ -76,6 +76,30 @@ Feature: Product switcher navigation
     Then the top bar shows my name with a "Personal" badge
 
   @integration
+  Scenario: LLM Ops opens from the personal workspace
+    Given I am on a Me page in the product-switcher mode
+    When I open the product switcher
+    Then LLM Ops is offered rather than greyed out
+    And picking it opens the project I last worked in
+    # The Me pages run in the personal workspace, and LLM Ops opens a
+    # project of the organization. Reading the personal project as "no
+    # project" left the way back into LLM Ops closed.
+
+  @integration
+  Scenario: LLM Ops opens a project I can reach when I have opened none yet
+    Given I am on a Me page in the product-switcher mode
+    And I have opened no project on this device
+    When I pick "LLM Ops" in the product switcher
+    Then I am sent to a project of a team I am allowed to open
+
+  @integration
+  Scenario: LLM Ops stays closed when the organization holds no project for me
+    Given I am on a Me page in the product-switcher mode
+    And no team I am allowed to open holds a project
+    When I open the product switcher
+    Then LLM Ops is greyed out
+
+  @integration
   Scenario: Gateway and Governance carry no scope control
     Given I am on a Gateway page in the product-switcher mode
     Then the top bar shows no project chip and no personal badge

--- a/specs/navigation/settings-shell-v2.feature
+++ b/specs/navigation/settings-shell-v2.feature
@@ -15,7 +15,12 @@ Feature: Settings shell in the new navigation modes
   be read first. Every settings page keeps its address, and every
   visibility gate keeps its current condition. The back entry and its
   rule sit above the scroll region, so a long settings menu never
-  scrolls the way out of the column.
+  scrolls the way out of the column, and the entries are cut at that
+  rule as they pass under it.
+
+  API Keys sits in the ORGANIZATION group, under General. In ACCESS it
+  came after four enterprise entries most readers cannot open, which put
+  a page they use often at the bottom of a group they have no use for.
 
   Devices on the legacy mode keep the current settings chrome
   unchanged.
@@ -58,6 +63,18 @@ Feature: Settings shell in the new navigation modes
     When the settings menu scrolls
     Then the way back entry stays where it is
     And only the pages under the rule move
+
+  @integration
+  Scenario: The pages are cut at the rule as they scroll under the way back
+    Given I open Settings in a new navigation mode
+    Then the part that scrolls starts at the rule under the way back
+    And the space under that rule scrolls with the pages
+
+  @integration
+  Scenario: API Keys sits under General
+    Given I open Settings in a new navigation mode
+    Then API Keys comes right after General in the ORGANIZATION group
+    And the ACCESS group does not hold it
 
   @integration
   Scenario: A lite member sees no restricted settings entries


### PR DESCRIPTION
Four fixes from one round of navigation feedback.

## LLM Ops was closed from the Me pages

The product switcher greyed LLM Ops out on every Me page, for an organization admin included.

The Me pages resolve the personal workspace on purpose, so the project the chrome carries there is private. The switcher read a private project as "no project", and LLM Ops is the one product that opens with a project, so it had nowhere to go and rendered as unavailable.

It ran the other way too. Visiting `/me` wrote the personal team and project over the remembered selection, which answers "where was I working". After one visit to Me, the app root and the switcher sent the reader into another team's first project instead of the one they left.

Now:

- **LLM Ops resolves its own project**: the one in the address, else the one last worked in, else the first project of a team the reader is allowed to open. It stays greyed out only when no such team holds a project. One resolver (`useLlmOpsProjectSlug`), read by the switcher, the icon rail, the way back out of Settings, and the app root, so the four cannot drift.
- **The personal workspace stays out of the remembered selection.** It is resolved from the `/me` address every time and needs nothing remembered.
- **A remembered project no longer decides the Me pages.** It was resolved before the personal-workspace preference could apply, so Langy and every other personal feature ran against the organization's shared project while the page said "Personal".

| Before | After |
|---|---|
| ![LLM Ops greyed out on Me](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-llmops-gate-and-rules/1-before-llmops-blocked.png) | ![LLM Ops offered on Me](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-llmops-gate-and-rules/2-after-llmops-open.png) |

## The sidebar rules

The rule above the bottom block sat 8px from the left of the column and 16px from the right. A negative margin cannot widen a box that already fills its parent: it moved the left edge and left the right one where it was. The inset moves to the wrapper, where both edges get it, and the entries of the bottom block now line up with the entries above them.

The entries also vanished 8px above that rule instead of being cut at it. The scrolling part now ends at the rule, and the space that holds the last entry off the line is padding inside it, which the entries travel through as the menu moves. The rule under the way back out of Settings gets the same treatment.

| Before | After |
|---|---|
| ![rule short on the right, entries cut early](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-llmops-gate-and-rules/3-before-sidebar-rules.png) | ![rule even, entries cut at the line](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-llmops-gate-and-rules/4-after-sidebar-rules.png) |

## The command bar drew a second line on the home page

The results carry a line above them, which separates them from the field in the raised Cmd+K bar, where the two share one card. The home mounts the same palette with the results as their own panel under the field, so that line became a second edge a few pixels inside the panel's own. It is now drawn on the raised bar only.

| Before | After |
|---|---|
| ![two lines at the top of the panel](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-llmops-gate-and-rules/5-before-command-bar-line.png) | ![one edge](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/navigation-llmops-gate-and-rules/6-after-command-bar-line.png) |

## API Keys moves under General

It was last in ACCESS, after four enterprise entries most readers cannot open, which put a page they use often at the bottom of a group with nothing in it for them. It is now the entry under General in ORGANIZATION, with the same gate.

## Specs

- `specs/navigation/product-switcher-navigation.feature`: LLM Ops opens from the personal workspace, opens a reachable project when nothing is remembered, and stays closed when no team the reader can open holds a project.
- `specs/ai-gateway/governance/personal-workspace-not-ambient-context.feature`: a remembered project does not follow the reader onto the personal-workspace page, and organization-scoped work goes on in the project they left.
- `specs/navigation/product-sidebars.feature`: the rule keeps the same distance from both edges, and the entries are cut at it.
- `specs/navigation/settings-shell-v2.feature`: the pages are cut at the rule under the way back, and API Keys sits under General.
- `specs/home/langy-home.feature`: the results panel draws one edge, not two.

## Testing

- New: `resolveLlmOpsProjectSlug.unit.test.ts` (8 cases over the resolution order), `CommandPaletteInlinePanel.integration.test.tsx` (both surfaces).
- Extended: the product-switcher shell suite (three Me cases), the product sidebar suite (rule geometry and the scroll edges), the settings shell suite (the rule under the way back, API Keys placement), the personal-workspace resolution suite (a remembered project on `/me`, and the organization-scoped page after it).
- Every new test was run against the unfixed code first and fails there.
- Full component lane green (4203 tests). `pnpm typecheck:all` clean. Feature parity: 24/24, 18/18, 18/18, 15/15, 11/11 on the five feature files.
- Checked in a browser on a real organization: LLM Ops opens from Me on the project last used, the remembered project survives a Me visit, both rules measure 8px from each edge with the scrolling part ending exactly on them, one bordered element in the home results panel where there were two, and API Keys second in ORGANIZATION.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LLM Ops navigation from personal workspaces, including remembered and fallback project selection.
  * Added API Keys to the Organization settings section for eligible members.
  * Improved personal-workspace selection without overriding shared workspace choices.
* **Bug Fixes**
  * Removed redundant separators from inline command and Langy result panels.
  * Improved sidebar spacing, scrolling boundaries, and alignment.
* **Tests**
  * Added coverage for navigation, workspace selection, settings placement, and panel styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->