### PR TITLE
fix(governance): price warehouse compute by the hours it ran in

### DIFF
--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -46,12 +46,24 @@ const CONVERSATION_ID = "conv-1";
 const MESSAGE_ID = "msg-1";
 const STATEMENT_ID = "stmt-abc";
 const WAREHOUSE_ID = "095eb666b2ed2762";
+/** The whole hour an instant falls in, as the workspace would report it. */
+function usageHourOf(atMs: number): string {
+  return new Date(
+    Math.floor(atMs / (60 * 60 * 1000)) * (60 * 60 * 1000),
+  ).toISOString();
+}
+
 /**
- * The hour a fixture row is about. Opaque to the adapter — it only ever groups
- * rows against each other — so one constant serves every fixture that does not
- * care which hours a statement spanned.
+ * The hour a fixture row is about.
+ *
+ * The hour the sweep is running in, and not a fixed date, because the reply is
+ * now served only to the chunk that owns the row's hour — the way a real
+ * workspace answers, and the premise the sweep relies on when it adds a
+ * straddler's chunks together. Every window these tests read, from two hours to
+ * thirty days, ends at the sweep's own clock, so this is the one hour all of
+ * them contain.
  */
-const USAGE_HOUR = "2026-08-01T09:00:00.000Z";
+const USAGE_HOUR = usageHourOf(Date.now());
 
 type CostPlan = {
   status?: number;
@@ -64,10 +76,57 @@ type CostPlan = {
   totalRowCount?: number;
 };
 
+/**
+ * The rows a real reply would carry back for the window it was asked about.
+ *
+ * The workspace answers per chunk, and the chunks tile the window: an hour
+ * belongs to exactly one of them, which is what lets the sweep add a
+ * straddler's chunks together without doubling anything. A fixture that served
+ * every row to every chunk would break that premise silently — the same
+ * statement-hour would arrive once per chunk and its cost would multiply by how
+ * many chunks the window happened to split into.
+ *
+ * Rows whose columns do not name `usage_hour` are served whole: those plans are
+ * about the adapter refusing a reply it cannot read, and the window is not what
+ * they are testing.
+ */
+function rowsInWindow({
+  rows,
+  columns,
+  body,
+}: {
+  rows: (string | null)[][];
+  columns: string[];
+  body: Record<string, unknown>;
+}): (string | null)[][] {
+  const at = columns.indexOf("usage_hour");
+  if (at === -1) return rows;
+
+  const parameters = (body.parameters ?? []) as {
+    name: string;
+    value: string;
+  }[];
+  const bound = (name: string): number => {
+    const found = parameters.find((parameter) => parameter.name === name);
+    return found === undefined ? NaN : Date.parse(found.value);
+  };
+  const fromMs = bound("from_ts");
+  const toMs = bound("to_ts");
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return rows;
+
+  return rows.filter((row) => {
+    const hourMs = Date.parse(String(row[at]));
+    if (!Number.isFinite(hourMs)) return true;
+    return hourMs >= fromMs && hourMs < toMs;
+  });
+}
+
 let server: http.Server;
 let baseUrl: string;
 /** Bodies the fixture was asked to run a statement with, in order. */
 let statementBodies: Record<string, unknown>[];
+/** What each of those calls was answered with, in the same order. */
+let servedRows: (string | null)[][][];
 let costPlan: CostPlan | null;
 /** Plans that answer the first N cost calls, in order, before `costPlan`. */
 let costPlanQueue: CostPlan[];
@@ -77,6 +136,7 @@ let messageRanSql: boolean;
 
 beforeEach(async () => {
   statementBodies = [];
+  servedRows = [];
   costPlan = null;
   costPlanQueue = [];
   messageCreatedMs = Date.now() - 60_000;
@@ -142,35 +202,38 @@ beforeEach(async () => {
         );
         // Queued plans answer one call each, then `costPlan` answers the rest.
         // Only tests about WHICH day was unpriced need this; the rest set one
-        // plan and mean it for every day.
+        // plan and mean it for every window.
         const plan = costPlanQueue.shift() ?? costPlan;
         if (plan?.status) {
           res.statusCode = plan.status;
           return send({ message: "permission denied" });
         }
+        const columns = plan?.columns ?? [
+          "statement_id",
+          "usage_hour",
+          "execution_ms_in_hour",
+          "hour_total_ms",
+          "hour_billable_usd",
+          "currency_code",
+          "sku_name",
+        ];
+        const served = rowsInWindow({
+          rows: plan?.rows ?? [],
+          columns,
+          body: statementBodies[statementBodies.length - 1]!,
+        });
+        servedRows.push(served);
         send({
           statement_id: "fixture",
           status: { state: plan?.state ?? "SUCCEEDED" },
           manifest: {
-            schema: {
-              columns: (
-                plan?.columns ?? [
-                  "statement_id",
-                  "usage_hour",
-                  "execution_ms_in_hour",
-                  "hour_total_ms",
-                  "hour_billable_usd",
-                  "currency_code",
-                  "sku_name",
-                ]
-              ).map((name) => ({ name })),
-            },
+            schema: { columns: columns.map((name) => ({ name })) },
             ...(plan?.totalRowCount === undefined
               ? {}
               : { total_row_count: plan.totalRowCount }),
           },
           result: {
-            data_array: plan?.rows ?? [],
+            data_array: served,
             ...(plan?.nextChunkIndex === undefined
               ? {}
               : { next_chunk_index: plan.nextChunkIndex }),
@@ -300,6 +363,73 @@ describe("a source that names a warehouse", () => {
     expect(result.events[0]?.actor).toBe("dana@acme.test");
   });
 
+  /** @scenario "A statement that runs across a chunk boundary keeps both halves" */
+  it("adds up a statement the window was read in two pieces of", async () => {
+    // The window is read oldest-first in chunks that tile it, and each chunk
+    // answers only for the hours it owns. A statement still running when a
+    // chunk ends therefore comes back twice, once from each side of the
+    // boundary, with a different part of itself each time — and the sweep
+    // emits its question exactly once. Keeping only the last answer is the
+    // defect: the earlier hours are billed to nobody while still diluting
+    // every other question's share of them.
+    //
+    // Ten days apart, so the two hours cannot land in the same seven-day
+    // chunk however the window happens to be aligned.
+    const earlierHour = usageHourOf(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    costPlan = {
+      rows: [
+        // Half of a $12 hour.
+        [
+          STATEMENT_ID,
+          earlierHour,
+          "1800000",
+          "3600000",
+          "12.00",
+          "USD",
+          "PREMIUM_SERVERLESS_SQL_COMPUTE_EU_WEST",
+        ],
+        // And a sixth of a $6 one.
+        [
+          STATEMENT_ID,
+          USAGE_HOUR,
+          "600000",
+          "3600000",
+          "6.00",
+          "USD",
+          "PREMIUM_SERVERLESS_SQL_COMPUTE_EU_WEST",
+        ],
+      ],
+    };
+
+    const result = await pull({ warehouseId: WAREHOUSE_ID });
+
+    // The premise first: the two hours really were answered by two different
+    // calls. Without this the sum below would also pass on a fixture that
+    // handed both rows to one chunk, which is the one arrangement that cannot
+    // exercise the merge.
+    const callsCarrying = (hour: string) =>
+      servedRows.filter((rows) => rows.some((row) => row[1] === hour)).length;
+    expect(callsCarrying(earlierHour)).toBe(1);
+    expect(callsCarrying(USAGE_HOUR)).toBe(1);
+    expect(
+      servedRows.findIndex((rows) =>
+        rows.some((row) => row[1] === earlierHour),
+      ),
+    ).not.toBe(
+      servedRows.findIndex((rows) => rows.some((row) => row[1] === USAGE_HOUR)),
+    );
+
+    // $6 from the earlier hour and $1 from the later one, exactly.
+    expect(hintOf(result).costUsd).toBe("7");
+    expect(result.events[0]?.cost_usd).toBe("7");
+    // And the ingredients span both hours, because each is a sum over the
+    // hours the statement ran through and the chunks partition those hours.
+    expect(result.events[0]?.extra?.warehouseHour).toEqual({
+      totalExecutionMs: "7200000",
+      billableUsd: "18",
+    });
+  });
+
   /** @scenario "A priced question carries the numbers its share was worked out from" */
   it("carries the hour's bill and executed time beside the cost", async () => {
     costPlan = {
@@ -395,6 +525,18 @@ describe("a source that names a warehouse", () => {
     // stalls for the seven-day hold. Every hourly scheduled query ends on a
     // boundary.
     expect(sql).toMatch(/unix_millis\(\s*r\.ended_at\s*\)\s*-\s*1\b/);
+
+    // And an HOUR decides which chunk answers for a row, not the statement's
+    // start. The window is read in chunks that tile it, so gating emission on
+    // `start_time` hands a straddler wholly to the chunk it began in — which
+    // has already dropped the hours past its own end. The next chunk counts
+    // that statement in its denominators and then excludes it from its rows,
+    // so those hours are billed to nobody while still diluting everyone else.
+    // The hour clip below is what keeps each statement-hour emitted exactly
+    // once across the whole window.
+    expect(sql).toMatch(/h\.usage_hour\s*>=\s*:from_ts/);
+    expect(sql).toMatch(/h\.usage_hour\s*<\s*:to_ts/);
+    expect(sql).not.toMatch(/w\.start_time\s*>=\s*:from_ts/);
   });
 
   /** @scenario "A question is still priced when its history row names no space" */
@@ -807,10 +949,13 @@ describe("a source that names a warehouse", () => {
 
     // Recorded at zero for now — its bill does not exist yet to price from.
     expect(hintOf(result).costUsd).toBe("0");
-    // But the watermark held at the start of the swept window, NOT at the
-    // sweep's clock. This is the assertion the old code failed: a seen-but-
-    // unbilled statement thirty days back would have been passed over for good.
-    expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
+    // But the watermark held BEHIND the unbilled hour, not at the sweep's
+    // clock. This is the assertion the old code failed: a seen-but-unbilled
+    // statement would have been passed over for good. The bound is the hour
+    // itself rather than the far end of the window, because the hold lands at
+    // the start of the chunk that could not be priced — the one owning this
+    // hour — and every earlier chunk keeps the cost it already worked out.
+    expect(cursor.sinceMs).toBeLessThan(Date.parse(USAGE_HOUR));
 
     // The other half: resuming from that held cursor, once the bill lands, the
     // same question is asked about again and now carries its real share.

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -46,6 +46,12 @@ const CONVERSATION_ID = "conv-1";
 const MESSAGE_ID = "msg-1";
 const STATEMENT_ID = "stmt-abc";
 const WAREHOUSE_ID = "095eb666b2ed2762";
+/**
+ * The hour a fixture row is about. Opaque to the adapter — it only ever groups
+ * rows against each other — so one constant serves every fixture that does not
+ * care which hours a statement spanned.
+ */
+const USAGE_HOUR = "2026-08-01T09:00:00.000Z";
 
 type CostPlan = {
   status?: number;
@@ -150,7 +156,8 @@ beforeEach(async () => {
               columns: (
                 plan?.columns ?? [
                   "statement_id",
-                  "execution_duration_ms",
+                  "usage_hour",
+                  "execution_ms_in_hour",
                   "hour_total_ms",
                   "hour_billable_usd",
                   "currency_code",
@@ -272,6 +279,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "1800000",
           "3600000",
           "6.00",
@@ -298,6 +306,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "1800000",
           "3600000",
           "6.00",
@@ -334,6 +343,39 @@ describe("a source that names a warehouse", () => {
     const sql = String(statementBodies[0]!.statement);
     expect(sql).toContain("w.genie_space_id IS NOT NULL");
     expect(sql).toContain("OR w.client_application = :genie_app");
+  });
+
+  /** @scenario "Traffic that began before the hour keeps its share of the bill" */
+  it("asks for execution time by the hours a statement ran in, not the one it began in", async () => {
+    costPlan = { rows: [] };
+
+    await pull({ warehouseId: WAREHOUSE_ID });
+
+    // The fixture cannot execute SQL, so what this pins is the question asked.
+    // The defect it guards is invisible in any result set: bucketing a
+    // statement wholly into its start hour leaves the NEXT hour's denominator
+    // holding only what happened to begin in it, and a one-second Genie
+    // question in that hour carries the whole hour's bill.
+    const sql = String(statementBodies[0]!.statement);
+
+    // The statement's end is read, and reconstructed when the row has none —
+    // an in-flight statement with a null end_time would otherwise drop out of
+    // the denominator entirely.
+    expect(sql).toContain("end_time");
+    expect(sql).toContain("execution_duration_ms");
+
+    // One row per hour the statement was awake in, not one per statement.
+    expect(sql).toMatch(/explode\(\s*sequence\(/);
+
+    // And the share's numerator is the part of the runtime inside THAT hour.
+    expect(sql).toContain("execution_ms_in_hour");
+
+    // The hour each row belongs to travels with it. Without it the allocator
+    // cannot tell one statement's two hours from one hour's two SKUs, and it
+    // has to treat them differently: two hours sum their totals, two SKUs do
+    // not, and an unbilled hour holds the watermark where an unbilled SKU
+    // beside a priced one does not.
+    expect(sql).toContain("usage_hour");
   });
 
   /** @scenario "A question is still priced when its history row names no space" */
@@ -432,8 +474,9 @@ describe("a source that names a warehouse", () => {
     costPlan = {
       columns: [
         "statement_id",
+        "usage_hour",
         "hour_total_ms",
-        "execution_duration_ms",
+        "execution_ms_in_hour",
         "hour_billable_usd",
         "currency_code",
         "sku_name",
@@ -441,6 +484,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "900000",
           "6.00",
@@ -465,6 +509,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -487,6 +532,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -509,6 +555,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           "some-other-statement",
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -531,6 +578,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -557,6 +605,7 @@ describe("a source that names a warehouse", () => {
       { length: WAREHOUSE_COST_ROW_LIMIT - 1 },
       (_, i): (string | null)[] => [
         `other-statement-${i}`,
+        USAGE_HOUR,
         "1",
         "3600000",
         "6.00",
@@ -568,6 +617,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -593,6 +643,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -614,6 +665,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -640,6 +692,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -679,6 +732,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -724,7 +778,9 @@ describe("a source that names a warehouse", () => {
     // A null SKU in the last column is exactly what the LEFT JOIN produces for
     // an unbilled hour.
     costPlan = {
-      rows: [[STATEMENT_ID, "3600000", "3600000", null, null, null]],
+      rows: [
+        [STATEMENT_ID, USAGE_HOUR, "3600000", "3600000", null, null, null],
+      ],
     };
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
@@ -743,6 +799,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -848,6 +905,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -923,6 +981,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -1013,6 +1072,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -1038,6 +1098,7 @@ describe("a source that names a warehouse", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",
@@ -1180,6 +1241,7 @@ describe("a billing answer that did not come back", () => {
       rows: [
         [
           STATEMENT_ID,
+          USAGE_HOUR,
           "3600000",
           "3600000",
           "6.00",

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -376,6 +376,14 @@ describe("a source that names a warehouse", () => {
     // not, and an unbilled hour holds the watermark where an unbilled SKU
     // beside a priced one does not.
     expect(sql).toContain("usage_hour");
+
+    // The last hour is half-open. `sequence` includes its stop value, so a
+    // statement ending at exactly 10:00:00.000 would otherwise emit a 10:00
+    // slice it did no work in — and if the warehouse shut down at 10:00, that
+    // hour never bills, the null SKU reads as "not billed yet", and the source
+    // stalls for the seven-day hold. Every hourly scheduled query ends on a
+    // boundary.
+    expect(sql).toMatch(/unix_millis\(\s*r\.ended_at\s*\)\s*-\s*1\b/);
   });
 
   /** @scenario "A question is still priced when its history row names no space" */

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -361,14 +361,25 @@ describe("a source that names a warehouse", () => {
     // The statement's end is read, and reconstructed when the row has none —
     // an in-flight statement with a null end_time would otherwise drop out of
     // the denominator entirely.
-    expect(sql).toContain("end_time");
+    expect(sql).toMatch(/COALESCE\(\s*end_time,/);
     expect(sql).toContain("execution_duration_ms");
 
-    // One row per hour the statement was awake in, not one per statement.
-    expect(sql).toMatch(/explode\(\s*sequence\(/);
+    // One row per hour the statement was awake in, not one per statement, and
+    // the span it is cut into runs from the statement's own start. Naming the
+    // bound matters more than naming the alias: bucketing every statement back
+    // into its start hour would keep all the aliases below and change only
+    // this line, which is exactly the defect this test exists to catch.
+    expect(sql).toMatch(
+      /explode\(\s*sequence\(\s*date_trunc\('HOUR',\s*r\.start_time\)/,
+    );
 
-    // And the share's numerator is the part of the runtime inside THAT hour.
+    // And the share's numerator is the part of the runtime inside THAT hour,
+    // divided with `div`. Spark's `/` returns a DOUBLE; a float here is money
+    // computed in floating point, which the rest of this path is built to
+    // avoid.
     expect(sql).toContain("execution_ms_in_hour");
+    expect(sql).toMatch(/r\.execution_duration_ms\s*\*[\s\S]{0,200}?\bdiv\b/);
+    expect(sql).not.toMatch(/r\.execution_duration_ms\s*\//);
 
     // The hour each row belongs to travels with it. Without it the allocator
     // cannot tell one statement's two hours from one hour's two SKUs, and it

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -363,7 +363,7 @@ describe("a source that names a warehouse", () => {
     expect(result.events[0]?.actor).toBe("dana@acme.test");
   });
 
-  /** @scenario "A statement that runs across a chunk boundary keeps both halves" */
+  /** @scenario "A query that outlives one billing read is charged in full" */
   it("adds up a statement the window was read in two pieces of", async () => {
     // The window is read oldest-first in chunks that tile it, and each chunk
     // answers only for the hours it owns. A statement still running when a
@@ -1501,6 +1501,60 @@ describe("a period with more statements than one answer can carry", () => {
     expect(spanOf(statementBodies[0]!)).toBeGreaterThan(24 * 60 * 60 * 1000);
     expect(spanOf(statementBodies[1]!)).toBeLessThanOrEqual(
       24 * 60 * 60 * 1000,
+    );
+  });
+
+  /** @scenario "A statement is held when an hour it ran through has no bill yet" */
+  it("keeps the billed share of a piece that still owes an hour", async () => {
+    // A piece can price one of a statement's hours and still owe another. The
+    // hold is right — the owed hour is re-read once its bill lands — but the
+    // billed share belongs to this run's record, exactly as it would had the
+    // chunk priced whole. Dropping it would emit the question at nothing and
+    // only correct it when billing settles, which the whole-chunk path never
+    // does.
+    //
+    // Deep enough into the window to land in the refused first chunk, and half
+    // a day off the piece boundaries so both hours sit in the same piece.
+    const billedHour = usageHourOf(
+      Date.now() - 29 * 24 * 60 * 60 * 1000 + 12 * 60 * 60 * 1000,
+    );
+    const owedHour = usageHourOf(Date.parse(billedHour) + 60 * 60 * 1000);
+    costPlanQueue = [{ rows: [], nextChunkIndex: 1 }];
+    costPlan = {
+      rows: [
+        // Half of a $6 hour, billed.
+        [
+          STATEMENT_ID,
+          billedHour,
+          "1800000",
+          "3600000",
+          "6.00",
+          "USD",
+          "PREMIUM_SERVERLESS_SQL_COMPUTE_EU_WEST",
+        ],
+        // And an hour whose bill has not landed: the LEFT JOIN's null SKU.
+        [STATEMENT_ID, owedHour, "600000", "3600000", null, null, null],
+      ],
+    };
+
+    const result = await pull({ warehouseId: WAREHOUSE_ID });
+    const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
+
+    // The premise: both hours were answered by one piece-sized call, so the
+    // share below was kept by the owed piece itself, not by a later chunk.
+    const carrying = servedRows.filter((rows) => rows.length > 0);
+    expect(carrying).toHaveLength(1);
+    expect(carrying[0]).toHaveLength(2);
+
+    // The billed hour's share survives the hold.
+    expect(hintOf(result).costUsd).toBe("3");
+    expect(result.events[0]?.cost_usd).toBe("3");
+
+    // And the hold still holds: the watermark stays at the owed piece rather
+    // than moving past the unbilled hour.
+    expect(cursor.sinceMs).toBeLessThan(Date.now() - 28 * 24 * 60 * 60 * 1000);
+    expect(cursor.sinceMs).toBeGreaterThan(
+      Date.now() - 30 * 24 * 60 * 60 * 1000,
     );
   });
 });

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
@@ -283,16 +283,10 @@ describe("allocateWarehouseCost", () => {
     });
 
     // 6 USD * 1000 / 2_281_000 — a quarter of a cent, not six dollars.
-    expect(Number(costByStatementId.get("question")?.costUsd)).toBeCloseTo(
-      0.00263,
-      5,
-    );
+    expect(costByStatementId.get("question")?.costUsd).toBe("0.002630425");
     // And the compute it did not do stays with the statement that did it:
     // 6 * 120000/120000 + 6 * 2280000/2281000.
-    expect(Number(costByStatementId.get("straddler")?.costUsd)).toBeCloseTo(
-      11.99737,
-      5,
-    );
+    expect(costByStatementId.get("straddler")?.costUsd).toBe("11.997369574");
 
     // The ingredients have to name every hour the share was drawn from. Costing
     // a statement out of two hours and then reporting the first hour's total

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
@@ -330,6 +330,47 @@ describe("allocateWarehouseCost", () => {
     expect(costByStatementId.get("straddler")?.costUsd).toBe("0.2");
   });
 
+  /** @scenario "An hour a statement did no work in cannot hold it" */
+  it("does not hold a statement for an hour it did no work in", () => {
+    // A statement ending exactly on the hour touches the next hour without
+    // working in it. If that hour is the one after the warehouse shut down, no
+    // bill for it will ever arrive — and reading a null SKU as "not billed
+    // yet" would hold the whole source here until the seven-day hold expires.
+    // Every hourly scheduled query lands on a boundary, so this is not a
+    // corner: it is a weekly stall waiting for one to end at :00.
+    const { costByStatementId, owed, skipped } = allocateWarehouseCost({
+      rows: [
+        row({
+          statementId: "on-the-hour",
+          usageHour: HOUR_09,
+          executionMsInHour: "1800000",
+          hourTotalMs: "3600000",
+        }),
+        row({
+          statementId: "on-the-hour",
+          usageHour: HOUR_10,
+          executionMsInHour: "0",
+          hourTotalMs: "0",
+          hourBillableUsd: null,
+          currencyCode: null,
+          skuName: null,
+        }),
+      ],
+    });
+
+    expect(owed.has("on-the-hour")).toBe(false);
+    expect(costByStatementId.get("on-the-hour")?.costUsd).toBe("3");
+    // Nor is it a gap worth reporting. Nothing was lost, so naming it as a
+    // skip would put a permanent hole in a record that has none.
+    expect(skipped).toHaveLength(0);
+    // And the hour it did not work in stays out of the ingredients, which are
+    // what anyone reconciling this figure divides by.
+    expect(costByStatementId.get("on-the-hour")?.hourTotalExecutionMs).toBe(
+      "3600000",
+    );
+    expect(costByStatementId.get("on-the-hour")?.hourBillableUsd).toBe("6");
+  });
+
   /** @scenario "Genie's own free usage is never charged" */
   it("charges nothing for Genie's own free-usage line", () => {
     const { costByStatementId } = allocateWarehouseCost({
@@ -349,12 +390,15 @@ describe("allocateWarehouseCost", () => {
 
   it("refuses an hour that reports no execution time at all", () => {
     // Guard rather than behaviour: dividing by it would be an exception on a
-    // path whose whole job is to not lose the visibility records.
+    // path whose whole job is to not lose the visibility records. The share is
+    // nonzero on purpose — an hour that totals less than one statement ran in
+    // it is the contradiction this branch is for, and a zero share would be
+    // caught earlier as an hour the statement did no work in.
     const { costByStatementId, skipped } = allocateWarehouseCost({
       rows: [
         row({
           statementId: "zero-hour",
-          executionMsInHour: "0",
+          executionMsInHour: "1000",
           hourTotalMs: "0",
         }),
       ],

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
@@ -19,8 +19,10 @@ import {
   allocateWarehouseCost,
   costReadFloorMs,
   GENIE_FREE_USAGE_SKU_MARKER,
+  mergeWarehouseCost,
   WAREHOUSE_COST_CHUNK_MS,
   WAREHOUSE_COST_SETTLING_LAG_MS,
+  type WarehousePricedStatement,
   warehouseCostChunks,
   warehouseCostPieces,
 } from "../databricksWarehouseCost";
@@ -588,5 +590,68 @@ describe("splitting the window into readable pieces", () => {
     // A clock or a stored watermark that arrived unreadable. Returning nothing
     // prices nothing, where looping on NaN would hang the run.
     expect(warehouseCostChunks({ fromMs: NaN, toMs: HOUR_START })).toEqual([]);
+  });
+});
+
+describe("mergeWarehouseCost", () => {
+  /** @scenario "A statement that runs across a chunk boundary keeps both halves" */
+  it("adds a straddler's two chunks together instead of replacing one with the other", () => {
+    // The window is read oldest-first in chunks, and a statement that begins
+    // near the end of one burns compute in the next. Each chunk prices the
+    // hours it owns, so the same statement comes back twice with a different
+    // part of itself — and the sweep emits its question exactly once, with
+    // whatever this map holds. Replacing would ship the later chunk's slice as
+    // if it were the whole cost.
+    const total = new Map<string, WarehousePricedStatement>();
+
+    mergeWarehouseCost(
+      total,
+      new Map([
+        [
+          "straddler",
+          {
+            costUsd: "0.25",
+            hourTotalExecutionMs: "1800000",
+            hourBillableUsd: "6",
+          },
+        ],
+      ]),
+    );
+    mergeWarehouseCost(
+      total,
+      new Map([
+        [
+          "straddler",
+          {
+            costUsd: "1.75",
+            hourTotalExecutionMs: "3600000",
+            hourBillableUsd: "12",
+          },
+        ],
+      ]),
+    );
+
+    // Exact strings, both halves. The ingredients are sums over the hours the
+    // statement ran through, so they add across chunks for the same reason the
+    // cost does.
+    expect(total.get("straddler")).toEqual({
+      costUsd: "2",
+      hourTotalExecutionMs: "5400000",
+      hourBillableUsd: "18",
+    });
+  });
+
+  /** @scenario "A statement that runs across a chunk boundary keeps both halves" */
+  it("leaves a statement only one chunk answered for exactly as it arrived", () => {
+    const total = new Map<string, WarehousePricedStatement>();
+    const priced: WarehousePricedStatement = {
+      costUsd: "0.002630425",
+      hourTotalExecutionMs: "2401000",
+      hourBillableUsd: "12",
+    };
+
+    mergeWarehouseCost(total, new Map([["question", priced]]));
+
+    expect(total.get("question")).toEqual(priced);
   });
 });

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
@@ -594,7 +594,7 @@ describe("splitting the window into readable pieces", () => {
 });
 
 describe("mergeWarehouseCost", () => {
-  /** @scenario "A statement that runs across a chunk boundary keeps both halves" */
+  /** @scenario "A query that outlives one billing read is charged in full" */
   it("adds a straddler's two chunks together instead of replacing one with the other", () => {
     // The window is read oldest-first in chunks, and a statement that begins
     // near the end of one burns compute in the next. Each chunk prices the
@@ -604,9 +604,9 @@ describe("mergeWarehouseCost", () => {
     // if it were the whole cost.
     const total = new Map<string, WarehousePricedStatement>();
 
-    mergeWarehouseCost(
-      total,
-      new Map([
+    mergeWarehouseCost({
+      into: total,
+      from: new Map([
         [
           "straddler",
           {
@@ -616,10 +616,10 @@ describe("mergeWarehouseCost", () => {
           },
         ],
       ]),
-    );
-    mergeWarehouseCost(
-      total,
-      new Map([
+    });
+    mergeWarehouseCost({
+      into: total,
+      from: new Map([
         [
           "straddler",
           {
@@ -629,7 +629,7 @@ describe("mergeWarehouseCost", () => {
           },
         ],
       ]),
-    );
+    });
 
     // Exact strings, both halves. The ingredients are sums over the hours the
     // statement ran through, so they add across chunks for the same reason the
@@ -641,7 +641,7 @@ describe("mergeWarehouseCost", () => {
     });
   });
 
-  /** @scenario "A statement that runs across a chunk boundary keeps both halves" */
+  /** @scenario "A query that outlives one billing read is charged in full" */
   it("leaves a statement only one chunk answered for exactly as it arrived", () => {
     const total = new Map<string, WarehousePricedStatement>();
     const priced: WarehousePricedStatement = {
@@ -650,7 +650,7 @@ describe("mergeWarehouseCost", () => {
       hourBillableUsd: "12",
     };
 
-    mergeWarehouseCost(total, new Map([["question", priced]]));
+    mergeWarehouseCost({ into: total, from: new Map([["question", priced]]) });
 
     expect(total.get("question")).toEqual(priced);
   });

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksWarehouseCost.unit.test.ts
@@ -28,24 +28,39 @@ import {
 /** One billable hour: $6.00 across 3600s of warehouse time. */
 const BILLABLE_SKU = "PREMIUM_SERVERLESS_SQL_COMPUTE_EU_WEST";
 
+/**
+ * The hour a row belongs to. Most rows here name one hour; the straddling
+ * cases name two, which is the whole point of them.
+ */
+const HOUR_09 = "2026-08-01T09:00:00.000Z";
+const HOUR_10 = "2026-08-01T10:00:00.000Z";
+
 function row({
   statementId,
-  executionDurationMs,
+  executionMsInHour,
   hourTotalMs,
+  usageHour = HOUR_09,
   hourBillableUsd = "6.00",
   currencyCode = "USD",
   skuName = BILLABLE_SKU,
 }: {
   statementId: string;
-  executionDurationMs: string;
+  /**
+   * The part of the statement's execution that fell inside THIS row's hour,
+   * not its whole runtime — a statement that ran through a boundary is
+   * several rows, one per hour it was awake in.
+   */
+  executionMsInHour: string;
   hourTotalMs: string;
+  usageHour?: string;
   hourBillableUsd?: string | null;
   currencyCode?: string | null;
   skuName?: string | null;
 }) {
   return {
     statementId,
-    executionDurationMs,
+    executionMsInHour,
+    usageHour,
     hourTotalMs,
     hourBillableUsd,
     currencyCode,
@@ -60,7 +75,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "stmt-1",
-          executionDurationMs: "3600000",
+          executionMsInHour: "3600000",
           hourTotalMs: "3600000",
         }),
       ],
@@ -76,12 +91,12 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "long",
-          executionDurationMs: "2000",
+          executionMsInHour: "2000",
           hourTotalMs: "3000",
         }),
         row({
           statementId: "short",
-          executionDurationMs: "1000",
+          executionMsInHour: "1000",
           hourTotalMs: "3000",
         }),
       ],
@@ -104,12 +119,12 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "genie-1",
-          executionDurationMs: "900000",
+          executionMsInHour: "900000",
           hourTotalMs: "3600000",
         }),
         row({
           statementId: "genie-2",
-          executionDurationMs: "900000",
+          executionMsInHour: "900000",
           hourTotalMs: "3600000",
         }),
       ],
@@ -128,7 +143,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "tiny",
-          executionDurationMs: "1",
+          executionMsInHour: "1",
           hourTotalMs: "3600000",
         }),
       ],
@@ -147,7 +162,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "eur",
-          executionDurationMs: "1000",
+          executionMsInHour: "1000",
           hourTotalMs: "1000",
           currencyCode: "EUR",
         }),
@@ -166,7 +181,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "unpriced",
-          executionDurationMs: "1000",
+          executionMsInHour: "1000",
           hourTotalMs: "1000",
           hourBillableUsd: null,
           currencyCode: null,
@@ -192,7 +207,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "unbilled",
-          executionDurationMs: "1000",
+          executionMsInHour: "1000",
           hourTotalMs: "1000",
           hourBillableUsd: null,
           currencyCode: null,
@@ -212,7 +227,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "stmt-1",
-          executionDurationMs: "3600000",
+          executionMsInHour: "3600000",
           hourTotalMs: "3600000",
           hourBillableUsd: "6.00",
           skuName: BILLABLE_SKU,
@@ -221,7 +236,7 @@ describe("allocateWarehouseCost", () => {
         // The priced line wins: the statement has a cost, so it is not owed.
         row({
           statementId: "stmt-1",
-          executionDurationMs: "3600000",
+          executionMsInHour: "3600000",
           hourTotalMs: "3600000",
           hourBillableUsd: null,
           currencyCode: null,
@@ -234,13 +249,100 @@ describe("allocateWarehouseCost", () => {
     expect(owed.has("stmt-1")).toBe(false);
   });
 
+  /** @scenario "Traffic that began before the hour keeps its share of the bill" */
+  it("leaves a straddling statement its share of the hour it ran into", () => {
+    // The case a start-hour denominator got wrong. A forty-minute statement
+    // begins at 09:58; a one-second question is the only thing to START in
+    // hour 10. Sliced by the hours it RAN in, the straddler is 38 of hour 10's
+    // 38-and-a-bit minutes, so the question pays for its second and nothing
+    // more. Bucketed by start hour, hour 10's denominator held only that
+    // second and the question carried the entire hour.
+    const { costByStatementId } = allocateWarehouseCost({
+      rows: [
+        // Two of its forty minutes fell in hour 09, which was otherwise idle.
+        row({
+          statementId: "straddler",
+          usageHour: HOUR_09,
+          executionMsInHour: "120000",
+          hourTotalMs: "120000",
+        }),
+        // The other thirty-eight landed in hour 10, beside the question.
+        row({
+          statementId: "straddler",
+          usageHour: HOUR_10,
+          executionMsInHour: "2280000",
+          hourTotalMs: "2281000",
+        }),
+        row({
+          statementId: "question",
+          usageHour: HOUR_10,
+          executionMsInHour: "1000",
+          hourTotalMs: "2281000",
+        }),
+      ],
+    });
+
+    // 6 USD * 1000 / 2_281_000 — a quarter of a cent, not six dollars.
+    expect(Number(costByStatementId.get("question")?.costUsd)).toBeCloseTo(
+      0.00263,
+      5,
+    );
+    // And the compute it did not do stays with the statement that did it:
+    // 6 * 120000/120000 + 6 * 2280000/2281000.
+    expect(Number(costByStatementId.get("straddler")?.costUsd)).toBeCloseTo(
+      11.99737,
+      5,
+    );
+
+    // The ingredients have to name every hour the share was drawn from. Costing
+    // a statement out of two hours and then reporting the first hour's total
+    // as the denominator makes the record read as a twentyfold error, and the
+    // record is what anyone reconciling the bill actually reads.
+    expect(costByStatementId.get("straddler")?.hourTotalExecutionMs).toBe(
+      "2401000",
+    );
+    expect(costByStatementId.get("straddler")?.hourBillableUsd).toBe("12");
+  });
+
+  /** @scenario "A statement is held when an hour it ran through has no bill yet" */
+  it("holds a statement whose later hour has not been billed yet", () => {
+    // A statement that ran through the boundary is priced by two hours, and the
+    // later one is the one still in flight. Reading "priced at all" as settled
+    // moves the watermark past the unbilled hour, and the part of this
+    // statement that ran in it is recorded at nothing for good.
+    const { costByStatementId, owed } = allocateWarehouseCost({
+      rows: [
+        row({
+          statementId: "straddler",
+          usageHour: HOUR_09,
+          executionMsInHour: "120000",
+          hourTotalMs: "3600000",
+        }),
+        row({
+          statementId: "straddler",
+          usageHour: HOUR_10,
+          executionMsInHour: "2280000",
+          hourTotalMs: "2281000",
+          hourBillableUsd: null,
+          currencyCode: null,
+          skuName: null,
+        }),
+      ],
+    });
+
+    expect(owed.has("straddler")).toBe(true);
+    // Held, not discarded: what did price stays on the record, and the re-read
+    // that lands the missing hour restates it.
+    expect(costByStatementId.get("straddler")?.costUsd).toBe("0.2");
+  });
+
   /** @scenario "Genie's own free usage is never charged" */
   it("charges nothing for Genie's own free-usage line", () => {
     const { costByStatementId } = allocateWarehouseCost({
       rows: [
         row({
           statementId: "free",
-          executionDurationMs: "1000",
+          executionMsInHour: "1000",
           hourTotalMs: "1000",
           skuName: `${GENIE_FREE_USAGE_SKU_MARKER}_SOMETHING`,
           hourBillableUsd: "99.00",
@@ -258,7 +360,7 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "zero-hour",
-          executionDurationMs: "0",
+          executionMsInHour: "0",
           hourTotalMs: "0",
         }),
       ],
@@ -275,14 +377,14 @@ describe("allocateWarehouseCost", () => {
       rows: [
         row({
           statementId: "stmt-1",
-          executionDurationMs: "3600000",
+          executionMsInHour: "3600000",
           hourTotalMs: "3600000",
           hourBillableUsd: "4.00",
           skuName: BILLABLE_SKU,
         }),
         row({
           statementId: "stmt-1",
-          executionDurationMs: "3600000",
+          executionMsInHour: "3600000",
           hourTotalMs: "3600000",
           hourBillableUsd: "2.00",
           skuName: "PREMIUM_SERVERLESS_SQL_COMPUTE_SURCHARGE",

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -62,6 +62,7 @@ import {
   costReadFloorMs,
   GENIE_CLIENT_APPLICATION,
   WAREHOUSE_COST_MAX_HOLD_MS,
+  WAREHOUSE_COST_STRADDLE_LOOKBACK_MS,
   type WarehousePricedStatement,
   warehouseCostChunks,
   warehouseCostPieces,
@@ -300,11 +301,12 @@ async function resolveWorkspaceToken(params: {
  *
  * Read it as three independent facts joined by the hour they share:
  *
- *   `windowed`    every statement the warehouse ran, Genie's or not
+ *   `sliced`      every statement the warehouse ran, Genie's or not, cut into
+ *                 one row per hour it was awake in
  *   `hour_total`  how much execution time that hour held IN TOTAL
  *   `hour_dbu`    what the warehouse was billed for that hour, per SKU
  *
- * `hour_total` deliberately sums `windowed` rather than filtering to Genie. A
+ * `hour_total` deliberately sums `sliced` rather than filtering to Genie. A
  * warehouse shared with dashboards and scheduled jobs whose denominator counted
  * only Genie's queries would hand Genie the entire warehouse bill. Live
  * validation put Genie at 13.3% of one workspace's warehouse compute; the rest
@@ -317,10 +319,43 @@ async function resolveWorkspaceToken(params: {
  * it. Rows with no matching price come back with nulls rather than being
  * dropped, so the caller can say so instead of silently reporting zero.
  *
- * Statements are bucketed by the hour their `start_time` falls in, which is how
- * the billing table buckets too. A statement straddling an hour boundary is
- * charged wholly to the hour it began — an approximation, and the same one the
- * live validation used.
+ * A statement is cut at every hour boundary it crosses, because the billing
+ * table is: `system.billing.usage` charges each hour for the compute that
+ * actually RAN in it. Bucketing a statement wholly into the hour it began — the
+ * shape this query used to have — put a 40-minute job's whole runtime in its
+ * start hour's denominator while 38 of those minutes were billed to the next
+ * one, leaving that next hour's bill to divide among whatever happened to start
+ * inside it. A one-second Genie question landing there could take the lot. The
+ * error ran in one direction: toward over-charging short questions, which is
+ * exactly what Genie sends.
+ *
+ * Three approximations survive, and this is what each costs:
+ *
+ *   Execution time is prorated across the hours by WALL-CLOCK overlap, because
+ *   the table reports one `execution_duration_ms` per statement and never says
+ *   which hour it was spent in. A statement that idles on a lock for 50 minutes
+ *   and computes for 10 has those 10 minutes spread evenly over the hour it
+ *   waited in. It moves a share between adjacent hours of the SAME statement;
+ *   it cannot invent or lose one, so a statement's total share is unaffected
+ *   and only its per-hour split is approximate.
+ *
+ *   A statement still running when the chunk's upper edge falls loses the tail
+ *   past that edge, and the hours in it under-count their denominator, which
+ *   over-states everyone else's share of those hours. At the top of the sweep
+ *   this heals: the settling lag re-reads those hours and the later answer
+ *   overwrites. At an interior chunk boundary during a backfill it does not —
+ *   the cost of chunking a backfill, bounded to statements longer than the
+ *   settling lag that also straddle a 7-day edge.
+ *
+ *   The look-back that catches statements which began BEFORE the window is
+ *   bounded (`WAREHOUSE_COST_STRADDLE_LOOKBACK_MS`). A statement running longer
+ *   than it is invisible to the window's first hours, whose denominators then
+ *   under-count — the same direction as the original bug, and the reason the
+ *   bound is a day rather than an hour.
+ *
+ * The row cap counts hour SLICES now, not statements: a warehouse whose
+ * statements routinely span hours reaches it sooner. Whichever it counts, the
+ * consequence is unchanged — the chunk is refused whole.
  */
 /**
  * The most rows one cost read will accept.
@@ -340,7 +375,7 @@ async function resolveWorkspaceToken(params: {
 export const WAREHOUSE_COST_ROW_LIMIT = 50_000;
 
 const WAREHOUSE_COST_STATEMENT = `
-WITH windowed AS (
+WITH ran AS (
   SELECT
     statement_id,
     client_application,
@@ -351,16 +386,71 @@ WITH windowed AS (
     query_source.genie_space_id AS genie_space_id,
     execution_duration_ms,
     compute.warehouse_id AS warehouse_id,
-    date_trunc('HOUR', start_time) AS usage_hour
+    start_time,
+    -- \`end_time\` is nullable; the duration reconstructs it when it is missing.
+    -- GREATEST pins the result at or after \`start_time\`, which is not defensive
+    -- tidiness: \`sequence()\` below RAISES on a stop before its start, so one
+    -- clock-skewed row would fail the whole read rather than skew one share.
+    GREATEST(
+      COALESCE(
+        end_time,
+        timestamp_millis(unix_millis(start_time) + execution_duration_ms)
+      ),
+      start_time
+    ) AS ended_at
   FROM system.query.history
-  WHERE start_time >= :from_ts
+  -- Wider than the window on purpose: a statement that BEGAN before it is still
+  -- burning compute inside it, and an hour whose denominator omits that
+  -- statement over-states everyone else's share of the hour.
+  WHERE start_time >= :scan_from_ts
     AND start_time < :to_ts
     AND execution_duration_ms IS NOT NULL
     AND compute.warehouse_id IS NOT NULL
 ),
+sliced AS (
+  SELECT
+    r.statement_id,
+    r.client_application,
+    r.genie_space_id,
+    r.warehouse_id,
+    r.start_time,
+    h.usage_hour,
+    -- The statement's execution time, prorated onto THIS hour by how much of its
+    -- wall clock fell inside it. \`div\` and not \`/\`: Spark's \`/\` returns a
+    -- DOUBLE, and no float may enter the money path. Truncation errs downward,
+    -- so the slices of a statement never add up to more than it ran.
+    --
+    -- The zero-wall branch is not a divide-by-zero guard bolted on: a statement
+    -- whose end lands on its start explodes to exactly one hour, so handing that
+    -- hour the whole duration is the correct answer, not a fallback.
+    CASE
+      WHEN unix_millis(r.ended_at) <= unix_millis(r.start_time)
+        THEN r.execution_duration_ms
+      ELSE (
+        r.execution_duration_ms * GREATEST(
+          0,
+          LEAST(unix_millis(r.ended_at), unix_millis(h.usage_hour) + 3600000)
+            - GREATEST(unix_millis(r.start_time), unix_millis(h.usage_hour))
+        )
+      ) div (unix_millis(r.ended_at) - unix_millis(r.start_time))
+    END AS execution_ms_in_hour
+  FROM ran r
+  LATERAL VIEW explode(
+    sequence(
+      date_trunc('HOUR', r.start_time),
+      date_trunc('HOUR', r.ended_at),
+      INTERVAL 1 HOUR
+    )
+  ) h AS usage_hour
+  -- Hours outside the window are dropped after the split, not before it: the
+  -- split needs the statement's real span to divide, the totals only want the
+  -- hours this read is answering for.
+  WHERE h.usage_hour >= :from_ts
+    AND h.usage_hour < :to_ts
+),
 hour_total AS (
-  SELECT usage_hour, warehouse_id, SUM(execution_duration_ms) AS total_ms
-  FROM windowed
+  SELECT usage_hour, warehouse_id, SUM(execution_ms_in_hour) AS total_ms
+  FROM sliced
   GROUP BY usage_hour, warehouse_id
 ),
 hour_dbu AS (
@@ -399,32 +489,35 @@ priced AS (
   WHERE pick = 1
 )
 SELECT
-  w.statement_id                          AS statement_id,
-  CAST(w.execution_duration_ms AS STRING) AS execution_duration_ms,
-  CAST(t.total_ms AS STRING)              AS hour_total_ms,
-  CAST(pr.billable_usd AS STRING)         AS hour_billable_usd,
-  pr.currency_code                        AS currency_code,
-  pr.sku_name                             AS sku_name
-FROM windowed w
+  w.statement_id                        AS statement_id,
+  CAST(w.usage_hour AS STRING)          AS usage_hour,
+  CAST(w.execution_ms_in_hour AS STRING) AS execution_ms_in_hour,
+  CAST(t.total_ms AS STRING)            AS hour_total_ms,
+  CAST(pr.billable_usd AS STRING)       AS hour_billable_usd,
+  pr.currency_code                      AS currency_code,
+  pr.sku_name                           AS sku_name
+FROM sliced w
 JOIN hour_total t
   ON t.usage_hour = w.usage_hour AND t.warehouse_id = w.warehouse_id
--- LEFT, not inner, and that is the whole fix for the zero-cost stall. An inner
--- join drops any Genie statement whose hour is not in \`system.billing.usage\`
--- yet, and that table lands minutes to days behind the question. Dropped, a
--- not-yet-billed statement is indistinguishable from a genuinely free one: both
--- are simply absent, the chunk reads as fully priced, the watermark moves past
--- them, and the fixed settling re-read never reaches back far enough to correct
--- them — a permanent zero. Kept, a not-yet-billed statement returns with a null
--- \`sku_name\`, which the allocator reads as "seen but unbilled" and holds the
--- watermark for until its bill lands (or the max hold expires).
+-- LEFT, not inner, and that is the whole fix for the zero-cost stall. An hour
+-- the workspace has not billed yet has no \`priced\` row, and an inner join would
+-- drop its statements entirely — indistinguishable from an hour with no Genie
+-- traffic, so the watermark would sail past work that was about to be billed and
+-- never come back for it. Kept with null price columns, the caller can tell "not
+-- billed yet" from "nothing to bill" and hold.
 LEFT JOIN priced pr
   ON pr.usage_hour = w.usage_hour AND pr.warehouse_id = w.warehouse_id
--- A union, because each half alone is a cliff. The label is a display string
--- the provider can rename or localize at will; the space id is structural but
--- observed on 103/103 Genie statements over 60 days, not documented as
--- guaranteed. Either change alone silently shrinks the priced set to zero —
--- together, both have to break at once.
+-- A union, because each half alone is a cliff. Older workspaces answer with a
+-- null \`genie_space_id\` and only the client application to go on; workspaces
+-- that renamed the client application answer with the space id and nothing that
+-- matches the name.
 WHERE (w.genie_space_id IS NOT NULL OR w.client_application = :genie_app)
+  -- The look-back exists to feed the denominators, not to re-emit statements a
+  -- previous chunk already priced. A statement is EMITTED for the chunk its
+  -- start falls in and counted in the totals of every chunk it burns compute in,
+  -- so no two chunks answer for the same statement.
+  AND w.start_time >= :from_ts
+  AND w.start_time < :to_ts
 LIMIT ${WAREHOUSE_COST_ROW_LIMIT}
 `;
 
@@ -470,14 +563,70 @@ const warehouseCostResponseSchema = z.object({
  * The columns `WAREHOUSE_COST_STATEMENT` selects, in order.
  *
  * The API answers in `JSON_ARRAY` form — rows are positional, with the names
- * only in the manifest — so reading a row means trusting that its third value
+ * only in the manifest — so reading a row means trusting that its fourth value
  * is still the hour's total. Every value here is a string, which means a
  * reordered SELECT would not fail any parse: it would quietly price questions
- * off the wrong column. Checking the manifest turns that into a refusal.
+ * off the wrong column. `execution_ms_in_hour` and `hour_total_ms` are now
+ * adjacent and both whole milliseconds, so a swap between them is a share of
+ * exactly one that nothing else would catch. Checking the manifest turns that
+ * into a refusal.
  */
+/**
+ * The window this question is asked about, as bound parameters.
+ *
+ * Bound, never interpolated. The window arrives from a clock, but the statement
+ * is a constant either way and this keeps it one.
+ *
+ * The warehouse id is deliberately absent. It says where this query runs, not
+ * what it may answer about: a Genie space answers on the warehouse it was
+ * authored against, which is routinely not the one the credential holds
+ * `CAN USE` on, and filtering to the executor would price every question at
+ * nothing.
+ */
+function warehouseCostParameters(chunk: {
+  fromMs: number;
+  toMs: number;
+}): { name: string; value: string; type: string }[] {
+  return [
+    // Whole hours, both ends. The warehouse is billed per hour and the
+    // statements are bucketed per hour, but the two are filtered separately: a
+    // window starting at 10:37 keeps hour 10's queries and drops hour 10's
+    // bill, so every question in that hour prices at nothing — and on a re-read
+    // that nothing would overwrite a cost an earlier run had already worked out
+    // correctly.
+    {
+      name: "from_ts",
+      value: new Date(startOfHourMs(chunk.fromMs)).toISOString(),
+      type: "TIMESTAMP",
+    },
+    // Where the SCAN starts, which is earlier than where the answer starts.
+    // Statements that began before the window still burn compute inside it, and
+    // an hour whose denominator omits them over-states everyone else's share of
+    // that hour.
+    {
+      name: "scan_from_ts",
+      value: new Date(
+        startOfHourMs(chunk.fromMs) - WAREHOUSE_COST_STRADDLE_LOOKBACK_MS,
+      ).toISOString(),
+      type: "TIMESTAMP",
+    },
+    {
+      name: "to_ts",
+      value: new Date(endOfHourMs(chunk.toMs)).toISOString(),
+      type: "TIMESTAMP",
+    },
+    {
+      name: "genie_app",
+      value: GENIE_CLIENT_APPLICATION,
+      type: "STRING",
+    },
+  ];
+}
+
 const WAREHOUSE_COST_COLUMNS = [
   "statement_id",
-  "execution_duration_ms",
+  "usage_hour",
+  "execution_ms_in_hour",
   "hour_total_ms",
   "hour_billable_usd",
   "currency_code",
@@ -719,14 +868,15 @@ function readWarehouseCost({
   const rows = data.flatMap((columns) => {
     const parsed = warehouseCostRowSchema.safeParse({
       statementId: columns[0],
-      executionDurationMs: columns[1],
-      hourTotalMs: columns[2],
-      hourBillableUsd: columns[3] ?? null,
-      currencyCode: columns[4] ?? null,
+      usageHour: columns[1],
+      executionMsInHour: columns[2],
+      hourTotalMs: columns[3],
+      hourBillableUsd: columns[4] ?? null,
+      currencyCode: columns[5] ?? null,
       // Null is meaningful now, not an empty-string fallback: the LEFT JOIN
       // returns a null SKU for a statement whose hour has no billing row yet,
       // and the allocator reads that as "seen but unbilled".
-      skuName: columns[5] ?? null,
+      skuName: columns[6] ?? null,
     });
     if (!parsed.success) {
       unreadable += 1;
@@ -2582,8 +2732,11 @@ export class DatabricksGeniePuller
     }
 
     if (read.outcome === "priced") {
-      // A statement is bucketed by the hour it started in and every hour lies
-      // inside exactly one chunk, so no two chunks answer for the same one.
+      // A statement is EMITTED for the chunk its `start_time` falls in, even
+      // though it may be counted in the totals of the next chunk too, so no two
+      // chunks answer for the same one. The overwrite is still deliberate: the
+      // settling lag re-reads the newest hours, and the later answer is the
+      // better one because it sees bills that had not landed the first time.
       mergeWarehouseCost(costByStatementId, read.costByStatementId);
       // Priced, but not wholly: a statement here was seen and has no bill yet.
       // Hold the watermark at the chunk's start so the whole chunk is re-read
@@ -2770,7 +2923,6 @@ export class DatabricksGeniePuller
     warehouseId: string;
     chunk: { fromMs: number; toMs: number };
   }): Promise<WarehouseCostRead> {
-    const { fromMs, toMs } = chunk;
     const askedAtMs = Date.now();
     const observed = warehouseCostObserved({
       adapter: this.id,
@@ -2807,37 +2959,7 @@ export class DatabricksGeniePuller
           on_wait_timeout: "CANCEL",
           format: "JSON_ARRAY",
           disposition: "INLINE",
-          // Bound, never interpolated. The window arrives from a clock, but the
-          // statement is a constant either way and this keeps it one.
-          //
-          // The warehouse id is deliberately absent. It says where this query
-          // runs, not what it may answer about: a Genie space answers on the
-          // warehouse it was authored against, which is routinely not the one
-          // the credential holds `CAN USE` on, and filtering to the executor
-          // would price every question at nothing.
-          parameters: [
-            // Whole hours, both ends. The warehouse is billed per hour and the
-            // statements are bucketed per hour, but the two are filtered
-            // separately: a window starting at 10:37 keeps hour 10's queries
-            // and drops hour 10's bill, so every question in that hour prices
-            // at nothing — and on a re-read that nothing would overwrite a
-            // cost an earlier run had already worked out correctly.
-            {
-              name: "from_ts",
-              value: new Date(startOfHourMs(fromMs)).toISOString(),
-              type: "TIMESTAMP",
-            },
-            {
-              name: "to_ts",
-              value: new Date(endOfHourMs(toMs)).toISOString(),
-              type: "TIMESTAMP",
-            },
-            {
-              name: "genie_app",
-              value: GENIE_CLIENT_APPLICATION,
-              type: "STRING",
-            },
-          ],
+          parameters: warehouseCostParameters(chunk),
         },
       });
 

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -340,13 +340,13 @@ async function resolveWorkspaceToken(params: {
  *   it cannot invent or lose one, so a statement's total share is unaffected
  *   and only its per-hour split is approximate.
  *
- *   A statement still running when the chunk's upper edge falls loses the tail
- *   past that edge, and the hours in it under-count their denominator, which
- *   over-states everyone else's share of those hours. At the top of the sweep
- *   this heals: the settling lag re-reads those hours and the later answer
- *   overwrites. At an interior chunk boundary during a backfill it does not —
- *   the cost of chunking a backfill, bounded to statements longer than the
- *   settling lag that also straddle a 7-day edge.
+ *   A statement still running when the chunk's upper edge falls is priced from
+ *   both sides — this chunk emits the hours below the edge, the next one emits
+ *   the hours above it, and the sweep adds them. What does not survive is a
+ *   tail whose chunk is HELD: an hour there with no bill yet stops the sweep,
+ *   the question is emitted with the part that did price, and the re-read drops
+ *   the hint rather than restating it. Bounded to statements that straddle a
+ *   chunk edge AND run into an hour the workspace has not billed.
  *
  *   The look-back that catches statements which began BEFORE the window is
  *   bounded (`WAREHOUSE_COST_STRADDLE_LOOKBACK_MS`). A statement running longer

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -2876,10 +2876,11 @@ export class DatabricksGeniePuller
   }
 
   /**
-   * The pieces in order: each that prices whole is merged, and the first that
-   * cannot be — refused, still owing a bill, or outrunning the run's budget —
-   * is returned as where the watermark holds. `"failed"` ends the whole sweep;
-   * `null` says every piece priced.
+   * The pieces in order: every piece that prices is merged — even one still
+   * owing a bill keeps its billed hours' worth — and the first that stops the
+   * walk (refused, owing, or outrunning the run's budget) is returned as where
+   * the watermark holds. `"failed"` ends the whole sweep; `null` says every
+   * piece priced whole.
    */
   private async walkWarehouseCostPieces({
     config,

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -61,6 +61,7 @@ import {
   allocateWarehouseCost,
   costReadFloorMs,
   GENIE_CLIENT_APPLICATION,
+  mergeWarehouseCost,
   WAREHOUSE_COST_MAX_HOLD_MS,
   WAREHOUSE_COST_STRADDLE_LOOKBACK_MS,
   type WarehousePricedStatement,
@@ -462,6 +463,19 @@ sliced AS (
   -- Hours outside the window are dropped after the split, not before it: the
   -- split needs the statement's real span to divide, the totals only want the
   -- hours this read is answering for.
+  --
+  -- This clip is also what decides which chunk answers for which row, and it
+  -- has to be the HOUR rather than the statement's start. Chunks tile the
+  -- window, so every hour falls in exactly one of them and every statement-hour
+  -- is emitted exactly once — a statement that begins near the end of a chunk
+  -- comes back from the next one too, carrying the hours it burned there.
+  -- Gating on \`start_time\` instead looks like the same duplicate-avoidance
+  -- rule and is not: it hands the straddler wholly to the chunk it began in,
+  -- which has already dropped every hour past its own end, while the next chunk
+  -- counts that statement in its denominators and then excludes it from its
+  -- rows. Those hours are then billed to nobody and still dilute every other
+  -- question's share of them, permanently and silently, at every interior chunk
+  -- boundary a backfill crosses.
   WHERE h.usage_hour >= :from_ts
     AND h.usage_hour < :to_ts
 ),
@@ -533,12 +547,6 @@ LEFT JOIN priced pr
 -- guaranteed. Either change alone silently shrinks the priced set to zero —
 -- together, both have to break at once.
 WHERE (w.genie_space_id IS NOT NULL OR w.client_application = :genie_app)
-  -- The look-back exists to feed the denominators, not to re-emit statements a
-  -- previous chunk already priced. A statement is EMITTED for the chunk its
-  -- start falls in and counted in the totals of every chunk it burns compute in,
-  -- so no two chunks answer for the same statement.
-  AND w.start_time >= :from_ts
-  AND w.start_time < :to_ts
 LIMIT ${WAREHOUSE_COST_ROW_LIMIT}
 `;
 
@@ -734,14 +742,6 @@ const WAREHOUSE_COST_UNFINISHED_STATES = new Set([
  */
 function unpricedFloor(chunk: { fromMs: number }): number {
   return chunk.fromMs - 1;
-}
-
-/** Fold one chunk's priced statements into the sweep's running total. */
-function mergeWarehouseCost(
-  into: Map<string, WarehousePricedStatement>,
-  from: Map<string, WarehousePricedStatement>,
-): void {
-  for (const [statementId, priced] of from) into.set(statementId, priced);
 }
 
 /**
@@ -2753,11 +2753,11 @@ export class DatabricksGeniePuller
     }
 
     if (read.outcome === "priced") {
-      // A statement is EMITTED for the chunk its `start_time` falls in, even
-      // though it may be counted in the totals of the next chunk too, so no two
-      // chunks answer for the same one. The overwrite is still deliberate: the
-      // settling lag re-reads the newest hours, and the later answer is the
-      // better one because it sees bills that had not landed the first time.
+      // A statement is emitted for every chunk it burned compute in, carrying
+      // that chunk's hours only, so a statement running across a boundary
+      // arrives here twice with a different part of itself. `mergeWarehouseCost`
+      // adds rather than replaces for exactly that reason — see the ownership
+      // note on the hour clip in `WAREHOUSE_COST_STATEMENT`.
       mergeWarehouseCost(costByStatementId, read.costByStatementId);
       // Priced, but not wholly: a statement here was seen and has no bill yet.
       // Hold the watermark at the chunk's start so the whole chunk is re-read

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -2758,7 +2758,10 @@ export class DatabricksGeniePuller
       // arrives here twice with a different part of itself. `mergeWarehouseCost`
       // adds rather than replaces for exactly that reason — see the ownership
       // note on the hour clip in `WAREHOUSE_COST_STATEMENT`.
-      mergeWarehouseCost(costByStatementId, read.costByStatementId);
+      mergeWarehouseCost({
+        into: costByStatementId,
+        from: read.costByStatementId,
+      });
       // Priced, but not wholly: a statement here was seen and has no bill yet.
       // Hold the watermark at the chunk's start so the whole chunk is re-read
       // once billing lands, rather than moving past the unbilled statement and
@@ -2915,15 +2918,22 @@ export class DatabricksGeniePuller
       if (pieceRead.outcome !== "priced") {
         return piece;
       }
-      // Priced, but a statement in this piece has no bill yet. Hold at the
-      // piece, exactly as a refusal to it would: the pieces before it kept
-      // their cost and are never re-asked, and this one is re-read once its
-      // billing settles. Merging the piece first would be overwritten by that
-      // re-read, so it is left for the re-read to price whole.
+      // Merged BEFORE the owed check, the same order the full-chunk path
+      // uses: a piece can be owed for one hour and priced for others, and the
+      // priced shares belong to this run's records rather than to nothing. The
+      // hold below re-reads the piece once billing settles, and that re-read
+      // replaces the ledger rows with the same figure — so keeping the cost
+      // now costs nothing later.
+      mergeWarehouseCost({
+        into: costByStatementId,
+        from: pieceRead.costByStatementId,
+      });
+      // A statement in this piece has no bill yet. Hold at the piece, exactly
+      // as a refusal to it would: the pieces before it kept their cost and are
+      // never re-asked, and this one is re-read once its billing settles.
       if (pieceRead.owed) {
         return piece;
       }
-      mergeWarehouseCost(costByStatementId, pieceRead.costByStatementId);
     }
     return null;
   }

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -499,18 +499,22 @@ SELECT
 FROM sliced w
 JOIN hour_total t
   ON t.usage_hour = w.usage_hour AND t.warehouse_id = w.warehouse_id
--- LEFT, not inner, and that is the whole fix for the zero-cost stall. An hour
--- the workspace has not billed yet has no \`priced\` row, and an inner join would
--- drop its statements entirely — indistinguishable from an hour with no Genie
--- traffic, so the watermark would sail past work that was about to be billed and
--- never come back for it. Kept with null price columns, the caller can tell "not
--- billed yet" from "nothing to bill" and hold.
+-- LEFT, not inner, and that is the whole fix for the zero-cost stall. An inner
+-- join drops any Genie statement whose hour is not in \`system.billing.usage\`
+-- yet, and that table lands minutes to days behind the question. Dropped, a
+-- not-yet-billed statement is indistinguishable from a genuinely free one: both
+-- are simply absent, the chunk reads as fully priced, the watermark moves past
+-- them, and the fixed settling re-read never reaches back far enough to correct
+-- them — a permanent zero. Kept, a not-yet-billed statement returns with a null
+-- \`sku_name\`, which the allocator reads as "seen but unbilled" and holds the
+-- watermark for until its bill lands (or the max hold expires).
 LEFT JOIN priced pr
   ON pr.usage_hour = w.usage_hour AND pr.warehouse_id = w.warehouse_id
--- A union, because each half alone is a cliff. Older workspaces answer with a
--- null \`genie_space_id\` and only the client application to go on; workspaces
--- that renamed the client application answer with the space id and nothing that
--- matches the name.
+-- A union, because each half alone is a cliff. The label is a display string
+-- the provider can rename or localize at will; the space id is structural but
+-- observed on 103/103 Genie statements over 60 days, not documented as
+-- guaranteed. Either change alone silently shrinks the priced set to zero —
+-- together, both have to break at once.
 WHERE (w.genie_space_id IS NOT NULL OR w.client_application = :genie_app)
   -- The look-back exists to feed the denominators, not to re-emit statements a
   -- previous chunk already priced. A statement is EMITTED for the chunk its
@@ -571,6 +575,16 @@ const warehouseCostResponseSchema = z.object({
  * exactly one that nothing else would catch. Checking the manifest turns that
  * into a refusal.
  */
+const WAREHOUSE_COST_COLUMNS = [
+  "statement_id",
+  "usage_hour",
+  "execution_ms_in_hour",
+  "hour_total_ms",
+  "hour_billable_usd",
+  "currency_code",
+  "sku_name",
+] as const;
+
 /**
  * The window this question is asked about, as bound parameters.
  *
@@ -622,16 +636,6 @@ function warehouseCostParameters(chunk: {
     },
   ];
 }
-
-const WAREHOUSE_COST_COLUMNS = [
-  "statement_id",
-  "usage_hour",
-  "execution_ms_in_hour",
-  "hour_total_ms",
-  "hour_billable_usd",
-  "currency_code",
-  "sku_name",
-] as const;
 
 /**
  * What one cost reply turned out to be worth.

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -435,10 +435,27 @@ sliced AS (
       ) div (unix_millis(r.ended_at) - unix_millis(r.start_time))
     END AS execution_ms_in_hour
   FROM ran r
+  -- The last hour is half-open, because \`sequence\` includes its stop value and
+  -- an hour is not. A statement ending at exactly 10:00:00.000 worked in hour
+  -- 09 and not at all in hour 10, and every hourly scheduled query ends on a
+  -- boundary. Emitting that empty hour is not merely untidy: if the warehouse
+  -- shut down at 10:00 no bill for hour 10 will ever arrive, the null SKU reads
+  -- as "not billed yet", and one such statement holds the whole source at this
+  -- chunk until the seven-day hold expires.
+  --
+  -- Backing the stop off by a millisecond cannot invert the range: it is only
+  -- done when the statement ran for at least that long, and a statement that
+  -- did not still needs its one hour to land somewhere.
   LATERAL VIEW explode(
     sequence(
       date_trunc('HOUR', r.start_time),
-      date_trunc('HOUR', r.ended_at),
+      date_trunc('HOUR',
+        CASE
+          WHEN unix_millis(r.ended_at) > unix_millis(r.start_time)
+            THEN timestamp_millis(unix_millis(r.ended_at) - 1)
+          ELSE r.start_time
+        END
+      ),
       INTERVAL 1 HOUR
     )
   ) h AS usage_hour

--- a/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
+++ b/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
@@ -635,3 +635,48 @@ export function costReadFloorMs({
   if (!costEnabled) return sinceMs;
   return Math.min(sinceMs, nowMs - WAREHOUSE_COST_SETTLING_LAG_MS);
 }
+
+/**
+ * Fold one chunk's priced statements into the sweep's running total.
+ *
+ * Added, not replaced, and that is the half of the chunk-boundary fix that
+ * lives outside the SQL. Each chunk emits the hours it owns, so a statement
+ * that ran across a boundary arrives twice with a different part of itself.
+ * The sweep emits its question exactly once, with whatever this map holds by
+ * the end — so replacing would ship the last chunk's slice as the whole cost,
+ * which is the same under-count the start-time ownership rule used to produce.
+ *
+ * All three fields add for the same reason: each is already a sum over the
+ * hours the statement ran through, and the chunks partition those hours. The
+ * money adds in nanoUSD and leaves as an exact decimal string, so no float ever
+ * touches it.
+ *
+ * Chunks never overlap and a refused chunk is merged only as its pieces, so no
+ * hour is ever read twice inside one sweep. Adding therefore cannot double a
+ * cost that was already counted.
+ */
+export function mergeWarehouseCost(
+  into: Map<string, WarehousePricedStatement>,
+  from: Map<string, WarehousePricedStatement>,
+): void {
+  for (const [statementId, priced] of from) {
+    const already = into.get(statementId);
+    if (already === undefined) {
+      into.set(statementId, priced);
+      continue;
+    }
+    into.set(statementId, {
+      costUsd: nanoUsdToDecimalString(
+        usdToNanoUsd(already.costUsd) + usdToNanoUsd(priced.costUsd),
+      ),
+      hourTotalExecutionMs: (
+        BigInt(already.hourTotalExecutionMs) +
+        BigInt(priced.hourTotalExecutionMs)
+      ).toString(),
+      hourBillableUsd: nanoUsdToDecimalString(
+        usdToNanoUsd(already.hourBillableUsd) +
+          usdToNanoUsd(priced.hourBillableUsd),
+      ),
+    });
+  }
+}

--- a/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
+++ b/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
@@ -97,6 +97,26 @@ const ONE_HOUR_MS = 60 * 60 * 1000;
 export const WAREHOUSE_COST_CHUNK_MS = 7 * 24 * ONE_HOUR_MS;
 
 /**
+ * How far BEFORE a window the cost read scans for statements still running in
+ * it.
+ *
+ * A statement that began at 09:58 and ran forty minutes is billed to hour 10
+ * for thirty-eight of them, so hour 10's denominator has to count it — but the
+ * statement's own row lives in hour 09, outside a window that starts at 10:00.
+ * Without a look-back that hour under-counts its execution time and hands every
+ * question inside it a larger share of the bill than it earned.
+ *
+ * A day, and the bound is the point. It is not free: it widens the scan of
+ * `system.query.history`, which on the normal seven-day chunk is +14% and on a
+ * refused chunk's one-day pieces is double. Unbounded it would be a full-table
+ * scan on every read. What a day buys is every plausible warehouse statement —
+ * a query still running after twenty-four hours is a runaway, and its
+ * under-counted first hours err in the same direction as the bug this bound
+ * exists to fix, but bounded to that one statement rather than to all of them.
+ */
+export const WAREHOUSE_COST_STRADDLE_LOOKBACK_MS = 24 * ONE_HOUR_MS;
+
+/**
  * How much of one refused chunk a follow-up request asks about.
  *
  * A day, because that is the size the whole window used to be read at: it is
@@ -231,7 +251,27 @@ export const GENIE_FREE_USAGE_SKU_MARKER = "GENIE_FREE_USAGE";
  */
 export const warehouseCostRowSchema = z.object({
   statementId: z.string().min(1),
-  executionDurationMs: z.string(),
+  /**
+   * The hour this row is about, as the warehouse rendered it. An opaque key,
+   * only ever compared against other rows of the same reply.
+   *
+   * It is load-bearing because one statement can now produce several rows for
+   * two entirely different reasons, and they fold in opposite ways. Several
+   * rows for ONE hour are several SKUs the warehouse billed that hour under:
+   * they share a denominator, and summing it would halve every share. Several
+   * rows for DIFFERENT hours are the hours a statement ran through: their
+   * denominators are different totals and must be summed, or the record claims
+   * a share of two hours' bills against one hour's execution time.
+   */
+  usageHour: z.string(),
+  /**
+   * The part of the statement's execution that fell inside THIS row's hour —
+   * not its whole runtime. The warehouse is billed per hour for the work that
+   * actually ran in that hour, so the share's numerator has to be cut the same
+   * way or it is answering a different question than the denominator.
+   */
+  executionMsInHour: z.string(),
+  /** Executed milliseconds across the whole warehouse in this row's hour. */
   hourTotalMs: z.string(),
   /** Null when the workspace publishes no USD price for the hour's SKU. */
   hourBillableUsd: z.string().nullable(),
@@ -276,19 +316,25 @@ export type WarehouseCostSkip = {
  * carries. So the record says what was measured and claims nothing more.
  */
 export type WarehousePricedStatement = {
-  /** The statement's share of its hour's bill, as an exact decimal USD string. */
+  /**
+   * The statement's share of the bill, as an exact decimal USD string. A
+   * statement that ran through an hour boundary is priced once per hour and
+   * this is the sum of those shares.
+   */
   costUsd: string;
   /**
-   * Executed milliseconds across ALL statements on the warehouse that hour —
-   * the share's denominator. A sum, not a utilization: concurrency can carry
-   * it past one hour of wall clock.
+   * Executed milliseconds across ALL statements on the warehouse, summed over
+   * the hours this statement itself ran through — the share's denominator. A
+   * sum, not a utilization: concurrency can carry a single hour past one hour
+   * of wall clock, and a statement spanning three hours adds three of them.
    */
   hourTotalExecutionMs: string;
   /**
-   * The hour's bill across the lines this statement priced on, as an exact
-   * decimal USD string — the share's other ingredient, so
+   * The bill across the lines this statement priced on, as an exact decimal USD
+   * string — the share's other ingredient, so
    * `costUsd ≈ hourBillableUsd × executionMs / hourTotalExecutionMs` holds on
-   * the record itself.
+   * the record itself. Both this and the denominator span the same hours, so
+   * the identity survives a statement that straddled.
    */
   hourBillableUsd: string;
 };
@@ -329,7 +375,7 @@ function wholeMs(value: string): bigint | null {
 function shareOf(
   row: WarehouseCostRow,
 ):
-  | { nanoUsd: bigint; hourNanoUsd: bigint }
+  | { nanoUsd: bigint; hourNanoUsd: bigint; hourTotalMs: bigint }
   | { reason: WarehouseCostSkipReason }
   | "free"
   | "owed" {
@@ -353,7 +399,7 @@ function shareOf(
     return { reason: "currency_not_usd" };
   }
 
-  const executionMs = wholeMs(row.executionDurationMs);
+  const executionMs = wholeMs(row.executionMsInHour);
   const totalMs = wholeMs(row.hourTotalMs);
   if (executionMs === null || totalMs === null) {
     return { reason: "unreadable_row" };
@@ -374,45 +420,53 @@ function shareOf(
   return {
     nanoUsd: (hourNanoUsd * executionMs) / totalMs,
     hourNanoUsd,
+    hourTotalMs: totalMs,
   };
 }
 
-/** A statement's running totals while its hour's lines are being folded in. */
+/** A statement's running totals while its lines are being folded in. */
 type PricedTotals = {
   costNanoUsd: bigint;
   hourNanoUsd: bigint;
-  hourTotalExecutionMs: string;
+  /**
+   * Each hour this statement drew from, and that hour's whole-warehouse total —
+   * keyed, not accumulated, because an hour billed under three SKUs sends the
+   * same total three times and adding them would treble the denominator the
+   * record reports. Summed once at the end, over the KEYS.
+   */
+  hourTotalMsByHour: Map<string, bigint>;
 };
 
 /** Fold one priced line into its statement's running totals. */
 function foldPricedLine(
   into: Map<string, PricedTotals>,
   row: WarehouseCostRow,
-  share: { nanoUsd: bigint; hourNanoUsd: bigint },
+  share: { nanoUsd: bigint; hourNanoUsd: bigint; hourTotalMs: bigint },
 ): void {
   const entry = into.get(row.statementId);
   if (entry) {
     entry.costNanoUsd += share.nanoUsd;
-    // Several lines are several PARTS of one hour's bill, so the hour's
-    // billable figure sums the same way the cost does.
+    // Several lines are several PARTS of a bill, so the billable figure sums
+    // the same way the cost does — whether they are one hour's SKUs or the
+    // several hours a long statement ran through.
     entry.hourNanoUsd += share.hourNanoUsd;
+    entry.hourTotalMsByHour.set(row.usageHour, share.hourTotalMs);
     return;
   }
   into.set(row.statementId, {
     costNanoUsd: share.nanoUsd,
     hourNanoUsd: share.hourNanoUsd,
-    // A statement lives in exactly one hour (bucketed by start_time), so
-    // every one of its lines names the same total.
-    hourTotalExecutionMs: row.hourTotalMs,
+    hourTotalMsByHour: new Map([[row.usageHour, share.hourTotalMs]]),
   });
 }
 
 /**
  * The per-statement share of each hour's warehouse bill.
  *
- * A statement may appear more than once: serverless SQL bills several lines for
- * the same hour, and each is a PART of the statement's cost. They are summed,
- * not treated as competing answers for the same thing.
+ * A statement may appear more than once, for two unrelated reasons, and both
+ * are PARTS of one cost rather than competing answers: serverless SQL bills
+ * several lines for the same hour, and a statement that ran through an hour
+ * boundary is cut into one line per hour it was awake in. Both are summed.
  */
 export function allocateWarehouseCost({
   rows,
@@ -421,13 +475,29 @@ export function allocateWarehouseCost({
 }): WarehouseCostAllocation {
   const nanoByStatementId = new Map<string, PricedTotals>();
   const skipped: WarehouseCostSkip[] = [];
-  const owed = new Set<string>();
+  // Both sides of the hold are tracked per HOUR, not per statement. A statement
+  // that ran through two hours can be settled for one of them and still be
+  // waiting on the other, and it is the unsettled hour that has to hold the
+  // watermark — pricing the hour that happens to be billed already is not
+  // evidence about the hour that is not.
+  const owedHours = new Map<string, Set<string>>();
+  const pricedHours = new Map<string, Set<string>>();
+
+  const noteHour = (
+    into: Map<string, Set<string>>,
+    statementId: string,
+    usageHour: string,
+  ): void => {
+    const hours = into.get(statementId);
+    if (hours) hours.add(usageHour);
+    else into.set(statementId, new Set([usageHour]));
+  };
 
   for (const row of rows) {
     const share = shareOf(row);
     if (share === "free") continue;
     if (share === "owed") {
-      owed.add(row.statementId);
+      noteHour(owedHours, row.statementId, row.usageHour);
       continue;
     }
 
@@ -444,24 +514,67 @@ export function allocateWarehouseCost({
       continue;
     }
 
+    noteHour(pricedHours, row.statementId, row.usageHour);
     foldPricedLine(nanoByStatementId, row, share);
   }
 
+  return {
+    costByStatementId: settleTotals(nanoByStatementId),
+    skipped,
+    owed: heldStatements({ owedHours, pricedHours }),
+  };
+}
+
+/**
+ * The per-hour running totals turned into the record's money fields.
+ *
+ * The denominator is summed over the KEYS of `hourTotalMsByHour`, so an hour
+ * billed under several SKUs contributes its total once while a statement that
+ * ran through two hours contributes both — which is what keeps
+ * `hourTotalExecutionMs` spanning exactly the hours `hourBillableUsd` came
+ * from.
+ */
+function settleTotals(
+  nanoByStatementId: Map<string, PricedTotals>,
+): Map<string, WarehousePricedStatement> {
   const costByStatementId = new Map<string, WarehousePricedStatement>();
   for (const [statementId, entry] of nanoByStatementId) {
+    let hourTotalMs = 0n;
+    for (const total of entry.hourTotalMsByHour.values()) hourTotalMs += total;
     costByStatementId.set(statementId, {
       costUsd: nanoUsdToDecimalString(entry.costNanoUsd),
-      hourTotalExecutionMs: entry.hourTotalExecutionMs,
+      hourTotalExecutionMs: hourTotalMs.toString(),
       hourBillableUsd: nanoUsdToDecimalString(entry.hourNanoUsd),
     });
   }
+  return costByStatementId;
+}
 
-  // A statement that priced on any line is priced, even if another of its lines
-  // had not been billed yet. Only statements with no priced line at all are
-  // owed.
-  for (const statementId of costByStatementId.keys()) owed.delete(statementId);
-
-  return { costByStatementId, skipped, owed };
+/**
+ * The statements whose cost is not settled yet, and so must hold the watermark.
+ *
+ * An hour that priced is settled; an hour that only ever showed up unbilled is
+ * not, and one such hour is enough to hold the whole statement. Within a single
+ * hour this is exactly the old rule — a line that priced settles the hour its
+ * unbilled sibling SKU left open.
+ */
+function heldStatements({
+  owedHours,
+  pricedHours,
+}: {
+  owedHours: Map<string, Set<string>>;
+  pricedHours: Map<string, Set<string>>;
+}): Set<string> {
+  const owed = new Set<string>();
+  for (const [statementId, hours] of owedHours) {
+    const priced = pricedHours.get(statementId);
+    for (const hour of hours) {
+      if (priced?.has(hour)) continue;
+      owed.add(statementId);
+      break;
+    }
+  }
+  return owed;
 }
 
 /**

--- a/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
+++ b/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
@@ -655,10 +655,13 @@ export function costReadFloorMs({
  * hour is ever read twice inside one sweep. Adding therefore cannot double a
  * cost that was already counted.
  */
-export function mergeWarehouseCost(
-  into: Map<string, WarehousePricedStatement>,
-  from: Map<string, WarehousePricedStatement>,
-): void {
+export function mergeWarehouseCost({
+  into,
+  from,
+}: {
+  into: Map<string, WarehousePricedStatement>;
+  from: Map<string, WarehousePricedStatement>;
+}): void {
   for (const [statementId, priced] of from) {
     const already = into.get(statementId);
     if (already === undefined) {

--- a/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
+++ b/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
@@ -331,10 +331,17 @@ export type WarehousePricedStatement = {
   hourTotalExecutionMs: string;
   /**
    * The bill across the lines this statement priced on, as an exact decimal USD
-   * string — the share's other ingredient, so
-   * `costUsd ≈ hourBillableUsd × executionMs / hourTotalExecutionMs` holds on
-   * the record itself. Both this and the denominator span the same hours, so
-   * the identity survives a statement that straddled.
+   * string — the share's other ingredient. Both this and the denominator span
+   * the same hours, so the pair says which bill the cost was drawn from.
+   *
+   * `costUsd` is NOT recoverable from them. Each hour's share is taken at that
+   * hour's own price and the three fields are then summed independently, so a
+   * one-line reconstruction only holds when every hour cost the same per
+   * millisecond. It does not for a straddler: the forty-minute statement in the
+   * unit suite costs 11.997369574, while bill x runtime / total reads
+   * 11.995001..., because its two minutes in an otherwise idle hour 09 were
+   * billed at nineteen times the per-millisecond price of hour 10. Reconciling
+   * a straddler needs the per-hour lines, which this record does not carry.
    */
   hourBillableUsd: string;
 };

--- a/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
+++ b/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
@@ -378,7 +378,16 @@ function shareOf(
   | { nanoUsd: bigint; hourNanoUsd: bigint; hourTotalMs: bigint }
   | { reason: WarehouseCostSkipReason }
   | "free"
+  | "idle"
   | "owed" {
+  // An hour the statement did no work in reveals nothing and can cost nothing,
+  // whatever its SKU says. Checked before the null-SKU branch on purpose: that
+  // branch holds the watermark, and holding the whole source for an hour this
+  // statement was not awake in is a stall bought for a share of exactly zero.
+  // It does not disturb the distinction below, because every row that turns on
+  // it has execution time by definition.
+  if (wholeMs(row.executionMsInHour) === 0n) return "idle";
+
   // No billing row for this statement's hour yet. Checked first, before every
   // other branch: a null SKU is not a free line and not an unreadable one, it
   // is a bill that has not landed. Reading it as anything else — or letting
@@ -495,7 +504,7 @@ export function allocateWarehouseCost({
 
   for (const row of rows) {
     const share = shareOf(row);
-    if (share === "free") continue;
+    if (share === "free" || share === "idle") continue;
     if (share === "owed") {
       noteHour(owedHours, row.statementId, row.usageHour);
       continue;

--- a/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
+++ b/platform/app/ee/governance/services/pullers/databricksWarehouseCost.ts
@@ -447,11 +447,15 @@ type PricedTotals = {
 };
 
 /** Fold one priced line into its statement's running totals. */
-function foldPricedLine(
-  into: Map<string, PricedTotals>,
-  row: WarehouseCostRow,
-  share: { nanoUsd: bigint; hourNanoUsd: bigint; hourTotalMs: bigint },
-): void {
+function foldPricedLine({
+  into,
+  row,
+  share,
+}: {
+  into: Map<string, PricedTotals>;
+  row: WarehouseCostRow;
+  share: { nanoUsd: bigint; hourNanoUsd: bigint; hourTotalMs: bigint };
+}): void {
   const entry = into.get(row.statementId);
   if (entry) {
     entry.costNanoUsd += share.nanoUsd;
@@ -492,11 +496,18 @@ export function allocateWarehouseCost({
   const owedHours = new Map<string, Set<string>>();
   const pricedHours = new Map<string, Set<string>>();
 
-  const noteHour = (
-    into: Map<string, Set<string>>,
-    statementId: string,
-    usageHour: string,
-  ): void => {
+  // Named on purpose: the two maps this writes to are the same type and mean
+  // opposite things, and a swapped first argument would hold every settled
+  // statement and settle every held one without failing to compile.
+  const noteHour = ({
+    into,
+    statementId,
+    usageHour,
+  }: {
+    into: Map<string, Set<string>>;
+    statementId: string;
+    usageHour: string;
+  }): void => {
     const hours = into.get(statementId);
     if (hours) hours.add(usageHour);
     else into.set(statementId, new Set([usageHour]));
@@ -506,7 +517,11 @@ export function allocateWarehouseCost({
     const share = shareOf(row);
     if (share === "free" || share === "idle") continue;
     if (share === "owed") {
-      noteHour(owedHours, row.statementId, row.usageHour);
+      noteHour({
+        into: owedHours,
+        statementId: row.statementId,
+        usageHour: row.usageHour,
+      });
       continue;
     }
 
@@ -523,8 +538,12 @@ export function allocateWarehouseCost({
       continue;
     }
 
-    noteHour(pricedHours, row.statementId, row.usageHour);
-    foldPricedLine(nanoByStatementId, row, share);
+    noteHour({
+      into: pricedHours,
+      statementId: row.statementId,
+      usageHour: row.usageHour,
+    });
+    foldPricedLine({ into: nanoByStatementId, row, share });
   }
 
   return {

--- a/specs/ai-governance/puller-framework/databricks-genie.feature
+++ b/specs/ai-governance/puller-framework/databricks-genie.feature
@@ -392,6 +392,20 @@ Feature: Databricks AI/BI Genie puller
       # hour.
 
     @unit
+    Scenario: An hour a statement did no work in cannot hold it
+      Given a query that ends exactly on the hour
+      And the hour it ends on has no bill
+      When the puller allocates warehouse cost
+      Then the query keeps what the hour it worked in is worth
+      And the query is not held for the hour it did not work in
+      # A null price means the bill has not landed yet, and holding the source
+      # until it does is right for an hour the query was awake in. For an hour
+      # it was not, no bill is coming — the warehouse may have shut down at
+      # that boundary — and holding stalls every later pull for the seven-day
+      # hold. Every hourly scheduled query ends on a boundary, so this is a
+      # weekly outage, not a corner.
+
+    @unit
     Scenario: The billing query only ever runs on the configured workspace
       Given a Genie source that names a warehouse
       When the puller asks for billing

--- a/specs/ai-governance/puller-framework/databricks-genie.feature
+++ b/specs/ai-governance/puller-framework/databricks-genie.feature
@@ -382,11 +382,14 @@ Feature: Databricks AI/BI Genie puller
       Given a query that ran through two hours
       And only the first of those hours has been billed
       When the puller allocates warehouse cost
-      Then the query is held rather than recorded at the first hour's cost
+      Then the query keeps what the billed hour is worth
+      And the query is held until the unbilled hour arrives
       # A query spanning two hours is only fully priced once both hours have
-      # billed. Recording it on the first hour alone understates it, and the
-      # record cannot be revised later, so the unbilled hour has to hold it —
-      # the same rule as an entirely unbilled question, applied per hour.
+      # billed. What did price is worth keeping, but settling there would
+      # leave the second hour recorded at nothing for good — so the unbilled
+      # hour holds the query and the re-read that lands it restates the
+      # total. The same rule as an entirely unbilled question, applied per
+      # hour.
 
     @unit
     Scenario: The billing query only ever runs on the configured workspace

--- a/specs/ai-governance/puller-framework/databricks-genie.feature
+++ b/specs/ai-governance/puller-framework/databricks-genie.feature
@@ -77,6 +77,18 @@ Feature: Databricks AI/BI Genie puller
       # Dividing the hour across Genie's queries alone hands Genie the whole
       # warehouse bill, including the dashboards and jobs sharing it.
 
+    @unit @integration
+    Scenario: Traffic that began before the hour keeps its share of the bill
+      Given a query that started in the hour before and ran on into this one
+      And a short question asked inside this hour
+      When the puller prices this hour
+      Then the query that ran in from before carries part of this hour's bill
+      And the short question carries only its own share of the time worked
+      # The bill is for the hour the work ran in, not the hour it was started
+      # in. Counting a straddling query only against the hour it began in
+      # leaves this hour's bill divided among whatever happened to start in it,
+      # so a one-second question can end up carrying an entire hour of compute.
+
     @integration
     Scenario: The puller's own billing query is not charged to a question
       Given the puller asks the warehouse for its billing
@@ -364,6 +376,17 @@ Feature: Databricks AI/BI Genie puller
       And it is not held waiting on the unbilled one
       # The priced line wins. Holding an already-priced statement would stall
       # the watermark on every hour where two SKUs bill at different speeds.
+
+    @unit
+    Scenario: A statement is held when an hour it ran through has no bill yet
+      Given a query that ran through two hours
+      And only the first of those hours has been billed
+      When the puller allocates warehouse cost
+      Then the query is held rather than recorded at the first hour's cost
+      # A query spanning two hours is only fully priced once both hours have
+      # billed. Recording it on the first hour alone understates it, and the
+      # record cannot be revised later, so the unbilled hour has to hold it —
+      # the same rule as an entirely unbilled question, applied per hour.
 
     @unit
     Scenario: The billing query only ever runs on the configured workspace

--- a/specs/ai-governance/puller-framework/databricks-genie.feature
+++ b/specs/ai-governance/puller-framework/databricks-genie.feature
@@ -377,7 +377,7 @@ Feature: Databricks AI/BI Genie puller
       # The priced line wins. Holding an already-priced statement would stall
       # the watermark on every hour where two SKUs bill at different speeds.
 
-    @unit
+    @unit @integration
     Scenario: A statement is held when an hour it ran through has no bill yet
       Given a query that ran through two hours
       And only the first of those hours has been billed
@@ -392,11 +392,11 @@ Feature: Databricks AI/BI Genie puller
       # hour.
 
     @unit @integration
-    Scenario: A statement that runs across a chunk boundary keeps both halves
-      Given a query still running when one read chunk ends
-      And the next chunk prices the hours it ran into
+    Scenario: A query that outlives one billing read is charged in full
+      Given a Genie question whose query was still running when one billing read ended
+      And a later read priced the hours it ran into
       When the puller allocates warehouse cost
-      Then the query is charged for both chunks together
+      Then the recorded cost covers the query's whole runtime
       # The window is read oldest-first in chunks that tile it, and each chunk
       # answers only for the hours it owns, so a straddler comes back once per
       # chunk with a different part of itself. The sweep emits its question

--- a/specs/ai-governance/puller-framework/databricks-genie.feature
+++ b/specs/ai-governance/puller-framework/databricks-genie.feature
@@ -391,6 +391,21 @@ Feature: Databricks AI/BI Genie puller
       # total. The same rule as an entirely unbilled question, applied per
       # hour.
 
+    @unit @integration
+    Scenario: A statement that runs across a chunk boundary keeps both halves
+      Given a query still running when one read chunk ends
+      And the next chunk prices the hours it ran into
+      When the puller allocates warehouse cost
+      Then the query is charged for both chunks together
+      # The window is read oldest-first in chunks that tile it, and each chunk
+      # answers only for the hours it owns, so a straddler comes back once per
+      # chunk with a different part of itself. The sweep emits its question
+      # once, so the parts are added. Deciding ownership by the statement's
+      # start instead hands it wholly to the chunk it began in — which has
+      # already dropped every hour past its own end — and the hours it ran into
+      # are then billed to nobody while still diluting every other question's
+      # share of them.
+
     @unit
     Scenario: An hour a statement did no work in cannot hold it
       Given a query that ends exactly on the hour


### PR DESCRIPTION
# Related Issue

- Resolves #7321

## For humans

A Databricks warehouse sends one bill per hour, and we divide that bill among the questions that used the warehouse in that hour. We were dividing it among the questions that *started* in that hour — which is not the same thing.

A report that starts at 09:58 and runs for forty minutes does two minutes of work in hour 09 and thirty-eight in hour 10. We put all forty minutes into hour 09's split and none into hour 10's. So hour 10's bill got divided among whatever happened to begin inside hour 10 — and if that was one Genie question that took a second, the question was charged for the whole hour of compute someone else's report was doing.

This is not a rounding error. It has a direction: short questions get overcharged, long straddling jobs get undercharged, and Genie questions are almost all short. Worst case is a one-second question carrying 100% of an hour's warehouse bill.

The fix splits each query across the hours it actually ran in, on both sides of the division. Same warehouse bill, attributed to the work that incurred it.

---

## The cause

`platform/app/ee/governance/services/pullers/databricksGenie.puller.ts:344` — the `windowed` CTE filtered and bucketed by `date_trunc('HOUR', start_time)` and never read `end_time`. `hour_total` (`:361`) then summed each statement's *whole* `execution_duration_ms` into its start hour. The numerator came from `system.query.history`, the denominator's counterpart `hour_dbu` from `system.billing.usage` — which bills each hour for the work that **ran** in it. The two sides disagreed about what an hour contains.

Blocking finding of review 4981294524 on #7188 (now merged), thread at `databricksGenie.puller.ts:362`. Filed as #7321.

## The fix

Option 1 of the three the reviewer offered: clip runtimes to hours, on both sides.

`ran` → `sliced` → `hour_total`. `sliced` explodes each statement over `sequence(date_trunc('HOUR', start_time), date_trunc('HOUR', ended_at), INTERVAL 1 HOUR)` and prorates `execution_duration_ms` onto each hour by the wall-clock overlap. One row per statement-hour instead of one per statement; the allocator sums a statement's per-hour shares.

**Why not option 2, which the issue recommended.** Option 2 keeps the start-hour numerator and only widens the denominator. It fails under both readings of "widen":

- *Clipped denominator, whole-runtime numerator*: the 09:58 straddler claims 40 minutes of an hour-10 denominator that only contains 38-and-a-bit — its share exceeds 100% of hour 10's bill, roughly 20× in the worst case here. That breaks the invariant the same reviewer praised, that shares never sum past the hour's bill.
- *Whole runtime in every touched hour's denominator*: the sum invariant survives, but the straddler still only ever *draws* from its start hour. Hour 10's bill is now divided by a denominator that includes 40 minutes of work drawing nothing from it, so ~38 minutes of real compute becomes permanently unattributable. That swaps a bias that overcharges Genie for one that overcharges whoever started first — quieter, not smaller.

Option 1 is verbatim one of the reviewer's three, so this stays inside the scope the review set.

**Look-back.** Denominators for the first hours of a window need statements that started before it, so `ran` scans from `from_ts − WAREHOUSE_COST_STRADDLE_LOOKBACK_MS` (24h) while the final `SELECT` still only emits statements whose `start_time` is inside the window. Cost of the bound: +14% scan on a 7-day chunk, double that on 1-day pieces. A statement running longer than 24h is a runaway; its first hours are undercounted, which errs in the same direction as the original bug but bounded to that one statement rather than to everything that shares its hour.

**No floats.** The proration uses Spark's `div`, not `/` — `/` returns DOUBLE. Truncation errs downward, so a statement's slices never add up to more than it ran. Belt and braces: `wholeMs` rejects any non-integer string, so a `/`-for-`div` regression degrades to skipped rows rather than float money.

## Failing first

```
× leaves a straddling statement its share of the hour it ran into
  AssertionError: expected '120000' to be '2401000'
× holds a statement whose later hour has not been billed yet
  AssertionError: expected false to be true
 Test Files  1 failed (1) | Tests  2 failed | 22 passed (24)
```
```
 ❯ ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts:359:17
    359|     expect(sql).toMatch(/explode\(\s*sequence\(/);
 Test Files  1 failed (1) | Tests  1 failed | 37 passed (38)
```

## Passing after

```
databricksWarehouseCost.unit.test.ts              27 passed (27)
databricksGenieWarehouseCost.integration.test.ts  40 passed (40)
databricksGeniePuller.integration.test.ts         36 passed | 1 skipped (37)
feature parity          64/64 scenarios bound ✓ all bound
biome new-violations    base 3447 / head 3447 — no new violations
```

## The second bug this surfaced

Slicing by hour splits pricing per statement, which means a statement can be priced in one hour and unbilled in the next. Settling it on the hours that did price records the unbilled hour at nothing, permanently. So the hold is now per hour: a statement keeps what the billed hours are worth *and* holds the watermark until every hour it ran through has billed — the same rule that already applied to an entirely unbilled question, applied one level down. Second unit test and second feature scenario cover it.

## The third bug this surfaced

Spark's `sequence()` includes its stop value; an hour does not. A statement running 09:30 → exactly 10:00:00.000 therefore emitted a 10:00 slice it did no work in. That slice is not merely untidy: if the warehouse shut down at 10:00, no bill for hour 10 ever arrives, the null SKU reads as "not billed yet", and one such statement holds the entire source until the seven-day hold expires. **Every hourly scheduled query ends on a boundary**, so this is a weekly outage, not a corner case.

Fixed on both sides, because either alone is insufficient:

- The SQL backs the sequence stop off one millisecond for positive spans, so the terminal hour is half-open. It cannot invert the range: the backoff only happens when the statement ran at least that long.
- `shareOf` returns a new `"idle"` verdict for a row with zero execution time, checked *before* the null-SKU branch that holds the watermark. `div` truncation can zero out a real hour for a mostly-idle query, which the boundary fix alone would not catch.

Third unit test and third feature scenario cover it. Found by review 4982160556 and independently by CodeRabbit.

## The fourth bug this surfaced

Slicing by hour made *which chunk answers for a row* a real question, and the answer was still the statement's `start_time` — which reads like the duplicate-avoidance rule it was written as, and is not. `sliced` drops every hour past `:to_ts` before the final `WHERE` sees the row, so a statement beginning near a chunk's end was handed wholly to the chunk that had already thrown away its later hours. The next chunk counted it in `hour_total` — correctly, it really did run there — and then excluded it from its rows. Those hours were billed to nobody while still diluting every other question's share of them.

An earlier revision of this description called that "tail loss at chunk edges", pre-existing and unchanged. **That was wrong**: before this PR a statement's whole duration landed in its start hour, so nothing was lost across a boundary. Hour slicing introduced it, and it hits every interior boundary a backfill crosses as well as the seam between sweeps.

Fixed on both sides, because either alone is insufficient:

- **Ownership is the hour clip in `sliced`.** Hours tile the window, so every statement-hour is emitted exactly once and a straddler comes back from both chunks with a different part of itself.
- **`mergeWarehouseCost` accumulates instead of replacing by statement id**, in bigint nanoUSD, next to the other money helpers. Without it the sweep would ship the last chunk's slice as the whole cost — the same under-count one boundary over. All three fields add: each is already a sum over the hours the statement ran through, and the chunks partition those hours.

The fixture was hiding this. It served one plan to every chunk, harmless while the merge replaced and a 5× overcharge the moment it added. It now answers only for the window it was asked about, the way the workspace does, and records what each call was served so a test can prove the two halves came from two different chunks. Fourth and fifth unit tests, an end-to-end straddler test, and a fourth feature scenario cover it. Found by review 4982850431.

## The fifth fix

Review on this PR (CodeRabbit): the split-piece walk held the watermark on an owed piece *before* merging what the piece did price, so a statement with one billed and one unbilled hour was emitted at nothing until billing settled — while the whole-chunk path merges first and holds second. The two now agree, and a piece-sized test proves the order matters (it fails at `'0'` without the reorder). Same round: `mergeWarehouseCost` takes named arguments, and the straddler scenario is worded by the recorded cost a customer sees rather than by read chunks.

## Sweep

One occurrence, the one fixed. Searched for the defect *shape* — a share computed by dividing a start-time-bucketed duration against an externally accrued denominator — across `platform/app/ee` and `platform/app/src` (`date_trunc`, `toStartOfHour`, `billing.usage`). Hits were analytics grouping, LWQL validation, gateway budget-total migrations and `usageReportingService.ts`; none of them prorate against a total accrued elsewhere. Inside `ee/governance/services/pullers/`, only these two files do share-of-total allocation at all.

## What this does not verify

**The SQL is not executed anywhere in CI.** No embeddable SQL engine is in `node_modules` and there are no Databricks credentials in the dev environment, so the query half of this fix is covered only by a structural assertion on the emitted query text — the same precedent the surrounding tests in that file already set. The arithmetic half is covered exactly, in bigint nanoUSD, by the unit suite. Someone with a real workspace should confirm the `sequence`/`explode` split against `system.billing.usage` before this is trusted for a customer invoice.

Two consequences that follow from that gap: `sequence()` raises "Illegal sequence boundaries" if stop < start, which is why `ended_at` is `GREATEST(..., start_time)`; and the per-chunk row cap now counts hour *slices*, not statements, so a workspace with many long-running queries hits the 50,000 refusal sooner and falls back to pieces. Both are handled in code, neither is proven against a live warehouse.

## Deliberately not fixed

- **Wall-clock proration.** A statement's execution time is spread across its hours by wall clock, not by where the work actually happened. A query that idles for an hour then computes for a minute is charged as though it spread evenly. Fixing it needs per-hour execution from Databricks, which `system.query.history` does not expose.
- **A straddler whose later chunk is held.** If an hour past the boundary has no bill yet, the sweep stops there and the question is emitted with the earlier chunk's part only; the re-read drops the hint rather than restating it. Closing this needs the hold to reach backwards across a chunk that has already settled — a separate change on the money path. Bounded to statements that straddle a chunk edge *and* run into an unbilled hour.
- Both are named in the comment above `WAREHOUSE_COST_STATEMENT`, with what each costs — the review's side ask (a).

Closes #7321


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allocated warehouse costs accurately for queries spanning multiple hours.
  * Added hourly execution tracking and reconstructed query timing.
  * Preserved execution records when billing data is unavailable for later reconciliation.
  * Added validation to accept only secure Databricks workspace origins.

* **Bug Fixes**
  * Corrected billing attribution at hour boundaries.
  * Prevented duplicate hourly allocations.
  * Improved settlement status for late, incomplete, or partially billed executions.
  * Avoided holding charges for hours in which a query did not run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


