### PR TITLE
fix(gateway): retire every cap scoped to a key when the key is revoked

### DIFF
--- a/platform/app/src/server/gateway/__tests__/budgetsEveryDimension.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/budgetsEveryDimension.integration.test.ts
@@ -826,6 +826,167 @@ describe("budgets on every dimension (real PG + real CH)", () => {
       expect(budget!.archivedAt).not.toBeNull();
     });
 
+    /** @scenario "Revoking a key retires a cap that targets only that key" */
+    it("archives a budget scoped to the key that the key never managed", async () => {
+      // The orphan case: a cap created on the Budgets page, targeting one
+      // key. It is not drawer-managed, so the key never owned it, but its
+      // scope is that key and nothing else. Once the key is REVOKED, which is
+      // terminal, it can never count spend again.
+      const service = VirtualKeyService.create(prisma);
+      const { virtualKey } = await service.create({
+        organizationId: ORG_ID,
+        name: `standalone-budget-${suffix}`,
+        actorUserId: USER_ID,
+        scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+      });
+      createdVirtualKeyIds.push(virtualKey.id);
+
+      const standalone = await prisma.gatewayBudget.create({
+        data: {
+          organizationId: ORG_ID,
+          scopeType: "VIRTUAL_KEY",
+          scopeId: virtualKey.id,
+          name: `standalone-hard-cap-${suffix}`,
+          window: "MONTH",
+          limitUsd: "5.00",
+          resetsAt: new Date(Date.now() + 86_400_000),
+          createdById: USER_ID,
+          managedByVirtualKeyId: null,
+        },
+      });
+
+      await service.revoke({
+        id: virtualKey.id,
+        organizationId: ORG_ID,
+        actorUserId: USER_ID,
+      });
+
+      const after = await prisma.gatewayBudget.findUnique({
+        where: { id: standalone.id },
+      });
+      expect(after!.archivedAt).not.toBeNull();
+    });
+
+    /** @scenario "Revoking a key retires a per-end-user allowance anchored on it" */
+    it("archives a per-end-user template anchored on the revoked key", async () => {
+      // ATTRIBUTED_USER hangs one allowance off each end user the anchor's
+      // traffic is attributed to. When the anchor is the key, a dead key
+      // means a template that can never open another bucket.
+      const service = VirtualKeyService.create(prisma);
+      const { virtualKey } = await service.create({
+        organizationId: ORG_ID,
+        name: `per-user-anchor-${suffix}`,
+        actorUserId: USER_ID,
+        scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+      });
+      createdVirtualKeyIds.push(virtualKey.id);
+
+      const template = await prisma.gatewayBudget.create({
+        data: {
+          organizationId: ORG_ID,
+          scopeType: "ATTRIBUTED_USER",
+          scopeId: virtualKey.id,
+          name: `per-user-cap-${suffix}`,
+          window: "MONTH",
+          limitUsd: "2.00",
+          resetsAt: new Date(Date.now() + 86_400_000),
+          createdById: USER_ID,
+        },
+      });
+
+      await service.revoke({
+        id: virtualKey.id,
+        organizationId: ORG_ID,
+        actorUserId: USER_ID,
+      });
+
+      const after = await prisma.gatewayBudget.findUnique({
+        where: { id: template.id },
+      });
+      expect(after!.archivedAt).not.toBeNull();
+    });
+
+    /** @scenario "Revoking a key leaves a project budget standing" */
+    it("leaves a project budget alone when a key scoped to it is revoked", async () => {
+      // The boundary the case above must not cross. A project outlives any
+      // one key, so its cap is still a live control the moment another key
+      // is scoped there.
+      const service = VirtualKeyService.create(prisma);
+      const { virtualKey } = await service.create({
+        organizationId: ORG_ID,
+        name: `project-budget-survivor-${suffix}`,
+        actorUserId: USER_ID,
+        scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+      });
+      createdVirtualKeyIds.push(virtualKey.id);
+
+      const projectBudget = await prisma.gatewayBudget.create({
+        data: {
+          organizationId: ORG_ID,
+          scopeType: "PROJECT",
+          scopeId: PROJECT_ID,
+          name: `project-hard-cap-${suffix}`,
+          window: "MONTH",
+          limitUsd: "50.00",
+          resetsAt: new Date(Date.now() + 86_400_000),
+          createdById: USER_ID,
+        },
+      });
+
+      await service.revoke({
+        id: virtualKey.id,
+        organizationId: ORG_ID,
+        actorUserId: USER_ID,
+      });
+
+      const after = await prisma.gatewayBudget.findUnique({
+        where: { id: projectBudget.id },
+      });
+      expect(after!.archivedAt).toBeNull();
+    });
+
+    /** @scenario "Clearing the drawer budget leaves an independently created cap alone" */
+    it("leaves a key-scoped budget alone when only the drawer field is cleared", async () => {
+      // The permission boundary the revoke change must not widen: the key is
+      // still alive here, so an independently created cap on it is still an
+      // enforcement control and virtualKeys:update must not retire it.
+      const service = VirtualKeyService.create(prisma);
+      const { virtualKey } = await service.create({
+        organizationId: ORG_ID,
+        name: `drawer-clear-keeps-${suffix}`,
+        actorUserId: USER_ID,
+        scopes: [{ scopeType: "PROJECT", scopeId: PROJECT_ID }],
+        budget: { limitUsd: "9.00", window: "MONTH" },
+      });
+      createdVirtualKeyIds.push(virtualKey.id);
+
+      const standalone = await prisma.gatewayBudget.create({
+        data: {
+          organizationId: ORG_ID,
+          scopeType: "VIRTUAL_KEY",
+          scopeId: virtualKey.id,
+          name: `survives-drawer-clear-${suffix}`,
+          window: "MONTH",
+          limitUsd: "3.00",
+          resetsAt: new Date(Date.now() + 86_400_000),
+          createdById: USER_ID,
+          managedByVirtualKeyId: null,
+        },
+      });
+
+      await service.update({
+        id: virtualKey.id,
+        organizationId: ORG_ID,
+        actorUserId: USER_ID,
+        budget: null,
+      });
+
+      const after = await prisma.gatewayBudget.findUnique({
+        where: { id: standalone.id },
+      });
+      expect(after!.archivedAt).toBeNull();
+    });
+
     /** @scenario "Removing a key's budget from the drawer archives it" */
     it("archives rather than deletes when the budget field is cleared", async () => {
       const service = VirtualKeyService.create(prisma);

--- a/platform/app/src/server/gateway/virtualKey.service.ts
+++ b/platform/app/src/server/gateway/virtualKey.service.ts
@@ -492,7 +492,12 @@ export class VirtualKeyService {
               tx,
             );
           } else {
-            await this.archiveKeyBudgets(vk, input.actorUserId, tx);
+            await this.archiveKeyBudgets({
+              vk,
+              actorUserId: input.actorUserId,
+              tx,
+              include: "drawerManaged",
+            });
           }
         }
 
