### PR TITLE
fix(webhooks): never drop a delivery — conflict-free appends, paused endpoints keep their queue, dead rows retained

### DIFF
--- a/platform/app/ee/webhooks/__tests__/deliveryControls.unit.test.ts
+++ b/platform/app/ee/webhooks/__tests__/deliveryControls.unit.test.ts
@@ -15,7 +15,10 @@ describe("webhook delivery control bounds", () => {
   /** @scenario Out of bounds delivery controls are rejected with the bound in the error */
   it("rejects out-of-bounds values naming the allowed range", async () => {
     // Validation throws before any prisma call; an empty object proves it.
-    const service = new WebhookEndpointService({ prisma: {} as PrismaClient });
+    const service = new WebhookEndpointService({
+      prisma: {} as PrismaClient,
+      processStore: { requeueDeadMessages: async () => 0 },
+    });
     await expect(
       service.create({
         organizationId: "org_test",

--- a/platform/app/ee/webhooks/__tests__/eventRegistry.unit.test.ts
+++ b/platform/app/ee/webhooks/__tests__/eventRegistry.unit.test.ts
@@ -63,6 +63,7 @@ describe("webhook event registry", () => {
     const service = new WebhookEndpointService({
       // Validation throws before any prisma call; an empty object proves it.
       prisma: {} as PrismaClient,
+      processStore: { requeueDeadMessages: async () => 0 },
     });
     await expect(
       service.create({

--- a/platform/app/ee/webhooks/__tests__/webhookDelivery.ladder.unit.test.ts
+++ b/platform/app/ee/webhooks/__tests__/webhookDelivery.ladder.unit.test.ts
@@ -9,31 +9,58 @@ import {
 const HOUR = 60 * 60 * 1000;
 
 describe("webhook retry ladder", () => {
-  /** @scenario The retry ladder holds its last attempt inside seventy two hours */
-  it("keeps the cumulative schedule within 72h and settles at 12h", () => {
+  /** @scenario The retry ladder holds its last attempt inside one day */
+  it("keeps the cumulative schedule within a day and settles at 4h", () => {
+    // Jitter pinned to its midpoint: the schedule under test is the ladder's.
+    const midpoint = () => 0.5;
     let elapsed = 0;
     const delays: number[] = [];
     for (let attempt = 1; attempt < WEBHOOK_SEND_MAX_ATTEMPTS; attempt++) {
-      const delay = webhookRetryDelayMs({ attempt });
+      const delay = webhookRetryDelayMs({ attempt, random: midpoint });
       delays.push(delay);
       elapsed += delay;
     }
-    // The final retry fires inside 72 hours of the first failure.
-    expect(elapsed).toBeLessThanOrEqual(72 * HOUR);
-    // And the ladder is not trivially short: it spans multiple days.
-    expect(elapsed).toBeGreaterThan(48 * HOUR);
-    // Cadence settles at 12h once the explicit rungs are exhausted.
-    expect(delays.at(-1)).toBe(12 * HOUR);
-    expect(webhookRetryDelayMs({ attempt: 99 })).toBe(12 * HOUR);
+    // The final retry fires inside one day of the first failure.
+    expect(elapsed).toBeLessThanOrEqual(24 * HOUR);
+    // And the ladder is not trivially short: it rides out a working day.
+    expect(elapsed).toBeGreaterThan(12 * HOUR);
+    // Cadence settles at 4h once the explicit rungs are exhausted.
+    expect(delays.at(-1)).toBe(4 * HOUR);
+    expect(webhookRetryDelayMs({ attempt: 99, random: midpoint })).toBe(
+      4 * HOUR,
+    );
     // The explicit rungs are exactly the documented schedule.
     expect(WEBHOOK_RETRY_LADDER_MS).toEqual([
       60_000,
       5 * 60_000,
+      15 * 60_000,
       30 * 60_000,
+      HOUR,
       2 * HOUR,
-      6 * HOUR,
-      12 * HOUR,
+      4 * HOUR,
     ]);
+  });
+
+  /** @scenario Retry delays spread so a failed cohort comes apart */
+  it("spreads delays a fifth of the step either side, never on one instant", () => {
+    const step = WEBHOOK_RETRY_LADDER_MS[0]!;
+    expect(webhookRetryDelayMs({ attempt: 1, random: () => 0 })).toBe(
+      step - step / 5,
+    );
+    expect(webhookRetryDelayMs({ attempt: 1, random: () => 1 })).toBe(
+      step + step / 5,
+    );
+    // Distinct draws land on distinct instants — the cohort comes apart.
+    const draws = new Set(
+      [0.1, 0.35, 0.62, 0.87].map((value) =>
+        webhookRetryDelayMs({ attempt: 1, random: () => value }),
+      ),
+    );
+    expect(draws.size).toBe(4);
+    for (const delay of draws) {
+      expect(delay).toBeGreaterThanOrEqual(step - step / 5);
+      expect(delay).toBeLessThanOrEqual(step + step / 5);
+    }
   });
 });
 

--- a/platform/app/ee/webhooks/__tests__/webhookDelivery.process.integration.test.ts
+++ b/platform/app/ee/webhooks/__tests__/webhookDelivery.process.integration.test.ts
@@ -21,6 +21,7 @@ import {
 } from "vitest";
 import type { Organization, Project, Team } from "~/generated/prisma/client";
 import { prisma } from "~/server/db";
+import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import { buildProcessManager } from "~/server/event-sourcing/pipeline/processBuilder";
 import {
   GATEWAY_SPEND_ADMITTED_EVENT_TYPE,
@@ -44,6 +45,7 @@ import {
   type WebhookDeliveryProcessDeps,
   type WebhookDeliveryState,
   webhookDeliveryPM,
+  webhookRetryDelayMs,
 } from "../process-manager/webhookDelivery.process";
 import { WebhookEndpointService } from "../webhookEndpoint.service";
 import { WebhookHealthService } from "../webhookHealth.service";
@@ -70,7 +72,10 @@ let team: Team;
 let project: Project;
 let endpointId: string;
 
-const endpoints = new WebhookEndpointService({ prisma });
+const endpoints = new WebhookEndpointService({
+  prisma,
+  processStore: new PrismaProcessStore(prisma),
+});
 
 let store: InMemoryProcessStore;
 let service: ProcessManagerService<WebhookDeliveryState>;
@@ -344,6 +349,8 @@ beforeEach(() => {
       }).config,
     ),
     processNames: [WEBHOOK_DELIVERY_PROCESS_NAME],
+    // The production ladder, so retry timing under test is the shipped one.
+    retryDelayMs: webhookRetryDelayMs,
   });
   sendWebhookMock.mockReset();
   sendWebhookMock.mockResolvedValue({
@@ -635,13 +642,13 @@ describe("webhook delivery via the transactional inbox", () => {
     });
   });
 
-  /** @scenario A disabled endpoint drains its queue without posting */
-  it("drops the batch without posting when the endpoint is disabled", async () => {
+  /** @scenario A disabled endpoint keeps its queued batches unsent */
+  it("keeps the batch queued without posting when the endpoint is disabled", async () => {
     const requestId = `req-${nanoid(8)}`;
     await consume(admittedEnvelope(requestId));
     await consume(confirmedEnvelope(requestId));
     // Level 1 fans out while the endpoint is ACTIVE; the disable lands
-    // between fan-out and the send, which is the case the drain covers.
+    // between fan-out and the send, which is the case a pause covers.
     await drainOutbox(1);
 
     await endpoints.disable({
@@ -651,14 +658,95 @@ describe("webhook delivery via the transactional inbox", () => {
     try {
       await drainOutbox();
       expect(sendWebhookMock).not.toHaveBeenCalled();
+      // The receiver is expected back: the batch waits on the ladder
+      // instead of draining, so nothing the customer queued is lost.
       const sends = await sendMessagesFor(endpointId);
-      expect(sends[0]!.status).toBe("dispatched");
+      expect(sends[0]!.status).toBe("pending");
+      expect(sends[0]!.attempts).toBeGreaterThanOrEqual(1);
     } finally {
       await endpoints.enable({
         organizationId: organization.id,
         endpointId,
       });
     }
+  });
+
+  /** @scenario A deleted endpoint discards its queued batches */
+  it("drains the batch without posting when the endpoint is deleted", async () => {
+    const doomed = await endpoints.create({
+      organizationId: organization.id,
+      url: "https://receiver.example.com/hooks",
+      enabledEvents: ["gateway.request.completed"],
+      maxBatchDelayMs: 0,
+    });
+    const requestId = `req-${nanoid(8)}`;
+    await consume(admittedEnvelope(requestId));
+    await consume(confirmedEnvelope(requestId));
+    await drainOutbox(1);
+
+    await endpoints.archive({
+      organizationId: organization.id,
+      endpointId: doomed.endpoint.id,
+    });
+    await drainOutbox();
+
+    // The customer asked us to stop: acknowledging the batch honours that.
+    const sends = await sendMessagesFor(doomed.endpoint.id);
+    expect(sends.length).toBeGreaterThanOrEqual(1);
+    for (const send of sends) expect(send.status).toBe("dispatched");
+    const posted = sendWebhookMock.mock.calls.filter(
+      (call) => call[0].endpointId === doomed.endpoint.id,
+    );
+    expect(posted).toHaveLength(0);
+  });
+
+  /** @scenario Re-enabling an endpoint revives its parked batches */
+  it("requeues an endpoint's dead batches with a fresh budget on enable", async () => {
+    // This service shares the process manager's store, so enable() can see
+    // the dead rows the ladder parked there.
+    const revivingEndpoints = new WebhookEndpointService({
+      prisma,
+      processStore: store,
+    });
+    const requestId = `req-${nanoid(8)}`;
+    await consume(admittedEnvelope(requestId));
+    await consume(confirmedEnvelope(requestId));
+    await drainOutbox(1);
+
+    await endpoints.disable({
+      organizationId: organization.id,
+      endpointId,
+    });
+    try {
+      // The pause outlives the ladder: the batch parks as dead.
+      const [leased] = await store.leaseDueMessages({
+        now: clock + 120_000,
+        limit: 10,
+        leaseDurationMs: 30_000,
+        processNames: [WEBHOOK_DELIVERY_PROCESS_NAME],
+      });
+      await store.markFailed({
+        identity: {
+          processName: leased!.processName,
+          projectId: leased!.projectId,
+          messageKey: leased!.messageKey,
+        },
+        leaseToken: leased!.leaseToken,
+        now: clock + 120_000,
+        nextAttemptAt: clock + 120_000,
+        dead: true,
+      });
+      expect((await sendMessagesFor(endpointId))[0]!.status).toBe("dead");
+    } finally {
+      await revivingEndpoints.enable({
+        organizationId: organization.id,
+        endpointId,
+      });
+    }
+
+    const sends = await sendMessagesFor(endpointId);
+    expect(sends[0]!.status).toBe("pending");
+    expect(sends[0]!.attempts).toBe(0);
   });
 
   /** @scenario Envelopes coalesce into one signed batch up to the endpoint's size */
@@ -771,7 +859,14 @@ describe("webhook delivery via the transactional inbox", () => {
       }
       await drainOutbox(1);
       // Capped: the three newcomers buffered instead of new POSTs.
-      expect((await endpointStream(endpointId))?.state.pending).toHaveLength(3);
+      const capped = await endpointStream(endpointId);
+      expect(capped?.state.pending).toHaveLength(3);
+      // And the wake is armed for when the laddered retry next becomes due
+      // (60s ± jitter), not a short-recheck poll that rewrites the row every
+      // few hundred milliseconds for the whole wait.
+      const laddered = (await sendMessagesFor(endpointId))[0]!;
+      expect(capped?.nextWakeAt).toBe(laddered.nextAttemptAt);
+      expect(capped!.nextWakeAt! - clock).toBeGreaterThan(30_000);
 
       // The receiver recovers; the retry ladder's next attempt succeeds and
       // frees the slot, and the wake flushes the accumulated three as ONE
@@ -781,7 +876,8 @@ describe("webhook delivery via the transactional inbox", () => {
         body: "ok",
         eventId: "x",
       });
-      clock += 61_000;
+      // Past the ladder step at its full +20% jitter, so the retry is due.
+      clock += 80_000;
       await drainOutbox(2);
       expect(await wakeEndpoint(endpointId)).toBe(true);
       await drainOutbox();

--- a/platform/app/ee/webhooks/__tests__/webhookEndpoint.service.integration.test.ts
+++ b/platform/app/ee/webhooks/__tests__/webhookEndpoint.service.integration.test.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Organization } from "~/generated/prisma/client";
 import { prisma } from "~/server/db";
+import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import {
   WEBHOOK_AUTO_DISABLE_AFTER_MS,
   WEBHOOK_DISABLED_REASON_AUTO,
@@ -14,7 +15,11 @@ const ns = `webhook-svc-${nanoid(8)}`;
 
 let organization: Organization;
 const notifyAutoDisabled = vi.fn().mockResolvedValue(undefined);
-const service = new WebhookEndpointService({ prisma, notifyAutoDisabled });
+const service = new WebhookEndpointService({
+  prisma,
+  processStore: new PrismaProcessStore(prisma),
+  notifyAutoDisabled,
+});
 
 beforeAll(async () => {
   organization = await prisma.organization.create({

--- a/platform/app/ee/webhooks/process-manager/webhookDelivery.process.ts
+++ b/platform/app/ee/webhooks/process-manager/webhookDelivery.process.ts
@@ -25,6 +25,9 @@ import type {
   NewOutboxMessage,
   ProcessStore,
 } from "~/server/event-sourcing/process-manager/stores/processStore.types";
+import { DIAGNOSTIC_SAFE } from "~/server/event-sourcing/process-manager/failureDiagnostic";
+import type { ProcessRef } from "~/server/event-sourcing/process-manager/processManager.types";
+import { captureTraceCarrier } from "~/server/event-sourcing/process-manager/traceCarrier";
 import { DispatchError } from "~/server/event-sourcing/queues/dispatchError";
 import type { SpendEventRow } from "~/server/gateway/spendEvents.clickhouse.repository";
 import { nanoUsdToDecimalString } from "~/server/gateway/wireMoney";
@@ -45,25 +48,51 @@ export const WEBHOOK_DELIVERY_PROCESS_NAME = "webhookDelivery" as const;
 
 /**
  * The Stripe-shaped retry ladder. `attempt` is the 1-based attempt that
- * just failed: the delay to the next one. After the sixth failure the
- * cadence holds at 12h; 11 attempts keep the last retry inside 72h of the
- * first failure (1m + 5m + 30m + 2h + 6h + 12h + 4 * 12h = 68h36m).
+ * just failed: the delay to the next one. After the seventh failure the
+ * cadence holds at 4h; 11 attempts keep the last retry inside 24h of the
+ * first failure (1m + 5m + 15m + 30m + 1h + 2h + 4h + 4h * 3 = 19h51m,
+ * which holds under full +20% jitter too).
+ *
+ * A day, not three. Retrying is only worth what a receiver's outage costs to
+ * ride out, and past that the message is better parked where someone can see
+ * it and push it through than quietly rattling around for another two days.
+ * Retiring does not discard it: the row is retained until it delivers or an
+ * operator discards it, so the ladder's end is where retrying stops, not
+ * where the event stops existing.
  */
 export const WEBHOOK_RETRY_LADDER_MS: readonly number[] = [
   60_000,
   5 * 60_000,
+  15 * 60_000,
   30 * 60_000,
+  60 * 60_000,
   2 * 60 * 60_000,
-  6 * 60 * 60_000,
-  12 * 60 * 60_000,
+  4 * 60 * 60_000,
 ];
 export const WEBHOOK_SEND_MAX_ATTEMPTS = 11;
 
-export function webhookRetryDelayMs({ attempt }: { attempt: number }): number {
-  return (
+/**
+ * How far either side of the ladder step a retry may land, as a fraction.
+ *
+ * Without it the ladder is a set of fixed offsets, so everything that failed
+ * together retries together — and a batch of deliveries that collided once
+ * re-collides at every rung, all the way to the end. The spread is what lets
+ * a cohort come apart instead of marching in step.
+ */
+const WEBHOOK_RETRY_JITTER = 0.2;
+
+export function webhookRetryDelayMs({
+  attempt,
+  random = Math.random,
+}: {
+  attempt: number;
+  random?: () => number;
+}): number {
+  const step =
     WEBHOOK_RETRY_LADDER_MS[attempt - 1] ??
-    WEBHOOK_RETRY_LADDER_MS[WEBHOOK_RETRY_LADDER_MS.length - 1]!
-  );
+    WEBHOOK_RETRY_LADDER_MS[WEBHOOK_RETRY_LADDER_MS.length - 1]!;
+  const spread = step * WEBHOOK_RETRY_JITTER;
+  return Math.max(0, Math.round(step - spread + random() * spread * 2));
 }
 
 /** How soon a stream capped on in-flight rechecks, and the floor for a
@@ -151,6 +180,27 @@ export interface EndpointStreamState {
 
 export function isEndpointStreamKey(processKey: string): boolean {
   return processKey.startsWith("endpoint:");
+}
+
+/**
+ * The one address of an endpoint's delivery stream and its outbox rows.
+ * Endpoints belong to the ORGANIZATION, so the stream does too: one row per
+ * endpoint holds one buffer, one outstanding-send count, and therefore one
+ * max_in_flight, no matter how many of the org's projects feed it. Keying by
+ * project would give an endpoint N of each.
+ */
+export function endpointStreamRef({
+  organizationId,
+  endpointId,
+}: {
+  organizationId: string;
+  endpointId: string;
+}): ProcessRef {
+  return {
+    processName: WEBHOOK_DELIVERY_PROCESS_NAME,
+    projectId: organizationId,
+    processKey: `endpoint:${endpointId}`,
+  };
 }
 
 /** Every quantity added after the first deploy carries a default: this rides
@@ -354,12 +404,14 @@ function planEndpointBatches({
   pending,
   outstanding,
   now,
+  traceCarrier,
 }: {
   organizationId: string;
   endpoint: WebhookEndpointView;
   pending: readonly PendingEnvelope[];
   outstanding: number;
   now: number;
+  traceCarrier: Record<string, string>;
 }): {
   messages: NewOutboxMessage[];
   remaining: PendingEnvelope[];
@@ -389,29 +441,45 @@ function planEndpointBatches({
         batchId,
         envelopes: batch,
       } as unknown as JsonValue,
-      traceCarrier: {},
+      traceCarrier,
     });
     inFlight++;
   }
   return { messages, remaining, inFlight };
 }
 
-/** Anything still buffered arms a wake: the coalescing deadline when the
- *  delay is holding it, a short recheck when the in-flight cap is. */
+/**
+ * Anything still buffered arms a wake: the coalescing deadline when the
+ * delay is holding it, and when the in-flight cap is, the soonest instant a
+ * slot can actually free.
+ *
+ * That second case matters. The cap counts pending sendBatch rows, and a row
+ * riding the retry ladder stays pending for the whole wait — hours at the
+ * ladder's tail. A flat short recheck there is a poll: every cycle takes the
+ * stream's lock, rewrites the whole buffer row and ships nothing, thousands
+ * of times per laddered retry. `outstandingDueAt` is when the earliest of
+ * those rows next becomes due, so the wake lands where something can have
+ * changed. The recheck floor still applies — a row that is due NOW is one a
+ * dispatcher is about to pick up, and the floor gives it time to settle.
+ */
 function nextStreamWakeAt({
   endpoint,
   remaining,
   inFlight,
+  outstandingDueAt,
   now,
 }: {
   endpoint: WebhookEndpointView;
   remaining: readonly PendingEnvelope[];
   inFlight: number;
+  outstandingDueAt: number | null;
   now: number;
 }): number | null {
   const oldest = remaining[0];
   if (!oldest) return null;
-  if (inFlight >= endpoint.maxInFlight) return now + WEBHOOK_FLUSH_RECHECK_MS;
+  if (inFlight >= endpoint.maxInFlight) {
+    return Math.max(outstandingDueAt ?? 0, now + WEBHOOK_FLUSH_RECHECK_MS);
+  }
   return Math.max(
     coalescingDeadline(oldest, endpoint),
     now + WEBHOOK_FLUSH_RECHECK_MS,
@@ -445,62 +513,98 @@ async function flushEndpointStream({
   sourceEventId?: string;
 }): Promise<void> {
   const now = (deps.now ?? Date.now)();
-  // Endpoints belong to the ORGANIZATION, so the stream does too: one row
-  // per endpoint holds one buffer, one outstanding-send count, and
-  // therefore one max_in_flight, no matter how many of the org's projects
-  // feed it. Keying by project would give an endpoint N of each.
-  const ref = {
-    processName: WEBHOOK_DELIVERY_PROCESS_NAME,
-    projectId: organizationId,
-    processKey: `endpoint:${endpoint.id}`,
-  };
-  const existing = await deps.processStore.findByRef<EndpointStreamState>({
+  const ref = endpointStreamRef({ organizationId, endpointId: endpoint.id });
+  // The in-flight count is read outside the stream's lock on purpose: it
+  // counts rows this transition does not own, and holding a lock across the
+  // query would put every one of the org's appends behind it. A count that
+  // races is what `max_in_flight` has always been — the cap bounds parallel
+  // POSTs to a slow receiver, and the wake rechecks it a moment later.
+  const outstanding = await deps.processStore.countPendingMessages({
     ref,
+    intentType: "sendBatch",
   });
-  const pending: PendingEnvelope[] = [
-    ...(existing?.state.pending ?? []),
-    ...(append
-      ? [
-          {
-            envelope: append,
-            appendedAtMs: now,
-            ...(appendSalt ? { salt: appendSalt } : {}),
-          },
-        ]
-      : []),
-  ];
+  const traceCarrier = captureTraceCarrier();
 
-  const outstanding = (
-    await deps.processStore.findMessagesByRef({ ref })
-  ).filter(
-    (m) => m.intentType === "sendBatch" && m.status === "pending",
-  ).length;
-
-  const { messages, remaining, inFlight } = planEndpointBatches({
-    organizationId,
-    endpoint,
-    pending,
-    outstanding,
-    now,
-  });
-
-  const result = await deps.processStore.commit<EndpointStreamState>({
-    ref,
-    tenantId: organizationId,
-    sourceEventId: sourceEventId ?? null,
-    expectedRevision: existing?.revision ?? 0,
-    state: { pending: remaining },
-    nextWakeAt: nextStreamWakeAt({ endpoint, remaining, inFlight, now }),
-    messages,
-    now,
-  });
-  if (result.outcome === "revisionConflict") {
-    // A concurrent append or flush won the stream's revision; retry this
-    // intent so nothing is lost (idempotent by inbox id and content key).
-    throw new Error(
-      `webhook stream flush hit a revision conflict on endpoint ${endpoint.id}; retrying`,
-    );
+  try {
+    // Every gateway request in the organization appends here, so the buffer
+    // is read INSIDE the store's lock rather than before it. Reading first
+    // and committing against the revision it saw is what made concurrent
+    // appends fail: the lock serialised them correctly and then the
+    // compare-and-swap rejected everyone who had read the pre-lock snapshot,
+    // which under real traffic is everyone but the winner. Appends have no
+    // order to preserve — two envelopes arriving together are equally valid
+    // in either sequence — so there is nothing for optimistic concurrency to
+    // protect here.
+    await deps.processStore.transact<EndpointStreamState>({
+      ref,
+      tenantId: organizationId,
+      sourceEventId: sourceEventId ?? null,
+      now,
+      apply: (current) => {
+        const pending: PendingEnvelope[] = [
+          ...(current?.state.pending ?? []),
+          ...(append
+            ? [
+                {
+                  envelope: append,
+                  appendedAtMs: now,
+                  ...(appendSalt ? { salt: appendSalt } : {}),
+                },
+              ]
+            : []),
+        ];
+        const { messages, remaining, inFlight } = planEndpointBatches({
+          organizationId,
+          endpoint,
+          pending,
+          outstanding: outstanding.count,
+          now,
+          traceCarrier,
+        });
+        return {
+          state: { pending: remaining },
+          nextWakeAt: nextStreamWakeAt({
+            endpoint,
+            remaining,
+            inFlight,
+            outstandingDueAt: outstanding.nextAttemptAt,
+            now,
+          }),
+          messages,
+        };
+      },
+    });
+  } catch (error) {
+    // An error whose message already survives redaction (a DispatchError, or
+    // one stamped diagnostic-safe) says more than any wrapper would.
+    if (
+      error instanceof Error &&
+      (error.name === "DispatchError" ||
+        Reflect.get(error, DIAGNOSTIC_SAFE) === true)
+    ) {
+      throw error;
+    }
+    // A foreign error's message is redacted at every telemetry surface, and
+    // this call is where a week-long retry storm once hid behind "Operation
+    // failed" — so name the failure ourselves. The wrapped message carries
+    // only ids we already log and the error's class, never its text.
+    throw new DispatchError({
+      message: `webhook stream flush failed on endpoint ${endpoint.id}: ${failureClassOf(error)}`,
+      retryable: true,
+    });
   }
+}
+
+/**
+ * The class of a foreign failure, safe to quote: the constructor name plus a
+ * machine code when the error carries one (Prisma's P-codes, node's ERRNO),
+ * and never the message text.
+ */
+function failureClassOf(error: unknown): string {
+  if (typeof error !== "object" || error === null) return "non-error";
+  const name = error instanceof Error ? error.name : "non-error";
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? `${name} (${code})` : name;
 }
 
 /** Settled requests are their own event type: an endpoint subscribed only
@@ -832,20 +936,36 @@ export function runWebhookSendBatch(deps: WebhookDeliveryProcessDeps) {
     payload: SendBatchPayload,
     context: IntentContext,
   ): Promise<void> => {
-    // The service's deliverable read owns the liveness predicate. A deleted
-    // or disabled endpoint drains its queue without delivering: the spend
-    // record keeps the events, re-enable plus replay covers the gap.
-    const endpoint = await deps.endpoints.getDeliverable({
+    // The service's disposition read owns the liveness predicate, and the
+    // two ways a batch can fail to ship are not the same thing.
+    //
+    // Gone means the customer deleted the endpoint: they asked us to stop, so
+    // acknowledging the batch is honouring that, not losing it.
+    //
+    // Paused means disabled — by the customer for now, or by our own
+    // auto-disable after a failing streak. The receiver is expected back, so
+    // the batch waits. It used to drain here on the premise that "the spend
+    // record keeps the events, re-enable plus replay covers the gap", which
+    // asks a customer to notice a gap they were never told about and replay it
+    // by hand. Staying queued costs a retry and covers the gap by itself.
+    const disposition = await deps.endpoints.getDeliveryDisposition({
       organizationId: payload.organizationId,
       endpointId: payload.endpointId,
     });
-    if (!endpoint) {
+    if (disposition.state === "gone") {
       logger.info(
         { endpointId: payload.endpointId, batchId: payload.batchId },
-        "webhook batch dropped: endpoint disabled or gone (replay covers the gap)",
+        "webhook batch discarded: endpoint deleted",
       );
       return;
     }
+    if (disposition.state === "paused") {
+      throw new DispatchError({
+        message: `Webhook endpoint ${payload.endpointId} is disabled; batch ${payload.batchId} stays queued`,
+        retryable: true,
+      });
+    }
+    const endpoint = disposition.endpoint;
 
     const startedAt = (deps.now ?? Date.now)();
     const result = await dispatchWebhookBatch({

--- a/platform/app/ee/webhooks/webhookEndpoint.service.ts
+++ b/platform/app/ee/webhooks/webhookEndpoint.service.ts
@@ -30,7 +30,9 @@ import {
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { decrypt, encrypt } from "~/utils/encryption";
 import type { WebhookDestinationKind } from "~/utils/webhookDestinations";
+import type { ProcessStore } from "~/server/event-sourcing/process-manager/stores/processStore.types";
 import { isValidEventSelector } from "./eventRegistry";
+import { endpointStreamRef } from "./process-manager/webhookDelivery.process";
 
 const logger = createLogger("langwatch:webhooks:endpoint-service");
 
@@ -591,6 +593,13 @@ function newSecret(): string {
 export interface WebhookEndpointDeps {
   prisma: PrismaClient;
   /**
+   * The delivery outbox, for the one thing endpoint lifecycle owes it:
+   * reviving batches that retired while the endpoint was disabled. Narrowed
+   * to the single method so the CRUD service never grows into a second
+   * delivery engine.
+   */
+  processStore: Pick<ProcessStore, "requeueDeadMessages">;
+  /**
    * Called when the 72h streak flips an endpoint to DISABLED. The transport
    * (email, in-app) is the caller's; the service guarantees the call fires
    * exactly once per auto-disable transition.
@@ -752,9 +761,15 @@ export class WebhookEndpointService {
 
   /**
    * Re-enable a disabled endpoint. Clears the failure streak so the 72h
-   * clock restarts from the next failure, not from history. Events that
-   * accrued while disabled are NOT re-sent automatically; the replay
-   * surface covers the gap window.
+   * clock restarts from the next failure, not from history.
+   *
+   * Batches that were already minted before the disable stayed queued while
+   * it lasted — a paused batch retries until the ladder runs out, then parks
+   * as dead — so re-enabling revives the parked ones with a fresh attempt
+   * budget and lets the pending ones flow on their next attempt. Nothing the
+   * customer queued is lost to the pause. Events that arrived DURING the
+   * disable were never appended (a disabled endpoint subscribes to nothing);
+   * the replay surface covers that window.
    */
   async enable(params: {
     organizationId: string;
@@ -770,6 +785,18 @@ export class WebhookEndpointService {
         failingSince: null,
       },
     });
+    const ref = endpointStreamRef(params);
+    const revived = await this.deps.processStore.requeueDeadMessages({
+      ...ref,
+      messageKeyPrefix: "send:",
+      now: Date.now(),
+    });
+    if (revived > 0) {
+      logger.info(
+        { endpointId: params.endpointId, revived },
+        "webhook endpoint re-enabled; parked batches requeued",
+      );
+    }
     return toView(updated);
   }
 
@@ -819,6 +846,33 @@ export class WebhookEndpointService {
       },
     });
     return endpoint ? toView(endpoint) : null;
+  }
+
+  /**
+   * Whether a frozen batch may ship, and when it may not, WHY.
+   *
+   * `getDeliverable` answers one question with a null that covers two very
+   * different situations, and a caller holding undelivered events has to tell
+   * them apart. An endpoint the customer deleted is gone, and the events they
+   * asked us to stop sending go with it. An endpoint that is merely disabled —
+   * including one our own auto-disable turned off after a failing streak — is
+   * a receiver that is expected back, and dropping its queue is throwing away
+   * events nobody chose to lose.
+   */
+  async getDeliveryDisposition(params: {
+    organizationId: string;
+    endpointId: string;
+  }): Promise<
+    | { state: "deliverable"; endpoint: WebhookEndpointView }
+    | { state: "paused" }
+    | { state: "gone" }
+  > {
+    const endpoint = await this.deps.prisma.webhookEndpoint.findFirst({
+      where: { id: params.endpointId, organizationId: params.organizationId },
+    });
+    if (!endpoint || endpoint.archivedAt !== null) return { state: "gone" };
+    if (endpoint.status !== "ACTIVE") return { state: "paused" };
+    return { state: "deliverable", endpoint: toView(endpoint) };
   }
 
   /**

--- a/platform/app/src/app/api/gateway-spend/[[...route]]/app.ts
+++ b/platform/app/src/app/api/gateway-spend/[[...route]]/app.ts
@@ -738,7 +738,10 @@ secured.access(requires("gatewaySpend:manage")).post(
     const organization = c.get("organization") as Organization;
     const body = c.req.valid("json");
 
-    const endpoints = new WebhookEndpointService({ prisma });
+    const endpoints = new WebhookEndpointService({
+      prisma,
+      processStore: new PrismaProcessStore(prisma),
+    });
     const endpoint = await endpoints.getDeliverable({
       organizationId: organization.id,
       endpointId: body.endpoint_id,

--- a/platform/app/src/app/api/gateway-spend/__tests__/gateway-spend-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/gateway-spend/__tests__/gateway-spend-rest-api.integration.test.ts
@@ -18,6 +18,7 @@ import {
 } from "~/generated/prisma/client";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { prisma } from "~/server/db";
+import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import {
   startTestContainers,
   stopTestContainers,
@@ -571,7 +572,10 @@ describe("Feature: Gateway spend reconciliation REST surface", () => {
     );
     const previous = process.env.WEBHOOKS_UNSAFE_ALLOW_LOCAL_URLS;
     process.env.WEBHOOKS_UNSAFE_ALLOW_LOCAL_URLS = "1";
-    const endpoints = new WebhookEndpointService({ prisma });
+    const endpoints = new WebhookEndpointService({
+      prisma,
+      processStore: new PrismaProcessStore(prisma),
+    });
     let endpointId = "";
     const ns2 = `${ns}-replay`;
     try {
@@ -690,7 +694,10 @@ describe("Feature: Gateway spend reconciliation REST surface", () => {
     );
     const previous = process.env.WEBHOOKS_UNSAFE_ALLOW_LOCAL_URLS;
     process.env.WEBHOOKS_UNSAFE_ALLOW_LOCAL_URLS = "1";
-    const endpoints = new WebhookEndpointService({ prisma });
+    const endpoints = new WebhookEndpointService({
+      prisma,
+      processStore: new PrismaProcessStore(prisma),
+    });
     const emitted = vi.spyOn(
       WebhookEventsService.prototype,
       "getEmittedEvents",

--- a/platform/app/src/app/api/webhooks/[[...route]]/app.ts
+++ b/platform/app/src/app/api/webhooks/[[...route]]/app.ts
@@ -48,7 +48,10 @@ import { handleWebhookApiError } from "./error-handler";
 
 patchZodOpenapi();
 
-const endpoints = new WebhookEndpointService({ prisma });
+const endpoints = new WebhookEndpointService({
+  prisma,
+  processStore: new PrismaProcessStore(prisma),
+});
 const health = new WebhookHealthService({
   endpoints,
   processStore: new PrismaProcessStore(prisma),

--- a/platform/app/src/app/api/webhooks/__tests__/webhooks-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/webhooks/__tests__/webhooks-rest-api.integration.test.ts
@@ -20,6 +20,7 @@ import {
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
+import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import {
   verifyWebhookSignature,
   WEBHOOK_SIGNATURE_HEADER,
@@ -1114,6 +1115,7 @@ describe("Feature: Webhook endpoints REST API", () => {
       );
       const destination = await new WebhookEndpointService({
         prisma,
+        processStore: new PrismaProcessStore(prisma),
       }).getDestinationConfig({
         organizationId: organization.id,
         endpointId: data.id,

--- a/platform/app/src/server/api/routers/webhookEndpoints.ts
+++ b/platform/app/src/server/api/routers/webhookEndpoints.ts
@@ -72,7 +72,10 @@ const requireWebhooksPlan = async ({
 };
 
 function service(prisma: PrismaClient) {
-  return new WebhookEndpointService({ prisma });
+  return new WebhookEndpointService({
+    prisma,
+    processStore: new PrismaProcessStore(prisma),
+  });
 }
 
 /** Map service errors onto tRPC codes so the UI gets actionable messages. */

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -893,7 +893,10 @@ export function initializeDefaultApp(options?: {
   // The webhook delivery process manager scans the spend table, so it
   // shares the same ClickHouse gate. Registration is global; the per-org
   // enterprise flag is enforced inside the scan (and at the REST surface).
-  const webhookEndpointService = new WebhookEndpointService({ prisma });
+  const webhookEndpointService = new WebhookEndpointService({
+    prisma,
+    processStore: new PrismaProcessStore(prisma),
+  });
   const webhookDelivery = clickhouseEnabled
     ? {
         processStore: repositories.processStore,

--- a/platform/app/src/server/event-sourcing/pipelines/process-manager-maintenance/process-manager/processRetentionSweep.process.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/process-manager-maintenance/process-manager/processRetentionSweep.process.ts
@@ -49,8 +49,14 @@ export const PROCESS_RETENTION_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
 export const DISPATCHED_OUTBOX_RETENTION_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Dead rows are the operator's failure record, not completed work, so they get
- * a month rather than a day.
+ * Terminal rows are the operator's failure record, not completed work, so they
+ * get a month rather than a day.
+ *
+ * The window applies to `discarded` ONLY. A `dead` row is undelivered work
+ * that ran out of attempts, and no one chose to lose it; sweeping it deleted
+ * the message and its payload a month later without a word. Undelivered means
+ * retained — until it delivers, or until an operator discards it and starts
+ * this clock deliberately.
  */
 export const DEAD_OUTBOX_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 

--- a/platform/app/src/server/event-sourcing/process-manager/__tests__/processRuntime.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/__tests__/processRuntime.unit.test.ts
@@ -36,6 +36,10 @@ function makeStubStore(overrides: Partial<ProcessStore> = {}): ProcessStore {
     commit: async () => {
       throw new Error("makeStubStore: commit not stubbed");
     },
+    transact: async () => {
+      throw new Error("makeStubStore: transact not stubbed");
+    },
+    countPendingMessages: async () => ({ count: 0, nextAttemptAt: null }),
     appendIntents: async () => ({
       insertedMessageKeys: [],
       duplicateMessageKeys: [],

--- a/platform/app/src/server/event-sourcing/process-manager/failureDiagnostic.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/failureDiagnostic.ts
@@ -2,33 +2,98 @@ const GENERIC_FAILURE_MESSAGE =
   "Operation failed; sensitive details were omitted";
 
 /**
+ * The marker an error carries to say its message was authored by us and holds
+ * no foreign content. Checked as a plain field rather than by `instanceof`,
+ * for the same reason `DispatchError` is checked by name: the error may have
+ * crossed a worker or serialisation boundary that stripped its prototype.
+ */
+export const DIAGNOSTIC_SAFE = "diagnosticSafe";
+
+/**
+ * Stamp an error we authored as safe to quote back to ourselves.
+ *
+ * Use it for internal failures whose message is a fixed sentence plus ids we
+ * already log — a lost compare-and-swap, a guard that refused, an invariant
+ * that did not hold. Do NOT use it to wrap a third-party error: a Prisma,
+ * ClickHouse or provider-SDK message can carry query parameters, row values
+ * or response bodies, which is exactly what the generic message exists for.
+ */
+export function markDiagnosticSafe<E extends Error>(error: E): E {
+  Reflect.set(error, DIAGNOSTIC_SAFE, true);
+  return error;
+}
+
+/** An error that names its own cause in a message we wrote. */
+export function safeDiagnosticError(message: string): Error {
+  return markDiagnosticSafe(new Error(message));
+}
+
+/**
+ * Whether this error's own message may be quoted.
+ *
+ * Three provenances qualify, and all three are about who wrote the words:
+ *
+ * - a `HandledError`, whose `message` is customer-safe by contract
+ *   (`dev/docs/best_practices/error-handling.md`);
+ * - a `DispatchError`, the delivery diagnostic our dispatch endpoints
+ *   assemble on purpose (ADR-027);
+ * - anything stamped by {@link markDiagnosticSafe}.
+ *
+ * Everything else is foreign until proven otherwise.
+ */
+function messageIsOurs(error: unknown): error is Error {
+  if (!(error instanceof Error)) return false;
+  if (Reflect.get(error, DIAGNOSTIC_SAFE) === true) return true;
+  if (
+    error.name === "DispatchError" &&
+    typeof Reflect.get(error, "retryable") === "boolean"
+  ) {
+    return true;
+  }
+  return typeof Reflect.get(error, "code") === "string" && isHandledError(error);
+}
+
+/** `HandledError` stamps `handled` in its constructor; the field survives a
+ *  serialisation boundary that the prototype does not. */
+function isHandledError(error: Error): boolean {
+  return Reflect.get(error, "handled") === true;
+}
+
+function builtinErrorType(error: unknown): string {
+  if (error instanceof AggregateError) return "AggregateError";
+  if (error instanceof TypeError) return "TypeError";
+  if (error instanceof RangeError) return "RangeError";
+  if (error instanceof ReferenceError) return "ReferenceError";
+  if (error instanceof SyntaxError) return "SyntaxError";
+  if (error instanceof URIError) return "URIError";
+  if (error instanceof EvalError) return "EvalError";
+  if (error instanceof Error) return "Error";
+  return "NonErrorThrown";
+}
+
+/**
  * Returns a bounded diagnostic that is safe for logs and exported telemetry.
- * Error messages and custom names are untrusted because process inputs and
- * provider failures can copy customer content or credentials into either.
+ *
+ * A third-party error's message is untrusted, because process inputs and
+ * provider failures can copy customer content or credentials into it, so it
+ * is replaced by a fixed sentence. An error WE authored is a different thing
+ * entirely: redacting it hides our own words from us and leaves an operator
+ * reading "Operation failed" eleven times over with no way to recover the
+ * cause — the failure this function is supposed to be describing becomes
+ * invisible in the logs, the span and the attempt log at once.
+ *
+ * So the rule is provenance, not audience: {@link messageIsOurs} decides, and
+ * every surface gets the same answer.
  */
 export function toSafeFailureDiagnostic(error: unknown): {
   errorType: string;
   errorMessage: string;
 } {
-  let errorType = "NonErrorThrown";
-
-  if (error instanceof AggregateError) {
-    errorType = "AggregateError";
-  } else if (error instanceof TypeError) {
-    errorType = "TypeError";
-  } else if (error instanceof RangeError) {
-    errorType = "RangeError";
-  } else if (error instanceof ReferenceError) {
-    errorType = "ReferenceError";
-  } else if (error instanceof SyntaxError) {
-    errorType = "SyntaxError";
-  } else if (error instanceof URIError) {
-    errorType = "URIError";
-  } else if (error instanceof EvalError) {
-    errorType = "EvalError";
-  } else if (error instanceof Error) {
-    errorType = "Error";
+  if (messageIsOurs(error)) {
+    return { errorType: error.name, errorMessage: error.message };
   }
-
-  return { errorType, errorMessage: GENERIC_FAILURE_MESSAGE };
+  return {
+    errorType: builtinErrorType(error),
+    errorMessage: GENERIC_FAILURE_MESSAGE,
+  };
 }

--- a/platform/app/src/server/event-sourcing/process-manager/processManagerService.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/processManagerService.ts
@@ -2,8 +2,6 @@ import { performance } from "node:perf_hooks";
 import { createLogger } from "@langwatch/observability";
 import {
   type Attributes,
-  context,
-  propagation,
   SpanKind,
   SpanStatusCode,
   type Tracer,
@@ -15,6 +13,7 @@ import {
   observeEsProcessManagerDuration,
 } from "~/server/metrics";
 import { toSafeFailureDiagnostic } from "./failureDiagnostic";
+import { captureTraceCarrier } from "./traceCarrier";
 import { ensureJsonSafe, isDeepJsonEqual } from "./json";
 import type {
   ProcessDefinition,
@@ -354,7 +353,7 @@ export class ProcessManagerService<State> {
     intents: ProcessIntent[];
     userId?: string;
   }): NewOutboxMessage[] {
-    const traceCarrier = this.captureTraceCarrier();
+    const traceCarrier = captureTraceCarrier();
     return intents.map((intent) => {
       ensureJsonSafe(intent.payload);
       return {
@@ -365,17 +364,6 @@ export class ProcessManagerService<State> {
         ...(userId ? { userId } : {}),
       };
     });
-  }
-
-  /**
-   * Captures the full active W3C propagation carrier
-   * (traceparent/tracestate/baggage as configured on the global propagator)
-   * so the outbox dispatch can continue this trace as its remote parent.
-   */
-  private captureTraceCarrier(): Record<string, string> {
-    const carrier: Record<string, string> = {};
-    propagation.inject(context.active(), carrier);
-    return carrier;
   }
 
   private async inEvolveSpan<T extends HandleResult>(params: {

--- a/platform/app/src/server/event-sourcing/process-manager/stores/__tests__/prismaProcessStore.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/__tests__/prismaProcessStore.integration.test.ts
@@ -287,6 +287,73 @@ describe("PrismaProcessStore", () => {
     expect(leases.flat().map((row) => row.messageKey)).toEqual(["message-1"]);
   });
 
+  describe("given many writers racing on one process", () => {
+    /** @scenario Concurrent envelopes for one endpoint all land */
+    it("transact lands every concurrent append with no conflict outcome", async () => {
+      const target = ref("hot-stream");
+      const writers = 8;
+
+      const results = await Promise.all(
+        Array.from({ length: writers }, (_, index) =>
+          store.transact<{ appended: string[] }>({
+            ref: target,
+            tenantId: "tenant-1",
+            sourceEventId: `event-${index}`,
+            now: 1_000 + index,
+            apply: (current) => ({
+              state: {
+                appended: [
+                  ...(current?.state.appended ?? []),
+                  `envelope-${index}`,
+                ],
+              },
+              nextWakeAt: null,
+              messages: [message(`append-${index}`)],
+            }),
+          }),
+        ),
+      );
+
+      // The lock serialised them, and because each read happened inside it,
+      // every writer landed: no revisionConflict outcome exists to return.
+      for (const result of results) expect(result.outcome).toBe("committed");
+      const instance = await store.findByRef<{ appended: string[] }>({
+        ref: target,
+      });
+      expect(instance?.revision).toBe(writers);
+      expect(instance?.state.appended).toHaveLength(writers);
+      expect(new Set(instance?.state.appended).size).toBe(writers);
+      const { count } = await store.countPendingMessages({
+        ref: target,
+        intentType: "langy.test.intent",
+      });
+      expect(count).toBe(writers);
+    });
+
+    it("transact still absorbs a duplicate source event", async () => {
+      const target = ref("dedup-stream");
+      const first = await store.transact<{ n: number }>({
+        ref: target,
+        tenantId: "tenant-1",
+        sourceEventId: "same-event",
+        now: 1_000,
+        apply: () => ({ state: { n: 1 }, nextWakeAt: null, messages: [] }),
+      });
+      const replay = await store.transact<{ n: number }>({
+        ref: target,
+        tenantId: "tenant-1",
+        sourceEventId: "same-event",
+        now: 2_000,
+        apply: () => ({ state: { n: 2 }, nextWakeAt: null, messages: [] }),
+      });
+
+      expect(first.outcome).toBe("committed");
+      expect(replay.outcome).toBe("duplicateEvent");
+      const instance = await store.findByRef<{ n: number }>({ ref: target });
+      expect(instance?.state.n).toBe(1);
+    });
+  });
+
   describe("given a leased outbox message", () => {
     const base = 1_700_000_000_000;
     // processName is regenerated per test, so the identity is built inside
@@ -1085,8 +1152,8 @@ describe("PrismaProcessStore", () => {
         expect(leased.map((row) => row.messageKey)).toEqual(["pending-msg"]);
       });
 
-      /** @scenario "Dead outbox rows are kept far longer than dispatched ones" */
-      it("keeps a dead row until its own longer window elapses", async () => {
+      /** @scenario "Dead messages are retained until delivered or discarded" */
+      it("keeps a dead row past every cutoff and reaps it only once discarded", async () => {
         const deadAt = 200_000;
         await store.commit(
           commit({
@@ -1114,8 +1181,8 @@ describe("PrismaProcessStore", () => {
           dead: true,
         });
 
-        // The dispatched family must not touch it, and neither must a dead sweep
-        // whose cutoff it still predates.
+        // Undelivered work is retained: no cutoff reaps a DEAD row, however
+        // far it predates one. Only the operator's discard starts its clock.
         expect(
           await store.deleteDispatchedOutboxBatch({
             before: cutoff,
@@ -1123,7 +1190,7 @@ describe("PrismaProcessStore", () => {
           }),
         ).toBe(0);
         expect(
-          await store.deleteDeadOutboxBatch({ before: deadAt, limit: 5_000 }),
+          await store.deleteDeadOutboxBatch({ before: recent, limit: 5_000 }),
         ).toBe(0);
         expect(
           await prisma.processManagerOutbox.count({
@@ -1131,6 +1198,10 @@ describe("PrismaProcessStore", () => {
           }),
         ).toBe(1);
 
+        await prisma.processManagerOutbox.updateMany({
+          where: { processName, projectId: "project-1" },
+          data: { status: "discarded", updatedAt: new Date(deadAt) },
+        });
         expect(
           await store.deleteDeadOutboxBatch({ before: recent, limit: 5_000 }),
         ).toBe(1);

--- a/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/inMemoryProcessStore.ts
@@ -12,7 +12,10 @@ import type {
   PersistedProcessInstance,
   ProcessCommit,
   ProcessStore,
+  ProcessTransaction,
+  TransactResult,
 } from "./processStore.types";
+import { safeDiagnosticError } from "../failureDiagnostic";
 
 interface StoredMessage extends OutboxMessageRecord {
   /** Epoch ms until which the message is exclusively leased; 0 = unleased. */
@@ -141,6 +144,48 @@ export class InMemoryProcessStore implements ProcessStore {
   }
 
   /**
+   * Read-modify-write with no window between the two. Every call here is
+   * synchronous, so the read this hands to `apply` cannot go stale before the
+   * write lands — which is the property the Postgres adapter buys with its
+   * advisory lock, and the reason neither can report a revision conflict.
+   */
+  async transact<State = unknown>(
+    transaction: ProcessTransaction<State>,
+  ): Promise<TransactResult> {
+    const { ref, sourceEventId } = transaction;
+
+    if (
+      sourceEventId !== null &&
+      this.inbox.has(inboxKey({ ref, sourceEventId }))
+    ) {
+      return { outcome: "duplicateEvent" };
+    }
+
+    const existing = this.instances.get(refKey(ref)) as
+      | PersistedProcessInstance<State>
+      | undefined;
+    const applied = transaction.apply(existing ?? null);
+
+    const result = await this.commit<State>({
+      ref,
+      tenantId: transaction.tenantId,
+      ...(transaction.userId ? { userId: transaction.userId } : {}),
+      sourceEventId,
+      expectedRevision: existing?.revision ?? 0,
+      state: applied.state,
+      nextWakeAt: applied.nextWakeAt,
+      messages: applied.messages,
+      now: transaction.now,
+    });
+    if (result.outcome === "revisionConflict") {
+      throw safeDiagnosticError(
+        `process transact reported a revision conflict on ${ref.processName}/${ref.processKey}`,
+      );
+    }
+    return result;
+  }
+
+  /**
    * The transient path: intents only, no instance and no inbox marker. The
    * durable adapter drops its transaction here too; this one is atomic per
    * call regardless, so the shared insert is the whole implementation.
@@ -211,6 +256,30 @@ export class InMemoryProcessStore implements ProcessStore {
         message.projectId === params.ref.projectId &&
         message.processKey === params.ref.processKey,
     );
+  }
+
+  async countPendingMessages(params: {
+    ref: ProcessRef;
+    intentType: string;
+  }): Promise<{ count: number; nextAttemptAt: number | null }> {
+    let count = 0;
+    let nextAttemptAt: number | null = null;
+    for (const message of this.messages.values()) {
+      if (
+        message.processName !== params.ref.processName ||
+        message.projectId !== params.ref.projectId ||
+        message.processKey !== params.ref.processKey ||
+        message.intentType !== params.intentType ||
+        message.status !== "pending"
+      ) {
+        continue;
+      }
+      count += 1;
+      if (nextAttemptAt === null || message.nextAttemptAt < nextAttemptAt) {
+        nextAttemptAt = message.nextAttemptAt;
+      }
+    }
+    return { count, nextAttemptAt };
   }
 
   async leaseDueMessages(params: {
@@ -378,15 +447,14 @@ export class InMemoryProcessStore implements ProcessStore {
     before: number;
     limit: number;
   }): Promise<number> {
-    // Reaped by `updatedAt`, the same column the durable store uses, which
-    // the markFailed that retired the row stamped. `discarded` rides the same
-    // family for the reason given on the durable store: no other predicate
-    // matches it, so leaving it out makes it immortal.
+    // Reaped by `updatedAt`, the same column the durable store uses. Only
+    // `discarded` is reaped, for the reason given on the durable store: a
+    // dead row is undelivered work nobody agreed to lose, retained until it
+    // delivers or an operator discards it and starts this clock.
     return this.deleteOutboxBatch(
       params,
       (message) =>
-        (message.status === "dead" || message.status === "discarded") &&
-        message.updatedAt < params.before,
+        message.status === "discarded" && message.updatedAt < params.before,
     );
   }
 

--- a/platform/app/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/prismaProcessStore.ts
@@ -21,7 +21,10 @@ import type {
   PersistedProcessInstance,
   ProcessCommit,
   ProcessStore,
+  ProcessTransaction,
+  TransactResult,
 } from "./processStore.types";
+import { safeDiagnosticError } from "../failureDiagnostic";
 
 class DuplicateInboxRollback extends Error {}
 
@@ -35,6 +38,21 @@ function refWhere(ref: ProcessRef) {
 
 function refLockKey(ref: ProcessRef): string {
   return JSON.stringify([ref.processName, ref.projectId, ref.processKey]);
+}
+
+function toPersisted<State>(
+  ref: ProcessRef,
+  row: ProcessManagerInstance,
+): PersistedProcessInstance<State> {
+  return {
+    ref,
+    tenantId: row.tenantId,
+    ...(row.userId === null ? {} : { userId: row.userId }),
+    state: row.state as State,
+    revision: row.revision,
+    nextWakeAt: row.nextWakeAt?.getTime() ?? null,
+    updatedAt: row.updatedAt.getTime(),
+  };
 }
 
 function asDate(epochMs: number): Date {
@@ -121,20 +139,83 @@ export class PrismaProcessStore implements ProcessStore {
       },
     });
     if (!row) return null;
-    return {
-      ref: params.ref,
-      tenantId: row.tenantId,
-      ...(row.userId === null ? {} : { userId: row.userId }),
-      state: row.state as State,
-      revision: row.revision,
-      nextWakeAt: row.nextWakeAt?.getTime() ?? null,
-      updatedAt: row.updatedAt.getTime(),
-    };
+    return toPersisted<State>(params.ref, row);
   }
 
   async commit<State = unknown>(
     commit: ProcessCommit<State>,
   ): Promise<CommitResult> {
+    return await this.writeUnderLock<State>({
+      ref: commit.ref,
+      tenantId: commit.tenantId,
+      ...(commit.userId === undefined ? {} : { userId: commit.userId }),
+      sourceEventId: commit.sourceEventId,
+      now: commit.now,
+      decide: (existing) => {
+        const actualRevision = existing?.revision ?? 0;
+        if (actualRevision !== commit.expectedRevision) {
+          return { outcome: "revisionConflict" as const, actualRevision };
+        }
+        return {
+          outcome: "write" as const,
+          state: commit.state,
+          nextWakeAt: commit.nextWakeAt,
+          messages: commit.messages,
+        };
+      },
+    });
+  }
+
+  async transact<State = unknown>(
+    transaction: ProcessTransaction<State>,
+  ): Promise<TransactResult> {
+    const result = await this.writeUnderLock<State>({
+      ref: transaction.ref,
+      tenantId: transaction.tenantId,
+      ...(transaction.userId === undefined ? {} : { userId: transaction.userId }),
+      sourceEventId: transaction.sourceEventId,
+      now: transaction.now,
+      decide: (existing) => ({
+        outcome: "write" as const,
+        ...transaction.apply(existing),
+      }),
+    });
+    if (result.outcome === "revisionConflict") {
+      // Unreachable: `decide` above never returns a conflict, and the write
+      // derives its expected revision from the read this lock is holding. If
+      // it ever fires, the lock stopped covering the read.
+      throw safeDiagnosticError(
+        `process transact reported a revision conflict on ${transaction.ref.processName}/${transaction.ref.processKey}`,
+      );
+    }
+    return result;
+  }
+
+  /**
+   * The one write body, shared by {@link commit} and {@link transact}: take the
+   * process-ref lock, consume the inbox marker, read the instance, let the
+   * caller decide from what it read, and persist state, wake and messages.
+   *
+   * The read sits INSIDE the lock. That is what lets `transact` promise no
+   * conflict, and it is why `decide` receives the instance rather than a
+   * revision the caller guessed at beforehand.
+   */
+  private async writeUnderLock<State = unknown>(params: {
+    ref: ProcessRef;
+    tenantId: string;
+    userId?: string;
+    sourceEventId: string | null;
+    now: number;
+    decide: (existing: PersistedProcessInstance<State> | null) =>
+      | { outcome: "revisionConflict"; actualRevision: number }
+      | {
+          outcome: "write";
+          state: State;
+          nextWakeAt: number | null;
+          messages: NewOutboxMessage[];
+        };
+  }): Promise<CommitResult> {
+    const commit = params;
     try {
       return await this.prisma.$transaction(async (tx) => {
         // This lock only serializes commits for the same process reference.
@@ -165,29 +246,26 @@ export class PrismaProcessStore implements ProcessStore {
           if (duplicate) return { outcome: "duplicateEvent" as const };
         }
 
-        const existing = await tx.processManagerInstance.findUnique({
+        const row = await tx.processManagerInstance.findUnique({
           where: {
             projectId: commit.ref.projectId,
             processName_projectId_processKey: refWhere(commit.ref),
           },
-          select: { revision: true },
         });
+        const existing = row === null ? null : toPersisted<State>(commit.ref, row);
         const actualRevision = existing?.revision ?? 0;
-        if (actualRevision !== commit.expectedRevision) {
-          return {
-            outcome: "revisionConflict" as const,
-            actualRevision,
-          };
-        }
+
+        const decided = commit.decide(existing);
+        if (decided.outcome === "revisionConflict") return decided;
 
         const revision = actualRevision + 1;
         const instanceData = {
           tenantId: commit.tenantId,
           userId: commit.userId ?? null,
-          state: toJsonInput(commit.state as JsonValue),
+          state: toJsonInput(decided.state as JsonValue),
           revision,
           nextWakeAt:
-            commit.nextWakeAt === null ? null : asDate(commit.nextWakeAt),
+            decided.nextWakeAt === null ? null : asDate(decided.nextWakeAt),
           updatedAt: asDate(commit.now),
         };
 
@@ -221,7 +299,7 @@ export class PrismaProcessStore implements ProcessStore {
           const updated = await tx.processManagerInstance.updateMany({
             where: {
               ...refWhere(commit.ref),
-              revision: commit.expectedRevision,
+              revision: actualRevision,
             },
             data: instanceData,
           });
@@ -261,7 +339,7 @@ export class PrismaProcessStore implements ProcessStore {
 
         const insertedMessageKeys: string[] = [];
         const duplicateMessageKeys: string[] = [];
-        for (const message of commit.messages) {
+        for (const message of decided.messages) {
           const inserted = await tx.processManagerOutbox.createMany({
             data: [
               {
@@ -388,6 +466,25 @@ export class PrismaProcessStore implements ProcessStore {
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     });
     return rows.map(toMessage);
+  }
+
+  async countPendingMessages(params: {
+    ref: ProcessRef;
+    intentType: string;
+  }): Promise<{ count: number; nextAttemptAt: number | null }> {
+    const aggregate = await this.prisma.processManagerOutbox.aggregate({
+      where: {
+        ...refWhere(params.ref),
+        intentType: params.intentType,
+        status: "pending",
+      },
+      _count: { _all: true },
+      _min: { nextAttemptAt: true },
+    });
+    return {
+      count: aggregate._count._all,
+      nextAttemptAt: aggregate._min.nextAttemptAt?.getTime() ?? null,
+    };
   }
 
   async leaseDueMessages(params: {
@@ -659,25 +756,30 @@ export class PrismaProcessStore implements ProcessStore {
     // No new index: `dead` is a rare status, so the existing
     // (status, nextAttemptAt, leasedUntil) index already makes this selective.
     //
-    // `discarded` is reaped on the same window and by the same sweep. It is
-    // the terminal state an operator writes rather than one the dispatcher
-    // writes, but it means the same thing to retention — a record of work
-    // that will never run, kept for as long as the operator might ask about
-    // it. Leaving it out is what would make it immortal: no other family's
-    // predicate matches it, and this is the highest-volume table in the
-    // system (specs/ops/dead-letter-recovery.feature).
+    // Only `discarded` is reaped, and the distinction is the whole point.
+    //
+    // `discarded` is the terminal state an OPERATOR writes: someone looked at
+    // the message and said never send this. Deleting it after the window is
+    // housekeeping on a decision that was already taken, and leaving it out
+    // would make it immortal — no other family's predicate matches it, on the
+    // highest-volume table in the system.
+    //
+    // `dead` is the state the DISPATCHER writes when a message ran out of
+    // attempts, and nobody agreed to lose it. Sweeping it turned "this one
+    // stopped retrying" into "this one no longer exists" thirty days later,
+    // silently and with no record of what was in it. A message that never
+    // delivered is retained until it delivers or an operator discards it,
+    // which is the only way `retire` can mean parked rather than dropped
+    // (specs/ops/dead-letter-recovery.feature).
     return await this.prisma.$executeRaw`
       DELETE FROM "ProcessManagerOutbox"
       WHERE "id" IN (
         SELECT "id" FROM "ProcessManagerOutbox"
-        WHERE "status" IN (
-            'dead'::"ProcessManagerOutboxStatus",
-            'discarded'::"ProcessManagerOutboxStatus"
-          )
+        WHERE "status" = 'discarded'::"ProcessManagerOutboxStatus"
           AND "updatedAt" < ${asDate(params.before)}
         LIMIT ${params.limit}
       )
-      -- @tenancy: process-manager retention sweep, dead outbox (system-owned maintenance)
+      -- @tenancy: process-manager retention sweep, discarded outbox (system-owned maintenance)
     `;
   }
 

--- a/platform/app/src/server/event-sourcing/process-manager/stores/processStore.types.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/stores/processStore.types.ts
@@ -125,6 +125,56 @@ export type CommitResult =
   | { outcome: "revisionConflict"; actualRevision: number };
 
 /**
+ * A read-modify-write held inside the store's own lock.
+ *
+ * `commit` asks the caller for `expectedRevision`, which means the caller read
+ * the state BEFORE the store took its advisory lock. The lock still serialises
+ * the writes, so nothing is lost — but every writer that read from the same
+ * pre-lock snapshot arrives holding a revision that the winner has already
+ * moved, and the compare-and-swap turns a serialisation that succeeded into a
+ * failure the caller has to handle. For a process key that many writers append
+ * to, that is not an edge case: it is the steady state, and each loser pays a
+ * whole outbox attempt for a race whose outcome it did not care about.
+ *
+ * `transact` closes the window instead of retrying inside it. The store takes
+ * the lock, reads the current instance, hands it to `apply`, and writes what
+ * comes back — one transaction, no gap for another writer to slip through, so
+ * there is no `revisionConflict` outcome to return.
+ *
+ * `expectedRevision` keeps its place for callers that genuinely want optimistic
+ * concurrency: a wake that must not act on state another commit has already
+ * advanced still wants to be told, rather than to recompute from underneath it.
+ *
+ * `apply` runs INSIDE the transaction and while the lock is held, so it must be
+ * pure and prompt: derive the next state from what it was handed, and nothing
+ * else. An I/O call in there holds the lock across a network round trip and
+ * turns one process key into everyone's bottleneck.
+ */
+export interface ProcessTransaction<State = unknown> {
+  ref: ProcessRef;
+  tenantId: string;
+  userId?: string;
+  /** Inbox identity, exactly as {@link ProcessCommit.sourceEventId}. */
+  sourceEventId: string | null;
+  now: number;
+  apply: (current: PersistedProcessInstance<State> | null) => {
+    state: State;
+    nextWakeAt: number | null;
+    messages: NewOutboxMessage[];
+  };
+}
+
+/** {@link CommitResult} minus the outcome `transact` exists to remove. */
+export type TransactResult =
+  | {
+      outcome: "committed";
+      revision: number;
+      insertedMessageKeys: string[];
+      duplicateMessageKeys: string[];
+    }
+  | { outcome: "duplicateEvent" };
+
+/**
  * The transient append: intents only, no instance row, no inbox row, and no
  * transaction.
  *
@@ -177,6 +227,14 @@ export interface ProcessStore {
   commit<State = unknown>(commit: ProcessCommit<State>): Promise<CommitResult>;
 
   /**
+   * The same write, with the read held inside the lock so no
+   * `revisionConflict` is possible. See {@link ProcessTransaction}.
+   */
+  transact<State = unknown>(
+    transaction: ProcessTransaction<State>,
+  ): Promise<TransactResult>;
+
+  /**
    * Appends a transient evolution's intents. See {@link AppendIntentsResult}
    * for why this is neither transactional nor inbox-backed.
    *
@@ -198,6 +256,22 @@ export interface ProcessStore {
   findMessagesByRef(params: {
     ref: ProcessRef;
   }): Promise<OutboxMessageRecord[]>;
+
+  /**
+   * How many of one process's messages of one intent type are still pending,
+   * and the soonest instant any of them becomes due again.
+   *
+   * This is the in-flight read on a hot append path, and it is a dedicated
+   * method because {@link findMessagesByRef} is the wrong tool there: that
+   * one fetches every row the ref has ever minted — dispatched history and
+   * payloads included — to answer what is ultimately a count. `nextAttemptAt`
+   * rides along because the caller holding a full in-flight cap wants to
+   * sleep until a slot can actually free, not poll.
+   */
+  countPendingMessages(params: {
+    ref: ProcessRef;
+    intentType: string;
+  }): Promise<{ count: number; nextAttemptAt: number | null }>;
 
   /**
    * Lease pending, due messages for exclusive dispatch until

--- a/platform/app/src/server/event-sourcing/process-manager/traceCarrier.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/traceCarrier.ts
@@ -1,0 +1,16 @@
+import { context, propagation } from "@opentelemetry/api";
+
+/**
+ * Captures the full active W3C propagation carrier
+ * (traceparent/tracestate/baggage as configured on the global propagator)
+ * so an outbox dispatch can continue this trace as its remote parent.
+ *
+ * Every minted outbox message must carry this rather than `{}`: an empty
+ * carrier extracts to a root context, and the dispatch becomes an orphan
+ * span with no path back to the work that minted it.
+ */
+export function captureTraceCarrier(): Record<string, string> {
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+  return carrier;
+}

--- a/specs/ops/dead-letter-recovery.feature
+++ b/specs/ops/dead-letter-recovery.feature
@@ -85,15 +85,24 @@ Feature: Dead-letter recovery
     When the retention sweep removes the message
     Then its attempt entries are removed with it
 
-  # A discarded row is terminal like a dead one, and no other family's
-  # predicate matches it. Left out of the sweep it would be the one state that
-  # never ages out, on the highest-volume table in the system.
+  # Discarded and dead age differently because they mean different things.
+  # Discarded is a decision an operator took; deleting it after the window is
+  # housekeeping on a closed case. Dead is undelivered work nobody agreed to
+  # lose — sweeping it would turn "stopped retrying" into "no longer exists"
+  # a month later, silently.
   @integration
   Scenario: Discarded messages age out on the dead-letter window
     Given a discarded outbox row older than the dead retention window
     And a discarded outbox row inside the dead retention window
     When the dead-letter retention batch is reaped
     Then only the row past the window is deleted
+
+  @integration
+  Scenario: Dead messages are retained until delivered or discarded
+    Given a dead outbox row older than the dead retention window
+    When the dead-letter retention batch is reaped
+    Then the dead row is still there
+    And discarding it is what starts its retention clock
 
   # Redrive resets the attempt counter, so the number stops being unique over
   # a message's life and only time orders the entries correctly.

--- a/specs/webhooks/webhook-endpoints.feature
+++ b/specs/webhooks/webhook-endpoints.feature
@@ -1,10 +1,12 @@
 Feature: Webhook endpoints, signed outbound event delivery
   Stripe-shaped webhook platform: an organization registers endpoints with
   per-endpoint event subscriptions, and the platform delivers signed,
-  batched, versioned envelopes with a multi-day retry ladder, a visible
+  batched, versioned envelopes with a day-long retry ladder, a visible
   per-attempt delivery log carrying the receiver's own status codes, and
   automatic disabling of endpoints that fail for three days straight.
-  Delivery is push over a persisted event log, never the only copy of it.
+  Delivery is push over a persisted event log, never the only copy of it,
+  and a batch that exhausts its retries is parked for the operator, never
+  deleted.
 
   Background:
     Given an organization on an enterprise plan with webhook endpoints
@@ -306,11 +308,24 @@ Feature: Webhook endpoints, signed outbound event delivery
 
   Rule: Retries follow the Stripe ladder and respect the receiver
 
+    # A day, not three: retrying is only worth what a receiver's outage costs
+    # to ride out, and past that the batch is better parked where an operator
+    # can see it and push it through. Parked is not dropped — the batch stays
+    # until it delivers or an operator discards it.
     @unit
-    Scenario: The retry ladder holds its last attempt inside seventy two hours
+    Scenario: The retry ladder holds its last attempt inside one day
       Given the ladder delays and the send attempt budget
-      Then the cumulative schedule stays within seventy two hours of the first failure
-      And the cadence settles at twelve hours
+      Then the cumulative schedule stays within one day of the first failure
+      And the cadence settles at four hours
+
+    # Everything that failed together would otherwise retry together, and a
+    # cohort that collided once re-collides at every rung.
+    @unit
+    Scenario: Retry delays spread so a failed cohort comes apart
+      Given a ladder step
+      When many retries are scheduled from it
+      Then their delays spread around the step instead of landing on one instant
+      And every delay stays within a fifth of the step either side
 
     @unit
     Scenario: A permanent receiver error retires the batch immediately
@@ -339,12 +354,30 @@ Feature: Webhook endpoints, signed outbound event delivery
       When a delivery attempt succeeds
       Then the streak is cleared
 
+    # Disabled and deleted are different promises. Deleted means the customer
+    # asked us to stop, so the queue drains without posting. Disabled means
+    # the receiver is expected back, so nothing the customer queued is lost
+    # to the pause: batches wait on the ladder, park when it runs out, and
+    # re-enabling revives them.
     @integration
-    Scenario: A disabled endpoint drains its queue without posting
+    Scenario: A disabled endpoint keeps its queued batches unsent
       Given a disabled endpoint with a pending batch
       When the batch dispatches
       Then nothing is sent to the receiver
+      And the batch stays queued for a later attempt
+
+    @integration
+    Scenario: A deleted endpoint discards its queued batches
+      Given a deleted endpoint with a pending batch
+      When the batch dispatches
+      Then nothing is sent to the receiver
       And the batch completes so the queue drains
+
+    @integration
+    Scenario: Re-enabling an endpoint revives its parked batches
+      Given a disabled endpoint whose batch exhausted its retries
+      When the endpoint is re-enabled
+      Then the parked batch is pending again with a fresh attempt budget
 
     @integration
     Scenario: Dead lettered batches can be requeued
@@ -365,6 +398,17 @@ Feature: Webhook endpoints, signed outbound event delivery
       Given the endpoint drawer is open
       Then the batch size, batch delay, and in-flight controls show their defaults
       And saving sends the edited values
+
+    # Appends have no order to preserve — two envelopes arriving together are
+    # equally valid in either sequence — so a racing append must never fail
+    # for having raced. Losing that race once cost the envelope a full
+    # delivery attempt and, eleven collisions later, the envelope itself.
+    @integration
+    Scenario: Concurrent envelopes for one endpoint all land
+      Given many spend events arriving together for one endpoint
+      When their appends race on the endpoint's stream
+      Then every envelope lands exactly once
+      And none of them fails for having raced
 
     @integration
     Scenario: Envelopes coalesce into one signed batch up to the endpoint's size


### PR DESCRIPTION
## What

Webhook delivery could lose customer events three ways, all confirmed against production telemetry over the last 7 days:

1. **The append conflict machine.** Every spend-event append to an endpoint stream read the stream's revision *before* taking the store's advisory lock, then compare-and-swapped *inside* it — so of K concurrent appends, K−1 were guaranteed to fail, and those failures rode the HTTP retry ladder (60s fixed, no jitter, shared 11-attempt budget). Prod: **33k retries for 29k dispatches (41% first-attempt failure)**, each failed envelope colliding ~2.8×, and **160 envelopes for confirmed spend events dead-lettered** — then silently deleted 30 days later by the retention sweep. Receivers were innocent: sendBatch retried 37 of 36k.
2. **The disabled-endpoint drain.** A disabled endpoint's queued batches were acknowledged without posting ("replay covers the gap"). Prod: 6 batches dropped in a week.
3. **Invisible causes.** The conflict threw a plain `Error`, which `toSafeFailureDiagnostic` redacts to *"Operation failed; sensitive details were omitted"* in logs **and** span exceptions — the storm was undiagnosable from telemetry alone.

## How

- **`ProcessStore.transact`** — the read happens inside the advisory lock, so concurrent appends serialise and all land; no `revisionConflict` outcome exists to return. Webhook appends and flushes use it.
- **Retry ladder**: last attempt inside 24h (was 72h), settling at 4h, ±20% jitter so failed cohorts come apart.
- **Paused ≠ gone**: disabled endpoints keep queued batches unsent (retryable); only deleted endpoints drain. **Re-enable requeues parked (dead) batches** with a fresh budget.
- **Dead rows retained** until delivered or operator-discarded; only `discarded` ages out on the retention window. *Store-wide semantic change* — see Deployment Impact.
- **Diagnosable failures**: known flush failures rethrow as `DispatchError` naming the endpoint + failure class (survives redaction); own-authored errors (`markDiagnosticSafe`) pass through the redactor.
- **Trace lineage**: minted `sendBatch` messages carry a captured trace carrier instead of `{}` — POSTs now link to their gateway request in Tempo.
- **Hot-path cost**: the in-flight count is an indexed aggregate (`countPendingMessages`) instead of fetching the ref's full payload history per append; a stream capped by laddered retries arms its wake at the next attempt's due time instead of a 500ms poll (~47k flush dispatches/week, more than actual sends).

## Specs

- `specs/webhooks/webhook-endpoints.feature`: ladder inside one day + jitter spread; disabled-keeps-queue / deleted-discards / re-enable-revives; concurrent appends all land.
- `specs/ops/dead-letter-recovery.feature`: dead retained until delivered or discarded.
All bound with `@scenario` annotations in the ladder unit tests, delivery process integration tests, and store integration tests.

## Deployment Impact

- **Retention**: `deleteDeadOutboxBatch` now reaps only `discarded` rows. Dead rows across **all** process-manager domains persist until an operator discards or requeues them. Follow-up (saas): a dead-depth/age alert on `es_process_outbox_total{status="dead"}` so accumulation is visible. Ops UI (DLQ depth, requeue, discard) already exists.
- **After deploy**: requeue the ~160 existing dead `webhookDelivery` deliver messages so affected customers receive their parked events.
- No schema changes; `transact` is additive on the store interface.

## Tests

161 passing across the touched suites: store integration (incl. new 8-writer transact concurrency + duplicate-absorption), webhook delivery process integration (18, incl. the three new disposition scenarios and wake-at-retry-due timing), endpoint service, both REST API suites, process-ops, ladder + jitter units, retention sweep units.