### PR TITLE
fix(governance): the codex harvest caps a long conversation in one pass

### DIFF
--- a/sdks/typescript/src/cli/utils/governance/__tests__/codex-rollout.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/codex-rollout.unit.test.ts
@@ -56,6 +56,44 @@ describe("parseCodexRollout", () => {
     });
   });
 
+  describe("given a conversation many times the request-body cap", () => {
+    describe("when it is parsed", () => {
+      /** @scenario "A conversation far above the cap is bounded in one pass" */
+      it("bounds every turn without reading the conversation again per dropped message", () => {
+        // The cost that mattered grows with the NUMBER of messages, not their
+        // size: every message dropped read the whole conversation again. A
+        // long-lived agent session reaches thousands of short exchanges.
+        const TURNS = 400;
+        const body = "y".repeat(400);
+        const lines: unknown[] = [];
+        for (let turn = 0; turn < TURNS; turn++) {
+          lines.push(
+            taskStarted(`trace-${turn}`, `t-${turn}`),
+            turnContext(`t-${turn}`),
+            userMsg(`${body} ${turn}`),
+            agentMessage(`${body} reply ${turn}`),
+            { type: "event_msg", payload: { type: "task_complete" } },
+          );
+        }
+        const transcript = rollout(...lines);
+
+        const startedAt = Date.now();
+        const { turns } = parseCodexRollout(transcript);
+        const elapsedMs = Date.now() - startedAt;
+
+        expect(turns).toHaveLength(TURNS);
+        for (const turn of turns) {
+          expect(JSON.stringify(turn.inputMessages).length).toBeLessThanOrEqual(
+            120_000,
+          );
+        }
+        // Reading the conversation again per dropped message takes seconds on
+        // this transcript, and minutes on a session that ran for weeks.
+        expect(elapsedMs).toBeLessThan(2_000);
+      });
+    });
+  });
+
   describe("given a developer message", () => {
     describe("when it is parsed", () => {
       /** @scenario "The developer message becomes the system prompt in the request body" */

--- a/sdks/typescript/src/cli/utils/governance/__tests__/codex-rollout.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/codex-rollout.unit.test.ts
@@ -58,7 +58,7 @@ describe("parseCodexRollout", () => {
 
   describe("given a conversation many times the request-body cap", () => {
     describe("when it is parsed", () => {
-      /** @scenario "A conversation far above the cap is bounded in one pass" */
+      /** @scenario "A conversation far above the cap still harvests in seconds" */
       it("bounds every turn without reading the conversation again per dropped message", () => {
         // The cost that mattered grows with the NUMBER of messages, not their
         // size: every message dropped read the whole conversation again. A

--- a/sdks/typescript/src/cli/utils/governance/codex-rollout.ts
+++ b/sdks/typescript/src/cli/utils/governance/codex-rollout.ts
@@ -142,26 +142,66 @@ function outputToText(output: unknown): string {
 }
 
 /**
+ * One message's capped form and the number of bytes it costs in the serialized
+ * array, remembered against the message it came from.
+ *
+ * Every turn caps the conversation SO FAR, so the same early messages are
+ * measured again on every later turn, and a session that runs for weeks
+ * measures its first message thousands of times. The messages never change
+ * once the accumulator pushes them, so each one is capped and measured once
+ * and the answer is kept here. A WeakMap, so a parsed rollout costs nothing
+ * once its messages are unreachable.
+ */
+const cappedMessages = new WeakMap<
+	CodexChatMessage,
+	{ message: CodexChatMessage; bytes: number }
+>();
+
+function capOneMessage(message: CodexChatMessage): {
+	message: CodexChatMessage;
+	bytes: number;
+} {
+	const remembered = cappedMessages.get(message);
+	if (remembered) return remembered;
+	const capped =
+		typeof message.content === "string" &&
+		message.content.length > MAX_CONTENT_CHARS
+			? { ...message, content: truncate(message.content, MAX_CONTENT_CHARS) }
+			: message;
+	const entry = { message: capped, bytes: JSON.stringify(capped).length };
+	cappedMessages.set(message, entry);
+	return entry;
+}
+
+/**
  * Bound the serialized input: cap each message's content, then drop the oldest
  * NON-system messages until the whole array is under the total cap. System
  * messages (the prompt the user actually asked to see) are always preserved.
+ *
+ * The total is tracked as the messages are dropped rather than measured again
+ * after each one. Measuring again read the whole conversation per dropped
+ * message, which on a long session took minutes per turn: codex runs the
+ * harvest after every completed turn, so the next harvest started before the
+ * last one finished and the conversation never reached the server.
  */
 function capInputMessages(messages: CodexChatMessage[]): CodexChatMessage[] {
-	const capped = messages.map((m) =>
-		typeof m.content === "string" && m.content.length > MAX_CONTENT_CHARS
-			? { ...m, content: truncate(m.content, MAX_CONTENT_CHARS) }
-			: m,
-	);
-	const serializedLength = () => JSON.stringify(capped).length;
-	let i = 0;
-	while (serializedLength() > MAX_INPUT_CHARS && i < capped.length) {
-		if (capped[i]?.role === "system") {
-			i++;
-			continue;
-		}
-		capped.splice(i, 1);
+	const entries = messages.map(capOneMessage);
+	let bytes = entries.reduce((total, entry) => total + entry.bytes, 0);
+	let kept = entries.length;
+	// What `JSON.stringify` of the kept messages would answer: the brackets,
+	// every message, and one comma between each neighbouring pair.
+	const serializedLength = () => 2 + bytes + Math.max(kept - 1, 0);
+	const dropped = new Set<number>();
+	for (let i = 0; i < entries.length && serializedLength() > MAX_INPUT_CHARS; i++) {
+		const entry = entries[i];
+		if (!entry || entry.message.role === "system") continue;
+		dropped.add(i);
+		bytes -= entry.bytes;
+		kept -= 1;
 	}
-	return capped;
+	return entries
+		.filter((_, index) => !dropped.has(index))
+		.map((entry) => entry.message);
 }
 
 /** One parsed rollout JSONL line: a tagged envelope with an opaque payload. */

--- a/specs/ai-governance/cli-wrappers/codex-rollout-io.feature
+++ b/specs/ai-governance/cli-wrappers/codex-rollout-io.feature
@@ -227,16 +227,16 @@ Feature: Codex Path B recovers the full request body from the rollout transcript
 
   Rule: a long session costs no more per turn than a short one
 
-    Codex runs the harvest after every completed turn, so the parse is paid
-    again on every turn. Each turn's request body is capped before it is sent,
-    and the cap measured the whole conversation again after each message it
-    dropped. A session that ran for weeks took four minutes to parse, so codex
-    started the next harvest before the last one finished and that session's
-    conversation never reached the server. Each message is capped and measured
-    once instead, and the total is tracked as messages are dropped.
+    Codex runs the harvest after every completed turn, so a long session pays
+    the parse again on every turn. Bounding each turn's request body re-read
+    the whole conversation once per dropped message, so the parse grew with
+    the number of messages times their size. A session that had run for weeks
+    took four minutes, and codex started the next harvest before that one
+    finished, so its conversation, its repository and its title never reached
+    the server and the session read as untitled in the product.
 
     @unit
-    Scenario: A conversation far above the cap is bounded in one pass
+    Scenario: A conversation far above the cap still harvests in seconds
       Given a rollout whose conversation is many times the request-body cap
       When the rollout is parsed
       Then every turn's request body is within the cap

--- a/specs/ai-governance/cli-wrappers/codex-rollout-io.feature
+++ b/specs/ai-governance/cli-wrappers/codex-rollout-io.feature
@@ -224,3 +224,20 @@ Feature: Codex Path B recovers the full request body from the rollout transcript
       Given a rollout whose first user_message is injected context in a tag
       When the completed turn is harvested
       Then the session-context record carries no title
+
+  Rule: a long session costs no more per turn than a short one
+
+    Codex runs the harvest after every completed turn, so the parse is paid
+    again on every turn. Each turn's request body is capped before it is sent,
+    and the cap measured the whole conversation again after each message it
+    dropped. A session that ran for weeks took four minutes to parse, so codex
+    started the next harvest before the last one finished and that session's
+    conversation never reached the server. Each message is capped and measured
+    once instead, and the total is tracked as messages are dropped.
+
+    @unit
+    Scenario: A conversation far above the cap is bounded in one pass
+      Given a rollout whose conversation is many times the request-body cap
+      When the rollout is parsed
+      Then every turn's request body is within the cap
+      And the parse finishes in seconds rather than minutes


### PR DESCRIPTION
## The problem

Codex exports no conversation content, so the CLI recovers it from the rollout transcript on disk. Codex runs `langwatch ingest codex --notify` after **every completed turn**, so the whole transcript is parsed again on every turn.

Each turn's request body is capped at 120,000 characters before it is sent. The cap dropped the oldest messages one at a time, and measured the whole conversation again after each one:

```js
const serializedLength = () => JSON.stringify(capped).length;
while (serializedLength() > MAX_INPUT_CHARS && i < capped.length) {
  if (capped[i]?.role === "system") { i++; continue; }
  capped.splice(i, 1);
}
```

The cost is the number of dropped messages times the size of the conversation, paid once per turn. It is invisible on a short session and fatal on a long one.

## What it cost us

One of our own background agents has run since the start of the month. Its transcript is 47MB across 11,229 lines and 40 turns. Measured on the box:

| | before | after |
|---|---|---|
| read the file | 114ms | 104ms |
| parse it | **242,062ms** | **138ms** |

Codex fires the harvest after each turn, so a 242 second parse never finished before the next one started. That session posted no conversation, no repository and no title, and it read as `Untitled session` in the product.

## The fix

Each message is capped and measured once, remembered against the message it came from (a `WeakMap`, so a parsed rollout costs nothing once its messages are unreachable). The serialized total is then tracked as messages are dropped instead of being measured again.

The output is unchanged. The same 47MB transcript yields the same 40 turns, and the last three request bodies are byte for byte identical (97,928, 119,041 and 108,734 bytes before and after).

## Tests

`specs/ai-governance/cli-wrappers/codex-rollout-io.feature` gains a rule and a scenario, bound by a unit test that builds a 400 turn conversation well above the cap and holds the parse under 2 seconds.

The guard was checked both ways:

- with this fix: passes, 41ms
- with the old code: fails, `expected 8598 to be less than 2000`

That is a 200x separation, so the bound is not flaky.

## Checks run

- `pnpm test:unit src/cli`: 2334 tests in 197 files pass
- `pnpm typecheck`: clean
- `eslint` on both touched files: clean
- feature parity: `codex-rollout-io.feature` 26/26 scenarios bound, whole repo OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved processing of long Codex conversations by enforcing request-size limits more efficiently.
  - Reduced the time required to manage oversized conversation histories.

- **Reliability**
  - Long conversations now stay within request-body limits while preserving as much history as possible.

- **Tests**
  - Added coverage for conversations with hundreds of turns, validating size limits, message retention, and processing speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->