@@ -628,7 +633,12 @@ export class VirtualKeyService {
         // cost us before we killed it" needs the budget row to read them
         // against. Archiving also stops the budget from showing up as an
         // active control that nothing can ever spend against.
-        await this.archiveKeyBudgets(vk, input.actorUserId, tx);
+        await this.archiveKeyBudgets({
+          vk,
+          actorUserId: input.actorUserId,
+          tx,
+          include: "scopedToKey",
+        });
         await this.changeEvents.append(
           {
             organizationId: input.organizationId,
@@ -891,22 +901,59 @@ export class VirtualKeyService {
   }
 
   /**
-   * Archive the drawer-managed budget of this key, and only that one.
-   * Budgets created independently on the Budgets page also target the
-   * key, but their lifecycle carries its own permission
-   * (gatewayBudgets:delete); archiving them from a key update would let
-   * virtualKeys:update silently remove an admin's enforcement control.
+   * Archive the budgets a key's lifecycle carries, which is a different set
+   * depending on what just happened to the key.
+   *
+   * `drawerManaged` is the key still being alive: the drawer's budget field
+   * was cleared, so that one row goes and nothing else does. Budgets created
+   * independently on the Budgets page also target the key, but their
+   * lifecycle carries its own permission (gatewayBudgets:delete); archiving
+   * them from a key update would let virtualKeys:update silently remove an
+   * admin's enforcement control.
+   *
+   * `scopedToKey` is the key being dead. REVOKED is terminal, so a budget
+   * whose scope is this key and nothing else can never count spend or refuse
+   * a request again, whoever created it. Leaving it active does not preserve
+   * an enforcement control, because there is nothing left to enforce against;
+   * it just leaves a row that reads as a live cap and shows up on the budgets
+   * list warning that no key sends traffic to it. The permission argument
+   * above does not carry over, because nothing is being taken away.
+   *
+   * Both cases archive rather than delete, so the ledger rows stay readable
+   * against the cap they accrued under.
    */
-  private async archiveKeyBudgets(
-    vk: VirtualKey,
-    actorUserId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
+  private async archiveKeyBudgets({
+    vk,
+    actorUserId,
+    tx,
+    include,
+  }: {
+    vk: VirtualKey;
+    actorUserId: string;
+    tx: Prisma.TransactionClient;
+    include: "drawerManaged" | "scopedToKey";
+  }): Promise<void> {
     const budgets = await tx.gatewayBudget.findMany({
       where: {
         organizationId: vk.organizationId,
-        managedByVirtualKeyId: vk.id,
         archivedAt: null,
+        ...(include === "drawerManaged"
+          ? { managedByVirtualKeyId: vk.id }
+          : {
+              OR: [
+                { managedByVirtualKeyId: vk.id },
+                // Scoped to this key and nothing else. ATTRIBUTED_USER counts
+                // when the key is its anchor: the per-end-user allowance hangs
+                // off the key's traffic, so a dead key means a template that
+                // can never open another bucket. The same scope type anchored
+                // on a project is untouched, and so is every PROJECT, TEAM or
+                // ORGANIZATION budget, because those outlive any one key.
+                {
+                  scopeType: { in: ["VIRTUAL_KEY", "ATTRIBUTED_USER"] },
+                  scopeId: vk.id,
+                },
+              ],
+            }),
       },
     });
     for (const budget of budgets) {

--- a/specs/ai-gateway/virtual-key-creation.feature
+++ b/specs/ai-gateway/virtual-key-creation.feature
@@ -306,6 +306,33 @@ Feature: AI Gateway virtual key creation
     And the budget row is kept with its spend history
 
   @integration
+  Scenario: Revoking a key retires a cap that targets only that key
+    Given a budget created on the budgets page that targets one key
+    When that key is revoked
+    Then the budget is retired too, because a revoked key can never spend again
+
+  @integration
+  Scenario: Revoking a key retires a per-end-user allowance anchored on it
+    Given a per-end-user budget anchored on a key
+    When that key is revoked
+    Then the allowance is retired, because no further end user can be attributed to it
+
+  @integration
+  Scenario: Revoking a key leaves a project budget standing
+    Given a project has a budget
+    And a key scoped to that project
+    When the key is revoked
+    Then the project budget still applies, because another key can be scoped there
+
+  @integration
+  Scenario: Clearing the drawer budget leaves an independently created cap alone
+    Given a key with a drawer budget
+    And a budget created on the budgets page that targets the same key
+    When the drawer budget field is cleared
+    Then only the drawer budget is retired
+    And the independently created cap still applies, because the key is still live
+
+  @integration
   Scenario: The drawer lists the budgets that already constrain this key
     Given the organization has a monthly budget
     And project "web-app" has a monthly budget


### PR DESCRIPTION
## Ask

From Slack: archiving a virtual key that has a budget attached to just it should archive that budget too, instead of leaving orphans.

## One correction before the change

The budgets in the screenshot are **project**-scoped, not key-scoped. The chip carries a folder icon, and `ProviderScopeChips` maps `Folder` to `PROJECT`; a key-scoped budget renders an orange `KeyRound` chip. They are also soft/hard cap pairs per project name, which is the shape of caps created on the Budgets page against a project.

So this PR does not clear the rows in that screenshot, and it should not: a project outlives any one key, and another key scoped there tomorrow makes that cap live again. Retiring project budgets because a key died would delete an enforcement control that is still doing its job. What is going on in the screenshot is the `unreachableByAnyKey` warning doing exactly what it was built for, on budgets whose projects currently have no active key.

What this PR fixes is the case the words describe: a cap attached to one key and nothing else.

## The defect

`revoke` already intends this. Its own comment says so:

> A dead key's cap is retired, not deleted: the ledger rows behind it are the spend record [...] Archiving also stops the budget from showing up as an active control that nothing can ever spend against.

But it called `archiveKeyBudgets`, whose filter is `managedByVirtualKeyId: vk.id`, and whose docstring was written for the *update* path:

> Archive the drawer-managed budget of this key, and only that one. Budgets created independently on the Budgets page also target the key, but their lifecycle carries its own permission (`gatewayBudgets:delete`); archiving them from a key update would let `virtualKeys:update` silently remove an admin's enforcement control.

That rationale is right for update and wrong for revoke, and reusing one helper for both silently applied the narrower rule. A cap created on the Budgets page targeting one key therefore outlived the key.

## Change

`archiveKeyBudgets` now takes what it should retire, because the two callers mean different things:

- `update` passes `drawerManaged`: the key is still live, so only the drawer's own row goes. Unchanged behaviour, and the permission argument above still holds.
- `revoke` passes `scopedToKey`: the drawer row, plus any budget whose scope is this key alone (`VIRTUAL_KEY`), plus a per-end-user template anchored on it (`ATTRIBUTED_USER` with the key as anchor).

The permission argument does not carry over to revoke. `REVOKED` is terminal, so such a budget can never count spend or refuse a request again, whoever created it. Nothing enforceable is being taken away; what is removed is a row that reads as a live cap and warns that no key sends traffic to it. Both paths archive rather than delete, so the ledger stays readable against the cap it accrued under.

`PROJECT`, `TEAM` and `ORGANIZATION` budgets are untouched on both paths.

## Evidence

Four new integration tests against real Postgres and ClickHouse, in the suite that already owns this area. 27/27 pass. Each pins a different edge of the rule, and each is mutation-checked:

```
revoke back to drawerManaged only            Tests  1 failed | 26 passed (27)   CAUGHT
update widened to scopedToKey                Tests  1 failed | 26 passed (27)   CAUGHT
scope narrowing dropped                      Tests  1 failed | 26 passed (27)   CAUGHT
ATTRIBUTED_USER anchor no longer retired     Tests  1 failed | 26 passed (27)   CAUGHT
```

Worth noting one mutation I ran first was inert rather than an escape: adding `PROJECT` to the scope-type list changes nothing, because the query also pins `scopeId: vk.id` and a project's id is never a key's id. The constraint that actually protects project budgets is the `scopeId` one, so that is the one the mutation above removes.

The `ATTRIBUTED_USER` case genuinely escaped on the first pass. I had included it in the fix without covering it; the test was added rather than the scope quietly dropped.

Four scenarios added to `specs/ai-gateway/virtual-key-creation.feature` and bound, 7859 to 7863 enforced. Binding verified by removing one annotation and confirming the parity gate fails.

`typecheck` and `typecheck:tests` both 0, new-violations gate 3446 to 3446.

## Still open, and it is the screenshot

This leaves no way to clear project-scoped budgets that nothing routes to any more. The data to do it already exists, since `unreachableByAnyKey` is computed and rendered per row. A filter or a bulk archive on the Budgets page would be the honest fix, and it keeps the decision with a person rather than inferring it from a key's death. Happy to build it, but it is a product call, not this PR.

---

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual-key budget lifecycle handling when keys are revoked or drawer-managed budgets are cleared.
  * Revoking a key now retires associated key-scoped budgets and per-end-user allowances while preserving project budgets.
  * Clearing a drawer-managed budget no longer retires independent budgets targeting the same key.
* **Tests**
  * Added integration coverage for budget archiving and preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->