### PR TITLE
fix(navigation): keep the settings chrome, mark the open page, and stop icon-rail pages overflowing

### DIFF
--- a/platform/app/src/features/navigation/__tests__/IconRailShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/IconRailShell.integration.test.tsx
@@ -264,6 +264,7 @@ vi.mock("~/components/sidebar/PresenceMenuItem", () => ({
 import { useNavigationModeStore } from "~/features/navigation/navigationModeStore";
 import { DashboardLayout } from "../../../components/DashboardLayout";
 import { ICON_RAIL_WIDTH } from "../shell/IconRail";
+import { SHELL_SIDEBAR_WIDTH_EXPANDED } from "../shell/shellLayout";
 
 function renderShell(props: Record<string, unknown> = {}) {
   return render(
@@ -318,6 +319,25 @@ describe("the icon-rail shell", () => {
       });
       expect(railTile("Gateway")).not.toHaveStyle({
         backgroundColor: "var(--chakra-colors-bg-panel)",
+      });
+    });
+  });
+
+  describe("when a page renders beside the rail", () => {
+    /** @scenario The page keeps its right edge inside the window */
+    it("gives the page the window less the rail and the sidebar", () => {
+      renderShell();
+
+      // Both are subtracted. Handing the rail over inside a `+` sum makes it
+      // `calc(100vw - sidebar + rail)`, which reads left to right and gives
+      // the page two rails it does not have.
+      const roomForThePage =
+        window.innerWidth -
+        Number.parseInt(SHELL_SIDEBAR_WIDTH_EXPANDED, 10) -
+        Number.parseInt(ICON_RAIL_WIDTH, 10);
+
+      expect(screen.getByTestId("shell-content-column")).toHaveStyle({
+        maxWidth: `${roomForThePage}px`,
       });
     });
   });

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -60,6 +60,12 @@ vi.mock("~/utils/compat/next-router", () => ({
   }),
 }));
 
