### PR TITLE
feat(migrations): per-organization claims, parallel passes, batched grants fold, previous-step cohorts

### DIFF
--- a/packages/system-migrations/src/__tests__/runner.unit.test.ts
+++ b/packages/system-migrations/src/__tests__/runner.unit.test.ts
@@ -158,6 +158,7 @@ describe("SystemMigrationRunnerService", () => {
     it("works them concurrently, so one slow organization never holds up the rest", async () => {
       let inFlight = 0;
       let peak = 0;
+      const completed: string[] = [];
       const migration = migrationOf("m1", async ({ tenantId }) => {
         inFlight += 1;
         peak = Math.max(peak, inFlight);
@@ -165,6 +166,7 @@ describe("SystemMigrationRunnerService", () => {
           setTimeout(resolve, tenantId === "org-00" ? 40 : 5),
         );
         inFlight -= 1;
+        completed.push(tenantId);
         return finalized;
       });
       const ids = Array.from(
@@ -183,6 +185,45 @@ describe("SystemMigrationRunnerService", () => {
 
       expect(summary.finalized).toBe(12);
       expect(peak).toBeGreaterThan(1);
+      // The LAST organization still finishes before the slow first one: a
+      // pool keeps pulling past the straggler, where a chunked convoy would
+      // hold the tail behind org-00's sleep.
+      expect(completed.indexOf("org-11")).toBeLessThan(
+        completed.indexOf("org-00"),
+      );
+    });
+  });
+
+  describe("when reading one tenant's state throws", () => {
+    it("parks that tenant in the summary and finishes the rest of the pass", async () => {
+      const failingState = new FakeStateRepository();
+      const originalFindRecord = failingState.findRecord.bind(failingState);
+      failingState.findRecord = async (args) => {
+        if (args.tenantId === "acme") throw new Error("postgres blinked");
+        return originalFindRecord(args);
+      };
+      const migrate = vi.fn(async () => finalized);
+      const runner = new SystemMigrationRunnerService({
+        state: failingState,
+        lease: new FakeLeaseRepository(),
+        tenants: tenantSourceOf(["acme", "globex", "initech"]),
+        cohort: () => true,
+        migrations: [migrationOf("m1", migrate)],
+      });
+
+      const summary = await runner.runPass();
+
+      // The throw is contained in the pool worker: the pass resolves with a
+      // summary (never rejects), the broken tenant counts as parked with no
+      // record (still pending, retried next pass), and the others finalize.
+      expect(summary.parked).toBe(1);
+      expect(summary.finalized).toBe(2);
+      expect(
+        await failingState.findRecord({
+          migrationName: "m1",
+          tenantId: "globex",
+        }),
+      ).toMatchObject({ status: "finalized" });
     });
   });
 

--- a/packages/system-migrations/src/__tests__/runner.unit.test.ts
+++ b/packages/system-migrations/src/__tests__/runner.unit.test.ts
@@ -38,44 +38,44 @@ class FakeStateRepository implements SystemMigrationStateRepository {
 }
 
 class FakeLeaseRepository implements MigrationLeaseRepository {
-  private holder: symbol | null = null;
   private readonly self = Symbol("lease-holder");
+  private readonly holders: Map<string, symbol>;
 
-  static shared(): [FakeLeaseRepository, FakeLeaseRepository] {
-    const first = new FakeLeaseRepository();
-    const second = new FakeLeaseRepository();
-    const state = { holder: null as symbol | null };
-    for (const repo of [first, second]) {
-      repo.acquire = async () => {
-        if (state.holder !== null && state.holder !== repo.self) return false;
-        state.holder = repo.self;
-        return true;
-      };
-      repo.renew = async () => state.holder === repo.self;
-      repo.release = async () => {
-        if (state.holder === repo.self) state.holder = null;
-      };
-    }
-    return [first, second];
+  constructor(holders?: Map<string, symbol>) {
+    this.holders = holders ?? new Map();
   }
 
-  async acquire(): Promise<boolean> {
-    if (this.holder !== null && this.holder !== this.self) return false;
-    this.holder = this.self;
+  /** Two repositories over one holder table: two processes, one Redis. */
+  static shared(): [FakeLeaseRepository, FakeLeaseRepository] {
+    const holders = new Map<string, symbol>();
+    return [
+      new FakeLeaseRepository(holders),
+      new FakeLeaseRepository(holders),
+    ];
+  }
+
+  async acquire({ name }: { name: string; ttlMs: number }): Promise<boolean> {
+    const holder = this.holders.get(name);
+    if (holder !== undefined && holder !== this.self) return false;
+    this.holders.set(name, this.self);
     return true;
   }
 
-  async renew(): Promise<boolean> {
-    return this.holder === this.self;
+  async renew({ name }: { name: string; ttlMs: number }): Promise<boolean> {
+    return this.holders.get(name) === this.self;
   }
 
-  async release(): Promise<void> {
-    if (this.holder === this.self) this.holder = null;
+  async release({ name }: { name: string }): Promise<void> {
+    if (this.holders.get(name) === this.self) this.holders.delete(name);
   }
 
-  /** Hand the lease to somebody else, so renewals start coming back false. */
-  stealForAnotherProcess(): void {
-    this.holder = Symbol("other-process");
+  /** Hand one claim to somebody else, so its renewals come back false. */
+  stealForAnotherProcess(name: string): void {
+    this.holders.set(name, Symbol("other-process"));
+  }
+
+  heldNames(): string[] {
+    return [...this.holders.keys()];
   }
 }
 
@@ -112,8 +112,8 @@ describe("SystemMigrationRunnerService", () => {
   });
 
   describe("when two processes boot at the same moment", () => {
-    /** @scenario "One process drives the migration at a time" */
-    it("lets exactly one acquire the lease while the other stands down", async () => {
+    /** @scenario "Each organization is claimed by one process at a time" */
+    it("lets exactly one claim each organization while the other moves on", async () => {
       const [leaseA, leaseB] = FakeLeaseRepository.shared();
       const touched: string[] = [];
       const migration = migrationOf("m1", async ({ tenantId }) => {
@@ -145,9 +145,44 @@ describe("SystemMigrationRunnerService", () => {
         ),
       ]);
 
-      expect(summaryA?.finalized).toBe(1);
-      expect(summaryB).toBeNull();
+      expect(summaryA.finalized).toBe(1);
+      // B's pass ran - it did not stand down - but left "acme" to A.
+      expect(summaryB.claimed).toBe(1);
+      expect(summaryB.finalized).toBe(0);
       expect(touched).toEqual(["acme"]);
+    });
+  });
+
+  describe("when several organizations are pending", () => {
+    /** @scenario "A pass migrates several organizations at once" */
+    it("works them concurrently, so one slow organization never holds up the rest", async () => {
+      let inFlight = 0;
+      let peak = 0;
+      const migration = migrationOf("m1", async ({ tenantId }) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) =>
+          setTimeout(resolve, tenantId === "org-00" ? 40 : 5),
+        );
+        inFlight -= 1;
+        return finalized;
+      });
+      const ids = Array.from(
+        { length: 12 },
+        (_, i) => `org-${String(i).padStart(2, "0")}`,
+      );
+      const runner = new SystemMigrationRunnerService({
+        state,
+        lease: new FakeLeaseRepository(),
+        tenants: tenantSourceOf(ids),
+        cohort: () => true,
+        migrations: [migration],
+      });
+
+      const summary = await runner.runPass();
+
+      expect(summary.finalized).toBe(12);
+      expect(peak).toBeGreaterThan(1);
     });
   });
 
@@ -417,37 +452,54 @@ describe("SystemMigrationRunnerService", () => {
     });
   });
 
-  describe("when the lease is lost while one tenant is still migrating", () => {
-    /** @scenario "The pass keeps its lease while one large organization migrates" */
-    it("stops at the next tenant rather than double-driving the fleet", async () => {
+  describe("when a claim is lost while one tenant is still migrating", () => {
+    /** @scenario "The pass keeps its claim while one large organization migrates" */
+    it("stops that tenant's remaining migrations and carries on with the rest", async () => {
       const lease = new FakeLeaseRepository();
       const touched: string[] = [];
-      const migration = migrationOf("m1", async ({ tenantId }) => {
-        touched.push(tenantId);
-        // Outlive the renew interval, then lose the lease to another driver
-        // mid-tenant - the case a between-tenants renewal cannot detect.
-        if (tenantId === "acme") {
-          lease.stealForAnotherProcess();
+      const migrationBody = async ({
+        tenantId,
+        name,
+      }: {
+        tenantId: string;
+        name: string;
+      }) => {
+        touched.push(`${name}:${tenantId}`);
+        // Outlive the renew interval, then lose the claim to another driver
+        // mid-tenant - the case a between-migrations renewal cannot detect.
+        if (tenantId === "acme" && name === "m1") {
+          lease.stealForAnotherProcess("tenant:acme");
           await new Promise((resolve) => setTimeout(resolve, 30));
         }
         return finalized;
-      });
+      };
       const runner = new SystemMigrationRunnerService({
         state,
         lease,
         tenants: tenantSourceOf(["acme", "globex"]),
         cohort: () => true,
-        migrations: [migration],
+        migrations: [
+          migrationOf("m1", ({ tenantId }) =>
+            migrationBody({ tenantId, name: "m1" }),
+          ),
+          migrationOf("m2", ({ tenantId }) =>
+            migrationBody({ tenantId, name: "m2" }),
+          ),
+        ],
         leaseTtlMs: 50,
         leaseRenewIntervalMs: 5,
       });
 
       const summary = await runner.runPass();
 
-      expect(touched).toEqual(["acme"]);
-      expect(summary?.tenantsSeen).toBe(1);
+      // The stolen claim stops "acme" before m2; "globex" is unaffected.
+      expect(touched).toContain("m1:acme");
+      expect(touched).not.toContain("m2:acme");
+      expect(touched).toContain("m1:globex");
+      expect(touched).toContain("m2:globex");
+      expect(summary.tenantsSeen).toBe(2);
       expect(
-        await state.findRecord({ migrationName: "m1", tenantId: "globex" }),
+        await state.findRecord({ migrationName: "m2", tenantId: "acme" }),
       ).toBeNull();
     });
   });
@@ -488,7 +540,7 @@ describe("SystemMigrationRunnerService", () => {
   });
 
   describe("when the pass is aborted", () => {
-    it("stops between tenants and releases the lease", async () => {
+    it("stops between tenants and releases every claim", async () => {
       const controller = new AbortController();
       const lease = new FakeLeaseRepository();
       const migration = migrationOf("m1", async () => {
@@ -499,6 +551,9 @@ describe("SystemMigrationRunnerService", () => {
         state,
         lease,
         tenants: tenantSourceOf(["acme", "globex"]),
+        // Serial on purpose: with a wider pool "globex" is already in
+        // flight before the abort lands, which is fine but not this test.
+        tenantConcurrency: 1,
         cohort: () => true,
         migrations: [migration],
       });
@@ -509,7 +564,8 @@ describe("SystemMigrationRunnerService", () => {
       expect(
         await state.findRecord({ migrationName: "m1", tenantId: "globex" }),
       ).toBeNull();
-      expect(await lease.acquire()).toBe(true);
+      // Every claim released, aborted mid-pass or not.
+      expect(lease.heldNames()).toEqual([]);
     });
   });
 

--- a/packages/system-migrations/src/lease.repository.ts
+++ b/packages/system-migrations/src/lease.repository.ts
@@ -1,11 +1,13 @@
 /**
- * The single-driver lease: one process runs a migration pass at a time,
- * fleet-wide. The app implements this on Redis (`SET NX PX` + delete);
- * tests use an in-memory fake.
+ * Named leases for the runner's per-organization claims: one process works
+ * one organization at a time, while any number of processes share the
+ * fleet. The app implements this on Redis (`SET NX PX` + delete); tests
+ * use an in-memory fake.
  *
- * Losing the lease mid-pass is safe by construction - every migration is
+ * Losing a claim mid-tenant is safe by construction - every migration is
  * idempotent and the state machine is re-entrant - so the runner treats a
- * failed renewal as "stop early", never as corruption.
+ * failed renewal as "leave this organization to the new holder", never as
+ * corruption.
  */
 export interface MigrationLeaseRepository {
   /** True when this process now holds the lease. */

--- a/packages/system-migrations/src/runner.service.ts
+++ b/packages/system-migrations/src/runner.service.ts
@@ -16,8 +16,11 @@ const DEFAULT_LEASE_TTL_MS = 60_000;
 const DEFAULT_LEASE_RENEW_INTERVAL_MS = 20_000;
 /** How many organizations one pass works at once. Each is its own claim,
  *  its own migrations, its own convergence waits - so one large
- *  organization's import never holds the rest of the fleet behind it. */
-const DEFAULT_TENANT_CONCURRENCY = 10;
+ *  organization's import never holds the rest of the fleet behind it. The
+ *  per-tenant work is light (the fold queue does the heavy lifting), so
+ *  the bound exists to cap claim heartbeats and convergence polls, not
+ *  throughput. */
+const DEFAULT_TENANT_CONCURRENCY = 25;
 
 /**
  * Which (tenant, migration) pairs a pass may touch. The app composes this:
@@ -44,7 +47,7 @@ export type SystemMigrationRunnerDeps = {
   leaseTtlMs?: number;
   /** How often a held claim renews. Must stay well inside the TTL. */
   leaseRenewIntervalMs?: number;
-  /** How many organizations to migrate concurrently. Defaults to 10. */
+  /** How many organizations to migrate concurrently. Defaults to 25. */
   tenantConcurrency?: number;
 };
 

--- a/packages/system-migrations/src/runner.service.ts
+++ b/packages/system-migrations/src/runner.service.ts
@@ -9,10 +9,15 @@ const logger = createLogger("langwatch:system-migrations");
 
 const TENANT_PAGE_SIZE = 100;
 
-const LEASE_NAME = "system-migrations:pass";
+/** One claim per organization: `system-migrations:lease:` + this + the id. */
+const TENANT_CLAIM_PREFIX = "tenant:";
 const DEFAULT_LEASE_TTL_MS = 60_000;
-/** Renew well inside the TTL so one slow round trip cannot drop the lease. */
+/** Renew well inside the TTL so one slow round trip cannot drop the claim. */
 const DEFAULT_LEASE_RENEW_INTERVAL_MS = 20_000;
+/** How many organizations one pass works at once. Each is its own claim,
+ *  its own migrations, its own convergence waits - so one large
+ *  organization's import never holds the rest of the fleet behind it. */
+const DEFAULT_TENANT_CONCURRENCY = 10;
 
 /**
  * Which (tenant, migration) pairs a pass may touch. The app composes this:
@@ -35,101 +40,53 @@ export type SystemMigrationRunnerDeps = {
   tenants: TenantSource;
   cohort: MigrationCohort;
   migrations: readonly SystemMigration[];
-  /** How long each lease grant lasts. Defaults to a minute. */
+  /** How long each claim grant lasts. Defaults to a minute. */
   leaseTtlMs?: number;
-  /** How often the pass renews its lease. Must stay well inside the TTL. */
+  /** How often a held claim renews. Must stay well inside the TTL. */
   leaseRenewIntervalMs?: number;
+  /** How many organizations to migrate concurrently. Defaults to 10. */
+  tenantConcurrency?: number;
 };
 
 /**
  * Drives every registered migration over every cohort tenant, once per
- * boot, under a fleet-wide lease (one driver at a time). Level-triggered
- * on the restart cadence: each pass re-attempts held and parked tenants,
- * so a tenant whose blocker was fixed heals itself with no manual state
- * change, and a pass that dies anywhere simply happens again next boot.
+ * boot, several tenants at a time. Coordination is per ORGANIZATION, not
+ * per process: each tenant is claimed under its own lease before any work,
+ * so any number of processes (booting workers, an operator's targeted run)
+ * share the fleet instead of standing down behind one fleet-wide driver -
+ * a tenant already claimed elsewhere is simply left to its claim holder.
+ * Level-triggered on the restart cadence: each pass re-attempts held and
+ * parked tenants, so a tenant whose blocker was fixed heals itself with no
+ * manual state change, and a pass that dies anywhere simply happens again
+ * next boot.
  */
 export class SystemMigrationRunnerService {
   constructor(private readonly deps: SystemMigrationRunnerDeps) {}
 
-  /**
-   * One full pass. Returns null when another process holds the lease -
-   * that process is running the same pass, so there is nothing to do.
-   */
-  async runPass(args?: {
-    signal?: AbortSignal;
-  }): Promise<MigrationPassSummary | null> {
-    const { lease, migrations } = this.deps;
+  /** One full pass. Always runs: tenants claimed by another process are
+   *  counted in `claimed` and left alone rather than the pass standing
+   *  down as a whole. */
+  async runPass(args?: { signal?: AbortSignal }): Promise<MigrationPassSummary> {
     const signal = args?.signal;
-    if (migrations.length === 0) {
-      return { tenantsSeen: 0, finalized: 0, held: 0, parked: 0, skipped: 0 };
-    }
-
-    const ttlMs = this.deps.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
-    if (!(await lease.acquire({ name: LEASE_NAME, ttlMs }))) {
-      logger.info("another process holds the migration lease; standing down");
-      return null;
-    }
-
     const summary: MigrationPassSummary = {
       tenantsSeen: 0,
       finalized: 0,
       held: 0,
       parked: 0,
       skipped: 0,
+      claimed: 0,
     };
+    if (this.deps.migrations.length === 0) return summary;
 
-    // A single tenant can outlive the lease TTL on its own - one large
-    // organization's parity sweep is a round trip per member - so the lease
-    // is held by a timer for as long as the pass runs, not renewed once per
-    // tenant between them.
-    const heartbeat = this.startLeaseHeartbeat();
-    try {
-      await this.driveTenants({
-        summary,
-        signal,
-        leaseLost: heartbeat.leaseLost,
-      });
-    } finally {
-      heartbeat.stop();
-      await lease.release({ name: LEASE_NAME });
-    }
-
+    await this.driveTenants({ summary, signal });
     logger.info({ summary }, "system migration pass complete");
     return summary;
   }
 
-  /**
-   * Keeps the lease alive for the whole pass. A renewal that comes back
-   * false means another driver has legitimately taken over, which the pass
-   * reads as "stop at the next tenant" - never as corruption, since every
-   * migration is idempotent.
-   */
-  private startLeaseHeartbeat(): {
-    leaseLost: () => boolean;
-    stop: () => void;
-  } {
-    let lost = false;
-    const ttlMs = this.deps.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
-    const timer = setInterval(() => {
-      void this.deps.lease
-        .renew({ name: LEASE_NAME, ttlMs })
-        .then((held) => {
-          if (!held) lost = true;
-        })
-        .catch(() => {
-          lost = true;
-        });
-    }, this.deps.leaseRenewIntervalMs ?? DEFAULT_LEASE_RENEW_INTERVAL_MS);
-    // Never let the heartbeat alone hold the process open at shutdown.
-    timer.unref?.();
-    return { leaseLost: () => lost, stop: () => clearInterval(timer) };
-  }
-
-  /** Every cohort tenant, a page at a time, until abort or lease loss. */
+  /** Every cohort tenant, a page at a time, until abort. */
   private async driveTenants(args: {
     summary: MigrationPassSummary;
     signal?: AbortSignal;
-    leaseLost: () => boolean;
   }): Promise<void> {
     let cursor: string | null = null;
     for (;;) {
@@ -143,28 +100,73 @@ export class SystemMigrationRunnerService {
     }
   }
 
-  /** One page of tenants. False means the pass must stop here. */
+  /** One page of tenants, worked by a bounded pool. False stops the pass. */
   private async drivePage({
     page,
     summary,
     signal,
-    leaseLost,
   }: {
     page: string[];
     summary: MigrationPassSummary;
     signal?: AbortSignal;
-    leaseLost: () => boolean;
   }): Promise<boolean> {
-    const { cohort, migrations } = this.deps;
-    for (const tenantId of page) {
-      if (signal?.aborted) return false;
-      if (leaseLost()) {
-        logger.warn("migration lease lost mid-pass; stopping early");
-        return false;
+    const pending = [...page];
+    const width = Math.min(
+      Math.max(1, this.deps.tenantConcurrency ?? DEFAULT_TENANT_CONCURRENCY),
+      pending.length,
+    );
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        if (signal?.aborted) return;
+        const tenantId = pending.shift();
+        if (tenantId === undefined) return;
+        await this.driveTenant({ tenantId, summary, signal });
       }
+    };
+    await Promise.all(Array.from({ length: width }, worker));
+    return !signal?.aborted;
+  }
 
-      summary.tenantsSeen += 1;
+  /**
+   * One tenant, under its own claim. A tenant claimed by another process is
+   * left to that process - its pass is running the very same migrations -
+   * and one this pass claims runs its migrations in registration order,
+   * heartbeat-renewed for as long as they take.
+   */
+  private async driveTenant({
+    tenantId,
+    summary,
+    signal,
+  }: {
+    tenantId: string;
+    summary: MigrationPassSummary;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const { lease, cohort, migrations } = this.deps;
+    summary.tenantsSeen += 1;
+
+    const claimName = `${TENANT_CLAIM_PREFIX}${tenantId}`;
+    const ttlMs = this.deps.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
+    if (!(await lease.acquire({ name: claimName, ttlMs }))) {
+      summary.claimed += 1;
+      return;
+    }
+
+    // A single tenant can outlive the claim TTL on its own - one large
+    // organization's parity sweep is a round trip per member - so the claim
+    // is held by a timer for as long as its migrations run, not renewed
+    // once between them.
+    const heartbeat = this.startClaimHeartbeat(claimName);
+    try {
       for (const migration of migrations) {
+        if (signal?.aborted) return;
+        if (heartbeat.claimLost()) {
+          logger.warn(
+            { tenantId },
+            "organization claim lost mid-migration; leaving the rest of its migrations to the new holder",
+          );
+          return;
+        }
         if (!(await cohort({ tenantId, migrationName: migration.name }))) {
           summary.skipped += 1;
           continue;
@@ -176,8 +178,38 @@ export class SystemMigrationRunnerService {
           summary,
         });
       }
+    } finally {
+      heartbeat.stop();
+      await lease.release({ name: claimName });
     }
-    return true;
+  }
+
+  /**
+   * Keeps one tenant's claim alive while its migrations run. A renewal that
+   * comes back false means another driver has legitimately taken the tenant
+   * over, which this pass reads as "stop at this tenant's next migration" -
+   * never as corruption, since every migration is idempotent. Other tenants
+   * are unaffected: each holds its own claim.
+   */
+  private startClaimHeartbeat(claimName: string): {
+    claimLost: () => boolean;
+    stop: () => void;
+  } {
+    let lost = false;
+    const ttlMs = this.deps.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
+    const timer = setInterval(() => {
+      void this.deps.lease
+        .renew({ name: claimName, ttlMs })
+        .then((held) => {
+          if (!held) lost = true;
+        })
+        .catch(() => {
+          lost = true;
+        });
+    }, this.deps.leaseRenewIntervalMs ?? DEFAULT_LEASE_RENEW_INTERVAL_MS);
+    // Never let a heartbeat alone hold the process open at shutdown.
+    timer.unref?.();
+    return { claimLost: () => lost, stop: () => clearInterval(timer) };
   }
 
   private async runMigrationForTenant({

--- a/packages/system-migrations/src/runner.service.ts
+++ b/packages/system-migrations/src/runner.service.ts
@@ -82,6 +82,16 @@ export class SystemMigrationRunnerService {
     if (this.deps.migrations.length === 0) return summary;
 
     await this.driveTenants({ summary, signal });
+    if (summary.claimed > 0 && summary.claimed === summary.tenantsSeen) {
+      // Every organization read as claimed. Genuine when another pass is
+      // sweeping the same page at the same moment - but it is also the only
+      // face an unreachable Redis wears (acquire fails safe to "held"), so
+      // a pass that repeats this across boots deserves a line of evidence.
+      logger.warn(
+        { summary },
+        "every organization was claimed by another process; if this repeats across boots, check Redis",
+      );
+    }
     logger.info({ summary }, "system migration pass complete");
     return summary;
   }
@@ -123,7 +133,20 @@ export class SystemMigrationRunnerService {
         if (signal?.aborted) return;
         const tenantId = pending.shift();
         if (tenantId === undefined) return;
-        await this.driveTenant({ tenantId, summary, signal });
+        try {
+          await this.driveTenant({ tenantId, summary, signal });
+        } catch (error) {
+          // Contained here, not just around migrateTenant: a throw outside
+          // that inner net (the state read, the cohort read) would reject
+          // the pool's Promise.all, killing the pass while its surviving
+          // workers drain on, detached and unobserved. The tenant stays
+          // pending and the next pass retries it, like any park.
+          summary.parked += 1;
+          logger.error(
+            { error, tenantId },
+            "tenant drive failed outside the migration; continuing the pass",
+          );
+        }
       }
     };
     await Promise.all(Array.from({ length: width }, worker));

--- a/packages/system-migrations/src/types.ts
+++ b/packages/system-migrations/src/types.ts
@@ -68,4 +68,6 @@ export type MigrationPassSummary = {
   parked: number;
   /** Finalized or rolled back before this pass, or outside the cohort. */
   skipped: number;
+  /** Claimed by another process's pass, so left to that process. */
+  claimed: number;
 };

--- a/platform/app/src/components/ops/migrations/MigrationsContent.tsx
+++ b/platform/app/src/components/ops/migrations/MigrationsContent.tsx
@@ -187,6 +187,7 @@ export function MigrationsContent() {
           key={migration.name}
           step={index + 1}
           migration={migration}
+          previousMigrationTitle={query.data?.[index - 1]?.title}
           enrollments={enrollments.filter(
             (enrollment) => enrollment.migrationName === migration.name,
           )}
@@ -267,12 +268,14 @@ function MigrationStatusBadges({ migration }: { migration: MigrationListing }) {
 function MigrationSection({
   step,
   migration,
+  previousMigrationTitle,
   enrollments,
   isSaaS,
   canManage,
 }: {
   step: number;
   migration: MigrationListing;
+  previousMigrationTitle?: string;
   enrollments: EnrollmentRecord[];
   isSaaS: boolean;
   canManage: boolean;
@@ -308,6 +311,7 @@ function MigrationSection({
                 <EnrollCohortAction
                   migrationName={migration.name}
                   migrationTitle={migration.title}
+                  previousMigrationTitle={previousMigrationTitle}
                   requiresConfirmation={requiresConfirmation}
                 />
               </>
@@ -523,19 +527,39 @@ function EnrollAction({
 }
 
 /**
- * Enroll a sampled cohort for THIS migration in one action. The sample is
- * drawn from organizations not yet enrolled, and the platform excludes the
- * ones it already knows to leave alone by data: an active enterprise
+ * Enroll a sampled cohort for THIS migration in one action. The first
+ * step's sample is drawn from organizations not yet enrolled; a later
+ * step's from the step before it. The platform excludes the ones it
+ * already knows to leave alone by data: an active enterprise
  * subscription, or a dedicated data plane configured in the environment.
  * No organization is ever named in code to exclude it.
  */
+function cohortDialogDescription({
+  previousMigrationTitle,
+  requiresConfirmation,
+}: {
+  previousMigrationTitle?: string;
+  requiresConfirmation: boolean;
+}): string {
+  const pool = previousMigrationTitle
+    ? `Enrolls a random sample of organizations enrolled for the ${previousMigrationTitle.toLowerCase()} but not yet for this step. `
+    : "Enrolls a random sample of organizations not yet enrolled for this step. ";
+  const consequence = requiresConfirmation
+    ? "Once their earlier steps finish, the next pass proves parity and moves every enrolled organization's permission checks onto the new engine. Organizations on an enterprise plan or with a dedicated data plane are always left out."
+    : "It changes nothing about who answers permission checks. Organizations on an enterprise plan or with a dedicated data plane are always left out.";
+  return pool + consequence;
+}
+
 function EnrollCohortAction({
   migrationName,
   migrationTitle,
+  previousMigrationTitle,
   requiresConfirmation,
 }: {
   migrationName: string;
   migrationTitle: string;
+  /** The step before this one; a later step's cohort samples from it. */
+  previousMigrationTitle?: string;
   requiresConfirmation: boolean;
 }) {
   const [open, setOpen] = useState(false);
@@ -595,11 +619,10 @@ function EnrollCohortAction({
           });
         }}
         title={`Enroll a cohort for the ${migrationTitle.toLowerCase()}`}
-        description={
-          requiresConfirmation
-            ? "Enrolls a random sample of organizations not yet enrolled for this step. Once their earlier steps finish, the next pass proves parity and moves every enrolled organization's permission checks onto the new engine. Organizations on an enterprise plan or with a dedicated data plane are always left out."
-            : "Enrolls a random sample of organizations not yet enrolled for this step. It changes nothing about who answers permission checks. Organizations on an enterprise plan or with a dedicated data plane are always left out."
-        }
+        description={cohortDialogDescription({
+          previousMigrationTitle,
+          requiresConfirmation,
+        })}
         isLoading={enrollCohort.isPending}
         confirmDisabled={!sampleSizeValid}
       >

--- a/platform/app/src/components/ops/migrations/MigrationsContent.tsx
+++ b/platform/app/src/components/ops/migrations/MigrationsContent.tsx
@@ -106,7 +106,7 @@ export function MigrationsContent() {
       toaster.create({
         title: "Migration pass started",
         description:
-          "The pass runs in the background under the fleet-wide lease. This page refreshes as organizations move.",
+          "The pass runs in the background, several organizations at a time. This page refreshes as organizations move.",
         type: "success",
       });
       await utils.ops.listSystemMigrations.invalidate();

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1074,9 +1074,9 @@ const presentations = {
     },
   },
   migration_pass_already_running: {
-    title: "This organization is already being migrated",
+    title: "This organization appears to be mid-migration",
     describe: () =>
-      "Another migration pass is working this organization right now. Wait for it to conclude, then retry.",
+      "Another migration pass holds this organization's claim. Wait a moment for it to conclude, then retry.",
   },
   migration_not_available_on_installation: {
     title: "This migration is not available here yet",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1074,9 +1074,9 @@ const presentations = {
     },
   },
   migration_pass_already_running: {
-    title: "A migration pass is already running",
+    title: "This organization is already being migrated",
     describe: () =>
-      "Only one pass runs at a time, and it may already be processing this organization. Wait for it to conclude, then retry.",
+      "Another migration pass is working this organization right now. Wait for it to conclude, then retry.",
   },
   migration_not_available_on_installation: {
     title: "This migration is not available here yet",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1076,7 +1076,7 @@ const presentations = {
   migration_pass_already_running: {
     title: "This organization appears to be mid-migration",
     describe: () =>
-      "Another migration pass holds this organization's claim. Wait a moment for it to conclude, then retry.",
+      "The migration cannot start for this organization right now — another pass appears to be working it. Wait a moment, then retry.",
   },
   migration_not_available_on_installation: {
     title: "This migration is not available here yet",

--- a/platform/app/src/server/api/routers/ops.ts
+++ b/platform/app/src/server/api/routers/ops.ts
@@ -1621,9 +1621,9 @@ export const opsRouter = createTRPCRouter({
   /**
    * Kick a migration pass now instead of waiting for the next worker boot -
    * the lever for processing a fresh enrollment right away or re-verifying
-   * held tenants after remediation. Fire-and-forget: the fleet-wide lease already
-   * guarantees a single driver, so the worst case for a double click is a
-   * pass that stands down immediately.
+   * held tenants after remediation. Fire-and-forget: per-organization claims
+   * already keep two passes off the same organization, so the worst case for
+   * a double click is a pass that finds everything claimed and does nothing.
    */
   runSystemMigrationPass: protectedProcedure
     .use(opsManagePermission)

--- a/platform/app/src/server/api/routers/ops.ts
+++ b/platform/app/src/server/api/routers/ops.ts
@@ -1589,8 +1589,8 @@ export const opsRouter = createTRPCRouter({
    * Run one migration for one organization now. Awaited: the operator asked
    * about one organization and gets the status it ended the run in. The
    * service refuses unknown migrations, unknown organizations, unenrolled
-   * organizations (cloud) and a pass already holding the fleet-wide lease,
-   * each with a handled error the page renders.
+   * organizations (cloud) and an organization whose claim another pass
+   * already holds, each with a handled error the page renders.
    */
   runSystemMigrationForOrganization: protectedProcedure
     .use(opsManagePermission)

--- a/platform/app/src/server/app-layer/authz/__tests__/cutover-rollback.integration.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/cutover-rollback.integration.test.ts
@@ -45,6 +45,17 @@ import { rollBackAuthzCutover } from "../../system-migrations/runtime";
 import { SystemMigrationsService } from "../../system-migrations/system-migrations.service";
 import { resetCutoverGateForTesting } from "../cutover-gate";
 
+function emptyPassSummary() {
+  return {
+    tenantsSeen: 0,
+    finalized: 0,
+    held: 0,
+    parked: 0,
+    skipped: 0,
+    claimed: 0,
+  };
+}
+
 const ns = `authz-cutover-rollback-${nanoid(8)}`;
 
 const OPERATOR_ID = `user_operator_${nanoid(6)}`;
@@ -98,8 +109,8 @@ describe("given a cut-over organization rolled back with the queue stopped", () 
       },
       privateDataplaneOrganizationIds: () => [],
       audit: async () => undefined,
-      runPass: async () => null,
-      runTargetedPass: async () => null,
+      runPass: async () => emptyPassSummary(),
+      runTargetedPass: async () => emptyPassSummary(),
       rollbackEffects: {
         [GRANTS_CUTOVER_MIGRATION_NAME]: async ({
           tenantId,

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/cohort-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/cohort-enrollment.unit.test.ts
@@ -17,10 +17,13 @@ function serviceWith({
   eligible = organizations(10),
   isSaaS = true,
   privateDataplaneOrganizationIds = [],
+  migrationNames = [MIGRATION],
 }: {
   eligible?: Array<{ id: string; name: string }>;
   isSaaS?: boolean;
   privateDataplaneOrganizationIds?: string[];
+  /** Registered migrations, in the order they run per organization. */
+  migrationNames?: string[];
 } = {}) {
   const findCohortEligibleOrganizations = vi
     .fn<SystemMigrationEnrollmentStore["findCohortEligibleOrganizations"]>()
@@ -38,15 +41,14 @@ function serviceWith({
       findRecord: vi.fn(),
       upsertRecord: vi.fn(),
     },
-    migrations: () => [
-      {
-        name: MIGRATION,
-        title: MIGRATION,
-        description: MIGRATION,
+    migrations: () =>
+      migrationNames.map((name) => ({
+        name,
+        title: name,
+        description: name,
         requiresOperatorConfirmation: false,
         runsAutomaticallyOnSelfHosted: false,
-      },
-    ],
+      })),
     isSaaS: () => isSaaS,
     enrollments: {
       findAll: vi.fn(),
@@ -120,8 +122,40 @@ describe("SystemMigrationsService.enrollCohort", () => {
 
         expect(findCohortEligibleOrganizations).toHaveBeenCalledWith({
           migrationName: MIGRATION,
+          enrolledForMigrationName: undefined,
           excludeOrganizationIds: ["org_isolated_inc"],
         });
+      });
+
+      /** @scenario "A later step's cohort samples only organizations enrolled for the step before it" */
+      it("pools a later step from the step before it, and the first step from everyone", async () => {
+        const { service, findCohortEligibleOrganizations } = serviceWith({
+          migrationNames: ["authz-team-user-backfill", MIGRATION],
+        });
+
+        await service.enrollCohort({
+          migrationName: MIGRATION,
+          sampleSize: 5,
+          actorUserId: "user_ops",
+        });
+        expect(findCohortEligibleOrganizations).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            migrationName: MIGRATION,
+            enrolledForMigrationName: "authz-team-user-backfill",
+          }),
+        );
+
+        await service.enrollCohort({
+          migrationName: "authz-team-user-backfill",
+          sampleSize: 5,
+          actorUserId: "user_ops",
+        });
+        expect(findCohortEligibleOrganizations).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            migrationName: "authz-team-user-backfill",
+            enrolledForMigrationName: undefined,
+          }),
+        );
       });
     });
 

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
@@ -20,6 +20,11 @@ const stubs = vi.hoisted(() => {
         findMany: enrollmentFindMany,
         findUnique: enrollmentFindUnique,
       },
+      // The pass pages tenants before claiming any (per-organization
+      // claims); an empty page ends it without touching Redis.
+      organization: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
     },
   };
 });
@@ -155,8 +160,8 @@ describe("migrationPassCohort on cloud", () => {
       process.env.AUTHZ_CUTOVER_COHORT = "none";
       stubs.enrollmentFindMany.mockResolvedValue([]);
       try {
-        // The pass stands down at the lease (no Redis here), but the warning
-        // and the enrollment read both happen before that.
+        // The pass sees no tenants (empty organization page), but the
+        // warning and the enrollment read both happen before that.
         await runSystemMigrationPass();
       } finally {
         delete process.env.SYSTEM_MIGRATIONS_COHORT;

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/system-migrations-service.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/system-migrations-service.unit.test.ts
@@ -79,7 +79,7 @@ function targetedPassStub() {
       (args: {
         organizationId: string;
         migrationName: string;
-      }) => Promise<MigrationPassSummary | null>
+      }) => Promise<MigrationPassSummary>
     >()
     .mockResolvedValue({
       tenantsSeen: 1,
@@ -87,6 +87,7 @@ function targetedPassStub() {
       held: 0,
       parked: 0,
       skipped: 0,
+      claimed: 0,
     });
 }
 
@@ -852,12 +853,19 @@ describe("SystemMigrationsService.runForOrganization", () => {
     });
   });
 
-  describe("when another pass holds the fleet-wide lease", () => {
+  describe("when another pass holds the organization's claim", () => {
     /** @scenario "A targeted run while a pass is already running is refused" */
     it("refuses with migration_pass_already_running", async () => {
       const { service } = serviceWith({
         record: null,
-        runTargetedPass: targetedPassStub().mockResolvedValue(null),
+        runTargetedPass: targetedPassStub().mockResolvedValue({
+          tenantsSeen: 1,
+          finalized: 0,
+          held: 0,
+          parked: 0,
+          skipped: 0,
+          claimed: 1,
+        }),
       });
 
       await expect(

--- a/platform/app/src/server/app-layer/system-migrations/boot.ts
+++ b/platform/app/src/server/app-layer/system-migrations/boot.ts
@@ -23,9 +23,7 @@ export function startSystemMigrations(args?: {
     redis: args?.redis,
   })
     .then((summary) => {
-      if (summary) {
-        logger.info({ summary }, "system migration pass finished");
-      }
+      logger.info({ summary }, "system migration pass finished");
     })
     .catch((error) => {
       logger.error(

--- a/platform/app/src/server/app-layer/system-migrations/errors.ts
+++ b/platform/app/src/server/app-layer/system-migrations/errors.ts
@@ -168,10 +168,9 @@ export class MigrationRunRequiresEnrollmentError extends HandledError {
 }
 
 /**
- * A targeted run refused because another pass holds the fleet-wide lease.
- * Not a failure of anything: the running pass may well be processing the
- * very organization the operator asked about, and the operator's action is
- * simply to retry once it concludes.
+ * A targeted run refused because another pass holds this organization's
+ * claim - it is being migrated right now. Not a failure of anything: the
+ * operator's action is simply to retry once that pass concludes.
  */
 export class MigrationPassAlreadyRunningError extends HandledError {
   declare readonly code: "migration_pass_already_running";
@@ -179,7 +178,7 @@ export class MigrationPassAlreadyRunningError extends HandledError {
   constructor() {
     super(
       "migration_pass_already_running",
-      "A migration pass is already running; try again once it concludes",
+      "This organization is already being migrated; try again once that pass concludes",
       { httpStatus: 409, fault: "customer" },
     );
     this.name = "MigrationPassAlreadyRunningError";

--- a/platform/app/src/server/app-layer/system-migrations/errors.ts
+++ b/platform/app/src/server/app-layer/system-migrations/errors.ts
@@ -178,7 +178,7 @@ export class MigrationPassAlreadyRunningError extends HandledError {
   constructor() {
     super(
       "migration_pass_already_running",
-      "This organization is already being migrated; try again once that pass concludes",
+      "Another migration pass appears to be working this organization; try again shortly",
       { httpStatus: 409, fault: "customer" },
     );
     this.name = "MigrationPassAlreadyRunningError";

--- a/platform/app/src/server/app-layer/system-migrations/repositories/__tests__/cohort-eligibility.integration.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/__tests__/cohort-eligibility.integration.test.ts
@@ -113,5 +113,23 @@ describe("given organizations of every eligibility kind", () => {
       expect(poolIds.has(enrolledOrgId)).toBe(false);
       expect(poolIds.has(excludedOrgId)).toBe(false);
     });
+
+    /** @scenario "A later step's cohort samples only organizations enrolled for the step before it" */
+    it("narrows to the predecessor's enrollment when one is named", async () => {
+      const laterStep = `${MIGRATION}-later`;
+      // Only the organization already enrolled for MIGRATION (the
+      // predecessor here) may enter the later step's pool; the plain
+      // organization, eligible for the first step, is not enrolled for the
+      // predecessor and stays out.
+      const pool = await repository.findCohortEligibleOrganizations({
+        migrationName: laterStep,
+        enrolledForMigrationName: MIGRATION,
+        excludeOrganizationIds: [],
+      });
+      const poolIds = new Set(pool.map((organization) => organization.id));
+
+      expect(poolIds.has(enrolledOrgId)).toBe(true);
+      expect(poolIds.has(plainOrgId)).toBe(false);
+    });
   });
 });

--- a/platform/app/src/server/app-layer/system-migrations/repositories/__tests__/system-migration-enrollment.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/__tests__/system-migration-enrollment.repository.unit.test.ts
@@ -189,6 +189,41 @@ describe("PrismaSystemMigrationEnrollmentRepository", () => {
         select: { id: true, name: true },
       });
     });
+
+    /** @scenario "A later step's cohort samples only organizations enrolled for the step before it" */
+    it("pools from the predecessor's enrollment when one is named", async () => {
+      const findMany = vi
+        .fn()
+        .mockImplementation(
+          async ({ where }: { where: { migrationName: string } }) =>
+            where.migrationName === "authz-grants-genesis-import"
+              ? [{ organizationId: "org_enrolled" }]
+              : [{ organizationId: "org_first_step" }],
+        );
+      const { prisma, repository } = repositoryWith({
+        enrollment: { findMany },
+        organization: { findMany: vi.fn().mockResolvedValue([]) },
+      });
+
+      await repository.findCohortEligibleOrganizations({
+        migrationName: "authz-grants-genesis-import",
+        enrolledForMigrationName: "authz-team-user-backfill",
+        excludeOrganizationIds: [],
+      });
+
+      expect(prisma.organization.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: ["org_first_step"], notIn: ["org_enrolled"] },
+          subscriptions: {
+            none: {
+              status: { in: ["ACTIVE", "PENDING"] },
+              plan: "ENTERPRISE",
+            },
+          },
+        },
+        select: { id: true, name: true },
+      });
+    });
   });
 
   describe("when a cohort is written", () => {

--- a/platform/app/src/server/app-layer/system-migrations/repositories/migration-lease.redis.repository.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/migration-lease.redis.repository.ts
@@ -52,10 +52,11 @@ export class RedisMigrationLeaseRepository implements MigrationLeaseRepository {
       );
       return result === "OK";
     } catch (error) {
-      // Standing down is right, but silence is not: the runner logs every
-      // falsy acquire as "another process holds the lease", so an unreachable
-      // Redis would read as ordinary contention and the migration would never
-      // run, on any boot, without a word anywhere.
+      // Standing down is right, but silence is not: the runner counts a
+      // falsy acquire as an organization claimed by another process, so an
+      // unreachable Redis would read as ordinary contention and no migration
+      // would ever run, on any boot. This warn is the evidence that it was
+      // an error, not contention.
       logger.warn(
         { error, name },
         "could not acquire the migration lease; treating it as held elsewhere",

--- a/platform/app/src/server/app-layer/system-migrations/repositories/migration-lease.redis.repository.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/migration-lease.redis.repository.ts
@@ -24,9 +24,10 @@ return 0
 `;
 
 /**
- * The fleet-wide single-driver lease on Redis. Fail-safe direction: no
- * Redis, or any Redis error, reads as "not acquired" - the pass simply does
- * not run on this boot, and the legacy paths keep answering.
+ * The runner's named leases on Redis - one claim per organization.
+ * Fail-safe direction: no Redis, or any Redis error, reads as "not
+ * acquired" - no organization is worked on this boot, and the legacy paths
+ * keep answering.
  */
 export class RedisMigrationLeaseRepository implements MigrationLeaseRepository {
   private readonly token = randomUUID();

--- a/platform/app/src/server/app-layer/system-migrations/repositories/system-migration-enrollment.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/system-migration-enrollment.prisma.repository.ts
@@ -146,14 +146,18 @@ export class PrismaSystemMigrationEnrollmentRepository {
    * The cohort's eligible pool for one migration: organizations with no
    * enrollment row for it, no active enterprise subscription, and not on the
    * caller's exclusion list (the private-dataplane organizations, whose ids
-   * the composition reads from the environment). Ids and names only - the
+   * the composition reads from the environment). A later pipeline step
+   * passes `enrolledForMigrationName` and the pool narrows to organizations
+   * already enrolled for that predecessor. Ids and names only - the
    * service samples from this in memory, so the pool never needs an order.
    */
   async findCohortEligibleOrganizations({
     migrationName,
+    enrolledForMigrationName,
     excludeOrganizationIds,
   }: {
     migrationName: string;
+    enrolledForMigrationName?: string;
     excludeOrganizationIds: string[];
   }): Promise<Array<{ id: string; name: string }>> {
     // The enrollment table has no relation to Organization (a plain string
@@ -163,9 +167,19 @@ export class PrismaSystemMigrationEnrollmentRepository {
       where: { migrationName },
       select: { organizationId: true },
     });
+    const pool =
+      enrolledForMigrationName === undefined
+        ? undefined
+        : (
+            await this.prisma.systemMigrationEnrollment.findMany({
+              where: { migrationName: enrolledForMigrationName },
+              select: { organizationId: true },
+            })
+          ).map((row) => row.organizationId);
     return this.prisma.organization.findMany({
       where: {
         id: {
+          ...(pool === undefined ? {} : { in: pool }),
           notIn: [
             ...excludeOrganizationIds,
             ...enrolled.map((row) => row.organizationId),

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -591,10 +591,11 @@ function warnWhenRetiredCohortVariablesAreSet(): void {
  */
 /**
  * One migration for one organization, now - the ops page's targeted run.
- * The same lease as a full pass (one driver fleet-wide, so a targeted run
- * can never double-drive an organization a pass is working through; null
- * means the lease is held and the service turns that into a retry-shaped
- * refusal), the same cohort read (enrollment stays the pacing source of
+ * The same per-organization claim as a full pass (so a targeted run can
+ * never double-drive an organization a pass is working through; a summary
+ * counting the organization as claimed is what the service turns into a
+ * retry-shaped refusal), the same cohort read (enrollment stays the pacing
+ * source of
  * truth even here - the service refuses unenrolled organizations before
  * composing this, and the cohort would skip them anyway), a tenant source
  * of exactly one id, and the migration list cut to the one asked for.

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -607,7 +607,7 @@ export async function runSystemMigrationTargetedPass({
   organizationId: string;
   migrationName: string;
   signal?: AbortSignal;
-}): Promise<MigrationPassSummary | null> {
+}): Promise<MigrationPassSummary> {
   const redis = tryGetApp()?.redis ?? null;
   const runner = new SystemMigrationRunnerService({
     state: systemMigrationState,
@@ -639,7 +639,7 @@ export async function runSystemMigrationPass(args?: {
    * no-op. Callers that run after startup (the ops action) can omit it.
    */
   redis?: Redis | Cluster | null;
-}): Promise<MigrationPassSummary | null> {
+}): Promise<MigrationPassSummary> {
   warnWhenRetiredCohortVariablesAreSet();
   const redis = args?.redis ?? tryGetApp()?.redis ?? null;
   const runner = new SystemMigrationRunnerService({

--- a/platform/app/src/server/app-layer/system-migrations/system-migrations.service.ts
+++ b/platform/app/src/server/app-layer/system-migrations/system-migrations.service.ts
@@ -523,8 +523,9 @@ export class SystemMigrationsService {
    * fire-and-forget - the operator asked about one organization and wants
    * its outcome. Enrollment stays the pacing source of truth on cloud: an
    * unenrolled organization is refused, never quietly migrated. The
-   * fleet-wide lease still applies, so a run during a full pass is refused
-   * with a retry-shaped error instead of double-driving the organization.
+   * organization's own claim still applies, so a run while another pass is
+   * working that organization is refused with a retry-shaped error instead
+   * of double-driving it.
    */
   async runForOrganization({
     organizationId,
@@ -615,9 +616,9 @@ export class SystemMigrationsService {
   /**
    * Kick a pass now instead of waiting for the next worker boot - the lever
    * for processing a fresh enrollment right away or re-verifying held
-   * tenants after remediation. Fire-and-forget: the fleet-wide lease already guarantees a
-   * single driver, so the worst case for a double click is a pass that
-   * stands down immediately.
+   * tenants after remediation. Fire-and-forget: per-organization claims keep
+   * two passes off the same organization, so the worst case for a double
+   * click is a pass that finds everything claimed and does nothing.
    */
   startPass(): void {
     void this.deps.runPass().catch((error) => {

--- a/platform/app/src/server/app-layer/system-migrations/system-migrations.service.ts
+++ b/platform/app/src/server/app-layer/system-migrations/system-migrations.service.ts
@@ -88,6 +88,9 @@ export interface SystemMigrationEnrollmentStore {
   }): Promise<void>;
   findCohortEligibleOrganizations(args: {
     migrationName: string;
+    /** When set, the pool is restricted to organizations already enrolled
+     *  for this migration - a later step samples the step before it. */
+    enrolledForMigrationName?: string;
     excludeOrganizationIds: string[];
   }): Promise<Array<{ id: string; name: string }>>;
   createMany(args: {
@@ -211,17 +214,18 @@ export class SystemMigrationsService {
         action: string;
         args?: Record<string, unknown>;
       }) => Promise<void>;
-      runPass: () => Promise<MigrationPassSummary | null>;
+      runPass: () => Promise<MigrationPassSummary>;
       /**
-       * One migration for one organization, now, under the same fleet-wide
-       * lease as a full pass (null when another pass holds it). The
+       * One migration for one organization, now, under the same
+       * per-organization claim as a full pass (the summary's `claimed`
+       * says another pass is already working the organization). The
        * composition supplies it because only the composition can build a
        * runner scoped to a single (tenant, migration) pair.
        */
       runTargetedPass: (args: {
         organizationId: string;
         migrationName: string;
-      }) => Promise<MigrationPassSummary | null>;
+      }) => Promise<MigrationPassSummary>;
       /**
        * Whether a migration's stored report means it merely WAITED, per
        * migration name. The state machine has no waiting status, so a
@@ -433,9 +437,19 @@ export class SystemMigrationsService {
   }> {
     if (!this.deps.isSaaS()) throw new MigrationEnrollmentCloudOnlyError();
     this.requireRegisteredMigration(migrationName);
+    // The steps run as an ordered pipeline per organization, so a later
+    // step's pool is the step before it: an organization enrolled for a
+    // step whose predecessor nothing will ever run would sit pending
+    // forever. The first step keeps sampling the whole installation.
+    const ordered = this.deps.migrations();
+    const index = ordered.findIndex(
+      (migration) => migration.name === migrationName,
+    );
+    const previous = index > 0 ? ordered[index - 1] : undefined;
     const eligible =
       await this.deps.enrollments.findCohortEligibleOrganizations({
         migrationName,
+        enrolledForMigrationName: previous?.name,
         excludeOrganizationIds: this.deps.privateDataplaneOrganizationIds(),
       });
     const picked = sample({ pool: eligible, count: sampleSize });
@@ -550,7 +564,7 @@ export class SystemMigrationsService {
       organizationId,
       migrationName,
     });
-    if (summary === null) throw new MigrationPassAlreadyRunningError();
+    if (summary.claimed > 0) throw new MigrationPassAlreadyRunningError();
     const record = await this.deps.state.findRecord({
       migrationName,
       tenantId: organizationId,

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/authzGrantsPipeline.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/authzGrantsPipeline.unit.test.ts
@@ -201,6 +201,17 @@ describe("authzGrantsState projection", () => {
     });
   }
 
+  describe("when a backed-up organization has many events queued", () => {
+    it("declares batch coalescing, so a backlog drains in load/apply/store cycles rather than one queue dispatch per event", () => {
+      // The state-projection lane defaults to one event per dispatch; on a
+      // loaded queue that is seconds per fact, and a genesis import's few
+      // hundred facts overran the convergence budget and parked the
+      // organization on every pass. The declaration is what turns on the
+      // queue's batch path - without it the executor's batching is dead code.
+      expect(projection.options?.coalesceMaxBatch ?? 1).toBeGreaterThan(1);
+    });
+  });
+
   describe("when events fold through the reducer", () => {
     it("attaches, learns the organization, and carries the envelope's business time onto the fact", () => {
       const state = projection.apply(

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/projections/authzGrantsState.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/projections/authzGrantsState.foldProjection.ts
@@ -7,7 +7,10 @@ import {
   AbstractFoldProjection,
   type FoldEventHandlers,
 } from "../../../projections/abstractFoldProjection";
-import type { StateProjectionStore } from "../../../projections/stateProjection.types";
+import type {
+  StateProjectionOptions,
+  StateProjectionStore,
+} from "../../../projections/stateProjection.types";
 import {
   type AuthzGrantsEvent,
   authzGrantsEventSchema,
@@ -37,6 +40,18 @@ import {
 import { wireEventToFact } from "./wireToFact";
 
 export const AUTHZ_GRANTS_PROJECTION_VERSION = "2026-08-17";
+
+/**
+ * The state-projection lane dispatches ONE event per queue job unless a
+ * projection opts into coalescing, and under fair dispatch on a loaded
+ * queue one dispatch per fact is seconds per fact - a genesis import's few
+ * hundred facts took the whole convergence budget to fold, parking the
+ * organization on every pass (observed in production, 2026-08-20). The fold
+ * is a pure reducer and the store writes once per batch, so draining a
+ * backed-up organization in one load/apply/store cycle is strictly cheaper.
+ * Matches the genesis import's own append chunk size.
+ */
+export const AUTHZ_GRANTS_COALESCE_MAX_BATCH = 500;
 
 const authzGrantsEvents = [
   grantAttachedEventSchema,
@@ -91,6 +106,10 @@ export class AuthzGrantsStateFoldProjection
   readonly name = "authzGrantsState";
   readonly version = AUTHZ_GRANTS_PROJECTION_VERSION;
   readonly store: StateProjectionStore<AuthzGrantsFoldState>;
+
+  override options: StateProjectionOptions = {
+    coalesceMaxBatch: AUTHZ_GRANTS_COALESCE_MAX_BATCH,
+  };
 
   protected readonly events = authzGrantsEvents;
 

--- a/platform/app/src/server/event-sourcing/projections/__tests__/stateProjectionCoalesce.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/stateProjectionCoalesce.unit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The state lane's coalescing chain, pinned link by link. A state projection
+ * that declares `options.coalesceMaxBatch` must actually get the queue's
+ * batch path — the declaration alone is dead code if either link drops it,
+ * and dropping it reproduces the 2026-08-20 production symptom (a genesis
+ * import's few hundred facts draining one queue dispatch each, overrunning
+ * the convergence budget and parking the organization on every pass).
+ *
+ * - router → queue manager: `initializeStateProjectionQueues` forwards the
+ *   projection's declared limit (not the default 1) and passes a batch
+ *   callback at all.
+ * - queue manager → registry: the entry carries the limit and registers
+ *   `processBatch`, which is the condition the GroupQueue keys batching on.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Event } from "../../domain/types";
+import { TEST_CONSTANTS } from "../../services/__tests__/testHelpers";
+import type { JobRegistryEntry } from "../../services/queues/queueManager";
+import { QueueManager } from "../../services/queues/queueManager";
+import { ProjectionRouter } from "../projectionRouter";
+import type { StateProjectionDefinition } from "../stateProjection.types";
+
+function stateProjectionOf(
+  name: string,
+  coalesceMaxBatch?: number,
+): StateProjectionDefinition<{ count: number }, Event> {
+  return {
+    name,
+    version: "test-1",
+    eventTypes: [],
+    init: () => ({ count: 0 }),
+    apply: (state) => state,
+    store: {
+      load: async () => null,
+      store: async () => undefined,
+    },
+    ...(coalesceMaxBatch === undefined
+      ? {}
+      : { options: { coalesceMaxBatch } }),
+  };
+}
+
+describe("state projection coalescing wiring", () => {
+  describe("when a state projection declares coalesceMaxBatch", () => {
+    it("forwards the declared limit and a batch callback into the queue registration", () => {
+      const queueManager = {
+        initializeStateProjectionQueues: vi.fn(),
+      };
+      const router = new ProjectionRouter<Event>(
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        TEST_CONSTANTS.PIPELINE_NAME,
+        queueManager as never,
+      );
+      router.registerStateProjection(stateProjectionOf("batched", 500));
+
+      router.initializeStateProjectionQueues();
+
+      const [defs, , onEventBatch] =
+        queueManager.initializeStateProjectionQueues.mock.calls[0] ?? [];
+      expect(defs?.batched?.coalesceMaxBatch).toBe(500);
+      expect(onEventBatch).toBeTypeOf("function");
+    });
+
+    it("scores dispatch by log-accept time so delivery order agrees with the cursor", () => {
+      const queueManager = {
+        initializeStateProjectionQueues: vi.fn(),
+      };
+      const router = new ProjectionRouter<Event>(
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        TEST_CONSTANTS.PIPELINE_NAME,
+        queueManager as never,
+      );
+      router.registerStateProjection(stateProjectionOf("batched", 500));
+
+      router.initializeStateProjectionQueues();
+
+      const [defs] =
+        queueManager.initializeStateProjectionQueues.mock.calls[0] ?? [];
+      // Business time a day in the past, appended now: without a createdAt
+      // score this event jumps the group's queue, and the cursor its drain
+      // commits silently drops everything appended before it.
+      const backdated = {
+        createdAt: 2_000,
+        occurredAt: 1_000,
+      } as unknown as Event;
+      expect(defs?.batched?.scoreFn?.(backdated)).toBe(2_000);
+    });
+  });
+
+  describe("when the queue manager registers the state lane", () => {
+    it("puts the limit and a processBatch on the registry entry, and omits processBatch for the default of one", () => {
+      const registry = new Map<string, JobRegistryEntry>();
+      const queueManager = new QueueManager<Event>({
+        aggregateType: TEST_CONSTANTS.AGGREGATE_TYPE,
+        pipelineName: TEST_CONSTANTS.PIPELINE_NAME,
+        globalQueue: {} as never,
+        globalJobRegistry: registry as never,
+      });
+
+      queueManager.initializeStateProjectionQueues(
+        {
+          batched: { name: "batched", coalesceMaxBatch: 500 },
+          oneAtATime: { name: "oneAtATime", coalesceMaxBatch: 1 },
+        },
+        async () => undefined,
+        async () => undefined,
+      );
+
+      const batched = registry.get(
+        `${TEST_CONSTANTS.PIPELINE_NAME}:stateProjection:batched`,
+      );
+      expect(batched?.coalesceMaxBatch).toBe(500);
+      expect(batched?.processBatch).toBeDefined();
+
+      const single = registry.get(
+        `${TEST_CONSTANTS.PIPELINE_NAME}:stateProjection:oneAtATime`,
+      );
+      expect(single?.processBatch).toBeUndefined();
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/projections/__tests__/stateProjectionCoalesce.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/projections/__tests__/stateProjectionCoalesce.unit.test.ts
@@ -20,10 +20,13 @@ import { QueueManager } from "../../services/queues/queueManager";
 import { ProjectionRouter } from "../projectionRouter";
 import type { StateProjectionDefinition } from "../stateProjection.types";
 
-function stateProjectionOf(
-  name: string,
-  coalesceMaxBatch?: number,
-): StateProjectionDefinition<{ count: number }, Event> {
+function stateProjectionOf({
+  name,
+  coalesceMaxBatch,
+}: {
+  name: string;
+  coalesceMaxBatch?: number;
+}): StateProjectionDefinition<{ count: number }, Event> {
   return {
     name,
     version: "test-1",
@@ -51,7 +54,9 @@ describe("state projection coalescing wiring", () => {
         TEST_CONSTANTS.PIPELINE_NAME,
         queueManager as never,
       );
-      router.registerStateProjection(stateProjectionOf("batched", 500));
+      router.registerStateProjection(
+        stateProjectionOf({ name: "batched", coalesceMaxBatch: 500 }),
+      );
 
       router.initializeStateProjectionQueues();
 
@@ -70,7 +75,9 @@ describe("state projection coalescing wiring", () => {
         TEST_CONSTANTS.PIPELINE_NAME,
         queueManager as never,
       );
-      router.registerStateProjection(stateProjectionOf("batched", 500));
+      router.registerStateProjection(
+        stateProjectionOf({ name: "batched", coalesceMaxBatch: 500 }),
+      );
 
       router.initializeStateProjectionQueues();
 

--- a/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/platform/app/src/server/event-sourcing/projections/projectionRouter.ts
@@ -543,6 +543,14 @@ export class ProjectionRouter<
       projectionDefs[name] = {
         name,
         groupKeyFn: projection.key,
+        // Dispatch in log-accept order, ALWAYS: the state executor's cursor
+        // is (createdAt, id), so a group ordered by business time can hand a
+        // late-appended event to an early drain, commit a cursor past the
+        // rest of the backlog, and silently drop every earlier-appended
+        // event still queued behind it - with no refold lane to heal the
+        // loss. Scoring by createdAt makes delivery order agree with the
+        // cursor, so the staleness guard only ever drops true redeliveries.
+        scoreFn: (event) => event.createdAt,
         coalesceMaxBatch: projection.options?.coalesceMaxBatch ?? 1,
         options: projection.options,
       };

--- a/specs/rbac/in-place-authz-migration.feature
+++ b/specs/rbac/in-place-authz-migration.feature
@@ -43,11 +43,19 @@ Feature: In-place authorization data migration
   # ============================================================================
 
   @unit
-  Scenario: One process drives the migration at a time
+  Scenario: Each organization is claimed by one process at a time
     Given two worker processes boot at the same moment
-    When both attempt to start the migration pass
-    Then exactly one acquires the lease and processes organizations
-    And the other stands down without touching any state
+    When both passes reach "acme" together
+    Then exactly one claims "acme" and migrates it
+    And the other leaves "acme" to the claim holder and moves on
+    And neither pass stands down as a whole
+
+  @unit
+  Scenario: A pass migrates several organizations at once
+    Given a fleet of pending organizations
+    When a migration pass runs
+    Then organizations migrate concurrently, several at a time
+    And one slow organization never holds up the rest of the fleet
 
   @unit
   Scenario: A self-hosted installation migrates every organization automatically
@@ -100,12 +108,12 @@ Feature: In-place authorization data migration
     And a pass that errors on "acme" cannot park over the rollback either
 
   @unit
-  Scenario: The pass keeps its lease while one large organization migrates
-    Given migrating "acme" takes longer than a single lease term
+  Scenario: The pass keeps its claim while one large organization migrates
+    Given migrating "acme" takes longer than a single claim term
     When the pass is working through "acme"
-    Then the lease is renewed for as long as the pass runs
-    And a lease lost to another process stops this pass at the next
-      organization
+    Then "acme"'s claim is renewed for as long as its migration runs
+    And a claim lost to another process stops work on "acme" only, while the
+      pass carries on with the other organizations
 
   # ============================================================================
   # Enrollment and self-hosted release pacing
@@ -217,6 +225,13 @@ Feature: In-place authorization data migration
     And the cohort is drawn entirely from organizations with no enrollment row
 
   @unit
+  Scenario: A later step's cohort samples only organizations enrolled for the step before it
+    Given "acme" is enrolled for the team backfill and "globex" is not
+    When an operator enrolls a cohort for the grants import
+    Then "acme" can be picked and "globex" cannot
+    And the first step's cohort keeps sampling from every organization
+
+  @unit
   Scenario: A cohort larger than the eligible pool enrolls the whole pool
     Given fewer eligible organizations remain than the requested cohort size
     When an operator enrolls the cohort
@@ -323,10 +338,10 @@ Feature: In-place authorization data migration
 
   @unit
   Scenario: A targeted run while a pass is already running is refused
-    Given a migration pass holds the fleet-wide lease
-    When an operator runs a migration for one organization now
+    Given a migration pass holds "acme"'s claim
+    When an operator runs a migration for "acme" now
     Then the run is refused with error code "migration_pass_already_running"
-    And the operator can simply retry once the pass concludes
+    And the operator can simply retry once that pass concludes
 
   # ============================================================================
   # The backfill (runbook M1)


### PR DESCRIPTION
## What

Three production pain points from today's authz rollout (the LangWatch genesis import parking twice, ABC's cutover left unattempted, and a cohort that could enroll organizations with no runnable predecessor), fixed at their causes.

### 1. The runner coordinates per organization, ten at a time

`packages/system-migrations`' runner replaces the single fleet-wide lease with a **claim per organization** (`system-migrations:lease:tenant:<id>`, same Redis repository, token-compared renew/release) and works each page of tenants through a pool of 25.

- One large organization's convergence wait no longer stalls the pass behind it. Today's 16:12Z park cost the pass its lease mid-flight and ABC's step-3 cutover was never attempted; with per-organization claims a lost claim stops that organization only.
- Booting workers now share the fleet instead of standing down behind one driver.
- `runPass` always runs (never returns null); the summary gains a `claimed` count for organizations another process was already working.
- The `migration_pass_already_running` 409 now means **this organization's claim is held** — a targeted Run is refused only while that organization is actually being migrated, not whenever any pass is running anywhere (today's Run-button 409s during a boot pass). Copy updated to match.

### 2. authzGrantsState folds in batches

The state-projection lane dispatches one event per queue job unless a projection declares `coalesceMaxBatch`. Under fair dispatch on a loaded queue that was ~0.4–0.9 facts/s in production — a 465-fact genesis import overran its 585s scaled convergence budget twice today. The projection now declares `coalesceMaxBatch: 500` (matching the import's append chunk), so a backed-up organization drains in a couple of load/apply/store cycles instead of 465 dispatches.

### 3. A later step's cohort samples the step before it

`enrollCohort` for a step with a predecessor draws its pool from organizations **enrolled for the previous step** (first step unchanged: whole installation minus the standing exclusions). Enrolling an organization for a step whose predecessor nothing will ever run would sit pending forever. The cohort dialog copy says which pool it samples.

## Spec

`specs/rbac/in-place-authz-migration.feature`: the single-driver and lease-renewal scenarios are rewritten for per-organization claims, plus new scenarios for concurrent passes and previous-step cohorts — 107/107 scenarios bound (`check:feature-parity`).

## Tests

- `packages/system-migrations` runner suite rewritten for claims + concurrency (14 passing)
- app system-migrations unit suites (76 passing), authz-grants pipeline suite (23 passing)
- new repository where-shape unit test + integration case for the predecessor pool (integration lane needs a datastore — verified in CI)
- scoped tsgo typecheck of every touched file: clean

## Deployment Impact

None beyond the app/worker images: the claims use the existing Redis lease keys' prefix with new names; stale `system-migrations:pass` keys expire on their 60s TTL and are simply never read again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Migration passes now process organizations concurrently while preventing duplicate work.
  - Summaries report organizations handled by another process.
  - Later migration cohorts include only organizations enrolled in the preceding step.
  - If one organization loses its claim, other migrations continue.
- **Bug Fixes**
  - Improved messaging explains organization-specific migration conflicts and retry timing.
  - Migration completion summaries are logged consistently.
- **Performance**
  - Authorization updates can be processed in batches of up to 500 events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Hardening from the PR's own adversarial audit

Three reviewer agents were run against this diff; what they found and what changed (`46e70924e0`):

- **Contained pool throws** (P2): a tenant whose *state read* threw (outside the migrate-tenant park net) rejected the pool's `Promise.all` — the pass died while its surviving workers drained on, detached. The worker now contains any per-tenant throw as a park; `runPass` always resolves its summary. Test: "when reading one tenant's state throws".
- **Cursor-safe state dispatch** (P1, pre-existing but promoted by coalescing): the state lane scored dispatch by business time (`occurredAt`) while the state executor's cursor advances in log-accept order (`createdAt, id`). A backdated fact appended late could jump the group's queue, commit a cursor past the backlog, and silently drop every earlier-appended event — unhealable in the state lane (no refold; idempotent appends dedupe). State dispatch now scores by `createdAt` so delivery order agrees with the cursor. Test: "scores dispatch by log-accept time".
- **Claim observability** (P3): an unreachable Redis wears the same face as ordinary contention (every acquire false → everything `claimed`). A pass that reads *every* organization as claimed now says so once at warn, and the 409 copy hedges ("appears to be mid-migration") instead of asserting a pass it cannot see.
- The audit also pinned the coalescing **wiring**, not just the declaration: `initializeStateProjectionQueues` forwarding the limit + batch callback, and the queue registry entry gaining `processBatch`, each have a test now.

Known follow-ups deliberately left out of this PR:
- The witnessing repository mints ledger command ids from `Date.now()`, so the (pre-existing) claim-loss race during a tenant's final migration can record duplicate witness facts for one transition — audit-trail noise, CAS-protected for correctness.
- The single-organization Enroll action doesn't enforce the previous-step prerequisite the cohort now does; the runner holds rather than corrupts, but the two actions on the same page are inconsistent.
- During a full Redis outage a boot pass scans the organization table and warns once per acquire error rather than standing down early.
