### PR TITLE
docs(lwql): add the LangWatchQL section under Observability

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -278,6 +278,19 @@
             ]
           },
           {
+            "group": "LangWatchQL (LWQL)",
+            "pages": [
+              "observability/lwql/introduction",
+              "observability/lwql/writing-queries",
+              "observability/lwql/querying-with-agents",
+              "observability/lwql/mcp",
+              "observability/lwql/cli",
+              "observability/lwql/self-hosted",
+              "observability/lwql/privacy-and-rbac",
+              "observability/lwql/use-cases"
+            ]
+          },
+          {
             "group": "SDKs",
             "pages": [
               {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -448,7 +448,7 @@ sidebarTitle: Handing the reins to your agent
 keywords: langwatchql, lwql, agent, claude code, cursor, llm, sql, analytics
 ---
 
-LWQL was designed to be driven by an agent as much as by a person. Every part of the surface is machine-legible: the schema endpoint describes each dataset down to column descriptions and units, errors carry stable codes with the exact parameter names that were missing, and diagnostics tell the agent when its answer is technically correct but probably not what was meant.
+LWQL was designed to be driven by an agent. Every part of the surface is machine-legible: the schema endpoint describes each dataset down to column descriptions and units, errors carry stable codes with the exact parameter names that were missing, and diagnostics tell the agent when its answer is technically correct but probably not what was meant.
 
 That means you can hand your coding agent — Claude Code, Cursor, or anything that can make HTTP calls — an API key and a question like *"why did our LLM costs spike on Tuesday?"* and let it figure out the SQL.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -192,6 +192,876 @@ Labels let you zoom in on specific features or A/B test different approaches rig
 
 ---
 
+# FILE: ./observability/lwql/cli.mdx
+
+---
+title: "LWQL CLI"
+description: "Query LangWatch from your terminal — coming soon"
+sidebarTitle: "CLI (coming soon)"
+keywords: langwatchql, lwql, cli, terminal, sql
+---
+
+<Note>
+The LWQL CLI is **coming soon**.
+</Note>
+
+We're building a CLI that brings LWQL to your terminal and your scripts:
+
+```bash
+# The shape of things to come
+langwatch query "SELECT toStartOfDay(OccurredAt) AS Day, sum(TotalCost) AS Cost \
+                 FROM traces WHERE OccurredAt >= now() - INTERVAL 7 DAY \
+                 GROUP BY Day ORDER BY Day"
+
+langwatch schema            # browse datasets and columns
+langwatch query --format csv ... > costs.csv
+```
+
+Planned niceties: schema-aware autocomplete, `--format table|json|csv`, reading SQL from a file or stdin, and profile-based auth so your key stays out of shell history.
+
+## Until then
+
+`curl` and `jq` cover the same ground — the API is two endpoints:
+
+```bash
+curl -s -X POST "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/query/clickhouse" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "SELECT count() AS Traces FROM traces WHERE OccurredAt >= now() - INTERVAL 1 DAY"}' \
+  | jq -r '.rows'
+```
+
+See [Writing queries](/observability/lwql/writing-queries) for the full request and response shapes.
+
+---
+
+# FILE: ./observability/lwql/introduction.mdx
+
+---
+title: "LangWatchQL (LWQL)"
+description: "Query your LLM observability data directly with SQL — traces, spans, evaluations, costs, and more — through a safe, tenant-isolated analytics API"
+sidebarTitle: Introduction
+keywords: langwatchql, lwql, sql, analytics, clickhouse, query, api, observability
+---
+
+LangWatchQL (LWQL) is LangWatch's analytics SQL API. It lets you — or your agent — run real ClickHouse `SELECT` queries over your observability data: traces, spans, evaluations, simulations, costs, token usage, prompts, experiments, and annotations. You get typed columns, rows, execution statistics, and advisory diagnostics back as JSON.
+
+Instead of being limited to pre-built dashboards, you write the exact question you want answered:
+
+```sql
+SELECT toStartOfDay(OccurredAt) AS Day,
+       count() AS Traces,
+       sum(TotalCost) AS Cost
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 7 DAY
+GROUP BY Day
+ORDER BY Day
+```
+
+<Note>
+LWQL is currently in preview. If you'd like it enabled for your project, [reach out to us](/support).
+</Note>
+
+## The API
+
+LWQL is two endpoints:
+
+| Endpoint | What it does |
+|---|---|
+| `POST /api/v1/projects/{projectId}/analytics/query/clickhouse` | Runs one read-only SQL statement and returns columns, rows, statistics, and diagnostics |
+| `GET /api/v1/projects/{projectId}/analytics/schema` | Describes every dataset your key can query — columns, types, join keys, freshness, and a runnable example per dataset |
+
+Both authenticate with your project API key (`X-Auth-Token: sk-lw-...`) and require the `analytics:view` scope. The project in the URL is a cross-check, not a selector: the tenant always comes from the credential, so a key can only ever read its own project's data.
+
+```bash
+curl -X POST "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/query/clickhouse" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "SELECT count() AS Traces FROM traces WHERE OccurredAt >= now() - INTERVAL 1 DAY"}'
+```
+
+```json
+{
+  "columns": [{ "name": "Traces", "type": "UInt64" }],
+  "rows": [{ "Traces": "1842" }],
+  "statistics": { "elapsedMs": 12, "rowsRead": 1842, "bytesRead": 58944, "rowsReturned": 1 },
+  "truncated": false,
+  "followsTimeWindow": false,
+  "diagnostics": []
+}
+```
+
+## The datasets
+
+Your SQL runs against a curated catalog of views, not raw tables. Each view has a documented grain (what one row *is*), join keys, and a time column for efficient filtering. The schema endpoint is the authoritative, always-current list; today it includes:
+
+| Dataset | One row is |
+|---|---|
+| `traces` | One trace, with duration, cost, token counts, error status, and captured input/output |
+| `spans` | One span, with timing, status, attributes, and cost |
+| `evaluations` | One evaluation run, with its score, verdict, and evaluator |
+| `simulations` | One simulation (scenario) run, with its verdict and criteria |
+| `trace_metrics` | One trace's metrics row, with user, conversation, customer, labels, and per-token-kind counts |
+| `trace_metrics_by_minute` | One minute bucket of trace metrics — counts, costs, durations, tokens, pre-aggregated |
+| `model_usage_by_minute` | One (minute, model, span type) bucket — span counts, cost, and tokens per model |
+| `evaluation_metrics` | One evaluation, enriched with user/conversation/customer context |
+| `evaluation_metrics_by_minute` | One (minute, evaluator type, status) bucket — pass/fail/error counts and score sums |
+| `annotations` | One human annotation, with its thumbs up/down |
+| `projects` | Your project's display name and slug |
+| `prompts` | One managed prompt |
+| `prompt_versions` | One version of a managed prompt |
+| `experiments` | One experiment |
+| `batch_evaluations` | One batch evaluation run within an experiment, with score, pass/fail, and cost |
+
+Use the *by-minute* datasets for time-series charts — they're pre-aggregated and orders of magnitude cheaper to scan than the row-level ones.
+
+## How it stays safe
+
+LWQL is designed so that arbitrary customer SQL can run without ever becoming a security or stability problem:
+
+- **A restricted database identity.** Queries never run as the application. They run as a dedicated read-only ClickHouse user that can see only the catalog views — no system tables, no raw tables, no other databases.
+- **Tenant isolation in the database, not the gateway.** Row policies scope every view to your project, resolved from a capability derived from your project's key. Even a bug in the API layer cannot return another tenant's rows.
+- **A default-deny SQL validator.** Before anything reaches the database, the statement is parsed and walked against an allowlist: a single `SELECT` (with CTEs, subqueries, joins, unions, aggregates, and window functions), an allowlisted set of functions, and nothing else. Writes, DDL, `SETTINGS`, table functions, and introspection functions are refused with actionable error codes.
+- **Resource ceilings.** The database pins read-only mode, execution time, memory, and scan limits as constants that no query can change. On top of that, responses are capped (10,000 rows / ~8 MB) and always marked `truncated` when a ceiling cuts them short.
+
+Read more in [Privacy & RBAC](/observability/lwql/privacy-and-rbac).
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Writing queries" href="/observability/lwql/writing-queries" icon="code">
+    The dialect, schema discovery, parameters, limits, and error codes.
+  </Card>
+  <Card title="Handing the reins to your agent" href="/observability/lwql/querying-with-agents" icon="robot">
+    Teach Claude Code, Cursor, or your own agent to answer questions with LWQL.
+  </Card>
+  <Card title="Use cases" href="/observability/lwql/use-cases" icon="lightbulb">
+    Copy-paste queries for cost, latency, quality, and adoption questions.
+  </Card>
+  <Card title="Self-hosted setup" href="/observability/lwql/self-hosted" icon="server">
+    Provision LWQL on your own deployment.
+  </Card>
+</CardGroup>
+
+---
+
+# FILE: ./observability/lwql/mcp.mdx
+
+---
+title: "LWQL MCP Server"
+description: "A first-party MCP server for LangWatchQL — coming soon"
+sidebarTitle: "MCP (coming soon)"
+keywords: langwatchql, lwql, mcp, model context protocol, agent
+---
+
+<Note>
+The LWQL MCP server is **coming soon**.
+</Note>
+
+A first-party [Model Context Protocol](https://modelcontextprotocol.io) server for LWQL is in the works. It will expose the two LWQL endpoints as MCP tools, so any MCP-capable client — Claude Code, Claude Desktop, Cursor, and others — can discover your analytics schema and run queries without any custom prompt wiring:
+
+- **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
+- **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
+
+Because LWQL is already read-only, tenant-isolated, and resource-capped at the database, connecting it to an agent through MCP doesn't require any additional sandboxing on your side.
+
+## Until then
+
+The HTTP API works with any agent today — see [Handing the reins to your agent](/observability/lwql/querying-with-agents) for a ready-made system prompt and the discover → query → repair loop. If you're using an MCP client that supports generic HTTP/fetch tools, that same prompt is enough.
+
+Want early access or have opinions on the tool surface? [Talk to us](/support).
+
+---
+
+# FILE: ./observability/lwql/privacy-and-rbac.mdx
+
+---
+title: "LWQL Privacy & RBAC"
+description: "How LangWatchQL enforces tenant isolation, permission-gated columns, and content protection on arbitrary SQL"
+sidebarTitle: Privacy & RBAC
+keywords: langwatchql, lwql, rbac, privacy, permissions, tenant isolation, security
+---
+
+LWQL accepts arbitrary SQL from customers and agents, so its access model is layered: every guarantee is enforced in at least two independent places, and the innermost one is always the database itself.
+
+## Tenant isolation lives in the database
+
+Every query runs as a restricted ClickHouse identity, and every LWQL view carries a **row policy** that scopes reads to the calling project. The tenant is resolved from a capability derived from your project's key, sent by the server — never from the SQL, never from the request body, and never from the project id in the URL (that one is only a cross-check; naming a different project returns 404).
+
+The consequence: there is no statement you can write that reads another tenant's rows. A bug in the API gateway can cost a caller a wrong refusal or acceptance of a malformed query — it cannot cross tenants, because the gateway was never the boundary.
+
+## What a key can do
+
+- LWQL requires an API key with the **`analytics:view`** scope, and the project must have LWQL enabled.
+- Access is **read-only by construction**: the database identity has `readonly = 1` pinned as a constant, and the validator refuses every write and DDL form before it ever reaches the database anyway.
+- The identity can see **only the LWQL views**. Raw tables, other databases, `system.*`, and `information_schema` are unreachable at the database and refused by name at the gateway.
+
+## Column-level permission gates
+
+Individual columns are gated on the same visibility permissions that govern the rest of LangWatch, resolved server-side per request:
+
+| Gate | Governs | Example columns |
+|---|---|---|
+| `input` | Captured user input | `traces.CapturedInput`, `spans.CapturedInput`, `evaluations.CapturedInputs` |
+| `output` | Captured model output | `traces.CapturedOutput`, `spans.CapturedOutput`, `simulations.MessageContents` |
+| `costs` | Cost figures | `traces.TotalCost`, `spans.Cost`, `trace_metrics_by_minute.CostSum` |
+
+The gates compose fail-closed:
+
+- The **schema endpoint** publishes each column's `gates` and whether *your* key holds them (`available`), so an agent can plan around what it may read. A dataset you can read nothing in disappears from the schema entirely.
+- The **validator refuses** any reference to a gated column — including unqualified references and columns of hidden datasets — with a structured violation, before execution.
+- If the permission resolver is unavailable, everything gated is withheld rather than granted.
+
+So a teammate (or agent) without content permissions can still count traces, chart costs they're allowed to see, group by model, and read evaluation verdicts — they just cannot select the captured conversations.
+
+## Attribute filtering inside allowed columns
+
+Even for callers *with* content permissions, span and trace attribute maps are content-filtered in the view definitions themselves: attribute keys known to carry captured content are separated from operational metadata, so `Attributes`/`SpanAttributes` stay useful for filtering and grouping without becoming a side-channel around the `CapturedInput`/`CapturedOutput` gates.
+
+## What errors and results reveal
+
+- Error messages never name hosts, credentials, server settings, physical tables, or other tenants. Validation refusals speak in terms of the published catalog.
+- Introspection functions (`currentUser`, `hostName`, `version`, `getSetting`, ...) are absent from the function allowlist — refused because they're not listed, not because someone remembered to deny them.
+- Whether *another* project exists is not discoverable: a URL naming one answers 404 identical to a nonexistent id.
+
+## Operational guardrails
+
+Abuse and accidents are bounded server-side, per query, as constants no caller can change: 10 s execution time, 1 GB memory, 1B rows / 10 GB scanned, 4 threads, and at most 10 concurrent queries across the identity. Responses are additionally capped at 10,000 rows / ~8 MB and marked `truncated` when cut. Every executed query is logged with its datasets, scan cost, and outcome — but never with the SQL's parameter values or your key.
+
+---
+
+# FILE: ./observability/lwql/querying-with-agents.mdx
+
+---
+title: "Handing the Reins to Your Agent"
+description: "Teach Claude Code, Cursor, or your own agent to answer observability questions by writing and running LWQL queries"
+sidebarTitle: Handing the reins to your agent
+keywords: langwatchql, lwql, agent, claude code, cursor, llm, sql, analytics
+---
+
+LWQL was designed to be driven by an agent as much as by a person. Every part of the surface is machine-legible: the schema endpoint describes each dataset down to column descriptions and units, errors carry stable codes with the exact parameter names that were missing, and diagnostics tell the agent when its answer is technically correct but probably not what was meant.
+
+That means you can hand your coding agent — Claude Code, Cursor, or anything that can make HTTP calls — an API key and a question like *"why did our LLM costs spike on Tuesday?"* and let it figure out the SQL.
+
+## The loop that works
+
+Teach your agent this loop; it's the same one the API was designed around:
+
+1. **Discover** — `GET /analytics/schema` once, and cache it. It lists every dataset, every column with its type and description, the grain, the join keys, the time column, and a runnable `exampleSql` per dataset.
+2. **Query** — `POST /analytics/query/clickhouse` with one `SELECT`. Filter the dataset's `timeColumn`; prefer the `*_by_minute` datasets for trends.
+3. **Repair** — on a 4xx, read the `code` and `meta`. `lwql_parameter_missing` names the parameters to add; validation violations name the exact table, column, or function that was refused. One edit, retry.
+4. **Sanity-check** — read `diagnostics` before trusting the rows. `POSSIBLE_FANOUT` means a join inflated the aggregates; `UNBOUNDED_TIME_RANGE` means the query read all of history; `RESULT_TRUNCATED` means the answer is incomplete.
+
+## A system prompt that teaches it
+
+Drop something like this into your agent's instructions (CLAUDE.md, .cursorrules, or a system prompt):
+
+````markdown
+## Querying LangWatch observability data
+
+You can answer questions about our LLM app (costs, latency, errors, evaluation
+quality, usage) by running SQL against LangWatch's LWQL API.
+
+- Schema discovery: GET https://app.langwatch.ai/api/v1/projects/{PROJECT_ID}/analytics/schema
+- Run a query:      POST https://app.langwatch.ai/api/v1/projects/{PROJECT_ID}/analytics/query/clickhouse
+  with JSON body {"sql": "...", "parameters": {...}}
+- Auth header:      X-Auth-Token: $LANGWATCH_API_KEY   (read it from the environment; never print it)
+
+Rules:
+- ClickHouse dialect, single SELECT only. No writes, no SETTINGS, no system tables.
+- ALWAYS call the schema endpoint first if you haven't this session; use only
+  datasets and columns it lists, and start from each dataset's exampleSql.
+- ALWAYS filter each dataset's timeColumn (e.g. OccurredAt) — unfiltered
+  queries scan all history and may hit scan limits.
+- Use bound parameters ({name:DateTime}) instead of interpolating values.
+- For time series, prefer trace_metrics_by_minute / model_usage_by_minute /
+  evaluation_metrics_by_minute — they are pre-aggregated and fast.
+- On errors, read the "code" and "meta" fields and fix precisely that.
+- After each result, check "diagnostics" and "truncated" before presenting
+  numbers; mention any diagnostic that affects the answer.
+````
+
+Two things make this reliable in practice:
+
+- **Keep the key in the environment.** The agent only needs to know the header name. LWQL keys are read-only over one project's analytics, which bounds the blast radius of a leaked prompt — but there's no reason to put the secret itself in one.
+- **Don't paste the schema into the prompt.** It's large, it changes, and the endpoint is cheap. Let the agent fetch it.
+
+## Why this is safe to do
+
+Handing an agent free-form SQL access normally means trusting it not to write, not to escape its tenant, and not to take the database down. LWQL removes all three from the trust equation:
+
+- The statement is validated against a default-deny allowlist before execution — an agent that hallucinates `INSERT`, a system table, or an exotic function gets a structured refusal, not a database error.
+- Tenant isolation is enforced by database row policies, not by anything the SQL says. There is no query the agent can write that reads another project.
+- Execution time, memory, and scan volume are capped server-side as constants. A runaway `CROSS JOIN` costs one killed query, not a cluster.
+
+The failure mode of a confused agent is a 400 with instructions for fixing itself — which is exactly what agents are good at consuming.
+
+## What the agent can answer
+
+With the loop above, questions like these become one or two queries (see [Use cases](/observability/lwql/use-cases) for the SQL):
+
+- "What did each model cost us per day this week, and which one drove the spike?"
+- "What's our p95 latency by trace name, and did it regress after yesterday's deploy?"
+- "Which evaluator is failing most, and on which conversations?"
+- "Which customers generate the most cost per message?"
+- "How did the pass rate of our simulations change across the last five batches?"
+
+## MCP and CLI
+
+A first-party MCP server and CLI for LWQL are coming soon — see [MCP](/observability/lwql/mcp) and [CLI](/observability/lwql/cli). Until then, the two HTTP endpoints plus the prompt above are all an agent needs.
+
+---
+
+# FILE: ./observability/lwql/self-hosted.mdx
+
+---
+title: "LWQL on Self-Hosted LangWatch"
+description: "Architecture, environment contract, provisioning, and gotchas for running LangWatchQL on your own deployment"
+sidebarTitle: Self-hosted / on-prem
+keywords: langwatchql, lwql, self-hosted, on-prem, clickhouse, provisioning, setup
+---
+
+<Note>
+LWQL support for self-hosted deployments is early. This page documents the architecture and the contract the application expects; the pieces marked *operator-provisioned* are not yet packaged into the Helm chart, so expect some assembly. If you're setting this up, [talk to us](/support) — we'll help, and it feeds directly into the packaged version.
+</Note>
+
+## Architecture in one paragraph
+
+Customer SQL never runs as the application. It runs as a dedicated **restricted ClickHouse identity** whose settings profile pins `readonly = 1` and all resource ceilings as constants, and which holds `SELECT` on a set of **LWQL views** in a dedicated analytics database — and on nothing else. **Row policies** on those views scope every read to the calling project, resolved through a tenant capability the application sends per query as a custom setting. PostgreSQL-resident datasets (prompts, experiments, annotations, ...) reach ClickHouse through **approved views** in PostgreSQL read by **PostgreSQL-engine tables** in the analytics database, so the same row policies apply to them too.
+
+A deployment that provisions none of this simply has no LWQL: the API answers `503 lwql_unavailable` and everything else works normally.
+
+## The environment contract
+
+The application looks for five variables. **All five are required** — with any subset missing, the executor is not built and every query is refused:
+
+| Variable | Meaning |
+|---|---|
+| `LWQL_CLICKHOUSE_URL` | ClickHouse HTTP endpoint the restricted identity connects to |
+| `LWQL_CLICKHOUSE_USER` | The restricted identity. **Never** an admin account — the isolation model assumes this user can only see the LWQL views |
+| `LWQL_CLICKHOUSE_PASSWORD` | Its password |
+| `LWQL_DATABASE` | The database the LWQL views live in; unqualified names in queries resolve here |
+| `LWQL_TENANT_SETTING` | The custom setting carrying the tenant capability. Must start with `custom_` |
+
+If you set *some* of these, the app logs a warning naming exactly which are absent (variable names only, never values) — check for it when queries unexpectedly return `lwql_unavailable`.
+
+## What the application provisions itself
+
+On startup (`start:prepare:db`), after ClickHouse migrations run:
+
+1. **Migrations** create the key-map table that resolves tenant capabilities to project ids.
+2. **The `provisionLwql` task** creates the LWQL views in ClickHouse, creates the approved views in PostgreSQL, and backfills the key map from every project's LWQL key. It is idempotent (`CREATE OR REPLACE` / `IF NOT EXISTS` throughout) and exits immediately when the `LWQL_*` environment is absent.
+
+The task runs DDL as the application's own ClickHouse connection (`CLICKHOUSE_URL`) — the restricted identity deliberately has no DDL privileges.
+
+## What the operator provisions
+
+The access model itself is deployed out of band (in LangWatch Cloud, by Terraform):
+
+- The **restricted user** and its **settings profile** — `readonly = 1`, `max_execution_time`, `max_memory_usage`, `max_threads`, `max_concurrent_queries_for_user`, `max_rows_to_read`, `max_bytes_to_read`, all `CONST`, plus the tenant setting declared `CHANGEABLE_IN_READONLY`
+- **Grants** — `SELECT` on the LWQL views (and the exact source columns the views read), nothing else
+- **Row policies** binding each view to the tenant capability
+- For PostgreSQL-resident datasets: a **read-only PostgreSQL role** granted `SELECT` on the approved views only, a ClickHouse **named collection** holding that role's connection, and the **PostgreSQL-engine tables** mapping the approved views into the analytics database
+
+## Gotchas
+
+<AccordionGroup>
+  <Accordion title="The tenant setting needs a server-side prefix allowance">
+    `LWQL_TENANT_SETTING` must begin with `custom_`, and your ClickHouse server config must allow that prefix via `custom_settings_prefixes`. Without it, every query fails at the server with an unknown-setting error.
+  </Accordion>
+  <Accordion title="Raising the execution-time ceiling has a second half">
+    The application's HTTP client waits slightly longer than the default 10-second `max_execution_time`, so server-side timeouts surface as a clean, coded `query_timeout`. If you provision a profile with a **higher** execution ceiling, the driver will abandon the socket first and callers get an anonymous transport failure instead of the coded error. Keep the profile at the default, or raise both together.
+  </Accordion>
+  <Accordion title="503 lwql_unavailable with the environment fully set">
+    This also fires when the configured identity exists but the database objects don't — the server answered `UNKNOWN_TABLE`/`UNKNOWN_DATABASE`/`ACCESS_DENIED` for a name the validator had already approved, which can't be the caller's SQL. Check that migrations and `provisionLwql` ran, and that the grants match the current catalog. The underlying reason is in the application logs, never in the API response.
+  </Accordion>
+  <Accordion title="Distinguishing the three refusals">
+    `401 invalid_credentials` — the key is wrong. `403 lwql_not_enabled` — key is fine, but the `release_lwql_workbench` feature flag is off for the project (a product switch, not a fault). `503 lwql_unavailable` — the deployment has no working LWQL execution path (an operator problem).
+  </Accordion>
+  <Accordion title="Connection budgets are shared">
+    The LWQL executor keeps its own pool (up to 10 connections) beside the application's ClickHouse client, and each PostgreSQL-engine table keeps a small pool against PostgreSQL. Count both against your servers' connection limits — particularly the PostgreSQL side, where the read-only role's connection limit should leave headroom for the application itself.
+  </Accordion>
+  <Accordion title="Never substitute the application's ClickHouse user">
+    If LWQL provisioning feels like too much, the tempting shortcut is pointing `LWQL_CLICKHOUSE_USER` at the app's own account. Don't: that account is not read-only, carries no row policies, and would run customer SQL with admin visibility. The application refuses to fall back to it internally for exactly this reason.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+# FILE: ./observability/lwql/use-cases.mdx
+
+---
+title: "LWQL Use Cases"
+description: "Copy-paste LangWatchQL queries for cost attribution, latency, quality, adoption, and experiment analysis"
+sidebarTitle: Use cases
+keywords: langwatchql, lwql, examples, sql, cost, latency, evaluations, analytics
+---
+
+Every query below runs as-is through `POST /api/v1/projects/{projectId}/analytics/query/clickhouse`. They all filter the dataset's time column — keep that habit; it's what makes queries fast and keeps them under the scan ceilings. Column names come from the [schema endpoint](/observability/lwql/writing-queries#start-with-the-schema), which is always the source of truth.
+
+## Cost
+
+### What is each model costing us per day?
+
+`model_usage_by_minute` is pre-aggregated per (minute, model, span type), so this scans almost nothing:
+
+```sql
+SELECT toStartOfDay(BucketStart) AS Day,
+       Model,
+       round(sum(CostSum), 4) AS CostUSD,
+       sum(PromptTokensSum) AS PromptTokens,
+       sum(CompletionTokensSum) AS CompletionTokens
+FROM model_usage_by_minute
+WHERE BucketStart >= now() - INTERVAL 14 DAY
+GROUP BY Day, Model
+ORDER BY Day, CostUSD DESC
+```
+
+### Which customers and users drive our cost?
+
+`trace_metrics` carries the user, conversation, and customer identifiers from your trace metadata:
+
+```sql
+SELECT CustomerId,
+       uniq(UserId) AS Users,
+       uniq(ConversationId) AS Conversations,
+       count() AS Traces,
+       round(sum(TotalCost), 2) AS CostUSD,
+       round(sum(TotalCost) / count(), 5) AS CostPerTrace
+FROM trace_metrics
+WHERE OccurredAt >= now() - INTERVAL 30 DAY
+GROUP BY CustomerId
+ORDER BY CostUSD DESC
+LIMIT 25
+```
+
+### How much is prompt caching saving us?
+
+```sql
+SELECT toStartOfDay(BucketStart) AS Day,
+       sum(CacheReadTokensSum) AS CachedTokens,
+       sum(PromptTokensSum) AS PromptTokens,
+       round(sum(CacheReadTokensSum) / (sum(PromptTokensSum) + sum(CacheReadTokensSum)), 3) AS CacheHitShare
+FROM trace_metrics_by_minute
+WHERE BucketStart >= now() - INTERVAL 14 DAY
+GROUP BY Day
+ORDER BY Day
+```
+
+### Did cost per conversation change week over week?
+
+```sql
+WITH weekly AS (
+  SELECT toStartOfWeek(OccurredAt) AS Week,
+         sum(TotalCost) / uniq(ConversationId) AS CostPerConversation
+  FROM trace_metrics
+  WHERE OccurredAt >= now() - INTERVAL 8 WEEK
+  GROUP BY Week
+)
+SELECT Week,
+       round(CostPerConversation, 4) AS CostPerConversation,
+       round(CostPerConversation - lagInFrame(CostPerConversation) OVER (ORDER BY Week), 4) AS ChangeVsPriorWeek
+FROM weekly
+ORDER BY Week
+```
+
+## Latency & reliability
+
+### p50 / p95 / p99 latency and time-to-first-token
+
+```sql
+SELECT quantile(0.5)(TotalDurationMs)  AS P50Ms,
+       quantile(0.95)(TotalDurationMs) AS P95Ms,
+       quantile(0.99)(TotalDurationMs) AS P99Ms,
+       quantile(0.95)(TimeToFirstTokenMs) AS P95FirstTokenMs,
+       avg(TokensPerSecond) AS AvgTokensPerSec
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 24 HOUR
+```
+
+### Error rate trend, hour by hour
+
+```sql
+SELECT toStartOfHour(BucketStart) AS Hour,
+       sum(TraceCount) AS Traces,
+       sum(ErrorCount) AS Errors,
+       round(sum(ErrorCount) / sum(TraceCount), 4) AS ErrorRate
+FROM trace_metrics_by_minute
+WHERE BucketStart >= now() - INTERVAL 48 HOUR
+GROUP BY Hour
+ORDER BY Hour
+```
+
+### Which operation regressed? Latency by trace name, this week vs last
+
+```sql
+SELECT TraceName,
+       quantile(0.95)(if(OccurredAt >= now() - INTERVAL 7 DAY, TotalDurationMs, NULL)) AS P95ThisWeek,
+       quantile(0.95)(if(OccurredAt <  now() - INTERVAL 7 DAY, TotalDurationMs, NULL)) AS P95LastWeek
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 14 DAY
+GROUP BY TraceName
+HAVING P95ThisWeek > P95LastWeek * 1.2
+ORDER BY P95ThisWeek DESC
+```
+
+### The slowest step inside slow traces
+
+Join spans to traces on their published join key to see where the time goes:
+
+```sql
+SELECT s.SpanName,
+       count() AS Occurrences,
+       round(avg(s.DurationMs)) AS AvgMs,
+       round(quantile(0.95)(s.DurationMs)) AS P95Ms
+FROM spans AS s
+JOIN traces AS t ON s.TraceId = t.TraceId
+WHERE s.StartTime >= now() - INTERVAL 24 HOUR
+  AND t.OccurredAt >= now() - INTERVAL 24 HOUR
+  AND t.TotalDurationMs > 10000
+GROUP BY s.SpanName
+ORDER BY P95Ms DESC
+LIMIT 20
+```
+
+## Quality
+
+### Pass rate per evaluator
+
+```sql
+SELECT EvaluatorName,
+       count() AS Runs,
+       countIf(Passed) AS Passed,
+       round(countIf(Passed) / count(), 3) AS PassRate,
+       round(avg(Score), 3) AS AvgScore
+FROM evaluations
+WHERE ScheduledAt >= now() - INTERVAL 7 DAY
+  AND Status = 'processed'
+GROUP BY EvaluatorName
+ORDER BY PassRate ASC
+```
+
+### Evaluation pass-rate trend (pre-aggregated)
+
+```sql
+SELECT toStartOfDay(BucketStart) AS Day,
+       EvaluatorType,
+       sum(PassCount) AS Passed,
+       sum(FailCount) AS Failed,
+       round(sum(PassCount) / (sum(PassCount) + sum(FailCount)), 3) AS PassRate,
+       round(sum(ScoreSum) / sum(ScoreCount), 3) AS AvgScore
+FROM evaluation_metrics_by_minute
+WHERE BucketStart >= now() - INTERVAL 30 DAY
+GROUP BY Day, EvaluatorType
+ORDER BY Day, EvaluatorType
+```
+
+### Which conversations keep failing a guardrail?
+
+```sql
+SELECT ConversationId,
+       countIf(NOT Passed) AS Failures,
+       count() AS Checks,
+       round(countIf(NOT Passed) / count(), 3) AS FailureRate
+FROM evaluation_metrics
+WHERE OccurredAt >= now() - INTERVAL 7 DAY
+  AND IsGuardrail
+GROUP BY ConversationId
+HAVING Failures >= 3
+ORDER BY Failures DESC
+LIMIT 50
+```
+
+### Do human annotations agree with the evaluators?
+
+```sql
+SELECT e.EvaluatorName,
+       countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed) AS Agree,
+       count() AS Overlap,
+       round((countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed)) / count(), 3) AS Agreement
+FROM annotations AS a
+JOIN evaluations AS e ON a.TraceId = e.TraceId
+WHERE a.CreatedAt >= now() - INTERVAL 30 DAY
+  AND e.Passed IS NOT NULL
+GROUP BY e.EvaluatorName
+ORDER BY Overlap DESC
+```
+
+### Simulation verdicts across recent batches
+
+```sql
+SELECT BatchRunId,
+       min(StartedAt) AS BatchStart,
+       count() AS Runs,
+       countIf(Verdict = 'success') AS Successes,
+       round(countIf(Verdict = 'success') / count(), 3) AS SuccessRate
+FROM simulations
+WHERE StartedAt >= now() - INTERVAL 14 DAY
+GROUP BY BatchRunId
+ORDER BY BatchStart DESC
+LIMIT 5
+```
+
+### Which criteria fail most often?
+
+```sql
+SELECT arrayJoin(UnmetCriteria) AS Criterion,
+       count() AS Failures
+FROM simulations
+WHERE StartedAt >= now() - INTERVAL 14 DAY
+GROUP BY Criterion
+ORDER BY Failures DESC
+LIMIT 10
+```
+
+## Adoption & product
+
+### Daily active users and conversations
+
+```sql
+SELECT toStartOfDay(OccurredAt) AS Day,
+       uniq(UserId) AS ActiveUsers,
+       uniq(ConversationId) AS Conversations,
+       count() AS Traces
+FROM trace_metrics
+WHERE OccurredAt >= now() - INTERVAL 30 DAY
+GROUP BY Day
+ORDER BY Day
+```
+
+### What are people talking about? Traces by topic
+
+```sql
+SELECT TopicId,
+       count() AS Traces,
+       round(avg(TotalDurationMs)) AS AvgDurationMs,
+       round(sum(TotalCost), 2) AS CostUSD
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 7 DAY
+  AND TopicId IS NOT NULL
+GROUP BY TopicId
+ORDER BY Traces DESC
+LIMIT 20
+```
+
+### User satisfaction by day
+
+```sql
+SELECT toStartOfDay(OccurredAt) AS Day,
+       round(avg(SatisfactionScore), 3) AS AvgSatisfaction,
+       count() AS ScoredTraces
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 30 DAY
+  AND SatisfactionScore IS NOT NULL
+GROUP BY Day
+ORDER BY Day
+```
+
+## Prompts & experiments
+
+### Which prompt versions are actually serving traffic?
+
+```sql
+SELECT p.PromptHandle,
+       t.LastUsedPromptVersionNumber AS Version,
+       count() AS Traces,
+       round(quantile(0.95)(t.TotalDurationMs)) AS P95Ms,
+       round(sum(t.TotalCost), 4) AS CostUSD
+FROM traces AS t
+JOIN prompts AS p ON t.LastUsedPromptId = p.PromptId
+WHERE t.OccurredAt >= now() - INTERVAL 7 DAY
+  AND t.ContainsPrompt
+GROUP BY p.PromptHandle, Version
+ORDER BY Traces DESC
+```
+
+### Compare batch evaluation scores across an experiment's runs
+
+```sql
+SELECT e.ExperimentName,
+       b.EvaluationName,
+       count() AS Rows,
+       round(avg(b.Score), 4) AS AvgScore,
+       round(countIf(b.Passed) / countIf(b.Passed IS NOT NULL), 3) AS PassRate,
+       round(sum(b.Cost), 4) AS CostUSD
+FROM batch_evaluations AS b
+JOIN experiments AS e ON b.ExperimentId = e.ExperimentId
+WHERE b.CreatedAt >= now() - INTERVAL 30 DAY
+GROUP BY e.ExperimentName, b.EvaluationName
+ORDER BY e.ExperimentName, AvgScore DESC
+```
+
+## Reusable, period-aware statements
+
+Any of the above becomes a reusable report by swapping the hard-coded interval for the reserved time-window parameters, and letting the caller supply the period:
+
+```json
+{
+  "sql": "SELECT toStartOfDay(BucketStart) AS Day, sum(CostSum) AS CostUSD FROM trace_metrics_by_minute WHERE BucketStart >= {period_start:DateTime} AND BucketStart < {period_end:DateTime} GROUP BY Day ORDER BY Day",
+  "timeWindow": { "start": "2026-08-01T00:00:00Z", "end": "2026-08-18T00:00:00Z" }
+}
+```
+
+See [Writing queries](/observability/lwql/writing-queries#the-reserved-time-window) for the contract, and check each response's `diagnostics` — `POSSIBLE_FANOUT` on the join examples and `MISSING_TIME_BUCKETS` on the trend examples are exactly the situations they exist to catch.
+
+---
+
+# FILE: ./observability/lwql/writing-queries.mdx
+
+---
+title: "Writing LWQL Queries"
+description: "The LangWatchQL dialect, schema discovery, bound parameters, time windows, result limits, and error codes"
+sidebarTitle: Writing queries
+keywords: langwatchql, lwql, sql, clickhouse, query, parameters, schema
+---
+
+LWQL is ClickHouse SQL, restricted to a single read-only `SELECT`. If you know ClickHouse — or standard SQL plus a few ClickHouse idioms like `toStartOfDay`, `countIf`, and `quantile` — you know LWQL.
+
+## Start with the schema
+
+Everything you can query is published by the schema endpoint, scoped to what your key can see:
+
+```bash
+curl "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/schema" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY"
+```
+
+For every dataset it returns:
+
+- **`columns`** — each with its ClickHouse `type`, a one-line `description`, its `unit` where it has one (`ms`, `USD`, `tokens`, `tokens/s`), the permission `gates` that unlock it, and `available` — whether *your* key holds them.
+- **`grain`** — what one row is (e.g. "one row per (TenantId, TraceId), latest version only"). Joins should match the full grain of the wider side, or you'll multiply rows.
+- **`joinKeys`** — the columns another dataset can be joined on.
+- **`timeColumn`** — the column to filter for partition pruning. Always constrain it.
+- **`freshness`** — how far behind live writes the dataset can be.
+- **`exampleSql`** — a runnable query to start from.
+
+Reference datasets by their bare name (`FROM traces`); they resolve to the analytics database your deployment configured.
+
+## Run a query
+
+```bash
+curl -X POST "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/query/clickhouse" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @- <<'EOF'
+{
+  "sql": "SELECT toStartOfDay(OccurredAt) AS Day, count() AS Traces, round(sum(TotalCost), 4) AS CostUSD FROM traces WHERE OccurredAt >= {since:DateTime} GROUP BY Day ORDER BY Day",
+  "parameters": { "since": "2026-08-01 00:00:00" }
+}
+EOF
+```
+
+The request body:
+
+| Field | Type | Notes |
+|---|---|---|
+| `sql` | string, required | One `SELECT` statement, up to 50,000 characters. Sent to the database exactly as written — never rewritten. |
+| `parameters` | object, optional | Values for the bound parameters the SQL declares. Scalars only: string, number, boolean, or null. |
+| `timeWindow` | `{ start, end }`, optional | The reporting period, as ISO strings, epoch milliseconds, or dates. Fills the reserved `period_start` / `period_end` parameters — see below. |
+
+The response:
+
+| Field | Meaning |
+|---|---|
+| `columns` | Output columns with their ClickHouse types, using your aliases |
+| `rows` | One JSON object per row |
+| `statistics` | `elapsedMs`, `rowsRead`, `bytesRead` (physical scan cost), and `rowsReturned` |
+| `truncated` | `true` when a response ceiling cut the result short — never silent |
+| `followsTimeWindow` | Whether the statement declared the reserved time-window parameters |
+| `diagnostics` | Advisory notes about the result (see below). Never a rejection. |
+
+## Bound parameters
+
+Use ClickHouse's typed parameter syntax rather than interpolating values into the SQL string:
+
+```sql
+SELECT count() AS Errors
+FROM traces
+WHERE OccurredAt >= {since:DateTime}
+  AND ContainsErrorStatus = {has_error:Bool}
+```
+
+Every parameter the statement declares must have a value in `parameters`, or the request is refused with `lwql_parameter_missing` — including the exact names that are missing, so an agent can repair its own request.
+
+### The reserved time window
+
+Two parameter names are reserved: `{period_start:DateTime}` and `{period_end:DateTime}`. They are filled from the request's `timeWindow`, never from `parameters` — supplying either under `parameters` is refused (`lwql_reserved_parameter_supplied`), and declaring them as anything but a date-time type is refused too (`lwql_reserved_parameter_type`).
+
+```json
+{
+  "sql": "SELECT count() AS Traces FROM traces WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}",
+  "timeWindow": { "start": "2026-08-01T00:00:00Z", "end": "2026-08-18T00:00:00Z" }
+}
+```
+
+The interval is half-open: `[period_start, period_end)`. Writing your statements against these two names makes them portable — the same SQL answers for whatever period the caller (a dashboard, a script, an agent) supplies, and the response's `followsTimeWindow` tells the consumer the statement was offered the period.
+
+## What's allowed — and what isn't
+
+Allowed: a single `SELECT`, optionally with `WITH`; joins; CTEs, subqueries and `UNION` (up to 8 levels of nesting); aggregates, `-If`/`DISTINCT` combinators, and window functions; array, map, and JSON access; bound parameters.
+
+Refused, always with a structured violation rather than a database error:
+
+- Anything that writes or defines: `INSERT`, `ALTER`, `CREATE`, `DROP`, ...
+- `SETTINGS` in any position
+- Table functions (`url`, `s3`, `remote`, `file`, ...)
+- The `system` and `information_schema` databases
+- Functions outside the allowlist — the allowlist covers the aggregation, date/time, string, array, map, JSON, and math functions analytics questions need, and omits introspection (`currentUser`, `hostName`, `version`, `getSetting`, ...) by construction
+- Columns your permissions gate (see [Privacy & RBAC](/observability/lwql/privacy-and-rbac))
+
+## Limits
+
+Two layers of ceilings apply, and they behave differently:
+
+**Database ceilings** (fixed per query; exceeding them fails the query with a coded error):
+
+| Ceiling | Default | Error code |
+|---|---|---|
+| Execution time | 10 s | `query_timeout` |
+| Memory | 1 GB | `query_memory_exceeded` |
+| Rows / bytes scanned | 1B rows / 10 GB | `query_scan_limit_exceeded` (HTTP 422) |
+
+**Response ceilings** (truncate rather than fail; always flagged):
+
+| Ceiling | Default |
+|---|---|
+| Rows returned | 10,000 |
+| Response size | ~8 MB |
+
+When you hit a scan or timeout ceiling, narrow the time filter on the dataset's `timeColumn` — it prunes partitions — or move to a pre-aggregated `*_by_minute` dataset. When you hit a response ceiling, aggregate more or paginate with `ORDER BY ... LIMIT ... OFFSET`.
+
+## Diagnostics
+
+Diagnostics are advisory notes about a result that ran successfully but deserves a second look. They never reject a query, and an empty list means no known issue was detected — not that the answer is the one you meant.
+
+| Code | What it flags |
+|---|---|
+| `RESULT_TRUNCATED` | A response ceiling cut the answer short |
+| `POSSIBLE_FANOUT` | A join repeats one dataset's rows once per row of another — aggregates may be inflated |
+| `UNBOUNDED_TIME_RANGE` | A dataset was read with no filter on its time column — the whole history was scanned |
+| `MISSING_TIME_BUCKETS` | A time-bucketed answer skips buckets inside the range it covers (charts will silently connect the gap) |
+| `INCOMPLETE_COMPARISON_PERIOD` | A period-over-period comparison includes an unfinished or unequal period |
+
+## Error codes
+
+Failures carry a stable `code` you (or your agent) can branch on:
+
+| HTTP | Code | Meaning | Fix |
+|---|---|---|---|
+| 400 | `lwql_parameter_missing` | The SQL declares parameters the request didn't supply (`meta.parameters` names them) | Add the values |
+| 400 | `lwql_reserved_parameter_supplied` | `period_start`/`period_end` sent under `parameters` | Move them to `timeWindow` |
+| 400 | `lwql_reserved_parameter_type` | A reserved parameter declared as a non-date-time | Declare `:DateTime` |
+| 400 | validation violations | The statement names something outside the allowlist | The violation says exactly what was refused |
+| 401 | `invalid_credentials` | Bad or missing API key | Check `X-Auth-Token` |
+| 403 | `lwql_not_enabled` | LWQL isn't enabled for this project | Ask your admin, or [contact us](/support) |
+| 422 | `query_scan_limit_exceeded` | The query would read more than the scan ceiling | Filter the time column, or use a `*_by_minute` dataset |
+| 5xx | `query_timeout`, `query_memory_exceeded` | A database ceiling killed the query | Narrow or pre-aggregate |
+| 503 | `lwql_unavailable` | This deployment has no LWQL identity provisioned | See [Self-hosted setup](/observability/lwql/self-hosted) |
+
+Error messages never name hosts, credentials, physical tables, or server internals — what you get is what's safe to show and enough to act on.
+
+---
+
 # FILE: ./observability/overview.mdx
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -370,7 +370,7 @@ A first-party [Model Context Protocol](https://modelcontextprotocol.io) server f
 - **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
 - **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
 
-LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write, cannot reach another tenant's rows, and cannot exhaust the server. Those are the guarantees the database enforces; whatever your agent then does with the rows it legitimately reads is your side of the boundary.
+LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write and cannot reach another tenant's rows, and every query it sends is bounded by the configured ceilings — one that exceeds them is refused, timed out, or truncated rather than left to run. Those are per-query and per-identity guarantees the database enforces, not a global availability guarantee for the cluster; and whatever your agent then does with the rows it legitimately reads is your side of the boundary.
 
 ## Until then
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -370,7 +370,7 @@ A first-party [Model Context Protocol](https://modelcontextprotocol.io) server f
 - **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
 - **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
 
-Because LWQL is already read-only, tenant-isolated, and resource-capped at the database, connecting it to an agent through MCP doesn't require any additional sandboxing on your side.
+LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write, cannot reach another tenant's rows, and cannot exhaust the server. Those are the guarantees the database enforces; whatever your agent then does with the rows it legitimately reads is your side of the boundary.
 
 ## Until then
 
@@ -393,7 +393,7 @@ LWQL accepts arbitrary SQL from customers and agents, so its access model is lay
 
 ## Tenant isolation lives in the database
 
-Every query runs as a restricted ClickHouse identity, and every LWQL view carries a **row policy** that scopes reads to the calling project. The tenant is resolved from a capability derived from your project's key, sent by the server — never from the SQL, never from the request body, and never from the project id in the URL (that one is only a cross-check; naming a different project returns 404).
+Every query runs as a restricted ClickHouse identity, and every **source table** the LWQL views read carries a **row policy** that scopes reads to the calling project. The policies sit on the source tables rather than on the views because the views are declared `SQL SECURITY INVOKER` — they read their sources *as the caller*, so the source-table policy is the boundary that actually enforces, and it holds no matter which view reaches the data. The tenant is resolved from a capability derived from your project's key, sent by the server — never from the SQL, never from the request body, and never from the project id in the URL (that one is only a cross-check; naming a different project returns 404).
 
 The consequence: there is no statement you can write that reads another tenant's rows. A bug in the API gateway can cost a caller a wrong refusal or acceptance of a malformed query — it cannot cross tenants, because the gateway was never the boundary.
 
@@ -401,7 +401,7 @@ The consequence: there is no statement you can write that reads another tenant's
 
 - LWQL requires an API key with the **`analytics:view`** scope, and the project must have LWQL enabled.
 - Access is **read-only by construction**: the database identity has `readonly = 1` pinned as a constant, and the validator refuses every write and DDL form before it ever reaches the database anyway.
-- The identity can see **only the LWQL views**. Raw tables, other databases, `system.*`, and `information_schema` are unreachable at the database and refused by name at the gateway.
+- The identity is granted `SELECT` on the **LWQL views** and on **exactly the source columns those views read** — nothing else. The source-column grant is deliberate: it is what makes an unauthorised column a database-level `ACCESS_DENIED` rather than something only the gateway refuses. Other databases and any table outside that set carry no grant at all. `system.*` and `information_schema` are refused by name at the gateway.
 
 ## Column-level permission gates
 
@@ -536,7 +536,7 @@ LWQL support for self-hosted deployments is early. This page documents the archi
 
 ## Architecture in one paragraph
 
-Customer SQL never runs as the application. It runs as a dedicated **restricted ClickHouse identity** whose settings profile pins `readonly = 1` and all resource ceilings as constants, and which holds `SELECT` on a set of **LWQL views** in a dedicated analytics database — and on nothing else. **Row policies** on those views scope every read to the calling project, resolved through a tenant capability the application sends per query as a custom setting. PostgreSQL-resident datasets (prompts, experiments, annotations, ...) reach ClickHouse through **approved views** in PostgreSQL read by **PostgreSQL-engine tables** in the analytics database, so the same row policies apply to them too.
+Customer SQL never runs as the application. It runs as a dedicated **restricted ClickHouse identity** whose settings profile pins `readonly = 1` and all resource ceilings as constants, and which holds `SELECT` on a set of **LWQL views** in a dedicated analytics database, plus the exact source columns those views read — and on nothing else. **Row policies** on the *source tables* those views read scope every read to the calling project (the views are `SQL SECURITY INVOKER`, so they read as the caller and the source-table policy is what enforces), resolved through a tenant capability the application sends per query as a custom setting. PostgreSQL-resident datasets (prompts, experiments, annotations, ...) reach ClickHouse through **approved views** in PostgreSQL read by **PostgreSQL-engine tables** in the analytics database, so the same row policies apply to them too.
 
 A deployment that provisions none of this simply has no LWQL: the API answers `503 lwql_unavailable` and everything else works normally.
 
@@ -576,7 +576,7 @@ The access model itself is deployed out of band (in LangWatch Cloud, by Terrafor
 
 - The **restricted user** and its **settings profile** — `readonly = 1`, `max_execution_time`, `max_memory_usage`, `max_threads`, `max_concurrent_queries_for_user`, `max_rows_to_read`, `max_bytes_to_read`, all `CONST`, plus the tenant setting declared `CHANGEABLE_IN_READONLY`
 - **Grants** — `SELECT` on the LWQL views (and the exact source columns the views read), nothing else
-- **Row policies** binding each view to the tenant capability
+- **Row policies** binding each *source table* to the tenant capability — not the views, which are `SQL SECURITY INVOKER` and read as the caller
 - For PostgreSQL-resident datasets: a **read-only PostgreSQL role** granted `SELECT` on the approved views only, a ClickHouse **named collection** holding that role's connection, and the **PostgreSQL-engine tables** mapping the approved views into the analytics database
 
 ## Gotchas
@@ -793,15 +793,26 @@ LIMIT 50
 ```sql
 SELECT e.EvaluatorName,
        countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed) AS Agree,
-       count() AS Overlap,
+       count() AS Pairs,
        round((countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed)) / count(), 3) AS Agreement
 FROM annotations AS a
 JOIN evaluations AS e ON a.TraceId = e.TraceId
 WHERE a.CreatedAt >= now() - INTERVAL 30 DAY
   AND e.Passed IS NOT NULL
 GROUP BY e.EvaluatorName
-ORDER BY Overlap DESC
+ORDER BY Pairs DESC
 ```
+
+<Note>
+  The unit here is an **(annotation, evaluation) pair**, not a trace. Both
+  datasets are one row per event — one human annotation, one evaluation run —
+  so a trace annotated twice and evaluated three times by the same evaluator
+  contributes six pairs, and weighs six times as much as a trace with one of
+  each. That is why the column is `Pairs` rather than a trace count. The
+  `POSSIBLE_FANOUT` diagnostic flags this on the result. For a trace-weighted
+  answer, restrict to one annotation and one evaluation per trace before
+  comparing.
+</Note>
 
 ### Simulation verdicts across recent batches
 
@@ -1006,7 +1017,7 @@ Refused, always with a structured violation rather than a database error:
 
 - Anything that writes or defines: `INSERT`, `ALTER`, `CREATE`, `DROP`, ...
 - `SETTINGS` in any position
-- Table functions (`url`, `s3`, `remote`, `file`, ...)
+- Table functions — **all** of them, refused positionally rather than by a name list, so `numbers(10)` is refused just as `url(...)` is
 - The `system` and `information_schema` databases
 - Functions outside the allowlist — the allowlist covers the aggregation, date/time, string, array, map, JSON, and math functions analytics questions need, and omits introspection (`currentUser`, `hostName`, `version`, `getSetting`, ...) by construction
 - Columns your permissions gate (see [Privacy & RBAC](/observability/lwql/privacy-and-rbac))
@@ -1019,8 +1030,8 @@ Two layers of ceilings apply, and they behave differently:
 
 | Ceiling | Default | Error code |
 |---|---|---|
-| Execution time | 10 s | `query_timeout` |
-| Memory | 1 GB | `query_memory_exceeded` |
+| Execution time | 10 s | HTTP 504 — no specific code (see the 5xx warning below) |
+| Memory | 1 GB | `query_memory_exceeded` (HTTP 422) |
 | Rows / bytes scanned | 1B rows / 10 GB | `query_scan_limit_exceeded` (HTTP 422) |
 
 **Response ceilings** (truncate rather than fail; always flagged):
@@ -1079,6 +1090,7 @@ Every 4xx carries a stable `code`:
 | 400 | `lwql_reserved_parameter_type` | A reserved parameter declared as a non-date-time | Declare `:DateTime` |
 | 401 | `invalid_credentials` | Bad or missing API key | Check `X-Auth-Token` |
 | 403 | `lwql_not_enabled` | LWQL isn't enabled for this project | Ask your admin, or [contact us](/support) |
+| 404 | `not_found` | The project id in the URL isn't one this key can reach | Check the id — an existing project you cannot see answers identically to one that doesn't exist |
 | 422 | `query_scan_limit_exceeded` | The query would read more than the scan ceiling | Filter the time column, or use a `*_by_minute` dataset |
 | 422 | `query_memory_exceeded` | The query exceeded the memory ceiling | Narrow or pre-aggregate — retrying as-is will fail identically |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -219,6 +219,14 @@ langwatch query --format csv ... > costs.csv
 
 Planned niceties: schema-aware autocomplete, `--format table|json|csv`, reading SQL from a file or stdin, and profile-based auth so your key stays out of shell history.
 
+<Warning>
+  The commands above do not exist yet, and the near-miss that *does* ship is a
+  different thing entirely: `langwatch analytics query` is the existing
+  timeseries metrics command (`--metric total-cost` and friends). It takes no
+  SQL and does not go through LWQL. If you try it today expecting the above,
+  you'll get a working command answering a different question.
+</Warning>
+
 ## Until then
 
 `curl` and `jq` cover the same ground — the API is two endpoints:
@@ -311,7 +319,6 @@ Your SQL runs against a curated catalog of views, not raw tables. Each view has 
 | `prompts` | One managed prompt |
 | `prompt_versions` | One version of a managed prompt |
 | `experiments` | One experiment |
-| `batch_evaluations` | One batch evaluation run within an experiment, with score, pass/fail, and cost |
 
 Use the *by-minute* datasets for time-series charts — they're pre-aggregated and orders of magnitude cheaper to scan than the row-level ones.
 
@@ -403,8 +410,10 @@ Individual columns are gated on the same visibility permissions that govern the 
 | Gate | Governs | Example columns |
 |---|---|---|
 | `input` | Captured user input | `traces.CapturedInput`, `spans.CapturedInput`, `evaluations.CapturedInputs` |
-| `output` | Captured model output | `traces.CapturedOutput`, `spans.CapturedOutput`, `simulations.MessageContents` |
+| `output` | Captured model output | `traces.CapturedOutput`, `spans.CapturedOutput` |
 | `costs` | Cost figures | `traces.TotalCost`, `spans.Cost`, `trace_metrics_by_minute.CostSum` |
+
+A column can sit behind more than one gate, and then it needs *all* of them: `simulations.MessageContents` carries both sides of a conversation, so it is gated on `input` **and** `output` and stays hidden from a caller holding only one.
 
 The gates compose fail-closed:
 
@@ -449,7 +458,7 @@ Teach your agent this loop; it's the same one the API was designed around:
 
 1. **Discover** — `GET /analytics/schema` once, and cache it. It lists every dataset, every column with its type and description, the grain, the join keys, the time column, and a runnable `exampleSql` per dataset.
 2. **Query** — `POST /analytics/query/clickhouse` with one `SELECT`. Filter the dataset's `timeColumn`; prefer the `*_by_minute` datasets for trends.
-3. **Repair** — on a 4xx, read the `code` and `meta`. `lwql_parameter_missing` names the parameters to add; validation violations name the exact table, column, or function that was refused. One edit, retry.
+3. **Repair** — on a 4xx, read `error.code` and `error.meta` (every field is nested under `error`). `lwql_parameter_missing` names the parameters to add; `lwql_not_permitted` and `lwql_unparseable` carry `error.meta.violations`, naming the exact table, column, or function that was refused. One edit, retry. On a 5xx there is nothing to repair — the code is always `internal_error`, so branch on the status: retry a 504 with a narrower query, and treat a 503 as a deployment problem rather than something a different query can fix.
 4. **Sanity-check** — read `diagnostics` before trusting the rows. `POSSIBLE_FANOUT` means a join inflated the aggregates; `UNBOUNDED_TIME_RANGE` means the query read all of history; `RESULT_TRUNCATED` means the answer is incomplete.
 
 ## A system prompt that teaches it
@@ -476,7 +485,7 @@ Rules:
 - Use bound parameters ({name:DateTime}) instead of interpolating values.
 - For time series, prefer trace_metrics_by_minute / model_usage_by_minute /
   evaluation_metrics_by_minute — they are pre-aggregated and fast.
-- On errors, read the "code" and "meta" fields and fix precisely that.
+- On errors, read the "error.code" and "error.meta" fields (they are nested under "error") and fix precisely that. A 5xx always reports "internal_error"; do not try to repair the SQL for one.
 - After each result, check "diagnostics" and "truncated" before presenting
   numbers; mention any diagnostic that affects the answer.
 ````
@@ -543,7 +552,14 @@ The application looks for five variables. **All five are required** — with any
 | `LWQL_DATABASE` | The database the LWQL views live in; unqualified names in queries resolve here |
 | `LWQL_TENANT_SETTING` | The custom setting carrying the tenant capability. Must start with `custom_` |
 
-If you set *some* of these, the app logs a warning naming exactly which are absent (variable names only, never values) — check for it when queries unexpectedly return `lwql_unavailable`.
+If you set *some* of these, the app logs a warning naming exactly which are absent (variable names only, never values) — check for it when queries unexpectedly return a 503.
+
+Two more affect provisioning rather than execution, and neither is part of the five:
+
+| Variable | Meaning |
+|---|---|
+| `LWQL_POSTGRES_READER_ROLE` | The PostgreSQL role the approved views' `SELECT` grants are issued to. Leave it unset and a newly added view ships with no grant, so every query touching it fails — see the 503 gotcha below |
+| `SKIP_LWQL_PROVISION` | Set to `true` to skip the provisioning step at boot entirely |
 
 ## What the application provisions itself
 
@@ -572,11 +588,11 @@ The access model itself is deployed out of band (in LangWatch Cloud, by Terrafor
   <Accordion title="Raising the execution-time ceiling has a second half">
     The application's HTTP client waits slightly longer than the default 10-second `max_execution_time`, so server-side timeouts surface as a clean, coded `query_timeout`. If you provision a profile with a **higher** execution ceiling, the driver will abandon the socket first and callers get an anonymous transport failure instead of the coded error. Keep the profile at the default, or raise both together.
   </Accordion>
-  <Accordion title="503 lwql_unavailable with the environment fully set">
+  <Accordion title="A 503 with the environment fully set">
     This also fires when the configured identity exists but the database objects don't — the server answered `UNKNOWN_TABLE`/`UNKNOWN_DATABASE`/`ACCESS_DENIED` for a name the validator had already approved, which can't be the caller's SQL. Check that migrations and `provisionLwql` ran, and that the grants match the current catalog. The underlying reason is in the application logs, never in the API response.
   </Accordion>
   <Accordion title="Distinguishing the three refusals">
-    `401 invalid_credentials` — the key is wrong. `403 lwql_not_enabled` — key is fine, but the `release_lwql_workbench` feature flag is off for the project (a product switch, not a fault). `503 lwql_unavailable` — the deployment has no working LWQL execution path (an operator problem).
+    `401 invalid_credentials` — the key is wrong. `403 lwql_not_enabled` — key is fine, but the `release_lwql_workbench` feature flag is off for the project (a product switch, not a fault). `503` — the deployment has no working LWQL execution path (an operator problem). Note that only the two 4xx cases name themselves in the response: the server raises `LangWatchQLUnavailableError` internally, but every 5xx body collapses to `internal_error`, so identify this one by its status and by the application logs, not by grepping responses for `lwql_unavailable`.
   </Accordion>
   <Accordion title="Connection budgets are shared">
     The LWQL executor keeps its own pool (up to 10 connections) beside the application's ClickHouse client, and each PostgreSQL-engine table keeps a small pool against PostgreSQL. Count both against your servers' connection limits — particularly the PostgreSQL side, where the read-only role's connection limit should leave headroom for the application itself.
@@ -875,22 +891,6 @@ GROUP BY p.PromptHandle, Version
 ORDER BY Traces DESC
 ```
 
-### Compare batch evaluation scores across an experiment's runs
-
-```sql
-SELECT e.ExperimentName,
-       b.EvaluationName,
-       count() AS Rows,
-       round(avg(b.Score), 4) AS AvgScore,
-       round(countIf(b.Passed) / countIf(b.Passed IS NOT NULL), 3) AS PassRate,
-       round(sum(b.Cost), 4) AS CostUSD
-FROM batch_evaluations AS b
-JOIN experiments AS e ON b.ExperimentId = e.ExperimentId
-WHERE b.CreatedAt >= now() - INTERVAL 30 DAY
-GROUP BY e.ExperimentName, b.EvaluationName
-ORDER BY e.ExperimentName, AvgScore DESC
-```
-
 ## Reusable, period-aware statements
 
 Any of the above becomes a reusable report by swapping the hard-coded interval for the reserved time-window parameters, and letting the caller supply the period:
@@ -935,7 +935,9 @@ For every dataset it returns:
 - **`freshness`** — how far behind live writes the dataset can be.
 - **`exampleSql`** — a runnable query to start from.
 
-Reference datasets by their bare name (`FROM traces`); they resolve to the analytics database your deployment configured.
+The response also carries a top-level `database` — the analytics database your deployment configured — and each dataset's `name` and `exampleSql` are qualified with it (`langwatch_lwql.traces`, `FROM langwatch_lwql.traces`).
+
+You don't have to repeat that qualification. Reference datasets by their bare name (`FROM traces`) and they resolve to the same database, which is why the two spellings you'll see are equivalent.
 
 ## Run a query
 
@@ -1044,19 +1046,54 @@ Diagnostics are advisory notes about a result that ran successfully but deserves
 
 ## Error codes
 
-Failures carry a stable `code` you (or your agent) can branch on:
+Every failure comes back in the same envelope, with the fields nested under
+`error`:
+
+```json
+{
+  "error": {
+    "type": "https://langwatch.ai/errors/lwql_not_permitted",
+    "code": "lwql_not_permitted",
+    "message": "The statement names something this query may not read",
+    "meta": {
+      "violations": [
+        { "code": "TABLE_NOT_ALLOWED", "detail": "unknown dataset \"internal_billing\"" }
+      ]
+    },
+    "trace_id": "0af7651916cd43dd8448eb211c80319c",
+    "span_id": "b7ad6b7169203331"
+  }
+}
+```
+
+So branch on `error.code`, not `code` — and read `error.meta`, not `meta`.
+
+Every 4xx carries a stable `code`:
 
 | HTTP | Code | Meaning | Fix |
 |---|---|---|---|
-| 400 | `lwql_parameter_missing` | The SQL declares parameters the request didn't supply (`meta.parameters` names them) | Add the values |
+| 400 | `lwql_unparseable` | The statement isn't valid SQL | `error.meta.violations` gives the parse failure |
+| 400 | `lwql_not_permitted` | The statement names a dataset, column, or function outside the allowlist | `error.meta.violations` says exactly what was refused |
+| 400 | `lwql_parameter_missing` | The SQL declares parameters the request didn't supply (`error.meta.parameters` names them) | Add the values |
 | 400 | `lwql_reserved_parameter_supplied` | `period_start`/`period_end` sent under `parameters` | Move them to `timeWindow` |
 | 400 | `lwql_reserved_parameter_type` | A reserved parameter declared as a non-date-time | Declare `:DateTime` |
-| 400 | validation violations | The statement names something outside the allowlist | The violation says exactly what was refused |
 | 401 | `invalid_credentials` | Bad or missing API key | Check `X-Auth-Token` |
 | 403 | `lwql_not_enabled` | LWQL isn't enabled for this project | Ask your admin, or [contact us](/support) |
 | 422 | `query_scan_limit_exceeded` | The query would read more than the scan ceiling | Filter the time column, or use a `*_by_minute` dataset |
-| 5xx | `query_timeout`, `query_memory_exceeded` | A database ceiling killed the query | Narrow or pre-aggregate |
-| 503 | `lwql_unavailable` | This deployment has no LWQL identity provisioned | See [Self-hosted setup](/observability/lwql/self-hosted) |
+| 422 | `query_memory_exceeded` | The query exceeded the memory ceiling | Narrow or pre-aggregate — retrying as-is will fail identically |
+
+<Warning>
+  **5xx responses carry no specific code.** Anything the server treats as its
+  own fault collapses to `"code": "internal_error"` with a generic message,
+  deliberately — a server-side failure must not leak internals to a caller.
+  A query that timed out (504) and a deployment with no LangWatchQL identity
+  provisioned (503) are therefore indistinguishable by `error.code`.
+
+  Branch on the **HTTP status** for these, not the code: a 504 is worth
+  retrying with a narrower query, a 503 usually means the deployment isn't
+  set up — see [Self-hosted setup](/observability/lwql/self-hosted) — and
+  retrying it will not help. Quote `error.trace_id` when you ask us about one.
+</Warning>
 
 Error messages never name hosts, credentials, physical tables, or server internals — what you get is what's safe to show and enough to act on.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -370,7 +370,7 @@ A first-party [Model Context Protocol](https://modelcontextprotocol.io) server f
 - **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
 - **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
 
-LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write and cannot reach another tenant's rows, and every query it sends is bounded by the configured ceilings — one that exceeds them is refused, timed out, or truncated rather than left to run. Those are per-query and per-identity guarantees the database enforces, not a global availability guarantee for the cluster; and whatever your agent then does with the rows it legitimately reads is your side of the boundary.
+LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write and cannot reach another tenant's rows, and every query it sends is bounded by the ceilings pinned in its settings profile as constants no caller can change — a query that exceeds them is refused, timed out, or truncated rather than left to run. Those are per-query and per-identity guarantees the database enforces, not a global availability guarantee for the cluster; and whatever your agent then does with the rows it legitimately reads is your side of the boundary.
 
 ## Until then
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -181,6 +181,17 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Getting Started](https://langwatch.ai/docs/integration/overview.md): LangWatch integrates with all major LLM providers, frameworks, and tools. See our complete list of integrations below.
 - [Choosing the right OTel endpoint](https://langwatch.ai/docs/observability/trace-vs-activity-ingestion.md): LangWatch exposes two OpenTelemetry-shaped URLs. They share the same internal pipeline; the split is auth + routing convenience. Trace ingestion (`/api/otel/v1/traces`) authenticates as a project; governance ingestion (`/api/ingest/otel/:sourceId`) authenticates as an IngestionSource the org admin authored. Both land in the same trace store, distinguished by origin metadata.
 
+## LangWatchQL (LWQL)
+
+- [LangWatchQL (LWQL)](https://langwatch.ai/docs/observability/lwql/introduction.md): Query your LLM observability data directly with SQL — traces, spans, evaluations, costs, and more — through a safe, tenant-isolated analytics API
+- [Writing LWQL Queries](https://langwatch.ai/docs/observability/lwql/writing-queries.md): The LangWatchQL dialect, schema discovery, bound parameters, time windows, result limits, and error codes
+- [Handing the Reins to Your Agent](https://langwatch.ai/docs/observability/lwql/querying-with-agents.md): Teach Claude Code, Cursor, or your own agent to answer observability questions by writing and running LWQL queries
+- [LWQL MCP Server](https://langwatch.ai/docs/observability/lwql/mcp.md): A first-party MCP server for LangWatchQL — coming soon
+- [LWQL CLI](https://langwatch.ai/docs/observability/lwql/cli.md): Query LangWatch from your terminal — coming soon
+- [LWQL on Self-Hosted LangWatch](https://langwatch.ai/docs/observability/lwql/self-hosted.md): Architecture, environment contract, provisioning, and gotchas for running LangWatchQL on your own deployment
+- [LWQL Privacy & RBAC](https://langwatch.ai/docs/observability/lwql/privacy-and-rbac.md): How LangWatchQL enforces tenant isolation, permission-gated columns, and content protection on arbitrary SQL
+- [LWQL Use Cases](https://langwatch.ai/docs/observability/lwql/use-cases.md): Copy-paste LangWatchQL queries for cost attribution, latency, quality, adoption, and experiment analysis
+
 ## SDKs
 
 ### Python

--- a/docs/observability/lwql/cli.mdx
+++ b/docs/observability/lwql/cli.mdx
@@ -1,0 +1,38 @@
+---
+title: "LWQL CLI"
+description: "Query LangWatch from your terminal — coming soon"
+sidebarTitle: "CLI (coming soon)"
+keywords: langwatchql, lwql, cli, terminal, sql
+---
+
+<Note>
+The LWQL CLI is **coming soon**.
+</Note>
+
+We're building a CLI that brings LWQL to your terminal and your scripts:
+
+```bash
+# The shape of things to come
+langwatch query "SELECT toStartOfDay(OccurredAt) AS Day, sum(TotalCost) AS Cost \
+                 FROM traces WHERE OccurredAt >= now() - INTERVAL 7 DAY \
+                 GROUP BY Day ORDER BY Day"
+
+langwatch schema            # browse datasets and columns
+langwatch query --format csv ... > costs.csv
+```
+
+Planned niceties: schema-aware autocomplete, `--format table|json|csv`, reading SQL from a file or stdin, and profile-based auth so your key stays out of shell history.
+
+## Until then
+
+`curl` and `jq` cover the same ground — the API is two endpoints:
+
+```bash
+curl -s -X POST "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/query/clickhouse" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "SELECT count() AS Traces FROM traces WHERE OccurredAt >= now() - INTERVAL 1 DAY"}' \
+  | jq -r '.rows'
+```
+
+See [Writing queries](/observability/lwql/writing-queries) for the full request and response shapes.

--- a/docs/observability/lwql/cli.mdx
+++ b/docs/observability/lwql/cli.mdx
@@ -23,6 +23,14 @@ langwatch query --format csv ... > costs.csv
 
 Planned niceties: schema-aware autocomplete, `--format table|json|csv`, reading SQL from a file or stdin, and profile-based auth so your key stays out of shell history.
 
+<Warning>
+  The commands above do not exist yet, and the near-miss that *does* ship is a
+  different thing entirely: `langwatch analytics query` is the existing
+  timeseries metrics command (`--metric total-cost` and friends). It takes no
+  SQL and does not go through LWQL. If you try it today expecting the above,
+  you'll get a working command answering a different question.
+</Warning>
+
 ## Until then
 
 `curl` and `jq` cover the same ground — the API is two endpoints:

--- a/docs/observability/lwql/introduction.mdx
+++ b/docs/observability/lwql/introduction.mdx
@@ -72,7 +72,6 @@ Your SQL runs against a curated catalog of views, not raw tables. Each view has 
 | `prompts` | One managed prompt |
 | `prompt_versions` | One version of a managed prompt |
 | `experiments` | One experiment |
-| `batch_evaluations` | One batch evaluation run within an experiment, with score, pass/fail, and cost |
 
 Use the *by-minute* datasets for time-series charts — they're pre-aggregated and orders of magnitude cheaper to scan than the row-level ones.
 

--- a/docs/observability/lwql/introduction.mdx
+++ b/docs/observability/lwql/introduction.mdx
@@ -1,0 +1,105 @@
+---
+title: "LangWatchQL (LWQL)"
+description: "Query your LLM observability data directly with SQL — traces, spans, evaluations, costs, and more — through a safe, tenant-isolated analytics API"
+sidebarTitle: Introduction
+keywords: langwatchql, lwql, sql, analytics, clickhouse, query, api, observability
+---
+
+LangWatchQL (LWQL) is LangWatch's analytics SQL API. It lets you — or your agent — run real ClickHouse `SELECT` queries over your observability data: traces, spans, evaluations, simulations, costs, token usage, prompts, experiments, and annotations. You get typed columns, rows, execution statistics, and advisory diagnostics back as JSON.
+
+Instead of being limited to pre-built dashboards, you write the exact question you want answered:
+
+```sql
+SELECT toStartOfDay(OccurredAt) AS Day,
+       count() AS Traces,
+       sum(TotalCost) AS Cost
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 7 DAY
+GROUP BY Day
+ORDER BY Day
+```
+
+<Note>
+LWQL is currently in preview. If you'd like it enabled for your project, [reach out to us](/support).
+</Note>
+
+## The API
+
+LWQL is two endpoints:
+
+| Endpoint | What it does |
+|---|---|
+| `POST /api/v1/projects/{projectId}/analytics/query/clickhouse` | Runs one read-only SQL statement and returns columns, rows, statistics, and diagnostics |
+| `GET /api/v1/projects/{projectId}/analytics/schema` | Describes every dataset your key can query — columns, types, join keys, freshness, and a runnable example per dataset |
+
+Both authenticate with your project API key (`X-Auth-Token: sk-lw-...`) and require the `analytics:view` scope. The project in the URL is a cross-check, not a selector: the tenant always comes from the credential, so a key can only ever read its own project's data.
+
+```bash
+curl -X POST "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/query/clickhouse" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "SELECT count() AS Traces FROM traces WHERE OccurredAt >= now() - INTERVAL 1 DAY"}'
+```
+
+```json
+{
+  "columns": [{ "name": "Traces", "type": "UInt64" }],
+  "rows": [{ "Traces": "1842" }],
+  "statistics": { "elapsedMs": 12, "rowsRead": 1842, "bytesRead": 58944, "rowsReturned": 1 },
+  "truncated": false,
+  "followsTimeWindow": false,
+  "diagnostics": []
+}
+```
+
+## The datasets
+
+Your SQL runs against a curated catalog of views, not raw tables. Each view has a documented grain (what one row *is*), join keys, and a time column for efficient filtering. The schema endpoint is the authoritative, always-current list; today it includes:
+
+| Dataset | One row is |
+|---|---|
+| `traces` | One trace, with duration, cost, token counts, error status, and captured input/output |
+| `spans` | One span, with timing, status, attributes, and cost |
+| `evaluations` | One evaluation run, with its score, verdict, and evaluator |
+| `simulations` | One simulation (scenario) run, with its verdict and criteria |
+| `trace_metrics` | One trace's metrics row, with user, conversation, customer, labels, and per-token-kind counts |
+| `trace_metrics_by_minute` | One minute bucket of trace metrics — counts, costs, durations, tokens, pre-aggregated |
+| `model_usage_by_minute` | One (minute, model, span type) bucket — span counts, cost, and tokens per model |
+| `evaluation_metrics` | One evaluation, enriched with user/conversation/customer context |
+| `evaluation_metrics_by_minute` | One (minute, evaluator type, status) bucket — pass/fail/error counts and score sums |
+| `annotations` | One human annotation, with its thumbs up/down |
+| `projects` | Your project's display name and slug |
+| `prompts` | One managed prompt |
+| `prompt_versions` | One version of a managed prompt |
+| `experiments` | One experiment |
+| `batch_evaluations` | One batch evaluation run within an experiment, with score, pass/fail, and cost |
+
+Use the *by-minute* datasets for time-series charts — they're pre-aggregated and orders of magnitude cheaper to scan than the row-level ones.
+
+## How it stays safe
+
+LWQL is designed so that arbitrary customer SQL can run without ever becoming a security or stability problem:
+
+- **A restricted database identity.** Queries never run as the application. They run as a dedicated read-only ClickHouse user that can see only the catalog views — no system tables, no raw tables, no other databases.
+- **Tenant isolation in the database, not the gateway.** Row policies scope every view to your project, resolved from a capability derived from your project's key. Even a bug in the API layer cannot return another tenant's rows.
+- **A default-deny SQL validator.** Before anything reaches the database, the statement is parsed and walked against an allowlist: a single `SELECT` (with CTEs, subqueries, joins, unions, aggregates, and window functions), an allowlisted set of functions, and nothing else. Writes, DDL, `SETTINGS`, table functions, and introspection functions are refused with actionable error codes.
+- **Resource ceilings.** The database pins read-only mode, execution time, memory, and scan limits as constants that no query can change. On top of that, responses are capped (10,000 rows / ~8 MB) and always marked `truncated` when a ceiling cuts them short.
+
+Read more in [Privacy & RBAC](/observability/lwql/privacy-and-rbac).
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Writing queries" href="/observability/lwql/writing-queries" icon="code">
+    The dialect, schema discovery, parameters, limits, and error codes.
+  </Card>
+  <Card title="Handing the reins to your agent" href="/observability/lwql/querying-with-agents" icon="robot">
+    Teach Claude Code, Cursor, or your own agent to answer questions with LWQL.
+  </Card>
+  <Card title="Use cases" href="/observability/lwql/use-cases" icon="lightbulb">
+    Copy-paste queries for cost, latency, quality, and adoption questions.
+  </Card>
+  <Card title="Self-hosted setup" href="/observability/lwql/self-hosted" icon="server">
+    Provision LWQL on your own deployment.
+  </Card>
+</CardGroup>

--- a/docs/observability/lwql/mcp.mdx
+++ b/docs/observability/lwql/mcp.mdx
@@ -14,7 +14,7 @@ A first-party [Model Context Protocol](https://modelcontextprotocol.io) server f
 - **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
 - **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
 
-LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write, cannot reach another tenant's rows, and cannot exhaust the server. Those are the guarantees the database enforces; whatever your agent then does with the rows it legitimately reads is your side of the boundary.
+LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write and cannot reach another tenant's rows, and every query it sends is bounded by the configured ceilings — one that exceeds them is refused, timed out, or truncated rather than left to run. Those are per-query and per-identity guarantees the database enforces, not a global availability guarantee for the cluster; and whatever your agent then does with the rows it legitimately reads is your side of the boundary.
 
 ## Until then
 

--- a/docs/observability/lwql/mcp.mdx
+++ b/docs/observability/lwql/mcp.mdx
@@ -14,7 +14,7 @@ A first-party [Model Context Protocol](https://modelcontextprotocol.io) server f
 - **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
 - **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
 
-LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write and cannot reach another tenant's rows, and every query it sends is bounded by the configured ceilings — one that exceeds them is refused, timed out, or truncated rather than left to run. Those are per-query and per-identity guarantees the database enforces, not a global availability guarantee for the cluster; and whatever your agent then does with the rows it legitimately reads is your side of the boundary.
+LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write and cannot reach another tenant's rows, and every query it sends is bounded by the ceilings pinned in its settings profile as constants no caller can change — a query that exceeds them is refused, timed out, or truncated rather than left to run. Those are per-query and per-identity guarantees the database enforces, not a global availability guarantee for the cluster; and whatever your agent then does with the rows it legitimately reads is your side of the boundary.
 
 ## Until then
 

--- a/docs/observability/lwql/mcp.mdx
+++ b/docs/observability/lwql/mcp.mdx
@@ -14,7 +14,7 @@ A first-party [Model Context Protocol](https://modelcontextprotocol.io) server f
 - **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
 - **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
 
-Because LWQL is already read-only, tenant-isolated, and resource-capped at the database, connecting it to an agent through MCP doesn't require any additional sandboxing on your side.
+LWQL is read-only, tenant-isolated and resource-capped at the database, so an agent connected through MCP cannot write, cannot reach another tenant's rows, and cannot exhaust the server. Those are the guarantees the database enforces; whatever your agent then does with the rows it legitimately reads is your side of the boundary.
 
 ## Until then
 

--- a/docs/observability/lwql/mcp.mdx
+++ b/docs/observability/lwql/mcp.mdx
@@ -1,0 +1,23 @@
+---
+title: "LWQL MCP Server"
+description: "A first-party MCP server for LangWatchQL — coming soon"
+sidebarTitle: "MCP (coming soon)"
+keywords: langwatchql, lwql, mcp, model context protocol, agent
+---
+
+<Note>
+The LWQL MCP server is **coming soon**.
+</Note>
+
+A first-party [Model Context Protocol](https://modelcontextprotocol.io) server for LWQL is in the works. It will expose the two LWQL endpoints as MCP tools, so any MCP-capable client — Claude Code, Claude Desktop, Cursor, and others — can discover your analytics schema and run queries without any custom prompt wiring:
+
+- **`lwql_schema`** — the dataset catalog your key can see, ready for the model's context
+- **`lwql_query`** — run one read-only SQL statement and get typed rows, statistics, and diagnostics back
+
+Because LWQL is already read-only, tenant-isolated, and resource-capped at the database, connecting it to an agent through MCP doesn't require any additional sandboxing on your side.
+
+## Until then
+
+The HTTP API works with any agent today — see [Handing the reins to your agent](/observability/lwql/querying-with-agents) for a ready-made system prompt and the discover → query → repair loop. If you're using an MCP client that supports generic HTTP/fetch tools, that same prompt is enough.
+
+Want early access or have opinions on the tool surface? [Talk to us](/support).

--- a/docs/observability/lwql/privacy-and-rbac.mdx
+++ b/docs/observability/lwql/privacy-and-rbac.mdx
@@ -1,0 +1,52 @@
+---
+title: "LWQL Privacy & RBAC"
+description: "How LangWatchQL enforces tenant isolation, permission-gated columns, and content protection on arbitrary SQL"
+sidebarTitle: Privacy & RBAC
+keywords: langwatchql, lwql, rbac, privacy, permissions, tenant isolation, security
+---
+
+LWQL accepts arbitrary SQL from customers and agents, so its access model is layered: every guarantee is enforced in at least two independent places, and the innermost one is always the database itself.
+
+## Tenant isolation lives in the database
+
+Every query runs as a restricted ClickHouse identity, and every LWQL view carries a **row policy** that scopes reads to the calling project. The tenant is resolved from a capability derived from your project's key, sent by the server — never from the SQL, never from the request body, and never from the project id in the URL (that one is only a cross-check; naming a different project returns 404).
+
+The consequence: there is no statement you can write that reads another tenant's rows. A bug in the API gateway can cost a caller a wrong refusal or acceptance of a malformed query — it cannot cross tenants, because the gateway was never the boundary.
+
+## What a key can do
+
+- LWQL requires an API key with the **`analytics:view`** scope, and the project must have LWQL enabled.
+- Access is **read-only by construction**: the database identity has `readonly = 1` pinned as a constant, and the validator refuses every write and DDL form before it ever reaches the database anyway.
+- The identity can see **only the LWQL views**. Raw tables, other databases, `system.*`, and `information_schema` are unreachable at the database and refused by name at the gateway.
+
+## Column-level permission gates
+
+Individual columns are gated on the same visibility permissions that govern the rest of LangWatch, resolved server-side per request:
+
+| Gate | Governs | Example columns |
+|---|---|---|
+| `input` | Captured user input | `traces.CapturedInput`, `spans.CapturedInput`, `evaluations.CapturedInputs` |
+| `output` | Captured model output | `traces.CapturedOutput`, `spans.CapturedOutput`, `simulations.MessageContents` |
+| `costs` | Cost figures | `traces.TotalCost`, `spans.Cost`, `trace_metrics_by_minute.CostSum` |
+
+The gates compose fail-closed:
+
+- The **schema endpoint** publishes each column's `gates` and whether *your* key holds them (`available`), so an agent can plan around what it may read. A dataset you can read nothing in disappears from the schema entirely.
+- The **validator refuses** any reference to a gated column — including unqualified references and columns of hidden datasets — with a structured violation, before execution.
+- If the permission resolver is unavailable, everything gated is withheld rather than granted.
+
+So a teammate (or agent) without content permissions can still count traces, chart costs they're allowed to see, group by model, and read evaluation verdicts — they just cannot select the captured conversations.
+
+## Attribute filtering inside allowed columns
+
+Even for callers *with* content permissions, span and trace attribute maps are content-filtered in the view definitions themselves: attribute keys known to carry captured content are separated from operational metadata, so `Attributes`/`SpanAttributes` stay useful for filtering and grouping without becoming a side-channel around the `CapturedInput`/`CapturedOutput` gates.
+
+## What errors and results reveal
+
+- Error messages never name hosts, credentials, server settings, physical tables, or other tenants. Validation refusals speak in terms of the published catalog.
+- Introspection functions (`currentUser`, `hostName`, `version`, `getSetting`, ...) are absent from the function allowlist — refused because they're not listed, not because someone remembered to deny them.
+- Whether *another* project exists is not discoverable: a URL naming one answers 404 identical to a nonexistent id.
+
+## Operational guardrails
+
+Abuse and accidents are bounded server-side, per query, as constants no caller can change: 10 s execution time, 1 GB memory, 1B rows / 10 GB scanned, 4 threads, and at most 10 concurrent queries across the identity. Responses are additionally capped at 10,000 rows / ~8 MB and marked `truncated` when cut. Every executed query is logged with its datasets, scan cost, and outcome — but never with the SQL's parameter values or your key.

--- a/docs/observability/lwql/privacy-and-rbac.mdx
+++ b/docs/observability/lwql/privacy-and-rbac.mdx
@@ -26,8 +26,10 @@ Individual columns are gated on the same visibility permissions that govern the 
 | Gate | Governs | Example columns |
 |---|---|---|
 | `input` | Captured user input | `traces.CapturedInput`, `spans.CapturedInput`, `evaluations.CapturedInputs` |
-| `output` | Captured model output | `traces.CapturedOutput`, `spans.CapturedOutput`, `simulations.MessageContents` |
+| `output` | Captured model output | `traces.CapturedOutput`, `spans.CapturedOutput` |
 | `costs` | Cost figures | `traces.TotalCost`, `spans.Cost`, `trace_metrics_by_minute.CostSum` |
+
+A column can sit behind more than one gate, and then it needs *all* of them: `simulations.MessageContents` carries both sides of a conversation, so it is gated on `input` **and** `output` and stays hidden from a caller holding only one.
 
 The gates compose fail-closed:
 

--- a/docs/observability/lwql/privacy-and-rbac.mdx
+++ b/docs/observability/lwql/privacy-and-rbac.mdx
@@ -9,7 +9,7 @@ LWQL accepts arbitrary SQL from customers and agents, so its access model is lay
 
 ## Tenant isolation lives in the database
 
-Every query runs as a restricted ClickHouse identity, and every LWQL view carries a **row policy** that scopes reads to the calling project. The tenant is resolved from a capability derived from your project's key, sent by the server — never from the SQL, never from the request body, and never from the project id in the URL (that one is only a cross-check; naming a different project returns 404).
+Every query runs as a restricted ClickHouse identity, and every **source table** the LWQL views read carries a **row policy** that scopes reads to the calling project. The policies sit on the source tables rather than on the views because the views are declared `SQL SECURITY INVOKER` — they read their sources *as the caller*, so the source-table policy is the boundary that actually enforces, and it holds no matter which view reaches the data. The tenant is resolved from a capability derived from your project's key, sent by the server — never from the SQL, never from the request body, and never from the project id in the URL (that one is only a cross-check; naming a different project returns 404).
 
 The consequence: there is no statement you can write that reads another tenant's rows. A bug in the API gateway can cost a caller a wrong refusal or acceptance of a malformed query — it cannot cross tenants, because the gateway was never the boundary.
 
@@ -17,7 +17,7 @@ The consequence: there is no statement you can write that reads another tenant's
 
 - LWQL requires an API key with the **`analytics:view`** scope, and the project must have LWQL enabled.
 - Access is **read-only by construction**: the database identity has `readonly = 1` pinned as a constant, and the validator refuses every write and DDL form before it ever reaches the database anyway.
-- The identity can see **only the LWQL views**. Raw tables, other databases, `system.*`, and `information_schema` are unreachable at the database and refused by name at the gateway.
+- The identity is granted `SELECT` on the **LWQL views** and on **exactly the source columns those views read** — nothing else. The source-column grant is deliberate: it is what makes an unauthorised column a database-level `ACCESS_DENIED` rather than something only the gateway refuses. Other databases and any table outside that set carry no grant at all. `system.*` and `information_schema` are refused by name at the gateway.
 
 ## Column-level permission gates
 

--- a/docs/observability/lwql/querying-with-agents.mdx
+++ b/docs/observability/lwql/querying-with-agents.mdx
@@ -15,7 +15,7 @@ Teach your agent this loop; it's the same one the API was designed around:
 
 1. **Discover** — `GET /analytics/schema` once, and cache it. It lists every dataset, every column with its type and description, the grain, the join keys, the time column, and a runnable `exampleSql` per dataset.
 2. **Query** — `POST /analytics/query/clickhouse` with one `SELECT`. Filter the dataset's `timeColumn`; prefer the `*_by_minute` datasets for trends.
-3. **Repair** — on a 4xx, read the `code` and `meta`. `lwql_parameter_missing` names the parameters to add; validation violations name the exact table, column, or function that was refused. One edit, retry.
+3. **Repair** — on a 4xx, read `error.code` and `error.meta` (every field is nested under `error`). `lwql_parameter_missing` names the parameters to add; `lwql_not_permitted` and `lwql_unparseable` carry `error.meta.violations`, naming the exact table, column, or function that was refused. One edit, retry. On a 5xx there is nothing to repair — the code is always `internal_error`, so branch on the status: retry a 504 with a narrower query, and treat a 503 as a deployment problem rather than something a different query can fix.
 4. **Sanity-check** — read `diagnostics` before trusting the rows. `POSSIBLE_FANOUT` means a join inflated the aggregates; `UNBOUNDED_TIME_RANGE` means the query read all of history; `RESULT_TRUNCATED` means the answer is incomplete.
 
 ## A system prompt that teaches it
@@ -42,7 +42,7 @@ Rules:
 - Use bound parameters ({name:DateTime}) instead of interpolating values.
 - For time series, prefer trace_metrics_by_minute / model_usage_by_minute /
   evaluation_metrics_by_minute — they are pre-aggregated and fast.
-- On errors, read the "code" and "meta" fields and fix precisely that.
+- On errors, read the "error.code" and "error.meta" fields (they are nested under "error") and fix precisely that. A 5xx always reports "internal_error"; do not try to repair the SQL for one.
 - After each result, check "diagnostics" and "truncated" before presenting
   numbers; mention any diagnostic that affects the answer.
 ````

--- a/docs/observability/lwql/querying-with-agents.mdx
+++ b/docs/observability/lwql/querying-with-agents.mdx
@@ -1,0 +1,77 @@
+---
+title: "Handing the Reins to Your Agent"
+description: "Teach Claude Code, Cursor, or your own agent to answer observability questions by writing and running LWQL queries"
+sidebarTitle: Handing the reins to your agent
+keywords: langwatchql, lwql, agent, claude code, cursor, llm, sql, analytics
+---
+
+LWQL was designed to be driven by an agent as much as by a person. Every part of the surface is machine-legible: the schema endpoint describes each dataset down to column descriptions and units, errors carry stable codes with the exact parameter names that were missing, and diagnostics tell the agent when its answer is technically correct but probably not what was meant.
+
+That means you can hand your coding agent — Claude Code, Cursor, or anything that can make HTTP calls — an API key and a question like *"why did our LLM costs spike on Tuesday?"* and let it figure out the SQL.
+
+## The loop that works
+
+Teach your agent this loop; it's the same one the API was designed around:
+
+1. **Discover** — `GET /analytics/schema` once, and cache it. It lists every dataset, every column with its type and description, the grain, the join keys, the time column, and a runnable `exampleSql` per dataset.
+2. **Query** — `POST /analytics/query/clickhouse` with one `SELECT`. Filter the dataset's `timeColumn`; prefer the `*_by_minute` datasets for trends.
+3. **Repair** — on a 4xx, read the `code` and `meta`. `lwql_parameter_missing` names the parameters to add; validation violations name the exact table, column, or function that was refused. One edit, retry.
+4. **Sanity-check** — read `diagnostics` before trusting the rows. `POSSIBLE_FANOUT` means a join inflated the aggregates; `UNBOUNDED_TIME_RANGE` means the query read all of history; `RESULT_TRUNCATED` means the answer is incomplete.
+
+## A system prompt that teaches it
+
+Drop something like this into your agent's instructions (CLAUDE.md, .cursorrules, or a system prompt):
+
+````markdown
+## Querying LangWatch observability data
+
+You can answer questions about our LLM app (costs, latency, errors, evaluation
+quality, usage) by running SQL against LangWatch's LWQL API.
+
+- Schema discovery: GET https://app.langwatch.ai/api/v1/projects/{PROJECT_ID}/analytics/schema
+- Run a query:      POST https://app.langwatch.ai/api/v1/projects/{PROJECT_ID}/analytics/query/clickhouse
+  with JSON body {"sql": "...", "parameters": {...}}
+- Auth header:      X-Auth-Token: $LANGWATCH_API_KEY   (read it from the environment; never print it)
+
+Rules:
+- ClickHouse dialect, single SELECT only. No writes, no SETTINGS, no system tables.
+- ALWAYS call the schema endpoint first if you haven't this session; use only
+  datasets and columns it lists, and start from each dataset's exampleSql.
+- ALWAYS filter each dataset's timeColumn (e.g. OccurredAt) — unfiltered
+  queries scan all history and may hit scan limits.
+- Use bound parameters ({name:DateTime}) instead of interpolating values.
+- For time series, prefer trace_metrics_by_minute / model_usage_by_minute /
+  evaluation_metrics_by_minute — they are pre-aggregated and fast.
+- On errors, read the "code" and "meta" fields and fix precisely that.
+- After each result, check "diagnostics" and "truncated" before presenting
+  numbers; mention any diagnostic that affects the answer.
+````
+
+Two things make this reliable in practice:
+
+- **Keep the key in the environment.** The agent only needs to know the header name. LWQL keys are read-only over one project's analytics, which bounds the blast radius of a leaked prompt — but there's no reason to put the secret itself in one.
+- **Don't paste the schema into the prompt.** It's large, it changes, and the endpoint is cheap. Let the agent fetch it.
+
+## Why this is safe to do
+
+Handing an agent free-form SQL access normally means trusting it not to write, not to escape its tenant, and not to take the database down. LWQL removes all three from the trust equation:
+
+- The statement is validated against a default-deny allowlist before execution — an agent that hallucinates `INSERT`, a system table, or an exotic function gets a structured refusal, not a database error.
+- Tenant isolation is enforced by database row policies, not by anything the SQL says. There is no query the agent can write that reads another project.
+- Execution time, memory, and scan volume are capped server-side as constants. A runaway `CROSS JOIN` costs one killed query, not a cluster.
+
+The failure mode of a confused agent is a 400 with instructions for fixing itself — which is exactly what agents are good at consuming.
+
+## What the agent can answer
+
+With the loop above, questions like these become one or two queries (see [Use cases](/observability/lwql/use-cases) for the SQL):
+
+- "What did each model cost us per day this week, and which one drove the spike?"
+- "What's our p95 latency by trace name, and did it regress after yesterday's deploy?"
+- "Which evaluator is failing most, and on which conversations?"
+- "Which customers generate the most cost per message?"
+- "How did the pass rate of our simulations change across the last five batches?"
+
+## MCP and CLI
+
+A first-party MCP server and CLI for LWQL are coming soon — see [MCP](/observability/lwql/mcp) and [CLI](/observability/lwql/cli). Until then, the two HTTP endpoints plus the prompt above are all an agent needs.

--- a/docs/observability/lwql/querying-with-agents.mdx
+++ b/docs/observability/lwql/querying-with-agents.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Handing the reins to your agent
 keywords: langwatchql, lwql, agent, claude code, cursor, llm, sql, analytics
 ---
 
-LWQL was designed to be driven by an agent as much as by a person. Every part of the surface is machine-legible: the schema endpoint describes each dataset down to column descriptions and units, errors carry stable codes with the exact parameter names that were missing, and diagnostics tell the agent when its answer is technically correct but probably not what was meant.
+LWQL was designed to be driven by an agent. Every part of the surface is machine-legible: the schema endpoint describes each dataset down to column descriptions and units, errors carry stable codes with the exact parameter names that were missing, and diagnostics tell the agent when its answer is technically correct but probably not what was meant.
 
 That means you can hand your coding agent — Claude Code, Cursor, or anything that can make HTTP calls — an API key and a question like *"why did our LLM costs spike on Tuesday?"* and let it figure out the SQL.
 

--- a/docs/observability/lwql/self-hosted.mdx
+++ b/docs/observability/lwql/self-hosted.mdx
@@ -27,7 +27,14 @@ The application looks for five variables. **All five are required** — with any
 | `LWQL_DATABASE` | The database the LWQL views live in; unqualified names in queries resolve here |
 | `LWQL_TENANT_SETTING` | The custom setting carrying the tenant capability. Must start with `custom_` |
 
-If you set *some* of these, the app logs a warning naming exactly which are absent (variable names only, never values) — check for it when queries unexpectedly return `lwql_unavailable`.
+If you set *some* of these, the app logs a warning naming exactly which are absent (variable names only, never values) — check for it when queries unexpectedly return a 503.
+
+Two more affect provisioning rather than execution, and neither is part of the five:
+
+| Variable | Meaning |
+|---|---|
+| `LWQL_POSTGRES_READER_ROLE` | The PostgreSQL role the approved views' `SELECT` grants are issued to. Leave it unset and a newly added view ships with no grant, so every query touching it fails — see the 503 gotcha below |
+| `SKIP_LWQL_PROVISION` | Set to `true` to skip the provisioning step at boot entirely |
 
 ## What the application provisions itself
 
@@ -56,11 +63,11 @@ The access model itself is deployed out of band (in LangWatch Cloud, by Terrafor
   <Accordion title="Raising the execution-time ceiling has a second half">
     The application's HTTP client waits slightly longer than the default 10-second `max_execution_time`, so server-side timeouts surface as a clean, coded `query_timeout`. If you provision a profile with a **higher** execution ceiling, the driver will abandon the socket first and callers get an anonymous transport failure instead of the coded error. Keep the profile at the default, or raise both together.
   </Accordion>
-  <Accordion title="503 lwql_unavailable with the environment fully set">
+  <Accordion title="A 503 with the environment fully set">
     This also fires when the configured identity exists but the database objects don't — the server answered `UNKNOWN_TABLE`/`UNKNOWN_DATABASE`/`ACCESS_DENIED` for a name the validator had already approved, which can't be the caller's SQL. Check that migrations and `provisionLwql` ran, and that the grants match the current catalog. The underlying reason is in the application logs, never in the API response.
   </Accordion>
   <Accordion title="Distinguishing the three refusals">
-    `401 invalid_credentials` — the key is wrong. `403 lwql_not_enabled` — key is fine, but the `release_lwql_workbench` feature flag is off for the project (a product switch, not a fault). `503 lwql_unavailable` — the deployment has no working LWQL execution path (an operator problem).
+    `401 invalid_credentials` — the key is wrong. `403 lwql_not_enabled` — key is fine, but the `release_lwql_workbench` feature flag is off for the project (a product switch, not a fault). `503` — the deployment has no working LWQL execution path (an operator problem). Note that only the two 4xx cases name themselves in the response: the server raises `LangWatchQLUnavailableError` internally, but every 5xx body collapses to `internal_error`, so identify this one by its status and by the application logs, not by grepping responses for `lwql_unavailable`.
   </Accordion>
   <Accordion title="Connection budgets are shared">
     The LWQL executor keeps its own pool (up to 10 connections) beside the application's ClickHouse client, and each PostgreSQL-engine table keeps a small pool against PostgreSQL. Count both against your servers' connection limits — particularly the PostgreSQL side, where the read-only role's connection limit should leave headroom for the application itself.

--- a/docs/observability/lwql/self-hosted.mdx
+++ b/docs/observability/lwql/self-hosted.mdx
@@ -1,0 +1,71 @@
+---
+title: "LWQL on Self-Hosted LangWatch"
+description: "Architecture, environment contract, provisioning, and gotchas for running LangWatchQL on your own deployment"
+sidebarTitle: Self-hosted / on-prem
+keywords: langwatchql, lwql, self-hosted, on-prem, clickhouse, provisioning, setup
+---
+
+<Note>
+LWQL support for self-hosted deployments is early. This page documents the architecture and the contract the application expects; the pieces marked *operator-provisioned* are not yet packaged into the Helm chart, so expect some assembly. If you're setting this up, [talk to us](/support) — we'll help, and it feeds directly into the packaged version.
+</Note>
+
+## Architecture in one paragraph
+
+Customer SQL never runs as the application. It runs as a dedicated **restricted ClickHouse identity** whose settings profile pins `readonly = 1` and all resource ceilings as constants, and which holds `SELECT` on a set of **LWQL views** in a dedicated analytics database — and on nothing else. **Row policies** on those views scope every read to the calling project, resolved through a tenant capability the application sends per query as a custom setting. PostgreSQL-resident datasets (prompts, experiments, annotations, ...) reach ClickHouse through **approved views** in PostgreSQL read by **PostgreSQL-engine tables** in the analytics database, so the same row policies apply to them too.
+
+A deployment that provisions none of this simply has no LWQL: the API answers `503 lwql_unavailable` and everything else works normally.
+
+## The environment contract
+
+The application looks for five variables. **All five are required** — with any subset missing, the executor is not built and every query is refused:
+
+| Variable | Meaning |
+|---|---|
+| `LWQL_CLICKHOUSE_URL` | ClickHouse HTTP endpoint the restricted identity connects to |
+| `LWQL_CLICKHOUSE_USER` | The restricted identity. **Never** an admin account — the isolation model assumes this user can only see the LWQL views |
+| `LWQL_CLICKHOUSE_PASSWORD` | Its password |
+| `LWQL_DATABASE` | The database the LWQL views live in; unqualified names in queries resolve here |
+| `LWQL_TENANT_SETTING` | The custom setting carrying the tenant capability. Must start with `custom_` |
+
+If you set *some* of these, the app logs a warning naming exactly which are absent (variable names only, never values) — check for it when queries unexpectedly return `lwql_unavailable`.
+
+## What the application provisions itself
+
+On startup (`start:prepare:db`), after ClickHouse migrations run:
+
+1. **Migrations** create the key-map table that resolves tenant capabilities to project ids.
+2. **The `provisionLwql` task** creates the LWQL views in ClickHouse, creates the approved views in PostgreSQL, and backfills the key map from every project's LWQL key. It is idempotent (`CREATE OR REPLACE` / `IF NOT EXISTS` throughout) and exits immediately when the `LWQL_*` environment is absent.
+
+The task runs DDL as the application's own ClickHouse connection (`CLICKHOUSE_URL`) — the restricted identity deliberately has no DDL privileges.
+
+## What the operator provisions
+
+The access model itself is deployed out of band (in LangWatch Cloud, by Terraform):
+
+- The **restricted user** and its **settings profile** — `readonly = 1`, `max_execution_time`, `max_memory_usage`, `max_threads`, `max_concurrent_queries_for_user`, `max_rows_to_read`, `max_bytes_to_read`, all `CONST`, plus the tenant setting declared `CHANGEABLE_IN_READONLY`
+- **Grants** — `SELECT` on the LWQL views (and the exact source columns the views read), nothing else
+- **Row policies** binding each view to the tenant capability
+- For PostgreSQL-resident datasets: a **read-only PostgreSQL role** granted `SELECT` on the approved views only, a ClickHouse **named collection** holding that role's connection, and the **PostgreSQL-engine tables** mapping the approved views into the analytics database
+
+## Gotchas
+
+<AccordionGroup>
+  <Accordion title="The tenant setting needs a server-side prefix allowance">
+    `LWQL_TENANT_SETTING` must begin with `custom_`, and your ClickHouse server config must allow that prefix via `custom_settings_prefixes`. Without it, every query fails at the server with an unknown-setting error.
+  </Accordion>
+  <Accordion title="Raising the execution-time ceiling has a second half">
+    The application's HTTP client waits slightly longer than the default 10-second `max_execution_time`, so server-side timeouts surface as a clean, coded `query_timeout`. If you provision a profile with a **higher** execution ceiling, the driver will abandon the socket first and callers get an anonymous transport failure instead of the coded error. Keep the profile at the default, or raise both together.
+  </Accordion>
+  <Accordion title="503 lwql_unavailable with the environment fully set">
+    This also fires when the configured identity exists but the database objects don't — the server answered `UNKNOWN_TABLE`/`UNKNOWN_DATABASE`/`ACCESS_DENIED` for a name the validator had already approved, which can't be the caller's SQL. Check that migrations and `provisionLwql` ran, and that the grants match the current catalog. The underlying reason is in the application logs, never in the API response.
+  </Accordion>
+  <Accordion title="Distinguishing the three refusals">
+    `401 invalid_credentials` — the key is wrong. `403 lwql_not_enabled` — key is fine, but the `release_lwql_workbench` feature flag is off for the project (a product switch, not a fault). `503 lwql_unavailable` — the deployment has no working LWQL execution path (an operator problem).
+  </Accordion>
+  <Accordion title="Connection budgets are shared">
+    The LWQL executor keeps its own pool (up to 10 connections) beside the application's ClickHouse client, and each PostgreSQL-engine table keeps a small pool against PostgreSQL. Count both against your servers' connection limits — particularly the PostgreSQL side, where the read-only role's connection limit should leave headroom for the application itself.
+  </Accordion>
+  <Accordion title="Never substitute the application's ClickHouse user">
+    If LWQL provisioning feels like too much, the tempting shortcut is pointing `LWQL_CLICKHOUSE_USER` at the app's own account. Don't: that account is not read-only, carries no row policies, and would run customer SQL with admin visibility. The application refuses to fall back to it internally for exactly this reason.
+  </Accordion>
+</AccordionGroup>

--- a/docs/observability/lwql/self-hosted.mdx
+++ b/docs/observability/lwql/self-hosted.mdx
@@ -11,7 +11,7 @@ LWQL support for self-hosted deployments is early. This page documents the archi
 
 ## Architecture in one paragraph
 
-Customer SQL never runs as the application. It runs as a dedicated **restricted ClickHouse identity** whose settings profile pins `readonly = 1` and all resource ceilings as constants, and which holds `SELECT` on a set of **LWQL views** in a dedicated analytics database — and on nothing else. **Row policies** on those views scope every read to the calling project, resolved through a tenant capability the application sends per query as a custom setting. PostgreSQL-resident datasets (prompts, experiments, annotations, ...) reach ClickHouse through **approved views** in PostgreSQL read by **PostgreSQL-engine tables** in the analytics database, so the same row policies apply to them too.
+Customer SQL never runs as the application. It runs as a dedicated **restricted ClickHouse identity** whose settings profile pins `readonly = 1` and all resource ceilings as constants, and which holds `SELECT` on a set of **LWQL views** in a dedicated analytics database, plus the exact source columns those views read — and on nothing else. **Row policies** on the *source tables* those views read scope every read to the calling project (the views are `SQL SECURITY INVOKER`, so they read as the caller and the source-table policy is what enforces), resolved through a tenant capability the application sends per query as a custom setting. PostgreSQL-resident datasets (prompts, experiments, annotations, ...) reach ClickHouse through **approved views** in PostgreSQL read by **PostgreSQL-engine tables** in the analytics database, so the same row policies apply to them too.
 
 A deployment that provisions none of this simply has no LWQL: the API answers `503 lwql_unavailable` and everything else works normally.
 
@@ -51,7 +51,7 @@ The access model itself is deployed out of band (in LangWatch Cloud, by Terrafor
 
 - The **restricted user** and its **settings profile** — `readonly = 1`, `max_execution_time`, `max_memory_usage`, `max_threads`, `max_concurrent_queries_for_user`, `max_rows_to_read`, `max_bytes_to_read`, all `CONST`, plus the tenant setting declared `CHANGEABLE_IN_READONLY`
 - **Grants** — `SELECT` on the LWQL views (and the exact source columns the views read), nothing else
-- **Row policies** binding each view to the tenant capability
+- **Row policies** binding each *source table* to the tenant capability — not the views, which are `SQL SECURITY INVOKER` and read as the caller
 - For PostgreSQL-resident datasets: a **read-only PostgreSQL role** granted `SELECT` on the approved views only, a ClickHouse **named collection** holding that role's connection, and the **PostgreSQL-engine tables** mapping the approved views into the analytics database
 
 ## Gotchas

--- a/docs/observability/lwql/use-cases.mdx
+++ b/docs/observability/lwql/use-cases.mdx
@@ -1,0 +1,313 @@
+---
+title: "LWQL Use Cases"
+description: "Copy-paste LangWatchQL queries for cost attribution, latency, quality, adoption, and experiment analysis"
+sidebarTitle: Use cases
+keywords: langwatchql, lwql, examples, sql, cost, latency, evaluations, analytics
+---
+
+Every query below runs as-is through `POST /api/v1/projects/{projectId}/analytics/query/clickhouse`. They all filter the dataset's time column — keep that habit; it's what makes queries fast and keeps them under the scan ceilings. Column names come from the [schema endpoint](/observability/lwql/writing-queries#start-with-the-schema), which is always the source of truth.
+
+## Cost
+
+### What is each model costing us per day?
+
+`model_usage_by_minute` is pre-aggregated per (minute, model, span type), so this scans almost nothing:
+
+```sql
+SELECT toStartOfDay(BucketStart) AS Day,
+       Model,
+       round(sum(CostSum), 4) AS CostUSD,
+       sum(PromptTokensSum) AS PromptTokens,
+       sum(CompletionTokensSum) AS CompletionTokens
+FROM model_usage_by_minute
+WHERE BucketStart >= now() - INTERVAL 14 DAY
+GROUP BY Day, Model
+ORDER BY Day, CostUSD DESC
+```
+
+### Which customers and users drive our cost?
+
+`trace_metrics` carries the user, conversation, and customer identifiers from your trace metadata:
+
+```sql
+SELECT CustomerId,
+       uniq(UserId) AS Users,
+       uniq(ConversationId) AS Conversations,
+       count() AS Traces,
+       round(sum(TotalCost), 2) AS CostUSD,
+       round(sum(TotalCost) / count(), 5) AS CostPerTrace
+FROM trace_metrics
+WHERE OccurredAt >= now() - INTERVAL 30 DAY
+GROUP BY CustomerId
+ORDER BY CostUSD DESC
+LIMIT 25
+```
+
+### How much is prompt caching saving us?
+
+```sql
+SELECT toStartOfDay(BucketStart) AS Day,
+       sum(CacheReadTokensSum) AS CachedTokens,
+       sum(PromptTokensSum) AS PromptTokens,
+       round(sum(CacheReadTokensSum) / (sum(PromptTokensSum) + sum(CacheReadTokensSum)), 3) AS CacheHitShare
+FROM trace_metrics_by_minute
+WHERE BucketStart >= now() - INTERVAL 14 DAY
+GROUP BY Day
+ORDER BY Day
+```
+
+### Did cost per conversation change week over week?
+
+```sql
+WITH weekly AS (
+  SELECT toStartOfWeek(OccurredAt) AS Week,
+         sum(TotalCost) / uniq(ConversationId) AS CostPerConversation
+  FROM trace_metrics
+  WHERE OccurredAt >= now() - INTERVAL 8 WEEK
+  GROUP BY Week
+)
+SELECT Week,
+       round(CostPerConversation, 4) AS CostPerConversation,
+       round(CostPerConversation - lagInFrame(CostPerConversation) OVER (ORDER BY Week), 4) AS ChangeVsPriorWeek
+FROM weekly
+ORDER BY Week
+```
+
+## Latency & reliability
+
+### p50 / p95 / p99 latency and time-to-first-token
+
+```sql
+SELECT quantile(0.5)(TotalDurationMs)  AS P50Ms,
+       quantile(0.95)(TotalDurationMs) AS P95Ms,
+       quantile(0.99)(TotalDurationMs) AS P99Ms,
+       quantile(0.95)(TimeToFirstTokenMs) AS P95FirstTokenMs,
+       avg(TokensPerSecond) AS AvgTokensPerSec
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 24 HOUR
+```
+
+### Error rate trend, hour by hour
+
+```sql
+SELECT toStartOfHour(BucketStart) AS Hour,
+       sum(TraceCount) AS Traces,
+       sum(ErrorCount) AS Errors,
+       round(sum(ErrorCount) / sum(TraceCount), 4) AS ErrorRate
+FROM trace_metrics_by_minute
+WHERE BucketStart >= now() - INTERVAL 48 HOUR
+GROUP BY Hour
+ORDER BY Hour
+```
+
+### Which operation regressed? Latency by trace name, this week vs last
+
+```sql
+SELECT TraceName,
+       quantile(0.95)(if(OccurredAt >= now() - INTERVAL 7 DAY, TotalDurationMs, NULL)) AS P95ThisWeek,
+       quantile(0.95)(if(OccurredAt <  now() - INTERVAL 7 DAY, TotalDurationMs, NULL)) AS P95LastWeek
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 14 DAY
+GROUP BY TraceName
+HAVING P95ThisWeek > P95LastWeek * 1.2
+ORDER BY P95ThisWeek DESC
+```
+
+### The slowest step inside slow traces
+
+Join spans to traces on their published join key to see where the time goes:
+
+```sql
+SELECT s.SpanName,
+       count() AS Occurrences,
+       round(avg(s.DurationMs)) AS AvgMs,
+       round(quantile(0.95)(s.DurationMs)) AS P95Ms
+FROM spans AS s
+JOIN traces AS t ON s.TraceId = t.TraceId
+WHERE s.StartTime >= now() - INTERVAL 24 HOUR
+  AND t.OccurredAt >= now() - INTERVAL 24 HOUR
+  AND t.TotalDurationMs > 10000
+GROUP BY s.SpanName
+ORDER BY P95Ms DESC
+LIMIT 20
+```
+
+## Quality
+
+### Pass rate per evaluator
+
+```sql
+SELECT EvaluatorName,
+       count() AS Runs,
+       countIf(Passed) AS Passed,
+       round(countIf(Passed) / count(), 3) AS PassRate,
+       round(avg(Score), 3) AS AvgScore
+FROM evaluations
+WHERE ScheduledAt >= now() - INTERVAL 7 DAY
+  AND Status = 'processed'
+GROUP BY EvaluatorName
+ORDER BY PassRate ASC
+```
+
+### Evaluation pass-rate trend (pre-aggregated)
+
+```sql
+SELECT toStartOfDay(BucketStart) AS Day,
+       EvaluatorType,
+       sum(PassCount) AS Passed,
+       sum(FailCount) AS Failed,
+       round(sum(PassCount) / (sum(PassCount) + sum(FailCount)), 3) AS PassRate,
+       round(sum(ScoreSum) / sum(ScoreCount), 3) AS AvgScore
+FROM evaluation_metrics_by_minute
+WHERE BucketStart >= now() - INTERVAL 30 DAY
+GROUP BY Day, EvaluatorType
+ORDER BY Day, EvaluatorType
+```
+
+### Which conversations keep failing a guardrail?
+
+```sql
+SELECT ConversationId,
+       countIf(NOT Passed) AS Failures,
+       count() AS Checks,
+       round(countIf(NOT Passed) / count(), 3) AS FailureRate
+FROM evaluation_metrics
+WHERE OccurredAt >= now() - INTERVAL 7 DAY
+  AND IsGuardrail
+GROUP BY ConversationId
+HAVING Failures >= 3
+ORDER BY Failures DESC
+LIMIT 50
+```
+
+### Do human annotations agree with the evaluators?
+
+```sql
+SELECT e.EvaluatorName,
+       countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed) AS Agree,
+       count() AS Overlap,
+       round((countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed)) / count(), 3) AS Agreement
+FROM annotations AS a
+JOIN evaluations AS e ON a.TraceId = e.TraceId
+WHERE a.CreatedAt >= now() - INTERVAL 30 DAY
+  AND e.Passed IS NOT NULL
+GROUP BY e.EvaluatorName
+ORDER BY Overlap DESC
+```
+
+### Simulation verdicts across recent batches
+
+```sql
+SELECT BatchRunId,
+       min(StartedAt) AS BatchStart,
+       count() AS Runs,
+       countIf(Verdict = 'success') AS Successes,
+       round(countIf(Verdict = 'success') / count(), 3) AS SuccessRate
+FROM simulations
+WHERE StartedAt >= now() - INTERVAL 14 DAY
+GROUP BY BatchRunId
+ORDER BY BatchStart DESC
+LIMIT 5
+```
+
+### Which criteria fail most often?
+
+```sql
+SELECT arrayJoin(UnmetCriteria) AS Criterion,
+       count() AS Failures
+FROM simulations
+WHERE StartedAt >= now() - INTERVAL 14 DAY
+GROUP BY Criterion
+ORDER BY Failures DESC
+LIMIT 10
+```
+
+## Adoption & product
+
+### Daily active users and conversations
+
+```sql
+SELECT toStartOfDay(OccurredAt) AS Day,
+       uniq(UserId) AS ActiveUsers,
+       uniq(ConversationId) AS Conversations,
+       count() AS Traces
+FROM trace_metrics
+WHERE OccurredAt >= now() - INTERVAL 30 DAY
+GROUP BY Day
+ORDER BY Day
+```
+
+### What are people talking about? Traces by topic
+
+```sql
+SELECT TopicId,
+       count() AS Traces,
+       round(avg(TotalDurationMs)) AS AvgDurationMs,
+       round(sum(TotalCost), 2) AS CostUSD
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 7 DAY
+  AND TopicId IS NOT NULL
+GROUP BY TopicId
+ORDER BY Traces DESC
+LIMIT 20
+```
+
+### User satisfaction by day
+
+```sql
+SELECT toStartOfDay(OccurredAt) AS Day,
+       round(avg(SatisfactionScore), 3) AS AvgSatisfaction,
+       count() AS ScoredTraces
+FROM traces
+WHERE OccurredAt >= now() - INTERVAL 30 DAY
+  AND SatisfactionScore IS NOT NULL
+GROUP BY Day
+ORDER BY Day
+```
+
+## Prompts & experiments
+
+### Which prompt versions are actually serving traffic?
+
+```sql
+SELECT p.PromptHandle,
+       t.LastUsedPromptVersionNumber AS Version,
+       count() AS Traces,
+       round(quantile(0.95)(t.TotalDurationMs)) AS P95Ms,
+       round(sum(t.TotalCost), 4) AS CostUSD
+FROM traces AS t
+JOIN prompts AS p ON t.LastUsedPromptId = p.PromptId
+WHERE t.OccurredAt >= now() - INTERVAL 7 DAY
+  AND t.ContainsPrompt
+GROUP BY p.PromptHandle, Version
+ORDER BY Traces DESC
+```
+
+### Compare batch evaluation scores across an experiment's runs
+
+```sql
+SELECT e.ExperimentName,
+       b.EvaluationName,
+       count() AS Rows,
+       round(avg(b.Score), 4) AS AvgScore,
+       round(countIf(b.Passed) / countIf(b.Passed IS NOT NULL), 3) AS PassRate,
+       round(sum(b.Cost), 4) AS CostUSD
+FROM batch_evaluations AS b
+JOIN experiments AS e ON b.ExperimentId = e.ExperimentId
+WHERE b.CreatedAt >= now() - INTERVAL 30 DAY
+GROUP BY e.ExperimentName, b.EvaluationName
+ORDER BY e.ExperimentName, AvgScore DESC
+```
+
+## Reusable, period-aware statements
+
+Any of the above becomes a reusable report by swapping the hard-coded interval for the reserved time-window parameters, and letting the caller supply the period:
+
+```json
+{
+  "sql": "SELECT toStartOfDay(BucketStart) AS Day, sum(CostSum) AS CostUSD FROM trace_metrics_by_minute WHERE BucketStart >= {period_start:DateTime} AND BucketStart < {period_end:DateTime} GROUP BY Day ORDER BY Day",
+  "timeWindow": { "start": "2026-08-01T00:00:00Z", "end": "2026-08-18T00:00:00Z" }
+}
+```
+
+See [Writing queries](/observability/lwql/writing-queries#the-reserved-time-window) for the contract, and check each response's `diagnostics` — `POSSIBLE_FANOUT` on the join examples and `MISSING_TIME_BUCKETS` on the trend examples are exactly the situations they exist to catch.

--- a/docs/observability/lwql/use-cases.mdx
+++ b/docs/observability/lwql/use-cases.mdx
@@ -185,15 +185,26 @@ LIMIT 50
 ```sql
 SELECT e.EvaluatorName,
        countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed) AS Agree,
-       count() AS Overlap,
+       count() AS Pairs,
        round((countIf(a.IsThumbsUp AND e.Passed) + countIf(NOT a.IsThumbsUp AND NOT e.Passed)) / count(), 3) AS Agreement
 FROM annotations AS a
 JOIN evaluations AS e ON a.TraceId = e.TraceId
 WHERE a.CreatedAt >= now() - INTERVAL 30 DAY
   AND e.Passed IS NOT NULL
 GROUP BY e.EvaluatorName
-ORDER BY Overlap DESC
+ORDER BY Pairs DESC
 ```
+
+<Note>
+  The unit here is an **(annotation, evaluation) pair**, not a trace. Both
+  datasets are one row per event — one human annotation, one evaluation run —
+  so a trace annotated twice and evaluated three times by the same evaluator
+  contributes six pairs, and weighs six times as much as a trace with one of
+  each. That is why the column is `Pairs` rather than a trace count. The
+  `POSSIBLE_FANOUT` diagnostic flags this on the result. For a trace-weighted
+  answer, restrict to one annotation and one evaluation per trace before
+  comparing.
+</Note>
 
 ### Simulation verdicts across recent batches
 

--- a/docs/observability/lwql/use-cases.mdx
+++ b/docs/observability/lwql/use-cases.mdx
@@ -283,22 +283,6 @@ GROUP BY p.PromptHandle, Version
 ORDER BY Traces DESC
 ```
 
-### Compare batch evaluation scores across an experiment's runs
-
-```sql
-SELECT e.ExperimentName,
-       b.EvaluationName,
-       count() AS Rows,
-       round(avg(b.Score), 4) AS AvgScore,
-       round(countIf(b.Passed) / countIf(b.Passed IS NOT NULL), 3) AS PassRate,
-       round(sum(b.Cost), 4) AS CostUSD
-FROM batch_evaluations AS b
-JOIN experiments AS e ON b.ExperimentId = e.ExperimentId
-WHERE b.CreatedAt >= now() - INTERVAL 30 DAY
-GROUP BY e.ExperimentName, b.EvaluationName
-ORDER BY e.ExperimentName, AvgScore DESC
-```
-
 ## Reusable, period-aware statements
 
 Any of the above becomes a reusable report by swapping the hard-coded interval for the reserved time-window parameters, and letting the caller supply the period:

--- a/docs/observability/lwql/writing-queries.mdx
+++ b/docs/observability/lwql/writing-queries.mdx
@@ -25,7 +25,9 @@ For every dataset it returns:
 - **`freshness`** — how far behind live writes the dataset can be.
 - **`exampleSql`** — a runnable query to start from.
 
-Reference datasets by their bare name (`FROM traces`); they resolve to the analytics database your deployment configured.
+The response also carries a top-level `database` — the analytics database your deployment configured — and each dataset's `name` and `exampleSql` are qualified with it (`langwatch_lwql.traces`, `FROM langwatch_lwql.traces`).
+
+You don't have to repeat that qualification. Reference datasets by their bare name (`FROM traces`) and they resolve to the same database, which is why the two spellings you'll see are equivalent.
 
 ## Run a query
 
@@ -134,18 +136,53 @@ Diagnostics are advisory notes about a result that ran successfully but deserves
 
 ## Error codes
 
-Failures carry a stable `code` you (or your agent) can branch on:
+Every failure comes back in the same envelope, with the fields nested under
+`error`:
+
+```json
+{
+  "error": {
+    "type": "https://langwatch.ai/errors/lwql_not_permitted",
+    "code": "lwql_not_permitted",
+    "message": "The statement names something this query may not read",
+    "meta": {
+      "violations": [
+        { "code": "TABLE_NOT_ALLOWED", "detail": "unknown dataset \"internal_billing\"" }
+      ]
+    },
+    "trace_id": "0af7651916cd43dd8448eb211c80319c",
+    "span_id": "b7ad6b7169203331"
+  }
+}
+```
+
+So branch on `error.code`, not `code` — and read `error.meta`, not `meta`.
+
+Every 4xx carries a stable `code`:
 
 | HTTP | Code | Meaning | Fix |
 |---|---|---|---|
-| 400 | `lwql_parameter_missing` | The SQL declares parameters the request didn't supply (`meta.parameters` names them) | Add the values |
+| 400 | `lwql_unparseable` | The statement isn't valid SQL | `error.meta.violations` gives the parse failure |
+| 400 | `lwql_not_permitted` | The statement names a dataset, column, or function outside the allowlist | `error.meta.violations` says exactly what was refused |
+| 400 | `lwql_parameter_missing` | The SQL declares parameters the request didn't supply (`error.meta.parameters` names them) | Add the values |
 | 400 | `lwql_reserved_parameter_supplied` | `period_start`/`period_end` sent under `parameters` | Move them to `timeWindow` |
 | 400 | `lwql_reserved_parameter_type` | A reserved parameter declared as a non-date-time | Declare `:DateTime` |
-| 400 | validation violations | The statement names something outside the allowlist | The violation says exactly what was refused |
 | 401 | `invalid_credentials` | Bad or missing API key | Check `X-Auth-Token` |
 | 403 | `lwql_not_enabled` | LWQL isn't enabled for this project | Ask your admin, or [contact us](/support) |
 | 422 | `query_scan_limit_exceeded` | The query would read more than the scan ceiling | Filter the time column, or use a `*_by_minute` dataset |
-| 5xx | `query_timeout`, `query_memory_exceeded` | A database ceiling killed the query | Narrow or pre-aggregate |
-| 503 | `lwql_unavailable` | This deployment has no LWQL identity provisioned | See [Self-hosted setup](/observability/lwql/self-hosted) |
+| 422 | `query_memory_exceeded` | The query exceeded the memory ceiling | Narrow or pre-aggregate — retrying as-is will fail identically |
+
+<Warning>
+  **5xx responses carry no specific code.** Anything the server treats as its
+  own fault collapses to `"code": "internal_error"` with a generic message,
+  deliberately — a server-side failure must not leak internals to a caller.
+  A query that timed out (504) and a deployment with no LangWatchQL identity
+  provisioned (503) are therefore indistinguishable by `error.code`.
+
+  Branch on the **HTTP status** for these, not the code: a 504 is worth
+  retrying with a narrower query, a 503 usually means the deployment isn't
+  set up — see [Self-hosted setup](/observability/lwql/self-hosted) — and
+  retrying it will not help. Quote `error.trace_id` when you ask us about one.
+</Warning>
 
 Error messages never name hosts, credentials, physical tables, or server internals — what you get is what's safe to show and enough to act on.

--- a/docs/observability/lwql/writing-queries.mdx
+++ b/docs/observability/lwql/writing-queries.mdx
@@ -96,7 +96,7 @@ Refused, always with a structured violation rather than a database error:
 
 - Anything that writes or defines: `INSERT`, `ALTER`, `CREATE`, `DROP`, ...
 - `SETTINGS` in any position
-- Table functions (`url`, `s3`, `remote`, `file`, ...)
+- Table functions — **all** of them, refused positionally rather than by a name list, so `numbers(10)` is refused just as `url(...)` is
 - The `system` and `information_schema` databases
 - Functions outside the allowlist — the allowlist covers the aggregation, date/time, string, array, map, JSON, and math functions analytics questions need, and omits introspection (`currentUser`, `hostName`, `version`, `getSetting`, ...) by construction
 - Columns your permissions gate (see [Privacy & RBAC](/observability/lwql/privacy-and-rbac))
@@ -109,8 +109,8 @@ Two layers of ceilings apply, and they behave differently:
 
 | Ceiling | Default | Error code |
 |---|---|---|
-| Execution time | 10 s | `query_timeout` |
-| Memory | 1 GB | `query_memory_exceeded` |
+| Execution time | 10 s | HTTP 504 — no specific code (see the 5xx warning below) |
+| Memory | 1 GB | `query_memory_exceeded` (HTTP 422) |
 | Rows / bytes scanned | 1B rows / 10 GB | `query_scan_limit_exceeded` (HTTP 422) |
 
 **Response ceilings** (truncate rather than fail; always flagged):
@@ -169,6 +169,7 @@ Every 4xx carries a stable `code`:
 | 400 | `lwql_reserved_parameter_type` | A reserved parameter declared as a non-date-time | Declare `:DateTime` |
 | 401 | `invalid_credentials` | Bad or missing API key | Check `X-Auth-Token` |
 | 403 | `lwql_not_enabled` | LWQL isn't enabled for this project | Ask your admin, or [contact us](/support) |
+| 404 | `not_found` | The project id in the URL isn't one this key can reach | Check the id — an existing project you cannot see answers identically to one that doesn't exist |
 | 422 | `query_scan_limit_exceeded` | The query would read more than the scan ceiling | Filter the time column, or use a `*_by_minute` dataset |
 | 422 | `query_memory_exceeded` | The query exceeded the memory ceiling | Narrow or pre-aggregate — retrying as-is will fail identically |
 

--- a/docs/observability/lwql/writing-queries.mdx
+++ b/docs/observability/lwql/writing-queries.mdx
@@ -1,0 +1,151 @@
+---
+title: "Writing LWQL Queries"
+description: "The LangWatchQL dialect, schema discovery, bound parameters, time windows, result limits, and error codes"
+sidebarTitle: Writing queries
+keywords: langwatchql, lwql, sql, clickhouse, query, parameters, schema
+---
+
+LWQL is ClickHouse SQL, restricted to a single read-only `SELECT`. If you know ClickHouse — or standard SQL plus a few ClickHouse idioms like `toStartOfDay`, `countIf`, and `quantile` — you know LWQL.
+
+## Start with the schema
+
+Everything you can query is published by the schema endpoint, scoped to what your key can see:
+
+```bash
+curl "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/schema" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY"
+```
+
+For every dataset it returns:
+
+- **`columns`** — each with its ClickHouse `type`, a one-line `description`, its `unit` where it has one (`ms`, `USD`, `tokens`, `tokens/s`), the permission `gates` that unlock it, and `available` — whether *your* key holds them.
+- **`grain`** — what one row is (e.g. "one row per (TenantId, TraceId), latest version only"). Joins should match the full grain of the wider side, or you'll multiply rows.
+- **`joinKeys`** — the columns another dataset can be joined on.
+- **`timeColumn`** — the column to filter for partition pruning. Always constrain it.
+- **`freshness`** — how far behind live writes the dataset can be.
+- **`exampleSql`** — a runnable query to start from.
+
+Reference datasets by their bare name (`FROM traces`); they resolve to the analytics database your deployment configured.
+
+## Run a query
+
+```bash
+curl -X POST "https://app.langwatch.ai/api/v1/projects/$PROJECT_ID/analytics/query/clickhouse" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @- <<'EOF'
+{
+  "sql": "SELECT toStartOfDay(OccurredAt) AS Day, count() AS Traces, round(sum(TotalCost), 4) AS CostUSD FROM traces WHERE OccurredAt >= {since:DateTime} GROUP BY Day ORDER BY Day",
+  "parameters": { "since": "2026-08-01 00:00:00" }
+}
+EOF
+```
+
+The request body:
+
+| Field | Type | Notes |
+|---|---|---|
+| `sql` | string, required | One `SELECT` statement, up to 50,000 characters. Sent to the database exactly as written — never rewritten. |
+| `parameters` | object, optional | Values for the bound parameters the SQL declares. Scalars only: string, number, boolean, or null. |
+| `timeWindow` | `{ start, end }`, optional | The reporting period, as ISO strings, epoch milliseconds, or dates. Fills the reserved `period_start` / `period_end` parameters — see below. |
+
+The response:
+
+| Field | Meaning |
+|---|---|
+| `columns` | Output columns with their ClickHouse types, using your aliases |
+| `rows` | One JSON object per row |
+| `statistics` | `elapsedMs`, `rowsRead`, `bytesRead` (physical scan cost), and `rowsReturned` |
+| `truncated` | `true` when a response ceiling cut the result short — never silent |
+| `followsTimeWindow` | Whether the statement declared the reserved time-window parameters |
+| `diagnostics` | Advisory notes about the result (see below). Never a rejection. |
+
+## Bound parameters
+
+Use ClickHouse's typed parameter syntax rather than interpolating values into the SQL string:
+
+```sql
+SELECT count() AS Errors
+FROM traces
+WHERE OccurredAt >= {since:DateTime}
+  AND ContainsErrorStatus = {has_error:Bool}
+```
+
+Every parameter the statement declares must have a value in `parameters`, or the request is refused with `lwql_parameter_missing` — including the exact names that are missing, so an agent can repair its own request.
+
+### The reserved time window
+
+Two parameter names are reserved: `{period_start:DateTime}` and `{period_end:DateTime}`. They are filled from the request's `timeWindow`, never from `parameters` — supplying either under `parameters` is refused (`lwql_reserved_parameter_supplied`), and declaring them as anything but a date-time type is refused too (`lwql_reserved_parameter_type`).
+
+```json
+{
+  "sql": "SELECT count() AS Traces FROM traces WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}",
+  "timeWindow": { "start": "2026-08-01T00:00:00Z", "end": "2026-08-18T00:00:00Z" }
+}
+```
+
+The interval is half-open: `[period_start, period_end)`. Writing your statements against these two names makes them portable — the same SQL answers for whatever period the caller (a dashboard, a script, an agent) supplies, and the response's `followsTimeWindow` tells the consumer the statement was offered the period.
+
+## What's allowed — and what isn't
+
+Allowed: a single `SELECT`, optionally with `WITH`; joins; CTEs, subqueries and `UNION` (up to 8 levels of nesting); aggregates, `-If`/`DISTINCT` combinators, and window functions; array, map, and JSON access; bound parameters.
+
+Refused, always with a structured violation rather than a database error:
+
+- Anything that writes or defines: `INSERT`, `ALTER`, `CREATE`, `DROP`, ...
+- `SETTINGS` in any position
+- Table functions (`url`, `s3`, `remote`, `file`, ...)
+- The `system` and `information_schema` databases
+- Functions outside the allowlist — the allowlist covers the aggregation, date/time, string, array, map, JSON, and math functions analytics questions need, and omits introspection (`currentUser`, `hostName`, `version`, `getSetting`, ...) by construction
+- Columns your permissions gate (see [Privacy & RBAC](/observability/lwql/privacy-and-rbac))
+
+## Limits
+
+Two layers of ceilings apply, and they behave differently:
+
+**Database ceilings** (fixed per query; exceeding them fails the query with a coded error):
+
+| Ceiling | Default | Error code |
+|---|---|---|
+| Execution time | 10 s | `query_timeout` |
+| Memory | 1 GB | `query_memory_exceeded` |
+| Rows / bytes scanned | 1B rows / 10 GB | `query_scan_limit_exceeded` (HTTP 422) |
+
+**Response ceilings** (truncate rather than fail; always flagged):
+
+| Ceiling | Default |
+|---|---|
+| Rows returned | 10,000 |
+| Response size | ~8 MB |
+
+When you hit a scan or timeout ceiling, narrow the time filter on the dataset's `timeColumn` — it prunes partitions — or move to a pre-aggregated `*_by_minute` dataset. When you hit a response ceiling, aggregate more or paginate with `ORDER BY ... LIMIT ... OFFSET`.
+
+## Diagnostics
+
+Diagnostics are advisory notes about a result that ran successfully but deserves a second look. They never reject a query, and an empty list means no known issue was detected — not that the answer is the one you meant.
+
+| Code | What it flags |
+|---|---|
+| `RESULT_TRUNCATED` | A response ceiling cut the answer short |
+| `POSSIBLE_FANOUT` | A join repeats one dataset's rows once per row of another — aggregates may be inflated |
+| `UNBOUNDED_TIME_RANGE` | A dataset was read with no filter on its time column — the whole history was scanned |
+| `MISSING_TIME_BUCKETS` | A time-bucketed answer skips buckets inside the range it covers (charts will silently connect the gap) |
+| `INCOMPLETE_COMPARISON_PERIOD` | A period-over-period comparison includes an unfinished or unequal period |
+
+## Error codes
+
+Failures carry a stable `code` you (or your agent) can branch on:
+
+| HTTP | Code | Meaning | Fix |
+|---|---|---|---|
+| 400 | `lwql_parameter_missing` | The SQL declares parameters the request didn't supply (`meta.parameters` names them) | Add the values |
+| 400 | `lwql_reserved_parameter_supplied` | `period_start`/`period_end` sent under `parameters` | Move them to `timeWindow` |
+| 400 | `lwql_reserved_parameter_type` | A reserved parameter declared as a non-date-time | Declare `:DateTime` |
+| 400 | validation violations | The statement names something outside the allowlist | The violation says exactly what was refused |
+| 401 | `invalid_credentials` | Bad or missing API key | Check `X-Auth-Token` |
+| 403 | `lwql_not_enabled` | LWQL isn't enabled for this project | Ask your admin, or [contact us](/support) |
+| 422 | `query_scan_limit_exceeded` | The query would read more than the scan ceiling | Filter the time column, or use a `*_by_minute` dataset |
+| 5xx | `query_timeout`, `query_memory_exceeded` | A database ceiling killed the query | Narrow or pre-aggregate |
+| 503 | `lwql_unavailable` | This deployment has no LWQL identity provisioned | See [Self-hosted setup](/observability/lwql/self-hosted) |
+
+Error messages never name hosts, credentials, physical tables, or server internals — what you get is what's safe to show and enough to act on.


### PR DESCRIPTION
## What

Adds a **LangWatchQL (LWQL)** documentation section under the **Observability** anchor of the docs site, focused on the API endpoints (not the analytics revamp/charts UI):

- **Introduction** — what LWQL is, the two endpoints, the dataset catalog, the safety model
- **Writing queries** — dialect, schema discovery, bound parameters, the reserved `period_start`/`period_end` time window, limits, diagnostics, and the full error-code table
- **Handing the reins to your agent** — the discover → query → repair → sanity-check loop, a ready-made system prompt, and why free-form agent SQL is safe here
- **MCP (coming soon)** / **CLI (coming soon)** — stubs with the interim HTTP path
- **Self-hosted / on-prem** — architecture, the five `LWQL_*` env vars, what `provisionLwql` does vs. what the operator provisions, and a gotchas accordion
- **Privacy & RBAC** — tenant isolation via row policies, `analytics:view` scope, the `input`/`output`/`costs` column gates, and operational ceilings
- **Use cases** — ~20 copy-paste queries across cost, latency/reliability, quality, adoption, and prompts/experiments

`docs/docs.json` gains the nav group (second group in the Observability anchor); `llms.txt`/`llms-full.txt` were regenerated by the pre-commit hook.

## Merge order

This section previously said the base was `fix/lwql-execution-findings` and that #7194 had to merge first. All of that is now out of date, and it is corrected here rather than left for a reader to act on:

- **#7194 merged** on 2026-08-20 (squash `76aa940`). Its branch was deleted, and this PR was rebased onto `main`. The base is now `main`.
- The `batch_evaluations` dataset named above **does not exist** — it was dropped as wrong-grain in #7194. It was documented here in error and has been removed from the pages during review.
- **This PR does not depend on #7331.** The dependency runs the other way: #7331 makes the chart self-provision, which invalidates the "not yet packaged into the Helm chart" framing in `self-hosted.mdx`. That rewrite is filed as #7373 and is blocked on #7331, so the two cannot land into a contradiction unnoticed.

Nothing gates this PR. It documents an endpoint already on `main` and is accurate against `main` as it stands.

## Accuracy notes

Content is grounded in the implementation, not prose from memory: endpoints and request/response shapes from `app.v1.ts`, ceilings from `provisioning.ts`/`executor.ts` (10 s / 1 GB / 1B rows / 10 GB scan; 10k rows / ~8 MB response), error codes from `errors.ts` + the ClickHouse error translation, diagnostics from `diagnostics.ts`, dataset list and column names from the catalog, and every function used in the example SQL checked against the validator's allowlist (`validation/functions.ts` — e.g. examples use `toStartOfDay`, not the unlisted `toDate`).

Not yet verified: the example queries have not been executed against production (LWQL is not fully provisioned there until #7194 deploys). Before promoting from draft, they should be smoke-run through the live endpoint.

## Use-proof

Rendered locally via `npx mintlify dev` from `docs/`, then screenshotted. Shows the new
"LangWatchQL (LWQL)" nav group under Observability and the rendered Introduction page
(endpoints table, curl example, response JSON, dataset catalog):

![LWQL introduction page rendered via mintlify dev](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7326/observability/lwql/introduction.png)

## Human verification

- Read the error-codes table against `platform/app/src/server/api/lwql/schemas.ts`
  and confirm every documented code nests under `error`, and that the documented
  statuses match the thrown errors (`query_timeout` 504, `query_memory_exceeded`
  422, `query_scan_limit_exceeded` 422, `lwql_unparseable` 400,
  `lwql_not_permitted` 400).
- Confirm the `<Warning>` about 5xx collapsing to `internal_error` matches
  `canonical-error.ts`, which rewrites any `status >= 500` to
  `FALLBACK_ERROR_CODE` before it reaches a caller.
- Confirm no documented dataset is absent from the catalog — `batch_evaluations`
  was removed for exactly this reason.
- Confirm the `llms-full.txt` blocks still match their source `.mdx` files (the
  round-trip reported match=8, drift=0).

## How I can prove I was successful

- Every page reads end-to-end with no placeholders; internal links target the eight new slugs, `/support`, and existing pages only.
- `docs/docs.json` still parses (`json.load` clean) and the diff is exactly the 13-line group insertion.
- Example SQL uses only catalog datasets/columns and allowlisted functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive LangWatchQL (LWQL) documentation under Observability, with dedicated navigation.
  * Documented API usage, query syntax, datasets, parameters, limits, diagnostics, and error handling.
  * Added guidance for agents, self-hosted deployments, privacy, RBAC, tenant isolation, and safe access.
  * Added planned CLI and MCP integration guides, including current alternatives and examples.
  * Added practical use-case queries for cost, latency, reliability, quality, adoption, prompts, and experiments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
