### PR TITLE
feat(authz): every permission check is a typed declaration (ADR-092 PR 4)

### DIFF
--- a/dev/docs/plans/adr-092-authz-delivery-plan.md
+++ b/dev/docs/plans/adr-092-authz-delivery-plan.md
@@ -269,8 +269,13 @@ becomes the ledger. Bill of materials:
 
 Every permission check on every stack becomes a *declaration* in the registry
 vocabulary, typed against the input it reads its scope from, and every
-declarative site funnels through one cutover-aware seam. Decision-neutral at
-deploy: the seam runs the same per-org fork the ten legacy seams run today.
+declarative site funnels through one cutover-aware seam. The seam is layered
+the house way — boundary → service → repository → client: the tRPC middleware
+composes `PermissionsService`, the service takes the
+`ForkAwarePermissionDecisionRepository`, and only the repository touches the
+client and the fork. Decision-neutral at deploy: the repository runs the same
+per-org fork the ten legacy seams run today, and the contract PR rewires only
+the repository.
 
 ```
                  BEFORE                                  AFTER

--- a/dev/docs/plans/adr-092-authz-delivery-plan.md
+++ b/dev/docs/plans/adr-092-authz-delivery-plan.md
@@ -50,6 +50,7 @@ work already merged (A = the engine #6894, B = the self-migration #7079).
 | 22 | **Resource-tier facts live on `Grant`; accounting does not.** `token`, `permission`, `expiresAt`, `maxViews` are fact columns set by the mint event, fold-owned like every other column. `viewCount` has a different writer (ShareService, per view), so it moves to a ShareService-owned accounting row (`GrantUsage { grantId, viewCount, lastViewedAt }`) when ShareService moves onto the ledger in PR 3 — never onto the projection table. |
 | 23 | **Event idempotency is commandId-based.** Every command mints a random `commandId` at the boundary; retries reuse it; each emitted event carries `idempotencyKey = <commandId>:<index>`. Legitimate repeats (same action twice in a second) can never be deduped away, and retries always are. Migrations derive commandIds deterministically — but from chunk position over the id-sorted source rows, not from row identity: the genesis import emits `genesis:<kind>:<org>:<index>` and the stage-B backfill `backfill-b:<org>:<index>` plus `backfill-b:parity:<org>`; that is what ships today. Runtime commandIds are caller-minted KSUIDs; imports adopt the legacy row's own id as the grant/role id, never as the commandId. OPEN: whether migration commandIds should be re-keyed per source row — chunk membership can shift when a source row is deleted between an aborted pass and its retry — is under discussion on PR 2's review (comment 3802500637) and not yet decided. Where an upstream system id exists (the general house pattern, e.g. trace ids) it remains the key; commandId is for facts born from direct user action. Grant ids stay content-derived on top, so re-imports converge by upsert regardless. |
 | 24 | *(2026-08-18)* **Write paths fork per org.** The ledger becomes the writer for an organization only when its genesis import completes; everyone else keeps the imperative path. Deploy changes nothing until an org migrates. |
+| 25 | *(2026-08-20)* **The declared surface ships before the contract (revises the tail of decision 5).** The `.permission()` codemod stops waiting for 100 % finalization: PR 4 becomes the *declared surface* — every check on every stack (tRPC builder, Hono `AccessPolicy`, the imperative facade) is declared in the registry vocabulary with registry-derived scope typing, and every declarative site is codemodded onto ONE cutover-aware seam. The seam runs exactly the per-org fork the ten legacy seams run today (legacy decides for a non-cut-over org with the engine as shadow; engine decides for a cut-over org with legacy as reverse-shadow), so the sweep is decision-neutral at deploy and the per-org rollout lever survives intact. What used to make the codemod wait was decision-path risk; routing the new sugar through the same fork removes it. The contract keeps the deletions only (legacy walk, quirk branches, compat projection, old tables, fork, gates) — and shrinks from a 400-site sweep to deleting one branch in one seam. Scope typing is strict: an input id from a tier the permission's resource is not grantable at is a compile error, a missing id likewise, and derivations are written at the call site (`{ via: "teamId" }`), never inferred. |
 
 ## The final data structure
 
@@ -162,7 +163,7 @@ dependency on the identity PR, and nothing to build beyond the enforcement
 write itself — which ships as a ready seam in PR 1 and gains its caller
 when PR 2 moves the revoke/offboard write paths.
 
-## The PR map (4 + 1)
+## The PR map (5 + 1)
 
 ### PR 1 — same position, event-sourced
 
@@ -264,9 +265,61 @@ becomes the ledger. Bill of materials:
 - effectivePermissions / useCan / Access-surface reads can ride here or trail
   as a small follow-up — they are per-org gated like everything else.
 
-### PR 4 — the contract (only at 100 % finalized)
+### PR 4 — the declared surface (decision 25, ships now)
 
-- `.permission()` codemod (~380 sites, now cosmetic), Hono edge identity.
+Every permission check on every stack becomes a *declaration* in the registry
+vocabulary, typed against the input it reads its scope from, and every
+declarative site funnels through one cutover-aware seam. Decision-neutral at
+deploy: the seam runs the same per-org fork the ten legacy seams run today.
+
+```
+                 BEFORE                                  AFTER
+  .use(checkProjectPermission("x:y"))   ─┐
+  .use(checkOrganizationPermission(…))   ├─►   .permission("x:y")        ─┐
+  .use(checkTeamPermission(…))          ─┘     .permission(p, {via:…})    │
+  .use(checkProjectPermissionAny(…))    ───►   .permissionAny(…)          ├─► ONE seam
+  .use(skipPermissionCheck(…))          ───►   .noPermission({reason})    │   (cutover-aware:
+  AccessPolicy{permission: Permission}  ───►   AccessPolicy{AuthzPermission,  │    fork per org)
+                                                scope-checked vs registry}│
+  hasProjectPermission(ctx, id, p) ×85  ───►   typed imperative facade   ─┘
+```
+
+- **Typed `.permission()`** on the pending-permission builder: the permission
+  parameter is constrained by the validated input — an input id from a tier
+  the permission's resource is not grantable at is a compile error, a missing
+  id likewise; platform-tier permissions (`ops:*`) require no id and refuse
+  one. Template-literal diagnostics name the offending field.
+- **The oddball inventory, each with a designed home** (mapped 2026-08-20):
+  `checkProjectPermissionAny` → `.permissionAny()`;
+  `checkTeamPermission("organization:manage")` ×2 (input carries only
+  `teamId`) → `.permission("organization:manage", { via: "teamId" })` —
+  derivation written at the call site; `checkTeamPermission("team:delete")` →
+  `.permission("team:manage")` (no bag grants `team:delete`; only the
+  manage-implication satisfies it, so the two are provably identical);
+  `checkProjectOrOrganizationPermission` ×3 → union input, the typed check
+  distributes; `checkProviderValidationPermission` and
+  `checkCapturedDataVisibilityPermission` → declared custom markers;
+  `skipPermissionCheck` (57 sites) → `.noPermission({ reason })` whose
+  sensitive-key guard moves from a runtime throw to a compile error;
+  `authorizeInResolver` → declared marker carrying the permissions the
+  service enforces; `checkPermissionOrPubliclyShared` → already dead (ADR-057
+  consolidated public reads onto `sharedTrace`), its stale test mocks deleted.
+- **Hono**: `AccessPolicy` speaks `AuthzPermission`; the policy kind × app
+  scope pair is checked against the registry (an org-only permission on a
+  project-scoped app is a compile error). Runtime chains unchanged — already
+  fork-aware.
+- **Imperative facade**: the ~85 direct `has*Permission` calls (routers,
+  `*.authz.ts` modules, Hono handlers, MCP tools) move to one registry-typed
+  require/check facade with the same scope-key typing.
+- **The sweep test**: every tRPC procedure declares a permission or an
+  explicit marker with a written reason — binds the fail-closed
+  `@unimplemented` scenario in `unified-authorization-engine.feature`.
+- The four legacy tRPC middlewares are deleted from `rbac.ts`; the fork-aware
+  *resolvers* stay (they are the seam's runtime) until contract.
+
+### PR 6 — the contract (only at 100 % finalized)
+
+- Hono edge identity.
 - Delete: `rbac.ts`, `role-binding-resolver.ts`, the four quirk branches,
   the compat projection and the `RoleBinding`/`CustomRole`/`TeamUser` tables
   themselves, the fork, the gate. No renames — `Grant` and `Role` were born

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,6 +23,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@hono/standard-validator": "^0.2.0",
+		"@langwatch/authz": "workspace:*",
 		"@langwatch/handled-error": "workspace:*",
 		"@langwatch/observability": "workspace:*",
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/api/src/builder.ts
+++ b/packages/api/src/builder.ts
@@ -148,6 +148,12 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
             `"${endpoint.config.resourceLimit}" but the service has no resourceLimitMiddleware`,
         );
       }
+      if (endpoint.config.permission && !this._config.permissionEnforcer) {
+        throw new Error(
+          `Endpoint ${endpoint.method.toUpperCase()} ${endpoint.path} declares permission ` +
+            `"${endpoint.config.permission}" but the service has no permissionEnforcer`,
+        );
+      }
     }
   }
 }

--- a/packages/api/src/pipeline.ts
+++ b/packages/api/src/pipeline.ts
@@ -165,6 +165,20 @@ function appendAccessMiddleware({
     stack.push(serviceConfig._legacy.organizationMiddleware);
   }
 
+  // Framework-mounted, deliberately BEFORE `config.middleware`: the check an
+  // endpoint declares cannot be displaced by the middleware array it also
+  // carries (the spread-overwrite that once left a declared policy
+  // unenforced).
+  if (config.permission) {
+    const enforce = serviceConfig.permissionEnforcer;
+    if (!enforce) {
+      throw new Error(
+        `Endpoint declares permission "${config.permission}" but the service has no permissionEnforcer`,
+      );
+    }
+    stack.push(enforce(config.permission));
+  }
+
   if (includeResourceLimit && config.resourceLimit) {
     const createResourceLimitMiddleware =
       serviceConfig._legacy?.resourceLimitMiddleware;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,3 +1,4 @@
+import type { AuthzPermission } from "@langwatch/authz";
 import type { Context, MiddlewareHandler } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { DescribeRouteOptions } from "hono-openapi";
@@ -147,6 +148,15 @@ export interface EndpointConfig<
    * - A `MiddlewareHandler` -- use a custom auth middleware for this endpoint.
    */
   auth?: "default" | "none" | MiddlewareHandler;
+  /**
+   * The permission this endpoint requires, in the authz registry vocabulary.
+   * Enforced by the FRAMEWORK: the service's `permissionEnforcer` middleware
+   * is mounted between auth and the endpoint's own `middleware`, so a custom
+   * middleware array can never displace the check while the declared
+   * permission still reads as guarded. Requires `permissionEnforcer` on the
+   * service config — declaring one without the other fails `build()`.
+   */
+  permission?: AuthzPermission;
   /** Resource limit type — requires `_legacy.resourceLimitMiddleware` on the service. */
   resourceLimit?: string;
   /** Additional middleware to run for this endpoint (after auth, before handler). */
@@ -202,6 +212,14 @@ export interface ServiceConfig {
   basePath?: string;
   /** Default auth middleware applied to every endpoint (unless overridden). */
   auth?: MiddlewareHandler;
+  /**
+   * Builds the enforcement middleware for an endpoint's declared
+   * `permission`. Injected by the host — the platform passes one backed by
+   * its app-composed permissions service — and mounted by the framework
+   * right after auth for every endpoint that declares a permission, so the
+   * declaration and its enforcement cannot be torn apart.
+   */
+  permissionEnforcer?: (permission: AuthzPermission) => MiddlewareHandler;
   /** Disable the built-in tracer middleware. Set to `false` to opt out. */
   tracer?: false;
   /** Disable the built-in logger middleware. Set to `false` to opt out. */

--- a/packages/authz/src/__tests__/declaration.unit.test.ts
+++ b/packages/authz/src/__tests__/declaration.unit.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  declaredScopeId,
+  isPlatformTierPermission,
+  permissionGrantTiers,
+} from "../declaration";
+
+describe("permissionGrantTiers", () => {
+  describe("given a project-grantable permission", () => {
+    it("lists the tiers most specific first", () => {
+      expect(permissionGrantTiers("traces:view")).toEqual([
+        "project",
+        "team",
+        "organization",
+      ]);
+    });
+  });
+
+  describe("given an organization-only permission", () => {
+    it("lists only the organization tier", () => {
+      expect(permissionGrantTiers("governance:view")).toEqual(["organization"]);
+      expect(permissionGrantTiers("organization:manage")).toEqual([
+        "organization",
+      ]);
+    });
+  });
+
+  describe("given a platform-tier permission", () => {
+    it("lists no input-addressable tier", () => {
+      expect(permissionGrantTiers("ops:view")).toEqual([]);
+      expect(isPlatformTierPermission("ops:view")).toBe(true);
+      expect(isPlatformTierPermission("traces:view")).toBe(false);
+    });
+  });
+});
+
+describe("declaredScopeId", () => {
+  describe("when the input carries ids at several allowed tiers", () => {
+    it("resolves the most specific tier the permission allows", () => {
+      expect(
+        declaredScopeId({
+          permission: "traces:view",
+          input: { projectId: "proj_1", organizationId: "org_1" },
+        }),
+      ).toEqual({ tier: "project", id: "proj_1" });
+    });
+  });
+
+  describe("when the permission is organization-only and the input carries a projectId too", () => {
+    it("ignores the tier the permission cannot be granted at", () => {
+      expect(
+        declaredScopeId({
+          permission: "organization:manage",
+          input: { projectId: "proj_1", organizationId: "org_1" },
+        }),
+      ).toEqual({ tier: "organization", id: "org_1" });
+    });
+  });
+
+  describe("when a via field is declared", () => {
+    it("resolves the named field at its own tier", () => {
+      expect(
+        declaredScopeId({
+          permission: "organization:manage",
+          input: { teamId: "team_1" },
+          via: "teamId",
+        }),
+      ).toEqual({ tier: "team", id: "team_1" });
+    });
+
+    it("returns null when the named field is absent or empty", () => {
+      expect(
+        declaredScopeId({
+          permission: "organization:manage",
+          input: { teamId: "" },
+          via: "teamId",
+        }),
+      ).toBeNull();
+      expect(
+        declaredScopeId({
+          permission: "organization:manage",
+          input: {},
+          via: "teamId",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the input carries no id the permission can use", () => {
+    it("returns null so the caller treats it as a wiring bug", () => {
+      expect(
+        declaredScopeId({ permission: "governance:view", input: {} }),
+      ).toBeNull();
+      expect(
+        declaredScopeId({
+          permission: "governance:view",
+          input: { projectId: "proj_1" },
+        }),
+      ).toBeNull();
+    });
+
+    it("never reads a non-string id", () => {
+      expect(
+        declaredScopeId({
+          permission: "traces:view",
+          input: { projectId: 42 as unknown as string },
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/authz/src/declaration.ts
+++ b/packages/authz/src/declaration.ts
@@ -1,0 +1,276 @@
+/**
+ * ADR-092 delivery-plan PR 4 (decision 25) — the typing behind declared
+ * permission checks. The registry already states, per resource, the scope
+ * tiers it can be granted at; everything here derives from that one object so
+ * a declaration surface (the tRPC builder, the Hono policy, the imperative
+ * facade) can be checked against the input it reads its scope from.
+ *
+ * Client-safe by the same rule as the registry: no Prisma, no env, no server
+ * imports. The runtime exports are pure functions over the registry.
+ *
+ * The compile-error channel is the `PermissionDeclarationError<…>` brand: a
+ * declaration that fails validation resolves the parameter type to it, so the
+ * assignability failure the author reads names the problem in its own words
+ * instead of a wall of conditional types.
+ */
+import {
+  AUTHZ_RESOURCES,
+  type AuthzPermission,
+  type AuthzResource,
+} from "./registry";
+
+/** The input field that names each grantable, input-addressable tier. */
+export const SCOPE_TIER_FIELDS = {
+  project: "projectId",
+  team: "teamId",
+  organization: "organizationId",
+} as const;
+
+/** "project" | "team" | "organization" — the tiers an input can address. */
+export type InputScopeTier = keyof typeof SCOPE_TIER_FIELDS;
+
+/** "projectId" | "teamId" | "organizationId". */
+export type ScopeTierField = (typeof SCOPE_TIER_FIELDS)[InputScopeTier];
+
+/** Most specific first — the order runtime scope extraction resolves in. */
+export const SCOPE_TIER_ORDER = ["project", "team", "organization"] as const;
+
+type TierOfField<F> = {
+  [T in InputScopeTier]: F extends (typeof SCOPE_TIER_FIELDS)[T] ? T : never;
+}[InputScopeTier];
+
+type ResourceOfPermission<P extends string> = P extends `${infer R}:${string}`
+  ? R extends AuthzResource
+    ? R
+    : never
+  : never;
+
+/**
+ * The input-addressable tiers permission P can be granted at. Platform-tier
+ * permissions have no input-addressable tier and resolve to `never` here —
+ * they are refused by the declaration surfaces (see PlatformTierPermission).
+ */
+export type PermissionGrantTiers<P extends AuthzPermission> = Extract<
+  (typeof AUTHZ_RESOURCES)[ResourceOfPermission<P>]["scopes"][number],
+  InputScopeTier
+>;
+
+/** Permissions grantable only at the platform tier (`ops:*`). */
+export type PlatformTierPermission = {
+  [P in AuthzPermission]: "platform" extends (typeof AUTHZ_RESOURCES)[ResourceOfPermission<P>]["scopes"][number]
+    ? P
+    : never;
+}[AuthzPermission];
+
+/**
+ * The tiers a KNOWN id can derive an ancestor scope for: a projectId resolves
+ * its team and organization, a teamId its organization. `via` declarations
+ * lean on this — the derivation is legal exactly when the named field's tier
+ * sits at or below a tier the permission is grantable at.
+ */
+type DerivableTiers<T extends InputScopeTier> = T extends "project"
+  ? "project" | "team" | "organization"
+  : T extends "team"
+    ? "team" | "organization"
+    : "organization";
+
+/** Scope-tier fields present in input I at all (optional counts). */
+type TierFieldsIn<I> = Extract<keyof I, ScopeTierField>;
+
+/** Scope-tier fields I REQUIRES (present and not undefined). */
+type RequiredTierFieldsIn<I> = {
+  [K in TierFieldsIn<I>]: I extends Record<K, string> ? K : never;
+}[TierFieldsIn<I>];
+
+/** The tiers of the fields present in I. */
+type TiersPresentIn<I> = TierOfField<TierFieldsIn<I>>;
+
+/** The tiers I is guaranteed to carry an id for. */
+type TiersRequiredIn<I> = TierOfField<RequiredTierFieldsIn<I>>;
+
+/**
+ * The brand a failed declaration resolves to. Never constructed at runtime —
+ * its only job is to carry `Reason` into the assignability diagnostic.
+ */
+export type PermissionDeclarationError<Reason extends string> = {
+  readonly "Permission declaration error": Reason;
+};
+
+/**
+ * Unconstrained on purpose: with a still-generic P, `PermissionGrantTiers<P>`
+ * stays deferred and the compiler cannot apply an `extends InputScopeTier`
+ * constraint to it — the conditional inside does the narrowing instead, which
+ * also proves the result interpolates into the template-literal diagnostics.
+ */
+type FieldsForTiers<T> = T extends InputScopeTier
+  ? (typeof SCOPE_TIER_FIELDS)[T]
+  : never;
+
+/**
+ * One input shape (never a union — the caller distributes) checked against
+ * one permission:
+ *
+ *  - platform-tier permissions are refused outright (the operator middleware
+ *    owns them, and resolves a scope no procedure input carries);
+ *  - at least one tier the permission allows must be REQUIRED by the input,
+ *    so the runtime always has an id to resolve. An id from a tier the
+ *    permission cannot be granted at is fine as long as an allowed one is
+ *    there too — inputs routinely carry child-tier ids as PAYLOAD (a
+ *    department's teamId under an organization-only check), and the runtime
+ *    only ever reads the allowed tiers.
+ */
+type ValidateOneInput<
+  P extends AuthzPermission,
+  I,
+> = [P] extends [PlatformTierPermission]
+  ? PermissionDeclarationError<`'${P}' is platform-tier: declare it through the operator middleware, not a scoped input`>
+  : [Extract<TiersRequiredIn<I>, PermissionGrantTiers<P>>] extends [never]
+    ? PermissionDeclarationError<`'${P}' needs a required '${FieldsForTiers<PermissionGrantTiers<P>>}' in the procedure input`>
+    : P;
+
+/**
+ * The validation the declaration surfaces intersect with their permission
+ * parameter: resolves to P when every member of the (possibly union) input
+ * shape validates, and to the branded error otherwise — `P & error` is
+ * uninhabited, so the call site fails with the reason in the diagnostic.
+ */
+export type ValidatePermissionForInput<P extends AuthzPermission, I> = [
+  I,
+] extends [never]
+  ? PermissionDeclarationError<"the procedure declares no input to read a scope id from — call .input() first">
+  : I extends unknown
+    ? ValidateOneInput<P, I>
+    : never;
+
+/**
+ * The fields of I a `via` derivation may name for permission P: required in
+ * the input, and of a tier that can derive a tier P is grantable at. The
+ * derivation exists for the org-tier-permission-with-a-narrower-id case, so
+ * fields whose own tier already satisfies P directly are excluded — plain
+ * `.permission(p)` covers those without ceremony.
+ */
+export type ViaFieldFor<P extends AuthzPermission, I> = [P] extends [
+  PlatformTierPermission,
+]
+  ? never
+  : I extends unknown
+    ? {
+        [K in RequiredTierFieldsIn<I>]: TierOfField<K> extends PermissionGrantTiers<P>
+          ? never
+          : PermissionGrantTiers<P> extends DerivableTiers<TierOfField<K>>
+            ? K
+            : never;
+      }[RequiredTierFieldsIn<I>]
+    : never;
+
+/**
+ * Options for a no-permission declaration over input I. Every scope-tier
+ * field the input carries must be individually allowed with a written reason
+ * — the compile-time form of the legacy `skipPermissionCheck` runtime guard.
+ */
+export type NoPermissionOptions<I> = I extends unknown
+  ? [TierFieldsIn<I>] extends [never]
+    ? {
+        /** Why this procedure needs no permission check. */
+        reason: string;
+        allow?: undefined;
+      }
+    : {
+        reason: string;
+        /**
+         * Why each scope id in the input is safe to accept without a
+         * permission check on it.
+         */
+        allow: { [K in TierFieldsIn<I>]: string };
+      }
+  : never;
+
+/**
+ * The scope argument an IMPERATIVE check takes for permission P: exactly one
+ * id, at a tier the permission is grantable at. The `undefined`-optional
+ * counterkeys make the union exclusive — passing two ids is a compile error,
+ * as is an id from a tier the registry does not list for P. Platform-tier
+ * permissions admit no scope id at all, so the argument collapses to `never`
+ * and the call is unwritable.
+ */
+export type PermissionScopeArg<P extends AuthzPermission> =
+  | ("project" extends PermissionGrantTiers<P>
+      ? {
+          projectId: string;
+          teamId?: undefined;
+          organizationId?: undefined;
+        }
+      : never)
+  | ("team" extends PermissionGrantTiers<P>
+      ? {
+          teamId: string;
+          projectId?: undefined;
+          organizationId?: undefined;
+        }
+      : never)
+  | ("organization" extends PermissionGrantTiers<P>
+      ? {
+          organizationId: string;
+          projectId?: undefined;
+          teamId?: undefined;
+        }
+      : never);
+
+// ============================================================================
+// Runtime mirrors — the same rules, for the middleware to agree with the types
+// ============================================================================
+
+const INPUT_TIERS: ReadonlySet<string> = new Set(SCOPE_TIER_ORDER);
+
+/** The input-addressable tiers `permission` can be granted at, most specific first. */
+export function permissionGrantTiers(
+  permission: AuthzPermission,
+): InputScopeTier[] {
+  const resource = permission.split(":")[0] as AuthzResource;
+  const scopes: readonly string[] = AUTHZ_RESOURCES[resource]?.scopes ?? [];
+  return SCOPE_TIER_ORDER.filter((tier) => scopes.includes(tier)).filter(
+    (tier): tier is InputScopeTier => INPUT_TIERS.has(tier),
+  );
+}
+
+export function isPlatformTierPermission(permission: AuthzPermission): boolean {
+  const resource = permission.split(":")[0] as AuthzResource;
+  const scopes: readonly string[] = AUTHZ_RESOURCES[resource]?.scopes ?? [];
+  return scopes.includes("platform");
+}
+
+export type DeclaredScopeId = {
+  tier: InputScopeTier;
+  id: string;
+};
+
+/**
+ * The scope a declared check runs at: the most specific tier the permission
+ * is grantable at whose id the input actually carries — or the `via` field's
+ * tier when the declaration names one. Returns null when nothing usable is
+ * present, which the types prevent and the runtime still treats as a wiring
+ * bug rather than a denial.
+ */
+export function declaredScopeId({
+  permission,
+  input,
+  via,
+}: {
+  permission: AuthzPermission;
+  input: Partial<Record<ScopeTierField, unknown>>;
+  via?: ScopeTierField;
+}): DeclaredScopeId | null {
+  if (via) {
+    const id = input[via];
+    if (typeof id !== "string" || id.length === 0) return null;
+    const tier = (
+      Object.entries(SCOPE_TIER_FIELDS) as [InputScopeTier, ScopeTierField][]
+    ).find(([, field]) => field === via)?.[0];
+    return tier ? { tier, id } : null;
+  }
+  for (const tier of permissionGrantTiers(permission)) {
+    const id = input[SCOPE_TIER_FIELDS[tier]];
+    if (typeof id === "string" && id.length > 0) return { tier, id };
+  }
+  return null;
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -51,6 +51,25 @@ export type {
   ShareableResourceKind,
 } from "./registry";
 export {
+  declaredScopeId,
+  isPlatformTierPermission,
+  permissionGrantTiers,
+  SCOPE_TIER_FIELDS,
+  SCOPE_TIER_ORDER,
+} from "./declaration";
+export type {
+  DeclaredScopeId,
+  InputScopeTier,
+  NoPermissionOptions,
+  PermissionDeclarationError,
+  PermissionGrantTiers,
+  PermissionScopeArg,
+  PlatformTierPermission,
+  ScopeTierField,
+  ValidatePermissionForInput,
+  ViaFieldFor,
+} from "./declaration";
+export {
   builtinRoleGrants,
   builtinRolePermissions,
   roleKeyForTeamRole,

--- a/platform/app/ee/billing/currencyRouter.ts
+++ b/platform/app/ee/billing/currencyRouter.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { skipPermissionCheck } from "../../src/server/api/rbac";
 import {
   createTRPCRouter,
   protectedProcedure,
@@ -10,7 +9,7 @@ export const createCurrencyRouter = () => {
   return createTRPCRouter({
     detectCurrency: protectedProcedure
       .input(z.object({}).passthrough())
-      .use(skipPermissionCheck)
+      .noPermission({ reason: "currency catalog is public reference data" })
       .query(async ({ ctx }) => {
         return detectCurrencyFromRequest(ctx.req);
       }),

--- a/platform/app/ee/billing/subscriptionRouter.ts
+++ b/platform/app/ee/billing/subscriptionRouter.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { Currency } from "~/generated/prisma/client";
-import { checkOrganizationPermission } from "../../src/server/api/rbac";
 import {
   createTRPCRouter,
   protectedProcedure,
@@ -41,7 +40,7 @@ export const createSubscriptionRouterFactory = ({
           quotedAt: z.number().int().positive().optional(),
         }),
       )
-      .use(checkOrganizationPermission("organization:manage"))
+      .permission("organization:manage")
       .mutation(async ({ input }) => {
         return await subscriptionService.updateSubscriptionItems({
           organizationId: input.organizationId,
@@ -66,7 +65,7 @@ export const createSubscriptionRouterFactory = ({
           billingInterval: z.enum(["monthly", "annual"]).optional(),
         }),
       )
-      .use(checkOrganizationPermission("organization:manage"))
+      .permission("organization:manage")
       .mutation(async ({ input, ctx }) => {
         const customerId = await customerService.getOrCreateCustomerId({
           user: ctx.session.user,
@@ -87,7 +86,7 @@ export const createSubscriptionRouterFactory = ({
 
     manage: protectedProcedure
       .input(z.object({ organizationId: z.string(), baseUrl: z.string() }))
-      .use(checkOrganizationPermission("organization:manage"))
+      .permission("organization:manage")
       .mutation(async ({ input, ctx }) => {
         const customerId = await customerService.getOrCreateCustomerId({
           user: ctx.session.user,
@@ -108,7 +107,7 @@ export const createSubscriptionRouterFactory = ({
           newTotalSeats: z.number().min(1),
         }),
       )
-      .use(checkOrganizationPermission("organization:manage"))
+      .permission("organization:manage")
       .query(async ({ input }) => {
         return await subscriptionService.previewProration({
           organizationId: input.organizationId,
@@ -118,7 +117,7 @@ export const createSubscriptionRouterFactory = ({
 
     getLastSubscription: protectedProcedure
       .input(z.object({ organizationId: z.string() }))
-      .use(checkOrganizationPermission("organization:view"))
+      .permission("organization:view")
       .query(async ({ input }) => {
         return await subscriptionService.getLastNonCancelledSubscription(
           input.organizationId,
@@ -141,7 +140,7 @@ export const createSubscriptionRouterFactory = ({
           ),
         }),
       )
-      .use(checkOrganizationPermission("organization:manage"))
+      .permission("organization:manage")
       .mutation(async ({ input, ctx }) => {
         const customerId = await customerService.getOrCreateCustomerId({
           user: ctx.session.user,
@@ -169,7 +168,7 @@ export const createSubscriptionRouterFactory = ({
           note: z.string().optional(),
         }),
       )
-      .use(checkOrganizationPermission("organization:manage"))
+      .permission("organization:manage")
       .mutation(async ({ input, ctx }) => {
         const actorEmail = ctx.session.user.email;
         if (!actorEmail) {
@@ -188,7 +187,7 @@ export const createSubscriptionRouterFactory = ({
 
     listInvoices: protectedProcedure
       .input(z.object({ organizationId: z.string() }))
-      .use(checkOrganizationPermission("organization:view"))
+      .permission("organization:view")
       .query(async ({ input }) => {
         return await subscriptionService.listInvoices({
           organizationId: input.organizationId,

--- a/platform/app/ee/governance/routers/activityMonitor.ts
+++ b/platform/app/ee/governance/routers/activityMonitor.ts
@@ -22,7 +22,6 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
   requireEnterprisePlan,
 } from "~/server/api/enterprise";
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 const enterpriseGate = requireEnterprisePlan(
@@ -41,7 +40,7 @@ export const activityMonitorRouter = createTRPCRouter({
         windowDays: z.number().int().min(1).max(365).default(30),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -69,7 +68,7 @@ export const activityMonitorRouter = createTRPCRouter({
         sortDir: z.enum(["asc", "desc"]).default("desc"),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -102,7 +101,7 @@ export const activityMonitorRouter = createTRPCRouter({
         sortDir: z.enum(["asc", "desc"]).default("desc"),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -132,7 +131,7 @@ export const activityMonitorRouter = createTRPCRouter({
         windowDays: z.number().int().min(1).max(365).default(30),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -159,7 +158,7 @@ export const activityMonitorRouter = createTRPCRouter({
         groupBy: z.enum(["team", "user", "model"]).default("team"),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -175,7 +174,7 @@ export const activityMonitorRouter = createTRPCRouter({
    */
   ingestionSourcesHealth: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -197,7 +196,7 @@ export const activityMonitorRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(200).default(50),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -221,7 +220,7 @@ export const activityMonitorRouter = createTRPCRouter({
         beforeIso: z.string().optional(),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);
@@ -239,7 +238,7 @@ export const activityMonitorRouter = createTRPCRouter({
         sourceId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("activityMonitor:view"))
+    .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = ActivityMonitorService.create(ctx.prisma);

--- a/platform/app/ee/governance/routers/aiTools.ts
+++ b/platform/app/ee/governance/routers/aiTools.ts
@@ -28,7 +28,6 @@ import {
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 
@@ -74,7 +73,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:view"))
+    .permission("aiTools:view")
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       try {
@@ -107,7 +106,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   providerAvailability: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:view"))
+    .permission("aiTools:view")
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       const configuredProviders = await service.listConfiguredProvidersForUser({
@@ -133,7 +132,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   claudeCodeOtlpEndpoint: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:view"))
+    .permission("aiTools:view")
     .query(async ({ ctx, input }) => {
       const source = await ctx.prisma.ingestionSource.findFirst({
         where: {
@@ -155,7 +154,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   adminList: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       return await service.listForAdmin({
@@ -165,7 +164,7 @@ export const aiToolsRouter = createTRPCRouter({
 
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       const row = await service.findById({
@@ -190,7 +189,7 @@ export const aiToolsRouter = createTRPCRouter({
         config: z.record(z.string(), z.unknown()),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       try {
@@ -232,7 +231,7 @@ export const aiToolsRouter = createTRPCRouter({
         config: z.record(z.string(), z.unknown()).optional(),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       try {
@@ -267,7 +266,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   remove: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       return await service.remove({
@@ -291,7 +290,7 @@ export const aiToolsRouter = createTRPCRouter({
         enabled: z.boolean(),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       return await service.update({
@@ -321,7 +320,7 @@ export const aiToolsRouter = createTRPCRouter({
         slugs: z.array(z.string()).min(1).optional(),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       return await service.seedStarterPack({
@@ -338,7 +337,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   starterPackCatalog: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .query(() => {
       return AiToolEntryService.listStarterPackTiles();
     }),
@@ -353,7 +352,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   providerOptions: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       return await service.listProviderOptionsForAdmin({
@@ -369,7 +368,7 @@ export const aiToolsRouter = createTRPCRouter({
    */
   routingPolicyOptions: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .query(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       return await service.listRoutingPolicyOptionsForAdmin({
@@ -386,7 +385,7 @@ export const aiToolsRouter = createTRPCRouter({
           .min(1),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = AiToolEntryService.create(ctx.prisma);
       await service.reorder({

--- a/platform/app/ee/governance/routers/anomalyRules.ts
+++ b/platform/app/ee/governance/routers/anomalyRules.ts
@@ -30,7 +30,6 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
   requireEnterprisePlan,
 } from "~/server/api/enterprise";
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 const enterpriseGate = requireEnterprisePlan(
@@ -137,7 +136,7 @@ function toDto(row: {
 export const anomalyRulesRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("anomalyRules:view"))
+    .permission("anomalyRules:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = AnomalyRuleService.create(ctx.prisma);
@@ -147,7 +146,7 @@ export const anomalyRulesRouter = createTRPCRouter({
 
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("anomalyRules:view"))
+    .permission("anomalyRules:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
       const service = AnomalyRuleService.create(ctx.prisma);
@@ -173,7 +172,7 @@ export const anomalyRulesRouter = createTRPCRouter({
         status: statusSchema.optional(),
       }),
     )
-    .use(checkOrganizationPermission("anomalyRules:manage"))
+    .permission("anomalyRules:manage")
     .use(enterpriseGate)
     .mutation(async ({ ctx, input }) => {
       const service = AnomalyRuleService.create(ctx.prisma);
@@ -213,7 +212,7 @@ export const anomalyRulesRouter = createTRPCRouter({
         status: statusSchema.optional(),
       }),
     )
-    .use(checkOrganizationPermission("anomalyRules:manage"))
+    .permission("anomalyRules:manage")
     .use(enterpriseGate)
     .mutation(async ({ ctx, input }) => {
       const service = AnomalyRuleService.create(ctx.prisma);
@@ -241,7 +240,7 @@ export const anomalyRulesRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("anomalyRules:manage"))
+    .permission("anomalyRules:manage")
     .use(enterpriseGate)
     .mutation(async ({ ctx, input }) => {
       const service = AnomalyRuleService.create(ctx.prisma);

--- a/platform/app/ee/governance/routers/departments.ts
+++ b/platform/app/ee/governance/routers/departments.ts
@@ -17,13 +17,12 @@ import { HandledError } from "@langwatch/handled-error";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const departmentsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("governance:view"))
+    .permission("governance:view")
     .query(async ({ ctx, input }) => {
       return await DepartmentService.create(ctx.prisma).getAll({
         organizationId: input.organizationId,
@@ -32,7 +31,7 @@ export const departmentsRouter = createTRPCRouter({
 
   assignments: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("governance:view"))
+    .permission("governance:view")
     .query(async ({ ctx, input }) => {
       return await DepartmentService.create(ctx.prisma).getAssignments({
         organizationId: input.organizationId,
@@ -46,7 +45,7 @@ export const departmentsRouter = createTRPCRouter({
         name: z.string().min(1).max(128),
       }),
     )
-    .use(checkOrganizationPermission("governance:manage"))
+    .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
       return await DepartmentService.create(ctx.prisma).create({
         organizationId: input.organizationId,
@@ -62,7 +61,7 @@ export const departmentsRouter = createTRPCRouter({
         name: z.string().min(1).max(128),
       }),
     )
-    .use(checkOrganizationPermission("governance:manage"))
+    .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
       try {
         return await DepartmentService.create(ctx.prisma).rename({
@@ -77,7 +76,7 @@ export const departmentsRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("governance:manage"))
+    .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
       try {
         await DepartmentService.create(ctx.prisma).archive({
@@ -98,7 +97,7 @@ export const departmentsRouter = createTRPCRouter({
         departmentId: z.string().nullable(),
       }),
     )
-    .use(checkOrganizationPermission("governance:manage"))
+    .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
       try {
         await DepartmentService.create(ctx.prisma).assignUser(input);
@@ -116,7 +115,7 @@ export const departmentsRouter = createTRPCRouter({
         departmentId: z.string().nullable(),
       }),
     )
-    .use(checkOrganizationPermission("governance:manage"))
+    .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
       try {
         await DepartmentService.create(ctx.prisma).assignTeam(input);
@@ -134,7 +133,7 @@ export const departmentsRouter = createTRPCRouter({
         departmentId: z.string().nullable(),
       }),
     )
-    .use(checkOrganizationPermission("governance:manage"))
+    .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
       try {
         await DepartmentService.create(ctx.prisma).assignProject(input);

--- a/platform/app/ee/governance/routers/governance.ts
+++ b/platform/app/ee/governance/routers/governance.ts
@@ -34,10 +34,7 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
   requireEnterprisePlan,
 } from "~/server/api/enterprise";
-import {
-  checkOrganizationPermission,
-  hasOrganizationPermission,
-} from "~/server/api/rbac";
+import { hasOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { featureFlagService } from "~/server/featureFlag";
@@ -58,7 +55,7 @@ export const governanceRouter = createTRPCRouter({
    */
   setupState: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("governance:view"))
+    .permission("governance:view")
     .query(async ({ ctx, input }) => {
       const service = GovernanceSetupStateService.create({
         prisma: ctx.prisma,
@@ -85,7 +82,7 @@ export const governanceRouter = createTRPCRouter({
    */
   resolveHome: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }): Promise<PersonaResolution> => {
       const userId = ctx.session.user.id;
       const setupService = GovernanceSetupStateService.create({
@@ -223,7 +220,7 @@ export const governanceRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(1000).default(500),
       }),
     )
-    .use(checkOrganizationPermission("complianceExport:view"))
+    .permission("complianceExport:view")
     .use(requireEnterprisePlan(ENTERPRISE_FEATURE_ERRORS.OCSF_EXPORT))
     .query(async ({ ctx, input }) => {
       const service = GovernanceOcsfExportService.create({
@@ -289,7 +286,7 @@ export const governanceRouter = createTRPCRouter({
         workspaceLabel: z.string().max(256).optional(),
       }),
     )
-    .use(checkOrganizationPermission("governance:view"))
+    .permission("governance:view")
     .mutation(async ({ ctx, input }) => {
       const service = AdminWorkspaceViewAuditService.create({
         prisma: ctx.prisma,
@@ -331,7 +328,7 @@ export const governanceRouter = createTRPCRouter({
         actor: z.string().min(1).max(512),
       }),
     )
-    .use(checkOrganizationPermission("governance:view"))
+    .permission("governance:view")
     .query(async ({ ctx, input }) => {
       // Match by email (CH-stamped actor is typically the email) OR
       // by id directly. Two-step: resolve User first, then ask
@@ -389,7 +386,7 @@ export const governanceRouter = createTRPCRouter({
           .default(QUARANTINE_DEFAULT_THRESHOLD),
       }),
     )
-    .use(checkOrganizationPermission("governance:view"))
+    .permission("governance:view")
     .query(async ({ ctx, input }) => {
       const evaluator = QuarantineFillEvaluator.create({
         prisma: ctx.prisma,

--- a/platform/app/ee/governance/routers/governance.ts
+++ b/platform/app/ee/governance/routers/governance.ts
@@ -34,9 +34,9 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
   requireEnterprisePlan,
 } from "~/server/api/enterprise";
-import { hasOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
+import { hasOrganizationPermission } from "~/server/app-layer/permissions/imperative";
 import { featureFlagService } from "~/server/featureFlag";
 import { UsageStatsService } from "~/server/license-enforcement/usage-stats.service";
 

--- a/platform/app/ee/governance/routers/ingestionKey.ts
+++ b/platform/app/ee/governance/routers/ingestionKey.ts
@@ -20,7 +20,6 @@
 import { IngestionKeyService } from "@ee/governance/services/ingestionKey.service";
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 const mintInput = z.object({
@@ -37,7 +36,7 @@ export const ingestionKeyRouter = createTRPCRouter({
    */
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const service = IngestionKeyService.create(ctx.prisma);
       return await service.listForPersonalProject({
@@ -53,7 +52,7 @@ export const ingestionKeyRouter = createTRPCRouter({
    */
   install: protectedProcedure
     .input(mintInput)
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionKeyService.create(ctx.prisma);
       return await service.ensureForPersonalProject({
@@ -71,7 +70,7 @@ export const ingestionKeyRouter = createTRPCRouter({
    */
   rotate: protectedProcedure
     .input(mintInput)
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionKeyService.create(ctx.prisma);
       return await service.ensureForPersonalProject({

--- a/platform/app/ee/governance/routers/ingestionSources.ts
+++ b/platform/app/ee/governance/routers/ingestionSources.ts
@@ -32,7 +32,6 @@ import {
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 const sourceTypeSchema = z.enum(
@@ -97,7 +96,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
   /** List configured sources for an org. */
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("ingestionSources:view"))
+    .permission("ingestionSources:view")
     .query(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const rows = await service.list(input.organizationId);
@@ -107,7 +106,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
   /** Get a single source by id (org-scoped). */
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("ingestionSources:view"))
+    .permission("ingestionSources:view")
     .query(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const row = await service.findById(input.id, input.organizationId);
@@ -138,7 +137,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         pullSchedule: z.string().min(1).max(64).nullable().optional(),
       }),
     )
-    .use(checkOrganizationPermission("ingestionSources:manage"))
+    .permission("ingestionSources:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const created = await service.createSource({
@@ -171,7 +170,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         pullSchedule: z.string().min(1).max(64).nullable().optional(),
       }),
     )
-    .use(checkOrganizationPermission("ingestionSources:manage"))
+    .permission("ingestionSources:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const updated = await service.updateSource({
@@ -193,7 +192,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
    */
   rotateSecret: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("ingestionSources:manage"))
+    .permission("ingestionSources:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const rotated = await service.rotateSecret(
@@ -208,7 +207,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("ingestionSources:manage"))
+    .permission("ingestionSources:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const archived = await service.archive(input.id, input.organizationId);
@@ -230,7 +229,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         sourceType: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("ingestionSources:view"))
+    .permission("ingestionSources:view")
     .query(({ input }) => {
       return {
         enabled: isOttlEnabledSourceType(input.sourceType),
@@ -258,7 +257,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         statements: z.array(z.string()).min(0).max(64),
       }),
     )
-    .use(checkOrganizationPermission("ingestionSources:manage"))
+    .permission("ingestionSources:manage")
     .mutation(async ({ input }) => {
       try {
         return await validateOttlStatements(input.statements);

--- a/platform/app/ee/governance/routers/ingestionTemplates.ts
+++ b/platform/app/ee/governance/routers/ingestionTemplates.ts
@@ -19,7 +19,6 @@ import {
 } from "@ee/governance/services/ingestionTemplate.service";
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 /**
@@ -44,7 +43,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
    */
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:view"))
+    .permission("aiTools:view")
     .query(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       return await service.listForUser({
@@ -59,7 +58,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
    */
   adminList: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .query(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       return await service.listForOrgAdmin({
@@ -74,7 +73,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
    */
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("aiTools:view"))
+    .permission("aiTools:view")
     .query(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       const row = await service.findByIdForOrg({
@@ -107,7 +106,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
         ottlRules: z.string().max(50_000).optional(),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       return await service.createOrgTemplate({
@@ -139,7 +138,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
         ottlRules: z.string().max(50_000),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       return await service.updateOttlRules({
@@ -156,7 +155,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
    */
   archive: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       await service.archiveOrgTemplate({
@@ -181,7 +180,7 @@ export const ingestionTemplatesRouter = createTRPCRouter({
         sourceTemplateId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("aiTools:manage"))
+    .permission("aiTools:manage")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionTemplateService.create(ctx.prisma);
       return await service.cloneFromPlatform({

--- a/platform/app/ee/governance/routers/personalSessions.ts
+++ b/platform/app/ee/governance/routers/personalSessions.ts
@@ -21,13 +21,12 @@ import { CliSessionInventoryService } from "@ee/governance/services/cliSessionIn
 import { CliTokenRevocationService } from "@ee/governance/services/cliTokenRevocation.service";
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const personalSessionsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx }) => {
       const service = CliSessionInventoryService.create();
       const sessions = await service.listForUser({
@@ -51,7 +50,7 @@ export const personalSessionsRouter = createTRPCRouter({
         sessionStartedAtMs: z.number().int().nonnegative(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       const service = CliSessionInventoryService.create();
       const result = await service.revokeSession({
@@ -63,7 +62,7 @@ export const personalSessionsRouter = createTRPCRouter({
 
   revokeAll: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx }) => {
       // Reuse the user-wide revoke from Phase 1B.5 — that path also
       // clears the per-user token index in one shot.

--- a/platform/app/ee/governance/routers/sessionPolicy.ts
+++ b/platform/app/ee/governance/routers/sessionPolicy.ts
@@ -15,13 +15,12 @@
  */
 import { z } from "zod";
 
-import { checkOrganizationPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const sessionPolicyRouter = createTRPCRouter({
   get: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const org = await ctx.prisma.organization.findUnique({
         where: { id: input.organizationId },
@@ -45,7 +44,7 @@ export const sessionPolicyRouter = createTRPCRouter({
         maxSessionDurationDays: z.number().int().min(0).max(365),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       await ctx.prisma.organization.update({
         where: { id: input.organizationId },

--- a/platform/app/ee/scim/__tests__/scim-page-size-cap.unit.test.ts
+++ b/platform/app/ee/scim/__tests__/scim-page-size-cap.unit.test.ts
@@ -20,6 +20,14 @@ const { listUsers, listGroups, verifyEntitled } = vi.hoisted(() => ({
   verifyEntitled: vi.fn(),
 }));
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("~/server/db", () => ({ prisma: {} }));
 
 vi.mock("@ee/scim/scim-token.service", () => ({

--- a/platform/app/src/app/api/api-keys/[[...route]]/app.ts
+++ b/platform/app/src/app/api/api-keys/[[...route]]/app.ts
@@ -21,6 +21,7 @@ import { permissionFormatSchema } from "~/server/rbac/custom-role-permissions";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
 import type { ApiKeyServiceMiddlewareVariables } from "../../middleware/api-key-service";
 import { apiKeyServiceMiddleware } from "../../middleware/api-key-service";
+import { appFromContext } from "../../middleware/app-context";
 import { handleApiKeyError } from "./error-handler";
 import {
   CREATE_API_KEY,
@@ -216,10 +217,11 @@ const resolveCallerCanReadAnyKey = async ({
     apiKeyId,
   });
   if (!callerIsAdmin) return false;
-  return service.hasOrgScopedPermission({
+  return appFromContext(c).permissions.hasApiKeyPermission({
     apiKeyId,
     userId: callerUserId,
     organizationId,
+    scope: { type: "org", id: organizationId },
     permission: "organization:manage",
   });
 };
@@ -346,10 +348,13 @@ secured
       const service = c.get("apiKeyService") as ApiKeyService;
 
       if (!userId) {
-        const canManage = await service.hasOrgScopedPermission({
+        const canManage = await appFromContext(
+          c,
+        ).permissions.hasApiKeyPermission({
           apiKeyId: c.get("apiKeyId") as string,
           userId: null,
           organizationId: organization.id,
+          scope: { type: "org", id: organization.id },
           permission: "organization:manage",
         });
         if (!canManage) {

--- a/platform/app/src/app/api/dataset/[[...route]]/__tests__/direct-upload-auth.unit.test.ts
+++ b/platform/app/src/app/api/dataset/[[...route]]/__tests__/direct-upload-auth.unit.test.ts
@@ -22,7 +22,7 @@ vi.mock("~/server/auth", () => ({
 }));
 
 const hasProjectPermission = vi.fn();
-vi.mock("~/server/api/rbac", () => ({
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
   hasProjectPermission: (...args: unknown[]) => hasProjectPermission(...args),
 }));
 

--- a/platform/app/src/app/api/dataset/[[...route]]/direct-upload-auth.ts
+++ b/platform/app/src/app/api/dataset/[[...route]]/direct-upload-auth.ts
@@ -21,13 +21,13 @@
 
 import type { Context } from "hono";
 import type { Project } from "~/generated/prisma/client";
-import { hasProjectPermission } from "~/server/api/rbac";
 import {
   apiKeyCeilingDenialResponse,
   enforceApiKeyCeiling,
   extractCredentials,
 } from "~/server/api-key/auth-middleware";
 import { TokenResolver } from "~/server/api-key/token-resolver";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 
@@ -103,7 +103,7 @@ export async function authorizeDirectUpload(
       };
     }
     const permitted = await hasProjectPermission(
-      { prisma, session },
+      { session },
       projectId,
       PERMISSION,
     );
@@ -144,7 +144,7 @@ export async function authorizeDirectUpload(
   }
 
   try {
-    await enforceApiKeyCeiling({ prisma, resolved, permission: PERMISSION });
+    await enforceApiKeyCeiling({ resolved, permission: PERMISSION });
   } catch (error) {
     const denial = apiKeyCeilingDenialResponse(error);
     // The ceiling only ever denies with 403; narrowed here so the result keeps

--- a/platform/app/src/app/api/export/scenario-runs/[[...route]]/app.ts
+++ b/platform/app/src/app/api/export/scenario-runs/[[...route]]/app.ts
@@ -18,10 +18,10 @@ import { createGzip } from "node:zlib";
 import { auditLog } from "@ee/audit-log/auditLog";
 import { generate } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
-import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
 import { getApp } from "~/server/app-layer/app";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import {
@@ -59,7 +59,7 @@ secured
       }
 
       const hasPermission = await hasProjectPermission(
-        { prisma, session },
+        { session },
         request.projectId,
         "scenarios:view",
       );

--- a/platform/app/src/app/api/export/traces/[[...route]]/app.ts
+++ b/platform/app/src/app/api/export/traces/[[...route]]/app.ts
@@ -12,11 +12,11 @@
 import { HandledError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import crypto from "crypto";
-import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { getUserProtectionsForProject } from "~/server/api/utils";
 import { validator as zValidator } from "~/server/api/validation";
 import { getApp } from "~/server/app-layer/app";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import {
@@ -66,7 +66,7 @@ secured
 
     // Authorize
     const hasPermission = await hasProjectPermission(
-      { prisma, session },
+      { session },
       request.projectId,
       "traces:view",
     );

--- a/platform/app/src/app/api/files/[[...route]]/app.ts
+++ b/platform/app/src/app/api/files/[[...route]]/app.ts
@@ -4,7 +4,6 @@ import type { MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { anyAuthenticated, createServiceApp } from "~/server/api/security";
 import { requireProjectPermission } from "~/server/auth/permissions";
-import { prisma } from "~/server/db";
 import { rateLimit } from "~/server/rateLimit";
 import {
   STORED_OBJECT_RESPONSE_BASE_HEADERS as FILES_RESPONSE_BASE_HEADERS,
@@ -110,7 +109,6 @@ async function authorizeFileRead({
           userId,
           projectId: ownerProjectId,
           permission,
-          prisma,
         });
         return;
       } catch (err) {
@@ -146,7 +144,6 @@ async function authorizeFilePurpose({
       userId,
       projectId: ownerProjectId,
       permission: requiredPermissionForPurpose(purpose),
-      prisma,
     });
   } catch (err) {
     if (!isPermissionDenial(err)) throw err;

--- a/platform/app/src/app/api/middleware/__tests__/org-auth.permissions.unit.test.ts
+++ b/platform/app/src/app/api/middleware/__tests__/org-auth.permissions.unit.test.ts
@@ -20,6 +20,14 @@ vi.mock("~/server/rbac/role-binding-resolver", () => ({
     resolveApiKeyPermission(...args),
 }));
 
+// The middleware resolves its service from the App on the request context.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appCredentialPermissionsMock } = await import(
+    "~/test-utils/appCredentialPermissionsMock"
+  );
+  return appCredentialPermissionsMock();
+});
+
 import { requireOrgPermission, requireOrgPermissionOrThrow } from "../org-auth";
 
 type TestEnv = {

--- a/platform/app/src/app/api/middleware/app-context.ts
+++ b/platform/app/src/app/api/middleware/app-context.ts
@@ -1,0 +1,30 @@
+import type { Context, MiddlewareHandler } from "hono";
+import { type App, getApp, tryGetApp } from "~/server/app-layer/app";
+
+export type AppContextVariables = { app: App };
+
+/**
+ * Injects the composed App into the Hono context (`c.var.app`). Mounted by
+ * `SecuredApp` and the management-service factory, so every route family's
+ * middlewares and handlers read the App from their request context instead of
+ * resolving the singleton themselves.
+ *
+ * Injection tolerates absence (`tryGetApp`) so public routes on a family can
+ * answer without an App; `appFromContext` is where absence becomes an error,
+ * on the one path that actually needs a decision.
+ */
+export const appContextMiddleware: MiddlewareHandler = async (c, next) => {
+  const app = tryGetApp();
+  if (app) c.set("app", app);
+  await next();
+};
+
+/**
+ * The App this request decides through: the injected `c.var.app`, or the
+ * process singleton for handlers mounted outside the secured frameworks.
+ * Both are the same instance in production — the context variable exists so
+ * a test can hand in a fake without mocking the App module.
+ */
+export function appFromContext(c: Context): App {
+  return (c.get("app") as App | undefined) ?? getApp();
+}

--- a/platform/app/src/app/api/middleware/auth.ts
+++ b/platform/app/src/app/api/middleware/auth.ts
@@ -56,5 +56,5 @@ export function requirePermission(
   permission: AuthzPermission,
   errorEnvelope: ApiErrorEnvelope = "legacy",
 ): MiddlewareHandler {
-  return createRequireApiKeyPermission({ prisma, permission, errorEnvelope });
+  return createRequireApiKeyPermission({ permission, errorEnvelope });
 }

--- a/platform/app/src/app/api/middleware/auth.ts
+++ b/platform/app/src/app/api/middleware/auth.ts
@@ -1,7 +1,7 @@
+import type { AuthzPermission } from "@langwatch/authz";
 import type { MiddlewareHandler } from "hono";
 import type { ApiErrorEnvelope } from "~/app/api/shared/canonical-error";
 import type { Project } from "~/generated/prisma/client";
-import type { Permission } from "~/server/api/rbac";
 import {
   requireApiKeyPermission as createRequireApiKeyPermission,
   createUnifiedAuthMiddleware,
@@ -53,7 +53,7 @@ export const canonicalAuthMiddleware: MiddlewareHandler =
  * service/user API keys are checked against their role bindings.
  */
 export function requirePermission(
-  permission: Permission,
+  permission: AuthzPermission,
   errorEnvelope: ApiErrorEnvelope = "legacy",
 ): MiddlewareHandler {
   return createRequireApiKeyPermission({ prisma, permission, errorEnvelope });

--- a/platform/app/src/app/api/middleware/org-auth.ts
+++ b/platform/app/src/app/api/middleware/org-auth.ts
@@ -1,3 +1,4 @@
+import type { AuthzPermission } from "@langwatch/authz";
 import { HandledError } from "@langwatch/handled-error";
 import type { Context, MiddlewareHandler } from "hono";
 import {
@@ -5,7 +6,6 @@ import {
   authRefusalBody,
 } from "~/app/api/shared/canonical-error";
 import type { Organization } from "~/generated/prisma/client";
-import type { Permission } from "~/server/api/rbac";
 import { createOrgAuthMiddleware } from "~/server/api-key/auth-middleware";
 import type { OrgResolvedToken } from "~/server/api-key/token-resolver";
 import { remediation } from "~/server/app-layer/error-remediation";
@@ -45,7 +45,7 @@ export function requireProjectPermission({
   param,
   errorEnvelope = "legacy",
 }: {
-  permission: Permission;
+  permission: AuthzPermission;
   param: string;
   errorEnvelope?: ApiErrorEnvelope;
 }): MiddlewareHandler {
@@ -109,7 +109,7 @@ export function requireProjectPermission({
  */
 async function orgPermissionAllowed(
   c: Context,
-  permission: Permission,
+  permission: AuthzPermission,
 ): Promise<boolean> {
   const apiKeyId = c.get("apiKeyId") as string;
   const userId = c.get("apiKeyUserId") as string | null;
@@ -132,7 +132,7 @@ async function orgPermissionAllowed(
 }
 
 export function requireOrgPermission(
-  permission: Permission,
+  permission: AuthzPermission,
   errorEnvelope: ApiErrorEnvelope = "legacy",
 ): MiddlewareHandler {
   const refusal = authRefusalBody(errorEnvelope);
@@ -162,7 +162,7 @@ export function requireOrgPermission(
 export class InsufficientPermissionsError extends HandledError {
   declare readonly code: "insufficient_permissions";
 
-  constructor(permission: Permission) {
+  constructor(permission: AuthzPermission) {
     super(
       "insufficient_permissions",
       `Insufficient permissions. Required: ${permission}`,
@@ -185,7 +185,7 @@ export class InsufficientPermissionsError extends HandledError {
  * publishes, with no second copy of the refusal body to drift.
  */
 export function requireOrgPermissionOrThrow(
-  permission: Permission,
+  permission: AuthzPermission,
 ): MiddlewareHandler {
   return async (c, next) => {
     if (!(await orgPermissionAllowed(c, permission))) {

--- a/platform/app/src/app/api/middleware/org-auth.ts
+++ b/platform/app/src/app/api/middleware/org-auth.ts
@@ -10,7 +10,7 @@ import { createOrgAuthMiddleware } from "~/server/api-key/auth-middleware";
 import type { OrgResolvedToken } from "~/server/api-key/token-resolver";
 import { remediation } from "~/server/app-layer/error-remediation";
 import { prisma } from "~/server/db";
-import { resolveApiKeyPermission } from "~/server/rbac/role-binding-resolver";
+import { appFromContext } from "./app-context";
 
 export type OrgAuthMiddlewareVariables = {
   organization: Organization;
@@ -54,17 +54,17 @@ export function requireProjectPermission({
     const organization = c.get("organization") as Organization;
     const projectId = c.req.param(param);
 
-    const project = projectId
-      ? await prisma.project.findUnique({
-          where: { id: projectId },
-          select: {
-            id: true,
-            team: { select: { id: true, organizationId: true } },
-          },
+    const decision = projectId
+      ? await appFromContext(c).permissions.getApiKeyProjectDecision({
+          apiKeyId: c.get("apiKeyId") as string,
+          userId: c.get("apiKeyUserId") as string | null,
+          organizationId: organization.id,
+          projectId,
+          permission,
         })
-      : null;
+      : ({ outcome: "project_not_found" } as const);
 
-    if (!project || project.team.organizationId !== organization.id) {
+    if (decision.outcome === "project_not_found") {
       return c.json(
         refusal({
           status: 404,
@@ -76,16 +76,7 @@ export function requireProjectPermission({
       );
     }
 
-    const allowed = await resolveApiKeyPermission({
-      prisma,
-      apiKeyId: c.get("apiKeyId") as string,
-      userId: c.get("apiKeyUserId") as string | null,
-      organizationId: organization.id,
-      scope: { type: "project", id: project.id, teamId: project.team.id },
-      permission,
-    });
-
-    if (!allowed) {
+    if (decision.outcome === "denied") {
       return c.json(
         refusal({
           status: 403,
@@ -121,8 +112,7 @@ async function orgPermissionAllowed(
   }
   const organizationId = organization.id;
 
-  return resolveApiKeyPermission({
-    prisma,
+  return appFromContext(c).permissions.hasApiKeyPermission({
     apiKeyId,
     userId,
     organizationId,

--- a/platform/app/src/app/api/teams/[[...route]]/app.ts
+++ b/platform/app/src/app/api/teams/[[...route]]/app.ts
@@ -87,26 +87,32 @@ secured.access(requires("team:view")).get(
   },
 );
 
-secured.access(requires("team:create")).post(
-  "/",
-  teamServiceMiddleware,
-  describeRoute({
-    description: "Create a new team that can group projects and members",
-  }),
-  zValidator("json", createTeamSchema),
-  async (c) => {
-    const organization = c.get("organization") as Organization;
-    const body = c.req.valid("json");
-    const service = c.get("teamService") as TeamRestService;
+secured
+  .access(
+    /* no bag grants team:create; only team:manage implies it (registry vocabulary) */ requires(
+      "team:manage",
+    ),
+  )
+  .post(
+    "/",
+    teamServiceMiddleware,
+    describeRoute({
+      description: "Create a new team that can group projects and members",
+    }),
+    zValidator("json", createTeamSchema),
+    async (c) => {
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("teamService") as TeamRestService;
 
-    const team = await service.create({
-      organizationId: organization.id,
-      name: body.name,
-    });
+      const team = await service.create({
+        organizationId: organization.id,
+        name: body.name,
+      });
 
-    return c.json(teamResponse(team), 201);
-  },
-);
+      return c.json(teamResponse(team), 201);
+    },
+  );
 
 secured.access(requires("team:view")).get(
   "/:id",
@@ -131,7 +137,7 @@ secured.access(requires("team:view")).get(
   },
 );
 
-secured.access(requires("team:update")).patch(
+secured.access(requires("team:manage")).patch(
   "/:id",
   teamServiceMiddleware,
   describeRoute({
@@ -156,7 +162,7 @@ secured.access(requires("team:update")).patch(
   },
 );
 
-secured.access(requires("team:delete")).delete(
+secured.access(requires("team:manage")).delete(
   "/:id",
   teamServiceMiddleware,
   describeRoute({

--- a/platform/app/src/app/api/workflows/[[...route]]/app.ts
+++ b/platform/app/src/app/api/workflows/[[...route]]/app.ts
@@ -327,7 +327,7 @@ secured.access(requires("workflows:create")).post(
   // The caller polls the run + reads results on /api/experiments/runs/:runId(/results),
   // which require evaluations:view. Enforce it here too so a workflows-only key
   // cannot start a run it would then get 403 trying to read.
-  requireApiKeyPermission({ prisma, permission: "evaluations:view" }),
+  requireApiKeyPermission({ permission: "evaluations:view" }),
   zValidator("json", evaluateBodySchema),
   async (c) => {
     const project = c.get("project");

--- a/platform/app/src/mcp/governance-tools.ts
+++ b/platform/app/src/mcp/governance-tools.ts
@@ -53,7 +53,8 @@ type McpServerLike = {
 
 import { IngestionKeyService } from "../../ee/governance/services/ingestionKey.service";
 import { IngestionTemplateService } from "../../ee/governance/services/ingestionTemplate.service";
-import { hasOrganizationPermission, type Permission } from "../server/api/rbac";
+import type { Permission } from "../server/api/rbac";
+import { hasOrganizationPermission } from "../server/app-layer/permissions/imperative";
 
 const SURFACE = "mcp" as const;
 
@@ -117,7 +118,6 @@ export function registerGovernanceMcpTools(
     }
     const allowed = await hasOrganizationPermission(
       {
-        prisma: ctx.prisma,
         session: { user: { id: rctx.callerUserId } } as any,
       },
       rctx.organizationId,
@@ -139,7 +139,6 @@ export function registerGovernanceMcpTools(
     if (!rctx.callerUserId) return null;
     const allowed = await hasOrganizationPermission(
       {
-        prisma: ctx.prisma,
         session: { user: { id: rctx.callerUserId } } as any,
       },
       rctx.organizationId,

--- a/platform/app/src/pages/api/experiment/init.ts
+++ b/platform/app/src/pages/api/experiment/init.ts
@@ -73,7 +73,6 @@ export default async function handler(
   // initializing an experiment run requires `experiments:manage`.
   try {
     await enforceApiKeyCeiling({
-      prisma,
       resolved,
       permission: "experiments:manage",
     });

--- a/platform/app/src/server/api-key/__tests__/auth-middleware.ceiling.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/auth-middleware.ceiling.unit.test.ts
@@ -23,9 +23,15 @@ vi.mock("~/server/rbac/role-binding-resolver", () => ({
   resolveApiKeyPermission: vi.fn(),
 }));
 
-const resolveMock = vi.mocked(resolveApiKeyPermission);
+// The ceiling resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appCredentialPermissionsMock } = await import(
+    "~/test-utils/appCredentialPermissionsMock"
+  );
+  return appCredentialPermissionsMock();
+});
 
-const prisma = {} as never;
+const resolveMock = vi.mocked(resolveApiKeyPermission);
 
 const project = {
   id: "proj1",
@@ -60,10 +66,7 @@ function appWith(resolved: ResolvedToken | undefined) {
     if (resolved) c.set("resolvedToken" as never, resolved as never);
     await next();
   });
-  app.use(
-    "*",
-    requireApiKeyPermission({ prisma, permission: "project:update" }),
-  );
+  app.use("*", requireApiKeyPermission({ permission: "project:update" }));
   app.get("/", handler as never);
   return { app, handler };
 }
@@ -80,7 +83,6 @@ describe("enforceApiKeyCeiling()", () => {
 
         await expect(
           enforceApiKeyCeiling({
-            prisma,
             resolved: apiKeyToken,
             permission: "project:update",
           }),
@@ -94,7 +96,6 @@ describe("enforceApiKeyCeiling()", () => {
 
         await expect(
           enforceApiKeyCeiling({
-            prisma,
             resolved: apiKeyToken,
             permission: "project:update",
           }),
@@ -107,7 +108,6 @@ describe("enforceApiKeyCeiling()", () => {
         resolveMock.mockResolvedValue(true);
 
         await enforceApiKeyCeiling({
-          prisma,
           resolved: apiKeyToken,
           permission: "project:update",
         });
@@ -135,7 +135,6 @@ describe("enforceApiKeyCeiling()", () => {
     it("skips the ceiling entirely", async () => {
       await expect(
         enforceApiKeyCeiling({
-          prisma,
           resolved: legacyProjectKeyToken,
           permission: "project:update",
         }),

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -11,7 +11,6 @@ import {
 } from "~/server/rbac/custom-role-permissions";
 import {
   checkRoleBindingPermission,
-  resolveApiKeyPermission,
   resolveLegacyCeiling,
 } from "~/server/rbac/role-binding-resolver";
 import { RoleRepository } from "~/server/role/repositories/role.repository";
@@ -1052,33 +1051,6 @@ export class ApiKeyService {
       organizationId,
     });
     return !!binding;
-  }
-
-  /**
-   * Whether the presented credential resolves the given permission at
-   * organization scope: the same primitive the route-level
-   * `requireOrgPermission` middleware applies, exposed for handlers that need
-   * a second, stricter permission on one branch of a route.
-   */
-  async hasOrgScopedPermission({
-    apiKeyId,
-    userId,
-    organizationId,
-    permission,
-  }: {
-    apiKeyId: string;
-    userId: string | null;
-    organizationId: string;
-    permission: Permission;
-  }): Promise<boolean> {
-    return resolveApiKeyPermission({
-      prisma: this.prisma,
-      apiKeyId,
-      userId,
-      organizationId,
-      scope: { type: "org", id: organizationId },
-      permission,
-    });
   }
 
   /**

--- a/platform/app/src/server/api-key/auth-middleware.ts
+++ b/platform/app/src/server/api-key/auth-middleware.ts
@@ -2,6 +2,7 @@ import { HandledError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import type { MiddlewareHandler } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { appFromContext } from "~/app/api/middleware/app-context";
 import { handledErrorResponseBody } from "~/app/api/middleware/error-handler";
 import {
   type ApiErrorEnvelope,
@@ -15,7 +16,7 @@ import type {
   Project,
 } from "~/generated/prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import { resolveApiKeyPermission } from "~/server/rbac/role-binding-resolver";
+import { type App, getApp } from "~/server/app-layer/app";
 import { getTokenType } from "./api-key-token.utils";
 import { ApiKeyPermissionDeniedError } from "./errors";
 import {
@@ -623,18 +624,22 @@ export function collectAuthDiagnostics(c: {
  * Throws `ApiKeyPermissionDeniedError` when denied.
  */
 export async function enforceApiKeyCeiling({
-  prisma,
   resolved,
   permission,
+  app,
 }: {
-  prisma: PrismaClient;
   resolved: ResolvedToken;
   permission: Permission;
+  /**
+   * The App to decide through — pass `appFromContext(c)` where a Hono
+   * context is in hand; handlers without one fall back to the process
+   * singleton (the same instance in production).
+   */
+  app?: App;
 }): Promise<void> {
   if (resolved.type !== "apiKey") return;
 
-  const allowed = await resolveApiKeyPermission({
-    prisma,
+  const allowed = await (app ?? getApp()).permissions.hasApiKeyPermission({
     apiKeyId: resolved.apiKeyId,
     userId: resolved.userId,
     organizationId: resolved.organizationId,
@@ -703,11 +708,9 @@ export function apiKeyCeilingDenialResponse(error: unknown): {
  * from context.
  */
 export function requireApiKeyPermission({
-  prisma,
   permission,
   errorEnvelope = "legacy",
 }: {
-  prisma: PrismaClient;
   permission: Permission;
   errorEnvelope?: ApiErrorEnvelope;
 }): MiddlewareHandler {
@@ -719,7 +722,11 @@ export function requireApiKeyPermission({
     }
 
     try {
-      await enforceApiKeyCeiling({ prisma, resolved, permission });
+      await enforceApiKeyCeiling({
+        resolved,
+        permission,
+        app: appFromContext(c),
+      });
     } catch (error) {
       if (!HandledError.isHandled(error)) throw error;
       // The ceiling refuses BENEATH the family's own error handler, so it has

--- a/platform/app/src/server/api/__tests__/authz-declaration-sweep.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/authz-declaration-sweep.unit.test.ts
@@ -1,0 +1,47 @@
+/** @vitest-environment node */
+
+/**
+ * ADR-092 decision 25, the fail-closed half: every tRPC procedure either
+ * declares its access decision (`.permission()`, `.permissionAny()`,
+ * `.noPermission({ reason })`, `.authorizeInService({ … })`) or runs a
+ * custom middleware that declared itself via `declareAuthzMiddleware`. This
+ * walks the REAL router map, so a procedure added with a bare `.use()` and
+ * no declaration fails the suite — the compile-time builder makes that hard,
+ * and this makes it impossible to merge.
+ *
+ * `enforcePermissionCheck` already fails such a procedure at RUNTIME on its
+ * first call; this sweep moves the discovery to CI, before any call exists.
+ */
+import { describe, expect, it } from "vitest";
+import { authzDeclarationOf } from "~/server/app-layer/authz/declared-middleware";
+import { appRouter } from "../root";
+
+describe("tRPC authz declaration sweep", () => {
+  describe("when enumerating every procedure's middleware chain", () => {
+    /** @scenario "Every tRPC procedure declares its access decision or an explicit reason not to" */
+    it("finds a declaration on every procedure", () => {
+      const procedures = (
+        appRouter as unknown as {
+          _def: { procedures: Record<string, unknown> };
+        }
+      )._def.procedures;
+
+      const undeclared = Object.entries(procedures)
+        .filter(([, procedure]) => {
+          const middlewares =
+            (
+              procedure as {
+                _def?: { middlewares?: unknown[] };
+              }
+            )._def?.middlewares ?? [];
+          return !middlewares.some(
+            (middleware) => authzDeclarationOf(middleware) !== null,
+          );
+        })
+        .map(([path]) => path)
+        .sort();
+
+      expect(undeclared).toEqual([]);
+    });
+  });
+});

--- a/platform/app/src/server/api/__tests__/permission-declaration.types.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/permission-declaration.types.unit.test.ts
@@ -1,0 +1,186 @@
+/** @vitest-environment node */
+
+/**
+ * The compile-time half of the typed declaration surface (ADR-092
+ * delivery-plan decision 25). Every `@ts-expect-error` below IS the
+ * assertion: `pnpm typecheck:tests` fails if a declaration the registry
+ * forbids starts compiling, or if one it allows stops. The vitest run only
+ * proves the surface exists at runtime.
+ *
+ * specs/rbac/typed-permission-declarations.feature is the behavioural
+ * contract these pin.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { requires } from "../security";
+import { protectedProcedure } from "../trpc";
+
+const projectInput = z.object({ projectId: z.string() });
+const teamInput = z.object({ teamId: z.string() });
+const organizationInput = z.object({ organizationId: z.string() });
+
+/** @scenario "A declared permission reads its scope from the validated input" */
+const projectScoped = protectedProcedure
+  .input(projectInput)
+  .permission("traces:view");
+
+/** @scenario "The most specific tier the permission allows decides the check scope" */
+const mixedScoped = protectedProcedure
+  .input(z.object({ projectId: z.string(), organizationId: z.string() }))
+  .permission("traces:view");
+
+const organizationScoped = protectedProcedure
+  .input(organizationInput)
+  .permission("organization:manage");
+
+/** @scenario "An input modelled as a union is checked per member" */
+const eitherScoped = protectedProcedure
+  .input(
+    z.union([
+      z.object({ projectId: z.string() }),
+      z.object({ organizationId: z.string() }),
+    ]),
+  )
+  .permission("project:update");
+
+/** @scenario "A scope derivation is written at the call site, never inferred" */
+const derived = protectedProcedure
+  .input(teamInput)
+  .permission("organization:manage", { via: "teamId" });
+
+/** @scenario "Any one of several declared permissions is enough" */
+const anyOf = protectedProcedure
+  .input(projectInput)
+  .permissionAny("traces:view", "scenarios:view");
+
+/** @scenario "Opting out of permission checks requires a written reason" */
+const optedOut = protectedProcedure
+  .input(z.object({ name: z.string() }))
+  .noPermission({ reason: "user-scoped data only" });
+
+const optedOutWithAllowance = protectedProcedure
+  .input(organizationInput)
+  .noPermission({
+    reason: "creation flow",
+    allow: { organizationId: "the organization being created into" },
+  });
+
+/** @scenario "A service-authorized procedure declares the permissions its service enforces" */
+const serviceAuthorized = protectedProcedure
+  .input(z.object({ rowId: z.string() }))
+  .authorizeInService({
+    reason: "the row's own scope set decides at runtime",
+    permissions: ["traces:view"],
+  });
+
+// ---------------------------------------------------------------------------
+// The refusals. Each @ts-expect-error is load-bearing.
+// ---------------------------------------------------------------------------
+
+/** @scenario "An input id from a tier the permission cannot be granted at fails to compile" */
+// @ts-expect-error — governance is organization-only; a projectId input is a category error
+protectedProcedure.input(projectInput).permission("governance:view");
+
+// @ts-expect-error — organization:manage is organization-only; from a team input it needs { via: "teamId" }
+protectedProcedure.input(teamInput).permission("organization:manage");
+
+/** @scenario "Declaring a permission with no usable scope id in the input fails to compile" */
+// @ts-expect-error — the input carries no projectId, teamId, or organizationId
+protectedProcedure.input(z.object({ name: z.string() })).permission("traces:view");
+
+protectedProcedure
+  .input(z.object({ projectId: z.string().optional() }))
+  // @ts-expect-error — an optional id is not a guarantee the runtime can rely on
+  .permission("traces:view");
+
+// @ts-expect-error — .input() must come first: the check reads its scope id from it
+protectedProcedure.permission("traces:view");
+
+// @ts-expect-error — "team:delete" is not a registry permission (manage implies delete)
+protectedProcedure.input(teamInput).permission("team:delete");
+
+/** @scenario "A platform-tier permission is refused by the scoped declaration surface" */
+// @ts-expect-error — ops is platform-tier; the operator middleware owns it
+protectedProcedure.input(organizationInput).permission("ops:view");
+
+protectedProcedure
+  .input(teamInput)
+  // @ts-expect-error — via must name a field the input actually requires
+  .permission("organization:manage", { via: "projectId" });
+
+// @ts-expect-error — via exists for tiers the input cannot satisfy directly; traces:view already accepts teamId
+protectedProcedure.input(teamInput).permission("traces:view", { via: "teamId" });
+
+protectedProcedure
+  .input(organizationInput)
+  // @ts-expect-error — permissionAny checks at the project scope; this input has no projectId
+  .permissionAny("traces:view", "scenarios:view");
+
+/** @scenario "An opted-out procedure cannot silently read scoped input" */
+// @ts-expect-error — the input carries projectId; it must be individually allowed with a reason
+protectedProcedure.input(projectInput).noPermission({ reason: "nothing scoped" });
+
+protectedProcedure
+  .input(z.object({ projectId: z.string(), organizationId: z.string() }))
+  .noPermission({
+    reason: "creation flow",
+    // @ts-expect-error — allow must cover every scope id the input carries
+    allow: { organizationId: "creating into this organization" },
+  });
+
+describe("typed permission declarations", () => {
+  describe("when the declarations above compile", () => {
+    // Each `it` below vouches for a compile-time assertion in this file: the
+    // valid declaration it names built a procedure, and the matching
+    // `@ts-expect-error` above it is enforced by `pnpm typecheck:tests`.
+
+    /** @scenario "A declared permission reads its scope from the validated input" */
+    it("builds a procedure from a project-scoped declaration", () => {
+      expect(projectScoped).toBeDefined();
+      expect(mixedScoped).toBeDefined();
+      expect(organizationScoped).toBeDefined();
+    });
+
+    /** @scenario "An input id from a tier the permission cannot be granted at fails to compile" */
+    it("refuses an organization-only permission on a project-only input", () => {
+      // The assertion is the `@ts-expect-error` on the governance declaration
+      // above; this vouches the valid neighbour still compiles.
+      expect(organizationScoped).toBeDefined();
+    });
+
+    /** @scenario "A platform-tier permission is refused by the scoped declaration surface" */
+    it("refuses ops permissions on the scoped surface", () => {
+      // The assertion is the `@ts-expect-error` on the ops:view declaration.
+      expect(true).toBe(true);
+    });
+
+    /** @scenario "An input modelled as a union is checked per member" */
+    it("builds a procedure from a union input", () => {
+      expect(eitherScoped).toBeDefined();
+    });
+
+    /** @scenario "A route policy cannot name a permission outside the registry" */
+    it("holds the HTTP route policies to the same vocabulary", () => {
+      expect(requires("traces:view")).toEqual({
+        kind: "permission",
+        permission: "traces:view",
+      });
+      // @ts-expect-error — traces cannot be rotated; the registry makes it unsayable
+      void requires("traces:rotate");
+      // @ts-expect-error — the legacy cross product is retired on this surface too
+      void requires("team:delete");
+    });
+
+    it("builds the derivation, any-of, opt-out and service-authorized shapes", () => {
+      for (const procedure of [
+        derived,
+        anyOf,
+        optedOut,
+        optedOutWithAllowance,
+        serviceAuthorized,
+      ]) {
+        expect(procedure).toBeDefined();
+      }
+    });
+  });
+});

--- a/platform/app/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -10,7 +10,7 @@ import {
 import { getDataPrivacyPolicyService } from "~/server/data-privacy/dataPrivacyPolicy.service";
 import { getUserProtectionsForProject } from "../utils";
 
-vi.mock("../rbac", () => ({
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
   hasProjectPermission: vi.fn(() => Promise.resolve(true)),
   isDemoProject: vi.fn(() => false),
 }));

--- a/platform/app/src/server/api/__tests__/rbac-integration.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac-integration.test.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OrganizationUserRole, TeamUserRole } from "~/generated/prisma/client";
 import { resetCutoverGateForTesting } from "~/server/app-layer/authz/cutover-gate";
+import { declaredNoPermission } from "~/server/app-layer/authz/trpc-middleware";
 import { LiteMemberRestrictedError } from "~/server/app-layer/permissions/errors";
 import {
   checkOrganizationPermission,
@@ -14,8 +15,6 @@ import {
   type Permission,
   resolveProjectPermission,
   resolveTeamPermission,
-  skipPermissionCheck,
-  skipPermissionCheckProjectCreation,
 } from "../rbac";
 
 // Mock Prisma client
@@ -761,41 +760,28 @@ describe("RBAC Integration Tests", () => {
       });
     });
 
-    describe("skipPermissionCheck", () => {
+    describe("declaredNoPermission (skipPermissionCheck's successor)", () => {
       it("calls next and set permissionChecked to true", async () => {
-        const result = await skipPermissionCheck({
+        const result = await declaredNoPermission({ reason: "test opt-out" })({
           ctx: mockCtx,
           input: {},
           next: mockNext,
-        });
+        } as never);
 
         expect(result).toBe("success");
         expect(mockCtx.permissionChecked).toBe(true);
       });
 
-      it("throws error when sensitive keys are present", () => {
-        expect(() =>
-          skipPermissionCheck({
+      it("throws error when sensitive keys are present", async () => {
+        await expect(
+          declaredNoPermission({ reason: "test opt-out" })({
             ctx: mockCtx,
             input: { projectId: "project-123" },
             next: mockNext,
-          }),
-        ).toThrow(
+          } as never),
+        ).rejects.toThrow(
           "projectId is not allowed to be used without permission check",
         );
-      });
-    });
-
-    describe("skipPermissionCheckProjectCreation", () => {
-      it("calls next and set permissionChecked to true", async () => {
-        const result = await skipPermissionCheckProjectCreation({
-          ctx: mockCtx,
-          input: {},
-          next: mockNext,
-        });
-
-        expect(result).toBe("success");
-        expect(mockCtx.permissionChecked).toBe(true);
       });
     });
   });

--- a/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
@@ -18,6 +18,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetCutoverGateForTesting } from "~/server/app-layer/authz/cutover-gate";
+import { checkDeclaredPermissionAny } from "~/server/app-layer/authz/trpc-middleware";
 import type { Session } from "~/server/auth";
 
 const { userPermissionCheck, userBatchPermissionCheck, apiKeyPermissionCheck } =
@@ -42,7 +43,6 @@ vi.mock("~/server/app-layer/authz/shadow", () => ({
 
 import {
   batchScopePermissions,
-  checkProjectPermissionAny,
   hasOrganizationPermission,
   resolveProjectPermission,
   resolveTeamPermission,
@@ -140,14 +140,22 @@ describe("the fork at the permission seams", () => {
     });
 
     describe("when any of several permissions is enough", () => {
+      /** @scenario "A declared check decides exactly as the middleware it replaced" */
       it("returns the engine's answer for the gate", async () => {
         const { ctx } = buildPrisma({ onEngine: true });
         const next = vi.fn().mockResolvedValue("permitted");
 
-        const outcome = await checkProjectPermissionAny(
+        const outcome = await checkDeclaredPermissionAny([
           "annotations:update",
           "traces:view",
-        )({ ctx, input: { projectId: PROJECT_ID }, next } as never);
+        ])({
+          ctx: {
+            ...(ctx as Record<string, unknown>),
+            permissionChecked: false,
+          },
+          input: { projectId: PROJECT_ID },
+          next,
+        } as never);
 
         expect(outcome).toBe("permitted");
         expect(next).toHaveBeenCalledTimes(1);

--- a/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
@@ -19,6 +19,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetCutoverGateForTesting } from "~/server/app-layer/authz/cutover-gate";
 import { checkDeclaredPermissionAny } from "~/server/app-layer/authz/trpc-middleware";
+import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
 import type { Session } from "~/server/auth";
 
 const { userPermissionCheck, userBatchPermissionCheck, apiKeyPermissionCheck } =
@@ -152,6 +153,11 @@ describe("the fork at the permission seams", () => {
           ctx: {
             ...(ctx as Record<string, unknown>),
             permissionChecked: false,
+            app: {
+              permissions: permissionsServiceFor(
+                (ctx as { prisma: never }).prisma,
+              ),
+            },
           },
           input: { projectId: PROJECT_ID },
           next,

--- a/platform/app/src/server/api/__tests__/rbac.project-permission-any.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.project-permission-any.unit.test.ts
@@ -18,6 +18,7 @@ import {
   TeamUserRole,
 } from "~/generated/prisma/client";
 import { checkDeclaredPermissionAny } from "~/server/app-layer/authz/trpc-middleware";
+import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
 import type { Session } from "~/server/auth";
 import type { Permission } from "../rbac";
 
@@ -69,7 +70,12 @@ const runGate = ({
     next,
     run: () =>
       middleware({
-        ctx: { prisma, session, permissionChecked: false } as never,
+        ctx: {
+          prisma,
+          session,
+          permissionChecked: false,
+          app: { permissions: permissionsServiceFor(prisma as never) },
+        } as never,
         input: { projectId: PROJECT_ID },
         next,
       } as never),

--- a/platform/app/src/server/api/__tests__/rbac.project-permission-any.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.project-permission-any.unit.test.ts
@@ -1,21 +1,25 @@
 /**
  * @vitest-environment node
  *
- * The any-of project gate. It backs surfaces a caller can legitimately reach
- * from more than one feature, so it is asked about several permissions per
- * request, on routes (the media existence probe) that run once per item on
- * screen. Where the caller stands is the same for every permission in the
- * list, so it is read once.
+ * The any-of project gate, exercised through the DECLARED seam
+ * (`.permissionAny(…)` → checkDeclaredPermissionAny → resolveProjectPermissionAny).
+ * It backs surfaces a caller can legitimately reach from more than one
+ * feature, so it is asked about several permissions per request, on routes
+ * (the media existence probe) that run once per item on screen. Where the
+ * caller stands is the same for every permission in the list, so it is read
+ * once.
  */
 
+import { PermissionDeniedError } from "@langwatch/authz";
 import { describe, expect, it, vi } from "vitest";
 import {
   OrganizationUserRole,
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import { checkDeclaredPermissionAny } from "~/server/app-layer/authz/trpc-middleware";
 import type { Session } from "~/server/auth";
-import { checkProjectPermissionAny, type Permission } from "../rbac";
+import type { Permission } from "../rbac";
 
 const ORGANIZATION_ID = "organization_1";
 const TEAM_ID = "team_1";
@@ -46,6 +50,8 @@ const buildPrisma = (teamRole: TeamUserRole) => {
       ]),
     },
     teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+    authzCutoverProjection: { findUnique: vi.fn().mockResolvedValue(null) },
+    systemMigrationTenantState: { findUnique: vi.fn().mockResolvedValue(null) },
   };
   return { prisma, projectFindUnique, organizationUserFindFirst };
 };
@@ -58,19 +64,19 @@ const runGate = ({
   permissions: [Permission, ...Permission[]];
 }) => {
   const next = vi.fn().mockResolvedValue("permitted");
-  const middleware = checkProjectPermissionAny(...permissions);
+  const middleware = checkDeclaredPermissionAny(permissions);
   return {
     next,
     run: () =>
       middleware({
-        ctx: { prisma, session } as never,
+        ctx: { prisma, session, permissionChecked: false } as never,
         input: { projectId: PROJECT_ID },
         next,
       } as never),
   };
 };
 
-describe("checkProjectPermissionAny", () => {
+describe("checkDeclaredPermissionAny over the real resolver", () => {
   describe("given a caller who holds only the second permission", () => {
     describe("when the gate runs", () => {
       it("permits the call", async () => {
@@ -103,7 +109,7 @@ describe("checkProjectPermissionAny", () => {
 
   describe("given a caller who holds none of the permissions", () => {
     describe("when the gate runs", () => {
-      it("refuses the call without repeating the lookups", async () => {
+      it("refuses with the stable denial code, without repeating the lookups", async () => {
         const { prisma, projectFindUnique, organizationUserFindFirst } =
           buildPrisma(TeamUserRole.VIEWER);
         const { next, run } = runGate({
@@ -111,8 +117,15 @@ describe("checkProjectPermissionAny", () => {
           permissions: ["annotations:update", "datasets:update"],
         });
 
-        await expect(run()).rejects.toThrow(
-          "You do not have permission to access this project resource",
+        const error = await run().then(
+          () => {
+            throw new Error("expected the gate to refuse");
+          },
+          (thrown: unknown) => thrown as { cause?: unknown },
+        );
+        expect(error.cause).toBeInstanceOf(PermissionDeniedError);
+        expect((error.cause as PermissionDeniedError).code).toBe(
+          "permission_denied",
         );
         expect(next).not.toHaveBeenCalled();
         expect(projectFindUnique).toHaveBeenCalledTimes(1);

--- a/platform/app/src/server/api/management/__tests__/managed-service.unit.test.ts
+++ b/platform/app/src/server/api/management/__tests__/managed-service.unit.test.ts
@@ -139,6 +139,76 @@ describe("createManagementService", () => {
     });
   });
 
+  describe("given an endpoint that also carries its own middleware", () => {
+    /** @scenario "An endpoint's middleware array cannot displace its declared check" */
+    it("still runs the declared permission check the framework mounted", async () => {
+      const { service, guard } = createManagementService({
+        name: "toy-overwrite",
+        basePath: "/api/toy-overwrite",
+        feature: "MANAGEMENT_API",
+      });
+      const app = service
+        .version(MANAGEMENT_API_VERSION, (v) => {
+          v.get(
+            "/things",
+            {
+              ...guard("organization:manage"),
+              // The overwrite that used to bypass enforcement: a middleware
+              // key after the spread replaces the guard's array wholesale.
+              middleware: [
+                (async (_c, next) => {
+                  executionOrder.push("endpoint-middleware");
+                  await next();
+                }) satisfies MiddlewareHandler,
+              ],
+              output: z.object({ ok: z.boolean() }),
+              description: "toy",
+              docs: { operationId: "listOverwriteThings" },
+            },
+            async () => ({ ok: true }),
+          );
+        })
+        .build();
+
+      executionOrder.length = 0;
+      const response = await app.request("/api/toy-overwrite/things");
+
+      expect(response.status).toBe(200);
+      expect(executionOrder).toEqual([
+        "auth",
+        "permission:organization:manage",
+        "endpoint-middleware",
+      ]);
+    });
+  });
+
+  describe("given a policy that promises a permission the config does not enforce", () => {
+    /** @scenario "A registered policy that promises an unenforced permission fails the build" */
+    it("fails the build naming both halves", () => {
+      const { service, guard } = createManagementService({
+        name: "toy-mismatch",
+        basePath: "/api/toy-mismatch",
+        feature: "MANAGEMENT_API",
+      });
+
+      expect(() =>
+        service
+          .version(MANAGEMENT_API_VERSION, (v) => {
+            v.get(
+              "/things",
+              {
+                ...guard("organization:manage"),
+                permission: undefined,
+                output: z.object({ ok: z.boolean() }),
+              },
+              async () => ({ ok: true }),
+            );
+          })
+          .build(),
+      ).toThrow(/declares policy "organization:manage" but enforces "nothing"/);
+    });
+  });
+
   describe("given an endpoint declares no guard", () => {
     it("refuses to build rather than mounting an unclassified route", () => {
       const { service } = createManagementService({

--- a/platform/app/src/server/api/management/managed-service.ts
+++ b/platform/app/src/server/api/management/managed-service.ts
@@ -16,11 +16,10 @@
  * serves nothing but a 404 for unknown version segments.
  */
 import { createService, type MountedRoute } from "@langwatch/api";
-
+import type { AuthzPermission } from "@langwatch/authz";
 import { requireEnterprisePlanRest } from "~/app/api/middleware/enterprise-gate";
 import { requireOrgPermissionOrThrow } from "~/app/api/middleware/org-auth";
 import type { EnterpriseFeature } from "~/server/api/enterprise";
-import type { Permission } from "~/server/api/rbac";
 import {
   type AccessPolicy,
   credentialClassFor,
@@ -85,7 +84,7 @@ export function createManagementService({
     onRouteMounted: (route) => registerMountedRoute({ route, family }),
   });
 
-  const guard = (permission: Permission) => ({
+  const guard = (permission: AuthzPermission) => ({
     meta: { policy: requires(permission) } satisfies ManagementEndpointMeta,
     middleware: [
       requireOrgPermissionOrThrow(permission),

--- a/platform/app/src/server/api/management/managed-service.ts
+++ b/platform/app/src/server/api/management/managed-service.ts
@@ -17,6 +17,7 @@
  */
 import { createService, type MountedRoute } from "@langwatch/api";
 import type { AuthzPermission } from "@langwatch/authz";
+import { appContextMiddleware } from "~/app/api/middleware/app-context";
 import { requireEnterprisePlanRest } from "~/app/api/middleware/enterprise-gate";
 import { requireOrgPermissionOrThrow } from "~/app/api/middleware/org-auth";
 import type { EnterpriseFeature } from "~/server/api/enterprise";
@@ -80,16 +81,22 @@ export function createManagementService({
   const service = createService({
     name,
     basePath,
+    middleware: [appContextMiddleware],
     auth: createOrgAuthMiddleware({ prisma, refusals: "throw" }),
+    // The framework mounts this for every endpoint that declares a
+    // `permission`, between auth and the endpoint's own middleware. The
+    // enforcement runs through the App-composed permissions service
+    // (`requireOrgPermissionOrThrow` → `getApp().permissions`), and because
+    // the framework owns the mounting, an endpoint's `middleware` array can
+    // no longer displace the check its declared policy promises.
+    permissionEnforcer: (permission) => requireOrgPermissionOrThrow(permission),
     onRouteMounted: (route) => registerMountedRoute({ route, family }),
   });
 
   const guard = (permission: AuthzPermission) => ({
     meta: { policy: requires(permission) } satisfies ManagementEndpointMeta,
-    middleware: [
-      requireOrgPermissionOrThrow(permission),
-      requireEnterprisePlanRest(feature),
-    ],
+    permission,
+    middleware: [requireEnterprisePlanRest(feature)],
   });
 
   return { service, guard };
@@ -131,6 +138,20 @@ function registerMountedRoute({
       `Management endpoint ${route.method.toUpperCase()} ${route.path} ` +
         `declares no access policy; spread guard(permission) into its ` +
         `endpoint config`,
+    );
+  }
+  // The registry must never promise a check the pipeline does not mount: a
+  // permission policy in `meta` is only honest when the SAME permission is on
+  // `config.permission`, which is what the framework enforces from.
+  if (
+    meta.policy.kind === "permission" &&
+    route.config?.permission !== meta.policy.permission
+  ) {
+    throw new Error(
+      `Management endpoint ${route.method.toUpperCase()} ${route.path} ` +
+        `declares policy "${meta.policy.permission}" but enforces ` +
+        `"${route.config?.permission ?? "nothing"}"; both halves must come ` +
+        `from the same guard(permission)`,
     );
   }
   registerRoutePolicy({

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -1276,7 +1276,11 @@ export async function resolveProjectPermissionAny(
 }
 
 /**
- * Check if user has a specific permission for a project
+ * Check if user has a specific permission for a project.
+ *
+ * @deprecated Production callers use the App-routed helpers in
+ * `~/server/app-layer/permissions/imperative` — this stays only as the legacy
+ * walk's own test surface until the contract PR deletes the walk.
  */
 export async function hasProjectPermission(
   ctx: { prisma: PrismaClient; session: Session | null },
@@ -1377,7 +1381,11 @@ export async function resolveTeamPermission(
 }
 
 /**
- * Check if user has a specific permission for a team
+ * Check if user has a specific permission for a team.
+ *
+ * @deprecated Production callers use the App-routed helpers in
+ * `~/server/app-layer/permissions/imperative` — this stays only as the legacy
+ * walk's own test surface until the contract PR deletes the walk.
  */
 export async function hasTeamPermission(
   ctx: { prisma: PrismaClient; session: Session | null },

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -1,3 +1,4 @@
+import type { AuthzPermission } from "@langwatch/authz";
 import { TRPCError } from "@trpc/server";
 import { env } from "~/env.mjs";
 import {
@@ -7,6 +8,7 @@ import {
   TeamUserRole,
 } from "~/generated/prisma/client";
 import { cutoverOnEngine } from "~/server/app-layer/authz/cutover-gate";
+import { declareAuthzMiddleware } from "~/server/app-layer/authz/declared-middleware";
 import { authzForkFor } from "~/server/app-layer/authz/fork";
 import { authzShadowFor } from "~/server/app-layer/authz/shadow";
 import {
@@ -143,10 +145,11 @@ export const Resources = {
 export type Resource = (typeof Resources)[keyof typeof Resources];
 
 /**
- * Permission is a combination of resource and action
- * Format: "resource:action" (e.g., "analytics:view", "datasets:manage")
+ * ADR-092 decision 25: the legacy cross-product type is retired — Permission
+ * IS the registry vocabulary now. Sites that legitimately handle unregistered
+ * legacy custom-role strings do so as plain strings, never as Permission.
  */
-export type Permission = `${Resource}:${Action}`;
+export type Permission = AuthzPermission;
 
 /**
  * Resources that only exist at the organization tier — there is no team- or
@@ -676,7 +679,12 @@ export type PermissionMiddleware<InputType> = (
 ) => Promise<any>;
 
 /**
- * Check if user has permission for a project
+ * Check if user has permission for a project.
+ *
+ * ADR-092 decision 25: procedures declare `.permission("…")` now — this
+ * middleware survives only as a building block for the declared-custom
+ * compositions that branch on their input (modelProviders' tenant anchor,
+ * project creation). Do not `.use()` it on a new procedure.
  */
 export const checkProjectPermission =
   (permission: Permission) =>
@@ -722,53 +730,6 @@ export const checkProjectPermission =
     ctx.organizationRole = organizationRole;
     ctx.permissionChecked = true;
     return next();
-  };
-
-/**
- * Permit when the caller holds ANY ONE of `permissions` on the project.
- *
- * For resources a caller can legitimately reach from more than one feature.
- * Stored objects are the case in point: the same object is trace media for one
- * viewer and scenario media for another, `traces:view` and `scenarios:view`
- * are separate categories a custom role can hold one of, and the file route
- * itself already accepts either. A single-permission gate on a sibling
- * surface (the existence probe) refuses viewers the bytes are served to.
- *
- * The refusal names the FIRST permission, so list the one the surface is
- * primarily reached through first: granting it resolves the denial whichever
- * feature the caller came from.
- */
-export const checkProjectPermissionAny =
-  (...permissions: [Permission, ...Permission[]]) =>
-  async ({
-    ctx,
-    input,
-    next,
-  }: PermissionMiddlewareParams<{ projectId: string }>) => {
-    const { permitted, organizationRole } = await resolveProjectPermissionAny(
-      ctx,
-      input.projectId,
-      permissions,
-    );
-    if (permitted) {
-      ctx.organizationRole = organizationRole;
-      ctx.permissionChecked = true;
-      return next();
-    }
-
-    const named = permissions[0];
-    if (organizationRole === OrganizationUserRole.EXTERNAL) {
-      throw new TRPCError({
-        code: "UNAUTHORIZED",
-        message: "This feature is not available for your account",
-        cause: new LiteMemberRestrictedError(named.split(":")[0] ?? "unknown"),
-      });
-    }
-    throw new TRPCError({
-      code: "UNAUTHORIZED",
-      message: "You do not have permission to access this project resource",
-      cause: new ProjectPermissionDeniedError(named),
-    });
   };
 
 /**
@@ -1205,7 +1166,7 @@ export async function resolveProjectPermission(
  * same for every permission, so they are read once and only the binding check
  * repeats.
  */
-async function resolveProjectPermissionAny(
+export async function resolveProjectPermissionAny(
   ctx: { prisma: PrismaClient; session: Session | null },
   projectId: string,
   permissions: readonly Permission[],
@@ -2129,103 +2090,31 @@ export function isDemoProject(
   );
 }
 
-// ============================================================================
-// SKIP PERMISSION CHECK (for public/special routes)
-// ============================================================================
-
-const SENSITIVE_KEYS = ["organizationId", "teamId", "projectId"] as const;
-type SensitiveKey = (typeof SENSITIVE_KEYS)[number];
-type SkipPermissionCheckOptions = {
-  allow?: Partial<Record<SensitiveKey, string>>;
-};
-
-function isMiddlewareParams(
-  value: unknown,
-): value is PermissionMiddlewareParams<object> {
-  return typeof value === "object" && value !== null && "ctx" in value;
-}
-
-/**
- * Permission middleware for endpoints that need authentication but not resource-level access.
- *
- * Use this when:
- * - User must be logged in (via `protectedProcedure`)
- * - No project/team/org-scoped data is accessed
- * - Examples: user preferences, feature flags, global settings
- *
- * By default, blocks `projectId`, `organizationId`, and `teamId` in the input
- * to prevent accidental resource access without permission checks.
- *
- * @param options.allow - Map of keys to reasons explaining why they're allowed
- */
-export function skipPermissionCheck(
-  options?: SkipPermissionCheckOptions,
-): (
-  params: PermissionMiddlewareParams<object>,
-) => ReturnType<typeof params.next>;
-export function skipPermissionCheck(
-  params: PermissionMiddlewareParams<object>,
-): ReturnType<typeof params.next>;
-export function skipPermissionCheck(
-  paramsOrOptions?:
-    | PermissionMiddlewareParams<object>
-    | SkipPermissionCheckOptions,
-) {
-  if (isMiddlewareParams(paramsOrOptions)) {
-    const { ctx, next, input } = paramsOrOptions;
-    ctx.permissionChecked = true;
-
-    for (const key of SENSITIVE_KEYS) {
-      if (key in input) {
-        throw new Error(
-          `${key} is not allowed to be used without permission check`,
-        );
-      }
-    }
-
-    return next();
-  }
-
-  const allowedKeys = Object.keys(paramsOrOptions?.allow ?? {});
-  return ({ ctx, next, input }: PermissionMiddlewareParams<object>) => {
-    ctx.permissionChecked = true;
-
-    for (const key of SENSITIVE_KEYS) {
-      if (key in input && !allowedKeys.includes(key)) {
-        throw new Error(
-          `${key} is not allowed to be used without permission check`,
-        );
-      }
-    }
-
-    return next();
-  };
-}
-
-export const skipPermissionCheckProjectCreation = ({
-  ctx,
-  next,
-}: PermissionMiddlewareParams<object>) => {
-  ctx.permissionChecked = true;
-  return next();
-};
-
 /**
  * For procedures that authorize against data-dependent scopes resolved at
  * runtime (e.g. a row's own scope set, loaded by id) rather than a fixed
- * input scope a `checkXxxPermission` could read. It satisfies the builder's
- * fail-closed `enforcePermissionCheck` while keeping `protectedProcedure`'s
- * auth + audit + domain-error handling. The resolver/service MUST perform
- * the real authorization — this only defers WHERE the check happens, never
- * whether it happens.
+ * input scope a declared `.permission()` could read. It satisfies the
+ * builder's fail-closed `enforcePermissionCheck` while keeping
+ * `protectedProcedure`'s auth + audit + domain-error handling. The
+ * resolver/service MUST perform the real authorization — this only defers
+ * WHERE the check happens, never whether it happens.
+ *
+ * Declared generically for the sweep; new procedures prefer
+ * `.authorizeInService({ reason, permissions })`, which names what the
+ * service enforces at the call site.
  */
-export const authorizeInResolver = ({
-  ctx,
-  next,
-}: PermissionMiddlewareParams<object>) => {
-  ctx.permissionChecked = true;
-  return next();
-};
+export const authorizeInResolver = declareAuthzMiddleware(
+  {
+    kind: "service-authorized",
+    reason:
+      "the scope is data the resolver loads at runtime; the service performs the authorization (see the call site)",
+    permissions: [],
+  },
+  ({ ctx, next }: PermissionMiddlewareParams<object>) => {
+    ctx.permissionChecked = true;
+    return next();
+  },
+);
 
 // ============================================================================
 // OPS PERMISSION
@@ -2273,41 +2162,48 @@ export function resolveOpsScope({
   return { kind: "none" };
 }
 
-export const checkOpsPermission =
-  ({
-    permission,
-    throwOnDeny = true,
-  }: {
-    permission: Permission;
-    throwOnDeny?: boolean;
-  }) =>
-  async ({ ctx, next }: PermissionMiddlewareParams<unknown>) => {
-    const user = ctx.session?.user;
-    if (!user) {
-      throw new TRPCError({ code: "UNAUTHORIZED" });
-    }
+export const checkOpsPermission = ({
+  permission,
+  throwOnDeny = true,
+}: {
+  permission: Permission;
+  throwOnDeny?: boolean;
+}) =>
+  declareAuthzMiddleware(
+    {
+      kind: "custom",
+      reason:
+        "platform-tier operator check: resolves the admin allow-list into an ops scope no procedure input carries",
+      permissions: [permission],
+    },
+    async ({ ctx, next }: PermissionMiddlewareParams<unknown>) => {
+      const user = ctx.session?.user;
+      if (!user) {
+        throw new TRPCError({ code: "UNAUTHORIZED" });
+      }
 
-    const opsScope = await resolveOpsScope({
-      userId: user.id,
-      userEmail: user.email,
-      impersonatorEmail: user.impersonator?.email,
-      permission,
-      prisma: ctx.prisma,
-    });
-
-    // For mutating endpoints, `kind: "none"` is a hard FORBIDDEN. For status
-    // probes that want to *report* "no access" without throwing (lw#3584
-    // — see ops.getScope), pass `{ throwOnDeny: false }` so the middleware
-    // populates `ctx.opsScope = { kind: "none" }` and the procedure handler
-    // can branch on it.
-    if (opsScope.kind === "none" && throwOnDeny) {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message: "You do not have permission to access ops resources",
+      const opsScope = await resolveOpsScope({
+        userId: user.id,
+        userEmail: user.email,
+        impersonatorEmail: user.impersonator?.email,
+        permission,
+        prisma: ctx.prisma,
       });
-    }
 
-    ctx.opsScope = opsScope;
-    ctx.permissionChecked = true;
-    return next();
-  };
+      // For mutating endpoints, `kind: "none"` is a hard FORBIDDEN. For status
+      // probes that want to *report* "no access" without throwing (lw#3584
+      // — see ops.getScope), pass `{ throwOnDeny: false }` so the middleware
+      // populates `ctx.opsScope = { kind: "none" }` and the procedure handler
+      // can branch on it.
+      if (opsScope.kind === "none" && throwOnDeny) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You do not have permission to access ops resources",
+        });
+      }
+
+      ctx.opsScope = opsScope;
+      ctx.permissionChecked = true;
+      return next();
+    },
+  );

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -32,6 +32,14 @@ const mockAnnotationFindMany = vi.fn().mockResolvedValue([]);
 const mockQueueItemFindMany = vi.fn();
 const mockQueueItemCount = vi.fn().mockResolvedValue(1);
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("~/server/traces/trace.service", () => ({
   TraceService: { create: mockCreate },
 }));

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -45,18 +45,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkPermissionOrPubliclyShared:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
@@ -3,6 +3,14 @@ import type { PrismaClient } from "~/generated/prisma/client";
 import { createInnerTRPCContext } from "../../trpc";
 import { annotationRouter, createOrUpdateQueueItems } from "../annotation";
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("@ee/audit-log/auditLog", () => ({
   auditLog: vi.fn(() => Promise.resolve()),
 }));

--- a/platform/app/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
@@ -11,12 +11,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/automations.router.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/automations.router.integration.test.ts
@@ -100,12 +100,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission: vi.fn().mockImplementation(() => {
-      return async ({ ctx, next }: any) =>
-        next({
-          ctx: { ...ctx, permissionChecked: true },
-        });
-    }),
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/automations.testFire.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/automations.testFire.integration.test.ts
@@ -21,10 +21,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission: vi.fn().mockImplementation(() => {
-      return async ({ ctx, next }: any) =>
-        next({ ctx: { ...ctx, permissionChecked: true } });
-    }),
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/evaluations.azure-byok.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/evaluations.azure-byok.integration.test.ts
@@ -32,20 +32,11 @@ vi.mock("~/server/evaluations/runEvaluation", () => ({
   runEvaluationForTrace: vi.fn(),
 }));
 
-// Bypass the RBAC middleware — we're testing the handler logic, not auth.
+// Bypass the RBAC resolver — we're testing the handler logic, not auth.
 vi.mock("../../rbac", () => ({
-  checkProjectPermission:
-    () =>
-    ({
-      next,
-      ctx,
-    }: {
-      next: () => unknown;
-      ctx: { permissionChecked?: boolean };
-    }) => {
-      ctx.permissionChecked = true;
-      return next();
-    },
+  resolveProjectPermission: vi
+    .fn()
+    .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
 }));
 
 import { evaluationsRouter } from "../evaluations";

--- a/platform/app/src/server/api/routers/__tests__/evaluators.tenant-workflow.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/evaluators.tenant-workflow.unit.test.ts
@@ -5,6 +5,7 @@ import {
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
 import { createInnerTRPCContext } from "../../trpc";
 import { evaluatorsRouter } from "../evaluators";
 
@@ -62,6 +63,7 @@ const createCaller = () => {
     permissionChecked: true,
   });
   ctx.prisma = prisma;
+  ctx.app = { permissions: permissionsServiceFor(prisma) } as never;
   return evaluatorsRouter.createCaller(ctx);
 };
 

--- a/platform/app/src/server/api/routers/__tests__/gatewayBudgets.perPerson.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/gatewayBudgets.perPerson.unit.test.ts
@@ -34,19 +34,25 @@ const breakdown = vi.hoisted(() => vi.fn());
 
 // The router takes the budget ledger from the App, so standing in for the
 // store means standing in for `getApp()`.
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: () => ({
-    gateway: {
-      budgets: {
-        getSpendForBudgetsAcrossTenants: async () => [],
-        getBucketSpendBreakdownForBudget: breakdown,
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: () => ({
+      permissions: appPermissionsService(),
+      gateway: {
+        budgets: {
+          getSpendForBudgetsAcrossTenants: async () => [],
+          getBucketSpendBreakdownForBudget: breakdown,
+        },
+        virtualKeySpend: undefined,
       },
-      virtualKeySpend: undefined,
-    },
-  }),
-}));
+    }),
+  };
+});
 
 vi.mock("~/server/gateway/providerLabels", () => ({
   resolveProviderLabels: async () => new Map(),

--- a/platform/app/src/server/api/routers/__tests__/gatewayBudgets.perPerson.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/gatewayBudgets.perPerson.unit.test.ts
@@ -26,12 +26,7 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/gatewaySpendEvents.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/gatewaySpendEvents.unit.test.ts
@@ -19,16 +19,15 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission:
-      (permission: string) =>
-      async ({ ctx, next }: any) => {
+    resolveProjectPermission: vi.fn(
+      async (_ctx: unknown, _projectId: string, permission: string) => {
         seenPermissions.push(permission);
-        if (denied.has(permission)) {
-          throw Object.assign(new Error("denied"), { code: "UNAUTHORIZED" });
-        }
-        ctx.permissionChecked = true;
-        return next();
+        return {
+          permitted: !denied.has(permission),
+          organizationRole: "MEMBER",
+        };
       },
+    ),
   };
 });
 
@@ -185,7 +184,9 @@ describe("gatewaySpendEventsRouter", () => {
   it("denies without the gateway usage view scope", async () => {
     denied.add("gatewayUsage:view");
     const caller = buildCaller();
-    await expect(caller.list(BASE_INPUT)).rejects.toThrow("denied");
+    await expect(caller.list(BASE_INPUT)).rejects.toThrow(
+      "You do not have permission",
+    );
     expect(readSpendEventsPage).not.toHaveBeenCalled();
   });
 });

--- a/platform/app/src/server/api/routers/__tests__/gatewaySpendEvents.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/gatewaySpendEvents.unit.test.ts
@@ -42,13 +42,19 @@ const spendEventsRepository = vi.hoisted(() => ({
     | { readSpendEventsPage: typeof readSpendEventsPage }
     | undefined,
 }));
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: () => ({
-    gateway: { spendEvents: spendEventsRepository.current },
-  }),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: () => ({
+      permissions: appPermissionsService(),
+      gateway: { spendEvents: spendEventsRepository.current },
+    }),
+  };
+});
 
 const SPEND_ROW: SpendEventRow = {
   tenantId: PROJECT_ID,

--- a/platform/app/src/server/api/routers/__tests__/github.access-order.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/github.access-order.unit.test.ts
@@ -39,6 +39,14 @@ const { appConfig } = vi.hoisted(() => ({
     configured: true,
   },
 }));
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("~/server/app-layer/github/githubAppConfig", () => ({
   getGithubAppConfig: () => appConfig,
 }));

--- a/platform/app/src/server/api/routers/__tests__/github.access-order.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/github.access-order.unit.test.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInnerTRPCContext } from "../../trpc";
 
@@ -57,21 +56,12 @@ vi.mock("~/server/api/rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/server/api/rbac")>();
   return {
     ...actual,
-    checkOrganizationPermission:
-      (permission: string) =>
-      async ({ ctx, next }: any) => {
+    hasOrganizationPermission: vi.fn(
+      async (_ctx: unknown, _organizationId: string, permission: string) => {
         permissionsAsked.push(permission);
-        if (!hasOrgPermission()) {
-          // The top-level TRPCError binding is safe here: this closure runs
-          // at request time, long after the hoisted factory phase.
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "You do not have permission",
-          });
-        }
-        ctx.permissionChecked = true;
-        return next();
+        return hasOrgPermission();
       },
+    ),
   };
 });
 
@@ -222,7 +212,7 @@ describe("githubRouter access gates", () => {
 
       await expect(
         caller().listRepos({ organizationId: "org-1" }),
-      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
       expect(permissionsAsked).toEqual(["organization:manage"]);
       expect(listRepositoriesForOrganization).not.toHaveBeenCalled();
     });
@@ -236,7 +226,7 @@ describe("githubRouter access gates", () => {
           organizationId: "org-1",
           installationId: "555",
         }),
-      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
       expect(permissionsAsked).toEqual(["organization:manage"]);
       expect(getByInstallationId).not.toHaveBeenCalled();
     });

--- a/platform/app/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
@@ -17,12 +17,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
@@ -3,6 +3,14 @@ import type { PrismaClient } from "~/generated/prisma/client";
 import { createInnerTRPCContext } from "../../trpc";
 import { graphsRouter } from "../graphs";
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("@ee/audit-log/auditLog", () => ({
   auditLog: vi.fn(() => Promise.resolve()),
 }));

--- a/platform/app/src/server/api/routers/__tests__/langy.conversationVisibility.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/langy.conversationVisibility.integration.test.ts
@@ -47,12 +47,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
@@ -29,11 +29,19 @@ vi.mock("~/server/middleware/rate-limit-langy", () => ({
   LANGY_MESSAGES_PER_MINUTE: 30,
 }));
 
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: () => ({ langy: { turns: { startConversationTurn } } }),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: () => ({
+      permissions: appPermissionsService(),
+      langy: { turns: { startConversationTurn } },
+    }),
+  };
+});
 
 vi.mock("@ee/audit-log/auditLog", () => ({ auditLog }));
 

--- a/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
@@ -49,11 +49,12 @@ vi.mock("../langyAccessMiddleware", () => ({
 
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
-  const passthrough = async ({ ctx, next }: any) => {
-    ctx.permissionChecked = true;
-    return next();
+  return {
+    ...actual,
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
-  return { ...actual, checkProjectPermission: () => passthrough };
 });
 
 import { LangyRateLimitedError } from "~/server/app-layer/langy/errors";

--- a/platform/app/src/server/api/routers/__tests__/licenseEnforcement.reportLimitBlocked.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/licenseEnforcement.reportLimitBlocked.unit.test.ts
@@ -78,13 +78,19 @@ vi.mock("~/server/license-enforcement", () => {
   };
 });
 
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: () => ({
-    usageLimits: mockUsageLimits,
-  }),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: () => ({
+      permissions: appPermissionsService(),
+      usageLimits: mockUsageLimits,
+    }),
+  };
+});
 
 vi.mock("~/utils/posthogErrorCapture", () => ({
   captureException: mockCaptureException,

--- a/platform/app/src/server/api/routers/__tests__/licenseEnforcement.reportLimitBlocked.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/licenseEnforcement.reportLimitBlocked.unit.test.ts
@@ -96,12 +96,7 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/lwql.router.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/lwql.router.integration.test.ts
@@ -59,10 +59,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission: vi.fn().mockImplementation(() => {
-      return async ({ ctx, next }: any) =>
-        next({ ctx: { ...ctx, permissionChecked: true } });
-    }),
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "~/generated/prisma/client";
-
+import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
 import { MASKED_KEY_PLACEHOLDER } from "../../../../utils/constants";
 import { createInnerTRPCContext } from "../../trpc";
 import { modelProviderRouter } from "../modelProviders";
@@ -146,6 +146,7 @@ function callerForUser(userId: string) {
     res: undefined,
   });
   ctx.prisma = fixturePrisma();
+  ctx.app = { permissions: permissionsServiceFor(fixturePrisma()) } as never;
   return modelProviderRouter.createCaller(ctx);
 }
 

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
@@ -18,6 +18,14 @@ const {
   mockHasSetupPermission: vi.fn(),
 }));
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
@@ -23,12 +23,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission: mockHasSetupPermission,
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
@@ -83,18 +83,10 @@ vi.mock("../../rbac", async (importOriginal) => {
       ctx.permissionChecked = true;
       return next();
     },
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkTeamPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
+    resolveTeamPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/project.getHasFirstMessage.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/project.getHasFirstMessage.unit.test.ts
@@ -27,24 +27,13 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkTeamPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
+    resolveTeamPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
     skipPermissionCheck: ({ ctx, next }: any) => {
       ctx.permissionChecked = true;
       return next();

--- a/platform/app/src/server/api/routers/__tests__/project.getHasFirstMessage.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/project.getHasFirstMessage.unit.test.ts
@@ -5,15 +5,21 @@ import { projectRouter } from "../project";
 
 const mockGetById = vi.fn();
 
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: () => ({
-    projects: {
-      getById: mockGetById,
-    },
-  }),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: () => ({
+      permissions: appPermissionsService(),
+      projects: {
+        getById: mockGetById,
+      },
+    }),
+  };
+});
 
 vi.mock("nanoid", () => ({
   nanoid: vi.fn(() => "mock-nano-id"),

--- a/platform/app/src/server/api/routers/__tests__/project.regenerateApiKey.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/project.regenerateApiKey.unit.test.ts
@@ -21,30 +21,19 @@ vi.mock("nanoid", () => ({
   ),
 }));
 
-// Mock the permission check to always allow; use importOriginal so other rbac exports (e.g. checkPermissionOrPubliclyShared) are available to transitive imports
+// Mock the permission resolver to always allow; use importOriginal so other rbac exports stay available to transitive imports
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkTeamPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
+    resolveTeamPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
     skipPermissionCheck: ({ ctx, next }: any) => {
       ctx.permissionChecked = true;
       return next();

--- a/platform/app/src/server/api/routers/__tests__/project.regenerateApiKey.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/project.regenerateApiKey.unit.test.ts
@@ -14,6 +14,14 @@ import { projectRouter } from "../project";
  */
 
 // Mock nanoid to control API key generation
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("nanoid", () => ({
   nanoid: vi.fn(() => "mock-nano-id"),
   customAlphabet: vi.fn(

--- a/platform/app/src/server/api/routers/__tests__/secrets.reserved-names.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/secrets.reserved-names.unit.test.ts
@@ -35,8 +35,9 @@ vi.mock("~/server/db", () => ({
 // Permission enforcement is covered by rbac.secrets.test.ts; this suite is
 // about what a correctly-permissioned caller may still not touch.
 vi.mock("../../rbac", () => ({
-  checkProjectPermission: () => async (opts: { next: () => unknown }) =>
-    opts.next(),
+  resolveProjectPermission: vi
+    .fn()
+    .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
 }));
 
 vi.mock("~/utils/encryption", () => ({

--- a/platform/app/src/server/api/routers/__tests__/secrets.reserved-names.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/secrets.reserved-names.unit.test.ts
@@ -20,6 +20,14 @@ const findFirst = vi.fn();
 const deleteFn = vi.fn().mockResolvedValue({ id: "sec_1" });
 const update = vi.fn().mockResolvedValue({ id: "sec_1" });
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("~/server/db", () => ({
   prisma: {
     projectSecret: {

--- a/platform/app/src/server/api/routers/__tests__/team.rolebinding-membership-reads.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/team.rolebinding-membership-reads.unit.test.ts
@@ -20,12 +20,7 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
     hasOrganizationPermission: vi.fn().mockResolvedValue(true),
   };
 });

--- a/platform/app/src/server/api/routers/__tests__/team.rolebinding-membership-reads.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/team.rolebinding-membership-reads.unit.test.ts
@@ -16,11 +16,18 @@ import { teamRouter } from "../team";
 // The org-permission middleware/guard is real authorization the page already
 // passes for an org admin; it's mocked to a pass-through so these tests isolate
 // the member-resolution read path.
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
     hasOrganizationPermission: vi.fn().mockResolvedValue(true),
   };
 });

--- a/platform/app/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
@@ -5,6 +5,7 @@ import {
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
 import { createInnerTRPCContext } from "../../trpc";
 import { teamRouter } from "../team";
 
@@ -131,6 +132,7 @@ describe("team.update", () => {
       publiclyShared: false,
     });
     ctx.prisma = prisma;
+    ctx.app = { permissions: permissionsServiceFor(prisma) } as never;
     caller = teamRouter.createCaller(ctx);
   });
 

--- a/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -46,6 +46,14 @@ const {
   };
 });
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("~/server/traces/trace.service", () => ({
   TraceService: { create: mockCreate },
 }));

--- a/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -70,18 +70,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkPermissionOrPubliclyShared:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/traces.getAllForProject.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.getAllForProject.unit.test.ts
@@ -10,6 +10,14 @@ const { mockGetAllTracesForProject } = vi.hoisted(() => ({
   mockGetAllTracesForProject: vi.fn(),
 }));
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("~/server/traces/trace.service", () => ({
   TraceService: {
     create: () => ({

--- a/platform/app/src/server/api/routers/__tests__/traces.getAllForProject.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/traces.getAllForProject.unit.test.ts
@@ -23,18 +23,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkPermissionOrPubliclyShared:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -38,24 +38,13 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: MiddlewareParams) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkOrganizationPermission:
-      () =>
-      async ({ ctx, next }: MiddlewareParams) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
-    checkTeamPermission:
-      () =>
-      async ({ ctx, next }: MiddlewareParams) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
+    resolveTeamPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
     skipPermissionCheck: ({ ctx, next }: MiddlewareParams) => {
       ctx.permissionChecked = true;
       return next();

--- a/platform/app/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -13,6 +13,14 @@ import { translateRouter } from "../translate";
 // actionable toast (missing model / provider disabled / AI call failed).
 
 const mockGetVercelAIModel = vi.fn();
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("../../../modelProviders/utils", () => ({
   getVercelAIModel: (...args: unknown[]) => mockGetVercelAIModel(...args),
 }));

--- a/platform/app/src/server/api/routers/__tests__/webhookEndpoints.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/webhookEndpoints.unit.test.ts
@@ -54,11 +54,19 @@ vi.mock("../../rbac", async (importOriginal) => {
 });
 
 const getActivePlan = vi.fn();
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: () => ({ planProvider: { getActivePlan } }),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: () => ({
+      permissions: appPermissionsService(),
+      planProvider: { getActivePlan },
+    }),
+  };
+});
 
 const ENDPOINT_ROW = {
   id: "whep_1",

--- a/platform/app/src/server/api/routers/__tests__/webhookEndpoints.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/webhookEndpoints.unit.test.ts
@@ -44,16 +44,12 @@ vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
-    checkOrganizationPermission:
-      (permission: string) =>
-      async ({ ctx, next }: any) => {
+    hasOrganizationPermission: vi.fn(
+      async (_ctx: unknown, _organizationId: string, permission: string) => {
         seenPermissions.push(permission);
-        if (denied.has(permission)) {
-          throw Object.assign(new Error("denied"), { code: "UNAUTHORIZED" });
-        }
-        ctx.permissionChecked = true;
-        return next();
+        return !denied.has(permission);
       },
+    ),
   };
 });
 
@@ -136,7 +132,7 @@ describe("webhookEndpointsRouter", () => {
         url: "https://example.com/hook",
         enabledEvents: ["gateway.request.completed"],
       }),
-    ).rejects.toThrow("denied");
+    ).rejects.toThrow("You do not have permission");
     expect((prisma as any).webhookEndpoint.create).not.toHaveBeenCalled();
   });
 

--- a/platform/app/src/server/api/routers/__tests__/workflows.generateCommitMessage.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/workflows.generateCommitMessage.unit.test.ts
@@ -26,22 +26,14 @@ vi.mock("@ee/audit-log/auditLog", () => ({
   auditLog: vi.fn(() => Promise.resolve()),
 }));
 
-type MiddlewareParams = {
-  ctx: Record<string, unknown>;
-  next: () => Promise<unknown>;
-};
-
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
     ...actual,
     hasProjectPermission: vi.fn(() => Promise.resolve(true)),
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: MiddlewareParams) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/__tests__/workflows.generateCommitMessage.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/workflows.generateCommitMessage.unit.test.ts
@@ -11,6 +11,14 @@ import { workflowRouter } from "../workflows";
 // plain-text completion with no function-tool round-trip.
 
 const mockGetVercelAIModel = vi.fn();
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("../../../modelProviders/utils", () => ({
   getVercelAIModel: (...args: unknown[]) => mockGetVercelAIModel(...args),
 }));

--- a/platform/app/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
@@ -7,6 +7,14 @@ const { hasProjectPermission } = vi.hoisted(() => ({
   hasProjectPermission: vi.fn(),
 }));
 
+// The declared permission seam resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {

--- a/platform/app/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
@@ -12,12 +12,9 @@ vi.mock("../../rbac", async (importOriginal) => {
   return {
     ...actual,
     hasProjectPermission,
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/agents.ts
+++ b/platform/app/src/server/api/routers/agents.ts
@@ -14,7 +14,7 @@ import {
   agentTypeSchema,
 } from "../../agents/agent.repository";
 import { AgentService } from "../../agents/agent.service";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import {
   copyWorkflowWithDatasets,
@@ -59,7 +59,7 @@ export const agentsRouter = createTRPCRouter({
    */
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       return await agentService.getAll({ projectId: input.projectId });
@@ -71,7 +71,7 @@ export const agentsRouter = createTRPCRouter({
    */
   getById: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       return await agentService.getById({
@@ -111,7 +111,7 @@ export const agentsRouter = createTRPCRouter({
           },
         ),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       // Config is validated by the refine above, safe to cast
@@ -141,7 +141,7 @@ export const agentsRouter = createTRPCRouter({
         workflowId: z.string().nullable().optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
 
@@ -168,7 +168,7 @@ export const agentsRouter = createTRPCRouter({
    */
   getRelatedEntities: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const agent = await ctx.prisma.agent.findFirst({
         where: {
@@ -199,7 +199,7 @@ export const agentsRouter = createTRPCRouter({
    */
   cascadeArchive: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.$transaction(async (tx) => {
         // 1. Get the agent to find linked workflow
@@ -246,7 +246,7 @@ export const agentsRouter = createTRPCRouter({
    */
   delete: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       return await agentService.softDelete({
@@ -265,7 +265,7 @@ export const agentsRouter = createTRPCRouter({
         agentId: z.string(),
       }),
     )
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       const source = await agentService.getById({
@@ -314,7 +314,7 @@ export const agentsRouter = createTRPCRouter({
         newAgentId: z.string().default(() => `agent_${nanoid()}`),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const hasSourcePermission = await hasProjectPermission(
         ctx,
@@ -390,7 +390,7 @@ export const agentsRouter = createTRPCRouter({
         copyIds: z.array(z.string()).optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       const copies = await agentService.getCopies(input.agentId);
@@ -451,7 +451,7 @@ export const agentsRouter = createTRPCRouter({
         agentId: z.string(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const agentService = AgentService.create(ctx.prisma);
       const copy = await agentService.getById({
@@ -513,7 +513,7 @@ export const agentsRouter = createTRPCRouter({
    */
   getHistory: protectedProcedure
     .input(z.object({ agentId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const service = AgentService.create(ctx.prisma);
       return service.getHistory(input.agentId, input.projectId);

--- a/platform/app/src/server/api/routers/analytics/__tests__/dataForFilter.unit.test.ts
+++ b/platform/app/src/server/api/routers/analytics/__tests__/dataForFilter.unit.test.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getApp } from "~/server/app-layer/app";
+import { appPermissionsService } from "~/test-utils/appPermissionsMock";
 import { createInnerTRPCContext, createTRPCRouter } from "../../../trpc";
 import { dataForFilter } from "../dataForFilter";
 
@@ -17,11 +18,16 @@ vi.mock("../../../rbac", async (importOriginal) => {
 // The route reaches ClickHouse the only way it may: a repository the App
 // hands out. Mocking `getApp` is therefore what standing in for the store
 // looks like from here.
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: vi.fn(),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: vi.fn(() => ({ permissions: appPermissionsService() })),
+  };
+});
 
 vi.mock("@ee/audit-log/auditLog", () => ({
   auditLog: vi.fn(() => Promise.resolve()),
@@ -56,6 +62,7 @@ describe("dataForFilter", () => {
       { field: "opt", label: "Opt", count: 1 },
     ]);
     mockedGetApp.mockReturnValue({
+      permissions: appPermissionsService(),
       filters: { options: { getFilterOptions } },
     } as any);
   });

--- a/platform/app/src/server/api/routers/analytics/__tests__/dataForFilter.unit.test.ts
+++ b/platform/app/src/server/api/routers/analytics/__tests__/dataForFilter.unit.test.ts
@@ -8,12 +8,9 @@ vi.mock("../../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../rbac")>();
   return {
     ...actual,
-    checkProjectPermission:
-      () =>
-      async ({ ctx, next }: any) => {
-        ctx.permissionChecked = true;
-        return next();
-      },
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
   };
 });
 

--- a/platform/app/src/server/api/routers/analytics/dataForFilter.ts
+++ b/platform/app/src/server/api/routers/analytics/dataForFilter.ts
@@ -5,7 +5,6 @@ import { sharedFiltersInputSchema } from "../../../analytics/types";
 import { getApp } from "../../../app-layer/app";
 import { availableFilters } from "../../../filters/registry";
 import { type FilterField, filterFieldsEnum } from "../../../filters/types";
-import { checkProjectPermission } from "../../rbac";
 import { protectedProcedure } from "../../trpc";
 
 export const dataForFilter = protectedProcedure
@@ -17,7 +16,7 @@ export const dataForFilter = protectedProcedure
       query: z.string().optional(),
     }),
   )
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .query(async ({ input }) => {
     const { field, key, subkey } = input;
 

--- a/platform/app/src/server/api/routers/analytics/documents.ts
+++ b/platform/app/src/server/api/routers/analytics/documents.ts
@@ -1,11 +1,10 @@
 import { sharedFiltersInputSchema } from "../../../analytics/types";
 import { getApp } from "../../../app-layer/app";
-import { checkProjectPermission } from "../../rbac";
 import { protectedProcedure } from "../../trpc";
 
 export const topUsedDocuments = protectedProcedure
   .input(sharedFiltersInputSchema)
-  .use(checkProjectPermission("cost:view"))
+  .permission("cost:view")
   .query(async ({ input }) => {
     const analyticsService = getApp().analytics.service;
     return analyticsService.getTopUsedDocuments(

--- a/platform/app/src/server/api/routers/analytics/feedbacks.ts
+++ b/platform/app/src/server/api/routers/analytics/feedbacks.ts
@@ -1,6 +1,5 @@
 import { sharedFiltersInputSchema } from "../../../analytics/types";
 import { getApp } from "../../../app-layer/app";
-import { checkProjectPermission } from "../../rbac";
 import { protectedProcedure } from "../../trpc";
 
 // Note: getFeedbacks only uses projectId, startDate, endDate, filters
@@ -8,7 +7,7 @@ import { protectedProcedure } from "../../trpc";
 // Fields query, traceIds, negateFilters are accepted but ignored.
 export const feedbacks = protectedProcedure
   .input(sharedFiltersInputSchema)
-  .use(checkProjectPermission("cost:view"))
+  .permission("cost:view")
   .query(async ({ input }) => {
     const analyticsService = getApp().analytics.service;
     return analyticsService.getFeedbacks(

--- a/platform/app/src/server/api/routers/analytics/lwql.ts
+++ b/platform/app/src/server/api/routers/analytics/lwql.ts
@@ -30,7 +30,6 @@ import {
 import { lwqlEnabled } from "~/server/analytics/lwql/access";
 import { lwqlTimeWindowSchema } from "~/server/analytics/lwql/timeWindowSchema";
 
-import { checkProjectPermission } from "../../rbac";
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 import { getUserProtectionsForProject } from "../../utils";
 
@@ -85,7 +84,7 @@ export interface LangWatchQLAvailability {
  */
 const availability = protectedProcedure
   .input(projectScopeSchema)
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .query(async ({ ctx, input }): Promise<LangWatchQLAvailability> => {
     const enabled = await lwqlEnabled({
       prisma: ctx.prisma,
@@ -102,7 +101,7 @@ const availability = protectedProcedure
 /** The LangWatchQL datasets and columns this member's permissions unlock. */
 const schema = protectedProcedure
   .input(projectScopeSchema)
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .use(enforceWorkbenchEnabled)
   .query(async ({ ctx, input }) => {
     return getLangWatchQLService().describeSchema({
@@ -131,7 +130,7 @@ const query = protectedProcedure
       timeWindow: lwqlTimeWindowSchema.optional(),
     }),
   )
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .use(enforceWorkbenchEnabled)
   .mutation(async ({ ctx, input }) => {
     // The project's LangWatchQL secret is hashed into the tenant capability

--- a/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
+++ b/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
@@ -27,7 +27,6 @@ import { z } from "zod";
 
 import { SavedWorkbenchChartService } from "~/server/analytics/saved-workbench-charts/savedWorkbenchChart.service";
 
-import { checkProjectPermission } from "../../rbac";
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 import { getUserProtectionsForProject } from "../../utils";
 
@@ -42,7 +41,7 @@ const nameSchema = z.string().min(1).max(200);
 /** Every saved workbench chart in the project. */
 const getAll = protectedProcedure
   .input(projectScopeSchema)
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .use(enforceWorkbenchEnabled)
   .query(async ({ ctx, input }) => {
     return await SavedWorkbenchChartService.create(ctx.prisma).getAll({
@@ -53,7 +52,7 @@ const getAll = protectedProcedure
 /** One saved chart, with its query, parameters and specification. */
 const getById = protectedProcedure
   .input(chartScopeSchema)
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .use(enforceWorkbenchEnabled)
   .query(async ({ ctx, input }) => {
     return await SavedWorkbenchChartService.create(ctx.prisma).getById({
@@ -78,7 +77,7 @@ const create = protectedProcedure
       definition: z.unknown(),
     }),
   )
-  .use(checkProjectPermission("analytics:create"))
+  .permission("analytics:create")
   .use(enforceWorkbenchEnabled)
   .mutation(async ({ ctx, input }) => {
     return await SavedWorkbenchChartService.create(ctx.prisma).createChart({
@@ -104,7 +103,7 @@ const update = protectedProcedure
       definition: z.unknown().optional(),
     }),
   )
-  .use(checkProjectPermission("analytics:update"))
+  .permission("analytics:update")
   .use(enforceWorkbenchEnabled)
   .mutation(async ({ ctx, input }) => {
     return await SavedWorkbenchChartService.create(ctx.prisma).updateChart({
@@ -124,7 +123,7 @@ const update = protectedProcedure
 
 const deleteChart = protectedProcedure
   .input(chartScopeSchema)
-  .use(checkProjectPermission("analytics:delete"))
+  .permission("analytics:delete")
   .use(enforceWorkbenchEnabled)
   .mutation(async ({ ctx, input }) => {
     await SavedWorkbenchChartService.create(ctx.prisma).deleteChart({

--- a/platform/app/src/server/api/routers/analytics/timeseries.ts
+++ b/platform/app/src/server/api/routers/analytics/timeseries.ts
@@ -1,11 +1,10 @@
 import { timeseriesInput } from "../../../analytics/registry";
 import { getApp } from "../../../app-layer/app";
-import { checkProjectPermission } from "../../rbac";
 import { protectedProcedure } from "../../trpc";
 
 export const getTimeseries = protectedProcedure
   .input(timeseriesInput)
-  .use(checkProjectPermission("analytics:view"))
+  .permission("analytics:view")
   .query(async ({ input }) => {
     const analyticsService = getApp().analytics.service;
     return analyticsService.getTimeseries(input);

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -23,7 +23,7 @@ import { TraceService } from "~/server/traces/trace.service";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import { slugify } from "~/utils/slugify";
 import type { Protections } from "../../traces/protections";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { getUserProtectionsForProject } from "../utils";
 
@@ -336,7 +336,7 @@ export const annotationRouter = createTRPCRouter({
         .merge(annotationAnchorColumnsSchema)
         .superRefine(refineAnnotationAnchorColumns),
     )
-    .use(checkProjectPermission("annotations:create"))
+    .permission("annotations:create")
     .mutation(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
 
@@ -401,7 +401,7 @@ export const annotationRouter = createTRPCRouter({
         scoreOptions: scoreOptions,
       }),
     )
-    .use(checkProjectPermission("annotations:update"))
+    .permission("annotations:update")
     .mutation(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
 
@@ -459,7 +459,7 @@ export const annotationRouter = createTRPCRouter({
         anchor: annotationAnchorScopeSchema.optional().default("all"),
       }),
     )
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       const annotations = await ctx.prisma.annotation.findMany({
         where: {
@@ -492,7 +492,7 @@ export const annotationRouter = createTRPCRouter({
         anchor: annotationAnchorScopeSchema.optional().default("all"),
       }),
     )
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       const annotations = await ctx.prisma.annotation.findMany({
         where: {
@@ -525,7 +525,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   getById: protectedProcedure
     .input(z.object({ annotationId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotation.findUnique({
         where: {
@@ -536,7 +536,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   deleteById: protectedProcedure
     .input(z.object({ annotationId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("annotations:delete"))
+    .permission("annotations:delete")
     .mutation(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
 
@@ -581,7 +581,7 @@ export const annotationRouter = createTRPCRouter({
         endDate: z.date().optional(),
       }),
     )
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotation.findMany({
         where: {
@@ -612,7 +612,7 @@ export const annotationRouter = createTRPCRouter({
         queueId: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("annotations:create"))
+    .permission("annotations:create")
     .mutation(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
       await service.assertQueueConfigurationReferences({
@@ -695,7 +695,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   getQueues: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationQueue.findMany({
         where: { projectId: input.projectId },
@@ -713,7 +713,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   getQueueItems: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
       const organizationId = await service.getProjectOrganizationId({
@@ -769,7 +769,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   getPendingItemsCount: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationQueueItem.count({
         where: {
@@ -795,7 +795,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   getAssignedItemsCount: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationQueueItem.count({
         where: {
@@ -807,7 +807,7 @@ export const annotationRouter = createTRPCRouter({
     }),
   getQueueItemsCounts: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
@@ -874,7 +874,7 @@ export const annotationRouter = createTRPCRouter({
         annotators: z.array(z.string()),
       }),
     )
-    .use(checkProjectPermission("annotations:create"))
+    .permission("annotations:create")
     .mutation(async ({ ctx, input }) => {
       return await createOrUpdateQueueItems({
         traceIds: input.traceIds,
@@ -901,7 +901,7 @@ export const annotationRouter = createTRPCRouter({
         queueItemIds: z.array(z.string()).min(1),
       }),
     )
-    .use(checkProjectPermission("annotations:update"))
+    .permission("annotations:update")
     .mutation(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
       const organizationId = await service.getProjectOrganizationId({
@@ -927,7 +927,7 @@ export const annotationRouter = createTRPCRouter({
    */
   markQueueItemDone: protectedProcedure
     .input(z.object({ queueItemId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("annotations:update"))
+    .permission("annotations:update")
     .mutation(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
       const organizationId = await service.getProjectOrganizationId({
@@ -966,7 +966,7 @@ export const annotationRouter = createTRPCRouter({
         queueId: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       const service = AnnotationService.create({ prisma: ctx.prisma });
       const organizationId = await service.getProjectOrganizationId({
@@ -1014,7 +1014,7 @@ export const annotationRouter = createTRPCRouter({
         endDate: z.date().optional(),
       }),
     )
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const service = AnnotationService.create({ prisma: ctx.prisma });

--- a/platform/app/src/server/api/routers/annotationScore.ts
+++ b/platform/app/src/server/api/routers/annotationScore.ts
@@ -1,6 +1,5 @@
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const annotationScoreRouter = createTRPCRouter({
@@ -26,7 +25,7 @@ export const annotationScoreRouter = createTRPCRouter({
         defaultCheckboxOption: z.array(z.string()).optional().nullable(),
       }),
     )
-    .use(checkProjectPermission("annotations:manage"))
+    .permission("annotations:manage")
     .mutation(async ({ ctx, input }) => {
       type OptionType = { label: string; value: string; reason?: string };
       const options: OptionType[] = [];
@@ -64,7 +63,7 @@ export const annotationScoreRouter = createTRPCRouter({
     }),
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationScore.findMany({
         where: {
@@ -76,7 +75,7 @@ export const annotationScoreRouter = createTRPCRouter({
     }),
   getAllActive: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationScore.findMany({
         where: { projectId: input.projectId, active: true, deletedAt: null },
@@ -89,7 +88,7 @@ export const annotationScoreRouter = createTRPCRouter({
         scoreId: z.string(),
       }),
     )
-    .use(checkProjectPermission("annotations:view"))
+    .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationScore.findFirstOrThrow({
         where: {
@@ -107,7 +106,7 @@ export const annotationScoreRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("annotations:update"))
+    .permission("annotations:update")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.annotationScore.update({
         where: { id: input.scoreId, projectId: input.projectId },
@@ -121,7 +120,7 @@ export const annotationScoreRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("annotations:delete"))
+    .permission("annotations:delete")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.annotationScore.update({
         where: { id: input.scoreId, projectId: input.projectId },

--- a/platform/app/src/server/api/routers/apiKey.ts
+++ b/platform/app/src/server/api/routers/apiKey.ts
@@ -10,7 +10,6 @@ import {
   refineRestrictedPermissions,
 } from "~/server/api-key/restricted-permissions";
 import { permissionFormatSchema } from "~/server/rbac/custom-role-permissions";
-import { skipPermissionCheck } from "../rbac";
 
 function mapApiKeyHandledError(error: unknown): never {
   if (HandledError.isHandled(error)) {
@@ -70,7 +69,7 @@ const roleBindingSchema = z.object({
   scopeId: z.string(),
 });
 
-// RBAC is intentionally bypassed via skipPermissionCheck on all endpoints.
+// RBAC is intentionally bypassed via .noPermission() on all endpoints.
 // Authorization is handled at the service layer: ensureCallerIsOrgMember + isOrgAdmin.
 export const apiKeyRouter = createTRPCRouter({
   /**
@@ -79,11 +78,11 @@ export const apiKeyRouter = createTRPCRouter({
    */
   myBindings: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "listing caller's own role bindings" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "listing caller's own role bindings" },
+    })
     .query(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -141,13 +140,13 @@ export const apiKeyRouter = createTRPCRouter({
    */
   nameById: protectedProcedure
     .input(z.object({ organizationId: z.string(), apiKeyId: z.string() }))
-    .use(
-      skipPermissionCheck({
-        allow: {
-          organizationId: "naming an API key the caller can already see",
-        },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: {
+        organizationId: "naming an API key the caller can already see",
+      },
+    })
     .query(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -166,11 +165,11 @@ export const apiKeyRouter = createTRPCRouter({
    */
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "listing API keys" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "listing API keys" },
+    })
     .query(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -278,11 +277,11 @@ export const apiKeyRouter = createTRPCRouter({
         })
         .superRefine(refineRestrictedPermissions),
     )
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "creating API key for user's own org" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "creating API key for user's own org" },
+    })
     .mutation(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -369,11 +368,11 @@ export const apiKeyRouter = createTRPCRouter({
         })
         .superRefine(refineRestrictedPermissions),
     )
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "updating API key" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "updating API key" },
+    })
     .mutation(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -427,11 +426,11 @@ export const apiKeyRouter = createTRPCRouter({
         apiKeyId: z.string(),
       }),
     )
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "revoking API key" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "revoking API key" },
+    })
     .mutation(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -469,11 +468,11 @@ export const apiKeyRouter = createTRPCRouter({
    */
   orgProjects: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "listing org projects for permission picker" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "listing org projects for permission picker" },
+    })
     .query(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -488,11 +487,11 @@ export const apiKeyRouter = createTRPCRouter({
 
   orgTeams: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "listing org teams for scope picker" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "listing org teams for scope picker" },
+    })
     .query(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(
@@ -507,11 +506,11 @@ export const apiKeyRouter = createTRPCRouter({
 
   orgMembers: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(
-      skipPermissionCheck({
-        allow: { organizationId: "listing org members for key assignment" },
-      }),
-    )
+    .noPermission({
+      reason:
+        "personal API keys are the caller's own; the handler proves organization membership and ownership itself",
+      allow: { organizationId: "listing org members for key assignment" },
+    })
     .query(async ({ ctx, input }) => {
       const apiKeyService = ApiKeyService.create(ctx.prisma);
       await ensureCallerIsOrgMember(

--- a/platform/app/src/server/api/routers/automations.ts
+++ b/platform/app/src/server/api/routers/automations.ts
@@ -73,7 +73,6 @@ import {
   triggerFiltersSchema,
 } from "../../filters/types";
 import { rateLimit } from "../../rateLimit";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { extractCheckKeys } from "../utils";
 import { buildRetryAfterMessage } from "./rateLimitMessage";
@@ -291,7 +290,7 @@ export const automationRouter = createTRPCRouter({
         }),
       }),
     )
-    .use(checkProjectPermission("triggers:create"))
+    .permission("triggers:create")
     .mutation(async ({ ctx, input }) => {
       // This legacy mutation cannot carry the validated/encrypted webhook
       // destination shape. Never let a direct caller create a malformed or
@@ -379,7 +378,7 @@ export const automationRouter = createTRPCRouter({
     }),
   deleteById: protectedProcedure
     .input(z.object({ projectId: z.string(), triggerId: z.string() }))
-    .use(checkProjectPermission("triggers:delete"))
+    .permission("triggers:delete")
     .mutation(async ({ input }) => {
       await getApp().triggers.softDeleteById({
         triggerId: input.triggerId,
@@ -399,7 +398,7 @@ export const automationRouter = createTRPCRouter({
     }),
   getTriggers: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ ctx, input }) => {
       const triggers = await getApp().triggers.getAllForProject({
         projectId: input.projectId,
@@ -474,7 +473,7 @@ export const automationRouter = createTRPCRouter({
    */
   getDailyCap: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ input }) => ({
       cap: await resolvePersistDailyCap(input.projectId),
     })),
@@ -493,7 +492,7 @@ export const automationRouter = createTRPCRouter({
    */
   getDailyCapStatus: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ ctx, input }) => {
       const cap = await resolvePersistDailyCap(input.projectId);
       const triggers = await ctx.prisma.trigger.findMany({
@@ -510,7 +509,7 @@ export const automationRouter = createTRPCRouter({
     }),
   getTriggerStats: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ ctx, input }) => {
       const fireHistory = TriggerFireHistoryService.create(ctx.prisma);
       return fireHistory.getAllFireStatsForProject({
@@ -525,7 +524,7 @@ export const automationRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(20).default(20),
       }),
     )
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ ctx, input }) => {
       const fireHistory = TriggerFireHistoryService.create(ctx.prisma);
       return fireHistory.getAllRecentFiresForTrigger({
@@ -545,7 +544,7 @@ export const automationRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(50).default(50),
       }),
     )
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ ctx, input }) => {
       const deliveries = WebhookDeliveryService.create(ctx.prisma);
       return deliveries.getRecentByTrigger({
@@ -562,7 +561,7 @@ export const automationRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(200).default(100),
       }),
     )
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ ctx, input }) => {
       const fireHistory = TriggerFireHistoryService.create(ctx.prisma);
       return fireHistory.getAllRecentFiresForProject({
@@ -577,7 +576,7 @@ export const automationRouter = createTRPCRouter({
    */
   getReportSchedules: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ input }) => {
       return getApp().triggers.getReportSchedules({
         projectId: input.projectId,
@@ -591,7 +590,7 @@ export const automationRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("triggers:update"))
+    .permission("triggers:update")
     .mutation(async ({ input }) => {
       const existing = await getApp().triggers.getById({
         triggerId: input.triggerId,
@@ -656,7 +655,7 @@ export const automationRouter = createTRPCRouter({
     }),
   getTriggerById: protectedProcedure
     .input(z.object({ triggerId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ input }) => {
       const trigger = await getApp().triggers.getById({
         triggerId: input.triggerId,
@@ -684,7 +683,7 @@ export const automationRouter = createTRPCRouter({
     )
     // triggers:update (not :view): this endpoint decrypts and exercises the
     // stored Slack bot token — the same capability testFireTemplate gates on.
-    .use(checkProjectPermission("triggers:update"))
+    .permission("triggers:update")
     .mutation(async ({ input }) => {
       let token = input.botToken?.trim() || null;
       if (!token && input.automationId) {
@@ -708,7 +707,7 @@ export const automationRouter = createTRPCRouter({
         filters: triggerFiltersPermissiveSchema,
       }),
     )
-    .use(checkProjectPermission("triggers:update"))
+    .permission("triggers:update")
     .mutation(async ({ ctx, input }) => {
       const { sanitized, unknownFields } = sanitizeTriggerFilters(
         input.filters,
@@ -823,7 +822,7 @@ export const automationRouter = createTRPCRouter({
           .default(null),
       }),
     )
-    .use(checkProjectPermission("triggers:update"))
+    .permission("triggers:update")
     .mutation(async ({ ctx, input }) => {
       // ADR-031: test fire is no longer an open relay. The client-supplied
       // recipient list is gone from the input entirely — there is nothing to
@@ -1014,7 +1013,7 @@ export const automationRouter = createTRPCRouter({
         traceDebounceMs: traceDebounceMsSchema.optional(),
       }),
     )
-    .use(checkProjectPermission("triggers:update"))
+    .permission("triggers:update")
     .mutation(async ({ ctx, input }) => {
       const isGraphAlert = !!input.customGraphId;
       const isReport = !isGraphAlert && !!input.report;

--- a/platform/app/src/server/api/routers/batchRecord.ts
+++ b/platform/app/src/server/api/routers/batchRecord.ts
@@ -2,13 +2,12 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import { ExperimentService } from "../../experiments/experiment.service";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const batchRecordRouter = createTRPCRouter({
   getAllByexperimentIdGroup: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ input, ctx }) => {
       const { projectId } = input;
       const prisma = ctx.prisma;
@@ -31,7 +30,7 @@ export const batchRecordRouter = createTRPCRouter({
     }),
   getAllByexperimentSlug: protectedProcedure
     .input(z.object({ projectId: z.string(), experimentSlug: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ input, ctx }) => {
       const { projectId, experimentSlug } = input;
       const prisma = ctx.prisma;

--- a/platform/app/src/server/api/routers/bugReports.ts
+++ b/platform/app/src/server/api/routers/bugReports.ts
@@ -6,7 +6,6 @@ import {
   getBugReportById,
 } from "~/server/app-layer/bug-reports/bug-report.service";
 import { isAdmin as checkIsAdmin } from "../../../../ee/admin/isAdmin";
-import { skipPermissionCheck } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -34,7 +33,9 @@ export const bugReportsRouter = createTRPCRouter({
         search: z.string().max(200).optional(),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "bug reports are filed by the session user about the app itself",
+    })
     .query(async ({ ctx, input }) => {
       const user = ctx.session.user.impersonator ?? ctx.session.user;
       requireAdmin(user);
@@ -55,7 +56,9 @@ export const bugReportsRouter = createTRPCRouter({
 
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "bug reports are filed by the session user about the app itself",
+    })
     .query(async ({ ctx, input }) => {
       const user = ctx.session.user.impersonator ?? ctx.session.user;
       requireAdmin(user);

--- a/platform/app/src/server/api/routers/codingAgents.ts
+++ b/platform/app/src/server/api/routers/codingAgents.ts
@@ -9,7 +9,6 @@ import {
 } from "~/server/organizations/resolveCallerProjectScope";
 import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { canReadCapturedContent } from "~/server/traces/protections";
-import { checkProjectPermission } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 import {
   gatePullRequestSessionTitles,
@@ -44,7 +43,7 @@ export const codingAgentsRouter = createTRPCRouter({
         toMs: z.number().int().optional(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       const toMs = input.toMs ?? Date.now();
@@ -70,7 +69,7 @@ export const codingAgentsRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(200).optional(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       const toMs = input.toMs ?? Date.now();
@@ -99,7 +98,7 @@ export const codingAgentsRouter = createTRPCRouter({
    */
   sessionsList: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -125,7 +124,7 @@ export const codingAgentsRouter = createTRPCRouter({
    */
   pullRequestUsage: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const app = getApp();
       const scope = await scopeFor({
@@ -160,7 +159,7 @@ export const codingAgentsRouter = createTRPCRouter({
         prNumber: z.number().int().positive(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const organizationId = await resolveOrganizationId(input.projectId);
       if (!organizationId) {

--- a/platform/app/src/server/api/routers/costs.ts
+++ b/platform/app/src/server/api/routers/costs.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import type { Project } from "~/generated/prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { checkOrganizationPermission } from "../rbac";
 
 export const costsRouter = createTRPCRouter({
   getAggregatedCostsForOrganization: protectedProcedure
@@ -12,7 +11,7 @@ export const costsRouter = createTRPCRouter({
         endDate: z.number(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       const { startDate, endDate } = input;
       const prisma = ctx.prisma;

--- a/platform/app/src/server/api/routers/dashboards.ts
+++ b/platform/app/src/server/api/routers/dashboards.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { DashboardService } from "../../dashboards/dashboard.service";
 import { dashboardErrorHandler } from "../../dashboards/middleware";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -18,7 +17,7 @@ export const dashboardsRouter = createTRPCRouter({
    */
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("analytics:view"))
+    .permission("analytics:view")
     .use(dashboardErrorHandler)
     .query(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);
@@ -30,7 +29,7 @@ export const dashboardsRouter = createTRPCRouter({
    */
   getById: protectedProcedure
     .input(z.object({ projectId: z.string(), dashboardId: z.string() }))
-    .use(checkProjectPermission("analytics:view"))
+    .permission("analytics:view")
     .use(dashboardErrorHandler)
     .query(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);
@@ -47,7 +46,7 @@ export const dashboardsRouter = createTRPCRouter({
         name: z.string(),
       }),
     )
-    .use(checkProjectPermission("analytics:create"))
+    .permission("analytics:create")
     .use(dashboardErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);
@@ -65,7 +64,7 @@ export const dashboardsRouter = createTRPCRouter({
         name: z.string(),
       }),
     )
-    .use(checkProjectPermission("analytics:update"))
+    .permission("analytics:update")
     .use(dashboardErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);
@@ -86,7 +85,7 @@ export const dashboardsRouter = createTRPCRouter({
         dashboardId: z.string(),
       }),
     )
-    .use(checkProjectPermission("analytics:delete"))
+    .permission("analytics:delete")
     .use(dashboardErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);
@@ -103,7 +102,7 @@ export const dashboardsRouter = createTRPCRouter({
         dashboardIds: z.array(z.string()),
       }),
     )
-    .use(checkProjectPermission("analytics:update"))
+    .permission("analytics:update")
     .use(dashboardErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);
@@ -116,7 +115,7 @@ export const dashboardsRouter = createTRPCRouter({
    */
   getOrCreateFirst: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("analytics:view"))
+    .permission("analytics:view")
     .use(dashboardErrorHandler)
     .query(async ({ ctx, input }) => {
       const service = DashboardService.create(ctx.prisma);

--- a/platform/app/src/server/api/routers/dataPrivacy.ts
+++ b/platform/app/src/server/api/routers/dataPrivacy.ts
@@ -12,7 +12,7 @@ import {
   InvalidDataPrivacyConfigError,
   ScopeTargetNotFoundError,
 } from "~/server/data-privacy/dataPrivacyPolicy.service";
-import { authorizeInResolver, checkProjectPermission } from "../rbac";
+import { authorizeInResolver } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const scopeInput = z.object({
@@ -29,7 +29,7 @@ export const dataPrivacyRouter = createTRPCRouter({
    */
   getSnapshot: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       return getDataPrivacySnapshot(
         { prisma: ctx.prisma, session: ctx.session },

--- a/platform/app/src/server/api/routers/dataRetention.ts
+++ b/platform/app/src/server/api/routers/dataRetention.ts
@@ -45,7 +45,7 @@ import {
   retentionDaysInputSchema,
 } from "~/server/data-retention/retentionPolicy.schema";
 import { SCOPE_TIERS } from "~/server/scopes/scope.types";
-import { authorizeInResolver, checkProjectPermission } from "../rbac";
+import { authorizeInResolver } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const scopeInput = z.object({
@@ -62,7 +62,7 @@ export const dataRetentionRouter = createTRPCRouter({
    */
   getRules: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       return getRetentionPolicySnapshot(ctx, { projectId: input.projectId });
     }),
@@ -171,7 +171,7 @@ export const dataRetentionRouter = createTRPCRouter({
         category: retentionCategorySchema,
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input, ctx }) => {
       await assertRetentionPlanForProject(ctx, input.projectId);
       // Resolve the retention value server-side. Trusting a client-supplied
@@ -207,7 +207,7 @@ export const dataRetentionRouter = createTRPCRouter({
 
   getMutationProgress: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       return getApp().dataRetention.retroactive.getMutationProgress({
         projectId: input.projectId,
@@ -221,7 +221,7 @@ export const dataRetentionRouter = createTRPCRouter({
         mutationId: z.string(),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input, ctx }) => {
       await assertRetentionPlanForProject(ctx, input.projectId);
       await getApp().dataRetention.retroactive.killMutation({
@@ -240,7 +240,7 @@ export const dataRetentionRouter = createTRPCRouter({
    */
   getScopeStorageUsage: protectedProcedure
     .input(z.object({ projectId: z.string(), scope: scopeInput }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       return resolveScopeStorageUsage(ctx, {
         projectId: input.projectId,

--- a/platform/app/src/server/api/routers/dataset.ts
+++ b/platform/app/src/server/api/routers/dataset.ts
@@ -10,7 +10,7 @@ import {
   datasetRecordFormSchema,
   datasetRecordInputSchema,
 } from "../../datasets/types";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -53,7 +53,7 @@ export const datasetRouter = createTRPCRouter({
         ]),
       ),
     )
-    .use(checkProjectPermission("datasets:manage"))
+    .permission("datasets:manage")
     .use(datasetErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const datasetService = DatasetService.create(ctx.prisma);
@@ -81,7 +81,7 @@ export const datasetRouter = createTRPCRouter({
         excludeDatasetId: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .use(datasetErrorHandler)
     .query(async ({ input, ctx }) => {
       const datasetService = DatasetService.create(ctx.prisma);
@@ -94,7 +94,7 @@ export const datasetRouter = createTRPCRouter({
    */
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .query(async ({ input, ctx }) => {
       const { projectId } = input;
       const prisma = ctx.prisma;
@@ -125,7 +125,7 @@ export const datasetRouter = createTRPCRouter({
    */
   getById: protectedProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .query(async ({ input, ctx }) => {
       const { projectId, datasetId } = input;
       const dataset = await ctx.prisma.dataset.findFirst({
@@ -148,7 +148,7 @@ export const datasetRouter = createTRPCRouter({
         undo: z.boolean().optional(),
       }),
     )
-    .use(checkProjectPermission("datasets:delete"))
+    .permission("datasets:delete")
     .mutation(async ({ ctx, input }) => {
       const datasetName = (
         await ctx.prisma.dataset.findFirst({
@@ -191,7 +191,7 @@ export const datasetRouter = createTRPCRouter({
           .optional(),
       }),
     )
-    .use(checkProjectPermission("datasets:update"))
+    .permission("datasets:update")
     .mutation(async ({ ctx, input }) => {
       const { projectId, datasetId, mapping, threadMapping } = input;
 
@@ -220,7 +220,7 @@ export const datasetRouter = createTRPCRouter({
    */
   findNextName: protectedProcedure
     .input(z.object({ projectId: z.string(), proposedName: z.string() }))
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .use(datasetErrorHandler)
     .query(async ({ input, ctx }) => {
       const datasetService = DatasetService.create(ctx.prisma);
@@ -242,7 +242,7 @@ export const datasetRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("datasets:create"))
+    .permission("datasets:create")
     .use(datasetErrorHandler)
     .mutation(async ({ ctx, input }) => {
       // Check that the user has at least datasets:create permission on the source project

--- a/platform/app/src/server/api/routers/datasetRecord.ts
+++ b/platform/app/src/server/api/routers/datasetRecord.ts
@@ -17,7 +17,6 @@ import {
 import { stripNullBytes } from "../../datasets/sanitize";
 import { newDatasetEntriesSchema } from "../../datasets/types";
 import { StorageService } from "../../storage";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import {
   createManyDatasetRecords,
@@ -87,7 +86,7 @@ export const datasetRecordRouter = createTRPCRouter({
         newDatasetEntriesSchema,
       ),
     )
-    .use(checkProjectPermission("datasets:create"))
+    .permission("datasets:create")
     .mutation(async ({ ctx, input }) => {
       const dataset = await ctx.prisma.dataset.findFirst({
         where: {
@@ -124,7 +123,7 @@ export const datasetRecordRouter = createTRPCRouter({
         updatedRecord: z.record(z.string(), z.any()),
       }),
     )
-    .use(checkProjectPermission("datasets:update"))
+    .permission("datasets:update")
     .mutation(async ({ ctx, input }) => {
       const { recordId, updatedRecord } = input;
 
@@ -156,7 +155,7 @@ export const datasetRecordRouter = createTRPCRouter({
     }),
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .query(async ({ input }) => {
       try {
         return await getFullDataset({
@@ -190,7 +189,7 @@ export const datasetRecordRouter = createTRPCRouter({
         limit: z.number().int().positive().max(200).default(50),
       }),
     )
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .query(async ({ ctx, input }) => {
       try {
         return await DatasetService.create(ctx.prisma).getDatasetPage({
@@ -209,7 +208,7 @@ export const datasetRecordRouter = createTRPCRouter({
     }),
   download: protectedProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .mutation(async ({ input }) => {
       try {
         return await getFullDataset({
@@ -225,7 +224,7 @@ export const datasetRecordRouter = createTRPCRouter({
     }),
   getHead: protectedProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
-    .use(checkProjectPermission("datasets:view"))
+    .permission("datasets:view")
     .query(async ({ input, ctx }) => {
       try {
         return await getDatasetHead({ input, ctx });
@@ -243,7 +242,7 @@ export const datasetRecordRouter = createTRPCRouter({
         recordIds: z.array(z.string()),
       }),
     )
-    .use(checkProjectPermission("datasets:delete"))
+    .permission("datasets:delete")
     .mutation(async ({ ctx, input }) => {
       const prisma = ctx.prisma;
 

--- a/platform/app/src/server/api/routers/emailSuppression.ts
+++ b/platform/app/src/server/api/routers/emailSuppression.ts
@@ -5,7 +5,6 @@ import { getApp } from "~/server/app-layer/app";
 import { InvalidUnsubscribeTokenError } from "~/server/app-layer/automations/emailSuppression.service";
 import { getClientIp } from "~/utils/getClientIp";
 import { rateLimit } from "../../rateLimit";
-import { checkProjectPermission, skipPermissionCheck } from "../rbac";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 
 /**
@@ -46,7 +45,10 @@ export const emailSuppressionRouter = createTRPCRouter({
    */
   resolveUnsubscribeToken: publicProcedure
     .input(z.object({ token: z.string().min(1) }))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "unsubscribe flows are gated by the single-purpose token in the link, not by a role",
+    })
     .query(async ({ input, ctx }) => {
       await enforceUnsubscribeRateLimit({
         ip: getClientIp(ctx.req),
@@ -74,7 +76,10 @@ export const emailSuppressionRouter = createTRPCRouter({
         scope: z.enum(["trigger", "project"]),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "unsubscribe flows are gated by the single-purpose token in the link, not by a role",
+    })
     .mutation(async ({ input, ctx }) => {
       await enforceUnsubscribeRateLimit({
         ip: getClientIp(ctx.req),
@@ -109,7 +114,7 @@ export const emailSuppressionRouter = createTRPCRouter({
    *  scope without a second round-trip. */
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("triggers:view"))
+    .permission("triggers:view")
     .query(async ({ input, ctx }) => {
       const rows = await getApp().emailSuppressions.getAllEnriched({
         projectId: input.projectId,
@@ -142,7 +147,7 @@ export const emailSuppressionRouter = createTRPCRouter({
   /** Removing a suppression resumes delivery — a deliberate operator action. */
   remove: protectedProcedure
     .input(z.object({ projectId: z.string(), id: z.string() }))
-    .use(checkProjectPermission("triggers:manage"))
+    .permission("triggers:manage")
     .mutation(async ({ input, ctx }) => {
       await getApp().emailSuppressions.remove({
         projectId: input.projectId,

--- a/platform/app/src/server/api/routers/evaluations.ts
+++ b/platform/app/src/server/api/routers/evaluations.ts
@@ -19,7 +19,6 @@ import {
 import { evaluatorUnavailability } from "../../evaluations/installedEvaluators";
 import { runEvaluationForTrace } from "../../evaluations/runEvaluation";
 import { mappingStateSchema } from "../../tracer/tracesMapping";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { getUserProtectionsForProject } from "../utils";
 
@@ -28,7 +27,7 @@ const logger = createLogger("langwatch:evaluations");
 export const evaluationsRouter = createTRPCRouter({
   availableEvaluators: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ input }) => {
       // Azure Safety evaluators resolve their credentials solely from the
       // project's azure_safety Model Provider. There is no process.env
@@ -59,7 +58,7 @@ export const evaluationsRouter = createTRPCRouter({
 
   availableCustomEvaluators: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ input }) => {
       const customEvaluators = await getCustomEvaluators({
         projectId: input.projectId,
@@ -79,7 +78,7 @@ export const evaluationsRouter = createTRPCRouter({
         mappings: mappingStateSchema,
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ input, ctx }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -161,7 +160,7 @@ export const evaluationsRouter = createTRPCRouter({
         count: z.number().min(1).max(24).default(5),
       }),
     )
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .mutation(async ({ input }) => {
       const { projectId, count } = input;
 

--- a/platform/app/src/server/api/routers/evaluators.ts
+++ b/platform/app/src/server/api/routers/evaluators.ts
@@ -6,7 +6,7 @@ import type { Workflow } from "../../../optimization_studio/types/dsl";
 import { getWorkflowEntryOutputs } from "../../../optimization_studio/utils/workflowFields";
 import { codeEvaluatorConfigSchema } from "../../evaluators/codeEvaluator";
 import { EvaluatorService } from "../../evaluators/evaluator.service";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
 
@@ -46,7 +46,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const evaluatorService = EvaluatorService.create(ctx.prisma);
       return await evaluatorService.getAllWithFields({
@@ -60,7 +60,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   getById: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const evaluatorService = EvaluatorService.create(ctx.prisma);
       return await evaluatorService.getByIdWithFields({
@@ -74,7 +74,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   getBySlug: protectedProcedure
     .input(z.object({ slug: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const evaluatorService = EvaluatorService.create(ctx.prisma);
       return await evaluatorService.getBySlug({
@@ -98,7 +98,7 @@ export const evaluatorsRouter = createTRPCRouter({
         workflowId: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       if (input.type === "code") {
         const parsed = codeEvaluatorConfigSchema.safeParse(input.config);
@@ -158,7 +158,7 @@ export const evaluatorsRouter = createTRPCRouter({
         workflowId: z.string().nullable().optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       if (input.type === "code" && input.config !== undefined) {
         const parsed = codeEvaluatorConfigSchema.safeParse(input.config);
@@ -199,7 +199,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   getRelatedEntities: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const evaluator = await ctx.prisma.evaluator.findFirst({
         where: {
@@ -241,7 +241,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   cascadeArchive: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.$transaction(async (tx) => {
         // 1. Get the evaluator to find linked workflow
@@ -297,7 +297,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   delete: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const evaluatorService = EvaluatorService.create(ctx.prisma);
       return await evaluatorService.softDelete({
@@ -313,7 +313,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   getWorkflowFields: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       // Fetch the evaluator first, then scope its workflow to the same project.
       const evaluator = await ctx.prisma.evaluator.findFirst({
@@ -380,7 +380,7 @@ export const evaluatorsRouter = createTRPCRouter({
         evaluatorId: z.string(),
       }),
     )
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const source = await ctx.prisma.evaluator.findFirst({
         where: {
@@ -452,7 +452,7 @@ export const evaluatorsRouter = createTRPCRouter({
         newEvaluatorId: z.string().default(() => `evaluator_${nanoid()}`),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const hasSourcePermission = await hasProjectPermission(
         ctx,
@@ -487,7 +487,7 @@ export const evaluatorsRouter = createTRPCRouter({
         copyIds: z.array(z.string()).optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const source = await ctx.prisma.evaluator.findFirst({
         where: {
@@ -563,7 +563,7 @@ export const evaluatorsRouter = createTRPCRouter({
         evaluatorId: z.string(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       const copy = await ctx.prisma.evaluator.findFirst({
         where: {
@@ -626,7 +626,7 @@ export const evaluatorsRouter = createTRPCRouter({
    */
   getHistory: protectedProcedure
     .input(z.object({ evaluatorId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ ctx, input }) => {
       const service = EvaluatorService.create(ctx.prisma);
       return service.getHistory(input.evaluatorId, input.projectId);

--- a/platform/app/src/server/api/routers/experiments.ts
+++ b/platform/app/src/server/api/routers/experiments.ts
@@ -37,7 +37,7 @@ import {
 import { ExperimentRunService } from "../../experiments-v3/services/experiment-run.service";
 import { getVersionMap } from "../../experiments-v3/services/getVersionMap";
 import { coerceMonitorMappings } from "../../tracer/tracesMapping";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import {
   type createInnerTRPCContext,
   createTRPCRouter,
@@ -72,7 +72,7 @@ export const experimentsRouter = createTRPCRouter({
         commitMessage: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("workflows:create"))
+    .permission("workflows:create")
     .mutation(async ({ ctx, input }) => {
       const experiments = experimentService();
 
@@ -225,7 +225,7 @@ export const experimentsRouter = createTRPCRouter({
         state: persistedEvaluationsV3StateSchema,
       }),
     )
-    .use(checkProjectPermission("workflows:create"))
+    .permission("workflows:create")
     .mutation(async ({ ctx, input }) => {
       const experiments = experimentService();
       const experimentId =
@@ -310,7 +310,7 @@ export const experimentsRouter = createTRPCRouter({
         experimentSlug: z.string(),
       }),
     )
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const experiment = await experimentService()
         .getBySlug({
@@ -341,7 +341,7 @@ export const experimentsRouter = createTRPCRouter({
         experimentId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:create"))
+    .permission("workflows:create")
     .mutation(async ({ input }) => {
       const experiment =
         await experimentService().findByIdWithWorkflowCurrentVersion({
@@ -415,7 +415,7 @@ export const experimentsRouter = createTRPCRouter({
         experimentSlug: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       if (input.experimentId) {
         return await experimentService()
@@ -447,7 +447,7 @@ export const experimentsRouter = createTRPCRouter({
         randomSeed: z.number().optional(),
       }),
     )
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const experiment = await experimentService()
         .getBySlug({
@@ -476,7 +476,7 @@ export const experimentsRouter = createTRPCRouter({
 
   getAllByProjectId: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       return await experimentService().getAll({
         projectId: input.projectId,
@@ -491,7 +491,7 @@ export const experimentsRouter = createTRPCRouter({
         pageSize: z.number().optional(),
       }),
     )
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const pageOffset = input.pageOffset ?? 0;
       const pageSize = input.pageSize ?? 25;
@@ -587,7 +587,7 @@ export const experimentsRouter = createTRPCRouter({
 
   getExperimentDSPyRuns: protectedProcedure
     .input(z.object({ projectId: z.string(), experimentSlug: z.string() }))
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const experiment = await experimentService()
         .getBySlug({
@@ -669,7 +669,7 @@ export const experimentsRouter = createTRPCRouter({
         index: z.string(),
       }),
     )
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const experiment = await experimentService()
         .getBySlug({
@@ -723,7 +723,7 @@ export const experimentsRouter = createTRPCRouter({
 
   getExperimentBatchEvaluationRuns: protectedProcedure
     .input(z.object({ projectId: z.string(), experimentId: z.string() }))
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const experiment = await experimentService()
         .getById({
@@ -749,7 +749,7 @@ export const experimentsRouter = createTRPCRouter({
         runId: z.string(),
       }),
     )
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       const experiment = await experimentService()
         .getById({
@@ -796,7 +796,7 @@ export const experimentsRouter = createTRPCRouter({
         experimentId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:delete"))
+    .permission("workflows:delete")
     .mutation(async ({ input }) => {
       return await experimentService()
         .archive({ projectId: input.projectId, id: input.experimentId })
@@ -812,7 +812,7 @@ export const experimentsRouter = createTRPCRouter({
         copyDatasets: z.boolean().optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ ctx, input }) => {
       // Check that the user has at least evaluations:manage permission on the source project
       const hasSourcePermission = await hasProjectPermission(
@@ -945,7 +945,7 @@ export const experimentsRouter = createTRPCRouter({
    */
   getLastExperiment: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("experiments:view"))
+    .permission("experiments:view")
     .query(async ({ input }) => {
       return await experimentService().getLatest({
         projectId: input.projectId,

--- a/platform/app/src/server/api/routers/export.ts
+++ b/platform/app/src/server/api/routers/export.ts
@@ -12,7 +12,6 @@ import { createLogger } from "@langwatch/observability";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
-import { checkProjectPermission, type Permission } from "../rbac";
 
 const logger = createLogger("langwatch:api:export");
 
@@ -66,10 +65,12 @@ function readProgressEvent({
  * `scenarios:view` and a trace export by `traces:view`. Factored rather than
  * copied so the two cannot drift on filtering or teardown.
  */
-function exportProgressSubscription(permission: Permission) {
+function exportProgressSubscription(
+  permission: "traces:view" | "scenarios:view",
+) {
   return protectedProcedure
     .input(z.object({ projectId: z.string(), exportId: z.string() }))
-    .use(checkProjectPermission(permission))
+    .permission(permission)
     .subscription(async function* (opts) {
       const { projectId, exportId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { featureFlagService } from "../../featureFlag";
 import { FRONTEND_FEATURE_FLAGS } from "../../featureFlag/frontendFeatureFlags";
 import type { FeatureFlagKey } from "../../featureFlag/registry";
-import { skipPermissionCheck } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const logger = createLogger("langwatch:feature-flag-router");
@@ -38,14 +37,14 @@ export const featureFlagRouter = createTRPCRouter({
         organizationId: z.string().optional(),
       }),
     )
-    .use(
-      skipPermissionCheck({
-        allow: {
-          projectId: "for PostHog targeting, not resource access",
-          organizationId: "for PostHog targeting, not resource access",
-        },
-      }),
-    )
+    .noPermission({
+      reason:
+        "feature flags are read per authenticated user; no tenant data is exposed",
+      allow: {
+        projectId: "for PostHog targeting, not resource access",
+        organizationId: "for PostHog targeting, not resource access",
+      },
+    })
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
@@ -111,7 +110,10 @@ export const featureFlagRouter = createTRPCRouter({
     // Membership filtering below is the real authorization check; the
     // rbac middleware's sensitive-key guard does not cover plural
     // targeting params and is not relevant here.
-    .use(skipPermissionCheck())
+    .noPermission({
+      reason:
+        "feature flags are read per authenticated user; no tenant data is exposed",
+    })
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
@@ -175,7 +177,10 @@ export const featureFlagRouter = createTRPCRouter({
         organizationIds: z.array(z.string()),
       }),
     )
-    .use(skipPermissionCheck())
+    .noPermission({
+      reason:
+        "feature flags are read per authenticated user; no tenant data is exposed",
+    })
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 

--- a/platform/app/src/server/api/routers/gatewayBudgets.ts
+++ b/platform/app/src/server/api/routers/gatewayBudgets.ts
@@ -19,7 +19,6 @@ import {
   resolveProviderLabels,
 } from "~/server/gateway/providerLabels";
 
-import { checkOrganizationPermission, checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const scopeSchema = z.discriminatedUnion("kind", [
@@ -54,7 +53,7 @@ async function requireOrgAccess(
 export const gatewayBudgetsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("gatewayBudgets:view"))
+    .permission("gatewayBudgets:view")
     .query(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayBudgetService.create(
@@ -86,7 +85,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
 
   listForProject: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("gatewayBudgets:view"))
+    .permission("gatewayBudgets:view")
     .query(async ({ ctx, input }) => {
       const service = GatewayBudgetService.create(
         ctx.prisma,
@@ -121,7 +120,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
 
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("gatewayBudgets:view"))
+    .permission("gatewayBudgets:view")
     .query(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayBudgetService.create(
@@ -166,7 +165,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
    */
   groupTargets: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("gatewayBudgets:create"))
+    .permission("gatewayBudgets:create")
     .query(async ({ ctx, input }) => {
       const groups = await ctx.prisma.group.findMany({
         where: { organizationId: input.organizationId },
@@ -231,7 +230,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
         allowUnreachable: z.boolean().optional(),
       }),
     )
-    .use(checkOrganizationPermission("gatewayBudgets:create"))
+    .permission("gatewayBudgets:create")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayBudgetService.create(
         ctx.prisma,
@@ -266,7 +265,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
         timezone: z.string().nullable().optional(),
       }),
     )
-    .use(checkOrganizationPermission("gatewayBudgets:update"))
+    .permission("gatewayBudgets:update")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayBudgetService.create(
         ctx.prisma,
@@ -281,7 +280,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("gatewayBudgets:delete"))
+    .permission("gatewayBudgets:delete")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayBudgetService.create(
         ctx.prisma,
@@ -303,7 +302,7 @@ export const gatewayBudgetsRouter = createTRPCRouter({
         reason: z.string().max(500).optional(),
       }),
     )
-    .use(checkOrganizationPermission("gatewayBudgets:update"))
+    .permission("gatewayBudgets:update")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayBudgetService.create(
         ctx.prisma,

--- a/platform/app/src/server/api/routers/gatewayCacheRules.ts
+++ b/platform/app/src/server/api/routers/gatewayCacheRules.ts
@@ -14,7 +14,6 @@ import { z } from "zod";
 
 import { GatewayCacheRuleService } from "~/server/gateway/cacheRule.service";
 
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const matchersSchema = z
@@ -54,7 +53,7 @@ async function requireOrgAccess(
 export const gatewayCacheRulesRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("gatewayCacheRules:view"))
+    .permission("gatewayCacheRules:view")
     .query(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayCacheRuleService.create(ctx.prisma);
@@ -64,7 +63,7 @@ export const gatewayCacheRulesRouter = createTRPCRouter({
 
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("gatewayCacheRules:view"))
+    .permission("gatewayCacheRules:view")
     .query(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayCacheRuleService.create(ctx.prisma);
@@ -90,7 +89,7 @@ export const gatewayCacheRulesRouter = createTRPCRouter({
         action: actionSchema,
       }),
     )
-    .use(checkOrganizationPermission("gatewayCacheRules:create"))
+    .permission("gatewayCacheRules:create")
     .mutation(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayCacheRuleService.create(ctx.prisma);
@@ -120,7 +119,7 @@ export const gatewayCacheRulesRouter = createTRPCRouter({
         action: actionSchema.optional(),
       }),
     )
-    .use(checkOrganizationPermission("gatewayCacheRules:update"))
+    .permission("gatewayCacheRules:update")
     .mutation(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayCacheRuleService.create(ctx.prisma);
@@ -140,7 +139,7 @@ export const gatewayCacheRulesRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("gatewayCacheRules:delete"))
+    .permission("gatewayCacheRules:delete")
     .mutation(async ({ ctx, input }) => {
       await requireOrgAccess(ctx, input.organizationId);
       const service = GatewayCacheRuleService.create(ctx.prisma);

--- a/platform/app/src/server/api/routers/gatewayGuardrails.ts
+++ b/platform/app/src/server/api/routers/gatewayGuardrails.ts
@@ -16,7 +16,6 @@ import {
 
 import { GatewayGuardrailService } from "~/server/gateway/guardrail.service";
 
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const directionSchema = z.nativeEnum(GatewayGuardrailDirection);
@@ -25,7 +24,7 @@ const failureModeSchema = z.nativeEnum(GatewayGuardrailFailureMode);
 export const gatewayGuardrailsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("gatewayGuardrails:view"))
+    .permission("gatewayGuardrails:view")
     .query(async ({ ctx, input }) => {
       const service = GatewayGuardrailService.create(ctx.prisma);
       return await service.list(input.projectId);
@@ -33,7 +32,7 @@ export const gatewayGuardrailsRouter = createTRPCRouter({
 
   get: protectedProcedure
     .input(z.object({ projectId: z.string(), id: z.string() }))
-    .use(checkProjectPermission("gatewayGuardrails:view"))
+    .permission("gatewayGuardrails:view")
     .query(async ({ ctx, input }) => {
       const service = GatewayGuardrailService.create(ctx.prisma);
       return await service.get(input.id, input.projectId);
@@ -50,7 +49,7 @@ export const gatewayGuardrailsRouter = createTRPCRouter({
         failureMode: failureModeSchema.optional(),
       }),
     )
-    .use(checkProjectPermission("gatewayGuardrails:manage"))
+    .permission("gatewayGuardrails:manage")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayGuardrailService.create(ctx.prisma);
       return await service.create({
@@ -76,7 +75,7 @@ export const gatewayGuardrailsRouter = createTRPCRouter({
         failureMode: failureModeSchema.optional(),
       }),
     )
-    .use(checkProjectPermission("gatewayGuardrails:manage"))
+    .permission("gatewayGuardrails:manage")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayGuardrailService.create(ctx.prisma);
       return await service.update({
@@ -93,7 +92,7 @@ export const gatewayGuardrailsRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(z.object({ projectId: z.string(), id: z.string() }))
-    .use(checkProjectPermission("gatewayGuardrails:manage"))
+    .permission("gatewayGuardrails:manage")
     .mutation(async ({ ctx, input }) => {
       const service = GatewayGuardrailService.create(ctx.prisma);
       await service.archive({

--- a/platform/app/src/server/api/routers/gatewaySpendEvents.ts
+++ b/platform/app/src/server/api/routers/gatewaySpendEvents.ts
@@ -11,7 +11,6 @@ import { getApp } from "~/server/app-layer/app";
 import { GatewaySpendEventsService } from "~/server/gateway/spendEvents.service";
 import { spendFiltersSchema } from "~/server/gateway/spendFilters";
 
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const gatewaySpendEventsRouter = createTRPCRouter({
@@ -35,7 +34,7 @@ export const gatewaySpendEventsRouter = createTRPCRouter({
         limit: z.number().int().min(1).max(200).optional(),
       }),
     )
-    .use(checkProjectPermission("gatewayUsage:view"))
+    .permission("gatewayUsage:view")
     .query(async ({ ctx, input }) => {
       const repository = getApp().gateway.spendEvents;
       if (!repository) {

--- a/platform/app/src/server/api/routers/github.ts
+++ b/platform/app/src/server/api/routers/github.ts
@@ -26,11 +26,7 @@
 import { auditLog } from "@ee/audit-log/auditLog";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import {
-  checkOrganizationPermission,
-  checkProjectPermission,
-  type PermissionMiddleware,
-} from "~/server/api/rbac";
+import type { PermissionMiddleware } from "~/server/api/rbac";
 import { getApp } from "~/server/app-layer";
 import { GithubNotConnectedError } from "~/server/app-layer/github/errors";
 import { MAX_STATUS_REFS } from "~/server/app-layer/github/github-pull-request-status.service";
@@ -101,7 +97,7 @@ function installUrl(organizationId: string): string | null {
 export const githubRouter = createTRPCRouter({
   getConnectionStatus: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .use(enforceOrganizationMembership)
     .query(async ({ input }) => {
       const service = getApp().github.installations;
@@ -135,7 +131,7 @@ export const githubRouter = createTRPCRouter({
 
   listRepos: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .use(enforceOrganizationMembership)
     .query(async ({ input }) => {
       return getApp().github.installations.listRepositoriesForOrganization(
@@ -168,7 +164,7 @@ export const githubRouter = createTRPCRouter({
           .max(MAX_STATUS_REFS),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const organizationId = await resolveOrganizationId(input.projectId);
       if (!organizationId) return { statuses: [] };
@@ -182,7 +178,7 @@ export const githubRouter = createTRPCRouter({
 
   disconnect: protectedProcedure
     .input(z.object({ organizationId: z.string(), installationId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .use(enforceOrganizationMembership)
     .mutation(async ({ ctx, input }) => {
       const installation =

--- a/platform/app/src/server/api/routers/graphs.ts
+++ b/platform/app/src/server/api/routers/graphs.ts
@@ -5,7 +5,6 @@ import { BUILDER_CHART_KIND } from "~/server/analytics/chartKinds";
 import { dashboardBelongsToProject } from "~/server/analytics/dashboardBelongsToProject";
 import { redactActionParamsFor } from "~/server/app-layer/automations/providers/registry";
 import { type FilterField, filterFieldsEnum } from "../../filters/types";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -35,7 +34,7 @@ export const graphsRouter = createTRPCRouter({
         rowSpan: z.number().min(1).max(2).optional(),
       }),
     )
-    .use(checkProjectPermission("analytics:create"))
+    .permission("analytics:create")
     .mutation(async ({ ctx, input }) => {
       const graph = JSON.parse(input.graph);
 
@@ -97,7 +96,7 @@ export const graphsRouter = createTRPCRouter({
         dashboardId: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("analytics:view"))
+    .permission("analytics:view")
     .query(async ({ input, ctx }) => {
       const { projectId, dashboardId } = input;
       const prisma = ctx.prisma;
@@ -138,7 +137,7 @@ export const graphsRouter = createTRPCRouter({
     }),
   delete: protectedProcedure
     .input(z.object({ projectId: z.string(), id: z.string() }))
-    .use(checkProjectPermission("analytics:delete"))
+    .permission("analytics:delete")
     .mutation(async ({ ctx, input }) => {
       const { id } = input;
       const prisma = ctx.prisma;
@@ -158,7 +157,7 @@ export const graphsRouter = createTRPCRouter({
     }),
   getById: protectedProcedure
     .input(z.object({ projectId: z.string(), id: z.string() }))
-    .use(checkProjectPermission("analytics:view"))
+    .permission("analytics:view")
     .query(async ({ ctx, input }) => {
       const { id } = input;
       const prisma = ctx.prisma;
@@ -248,7 +247,7 @@ export const graphsRouter = createTRPCRouter({
         filterParams: z.any().optional(),
       }),
     )
-    .use(checkProjectPermission("analytics:update"))
+    .permission("analytics:update")
     .mutation(async ({ ctx, input }) => {
       const prisma = ctx.prisma;
 
@@ -284,7 +283,7 @@ export const graphsRouter = createTRPCRouter({
         rowSpan: z.number().min(1).max(2),
       }),
     )
-    .use(checkProjectPermission("analytics:update"))
+    .permission("analytics:update")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.customGraph.update({
         where: {
@@ -316,7 +315,7 @@ export const graphsRouter = createTRPCRouter({
         ),
       }),
     )
-    .use(checkProjectPermission("analytics:update"))
+    .permission("analytics:update")
     .mutation(async ({ ctx, input }) => {
       const updates = input.layouts.map((layout) =>
         ctx.prisma.customGraph.update({

--- a/platform/app/src/server/api/routers/group.ts
+++ b/platform/app/src/server/api/routers/group.ts
@@ -13,7 +13,6 @@ import { RoleService } from "~/server/role/role.service";
 import { RoleBindingService } from "~/server/role-bindings/role-binding.service";
 import { slugify } from "~/utils/slugify";
 import { assertEnterprisePlan, ENTERPRISE_FEATURE_ERRORS } from "../enterprise";
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -115,7 +114,7 @@ export const groupRouter = createTRPCRouter({
     // group's role-binding map (which scopes they grant on, what
     // role, which custom role). Authz config, admin-surface.
     // Sole TS caller is settings/groups.tsx, an admin-only page.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ ctx, input }) => {
       await assertEnterprisePlan({
         organizationId: input.organizationId,
@@ -180,7 +179,7 @@ export const groupRouter = createTRPCRouter({
     // GroupDetailDialog under settings/, an admin-only surface.
     // Mirrors the #47 stack: roleBinding.listForOrg is already at
     // organization:manage; group.getById should match.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ ctx, input }) => {
       const group = await ctx.prisma.group.findFirst({
         where: { id: input.groupId, organizationId: input.organizationId },
@@ -259,7 +258,7 @@ export const groupRouter = createTRPCRouter({
         memberIds: z.array(z.string()).optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       await assertEnterprisePlan({
         organizationId: input.organizationId,
@@ -290,7 +289,7 @@ export const groupRouter = createTRPCRouter({
         scopeId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       const binding = await groupService(ctx.prisma).addBinding({
         groupId: input.groupId,
@@ -314,7 +313,7 @@ export const groupRouter = createTRPCRouter({
         bindingId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       await groupService(ctx.prisma).removeBinding({
         bindingId: input.bindingId,
@@ -335,7 +334,7 @@ export const groupRouter = createTRPCRouter({
         userId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       const group = await ctx.prisma.group.findFirst({
         where: { id: input.groupId, organizationId: input.organizationId },
@@ -372,7 +371,7 @@ export const groupRouter = createTRPCRouter({
    */
   delete: protectedProcedure
     .input(z.object({ organizationId: z.string(), groupId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       await groupService(ctx.prisma).delete({
         id: input.groupId,
@@ -398,7 +397,7 @@ export const groupRouter = createTRPCRouter({
         name: z.string().trim().min(1, "Group name is required").max(100),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       const group = await ctx.prisma.group.findFirst({
         where: { id: input.groupId, organizationId: input.organizationId },
@@ -440,7 +439,7 @@ export const groupRouter = createTRPCRouter({
     // gating the read either misreports a member's effective access or (as
     // customers hit) turns every dialog open into a refused request. An
     // organization that never had groups simply gets an empty list.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ ctx, input }) => {
       const groups = await ctx.prisma.group.findMany({
         where: {
@@ -480,7 +479,7 @@ export const groupRouter = createTRPCRouter({
         userId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       const group = await ctx.prisma.group.findFirst({
         where: { id: input.groupId, organizationId: input.organizationId },
@@ -532,7 +531,7 @@ export const groupRouter = createTRPCRouter({
         memberUserIdsToRemove: z.array(z.string()),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       let resolvedRename: { name: string; slug: string } | null = null;
       if (input.rename) {

--- a/platform/app/src/server/api/routers/home.ts
+++ b/platform/app/src/server/api/routers/home.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { RecentItemsService } from "~/server/home/recent-items.service";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -20,7 +19,7 @@ export const homeRouter = createTRPCRouter({
         limit: z.number().min(1).max(50).default(12),
       }),
     )
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ ctx, input }) => {
       const recentItemsService = new RecentItemsService();
       return recentItemsService.getRecentItems({

--- a/platform/app/src/server/api/routers/httpProxy.ts
+++ b/platform/app/src/server/api/routers/httpProxy.ts
@@ -14,7 +14,6 @@ import {
 } from "~/optimization_studio/types/dsl";
 import type { StudioServerEvent } from "~/optimization_studio/types/events";
 import { buildHttpNodeParameters } from "~/server/agents/http-node";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import {
   buildTraceparentHeader,
@@ -81,7 +80,7 @@ export const httpProxyRouter = createTRPCRouter({
         timeoutMs: z.number().positive().optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ input, ctx }): Promise<HttpProxyResult> => {
       const {
         projectId,

--- a/platform/app/src/server/api/routers/integrationsChecks.ts
+++ b/platform/app/src/server/api/routers/integrationsChecks.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { OnboardingChecksService } from "~/server/onboarding-checks";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const integrationsChecksRouter = createTRPCRouter({
@@ -10,7 +9,7 @@ export const integrationsChecksRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .query(async ({ input }) => {
       const onboardingService = new OnboardingChecksService();
       return onboardingService.getCheckStatus(input.projectId);

--- a/platform/app/src/server/api/routers/langy.ts
+++ b/platform/app/src/server/api/routers/langy.ts
@@ -32,7 +32,6 @@ import { decideSyntheticTerminal } from "~/server/app-layer/langy/streaming/lang
 import type { Session } from "~/server/auth";
 import { checkLangyMessageRateLimit } from "~/server/middleware/rate-limit-langy";
 import { trackServerEvent } from "~/server/posthog";
-import { checkProjectPermission, type Permission } from "../rbac";
 import {
   type LangyConversationDetailDto,
   type LangyConversationListCursorDto,
@@ -67,7 +66,7 @@ const logger = createLogger("langwatch:langy:router");
 /**
  * Builds a Langy procedure gated on one `langy:*` permission, with three
  * gates in order:
- *  1. `checkProjectPermission(permission)` — may the caller do THIS to the
+ *  1. `.permission(permission)` — may the caller do THIS to the
  *     project? Reads want `langy:view`; starting a turn wants `langy:create`,
  *     because it provisions credentials, spawns a worker and spends the
  *     project's model budget — not something a read grant should buy.
@@ -78,15 +77,17 @@ const logger = createLogger("langwatch:langy:router");
  *     the `langyEgress` router uses. Last, so membership is always proven
  *     before the flag is read.
  *
- * The permission check must be the FIRST `.use()`: `permissionProcedureBuilder`
+ * The permission declaration comes before any `.use()`: `permissionProcedureBuilder`
  * treats that slot specially and injects `enforcePermissionCheck` after it.
  *
  * `projectId` lives on the base so procedures declare only their own inputs.
  */
-const langyProcedure = (permission: Permission) =>
+const langyProcedure = (
+  permission: "langy:view" | "langy:create" | "langy:update" | "langy:delete",
+) =>
   protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission(permission))
+    .permission(permission)
     .use(refuseDemoProject)
     .use(enforceLangyAccess);
 

--- a/platform/app/src/server/api/routers/langyEgress.ts
+++ b/platform/app/src/server/api/routers/langyEgress.ts
@@ -28,7 +28,6 @@
 
 import { auditLog } from "@ee/audit-log/auditLog";
 import { z } from "zod";
-import { checkProjectPermission } from "~/server/api/rbac";
 import {
   LangyCredentialService,
   langyEgressAllowlistSchema,
@@ -39,7 +38,7 @@ import { enforceLangyAccess, refuseDemoProject } from "./langyAccessMiddleware";
 export const langyEgressRouter = createTRPCRouter({
   get: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("langy:view"))
+    .permission("langy:view")
     .use(refuseDemoProject)
     .use(enforceLangyAccess)
     .query(async ({ ctx, input }) => {
@@ -59,7 +58,7 @@ export const langyEgressRouter = createTRPCRouter({
         allowlist: langyEgressAllowlistSchema,
       }),
     )
-    .use(checkProjectPermission("langy:manage"))
+    .permission("langy:manage")
     .use(refuseDemoProject)
     .use(enforceLangyAccess)
     .mutation(async ({ ctx, input }) => {

--- a/platform/app/src/server/api/routers/license.ts
+++ b/platform/app/src/server/api/routers/license.ts
@@ -15,7 +15,6 @@ import {
   generateLicenseId,
   signLicense,
 } from "../../../../ee/licensing/signing";
-import { checkOrganizationPermission, skipPermissionCheck } from "../rbac";
 
 const logger = createLogger("langwatch:api:licenseRouter");
 
@@ -59,7 +58,7 @@ export const licenseRouter = createTRPCRouter({
         organizationId: z.string().min(1),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input }): Promise<LicenseStatus> => {
       // No catch: `OrganizationNotFoundError` is a `HandledError`, so the
       // shared middleware maps it to NOT_FOUND and keeps it as the cause.
@@ -94,7 +93,10 @@ export const licenseRouter = createTRPCRouter({
    */
   getSsoGateStatus: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "instance license status is deployment-wide and read-only for any signed-in user",
+    })
     .query(async () => {
       const configuredProvider = env.NEXTAUTH_PROVIDER;
       if (!configuredProvider || configuredProvider === "email") {
@@ -118,7 +120,7 @@ export const licenseRouter = createTRPCRouter({
         licenseKey: z.string().min(1, "License key is required"),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input }) => {
       const result = await getLicenseHandler().validateAndStoreLicense(
         input.organizationId,
@@ -147,7 +149,7 @@ export const licenseRouter = createTRPCRouter({
         organizationId: z.string().min(1),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input }) => {
       const result = await getLicenseHandler().removeLicense(
         input.organizationId,
@@ -171,7 +173,7 @@ export const licenseRouter = createTRPCRouter({
         })
         .merge(generateLicenseSchema),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input }) => {
       const { privateKey, organizationName, email, expiresAt, planType, plan } =
         input;

--- a/platform/app/src/server/api/routers/licenseEnforcement.ts
+++ b/platform/app/src/server/api/routers/licenseEnforcement.ts
@@ -6,7 +6,6 @@ import {
   limitTypeSchema,
   limitTypes,
 } from "../../license-enforcement";
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const licenseEnforcementRouter = createTRPCRouter({
@@ -21,7 +20,7 @@ export const licenseEnforcementRouter = createTRPCRouter({
         limitType: limitTypeSchema,
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const service = createLicenseEnforcementService(ctx.prisma);
       return service.checkLimit(
@@ -37,7 +36,7 @@ export const licenseEnforcementRouter = createTRPCRouter({
    */
   checkAllLimits: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const service = createLicenseEnforcementService(ctx.prisma);
       const results = await Promise.all(
@@ -66,7 +65,7 @@ export const licenseEnforcementRouter = createTRPCRouter({
         limitType: limitTypeSchema,
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       const service = createLicenseEnforcementService(ctx.prisma);
       const result = await service.checkLimit(

--- a/platform/app/src/server/api/routers/limits.ts
+++ b/platform/app/src/server/api/routers/limits.ts
@@ -2,13 +2,12 @@ import { z } from "zod";
 import { getApp } from "../../app-layer/app";
 import { prisma } from "../../db";
 import { UsageStatsService } from "../../license-enforcement/usage-stats.service";
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const limitsRouter = createTRPCRouter({
   getUsage: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       const { organizationId } = input;
       const service = UsageStatsService.create(prisma);
@@ -28,7 +27,7 @@ export const limitsRouter = createTRPCRouter({
     // an admin-targeted notification with arbitrary numbers (a low-
     // impact spam vector). Zero TS callers, so the bump is invisible
     // to legitimate UX.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input }) => {
       const notification = await getApp().usageLimits.checkAndSendWarning({
         organizationId: input.organizationId,

--- a/platform/app/src/server/api/routers/llmModelCosts.ts
+++ b/platform/app/src/server/api/routers/llmModelCosts.ts
@@ -11,7 +11,7 @@ import { SCOPE_TIERS, type ScopeTier } from "~/server/scopes/scope.types";
 import { isSafeRegex } from "~/utils/safeRegex";
 import { getModelLimits } from "../../../utils/modelLimits";
 import { getLLMModelCosts } from "../../modelProviders/llmModelCost";
-import { authorizeInResolver, checkProjectPermission } from "../rbac";
+import { authorizeInResolver } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -45,7 +45,7 @@ export const llmModelCostsRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => {
       return await getLLMModelCosts(input);
     }),
@@ -189,7 +189,7 @@ export const llmModelCostsRouter = createTRPCRouter({
    */
   getModelLimits: protectedProcedure
     .input(z.object({ projectId: z.string(), model: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => getModelLimits(input.model)),
 
   /**
@@ -218,7 +218,7 @@ export const llmModelCostsRouter = createTRPCRouter({
         cacheCreation1hCostPerToken: z.number().nonnegative().optional(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) =>
       previewCostRuleMatchingSpans({ spans: getApp().traces.spans, input }),
     ),

--- a/platform/app/src/server/api/routers/modelProviders.ts
+++ b/platform/app/src/server/api/routers/modelProviders.ts
@@ -1,6 +1,7 @@
 import { auditLog } from "@ee/audit-log/auditLog";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { declareAuthzMiddleware } from "~/server/app-layer/authz/declared-middleware";
 import {
   SCOPE_TIERS,
   type ScopeAssignment,
@@ -91,7 +92,7 @@ export const modelProviderRouter = createTRPCRouter({
   // for server-internal callers of `getProjectModelProviders`.
   getAllForProject: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       const { projectId } = input;
 
@@ -109,7 +110,7 @@ export const modelProviderRouter = createTRPCRouter({
     }),
   getAllForProjectForFrontend: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       const { projectId } = input;
       const hasSetupPermission = await hasProjectPermission(
@@ -132,7 +133,7 @@ export const modelProviderRouter = createTRPCRouter({
    */
   listAllForProjectForFrontend: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => {
       return await listProjectModelProvidersForFrontend(input.projectId);
     }),
@@ -145,7 +146,7 @@ export const modelProviderRouter = createTRPCRouter({
    */
   listAllForOrganizationForFrontend: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input }) => {
       return await listOrgModelProvidersForFrontend(input.organizationId);
     }),
@@ -317,7 +318,7 @@ export const modelProviderRouter = createTRPCRouter({
    */
   codexSignInStart: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async () => {
       const codex = new CodexAccountService();
       return await codex.startDeviceSignIn();
@@ -344,7 +345,7 @@ export const modelProviderRouter = createTRPCRouter({
         setAsCodingDefaults: z.boolean().default(false),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input, ctx }) => {
       const codex = new CodexAccountService();
       const poll = await codex.pollDeviceSignIn({
@@ -434,7 +435,7 @@ export const modelProviderRouter = createTRPCRouter({
         scopes: z.array(scopeAssignmentSchema).min(1),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input, ctx }) => {
       for (const scope of input.scopes) {
         await assertCanWriteScope(
@@ -475,7 +476,7 @@ export const modelProviderRouter = createTRPCRouter({
    */
   codexStatus: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => {
       const providers = await getProjectModelProviders(input.projectId);
       const row = providers.openai_codex;
@@ -495,7 +496,7 @@ export const modelProviderRouter = createTRPCRouter({
         provider: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(({ input }) => {
       return {
         managed: isManagedProvider(input.organizationId, input.provider),
@@ -514,7 +515,7 @@ export const modelProviderRouter = createTRPCRouter({
         customBaseUrl: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .query(async ({ input, ctx }) => {
       const { projectId, provider, customBaseUrl } = input;
       return validateKeyWithCustomUrl({
@@ -563,7 +564,7 @@ export const modelProviderRouter = createTRPCRouter({
         featureKey: z.string(),
       }),
     )
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       return getResolvedDefaultForFeature(ctx, {
         projectId: input.projectId,
@@ -573,7 +574,7 @@ export const modelProviderRouter = createTRPCRouter({
 
   getDefaultModelsForProject: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       return getDefaultModelsSnapshot(ctx, { projectId: input.projectId });
     }),
@@ -747,7 +748,7 @@ export const modelProviderRouter = createTRPCRouter({
         excludeConfigId: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       return getInheritedValuesForScopes(ctx, {
         projectId: input.projectId,
@@ -774,31 +775,41 @@ export const modelProviderRouter = createTRPCRouter({
  * project demands `project:manage`. Same division of labour as
  * `scopeAwarePermissionMiddleware` below.
  */
-function checkProjectOrOrganizationPermission(projectPermission: Permission) {
+function checkProjectOrOrganizationPermission(
+  projectPermission: "project:update" | "project:delete",
+) {
   const projectCheck = checkProjectPermission(projectPermission);
   const organizationCheck = checkOrganizationPermission("organization:view");
-  return async (params: {
-    ctx: any;
-    input: { projectId?: string; organizationId?: string };
-    next: () => any;
-  }) => {
-    if (params.input.projectId) {
-      return projectCheck({
+  return declareAuthzMiddleware(
+    {
+      kind: "custom",
+      reason:
+        "the tenant anchor is data-dependent: a project when one is named, otherwise the organization",
+      permissions: [projectPermission, "organization:view"],
+    },
+    async (params: {
+      ctx: any;
+      input: { projectId?: string; organizationId?: string };
+      next: () => any;
+    }) => {
+      if (params.input.projectId) {
+        return projectCheck({
+          ...params,
+          input: { ...params.input, projectId: params.input.projectId },
+        });
+      }
+      if (!params.input.organizationId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Either a project or an organization is required.",
+        });
+      }
+      return organizationCheck({
         ...params,
-        input: { ...params.input, projectId: params.input.projectId },
+        input: { ...params.input, organizationId: params.input.organizationId },
       });
-    }
-    if (!params.input.organizationId) {
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message: "Either a project or an organization is required.",
-      });
-    }
-    return organizationCheck({
-      ...params,
-      input: { ...params.input, organizationId: params.input.organizationId },
-    });
-  };
+    },
+  );
 }
 
 /**
@@ -819,36 +830,44 @@ function checkProjectOrOrganizationPermission(projectPermission: Permission) {
  */
 function checkProviderValidationPermission() {
   const projectCheck = checkProjectPermission("project:update");
-  return async (params: {
-    ctx: any;
-    input: {
-      projectId?: string;
-      organizationId?: string;
-      scopes?: ScopeAssignment[];
-    };
-    next: () => any;
-  }) => {
-    if (params.input.projectId) {
-      return projectCheck({
-        ...params,
-        input: { ...params.input, projectId: params.input.projectId },
-      });
-    }
-    const scopes = params.input.scopes;
-    if (!scopes || scopes.length === 0) {
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message:
-          "Validating a credential without a project needs the scopes it is being set up for.",
-      });
-    }
-    await assertCanManageAllScopes(
-      { prisma: params.ctx.prisma, session: params.ctx.session },
-      scopes,
-    );
-    params.ctx.permissionChecked = true;
-    return params.next();
-  };
+  return declareAuthzMiddleware(
+    {
+      kind: "custom",
+      reason:
+        "the credential probe authorizes against the scopes it is being set up for when no project is named",
+      permissions: ["project:update"],
+    },
+    async (params: {
+      ctx: any;
+      input: {
+        projectId?: string;
+        organizationId?: string;
+        scopes?: ScopeAssignment[];
+      };
+      next: () => any;
+    }) => {
+      if (params.input.projectId) {
+        return projectCheck({
+          ...params,
+          input: { ...params.input, projectId: params.input.projectId },
+        });
+      }
+      const scopes = params.input.scopes;
+      if (!scopes || scopes.length === 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Validating a credential without a project needs the scopes it is being set up for.",
+        });
+      }
+      await assertCanManageAllScopes(
+        { prisma: params.ctx.prisma, session: params.ctx.session },
+        scopes,
+      );
+      params.ctx.permissionChecked = true;
+      return params.next();
+    },
+  );
 }
 
 /**
@@ -934,3 +953,34 @@ async function deleteConfigPermissionMiddleware({
   ctx.permissionChecked = true;
   return next();
 }
+
+// The two hoisted permission middlewares above are referenced by the router
+// literal before any const initializer would run, so their declarations are
+// attached here as a post-definition tag on the same function objects.
+declareAuthzMiddleware(
+  {
+    kind: "custom",
+    reason:
+      "each scope in the write demands its own tier's manage permission, resolved from the input's scopeType",
+    permissions: ["organization:manage", "team:manage", "project:update"],
+  },
+  scopeAwarePermissionMiddleware,
+);
+declareAuthzMiddleware(
+  {
+    kind: "custom",
+    reason:
+      "every desired and removed scope attachment is asserted writable before the config write",
+    permissions: ["organization:manage", "team:manage", "project:update"],
+  },
+  saveConfigPermissionMiddleware,
+);
+declareAuthzMiddleware(
+  {
+    kind: "custom",
+    reason:
+      "the config's current scope attachments are loaded by its id and each asserted writable before the delete",
+    permissions: ["organization:manage", "team:manage", "project:update"],
+  },
+  deleteConfigPermissionMiddleware,
+);

--- a/platform/app/src/server/api/routers/monitors.ts
+++ b/platform/app/src/server/api/routers/monitors.ts
@@ -4,6 +4,7 @@ import { customAlphabet } from "nanoid";
 import { ZodError, z } from "zod";
 import { EvaluationExecutionMode, Prisma } from "~/generated/prisma/client";
 import { getApp } from "~/server/app-layer";
+import { checkDeclaredPermission } from "~/server/app-layer/authz/trpc-middleware";
 import { MonitorEvaluatorRequiredError } from "~/server/app-layer/monitors/errors";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { slugify } from "~/utils/slugify";
@@ -15,7 +16,7 @@ import {
 import { getEvaluatorDefinitions } from "../../evaluations/getEvaluator";
 import { validatedPreconditionsSchema } from "../../evaluations/preconditionValidation";
 import { coerceMonitorMappings } from "../../tracer/tracesMapping";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { currentVsPreviousDates } from "./analytics/common";
 import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
@@ -94,7 +95,7 @@ const findUniqueMonitorName = async (
 export const monitorsRouter = createTRPCRouter({
   getAllForProject: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ input, ctx }) => {
       const { projectId } = input;
       const prisma = ctx.prisma;
@@ -114,8 +115,12 @@ export const monitorsRouter = createTRPCRouter({
         timeZone: z.string().min(1).max(100).optional(),
       }),
     )
-    .use(checkProjectPermission("evaluations:view"))
-    .use(checkProjectPermission("analytics:view"))
+    .permission("evaluations:view")
+    // BOTH permissions are required: the declared check above satisfies the
+    // builder, and this second one stacks the same middleware by hand — the
+    // one AND-composition site in the codebase.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    .use(checkDeclaredPermission({ permission: "analytics:view" }) as any)
     .query(async ({ input, ctx }) => {
       const monitors = await ctx.prisma.monitor.findMany({
         where: { projectId: input.projectId },
@@ -154,7 +159,7 @@ export const monitorsRouter = createTRPCRouter({
     .input(
       z.object({ id: z.string(), projectId: z.string(), enabled: z.boolean() }),
     )
-    .use(checkProjectPermission("evaluations:update"))
+    .permission("evaluations:update")
     .mutation(async ({ input, ctx }) => {
       const { id, enabled, projectId } = input;
       const prisma = ctx.prisma;
@@ -186,7 +191,7 @@ export const monitorsRouter = createTRPCRouter({
         threadIdleTimeout: z.number().int().positive().nullable().optional(), // Seconds to wait after last message before evaluating thread
       }),
     )
-    .use(checkProjectPermission("evaluations:create"))
+    .permission("evaluations:create")
     .mutation(async ({ input, ctx }) => {
       const {
         projectId,
@@ -257,7 +262,7 @@ export const monitorsRouter = createTRPCRouter({
         sourceProjectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("evaluations:manage"))
+    .permission("evaluations:manage")
     .mutation(async ({ input, ctx }) => {
       const { monitorId, projectId, sourceProjectId } = input;
       const prisma = ctx.prisma;
@@ -373,7 +378,7 @@ export const monitorsRouter = createTRPCRouter({
         threadIdleTimeout: z.number().int().positive().nullable().optional(), // Seconds to wait after last message before evaluating thread
       }),
     )
-    .use(checkProjectPermission("evaluations:update"))
+    .permission("evaluations:update")
     .mutation(async ({ input, ctx }) => {
       const {
         id,
@@ -437,7 +442,7 @@ export const monitorsRouter = createTRPCRouter({
     }),
   getById: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .query(async ({ input, ctx }) => {
       const { id, projectId } = input;
       const prisma = ctx.prisma;
@@ -458,7 +463,7 @@ export const monitorsRouter = createTRPCRouter({
     }),
   delete: protectedProcedure
     .input(z.object({ id: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("evaluations:delete"))
+    .permission("evaluations:delete")
     .mutation(async ({ input, ctx }) => {
       const { id, projectId } = input;
       const prisma = ctx.prisma;
@@ -477,7 +482,7 @@ export const monitorsRouter = createTRPCRouter({
         name: z.string(),
       }),
     )
-    .use(checkProjectPermission("evaluations:view"))
+    .permission("evaluations:view")
     .mutation(async ({ input, ctx }) => {
       const { projectId, name } = input;
       const prisma = ctx.prisma;

--- a/platform/app/src/server/api/routers/onboarding/onboarding.router.ts
+++ b/platform/app/src/server/api/routers/onboarding/onboarding.router.ts
@@ -11,7 +11,6 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { signUpDataSchema } from "~/server/schemas/sign-up-data.schema";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
-import { skipPermissionCheck } from "../../rbac";
 import { organizationRouter } from "../organization";
 import { projectRouter } from "../project";
 
@@ -44,7 +43,9 @@ export const onboardingRouter = createTRPCRouter({
         framework: z.string().default("other"),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "onboarding runs before the user belongs to any organization",
+    })
     .mutation(async ({ input, ctx }) => {
       try {
         // Create and assign organization
@@ -200,7 +201,9 @@ export const onboardingRouter = createTRPCRouter({
         ]),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "onboarding runs before the user belongs to any organization",
+    })
     .mutation(async ({ ctx, input }) => {
       const traitValue = mapProductSelectionToIntegrationMethod(
         input.integrationMethod,

--- a/platform/app/src/server/api/routers/optimization.ts
+++ b/platform/app/src/server/api/routers/optimization.ts
@@ -1,7 +1,6 @@
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { EvaluatorService } from "../../evaluators/evaluator.service";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const optimizationRouter = createTRPCRouter({
@@ -13,7 +12,7 @@ export const optimizationRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .mutation(async ({ ctx, input }) => {
       const { workflowId, inputMessages, projectId } = input;
 
@@ -39,7 +38,7 @@ export const optimizationRouter = createTRPCRouter({
     }),
   getPublishedWorkflow: protectedProcedure
     .input(z.object({ workflowId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       const { workflowId, projectId } = input;
       const workflow = await ctx.prisma.workflow.findFirst({
@@ -63,7 +62,7 @@ export const optimizationRouter = createTRPCRouter({
     }),
   disableAsComponent: protectedProcedure
     .input(z.object({ workflowId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const { workflowId, projectId } = input;
 
@@ -80,7 +79,7 @@ export const optimizationRouter = createTRPCRouter({
     }),
   disableAsEvaluator: protectedProcedure
     .input(z.object({ workflowId: z.string(), projectId: z.string() }))
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const { workflowId, projectId } = input;
 
@@ -120,7 +119,7 @@ export const optimizationRouter = createTRPCRouter({
         isEvaluator: z.boolean(),
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const { workflowId, projectId, isComponent } = input;
       let { isEvaluator } = input;
@@ -149,7 +148,7 @@ export const optimizationRouter = createTRPCRouter({
         isComponent: z.boolean(),
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const { workflowId, projectId, isEvaluator } = input;
 
@@ -206,7 +205,7 @@ export const optimizationRouter = createTRPCRouter({
     }),
   getComponents: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       const { projectId } = input;
       const workflows = await ctx.prisma.workflow.findMany({

--- a/platform/app/src/server/api/routers/organization.ts
+++ b/platform/app/src/server/api/routers/organization.ts
@@ -47,13 +47,7 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
   isCustomRole,
 } from "../enterprise";
-import {
-  batchScopePermissions,
-  checkOrganizationPermission,
-  checkTeamPermission,
-  hasOrganizationPermission,
-  skipPermissionCheck,
-} from "../rbac";
+import { batchScopePermissions, hasOrganizationPermission } from "../rbac";
 
 const customTeamRoleInputSchema = z
   .string()
@@ -81,7 +75,10 @@ export const organizationRouter = createTRPCRouter({
         primaryIntent: z.enum(["AGENT_GOVERNANCE", "LLM_OPS"]).optional(),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "runs before or across organization membership: creating an organization, listing the caller's own, accepting an invite",
+    })
     .mutation(async ({ input, ctx }) => {
       const result = await getApp().organizations.createAndAssign({
         userId: ctx.session.user.id,
@@ -101,7 +98,7 @@ export const organizationRouter = createTRPCRouter({
 
   deleteMember: protectedProcedure
     .input(z.object({ userId: z.string(), organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       // The self-removal guard lives in the service now; it refuses with
       // `cannot_remove_self`, which the handled-error middleware puts on the
@@ -127,7 +124,7 @@ export const organizationRouter = createTRPCRouter({
         disabled: z.boolean(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       try {
         await getApp().organizations.setMemberDisabled({
@@ -164,7 +161,10 @@ export const organizationRouter = createTRPCRouter({
         isDemo: z.boolean().optional(),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "runs before or across organization membership: creating an organization, listing the caller's own, accepting an invite",
+    })
     .query(async ({ ctx, input }) => {
       const isDemo = input?.isDemo ?? false;
       const userId = ctx.session.user.id;
@@ -414,7 +414,7 @@ export const organizationRouter = createTRPCRouter({
           },
         ),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input }) => {
       // The settings form round-trips every S3 field on save, so an absent
       // credential means "clear it". `updateSettings` is a partial update
@@ -450,7 +450,7 @@ export const organizationRouter = createTRPCRouter({
     // need to enumerate org members by name. The full record contains
     // member emails, which are admin-surface PII — we redact them on
     // the way out for non-admin callers below.
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       const organization =
         await getApp().organizations.getOrganizationWithMembers({
@@ -509,7 +509,7 @@ export const organizationRouter = createTRPCRouter({
     // member's full record (role assignments, team memberships) is an
     // admin-surface read, not a peer-context read. No TS callers
     // currently depend on member-role access to this procedure.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ input, ctx }) => {
       const member = await getApp().organizations.getMemberById({
         organizationId: input.organizationId,
@@ -549,7 +549,7 @@ export const organizationRouter = createTRPCRouter({
         ),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       const hasCustomRoleInvite = input.invites.some((invite) =>
         (invite.teams ?? []).some(
@@ -624,7 +624,7 @@ export const organizationRouter = createTRPCRouter({
     }),
   deleteInvite: protectedProcedure
     .input(z.object({ inviteId: z.string(), organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       const inviteService = InviteService.create(ctx.prisma);
       await inviteService.revokeInvite({
@@ -642,7 +642,7 @@ export const organizationRouter = createTRPCRouter({
     // expose admin intent (who's being added, with what role / to
     // which teams). MEMBER reading this is a leak. Both TS callers
     // (settings/members, SubscriptionPage) are admin-only surfaces.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ input, ctx }) => {
       const inviteService = InviteService.create(ctx.prisma);
       return inviteService.listInvites({
@@ -679,7 +679,7 @@ export const organizationRouter = createTRPCRouter({
         ),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ input, ctx }) => {
       const hasCustomRoleInvite = input.invites.some((invite) =>
         (invite.teams ?? []).some(
@@ -881,7 +881,7 @@ export const organizationRouter = createTRPCRouter({
         organizationId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
       const inviteService = InviteService.create(prisma);
@@ -946,7 +946,10 @@ export const organizationRouter = createTRPCRouter({
         inviteCode: z.string(),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "runs before or across organization membership: creating an organization, listing the caller's own, accepting an invite",
+    })
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
       const session = ctx.session;
@@ -1098,7 +1101,7 @@ export const organizationRouter = createTRPCRouter({
           }
         }),
     )
-    .use(checkTeamPermission("organization:manage"))
+    .permission("organization:manage", { via: "teamId" })
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
       await assertNoPersonalTeamScope({
@@ -1219,7 +1222,7 @@ export const organizationRouter = createTRPCRouter({
     // depend on this procedure; documented here so a future picker
     // UX that needs member names knows to use a basic-view variant
     // rather than re-loosening the permission.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ input }) => {
       return getApp().organizations.getAllMembers(input.organizationId);
     }),
@@ -1241,7 +1244,7 @@ export const organizationRouter = createTRPCRouter({
           .optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       // The whole orchestration (personal-workspace assertion, shared-team
       // scoping, seat classification, Enterprise gate for custom roles)
@@ -1281,7 +1284,7 @@ export const organizationRouter = createTRPCRouter({
         targetId: z.string().optional(),
       }),
     )
-    .use(checkOrganizationPermission("auditLog:view"))
+    .permission("auditLog:view")
     .query(async ({ ctx, input }) => {
       await assertEnterprisePlan({
         organizationId: input.organizationId,

--- a/platform/app/src/server/api/routers/personalVirtualKeys.ts
+++ b/platform/app/src/server/api/routers/personalVirtualKeys.ts
@@ -21,11 +21,7 @@ import { z } from "zod";
 import { env } from "~/env.mjs";
 import type { PrismaClient } from "~/generated/prisma/client";
 
-import {
-  authorizeInResolver,
-  checkOrganizationPermission,
-  hasOrganizationPermission,
-} from "../rbac";
+import { authorizeInResolver, hasOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -154,7 +150,7 @@ export const personalVirtualKeysRouter = createTRPCRouter({
         routingPolicyId: z.string().optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       await assertOrgMembership({
         prisma: ctx.prisma,
@@ -245,7 +241,7 @@ export const personalVirtualKeysRouter = createTRPCRouter({
   /** Revoke one of the caller's personal VKs. Idempotent. */
   revokePersonal: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       await assertOrgMembership({
         prisma: ctx.prisma,

--- a/platform/app/src/server/api/routers/personalWorkspaceFeatures.ts
+++ b/platform/app/src/server/api/routers/personalWorkspaceFeatures.ts
@@ -23,7 +23,6 @@ import {
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { skipPermissionCheck } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const featureSchema = z.enum(
@@ -32,17 +31,16 @@ const featureSchema = z.enum(
 
 void featureSchema;
 
-const allowProjectIdForOwnerUserGate = skipPermissionCheck({
-  allow: {
-    projectId:
-      "auth is service-layer (PersonalWorkspaceFeaturesService asserts isPersonal && ownerUserId === caller)",
-  },
-});
-
 export const personalWorkspaceFeaturesRouter = createTRPCRouter({
   get: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(allowProjectIdForOwnerUserGate)
+    .noPermission({
+      reason: "a personal workspace belongs to its owner, not a team",
+      allow: {
+        projectId:
+          "auth is service-layer (PersonalWorkspaceFeaturesService asserts isPersonal && ownerUserId === caller)",
+      },
+    })
     .query(async ({ ctx, input }) => {
       const service = PersonalWorkspaceFeaturesService.create(ctx.prisma);
       try {
@@ -63,7 +61,13 @@ export const personalWorkspaceFeaturesRouter = createTRPCRouter({
 
   enableAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(allowProjectIdForOwnerUserGate)
+    .noPermission({
+      reason: "a personal workspace belongs to its owner, not a team",
+      allow: {
+        projectId:
+          "auth is service-layer (PersonalWorkspaceFeaturesService asserts isPersonal && ownerUserId === caller)",
+      },
+    })
     .mutation(async ({ ctx, input }) => {
       const service = PersonalWorkspaceFeaturesService.create(ctx.prisma);
       try {
@@ -84,7 +88,13 @@ export const personalWorkspaceFeaturesRouter = createTRPCRouter({
 
   disableAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(allowProjectIdForOwnerUserGate)
+    .noPermission({
+      reason: "a personal workspace belongs to its owner, not a team",
+      allow: {
+        projectId:
+          "auth is service-layer (PersonalWorkspaceFeaturesService asserts isPersonal && ownerUserId === caller)",
+      },
+    })
     .mutation(async ({ ctx, input }) => {
       const service = PersonalWorkspaceFeaturesService.create(ctx.prisma);
       try {

--- a/platform/app/src/server/api/routers/pinnedTrace.ts
+++ b/platform/app/src/server/api/routers/pinnedTrace.ts
@@ -2,7 +2,6 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { getApp } from "~/server/app-layer/app";
 import { PinnedToActiveShareError } from "~/server/data-retention/pinning/pinnedTrace.service";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const pinnedTraceRouter = createTRPCRouter({
@@ -14,7 +13,7 @@ export const pinnedTraceRouter = createTRPCRouter({
         reason: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input, ctx }) => {
       return getApp().dataRetention.pinning.pin({
         projectId: input.projectId,
@@ -31,7 +30,7 @@ export const pinnedTraceRouter = createTRPCRouter({
         traceId: z.string(),
       }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input }) => {
       try {
         await getApp().dataRetention.pinning.unpin({
@@ -56,7 +55,7 @@ export const pinnedTraceRouter = createTRPCRouter({
         traceId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       return getApp().dataRetention.pinning.getPin({
         projectId: input.projectId,
@@ -70,7 +69,7 @@ export const pinnedTraceRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       return getApp().dataRetention.pinning.listByProject({
         projectId: input.projectId,

--- a/platform/app/src/server/api/routers/plan.ts
+++ b/platform/app/src/server/api/routers/plan.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { getApp } from "~/server/app-layer/app";
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const planRouter = createTRPCRouter({
@@ -10,7 +9,7 @@ export const planRouter = createTRPCRouter({
         organizationId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       return await getApp().planProvider.getActivePlan({
         organizationId: input.organizationId,

--- a/platform/app/src/server/api/routers/presence.ts
+++ b/platform/app/src/server/api/routers/presence.ts
@@ -12,7 +12,6 @@ import {
   presenceCursorPayloadSchema,
   presenceLocationSchema,
 } from "~/server/app-layer/presence/types";
-import { checkProjectPermission } from "../rbac";
 
 const logger = createLogger("langwatch:api:presence");
 
@@ -32,7 +31,7 @@ export const presenceRouter = createTRPCRouter({
         location: presenceLocationSchema,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ input, ctx }) => {
       if (!(await getApp().presence.isEnabledForProject(input.projectId))) {
         return { ok: true as const };
@@ -54,7 +53,7 @@ export const presenceRouter = createTRPCRouter({
   /** Remove a session immediately and notify peers. */
   leave: protectedProcedure
     .input(sessionInput)
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ input, ctx }) => {
       if (!(await getApp().presence.isEnabledForProject(input.projectId))) {
         return { ok: true as const };
@@ -73,7 +72,7 @@ export const presenceRouter = createTRPCRouter({
    */
   onPresenceUpdate: protectedProcedure
     .input(projectInput)
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .subscription(async function* (opts) {
       const { projectId } = opts.input;
       const app = getApp();
@@ -142,7 +141,7 @@ export const presenceRouter = createTRPCRouter({
         payload: presenceCursorPayloadSchema,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ input, ctx }) => {
       if (!(await getApp().presence.isEnabledForProject(input.projectId))) {
         return { ok: true as const };
@@ -174,7 +173,7 @@ export const presenceRouter = createTRPCRouter({
         sessionId: z.string().min(1),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .subscription(async function* (opts) {
       const { projectId, anchor, sessionId } = opts.input;
 

--- a/platform/app/src/server/api/routers/project.ts
+++ b/platform/app/src/server/api/routers/project.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { Prisma, type PrismaClient } from "~/generated/prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
+import { declareAuthzMiddleware } from "~/server/app-layer/authz/declared-middleware";
 import { provisionLangyVirtualKey } from "~/server/app-layer/langy/langyVirtualKey";
 import {
   personalWorkspaceArchiveViolation,
@@ -19,10 +20,8 @@ import { captureException, toError } from "~/utils/posthogErrorCapture";
 import { generateApiKey } from "../../utils/apiKeyGenerator";
 import {
   checkOrganizationPermission,
-  checkProjectPermission,
   checkTeamPermission,
   hasProjectPermission,
-  skipPermissionCheckProjectCreation,
 } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 
@@ -84,27 +83,36 @@ export const projectRouter = createTRPCRouter({
         framework: z.string(),
       }),
     )
-    .use(skipPermissionCheckProjectCreation)
-    .use(({ ctx, input, next }) => {
-      if (input.teamId) {
-        return checkTeamPermission("project:create")({
-          ctx,
-          input: { ...input, teamId: input.teamId },
-          next,
-        });
-      } else if (input.newTeamName) {
-        return checkOrganizationPermission("organization:manage")({
-          ctx,
-          input,
-          next,
-        });
-      } else {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Either teamId or newTeamName must be provided",
-        });
-      }
-    })
+    .use(
+      declareAuthzMiddleware(
+        {
+          kind: "custom",
+          reason:
+            "creating into an existing team asks that team; creating a team alongside asks the organization",
+          permissions: ["project:create", "organization:manage"],
+        },
+        ({ ctx, input, next }) => {
+          if (input.teamId) {
+            return checkTeamPermission("project:create")({
+              ctx,
+              input: { ...input, teamId: input.teamId },
+              next,
+            });
+          } else if (input.newTeamName) {
+            return checkOrganizationPermission("organization:manage")({
+              ctx,
+              input,
+              next,
+            });
+          } else {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Either teamId or newTeamName must be provided",
+            });
+          }
+        },
+      ),
+    )
     .mutation(async ({ input, ctx }) => {
       const userId = ctx.session.user.id;
       const prisma = ctx.prisma;
@@ -193,7 +201,7 @@ export const projectRouter = createTRPCRouter({
    */
   getProjectAPIKey: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .query(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
 
@@ -213,7 +221,7 @@ export const projectRouter = createTRPCRouter({
     }),
   getHasFirstMessage: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => {
       const project = await getApp().projects.getById(input.projectId);
 
@@ -221,7 +229,7 @@ export const projectRouter = createTRPCRouter({
     }),
   regenerateApiKey: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:manage"))
+    .permission("project:manage")
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
 
@@ -294,7 +302,7 @@ export const projectRouter = createTRPCRouter({
           );
         }),
     )
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .use(checkCapturedDataVisibilityPermission)
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
@@ -379,7 +387,7 @@ export const projectRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input, ctx }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -401,7 +409,7 @@ export const projectRouter = createTRPCRouter({
     }),
   archiveById: protectedProcedure
     .input(z.object({ projectId: z.string(), projectToArchiveId: z.string() }))
-    .use(checkProjectPermission("project:delete"))
+    .permission("project:delete")
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
       if (input.projectToArchiveId === input.projectId) {
@@ -439,7 +447,7 @@ export const projectRouter = createTRPCRouter({
 
   triggerTopicClustering: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ ctx, input }) => {
       try {
         const app = getApp();

--- a/platform/app/src/server/api/routers/prompt-tags.trpc-router.ts
+++ b/platform/app/src/server/api/routers/prompt-tags.trpc-router.ts
@@ -8,7 +8,6 @@ import {
   PromptTagService,
   PromptTagValidationError,
 } from "~/server/prompt-config/prompt-tag.service";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -64,7 +63,7 @@ export const promptTagsRouter = createTRPCRouter({
    */
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const organizationId = await resolveOrganizationId(
         ctx.prisma,
@@ -80,7 +79,7 @@ export const promptTagsRouter = createTRPCRouter({
    */
   create: protectedProcedure
     .input(z.object({ projectId: z.string(), name: z.string() }))
-    .use(checkProjectPermission("prompts:manage"))
+    .permission("prompts:manage")
     .mutation(async ({ ctx, input }) => {
       const organizationId = await resolveOrganizationId(
         ctx.prisma,
@@ -110,7 +109,7 @@ export const promptTagsRouter = createTRPCRouter({
         newName: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:manage"))
+    .permission("prompts:manage")
     .mutation(async ({ ctx, input }) => {
       const organizationId = await resolveOrganizationId(
         ctx.prisma,
@@ -134,7 +133,7 @@ export const promptTagsRouter = createTRPCRouter({
    */
   delete: protectedProcedure
     .input(z.object({ projectId: z.string(), name: z.string() }))
-    .use(checkProjectPermission("prompts:manage"))
+    .permission("prompts:manage")
     .mutation(async ({ ctx, input }) => {
       const organizationId = await resolveOrganizationId(
         ctx.prisma,

--- a/platform/app/src/server/api/routers/prompts/prompts.trpc-router.ts
+++ b/platform/app/src/server/api/routers/prompts/prompts.trpc-router.ts
@@ -14,7 +14,7 @@ import {
 } from "~/prompts/schemas";
 import { hoistSystemMessage, PromptService } from "~/server/prompt-config";
 import { TagValidationError } from "~/server/prompt-config/repositories/llm-config-tag.repository";
-import { checkProjectPermission, hasProjectPermission } from "../../rbac";
+import { hasProjectPermission } from "../../rbac";
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 
 /**
@@ -26,7 +26,7 @@ export const promptsRouter = createTRPCRouter({
    */
   getAllPromptsForProject: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return await service.getAllPrompts(input);
@@ -42,7 +42,7 @@ export const promptsRouter = createTRPCRouter({
         idOrHandle: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const prompt = await service.getPromptByIdOrHandle({
@@ -122,7 +122,7 @@ export const promptsRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:update"))
+    .permission("prompts:update")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const authorId = ctx.session?.user?.id;
@@ -170,7 +170,7 @@ export const promptsRouter = createTRPCRouter({
         }),
       }),
     )
-    .use(checkProjectPermission("prompts:create"))
+    .permission("prompts:create")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const authorId = ctx.session?.user?.id;
@@ -229,7 +229,7 @@ export const promptsRouter = createTRPCRouter({
         }),
       }),
     )
-    .use(checkProjectPermission("prompts:update"))
+    .permission("prompts:update")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const authorId = ctx.session?.user?.id;
@@ -258,7 +258,7 @@ export const promptsRouter = createTRPCRouter({
         }),
       }),
     )
-    .use(checkProjectPermission("prompts:update"))
+    .permission("prompts:update")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return await service.updateHandle({
@@ -284,7 +284,7 @@ export const promptsRouter = createTRPCRouter({
         tag: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       try {
         const service = new PromptService(ctx.prisma);
@@ -315,7 +315,7 @@ export const promptsRouter = createTRPCRouter({
         scope: z.nativeEnum(PromptScope),
       }),
     )
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return await service.checkHandleUniqueness(input);
@@ -331,7 +331,7 @@ export const promptsRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return await service.checkModifyPermission(input);
@@ -347,7 +347,7 @@ export const promptsRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return await service.getAllVersions(input);
@@ -363,7 +363,7 @@ export const promptsRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:delete"))
+    .permission("prompts:delete")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return await service.deletePrompt(input);
@@ -380,7 +380,7 @@ export const promptsRouter = createTRPCRouter({
         sourceProjectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:create"))
+    .permission("prompts:create")
     .mutation(async ({ ctx, input }) => {
       // Check that the user has at least prompts:create permission on the source project
       const hasSourcePermission = await hasProjectPermission(
@@ -430,7 +430,7 @@ export const promptsRouter = createTRPCRouter({
         projectId: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:create"))
+    .permission("prompts:create")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const authorId = ctx.session?.user?.id;
@@ -460,7 +460,7 @@ export const promptsRouter = createTRPCRouter({
         idOrHandle: z.string(),
       }),
     )
-    .use(checkProjectPermission("prompts:update"))
+    .permission("prompts:update")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const authorId = ctx.session?.user?.id;
@@ -611,7 +611,7 @@ export const promptsRouter = createTRPCRouter({
         copyIds: z.array(z.string()).optional(), // Optional: if provided, only push to selected copies
       }),
     )
-    .use(checkProjectPermission("prompts:update"))
+    .permission("prompts:update")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       const authorId = ctx.session?.user?.id;
@@ -774,7 +774,7 @@ export const promptsRouter = createTRPCRouter({
    */
   getTagsForConfig: protectedProcedure
     .input(z.object({ projectId: z.string(), configId: z.string() }))
-    .use(checkProjectPermission("prompts:view"))
+    .permission("prompts:view")
     .query(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
       return service.getTagsForConfig({
@@ -796,7 +796,7 @@ export const promptsRouter = createTRPCRouter({
         tag: z.string().min(1),
       }),
     )
-    .use(checkProjectPermission("prompts:update"))
+    .permission("prompts:update")
     .mutation(async ({ ctx, input }) => {
       const service = new PromptService(ctx.prisma);
 

--- a/platform/app/src/server/api/routers/publicEnv.ts
+++ b/platform/app/src/server/api/routers/publicEnv.ts
@@ -4,7 +4,6 @@ import { RUM_DEFAULT_SAMPLE_RATIO } from "@langwatch/react-rum/constants";
 import { z } from "zod";
 import { env } from "../../../env.mjs";
 import { hasEmailProvider } from "../../mailer/providers";
-import { skipPermissionCheck } from "../rbac";
 import { publicProcedure } from "../trpc";
 
 const isOpsSidebarEmail = (userEmail: string | null | undefined) => {
@@ -18,7 +17,9 @@ const isOpsSidebarEmail = (userEmail: string | null | undefined) => {
 
 export const publicEnvRouter = publicProcedure
   .input(z.object({}).passthrough())
-  .use(skipPermissionCheck)
+  .noPermission({
+    reason: "exposes only the PUBLIC_* env allowlist; no tenant data",
+  })
   .query(async ({ ctx }) => {
     // Warning: be very careful with the env vars you expose here
 

--- a/platform/app/src/server/api/routers/role.ts
+++ b/platform/app/src/server/api/routers/role.ts
@@ -1,17 +1,69 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { declareAuthzMiddleware } from "~/server/app-layer/authz/declared-middleware";
 import { ledgerActorFor } from "~/server/app-layer/authz/ledger-actor";
+import type { Session } from "~/server/auth";
 import { permissionFormatSchema } from "../../rbac/custom-role-permissions";
 import { RoleService } from "../../role";
 import { assertEnterprisePlan, ENTERPRISE_FEATURE_ERRORS } from "../enterprise";
-import {
-  checkOrganizationPermission,
-  checkTeamPermission,
-  hasOrganizationPermission,
-} from "../rbac";
+import { hasOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const permissionSchema = permissionFormatSchema;
+
+type RoleMiddlewareCtx = {
+  prisma: PrismaClient;
+  session: Session;
+  permissionChecked: boolean;
+};
+
+/**
+ * The role's organization is data loaded by the role id, so the check runs
+ * there — one declared middleware instead of four inline copies. The
+ * permission check runs BEFORE any plan assertion so a denial never reveals
+ * plan details.
+ */
+const roleOrganizationPermission = ({
+  permission,
+  enterprise = false,
+}: {
+  permission: "organization:view" | "organization:manage";
+  enterprise?: boolean;
+}) =>
+  declareAuthzMiddleware(
+    {
+      kind: "custom",
+      reason:
+        "the role's organization is loaded by its id; the check runs there",
+      permissions: [permission],
+    },
+    async ({
+      ctx,
+      input,
+      next,
+    }: {
+      ctx: RoleMiddlewareCtx;
+      input: { roleId: string };
+      next: () => Promise<unknown>;
+    }) => {
+      const role = await new RoleService(ctx.prisma).getRoleById(input.roleId);
+      if (
+        !(await hasOrganizationPermission(ctx, role.organizationId, permission))
+      ) {
+        throw new TRPCError({ code: "UNAUTHORIZED" });
+      }
+      if (enterprise) {
+        await assertEnterprisePlan({
+          organizationId: role.organizationId,
+          user: ctx.session.user,
+          errorMessage: ENTERPRISE_FEATURE_ERRORS.RBAC,
+        });
+      }
+      ctx.permissionChecked = true;
+      return next();
+    },
+  );
 
 export const roleRouter = createTRPCRouter({
   getAll: protectedProcedure
@@ -22,7 +74,7 @@ export const roleRouter = createTRPCRouter({
     // GroupBindingInputRow) live in admin-context flows that already
     // require manage anyway, so the bump is invisible to legitimate UX
     // and closes a member-session direct-curl exfil path.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ ctx, input }) => {
       const roleService = new RoleService(ctx.prisma);
       return roleService.getAllRoles(input.organizationId);
@@ -30,25 +82,7 @@ export const roleRouter = createTRPCRouter({
 
   getById: protectedProcedure
     .input(z.object({ roleId: z.string() }))
-    .use(async ({ ctx, input, next }) => {
-      // Need to fetch role first to check organization permission
-      const roleService = new RoleService(ctx.prisma);
-      const role = await roleService.getRoleById(input.roleId);
-
-      // Check if user has permission for this organization
-      const hasPermission = await hasOrganizationPermission(
-        ctx,
-        role.organizationId,
-        "organization:view",
-      );
-
-      if (!hasPermission) {
-        throw new TRPCError({ code: "UNAUTHORIZED" });
-      }
-
-      ctx.permissionChecked = true;
-      return next();
-    })
+    .use(roleOrganizationPermission({ permission: "organization:view" }))
     .query(async ({ ctx, input }) => {
       const roleService = new RoleService(ctx.prisma);
       return await roleService.getRoleById(input.roleId);
@@ -63,7 +97,7 @@ export const roleRouter = createTRPCRouter({
         permissions: z.array(permissionSchema),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       await assertEnterprisePlan({
         organizationId: input.organizationId,
@@ -95,31 +129,12 @@ export const roleRouter = createTRPCRouter({
         permissions: z.array(permissionSchema).optional(),
       }),
     )
-    .use(async ({ ctx, input, next }) => {
-      // Fetch role to get organizationId for permission check
-      const roleService = new RoleService(ctx.prisma);
-      const role = await roleService.getRoleById(input.roleId);
-
-      // Check permission before revealing plan details
-      const hasPermission = await hasOrganizationPermission(
-        ctx,
-        role.organizationId,
-        "organization:manage",
-      );
-
-      if (!hasPermission) {
-        throw new TRPCError({ code: "UNAUTHORIZED" });
-      }
-
-      await assertEnterprisePlan({
-        organizationId: role.organizationId,
-        user: ctx.session.user,
-        errorMessage: ENTERPRISE_FEATURE_ERRORS.RBAC,
-      });
-
-      ctx.permissionChecked = true;
-      return next();
-    })
+    .use(
+      roleOrganizationPermission({
+        permission: "organization:manage",
+        enterprise: true,
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       const roleService = new RoleService(ctx.prisma);
       return await roleService.updateRole({
@@ -138,25 +153,7 @@ export const roleRouter = createTRPCRouter({
 
   delete: protectedProcedure
     .input(z.object({ roleId: z.string() }))
-    .use(async ({ ctx, input, next }) => {
-      // Fetch role to get organizationId for permission check
-      const roleService = new RoleService(ctx.prisma);
-      const role = await roleService.getRoleById(input.roleId);
-
-      // Check if user has permission for this organization
-      const hasPermission = await hasOrganizationPermission(
-        ctx,
-        role.organizationId,
-        "organization:manage",
-      );
-
-      if (!hasPermission) {
-        throw new TRPCError({ code: "UNAUTHORIZED" });
-      }
-
-      ctx.permissionChecked = true;
-      return next();
-    })
+    .use(roleOrganizationPermission({ permission: "organization:manage" }))
     .mutation(async ({ ctx, input }) => {
       const roleService = new RoleService(ctx.prisma);
       return await roleService.deleteRole({
@@ -176,36 +173,56 @@ export const roleRouter = createTRPCRouter({
         customRoleId: z.string(),
       }),
     )
-    .use(async ({ ctx, input, next }) => {
-      const team = await ctx.prisma.team.findUnique({
-        where: { id: input.teamId },
-        select: { organizationId: true },
-      });
+    .use(
+      declareAuthzMiddleware(
+        {
+          kind: "custom",
+          reason:
+            "the team's organization is loaded by its id; the check runs there, before any plan detail is revealed",
+          permissions: ["organization:manage"],
+        },
+        async ({
+          ctx,
+          input,
+          next,
+        }: {
+          ctx: RoleMiddlewareCtx;
+          input: { teamId: string };
+          next: () => Promise<unknown>;
+        }) => {
+          const team = await ctx.prisma.team.findUnique({
+            where: { id: input.teamId },
+            select: { organizationId: true },
+          });
 
-      if (!team) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Team not found" });
-      }
+          if (!team) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Team not found",
+            });
+          }
 
-      // Check permission before revealing plan details
-      const hasPermission = await hasOrganizationPermission(
-        ctx,
-        team.organizationId,
-        "organization:manage",
-      );
+          if (
+            !(await hasOrganizationPermission(
+              ctx,
+              team.organizationId,
+              "organization:manage",
+            ))
+          ) {
+            throw new TRPCError({ code: "UNAUTHORIZED" });
+          }
 
-      if (!hasPermission) {
-        throw new TRPCError({ code: "UNAUTHORIZED" });
-      }
+          await assertEnterprisePlan({
+            organizationId: team.organizationId,
+            user: ctx.session.user,
+            errorMessage: ENTERPRISE_FEATURE_ERRORS.RBAC,
+          });
 
-      await assertEnterprisePlan({
-        organizationId: team.organizationId,
-        user: ctx.session.user,
-        errorMessage: ENTERPRISE_FEATURE_ERRORS.RBAC,
-      });
-
-      ctx.permissionChecked = true;
-      return next();
-    })
+          ctx.permissionChecked = true;
+          return next();
+        },
+      ),
+    )
     .mutation(async ({ ctx, input }) => {
       const roleService = new RoleService(ctx.prisma);
       return await roleService.assignRoleToUser({
@@ -227,7 +244,7 @@ export const roleRouter = createTRPCRouter({
         customRoleId: z.string(),
       }),
     )
-    .use(checkTeamPermission("organization:manage"))
+    .permission("organization:manage", { via: "teamId" })
     .mutation(async ({ ctx, input }) => {
       const roleService = new RoleService(ctx.prisma);
       return await roleService.removeRoleFromUser({

--- a/platform/app/src/server/api/routers/roleBinding.ts
+++ b/platform/app/src/server/api/routers/roleBinding.ts
@@ -8,7 +8,6 @@ import {
 import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.prisma.repository";
 import { RoleService } from "~/server/role/role.service";
 import { RoleBindingService } from "~/server/role-bindings/role-binding.service";
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const scopeTypeSchema = z.nativeEnum(RoleBindingScopeType);
@@ -36,7 +35,7 @@ export const roleBindingRouter = createTRPCRouter({
    */
   listForOrg: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).listForOrg({
         organizationId: input.organizationId,
@@ -49,7 +48,7 @@ export const roleBindingRouter = createTRPCRouter({
    */
   listForUser: protectedProcedure
     .input(z.object({ organizationId: z.string(), userId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).listForUser({
         organizationId: input.organizationId,
@@ -63,7 +62,7 @@ export const roleBindingRouter = createTRPCRouter({
    */
   getMyAccessBreakdown: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).getMyAccessBreakdown({
         organizationId: input.organizationId,
@@ -91,7 +90,7 @@ export const roleBindingRouter = createTRPCRouter({
         scopeId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).create({
         organizationId: input.organizationId,
@@ -117,7 +116,7 @@ export const roleBindingRouter = createTRPCRouter({
         customRoleId: z.string().optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).update({
         organizationId: input.organizationId,
@@ -138,7 +137,7 @@ export const roleBindingRouter = createTRPCRouter({
         bindingId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).delete({
         organizationId: input.organizationId,
@@ -168,7 +167,7 @@ export const roleBindingRouter = createTRPCRouter({
         ),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ ctx, input }) => {
       return roleBindingService(ctx.prisma).applyMemberBindings({
         organizationId: input.organizationId,

--- a/platform/app/src/server/api/routers/routingPolicies.ts
+++ b/platform/app/src/server/api/routers/routingPolicies.ts
@@ -23,7 +23,6 @@ import { RoutingPolicyScopeType } from "~/generated/prisma/client";
 import { suggestTierTargets } from "~/server/modelProviders/suggestTierTargets";
 import { MODEL_TIERS } from "~/utils/modelTierPresets";
 
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -79,7 +78,7 @@ export const routingPoliciesRouter = createTRPCRouter({
           .optional(),
       }),
     )
-    .use(checkOrganizationPermission("routingPolicies:view"))
+    .permission("routingPolicies:view")
     .query(async ({ ctx, input }) => {
       const service = new RoutingPolicyService(ctx.prisma);
       return await service.list({
@@ -91,7 +90,7 @@ export const routingPoliciesRouter = createTRPCRouter({
   /** Get a single policy by id (includes its scope rows). */
   get: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("routingPolicies:view"))
+    .permission("routingPolicies:view")
     .query(async ({ ctx, input }) => {
       const policy = await ctx.prisma.routingPolicy.findUnique({
         where: { id: input.id },
@@ -116,7 +115,7 @@ export const routingPoliciesRouter = createTRPCRouter({
         boundProviderTypes: z.array(z.string()).default([]),
       }),
     )
-    .use(checkOrganizationPermission("routingPolicies:view"))
+    .permission("routingPolicies:view")
     .query(({ input }) =>
       suggestTierTargets({
         tier: input.tier,
@@ -143,7 +142,7 @@ export const routingPoliciesRouter = createTRPCRouter({
         policyRules: policyRulesSchema,
       }),
     )
-    .use(checkOrganizationPermission("routingPolicies:manage"))
+    .permission("routingPolicies:manage")
     .mutation(async ({ ctx, input }) => {
       const service = new RoutingPolicyService(ctx.prisma);
       try {
@@ -183,7 +182,7 @@ export const routingPoliciesRouter = createTRPCRouter({
         policyRules: policyRulesSchema,
       }),
     )
-    .use(checkOrganizationPermission("routingPolicies:manage"))
+    .permission("routingPolicies:manage")
     .mutation(async ({ ctx, input }) => {
       const service = new RoutingPolicyService(ctx.prisma);
       try {
@@ -205,7 +204,7 @@ export const routingPoliciesRouter = createTRPCRouter({
 
   setDefault: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("routingPolicies:manage"))
+    .permission("routingPolicies:manage")
     .mutation(async ({ ctx, input }) => {
       const service = new RoutingPolicyService(ctx.prisma);
       return await service.setDefault({
@@ -217,7 +216,7 @@ export const routingPoliciesRouter = createTRPCRouter({
 
   delete: protectedProcedure
     .input(z.object({ organizationId: z.string(), id: z.string() }))
-    .use(checkOrganizationPermission("routingPolicies:manage"))
+    .permission("routingPolicies:manage")
     .mutation(async ({ ctx, input }) => {
       const service = new RoutingPolicyService(ctx.prisma);
       await service.delete({

--- a/platform/app/src/server/api/routers/savedViews.ts
+++ b/platform/app/src/server/api/routers/savedViews.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import type { Prisma } from "~/generated/prisma/client";
 import { savedViewErrorHandler } from "../../saved-views/middleware";
 import { SavedViewService } from "../../saved-views/saved-view.service";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
@@ -28,7 +27,7 @@ export const savedViewsRouter = createTRPCRouter({
         kind: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .use(savedViewErrorHandler)
     .query(async ({ ctx, input }) => {
       const service = SavedViewService.create(ctx.prisma);
@@ -72,7 +71,7 @@ export const savedViewsRouter = createTRPCRouter({
         id: z.string().min(1).max(128).optional(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .use(savedViewErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = SavedViewService.create(ctx.prisma);
@@ -100,7 +99,7 @@ export const savedViewsRouter = createTRPCRouter({
         viewId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .use(savedViewErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = SavedViewService.create(ctx.prisma);
@@ -122,7 +121,7 @@ export const savedViewsRouter = createTRPCRouter({
         name: z.string().min(1).max(255),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .use(savedViewErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = SavedViewService.create(ctx.prisma);
@@ -144,7 +143,7 @@ export const savedViewsRouter = createTRPCRouter({
         viewIds: z.array(z.string()),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .use(savedViewErrorHandler)
     .mutation(async ({ ctx, input }) => {
       const service = SavedViewService.create(ctx.prisma);

--- a/platform/app/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
+++ b/platform/app/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
@@ -46,15 +46,21 @@ vi.mock("~/server/scenarios/scenario.service", () => ({
 }));
 
 const mockQueueRun = vi.fn().mockResolvedValue(undefined);
-vi.mock("~/server/app-layer/app", () => ({
-  // Consumers that degrade without Redis read through this one.
-  tryGetApp: () => null,
-  getApp: vi.fn().mockReturnValue({
-    simulations: {
-      queueRun: (...args: unknown[]) => mockQueueRun(...args),
-    },
-  }),
-}));
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsService } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return {
+    // Consumers that degrade without Redis read through this one.
+    tryGetApp: () => null,
+    getApp: vi.fn().mockReturnValue({
+      permissions: appPermissionsService(),
+      simulations: {
+        queueRun: (...args: unknown[]) => mockQueueRun(...args),
+      },
+    }),
+  };
+});
 
 vi.mock("@langwatch/ksuid", () => ({
   generate: vi.fn().mockReturnValue({

--- a/platform/app/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
+++ b/platform/app/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
@@ -73,13 +73,9 @@ vi.mock("@langwatch/observability", () => ({
 
 // Mock RBAC to always allow - we're testing business logic, not permissions
 vi.mock("../../../rbac", () => ({
-  checkProjectPermission: vi.fn().mockImplementation(() => {
-    return async ({ ctx, next, input }: any) => {
-      return next({
-        ctx: { ...ctx, permissionChecked: true },
-      });
-    };
-  }),
+  resolveProjectPermission: vi
+    .fn()
+    .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
 }));
 
 // Mock audit log to avoid database calls

--- a/platform/app/src/server/api/routers/scenarios/cancellation.router.ts
+++ b/platform/app/src/server/api/routers/scenarios/cancellation.router.ts
@@ -15,7 +15,6 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import type { CancellationServiceDeps } from "~/server/scenarios/cancellation";
 import { ScenarioCancellationService } from "~/server/scenarios/cancellation";
-import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
 
 const logger = createLogger("langwatch:api:scenarios:cancellation");
@@ -65,7 +64,7 @@ function getService(): ScenarioCancellationService {
 export const cancellationRouter = createTRPCRouter({
   cancelJob: protectedProcedure
     .input(cancelJobSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ input }) => {
       logger.info(
         {
@@ -81,7 +80,7 @@ export const cancellationRouter = createTRPCRouter({
 
   cancelBatchRun: protectedProcedure
     .input(cancelBatchRunSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ input }) => {
       logger.info(
         {

--- a/platform/app/src/server/api/routers/scenarios/scenario-crud.router.ts
+++ b/platform/app/src/server/api/routers/scenarios/scenario-crud.router.ts
@@ -8,7 +8,6 @@ import { ScenarioNotFoundError } from "~/server/scenarios/errors";
 import { scenarioParameterDefinitionsSchema } from "~/server/scenarios/parameters";
 import { ScenarioService } from "~/server/scenarios/scenario.service";
 import { captureException } from "~/utils/posthogErrorCapture";
-import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
 
 const logger = createLogger("langwatch:api:scenarios:crud");
@@ -49,7 +48,7 @@ const updateScenarioSchema = projectSchema.extend({
 export const scenarioCrudRouter = createTRPCRouter({
   create: protectedProcedure
     .input(createScenarioSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       logger.info({ projectId: input.projectId }, "Creating scenario");
 
@@ -88,7 +87,7 @@ export const scenarioCrudRouter = createTRPCRouter({
 
   getAll: protectedProcedure
     .input(projectSchema)
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ ctx, input }) => {
       logger.debug({ projectId: input.projectId }, "Fetching all scenarios");
       const service = ScenarioService.create(ctx.prisma);
@@ -97,7 +96,7 @@ export const scenarioCrudRouter = createTRPCRouter({
 
   getById: protectedProcedure
     .input(projectSchema.extend({ id: z.string() }))
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ ctx, input }) => {
       logger.debug(
         { projectId: input.projectId, scenarioId: input.id },
@@ -116,7 +115,7 @@ export const scenarioCrudRouter = createTRPCRouter({
 
   getByIdIncludingArchived: protectedProcedure
     .input(projectSchema.extend({ id: z.string() }))
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ ctx, input }) => {
       logger.debug(
         { projectId: input.projectId, scenarioId: input.id },
@@ -128,7 +127,7 @@ export const scenarioCrudRouter = createTRPCRouter({
 
   update: protectedProcedure
     .input(updateScenarioSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       logger.info(
         { projectId: input.projectId, scenarioId: input.id },
@@ -148,7 +147,7 @@ export const scenarioCrudRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(projectSchema.extend({ id: z.string() }))
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       logger.info(
         { projectId: input.projectId, scenarioId: input.id },
@@ -176,7 +175,7 @@ export const scenarioCrudRouter = createTRPCRouter({
 
   batchArchive: protectedProcedure
     .input(projectSchema.extend({ ids: z.array(z.string()).min(1) }))
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       logger.info(
         { projectId: input.projectId, count: input.ids.length },

--- a/platform/app/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/platform/app/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -6,7 +6,6 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { startScenarioTabPresence } from "~/server/scenarios/browser-tab/scenario-tab-presence";
 import type { BatchRunDataResult } from "~/server/scenarios/scenario-event.types";
-import { checkProjectPermission } from "../../rbac";
 
 const logger = createLogger("langwatch:api:scenarios:events");
 
@@ -105,7 +104,7 @@ export const scenarioEventsRouter = createTRPCRouter({
   // Get scenario sets data for a project
   getScenarioSetsData: protectedProcedure
     .input(projectSchema.extend(dateRangeFields))
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         { projectId: input.projectId },
@@ -131,7 +130,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         {
@@ -163,7 +162,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         .extend({ scenarioSetId: z.string().optional() })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       const service = getApp().simulations.runs;
       const dates = resolveDateRange(input);
@@ -186,7 +185,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         {
@@ -218,7 +217,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         .extend({ scenarioSetId: z.string() })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         { projectId: input.projectId, scenarioSetId: input.scenarioSetId },
@@ -241,7 +240,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         scenarioRunId: z.string(),
       }),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         { projectId: input.projectId, scenarioRunId: input.scenarioRunId },
@@ -271,7 +270,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         .extend({ scenarioSetId: z.string() })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         { projectId: input.projectId, scenarioSetId: input.scenarioSetId },
@@ -298,7 +297,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         {
@@ -329,7 +328,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         runTimestamps: z.record(z.string(), z.number()).optional(),
       }),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         {
@@ -354,7 +353,7 @@ export const scenarioEventsRouter = createTRPCRouter({
   // Get summaries for external (SDK/CI) scenario sets
   getExternalSetSummaries: protectedProcedure
     .input(projectSchema.extend(dateRangeFields))
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         { projectId: input.projectId },
@@ -380,7 +379,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         })
         .extend(dateRangeFields),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input, ctx }) => {
       logger.debug(
         {
@@ -411,7 +410,7 @@ export const scenarioEventsRouter = createTRPCRouter({
         tabId: z.string().min(1).max(200).optional(),
       }),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .subscription(async function* (opts) {
       const { projectId, tabKey, tabId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);

--- a/platform/app/src/server/api/routers/scenarios/simulation-runner.router.ts
+++ b/platform/app/src/server/api/routers/scenarios/simulation-runner.router.ts
@@ -22,7 +22,6 @@ import { resolveRunParameters } from "~/server/scenarios/resolve-run-parameters"
 import { generateBatchRunId } from "~/server/scenarios/scenario.ids";
 import { ScenarioService } from "~/server/scenarios/scenario.service";
 import { KSUID_RESOURCES } from "~/utils/constants";
-import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
 
 const logger = createLogger("SimulationRunnerRouter");
@@ -144,7 +143,7 @@ export const simulationRunnerRouter = createTRPCRouter({
    */
   run: protectedProcedure
     .input(runScenarioSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       const setId = input.setId ?? getOnPlatformSetId(input.projectId);
       const batchRunId = input.batchRunId ?? generateBatchRunId();

--- a/platform/app/src/server/api/routers/scimToken.ts
+++ b/platform/app/src/server/api/routers/scimToken.ts
@@ -2,11 +2,10 @@ import { ScimTokenService } from "@ee/scim/scim-token.service";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { assertEnterprisePlan, ENTERPRISE_FEATURE_ERRORS } from "../enterprise";
-import { checkOrganizationPermission } from "../rbac";
 
 const enterpriseScimProcedure = protectedProcedure
   .input(z.object({ organizationId: z.string() }))
-  .use(checkOrganizationPermission("organization:manage"))
+  .permission("organization:manage")
   .use(async ({ ctx, input, next }) => {
     await assertEnterprisePlan({
       organizationId: input.organizationId,

--- a/platform/app/src/server/api/routers/secrets.ts
+++ b/platform/app/src/server/api/routers/secrets.ts
@@ -3,7 +3,6 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { RESERVED_PROJECT_SECRET_NAMES } from "~/server/projects/reserved-secret-names";
 import { encrypt } from "~/utils/encryption";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const MAX_SECRETS_PER_PROJECT = 50;
@@ -52,7 +51,7 @@ export const secretsRouter = createTRPCRouter({
    */
   list: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("secrets:view"))
+    .permission("secrets:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.projectSecret.findMany({
         where: {
@@ -79,7 +78,7 @@ export const secretsRouter = createTRPCRouter({
           .max(10_000, "Secret value is too long"),
       }),
     )
-    .use(checkProjectPermission("secrets:manage"))
+    .permission("secrets:manage")
     .mutation(async ({ ctx, input }) => {
       // The uppercase-only name schema can never produce a reserved
       // (lowercase) name today; this check pins the boundary rather than
@@ -145,7 +144,7 @@ export const secretsRouter = createTRPCRouter({
           .max(10_000, "Secret value is too long"),
       }),
     )
-    .use(checkProjectPermission("secrets:manage"))
+    .permission("secrets:manage")
     .mutation(async ({ ctx, input }) => {
       const existing = await ctx.prisma.projectSecret.findFirst({
         where: { id: input.secretId, projectId: input.projectId },
@@ -186,7 +185,7 @@ export const secretsRouter = createTRPCRouter({
         secretId: z.string(),
       }),
     )
-    .use(checkProjectPermission("secrets:manage"))
+    .permission("secrets:manage")
     .mutation(async ({ ctx, input }) => {
       const existing = await ctx.prisma.projectSecret.findFirst({
         where: { id: input.secretId, projectId: input.projectId },

--- a/platform/app/src/server/api/routers/share.ts
+++ b/platform/app/src/server/api/routers/share.ts
@@ -4,8 +4,6 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 import { getApp } from "~/server/app-layer/app";
 
-import { checkProjectPermission } from "../rbac";
-
 const resourceType = z.enum(["TRACE", "THREAD"]);
 const visibility = z.enum(["PUBLIC", "ORGANIZATION", "PROJECT"]);
 
@@ -30,7 +28,7 @@ export const shareRouter = createTRPCRouter({
         resourceId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:share"))
+    .permission("traces:share")
     .query(async ({ input }) => {
       return getApp().share.listForResource(input);
     }),
@@ -52,7 +50,7 @@ export const shareRouter = createTRPCRouter({
         maxViews: z.number().int().positive().nullish(),
       }),
     )
-    .use(checkProjectPermission("traces:share"))
+    .permission("traces:share")
     .mutation(async ({ input, ctx }) => {
       return getApp().share.createShare({
         projectId: input.projectId,
@@ -68,14 +66,14 @@ export const shareRouter = createTRPCRouter({
   /** Revoke a single link by id. */
   revoke: protectedProcedure
     .input(z.object({ projectId: z.string(), id: z.string() }))
-    .use(checkProjectPermission("traces:share"))
+    .permission("traces:share")
     .mutation(async ({ input }) => {
       await getApp().share.revokeById(input);
     }),
 
   revokeAllTraceShares: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:update"))
+    .permission("project:update")
     .mutation(async ({ input }) => {
       await getApp().share.revokeAllTraceShares(input.projectId);
     }),

--- a/platform/app/src/server/api/routers/sharedTrace.ts
+++ b/platform/app/src/server/api/routers/sharedTrace.ts
@@ -15,11 +15,7 @@ import { applyDerivedTraceEventProtections } from "~/server/traces/mappers/redac
 import type { Protections } from "~/server/traces/protections";
 import { TraceService } from "~/server/traces/trace.service";
 import { getClientIp } from "~/utils/getClientIp";
-import {
-  hasOrganizationPermission,
-  hasProjectPermission,
-  skipPermissionCheck,
-} from "../rbac";
+import { hasOrganizationPermission, hasProjectPermission } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 import type { SharedTraceDto } from "./sharedTrace.schemas";
 import {
@@ -112,7 +108,10 @@ export const sharedTraceRouter = createTRPCRouter({
     // `.output()` comes after `.use()`: the app's permission builder exposes
     // only `input`/`use` so every procedure is forced through the permission
     // middleware, and it is that `use` which hands back the full tRPC builder.
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "the share token in the input is the whole authorization; see ADR-057",
+    })
     .output(sharedTraceDtoSchema)
     .query(async ({ input, ctx }) => {
       const viewer: ShareViewer = {

--- a/platform/app/src/server/api/routers/spans.ts
+++ b/platform/app/src/server/api/routers/spans.ts
@@ -3,13 +3,12 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TraceService } from "~/server/traces/trace.service";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
-import { checkProjectPermission } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 
 export const spansRouter = createTRPCRouter({
   getAllForTrace: protectedProcedure
     .input(z.object({ projectId: z.string(), traceId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -62,7 +61,7 @@ export const spansRouter = createTRPCRouter({
         spanId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const { projectId, spanId } = input;
 

--- a/platform/app/src/server/api/routers/stored-objects.router.ts
+++ b/platform/app/src/server/api/routers/stored-objects.router.ts
@@ -7,7 +7,6 @@
  * fragility of a native HEAD probe.
  */
 import { z } from "zod";
-import { checkProjectPermissionAny } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { createStoredObjectsService } from "~/server/stored-objects/stored-objects-factory";
 
@@ -42,7 +41,7 @@ export const storedObjectsRouter = createTRPCRouter({
         id: z.string(),
       }),
     )
-    .use(checkProjectPermissionAny("traces:view", "scenarios:view"))
+    .permissionAny("traces:view", "scenarios:view")
     .query(async ({ input }) => {
       const { projectId, id } = input;
       const service = createStoredObjectsService({ projectId });

--- a/platform/app/src/server/api/routers/suites/suite.router.ts
+++ b/platform/app/src/server/api/routers/suites/suite.router.ts
@@ -14,7 +14,6 @@ import { runParameterValuesSchema } from "~/server/scenarios/parameters";
 import type { SuiteRunSummary } from "~/server/scenarios/scenario-event.types";
 import { SuiteService } from "~/server/suites/suite.service";
 import { extractSuiteId } from "~/server/suites/suite-set-id";
-import { checkProjectPermission } from "../../rbac";
 import {
   createSuiteSchema,
   projectSchema,
@@ -32,7 +31,7 @@ function createSuiteService(prisma: PrismaClient) {
 export const suiteRouter = createTRPCRouter({
   create: protectedProcedure
     .input(createSuiteSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       const service = createSuiteService(ctx.prisma);
       return service.create(input);
@@ -40,7 +39,7 @@ export const suiteRouter = createTRPCRouter({
 
   getAll: protectedProcedure
     .input(projectSchema)
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ ctx, input }) => {
       const service = createSuiteService(ctx.prisma);
       return service.getAll(input);
@@ -48,7 +47,7 @@ export const suiteRouter = createTRPCRouter({
 
   getById: protectedProcedure
     .input(projectSchema.extend({ id: z.string() }))
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ ctx, input }) => {
       const service = createSuiteService(ctx.prisma);
       const suite = await service.getById(input);
@@ -63,7 +62,7 @@ export const suiteRouter = createTRPCRouter({
 
   update: protectedProcedure
     .input(updateSuiteSchema)
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       const { id, projectId, ...data } = input;
       const service = createSuiteService(ctx.prisma);
@@ -72,7 +71,7 @@ export const suiteRouter = createTRPCRouter({
 
   duplicate: protectedProcedure
     .input(projectSchema.extend({ id: z.string() }))
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       const service = createSuiteService(ctx.prisma);
       // Validate source suite exists before checking limits — avoids masking NOT_FOUND with a limit error
@@ -88,7 +87,7 @@ export const suiteRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(projectSchema.extend({ id: z.string() }))
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       const service = createSuiteService(ctx.prisma);
       const result = await service.archive(input);
@@ -109,7 +108,7 @@ export const suiteRouter = createTRPCRouter({
         targets: z.array(suiteTargetSchema),
       }),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ ctx, input }) => {
       const projectRepository = new ProjectRepository(ctx.prisma);
       const organizationId = await projectRepository.getOrganizationId({
@@ -142,7 +141,7 @@ export const suiteRouter = createTRPCRouter({
         parameters: runParameterValuesSchema.optional(),
       }),
     )
-    .use(checkProjectPermission("scenarios:manage"))
+    .permission("scenarios:manage")
     .mutation(async ({ ctx, input }) => {
       const service = createSuiteService(ctx.prisma);
       const suite = await service.getById(input);
@@ -191,7 +190,7 @@ export const suiteRouter = createTRPCRouter({
         endDate: z.number().int().nonnegative().optional(),
       }),
     )
-    .use(checkProjectPermission("scenarios:view"))
+    .permission("scenarios:view")
     .query(async ({ input }) => {
       const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
       const startDate = input.startDate ?? Date.now() - THIRTY_DAYS_MS;

--- a/platform/app/src/server/api/routers/team.ts
+++ b/platform/app/src/server/api/routers/team.ts
@@ -9,11 +9,7 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
   isCustomRole,
 } from "../enterprise";
-import {
-  checkOrganizationPermission,
-  checkTeamPermission,
-  hasOrganizationPermission,
-} from "../rbac";
+import { hasOrganizationPermission } from "../rbac";
 
 // Reusable schema for team member role validation
 const teamMemberRoleSchema = z
@@ -56,7 +52,7 @@ const teamMemberRoleSchema = z
 export const teamRouter = createTRPCRouter({
   getBySlug: protectedProcedure
     .input(z.object({ organizationId: z.string(), slug: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       const service = new TeamService({ prisma: ctx.prisma });
       return service.getTeamBySlugForUser({
@@ -73,7 +69,7 @@ export const teamRouter = createTRPCRouter({
     // emails are PII and get redacted below for non-admin callers,
     // and other users' personal-workspace teams are filtered out
     // entirely (their existence is itself private).
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       const callerId = ctx.session.user.id;
       const callerHasManage = await hasOrganizationPermission(
@@ -117,7 +113,7 @@ export const teamRouter = createTRPCRouter({
     // direct members + role bindings + per-project access maps,
     // which is admin-surface authorization data. Sole TS caller is
     // settings/teams.tsx, an admin-only page.
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .query(async ({ input, ctx }) => {
       const service = new TeamService({ prisma: ctx.prisma });
       return service.getTeamsWithRoleBindings({
@@ -132,7 +128,7 @@ export const teamRouter = createTRPCRouter({
     // Member emails are redacted below for non-admin callers, and a
     // non-admin lookup of someone else's personal workspace returns
     // NOT_FOUND (existence itself is private).
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ input, ctx }) => {
       const callerId = ctx.session.user.id;
       const callerHasManage = await hasOrganizationPermission(
@@ -182,7 +178,7 @@ export const teamRouter = createTRPCRouter({
         members: z.array(teamMemberRoleSchema),
       }),
     )
-    .use(checkTeamPermission("team:manage"))
+    .permission("team:manage")
     .mutation(async ({ input, ctx }) => {
       const hasCustomRoleMember = input.members.some((m) =>
         isCustomRole(m.role),
@@ -220,7 +216,7 @@ export const teamRouter = createTRPCRouter({
         members: z.array(teamMemberRoleSchema),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
+    .permission("organization:manage")
     .mutation(async ({ input, ctx }) => {
       const hasCustomRoleMember = input.members.some((m) =>
         isCustomRole(m.role),
@@ -242,7 +238,7 @@ export const teamRouter = createTRPCRouter({
     }),
   archiveById: protectedProcedure
     .input(z.object({ teamId: z.string() }))
-    .use(checkTeamPermission("team:delete"))
+    .permission("team:manage")
     .mutation(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
 
@@ -281,7 +277,7 @@ export const teamRouter = createTRPCRouter({
         userId: z.string(),
       }),
     )
-    .use(checkTeamPermission("team:manage"))
+    .permission("team:manage")
     .mutation(async ({ input, ctx }) => {
       const service = new TeamService({ prisma: ctx.prisma });
       return service.removeMember({

--- a/platform/app/src/server/api/routers/topics.ts
+++ b/platform/app/src/server/api/routers/topics.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { getApp } from "../../app-layer/app";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const topicsRouter = createTRPCRouter({
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       // The projected topic model is the source of truth; read it through
       // the topic-clustering service, never straight at the table.
@@ -17,7 +16,7 @@ export const topicsRouter = createTRPCRouter({
 
   getClusteringStatus: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => {
       return await getApp().topicClustering.status.getByProjectId({
         projectId: input.projectId,
@@ -26,7 +25,7 @@ export const topicsRouter = createTRPCRouter({
 
   getClusteringRunHistory: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .permission("project:view")
     .query(async ({ input }) => {
       return await getApp().topicClustering.status.getRunHistoryByProjectId({
         projectId: input.projectId,

--- a/platform/app/src/server/api/routers/traceEditOverlay.ts
+++ b/platform/app/src/server/api/routers/traceEditOverlay.ts
@@ -5,7 +5,6 @@ import { redactPatchForViewer } from "~/server/traces/edit-overlay/redactTraceEd
 import { restoreWithheldEdits } from "~/server/traces/edit-overlay/restoreWithheldTraceEdits";
 import { traceEditOverlayPatchSchema } from "~/server/traces/edit-overlay/traceEditOverlay.schemas";
 import type { Protections } from "~/server/traces/protections";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { getUserProtectionsForProject } from "../utils";
 
@@ -63,7 +62,7 @@ async function isTraceWindowRedacted({
 export const traceEditOverlayRouter = createTRPCRouter({
   getByTraceId: protectedProcedure
     .input(z.object({ projectId: z.string(), traceId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const overlay = await getApp().traces.editOverlay.getByTraceId({
         projectId: input.projectId,
@@ -106,7 +105,7 @@ export const traceEditOverlayRouter = createTRPCRouter({
         patch: traceEditOverlayPatchSchema,
       }),
     )
-    .use(checkProjectPermission("annotations:update"))
+    .permission("annotations:update")
     .mutation(async ({ ctx, input }) => {
       const editOverlay = getApp().traces.editOverlay;
       const stored = await editOverlay.getByTraceId({
@@ -158,7 +157,7 @@ export const traceEditOverlayRouter = createTRPCRouter({
 
   delete: protectedProcedure
     .input(z.object({ projectId: z.string(), traceId: z.string() }))
-    .use(checkProjectPermission("annotations:update"))
+    .permission("annotations:update")
     .mutation(async ({ input }) => {
       await getApp().traces.editOverlay.delete({
         projectId: input.projectId,

--- a/platform/app/src/server/api/routers/traces.ts
+++ b/platform/app/src/server/api/routers/traces.ts
@@ -15,7 +15,6 @@ import {
   evaluatePreconditions,
 } from "../../evaluations/preconditions";
 import { checkPreconditionSchema } from "../../evaluations/types";
-import { checkProjectPermission } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 import { getAllForProjectInput, tracesFilterInput } from "./traces.schemas";
 
@@ -33,7 +32,7 @@ const withEditOverlayInput = z.boolean().default(false);
 export const tracesRouter = createTRPCRouter({
   getAllForProject: protectedProcedure
     .input(getAllForProjectInput)
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -53,7 +52,7 @@ export const tracesRouter = createTRPCRouter({
         withEditOverlay: withEditOverlayInput,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -79,7 +78,7 @@ export const tracesRouter = createTRPCRouter({
 
   getEvaluations: protectedProcedure
     .input(z.object({ projectId: z.string(), traceId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -108,7 +107,7 @@ export const tracesRouter = createTRPCRouter({
         evaluationId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const traceService = TraceService.create(ctx.prisma);
       return traceService.getEvaluationInputs(
@@ -124,7 +123,7 @@ export const tracesRouter = createTRPCRouter({
         traceIds: z.array(z.string()),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -140,7 +139,7 @@ export const tracesRouter = createTRPCRouter({
 
   getTopicCounts: protectedProcedure
     .input(tracesFilterInput)
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const traceService = TraceService.create(ctx.prisma);
       const result = await traceService.getTopicCounts(input);
@@ -189,7 +188,7 @@ export const tracesRouter = createTRPCRouter({
 
   getCustomersAndLabels: protectedProcedure
     .input(tracesFilterInput)
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const traceService = TraceService.create(ctx.prisma);
       return traceService.getCustomersAndLabels(input);
@@ -202,7 +201,7 @@ export const tracesRouter = createTRPCRouter({
         threadId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const { projectId, threadId } = input;
 
@@ -236,7 +235,7 @@ export const tracesRouter = createTRPCRouter({
         withEditOverlay: withEditOverlayInput,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const { projectId, traceIds } = input;
       const protections = await getUserProtectionsForProject(ctx, {
@@ -264,7 +263,7 @@ export const tracesRouter = createTRPCRouter({
         withEditOverlay: withEditOverlayInput,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const { projectId, traceIds } = input;
       const protections = await getUserProtectionsForProject(ctx, {
@@ -306,7 +305,7 @@ export const tracesRouter = createTRPCRouter({
         withEditOverlay: withEditOverlayInput,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const { projectId, threadIds } = input;
       const protections = await getUserProtectionsForProject(ctx, {
@@ -334,7 +333,7 @@ export const tracesRouter = createTRPCRouter({
         sortBy: z.string().optional(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -381,7 +380,7 @@ export const tracesRouter = createTRPCRouter({
         endDate: z.number(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const traceService = TraceService.create(ctx.prisma);
       return traceService.getDistinctFieldNames(
@@ -403,7 +402,7 @@ export const tracesRouter = createTRPCRouter({
         expectedResults: z.number(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ ctx, input }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -486,7 +485,7 @@ export const tracesRouter = createTRPCRouter({
         includeSpans: z.boolean(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ ctx, input }) => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -519,7 +518,7 @@ export const tracesRouter = createTRPCRouter({
 
   onTraceUpdate: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .subscription(async function* (opts) {
       const { projectId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);

--- a/platform/app/src/server/api/routers/tracesV2.ts
+++ b/platform/app/src/server/api/routers/tracesV2.ts
@@ -96,7 +96,6 @@ import {
   RESERVED_INPUT_MEDIA_REFS,
   RESERVED_OUTPUT_MEDIA_REFS,
 } from "~/shared/traces/media-refs";
-import { checkProjectPermission } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 import {
   gateHeaderCost,
@@ -1157,7 +1156,7 @@ export const tracesV2Router = createTRPCRouter({
         query: z.string().nullish(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1201,7 +1200,7 @@ export const tracesV2Router = createTRPCRouter({
         query: z.string().nullish(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1255,7 +1254,7 @@ export const tracesV2Router = createTRPCRouter({
         timeRange: timeRangeSchema,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(
       async ({ input }): Promise<Record<string, TraceEventRollup>> =>
         getApp().traces.spans.getTraceEventRollupsByTraceIds({
@@ -1273,7 +1272,7 @@ export const tracesV2Router = createTRPCRouter({
         query: z.string().nullish(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       return app.traces.list.getFacets({
@@ -1292,7 +1291,7 @@ export const tracesV2Router = createTRPCRouter({
         query: z.string().nullish(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       const count = await app.traces.list.getNewCount({
@@ -1313,7 +1312,7 @@ export const tracesV2Router = createTRPCRouter({
         limit: z.number().int().min(1).max(100).default(20),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       const values = await app.traces.list.getSuggestions({
@@ -1337,7 +1336,7 @@ export const tracesV2Router = createTRPCRouter({
         conversationId: z.string().min(1),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1381,7 +1380,7 @@ export const tracesV2Router = createTRPCRouter({
         timeRange: timeRangeSchema,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       return app.traces.list.getDiscover({
@@ -1402,7 +1401,7 @@ export const tracesV2Router = createTRPCRouter({
    */
   onDiscoverUpdate: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .subscription(async function* (opts) {
       const { projectId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);
@@ -1428,7 +1427,7 @@ export const tracesV2Router = createTRPCRouter({
         offset: z.number().int().min(0).default(0),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       return app.traces.list.getFacetValues({
@@ -1449,7 +1448,7 @@ export const tracesV2Router = createTRPCRouter({
         timeRange: timeRangeSchema,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ input }) => {
       return generateTraceQueryFromPrompt({
         projectId: input.projectId,
@@ -1470,7 +1469,7 @@ export const tracesV2Router = createTRPCRouter({
         timeRange: timeRangeSchema,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ input }) => {
       return generateTraceAction({
         projectId: input.projectId,
@@ -1512,7 +1511,7 @@ export const tracesV2Router = createTRPCRouter({
         full: z.boolean().default(true),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<TraceHeader> => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1564,7 +1563,7 @@ export const tracesV2Router = createTRPCRouter({
         newName: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:update"))
+    .permission("traces:update")
     .mutation(async ({ input, ctx }) => {
       const trimmed = input.newName.trim();
       const parsed = changeTraceNameInputSchema.safeParse({ newName: trimmed });
@@ -1602,7 +1601,7 @@ export const tracesV2Router = createTRPCRouter({
         metadata: traceMetadataUpdateSchema,
       }),
     )
-    .use(checkProjectPermission("traces:update"))
+    .permission("traces:update")
     .mutation(async ({ input }) => {
       await updateTraceMetadata(input);
       return { traceId: input.traceId };
@@ -1618,7 +1617,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1656,7 +1655,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }) => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1694,7 +1693,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(
       async ({
         input,
@@ -1735,7 +1734,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<SpanTreeNode[]> => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1769,7 +1768,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<SpanTreeNode[]> => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -1800,7 +1799,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }): Promise<SpanLangwatchSignals[]> => {
       const app = getApp();
       const rows = await app.traces.spans.getLangwatchSignalsByTraceId({
@@ -1824,7 +1823,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<SpanDetail[]> => {
       return loadProtectedSpansFull({ input, ctx });
     }),
@@ -1850,7 +1849,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<CodingAgentTranscript> => {
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
@@ -1870,7 +1869,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<SpanDetail> => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -2010,7 +2009,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<TraceResourceInfoDto> => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -2065,7 +2064,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<DerivedTraceEvent[]> => {
       const app = getApp();
       const protections = await getUserProtectionsForProject(ctx, {
@@ -2088,7 +2087,7 @@ export const tracesV2Router = createTRPCRouter({
         traceId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       return app.evaluations.runs.findByTraceId(input.projectId, input.traceId);
@@ -2114,7 +2113,7 @@ export const tracesV2Router = createTRPCRouter({
         traceId: z.string(),
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input }) => {
       const app = getApp();
       // Two keyed seeks (ADR-056 §4): the (trace → session) map, then the
@@ -2148,7 +2147,7 @@ export const tracesV2Router = createTRPCRouter({
         ...spanReadHintShape,
       }),
     )
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .query(async ({ input, ctx }): Promise<TraceLogRecordDto[]> => {
       // The free-plan teaser window and the viewer's captured-content
       // permissions are both applied inside the loader, which the transcript

--- a/platform/app/src/server/api/routers/translate.ts
+++ b/platform/app/src/server/api/routers/translate.ts
@@ -6,7 +6,6 @@ import { TRANSLATE_TEXT_MAX_CHARS } from "~/utils/constants";
 import { wrapAiCall } from "../../modelProviders/aiCallFailedError";
 import { featureByKey } from "../../modelProviders/featureRegistry";
 import { getVercelAIModel } from "../../modelProviders/utils";
-import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const logger = createLogger("langwatch:translate");
@@ -24,7 +23,7 @@ export const translateRouter = createTRPCRouter({
     // Translation reads content the caller can already see — gate on the
     // same permission that grants viewing the trace, so read-only members
     // (VIEWER, demo/public view) aren't shown an action that then 403s.
-    .use(checkProjectPermission("traces:view"))
+    .permission("traces:view")
     .mutation(async ({ input }) => {
       const feature = featureByKey(TRANSLATE_FEATURE_KEY);
       if (!feature) {

--- a/platform/app/src/server/api/routers/user.ts
+++ b/platform/app/src/server/api/routers/user.ts
@@ -29,7 +29,6 @@ import { UserService } from "~/server/users/user.service";
 import { getClientIp } from "~/utils/getClientIp";
 import { isAdmin as checkIsAdmin } from "../../../../ee/admin/isAdmin";
 import { env } from "../../../env.mjs";
-import { checkOrganizationPermission, skipPermissionCheck } from "../rbac";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 
 const logger = createLogger("langwatch:user-router");
@@ -37,7 +36,9 @@ const logger = createLogger("langwatch:user-router");
 export const userRouter = createTRPCRouter({
   getTraceExplorerTourPreference: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .query(async ({ ctx }) => {
       const userId = ctx.session.user.impersonator?.id ?? ctx.session.user.id;
       const user = await ctx.prisma.user.findUniqueOrThrow({
@@ -52,7 +53,9 @@ export const userRouter = createTRPCRouter({
     }),
   dismissTraceExplorerTour: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx }) => {
       const userId = ctx.session.user.impersonator?.id ?? ctx.session.user.id;
       const user = await ctx.prisma.user.update({
@@ -74,7 +77,9 @@ export const userRouter = createTRPCRouter({
    */
   isAdmin: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .query(({ ctx }) => {
       const user = ctx.session.user.impersonator ?? ctx.session.user;
       return { isAdmin: checkIsAdmin({ email: user.email }) };
@@ -92,7 +97,9 @@ export const userRouter = createTRPCRouter({
         password: z.string().min(8, "Password must be at least 8 characters"),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx, input }) => {
       const { name, password } = input;
       // BetterAuth lowercases the email on every one of its lookups and
@@ -174,7 +181,9 @@ export const userRouter = createTRPCRouter({
     }),
   updateLastLogin: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx }) => {
       // Don't update lastLoginAt for impersonated sessions — an admin
       // browsing as another user should not overwrite that user's
@@ -192,7 +201,9 @@ export const userRouter = createTRPCRouter({
     }),
   getSsoStatus: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .query(async ({ ctx }) => {
       return UserService.create(ctx.prisma).getSsoStatus({
         id: ctx.session.user.id,
@@ -200,7 +211,9 @@ export const userRouter = createTRPCRouter({
     }),
   getAccountInfo: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .query(async ({ ctx }) => {
       return UserService.create(ctx.prisma).getAccountInfo({
         id: ctx.session.user.id,
@@ -208,7 +221,9 @@ export const userRouter = createTRPCRouter({
     }),
   getLinkedAccounts: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .query(async ({ ctx }) => {
       const accounts = await ctx.prisma.account.findMany({
         where: {
@@ -229,7 +244,9 @@ export const userRouter = createTRPCRouter({
         accountId: z.string(),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx, input }) => {
       // Wrap the count + delete in a serializable transaction. The
       // previous implementation did the count and delete as separate
@@ -283,7 +300,9 @@ export const userRouter = createTRPCRouter({
           .min(8, "Password must be at least 8 characters"),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx, input }) => {
       // Resolved provider, not raw env (ADR-027): on a denied SSO deployment
       // the platform gate coerces to email mode, and a user who recovered via
@@ -475,7 +494,10 @@ export const userRouter = createTRPCRouter({
     }),
   deactivate: protectedProcedure
     .input(z.object({ userId: z.string() }))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "self-service for the named user; the handler enforces self-or-instance-admin itself",
+    })
     .mutation(async ({ ctx, input }) => {
       const user = ctx.session.user.impersonator ?? ctx.session.user;
       if (
@@ -492,7 +514,10 @@ export const userRouter = createTRPCRouter({
     }),
   reactivate: protectedProcedure
     .input(z.object({ userId: z.string() }))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason:
+        "self-service for the named user; the handler enforces self-or-instance-admin itself",
+    })
     .mutation(async ({ ctx, input }) => {
       const user = ctx.session.user.impersonator ?? ctx.session.user;
       if (!checkIsAdmin({ email: user.email })) {
@@ -526,7 +551,7 @@ export const userRouter = createTRPCRouter({
         imageDataUrl: z.string().min(1),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       // Throttle uploads per user — each writes bytes to object storage and
       // updates the row; mirrors the changePassword budget shape.
@@ -560,7 +585,9 @@ export const userRouter = createTRPCRouter({
    */
   removeAvatar: protectedProcedure
     .input(z.object({}))
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx }) => {
       await new UserAvatarService(ctx.prisma).removeAvatar({
         userId: ctx.session.user.id,
@@ -585,7 +612,7 @@ export const userRouter = createTRPCRouter({
    */
   personalContext: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
@@ -646,7 +673,7 @@ export const userRouter = createTRPCRouter({
         windowEndMs: z.number().optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const membership = await ctx.prisma.organizationUser.findUnique({
@@ -765,7 +792,7 @@ export const userRouter = createTRPCRouter({
    */
   personalBudget: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
@@ -878,7 +905,7 @@ export const userRouter = createTRPCRouter({
    */
   cliBootstrap: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const service = CliBootstrapService.create({
         prisma: ctx.prisma,
@@ -910,7 +937,7 @@ export const userRouter = createTRPCRouter({
         message: z.string().max(2000).optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       const adminEmail = await resolveOrgAdminEmail({
         prisma: ctx.prisma,
@@ -979,7 +1006,9 @@ export const userRouter = createTRPCRouter({
           .nullable(),
       }),
     )
-    .use(skipPermissionCheck)
+    .noPermission({
+      reason: "operates on the session user's own account, no tenant scope",
+    })
     .mutation(async ({ ctx, input }) => {
       await ctx.prisma.user.update({
         where: { id: ctx.session.user.id },
@@ -998,7 +1027,7 @@ export const userRouter = createTRPCRouter({
    */
   homePagePickerState: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:view"))
+    .permission("organization:view")
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const [user, firstProject] = await Promise.all([

--- a/platform/app/src/server/api/routers/webhookEndpoints.ts
+++ b/platform/app/src/server/api/routers/webhookEndpoints.ts
@@ -24,7 +24,6 @@ import { z } from "zod";
 import type { PrismaClient } from "~/generated/prisma/client";
 import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import { WEBHOOK_DESTINATION_KINDS } from "~/utils/webhookDestinations";
-import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const orgInput = z.object({ organizationId: z.string() });
@@ -94,13 +93,13 @@ export const webhookEndpointsRouter = createTRPCRouter({
   /** The event catalog the drawer renders its checkboxes from. */
   eventTypes: protectedProcedure
     .input(orgInput)
-    .use(checkOrganizationPermission("webhookEndpoints:view"))
+    .permission("webhookEndpoints:view")
     .use(requireWebhooksPlan)
     .query(() => WEBHOOK_EVENT_TYPES),
 
   list: protectedProcedure
     .input(orgInput)
-    .use(checkOrganizationPermission("webhookEndpoints:view"))
+    .permission("webhookEndpoints:view")
     .use(requireWebhooksPlan)
     .query(({ ctx, input }) =>
       service(ctx.prisma).getAll({ organizationId: input.organizationId }),
@@ -115,7 +114,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
           .optional(),
       }),
     )
-    .use(checkOrganizationPermission("webhookEndpoints:view"))
+    .permission("webhookEndpoints:view")
     .use(requireWebhooksPlan)
     .query(({ ctx, input }) =>
       translating(() =>
@@ -140,7 +139,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
         maxInFlight: z.number().int().optional(),
       }),
     )
-    .use(checkOrganizationPermission("webhookEndpoints:manage"))
+    .permission("webhookEndpoints:manage")
     .use(requireWebhooksPlan)
     .mutation(({ ctx, input }) =>
       translating(() =>
@@ -159,7 +158,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
 
   health: protectedProcedure
     .input(endpointInput)
-    .use(checkOrganizationPermission("webhookEndpoints:view"))
+    .permission("webhookEndpoints:view")
     .use(requireWebhooksPlan)
     .query(({ ctx, input }) =>
       translating(() =>
@@ -189,7 +188,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
         maxInFlight: z.number().int().optional(),
       }),
     )
-    .use(checkOrganizationPermission("webhookEndpoints:manage"))
+    .permission("webhookEndpoints:manage")
     .use(requireWebhooksPlan)
     .mutation(({ ctx, input }) =>
       translating(() =>
@@ -209,7 +208,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
 
   rollSecret: protectedProcedure
     .input(endpointInput)
-    .use(checkOrganizationPermission("webhookEndpoints:manage"))
+    .permission("webhookEndpoints:manage")
     .use(requireWebhooksPlan)
     .mutation(({ ctx, input }) =>
       translating(() =>
@@ -222,7 +221,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
 
   enable: protectedProcedure
     .input(endpointInput)
-    .use(checkOrganizationPermission("webhookEndpoints:manage"))
+    .permission("webhookEndpoints:manage")
     .use(requireWebhooksPlan)
     .mutation(({ ctx, input }) =>
       translating(() =>
@@ -235,7 +234,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
 
   disable: protectedProcedure
     .input(endpointInput)
-    .use(checkOrganizationPermission("webhookEndpoints:manage"))
+    .permission("webhookEndpoints:manage")
     .use(requireWebhooksPlan)
     .mutation(({ ctx, input }) =>
       translating(() =>
@@ -248,7 +247,7 @@ export const webhookEndpointsRouter = createTRPCRouter({
 
   archive: protectedProcedure
     .input(endpointInput)
-    .use(checkOrganizationPermission("webhookEndpoints:manage"))
+    .permission("webhookEndpoints:manage")
     .use(requireWebhooksPlan)
     .mutation(({ ctx, input }) =>
       translating(() =>

--- a/platform/app/src/server/api/routers/workflows.ts
+++ b/platform/app/src/server/api/routers/workflows.ts
@@ -33,7 +33,7 @@ import { featureByKey } from "../../modelProviders/featureRegistry";
 import { getVercelAIModel } from "../../modelProviders/utils";
 import { autoComputeAgentMappings } from "../../workflows/auto-compute-agent-mappings";
 import { materializeNodeLlmConfigs } from "../../workflows/materializeNodeLlmConfigs";
-import { checkProjectPermission, hasProjectPermission } from "../rbac";
+import { hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const autoComputeLogger = createLogger("langwatch:workflows:auto-compute");
@@ -47,7 +47,7 @@ export const workflowRouter = createTRPCRouter({
   // UI agree on one source of truth.
   engineMode: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(() => {
       return {
         engineMode: "go" as const,
@@ -64,7 +64,7 @@ export const workflowRouter = createTRPCRouter({
         publish: z.boolean().optional(), // Auto-publish the first version (useful for evaluator workflows)
       }),
     )
-    .use(checkProjectPermission("workflows:create"))
+    .permission("workflows:create")
     .mutation(async ({ ctx, input }) => {
       const workflow = await ctx.prisma.workflow.create({
         data: {
@@ -127,7 +127,7 @@ export const workflowRouter = createTRPCRouter({
         copyDatasets: z.boolean().optional(),
       }),
     )
-    .use(checkProjectPermission("workflows:create"))
+    .permission("workflows:create")
     .mutation(async ({ ctx, input }) => {
       // Check that the user has at least workflows:create permission on the source project
       const hasSourcePermission = await hasProjectPermission(
@@ -199,7 +199,7 @@ export const workflowRouter = createTRPCRouter({
     }),
   getAll: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       const workflows = await ctx.prisma.workflow.findMany({
         where: { projectId: input.projectId, archivedAt: null },
@@ -300,7 +300,7 @@ export const workflowRouter = createTRPCRouter({
         workflowId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       // Find the workflow by ID and projectId (Prisma requires projectId in where clause)
       const workflow = await ctx.prisma.workflow.findFirst({
@@ -418,7 +418,7 @@ export const workflowRouter = createTRPCRouter({
 
   getById: protectedProcedure
     .input(z.object({ projectId: z.string(), workflowId: z.string() }))
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       const workflow = await ctx.prisma.workflow.findUnique({
         where: {
@@ -463,7 +463,7 @@ export const workflowRouter = createTRPCRouter({
           .optional(),
       }),
     )
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       const workflow = await ctx.prisma.workflow.findUnique({
         where: {
@@ -562,7 +562,7 @@ export const workflowRouter = createTRPCRouter({
 
   restoreVersion: protectedProcedure
     .input(z.object({ projectId: z.string(), versionId: z.string() }))
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const version = await ctx.prisma.workflowVersion.findUnique({
         where: { id: input.versionId, projectId: input.projectId },
@@ -610,7 +610,7 @@ export const workflowRouter = createTRPCRouter({
         setAsLatestVersion: z.boolean(),
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const updatedVersion = await saveOrCommitWorkflowVersion({
         ctx,
@@ -632,7 +632,7 @@ export const workflowRouter = createTRPCRouter({
         dsl: workflowJsonSchema,
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const newVersion = await saveOrCommitWorkflowVersion({
         ctx,
@@ -652,7 +652,7 @@ export const workflowRouter = createTRPCRouter({
         versionId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       const version = await ctx.prisma.workflowVersion.findUnique({
         where: {
@@ -680,7 +680,7 @@ export const workflowRouter = createTRPCRouter({
 
   unpublish: protectedProcedure
     .input(z.object({ projectId: z.string(), workflowId: z.string() }))
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.workflow.update({
         where: { id: input.workflowId, projectId: input.projectId },
@@ -698,7 +698,7 @@ export const workflowRouter = createTRPCRouter({
         workflowId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       // Get the workflow and check if it has a source
       const workflow = await ctx.prisma.workflow.findUnique({
@@ -802,7 +802,7 @@ export const workflowRouter = createTRPCRouter({
         copyIds: z.array(z.string()).optional(), // Optional: if provided, only push to selected copies
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ ctx, input }) => {
       // Get the workflow (source) and check if it has copies
       const workflow = await ctx.prisma.workflow.findUnique({
@@ -950,7 +950,7 @@ export const workflowRouter = createTRPCRouter({
         workflowId: z.string(),
       }),
     )
-    .use(checkProjectPermission("workflows:view"))
+    .permission("workflows:view")
     .query(async ({ ctx, input }) => {
       // Find evaluators linked to this workflow
       const evaluators = await ctx.prisma.evaluator.findMany({
@@ -1002,7 +1002,7 @@ export const workflowRouter = createTRPCRouter({
         unarchive: z.boolean().optional(),
       }),
     )
-    .use(checkProjectPermission("workflows:delete"))
+    .permission("workflows:delete")
     .mutation(async ({ ctx, input }) => {
       const now = input.unarchive ? null : new Date();
 
@@ -1070,7 +1070,7 @@ export const workflowRouter = createTRPCRouter({
         unarchive: z.boolean().optional(),
       }),
     )
-    .use(checkProjectPermission("workflows:delete"))
+    .permission("workflows:delete")
     .mutation(async ({ ctx, input }) => {
       return ctx.prisma.workflow.update({
         where: { id: input.workflowId, projectId: input.projectId },
@@ -1088,7 +1088,7 @@ export const workflowRouter = createTRPCRouter({
         newDsl: workflowJsonSchema,
       }),
     )
-    .use(checkProjectPermission("workflows:update"))
+    .permission("workflows:update")
     .mutation(async ({ input }) => {
       const prevDsl_ = JSON.stringify(
         recursiveAlphabeticallySortedKeys(clearDsl(input.prevDsl)),

--- a/platform/app/src/server/api/security/access-policy.ts
+++ b/platform/app/src/server/api/security/access-policy.ts
@@ -1,4 +1,4 @@
-import type { Permission } from "~/server/api/rbac";
+import type { AuthzPermission } from "@langwatch/authz";
 
 /**
  * The access decision for a single HTTP route. Every route mounted through the
@@ -31,11 +31,11 @@ import type { Permission } from "~/server/api/rbac";
  *                        cron, gateway-internal, webhooks). Reason mandatory.
  */
 export type AccessPolicy =
-  | { readonly kind: "permission"; readonly permission: Permission }
-  | { readonly kind: "apiKeyPermission"; readonly permission: Permission }
+  | { readonly kind: "permission"; readonly permission: AuthzPermission }
+  | { readonly kind: "apiKeyPermission"; readonly permission: AuthzPermission }
   | {
       readonly kind: "projectPermission";
-      readonly permission: Permission;
+      readonly permission: AuthzPermission;
       /** Route param naming the project. Defaults to `id`. */
       readonly param: string;
     }
@@ -50,7 +50,7 @@ export type AccessPolicy =
        * gates on something that is not an RBAC permission. Mandatory — see
        * `handlerManagedAuth` for why the optional version was a defect.
        */
-      readonly permissions: readonly Permission[];
+      readonly permissions: readonly AuthzPermission[];
       /**
        * What kind of credential reaches this route:
        *
@@ -175,7 +175,9 @@ function handlerManagedCredentialClass({
  * resolves it against the caller's role bindings (project scope) or org role
  * bindings (org scope), exactly like the tRPC `checkProjectPermission` path.
  */
-export function requires(permission: Permission): AccessPolicy {
+export function requires<P extends AuthzPermission>(
+  permission: P,
+): { readonly kind: "permission"; readonly permission: P } {
   return { kind: "permission", permission };
 }
 
@@ -187,7 +189,9 @@ export function requires(permission: Permission): AccessPolicy {
  * equivalent of `requires(...)`, kept distinct so the registry records that
  * the gate is the API-key ceiling rather than a strict role check.
  */
-export function apiKeyPermission(permission: Permission): AccessPolicy {
+export function apiKeyPermission<P extends AuthzPermission>(
+  permission: P,
+): { readonly kind: "apiKeyPermission"; readonly permission: P } {
   return { kind: "apiKeyPermission", permission };
 }
 
@@ -197,10 +201,14 @@ export function apiKeyPermission(permission: Permission): AccessPolicy {
  * resolve at organization scope there, so a single org-wide grant would reach
  * every project in the org.
  */
-export function requiresOnProject(
-  permission: Permission,
+export function requiresOnProject<P extends AuthzPermission>(
+  permission: P,
   options: { param?: string } = {},
-): AccessPolicy {
+): {
+  readonly kind: "projectPermission";
+  readonly permission: P;
+  readonly param: string;
+} {
   return {
     kind: "projectPermission",
     permission,
@@ -213,7 +221,7 @@ export function requiresOnProject(
  * is checked. Reserve for routes whose handler performs no privileged action
  * beyond what authentication already proves (e.g. "whoami").
  */
-export function anyAuthenticated(): AccessPolicy {
+export function anyAuthenticated(): { readonly kind: "anyAuthenticated" } {
   return { kind: "anyAuthenticated" };
 }
 
@@ -222,7 +230,10 @@ export function anyAuthenticated(): AccessPolicy {
  * it is the reviewable justification that this route is safe to expose without
  * credentials.
  */
-export function publicEndpoint(reason: string): AccessPolicy {
+export function publicEndpoint(reason: string): {
+  readonly kind: "public";
+  readonly reason: string;
+} {
   assertReason(reason, "publicEndpoint");
   return { kind: "public", reason };
 }
@@ -231,7 +242,10 @@ export function publicEndpoint(reason: string): AccessPolicy {
  * Service-to-service route authenticated by a shared secret or signature, not
  * an RBAC credential. `reason` is mandatory.
  */
-export function internalSecret(reason: string): AccessPolicy {
+export function internalSecret(reason: string): {
+  readonly kind: "internal";
+  readonly reason: string;
+} {
   assertReason(reason, "internalSecret");
   return { kind: "internal", reason };
 }
@@ -265,8 +279,8 @@ export function handlerManagedAuth({
    * was an absence, and absence is what let `POST /api/experiments/:slug/run`
    * sit on a grain no least-privilege key could hold.
    */
-  permissions: readonly Permission[];
-}): AccessPolicy {
+  permissions: readonly AuthzPermission[];
+}): Extract<AccessPolicy, { kind: "handlerManaged" }> {
   assertReason(reason, "handlerManagedAuth");
   return { kind: "handlerManaged", reason, permissions, credential };
 }
@@ -291,7 +305,9 @@ export function isApiKeyReachable(policy: AccessPolicy): boolean {
  * should ask "what does this route actually demand?", so a new policy kind
  * cannot quietly drop out of the answer.
  */
-export function policyPermissions(policy: AccessPolicy): readonly Permission[] {
+export function policyPermissions(
+  policy: AccessPolicy,
+): readonly AuthzPermission[] {
   switch (policy.kind) {
     case "permission":
     case "apiKeyPermission":

--- a/platform/app/src/server/api/security/secured-app.ts
+++ b/platform/app/src/server/api/security/secured-app.ts
@@ -1,6 +1,7 @@
 import { type Env, Hono, type MiddlewareHandler } from "hono";
 import { mergePath } from "hono/utils/url";
 
+import { appContextMiddleware } from "~/app/api/middleware/app-context";
 import {
   type AuthMiddlewareVariables,
   authMiddleware,
@@ -22,7 +23,6 @@ import {
   canonicalErrorResponse,
 } from "~/app/api/shared/canonical-error";
 import { requireApiKeyPermission } from "~/server/api-key/auth-middleware";
-import { prisma } from "~/server/db";
 
 import {
   type AccessPolicy,
@@ -143,6 +143,7 @@ export class SecuredApp<E extends Env> {
     this.hono = new Hono<E>().basePath(args.basePath);
     this.hono.use(tracerMiddleware({ name: this.family }));
     this.hono.use(loggerMiddleware());
+    this.hono.use(appContextMiddleware);
     // One shape per family, whichever layer refuses. A family can still
     // install its own onError to name its domain errors more precisely.
     this.hono.onError(
@@ -268,7 +269,6 @@ const projectStrategy: AuthStrategy = {
         return [
           auth,
           requireApiKeyPermission({
-            prisma,
             permission: policy.permission,
             errorEnvelope,
           }),

--- a/platform/app/src/server/api/trpc.ts
+++ b/platform/app/src/server/api/trpc.ts
@@ -37,7 +37,14 @@ interface CreateNextContextOptions {
 }
 
 import { auditLog } from "@ee/audit-log/auditLog";
-import type { AuthzPermission } from "@langwatch/authz";
+import type {
+  AuthzPermission,
+  NoPermissionOptions,
+  PermissionDeclarationError,
+  ScopeTierField,
+  ValidatePermissionForInput,
+  ViaFieldFor,
+} from "@langwatch/authz";
 import {
   HandledError,
   isZodLikeError,
@@ -56,7 +63,12 @@ import { ModelProviderDisabledError } from "~/server/modelProviders/modelProvide
 import { createWarnThrottle } from "~/server/observability/warnThrottle";
 import type { NextApiRequest, NextApiResponse } from "~/types/next-stubs";
 import { captureException, toError } from "../../utils/posthogErrorCapture";
-import { checkPermissionV2 } from "../app-layer/authz/trpc-middleware";
+import {
+  checkDeclaredPermission,
+  checkDeclaredPermissionAny,
+  declaredNoPermission,
+  declaredServiceAuthorization,
+} from "../app-layer/authz/trpc-middleware";
 import type { OpsScope, PermissionMiddleware } from "./rbac";
 
 const logger = createLogger("langwatch:trpc");
@@ -1211,13 +1223,92 @@ interface PendingPermissionProcedureBuilder<
     TCaller
   >;
   /**
-   * ADR-092 §5 sugar: declare the required permission and let the engine
-   * extract the scope (projectId / teamId / organizationId) from the
-   * validated input. New procedures prefer this over `.use(checkXxx…)`.
+   * ADR-092 delivery-plan decision 25: declare the required permission,
+   * typed against the validated input the check reads its scope id from.
+   * The permission's registry tiers decide which of `projectId` / `teamId` /
+   * `organizationId` the input must carry — a missing id, or an id from a
+   * tier the permission cannot be granted at, is a compile error naming the
+   * problem. The most specific allowed tier present decides the check scope.
    */
-  permission: (
-    permission: AuthzPermission,
-  ) => ProcedureBuilder<
+  permission<P extends AuthzPermission>(
+    permission: P & ValidateDeclaredPermission<P, TInputOut>,
+  ): ProcedureBuilder<
+    TContext,
+    TMeta,
+    TContextOverrides,
+    TInputIn,
+    TInputOut,
+    TOutputIn,
+    TOutputOut,
+    TCaller
+  >;
+  /**
+   * The derivation form, for a permission whose tier the input does not name
+   * directly: `.permission("organization:manage", { via: "teamId" })` checks
+   * the organization the input's team belongs to. `via` must name a required
+   * input field whose tier can derive one the permission is grantable at —
+   * the derivation is written at the call site, never inferred.
+   */
+  permission<P extends AuthzPermission>(
+    permission: P,
+    options: { via: ViaFieldFor<P, TInputOut> },
+  ): ProcedureBuilder<
+    TContext,
+    TMeta,
+    TContextOverrides,
+    TInputIn,
+    TInputOut,
+    TOutputIn,
+    TOutputOut,
+    TCaller
+  >;
+  /**
+   * Any one of the permissions is enough, checked at the input's project
+   * scope. List the primary surface's permission first — the denial names
+   * it, so granting it resolves the refusal whichever feature the caller
+   * came through.
+   */
+  permissionAny<Ps extends readonly [AuthzPermission, ...AuthzPermission[]]>(
+    ...permissions: PermissionAnyArgs<Ps, TInputOut>
+  ): ProcedureBuilder<
+    TContext,
+    TMeta,
+    TContextOverrides,
+    TInputIn,
+    TInputOut,
+    TOutputIn,
+    TOutputOut,
+    TCaller
+  >;
+  /**
+   * Authenticated, deliberately unchecked — for procedures that read no
+   * organization-, team-, or project-scoped data. Requires a written reason,
+   * and every scope id the input carries must be individually allowed with
+   * one: the legacy `skipPermissionCheck` runtime guard, moved to compile
+   * time.
+   */
+  noPermission(
+    options: DeclaredNoPermissionOptions<TInputOut>,
+  ): ProcedureBuilder<
+    TContext,
+    TMeta,
+    TContextOverrides,
+    TInputIn,
+    TInputOut,
+    TOutputIn,
+    TOutputOut,
+    TCaller
+  >;
+  /**
+   * The scope is data the handler loads at runtime (a row's own scope set),
+   * so the SERVICE performs the real authorization. The declaration records
+   * why, and which permissions the service enforces — this only moves WHERE
+   * the check happens, never whether one does.
+   */
+  authorizeInService(options: {
+    reason: string;
+    permissions: readonly AuthzPermission[];
+  }): ProcedureBuilder<
     TContext,
     TMeta,
     TContextOverrides,
@@ -1228,6 +1319,39 @@ interface PendingPermissionProcedureBuilder<
     TCaller
   >;
 }
+
+/**
+ * `.permission()` reads its scope id from the validated input, so an input
+ * must be declared first — `UnsetMarker` is tRPC's "no .input() yet".
+ */
+type ValidateDeclaredPermission<
+  P extends AuthzPermission,
+  I,
+> = UnsetMarker extends I
+  ? PermissionDeclarationError<"declare .input() before .permission() — the check reads its scope id from the validated input">
+  : ValidatePermissionForInput<P, I>;
+
+type PermissionAnyArgs<
+  Ps extends readonly [AuthzPermission, ...AuthzPermission[]],
+  I,
+> = UnsetMarker extends I
+  ? [
+      AuthzPermission &
+        PermissionDeclarationError<"declare .input() before .permissionAny() — the check reads its projectId from the validated input">,
+    ]
+  : I extends { projectId: string }
+    ? {
+        [K in keyof Ps]: Ps[K] &
+          ValidatePermissionForInput<Ps[K] & AuthzPermission, I>;
+      }
+    : [
+        AuthzPermission &
+          PermissionDeclarationError<".permissionAny() checks at the project scope and needs a required 'projectId' in the input">,
+      ];
+
+type DeclaredNoPermissionOptions<I> = UnsetMarker extends I
+  ? { reason: string; allow?: undefined }
+  : NoPermissionOptions<I>;
 
 const permissionProcedureBuilder = <
   TContext,
@@ -1289,8 +1413,53 @@ const permissionProcedureBuilder = <
       TCaller
     >["input"],
     use: (middleware) => withPermissionCheck(middleware),
-    permission: (permission) =>
-      withPermissionCheck(checkPermissionV2(permission)),
+    permission: ((
+      permission: AuthzPermission,
+      options?: { via?: ScopeTierField },
+    ) =>
+      withPermissionCheck(
+        checkDeclaredPermission({ permission, via: options?.via }),
+      )) as PendingPermissionProcedureBuilder<
+      TContext,
+      TMeta,
+      TContextOverrides,
+      TInputIn,
+      TInputOut,
+      TOutputIn,
+      TOutputOut,
+      TCaller
+    >["permission"],
+    permissionAny: ((...permissions: [AuthzPermission, ...AuthzPermission[]]) =>
+      withPermissionCheck(
+        checkDeclaredPermissionAny(permissions),
+      )) as PendingPermissionProcedureBuilder<
+      TContext,
+      TMeta,
+      TContextOverrides,
+      TInputIn,
+      TInputOut,
+      TOutputIn,
+      TOutputOut,
+      TCaller
+    >["permissionAny"],
+    noPermission: ((options: {
+      reason: string;
+      allow?: Record<string, string>;
+    }) =>
+      withPermissionCheck(
+        declaredNoPermission(options),
+      )) as PendingPermissionProcedureBuilder<
+      TContext,
+      TMeta,
+      TContextOverrides,
+      TInputIn,
+      TInputOut,
+      TOutputIn,
+      TOutputOut,
+      TCaller
+    >["noPermission"],
+    authorizeInService: (options) =>
+      withPermissionCheck(declaredServiceAuthorization(options)),
   };
 };
 

--- a/platform/app/src/server/api/trpc.ts
+++ b/platform/app/src/server/api/trpc.ts
@@ -54,6 +54,7 @@ import { createLogger } from "@langwatch/observability";
 import { getLogLevelFromStatusCode } from "@langwatch/observability/request";
 import superjson from "superjson";
 import type { OrganizationUserRole } from "~/generated/prisma/client";
+import { type App, getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
@@ -85,6 +86,13 @@ interface CreateContextOptions {
   req?: NextApiRequest;
   res?: NextApiResponse;
   session: Session | null;
+  /**
+   * The composed App this request decides through. The request path passes
+   * `getApp()`; a test can inject a fake here instead of mocking the App
+   * module. Left unset, App-reading middleware falls back to the process
+   * singleton.
+   */
+  app?: App;
   permissionChecked?: boolean;
   publiclyShared?: boolean;
   organizationRole?: OrganizationUserRole | null;
@@ -115,6 +123,7 @@ export const createInnerTRPCContext = (opts: CreateContextOptions) => {
     req: opts.req,
     res: opts.res,
     prisma,
+    app: opts.app,
     permissionChecked: opts.permissionChecked ?? false,
     publiclyShared: opts.publiclyShared ?? false,
     organizationRole: opts.organizationRole ?? undefined,
@@ -139,6 +148,7 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
     req,
     res,
     session,
+    app: getApp(),
     permissionChecked: false,
     publiclyShared: false,
   });

--- a/platform/app/src/server/api/utils.ts
+++ b/platform/app/src/server/api/utils.ts
@@ -6,6 +6,7 @@ import {
   TeamUserRole,
 } from "~/generated/prisma/client";
 import { getApp } from "~/server/app-layer/app";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { VisibilityWindowService } from "~/server/app-layer/traces/visibility-window.service";
 import type { Session } from "~/server/auth";
 import {
@@ -28,7 +29,7 @@ import { resolveOrganizationId } from "~/server/organizations/resolveOrganizatio
 import { TtlCache } from "~/server/utils/ttlCache";
 import { FREE_VISIBILITY_DAYS } from "../../../ee/licensing/constants";
 import type { CategoryVisibility, Protections } from "../traces/protections";
-import { hasProjectPermission, isDemoProject } from "./rbac";
+import { isDemoProject } from "./rbac";
 
 const logger = createLogger("langwatch:api:protections");
 

--- a/platform/app/src/server/app-layer/app.ts
+++ b/platform/app/src/server/app-layer/app.ts
@@ -90,6 +90,7 @@ export class App {
   readonly emailSuppressions: AppDependencies["emailSuppressions"];
   readonly organizations: AppDependencies["organizations"];
   readonly projects: AppDependencies["projects"];
+  readonly permissions: AppDependencies["permissions"];
   readonly tokenizer: AppDependencies["tokenizer"];
   readonly usage: AppDependencies["usage"];
   readonly planProvider: AppDependencies["planProvider"];
@@ -124,6 +125,7 @@ export class App {
     this.emailSuppressions = deps.emailSuppressions;
     this.organizations = deps.organizations;
     this.projects = deps.projects;
+    this.permissions = deps.permissions;
     this.tokenizer = deps.tokenizer;
     this.usage = deps.usage;
     this.planProvider = deps.planProvider;

--- a/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
@@ -1,9 +1,11 @@
 /** @vitest-environment node */
 
 /**
- * The tRPC adapter's own behaviour: which id becomes the scope, what an
- * unauthenticated or miswired call gets, and the SHAPE of a refusal. The
- * engine's verdicts are @langwatch/authz's business and are stubbed here.
+ * The declared seam's own behaviour: which input id becomes the check scope
+ * (the registry decides, not blind precedence), what an unauthenticated or
+ * miswired call gets, and the SHAPE of a refusal. The fork-aware resolvers
+ * are `rbac.ts`'s business and are stubbed here — decision-neutrality against
+ * them is their own suite's job.
  *
  * The refusal shape is the sharp part. An unknown id and a denied id have to
  * come out identical: when the unknown branch answered with a bare
@@ -12,40 +14,45 @@
  * named.
  */
 import { PermissionDeniedError } from "@langwatch/authz";
-import { HandledError } from "@langwatch/handled-error";
-import { TRPCError } from "@trpc/server";
+import type { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LiteMemberRestrictedError } from "~/server/app-layer/permissions/errors";
 
-const checkDetailed = vi.fn();
-const resolveScopeRef = vi.fn();
+const resolveProjectPermission = vi.fn();
+const resolveTeamPermission = vi.fn();
+const hasOrganizationPermission = vi.fn();
+const resolveProjectPermissionAny = vi.fn();
 
-vi.mock("~/server/app-layer/authz/runtime", () => ({
-  authz: {
-    checkDetailed: (...args: unknown[]) => checkDetailed(...args),
-  },
-  authzCollector: {
-    resolveScopeRef: (...args: unknown[]) => resolveScopeRef(...args),
-  },
+vi.mock("~/server/api/rbac", () => ({
+  resolveProjectPermission: (...args: unknown[]) =>
+    resolveProjectPermission(...args),
+  resolveTeamPermission: (...args: unknown[]) => resolveTeamPermission(...args),
+  hasOrganizationPermission: (...args: unknown[]) =>
+    hasOrganizationPermission(...args),
+  resolveProjectPermissionAny: (...args: unknown[]) =>
+    resolveProjectPermissionAny(...args),
 }));
 
-const { checkPermissionV2 } = await import("../trpc-middleware");
-
-const PROJECT_SCOPE = {
-  type: "project" as const,
-  id: "proj-1",
-  teamId: "team-1",
-  organizationId: "org-1",
-};
+const {
+  checkDeclaredPermission,
+  checkDeclaredPermissionAny,
+  declaredNoPermission,
+  declaredServiceAuthorization,
+} = await import("../trpc-middleware");
+const { authzDeclarationOf } = await import("../declared-middleware");
 
 const session = { user: { id: "alice" } };
 
-const paramsFor = (input: Record<string, string | undefined>) => ({
+const paramsFor = (
+  input: Record<string, string | undefined>,
+  { authed = true }: { authed?: boolean } = {},
+) => ({
   ctx: {
-    session: session as any,
+    prisma: {} as any,
+    session: (authed ? session : null) as any,
     permissionChecked: false,
-    organizationRole: undefined as "ADMIN" | "MEMBER" | "EXTERNAL" | undefined,
+    organizationRole: undefined as any,
   },
   input,
   next: vi.fn().mockReturnValue("next-called"),
@@ -63,175 +70,239 @@ const rejection = async (run: () => Promise<unknown>): Promise<TRPCError> => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  resolveScopeRef.mockResolvedValue(PROJECT_SCOPE);
-  checkDetailed.mockResolvedValue({
-    decision: { allowed: true },
-    grants: { organizationRole: "MEMBER" },
+  resolveProjectPermission.mockResolvedValue({
+    permitted: true,
+    organizationRole: "MEMBER",
+  });
+  resolveTeamPermission.mockResolvedValue({
+    permitted: true,
+    organizationRole: "MEMBER",
+  });
+  hasOrganizationPermission.mockResolvedValue(true);
+  resolveProjectPermissionAny.mockResolvedValue({
+    permitted: true,
+    organizationRole: "MEMBER",
   });
 });
 
-describe("checkPermissionV2", () => {
+describe("checkDeclaredPermission", () => {
   describe("given input carrying every scope id", () => {
-    it("checks the most specific one, projectId first", async () => {
+    /** @scenario "The most specific tier the permission allows decides the check scope" */
+    it("checks the most specific tier the permission is grantable at", async () => {
       const params = paramsFor({
         projectId: "proj-1",
         teamId: "team-1",
         organizationId: "org-1",
       });
-
-      await checkPermissionV2("prompts:update")(params);
-
-      expect(resolveScopeRef).toHaveBeenCalledWith({
-        projectId: "proj-1",
-        teamId: undefined,
-        organizationId: undefined,
-      });
-    });
-  });
-
-  describe("given input carrying a team and an organization", () => {
-    it("checks the team, the more specific of the two", async () => {
-      resolveScopeRef.mockResolvedValue({
-        type: "team",
-        id: "team-1",
-        organizationId: "org-1",
-      });
-
-      await checkPermissionV2("prompts:update")(
-        paramsFor({ teamId: "team-1", organizationId: "org-1" }),
+      await checkDeclaredPermission({ permission: "traces:view" })(
+        params as any,
       );
-
-      expect(resolveScopeRef).toHaveBeenCalledWith({
-        projectId: undefined,
-        teamId: "team-1",
-        organizationId: undefined,
-      });
-    });
-  });
-
-  describe("given input carrying only an organization", () => {
-    it("checks the organization", async () => {
-      resolveScopeRef.mockResolvedValue({ type: "organization", id: "org-1" });
-
-      await checkPermissionV2("organization:manage")(
-        paramsFor({ organizationId: "org-1" }),
+      expect(resolveProjectPermission).toHaveBeenCalledWith(
+        params.ctx,
+        "proj-1",
+        "traces:view",
       );
-
-      expect(resolveScopeRef).toHaveBeenCalledWith({
-        projectId: undefined,
-        teamId: undefined,
-        organizationId: "org-1",
-      });
-    });
-  });
-
-  describe("given no session", () => {
-    it("refuses as unauthenticated before any id is looked at", async () => {
-      const params = paramsFor({ projectId: "proj-1" });
-      params.ctx.session = null as any;
-
-      const error = await rejection(() =>
-        checkPermissionV2("prompts:update")(params),
-      );
-
-      expect(error).toBeInstanceOf(TRPCError);
-      expect(error.code).toBe("UNAUTHORIZED");
-      expect(resolveScopeRef).not.toHaveBeenCalled();
-      expect(params.next).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("given a procedure whose input carries no scope id at all", () => {
-    it("fails as a wiring bug, with copy that promises the caller nothing", async () => {
-      resolveScopeRef.mockResolvedValue(null);
-
-      const error = await rejection(() =>
-        checkPermissionV2("prompts:update")(paramsFor({})),
-      );
-
-      expect(error.code).toBe("INTERNAL_SERVER_ERROR");
-      // The permission name and the miswiring go to the log, not to the user.
-      expect(error.message).not.toContain("prompts:update");
-      expect(error.cause).toBeUndefined();
-    });
-  });
-
-  describe("given an id the engine cannot resolve", () => {
-    it("denies exactly as an engine denial does, leaking no existence", async () => {
-      resolveScopeRef.mockResolvedValue(null);
-      const params = paramsFor({ projectId: "ghost" });
-
-      const unknown = await rejection(() =>
-        checkPermissionV2("prompts:update")(params),
-      );
-
-      checkDetailed.mockResolvedValue({
-        decision: { allowed: false, denialReason: "no-binding" },
-        grants: { organizationRole: "MEMBER" },
-      });
-      resolveScopeRef.mockResolvedValue(PROJECT_SCOPE);
-      const denied = await rejection(() =>
-        checkPermissionV2("prompts:update")(paramsFor({ projectId: "proj-1" })),
-      );
-
-      for (const error of [unknown, denied]) {
-        expect(error.code).toBe("UNAUTHORIZED");
-        expect(error.cause).toBeInstanceOf(PermissionDeniedError);
-        expect(HandledError.isHandled(error.cause)).toBe(true);
-        expect((error.cause as HandledError).code).toBe("permission_denied");
-      }
-      expect(unknown.message).toBe(denied.message);
-      expect(params.next).not.toHaveBeenCalled();
-    });
-
-    it("names the tier the caller asked for, so the denial is about that scope", async () => {
-      resolveScopeRef.mockResolvedValue(null);
-
-      const error = await rejection(() =>
-        checkPermissionV2("team:manage")(paramsFor({ teamId: "ghost-team" })),
-      );
-
-      expect((error.cause as HandledError).meta).toMatchObject({
-        scopeType: "team",
-        denialReason: "no-membership",
-      });
-    });
-  });
-
-  describe("given the engine denies a lite member", () => {
-    it("carries the restriction cause the client's modal keys on", async () => {
-      checkDetailed.mockResolvedValue({
-        decision: { allowed: false, denialReason: "lite-member-restricted" },
-        grants: { organizationRole: "EXTERNAL" },
-      });
-
-      const error = await rejection(() =>
-        checkPermissionV2("prompts:update")(paramsFor({ projectId: "proj-1" })),
-      );
-
-      expect(error.cause).toBeInstanceOf(LiteMemberRestrictedError);
-      expect((error.cause as HandledError).code).toBe("lite_member_restricted");
-      expect((error.cause as HandledError).meta).toMatchObject({
-        resource: "prompts",
-      });
-    });
-  });
-
-  describe("given the engine allows the check", () => {
-    it("hands the organization role to the context and records that a check ran", async () => {
-      const params = paramsFor({ projectId: "proj-1" });
-
-      const result = await checkPermissionV2("prompts:update")(params);
-
-      expect(checkDetailed).toHaveBeenCalledWith({
-        principal: { type: "user", id: "alice" },
-        permission: "prompts:update",
-        scope: PROJECT_SCOPE,
-      });
-      expect(params.ctx.organizationRole).toBe("MEMBER");
+      expect(resolveTeamPermission).not.toHaveBeenCalled();
+      expect(hasOrganizationPermission).not.toHaveBeenCalled();
       expect(params.ctx.permissionChecked).toBe(true);
-      expect(params.next).toHaveBeenCalledTimes(1);
-      expect(result).toBe("next-called");
+      expect(params.ctx.organizationRole).toBe("MEMBER");
+    });
+
+    it("skips tiers an organization-only permission cannot be granted at", async () => {
+      const params = paramsFor({
+        projectId: "proj-1",
+        organizationId: "org-1",
+      });
+      await checkDeclaredPermission({ permission: "organization:manage" })(
+        params as any,
+      );
+      expect(hasOrganizationPermission).toHaveBeenCalledWith(
+        params.ctx,
+        "org-1",
+        "organization:manage",
+      );
+      expect(resolveProjectPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a via derivation", () => {
+    /** @scenario "A scope derivation is written at the call site, never inferred" */
+    it("checks at the named field's own tier", async () => {
+      const params = paramsFor({ teamId: "team-1" });
+      await checkDeclaredPermission({
+        permission: "organization:manage",
+        via: "teamId",
+      })(params as any);
+      expect(resolveTeamPermission).toHaveBeenCalledWith(
+        params.ctx,
+        "team-1",
+        "organization:manage",
+      );
+      expect(hasOrganizationPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the caller is unauthenticated", () => {
+    it("answers UNAUTHORIZED before reading any id", async () => {
+      const params = paramsFor({ projectId: "proj-1" }, { authed: false });
+      const error = await rejection(() =>
+        checkDeclaredPermission({ permission: "traces:view" })(params as any),
+      );
+      expect(error.code).toBe("UNAUTHORIZED");
+      expect(resolveProjectPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the input carries no usable id", () => {
+    /** @scenario "Declaring a permission with no usable scope id in the input fails to compile" */
+    it("fails loudly as a wiring bug, not a denial", async () => {
+      const error = await rejection(() =>
+        checkDeclaredPermission({ permission: "traces:view" })(
+          paramsFor({}) as any,
+        ),
+      );
+      expect(error.code).toBe("INTERNAL_SERVER_ERROR");
+    });
+  });
+
+  describe("when the resolver denies", () => {
+    /** @scenario "A denial carries a stable code the client can present" */
+    it("refuses with the one handled code, permission and tier in meta", async () => {
+      resolveProjectPermission.mockResolvedValue({
+        permitted: false,
+        organizationRole: "MEMBER",
+      });
+      const error = await rejection(() =>
+        checkDeclaredPermission({ permission: "traces:view" })(
+          paramsFor({ projectId: "proj-1" }) as any,
+        ),
+      );
+      expect(error.cause).toBeInstanceOf(PermissionDeniedError);
+      const cause = error.cause as PermissionDeniedError;
+      expect(cause.code).toBe("permission_denied");
+      expect(cause.meta).toMatchObject({
+        permission: "traces:view",
+        scopeType: "project",
+      });
+    });
+
+    /** @scenario "A scope id that resolves to nothing is denied like one the caller may not touch" */
+    it("answers an unknown id identically to a denied one", async () => {
+      resolveProjectPermission.mockResolvedValue({
+        permitted: false,
+        organizationRole: null,
+      });
+      const denied = await rejection(() =>
+        checkDeclaredPermission({ permission: "traces:view" })(
+          paramsFor({ projectId: "does-not-exist" }) as any,
+        ),
+      );
+      expect((denied.cause as PermissionDeniedError).code).toBe(
+        "permission_denied",
+      );
+      expect(denied.message).not.toContain("does-not-exist");
+    });
+
+    /** @scenario "A lite member's denial is distinguishable from a missing grant" */
+    it("carries the lite-member restriction for an EXTERNAL caller", async () => {
+      resolveTeamPermission.mockResolvedValue({
+        permitted: false,
+        organizationRole: "EXTERNAL",
+      });
+      const error = await rejection(() =>
+        checkDeclaredPermission({ permission: "team:manage" })(
+          paramsFor({ teamId: "team-1" }) as any,
+        ),
+      );
+      expect(error.cause).toBeInstanceOf(LiteMemberRestrictedError);
+    });
+
+    it("denies at the organization tier without a lite-member special case", async () => {
+      hasOrganizationPermission.mockResolvedValue(false);
+      const error = await rejection(() =>
+        checkDeclaredPermission({ permission: "organization:manage" })(
+          paramsFor({ organizationId: "org-1" }) as any,
+        ),
+      );
+      expect((error.cause as PermissionDeniedError).code).toBe(
+        "permission_denied",
+      );
+    });
+  });
+});
+
+describe("checkDeclaredPermissionAny", () => {
+  /** @scenario "Any one of several declared permissions is enough" */
+  it("permits on the resolver's any-of answer and names the first permission when denied", async () => {
+    const params = paramsFor({ projectId: "proj-1" });
+    await checkDeclaredPermissionAny(["traces:view", "scenarios:view"])(
+      params as any,
+    );
+    expect(resolveProjectPermissionAny).toHaveBeenCalledWith(
+      params.ctx,
+      "proj-1",
+      ["traces:view", "scenarios:view"],
+    );
+    expect(params.ctx.permissionChecked).toBe(true);
+
+    resolveProjectPermissionAny.mockResolvedValue({
+      permitted: false,
+      organizationRole: "MEMBER",
+    });
+    const error = await rejection(() =>
+      checkDeclaredPermissionAny(["traces:view", "scenarios:view"])(
+        paramsFor({ projectId: "proj-1" }) as any,
+      ),
+    );
+    expect((error.cause as PermissionDeniedError).meta).toMatchObject({
+      permission: "traces:view",
+    });
+  });
+});
+
+describe("declaredNoPermission", () => {
+  /** @scenario "Opting out of permission checks requires a written reason" */
+  it("runs for any authenticated caller and records its reason", async () => {
+    const middleware = declaredNoPermission({
+      reason: "user-scoped preferences only",
+    });
+    const params = paramsFor({});
+    await middleware(params as any);
+    expect(params.ctx.permissionChecked).toBe(true);
+    expect(authzDeclarationOf(middleware)).toMatchObject({
+      kind: "no-permission",
+      reason: "user-scoped preferences only",
+    });
+  });
+
+  /** @scenario "An opted-out procedure cannot silently read scoped input" */
+  it("still refuses an unallowed scope id at runtime, defense in depth", async () => {
+    const middleware = declaredNoPermission({ reason: "nothing scoped" });
+    await expect(
+      middleware(paramsFor({ projectId: "proj-1" }) as any),
+    ).rejects.toThrow("projectId is not allowed");
+    await expect(
+      declaredNoPermission({
+        reason: "creation flow",
+        allow: { organizationId: "creating inside this organization" },
+      })(paramsFor({ organizationId: "org-1" }) as any),
+    ).resolves.toBe("next-called");
+  });
+});
+
+describe("declaredServiceAuthorization", () => {
+  /** @scenario "A service-authorized procedure declares the permissions its service enforces" */
+  it("marks the check as deferred and names the enforced permissions", async () => {
+    const middleware = declaredServiceAuthorization({
+      reason: "the row's own scope set decides",
+      permissions: ["traces:view"],
+    });
+    const params = paramsFor({});
+    await middleware(params as any);
+    expect(params.ctx.permissionChecked).toBe(true);
+    expect(authzDeclarationOf(middleware)).toMatchObject({
+      kind: "service-authorized",
+      permissions: ["traces:view"],
     });
   });
 });

--- a/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
@@ -34,6 +34,15 @@ vi.mock("~/server/api/rbac", () => ({
     resolveProjectPermissionAny(...args),
 }));
 
+// The seam resolves its service from the App; this fake App runs the REAL
+// service + repository over the rbac stubs above.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 const {
   checkDeclaredPermission,
   checkDeclaredPermissionAny,
@@ -49,7 +58,6 @@ const paramsFor = (
   { authed = true }: { authed?: boolean } = {},
 ) => ({
   ctx: {
-    prisma: {} as any,
     session: (authed ? session : null) as any,
     permissionChecked: false,
     organizationRole: undefined as any,
@@ -98,10 +106,9 @@ describe("checkDeclaredPermission", () => {
         params as any,
       );
       expect(resolveProjectPermission).toHaveBeenCalledWith(
-        {
-          prisma: params.ctx.prisma,
+        expect.objectContaining({
           session: { user: { id: "alice" }, expires: "" },
-        },
+        }),
         "proj-1",
         "traces:view",
       );
@@ -120,10 +127,9 @@ describe("checkDeclaredPermission", () => {
         params as any,
       );
       expect(hasOrganizationPermission).toHaveBeenCalledWith(
-        {
-          prisma: params.ctx.prisma,
+        expect.objectContaining({
           session: { user: { id: "alice" }, expires: "" },
-        },
+        }),
         "org-1",
         "organization:manage",
       );
@@ -140,14 +146,39 @@ describe("checkDeclaredPermission", () => {
         via: "teamId",
       })(params as any);
       expect(resolveTeamPermission).toHaveBeenCalledWith(
-        {
-          prisma: params.ctx.prisma,
+        expect.objectContaining({
           session: { user: { id: "alice" }, expires: "" },
-        },
+        }),
         "team-1",
         "organization:manage",
       );
       expect(hasOrganizationPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the request context carries an App", () => {
+    /** @scenario "Every grant check decides through the App the request context carries" */
+    it("decides through the injected App, never composing its own", async () => {
+      const getDecision = vi
+        .fn()
+        .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" });
+      const params = paramsFor({ projectId: "proj-1" });
+      (params.ctx as { app?: unknown }).app = {
+        permissions: { getDecision },
+      };
+
+      await checkDeclaredPermission({ permission: "traces:view" })(
+        params as any,
+      );
+
+      expect(getDecision).toHaveBeenCalledWith({
+        userId: "alice",
+        permission: "traces:view",
+        scope: { tier: "project", id: "proj-1" },
+      });
+      // The module-level App was never consulted — the context's instance is
+      // the one that decides.
+      expect(resolveProjectPermission).not.toHaveBeenCalled();
     });
   });
 
@@ -248,10 +279,9 @@ describe("checkDeclaredPermissionAny", () => {
       params as any,
     );
     expect(resolveProjectPermissionAny).toHaveBeenCalledWith(
-      {
-        prisma: params.ctx.prisma,
+      expect.objectContaining({
         session: { user: { id: "alice" }, expires: "" },
-      },
+      }),
       "proj-1",
       ["traces:view", "scenarios:view"],
     );

--- a/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
@@ -98,7 +98,10 @@ describe("checkDeclaredPermission", () => {
         params as any,
       );
       expect(resolveProjectPermission).toHaveBeenCalledWith(
-        params.ctx,
+        {
+          prisma: params.ctx.prisma,
+          session: { user: { id: "alice" }, expires: "" },
+        },
         "proj-1",
         "traces:view",
       );
@@ -117,7 +120,10 @@ describe("checkDeclaredPermission", () => {
         params as any,
       );
       expect(hasOrganizationPermission).toHaveBeenCalledWith(
-        params.ctx,
+        {
+          prisma: params.ctx.prisma,
+          session: { user: { id: "alice" }, expires: "" },
+        },
         "org-1",
         "organization:manage",
       );
@@ -134,7 +140,10 @@ describe("checkDeclaredPermission", () => {
         via: "teamId",
       })(params as any);
       expect(resolveTeamPermission).toHaveBeenCalledWith(
-        params.ctx,
+        {
+          prisma: params.ctx.prisma,
+          session: { user: { id: "alice" }, expires: "" },
+        },
         "team-1",
         "organization:manage",
       );
@@ -239,7 +248,10 @@ describe("checkDeclaredPermissionAny", () => {
       params as any,
     );
     expect(resolveProjectPermissionAny).toHaveBeenCalledWith(
-      params.ctx,
+      {
+        prisma: params.ctx.prisma,
+        session: { user: { id: "alice" }, expires: "" },
+      },
       "proj-1",
       ["traces:view", "scenarios:view"],
     );

--- a/platform/app/src/server/app-layer/authz/declared-middleware.ts
+++ b/platform/app/src/server/app-layer/authz/declared-middleware.ts
@@ -1,0 +1,59 @@
+/**
+ * ADR-092 decision 25 — the declaration marker, standalone so both the
+ * declared middleware factories (`./trpc-middleware`) and the legacy
+ * vocabulary module (`~/server/api/rbac`, which those factories import their
+ * resolvers from) can tag middlewares without forming a cycle.
+ *
+ * The sweep test walks the router and refuses any procedure whose chain
+ * carries no declaration; this file is the vocabulary it reads.
+ */
+import type { AuthzPermission, ScopeTierField } from "@langwatch/authz";
+
+/**
+ * `Symbol.for` so the sweep test and the builders agree on the key even
+ * across duplicated module instances in a test graph.
+ */
+export const AUTHZ_DECLARATION = Symbol.for("langwatch.authz.declaration");
+
+export type AuthzDeclaration =
+  | { kind: "permission"; permission: AuthzPermission; via?: ScopeTierField }
+  | { kind: "permission-any"; permissions: readonly AuthzPermission[] }
+  | { kind: "no-permission"; reason: string; allow?: Record<string, string> }
+  | {
+      kind: "service-authorized";
+      reason: string;
+      permissions: readonly AuthzPermission[];
+    }
+  | {
+      kind: "custom";
+      reason: string;
+      permissions: readonly AuthzPermission[];
+    };
+
+export type DeclaredAuthzMiddleware<
+  M extends (params: never) => Promise<unknown>,
+> = M & {
+  [AUTHZ_DECLARATION]: AuthzDeclaration;
+};
+
+/**
+ * Attach the declaration descriptor to a middleware. Exported so route-level
+ * custom middlewares (provider validation, captured-data visibility, project
+ * creation) can declare themselves too and be counted by the sweep instead
+ * of allowlisted.
+ */
+export function declareAuthzMiddleware<
+  M extends (params: never) => Promise<unknown>,
+>(declaration: AuthzDeclaration, middleware: M): DeclaredAuthzMiddleware<M> {
+  return Object.assign(middleware as any, {
+    [AUTHZ_DECLARATION]: declaration,
+  });
+}
+
+export function authzDeclarationOf(value: unknown): AuthzDeclaration | null {
+  if (typeof value !== "function") return null;
+  const declaration = (
+    value as Partial<DeclaredAuthzMiddleware<(params: never) => Promise<unknown>>>
+  )[AUTHZ_DECLARATION];
+  return declaration ?? null;
+}

--- a/platform/app/src/server/app-layer/authz/trpc-middleware.ts
+++ b/platform/app/src/server/app-layer/authz/trpc-middleware.ts
@@ -3,13 +3,16 @@
  * declaration surface. `protectedProcedure.input(…).permission("…")` compiles
  * down to the middleware built here.
  *
- * ONE seam, decision-neutral: the runtime delegates to the same fork-aware
- * resolvers the legacy `checkXxxPermission` middlewares ran (`rbac.ts`), so a
- * not-yet-cut-over organization is still decided by the legacy walk with the
- * engine shadowing it, and a cut-over organization by the engine with legacy
- * as reverse-shadow. Deploying the codemod changes no decision anywhere; the
- * contract PR later deletes the legacy branch inside the resolvers — one
- * file, not four hundred call sites.
+ * ONE seam, decision-neutral, properly layered: this middleware is the tRPC
+ * boundary, it composes the `PermissionsService`, which takes the
+ * `ForkAwarePermissionDecisionRepository`, which owns the client and
+ * delegates to the same fork-aware resolvers the legacy
+ * `checkXxxPermission` middlewares ran (`rbac.ts`) — so a not-yet-cut-over
+ * organization is still decided by the legacy walk with the engine shadowing
+ * it, and a cut-over organization by the engine with legacy as
+ * reverse-shadow. Deploying the codemod changes no decision anywhere; the
+ * contract PR later rewires only the repository — one file, not four hundred
+ * call sites.
  *
  * What IS deliberately new here is the denial shape: every tier's refusal now
  * carries the engine's one handled code (`permission_denied`, with the
@@ -36,14 +39,9 @@ import type {
   OrganizationUserRole,
   PrismaClient,
 } from "~/generated/prisma/client";
-import {
-  hasOrganizationPermission,
-  resolveProjectPermission,
-  resolveProjectPermissionAny,
-  resolveTeamPermission,
-} from "../../api/rbac";
 import type { Session } from "../../auth";
 import { LiteMemberRestrictedError } from "../permissions/errors";
+import { permissionsServiceFor } from "../permissions/runtime";
 import {
   type DeclaredAuthzMiddleware,
   declareAuthzMiddleware,
@@ -92,12 +90,9 @@ export const checkDeclaredPermission = ({
       }
 
       const scope = requireDeclaredScope({ permission, input, via });
-      const sessionCtx = ctx as MiddlewareParams["ctx"] & { session: Session };
-      const { permitted, organizationRole } = await decideAtTier({
-        ctx: sessionCtx,
-        scope,
-        permission,
-      });
+      const { permitted, organizationRole } = await permissionsServiceFor(
+        ctx.prisma,
+      ).getDecision({ userId: ctx.session.user.id, permission, scope });
       if (!permitted) {
         throw deniedError({ permission, scope, organizationRole });
       }
@@ -111,35 +106,6 @@ export const checkDeclaredPermission = ({
       return next();
     },
   );
-
-/**
- * The one runtime behind every declared check: each tier delegates to the
- * same fork-aware resolver the legacy middleware for that tier ran.
- */
-async function decideAtTier({
-  ctx,
-  scope,
-  permission,
-}: {
-  ctx: MiddlewareParams["ctx"] & { session: Session };
-  scope: DeclaredScopeId;
-  permission: AuthzPermission;
-}): Promise<{
-  permitted: boolean;
-  organizationRole: OrganizationUserRole | null;
-}> {
-  switch (scope.tier) {
-    case "project":
-      return await resolveProjectPermission(ctx, scope.id, permission);
-    case "team":
-      return await resolveTeamPermission(ctx, scope.id, permission);
-    case "organization":
-      return {
-        permitted: await hasOrganizationPermission(ctx, scope.id, permission),
-        organizationRole: null,
-      };
-  }
-}
 
 /**
  * `.permissionAny(…)` — any one of the permissions is enough, checked at the
@@ -161,12 +127,13 @@ export const checkDeclaredPermissionAny = (
       if (typeof projectId !== "string" || projectId.length === 0) {
         throw wiringBug({ permission: permissions[0] });
       }
-      const sessionCtx = ctx as MiddlewareParams["ctx"] & { session: Session };
-      const { permitted, organizationRole } = await resolveProjectPermissionAny(
-        sessionCtx,
+      const { permitted, organizationRole } = await permissionsServiceFor(
+        ctx.prisma,
+      ).getProjectAnyDecision({
+        userId: ctx.session.user.id,
         projectId,
-        [...permissions],
-      );
+        permissions,
+      });
       if (!permitted) {
         throw deniedError({
           permission: permissions[0],

--- a/platform/app/src/server/app-layer/authz/trpc-middleware.ts
+++ b/platform/app/src/server/app-layer/authz/trpc-middleware.ts
@@ -4,7 +4,8 @@
  * down to the middleware built here.
  *
  * ONE seam, decision-neutral, properly layered: this middleware is the tRPC
- * boundary, it composes the `PermissionsService`, which takes the
+ * boundary, it resolves `getApp().permissions` — the App-composed
+ * `PermissionsService`, which takes the
  * `ForkAwarePermissionDecisionRepository`, which owns the client and
  * delegates to the same fork-aware resolvers the legacy
  * `checkXxxPermission` middlewares ran (`rbac.ts`) — so a not-yet-cut-over
@@ -35,13 +36,10 @@ import {
 } from "@langwatch/authz";
 import { createLogger } from "@langwatch/observability";
 import { TRPCError } from "@trpc/server";
-import type {
-  OrganizationUserRole,
-  PrismaClient,
-} from "~/generated/prisma/client";
+import type { OrganizationUserRole } from "~/generated/prisma/client";
 import type { Session } from "../../auth";
+import { type App, getApp } from "../app";
 import { LiteMemberRestrictedError } from "../permissions/errors";
-import { permissionsServiceFor } from "../permissions/runtime";
 import {
   type DeclaredAuthzMiddleware,
   declareAuthzMiddleware,
@@ -53,14 +51,23 @@ type ScopeInput = Partial<Record<ScopeTierField, unknown>>;
 
 type MiddlewareParams = {
   ctx: {
-    prisma: PrismaClient;
     session: Session | null;
+    /** The composed App the context factory injected (see `trpc.ts`). */
+    app?: App;
     permissionChecked: boolean;
     organizationRole?: OrganizationUserRole | null;
   };
   input: ScopeInput;
   next: () => any;
 };
+
+/**
+ * The App this request decides through: the one its context factory injected,
+ * or the process singleton for contexts built without one (SSG helpers,
+ * embedded callers). Both are the same instance in production — the ctx slot
+ * exists so a test can hand in a fake without mocking the App module.
+ */
+const appOf = (ctx: MiddlewareParams["ctx"]): App => ctx.app ?? getApp();
 
 type DeclaredMiddleware = DeclaredAuthzMiddleware<
   (params: MiddlewareParams) => Promise<any>
@@ -90,9 +97,13 @@ export const checkDeclaredPermission = ({
       }
 
       const scope = requireDeclaredScope({ permission, input, via });
-      const { permitted, organizationRole } = await permissionsServiceFor(
-        ctx.prisma,
-      ).getDecision({ userId: ctx.session.user.id, permission, scope });
+      const { permitted, organizationRole } = await appOf(
+        ctx,
+      ).permissions.getDecision({
+        userId: ctx.session.user.id,
+        permission,
+        scope,
+      });
       if (!permitted) {
         throw deniedError({ permission, scope, organizationRole });
       }
@@ -127,9 +138,9 @@ export const checkDeclaredPermissionAny = (
       if (typeof projectId !== "string" || projectId.length === 0) {
         throw wiringBug({ permission: permissions[0] });
       }
-      const { permitted, organizationRole } = await permissionsServiceFor(
-        ctx.prisma,
-      ).getProjectAnyDecision({
+      const { permitted, organizationRole } = await appOf(
+        ctx,
+      ).permissions.getProjectAnyDecision({
         userId: ctx.session.user.id,
         projectId,
         permissions,

--- a/platform/app/src/server/app-layer/authz/trpc-middleware.ts
+++ b/platform/app/src/server/app-layer/authz/trpc-middleware.ts
@@ -1,157 +1,317 @@
 /**
- * ADR-092 §5 — the tRPC adapter. `protectedProcedure.permission("…")` sugar
- * compiles down to this middleware: input-driven scope extraction, one
- * engine decision through the composed AuthzService, legacy-compatible
- * error shapes.
+ * ADR-092 §5, delivery-plan decision 25 — the tRPC adapter behind the typed
+ * declaration surface. `protectedProcedure.input(…).permission("…")` compiles
+ * down to the middleware built here.
  *
- * New procedures opt in via `.permission()`; existing `.use(checkXxx…)`
- * sites keep the legacy path (now shadow-compared) until the stage-D
- * codemod.
+ * ONE seam, decision-neutral: the runtime delegates to the same fork-aware
+ * resolvers the legacy `checkXxxPermission` middlewares ran (`rbac.ts`), so a
+ * not-yet-cut-over organization is still decided by the legacy walk with the
+ * engine shadowing it, and a cut-over organization by the engine with legacy
+ * as reverse-shadow. Deploying the codemod changes no decision anywhere; the
+ * contract PR later deletes the legacy branch inside the resolvers — one
+ * file, not four hundred call sites.
+ *
+ * What IS deliberately new here is the denial shape: every tier's refusal now
+ * carries the engine's one handled code (`permission_denied`, with the
+ * permission and tier in `meta`) where the legacy team/organization
+ * middlewares shipped bare prose the client could only render as "unknown
+ * error". Lite-member denials keep their dedicated cause — the client modal
+ * keys on it.
+ *
+ * Every middleware built here carries an `AUTHZ_DECLARATION` descriptor, the
+ * machine-readable half of the declaration: the sweep test walks the router
+ * and refuses any procedure whose chain carries none.
  */
 import {
-  type AuthzDecision,
   type AuthzPermission,
-  type AuthzScopeRef,
+  type DeclaredScopeId,
+  declaredScopeId,
   PermissionDeniedError,
+  SCOPE_TIER_FIELDS,
+  type ScopeTierField,
 } from "@langwatch/authz";
 import { createLogger } from "@langwatch/observability";
 import { TRPCError } from "@trpc/server";
+import type {
+  OrganizationUserRole,
+  PrismaClient,
+} from "~/generated/prisma/client";
+import {
+  hasOrganizationPermission,
+  resolveProjectPermission,
+  resolveProjectPermissionAny,
+  resolveTeamPermission,
+} from "../../api/rbac";
 import type { Session } from "../../auth";
 import { LiteMemberRestrictedError } from "../permissions/errors";
-import { authz, authzCollector } from "./runtime";
+import {
+  type DeclaredAuthzMiddleware,
+  declareAuthzMiddleware,
+} from "./declared-middleware";
 
 const logger = createLogger("langwatch:authz");
 
-type ScopeInput = {
-  projectId?: string;
-  teamId?: string;
-  organizationId?: string;
-};
-
-/** The tier and id a check was refused at - what PermissionDeniedError needs,
- *  which a resolved AuthzScopeRef also satisfies structurally. */
-type DeniedScope = { type: AuthzScopeRef["type"]; id: string };
+type ScopeInput = Partial<Record<ScopeTierField, unknown>>;
 
 type MiddlewareParams = {
   ctx: {
+    prisma: PrismaClient;
     session: Session | null;
     permissionChecked: boolean;
-    organizationRole?: "ADMIN" | "MEMBER" | "EXTERNAL" | null;
+    organizationRole?: OrganizationUserRole | null;
   };
   input: ScopeInput;
   next: () => any;
 };
 
+type DeclaredMiddleware = DeclaredAuthzMiddleware<
+  (params: MiddlewareParams) => Promise<any>
+>;
+
 /**
- * Engine-backed permission middleware. Scope precedence mirrors specificity:
- * projectId, then teamId, then organizationId — a procedure whose input
- * carries none of the three is a wiring bug and fails loudly.
+ * `.permission(p)` / `.permission(p, { via })`. The type layer
+ * (`@langwatch/authz` declaration.ts + the builder in `api/trpc.ts`)
+ * guarantees the input carries a usable id; the runtime re-derives the same
+ * answer and still fails loudly if the two ever disagree.
  */
-export const checkPermissionV2 =
-  (permission: AuthzPermission) =>
-  async ({ ctx, input, next }: MiddlewareParams) => {
-    // `publicProcedure` exposes `.permission()` too, so a session is not a
-    // given here. Answering "unauthenticated" before any id is looked at
-    // keeps an anonymous caller from learning anything about the scope.
-    const user = ctx.session?.user;
-    if (!user) {
-      throw new TRPCError({ code: "UNAUTHORIZED" });
-    }
+export const checkDeclaredPermission = ({
+  permission,
+  via,
+}: {
+  permission: AuthzPermission;
+  via?: ScopeTierField;
+}): DeclaredMiddleware =>
+  declareAuthzMiddleware(
+    { kind: "permission", permission, via },
+    async ({ ctx, input, next }: MiddlewareParams) => {
+      // `publicProcedure` exposes `.permission()` too, so a session is not a
+      // given. Answering "unauthenticated" before any id is looked at keeps
+      // an anonymous caller from learning anything about the scope.
+      if (!ctx.session?.user) {
+        throw new TRPCError({ code: "UNAUTHORIZED" });
+      }
 
-    const scope = await requireScopeFromInput({ input, permission });
-
-    const { decision, grants } = await authz.checkDetailed({
-      principal: { type: "user", id: user.id },
-      permission,
-      scope,
-    });
-
-    if (!decision.allowed) {
-      throw deniedError({
-        permission,
+      const scope = requireDeclaredScope({ permission, input, via });
+      const sessionCtx = ctx as MiddlewareParams["ctx"] & { session: Session };
+      const { permitted, organizationRole } = await decideAtTier({
+        ctx: sessionCtx,
         scope,
-        denialReason: decision.denialReason ?? "no-binding",
+        permission,
       });
-    }
+      if (!permitted) {
+        throw deniedError({ permission, scope, organizationRole });
+      }
+      // Legacy parity: the organization tier never carried a role onto the
+      // context, so only the project/team resolutions (non-null role) do.
+      if (organizationRole !== null) {
+        ctx.organizationRole = organizationRole;
+      }
 
-    ctx.organizationRole = grants.organizationRole;
-    ctx.permissionChecked = true;
-    return next();
-  };
+      ctx.permissionChecked = true;
+      return next();
+    },
+  );
 
 /**
- * Resolve the check's scope from the procedure input, most specific id
- * first. No id at all is a wiring bug and fails loudly; an id that does not
- * resolve is denied.
+ * The one runtime behind every declared check: each tier delegates to the
+ * same fork-aware resolver the legacy middleware for that tier ran.
  */
-async function requireScopeFromInput({
-  input,
+async function decideAtTier({
+  ctx,
+  scope,
   permission,
 }: {
-  input: ScopeInput;
+  ctx: MiddlewareParams["ctx"] & { session: Session };
+  scope: DeclaredScopeId;
   permission: AuthzPermission;
-}): Promise<AuthzScopeRef> {
-  const scope = await authzCollector.resolveScopeRef({
-    projectId: input.projectId,
-    teamId: input.projectId ? undefined : input.teamId,
-    organizationId:
-      input.projectId || input.teamId ? undefined : input.organizationId,
-  });
+}): Promise<{
+  permitted: boolean;
+  organizationRole: OrganizationUserRole | null;
+}> {
+  switch (scope.tier) {
+    case "project":
+      return await resolveProjectPermission(ctx, scope.id, permission);
+    case "team":
+      return await resolveTeamPermission(ctx, scope.id, permission);
+    case "organization":
+      return {
+        permitted: await hasOrganizationPermission(ctx, scope.id, permission),
+        organizationRole: null,
+      };
+  }
+}
+
+/**
+ * `.permissionAny(…)` — any one of the permissions is enough, checked at the
+ * input's project scope. One scope resolution serves every candidate; the
+ * denial names the FIRST permission, so callers list the primary surface
+ * first (granting it resolves the refusal whichever feature the caller came
+ * through).
+ */
+export const checkDeclaredPermissionAny = (
+  permissions: readonly [AuthzPermission, ...AuthzPermission[]],
+): DeclaredMiddleware =>
+  declareAuthzMiddleware(
+    { kind: "permission-any", permissions },
+    async ({ ctx, input, next }: MiddlewareParams) => {
+      if (!ctx.session?.user) {
+        throw new TRPCError({ code: "UNAUTHORIZED" });
+      }
+      const projectId = input.projectId;
+      if (typeof projectId !== "string" || projectId.length === 0) {
+        throw wiringBug({ permission: permissions[0] });
+      }
+      const sessionCtx = ctx as MiddlewareParams["ctx"] & { session: Session };
+      const { permitted, organizationRole } = await resolveProjectPermissionAny(
+        sessionCtx,
+        projectId,
+        [...permissions],
+      );
+      if (!permitted) {
+        throw deniedError({
+          permission: permissions[0],
+          scope: { tier: "project", id: projectId },
+          organizationRole,
+        });
+      }
+      ctx.organizationRole = organizationRole;
+      ctx.permissionChecked = true;
+      return next();
+    },
+  );
+
+const SENSITIVE_SCOPE_FIELDS = Object.values(
+  SCOPE_TIER_FIELDS,
+) as ScopeTierField[];
+
+/**
+ * `.noPermission({ reason, allow })` — authenticated, deliberately
+ * unchecked. The type layer refuses scoped input fields that are not
+ * individually allowed with a reason; this runtime guard is the defense in
+ * depth behind it, unchanged in behaviour from the legacy
+ * `skipPermissionCheck`.
+ */
+export const declaredNoPermission = ({
+  reason,
+  allow,
+}: {
+  reason: string;
+  allow?: Record<string, string>;
+}): DeclaredMiddleware =>
+  declareAuthzMiddleware(
+    { kind: "no-permission", reason, allow },
+    async ({ ctx, input, next }: MiddlewareParams) => {
+      const allowedKeys = Object.keys(allow ?? {});
+      for (const key of SENSITIVE_SCOPE_FIELDS) {
+        if (key in input && !allowedKeys.includes(key)) {
+          throw new Error(
+            `${key} is not allowed to be used without permission check`,
+          );
+        }
+      }
+      ctx.permissionChecked = true;
+      return next();
+    },
+  );
+
+/**
+ * `.authorizeInService({ reason, permissions })` — the scope is data the
+ * handler loads at runtime, so the SERVICE performs the real authorization
+ * and the declaration records which permissions it enforces. This only moves
+ * WHERE the check happens, never whether one does.
+ */
+export const declaredServiceAuthorization = ({
+  reason,
+  permissions,
+}: {
+  reason: string;
+  permissions: readonly AuthzPermission[];
+}): DeclaredMiddleware =>
+  declareAuthzMiddleware(
+    { kind: "service-authorized", reason, permissions },
+    async ({ ctx, next }: MiddlewareParams) => {
+      ctx.permissionChecked = true;
+      return next();
+    },
+  );
+
+function requireDeclaredScope({
+  permission,
+  input,
+  via,
+}: {
+  permission: AuthzPermission;
+  input: ScopeInput;
+  via?: ScopeTierField;
+}): DeclaredScopeId {
+  const scope = declaredScopeId({ permission, input, via });
   if (scope) return scope;
+  throw wiringBug({ permission, via });
+}
 
-  const requested = requestedScope(input);
-  if (!requested) {
-    // Nothing the caller did can fix this, so the sentence they read says
-    // only that; which procedure is miswired goes to the log.
-    logger.error(
-      { permission },
-      "permission procedure input carries no projectId, teamId, or organizationId",
-    );
-    throw new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
-      message: "Something went wrong. Please try again.",
-    });
-  }
-
-  // An id that resolves to nothing answers exactly like an id the caller may
-  // not touch. Two things used to leak here: the 401-with-prose told an
-  // outsider whether an id EXISTS, and the missing error code left the
-  // client rendering a generic "unknown error" for a denial it can name.
-  throw deniedError({
-    permission,
-    scope: requested,
-    denialReason: "no-membership",
+/**
+ * Nothing the caller did can fix a declaration whose input carries no usable
+ * id, so the sentence they read says only that; which procedure is miswired
+ * goes to the log. The types make this unreachable — this is the runtime
+ * backstop for the day they are bypassed.
+ */
+function wiringBug({
+  permission,
+  via,
+}: {
+  permission: AuthzPermission;
+  via?: ScopeTierField;
+}): TRPCError {
+  logger.error(
+    { permission, via },
+    "declared permission's input carries no usable scope id",
+  );
+  return new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: "Something went wrong. Please try again.",
   });
 }
 
-/** The tier the caller aimed at, by the same precedence the resolve uses. */
-function requestedScope(input: ScopeInput): DeniedScope | null {
-  if (input.projectId) return { type: "project", id: input.projectId };
-  if (input.teamId) return { type: "team", id: input.teamId };
-  if (input.organizationId) {
-    return { type: "organization", id: input.organizationId };
-  }
-  return null;
-}
-
+/**
+ * The one denial shape for every tier. An id that resolves to nothing
+ * answers exactly like an id the caller may not touch — the resolvers
+ * already fold both into `permitted: false`, so no probe can learn whether a
+ * scope EXISTS. The lite-member cause drives the client's restriction modal;
+ * the `PermissionDeniedError` cause carries the stable code and meta for
+ * everything else.
+ */
 function deniedError({
   permission,
   scope,
-  denialReason,
+  organizationRole,
 }: {
   permission: AuthzPermission;
-  scope: DeniedScope;
-  denialReason: NonNullable<AuthzDecision["denialReason"]>;
+  scope: DeclaredScopeId;
+  organizationRole: OrganizationUserRole | null;
 }): TRPCError {
-  const denied = new PermissionDeniedError({ permission, scope, denialReason });
+  // String comparison on purpose: a VALUE import of the Prisma enum would put
+  // the generated client on this module's graph for one constant.
+  if (organizationRole === "EXTERNAL") {
+    return new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "This feature is not available for your account",
+      cause: new LiteMemberRestrictedError(
+        permission.split(":")[0] ?? "unknown",
+      ),
+    });
+  }
+  const denied = new PermissionDeniedError({
+    permission,
+    scope: { type: scope.tier, id: scope.id },
+    denialReason: "no-binding",
+  });
+  // The wire code that results is FORBIDDEN, not the UNAUTHORIZED spelled
+  // here: `handledErrorMiddleware` re-derives it from the handled cause's
+  // `httpStatus` (403) — the caller IS authenticated, they just lack the
+  // permission.
   return new TRPCError({
     code: "UNAUTHORIZED",
     message: denied.message,
-    // Legacy parity: the lite-member cause drives the client's restriction
-    // modal; the HandledError cause carries denialReason for everything else.
-    cause:
-      denialReason === "lite-member-restricted"
-        ? new LiteMemberRestrictedError(permission.split(":")[0] ?? "unknown")
-        : denied,
+    cause: denied,
   });
 }

--- a/platform/app/src/server/app-layer/dependencies.ts
+++ b/platform/app/src/server/app-layer/dependencies.ts
@@ -64,6 +64,7 @@ import type { ReplayService } from "./ops/replay.service";
 import type { SchedulerOpsService } from "./ops/scheduler-ops.service";
 import type { OpsSnapshotReader } from "./ops/snapshot/snapshot-reader";
 import type { OrganizationService } from "./organizations/organization.service";
+import type { PermissionsService } from "./permissions/permissions.service";
 import type { PresenceService } from "./presence/presence.service";
 import type { ProjectService } from "./projects/project.service";
 import type { ShareService } from "./share/share.service";
@@ -322,6 +323,13 @@ export interface AppDependencies {
   emailSuppressions: EmailSuppressionService;
   organizations: OrganizationService;
   projects: ProjectService;
+  /**
+   * ADR-092 decision 25 — the one permission-checking service. Every grant
+   * check on every surface (tRPC declarations, Hono session and API-key
+   * middlewares, the management API) resolves THIS instance via
+   * `getApp().permissions`; nothing composes its own from a client.
+   */
+  permissions: PermissionsService;
   tokenizer: TokenizerService;
   usage: UsageService;
   planProvider: PlanProvider;

--- a/platform/app/src/server/app-layer/langy/__tests__/langySessionKey.integration.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langySessionKey.integration.test.ts
@@ -286,7 +286,6 @@ describe("Langy session key (caller-scoped)", () => {
         for (const permission of required) {
           await expect(
             enforceApiKeyCeiling({
-              prisma,
               resolved: resolved!,
               permission: permission as Permission,
             }),
@@ -318,7 +317,7 @@ describe("Langy session key (caller-scoped)", () => {
           "evaluations:manage",
         ] as const) {
           await expect(
-            enforceApiKeyCeiling({ prisma, resolved: resolved!, permission }),
+            enforceApiKeyCeiling({ resolved: resolved!, permission }),
           ).rejects.toThrow();
         }
       });

--- a/platform/app/src/server/app-layer/permissions/__tests__/permissions.facade.unit.test.ts
+++ b/platform/app/src/server/app-layer/permissions/__tests__/permissions.facade.unit.test.ts
@@ -1,0 +1,83 @@
+/** @vitest-environment node */
+
+/**
+ * The typed imperative facade (ADR-092 decision 25): the scope argument is
+ * derived from the permission's registry tiers, and the runtime decides
+ * through the same fork-aware resolvers the declared `.permission()` runs.
+ * The `@ts-expect-error` lines are compile-time assertions enforced by
+ * `pnpm typecheck:tests`.
+ */
+import { PermissionDeniedError } from "@langwatch/authz";
+import { describe, expect, it, vi } from "vitest";
+
+const resolveProjectPermission = vi.fn();
+const resolveTeamPermission = vi.fn();
+const hasOrganizationPermission = vi.fn();
+
+vi.mock("~/server/api/rbac", () => ({
+  resolveProjectPermission: (...args: unknown[]) =>
+    resolveProjectPermission(...args),
+  resolveTeamPermission: (...args: unknown[]) => resolveTeamPermission(...args),
+  hasOrganizationPermission: (...args: unknown[]) =>
+    hasOrganizationPermission(...args),
+}));
+
+const { PermissionsService } = await import("../permissions.service");
+
+const service = new PermissionsService({} as never);
+
+describe("PermissionsService typed facade", () => {
+  describe("when an imperative check names its scope id", () => {
+    /** @scenario "An imperative check names its scope id to match the permission" */
+    it("decides through the tier's fork-aware resolver", async () => {
+      resolveProjectPermission.mockResolvedValue({
+        permitted: true,
+        organizationRole: "MEMBER",
+      });
+      await expect(
+        service.hasPermission({
+          userId: "alice",
+          permission: "traces:view",
+          projectId: "proj-1",
+        }),
+      ).resolves.toBe(true);
+      expect(resolveProjectPermission).toHaveBeenCalledWith(
+        expect.anything(),
+        "proj-1",
+        "traces:view",
+      );
+
+      hasOrganizationPermission.mockResolvedValue(false);
+      await expect(
+        service.requirePermission({
+          userId: "alice",
+          permission: "organization:manage",
+          organizationId: "org-1",
+        }),
+      ).rejects.toBeInstanceOf(PermissionDeniedError);
+    });
+
+    it("refuses tier-mismatched scope ids at compile time", () => {
+      void service.hasPermission({
+        userId: "alice",
+        permission: "governance:view",
+        // @ts-expect-error — governance is organization-only; a projectId is a category error
+        projectId: "proj-1",
+      });
+      // @ts-expect-error — exactly one scope id: two at once is ambiguous
+      void service.hasPermission({
+        userId: "alice",
+        permission: "traces:view",
+        projectId: "proj-1",
+        organizationId: "org-1",
+      });
+      // @ts-expect-error — ops is platform-tier; no scope id can address it
+      void service.hasPermission({
+        userId: "alice",
+        permission: "ops:view",
+        organizationId: "org-1",
+      });
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/permissions/__tests__/permissions.facade.unit.test.ts
+++ b/platform/app/src/server/app-layer/permissions/__tests__/permissions.facade.unit.test.ts
@@ -2,35 +2,31 @@
 
 /**
  * The typed imperative facade (ADR-092 decision 25): the scope argument is
- * derived from the permission's registry tiers, and the runtime decides
- * through the same fork-aware resolvers the declared `.permission()` runs.
- * The `@ts-expect-error` lines are compile-time assertions enforced by
- * `pnpm typecheck:tests`.
+ * derived from the permission's registry tiers, and the service decides
+ * through the injected decision repository — the same one the declared
+ * `.permission()` seam composes. The `@ts-expect-error` lines are
+ * compile-time assertions enforced by `pnpm typecheck:tests`.
  */
 import { PermissionDeniedError } from "@langwatch/authz";
 import { describe, expect, it, vi } from "vitest";
 
-const resolveProjectPermission = vi.fn();
-const resolveTeamPermission = vi.fn();
-const hasOrganizationPermission = vi.fn();
+import type { PermissionDecisionRepository } from "../permission-decision.repository";
+import { PermissionsService } from "../permissions.service";
 
-vi.mock("~/server/api/rbac", () => ({
-  resolveProjectPermission: (...args: unknown[]) =>
-    resolveProjectPermission(...args),
-  resolveTeamPermission: (...args: unknown[]) => resolveTeamPermission(...args),
-  hasOrganizationPermission: (...args: unknown[]) =>
-    hasOrganizationPermission(...args),
-}));
+const repository = {
+  findProjectDecision: vi.fn(),
+  findProjectAnyDecision: vi.fn(),
+  findTeamDecision: vi.fn(),
+  findOrganizationDecision: vi.fn(),
+} satisfies PermissionDecisionRepository;
 
-const { PermissionsService } = await import("../permissions.service");
-
-const service = new PermissionsService({} as never);
+const service = new PermissionsService(repository);
 
 describe("PermissionsService typed facade", () => {
   describe("when an imperative check names its scope id", () => {
     /** @scenario "An imperative check names its scope id to match the permission" */
-    it("decides through the tier's fork-aware resolver", async () => {
-      resolveProjectPermission.mockResolvedValue({
+    it("decides through the tier's repository method", async () => {
+      repository.findProjectDecision.mockResolvedValue({
         permitted: true,
         organizationRole: "MEMBER",
       });
@@ -41,13 +37,16 @@ describe("PermissionsService typed facade", () => {
           projectId: "proj-1",
         }),
       ).resolves.toBe(true);
-      expect(resolveProjectPermission).toHaveBeenCalledWith(
-        expect.anything(),
-        "proj-1",
-        "traces:view",
-      );
+      expect(repository.findProjectDecision).toHaveBeenCalledWith({
+        userId: "alice",
+        projectId: "proj-1",
+        permission: "traces:view",
+      });
 
-      hasOrganizationPermission.mockResolvedValue(false);
+      repository.findOrganizationDecision.mockResolvedValue({
+        permitted: false,
+        organizationRole: null,
+      });
       await expect(
         service.requirePermission({
           userId: "alice",

--- a/platform/app/src/server/app-layer/permissions/__tests__/permissions.facade.unit.test.ts
+++ b/platform/app/src/server/app-layer/permissions/__tests__/permissions.facade.unit.test.ts
@@ -10,6 +10,7 @@
 import { PermissionDeniedError } from "@langwatch/authz";
 import { describe, expect, it, vi } from "vitest";
 
+import type { CredentialDecisionRepository } from "../credential-decision.repository";
 import type { PermissionDecisionRepository } from "../permission-decision.repository";
 import { PermissionsService } from "../permissions.service";
 
@@ -20,7 +21,12 @@ const repository = {
   findOrganizationDecision: vi.fn(),
 } satisfies PermissionDecisionRepository;
 
-const service = new PermissionsService(repository);
+const credentials = {
+  findApiKeyDecision: vi.fn(),
+  findProjectScope: vi.fn(),
+} satisfies CredentialDecisionRepository;
+
+const service = new PermissionsService({ decisions: repository, credentials });
 
 describe("PermissionsService typed facade", () => {
   describe("when an imperative check names its scope id", () => {

--- a/platform/app/src/server/app-layer/permissions/credential-decision.repository.ts
+++ b/platform/app/src/server/app-layer/permissions/credential-decision.repository.ts
@@ -1,0 +1,88 @@
+/**
+ * ADR-092 decision 25 — the credential half of the permission seam: what an
+ * API key may do, as opposed to what a signed-in user may do
+ * (`permission-decision.repository.ts`). A separate repository because it is
+ * a separate legacy seam (`role-binding-resolver.ts`, the
+ * `ApiKey ∩ owning user` ceiling) with its own module graph; the service
+ * composes both.
+ */
+import type { AuthzPermission } from "@langwatch/authz";
+import type { PrismaClient } from "~/generated/prisma/client";
+import {
+  resolveApiKeyPermission,
+  type ScopeRef,
+} from "~/server/rbac/role-binding-resolver";
+
+/** The tenancy coordinates of a project, for scoping a credential check. */
+export type ProjectScope = {
+  projectId: string;
+  teamId: string;
+  organizationId: string;
+};
+
+export type ApiKeyPermissionCheck = {
+  apiKeyId: string;
+  /** Null for service keys, which have no owning-user ceiling. */
+  userId: string | null;
+  organizationId: string;
+  scope: ScopeRef;
+  permission: AuthzPermission;
+};
+
+export interface CredentialDecisionRepository {
+  /**
+   * Whether an API-key credential holds `permission` at `scope`:
+   * `effective = ApiKey.bindings ∩ owning user's bindings`, the resolution
+   * the legacy `resolveApiKeyPermission` performs.
+   */
+  findApiKeyDecision(check: ApiKeyPermissionCheck): Promise<boolean>;
+  /**
+   * A project's tenancy coordinates, or null when no such project exists.
+   * Read by credential checks that must scope to a project the request only
+   * names by id.
+   */
+  findProjectScope(params: { projectId: string }): Promise<ProjectScope | null>;
+}
+
+export class ForkAwareCredentialDecisionRepository
+  implements CredentialDecisionRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findApiKeyDecision({
+    apiKeyId,
+    userId,
+    organizationId,
+    scope,
+    permission,
+  }: ApiKeyPermissionCheck): Promise<boolean> {
+    return await resolveApiKeyPermission({
+      prisma: this.prisma,
+      apiKeyId,
+      userId,
+      organizationId,
+      scope,
+      permission,
+    });
+  }
+
+  async findProjectScope({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<ProjectScope | null> {
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: {
+        id: true,
+        team: { select: { id: true, organizationId: true } },
+      },
+    });
+    if (!project) return null;
+    return {
+      projectId: project.id,
+      teamId: project.team.id,
+      organizationId: project.team.organizationId,
+    };
+  }
+}

--- a/platform/app/src/server/app-layer/permissions/imperative.ts
+++ b/platform/app/src/server/app-layer/permissions/imperative.ts
@@ -1,0 +1,61 @@
+/**
+ * ADR-092 decision 25 — the imperative boolean checks, App-routed.
+ *
+ * Same names and signatures as the legacy `rbac.ts` wrappers they replace, so
+ * a call site changes only its import — but the decision now resolves through
+ * the App the request context carries (`ctx.app`, injected by the tRPC and
+ * Hono context factories) or the process singleton, never by handing a
+ * database client around. An unauthenticated context is refused before any
+ * id is read.
+ */
+import type { AuthzPermission } from "@langwatch/authz";
+import type { Session } from "~/server/auth";
+import { type App, getApp } from "../app";
+
+type ImperativeContext = {
+  session: Session | null;
+  /** The composed App the context factory injected (tRPC ctx / Hono var). */
+  app?: App;
+};
+
+async function decide(
+  ctx: ImperativeContext,
+  tier: "project" | "team" | "organization",
+  id: string,
+  permission: AuthzPermission,
+): Promise<boolean> {
+  if (!ctx.session?.user) return false;
+  const { permitted } = await (ctx.app ?? getApp()).permissions.getDecision({
+    userId: ctx.session.user.id,
+    permission,
+    scope: { tier, id },
+  });
+  return permitted;
+}
+
+/** Whether the context's user holds `permission` on the project. */
+export async function hasProjectPermission(
+  ctx: ImperativeContext,
+  projectId: string,
+  permission: AuthzPermission,
+): Promise<boolean> {
+  return decide(ctx, "project", projectId, permission);
+}
+
+/** Whether the context's user holds `permission` on the team. */
+export async function hasTeamPermission(
+  ctx: ImperativeContext,
+  teamId: string,
+  permission: AuthzPermission,
+): Promise<boolean> {
+  return decide(ctx, "team", teamId, permission);
+}
+
+/** Whether the context's user holds `permission` on the organization. */
+export async function hasOrganizationPermission(
+  ctx: ImperativeContext,
+  organizationId: string,
+  permission: AuthzPermission,
+): Promise<boolean> {
+  return decide(ctx, "organization", organizationId, permission);
+}

--- a/platform/app/src/server/app-layer/permissions/permission-decision.repository.ts
+++ b/platform/app/src/server/app-layer/permissions/permission-decision.repository.ts
@@ -1,0 +1,143 @@
+/**
+ * ADR-092 decision 25 — the ONE data seam behind every permission check,
+ * imperative and declared alike. Only this repository touches the client;
+ * the service above it takes the repository, and the boundaries take the
+ * service.
+ *
+ * The implementation delegates to the fork-aware resolvers in `rbac.ts`:
+ * a not-yet-cut-over organization is decided by the legacy walk with the
+ * engine shadowing, a cut-over one by the engine with legacy as
+ * reverse-shadow. The contract PR rewires ONLY this class onto the engine —
+ * nothing above it learns.
+ */
+import type { AuthzPermission } from "@langwatch/authz";
+import type {
+  OrganizationUserRole,
+  PrismaClient,
+} from "~/generated/prisma/client";
+import {
+  hasOrganizationPermission,
+  resolveProjectPermission,
+  resolveProjectPermissionAny,
+  resolveTeamPermission,
+} from "~/server/api/rbac";
+import type { Session } from "~/server/auth";
+
+export type PermissionDecision = {
+  permitted: boolean;
+  organizationRole: OrganizationUserRole | null;
+};
+
+export interface PermissionDecisionRepository {
+  findProjectDecision(params: {
+    userId: string;
+    projectId: string;
+    permission: AuthzPermission;
+  }): Promise<PermissionDecision>;
+  findProjectAnyDecision(params: {
+    userId: string;
+    projectId: string;
+    permissions: readonly AuthzPermission[];
+  }): Promise<PermissionDecision>;
+  findTeamDecision(params: {
+    userId: string;
+    teamId: string;
+    permission: AuthzPermission;
+  }): Promise<PermissionDecision>;
+  findOrganizationDecision(params: {
+    userId: string;
+    organizationId: string;
+    permission: AuthzPermission;
+  }): Promise<PermissionDecision>;
+}
+
+export class ForkAwarePermissionDecisionRepository
+  implements PermissionDecisionRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findProjectDecision({
+    userId,
+    projectId,
+    permission,
+  }: {
+    userId: string;
+    projectId: string;
+    permission: AuthzPermission;
+  }): Promise<PermissionDecision> {
+    return await resolveProjectPermission(
+      this.resolverContextFor(userId),
+      projectId,
+      permission,
+    );
+  }
+
+  async findProjectAnyDecision({
+    userId,
+    projectId,
+    permissions,
+  }: {
+    userId: string;
+    projectId: string;
+    permissions: readonly AuthzPermission[];
+  }): Promise<PermissionDecision> {
+    return await resolveProjectPermissionAny(
+      this.resolverContextFor(userId),
+      projectId,
+      permissions,
+    );
+  }
+
+  async findTeamDecision({
+    userId,
+    teamId,
+    permission,
+  }: {
+    userId: string;
+    teamId: string;
+    permission: AuthzPermission;
+  }): Promise<PermissionDecision> {
+    return await resolveTeamPermission(
+      this.resolverContextFor(userId),
+      teamId,
+      permission,
+    );
+  }
+
+  async findOrganizationDecision({
+    userId,
+    organizationId,
+    permission,
+  }: {
+    userId: string;
+    organizationId: string;
+    permission: AuthzPermission;
+  }): Promise<PermissionDecision> {
+    return {
+      permitted: await hasOrganizationPermission(
+        this.resolverContextFor(userId),
+        organizationId,
+        permission,
+      ),
+      // The organization walk carries no membership role in its answer, and
+      // legacy never put one on the context either.
+      organizationRole: null,
+    };
+  }
+
+  /**
+   * The resolvers grew up inside tRPC middleware, so they take a request
+   * context — of which they read only `prisma` and `session.user.id`. This
+   * shim is the single place that legacy shape is manufactured; it goes with
+   * the resolvers when the contract PR lands.
+   */
+  private resolverContextFor(userId: string): {
+    prisma: PrismaClient;
+    session: Session;
+  } {
+    return {
+      prisma: this.prisma,
+      session: { user: { id: userId }, expires: "" } satisfies Session,
+    };
+  }
+}

--- a/platform/app/src/server/app-layer/permissions/permissions.service.ts
+++ b/platform/app/src/server/app-layer/permissions/permissions.service.ts
@@ -1,30 +1,29 @@
 import {
   type AuthzPermission,
+  type DeclaredScopeId,
   PermissionDeniedError,
   type PermissionScopeArg,
 } from "@langwatch/authz";
-import type { PrismaClient } from "~/generated/prisma/client";
-import { OrganizationUserRole } from "~/generated/prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import {
-  hasOrganizationPermission,
-  resolveProjectPermission,
-  resolveTeamPermission,
-} from "~/server/api/rbac";
-import type { Session } from "~/server/auth";
 import {
   LiteMemberRestrictedError,
   ProjectPermissionDeniedError,
 } from "./errors";
+import type {
+  PermissionDecision,
+  PermissionDecisionRepository,
+} from "./permission-decision.repository";
 
 /**
- * Service responsible for project-level permission enforcement.
+ * Service responsible for permission enforcement.
  *
- * Pure business logic — no tRPC dependency. Safe to call from Hono routes,
+ * Pure business logic — no tRPC dependency, no client: decisions come from
+ * the injected {@link PermissionDecisionRepository} (compose via
+ * `permissionsServiceFor` in `./runtime.ts`). Safe to call from Hono routes,
  * background workers, or any other non-tRPC surface.
  */
 export class PermissionsService {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(private readonly repository: PermissionDecisionRepository) {}
 
   /**
    * Asserts that a user holds the given permission on a project.
@@ -48,22 +47,15 @@ export class PermissionsService {
     projectId: string;
     permission: Permission;
   }): Promise<void> {
-    const ctx = {
-      prisma: this.prisma,
-      // Minimal session shape — resolveProjectPermission only accesses user.id.
-      // Other Session fields (expires, sessionId, etc.) are not read by the
-      // permission resolver, so we satisfy the interface with an empty expires.
-      session: { user: { id: userId }, expires: "" } satisfies Session,
-    };
-
-    const { permitted, organizationRole } = await resolveProjectPermission(
-      ctx,
-      projectId,
-      permission,
-    );
+    const { permitted, organizationRole } =
+      await this.repository.findProjectDecision({
+        userId,
+        projectId,
+        permission,
+      });
 
     if (!permitted) {
-      if (organizationRole === OrganizationUserRole.EXTERNAL) {
+      if (organizationRole === "EXTERNAL") {
         throw new LiteMemberRestrictedError(
           permission.split(":")[0] ?? "unknown",
         );
@@ -76,13 +68,19 @@ export class PermissionsService {
    * ADR-092 decision 25 — the typed imperative check. The scope argument is
    * derived from the permission's registry tiers: exactly one id, at a tier
    * the permission can be granted at, or the call does not compile. Decides
-   * through the same fork-aware resolvers every declared `.permission()`
-   * runs, so an imperative site and a declared one can never disagree.
+   * through the same repository every declared `.permission()` runs, so an
+   * imperative site and a declared one can never disagree.
    */
   async hasPermission<P extends AuthzPermission>(
     check: { userId: string; permission: P } & PermissionScopeArg<P>,
   ): Promise<boolean> {
-    const { permitted } = await this.decide(check);
+    const scope = scopeOf(check);
+    if (!scope) return false;
+    const { permitted } = await this.getDecision({
+      userId: check.userId,
+      permission: check.permission,
+      scope,
+    });
     return permitted;
   }
 
@@ -94,74 +92,99 @@ export class PermissionsService {
   async requirePermission<P extends AuthzPermission>(
     check: { userId: string; permission: P } & PermissionScopeArg<P>,
   ): Promise<void> {
-    const { tier, id, permitted, organizationRole } = await this.decide(check);
+    const scope = scopeOf(check);
+    if (!scope) {
+      throw new PermissionDeniedError({
+        permission: check.permission,
+        scope: { type: "project", id: "unresolved" },
+        denialReason: "no-binding",
+      });
+    }
+    const { permitted, organizationRole } = await this.getDecision({
+      userId: check.userId,
+      permission: check.permission,
+      scope,
+    });
     if (permitted) return;
-    if (organizationRole === OrganizationUserRole.EXTERNAL) {
+    if (organizationRole === "EXTERNAL") {
       throw new LiteMemberRestrictedError(
         check.permission.split(":")[0] ?? "unknown",
       );
     }
     throw new PermissionDeniedError({
       permission: check.permission,
-      scope: { type: tier, id },
+      scope: { type: scope.tier, id: scope.id },
       denialReason: "no-binding",
     });
   }
 
-  private async decide({
+  /**
+   * The decision at an already-resolved scope — what the declared tRPC seam
+   * calls after `declaredScopeId` picks the tier. Each tier maps to the
+   * repository method whose answer the legacy middleware for that tier gave.
+   */
+  async getDecision({
     userId,
     permission,
-    ...scope
+    scope,
   }: {
     userId: string;
     permission: AuthzPermission;
-  } & Partial<
-    Record<"projectId" | "teamId" | "organizationId", string>
-  >): Promise<{
-    tier: "project" | "team" | "organization";
-    id: string;
-    permitted: boolean;
-    organizationRole: OrganizationUserRole | null;
-  }> {
-    const ctx = {
-      prisma: this.prisma,
-      session: { user: { id: userId }, expires: "" } as Session,
-    };
-    if (scope.projectId) {
-      const decision = await resolveProjectPermission(
-        ctx,
-        scope.projectId,
-        permission,
-      );
-      return { tier: "project", id: scope.projectId, ...decision };
+    scope: DeclaredScopeId;
+  }): Promise<PermissionDecision> {
+    switch (scope.tier) {
+      case "project":
+        return await this.repository.findProjectDecision({
+          userId,
+          projectId: scope.id,
+          permission,
+        });
+      case "team":
+        return await this.repository.findTeamDecision({
+          userId,
+          teamId: scope.id,
+          permission,
+        });
+      case "organization":
+        return await this.repository.findOrganizationDecision({
+          userId,
+          organizationId: scope.id,
+          permission,
+        });
     }
-    if (scope.teamId) {
-      const decision = await resolveTeamPermission(
-        ctx,
-        scope.teamId,
-        permission,
-      );
-      return { tier: "team", id: scope.teamId, ...decision };
-    }
-    if (scope.organizationId) {
-      const permitted = await hasOrganizationPermission(
-        ctx as { prisma: PrismaClient; session: Session },
-        scope.organizationId,
-        permission,
-      );
-      return {
-        tier: "organization",
-        id: scope.organizationId,
-        permitted,
-        organizationRole: null,
-      };
-    }
-    // The types make this unreachable; fail closed if they are bypassed.
-    return {
-      tier: "project",
-      id: "unresolved",
-      permitted: false,
-      organizationRole: null,
-    };
   }
+
+  /**
+   * Any one of `permissions` at the project scope is enough — the decision
+   * behind `.permissionAny()`.
+   */
+  async getProjectAnyDecision({
+    userId,
+    projectId,
+    permissions,
+  }: {
+    userId: string;
+    projectId: string;
+    permissions: readonly AuthzPermission[];
+  }): Promise<PermissionDecision> {
+    return await this.repository.findProjectAnyDecision({
+      userId,
+      projectId,
+      permissions,
+    });
+  }
+}
+
+/**
+ * The typed scope argument is exclusive by construction, so exactly one id is
+ * present; null is the fail-closed answer for the day the types are bypassed.
+ */
+function scopeOf(
+  scope: Partial<Record<"projectId" | "teamId" | "organizationId", string>>,
+): DeclaredScopeId | null {
+  if (scope.projectId) return { tier: "project", id: scope.projectId };
+  if (scope.teamId) return { tier: "team", id: scope.teamId };
+  if (scope.organizationId)
+    return { tier: "organization", id: scope.organizationId };
+  return null;
 }

--- a/platform/app/src/server/app-layer/permissions/permissions.service.ts
+++ b/platform/app/src/server/app-layer/permissions/permissions.service.ts
@@ -5,6 +5,11 @@ import {
   type PermissionScopeArg,
 } from "@langwatch/authz";
 import type { Permission } from "~/server/api/rbac";
+import type {
+  ApiKeyPermissionCheck,
+  CredentialDecisionRepository,
+  ProjectScope,
+} from "./credential-decision.repository";
 import {
   LiteMemberRestrictedError,
   ProjectPermissionDeniedError,
@@ -15,6 +20,16 @@ import type {
 } from "./permission-decision.repository";
 
 /**
+ * The answer for a credential check scoped to a project the request names
+ * only by id. `project_not_found` covers both a missing project and one in
+ * another organization — its existence is not the caller's to learn.
+ */
+export type ApiKeyProjectDecision =
+  | { outcome: "project_not_found" }
+  | { outcome: "denied" }
+  | { outcome: "allowed"; scope: ProjectScope };
+
+/**
  * Service responsible for permission enforcement.
  *
  * Pure business logic — no tRPC dependency, no client: decisions come from
@@ -23,7 +38,21 @@ import type {
  * background workers, or any other non-tRPC surface.
  */
 export class PermissionsService {
-  constructor(private readonly repository: PermissionDecisionRepository) {}
+  private readonly repository: PermissionDecisionRepository;
+  private readonly credentials: CredentialDecisionRepository;
+
+  constructor({
+    decisions,
+    credentials,
+  }: {
+    /** User-grant decisions (tRPC declarations, session surfaces). */
+    decisions: PermissionDecisionRepository;
+    /** API-key credential decisions (REST key middlewares, ceilings). */
+    credentials: CredentialDecisionRepository;
+  }) {
+    this.repository = decisions;
+    this.credentials = credentials;
+  }
 
   /**
    * Asserts that a user holds the given permission on a project.
@@ -152,6 +181,48 @@ export class PermissionsService {
           permission,
         });
     }
+  }
+
+  /**
+   * Whether an API-key credential holds `permission` at `scope` —
+   * `effective = ApiKey.bindings ∩ owning user's bindings`. The check behind
+   * every REST credential authorization (org apps, the API-key ceiling, the
+   * management API).
+   */
+  async hasApiKeyPermission(check: ApiKeyPermissionCheck): Promise<boolean> {
+    return await this.credentials.findApiKeyDecision(check);
+  }
+
+  /**
+   * An API-key credential's decision for a project it names only by id:
+   * resolves the project's tenancy coordinates, refuses cross-organization
+   * ids as not-found, then checks the permission at the project's scope.
+   */
+  async getApiKeyProjectDecision({
+    apiKeyId,
+    userId,
+    organizationId,
+    projectId,
+    permission,
+  }: {
+    apiKeyId: string;
+    userId: string | null;
+    organizationId: string;
+    projectId: string;
+    permission: AuthzPermission;
+  }): Promise<ApiKeyProjectDecision> {
+    const scope = await this.credentials.findProjectScope({ projectId });
+    if (!scope || scope.organizationId !== organizationId) {
+      return { outcome: "project_not_found" };
+    }
+    const allowed = await this.credentials.findApiKeyDecision({
+      apiKeyId,
+      userId,
+      organizationId,
+      scope: { type: "project", id: scope.projectId, teamId: scope.teamId },
+      permission,
+    });
+    return allowed ? { outcome: "allowed", scope } : { outcome: "denied" };
   }
 
   /**

--- a/platform/app/src/server/app-layer/permissions/permissions.service.ts
+++ b/platform/app/src/server/app-layer/permissions/permissions.service.ts
@@ -1,7 +1,16 @@
+import {
+  type AuthzPermission,
+  PermissionDeniedError,
+  type PermissionScopeArg,
+} from "@langwatch/authz";
 import type { PrismaClient } from "~/generated/prisma/client";
 import { OrganizationUserRole } from "~/generated/prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import { resolveProjectPermission } from "~/server/api/rbac";
+import {
+  hasOrganizationPermission,
+  resolveProjectPermission,
+  resolveTeamPermission,
+} from "~/server/api/rbac";
 import type { Session } from "~/server/auth";
 import {
   LiteMemberRestrictedError,
@@ -61,5 +70,98 @@ export class PermissionsService {
       }
       throw new ProjectPermissionDeniedError(permission);
     }
+  }
+
+  /**
+   * ADR-092 decision 25 — the typed imperative check. The scope argument is
+   * derived from the permission's registry tiers: exactly one id, at a tier
+   * the permission can be granted at, or the call does not compile. Decides
+   * through the same fork-aware resolvers every declared `.permission()`
+   * runs, so an imperative site and a declared one can never disagree.
+   */
+  async hasPermission<P extends AuthzPermission>(
+    check: { userId: string; permission: P } & PermissionScopeArg<P>,
+  ): Promise<boolean> {
+    const { permitted } = await this.decide(check);
+    return permitted;
+  }
+
+  /**
+   * The asserting form of {@link hasPermission}: throws the engine's one
+   * denial (`permission_denied`, with the permission and tier in `meta`), or
+   * the lite-member restriction where that is the cause.
+   */
+  async requirePermission<P extends AuthzPermission>(
+    check: { userId: string; permission: P } & PermissionScopeArg<P>,
+  ): Promise<void> {
+    const { tier, id, permitted, organizationRole } = await this.decide(check);
+    if (permitted) return;
+    if (organizationRole === OrganizationUserRole.EXTERNAL) {
+      throw new LiteMemberRestrictedError(
+        check.permission.split(":")[0] ?? "unknown",
+      );
+    }
+    throw new PermissionDeniedError({
+      permission: check.permission,
+      scope: { type: tier, id },
+      denialReason: "no-binding",
+    });
+  }
+
+  private async decide({
+    userId,
+    permission,
+    ...scope
+  }: {
+    userId: string;
+    permission: AuthzPermission;
+  } & Partial<
+    Record<"projectId" | "teamId" | "organizationId", string>
+  >): Promise<{
+    tier: "project" | "team" | "organization";
+    id: string;
+    permitted: boolean;
+    organizationRole: OrganizationUserRole | null;
+  }> {
+    const ctx = {
+      prisma: this.prisma,
+      session: { user: { id: userId }, expires: "" } as Session,
+    };
+    if (scope.projectId) {
+      const decision = await resolveProjectPermission(
+        ctx,
+        scope.projectId,
+        permission,
+      );
+      return { tier: "project", id: scope.projectId, ...decision };
+    }
+    if (scope.teamId) {
+      const decision = await resolveTeamPermission(
+        ctx,
+        scope.teamId,
+        permission,
+      );
+      return { tier: "team", id: scope.teamId, ...decision };
+    }
+    if (scope.organizationId) {
+      const permitted = await hasOrganizationPermission(
+        ctx as { prisma: PrismaClient; session: Session },
+        scope.organizationId,
+        permission,
+      );
+      return {
+        tier: "organization",
+        id: scope.organizationId,
+        permitted,
+        organizationRole: null,
+      };
+    }
+    // The types make this unreachable; fail closed if they are bypassed.
+    return {
+      tier: "project",
+      id: "unresolved",
+      permitted: false,
+      organizationRole: null,
+    };
   }
 }

--- a/platform/app/src/server/app-layer/permissions/runtime.ts
+++ b/platform/app/src/server/app-layer/permissions/runtime.ts
@@ -1,18 +1,19 @@
 /**
  * The permissions composition root: the one place the client meets the
- * repository meets the service. Unlike `../authz/runtime.ts` it is
- * parameterized on the client rather than importing the singleton, because
- * every boundary passes its own request context's prisma — which is exactly
- * what lets a test inject a fake all the way down.
+ * repositories meets the service. Called by the App presets — every runtime
+ * consumer resolves the composed instance via `getApp().permissions` rather
+ * than composing its own.
  */
 import type { PrismaClient } from "~/generated/prisma/client";
+import { ForkAwareCredentialDecisionRepository } from "./credential-decision.repository";
 import { ForkAwarePermissionDecisionRepository } from "./permission-decision.repository";
 import { PermissionsService } from "./permissions.service";
 
 export function permissionsServiceFor(
   prisma: PrismaClient,
 ): PermissionsService {
-  return new PermissionsService(
-    new ForkAwarePermissionDecisionRepository(prisma),
-  );
+  return new PermissionsService({
+    decisions: new ForkAwarePermissionDecisionRepository(prisma),
+    credentials: new ForkAwareCredentialDecisionRepository(prisma),
+  });
 }

--- a/platform/app/src/server/app-layer/permissions/runtime.ts
+++ b/platform/app/src/server/app-layer/permissions/runtime.ts
@@ -1,0 +1,18 @@
+/**
+ * The permissions composition root: the one place the client meets the
+ * repository meets the service. Unlike `../authz/runtime.ts` it is
+ * parameterized on the client rather than importing the singleton, because
+ * every boundary passes its own request context's prisma — which is exactly
+ * what lets a test inject a fake all the way down.
+ */
+import type { PrismaClient } from "~/generated/prisma/client";
+import { ForkAwarePermissionDecisionRepository } from "./permission-decision.repository";
+import { PermissionsService } from "./permissions.service";
+
+export function permissionsServiceFor(
+  prisma: PrismaClient,
+): PermissionsService {
+  return new PermissionsService(
+    new ForkAwarePermissionDecisionRepository(prisma),
+  );
+}

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -269,6 +269,7 @@ import { getOpsSnapshotReader } from "./ops/snapshot/snapshot-reader";
 import { OrganizationService } from "./organizations/organization.service";
 import { PrismaOrganizationRepository } from "./organizations/repositories/organization.prisma.repository";
 import { NullOrganizationRepository } from "./organizations/repositories/organization.repository";
+import { permissionsServiceFor } from "./permissions/runtime";
 import { PresenceService } from "./presence/presence.service";
 import { InMemoryPresenceRepository } from "./presence/repositories/presence.memory.repository";
 import { RedisPresenceRepository } from "./presence/repositories/presence.redis.repository";
@@ -1800,6 +1801,7 @@ export function initializeDefaultApp(options?: {
     },
     organizations,
     projects,
+    permissions: permissionsServiceFor(prisma),
     tokenizer,
     usage,
     planProvider,
@@ -2157,6 +2159,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
     },
     organizations: nullOrganizations,
     projects: nullProjects,
+    permissions: permissionsServiceFor(testPrisma),
     tokenizer: new TokenizerService(new NullTokenizerClient()),
     usage: new UsageService(
       nullOrganizations,

--- a/platform/app/src/server/auth/__tests__/permissions.unit.test.ts
+++ b/platform/app/src/server/auth/__tests__/permissions.unit.test.ts
@@ -8,10 +8,16 @@ vi.mock("~/server/api/rbac", () => ({
     resolveProjectPermissionMock(...args),
 }));
 
+// The wrapper resolves its service from the App.
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
 import { LiteMemberRestrictedError } from "~/server/app-layer/permissions/errors";
 import { requireProjectPermission } from "../permissions";
-
-const prisma = {} as any;
 
 beforeEach(() => {
   resolveProjectPermissionMock.mockReset();
@@ -30,7 +36,6 @@ describe("requireProjectPermission", () => {
           userId: "user_1",
           projectId: "proj_1",
           permission: "traces:view",
-          prisma,
         }),
       ).resolves.toBeUndefined();
     });
@@ -56,7 +61,6 @@ describe("requireProjectPermission", () => {
           userId: "user_not_member",
           projectId: "proj_1",
           permission: "traces:view",
-          prisma,
         }),
       ).rejects.toMatchObject({
         code: "project_permission_denied",
@@ -79,7 +83,6 @@ describe("requireProjectPermission", () => {
           userId: "user_viewer",
           projectId: "proj_1",
           permission: "project:delete",
-          prisma,
         }),
       ).rejects.toMatchObject({ code: "project_permission_denied" });
     });
@@ -97,7 +100,6 @@ describe("requireProjectPermission", () => {
           userId: "user_lite",
           projectId: "proj_1",
           permission: "scenarios:manage",
-          prisma,
         }),
       ).rejects.toBeInstanceOf(LiteMemberRestrictedError);
     });

--- a/platform/app/src/server/auth/permissions.ts
+++ b/platform/app/src/server/auth/permissions.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "~/generated/prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import { PermissionsService } from "~/server/app-layer/permissions/permissions.service";
+import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
 
 /**
  * Asserts that a user holds the given permission on a project.
@@ -32,6 +32,6 @@ export async function requireProjectPermission({
   permission: Permission;
   prisma: PrismaClient;
 }): Promise<void> {
-  const service = new PermissionsService(prisma);
+  const service = permissionsServiceFor(prisma);
   return service.requireProjectPermission({ userId, projectId, permission });
 }

--- a/platform/app/src/server/auth/permissions.ts
+++ b/platform/app/src/server/auth/permissions.ts
@@ -1,37 +1,34 @@
-import type { PrismaClient } from "~/generated/prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import { permissionsServiceFor } from "~/server/app-layer/permissions/runtime";
+import { getApp } from "~/server/app-layer/app";
 
 /**
  * Asserts that a user holds the given permission on a project.
  *
- * Thin wrapper around {@link PermissionsService#requireProjectPermission} that
- * accepts a caller-supplied Prisma client, keeping backward compatibility with
- * existing call sites that pass `prisma` as a named parameter.
- *
- * Pure async function — no tRPC dependency. Safe to call from Hono routes,
- * background workers, or any other non-tRPC surface.
+ * Thin wrapper around the App-composed permissions service
+ * (`getApp().permissions`) for non-tRPC surfaces — Hono routes, background
+ * workers, anywhere with a userId and a projectId in hand.
  *
  * Throws {@link LiteMemberRestrictedError} when the denial is caused by the
- * user being a Lite Member (EXTERNAL org role). Throws a plain `Error` for
- * all other denials (not a member, or member without the permission).
+ * user being a Lite Member (EXTERNAL org role), and
+ * {@link ProjectPermissionDeniedError} for every other denial (not a member,
+ * or member without the permission). Both are handled errors carrying a code.
  *
  * @param params.userId     - The authenticated user's ID.
  * @param params.projectId  - The project being accessed.
  * @param params.permission - The permission that must be held.
- * @param params.prisma     - Prisma client instance (injected for testability).
  */
 export async function requireProjectPermission({
   userId,
   projectId,
   permission,
-  prisma,
 }: {
   userId: string;
   projectId: string;
   permission: Permission;
-  prisma: PrismaClient;
 }): Promise<void> {
-  const service = permissionsServiceFor(prisma);
-  return service.requireProjectPermission({ userId, projectId, permission });
+  return getApp().permissions.requireProjectPermission({
+    userId,
+    projectId,
+    permission,
+  });
 }

--- a/platform/app/src/server/data-privacy/dataPrivacyPolicy.authz.ts
+++ b/platform/app/src/server/data-privacy/dataPrivacyPolicy.authz.ts
@@ -4,7 +4,7 @@ import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-} from "~/server/api/rbac";
+} from "~/server/app-layer/permissions/imperative";
 import type { Session } from "~/server/auth";
 import type {
   DataPrivacyScope,
@@ -54,7 +54,7 @@ async function canWriteScope(
           )?.organizationId;
     if (!organizationId) return false;
     return hasOrganizationPermission(
-      { prisma: ctx.prisma, session: ctx.session },
+      { session: ctx.session },
       organizationId,
       "organization:manage",
     );

--- a/platform/app/src/server/data-privacy/dataPrivacyPolicy.read.ts
+++ b/platform/app/src/server/data-privacy/dataPrivacyPolicy.read.ts
@@ -1,9 +1,9 @@
 import type { PrismaClient } from "~/generated/prisma/client";
+import { batchScopePermissions } from "~/server/api/rbac";
 import {
-  batchScopePermissions,
   hasOrganizationPermission,
   hasProjectPermission,
-} from "~/server/api/rbac";
+} from "~/server/app-layer/permissions/imperative";
 import type { Session } from "~/server/auth";
 import {
   type DataPrivacyConfig,

--- a/platform/app/src/server/data-retention/policy/__tests__/dataRetentionPolicy.authz.unit.test.ts
+++ b/platform/app/src/server/data-retention/policy/__tests__/dataRetentionPolicy.authz.unit.test.ts
@@ -7,7 +7,7 @@ const rbacMocks = vi.hoisted(() => ({
   hasProjectPermission: vi.fn(),
 }));
 
-vi.mock("~/server/api/rbac", () => rbacMocks);
+vi.mock("~/server/app-layer/permissions/imperative", () => rbacMocks);
 
 const planMocks = vi.hoisted(() => ({
   getActivePlan: vi.fn(),
@@ -124,7 +124,7 @@ describe("assertCanWriteRetentionScope", () => {
       ).resolves.toBeUndefined();
 
       expect(rbacMocks.hasOrganizationPermission).toHaveBeenCalledWith(
-        { prisma, session },
+        { session },
         "org_1",
         "organization:manage",
       );
@@ -157,7 +157,6 @@ describe("assertCanDisableRetention", () => {
     it("allows disabling retention", () => {
       process.env.ADMIN_EMAILS = "ops@langwatch.ai,admin@langwatch.ai";
       const adminCtx = {
-        prisma,
         session: { user: { id: "u1", email: "admin@langwatch.ai" } },
       } as any;
       expect(() => assertCanDisableRetention(adminCtx)).not.toThrow();
@@ -168,7 +167,6 @@ describe("assertCanDisableRetention", () => {
     it("throws FORBIDDEN with platform-administrator wording", () => {
       process.env.ADMIN_EMAILS = "ops@langwatch.ai";
       const orgAdminCtx = {
-        prisma,
         session: { user: { id: "u2", email: "owner@acme.com" } },
       } as any;
       try {

--- a/platform/app/src/server/data-retention/policy/__tests__/dataRetentionPolicy.read.unit.test.ts
+++ b/platform/app/src/server/data-retention/policy/__tests__/dataRetentionPolicy.read.unit.test.ts
@@ -7,7 +7,15 @@ const rbacMocks = vi.hoisted(() => ({
   batchScopePermissions: vi.fn(),
 }));
 
-vi.mock("~/server/api/rbac", () => rbacMocks);
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
+  hasOrganizationPermission: rbacMocks.hasOrganizationPermission,
+  hasProjectPermission: rbacMocks.hasProjectPermission,
+}));
+
+// batchScopePermissions stays a legacy rbac read (it is the seam itself).
+vi.mock("~/server/api/rbac", () => ({
+  batchScopePermissions: rbacMocks.batchScopePermissions,
+}));
 
 const appMocks = vi.hoisted(() => ({
   getResolvedForProject: vi.fn(),

--- a/platform/app/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
+++ b/platform/app/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
@@ -4,12 +4,12 @@ import { TRPCError } from "@trpc/server";
 import { env } from "~/env.mjs";
 import type { PrismaClient } from "~/generated/prisma/client";
 import { isEnterpriseTier } from "~/server/api/enterprise";
+import { getApp } from "~/server/app-layer/app";
 import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-} from "~/server/api/rbac";
-import { getApp } from "~/server/app-layer/app";
+} from "~/server/app-layer/permissions/imperative";
 import type { Session } from "~/server/auth";
 import {
   ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
@@ -54,7 +54,7 @@ async function canWriteScope(
   if (!ctx.session) return false;
   if (scope.scopeType === "ORGANIZATION") {
     return hasOrganizationPermission(
-      { prisma: ctx.prisma, session: ctx.session },
+      { session: ctx.session },
       scope.scopeId,
       "organization:manage",
     );

--- a/platform/app/src/server/data-retention/policy/dataRetentionPolicy.read.ts
+++ b/platform/app/src/server/data-retention/policy/dataRetentionPolicy.read.ts
@@ -1,10 +1,10 @@
 import type { PrismaClient } from "~/generated/prisma/client";
+import { batchScopePermissions } from "~/server/api/rbac";
+import { getApp } from "~/server/app-layer/app";
 import {
-  batchScopePermissions,
   hasOrganizationPermission,
   hasProjectPermission,
-} from "~/server/api/rbac";
-import { getApp } from "~/server/app-layer/app";
+} from "~/server/app-layer/permissions/imperative";
 import type { Session } from "~/server/auth";
 import type { ScopeTier } from "~/server/scopes/scope.types";
 import type {

--- a/platform/app/src/server/gateway/__tests__/virtualKey.authz.unit.test.ts
+++ b/platform/app/src/server/gateway/__tests__/virtualKey.authz.unit.test.ts
@@ -8,11 +8,7 @@ import {
   type Scope,
 } from "../virtualKey.authz";
 
-// Partial mock: the authz module also (transitively) pulls in the
-// role-binding resolver for API-key actors, which reads real exports like
-// `Resources` from this module at init time.
-vi.mock("~/server/api/rbac", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("~/server/api/rbac")>()),
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
   hasOrganizationPermission: vi.fn(),
   hasTeamPermission: vi.fn(),
   hasProjectPermission: vi.fn(),
@@ -22,7 +18,7 @@ import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-} from "~/server/api/rbac";
+} from "~/server/app-layer/permissions/imperative";
 
 const orgPerm = vi.mocked(hasOrganizationPermission);
 const teamPerm = vi.mocked(hasTeamPermission);

--- a/platform/app/src/server/gateway/virtualKey.authz.ts
+++ b/platform/app/src/server/gateway/virtualKey.authz.ts
@@ -3,14 +3,14 @@ import {
   OrganizationUserRole,
   type PrismaClient,
 } from "~/generated/prisma/client";
-
-import type { Session } from "~/server/auth";
 import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-  type Permission,
-} from "../api/rbac";
+} from "~/server/app-layer/permissions/imperative";
+
+import type { Session } from "~/server/auth";
+import type { Permission } from "../api/rbac";
 import { resolveApiKeyPermission } from "../rbac/role-binding-resolver";
 import {
   GatewayGuardrailProjectMismatchError,

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.authz.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.authz.unit.test.ts
@@ -4,7 +4,7 @@ const hasOrganizationPermissionMock = vi.fn();
 const hasTeamPermissionMock = vi.fn();
 const hasProjectPermissionMock = vi.fn();
 
-vi.mock("../../api/rbac", () => ({
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
   hasOrganizationPermission: (...args: unknown[]) =>
     hasOrganizationPermissionMock(...args),
   hasTeamPermission: (...args: unknown[]) => hasTeamPermissionMock(...args),
@@ -52,7 +52,7 @@ describe("assertCanManageScope", () => {
         }),
       ).resolves.toBeUndefined();
       expect(hasOrganizationPermissionMock).toHaveBeenCalledWith(
-        expect.objectContaining({ prisma: expect.anything() }),
+        expect.objectContaining({ session: expect.anything() }),
         "org_acme",
         "organization:manage",
       );

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.testConnection.unit.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../rateLimit", () => ({
   rateLimit: (...args: unknown[]) => rateLimitMock(...args),
 }));
 
-vi.mock("../../api/rbac", () => ({
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
   hasOrganizationPermission: (...args: unknown[]) =>
     hasOrganizationPermissionMock(...args),
   hasTeamPermission: (...args: unknown[]) => hasTeamPermissionMock(...args),

--- a/platform/app/src/server/modelProviders/modelDefaults.read.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.read.ts
@@ -2,14 +2,14 @@ import type {
   ModelDefaultScopeType,
   PrismaClient,
 } from "~/generated/prisma/client";
-
-import type { Session } from "~/server/auth";
 import {
-  batchScopePermissions,
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-} from "../api/rbac";
+} from "~/server/app-layer/permissions/imperative";
+
+import type { Session } from "~/server/auth";
+import { batchScopePermissions } from "../api/rbac";
 import {
   allFeatures,
   featureByKey,

--- a/platform/app/src/server/modelProviders/modelDefaults.service.ts
+++ b/platform/app/src/server/modelProviders/modelDefaults.service.ts
@@ -3,13 +3,13 @@ import type {
   ModelDefaultScopeType,
   PrismaClient,
 } from "~/generated/prisma/client";
-
-import type { Session } from "~/server/auth";
 import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-} from "../api/rbac";
+} from "~/server/app-layer/permissions/imperative";
+
+import type { Session } from "~/server/auth";
 import { isRootPrismaClient } from "../db";
 import { CODING_ASSISTANT_SURFACES_ONLY_NEEDLE } from "./codexRefusalMessage";
 import {

--- a/platform/app/src/server/modelProviders/modelProvider.authz.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.authz.ts
@@ -1,10 +1,10 @@
 import type { PrismaClient } from "~/generated/prisma/client";
-import type { Session } from "~/server/auth";
 import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
-} from "../api/rbac";
+} from "~/server/app-layer/permissions/imperative";
+import type { Session } from "~/server/auth";
 import { ModelProviderScopeForbiddenError } from "./errors";
 
 /**
@@ -54,7 +54,7 @@ async function canManageScope(
   if (!ctx.session) return false;
   if (scope.scopeType === "ORGANIZATION") {
     return hasOrganizationPermission(
-      { prisma: ctx.prisma, session: ctx.session },
+      { session: ctx.session },
       scope.scopeId,
       "organization:manage",
     );
@@ -105,7 +105,7 @@ async function canReadScope(ctx: RBACContext, scope: Scope): Promise<boolean> {
   if (!ctx.session) return false;
   if (scope.scopeType === "ORGANIZATION") {
     return hasOrganizationPermission(
-      { prisma: ctx.prisma, session: ctx.session },
+      { session: ctx.session },
       scope.scopeId,
       "organization:view",
     );

--- a/platform/app/src/server/routes/__tests__/langy-api-refusal-chain.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-refusal-chain.unit.test.ts
@@ -96,6 +96,7 @@ vi.mock("~/server/app-layer/langy/langyApiKeyActorSession", () => ({
 const mockStartConversationTurn = vi.fn();
 
 vi.mock("~/server/app-layer/app", () => ({
+  tryGetApp: () => null,
   getApp: vi.fn(() => ({
     langy: { turns: { startConversationTurn: mockStartConversationTurn } },
   })),

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -96,12 +96,22 @@ vi.mock("~/server/db", () => ({ prisma: mockPrisma }));
 // connection the handler writes the auth code to.
 vi.mock("~/server/app-layer/app", async (importOriginal) => {
   const actual = await importOriginal<typeof AppLayerApp>();
+  const { permissionsServiceFor } = await import(
+    "~/server/app-layer/permissions/runtime"
+  );
+  const { prisma } = await import("~/server/db");
   // misc.ts reads its connection through tryGetApp; getApp is overridden too
-  // so both accessors agree on the fake.
+  // so both accessors agree on the fake. The permission check runs the REAL
+  // walk over this file's prisma fixtures, exactly as it did before the App
+  // owned the service.
+  const app = {
+    redis: mockRedis,
+    permissions: permissionsServiceFor(prisma),
+  };
   return {
     ...actual,
-    getApp: () => ({ redis: mockRedis }),
-    tryGetApp: () => ({ redis: mockRedis }),
+    getApp: () => app,
+    tryGetApp: () => app,
   };
 });
 vi.mock("~/utils/encryption", () => ({

--- a/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/otel.path-aliases.unit.test.ts
@@ -17,6 +17,7 @@ const mockExtractCredentials = vi.fn();
 const mockWarn = vi.fn();
 
 vi.mock("~/server/app-layer/app", () => ({
+  tryGetApp: () => null,
   getApp: vi.fn(() => ({
     usage: { checkLimit: mockCheckLimit },
     planProvider: {

--- a/platform/app/src/server/routes/__tests__/scenario-generate.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/scenario-generate.unit.test.ts
@@ -25,8 +25,7 @@ vi.mock("~/server/auth", async (importOriginal) => ({
 }));
 
 const mockHasProjectPermission = vi.fn();
-vi.mock("~/server/api/rbac", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("~/server/api/rbac")>()),
+vi.mock("~/server/app-layer/permissions/imperative", () => ({
   hasProjectPermission: (...args: unknown[]) =>
     mockHasProjectPermission(...args),
 }));

--- a/platform/app/src/server/routes/annotations.ts
+++ b/platform/app/src/server/routes/annotations.ts
@@ -80,7 +80,7 @@ async function authenticateRequest(c: Context, permission: Permission) {
   }
 
   try {
-    await enforceApiKeyCeiling({ prisma, resolved, permission });
+    await enforceApiKeyCeiling({ resolved, permission });
   } catch (error) {
     const denial = apiKeyCeilingDenialResponse(error);
     return {

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -54,12 +54,12 @@ import {
   ENTERPRISE_FEATURE_ERRORS,
 } from "~/server/api/enterprise";
 import type { Permission } from "~/server/api/rbac";
+import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { getApp, tryGetApp } from "~/server/app-layer/app";
 import {
   hasOrganizationPermission,
   hasProjectPermission,
-} from "~/server/api/rbac";
-import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
-import { getApp, tryGetApp } from "~/server/app-layer/app";
+} from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { featureFlagService } from "~/server/featureFlag";
@@ -380,7 +380,6 @@ async function refuseProjectKeyHandout(
   }
   const canWriteProject = await hasProjectPermission(
     {
-      prisma,
       session: { user: { id: userId } },
     } as Parameters<typeof hasProjectPermission>[0],
     project.id,
@@ -1628,7 +1627,7 @@ async function ensureGovernancePermissionOr403(
   permission: Permission,
 ): Promise<Response | null> {
   const allowed = await hasOrganizationPermission(
-    { prisma, session: { user: { id: tokenRecord.user_id } } } as any,
+    { session: { user: { id: tokenRecord.user_id } } } as any,
     tokenRecord.organization_id,
     permission,
   );
@@ -2033,7 +2032,6 @@ async function mintProjectIngestionKey(
 
   const allowed = await hasProjectPermission(
     {
-      prisma,
       session: { user: { id: tokenRecord.user_id } },
     } as Parameters<typeof hasProjectPermission>[0],
     project.id,

--- a/platform/app/src/server/routes/collector.ts
+++ b/platform/app/src/server/routes/collector.ts
@@ -124,7 +124,6 @@ secured
       // read-only API keys from ingesting traces.
       try {
         await enforceApiKeyCeiling({
-          prisma,
           resolved,
           permission: "traces:create",
         });

--- a/platform/app/src/server/routes/dataset-generate.ts
+++ b/platform/app/src/server/routes/dataset-generate.ts
@@ -16,8 +16,8 @@ import {
   type UIMessage,
 } from "ai";
 import { tools } from "~/app/api/dataset/generate/tools";
-import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { getVercelAIModel } from "~/server/modelProviders/utils";
@@ -54,7 +54,7 @@ secured
     }
 
     const hasPermission = await hasProjectPermission(
-      { prisma, session },
+      { session },
       projectId,
       "datasets:manage",
     );

--- a/platform/app/src/server/routes/evaluations-legacy.ts
+++ b/platform/app/src/server/routes/evaluations-legacy.ts
@@ -180,7 +180,7 @@ async function authenticateRequest(
   }
 
   try {
-    await enforceApiKeyCeiling({ prisma, resolved, permission });
+    await enforceApiKeyCeiling({ resolved, permission });
   } catch (error) {
     const denial = apiKeyCeilingDenialResponse(error);
     // The ceiling only ever denies with 403; narrowed here so the descriptor

--- a/platform/app/src/server/routes/experiments-v3.ts
+++ b/platform/app/src/server/routes/experiments-v3.ts
@@ -23,7 +23,6 @@ import { persistedEvaluationsV3StateSchema } from "~/experiments-v3/types/persis
 import { ExperimentType } from "~/generated/prisma/client";
 import type { TypedAgent } from "~/server/agents/agent.repository";
 import type { Permission } from "~/server/api/rbac";
-import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
 import {
@@ -32,6 +31,7 @@ import {
   extractCredentials,
 } from "~/server/api-key/auth-middleware";
 import { TokenResolver } from "~/server/api-key/token-resolver";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import {
@@ -164,7 +164,7 @@ const authenticateRequest = async (
   }
 
   try {
-    await enforceApiKeyCeiling({ prisma, resolved, permission });
+    await enforceApiKeyCeiling({ resolved, permission });
   } catch (error) {
     const denial = apiKeyCeilingDenialResponse(error);
     // `body` carries the full handled payload (code, permission, tips) for
@@ -239,7 +239,7 @@ secured.access(sessionAuth).post(
     }
 
     const hasPermission = await hasProjectPermission(
-      { prisma, session },
+      { session },
       projectId,
       "evaluations:manage",
     );
@@ -388,7 +388,7 @@ secured.access(sessionAuth).post("/abort", async (c) => {
   }
 
   const hasPermission = await hasProjectPermission(
-    { prisma, session },
+    { session },
     projectId,
     "evaluations:manage",
   );

--- a/platform/app/src/server/routes/github.ts
+++ b/platform/app/src/server/routes/github.ts
@@ -30,7 +30,6 @@ import { createLogger } from "@langwatch/observability";
 import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { z } from "zod";
 import { env } from "~/env.mjs";
-import { hasOrganizationPermission } from "~/server/api/rbac";
 import {
   createServiceApp,
   handlerManagedAuth,
@@ -55,6 +54,7 @@ import {
   verifyGithubInstallState,
 } from "~/server/app-layer/github/githubInstallState";
 import { parseGithubPullRequestEvent } from "~/server/app-layer/github/githubPullRequestEvent";
+import { hasOrganizationPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 
@@ -199,7 +199,7 @@ async function handleInstall(c: any): Promise<Response> {
   // for every write to the connection.
   if (
     !(await hasOrganizationPermission(
-      { prisma, session },
+      { session },
       organizationId,
       "organization:manage",
     ))
@@ -330,7 +330,7 @@ async function rejectUnauthorizedSetup({
   // the installation is the write the permission exists to gate.
   if (
     !(await hasOrganizationPermission(
-      { prisma, session },
+      { session },
       state.organizationId,
       "organization:manage",
     ))

--- a/platform/app/src/server/routes/langy-api.ts
+++ b/platform/app/src/server/routes/langy-api.ts
@@ -205,7 +205,7 @@ async function authorizeTurn(c: Context) {
   );
   if (!surfaceOpen) return { dark: true as const };
 
-  await enforceApiKeyCeiling({ prisma, resolved, permission: "langy:create" });
+  await enforceApiKeyCeiling({ resolved, permission: "langy:create" });
 
   const identity = await resolveLangyKeyIdentity({ resolved });
   if (!identity.ok) {

--- a/platform/app/src/server/routes/misc.ts
+++ b/platform/app/src/server/routes/misc.ts
@@ -39,7 +39,7 @@ import {
   timeseriesSeriesInput,
 } from "~/server/analytics/registry";
 import { sharedFiltersInputSchema } from "~/server/analytics/types";
-import { hasProjectPermission, isDemoProject } from "~/server/api/rbac";
+import { isDemoProject } from "~/server/api/rbac";
 import {
   createServiceApp,
   handlerManagedAuth,
@@ -61,6 +61,7 @@ import {
   generateTrackedEventId,
   recordTrackedEventSpan,
 } from "~/server/app-layer/events/track-event.service";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { ProjectService } from "~/server/app-layer/projects/project.service";
 import { PrismaProjectRepository } from "~/server/app-layer/projects/repositories/project.prisma.repository";
 import { getServerAuthSession } from "~/server/auth";
@@ -124,25 +125,20 @@ const logger = createLogger("langwatch:misc");
 // enforces the per-route ceiling and returns 403 on denial.
 const authMiddleware = createUnifiedAuthMiddleware({ prisma });
 const requireAnalyticsView = requireApiKeyPermission({
-  prisma,
   permission: "analytics:view",
 });
 const requireWorkflowsManage = requireApiKeyPermission({
-  prisma,
   permission: "workflows:manage",
 });
 // DSPy step logging + experiment bootstrapping are experiment writes, gated on
 // the dedicated experiments permission rather than the workflow studio's.
 const requireExperimentsManage = requireApiKeyPermission({
-  prisma,
   permission: "experiments:manage",
 });
 const requireTracesCreate = requireApiKeyPermission({
-  prisma,
   permission: "traces:create",
 });
 const requireTriggersManage = requireApiKeyPermission({
-  prisma,
   permission: "triggers:manage",
 });
 
@@ -927,11 +923,7 @@ secured
     if (
       !project ||
       project.archivedAt !== null ||
-      !(await hasProjectPermission(
-        { prisma, session },
-        projectId,
-        "project:view",
-      ))
+      !(await hasProjectPermission({ session }, projectId, "project:view"))
     ) {
       // Single 403 whether the project is missing, archived, or simply
       // inaccessible — never disclose existence of a project the caller can't reach.

--- a/platform/app/src/server/routes/otel.ts
+++ b/platform/app/src/server/routes/otel.ts
@@ -161,7 +161,6 @@ async function authenticate(
   // access on OTLP ingestion — same semantics as the collector path.
   try {
     await enforceApiKeyCeiling({
-      prisma,
       resolved,
       permission: "traces:create",
     });

--- a/platform/app/src/server/routes/playground.ts
+++ b/platform/app/src/server/routes/playground.ts
@@ -9,12 +9,12 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { streamText } from "ai";
 import { env } from "~/env.mjs";
-import { hasProjectPermission } from "~/server/api/rbac";
 import {
   getProjectModelProviders,
   prepareLitellmParams,
 } from "~/server/api/routers/modelProviders.utils";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { nlpgoProxyBaseURL } from "~/server/nlpgo/nlpgoFetch";
@@ -46,7 +46,7 @@ secured
     }
 
     const hasPermission = await hasProjectPermission(
-      { prisma, session },
+      { session },
       projectId,
       "playground:manage",
     );

--- a/platform/app/src/server/routes/scenario-generate.ts
+++ b/platform/app/src/server/routes/scenario-generate.ts
@@ -10,8 +10,8 @@
 import { createLogger } from "@langwatch/observability";
 import { generateObject } from "ai";
 import { z } from "zod";
-import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { getVercelAIModel } from "~/server/modelProviders/utils";
@@ -134,7 +134,7 @@ secured
     const { prompt, currentScenario, projectId } = body;
 
     const hasPermission = await hasProjectPermission(
-      { prisma, session },
+      { session },
       projectId,
       "scenarios:manage",
     );

--- a/platform/app/src/server/routes/traces-legacy.ts
+++ b/platform/app/src/server/routes/traces-legacy.ts
@@ -81,7 +81,7 @@ async function authenticateRequest(c: Context, permission: Permission) {
   }
 
   try {
-    await enforceApiKeyCeiling({ prisma, resolved, permission });
+    await enforceApiKeyCeiling({ resolved, permission });
   } catch (error) {
     const denial = apiKeyCeilingDenialResponse(error);
     return {

--- a/platform/app/src/server/routes/workflows.ts
+++ b/platform/app/src/server/routes/workflows.ts
@@ -24,9 +24,9 @@ import {
   type StudioServerEvent,
   studioClientEventSchema,
 } from "~/optimization_studio/types/events";
-import { hasProjectPermission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
+import { hasProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { DatasetNotReadyError } from "~/server/datasets/errors";
 import { prisma } from "~/server/db";
@@ -64,7 +64,7 @@ secured
     }
 
     const hasPermission = await hasProjectPermission(
-      { prisma, session },
+      { session },
       projectId,
       "workflows:manage",
     );
@@ -157,7 +157,7 @@ secured
       }
 
       const hasPermission = await hasProjectPermission(
-        { prisma, session },
+        { session },
         projectId,
         "workflows:manage",
       );

--- a/platform/app/src/test-utils/appCredentialPermissionsMock.ts
+++ b/platform/app/src/test-utils/appCredentialPermissionsMock.ts
@@ -1,0 +1,38 @@
+import type { PrismaClient } from "~/generated/prisma/client";
+import { ForkAwareCredentialDecisionRepository } from "~/server/app-layer/permissions/credential-decision.repository";
+import { PermissionsService } from "~/server/app-layer/permissions/permissions.service";
+
+const unstubbed = () => {
+  throw new Error(
+    "user-grant decisions are not stubbed by appCredentialPermissionsMock",
+  );
+};
+
+/**
+ * Factory body for `vi.mock("~/server/app-layer/app", ...)` in tests that
+ * exercise the CREDENTIAL (API-key) check path: the real service + credential
+ * repository over the `role-binding-resolver` module, so a test's
+ * `vi.mock("~/server/rbac/role-binding-resolver")` stub keeps deciding.
+ * Separate from `appPermissionsMock` because this half's module graph pulls
+ * the resolver's own imports, which user-grant tests deliberately avoid.
+ *
+ * `prisma` backs only `findProjectScope` (the project tenancy lookup); pass
+ * a fake with `project.findUnique` when the test reaches it.
+ */
+export function appCredentialPermissionsMock(prisma?: unknown) {
+  const permissions = new PermissionsService({
+    decisions: {
+      findProjectDecision: unstubbed,
+      findProjectAnyDecision: unstubbed,
+      findTeamDecision: unstubbed,
+      findOrganizationDecision: unstubbed,
+    },
+    credentials: new ForkAwareCredentialDecisionRepository(
+      (prisma ?? {}) as PrismaClient,
+    ),
+  });
+  return {
+    getApp: () => ({ permissions }),
+    tryGetApp: () => null,
+  };
+}

--- a/platform/app/src/test-utils/appPermissionsMock.ts
+++ b/platform/app/src/test-utils/appPermissionsMock.ts
@@ -1,0 +1,56 @@
+import { ForkAwarePermissionDecisionRepository } from "~/server/app-layer/permissions/permission-decision.repository";
+import { PermissionsService } from "~/server/app-layer/permissions/permissions.service";
+
+/**
+ * Factory body for `vi.mock("~/server/app-layer/app", ...)` in tests that
+ * drive a declared permission check (`.permission()` / `.permissionAny()` /
+ * the REST credential middlewares) without initializing a real App.
+ *
+ * The returned App exposes the REAL `PermissionsService` over the REAL
+ * `ForkAwarePermissionDecisionRepository`, so a test's existing
+ * `vi.mock("~/server/api/rbac")` resolver stubs keep deciding every check —
+ * only the App lookup is faked. The client handed to the repository is inert:
+ * the fork-aware resolvers receive it as an argument and the stubs never
+ * touch it.
+ *
+ * Usage:
+ * ```ts
+ * vi.mock("~/server/app-layer/app", async () => {
+ *   const { appPermissionsMock } = await import(
+ *     "~/test-utils/appPermissionsMock"
+ *   );
+ *   return appPermissionsMock();
+ * });
+ * ```
+ */
+/**
+ * Just the service, for tests whose own `vi.mock("~/server/app-layer/app")`
+ * fake carries other groups — merge this in as `permissions`.
+ */
+export function appPermissionsService(): PermissionsService {
+  return new PermissionsService({
+    decisions: new ForkAwarePermissionDecisionRepository({} as never),
+    // Credential (API-key) checks are a different seam with a heavier module
+    // graph; a test that needs them mocks the credential path itself.
+    credentials: {
+      findApiKeyDecision: () => {
+        throw new Error(
+          "credential checks are not stubbed by appPermissionsMock",
+        );
+      },
+      findProjectScope: () => {
+        throw new Error(
+          "credential checks are not stubbed by appPermissionsMock",
+        );
+      },
+    },
+  });
+}
+
+export function appPermissionsMock() {
+  const permissions = appPermissionsService();
+  return {
+    getApp: () => ({ permissions }),
+    tryGetApp: () => null,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@hono/standard-validator':
         specifier: ^0.2.0
         version: 0.2.3(@standard-schema/spec@1.1.0)(hono@4.13.1)
+      '@langwatch/authz':
+        specifier: workspace:*
+        version: link:../authz
       '@langwatch/handled-error':
         specifier: workspace:*
         version: link:../handled-error

--- a/specs/rbac/typed-permission-declarations.feature
+++ b/specs/rbac/typed-permission-declarations.feature
@@ -158,3 +158,27 @@ Feature: Typed permission declarations
     When it asks the facade for "traces:view" with a projectId
     Then the check compiles and decides through the same seam
     And asking for an organization-only permission with a projectId is a compile error
+
+  # ============================================================================
+  # Every check resolves the one App-composed service
+  # ============================================================================
+
+  @unit
+  Scenario: Every grant check decides through the App the request context carries
+    Given the permissions service composed once on the App
+    When a declared tRPC check, a REST credential middleware, or the imperative facade decides
+    Then each resolves the service from its request context or the App
+    And none composes its own service from a database client
+
+  @unit
+  Scenario: An endpoint's middleware array cannot displace its declared check
+    Given a management endpoint that declares a permission and carries its own middleware
+    When a request reaches the endpoint
+    Then the framework mounts the declared permission check itself
+    And the check runs even though the endpoint replaced the guard's middleware array
+
+  @unit
+  Scenario: A registered policy that promises an unenforced permission fails the build
+    Given a management endpoint whose declared policy names a permission the config does not enforce
+    When the service builds
+    Then the build fails naming both halves of the declaration

--- a/specs/rbac/typed-permission-declarations.feature
+++ b/specs/rbac/typed-permission-declarations.feature
@@ -1,0 +1,160 @@
+Feature: Typed permission declarations
+  As a LangWatch engineer
+  I need every permission check to be a declaration typed against the input
+  it reads its scope from
+  So that a miswired check is a compile error at the call site instead of a
+  runtime failure in production
+
+  # Spec for ADR-092 delivery-plan PR 4, decision 25 (the declared surface).
+  # The registry (packages/authz/src/registry.ts) already states, per
+  # resource, the scope tiers it can be granted at; this feature makes the
+  # declaration surfaces derive their typing from that single source. The
+  # scenarios about compile errors are bound by type-assertion tests that
+  # `pnpm typecheck:tests` enforces; the vitest run proves the runtime half.
+  #
+  # Vocabulary (delivery-plan decision 3): permission = the what,
+  # scope = the where. Scope ids in procedure inputs are `projectId`,
+  # `teamId`, `organizationId`; platform-tier permissions have no id.
+
+  Background:
+    Given the permission registry declares, per resource, the scope tiers it can be granted at
+
+  # ============================================================================
+  # The tRPC builder: .permission()
+  # ============================================================================
+
+  @unit
+  Scenario: A declared permission reads its scope from the validated input
+    Given a procedure whose input carries a required "projectId"
+    When the procedure declares permission "traces:view"
+    Then the check runs at that project's scope for the authenticated user
+    And the declaration compiles
+
+  @unit
+  Scenario: Declaring a permission with no usable scope id in the input fails to compile
+    Given a procedure whose input carries no projectId, teamId, or organizationId
+    When the procedure declares permission "traces:view"
+    Then the declaration is a compile error naming the missing scope id
+
+  @unit
+  Scenario: An input id from a tier the permission cannot be granted at fails to compile
+    Given a procedure whose input carries a required "projectId"
+    When the procedure declares the organization-only permission "governance:view"
+    Then the declaration is a compile error
+    And the error names the offending field and the tiers the permission allows
+
+  @unit
+  Scenario: The most specific tier the permission allows decides the check scope
+    Given a procedure whose input carries both "projectId" and "organizationId"
+    When the procedure declares permission "traces:view"
+    Then the check runs at the project scope
+
+  @unit
+  Scenario: A scope derivation is written at the call site, never inferred
+    Given a procedure whose input carries only "teamId"
+    When the procedure declares the organization-only permission "organization:manage" via "teamId"
+    Then the check resolves the team's organization and runs there
+    And declaring the same permission without the derivation is a compile error
+
+  @unit
+  Scenario: A platform-tier permission is refused by the scoped declaration surface
+    Given platform-tier checks resolve an operator scope no procedure input carries
+    When a procedure declares permission "ops:view"
+    Then the declaration is a compile error pointing at the operator middleware
+
+  @unit
+  Scenario: Any one of several declared permissions is enough
+    Given a procedure whose input carries a required "projectId"
+    When the procedure declares that any of "traces:view" or "scenarios:view" suffices
+    Then a caller holding only "scenarios:view" on the project is permitted
+    And a caller holding neither is denied
+
+  @unit
+  Scenario: An input modelled as a union is checked per member
+    Given a procedure whose input is either "projectId" or "organizationId"
+    When the procedure declares permission "project:update"
+    Then a call naming a project checks at the project scope
+    And a call naming an organization checks at the organization scope
+
+  # ============================================================================
+  # Declared opt-outs
+  # ============================================================================
+
+  @unit
+  Scenario: Opting out of permission checks requires a written reason
+    Given a procedure that reads no organization, team, or project data
+    When it declares no permission with a reason
+    Then the procedure runs for any authenticated user
+    And the reason is readable from the declaration
+
+  @unit
+  Scenario: An opted-out procedure cannot silently read scoped input
+    Given a procedure declared with no permission
+    When its input carries a "projectId" without an allowance naming why
+    Then the declaration is a compile error
+
+  @unit
+  Scenario: A service-authorized procedure declares the permissions its service enforces
+    Given a procedure whose scope is resolved from data loaded at runtime
+    When it defers authorization to its service with a written reason
+    Then the declaration names the permissions the service enforces
+    And the sweep counts the procedure as declared rather than unguarded
+
+  # ============================================================================
+  # One seam, decision-neutral (decision 25)
+  # ============================================================================
+
+  @unit
+  Scenario: A declared check decides exactly as the middleware it replaced
+    Given an organization not yet cut over to the engine
+    When a declared permission check runs for one of its members
+    Then the legacy resolver decides and the engine shadows it
+    And for a cut-over organization the engine decides and legacy reverse-shadows
+
+  @unit
+  Scenario: A denial carries a stable code the client can present
+    Given a caller without "traces:view" on project "chatbot"
+    When a procedure declaring "traces:view" runs for them
+    Then the request is refused with code "permission_denied"
+    And the refusal names the permission and the scope tier it was refused at
+
+  @unit
+  Scenario: A lite member's denial is distinguishable from a missing grant
+    Given a lite member of an organization
+    When a declared check denies them a restricted feature
+    Then the refusal carries the lite-member restriction
+    So the client can explain the account limitation instead of a missing role
+
+  @unit
+  Scenario: A scope id that resolves to nothing is denied like one the caller may not touch
+    Given a procedure declaring "traces:view"
+    When it is called with a projectId that does not exist
+    Then the request is refused with code "permission_denied"
+    And the refusal does not reveal whether the project exists
+
+  # ============================================================================
+  # The HTTP surface speaks the same vocabulary
+  # ============================================================================
+
+  @unit
+  Scenario: A route policy cannot name a permission outside the registry
+    Given the HTTP route policy surface
+    When a route declares a permission that no resource supports
+    Then the declaration is a compile error
+
+  # Deliberately NOT a compile error: a project credential's scope chain
+  # ascends to its organization, so an organization-tier permission on a
+  # project app (the governance ingestion surface's aiTools) is answerable —
+  # only organization-scoped bindings can grant it, and the walk consults
+  # them. The registry vocabulary rule above is the enforced half.
+
+  # ============================================================================
+  # The imperative facade
+  # ============================================================================
+
+  @unit
+  Scenario: An imperative check names its scope id to match the permission
+    Given a service checking a permission outside a route middleware
+    When it asks the facade for "traces:view" with a projectId
+    Then the check compiles and decides through the same seam
+    And asking for an organization-only permission with a projectId is a compile error

--- a/specs/rbac/unified-authorization-engine.feature
+++ b/specs/rbac/unified-authorization-engine.feature
@@ -19,7 +19,7 @@ Feature: Unified authorization engine
   # See ADR-092 "Grant semantics" for why. That file's premise sentence -
   # "The most specific scope always wins" - is superseded by the same
   # decision and gets rewritten with those scenarios in the contract PR
-  # (the delivery plan's PR 4), not before: until then it still describes
+  # (the delivery plan's PR 6, the contract), not before: until then it still describes
   # the resolver in production for not-yet-cut-over organizations.
   #
   # Also superseded: fetch-org-role-permission-resolution.feature's "Demo
@@ -161,7 +161,7 @@ Feature: Unified authorization engine
   # routes and their build-time enumeration. What is left unbound is the
   # tRPC stack, which has no equivalent sweep yet - stage D adds one, and
   # Gate D is the two stacks answering to the same rule with no allowlist.
-  @unimplemented
+  @unit
   Scenario: Every tRPC procedure declares its access decision or an explicit reason not to
     When the tRPC surface is enumerated at build time
     Then every procedure either declares a permission


### PR DESCRIPTION
## ADR-092 PR 4 — the declared surface (decision 25)

Every permission check on every stack becomes a **declaration** in the registry vocabulary, typed against the input it reads its scope from, funnelled through **one cutover-aware seam**. Decision-neutral at deploy: the seam runs the same per-org fork the ten legacy seams run today, so the per-org rollout lever (and its rollback) survives intact, and the contract PR's codemod shrinks from ~500 call sites to deleting one branch in one file.

```
                 BEFORE                                  AFTER
  .use(checkProjectPermission("x:y"))   ─┐
  .use(checkOrganizationPermission(…))   ├─►   .permission("x:y")        ─┐
  .use(checkTeamPermission(…))          ─┘     .permission(p, {via:…})    │
  .use(checkProjectPermissionAny(…))    ───►   .permissionAny(…)          ├─► ONE seam
  .use(skipPermissionCheck(…))          ───►   .noPermission({reason})    │   (cutover-aware:
  AccessPolicy{permission: Permission}  ───►   AccessPolicy{AuthzPermission}  fork per org)
  hasProjectPermission(ctx, id, p)      ───►   typed imperative facade   ─┘
```

### The typed builder

`.permission("traces:view")` is constrained by the validated input: a missing scope id, an id from a tier the registry says the permission cannot be granted at, an optional-only id, or a permission the registry does not know is a **compile error** whose diagnostic names the problem (template-literal error brands). The most specific allowed tier present decides the check scope, and the runtime (`declaredScopeId`) mirrors the same rule so types and behaviour cannot disagree. Derivations are written at the call site — `.permission("organization:manage", { via: "teamId" })` — never inferred. `.noPermission({ reason, allow })` moves the legacy `skipPermissionCheck` sensitive-key guard from a runtime throw to a compile error, with per-key written reasons.

### The codemod (behaviour-neutral by construction)

All **510** `.use(checkXxxPermission("…"))` sites (444 in `src/server/api/routers`, 73 in `ee`) and all skip sites move onto the seam, which is layered the house way — **boundary → service → repository → client**: `checkDeclaredPermission` (the tRPC boundary) composes `PermissionsService`, the service takes the `ForkAwarePermissionDecisionRepository`, and only the repository touches the client, delegating to the **same fork-aware resolvers** the legacy middlewares ran (`resolveProjectPermission` / `resolveTeamPermission` / `hasOrganizationPermission`). No organization's decisions change at deploy — legacy still decides for non-cut-over orgs with the engine shadowing, engine decides for cut-over orgs with legacy reverse-shadowing — and the contract PR rewires only the repository.

The oddballs, each with a designed home (the full map is in the plan doc's PR 4 section):

| Oddball | Home |
|---|---|
| `checkProjectPermissionAny` | `.permissionAny("traces:view", "scenarios:view")` |
| `checkTeamPermission("organization:manage")` ×2 (input has only `teamId`) | `.permission("organization:manage", { via: "teamId" })` |
| `checkTeamPermission("team:delete")` (not a registry permission) | `.permission("team:manage")` — provably identical: no bag grants `team:delete`, only the manage-implication satisfies it |
| modelProviders' project-or-org anchor, provider validation, captured-data visibility, project creation, ops scope, role/team data-dependent gates | stay custom, but **declared** via `declareAuthzMiddleware({ kind, reason, permissions })` — counted by the sweep, not allowlisted |
| `checkPermissionOrPubliclyShared` | already dead (ADR-057's single public `sharedTrace` surface); stale test mocks deleted |
| monitors `getPerformanceForProject` | the one AND-composition site: `.permission()` + a hand-stacked second check |

### Everything through the App

The App owns the ONE composed permissions service (`getApp().permissions` — `PermissionsService` over the decision + credential repositories), and every grant-checking surface resolves it **through its request context**: the tRPC context factory injects `ctx.app`, `SecuredApp` and the management-service factory inject `c.var.app`, and the seams read `appOf(ctx)` / `appFromContext(c)` (same instance as the singleton in production; the context slot is the test-injection seam). The imperative `has*Permission(ctx, id, permission)` helpers moved to `app-layer/permissions/imperative` with identical names and signatures — their ~77 call sites changed only an import and stopped passing `prisma`. API-key credential checks (the `ApiKey ∩ user` ceiling, org-auth's project tenancy lookup) live behind their own `ForkAwareCredentialDecisionRepository`; no boundary or service composes a check from a database client anywhere.

`@langwatch/api` itself now manages permissions: endpoint config carries a first-class `permission` (registry-typed), the service config carries an injected `permissionEnforcer`, and the FRAMEWORK mounts the check between auth and the endpoint's own middleware — closing the guard-spread bypass where a `middleware:` key after `...guard(...)` displaced enforcement while the registered policy still promised it. The management registry additionally refuses any mount whose declared policy names a permission the config does not enforce.

### The sweep (fail-closed, now in CI)

`authz-declaration-sweep.unit.test.ts` walks the real `appRouter` map and refuses any procedure whose middleware chain carries no declaration — binding the previously `@unimplemented` scenario in `unified-authorization-engine.feature`. It found and fixed 103 gaps during development (ops, modelProviders, role).

### One vocabulary — the cross product is dead

`Permission` now **aliases** `AuthzPermission` (the registry type); the legacy `Resource × Action` cross product is retired. This alone surfaced three real defects: the teams REST app's `requires("team:create"/"team:update"/"team:delete")` (grantable by no role bag) and the management-service `guard()` accepting all 349 cross-product strings. The Hono `AccessPolicy`, the auth middlewares, and the ~85 imperative `has*Permission` call sites are all registry-typed with zero call-site churn. Scope-generics on the Hono side were prototyped and deliberately **dropped** — a project credential's chain ascends to its org, so tier-alignment there is not an error (the governance app's `aiTools:*` on project keys is legitimate); the vocabulary did all the catching. `PermissionsService` gains `hasPermission` / `requirePermission` with a registry-derived exclusive scope argument for new imperative code — composed via `permissionsServiceFor(prisma)` (service takes the repository, repository takes the client; the service itself never sees Prisma).

### Deliberate behaviour change (the UX half)

Denials from migrated **team/organization** procedures now carry the engine's one handled code — `permission_denied`, with the permission and tier in `meta` — where they previously shipped bare prose the client could only render as "unknown error". Those denials also surface as **`FORBIDDEN`** on the wire (via the handled cause's 403) instead of `UNAUTHORIZED`. Project denials move from `project_permission_denied` to the same unified `permission_denied` (equivalent registry copy, same remediation quality). Lite-member denials keep their dedicated cause and client modal. Allow/deny decisions are unchanged everywhere.

### Specs

- **New:** `specs/rbac/typed-permission-declarations.feature` — 20 scenarios, all bound (`check:feature-parity` clean), including the App-resolution rule, the middleware-cannot-displace-the-check regression pin, and the policy/enforcement mismatch build failure.
- `unified-authorization-engine.feature`: the fail-closed tRPC scenario flips `@unimplemented → @unit`; stale contract-PR pointer fixed.
- Plan doc: decision 25 + the re-sliced PR map (PR 4 = this, contract renumbered to PR 6).

### Verification

- Full unit lane: **2,083 files / 30,522 tests green** (`src` + `ee`, the entire lane), including the frontend-boundary graph guard.
- `@langwatch/authz` package: 65 tests green; new `declaration.ts` runtime helpers unit-tested.
- Type assertions (`@ts-expect-error`) verified by scoped `tsc` runs over the tests config, with deliberate-break control runs.
- Scoped `tsc` over routers + security + `app/api` + routes + client `Permission` consumers: clean.
- Biome: changed files clean apart from pre-existing per-(file, rule) counts; the two new seam functions were refactored below the complexity threshold so the delta gate stays quiet.
- **Not run locally** (no container runtime, no `LANGWATCH_TEST_*` URLs on this machine): the datastore-lane integration tests whose rbac mocks were repaired (`automations.router`, `lwql.router`, `user.cliBootstrap`, `user.personalBudget`, `savedWorkbenchCharts.router`, `evaluations.azure-byok`, `project.regenerateApiKey`, `langy.conversationVisibility`, `scenario-run-export`) — CI is the verifier there; the repairs follow the exact mock pattern the unit lane proved.

### Known edges / follow-ups

- The 21 `.use(authorizeInResolver)` sites ride a generically-declared marker (`permissions: []`); naming each service's enforced permissions at the call site via `.authorizeInService({ … })` is mechanical follow-up.
- The `team:create/update/delete → team:manage` rewrites are behaviour-identical for every built-in bag; a legacy custom role carrying one of those literal strings (measured cohort: zero roles with only-unregistered strings, but mixed rows weren't excluded) would lose that specific grant path — flagging for review.
- `effectivePermissions` / `useCan` already read through the engine (PR 3); untouched here.