+// The sidebar marks its entries against the address in the address bar, not
+// the route pattern, so this is the one the fixtures below set.
+vi.mock("~/utils/compat/next-navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
 vi.mock("~/hooks/useRequiredSession", () => ({
   useRequiredSession: () => ({
     data: {

--- a/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/SettingsShellV2.integration.test.tsx
@@ -46,9 +46,20 @@ const organization = {
   teams: [team],
 };
 
+// The real resolver, so `router.pathname` carries the route pattern here
+// exactly as it does in the app. Returning the address instead hid a bug
+// where the settings menu matched its entries against the pattern: one
+// `/settings/*` pattern covers nearly every settings page, so none matched.
+const { resolvePathname } = await vi.hoisted(
+  async () =>
+    await vi.importActual<typeof import("~/utils/compat/next-router")>(
+      "~/utils/compat/next-router",
+    ),
+);
+
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
-    pathname: mockPathname,
+    pathname: resolvePathname(mockPathname),
     query: {},
     asPath: mockPathname,
     push: pushMock,
@@ -413,6 +424,19 @@ describe("the settings shell in a new navigation mode", () => {
       expect(entries.indexOf("API Keys")).toBeLessThan(
         entries.indexOf("Members"),
       );
+    });
+
+    /** @scenario The menu marks the page that is open */
+    it("marks the entry of the page on screen, and only that one", () => {
+      mockPathname = "/settings/email-suppressions";
+      renderSettings();
+
+      const marked = within(screen.getByTestId("sidebar-scroll-region"))
+        .getAllByRole("link")
+        .filter((link) => link.getAttribute("aria-current") === "page")
+        .map((link) => link.textContent?.trim());
+
+      expect(marked).toEqual(["Email Suppressions"]);
     });
 
     it("hides the enterprise entries outside an enterprise plan", () => {

--- a/platform/app/src/features/navigation/__tests__/isSettingsMenuItemActive.unit.test.ts
+++ b/platform/app/src/features/navigation/__tests__/isSettingsMenuItemActive.unit.test.ts
@@ -41,7 +41,7 @@ const PROJECTIONS: SettingsMenuItem = {
 };
 
 describe("isSettingsMenuItemActive", () => {
-  describe("given the address of the page on screen", () => {
+  describe("when the address of the page on screen is passed", () => {
     it("marks the entry the address belongs to", () => {
       expect(
         isSettingsMenuItemActive({
@@ -79,7 +79,7 @@ describe("isSettingsMenuItemActive", () => {
     });
   });
 
-  describe("given an entry that answers for more than one address", () => {
+  describe("when an entry answers for more than one address", () => {
     it("marks it on the address it also answers for", () => {
       expect(
         isSettingsMenuItemActive({
@@ -90,7 +90,7 @@ describe("isSettingsMenuItemActive", () => {
     });
   });
 
-  describe("given an entry that only its own page marks", () => {
+  describe("when an entry is one that only its own page marks", () => {
     it("marks General on the settings home", () => {
       expect(
         isSettingsMenuItemActive({ item: GENERAL, pathname: "/settings" }),

--- a/platform/app/src/features/navigation/__tests__/isSettingsMenuItemActive.unit.test.ts
+++ b/platform/app/src/features/navigation/__tests__/isSettingsMenuItemActive.unit.test.ts
@@ -1,0 +1,126 @@
+import { KeyRound, Repeat, Settings2, Users } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  isSettingsMenuItemActive,
+  type SettingsMenuItem,
+} from "../useSettingsMenu";
+
+// The unit lane stubs the compat router, so the real resolver is asked for
+// by name. It is what turns an address into the route pattern below.
+const { resolvePathname } = await vi.importActual<
+  typeof import("~/utils/compat/next-router")
+>("~/utils/compat/next-router");
+
+/**
+ * Which settings entry the sidebar marks as the page on screen.
+ *
+ * Spec: specs/navigation/settings-shell-v2.feature
+ */
+const GENERAL: SettingsMenuItem = {
+  label: "General",
+  href: "/settings",
+  isExactMatch: true,
+  icon: Settings2,
+};
+const API_KEYS: SettingsMenuItem = {
+  label: "API Keys",
+  href: "/settings/api-keys",
+  icon: KeyRound,
+};
+const MEMBERS: SettingsMenuItem = {
+  label: "Members",
+  href: "/settings/members",
+  includePath: "/settings/members",
+  icon: Users,
+};
+const PROJECTIONS: SettingsMenuItem = {
+  label: "Projection Replay",
+  href: "/ops/projections",
+  alsoActiveAt: ["/ops/replay"],
+  icon: Repeat,
+};
+
+describe("isSettingsMenuItemActive", () => {
+  describe("given the address of the page on screen", () => {
+    it("marks the entry the address belongs to", () => {
+      expect(
+        isSettingsMenuItemActive({
+          item: API_KEYS,
+          pathname: "/settings/api-keys",
+        }),
+      ).toBe(true);
+    });
+
+    it("leaves the other entries unmarked", () => {
+      expect(
+        isSettingsMenuItemActive({
+          item: MEMBERS,
+          pathname: "/settings/api-keys",
+        }),
+      ).toBe(false);
+    });
+
+    it("marks an entry from a page below it", () => {
+      expect(
+        isSettingsMenuItemActive({
+          item: MEMBERS,
+          pathname: "/settings/members/member-1",
+        }),
+      ).toBe(true);
+    });
+
+    it("does not mark an entry whose address is only a name prefix", () => {
+      expect(
+        isSettingsMenuItemActive({
+          item: MEMBERS,
+          pathname: "/settings/members-import",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("given an entry that answers for more than one address", () => {
+    it("marks it on the address it also answers for", () => {
+      expect(
+        isSettingsMenuItemActive({
+          item: PROJECTIONS,
+          pathname: "/ops/replay",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("given an entry that only its own page marks", () => {
+    it("marks General on the settings home", () => {
+      expect(
+        isSettingsMenuItemActive({ item: GENERAL, pathname: "/settings" }),
+      ).toBe(true);
+    });
+
+    it("leaves General unmarked on a page below it", () => {
+      expect(
+        isSettingsMenuItemActive({
+          item: GENERAL,
+          pathname: "/settings/api-keys",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when the route pattern is passed in place of the address", () => {
+    /**
+     * What the bug was. The compat router registers one `/settings/*`
+     * pattern, so it reports the same pathname for every settings page but
+     * General and Audit Log, and no entry could match it.
+     */
+    /** @scenario The menu marks the page that is open */
+    it("matches no entry, which is why the address is what gets passed", () => {
+      const pattern = resolvePathname("/settings/api-keys");
+
+      expect(pattern).toBe("/settings/[[...path]]");
+      expect(
+        isSettingsMenuItemActive({ item: API_KEYS, pathname: pattern }),
+      ).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/features/navigation/shell/NavigationV2Shell.tsx
+++ b/platform/app/src/features/navigation/shell/NavigationV2Shell.tsx
@@ -12,6 +12,7 @@ import Head from "~/utils/compat/next-head";
 import { ICON_RAIL_WIDTH, IconRail } from "./IconRail";
 import { ProductSidebar } from "./ProductSidebar";
 import { ShellTopBar } from "./ShellTopBar";
+import { shellContentMaxWidth } from "./shellLayout";
 import {
   type NavigationV2ShellReadyState,
   useNavigationV2ShellState,
@@ -128,11 +129,12 @@ function ShellContentRow({
 }) {
   const { activeProductId, isCompactSidebar, langyDockInset, menuWidth } =
     state;
-  // The rail is a sibling of this column, so its width is already gone from
-  // the space the content can use. The cap subtracts both it and the sidebar.
-  const contentInsetWidth = isIconRail
-    ? `${menuWidth} + ${ICON_RAIL_WIDTH}`
-    : menuWidth;
+  // The rail is a sibling of this column, so its width is room the page does
+  // not have, the same as the sidebar's.
+  const contentMaxWidth = shellContentMaxWidth({
+    menuWidth,
+    railWidth: isIconRail ? ICON_RAIL_WIDTH : null,
+  });
 
   return (
     <HStack
@@ -153,7 +155,7 @@ function ShellContentRow({
         background="bg.page"
         minHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
         maxHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
-        maxWidth={`calc(100vw - ${contentInsetWidth})`}
+        maxWidth={contentMaxWidth}
         paddingRight={`${langyDockInset}px`}
         transition={`padding-right ${LANGY_TRANSITION}`}
       >

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -14,7 +14,7 @@ import { useCommandBar } from "~/features/command-bar";
 import { getCommandBarShortcut } from "~/features/command-bar/utils/platform";
 import { APP_HEADER_HEIGHT } from "~/features/langy/logic/langyPanelLayout";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { useRouter } from "~/utils/compat/next-router";
+import { usePathname } from "~/utils/compat/next-navigation";
 import { featureIcons } from "~/utils/featureIcons";
 import { readLastVisitedProduct } from "../logic/productMemory";
 import { resolveSettingsBackTarget } from "../logic/resolveSettingsBackTarget";
@@ -26,7 +26,7 @@ import {
 } from "../sectionNavItems";
 import { useLlmOpsProjectSlug } from "../useLlmOpsProjectSlug";
 import { useReachableProducts } from "../useReachableProducts";
-import { useSettingsMenu } from "../useSettingsMenu";
+import { isSettingsMenuItemActive, useSettingsMenu } from "../useSettingsMenu";
 import { QUIET_SIDEBAR_CHIP } from "./quietChipStyle";
 import {
   SHELL_SIDEBAR_WIDTH_COMPACT,
@@ -85,7 +85,7 @@ function SidebarBottomBlock({
   showExpanded: boolean;
   shouldIncludeSettingsLink: boolean;
 }) {
-  const router = useRouter();
+  const pathname = usePathname();
   const { hasPermission } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
@@ -112,10 +112,7 @@ function SidebarBottomBlock({
           icon={featureIcons.settings.icon}
           label="Settings"
           href="/settings"
-          isActive={isPathUnder({
-            pathname: router.pathname,
-            base: "/settings",
-          })}
+          isActive={isPathUnder({ pathname, base: "/settings" })}
           showLabel={showExpanded}
         />
       )}
@@ -172,7 +169,7 @@ function SettingsBackEntry({ showLabel }: { showLabel: boolean }) {
  * entries carry the quiet grey pill.
  */
 function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
-  const router = useRouter();
+  const pathname = usePathname();
   const groups = useSettingsMenu();
 
   return (
@@ -190,12 +187,7 @@ function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
               icon={item.icon}
               label={item.label}
               href={item.href}
-              isActive={
-                (item.alsoActiveAt?.includes(router.pathname) ?? false) ||
-                (item.isExactMatch
-                  ? router.pathname === item.href
-                  : router.pathname.startsWith(item.includePath ?? item.href))
-              }
+              isActive={isSettingsMenuItemActive({ item, pathname })}
               showLabel={showExpanded}
               rightElement={
                 item.isEnterprise ? (
@@ -231,7 +223,7 @@ function SectionItemsNav({
   items: readonly SectionNavItemData[];
   showExpanded: boolean;
 }) {
-  const router = useRouter();
+  const pathname = usePathname();
   return (
     <>
       {items.map((item) => (
@@ -242,8 +234,8 @@ function SectionItemsNav({
           href={item.href}
           isActive={
             item.includePath
-              ? router.pathname.startsWith(item.includePath)
-              : router.pathname === item.href
+              ? isPathUnder({ pathname, base: item.includePath })
+              : pathname === item.href
           }
           showLabel={showExpanded}
           isExternal={item.isExternal}

--- a/platform/app/src/features/navigation/shell/shellLayout.ts
+++ b/platform/app/src/features/navigation/shell/shellLayout.ts
@@ -12,3 +12,27 @@ export const SHELL_SIDEBAR_WIDTH_EXPANDED = "212px";
 
 /** Small screens keep the same collapsed width the current chrome has. */
 export const SHELL_SIDEBAR_WIDTH_COMPACT = MENU_WIDTH_COMPACT;
+
+/**
+ * The room a page has: the window less every column beside it. Pass the
+ * rail width on the icon-rail mode, null on the modes with no rail.
+ *
+ * The columns are added up here rather than inside the `calc`, where
+ * `100vw - sidebar + rail` reads left to right and hands the page the width
+ * of the rail instead of taking it away, which put the right edge of a full
+ * page off the window.
+ *
+ * Spec: specs/navigation/icon-rail-navigation.feature
+ */
+export function shellContentMaxWidth({
+  menuWidth,
+  railWidth,
+}: {
+  menuWidth: string;
+  railWidth: string | null;
+}): string {
+  const inset =
+    Number.parseInt(menuWidth, 10) +
+    (railWidth ? Number.parseInt(railWidth, 10) : 0);
+  return `calc(100vw - ${inset}px)`;
+}

--- a/platform/app/src/features/navigation/useSettingsMenu.ts
+++ b/platform/app/src/features/navigation/useSettingsMenu.ts
@@ -35,6 +35,7 @@ import {
   UsersRound,
   Workflow,
 } from "lucide-react";
+import { isPathUnder } from "~/features/navigation/products";
 import { useActivePlan } from "~/hooks/useActivePlan";
 import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
 import { useOpsPermission } from "~/hooks/useOpsPermission";
@@ -60,6 +61,28 @@ export interface SettingsMenuItem {
   icon: LucideIcon;
   /** Enterprise-plan entry; renders the quiet grey pill. */
   isEnterprise?: boolean;
+}
+
+/**
+ * Whether a settings entry is the page on screen.
+ *
+ * `pathname` is the address in the address bar, never the route pattern the
+ * compat router resolves: `/settings/*` is one registered pattern, so every
+ * settings page but General and Audit Log reports the same
+ * `/settings/[[...path]]` and no entry matched.
+ *
+ * Spec: specs/navigation/settings-shell-v2.feature
+ */
+export function isSettingsMenuItemActive({
+  item,
+  pathname,
+}: {
+  item: SettingsMenuItem;
+  pathname: string;
+}): boolean {
+  if (item.alsoActiveAt?.includes(pathname)) return true;
+  if (item.isExactMatch) return pathname === item.href;
+  return isPathUnder({ pathname, base: item.includePath ?? item.href });
 }
 
 export interface SettingsMenuGroup {

--- a/platform/app/src/pages/settings/__tests__/email-suppressions.chrome.integration.test.tsx
+++ b/platform/app/src/pages/settings/__tests__/email-suppressions.chrome.integration.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The email suppressions page renders inside the settings chrome.
+ *
+ * `SettingsLayout` stands in for the real one here, which lets the test say
+ * where the page content sits rather than only that the layout was imported.
+ * The layout itself carries the top bar and the settings menu, and its own
+ * suites cover what it draws.
+ *
+ * Spec: specs/settings/settings-page-chrome.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: {}, push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    project: { id: "proj-1", slug: "test-project" },
+    hasPermission: () => true,
+    hasAnyPermission: () => true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("~/components/SettingsLayout", () => ({
+  default: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="settings-layout">{children}</div>
+  ),
+}));
+
+vi.mock("~/components/ui/toaster", () => ({ toaster: { create: vi.fn() } }));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      emailSuppression: { getAll: { invalidate: vi.fn() } },
+    }),
+    emailSuppression: {
+      getAll: {
+        useQuery: () => ({
+          data: [],
+          isLoading: false,
+          isError: false,
+          isRefetching: false,
+          refetch: vi.fn(),
+        }),
+      },
+      remove: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}));
+
+const { default: EmailSuppressionsPage } = await import(
+  "~/pages/settings/email-suppressions"
+);
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <EmailSuppressionsPage />
+    </ChakraProvider>,
+  );
+}
+
+describe("the email suppressions page", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when a reader who can view triggers opens it", () => {
+    /** @scenario The email suppressions page carries the settings chrome */
+    it("puts its content inside the settings layout", () => {
+      renderPage();
+
+      const layout = within(screen.getByTestId("settings-layout"));
+
+      expect(layout.getByText("Email Suppressions")).toBeTruthy();
+      expect(layout.getByText("No suppressions yet")).toBeTruthy();
+    });
+  });
+});

--- a/platform/app/src/pages/settings/__tests__/email-suppressions.chrome.integration.test.tsx
+++ b/platform/app/src/pages/settings/__tests__/email-suppressions.chrome.integration.test.tsx
@@ -77,7 +77,7 @@ describe("the email suppressions page", () => {
   });
 
   describe("when a reader who can view triggers opens it", () => {
-    /** @scenario The email suppressions page carries the settings chrome */
+    /** @scenario The email suppressions page keeps it */
     it("puts its content inside the settings layout", () => {
       renderPage();
 

--- a/platform/app/src/pages/settings/__tests__/settings-page-chrome.unit.test.ts
+++ b/platform/app/src/pages/settings/__tests__/settings-page-chrome.unit.test.ts
@@ -17,13 +17,33 @@ import { describe, expect, it } from "vitest";
  */
 const SOURCE_ROOT = join(__dirname, "..", "..", "..");
 
-/** Every `/settings` route in the table, as the module path it loads. */
+const routesSource = readFileSync(join(SOURCE_ROOT, "routes.tsx"), "utf-8");
+
+/**
+ * Every `/settings` route in the table, as the module path it loads.
+ *
+ * The table is cut into one chunk per route first, so a route can only be
+ * paired with the module named inside its own entry, and one that names none
+ * throws rather than borrowing the next route's.
+ */
 function registeredSettingsPageModules(): string[] {
-  const routes = readFileSync(join(SOURCE_ROOT, "routes.tsx"), "utf-8");
-  const entries = routes.matchAll(
-    /path:\s*"(\/settings[^"]*)"[\s\S]{0,120}?import\("\.\/(pages\/settings[^"]*)"\)/g,
-  );
-  return [...entries].map((entry) => entry[2]!);
+  return routesSource
+    .split(/path:\s*"/)
+    .slice(1)
+    .filter((entry) => entry.startsWith("/settings"))
+    .map((entry) => {
+      const address = entry.slice(0, entry.indexOf('"'));
+      const module = /import\("\.\/(pages\/settings[^"]*)"\)/.exec(entry);
+      if (!module) {
+        throw new Error(`The route ${address} names no page module`);
+      }
+      return module[1]!;
+    });
+}
+
+/** The same routes counted a second way, to hold the reading above to it. */
+function declaredSettingsRouteCount(): number {
+  return (routesSource.match(/path:\s*"\/settings/g) ?? []).length;
 }
 
 /** Where a route's module specifier lives on disk. */
@@ -42,15 +62,18 @@ describe("the pages under /settings", () => {
 
   describe("when the routes table is read", () => {
     it("finds every settings page, so the check below covers them all", () => {
-      // Guards the regex itself: a routes-table edit that stops matching
-      // would otherwise leave this suite passing over an empty list.
-      expect(modules.length).toBeGreaterThanOrEqual(23);
+      // Both counts come from the table but are read differently, so a page
+      // the reading above drops is a page these two disagree about. The floor
+      // catches the case where both readings break at once and the check
+      // below would pass over an empty list.
+      expect(declaredSettingsRouteCount()).toBeGreaterThan(20);
+      expect(modules).toHaveLength(declaredSettingsRouteCount());
       expect(modules).toContain("pages/settings/email-suppressions");
     });
   });
 
   describe("when a settings page renders", () => {
-    /** @scenario Every settings page in the routes table renders the layout */
+    /** @scenario No page the Settings menu opens is left without it */
     it.each(modules)("%s renders SettingsLayout", (moduleSpecifier) => {
       const source = readFileSync(sourceFileOf(moduleSpecifier), "utf-8");
 

--- a/platform/app/src/pages/settings/__tests__/settings-page-chrome.unit.test.ts
+++ b/platform/app/src/pages/settings/__tests__/settings-page-chrome.unit.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every page registered under `/settings` frames itself with
+ * `SettingsLayout`. A page that skips it renders with no top bar, no
+ * settings menu and no page frame, which is how the email suppressions page
+ * shipped: it named the layout as `withPermissionGuard`'s `layoutComponent`,
+ * which frames only the refusal a reader without the permission sees.
+ *
+ * The list comes from the routes table rather than a directory listing, so a
+ * new settings page is covered the moment it is reachable, and the component
+ * files that sit next to the pages are left out.
+ *
+ * Spec: specs/settings/settings-page-chrome.feature
+ */
+const SOURCE_ROOT = join(__dirname, "..", "..", "..");
+
+/** Every `/settings` route in the table, as the module path it loads. */
+function registeredSettingsPageModules(): string[] {
+  const routes = readFileSync(join(SOURCE_ROOT, "routes.tsx"), "utf-8");
+  const entries = routes.matchAll(
+    /path:\s*"(\/settings[^"]*)"[\s\S]{0,120}?import\("\.\/(pages\/settings[^"]*)"\)/g,
+  );
+  return [...entries].map((entry) => entry[2]!);
+}
+
+/** Where a route's module specifier lives on disk. */
+function sourceFileOf(moduleSpecifier: string): string {
+  const asFile = join(SOURCE_ROOT, `${moduleSpecifier}.tsx`);
+  try {
+    readFileSync(asFile);
+    return asFile;
+  } catch {
+    return join(SOURCE_ROOT, moduleSpecifier, "index.tsx");
+  }
+}
+
+describe("the pages under /settings", () => {
+  const modules = registeredSettingsPageModules();
+
+  describe("when the routes table is read", () => {
+    it("finds every settings page, so the check below covers them all", () => {
+      // Guards the regex itself: a routes-table edit that stops matching
+      // would otherwise leave this suite passing over an empty list.
+      expect(modules.length).toBeGreaterThanOrEqual(23);
+      expect(modules).toContain("pages/settings/email-suppressions");
+    });
+  });
+
+  describe("when a settings page renders", () => {
+    /** @scenario Every settings page in the routes table renders the layout */
+    it.each(modules)("%s renders SettingsLayout", (moduleSpecifier) => {
+      const source = readFileSync(sourceFileOf(moduleSpecifier), "utf-8");
+
+      expect(source).toContain("<SettingsLayout");
+    });
+  });
+});

--- a/platform/app/src/pages/settings/email-suppressions.tsx
+++ b/platform/app/src/pages/settings/email-suppressions.tsx
@@ -52,104 +52,103 @@ function EmailSuppressionsPage({
   });
 
   return (
-    <VStack
-      align="stretch"
-      gap={6}
-      width="full"
-      maxW="container.lg"
-      padding={6}
-    >
-      <VStack align="start" gap={1}>
-        <Heading size="lg">Email Suppressions</Heading>
-        <Text color="fg.muted">
-          Recipients who unsubscribed from this project&apos;s trigger
-          notifications. Removing an entry resumes delivery to that address.
-        </Text>
-      </VStack>
+    <SettingsLayout>
+      <VStack gap={6} width="full" align="start" paddingX={6} paddingY={4}>
+        <VStack align="start" gap={1} width="full" marginTop={2}>
+          <Heading as="h2" fontSize="xl">
+            Email Suppressions
+          </Heading>
+          <Text color="fg.muted">
+            Recipients who unsubscribed from this project&apos;s trigger
+            notifications. Removing an entry resumes delivery to that address.
+          </Text>
+        </VStack>
 
-      <Card.Root>
-        <Card.Body>
-          {suppressions.isLoading ? (
-            <HStack justify="center" padding={8}>
-              <Spinner />
-            </HStack>
-          ) : suppressions.isError ? (
-            <VStack align="center" gap={3} padding={8}>
-              <Text color="fg.error">
-                Could not load suppressions. Please try again.
-              </Text>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => void suppressions.refetch()}
-                loading={suppressions.isRefetching}
-              >
-                Retry
-              </Button>
-            </VStack>
-          ) : !suppressions.data || suppressions.data.length === 0 ? (
-            <EmptyState.Root>
-              <EmptyState.Content>
-                <EmptyState.Indicator>
-                  <MailX />
-                </EmptyState.Indicator>
-                <EmptyState.Title>No suppressions yet</EmptyState.Title>
-                <EmptyState.Description>
-                  When a recipient unsubscribes from a notification, they appear
-                  here.
-                </EmptyState.Description>
-              </EmptyState.Content>
-            </EmptyState.Root>
-          ) : (
-            <Table.Root size="sm">
-              <Table.Header>
-                <Table.Row>
-                  <Table.ColumnHeader>Email</Table.ColumnHeader>
-                  <Table.ColumnHeader>Scope</Table.ColumnHeader>
-                  <Table.ColumnHeader>Date</Table.ColumnHeader>
-                  <Table.ColumnHeader />
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {suppressions.data.map((row) => (
-                  <Table.Row key={row.id}>
-                    <Table.Cell>{row.email}</Table.Cell>
-                    <Table.Cell>
-                      {row.triggerId == null ? (
-                        <Badge colorPalette="red">All notifications</Badge>
-                      ) : (
-                        <Badge colorPalette="gray">
-                          {row.triggerName ?? "Notification"}
-                        </Badge>
-                      )}
-                    </Table.Cell>
-                    <Table.Cell>
-                      {new Date(row.createdAt).toLocaleDateString()}
-                    </Table.Cell>
-                    <Table.Cell textAlign="end">
-                      {canManage && (
-                        <Button
-                          size="xs"
-                          variant="ghost"
-                          loading={
-                            remove.isPending && remove.variables?.id === row.id
-                          }
-                          onClick={() =>
-                            remove.mutate({ projectId, id: row.id })
-                          }
-                          aria-label="Remove suppression"
-                        >
-                          <Trash2 size={14} />
-                        </Button>
-                      )}
-                    </Table.Cell>
+        <Card.Root width="full">
+          <Card.Body>
+            {suppressions.isLoading ? (
+              <HStack justify="center" padding={8}>
+                <Spinner />
+              </HStack>
+            ) : suppressions.isError ? (
+              <VStack align="center" gap={3} padding={8}>
+                <Text color="fg.error">
+                  Could not load suppressions. Please try again.
+                </Text>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void suppressions.refetch()}
+                  loading={suppressions.isRefetching}
+                >
+                  Retry
+                </Button>
+              </VStack>
+            ) : !suppressions.data || suppressions.data.length === 0 ? (
+              <EmptyState.Root>
+                <EmptyState.Content>
+                  <EmptyState.Indicator>
+                    <MailX />
+                  </EmptyState.Indicator>
+                  <EmptyState.Title>No suppressions yet</EmptyState.Title>
+                  <EmptyState.Description>
+                    When a recipient unsubscribes from a notification, they
+                    appear here.
+                  </EmptyState.Description>
+                </EmptyState.Content>
+              </EmptyState.Root>
+            ) : (
+              <Table.Root size="sm">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.ColumnHeader>Email</Table.ColumnHeader>
+                    <Table.ColumnHeader>Scope</Table.ColumnHeader>
+                    <Table.ColumnHeader>Date</Table.ColumnHeader>
+                    <Table.ColumnHeader />
                   </Table.Row>
-                ))}
-              </Table.Body>
-            </Table.Root>
-          )}
-        </Card.Body>
-      </Card.Root>
-    </VStack>
+                </Table.Header>
+                <Table.Body>
+                  {suppressions.data.map((row) => (
+                    <Table.Row key={row.id}>
+                      <Table.Cell>{row.email}</Table.Cell>
+                      <Table.Cell>
+                        {row.triggerId == null ? (
+                          <Badge colorPalette="red">All notifications</Badge>
+                        ) : (
+                          <Badge colorPalette="gray">
+                            {row.triggerName ?? "Notification"}
+                          </Badge>
+                        )}
+                      </Table.Cell>
+                      <Table.Cell>
+                        {new Date(row.createdAt).toLocaleDateString()}
+                      </Table.Cell>
+                      <Table.Cell textAlign="end">
+                        {canManage && (
+                          <Button
+                            size="xs"
+                            variant="ghost"
+                            loading={
+                              remove.isPending &&
+                              remove.variables?.id === row.id
+                            }
+                            onClick={() =>
+                              remove.mutate({ projectId, id: row.id })
+                            }
+                            aria-label="Remove suppression"
+                          >
+                            <Trash2 size={14} />
+                          </Button>
+                        )}
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            )}
+          </Card.Body>
+        </Card.Root>
+      </VStack>
+    </SettingsLayout>
   );
 }

--- a/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -14,7 +14,10 @@ import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { prisma } from "~/server/db";
-import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoints";
+import {
+  privateRouteOrgId,
+  startTestClickHouseEndpoints,
+} from "~/test-utils/clickhouseTestEndpoints";
 
 const TEST_TABLE = "routing_test";
 
@@ -22,11 +25,13 @@ let sharedClient: ClickHouseClient;
 let privateClient: ClickHouseClient;
 
 // The org IDs we'll use — set the env var BEFORE importing clickhouseClient
-const PRIVATE_ORG_ID = `test-private-org-${nanoid(6)}`;
-const SHARED_ORG_ID = `test-shared-org-${nanoid(6)}`;
+const PRIVATE_ORG_ID = privateRouteOrgId("test-private-org");
+const SHARED_ORG_ID = privateRouteOrgId("test-shared-org");
 // An organization that owns no project, because it is the tenant itself: the
 // grants ledger's aggregate is one organization (ADR-092 §13).
-const PRIVATE_ORG_ID_WITHOUT_PROJECTS = `test-private-org-tenant-${nanoid(6)}`;
+const PRIVATE_ORG_ID_WITHOUT_PROJECTS = privateRouteOrgId(
+  "test-private-org-tenant",
+);
 
 // Table names stay unqualified throughout: each endpoint's client carries its
 // own database in the connection URL, and that is precisely the separation

--- a/platform/app/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/privateClickhouseDataIsolation.integration.test.ts
@@ -15,14 +15,17 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SpanInsertData } from "~/server/app-layer/traces/types";
 import { prisma } from "~/server/db";
 import type { EventRecord } from "~/server/event-sourcing/stores/repositories/eventRepository.types";
-import { startTestClickHouseEndpoints } from "~/test-utils/clickhouseTestEndpoints";
+import {
+  privateRouteOrgId,
+  startTestClickHouseEndpoints,
+} from "~/test-utils/clickhouseTestEndpoints";
 import type { ClickHouseClientResolver } from "../clickhouseClient";
 
 let sharedClient: ClickHouseClient;
 let privateClient: ClickHouseClient;
 
-const PRIVATE_ORG_ID = `test-iso-priv-org-${nanoid(6)}`;
-const SHARED_ORG_ID = `test-iso-shared-org-${nanoid(6)}`;
+const PRIVATE_ORG_ID = privateRouteOrgId("test-iso-priv-org");
+const SHARED_ORG_ID = privateRouteOrgId("test-iso-shared-org");
 
 // Set the private CH env var BEFORE importing clickhouseClient module
 // so parsePrivateClickHouseEnvVars() picks it up at module load.

--- a/platform/app/src/test-utils/__tests__/privateRouteOrgId.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/privateRouteOrgId.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseRouteKey } from "~/server/clickhouse/privateRouteKey";
+import { privateRouteOrgId } from "../clickhouseTestEndpoints";
+
+/**
+ * The organization ids the private-ClickHouse suites route with.
+ *
+ * Each id goes into a `CLICKHOUSE_URL__<label>__<orgId>` variable name, so the
+ * only property that matters is that the parser reads back the id the suite
+ * wrote. An id carrying a `__` of its own splits the name in the wrong place,
+ * and the suite then fails on a run in which nothing changed.
+ */
+describe("privateRouteOrgId", () => {
+  const PREFIX = "CLICKHOUSE_URL__";
+  const RUNS = 20_000;
+
+  describe("when an id is put in an env var name", () => {
+    it("reads back whole, over enough ids to catch a rare one", () => {
+      for (let run = 0; run < RUNS; run++) {
+        const orgId = privateRouteOrgId("test-org");
+
+        expect(
+          parseRouteKey({
+            key: `${PREFIX}testcustomer__${orgId}`,
+            prefix: PREFIX,
+          }),
+        ).toEqual({ orgId, cluster: "testcustomer" });
+      }
+    });
+  });
+
+  describe("when the id is read on its own", () => {
+    it("names the namespace it was asked for", () => {
+      expect(privateRouteOrgId("test-org")).toMatch(/^test-org-[0-9a-z]{6}$/);
+    });
+  });
+});

--- a/platform/app/src/test-utils/__tests__/privateRouteOrgId.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/privateRouteOrgId.unit.test.ts
@@ -34,4 +34,10 @@ describe("privateRouteOrgId", () => {
       expect(privateRouteOrgId("test-org")).toMatch(/^test-org-[0-9a-z]{6}$/);
     });
   });
+
+  describe("when the namespace carries the separator itself", () => {
+    it("refuses it, rather than minting an id that reads back short", () => {
+      expect(() => privateRouteOrgId("test__org")).toThrow("test__org");
+    });
+  });
 });

--- a/platform/app/src/test-utils/clickhouseTestEndpoints.ts
+++ b/platform/app/src/test-utils/clickhouseTestEndpoints.ts
@@ -110,6 +110,10 @@ export interface TestClickHouseEndpoint {
  * registers under a fragment of the id, and the organization silently falls
  * back to the shared client. The alphabet here has no `_`, so the name a suite
  * writes is the name the parser reads back.
+ *
+ * `name` is held to the same rule, and refused rather than repaired: a suite
+ * that asks for a namespace the variable cannot carry has a mistake to fix in
+ * the line it wrote, and a quietly rewritten namespace would hide it.
  */
 const routableIdSuffix = customAlphabet(
   "0123456789abcdefghijklmnopqrstuvwxyz",
@@ -117,6 +121,11 @@ const routableIdSuffix = customAlphabet(
 );
 
 export function privateRouteOrgId(name: string): string {
+  if (name.includes("__")) {
+    throw new Error(
+      `A private-route org id cannot be named "${name}": "__" separates the label from the organization in the env var name, so the parser would read back only what follows it.`,
+    );
+  }
   return `${name}-${routableIdSuffix()}`;
 }
 

--- a/platform/app/src/test-utils/clickhouseTestEndpoints.ts
+++ b/platform/app/src/test-utils/clickhouseTestEndpoints.ts
@@ -24,6 +24,7 @@ import {
   ClickHouseContainer,
   type StartedClickHouseContainer,
 } from "@testcontainers/clickhouse";
+import { customAlphabet } from "nanoid";
 
 /**
  * The ClickHouse image every container-backed test starts, here and in
@@ -96,6 +97,27 @@ export interface TestClickHouseEndpoint {
   url: string;
   /** The database this endpoint owns, for statements that qualify a table. */
   database: string;
+}
+
+/**
+ * A random organization id for a suite that routes it with a
+ * `CLICKHOUSE_URL__<label>__<orgId>` variable.
+ *
+ * The id lands inside the variable NAME, where `__` separates the label from
+ * the organization and the organization is read as the last such segment. Plain
+ * `nanoid` draws from an alphabet that contains `_`, so about one id in 800
+ * carries a `__` of its own; the name then splits in the wrong place, the route
+ * registers under a fragment of the id, and the organization silently falls
+ * back to the shared client. The alphabet here has no `_`, so the name a suite
+ * writes is the name the parser reads back.
+ */
+const routableIdSuffix = customAlphabet(
+  "0123456789abcdefghijklmnopqrstuvwxyz",
+  6,
+);
+
+export function privateRouteOrgId(name: string): string {
+  return `${name}-${routableIdSuffix()}`;
 }
 
 /**

--- a/specs/navigation/icon-rail-navigation.feature
+++ b/specs/navigation/icon-rail-navigation.feature
@@ -20,6 +20,17 @@ Feature: Icon rail navigation
     And an edge closes the rail against the sidebar
 
   @integration
+  Scenario: The page keeps its right edge inside the window
+    Given I am on the icon-rail mode
+    When a page wider than the room it has renders
+    Then the page ends at the right edge of the window
+    And the room it has is the window less the rail and the sidebar
+    # The rail and the sidebar both take room from the page. Counting the
+    # rail as room the page gains instead of room it loses left every page
+    # in this mode two rails too wide, and the right of a full page (the ops
+    # dashboard first) was cut off the window.
+
+  @integration
   Scenario: Only the active tile carries a surface
     Given I am on the icon-rail mode
     Then the tile of the product I am in has a raised white surface

--- a/specs/navigation/icon-rail-navigation.feature
+++ b/specs/navigation/icon-rail-navigation.feature
@@ -25,10 +25,6 @@ Feature: Icon rail navigation
     When a page wider than the room it has renders
     Then the page ends at the right edge of the window
     And the room it has is the window less the rail and the sidebar
-    # The rail and the sidebar both take room from the page. Counting the
-    # rail as room the page gains instead of room it loses left every page
-    # in this mode two rails too wide, and the right of a full page (the ops
-    # dashboard first) was cut off the window.
 
   @integration
   Scenario: Only the active tile carries a surface

--- a/specs/navigation/settings-shell-v2.feature
+++ b/specs/navigation/settings-shell-v2.feature
@@ -77,6 +77,16 @@ Feature: Settings shell in the new navigation modes
     And the ACCESS group does not hold it
 
   @integration
+  Scenario: The menu marks the page that is open
+    Given I open the Email Suppressions settings page
+    Then the Email Suppressions entry is marked as the open one
+    And no other entry is marked
+    # The entry is matched against the address in the address bar. Matching
+    # it against the route pattern instead left every settings page except
+    # General and Audit Log with nothing marked, because the pattern for all
+    # the others is the one wildcard they share.
+
+  @integration
   Scenario: A lite member sees no restricted settings entries
     Given I am a lite member
     When the settings sidebar renders in a new navigation mode

--- a/specs/navigation/settings-shell-v2.feature
+++ b/specs/navigation/settings-shell-v2.feature
@@ -81,10 +81,6 @@ Feature: Settings shell in the new navigation modes
     Given I open the Email Suppressions settings page
     Then the Email Suppressions entry is marked as the open one
     And no other entry is marked
-    # The entry is matched against the address in the address bar. Matching
-    # it against the route pattern instead left every settings page except
-    # General and Audit Log with nothing marked, because the pattern for all
-    # the others is the one wildcard they share.
 
   @integration
   Scenario: A lite member sees no restricted settings entries

--- a/specs/settings/settings-page-chrome.feature
+++ b/specs/settings/settings-page-chrome.feature
@@ -1,0 +1,25 @@
+Feature: Every settings page keeps the settings chrome
+  As someone who opens a page under Settings
+  I want the same header, navigation and page frame on all of them
+  So that I know where I am and can reach the other settings pages
+
+  The chrome comes from `SettingsLayout`, which each page renders around its
+  own content. `withPermissionGuard` takes a `layoutComponent` too, but that
+  one frames only the refusal that a reader without the permission sees. A
+  page that names the layout there and nowhere else is framed when it refuses
+  the reader and bare when it serves them: no top bar, no menu, no way back
+  out except the browser.
+
+  Rule: a settings page puts its content inside the settings layout
+
+    @integration
+    Scenario: The email suppressions page carries the settings chrome
+      Given I can view the triggers of this project
+      When I open the email suppressions page
+      Then the page content is inside the settings layout
+
+    @unit
+    Scenario: Every settings page in the routes table renders the layout
+      Given the routes table registers pages under "/settings"
+      When each of those pages is read
+      Then every one of them renders the settings layout

--- a/specs/settings/settings-page-chrome.feature
+++ b/specs/settings/settings-page-chrome.feature
@@ -1,25 +1,26 @@
 Feature: Every settings page keeps the settings chrome
   As someone who opens a page under Settings
-  I want the same header, navigation and page frame on all of them
+  I want the same header, menu and page frame on all of them
   So that I know where I am and can reach the other settings pages
 
-  The chrome comes from `SettingsLayout`, which each page renders around its
-  own content. `withPermissionGuard` takes a `layoutComponent` too, but that
-  one frames only the refusal that a reader without the permission sees. A
-  page that names the layout there and nowhere else is framed when it refuses
-  the reader and bare when it serves them: no top bar, no menu, no way back
-  out except the browser.
+  The settings chrome is the top bar, the settings menu beside the page, and
+  the frame the page sits in. A page that opens without it stands alone on
+  an empty background, with no menu and no way back except the browser.
 
-  Rule: a settings page puts its content inside the settings layout
+  What the reader is allowed to see does not change this. The frame around a
+  "you do not have permission" message and the frame around the page itself
+  are two different things, so a page can be framed when it refuses the
+  reader and bare when it serves them.
+
+  Rule: a settings page opens inside the settings chrome
 
     @integration
-    Scenario: The email suppressions page carries the settings chrome
+    Scenario: The email suppressions page keeps it
       Given I can view the triggers of this project
       When I open the email suppressions page
-      Then the page content is inside the settings layout
+      Then the page opens inside the settings chrome
 
     @unit
-    Scenario: Every settings page in the routes table renders the layout
-      Given the routes table registers pages under "/settings"
-      When each of those pages is read
-      Then every one of them renders the settings layout
+    Scenario: No page the Settings menu opens is left without it
+      Given every page that Settings can open
+      Then each of them keeps the settings chrome


### PR DESCRIPTION
Three fixes from one round of feedback on the settings pages and the icon rail.

## The email suppressions page opened with no chrome

Reported from the app: `/settings/email-suppressions` opened with no top bar, no settings menu, no page frame, and no way back out except the browser.

The page named `SettingsLayout` in one place only:

```tsx
export default withPermissionGuard("triggers:view", {
  layoutComponent: SettingsLayout,
})(EmailSuppressionsSettings);
```

That option frames the refusal a reader without `triggers:view` sees. It does not frame the page. A reader who holds the permission got the page body on its own, so the page was framed when it refused the reader and bare when it served them.

It now renders the layout the way the other 23 settings pages do, and its content follows the spacing of Data Retention and Data Privacy, which sit next to it in the menu.

| Before | After |
|---|---|
| ![no chrome at all](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/settings-email-suppressions-layout/1-before-no-layout.png) | ![the settings chrome](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/settings-email-suppressions-layout/2-after-settings-chrome.png) |

A source check now reads every `/settings` route out of the routes table and holds each one to rendering the layout, so the next page cannot ship bare. It cuts the table into one entry per route first, so a route can only be paired with the module named inside its own entry, and a route naming none fails rather than borrowing the next one's. Run against the unfixed code it passes 23 pages and fails exactly one.

## The settings menu marked no entry

The menu marked the page you were on only on General and Audit Log. Everywhere else nothing was marked.

The entries were matched against `router.pathname`, which is the route PATTERN, not the address. The compat router registers one `/settings/*` pattern, so every settings page except those two reports `/settings/[[...path]]`, and no entry could match it. General and Audit Log have patterns of their own, which is why they alone worked.

The menu now matches against the address in the address bar, which is what the old navigation always did.

| Before | After |
|---|---|
| ![no entry marked](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/settings-email-suppressions-layout/3-before-menu-unmarked.png) | ![the open page marked](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/settings-email-suppressions-layout/4-after-menu-marked.png) |

The settings shell fixture is part of this: it reported the address where the app reports the pattern, which is why no test caught the bug. It now runs the real resolver, so the fixture and the app agree.

## Icon-rail pages ran off the right of the window

On the icon-rail mode the ops dashboard was cut on the right: the header button, the right of the chart, and the last table column were all off the window.

The width cap was built as `calc(100vw - sidebar + rail)`. That reads left to right, so the rail was handed back to the page instead of taken away, and every page in that mode was two rails (128px) wider than the room it had. The ops dashboard shows it first because it fills the width.

The widths are added up in JavaScript now, so the cap has a single term to subtract and no precedence left to get wrong.

| Before | After |
|---|---|
| ![cut on the right](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/settings-email-suppressions-layout/ops-iconrail-before.png) | ![inside the window](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/settings-email-suppressions-layout/ops-iconrail-after.png) |

This was one cap for every page in the mode, so it was never only the ops page.

## One test fixture, carried along

CI hit `test-integration (mocking 2/2)` on a ClickHouse routing suite, which this PR does not touch. The suite routes an organization with a `CLICKHOUSE_URL__<label>__<orgId>` variable and built the organization id with `nanoid`. That alphabet contains `_`, so about one id in 800 carries a `__` of its own. The parser reads the organization as the last `__` segment, so such a name splits in the wrong place: the route registers under a fragment of the id, or under nothing when the id ends with the separator. The organization then gets the shared client and two assertions fail on a run that changed nothing.

The ids now come from `privateRouteOrgId`, whose alphabet has no `_`, and a unit test mints 20,000 of them through the real parser. Put the separator back in the alphabet and that test fails on the first run.

Worth a look separately: a real organization id is a 21-character `nanoid`, and 0.47% of those carry a `__` as well. For a customer on a dedicated ClickHouse that reads as a silent fall back to the shared instance. Changing how the variable name is parsed changes where customer data lands, so it is not in this PR.

## Specs

- `specs/settings/settings-page-chrome.feature`: the email suppressions page opens inside the settings chrome, and no page the Settings menu opens is left without it.
- `specs/navigation/settings-shell-v2.feature`: the menu marks the page that is open, and only that one.
- `specs/navigation/icon-rail-navigation.feature`: the page keeps its right edge inside the window.

## Testing

- New: `settings-page-chrome.unit.test.ts` (24 pages), `email-suppressions.chrome.integration.test.tsx`, `isSettingsMenuItemActive.unit.test.ts` (8 cases, one of which pins what the route pattern does), `privateRouteOrgId.unit.test.ts`.
- Extended: the icon-rail shell suite (the width cap), the settings shell suite (the marked entry).
- Every new test was run against the unfixed code first and fails there.
- Navigation and settings suites green (185 component, 117 unit). `pnpm typecheck:all` clean. Feature parity: 2/2, 12/12, 8/8.
- Checked in a browser on a real project, in all three navigation modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the Email Suppressions settings page with a consistent layout, improved spacing and typography, and full-width presentation.
  * Improved settings navigation highlighting based on the current address.
  * Adjusted navigation shell sizing to prevent content clipping when the icon rail is visible.
  * Preserved existing loading, error, retry, empty-state, and table behaviors.

* **Tests**
  * Added coverage for settings layouts, navigation highlighting, shell sizing, and the Email Suppressions page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->