### PR TITLE
feat(governance): the composer speaks cadence in plain words, and Genie leads with the service principal

### DIFF
--- a/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
+++ b/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+import {
+  Field,
+  HStack,
+  Input,
+  NativeSelect,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { useMemo, useState } from "react";
+import { SegmentedControl } from "~/components/ui/segmented-control";
+import { Switch } from "~/components/ui/switch";
+import {
+  timeOfDay,
+  WEEKDAY_OPTIONS,
+} from "~/features/automations/logic/reportSchedule";
+import {
+  cronFromPullParts,
+  type PullCadenceParts,
+  type PullFrequency,
+  partsFromPullCron,
+  pullCadenceCronError,
+  recommendedPullSchedule,
+  summarizePullCadence,
+} from "../logic/pullCadence";
+import type { SourceType } from "./ingestionSourceCatalog";
+
+/**
+ * The Cadence section of the source composer: how often a pull-mode source
+ * checks for new activity, said in plain words. Controlled like the raw
+ * input it replaces: `value` is the composer's pullSchedule where "" means
+ * "the recommended schedule" (resolved to an explicit cron at create — a
+ * saved schedule of null would mean the source never runs), and every edit
+ * comes back through `onChange` as a cron string.
+ *
+ * Cron editing stays behind an explicit toggle; a stored cron the picker
+ * cannot express opens with the toggle already on so the value is editable
+ * rather than clobbered by picker defaults. Renders nothing for source
+ * types without a pull adapter.
+ */
+
+/** One flat select collapses frequency + minute interval: "every 15
+ *  minutes" is one thought to an admin, not two controls. */
+const FREQUENCY_CHOICES: Array<{ value: string; label: string }> = [
+  { value: "m5", label: "Every 5 minutes" },
+  { value: "m10", label: "Every 10 minutes" },
+  { value: "m15", label: "Every 15 minutes" },
+  { value: "m30", label: "Every 30 minutes" },
+  { value: "hourly", label: "Every hour" },
+  { value: "daily", label: "Every day" },
+  { value: "weekly", label: "Every week" },
+];
+
+function choiceFromParts(parts: PullCadenceParts): string {
+  return parts.frequency === "minutes"
+    ? `m${parts.everyMinutes}`
+    : parts.frequency;
+}
+
+function partsFromChoice(
+  choice: string,
+  current: PullCadenceParts,
+): PullCadenceParts {
+  if (choice.startsWith("m")) {
+    return {
+      ...current,
+      frequency: "minutes",
+      everyMinutes: Number(choice.slice(1)),
+    };
+  }
+  return { ...current, frequency: choice as PullFrequency };
+}
+
+export function PullCadenceField({
+  sourceType,
+  value,
+  onChange,
+}: {
+  sourceType: SourceType;
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const recommended = recommendedPullSchedule(sourceType);
+  const effectiveCron = value.trim() || recommended || "";
+  // A cron the picker can't say opens the cron editor so the value stays
+  // editable instead of being clobbered by picker defaults.
+  const [cronMode, setCronMode] = useState(
+    () => effectiveCron !== "" && partsFromPullCron(effectiveCron) === null,
+  );
+
+  const parts = useMemo(
+    () =>
+      partsFromPullCron(effectiveCron) ?? {
+        frequency: "minutes" as const,
+        everyMinutes: 15,
+        minute: 0,
+        hour: 9,
+        dayOfWeek: 1,
+      },
+    [effectiveCron],
+  );
+
+  if (!recommended) return null;
+
+  const emitParts = (next: Partial<PullCadenceParts>) => {
+    onChange(cronFromPullParts({ ...parts, ...next }));
+  };
+
+  const onToggleCronMode = (toCronMode: boolean) => {
+    // Entering cron mode makes the schedule explicit so the editor holds a
+    // real value; leaving it with an unparseable cron re-syncs to the
+    // friendly parts so the picker and the value can't disagree.
+    if (toCronMode && value.trim() === "") {
+      onChange(effectiveCron);
+    }
+    if (!toCronMode && partsFromPullCron(effectiveCron) === null) {
+      onChange(cronFromPullParts(parts));
+    }
+    setCronMode(toCronMode);
+  };
+
+  const onTimeChange = (timeValue: string) => {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(timeValue);
+    if (!match) return;
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    if (hour > 23 || minute > 59) return;
+    emitParts({ hour, minute });
+  };
+
+  // Blank means "the recommended schedule" and is always saveable; only a
+  // typed cron can be one the scheduler would refuse.
+  const cronError =
+    cronMode && value.trim() !== "" ? pullCadenceCronError(value) : null;
+
+  return (
+    <VStack align="stretch" gap={3}>
+      <HStack justify="space-between" gap={2}>
+        <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+          Cadence
+        </Text>
+        <HStack gap={2}>
+          <Text fontSize="xs" color="fg.muted">
+            Edit as a cron expression
+          </Text>
+          <Switch
+            size="sm"
+            checked={cronMode}
+            onCheckedChange={({ checked }) => onToggleCronMode(checked)}
+            inputProps={{ "aria-label": "Edit as a cron expression" }}
+          />
+        </HStack>
+      </HStack>
+
+      {cronMode ? (
+        <Field.Root invalid={cronError !== null}>
+          <Field.Label fontSize="xs">Cron expression</Field.Label>
+          <Input
+            size="sm"
+            fontFamily="mono"
+            value={value}
+            placeholder={recommended}
+            onChange={(e) => onChange(e.target.value)}
+          />
+          {cronError !== null ? (
+            <Field.ErrorText fontSize="xs">{cronError}</Field.ErrorText>
+          ) : null}
+        </Field.Root>
+      ) : (
+        <VStack align="stretch" gap={3}>
+          <HStack gap={3} align="flex-start">
+            <Field.Root flex="1">
+              <Field.Label fontSize="xs">Frequency</Field.Label>
+              <NativeSelect.Root size="sm">
+                <NativeSelect.Field
+                  value={choiceFromParts(parts)}
+                  onChange={(e) =>
+                    onChange(
+                      cronFromPullParts(partsFromChoice(e.target.value, parts)),
+                    )
+                  }
+                >
+                  {FREQUENCY_CHOICES.map((choice) => (
+                    <option key={choice.value} value={choice.value}>
+                      {choice.label}
+                    </option>
+                  ))}
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
+            </Field.Root>
+
+            {parts.frequency === "hourly" ? (
+              <Field.Root flex="1">
+                <Field.Label fontSize="xs">Minutes past the hour</Field.Label>
+                <Input
+                  size="sm"
+                  type="number"
+                  min={0}
+                  max={59}
+                  value={parts.minute}
+                  onChange={(e) => {
+                    const minute = Number(e.target.value);
+                    if (Number.isInteger(minute) && minute >= 0 && minute <= 59)
+                      emitParts({ minute });
+                  }}
+                />
+              </Field.Root>
+            ) : null}
+
+            {parts.frequency === "daily" || parts.frequency === "weekly" ? (
+              <Field.Root flex="1">
+                <Field.Label fontSize="xs">Time (UTC)</Field.Label>
+                <Input
+                  size="sm"
+                  type="time"
+                  value={timeOfDay(parts)}
+                  onChange={(e) => onTimeChange(e.target.value)}
+                />
+              </Field.Root>
+            ) : null}
+          </HStack>
+
+          {parts.frequency === "weekly" ? (
+            <Field.Root>
+              <Field.Label fontSize="xs">Day of week</Field.Label>
+              <SegmentedControl
+                size="sm"
+                value={String(parts.dayOfWeek)}
+                onValueChange={({ value: day }) =>
+                  emitParts({ dayOfWeek: Number(day) })
+                }
+                items={WEEKDAY_OPTIONS.map((d) => ({
+                  value: String(d.value),
+                  label: d.short,
+                }))}
+              />
+            </Field.Root>
+          ) : null}
+        </VStack>
+      )}
+
+      <Text fontSize="xs" color="fg.muted">
+        {(() => {
+          const summaryParts = partsFromPullCron(effectiveCron);
+          return summaryParts
+            ? summarizePullCadence(summaryParts)
+            : `Runs on the schedule ${effectiveCron}`;
+        })()}
+      </Text>
+      <Text fontSize="xs" color="fg.muted">
+        How often we check this source for new activity. Leave as-is to use the
+        recommended schedule.
+      </Text>
+    </VStack>
+  );
+}

--- a/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
+++ b/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
@@ -147,7 +147,7 @@ function CadenceFrequencyPicker({
   emitParts: (next: Partial<PullCadenceParts>) => void;
   onPickChoice: (choice: string) => void;
 }) {
-  const wantsTimeOfDay =
+  const isTimeOfDayVisible =
     parts.frequency === "daily" || parts.frequency === "weekly";
   return (
     <VStack align="stretch" gap={3}>
@@ -176,7 +176,7 @@ function CadenceFrequencyPicker({
           />
         ) : null}
 
-        {wantsTimeOfDay ? (
+        {isTimeOfDayVisible ? (
           <CadenceTimeField parts={parts} emitParts={emitParts} />
         ) : null}
       </HStack>
@@ -244,7 +244,7 @@ export function PullCadenceField({
   const effectiveCron = value.trim() || recommended || "";
   // A cron the picker can't say opens the cron editor so the value stays
   // editable instead of being clobbered by picker defaults.
-  const [cronMode, setCronMode] = useState(
+  const [isCronMode, setIsCronMode] = useState(
     () => effectiveCron !== "" && partsFromPullCron(effectiveCron) === null,
   );
 
@@ -266,23 +266,23 @@ export function PullCadenceField({
     onChange(cronFromPullParts({ ...parts, ...next }));
   };
 
-  const onToggleCronMode = (toCronMode: boolean) => {
+  const onToggleCronMode = (isEnteringCronMode: boolean) => {
     // Entering cron mode makes the schedule explicit so the editor holds a
     // real value; leaving it with an unparseable cron re-syncs to the
     // friendly parts so the picker and the value can't disagree.
-    if (toCronMode && value.trim() === "") {
+    if (isEnteringCronMode && value.trim() === "") {
       onChange(effectiveCron);
     }
-    if (!toCronMode && partsFromPullCron(effectiveCron) === null) {
+    if (!isEnteringCronMode && partsFromPullCron(effectiveCron) === null) {
       onChange(cronFromPullParts(parts));
     }
-    setCronMode(toCronMode);
+    setIsCronMode(isEnteringCronMode);
   };
 
   // Blank means "the recommended schedule" and is always saveable; only a
   // typed cron can be one the scheduler would refuse.
   const cronError =
-    cronMode && value.trim() !== "" ? pullCadenceCronError(value) : null;
+    isCronMode && value.trim() !== "" ? pullCadenceCronError(value) : null;
 
   return (
     <VStack align="stretch" gap={3}>
@@ -296,14 +296,14 @@ export function PullCadenceField({
           </Text>
           <Switch
             size="sm"
-            checked={cronMode}
+            checked={isCronMode}
             onCheckedChange={({ checked }) => onToggleCronMode(checked)}
             inputProps={{ "aria-label": "Edit as a cron expression" }}
           />
         </HStack>
       </HStack>
 
-      {cronMode ? (
+      {isCronMode ? (
         <CadenceCronEditor
           value={value}
           recommended={recommended}

--- a/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
+++ b/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
@@ -25,20 +25,6 @@ import {
 } from "../logic/pullCadence";
 import type { SourceType } from "./ingestionSourceCatalog";
 
-/**
- * The Cadence section of the source composer: how often a pull-mode source
- * checks for new activity, said in plain words. Controlled like the raw
- * input it replaces: `value` is the composer's pullSchedule where "" means
- * "the recommended schedule" (resolved to an explicit cron at create — a
- * saved schedule of null would mean the source never runs), and every edit
- * comes back through `onChange` as a cron string.
- *
- * Cron editing stays behind an explicit toggle; a stored cron the picker
- * cannot express opens with the toggle already on so the value is editable
- * rather than clobbered by picker defaults. Renders nothing for source
- * types without a pull adapter.
- */
-
 /** One flat select collapses frequency + minute interval: "every 15
  *  minutes" is one thought to an admin, not two controls. */
 const FREQUENCY_CHOICES: Array<{ value: string; label: string }> = [
@@ -71,6 +57,19 @@ function partsFromChoice(
   return { ...current, frequency: choice as PullFrequency };
 }
 
+/**
+ * The Cadence section of the source composer: how often a pull-mode source
+ * checks for new activity, said in plain words. Controlled like the raw
+ * input it replaces: `value` is the composer's pullSchedule where "" means
+ * "the recommended schedule" (resolved to an explicit cron at create — a
+ * saved schedule of null would mean the source never runs), and every edit
+ * comes back through `onChange` as a cron string.
+ *
+ * Cron editing stays behind an explicit toggle; a stored cron the picker
+ * cannot express opens with the toggle already on so the value is editable
+ * rather than clobbered by picker defaults. Renders nothing for source
+ * types without a pull adapter.
+ */
 export function PullCadenceField({
   sourceType,
   value,

--- a/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
+++ b/platform/app/ee/governance/dashboard/components/PullCadenceField.tsx
@@ -57,6 +57,167 @@ function partsFromChoice(
   return { ...current, frequency: choice as PullFrequency };
 }
 
+function CadenceCronEditor({
+  value,
+  recommended,
+  error,
+  onChange,
+}: {
+  value: string;
+  recommended: string;
+  error: string | null;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <Field.Root invalid={error !== null}>
+      <Field.Label fontSize="xs">Cron expression</Field.Label>
+      <Input
+        size="sm"
+        fontFamily="mono"
+        value={value}
+        placeholder={recommended}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {error !== null ? (
+        <Field.ErrorText fontSize="xs">{error}</Field.ErrorText>
+      ) : null}
+    </Field.Root>
+  );
+}
+
+function CadenceMinutePastField({
+  minute,
+  onMinute,
+}: {
+  minute: number;
+  onMinute: (minute: number) => void;
+}) {
+  return (
+    <Field.Root flex="1">
+      <Field.Label fontSize="xs">Minutes past the hour</Field.Label>
+      <Input
+        size="sm"
+        type="number"
+        min={0}
+        max={59}
+        value={minute}
+        onChange={(e) => {
+          const next = Number(e.target.value);
+          if (Number.isInteger(next) && next >= 0 && next <= 59) onMinute(next);
+        }}
+      />
+    </Field.Root>
+  );
+}
+
+function CadenceTimeField({
+  parts,
+  emitParts,
+}: {
+  parts: PullCadenceParts;
+  emitParts: (next: Partial<PullCadenceParts>) => void;
+}) {
+  const onTimeChange = (timeValue: string) => {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(timeValue);
+    if (!match) return;
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    if (hour > 23 || minute > 59) return;
+    emitParts({ hour, minute });
+  };
+  return (
+    <Field.Root flex="1">
+      <Field.Label fontSize="xs">Time (UTC)</Field.Label>
+      <Input
+        size="sm"
+        type="time"
+        value={timeOfDay(parts)}
+        onChange={(e) => onTimeChange(e.target.value)}
+      />
+    </Field.Root>
+  );
+}
+
+function CadenceFrequencyPicker({
+  parts,
+  emitParts,
+  onPickChoice,
+}: {
+  parts: PullCadenceParts;
+  emitParts: (next: Partial<PullCadenceParts>) => void;
+  onPickChoice: (choice: string) => void;
+}) {
+  const wantsTimeOfDay =
+    parts.frequency === "daily" || parts.frequency === "weekly";
+  return (
+    <VStack align="stretch" gap={3}>
+      <HStack gap={3} align="flex-start">
+        <Field.Root flex="1">
+          <Field.Label fontSize="xs">Frequency</Field.Label>
+          <NativeSelect.Root size="sm">
+            <NativeSelect.Field
+              value={choiceFromParts(parts)}
+              onChange={(e) => onPickChoice(e.target.value)}
+            >
+              {FREQUENCY_CHOICES.map((choice) => (
+                <option key={choice.value} value={choice.value}>
+                  {choice.label}
+                </option>
+              ))}
+            </NativeSelect.Field>
+            <NativeSelect.Indicator />
+          </NativeSelect.Root>
+        </Field.Root>
+
+        {parts.frequency === "hourly" ? (
+          <CadenceMinutePastField
+            minute={parts.minute}
+            onMinute={(minute) => emitParts({ minute })}
+          />
+        ) : null}
+
+        {wantsTimeOfDay ? (
+          <CadenceTimeField parts={parts} emitParts={emitParts} />
+        ) : null}
+      </HStack>
+
+      {parts.frequency === "weekly" ? (
+        <Field.Root>
+          <Field.Label fontSize="xs">Day of week</Field.Label>
+          <SegmentedControl
+            size="sm"
+            value={String(parts.dayOfWeek)}
+            onValueChange={({ value: day }) =>
+              emitParts({ dayOfWeek: Number(day) })
+            }
+            items={WEEKDAY_OPTIONS.map((d) => ({
+              value: String(d.value),
+              label: d.short,
+            }))}
+          />
+        </Field.Root>
+      ) : null}
+    </VStack>
+  );
+}
+
+function CadenceSummary({ effectiveCron }: { effectiveCron: string }) {
+  const summaryParts = partsFromPullCron(effectiveCron);
+  return (
+    <>
+      <Text fontSize="xs" color="fg.muted">
+        {summaryParts
+          ? summarizePullCadence(summaryParts)
+          : `Runs on the schedule ${effectiveCron}`}
+      </Text>
+      <Text fontSize="xs" color="fg.muted">
+        How often we check this source for new activity. Leave as-is to use the
+        recommended schedule.
+      </Text>
+    </>
+  );
+}
+
 /**
  * The Cadence section of the source composer: how often a pull-mode source
  * checks for new activity, said in plain words. Controlled like the raw
@@ -118,15 +279,6 @@ export function PullCadenceField({
     setCronMode(toCronMode);
   };
 
-  const onTimeChange = (timeValue: string) => {
-    const match = /^(\d{1,2}):(\d{2})$/.exec(timeValue);
-    if (!match) return;
-    const hour = Number(match[1]);
-    const minute = Number(match[2]);
-    if (hour > 23 || minute > 59) return;
-    emitParts({ hour, minute });
-  };
-
   // Blank means "the recommended schedule" and is always saveable; only a
   // typed cron can be one the scheduler would refuse.
   const cronError =
@@ -152,105 +304,23 @@ export function PullCadenceField({
       </HStack>
 
       {cronMode ? (
-        <Field.Root invalid={cronError !== null}>
-          <Field.Label fontSize="xs">Cron expression</Field.Label>
-          <Input
-            size="sm"
-            fontFamily="mono"
-            value={value}
-            placeholder={recommended}
-            onChange={(e) => onChange(e.target.value)}
-          />
-          {cronError !== null ? (
-            <Field.ErrorText fontSize="xs">{cronError}</Field.ErrorText>
-          ) : null}
-        </Field.Root>
+        <CadenceCronEditor
+          value={value}
+          recommended={recommended}
+          error={cronError}
+          onChange={onChange}
+        />
       ) : (
-        <VStack align="stretch" gap={3}>
-          <HStack gap={3} align="flex-start">
-            <Field.Root flex="1">
-              <Field.Label fontSize="xs">Frequency</Field.Label>
-              <NativeSelect.Root size="sm">
-                <NativeSelect.Field
-                  value={choiceFromParts(parts)}
-                  onChange={(e) =>
-                    onChange(
-                      cronFromPullParts(partsFromChoice(e.target.value, parts)),
-                    )
-                  }
-                >
-                  {FREQUENCY_CHOICES.map((choice) => (
-                    <option key={choice.value} value={choice.value}>
-                      {choice.label}
-                    </option>
-                  ))}
-                </NativeSelect.Field>
-                <NativeSelect.Indicator />
-              </NativeSelect.Root>
-            </Field.Root>
-
-            {parts.frequency === "hourly" ? (
-              <Field.Root flex="1">
-                <Field.Label fontSize="xs">Minutes past the hour</Field.Label>
-                <Input
-                  size="sm"
-                  type="number"
-                  min={0}
-                  max={59}
-                  value={parts.minute}
-                  onChange={(e) => {
-                    const minute = Number(e.target.value);
-                    if (Number.isInteger(minute) && minute >= 0 && minute <= 59)
-                      emitParts({ minute });
-                  }}
-                />
-              </Field.Root>
-            ) : null}
-
-            {parts.frequency === "daily" || parts.frequency === "weekly" ? (
-              <Field.Root flex="1">
-                <Field.Label fontSize="xs">Time (UTC)</Field.Label>
-                <Input
-                  size="sm"
-                  type="time"
-                  value={timeOfDay(parts)}
-                  onChange={(e) => onTimeChange(e.target.value)}
-                />
-              </Field.Root>
-            ) : null}
-          </HStack>
-
-          {parts.frequency === "weekly" ? (
-            <Field.Root>
-              <Field.Label fontSize="xs">Day of week</Field.Label>
-              <SegmentedControl
-                size="sm"
-                value={String(parts.dayOfWeek)}
-                onValueChange={({ value: day }) =>
-                  emitParts({ dayOfWeek: Number(day) })
-                }
-                items={WEEKDAY_OPTIONS.map((d) => ({
-                  value: String(d.value),
-                  label: d.short,
-                }))}
-              />
-            </Field.Root>
-          ) : null}
-        </VStack>
+        <CadenceFrequencyPicker
+          parts={parts}
+          emitParts={emitParts}
+          onPickChoice={(choice) =>
+            onChange(cronFromPullParts(partsFromChoice(choice, parts)))
+          }
+        />
       )}
 
-      <Text fontSize="xs" color="fg.muted">
-        {(() => {
-          const summaryParts = partsFromPullCron(effectiveCron);
-          return summaryParts
-            ? summarizePullCadence(summaryParts)
-            : `Runs on the schedule ${effectiveCron}`;
-        })()}
-      </Text>
-      <Text fontSize="xs" color="fg.muted">
-        How often we check this source for new activity. Leave as-is to use the
-        recommended schedule.
-      </Text>
+      <CadenceSummary effectiveCron={effectiveCron} />
     </VStack>
   );
 }

--- a/platform/app/ee/governance/dashboard/components/__tests__/PullCadenceField.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/PullCadenceField.integration.test.tsx
@@ -14,6 +14,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
+import type { SourceType } from "../ingestionSourceCatalog";
 import { PullCadenceField } from "../PullCadenceField";
 
 function Harness({
@@ -21,14 +22,14 @@ function Harness({
   initialValue,
   onChangeSpy,
 }: {
-  sourceType: string;
+  sourceType: SourceType;
   initialValue: string;
   onChangeSpy?: (next: string) => void;
 }) {
   const [value, setValue] = useState(initialValue);
   return (
     <PullCadenceField
-      sourceType={sourceType as never}
+      sourceType={sourceType}
       value={value}
       onChange={(next) => {
         onChangeSpy?.(next);

--- a/platform/app/ee/governance/dashboard/components/__tests__/PullCadenceField.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/PullCadenceField.integration.test.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+// @vitest-environment jsdom
+/**
+ * The Cadence section of the source composer: a friendly frequency picker
+ * for pull-mode sources, with cron editing behind an explicit toggle.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * Controlled like the drawer uses it: `value` is the composer's
+ * pullSchedule ("" = recommended default, resolved at create), edits come
+ * back through `onChange` as a cron string.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PullCadenceField } from "../PullCadenceField";
+
+function Harness({
+  sourceType,
+  initialValue,
+  onChangeSpy,
+}: {
+  sourceType: string;
+  initialValue: string;
+  onChangeSpy?: (next: string) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <PullCadenceField
+      sourceType={sourceType as never}
+      value={value}
+      onChange={(next) => {
+        onChangeSpy?.(next);
+        setValue(next);
+      }}
+    />
+  );
+}
+
+const renderField = (props: Parameters<typeof Harness>[0]) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <Harness {...props} />
+    </ChakraProvider>,
+  );
+
+describe("given the Cadence section of the composer", () => {
+  describe("when a pull-mode source is being composed", () => {
+    /** @scenario "The Cadence section opens on a friendly picker, prefilled" */
+    it("shows a Cadence title and a frequency picker, not a cron text box", () => {
+      renderField({ sourceType: "databricks_genie", initialValue: "" });
+      expect(screen.getByText("Cadence")).toBeTruthy();
+      const frequency = screen.getByLabelText<HTMLSelectElement>("Frequency");
+      expect(frequency.value).toBe("m15");
+      expect(screen.queryByLabelText("Cron expression")).toBeNull();
+    });
+
+    /** @scenario "The Cadence section opens on a friendly picker, prefilled" */
+    it("prefills from the source's recommended schedule and says so in plain words", () => {
+      renderField({ sourceType: "anthropic_admin", initialValue: "" });
+      const frequency = screen.getByLabelText<HTMLSelectElement>("Frequency");
+      expect(frequency.value).toBe("hourly");
+      expect(
+        screen.getByText("Checks for new activity every hour, on the hour"),
+      ).toBeTruthy();
+    });
+
+    it("renders nothing for a source that has no pull schedule", () => {
+      renderField({ sourceType: "otel_generic", initialValue: "" });
+      expect(screen.queryByText("Cadence")).toBeNull();
+    });
+  });
+
+  describe("when the admin picks a different cadence", () => {
+    /** @scenario "Picking a cadence saves exactly that schedule" */
+    it("emits the matching cron and updates the summary sentence", async () => {
+      const onChangeSpy = vi.fn();
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "",
+        onChangeSpy,
+      });
+      const user = userEvent.setup();
+      await user.selectOptions(screen.getByLabelText("Frequency"), "hourly");
+      expect(onChangeSpy).toHaveBeenLastCalledWith("0 * * * *");
+      expect(
+        screen.getByText("Checks for new activity every hour, on the hour"),
+      ).toBeTruthy();
+    });
+
+    /** @scenario "Leaving the cadence untouched keeps the recommended schedule" */
+    it("emits nothing while the picker is untouched", () => {
+      const onChangeSpy = vi.fn();
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "",
+        onChangeSpy,
+      });
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the admin turns on cron editing", () => {
+    /** @scenario "Cron editing is still there for schedules the picker cannot say" */
+    it("shows the effective cron and keeps a hand-typed one as typed", async () => {
+      renderField({ sourceType: "databricks_genie", initialValue: "" });
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText("Edit as a cron expression"));
+      const input = screen.getByLabelText<HTMLInputElement>("Cron expression");
+      expect(input.value).toBe("*/15 * * * *");
+      await user.clear(input);
+      await user.type(input, "0 9 1 * *");
+      expect(input.value).toBe("0 9 1 * *");
+    });
+
+    /** @scenario "Cron editing is still there for schedules the picker cannot say" */
+    it("refuses a cron that can never run with a plain message", async () => {
+      renderField({ sourceType: "databricks_genie", initialValue: "" });
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText("Edit as a cron expression"));
+      const input = screen.getByLabelText<HTMLInputElement>("Cron expression");
+      await user.clear(input);
+      await user.type(input, "99 * * * *");
+      expect(
+        screen.getByText(/five fields|can't run|cannot run/i),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("when a stored cron is outside the picker's shapes", () => {
+    /** @scenario "Cron editing is still there for schedules the picker cannot say" */
+    it("opens in cron mode with the value intact", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "0 9 1 * *",
+      });
+      const input = screen.getByLabelText<HTMLInputElement>("Cron expression");
+      expect(input.value).toBe("0 9 1 * *");
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/components/__tests__/PullCadenceField.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/PullCadenceField.integration.test.tsx
@@ -126,6 +126,11 @@ describe("given the Cadence section of the composer", () => {
       expect(
         screen.getByText(/five fields|can't run|cannot run/i),
       ).toBeTruthy();
+      // A cron that parses but never fires — February 30th — gets its own
+      // message, matching the server's next-run refusal.
+      await user.clear(input);
+      await user.type(input, "0 9 30 2 *");
+      expect(screen.getByText(/never comes around/i)).toBeTruthy();
     });
   });
 

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -136,7 +136,7 @@ export const SOURCE_TYPE_OPTIONS = [
     label: "Databricks AI/BI Genie",
     mode: "pull",
     blurb:
-      "Records who asked what in Genie and the SQL it ran against your warehouse. Needs a workspace token with Can Manage on every Genie space you want covered — anything less returns only that token's own conversations.",
+      "Records who asked what in Genie and the SQL it ran against your warehouse. Sign in with a Databricks service principal holding Can Manage on every Genie space you want covered — anything less returns only its own conversations.",
     icon: <Databricks />,
   },
   {

--- a/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
@@ -13,19 +13,23 @@ import {
   composerCadenceError,
   cronFromPullParts,
   MINUTE_INTERVALS,
+  PULL_SCHEDULE_DEFAULTS,
   partsFromPullCron,
   pullCadenceCronError,
   summarizePullCadence,
 } from "../pullCadence";
 
-/** Mirrors PULL_SCHEDULE_DEFAULTS in ingestion-sources.tsx — restated here
- *  so a default added there without picker support fails loudly. */
-const RECOMMENDED_SCHEDULES = ["*/15 * * * *", "0 * * * *"];
+/** Derived from the real defaults so an adapter added with a schedule the
+ *  picker cannot speak fails here the day it lands. */
+const RECOMMENDED_SCHEDULES = [
+  ...new Set(Object.values(PULL_SCHEDULE_DEFAULTS)),
+];
 
 describe("given the pull-cadence cron mapping", () => {
   describe("when a recommended adapter schedule arrives", () => {
     /** @scenario "The picker speaks every recommended schedule" */
     it("round-trips every recommended schedule through the friendly parts", () => {
+      expect(RECOMMENDED_SCHEDULES.length).toBeGreaterThan(0);
       for (const cron of RECOMMENDED_SCHEDULES) {
         const parts = partsFromPullCron(cron);
         expect(parts, `picker cannot speak ${cron}`).not.toBeNull();
@@ -143,16 +147,34 @@ describe("given the pull-cadence cron mapping", () => {
       // This is the predicate the Create button's disabled state reads, so
       // "the create button refuses until it is fixed" is pinned here.
       expect(
-        composerCadenceError("databricks_genie", "99 * * * *"),
+        composerCadenceError({
+          sourceType: "databricks_genie",
+          pullSchedule: "99 * * * *",
+        }),
       ).not.toBeNull();
-      expect(composerCadenceError("databricks_genie", "0 * * * *")).toBeNull();
+      expect(
+        composerCadenceError({
+          sourceType: "databricks_genie",
+          pullSchedule: "0 * * * *",
+        }),
+      ).toBeNull();
     });
 
     /** @scenario "Leaving the cadence untouched keeps the recommended schedule" */
     it("never blocks an untouched cadence or a source without one", () => {
-      expect(composerCadenceError("databricks_genie", "")).toBeNull();
+      expect(
+        composerCadenceError({
+          sourceType: "databricks_genie",
+          pullSchedule: "",
+        }),
+      ).toBeNull();
       // Push sources carry no cadence; junk in the field must not block them.
-      expect(composerCadenceError("otel_generic", "junk")).toBeNull();
+      expect(
+        composerCadenceError({
+          sourceType: "otel_generic",
+          pullSchedule: "junk",
+        }),
+      ).toBeNull();
     });
   });
 

--- a/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  composerCadenceError,
   cronFromPullParts,
   MINUTE_INTERVALS,
   partsFromPullCron,
@@ -133,6 +134,25 @@ describe("given the pull-cadence cron mapping", () => {
       expect(pullCadenceCronError("*/15 * * * *")).toBeNull();
       // Shapes the picker can't say must still be saveable from cron mode.
       expect(pullCadenceCronError("0 9 1 * *")).toBeNull();
+    });
+  });
+
+  describe("when the composer decides whether Create may proceed", () => {
+    /** @scenario "Cron editing is still there for schedules the picker cannot say" */
+    it("refuses an impossible cron for a pull source, and only then", () => {
+      // This is the predicate the Create button's disabled state reads, so
+      // "the create button refuses until it is fixed" is pinned here.
+      expect(
+        composerCadenceError("databricks_genie", "99 * * * *"),
+      ).not.toBeNull();
+      expect(composerCadenceError("databricks_genie", "0 * * * *")).toBeNull();
+    });
+
+    /** @scenario "Leaving the cadence untouched keeps the recommended schedule" */
+    it("never blocks an untouched cadence or a source without one", () => {
+      expect(composerCadenceError("databricks_genie", "")).toBeNull();
+      // Push sources carry no cadence; junk in the field must not block them.
+      expect(composerCadenceError("otel_generic", "junk")).toBeNull();
     });
   });
 

--- a/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * Pure round-trip contract for the pull-cadence picker's cron mapping.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * The whole reason this module exists (instead of reusing the automations
+ * reportSchedule parts) is that the pull adapters' recommended schedules are
+ * step ("*\/15") and hourly ("0 * * * *") crons the report picker refuses to
+ * parse. So the load-bearing test is: every recommended schedule round-trips.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  cronFromPullParts,
+  MINUTE_INTERVALS,
+  partsFromPullCron,
+  pullCadenceCronError,
+  summarizePullCadence,
+} from "../pullCadence";
+
+/** Mirrors PULL_SCHEDULE_DEFAULTS in ingestion-sources.tsx — restated here
+ *  so a default added there without picker support fails loudly. */
+const RECOMMENDED_SCHEDULES = ["*/15 * * * *", "0 * * * *"];
+
+describe("given the pull-cadence cron mapping", () => {
+  describe("when a recommended adapter schedule arrives", () => {
+    /** @scenario "The picker speaks every recommended schedule" */
+    it("round-trips every recommended schedule through the friendly parts", () => {
+      for (const cron of RECOMMENDED_SCHEDULES) {
+        const parts = partsFromPullCron(cron);
+        expect(parts, `picker cannot speak ${cron}`).not.toBeNull();
+        expect(cronFromPullParts(parts!)).toBe(cron);
+      }
+    });
+
+    /** @scenario "The picker speaks every recommended schedule" */
+    it("maps */15 to the every-15-minutes frequency", () => {
+      expect(partsFromPullCron("*/15 * * * *")).toMatchObject({
+        frequency: "minutes",
+        everyMinutes: 15,
+      });
+    });
+
+    /** @scenario "The picker speaks every recommended schedule" */
+    it("maps 0 * * * * to hourly on the hour", () => {
+      expect(partsFromPullCron("0 * * * *")).toMatchObject({
+        frequency: "hourly",
+        minute: 0,
+      });
+    });
+  });
+
+  describe("when the friendly parts emit a cron", () => {
+    it("emits the four shapes the picker offers", () => {
+      expect(
+        cronFromPullParts({
+          frequency: "minutes",
+          everyMinutes: 30,
+          minute: 0,
+          hour: 0,
+          dayOfWeek: 1,
+        }),
+      ).toBe("*/30 * * * *");
+      expect(
+        cronFromPullParts({
+          frequency: "hourly",
+          everyMinutes: 15,
+          minute: 5,
+          hour: 0,
+          dayOfWeek: 1,
+        }),
+      ).toBe("5 * * * *");
+      expect(
+        cronFromPullParts({
+          frequency: "daily",
+          everyMinutes: 15,
+          minute: 0,
+          hour: 9,
+          dayOfWeek: 1,
+        }),
+      ).toBe("0 9 * * *");
+      expect(
+        cronFromPullParts({
+          frequency: "weekly",
+          everyMinutes: 15,
+          minute: 0,
+          hour: 9,
+          dayOfWeek: 1,
+        }),
+      ).toBe("0 9 * * 1");
+    });
+
+    it("only offers minute intervals it can parse back", () => {
+      for (const everyMinutes of MINUTE_INTERVALS) {
+        const cron = cronFromPullParts({
+          frequency: "minutes",
+          everyMinutes,
+          minute: 0,
+          hour: 0,
+          dayOfWeek: 1,
+        });
+        expect(partsFromPullCron(cron)).toMatchObject({
+          frequency: "minutes",
+          everyMinutes,
+        });
+      }
+    });
+  });
+
+  describe("when a cron is outside the picker's four shapes", () => {
+    /** @scenario "Cron editing is still there for schedules the picker cannot say" */
+    it("returns null so the caller falls back to cron editing", () => {
+      // monthly, cron the report picker DOES speak but this one hands off
+      expect(partsFromPullCron("0 9 1 * *")).toBeNull();
+      // step outside the offered intervals
+      expect(partsFromPullCron("*/7 * * * *")).toBeNull();
+      // lists, ranges, six fields, junk
+      expect(partsFromPullCron("0,30 * * * *")).toBeNull();
+      expect(partsFromPullCron("0 9-17 * * *")).toBeNull();
+      expect(partsFromPullCron("0 * * * * *")).toBeNull();
+      expect(partsFromPullCron("every so often")).toBeNull();
+    });
+  });
+
+  describe("when the cron editor validates before create", () => {
+    /** @scenario "Cron editing is still there for schedules the picker cannot say" */
+    it("refuses an empty or impossible cron with a message, accepts runnable ones", () => {
+      expect(pullCadenceCronError("")).not.toBeNull();
+      expect(pullCadenceCronError("not a cron")).not.toBeNull();
+      expect(pullCadenceCronError("99 * * * *")).not.toBeNull();
+      expect(pullCadenceCronError("*/15 * * * *")).toBeNull();
+      // Shapes the picker can't say must still be saveable from cron mode.
+      expect(pullCadenceCronError("0 9 1 * *")).toBeNull();
+    });
+  });
+
+  describe("when the summary sentence renders", () => {
+    /** @scenario "The Cadence section opens on a friendly picker, prefilled" */
+    it("states each shape in plain words", () => {
+      expect(
+        summarizePullCadence({
+          frequency: "minutes",
+          everyMinutes: 15,
+          minute: 0,
+          hour: 0,
+          dayOfWeek: 1,
+        }),
+      ).toBe("Checks for new activity every 15 minutes");
+      expect(
+        summarizePullCadence({
+          frequency: "hourly",
+          everyMinutes: 15,
+          minute: 0,
+          hour: 0,
+          dayOfWeek: 1,
+        }),
+      ).toBe("Checks for new activity every hour, on the hour");
+      expect(
+        summarizePullCadence({
+          frequency: "hourly",
+          everyMinutes: 15,
+          minute: 5,
+          hour: 0,
+          dayOfWeek: 1,
+        }),
+      ).toBe("Checks for new activity every hour at 5 minutes past");
+      expect(
+        summarizePullCadence({
+          frequency: "daily",
+          everyMinutes: 15,
+          minute: 0,
+          hour: 9,
+          dayOfWeek: 1,
+        }),
+      ).toBe("Checks for new activity every day at 09:00 UTC");
+      expect(
+        summarizePullCadence({
+          frequency: "weekly",
+          everyMinutes: 15,
+          minute: 0,
+          hour: 9,
+          dayOfWeek: 1,
+        }),
+      ).toBe("Checks for new activity every Monday at 09:00 UTC");
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
@@ -127,6 +127,9 @@ describe("given the pull-cadence cron mapping", () => {
       expect(pullCadenceCronError("")).not.toBeNull();
       expect(pullCadenceCronError("not a cron")).not.toBeNull();
       expect(pullCadenceCronError("99 * * * *")).not.toBeNull();
+      // Parses fine but never fires (February 30th): the server refuses it,
+      // so the client must too — that is the whole point of "before create".
+      expect(pullCadenceCronError("0 9 30 2 *")).not.toBeNull();
       expect(pullCadenceCronError("*/15 * * * *")).toBeNull();
       // Shapes the picker can't say must still be saveable from cron mode.
       expect(pullCadenceCronError("0 9 1 * *")).toBeNull();

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -48,9 +48,13 @@ export interface PullCadenceParts {
 export const MINUTE_INTERVALS = [5, 10, 15, 30] as const;
 
 /**
- * Which puller adapter serves each pull-mode source type. Lives here (not in
- * the page) so the Cadence field can resolve a source's recommended schedule
- * without importing the page it is rendered by.
+ * Maps user-facing pull-mode source-types onto the PullerAdapter id
+ * registered server-side (`pullerAdapterRegistry.ids()`). A hardcoded
+ * curated list - keeps the UI free of a round-trip enumeration call;
+ * entries land in lockstep with the reference adapters in
+ * `services/pullers/`. Lives here (not in the page) so the Cadence field
+ * can resolve a source's recommended schedule without importing the page
+ * it is rendered by.
  */
 export const PULL_ADAPTER_FOR_SOURCE: Partial<Record<SourceType, string>> = {
   copilot_studio: "copilot_studio",

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -171,10 +171,12 @@ export function summarizePullCadence(parts: PullCadenceParts): string {
 
 /**
  * Why this cron can't be saved, or null when it's fine. Mirrors the server's
- * `pullScheduleSchema` (five fields + croner parse) without importing the
- * event-sourcing module chain into the client bundle — croner is the same
- * library the scheduler computes next-run-at with, so a cron this accepts is
- * a cron the scheduler can register.
+ * `pullScheduleSchema` — five fields, croner parse, AND a reachable next run
+ * (the server computes next-run-at and refuses a cron that never fires, e.g.
+ * February 30th) — without importing the event-sourcing module chain into
+ * the client bundle. Croner is the same library the scheduler uses, so a
+ * cron this accepts is a cron the scheduler can register, never-firing
+ * shapes included.
  */
 export function pullCadenceCronError(cron: string): string | null {
   if (cron.trim() === "") return "Enter a schedule.";
@@ -182,7 +184,10 @@ export function pullCadenceCronError(cron: string): string | null {
     return "A cron schedule has five fields: minute, hour, day of month, month, day of week.";
   }
   try {
-    new Cron(cron, { timezone: "UTC" });
+    const next = new Cron(cron, { timezone: "UTC" }).nextRun();
+    if (next === null) {
+      return "This schedule never comes around — it names a date that does not exist.";
+    }
     return null;
   } catch {
     return "This schedule can't run as written. Minutes go 0-59, hours 0-23.";

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -110,6 +110,58 @@ export function cronFromPullParts(parts: PullCadenceParts): string {
   }
 }
 
+/** Neutral values for the parts a given frequency does not use, so the
+ *  picker lands somewhere sensible when the admin switches frequency. */
+const BASE_PARTS = { everyMinutes: 15, minute: 0, hour: 9, dayOfWeek: 1 };
+
+interface CronShapeFields {
+  minField: string;
+  hourField: string;
+  dowField: string;
+}
+
+/** The `*\/N * * * *` shape, N from MINUTE_INTERVALS. */
+function minutesShape({
+  minField,
+  hourField,
+  dowField,
+}: CronShapeFields): PullCadenceParts | null {
+  const stepMatch = /^\*\/(\d+)$/.exec(minField);
+  if (!stepMatch) return null;
+  const everyMinutes = Number(stepMatch[1]);
+  if (!(MINUTE_INTERVALS as readonly number[]).includes(everyMinutes)) {
+    return null;
+  }
+  if (hourField !== "*" || dowField !== "*") return null;
+  return { ...BASE_PARTS, frequency: "minutes", everyMinutes };
+}
+
+/** The hourly / daily / weekly shapes, all anchored on a plain minute. */
+function fixedMinuteShape({
+  minField,
+  hourField,
+  dowField,
+}: CronShapeFields): PullCadenceParts | null {
+  const minute = parsePlainInt(minField, 0, 59);
+  if (minute === null) return null;
+
+  if (hourField === "*") {
+    if (dowField !== "*") return null;
+    return { ...BASE_PARTS, frequency: "hourly", minute };
+  }
+
+  const hour = parsePlainInt(hourField, 0, 23);
+  if (hour === null) return null;
+
+  if (dowField === "*") {
+    return { ...BASE_PARTS, frequency: "daily", minute, hour };
+  }
+
+  const dayOfWeek = parsePlainInt(dowField, 0, 6);
+  if (dayOfWeek === null) return null;
+  return { ...BASE_PARTS, frequency: "weekly", minute, hour, dayOfWeek };
+}
+
 /**
  * Map a cron string back to the friendly picker parts. Returns null for any
  * expression outside the four shapes we generate ("custom") so the caller
@@ -122,37 +174,8 @@ export function partsFromPullCron(cron: string): PullCadenceParts | null {
     fields;
   // Month and day-of-month are wildcards in every shape we speak.
   if (monField !== "*" || domField !== "*") return null;
-
-  const base = { everyMinutes: 15, minute: 0, hour: 9, dayOfWeek: 1 };
-
-  const stepMatch = /^\*\/(\d+)$/.exec(minField);
-  if (stepMatch) {
-    const everyMinutes = Number(stepMatch[1]);
-    if (!(MINUTE_INTERVALS as readonly number[]).includes(everyMinutes)) {
-      return null;
-    }
-    if (hourField !== "*" || dowField !== "*") return null;
-    return { ...base, frequency: "minutes", everyMinutes };
-  }
-
-  const minute = parsePlainInt(minField, 0, 59);
-  if (minute === null) return null;
-
-  if (hourField === "*") {
-    if (dowField !== "*") return null;
-    return { ...base, frequency: "hourly", minute };
-  }
-
-  const hour = parsePlainInt(hourField, 0, 23);
-  if (hour === null) return null;
-
-  if (dowField === "*") {
-    return { ...base, frequency: "daily", minute, hour };
-  }
-
-  const dayOfWeek = parsePlainInt(dowField, 0, 6);
-  if (dayOfWeek === null) return null;
-  return { ...base, frequency: "weekly", minute, hour, dayOfWeek };
+  const shape = { minField, hourField, dowField };
+  return minutesShape(shape) ?? fixedMinuteShape(shape);
 }
 
 /**

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -90,7 +90,15 @@ export function recommendedPullSchedule(sourceType: SourceType): string | null {
 
 /** Parse one plain integer cron field, or null for anything with an
  *  operator ("*", steps, lists, ranges) or out of range. */
-function parsePlainInt(field: string, min: number, max: number): number | null {
+function parsePlainInt({
+  field,
+  min,
+  max,
+}: {
+  field: string;
+  min: number;
+  max: number;
+}): number | null {
   if (!/^\d+$/.test(field)) return null;
   const n = Number(field);
   return n >= min && n <= max ? n : null;
@@ -142,7 +150,7 @@ function fixedMinuteShape({
   hourField,
   dowField,
 }: CronShapeFields): PullCadenceParts | null {
-  const minute = parsePlainInt(minField, 0, 59);
+  const minute = parsePlainInt({ field: minField, min: 0, max: 59 });
   if (minute === null) return null;
 
   if (hourField === "*") {
@@ -150,14 +158,14 @@ function fixedMinuteShape({
     return { ...BASE_PARTS, frequency: "hourly", minute };
   }
 
-  const hour = parsePlainInt(hourField, 0, 23);
+  const hour = parsePlainInt({ field: hourField, min: 0, max: 23 });
   if (hour === null) return null;
 
   if (dowField === "*") {
     return { ...BASE_PARTS, frequency: "daily", minute, hour };
   }
 
-  const dayOfWeek = parsePlainInt(dowField, 0, 6);
+  const dayOfWeek = parsePlainInt({ field: dowField, min: 0, max: 6 });
   if (dayOfWeek === null) return null;
   return { ...BASE_PARTS, frequency: "weekly", minute, hour, dayOfWeek };
 }
@@ -226,10 +234,13 @@ export function pullCadenceCronError(cron: string): string | null {
  * recommended schedule" and is always fine; anything typed must be runnable.
  * Sources without a pull adapter carry no cadence at all.
  */
-export function composerCadenceError(
-  sourceType: SourceType,
-  pullSchedule: string,
-): string | null {
+export function composerCadenceError({
+  sourceType,
+  pullSchedule,
+}: {
+  sourceType: SourceType;
+  pullSchedule: string;
+}): string | null {
   if (!PULL_ADAPTER_FOR_SOURCE[sourceType]) return null;
   if (pullSchedule.trim() === "") return null;
   return pullCadenceCronError(pullSchedule);

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
-import type { SourceType } from "@ee/governance/dashboard/components/ingestionSourceCatalog";
 import { Cron } from "croner";
 import {
   timeOfDay,
   WEEKDAYS,
 } from "~/features/automations/logic/reportSchedule";
+import type { SourceType } from "../components/ingestionSourceCatalog";
 
 /**
  * Pure cadence <-> cron helpers for the pull-source Cadence picker. Kept out

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+import type { SourceType } from "@ee/governance/dashboard/components/ingestionSourceCatalog";
+import { Cron } from "croner";
+import {
+  timeOfDay,
+  WEEKDAYS,
+} from "~/features/automations/logic/reportSchedule";
+
+/**
+ * Pure cadence <-> cron helpers for the pull-source Cadence picker. Kept out
+ * of the React component so the round-trip (friendly picker -> cron ->
+ * friendly picker) is unit-testable as plain functions.
+ *
+ * This is deliberately NOT the automations reportSchedule parts model: the
+ * pull adapters' recommended schedules are step ("*\/15 * * * *") and hourly
+ * ("0 * * * *") crons, which `partsFromCron` over there rejects by design (a
+ * report every 15 minutes is 96 emails a day). Pull sources poll; sub-daily
+ * is their normal, so this model speaks four shapes:
+ *   minutes  `*\/N * * * *`   (N from MINUTE_INTERVALS)
+ *   hourly   `m * * * *`
+ *   daily    `m h * * *`
+ *   weekly   `m h * * D`     (D = 0-6, 0 = Sunday)
+ * Anything else is "custom" — `partsFromPullCron` returns null so the field
+ * can drop into the raw-cron editor without losing the value.
+ *
+ * Schedules run in UTC — the scheduler stores a bare cron with no timezone,
+ * so offering a timezone picker here would promise something the backend
+ * does not keep.
+ */
+
+export type PullFrequency = "minutes" | "hourly" | "daily" | "weekly";
+
+export interface PullCadenceParts {
+  frequency: PullFrequency;
+  /** Interval for the minutes frequency; one of MINUTE_INTERVALS. */
+  everyMinutes: number;
+  /** 0-59. Meaningful for hourly, daily, and weekly. */
+  minute: number;
+  /** 0-23. Meaningful for daily and weekly. */
+  hour: number;
+  /** cron day-of-week, 0-6 (0 = Sunday). Meaningful for weekly. */
+  dayOfWeek: number;
+}
+
+/** The step intervals the picker offers. Only these parse back, so adding
+ *  one here is all it takes to offer it. */
+export const MINUTE_INTERVALS = [5, 10, 15, 30] as const;
+
+/**
+ * Which puller adapter serves each pull-mode source type. Lives here (not in
+ * the page) so the Cadence field can resolve a source's recommended schedule
+ * without importing the page it is rendered by.
+ */
+export const PULL_ADAPTER_FOR_SOURCE: Partial<Record<SourceType, string>> = {
+  copilot_studio: "copilot_studio",
+  openai_compliance: "openai_compliance",
+  claude_compliance: "claude_compliance",
+  anthropic_admin: "anthropic_admin",
+  databricks_genie: "databricks_genie",
+  http_custom: "http_polling",
+};
+
+/**
+ * Recommended cron schedule per puller adapter - mirrors the locked
+ * `*_PULL_CONFIG.schedule` from the reference impl. Keeps the UI in
+ * sync without a server round-trip; if the locked default ever
+ * diverges, update both ends.
+ */
+export const PULL_SCHEDULE_DEFAULTS: Record<string, string> = {
+  copilot_studio: "*/15 * * * *",
+  openai_compliance: "*/15 * * * *",
+  claude_compliance: "*/15 * * * *",
+  anthropic_admin: "0 * * * *",
+  databricks_genie: "*/15 * * * *",
+  http_polling: "*/15 * * * *",
+};
+
+/** The recommended schedule for a source type, or null when it has no
+ *  pull adapter (push and s3 sources carry no cadence). */
+export function recommendedPullSchedule(sourceType: SourceType): string | null {
+  const adapter = PULL_ADAPTER_FOR_SOURCE[sourceType];
+  if (!adapter) return null;
+  return PULL_SCHEDULE_DEFAULTS[adapter] ?? "*/15 * * * *";
+}
+
+/** Parse one plain integer cron field, or null for anything with an
+ *  operator ("*", steps, lists, ranges) or out of range. */
+function parsePlainInt(field: string, min: number, max: number): number | null {
+  if (!/^\d+$/.test(field)) return null;
+  const n = Number(field);
+  return n >= min && n <= max ? n : null;
+}
+
+/** Build the cron expression for the current friendly parts. */
+export function cronFromPullParts(parts: PullCadenceParts): string {
+  switch (parts.frequency) {
+    case "minutes":
+      return `*/${parts.everyMinutes} * * * *`;
+    case "hourly":
+      return `${parts.minute} * * * *`;
+    case "daily":
+      return `${parts.minute} ${parts.hour} * * *`;
+    case "weekly":
+      return `${parts.minute} ${parts.hour} * * ${parts.dayOfWeek}`;
+  }
+}
+
+/**
+ * Map a cron string back to the friendly picker parts. Returns null for any
+ * expression outside the four shapes we generate ("custom") so the caller
+ * can fall back to the raw-cron editor.
+ */
+export function partsFromPullCron(cron: string): PullCadenceParts | null {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+  const [minField = "", hourField = "", domField, monField, dowField = ""] =
+    fields;
+  // Month and day-of-month are wildcards in every shape we speak.
+  if (monField !== "*" || domField !== "*") return null;
+
+  const base = { everyMinutes: 15, minute: 0, hour: 9, dayOfWeek: 1 };
+
+  const stepMatch = /^\*\/(\d+)$/.exec(minField);
+  if (stepMatch) {
+    const everyMinutes = Number(stepMatch[1]);
+    if (!(MINUTE_INTERVALS as readonly number[]).includes(everyMinutes)) {
+      return null;
+    }
+    if (hourField !== "*" || dowField !== "*") return null;
+    return { ...base, frequency: "minutes", everyMinutes };
+  }
+
+  const minute = parsePlainInt(minField, 0, 59);
+  if (minute === null) return null;
+
+  if (hourField === "*") {
+    if (dowField !== "*") return null;
+    return { ...base, frequency: "hourly", minute };
+  }
+
+  const hour = parsePlainInt(hourField, 0, 23);
+  if (hour === null) return null;
+
+  if (dowField === "*") {
+    return { ...base, frequency: "daily", minute, hour };
+  }
+
+  const dayOfWeek = parsePlainInt(dowField, 0, 6);
+  if (dayOfWeek === null) return null;
+  return { ...base, frequency: "weekly", minute, hour, dayOfWeek };
+}
+
+/**
+ * Plain-words summary for the live "this checks…" line under the picker.
+ */
+export function summarizePullCadence(parts: PullCadenceParts): string {
+  switch (parts.frequency) {
+    case "minutes":
+      return `Checks for new activity every ${parts.everyMinutes} minutes`;
+    case "hourly":
+      return parts.minute === 0
+        ? "Checks for new activity every hour, on the hour"
+        : `Checks for new activity every hour at ${parts.minute} minutes past`;
+    case "daily":
+      return `Checks for new activity every day at ${timeOfDay(parts)} UTC`;
+    case "weekly":
+      return `Checks for new activity every ${WEEKDAYS[parts.dayOfWeek] ?? "day"} at ${timeOfDay(parts)} UTC`;
+  }
+}
+
+/**
+ * Why this cron can't be saved, or null when it's fine. Mirrors the server's
+ * `pullScheduleSchema` (five fields + croner parse) without importing the
+ * event-sourcing module chain into the client bundle — croner is the same
+ * library the scheduler computes next-run-at with, so a cron this accepts is
+ * a cron the scheduler can register.
+ */
+export function pullCadenceCronError(cron: string): string | null {
+  if (cron.trim() === "") return "Enter a schedule.";
+  if (cron.trim().split(/\s+/).length !== 5) {
+    return "A cron schedule has five fields: minute, hour, day of month, month, day of week.";
+  }
+  try {
+    new Cron(cron, { timezone: "UTC" });
+    return null;
+  } catch {
+    return "This schedule can't run as written. Minutes go 0-59, hours 0-23.";
+  }
+}
+
+/**
+ * The create-blocking cadence error for the composer: blank means "use the
+ * recommended schedule" and is always fine; anything typed must be runnable.
+ * Sources without a pull adapter carry no cadence at all.
+ */
+export function composerCadenceError(
+  sourceType: SourceType,
+  pullSchedule: string,
+): string | null {
+  if (!PULL_ADAPTER_FOR_SOURCE[sourceType]) return null;
+  if (pullSchedule.trim() === "") return null;
+  return pullCadenceCronError(pullSchedule);
+}

--- a/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
@@ -86,7 +86,10 @@ describe("given the create input for a pull-mode source", () => {
   describe("when the admin never touched the cadence", () => {
     /** @scenario "Leaving the cadence untouched keeps the recommended schedule" */
     it("carries the recommended schedule, never a schedule of none", () => {
-      const input = buildCreateInput(genieComposer({}), "org-1");
+      const input = buildCreateInput({
+        composer: genieComposer({}),
+        organizationId: "org-1",
+      });
       expect(input?.pullSchedule).toBe("*/15 * * * *");
     });
   });
@@ -94,10 +97,10 @@ describe("given the create input for a pull-mode source", () => {
   describe("when the admin picked an hourly cadence", () => {
     /** @scenario "Picking a cadence saves exactly that schedule" */
     it("carries that schedule everywhere the schedule travels", () => {
-      const input = buildCreateInput(
-        genieComposer({ pullSchedule: "0 * * * *" }),
-        "org-1",
-      );
+      const input = buildCreateInput({
+        composer: genieComposer({ pullSchedule: "0 * * * *" }),
+        organizationId: "org-1",
+      });
       expect(input?.pullSchedule).toBe("0 * * * *");
       // The Genie pull settings carry their own copy of the schedule; a
       // mismatch here means the puller runs a different cadence than the
@@ -111,7 +114,10 @@ describe("given the create input for a pull-mode source", () => {
   describe("when the Advanced group was never opened", () => {
     /** @scenario "Advanced options stay collapsed and never block create" */
     it("creates with an empty space list covering every visible space", () => {
-      const input = buildCreateInput(genieComposer({}), "org-1");
+      const input = buildCreateInput({
+        composer: genieComposer({}),
+        organizationId: "org-1",
+      });
       expect(input).not.toBeNull();
       expect((input?.pullConfig as { spaceIds?: string[] }).spaceIds).toEqual(
         [],

--- a/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * The Genie composer's field order and the create payload it produces.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * Databricks expires pasted workspace tokens ~1h after issuing, so the
+ * service principal must be the way in and the token an Advanced option.
+ * These tests pin the FieldDef declarations (order + advanced flags + hint
+ * prose) and the pure buildCreateInput schedule resolution, so the drawer
+ * integration tests can stay about rendering.
+ */
+import { describe, expect, it } from "vitest";
+import type { ComposerState } from "../ingestion-sources";
+import { buildCreateInput, PARSER_FIELDS } from "../ingestion-sources";
+
+const genieFields = PARSER_FIELDS.databricks_genie;
+const keysInOrder = genieFields.map((f) => f.key);
+
+const genieComposer = (overrides: Partial<ComposerState>): ComposerState => ({
+  sourceType: "databricks_genie",
+  name: "Genie fleet",
+  description: "",
+  parserConfig: {
+    workspaceUrl: "https://adb-123.7.azuredatabricks.net",
+    credentialsClientId: "client-id",
+    credentialsClientSecret: "client-secret",
+  },
+  ottlStatements: [],
+  pullSchedule: "",
+  ...overrides,
+});
+
+describe("given the Genie composer field definitions", () => {
+  describe("when the form lays out its fields", () => {
+    /** @scenario "Genie setup asks for the service principal first" */
+    it("asks for workspace URL, then client ID, then secret, before anything else", () => {
+      expect(keysInOrder.slice(0, 3)).toEqual([
+        "workspaceUrl",
+        "credentialsClientId",
+        "credentialsClientSecret",
+      ]);
+    });
+
+    /** @scenario "Genie setup asks for the service principal first" */
+    it("marks the token, space IDs, and warehouse ID as Advanced", () => {
+      const advancedKeys = genieFields
+        .filter((f) => f.advanced)
+        .map((f) => f.key);
+      expect(advancedKeys).toEqual([
+        "credentialsToken",
+        "spaceIds",
+        "warehouseId",
+      ]);
+    });
+
+    /** @scenario "Genie setup asks for the service principal first" */
+    it("keeps the primary trio out of the Advanced group", () => {
+      for (const key of [
+        "workspaceUrl",
+        "credentialsClientId",
+        "credentialsClientSecret",
+      ]) {
+        expect(genieFields.find((f) => f.key === key)?.advanced).toBeFalsy();
+      }
+    });
+  });
+
+  describe("when a hint mentions another field", () => {
+    /** @scenario "Field hints name their fields instead of pointing at them" */
+    it("names the field instead of locating it above or below", () => {
+      for (const field of genieFields) {
+        expect(
+          field.hint ?? "",
+          `${field.key} hint points positionally`,
+        ).not.toMatch(/\babove\b|\bbelow\b/i);
+      }
+    });
+  });
+});
+
+describe("given the create input for a pull-mode source", () => {
+  describe("when the admin never touched the cadence", () => {
+    /** @scenario "Leaving the cadence untouched keeps the recommended schedule" */
+    it("carries the recommended schedule, never a schedule of none", () => {
+      const input = buildCreateInput(genieComposer({}), "org-1");
+      expect(input?.pullSchedule).toBe("*/15 * * * *");
+    });
+  });
+
+  describe("when the admin picked an hourly cadence", () => {
+    /** @scenario "Picking a cadence saves exactly that schedule" */
+    it("carries that schedule everywhere the schedule travels", () => {
+      const input = buildCreateInput(
+        genieComposer({ pullSchedule: "0 * * * *" }),
+        "org-1",
+      );
+      expect(input?.pullSchedule).toBe("0 * * * *");
+      // The Genie pull settings carry their own copy of the schedule; a
+      // mismatch here means the puller runs a different cadence than the
+      // one the admin was shown.
+      expect(
+        (input?.pullConfig as { schedule?: string } | null)?.schedule,
+      ).toBe("0 * * * *");
+    });
+  });
+
+  describe("when the Advanced group was never opened", () => {
+    /** @scenario "Advanced options stay collapsed and never block create" */
+    it("creates with an empty space list covering every visible space", () => {
+      const input = buildCreateInput(genieComposer({}), "org-1");
+      expect(input).not.toBeNull();
+      expect((input?.pullConfig as { spaceIds?: string[] }).spaceIds).toEqual(
+        [],
+      );
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+// @vitest-environment jsdom
+/**
+ * The Advanced group in the composer's source-specific fields: options an
+ * admin rarely needs stay collapsed and out of the way until asked for.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { ParserConfigFields } from "../ingestion-sources";
+
+function Harness({ sourceType }: { sourceType: string }) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  return (
+    <ParserConfigFields
+      sourceType={sourceType as never}
+      values={values}
+      onChange={setValues}
+    />
+  );
+}
+
+const renderFields = (sourceType: string) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <Harness sourceType={sourceType} />
+    </ChakraProvider>,
+  );
+
+describe("given the Genie source-specific fields", () => {
+  describe("when the form first renders", () => {
+    /** @scenario "Genie setup asks for the service principal first" */
+    it("shows workspace URL and the service principal pair, in that order", () => {
+      renderFields("databricks_genie");
+      const labels = screen
+        .getAllByText(
+          /Workspace URL|Service principal client ID|Service principal secret/,
+        )
+        .map((el) => el.textContent);
+      expect(labels.slice(0, 3)).toEqual([
+        expect.stringContaining("Workspace URL"),
+        expect.stringContaining("Service principal client ID"),
+        expect.stringContaining("Service principal secret"),
+      ]);
+    });
+
+    /** @scenario "Genie setup asks for the service principal first" */
+    it("keeps the token, space IDs, and warehouse ID hidden until Advanced expands", async () => {
+      renderFields("databricks_genie");
+      expect(screen.queryByText("Workspace token")).toBeNull();
+      expect(screen.queryByText(/Genie space IDs/)).toBeNull();
+      expect(screen.queryByText(/SQL warehouse ID/)).toBeNull();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByText("Advanced"));
+      await waitFor(() => {
+        expect(screen.getByText("Workspace token")).toBeTruthy();
+      });
+      expect(screen.getByText(/Genie space IDs/)).toBeTruthy();
+      expect(screen.getByText(/SQL warehouse ID/)).toBeTruthy();
+    });
+  });
+
+  describe("when a source type declares no Advanced fields", () => {
+    it("renders no Advanced group at all", () => {
+      renderFields("s3_custom");
+      expect(screen.queryByText("Advanced")).toBeNull();
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
@@ -10,20 +10,21 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it } from "vitest";
+import type { SourceType } from "../../components/ingestionSourceCatalog";
 import { ParserConfigFields } from "../ingestion-sources";
 
-function Harness({ sourceType }: { sourceType: string }) {
+function Harness({ sourceType }: { sourceType: SourceType }) {
   const [values, setValues] = useState<Record<string, string>>({});
   return (
     <ParserConfigFields
-      sourceType={sourceType as never}
+      sourceType={sourceType}
       values={values}
       onChange={setValues}
     />
   );
 }
 
-const renderFields = (sourceType: string) =>
+const renderFields = (sourceType: SourceType) =>
   render(
     <ChakraProvider value={defaultSystem}>
       <Harness sourceType={sourceType} />

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -390,10 +390,13 @@ function IngestionSourceList({
  * either unnamed, or carrying a pull config the adapter cannot honour (which
  * `resolvePullConfig` has already toasted about).
  */
-export function buildCreateInput(
-  composer: ComposerState,
-  organizationId: string,
-) {
+export function buildCreateInput({
+  composer,
+  organizationId,
+}: {
+  composer: ComposerState;
+  organizationId: string;
+}) {
   if (!composer.name.trim()) return null;
   const resolved = resolvePullConfig(composer);
   if (!resolved) return null;
@@ -535,7 +538,7 @@ function useIngestionSourcesPage() {
   });
 
   const onSubmit = () => {
-    const input = buildCreateInput(composer, orgId);
+    const input = buildCreateInput({ composer, organizationId: orgId });
     // A null input means a required field is missing or malformed;
     // resolvePullConfig has already said which, and the drawer stays open so
     // the user can fix it.
@@ -895,10 +898,10 @@ function SourceComposerDrawer({
               loading={isPending}
               disabled={
                 !composer.name.trim() ||
-                composerCadenceError(
-                  composer.sourceType,
-                  composer.pullSchedule,
-                ) !== null
+                composerCadenceError({
+                  sourceType: composer.sourceType,
+                  pullSchedule: composer.pullSchedule,
+                }) !== null
               }
             >
               Create source

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   Code,
+  Collapsible,
   Heading,
   HStack,
   Input,
@@ -25,9 +26,16 @@ import {
   SourceTypeIconGlyph,
 } from "@ee/governance/dashboard/components/ingestionSourceCatalog";
 import { OttlEditor } from "@ee/governance/dashboard/components/OttlEditor";
+import { PullCadenceField } from "@ee/governance/dashboard/components/PullCadenceField";
+import {
+  composerCadenceError,
+  PULL_ADAPTER_FOR_SOURCE,
+  PULL_SCHEDULE_DEFAULTS,
+} from "@ee/governance/dashboard/logic/pullCadence";
 import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "@ee/governance/services/activity-monitor/ingestionSource.constants";
 import { isOttlEnabledSourceType } from "@ee/governance/services/activity-monitor/ottlStarterTemplates";
 import {
+  ChevronRight,
   CircleCheck,
   CircleDashed,
   CircleX,
@@ -120,30 +128,6 @@ export interface ComposerState {
  * free of a round-trip enumeration call. Entries land in lockstep
  * with the reference adapters Sergey ships in `services/pullers/`.
  */
-const PULL_ADAPTER_FOR_SOURCE: Partial<Record<SourceType, string>> = {
-  copilot_studio: "copilot_studio",
-  openai_compliance: "openai_compliance",
-  claude_compliance: "claude_compliance",
-  anthropic_admin: "anthropic_admin",
-  databricks_genie: "databricks_genie",
-  http_custom: "http_polling",
-};
-
-/**
- * Default cron schedule per puller adapter - mirrors the locked
- * `*_PULL_CONFIG.schedule` from the reference impl. Keeps the UI in
- * sync without a server round-trip; if the locked default ever
- * diverges, update both ends.
- */
-const PULL_SCHEDULE_DEFAULTS: Record<string, string> = {
-  copilot_studio: "*/15 * * * *",
-  openai_compliance: "*/15 * * * *",
-  claude_compliance: "*/15 * * * *",
-  anthropic_admin: "0 * * * *",
-  databricks_genie: "*/15 * * * *",
-  http_polling: "*/15 * * * *",
-};
-
 const blankComposer = (): ComposerState => ({
   sourceType: "otel_generic",
   name: "",
@@ -413,7 +397,10 @@ function IngestionSourceList({
  * either unnamed, or carrying a pull config the adapter cannot honour (which
  * `resolvePullConfig` has already toasted about).
  */
-function buildCreateInput(composer: ComposerState, organizationId: string) {
+export function buildCreateInput(
+  composer: ComposerState,
+  organizationId: string,
+) {
   if (!composer.name.trim()) return null;
   const resolved = resolvePullConfig(composer);
   if (!resolved) return null;
@@ -893,7 +880,7 @@ function SourceComposerDrawer({
               enabled={isOttlEnabledSourceType(composer.sourceType)}
             />
 
-            <PullScheduleField
+            <PullCadenceField
               sourceType={composer.sourceType}
               value={composer.pullSchedule}
               onChange={(pullSchedule) =>
@@ -913,7 +900,13 @@ function SourceComposerDrawer({
               colorPalette="blue"
               onClick={onSubmit}
               loading={isPending}
-              disabled={!composer.name.trim()}
+              disabled={
+                !composer.name.trim() ||
+                composerCadenceError(
+                  composer.sourceType,
+                  composer.pullSchedule,
+                ) !== null
+              }
             >
               Create source
             </Button>
@@ -1095,6 +1088,12 @@ interface FieldDef {
    * that matters.
    */
   secret?: boolean;
+  /**
+   * True for fields most admins never need: rendered inside a collapsed
+   * "Advanced" group so the form leads with the required path. Leaving
+   * every advanced field untouched must always produce a working source.
+   */
+  advanced?: boolean;
 }
 
 export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
@@ -1234,41 +1233,42 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       required: true,
     },
     {
-      // Named `credentialsToken` on purpose: `buildParserConfig` routes every
+      // Named `credentials*` on purpose: `buildParserConfig` routes every
       // `credentials*` field into the `credentials` subtree, which is the ONLY
       // part of parserConfig the server encrypts before it reaches the
-      // database. A field named `token` would sit in the JSONB in plaintext.
-      key: "credentialsToken",
-      label: "Workspace token",
-      placeholder: "dapi...",
-      hint: "A personal access token or OAuth token for a service principal holding Can Manage on every Genie space you want covered. Read access is not enough — Databricks only returns other people's conversations to a token that can manage the space, so a weaker token records nothing and reports no error. Databricks expires these about an hour after issuing them, so give a client id and secret below instead if this source runs on a schedule. We encrypt this server-side.",
-      secret: true,
-    },
-    {
-      // Both named `credentials*` for the same reason as the token above:
-      // that prefix is what routes a field into the encrypted subtree.
+      // database. A field named `clientId` would sit in the JSONB in plaintext.
       key: "credentialsClientId",
       label: "Service principal client ID",
       placeholder: "0a1b2c3d-4e5f-6789-abcd-ef0123456789",
-      hint: "Give this and the secret below instead of a workspace token, and the source signs in for itself at the start of every run. A pasted token expires about an hour after Databricks issues it, which is fine for a one-off but leaves a scheduled source dead by the next morning.",
+      hint: "The source signs in with this service principal at the start of every run. It needs Can Manage on every Genie space you want covered — read access is not enough. Databricks only returns other people's conversations to an identity that can manage the space, so a weaker one records nothing and reports no error.",
       secret: true,
     },
     {
       key: "credentialsClientSecret",
       label: "Service principal secret",
       placeholder: "dose...",
-      hint: "The OAuth secret for that service principal. It needs the same Can Manage on every Genie space you want covered. We encrypt this server-side. If you also fill in a workspace token above, the token is used and this is ignored.",
+      hint: "The OAuth secret for that service principal. We encrypt this server-side.",
       secret: true,
+    },
+    {
+      key: "credentialsToken",
+      label: "Workspace token",
+      placeholder: "dapi...",
+      hint: "A personal access token, pasted instead of the service principal client ID and secret; when both are given, the token wins. Databricks expires these about an hour after issuing them, so a source that runs on a schedule is dead by the next morning — only use a token for a one-off backfill. It needs the same Can Manage on every Genie space. We encrypt this server-side.",
+      secret: true,
+      advanced: true,
     },
     {
       key: "spaceIds",
       label: "Genie space IDs (optional)",
-      placeholder: "Leave empty to cover every space the token can see",
-      hint: "Comma-separated. Empty is the usual setting — new spaces are then covered the day someone creates them.",
+      placeholder: "Leave empty to cover every space the credential can see",
+      hint: "Comma-separated. Empty is the usual setting — every space the credential can see is covered, including spaces created later.",
+      advanced: true,
     },
     {
       key: "warehouseId",
       label: "SQL warehouse ID (optional)",
+      advanced: true,
       placeholder: "095eb666b2ed2762",
       hint: "Any warehouse this credential can run a query on. It is where the billing lookup itself runs — NOT the warehouse being priced, which is every warehouse the questions used. Set it to attribute the compute behind each question to the person who asked; leave it empty and questions are recorded at zero cost, which is what Genie itself charges. Naming one makes every run submit a query, so a stopped warehouse is started and billed on the source's schedule. The token additionally needs SELECT on the `system` catalogue, which only a metastore admin can grant — without it questions are still recorded, without cost. The figure is a share of the hourly bill at list prices, so it is an estimate, not the invoice.",
     },
@@ -1628,7 +1628,53 @@ function genieCredentialsFrom(
   return Object.keys(credentials).length > 0 ? credentials : null;
 }
 
-function ParserConfigFields({
+function ParserConfigField({
+  field,
+  values,
+  onChange,
+}: {
+  field: FieldDef;
+  values: Record<string, string>;
+  onChange: (next: Record<string, string>) => void;
+}) {
+  return (
+    <VStack align="stretch" gap={1}>
+      <Text fontSize="xs" fontWeight="medium">
+        {field.label}
+        {field.required && (
+          <Text as="span" color="red.500" marginLeft={1}>
+            *
+          </Text>
+        )}
+      </Text>
+      {field.key === "parserDsl" || field.key === "eventMappingDsl" ? (
+        <Textarea
+          size="sm"
+          rows={6}
+          value={values[field.key] ?? ""}
+          onChange={(e) => onChange({ ...values, [field.key]: e.target.value })}
+          placeholder={field.placeholder}
+          fontFamily="mono"
+        />
+      ) : (
+        <Input
+          size="sm"
+          type={isSecretFieldKey(field.key) ? "password" : "text"}
+          value={values[field.key] ?? ""}
+          onChange={(e) => onChange({ ...values, [field.key]: e.target.value })}
+          placeholder={field.placeholder}
+        />
+      )}
+      {field.hint && (
+        <Text fontSize="xs" color="fg.muted">
+          {field.hint}
+        </Text>
+      )}
+    </VStack>
+  );
+}
+
+export function ParserConfigFields({
   sourceType,
   values,
   onChange,
@@ -1638,80 +1684,46 @@ function ParserConfigFields({
   onChange: (next: Record<string, string>) => void;
 }) {
   const fields = PARSER_FIELDS[sourceType];
+  const primaryFields = fields.filter((f) => !f.advanced);
+  const advancedFields = fields.filter((f) => f.advanced);
   if (fields.length === 0) return null;
   return (
     <VStack align="stretch" gap={3}>
       <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
         Source-specific configuration
       </Text>
-      {fields.map((f) => (
-        <VStack key={f.key} align="stretch" gap={1}>
-          <Text fontSize="xs" fontWeight="medium">
-            {f.label}
-            {f.required && (
-              <Text as="span" color="red.500" marginLeft={1}>
-                *
-              </Text>
-            )}
-          </Text>
-          {f.key === "parserDsl" || f.key === "eventMappingDsl" ? (
-            <Textarea
-              size="sm"
-              rows={6}
-              value={values[f.key] ?? ""}
-              onChange={(e) => onChange({ ...values, [f.key]: e.target.value })}
-              placeholder={f.placeholder}
-              fontFamily="mono"
-            />
-          ) : (
-            <Input
-              size="sm"
-              type={isSecretFieldKey(f.key) ? "password" : "text"}
-              value={values[f.key] ?? ""}
-              onChange={(e) => onChange({ ...values, [f.key]: e.target.value })}
-              placeholder={f.placeholder}
-            />
-          )}
-          {f.hint && (
-            <Text fontSize="xs" color="fg.muted">
-              {f.hint}
-            </Text>
-          )}
-        </VStack>
+      {primaryFields.map((f) => (
+        <ParserConfigField
+          key={f.key}
+          field={f}
+          values={values}
+          onChange={onChange}
+        />
       ))}
-    </VStack>
-  );
-}
-
-function PullScheduleField({
-  sourceType,
-  value,
-  onChange,
-}: {
-  sourceType: SourceType;
-  value: string;
-  onChange: (next: string) => void;
-}) {
-  const adapter = PULL_ADAPTER_FOR_SOURCE[sourceType];
-  if (!adapter) return null;
-  const defaultSchedule = PULL_SCHEDULE_DEFAULTS[adapter] ?? "";
-  return (
-    <VStack align="stretch" gap={1}>
-      <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
-        Polling schedule
-      </Text>
-      <Input
-        size="sm"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={defaultSchedule}
-        fontFamily="mono"
-      />
-      <Text fontSize="xs" color="fg.muted">
-        Standard 5-field cron. Leave blank to use the adapter default (
-        <code>{defaultSchedule}</code>). The puller worker honors this on the
-        next BullMQ tick after save.
-      </Text>
+      {advancedFields.length > 0 && (
+        // Unmounted while closed so the collapsed state genuinely holds
+        // nothing the admin needs: create must work without ever opening it.
+        <Collapsible.Root lazyMount unmountOnExit>
+          <Collapsible.Trigger asChild>
+            <Button size="xs" variant="ghost" color="fg.muted">
+              <ChevronRight />
+              Advanced
+            </Button>
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <VStack align="stretch" gap={3} paddingTop={2}>
+              {advancedFields.map((f) => (
+                <ParserConfigField
+                  key={f.key}
+                  field={f}
+                  values={values}
+                  onChange={onChange}
+                />
+              ))}
+            </VStack>
+          </Collapsible.Content>
+        </Collapsible.Root>
+      )}
     </VStack>
   );
 }

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -112,22 +112,15 @@ export interface ComposerState {
    */
   ottlStatements: string[];
   /**
-   * Phase 10: optional cron override for puller-mode sources. When the
-   * source-type maps to a registered PullerAdapter, the composer
-   * auto-fills this with the adapter's locked default schedule (15min
-   * for copilot_studio); admins can edit before save. Ignored for
-   * push/webhook source types.
+   * Cron override for puller-mode sources. Stays "" while the admin
+   * leaves the Cadence picker untouched — meaning "the recommended
+   * schedule", which `buildCreateInput` resolves to an explicit cron at
+   * create (a stored null would mean the source never runs). Ignored
+   * for push/webhook source types.
    */
   pullSchedule: string;
 }
 
-/**
- * Maps user-facing pull-mode source-types onto the PullerAdapter id
- * registered server-side (`pullerAdapterRegistry.ids()`). Hardcoded
- * curated list per @ai_gateway_sergey_2's directive - keeps the UI
- * free of a round-trip enumeration call. Entries land in lockstep
- * with the reference adapters Sergey ships in `services/pullers/`.
- */
 const blankComposer = (): ComposerState => ({
   sourceType: "otel_generic",
   name: "",

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -61,6 +61,78 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
     And the composer starts from a blank configuration for the picked type,
       even when a different type was being composed moments before
 
+  Rule: The Genie composer leads with the credential that survives a schedule
+
+    Databricks expires pasted workspace tokens about an hour after issuing
+    them, so a token-backed scheduled source dies by the next morning. The
+    service principal (client id + secret) signs itself in at the start of
+    every run. The form therefore presents client id + secret as the way
+    in, and demotes the token — together with the tuning fields most
+    admins never touch — into a collapsed "Advanced" group.
+
+    @integration
+    Scenario: Genie setup asks for the service principal first
+      When the admin picks "Databricks AI/BI Genie" from the Add source menu
+      Then the form asks for the workspace URL, the service principal
+        client ID, and the service principal secret, in that order
+      And the workspace token, Genie space IDs, and SQL warehouse ID
+        are not visible until the admin expands "Advanced"
+
+    @integration
+    Scenario: Advanced options stay collapsed and never block create
+      When the admin fills a display name, the workspace URL, client ID,
+        and secret, leaving "Advanced" closed
+      Then the source can be created
+      And the create request carries an empty space list, which the
+        space IDs hint explains covers every space the credential can see
+
+    @unit
+    Scenario: Field hints name their fields instead of pointing at them
+      Then every Genie field hint that mentions another field names it,
+        and none locates one as "above" or "below"
+
+  Rule: Every scheduled source states its cadence in plain language
+
+    The raw five-field cron input assumed the admin speaks cron. The
+    composer instead offers a "Cadence" section with a friendly picker;
+    cron editing remains behind an explicit toggle for the admins who
+    want it.
+
+    @integration
+    Scenario: The Cadence section opens on a friendly picker, prefilled
+      When the admin composes any pull-mode source
+      Then a section titled "Cadence" shows a frequency picker, not a
+        cron text box
+      And the picker arrives prefilled with that source's recommended
+        schedule (for example "every 15 minutes")
+      And a sentence below states the chosen schedule in plain words
+
+    @unit
+    Scenario: The picker speaks every recommended schedule
+      Then each pull source's recommended schedule round-trips through
+        the friendly picker without falling back to cron editing
+
+    @integration
+    Scenario: Leaving the cadence untouched keeps the recommended schedule
+      When the admin creates a pull-mode source without touching Cadence
+      Then the create request carries that source's recommended schedule
+        (a saved schedule of "none" would mean the source never runs)
+
+    @integration
+    Scenario: Picking a cadence saves exactly that schedule
+      When the admin changes the cadence to hourly
+      Then the create request carries the matching schedule everywhere
+        the schedule travels, including inside the source's pull settings
+      And the summary sentence updates to say so
+
+    @integration
+    Scenario: Cron editing is still there for schedules the picker cannot say
+      When the admin turns on "Edit as a cron expression"
+      And types a cron the friendly picker cannot express
+      Then the value is kept as typed, not clobbered by picker defaults
+      And a cron that can never run shows a plain-language message next
+        to the input, and the create button refuses until it is fixed
+
   @unit
   Scenario: The configured-source list groups under the same two headings
     Given configured sources of push, pull, and s3 modes exist


### PR DESCRIPTION
## Why

The ingestion-source composer asked admins for a raw five-field cron ("Standard 5-field cron… the puller worker honors this on the next BullMQ tick") — jargon for a form most admins touch once. And the Databricks AI/BI Genie form led with the workspace token, which Databricks expires about an hour after issuing: a token-backed scheduled source is dead by the next morning, while the service principal (client ID + secret) signs itself in at the start of every run and was buried third in the form.

## What changed

**Cadence picker for every pull-mode source.** The "Polling schedule" cron input becomes a "Cadence" section: a frequency picker (every 5/10/15/30 minutes, hourly, daily, weekly) prefilled with each source's recommended schedule, a plain-words summary line ("Checks for new activity every 15 minutes"), and cron editing behind an explicit "Edit as a cron expression" toggle. A stored cron the picker cannot express opens in cron mode with the value intact. An impossible cron shows a plain message and disables Create.

**Genie leads with the service principal.** Workspace URL, client ID, and secret come first; the workspace token, Genie space IDs, and SQL warehouse ID move into a collapsed **Advanced** group (a generic `advanced` flag on the field renderer — other source types are unaffected). Leaving Advanced closed always produces a working source: empty space IDs mean "every space the credential can see". Hints now name fields instead of pointing "above/below", and the catalog blurb recommends the service principal.

## How it works

- The automations `ReportScheduleField` could not be reused verbatim: its parts model rejects step (`*/15`) and hourly (`0 * * * *`) crons by design — exactly the pull adapters' defaults — so every pull source would have opened in raw-cron mode. A governance-local parts model (`ee/governance/dashboard/logic/pullCadence.ts`) speaks the four shapes pull adapters actually run; the weekday/time helpers are reused from automations.
- Blank `pullSchedule` still means "recommended" and is resolved to an explicit cron at create, because a stored `null` means the source never runs (no pull process is registered) — that semantic is load-bearing and unchanged.
- Client-side cron validation mirrors the server's `pullScheduleSchema` with croner directly (five fields + parse + a reachable next run) instead of importing the event-sourcing module chain into the client bundle. Never-firing crons like February 30th are refused before create, matching the server.
- `credentials*` field keys are unchanged — that prefix routes values into the encrypted subtree. The reorder is create-only: the edit drawer never renders these fields, so saved sources cannot be affected.
- Schedules run in UTC; no timezone picker, because the scheduler stores a bare cron with no timezone — deliberately cut rather than promising what the backend does not keep.

## Test plan

Eight new spec scenarios in `specs/ai-gateway/governance/ingestion-sources.feature` (adversarially challenged before writing tests), bound by:

- `pullCadence.unit.test.ts` — every recommended schedule round-trips through the picker; unparseable shapes fall back to cron mode; the validator refuses empty/impossible/never-firing crons; the Create-button predicate blocks only what it should.
- `genieComposerFields.unit.test.ts` — field order, `advanced` flags, no positional hint prose, and the create payload: untouched cadence carries the recommended schedule in **both** places it travels (`pullSchedule` and `pullConfig.schedule`), empty space list rides along.
- `PullCadenceField.integration.test.tsx` + `parserConfigFields.integration.test.tsx` (jsdom) — prefill, summary sentence, cron-mode fallback with value intact, error message, Advanced hidden until expanded.

All tests were watched fail before implementation. Component lane 572 files / 4202 tests green; governance + automations unit 62 files / 634 tests green; lint, typecheck, typecheck:tests, feature-parity all clean.

## Anything surprising?

- **Browser proof pending.** No local stack was running when the browser-verification pass ran (hard stop by policy — it does not start one). jsdom coverage stands in; the visual claims (picker rendering, disabled Create button, catalog blurb) should be spot-checked once a stack is up.
- **Inherited, not regressed:** creating a Genie source with no credentials at all is a silent no-op (`buildCreateInput` returns null, no toast). Pre-existing on main; this PR neither causes nor fixes it.
- A self-review pass already fixed its own findings on-branch (see the commit list): the never-firing-cron gap, stale/orphaned comments after the constants moved, `as never` casts in test harnesses, and a vacuously bound scenario clause.
- Two schedule pickers now exist (reports, pull sources) with deliberately different frequency vocabularies. If a third appears, that is the moment to extract a shared core — noted, not built.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable pull schedules with friendly frequency options and advanced cron editing.
  * Added recommended defaults, schedule summaries, validation, and preservation of custom schedules.
  * Improved Databricks Genie setup with service-principal guidance and optional advanced workspace-token settings.
  * Grouped advanced ingestion settings into a collapsible section.

* **Bug Fixes**
  * Prevented creation when pull schedules contain invalid cron expressions.

* **Tests**
  * Added coverage for cadence behavior, Genie configuration, and advanced-field interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->