### PR TITLE
feat(governance): the source detail page tables every event, cursor-walked

### DIFF
--- a/platform/app/ee/governance/dashboard/components/SourceEventDetailPanels.tsx
+++ b/platform/app/ee/governance/dashboard/components/SourceEventDetailPanels.tsx
@@ -72,7 +72,7 @@ function RawPanel({ event }: { event: SourceEventRowData }) {
   try {
     parsed = JSON.parse(event.rawPayload);
   } catch {
-    // not JSON, render as text
+    // fall through with parsed = null
   }
   return (
     <Box>

--- a/platform/app/ee/governance/dashboard/components/SourceEventDetailPanels.tsx
+++ b/platform/app/ee/governance/dashboard/components/SourceEventDetailPanels.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+import { Box, Code, SimpleGrid, Table, Text } from "@chakra-ui/react";
+
+import type { SourceEventRowData } from "./SourceEventsTable";
+
+/**
+ * The expanded detail of one event row: the normalised OCSF record next
+ * to the raw payload as ingested. Rendered as a full-width row directly
+ * under the event it belongs to.
+ */
+export function EventDetailRow({
+  event,
+  colSpan,
+}: {
+  event: SourceEventRowData;
+  colSpan: number;
+}) {
+  return (
+    <Table.Row>
+      <Table.Cell colSpan={colSpan} bg="bg.subtle">
+        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={3} paddingY={1}>
+          <NormalisedPanel event={event} />
+          <RawPanel event={event} />
+        </SimpleGrid>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+function NormalisedPanel({ event }: { event: SourceEventRowData }) {
+  return (
+    <Box>
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        marginBottom={1}
+      >
+        Normalised (OCSF)
+      </Text>
+      <Code
+        display="block"
+        padding={3}
+        fontSize="xs"
+        whiteSpace="pre-wrap"
+        wordBreak="break-all"
+        backgroundColor="bg.panel"
+      >
+        {JSON.stringify(
+          {
+            eventId: event.eventId,
+            eventType: event.eventType,
+            actor: event.actor,
+            action: event.action,
+            target: event.target,
+            costUsd: event.costUsd,
+            tokensInput: event.tokensInput,
+            tokensOutput: event.tokensOutput,
+            eventTimestamp: event.eventTimestampIso,
+            ingestedAt: event.ingestedAtIso,
+          },
+          null,
+          2,
+        )}
+      </Code>
+    </Box>
+  );
+}
+
+function RawPanel({ event }: { event: SourceEventRowData }) {
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(event.rawPayload);
+  } catch {
+    // not JSON, render as text
+  }
+  return (
+    <Box>
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        marginBottom={1}
+      >
+        Raw payload (as ingested)
+      </Text>
+      {event.rawPayload ? (
+        <Code
+          display="block"
+          padding={3}
+          fontSize="xs"
+          whiteSpace="pre-wrap"
+          wordBreak="break-all"
+          backgroundColor="bg.panel"
+        >
+          {parsed != null ? JSON.stringify(parsed, null, 2) : event.rawPayload}
+        </Code>
+      ) : (
+        <Text fontSize="xs" color="fg.muted">
+          The raw body is not stored for this source type — pushed events are
+          normalised at the edge and only the normalised record is kept.
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/platform/app/ee/governance/dashboard/components/SourceEventsTable.tsx
+++ b/platform/app/ee/governance/dashboard/components/SourceEventsTable.tsx
@@ -2,9 +2,7 @@
 import {
   Badge,
   Box,
-  Code,
   Heading,
-  SimpleGrid,
   Skeleton,
   Table,
   Text,
@@ -19,6 +17,7 @@ import { Tooltip } from "~/components/ui/tooltip";
 import { HandledErrorAlert } from "~/features/errors";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 
+import { EventDetailRow } from "./SourceEventDetailPanels";
 import type { SourceEventsPager } from "./useSourceEventsPager";
 
 /**
@@ -85,9 +84,18 @@ function EventsTableHeader() {
 }
 
 function EventTimeCell({ iso }: { iso: string }) {
-  const ms = new Date(iso).getTime();
+  const ms = Date.parse(iso);
+  // An unparsable timestamp gets a plain dash — a tooltip would only
+  // have "Invalid Date" to say.
+  if (Number.isNaN(ms)) {
+    return (
+      <Text textStyle="sm" whiteSpace="nowrap">
+        —
+      </Text>
+    );
+  }
   return (
-    <Tooltip content={new Date(iso).toLocaleString()}>
+    <Tooltip content={new Date(ms).toLocaleString()}>
       <Text textStyle="sm" cursor="help" whiteSpace="nowrap">
         {formatTimeAgo(ms) ?? "—"}
       </Text>
@@ -97,11 +105,11 @@ function EventTimeCell({ iso }: { iso: string }) {
 
 function EventDataRow({
   event,
-  expanded,
+  isExpanded,
   onToggle,
 }: {
   event: SourceEventRowData;
-  expanded: boolean;
+  isExpanded: boolean;
   onToggle: () => void;
 }) {
   const hasTokens = event.tokensInput > 0 || event.tokensOutput > 0;
@@ -110,8 +118,18 @@ function EventDataRow({
       data-testid="source-event-row"
       cursor="pointer"
       onClick={onToggle}
+      // A <tr> is not focusable or activatable on its own; the row is a
+      // disclosure control, so it gets the keyboard affordances too.
+      tabIndex={0}
+      aria-expanded={isExpanded}
+      onKeyDown={(keyEvent) => {
+        if (keyEvent.key !== "Enter" && keyEvent.key !== " ") return;
+        keyEvent.preventDefault();
+        onToggle();
+      }}
       _hover={{ bg: "bg.subtle" }}
-      bg={expanded ? "bg.subtle" : undefined}
+      _focusVisible={{ bg: "bg.subtle", outline: "none" }}
+      bg={isExpanded ? "bg.subtle" : undefined}
     >
       <Table.Cell whiteSpace="nowrap">
         <EventTimeCell iso={event.eventTimestampIso} />
@@ -154,97 +172,6 @@ function EventDataRow({
   );
 }
 
-function EventDetailRow({ event }: { event: SourceEventRowData }) {
-  return (
-    <Table.Row>
-      <Table.Cell colSpan={COLUMNS.length} bg="bg.subtle">
-        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={3} paddingY={1}>
-          <NormalisedPanel event={event} />
-          <RawPanel event={event} />
-        </SimpleGrid>
-      </Table.Cell>
-    </Table.Row>
-  );
-}
-
-function NormalisedPanel({ event }: { event: SourceEventRowData }) {
-  return (
-    <Box>
-      <Text
-        fontSize="xs"
-        fontWeight="semibold"
-        color="fg.muted"
-        marginBottom={1}
-      >
-        Normalised (OCSF)
-      </Text>
-      <Code
-        display="block"
-        padding={3}
-        fontSize="xs"
-        whiteSpace="pre-wrap"
-        wordBreak="break-all"
-        backgroundColor="bg.panel"
-      >
-        {JSON.stringify(
-          {
-            eventId: event.eventId,
-            eventType: event.eventType,
-            actor: event.actor,
-            action: event.action,
-            target: event.target,
-            costUsd: event.costUsd,
-            tokensInput: event.tokensInput,
-            tokensOutput: event.tokensOutput,
-            eventTimestamp: event.eventTimestampIso,
-            ingestedAt: event.ingestedAtIso,
-          },
-          null,
-          2,
-        )}
-      </Code>
-    </Box>
-  );
-}
-
-function RawPanel({ event }: { event: SourceEventRowData }) {
-  let parsed: unknown = null;
-  try {
-    parsed = JSON.parse(event.rawPayload);
-  } catch {
-    // not JSON, render as text
-  }
-  return (
-    <Box>
-      <Text
-        fontSize="xs"
-        fontWeight="semibold"
-        color="fg.muted"
-        marginBottom={1}
-      >
-        Raw payload (as ingested)
-      </Text>
-      {event.rawPayload ? (
-        <Code
-          display="block"
-          padding={3}
-          fontSize="xs"
-          whiteSpace="pre-wrap"
-          wordBreak="break-all"
-          backgroundColor="bg.panel"
-        >
-          {parsed != null ? JSON.stringify(parsed, null, 2) : event.rawPayload}
-        </Code>
-      ) : (
-        <Text fontSize="xs" color="fg.muted">
-          The raw body is not stored for this source type — pushed events are
-          normalised at the edge and only the normalised record is kept.
-        </Text>
-      )}
-    </Box>
-  );
-}
-
 function SkeletonRows({ pageSize }: { pageSize: number }) {
   const rowCount = Math.min(pageSize, 5);
   return (
@@ -277,7 +204,7 @@ function EventsTableBody({
         <Fragment key={event.eventId}>
           <EventDataRow
             event={event}
-            expanded={expandedEventId === event.eventId}
+            isExpanded={expandedEventId === event.eventId}
             onToggle={() =>
               setExpandedEventId((current) =>
                 current === event.eventId ? null : event.eventId,
@@ -285,7 +212,7 @@ function EventsTableBody({
             }
           />
           {expandedEventId === event.eventId && (
-            <EventDetailRow event={event} />
+            <EventDetailRow event={event} colSpan={COLUMNS.length} />
           )}
         </Fragment>
       ))}

--- a/platform/app/ee/governance/dashboard/components/SourceEventsTable.tsx
+++ b/platform/app/ee/governance/dashboard/components/SourceEventsTable.tsx
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+import {
+  Badge,
+  Box,
+  Code,
+  Heading,
+  SimpleGrid,
+  Skeleton,
+  Table,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import numeral from "numeral";
+import { Fragment, type ReactNode, useState } from "react";
+
+import { ListTable } from "~/components/ui/ListTable";
+import { Pagination } from "~/components/ui/Pagination";
+import { Tooltip } from "~/components/ui/tooltip";
+import { HandledErrorAlert } from "~/features/errors";
+import { formatTimeAgo } from "~/utils/formatTimeAgo";
+
+import type { SourceEventsPager } from "./useSourceEventsPager";
+
+/**
+ * The events section of the ingestion-source detail page: a cursor-walked
+ * table over everything the source ever ingested, newest first.
+ *
+ * Deliberately absent, because the cursor cannot honour them: sort
+ * headers, a search box, a grand total, and jumping to a page nobody
+ * has walked to yet.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *       (rule "The events table pages through everything the source
+ *       ever ingested")
+ */
+
+/** Structural shape of `eventsForSource`'s rows — no tRPC import, so the
+ * table stays testable against plain fixtures. */
+export type SourceEventRowData = {
+  eventId: string;
+  eventType: string;
+  actor: string;
+  action: string;
+  target: string | null;
+  costUsd: string;
+  tokensInput: number;
+  tokensOutput: number;
+  eventTimestampIso: string;
+  ingestedAtIso: string;
+  rawPayload: string;
+};
+
+const fmtUsd = (raw: string) => {
+  const value = Number(raw);
+  return value === 0 ? "$0.00" : numeral(value).format("$0,0.0000");
+};
+
+const COLUMNS = [
+  "Time",
+  "Type",
+  "Actor",
+  "Action",
+  "Target",
+  "Cost",
+  "Tokens",
+] as const;
+
+function EventsTableHeader() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        {COLUMNS.map((column) => (
+          <Table.ColumnHeader
+            key={column}
+            textAlign={
+              column === "Cost" || column === "Tokens" ? "end" : undefined
+            }
+          >
+            {column}
+          </Table.ColumnHeader>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function EventTimeCell({ iso }: { iso: string }) {
+  const ms = new Date(iso).getTime();
+  return (
+    <Tooltip content={new Date(iso).toLocaleString()}>
+      <Text textStyle="sm" cursor="help" whiteSpace="nowrap">
+        {formatTimeAgo(ms) ?? "—"}
+      </Text>
+    </Tooltip>
+  );
+}
+
+function EventDataRow({
+  event,
+  expanded,
+  onToggle,
+}: {
+  event: SourceEventRowData;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const hasTokens = event.tokensInput > 0 || event.tokensOutput > 0;
+  return (
+    <Table.Row
+      data-testid="source-event-row"
+      cursor="pointer"
+      onClick={onToggle}
+      _hover={{ bg: "bg.subtle" }}
+      bg={expanded ? "bg.subtle" : undefined}
+    >
+      <Table.Cell whiteSpace="nowrap">
+        <EventTimeCell iso={event.eventTimestampIso} />
+      </Table.Cell>
+      <Table.Cell>
+        <Badge size="sm" variant="surface">
+          {event.eventType}
+        </Badge>
+      </Table.Cell>
+      <Table.Cell>
+        <Text textStyle="sm" fontWeight="medium" lineClamp={1}>
+          {event.actor || "—"}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text textStyle="sm" color="fg.muted" lineClamp={1}>
+          {event.action || "—"}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text textStyle="sm" color="fg.muted" lineClamp={1}>
+          {event.target || "—"}
+        </Text>
+      </Table.Cell>
+      <Table.Cell textAlign="end" whiteSpace="nowrap">
+        <Text textStyle="sm" color="fg.muted">
+          {fmtUsd(event.costUsd)}
+        </Text>
+      </Table.Cell>
+      <Table.Cell textAlign="end" whiteSpace="nowrap">
+        <Text textStyle="sm" color="fg.muted">
+          {hasTokens
+            ? `${numeral(event.tokensInput).format("0,0")} → ${numeral(
+                event.tokensOutput,
+              ).format("0,0")}`
+            : "—"}
+        </Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+function EventDetailRow({ event }: { event: SourceEventRowData }) {
+  return (
+    <Table.Row>
+      <Table.Cell colSpan={COLUMNS.length} bg="bg.subtle">
+        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={3} paddingY={1}>
+          <NormalisedPanel event={event} />
+          <RawPanel event={event} />
+        </SimpleGrid>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+function NormalisedPanel({ event }: { event: SourceEventRowData }) {
+  return (
+    <Box>
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        marginBottom={1}
+      >
+        Normalised (OCSF)
+      </Text>
+      <Code
+        display="block"
+        padding={3}
+        fontSize="xs"
+        whiteSpace="pre-wrap"
+        wordBreak="break-all"
+        backgroundColor="bg.panel"
+      >
+        {JSON.stringify(
+          {
+            eventId: event.eventId,
+            eventType: event.eventType,
+            actor: event.actor,
+            action: event.action,
+            target: event.target,
+            costUsd: event.costUsd,
+            tokensInput: event.tokensInput,
+            tokensOutput: event.tokensOutput,
+            eventTimestamp: event.eventTimestampIso,
+            ingestedAt: event.ingestedAtIso,
+          },
+          null,
+          2,
+        )}
+      </Code>
+    </Box>
+  );
+}
+
+function RawPanel({ event }: { event: SourceEventRowData }) {
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(event.rawPayload);
+  } catch {
+    // not JSON, render as text
+  }
+  return (
+    <Box>
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        marginBottom={1}
+      >
+        Raw payload (as ingested)
+      </Text>
+      {event.rawPayload ? (
+        <Code
+          display="block"
+          padding={3}
+          fontSize="xs"
+          whiteSpace="pre-wrap"
+          wordBreak="break-all"
+          backgroundColor="bg.panel"
+        >
+          {parsed != null ? JSON.stringify(parsed, null, 2) : event.rawPayload}
+        </Code>
+      ) : (
+        <Text fontSize="xs" color="fg.muted">
+          The raw body is not stored for this source type — pushed events are
+          normalised at the edge and only the normalised record is kept.
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+function SkeletonRows({ pageSize }: { pageSize: number }) {
+  const rowCount = Math.min(pageSize, 5);
+  return (
+    <>
+      {Array.from({ length: rowCount }, (_, index) => (
+        <Table.Row key={index} data-testid="source-event-skeleton-row">
+          {COLUMNS.map((column) => (
+            <Table.Cell key={column}>
+              <Skeleton height="14px" maxWidth="120px" borderRadius="sm" />
+            </Table.Cell>
+          ))}
+        </Table.Row>
+      ))}
+    </>
+  );
+}
+
+function EventsTableBody({
+  pager,
+}: {
+  pager: SourceEventsPager<SourceEventRowData>;
+}) {
+  const [expandedEventId, setExpandedEventId] = useState<string | null>(null);
+  if (pager.status === "loading") {
+    return <SkeletonRows pageSize={pager.pageSize} />;
+  }
+  return (
+    <>
+      {pager.rows.map((event) => (
+        <Fragment key={event.eventId}>
+          <EventDataRow
+            event={event}
+            expanded={expandedEventId === event.eventId}
+            onToggle={() =>
+              setExpandedEventId((current) =>
+                current === event.eventId ? null : event.eventId,
+              )
+            }
+          />
+          {expandedEventId === event.eventId && (
+            <EventDetailRow event={event} />
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+export function SourceEventsTable({
+  pager,
+  emptyState,
+}: {
+  pager: SourceEventsPager<SourceEventRowData>;
+  emptyState: ReactNode;
+}) {
+  return (
+    <VStack align="stretch" gap={3}>
+      <VStack align="start" gap={1}>
+        <Heading as="h3" size="sm">
+          Events
+        </Heading>
+        {pager.status !== "error" && (
+          <Text fontSize="sm" color="fg.muted">
+            Every OCSF-normalised event from this source, newest first. Click a
+            row for the raw and normalised records.
+          </Text>
+        )}
+      </VStack>
+
+      {pager.status === "error" ? (
+        <HandledErrorAlert
+          error={pager.error}
+          fallbackTitle="Couldn't load this source's events"
+        />
+      ) : pager.status === "ready" && pager.loadedCount === 0 ? (
+        emptyState
+      ) : (
+        <Box>
+          <ListTable size="sm" containerProps={{ overflowX: "auto" }}>
+            <EventsTableHeader />
+            <Table.Body>
+              <EventsTableBody pager={pager} />
+            </Table.Body>
+          </ListTable>
+          <Pagination
+            page={pager.page}
+            pageSize={pager.pageSize}
+            totalCount={pager.totalCount}
+            visibleCount={pager.rows.length}
+            onPageChange={pager.goToPage}
+            onPageSizeChange={pager.setPageSize}
+            isLoading={pager.status === "loading"}
+            navDisabled={pager.isFetching}
+            isPageReachable={pager.isPageReachable}
+            canGoNext={pager.canGoNext}
+          />
+        </Box>
+      )}
+    </VStack>
+  );
+}

--- a/platform/app/ee/governance/dashboard/components/SourceEventsTable.tsx
+++ b/platform/app/ee/governance/dashboard/components/SourceEventsTable.tsx
@@ -250,6 +250,17 @@ export function SourceEventsTable({
         emptyState
       ) : (
         <Box>
+          {/* A failure while pages are already on screen must not hide
+              them — it names itself above the table and the next click
+              retries the walk. */}
+          {pager.error != null && (
+            <Box marginBottom={2}>
+              <HandledErrorAlert
+                error={pager.error}
+                fallbackTitle="Couldn't load more events"
+              />
+            </Box>
+          )}
           <ListTable size="sm" containerProps={{ overflowX: "auto" }}>
             <EventsTableHeader />
             <Table.Body>

--- a/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
@@ -25,13 +25,16 @@ import { useSourceEventsPager } from "../useSourceEventsPager";
 
 const BASE_TS = Date.now() - 5 * 60 * 1000; // recent, so times read "ago"
 
-function makeEvent(
-  eventId: string,
-  tsMs: number,
-  overrides: Partial<SourceEventRowData> = {},
-): SourceEventRowData {
+function makeEvent({
+  id,
+  ts,
+  ...overrides
+}: {
+  id: string;
+  ts: number;
+} & Partial<SourceEventRowData>): SourceEventRowData {
   return {
-    eventId,
+    eventId: id,
     eventType: "api_call",
     actor: "dev@acme.test",
     action: "chat.completion",
@@ -39,9 +42,9 @@ function makeEvent(
     costUsd: "0.0250",
     tokensInput: 120,
     tokensOutput: 480,
-    eventTimestampIso: new Date(tsMs).toISOString(),
-    ingestedAtIso: new Date(tsMs + 500).toISOString(),
-    rawPayload: JSON.stringify({ marker: `raw-${eventId}` }),
+    eventTimestampIso: new Date(ts).toISOString(),
+    ingestedAtIso: new Date(ts + 500).toISOString(),
+    rawPayload: JSON.stringify({ marker: `raw-${id}` }),
     ...overrides,
   };
 }
@@ -92,8 +95,8 @@ describe("given a source with ingested events", () => {
   /** @scenario "Events render as a table, newest first" */
   it("renders the events as table rows, newest first, with every column", async () => {
     const events = [
-      makeEvent("new", BASE_TS + 2000, { actor: "newest@acme.test" }),
-      makeEvent("old", BASE_TS + 1000, { actor: "oldest@acme.test" }),
+      makeEvent({ id: "new", ts: BASE_TS + 2000, actor: "newest@acme.test" }),
+      makeEvent({ id: "old", ts: BASE_TS + 1000, actor: "oldest@acme.test" }),
     ];
     renderTable({ fetchPage: fakeServer(events), pageSize: 10 });
 
@@ -123,7 +126,7 @@ describe("given a source with ingested events", () => {
   it("expands a clicked row into raw + normalised detail and folds it on a second click", async () => {
     const user = userEvent.setup();
     renderTable({
-      fetchPage: fakeServer([makeEvent("only", BASE_TS)]),
+      fetchPage: fakeServer([makeEvent({ id: "only", ts: BASE_TS })]),
       pageSize: 10,
     });
     const rowEl = await screen.findByTestId("source-event-row");
@@ -141,7 +144,9 @@ describe("given a source with ingested events", () => {
   it("says a pushed event's raw body was never stored instead of an empty panel", async () => {
     const user = userEvent.setup();
     renderTable({
-      fetchPage: fakeServer([makeEvent("pushed", BASE_TS, { rawPayload: "" })]),
+      fetchPage: fakeServer([
+        makeEvent({ id: "pushed", ts: BASE_TS, rawPayload: "" }),
+      ]),
       pageSize: 10,
     });
     await user.click(await screen.findByTestId("source-event-row"));
@@ -150,11 +155,52 @@ describe("given a source with ingested events", () => {
       screen.getByText(/raw body is not stored for this source type/i),
     ).toBeTruthy();
   });
+
+  /** @scenario "A row opens into raw + normalised detail" */
+  it("opens and closes the detail from the keyboard as well as the mouse", async () => {
+    const user = userEvent.setup();
+    renderTable({
+      fetchPage: fakeServer([makeEvent({ id: "only", ts: BASE_TS })]),
+      pageSize: 10,
+    });
+    const rowEl = await screen.findByTestId("source-event-row");
+
+    rowEl.focus();
+    expect(rowEl).toHaveProperty("tabIndex", 0);
+    await user.keyboard("{Enter}");
+    expect(screen.getByText("Normalised (OCSF)")).toBeTruthy();
+    expect(rowEl.getAttribute("aria-expanded")).toBe("true");
+
+    await user.keyboard("{Enter}");
+    expect(screen.queryByText("Normalised (OCSF)")).toBeNull();
+    expect(rowEl.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows a dash, never 'Invalid Date', for a timestamp that does not parse", async () => {
+    const user = userEvent.setup();
+    // Not through fakeServer: its cursor filter needs a parseable
+    // timestamp, and the point here is what the CELL does with a bad one.
+    renderTable({
+      fetchPage: async () => [
+        makeEvent({
+          id: "only",
+          ts: BASE_TS,
+          eventTimestampIso: "not-a-timestamp",
+        }),
+      ],
+      pageSize: 10,
+    });
+    const rowEl = await screen.findByTestId("source-event-row");
+    await user.hover(within(rowEl).getAllByText("—")[0]!);
+    expect(screen.queryByText(/invalid date/i)).toBeNull();
+  });
 });
 
 describe("given more events than one page holds", () => {
   const twelve = Array.from({ length: 12 }, (_, i) =>
-    makeEvent(`e${String(i).padStart(2, "0")}`, BASE_TS - i * 1000, {
+    makeEvent({
+      id: `e${String(i).padStart(2, "0")}`,
+      ts: BASE_TS - i * 1000,
       actor: `actor-e${String(i).padStart(2, "0")}@acme.test`,
     }),
   );
@@ -205,12 +251,14 @@ describe("given events stamped with the same millisecond straddling a page bound
     // 9 distinct + 3 tied at T; page size 10 cuts through the tie: page 1
     // ends with 1 tied row shown, 2 tied rows unreachable to a naive walk.
     const distinct = Array.from({ length: 9 }, (_, i) =>
-      makeEvent(`d${i}`, T + (9 - i) * 1000, {
+      makeEvent({
+        id: `d${i}`,
+        ts: T + (9 - i) * 1000,
         actor: `actor-d${i}@acme.test`,
       }),
     );
     const tied = ["z", "y", "x"].map((s) =>
-      makeEvent(`tie-${s}`, T, { actor: `actor-tie-${s}@acme.test` }),
+      makeEvent({ id: `tie-${s}`, ts: T, actor: `actor-tie-${s}@acme.test` }),
     );
     const server = fakeServer([...distinct, ...tied]);
     renderTable({ fetchPage: server, pageSize: 10 });
@@ -232,10 +280,10 @@ describe("given the page stays mounted while the source it addresses changes", (
     // Multi-hop history navigation lands on another :id without a remount;
     // the pager must not keep showing the previous source's events.
     const sourceA = fakeServer([
-      makeEvent("a1", BASE_TS, { actor: "actor-source-a@acme.test" }),
+      makeEvent({ id: "a1", ts: BASE_TS, actor: "actor-source-a@acme.test" }),
     ]);
     const sourceB = fakeServer([
-      makeEvent("b1", BASE_TS, { actor: "actor-source-b@acme.test" }),
+      makeEvent({ id: "b1", ts: BASE_TS, actor: "actor-source-b@acme.test" }),
     ]);
     const view = renderTable({ fetchPage: sourceA, pageSize: 10 });
     await screen.findByText("actor-source-a@acme.test");
@@ -276,7 +324,7 @@ describe("given the pager can only honour what the cursor gives it", () => {
   /** @scenario "The pager offers no control it cannot honour" */
   it("offers no sort headers, no search box and no grand total", async () => {
     const events = Array.from({ length: 12 }, (_, i) =>
-      makeEvent(`e${i}`, BASE_TS - i * 1000),
+      makeEvent({ id: `e${i}`, ts: BASE_TS - i * 1000 }),
     );
     renderTable({ fetchPage: fakeServer(events), pageSize: 10 });
     const table = await screen.findByRole("table");

--- a/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+// @vitest-environment jsdom
+/**
+ * The events table on the ingestion-source detail page: a cursor-walked
+ * ListTable that pages through every event the source ever ingested.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *       (rule "The events table pages through everything the source
+ *       ever ingested")
+ *
+ * The harness feeds the real pager hook a fake server that mimics the
+ * endpoint's actual contract: strictly-older-than-cursor, newest first,
+ * sliced to limit, no total.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PageRequest } from "../../logic/eventsPager";
+import {
+  type SourceEventRowData,
+  SourceEventsTable,
+} from "../SourceEventsTable";
+import { useSourceEventsPager } from "../useSourceEventsPager";
+
+const BASE_TS = Date.now() - 5 * 60 * 1000; // recent, so times read "ago"
+
+function makeEvent(
+  eventId: string,
+  tsMs: number,
+  overrides: Partial<SourceEventRowData> = {},
+): SourceEventRowData {
+  return {
+    eventId,
+    eventType: "api_call",
+    actor: "dev@acme.test",
+    action: "chat.completion",
+    target: "claude-sonnet-5",
+    costUsd: "0.0250",
+    tokensInput: 120,
+    tokensOutput: 480,
+    eventTimestampIso: new Date(tsMs).toISOString(),
+    ingestedAtIso: new Date(tsMs + 500).toISOString(),
+    rawPayload: JSON.stringify({ marker: `raw-${eventId}` }),
+    ...overrides,
+  };
+}
+
+/** The endpoint's real behaviour: ts < cursor, newest first, slice(limit). */
+function fakeServer(events: SourceEventRowData[]) {
+  return vi.fn(async (req: PageRequest) => {
+    const beforeMs = req.beforeIso ? Date.parse(req.beforeIso) : Date.now();
+    return events
+      .filter((e) => Date.parse(e.eventTimestampIso) < beforeMs)
+      .sort(
+        (a, b) =>
+          Date.parse(b.eventTimestampIso) - Date.parse(a.eventTimestampIso) ||
+          b.eventId.localeCompare(a.eventId),
+      )
+      .slice(0, req.limit);
+  });
+}
+
+function Harness({
+  fetchPage,
+  pageSize,
+}: {
+  fetchPage: (req: PageRequest) => Promise<SourceEventRowData[]>;
+  pageSize: number;
+}) {
+  const pager = useSourceEventsPager({
+    enabled: true,
+    initialPageSize: pageSize,
+    fetchPage,
+  });
+  return (
+    <SourceEventsTable
+      pager={pager}
+      emptyState={<div>walkthrough: push your first event</div>}
+    />
+  );
+}
+
+const renderTable = (props: Parameters<typeof Harness>[0]) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <Harness {...props} />
+    </ChakraProvider>,
+  );
+
+describe("given a source with ingested events", () => {
+  /** @scenario "Events render as a table, newest first" */
+  it("renders the events as table rows, newest first, with every column", async () => {
+    const events = [
+      makeEvent("new", BASE_TS + 2000, { actor: "newest@acme.test" }),
+      makeEvent("old", BASE_TS + 1000, { actor: "oldest@acme.test" }),
+    ];
+    renderTable({ fetchPage: fakeServer(events), pageSize: 10 });
+
+    const table = await screen.findByRole("table");
+    for (const header of [
+      "Time",
+      "Type",
+      "Actor",
+      "Action",
+      "Target",
+      "Cost",
+      "Tokens",
+    ]) {
+      expect(
+        within(table).getByRole("columnheader", { name: header }),
+      ).toBeTruthy();
+    }
+    const rows = within(table).getAllByTestId("source-event-row");
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]!).getByText("newest@acme.test")).toBeTruthy();
+    expect(within(rows[1]!).getByText("oldest@acme.test")).toBeTruthy();
+    // Relative time reads as "ago"; the exact instant lives in a tooltip.
+    expect(within(rows[0]!).getByText(/ago/)).toBeTruthy();
+  });
+
+  /** @scenario "A row opens into raw + normalised detail" */
+  it("expands a clicked row into raw + normalised detail and folds it on a second click", async () => {
+    const user = userEvent.setup();
+    renderTable({
+      fetchPage: fakeServer([makeEvent("only", BASE_TS)]),
+      pageSize: 10,
+    });
+    const rowEl = await screen.findByTestId("source-event-row");
+
+    await user.click(rowEl);
+    expect(screen.getByText("Normalised (OCSF)")).toBeTruthy();
+    expect(screen.getByText("Raw payload (as ingested)")).toBeTruthy();
+    expect(screen.getByText(/raw-only/)).toBeTruthy();
+
+    await user.click(rowEl);
+    expect(screen.queryByText("Normalised (OCSF)")).toBeNull();
+  });
+
+  /** @scenario "A row opens into raw + normalised detail" */
+  it("says a pushed event's raw body was never stored instead of an empty panel", async () => {
+    const user = userEvent.setup();
+    renderTable({
+      fetchPage: fakeServer([makeEvent("pushed", BASE_TS, { rawPayload: "" })]),
+      pageSize: 10,
+    });
+    await user.click(await screen.findByTestId("source-event-row"));
+    expect(screen.getByText("Normalised (OCSF)")).toBeTruthy();
+    expect(
+      screen.getByText(/raw body is not stored for this source type/i),
+    ).toBeTruthy();
+  });
+});
+
+describe("given more events than one page holds", () => {
+  const twelve = Array.from({ length: 12 }, (_, i) =>
+    makeEvent(`e${String(i).padStart(2, "0")}`, BASE_TS - i * 1000, {
+      actor: `actor-e${String(i).padStart(2, "0")}@acme.test`,
+    }),
+  );
+
+  /** @scenario "The table pages through more events than fit at once" */
+  it("walks to the next page of older events and back to the exact rows it left", async () => {
+    const user = userEvent.setup();
+    const server = fakeServer(twelve);
+    renderTable({ fetchPage: server, pageSize: 10 });
+
+    await screen.findByText("actor-e00@acme.test");
+    expect(screen.queryByText("actor-e10@acme.test")).toBeNull();
+
+    await user.click(screen.getByTestId("pagination-next"));
+    await screen.findByText("actor-e10@acme.test");
+    expect(screen.queryByText("actor-e00@acme.test")).toBeNull();
+    expect(screen.getByText("actor-e11@acme.test")).toBeTruthy();
+
+    const fetchesAfterWalk = server.mock.calls.length;
+    await user.click(screen.getByTestId("pagination-prev"));
+    await screen.findByText("actor-e00@acme.test");
+    expect(screen.queryByText("actor-e10@acme.test")).toBeNull();
+    // Going back re-reads what was already loaded; it does not refetch.
+    expect(server.mock.calls.length).toBe(fetchesAfterWalk);
+  });
+
+  /** @scenario "Changing rows-per-page starts over from the first page" */
+  it("returns to the first page at the new size when rows-per-page changes", async () => {
+    const user = userEvent.setup();
+    renderTable({ fetchPage: fakeServer(twelve), pageSize: 10 });
+
+    await screen.findByText("actor-e00@acme.test");
+    await user.click(screen.getByTestId("pagination-next"));
+    await screen.findByText("actor-e10@acme.test");
+
+    await user.selectOptions(screen.getByTestId("pagination-page-size"), "25");
+    await screen.findByText("actor-e00@acme.test");
+    // All twelve fit on the one, first page now.
+    expect(screen.getByText("actor-e11@acme.test")).toBeTruthy();
+  });
+});
+
+describe("given events stamped with the same millisecond straddling a page boundary", () => {
+  /** @scenario "Events sharing a timestamp are not lost at a page boundary" */
+  it("recovers tied events that fell off the previous page's slice", async () => {
+    const user = userEvent.setup();
+    const T = BASE_TS;
+    // 9 distinct + 3 tied at T; page size 10 cuts through the tie: page 1
+    // ends with 1 tied row shown, 2 tied rows unreachable to a naive walk.
+    const distinct = Array.from({ length: 9 }, (_, i) =>
+      makeEvent(`d${i}`, T + (9 - i) * 1000, {
+        actor: `actor-d${i}@acme.test`,
+      }),
+    );
+    const tied = ["z", "y", "x"].map((s) =>
+      makeEvent(`tie-${s}`, T, { actor: `actor-tie-${s}@acme.test` }),
+    );
+    const server = fakeServer([...distinct, ...tied]);
+    renderTable({ fetchPage: server, pageSize: 10 });
+
+    await screen.findByText("actor-d0@acme.test");
+    expect(screen.getByText("actor-tie-z@acme.test")).toBeTruthy();
+    expect(screen.queryByText("actor-tie-x@acme.test")).toBeNull();
+
+    await user.click(screen.getByTestId("pagination-next"));
+    await screen.findByText("actor-tie-y@acme.test");
+    expect(screen.getByText("actor-tie-x@acme.test")).toBeTruthy();
+    // And nothing shown twice: the tied row from page 1 stays on page 1.
+    expect(screen.queryByText("actor-tie-z@acme.test")).toBeNull();
+  });
+});
+
+describe("given the events request fails", () => {
+  /** @scenario "A failed load is an error, never an empty list" */
+  it("shows an error and never the empty-state walkthrough", async () => {
+    renderTable({
+      fetchPage: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+      pageSize: 10,
+    });
+    await screen.findByText("Couldn't load this source's events");
+    expect(screen.queryByText("walkthrough: push your first event")).toBeNull();
+  });
+});
+
+describe("given a source that has ingested nothing", () => {
+  it("shows the setup walkthrough and no pagination bar", async () => {
+    renderTable({ fetchPage: fakeServer([]), pageSize: 10 });
+    await screen.findByText("walkthrough: push your first event");
+    expect(screen.queryByTestId("pagination")).toBeNull();
+  });
+});
+
+describe("given the pager can only honour what the cursor gives it", () => {
+  /** @scenario "The pager offers no control it cannot honour" */
+  it("offers no sort headers, no search box and no grand total", async () => {
+    const events = Array.from({ length: 12 }, (_, i) =>
+      makeEvent(`e${i}`, BASE_TS - i * 1000),
+    );
+    renderTable({ fetchPage: fakeServer(events), pageSize: 10 });
+    const table = await screen.findByRole("table");
+
+    for (const header of within(table).getAllByRole("columnheader")) {
+      expect(within(header).queryByRole("button")).toBeNull();
+    }
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    const indicator = screen.getByTestId("pagination-indicator");
+    expect(indicator.textContent).toContain("showing 1–10");
+    expect(indicator.textContent).not.toMatch(/\d+\s*events/);
+
+    await waitFor(() => {
+      // One loaded page + the sentinel: page 2 offered, page 3 not.
+      expect(screen.getByTestId("pagination-page-2")).toBeTruthy();
+      expect(screen.queryByTestId("pagination-page-3")).toBeNull();
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
@@ -227,6 +227,29 @@ describe("given events stamped with the same millisecond straddling a page bound
   });
 });
 
+describe("given the page stays mounted while the source it addresses changes", () => {
+  it("throws away the old source's pages and loads the new source's events", async () => {
+    // Multi-hop history navigation lands on another :id without a remount;
+    // the pager must not keep showing the previous source's events.
+    const sourceA = fakeServer([
+      makeEvent("a1", BASE_TS, { actor: "actor-source-a@acme.test" }),
+    ]);
+    const sourceB = fakeServer([
+      makeEvent("b1", BASE_TS, { actor: "actor-source-b@acme.test" }),
+    ]);
+    const view = renderTable({ fetchPage: sourceA, pageSize: 10 });
+    await screen.findByText("actor-source-a@acme.test");
+
+    view.rerender(
+      <ChakraProvider value={defaultSystem}>
+        <Harness fetchPage={sourceB} pageSize={10} />
+      </ChakraProvider>,
+    );
+    await screen.findByText("actor-source-b@acme.test");
+    expect(screen.queryByText("actor-source-a@acme.test")).toBeNull();
+  });
+});
+
 describe("given the events request fails", () => {
   /** @scenario "A failed load is an error, never an empty list" */
   it("shows an error and never the empty-state walkthrough", async () => {

--- a/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
@@ -14,6 +14,7 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PageRequest } from "../../logic/eventsPager";
@@ -295,6 +296,61 @@ describe("given the page stays mounted while the source it addresses changes", (
     );
     await screen.findByText("actor-source-b@acme.test");
     expect(screen.queryByText("actor-source-a@acme.test")).toBeNull();
+  });
+});
+
+describe("given React mounts the table twice, as StrictMode does in development", () => {
+  it("loads the first page exactly once, never a duplicate", async () => {
+    const server = fakeServer([
+      makeEvent({ id: "only", ts: BASE_TS, actor: "actor-once@acme.test" }),
+    ]);
+    render(
+      <StrictMode>
+        <ChakraProvider value={defaultSystem}>
+          <Harness fetchPage={server} pageSize={10} />
+        </ChakraProvider>
+      </StrictMode>,
+    );
+    await screen.findByText("actor-once@acme.test");
+    // A second landing of the same walk must be dropped, not appended
+    // as a phantom second page.
+    expect(screen.getAllByTestId("source-event-row")).toHaveLength(1);
+    expect(screen.queryByTestId("pagination-page-2")).toBeNull();
+  });
+});
+
+describe("given a page fetch fails mid-walk", () => {
+  /** @scenario "A failed load is an error, never an empty list" */
+  it("keeps the rows already loaded and lets the next click retry", async () => {
+    const user = userEvent.setup();
+    const twelve = Array.from({ length: 12 }, (_, i) =>
+      makeEvent({
+        id: `e${String(i).padStart(2, "0")}`,
+        ts: BASE_TS - i * 1000,
+        actor: `actor-e${String(i).padStart(2, "0")}@acme.test`,
+      }),
+    );
+    const realServer = fakeServer(twelve);
+    let failNext = false;
+    const flakyServer = vi.fn(async (req: PageRequest) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error("transient");
+      }
+      return realServer(req);
+    });
+    renderTable({ fetchPage: flakyServer, pageSize: 10 });
+    await screen.findByText("actor-e00@acme.test");
+
+    failNext = true;
+    await user.click(screen.getByTestId("pagination-next"));
+    await screen.findByText("Couldn't load more events");
+    // The walked pages survive the failure.
+    expect(screen.getByText("actor-e00@acme.test")).toBeTruthy();
+
+    await user.click(screen.getByTestId("pagination-next"));
+    await screen.findByText("actor-e10@acme.test");
+    expect(screen.queryByText("Couldn't load more events")).toBeNull();
   });
 });
 

--- a/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
+++ b/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
@@ -21,8 +21,11 @@ import {
  * fake server.
  */
 export type SourceEventsPager<R extends PagerRow> = {
-  /** Loading covers only the very first page; later walks set isFetching. */
+  /** Loading covers only the very first page; later walks set
+   * isFetching. "error" means nothing ever loaded — a failure with
+   * pages on screen keeps status "ready" and travels in `error`. */
   status: "loading" | "error" | "ready";
+  /** The last walk's failure, if any; cleared when a new fetch starts. */
   error: unknown;
   page: number;
   pageSize: number;
@@ -70,23 +73,40 @@ const initPagerState = <R extends PagerRow>(
   generation: 0,
 });
 
-function landFetch<R extends PagerRow>(
-  state: PagerState<R>,
-  action: { rows: R[]; hasMore: boolean },
-): PagerState<R> {
+function landFetch<R extends PagerRow>({
+  state,
+  rows,
+  hasMore,
+}: {
+  state: PagerState<R>;
+  rows: R[];
+  hasMore: boolean;
+}): PagerState<R> {
   const pages = [...(state.pages ?? [])];
   // An empty page is only kept as the very first one — it is how "this
   // source has no events" is represented; later empty results just end
   // the walk on the page already shown.
-  if (action.rows.length > 0 || pages.length === 0) pages.push(action.rows);
+  if (rows.length > 0 || pages.length === 0) pages.push(rows);
   return {
     ...state,
     pages,
     page: pages.length,
-    hasMore: action.rows.length > 0 && action.hasMore,
+    hasMore: rows.length > 0 && hasMore,
     isFetching: false,
   };
 }
+
+/**
+ * A landing only counts while its walk is still the current one: same
+ * generation AND a fetch still marked in flight. The second guard makes
+ * a duplicated start (StrictMode's double effect run) harmless — the
+ * first landing clears `isFetching`, so the echo is dropped instead of
+ * appended as a phantom page.
+ */
+const isCurrentWalk = <R extends PagerRow>(
+  state: PagerState<R>,
+  generation: number,
+) => generation === state.generation && state.isFetching;
 
 function pagerReducer<R extends PagerRow>(
   state: PagerState<R>,
@@ -104,13 +124,15 @@ function pagerReducer<R extends PagerRow>(
         generation: state.generation + 1,
       };
     case "fetchStart":
-      return { ...state, isFetching: true };
+      // Starting a walk is also the retry: a failure from the previous
+      // attempt stops being true the moment a new fetch is in flight.
+      return { ...state, isFetching: true, error: null };
     case "fetchLanded":
-      return action.generation === state.generation
-        ? landFetch(state, action)
+      return isCurrentWalk(state, action.generation)
+        ? landFetch({ state, rows: action.rows, hasMore: action.hasMore })
         : state;
     case "fetchFailed":
-      return action.generation === state.generation
+      return isCurrentWalk(state, action.generation)
         ? { ...state, error: action.error, isFetching: false }
         : state;
     case "show":
@@ -149,10 +171,13 @@ async function walkOnePage<R extends PagerRow>({
 }
 
 /** The state, shaped for the table and the pagination bar. */
-function presentPager<R extends PagerRow>(
-  state: PagerState<R>,
-  controls: Pick<SourceEventsPager<R>, "goToPage" | "setPageSize">,
-): SourceEventsPager<R> {
+function presentPager<R extends PagerRow>({
+  state,
+  controls,
+}: {
+  state: PagerState<R>;
+  controls: Pick<SourceEventsPager<R>, "goToPage" | "setPageSize">;
+}): SourceEventsPager<R> {
   const loadedCount = state.pages?.reduce((sum, p) => sum + p.length, 0) ?? 0;
   const view = paginationView({
     pageSize: state.pageSize,
@@ -161,12 +186,15 @@ function presentPager<R extends PagerRow>(
     hasMore: state.hasMore,
   });
   return {
+    // A failure with pages on screen is not the table's whole story:
+    // "error" is reserved for a walk that never loaded anything. A
+    // mid-walk failure keeps status "ready" and travels in `error`.
     status:
-      state.error !== null
-        ? "error"
-        : state.pages === null
-          ? "loading"
-          : "ready",
+      state.pages === null
+        ? state.error !== null
+          ? "error"
+          : "loading"
+        : "ready",
     error: state.error,
     page: state.page,
     pageSize: state.pageSize,
@@ -257,5 +285,5 @@ export function useSourceEventsPager<R extends PagerRow>({
     [],
   );
 
-  return presentPager(state, { goToPage, setPageSize });
+  return presentPager({ state, controls: { goToPage, setPageSize } });
 }

--- a/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
+++ b/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 
 import {
   absorbFetch,
@@ -38,6 +38,86 @@ export type SourceEventsPager<R extends PagerRow> = {
   setPageSize: (size: number) => void;
 };
 
+type PagerState<R extends PagerRow> = {
+  pages: R[][] | null;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+  error: unknown;
+  isFetching: boolean;
+  /** Bumped on every reset; a fetch started before a reset landed in a
+   * world that no longer exists and its result is discarded. */
+  generation: number;
+};
+
+type PagerAction<R extends PagerRow> =
+  | { type: "reset" }
+  | { type: "resize"; pageSize: number }
+  | { type: "fetchStart" }
+  | { type: "fetchLanded"; generation: number; rows: R[]; hasMore: boolean }
+  | { type: "fetchFailed"; generation: number; error: unknown }
+  | { type: "show"; page: number };
+
+const initPagerState = <R extends PagerRow>(
+  pageSize: number,
+): PagerState<R> => ({
+  pages: null,
+  page: 1,
+  pageSize,
+  hasMore: false,
+  error: null,
+  isFetching: false,
+  generation: 0,
+});
+
+function landFetch<R extends PagerRow>(
+  state: PagerState<R>,
+  action: { rows: R[]; hasMore: boolean },
+): PagerState<R> {
+  const pages = [...(state.pages ?? [])];
+  // An empty page is only kept as the very first one — it is how "this
+  // source has no events" is represented; later empty results just end
+  // the walk on the page already shown.
+  if (action.rows.length > 0 || pages.length === 0) pages.push(action.rows);
+  return {
+    ...state,
+    pages,
+    page: pages.length,
+    hasMore: action.rows.length > 0 && action.hasMore,
+    isFetching: false,
+  };
+}
+
+function pagerReducer<R extends PagerRow>(
+  state: PagerState<R>,
+  action: PagerAction<R>,
+): PagerState<R> {
+  switch (action.type) {
+    case "reset":
+      return {
+        ...initPagerState<R>(state.pageSize),
+        generation: state.generation + 1,
+      };
+    case "resize":
+      return {
+        ...initPagerState<R>(action.pageSize),
+        generation: state.generation + 1,
+      };
+    case "fetchStart":
+      return { ...state, isFetching: true };
+    case "fetchLanded":
+      return action.generation === state.generation
+        ? landFetch(state, action)
+        : state;
+    case "fetchFailed":
+      return action.generation === state.generation
+        ? { ...state, error: action.error, isFetching: false }
+        : state;
+    case "show":
+      return { ...state, page: action.page };
+  }
+}
+
 /**
  * One step of the walk: build the request for the page after
  * `displayedRows`, fetch, and absorb — falling back to a skip past the
@@ -68,6 +148,37 @@ async function walkOnePage<R extends PagerRow>({
   });
 }
 
+/** The state, shaped for the table and the pagination bar. */
+function presentPager<R extends PagerRow>(
+  state: PagerState<R>,
+  controls: Pick<SourceEventsPager<R>, "goToPage" | "setPageSize">,
+): SourceEventsPager<R> {
+  const loadedCount = state.pages?.reduce((sum, p) => sum + p.length, 0) ?? 0;
+  const view = paginationView({
+    loadedCount,
+    loadedPages: state.pages?.length ?? 0,
+    hasMore: state.hasMore,
+  });
+  return {
+    status:
+      state.error !== null
+        ? "error"
+        : state.pages === null
+          ? "loading"
+          : "ready",
+    error: state.error,
+    page: state.page,
+    pageSize: state.pageSize,
+    rows: state.pages?.[state.page - 1] ?? [],
+    loadedCount,
+    totalCount: view.totalCount,
+    canGoNext: view.canGoNext,
+    isPageReachable: view.isPageReachable,
+    isFetching: state.isFetching,
+    ...controls,
+  };
+}
+
 export function useSourceEventsPager<R extends PagerRow>({
   enabled,
   initialPageSize = 25,
@@ -77,24 +188,38 @@ export function useSourceEventsPager<R extends PagerRow>({
   initialPageSize?: number;
   fetchPage: (request: PageRequest) => Promise<R[]>;
 }): SourceEventsPager<R> {
-  const [pages, setPages] = useState<R[][] | null>(null);
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSizeState] = useState(initialPageSize);
-  const [hasMore, setHasMore] = useState(false);
-  const [error, setError] = useState<unknown>(null);
-  const [isFetching, setIsFetching] = useState(false);
-  // Bumped on every reset; in-flight fetches from before a reset land
-  // in a world that no longer exists and must be discarded.
-  const generationRef = useRef(0);
+  const [state, dispatch] = useReducer(
+    (current: PagerState<R>, action: PagerAction<R>) =>
+      pagerReducer(current, action),
+    initialPageSize,
+    initPagerState<R>,
+  );
 
-  const reset = useCallback(() => {
-    generationRef.current += 1;
-    setPages(null);
-    setPage(1);
-    setHasMore(false);
-    setError(null);
-    setIsFetching(false);
-  }, []);
+  const startFetch = useCallback(
+    (snapshot: PagerState<R>) => {
+      dispatch({ type: "fetchStart" });
+      walkOnePage({
+        pageSize: snapshot.pageSize,
+        displayedRows: snapshot.pages?.flat() ?? [],
+        fetchPage,
+      }).then(
+        ({ rows, hasMore }) =>
+          dispatch({
+            type: "fetchLanded",
+            generation: snapshot.generation,
+            rows,
+            hasMore,
+          }),
+        (error: unknown) =>
+          dispatch({
+            type: "fetchFailed",
+            generation: snapshot.generation,
+            error,
+          }),
+      );
+    },
+    [fetchPage],
+  );
 
   // `fetchPage` closes over the org and source ids, so a new identity
   // means the walk now addresses different data — everything loaded so
@@ -105,80 +230,31 @@ export function useSourceEventsPager<R extends PagerRow>({
   useEffect(() => {
     if (previousFetchPageRef.current === fetchPage) return;
     previousFetchPageRef.current = fetchPage;
-    reset();
-  }, [fetchPage, reset]);
-
-  const fetchNextPage = useCallback(
-    async (currentPages: R[][] | null, currentPageSize: number) => {
-      const generation = generationRef.current;
-      setIsFetching(true);
-      try {
-        const result = await walkOnePage({
-          pageSize: currentPageSize,
-          displayedRows: currentPages?.flat() ?? [],
-          fetchPage,
-        });
-        if (generationRef.current !== generation) return;
-        const nextPages = [...(currentPages ?? [])];
-        if (result.rows.length > 0 || nextPages.length === 0) {
-          nextPages.push(result.rows);
-        }
-        setPages(nextPages);
-        setHasMore(result.rows.length > 0 && result.hasMore);
-        setPage(nextPages.length);
-      } catch (fetchError) {
-        if (generationRef.current !== generation) return;
-        setError(fetchError);
-      } finally {
-        if (generationRef.current === generation) setIsFetching(false);
-      }
-    },
-    [fetchPage],
-  );
+    dispatch({ type: "reset" });
+  }, [fetchPage]);
 
   useEffect(() => {
-    if (!enabled || pages !== null || error !== null || isFetching) return;
-    void fetchNextPage(null, pageSize);
-  }, [enabled, pages, error, isFetching, pageSize, fetchNextPage]);
+    const untouched =
+      state.pages === null && state.error === null && !state.isFetching;
+    if (enabled && untouched) startFetch(state);
+  }, [enabled, state, startFetch]);
 
   const goToPage = useCallback(
     (target: number) => {
-      if (target < 1 || pages === null || isFetching) return;
-      if (target <= pages.length) {
-        setPage(target);
-        return;
-      }
-      if (target === pages.length + 1 && hasMore) {
-        void fetchNextPage(pages, pageSize);
+      if (target < 1 || state.pages === null || state.isFetching) return;
+      if (target <= state.pages.length) {
+        dispatch({ type: "show", page: target });
+      } else if (target === state.pages.length + 1 && state.hasMore) {
+        startFetch(state);
       }
     },
-    [pages, isFetching, hasMore, pageSize, fetchNextPage],
+    [state, startFetch],
   );
 
   const setPageSize = useCallback(
-    (size: number) => {
-      reset();
-      setPageSizeState(size);
-    },
-    [reset],
+    (size: number) => dispatch({ type: "resize", pageSize: size }),
+    [],
   );
 
-  const loadedPages = pages?.length ?? 0;
-  const loadedCount = pages?.reduce((sum, p) => sum + p.length, 0) ?? 0;
-  const view = paginationView({ loadedCount, loadedPages, hasMore });
-
-  return {
-    status: error !== null ? "error" : pages === null ? "loading" : "ready",
-    error,
-    page,
-    pageSize,
-    rows: pages?.[page - 1] ?? [],
-    loadedCount,
-    totalCount: view.totalCount,
-    canGoNext: view.canGoNext,
-    isPageReachable: view.isPageReachable,
-    isFetching,
-    goToPage,
-    setPageSize,
-  };
+  return presentPager(state, { goToPage, setPageSize });
 }

--- a/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
+++ b/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
@@ -139,7 +139,7 @@ async function walkOnePage<R extends PagerRow>({
     request,
     fetched: await fetchPage(request),
   });
-  if (!result.stalled) return result;
+  if (!result.isStalled) return result;
   const skip = stallSkipRequest({ pageSize, displayedRows });
   return absorbFetch({
     pageSize,
@@ -155,8 +155,9 @@ function presentPager<R extends PagerRow>(
 ): SourceEventsPager<R> {
   const loadedCount = state.pages?.reduce((sum, p) => sum + p.length, 0) ?? 0;
   const view = paginationView({
-    loadedCount,
+    pageSize: state.pageSize,
     loadedPages: state.pages?.length ?? 0,
+    lastPageCount: state.pages?.[state.pages.length - 1]?.length ?? 0,
     hasMore: state.hasMore,
   });
   return {

--- a/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
+++ b/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
@@ -87,6 +87,27 @@ export function useSourceEventsPager<R extends PagerRow>({
   // in a world that no longer exists and must be discarded.
   const generationRef = useRef(0);
 
+  const reset = useCallback(() => {
+    generationRef.current += 1;
+    setPages(null);
+    setPage(1);
+    setHasMore(false);
+    setError(null);
+    setIsFetching(false);
+  }, []);
+
+  // `fetchPage` closes over the org and source ids, so a new identity
+  // means the walk now addresses different data — everything loaded so
+  // far belongs to the previous source and must go. Without this, a
+  // param-only route change (multi-hop history navigation between two
+  // detail pages) keeps showing the old source's events.
+  const previousFetchPageRef = useRef(fetchPage);
+  useEffect(() => {
+    if (previousFetchPageRef.current === fetchPage) return;
+    previousFetchPageRef.current = fetchPage;
+    reset();
+  }, [fetchPage, reset]);
+
   const fetchNextPage = useCallback(
     async (currentPages: R[][] | null, currentPageSize: number) => {
       const generation = generationRef.current;
@@ -134,15 +155,13 @@ export function useSourceEventsPager<R extends PagerRow>({
     [pages, isFetching, hasMore, pageSize, fetchNextPage],
   );
 
-  const setPageSize = useCallback((size: number) => {
-    generationRef.current += 1;
-    setPages(null);
-    setPage(1);
-    setHasMore(false);
-    setError(null);
-    setIsFetching(false);
-    setPageSizeState(size);
-  }, []);
+  const setPageSize = useCallback(
+    (size: number) => {
+      reset();
+      setPageSizeState(size);
+    },
+    [reset],
+  );
 
   const loadedPages = pages?.length ?? 0;
   const loadedCount = pages?.reduce((sum, p) => sum + p.length, 0) ?? 0;

--- a/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
+++ b/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  absorbFetch,
+  buildPageRequest,
+  type PageRequest,
+  type PagerRow,
+  paginationView,
+  stallSkipRequest,
+} from "../logic/eventsPager";
+
+/**
+ * Cursor walk over `eventsForSource`, shaped for the pagination bar.
+ *
+ * Pages once loaded are kept in memory and never re-asked from the
+ * server, and the first page's time anchor is fixed by its cursor
+ * chain — so walking back always lands on the exact rows the admin
+ * came from, even while new events keep arriving upstream. The fetch
+ * itself is injected, which keeps the whole walk testable against a
+ * fake server.
+ */
+export type SourceEventsPager<R extends PagerRow> = {
+  /** Loading covers only the very first page; later walks set isFetching. */
+  status: "loading" | "error" | "ready";
+  error: unknown;
+  page: number;
+  pageSize: number;
+  /** Rows of the page currently shown. */
+  rows: R[];
+  /** Every row loaded across all visited pages. */
+  loadedCount: number;
+  totalCount: number;
+  canGoNext: boolean;
+  isPageReachable: (page: number) => boolean;
+  isFetching: boolean;
+  goToPage: (page: number) => void;
+  setPageSize: (size: number) => void;
+};
+
+/**
+ * One step of the walk: build the request for the page after
+ * `displayedRows`, fetch, and absorb — falling back to a skip past the
+ * boundary when a tied millisecond is wider than one fetch, rather than
+ * re-reading the same window forever.
+ */
+async function walkOnePage<R extends PagerRow>({
+  pageSize,
+  displayedRows,
+  fetchPage,
+}: {
+  pageSize: number;
+  displayedRows: readonly R[];
+  fetchPage: (request: PageRequest) => Promise<R[]>;
+}): Promise<{ rows: R[]; hasMore: boolean }> {
+  const request = buildPageRequest({ pageSize, displayedRows });
+  const result = absorbFetch({
+    pageSize,
+    request,
+    fetched: await fetchPage(request),
+  });
+  if (!result.stalled) return result;
+  const skip = stallSkipRequest({ pageSize, displayedRows });
+  return absorbFetch({
+    pageSize,
+    request: skip,
+    fetched: await fetchPage(skip),
+  });
+}
+
+export function useSourceEventsPager<R extends PagerRow>({
+  enabled,
+  initialPageSize = 25,
+  fetchPage,
+}: {
+  enabled: boolean;
+  initialPageSize?: number;
+  fetchPage: (request: PageRequest) => Promise<R[]>;
+}): SourceEventsPager<R> {
+  const [pages, setPages] = useState<R[][] | null>(null);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSizeState] = useState(initialPageSize);
+  const [hasMore, setHasMore] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  // Bumped on every reset; in-flight fetches from before a reset land
+  // in a world that no longer exists and must be discarded.
+  const generationRef = useRef(0);
+
+  const fetchNextPage = useCallback(
+    async (currentPages: R[][] | null, currentPageSize: number) => {
+      const generation = generationRef.current;
+      setIsFetching(true);
+      try {
+        const result = await walkOnePage({
+          pageSize: currentPageSize,
+          displayedRows: currentPages?.flat() ?? [],
+          fetchPage,
+        });
+        if (generationRef.current !== generation) return;
+        const nextPages = [...(currentPages ?? [])];
+        if (result.rows.length > 0 || nextPages.length === 0) {
+          nextPages.push(result.rows);
+        }
+        setPages(nextPages);
+        setHasMore(result.rows.length > 0 && result.hasMore);
+        setPage(nextPages.length);
+      } catch (fetchError) {
+        if (generationRef.current !== generation) return;
+        setError(fetchError);
+      } finally {
+        if (generationRef.current === generation) setIsFetching(false);
+      }
+    },
+    [fetchPage],
+  );
+
+  useEffect(() => {
+    if (!enabled || pages !== null || error !== null || isFetching) return;
+    void fetchNextPage(null, pageSize);
+  }, [enabled, pages, error, isFetching, pageSize, fetchNextPage]);
+
+  const goToPage = useCallback(
+    (target: number) => {
+      if (target < 1 || pages === null || isFetching) return;
+      if (target <= pages.length) {
+        setPage(target);
+        return;
+      }
+      if (target === pages.length + 1 && hasMore) {
+        void fetchNextPage(pages, pageSize);
+      }
+    },
+    [pages, isFetching, hasMore, pageSize, fetchNextPage],
+  );
+
+  const setPageSize = useCallback((size: number) => {
+    generationRef.current += 1;
+    setPages(null);
+    setPage(1);
+    setHasMore(false);
+    setError(null);
+    setIsFetching(false);
+    setPageSizeState(size);
+  }, []);
+
+  const loadedPages = pages?.length ?? 0;
+  const loadedCount = pages?.reduce((sum, p) => sum + p.length, 0) ?? 0;
+  const view = paginationView({ loadedCount, loadedPages, hasMore });
+
+  return {
+    status: error !== null ? "error" : pages === null ? "loading" : "ready",
+    error,
+    page,
+    pageSize,
+    rows: pages?.[page - 1] ?? [],
+    loadedCount,
+    totalCount: view.totalCount,
+    canGoNext: view.canGoNext,
+    isPageReachable: view.isPageReachable,
+    isFetching,
+    goToPage,
+    setPageSize,
+  };
+}

--- a/platform/app/ee/governance/dashboard/logic/__tests__/eventsPager.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/eventsPager.unit.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * Cursor-walk logic for the source events table. The server hands out
+ * events strictly OLDER than a timestamp cursor (no id tiebreak, no
+ * total), so the walk overlaps each boundary by one millisecond and
+ * drops the rows it has already shown — otherwise events sharing the
+ * boundary millisecond would be skipped forever.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *       (rule "The events table pages through everything the source
+ *       ever ingested")
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  absorbFetch,
+  buildPageRequest,
+  paginationView,
+  SERVER_MAX_LIMIT,
+  stallSkipRequest,
+} from "../eventsPager";
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+const row = (eventId: string, tsMs: number) => ({
+  eventId,
+  eventTimestampIso: iso(tsMs),
+});
+
+const T = Date.parse("2026-08-20T12:00:00.000Z");
+
+describe("given the first page of events", () => {
+  it("anchors at server-now (no cursor) and asks for one sentinel row extra", () => {
+    const req = buildPageRequest({ pageSize: 25, displayedRows: [] });
+    expect(req.beforeIso).toBeUndefined();
+    expect(req.limit).toBe(26);
+    expect(req.dropIds).toEqual([]);
+  });
+
+  /** @scenario "The table pages through more events than fit at once" */
+  it("shows pageSize rows and knows there is more when the sentinel came back", () => {
+    const req = buildPageRequest({ pageSize: 3, displayedRows: [] });
+    const fetched = [
+      row("a", T + 40),
+      row("b", T + 30),
+      row("c", T + 20),
+      row("d", T + 10),
+    ];
+    const result = absorbFetch({ pageSize: 3, request: req, fetched });
+    expect(result.rows.map((r) => r.eventId)).toEqual(["a", "b", "c"]);
+    expect(result.hasMore).toBe(true);
+    expect(result.stalled).toBe(false);
+  });
+
+  it("shows everything and stops when the fetch came back short", () => {
+    const req = buildPageRequest({ pageSize: 3, displayedRows: [] });
+    const fetched = [row("a", T + 40), row("b", T + 30)];
+    const result = absorbFetch({ pageSize: 3, request: req, fetched });
+    expect(result.rows.map((r) => r.eventId)).toEqual(["a", "b"]);
+    expect(result.hasMore).toBe(false);
+  });
+});
+
+describe("given a next-page request after distinct timestamps", () => {
+  it("overlaps the boundary by 1ms and drops only the boundary row", () => {
+    const displayed = [row("a", T + 40), row("b", T + 30), row("c", T + 20)];
+    const req = buildPageRequest({ pageSize: 3, displayedRows: displayed });
+    expect(req.beforeIso).toBe(iso(T + 21));
+    expect(req.dropIds).toEqual(["c"]);
+    // pageSize + 1 dropped row to re-fetch + 1 sentinel
+    expect(req.limit).toBe(5);
+  });
+});
+
+describe("given events stamped with the same millisecond at a page boundary", () => {
+  /** @scenario "Events sharing a timestamp are not lost at a page boundary" */
+  it("re-fetches the tied rows, drops the ones already shown, and keeps the rest", () => {
+    // Page 1 showed a, b, c where b and c are tied at T — and d, also at T,
+    // fell off the server's slice. A naive `beforeIso = T` walk loses d.
+    const displayed = [row("a", T + 40), row("b", T), row("c", T)];
+    const req = buildPageRequest({ pageSize: 3, displayedRows: displayed });
+    expect(req.beforeIso).toBe(iso(T + 1));
+    expect(req.dropIds).toEqual(["b", "c"]);
+    expect(req.limit).toBe(6);
+
+    const fetched = [row("b", T), row("c", T), row("d", T), row("e", T - 10)];
+    const result = absorbFetch({ pageSize: 3, request: req, fetched });
+    expect(result.rows.map((r) => r.eventId)).toEqual(["d", "e"]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("collects boundary drops across the whole displayed history, not just the last page", () => {
+    // Both trailing rows of the history share the boundary millisecond.
+    const displayed = [row("a", T + 40), row("b", T), row("c", T), row("d", T)];
+    const req = buildPageRequest({ pageSize: 4, displayedRows: displayed });
+    expect(req.dropIds).toEqual(["b", "c", "d"]);
+  });
+
+  it("caps the over-fetch at the server's maximum limit", () => {
+    const displayed = Array.from({ length: 199 }, (_, i) => row(`t${i}`, T));
+    const req = buildPageRequest({ pageSize: 100, displayedRows: displayed });
+    expect(req.limit).toBe(SERVER_MAX_LIMIT);
+  });
+
+  it("declares a stall when a full fetch contained nothing new, and the skip request moves strictly past the boundary", () => {
+    const displayed = [row("b", T), row("c", T)];
+    const req = buildPageRequest({ pageSize: 2, displayedRows: displayed });
+    const fetched = [
+      row("b", T),
+      row("c", T),
+      row("x-seen-not-dropped", T),
+      row("y", T),
+      row("z", T),
+    ];
+    // Simulate the pathological case: everything fresh got filtered or the
+    // server keeps returning the same tied window. Here: all returned rows
+    // are drops.
+    const stalledResult = absorbFetch({
+      pageSize: 2,
+      request: { ...req, dropIds: ["b", "c", "x-seen-not-dropped", "y", "z"] },
+      fetched,
+    });
+    expect(stalledResult.rows).toEqual([]);
+    expect(stalledResult.stalled).toBe(true);
+
+    const skip = stallSkipRequest({ pageSize: 2, displayedRows: displayed });
+    expect(skip.beforeIso).toBe(iso(T)); // strict <, ties knowingly skipped
+    expect(skip.dropIds).toEqual([]);
+    expect(skip.limit).toBe(3);
+  });
+
+  it("does not declare a stall when the empty fetch was simply short (end of data)", () => {
+    const req = buildPageRequest({ pageSize: 2, displayedRows: [row("b", T)] });
+    const result = absorbFetch({
+      pageSize: 2,
+      request: req,
+      fetched: [row("b", T)],
+    });
+    expect(result.rows).toEqual([]);
+    expect(result.stalled).toBe(false);
+    expect(result.hasMore).toBe(false);
+  });
+});
+
+describe("given the pagination bar needs numbers a cursor cannot give", () => {
+  /** @scenario "The pager offers no control it cannot honour" */
+  it("counts only what was loaded, plus one sentinel row while more exists", () => {
+    const midWalk = paginationView({
+      loadedCount: 75,
+      loadedPages: 3,
+      hasMore: true,
+    });
+    expect(midWalk.totalCount).toBe(76);
+    expect(midWalk.canGoNext).toBe(true);
+    expect(midWalk.maxReachablePage).toBe(4);
+    expect(midWalk.isPageReachable(3)).toBe(true);
+    expect(midWalk.isPageReachable(4)).toBe(true);
+    expect(midWalk.isPageReachable(5)).toBe(false);
+  });
+
+  it("settles on the exact count once the walk hits the end", () => {
+    const done = paginationView({
+      loadedCount: 85,
+      loadedPages: 4,
+      hasMore: false,
+    });
+    expect(done.totalCount).toBe(85);
+    expect(done.canGoNext).toBe(false);
+    expect(done.maxReachablePage).toBe(4);
+  });
+});

--- a/platform/app/ee/governance/dashboard/logic/__tests__/eventsPager.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/eventsPager.unit.test.ts
@@ -49,7 +49,7 @@ describe("given the first page of events", () => {
     const result = absorbFetch({ pageSize: 3, request: req, fetched });
     expect(result.rows.map((r) => r.eventId)).toEqual(["a", "b", "c"]);
     expect(result.hasMore).toBe(true);
-    expect(result.stalled).toBe(false);
+    expect(result.isStalled).toBe(false);
   });
 
   it("shows everything and stops when the fetch came back short", () => {
@@ -121,7 +121,7 @@ describe("given events stamped with the same millisecond at a page boundary", ()
       fetched,
     });
     expect(stalledResult.rows).toEqual([]);
-    expect(stalledResult.stalled).toBe(true);
+    expect(stalledResult.isStalled).toBe(true);
 
     const skip = stallSkipRequest({ pageSize: 2, displayedRows: displayed });
     expect(skip.beforeIso).toBe(iso(T)); // strict <, ties knowingly skipped
@@ -137,17 +137,18 @@ describe("given events stamped with the same millisecond at a page boundary", ()
       fetched: [row("b", T)],
     });
     expect(result.rows).toEqual([]);
-    expect(result.stalled).toBe(false);
+    expect(result.isStalled).toBe(false);
     expect(result.hasMore).toBe(false);
   });
 });
 
 describe("given the pagination bar needs numbers a cursor cannot give", () => {
   /** @scenario "The pager offers no control it cannot honour" */
-  it("counts only what was loaded, plus one sentinel row while more exists", () => {
+  it("counts page slots plus one sentinel row while more exists", () => {
     const midWalk = paginationView({
-      loadedCount: 75,
+      pageSize: 25,
       loadedPages: 3,
+      lastPageCount: 25,
       hasMore: true,
     });
     expect(midWalk.totalCount).toBe(76);
@@ -160,12 +161,40 @@ describe("given the pagination bar needs numbers a cursor cannot give", () => {
 
   it("settles on the exact count once the walk hits the end", () => {
     const done = paginationView({
-      loadedCount: 85,
+      pageSize: 25,
       loadedPages: 4,
+      lastPageCount: 10,
       hasMore: false,
     });
     expect(done.totalCount).toBe(85);
     expect(done.canGoNext).toBe(false);
     expect(done.maxReachablePage).toBe(4);
+  });
+
+  it("keeps the next page reachable even when a loaded page came up short", () => {
+    // Tie-drops (or the server cap) can leave a non-final page holding
+    // fewer than pageSize rows. A row-count total would then put
+    // totalPages below the pages already walked, and the bar's clamp
+    // would strand the walk. Slots, not rows, drive the page count.
+    const shortMidWalk = paginationView({
+      pageSize: 10,
+      loadedPages: 2,
+      lastPageCount: 3,
+      hasMore: true,
+    });
+    expect(shortMidWalk.maxReachablePage).toBe(3);
+    expect(Math.ceil(shortMidWalk.totalCount / 10)).toBe(3);
+    expect(shortMidWalk.canGoNext).toBe(true);
+    expect(shortMidWalk.isPageReachable(3)).toBe(true);
+  });
+
+  it("reports zero for a source that loaded nothing, hiding the bar", () => {
+    const empty = paginationView({
+      pageSize: 25,
+      loadedPages: 1,
+      lastPageCount: 0,
+      hasMore: false,
+    });
+    expect(empty.totalCount).toBe(0);
   });
 });

--- a/platform/app/ee/governance/dashboard/logic/eventsPager.ts
+++ b/platform/app/ee/governance/dashboard/logic/eventsPager.ts
@@ -112,31 +112,40 @@ export function absorbFetch<R extends PagerRow>({
   pageSize: number;
   request: PageRequest;
   fetched: readonly R[];
-}): { rows: R[]; hasMore: boolean; stalled: boolean } {
+}): { rows: R[]; hasMore: boolean; isStalled: boolean } {
   const drop = new Set(request.dropIds);
   const fresh = fetched.filter((row) => !drop.has(row.eventId));
-  const fullResponse = fetched.length >= request.limit;
+  const isFullResponse = fetched.length >= request.limit;
   return {
     rows: fresh.slice(0, pageSize),
     // The sentinel row proves more; a full response with the sentinel
     // eaten by drops can only assume it.
-    hasMore: fresh.length > pageSize || fullResponse,
-    stalled: fresh.length === 0 && fullResponse,
+    hasMore: fresh.length > pageSize || isFullResponse,
+    isStalled: fresh.length === 0 && isFullResponse,
   };
 }
 
 /**
- * What the pagination bar may honestly claim without a server total:
- * the rows actually loaded, plus one sentinel row while more exist —
- * enough to keep a "next" page open without ever printing a total.
+ * What the pagination bar may honestly claim without a server total.
+ *
+ * The count is built from page SLOTS, not loaded rows: the bar derives
+ * its page count as `ceil(totalCount / pageSize)` and clamps the
+ * current page to it, so a short non-final page (tie-drops, the server
+ * cap) under a row-count total would put the clamp below pages already
+ * walked and strand the walk. Full slots for every page but the last,
+ * the last page's real row count, and one sentinel row while more
+ * exist — the page count always equals the reachable pages, and no
+ * grand total is ever printed.
  */
 export function paginationView({
-  loadedCount,
+  pageSize,
   loadedPages,
+  lastPageCount,
   hasMore,
 }: {
-  loadedCount: number;
+  pageSize: number;
   loadedPages: number;
+  lastPageCount: number;
   hasMore: boolean;
 }): {
   totalCount: number;
@@ -145,8 +154,11 @@ export function paginationView({
   isPageReachable: (page: number) => boolean;
 } {
   const maxReachablePage = loadedPages + (hasMore ? 1 : 0);
+  const totalCount = hasMore
+    ? loadedPages * pageSize + 1
+    : Math.max(0, (loadedPages - 1) * pageSize + lastPageCount);
   return {
-    totalCount: loadedCount + (hasMore ? 1 : 0),
+    totalCount,
     canGoNext: hasMore,
     maxReachablePage,
     isPageReachable: (page) => page >= 1 && page <= maxReachablePage,

--- a/platform/app/ee/governance/dashboard/logic/eventsPager.ts
+++ b/platform/app/ee/governance/dashboard/logic/eventsPager.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * Cursor-walk arithmetic for the source events table.
+ *
+ * The server (`activityMonitor.eventsForSource`) pages by timestamp
+ * only: strictly-older-than `beforeIso`, newest first, sliced to
+ * `limit`, no total and no id tiebreak on the wire. Walking it naively
+ * — "next cursor = last row's timestamp" — permanently skips any event
+ * that shares the boundary millisecond with the last row but fell off
+ * the server's slice.
+ *
+ * So every next-page request overlaps the boundary by one millisecond
+ * and names the rows already shown there, to be dropped from the
+ * response. One sentinel row beyond the page size doubles as the
+ * has-more signal. The recovery holds while a single tied millisecond
+ * fits in one server fetch (`SERVER_MAX_LIMIT`); past that the walk
+ * skips the remainder deterministically rather than looping.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *       (rule "The events table pages through everything the source
+ *       ever ingested")
+ */
+
+/** The two fields the walk itself needs from an event. */
+export type PagerRow = {
+  eventId: string;
+  eventTimestampIso: string;
+};
+
+export type PageRequest = {
+  /** Absent on the first page: the server anchors at its own "now". */
+  beforeIso: string | undefined;
+  limit: number;
+  /** Rows already displayed at the boundary millisecond, to discard. */
+  dropIds: readonly string[];
+};
+
+/** `eventsForSource`'s input schema caps `limit` at 200. */
+export const SERVER_MAX_LIMIT = 200;
+
+const tsMs = (row: PagerRow) => Date.parse(row.eventTimestampIso);
+
+/** All trailing displayed rows that share the last row's millisecond. */
+const boundaryTies = (displayedRows: readonly PagerRow[]): PagerRow[] => {
+  const last = displayedRows[displayedRows.length - 1];
+  if (!last) return [];
+  const boundaryMs = tsMs(last);
+  const ties: PagerRow[] = [];
+  for (let i = displayedRows.length - 1; i >= 0; i--) {
+    if (tsMs(displayedRows[i]!) !== boundaryMs) break;
+    ties.unshift(displayedRows[i]!);
+  }
+  return ties;
+};
+
+/**
+ * The request for the page after `displayedRows` (empty → first page).
+ * One extra row is always asked for: it is never displayed, its
+ * presence is what proves another page exists.
+ */
+export function buildPageRequest({
+  pageSize,
+  displayedRows,
+}: {
+  pageSize: number;
+  displayedRows: readonly PagerRow[];
+}): PageRequest {
+  const last = displayedRows[displayedRows.length - 1];
+  if (!last) {
+    return {
+      beforeIso: undefined,
+      limit: Math.min(pageSize + 1, SERVER_MAX_LIMIT),
+      dropIds: [],
+    };
+  }
+  const dropIds = boundaryTies(displayedRows).map((row) => row.eventId);
+  return {
+    // One millisecond PAST the boundary, so the strict `<` on the server
+    // re-includes the boundary millisecond and its cut-off siblings.
+    beforeIso: new Date(tsMs(last) + 1).toISOString(),
+    limit: Math.min(pageSize + dropIds.length + 1, SERVER_MAX_LIMIT),
+    dropIds,
+  };
+}
+
+/**
+ * When a full response contained nothing new (a tied millisecond wider
+ * than one fetch), move strictly past the boundary. Ties still unseen
+ * there are knowingly skipped — the alternative is re-fetching the same
+ * window forever.
+ */
+export function stallSkipRequest({
+  pageSize,
+  displayedRows,
+}: {
+  pageSize: number;
+  displayedRows: readonly PagerRow[];
+}): PageRequest {
+  const last = displayedRows[displayedRows.length - 1];
+  return {
+    beforeIso: last ? new Date(tsMs(last)).toISOString() : undefined,
+    limit: Math.min(pageSize + 1, SERVER_MAX_LIMIT),
+    dropIds: [],
+  };
+}
+
+export function absorbFetch<R extends PagerRow>({
+  pageSize,
+  request,
+  fetched,
+}: {
+  pageSize: number;
+  request: PageRequest;
+  fetched: readonly R[];
+}): { rows: R[]; hasMore: boolean; stalled: boolean } {
+  const drop = new Set(request.dropIds);
+  const fresh = fetched.filter((row) => !drop.has(row.eventId));
+  const fullResponse = fetched.length >= request.limit;
+  return {
+    rows: fresh.slice(0, pageSize),
+    // The sentinel row proves more; a full response with the sentinel
+    // eaten by drops can only assume it.
+    hasMore: fresh.length > pageSize || fullResponse,
+    stalled: fresh.length === 0 && fullResponse,
+  };
+}
+
+/**
+ * What the pagination bar may honestly claim without a server total:
+ * the rows actually loaded, plus one sentinel row while more exist —
+ * enough to keep a "next" page open without ever printing a total.
+ */
+export function paginationView({
+  loadedCount,
+  loadedPages,
+  hasMore,
+}: {
+  loadedCount: number;
+  loadedPages: number;
+  hasMore: boolean;
+}): {
+  totalCount: number;
+  canGoNext: boolean;
+  maxReachablePage: number;
+  isPageReachable: (page: number) => boolean;
+} {
+  const maxReachablePage = loadedPages + (hasMore ? 1 : 0);
+  return {
+    totalCount: loadedCount + (hasMore ? 1 : 0),
+    canGoNext: hasMore,
+    maxReachablePage,
+    isPageReachable: (page) => page >= 1 && page <= maxReachablePage,
+  };
+}

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -24,7 +24,7 @@ import {
   Trash2,
 } from "lucide-react";
 import numeral from "numeral";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useCallback, useState } from "react";
 
 import { EnterpriseLockedSurface } from "~/components/enterprise/EnterpriseLockedSurface";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
@@ -51,14 +51,23 @@ import {
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api, type RouterOutputs } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
+import { formatTimeAgo } from "~/utils/formatTimeAgo";
+
+import { SourceEventsTable } from "../components/SourceEventsTable";
+import {
+  type SourceEventsPager,
+  useSourceEventsPager,
+} from "../components/useSourceEventsPager";
+import type { PageRequest } from "../logic/eventsPager";
 
 /**
- * Per-source detail page - health metrics + recent events with raw vs
- * normalised side-by-side. Wired to api.activityMonitor.eventsForSource +
- * sourceHealthMetrics (Sergey f2cb9de7a).
+ * Per-source detail page - health metrics + a cursor-walked table of every
+ * event the source ever ingested, raw vs normalised on expand. Wired to
+ * api.activityMonitor.eventsForSource + sourceHealthMetrics.
  *
  * Spec: specs/ai-gateway/governance/ingestion-sources.feature
- *       (scenario "Per-source detail page shows health")
+ *       (scenario "Per-source detail page shows health" and rule "The
+ *       events table pages through everything the source ever ingested")
  */
 
 type Source = RouterOutputs["ingestionSources"]["get"];
@@ -94,23 +103,8 @@ function isNotFoundError(error: unknown): boolean {
   return readHandledError(error)?.httpStatus === 404;
 }
 
-const fmtUsd = (n: number | string) => {
-  const v = typeof n === "string" ? Number(n) : n;
-  return v === 0 ? "$0.00" : numeral(v).format("$0,0.0000");
-};
-
-const fmtRelative = (iso: string | null): string => {
-  if (!iso) return "-";
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const sec = Math.floor(diffMs / 1000);
-  if (sec < 60) return `${sec}s ago`;
-  const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  const days = Math.floor(hr / 24);
-  return `${days}d ago`;
-};
+const fmtRelative = (iso: string | null): string =>
+  iso ? (formatTimeAgo(new Date(iso).getTime()) ?? "-") : "-";
 
 /** Back link, name, status, and the two manage-only controls. */
 function SourceDetailHeader({
@@ -252,62 +246,6 @@ function SourceHealthCards({
   );
 }
 
-/** The newest 50 OCSF-normalised events, raw next to normalised. */
-function RecentEventsPanel({
-  source,
-  events,
-  error,
-  isLoading,
-}: {
-  source: Source;
-  events: EventRow[];
-  error: unknown;
-  isLoading: boolean;
-}) {
-  return (
-    <Box
-      borderWidth="1px"
-      borderColor="border.muted"
-      borderRadius="md"
-      padding={5}
-    >
-      <VStack align="start" gap={1} marginBottom={3}>
-        <Heading as="h3" size="sm">
-          Recent events
-        </Heading>
-        {!error && (
-          <Text fontSize="sm" color="fg.muted">
-            Last {events.length} OCSF-normalised events from this source. Raw
-            payload + normalised fields shown side-by-side. Newest first.
-          </Text>
-        )}
-      </VStack>
-
-      {isLoading && <Spinner size="sm" />}
-
-      {/* `EmptyEventsHint` walks an admin through setting up an integration.
-          Showing it because the events query failed sends someone debugging a
-          live source off to re-install something that is already working. */}
-      <HandledErrorAlert
-        error={error}
-        fallbackTitle="Couldn't load recent events"
-      />
-
-      {!isLoading && !error && events.length === 0 && (
-        <EmptyEventsHint source={source} />
-      )}
-
-      {events.length > 0 && (
-        <VStack align="stretch" gap={2}>
-          {events.map((ev) => (
-            <EventRow key={ev.eventId} event={ev} />
-          ))}
-        </VStack>
-      )}
-    </Box>
-  );
-}
-
 /**
  * Health counts, the stale-timestamp callout and the event feed. All three
  * come from the activity monitor, which has a grant of its own, so naming
@@ -318,7 +256,7 @@ function SourceActivityPanels({
   source,
   canReadActivity,
   healthQuery,
-  eventsQuery,
+  eventsPager,
 }: {
   source: Source;
   canReadActivity: boolean;
@@ -327,11 +265,7 @@ function SourceActivityPanels({
     error: unknown;
     isLoading: boolean;
   };
-  eventsQuery: {
-    data: EventRow[] | undefined;
-    error: unknown;
-    isLoading: boolean;
-  };
+  eventsPager: SourceEventsPager<EventRow>;
 }) {
   if (!canReadActivity) {
     return (
@@ -342,7 +276,6 @@ function SourceActivityPanels({
     );
   }
   const health = healthQuery.data;
-  const events = eventsQuery.data ?? [];
   return (
     <>
       <SourceHealthCards
@@ -352,13 +285,15 @@ function SourceActivityPanels({
       />
       <StaleTimestampCallout
         health={health ?? null}
-        eventsCount={events.length}
+        eventsCount={eventsPager.loadedCount}
       />
-      <RecentEventsPanel
-        source={source}
-        events={events}
-        error={eventsQuery.error}
-        isLoading={eventsQuery.isLoading}
+      {/* `EmptyEventsHint` walks an admin through setting up an integration.
+          The table only shows it once a load SUCCEEDED and came back empty —
+          showing it on a failed load sends someone debugging a live source
+          off to re-install something that is already working. */}
+      <SourceEventsTable
+        pager={eventsPager}
+        emptyState={<EmptyEventsHint source={source} />}
       />
     </>
   );
@@ -469,13 +404,25 @@ function useIngestionSourceDetailPage() {
       refetchOnWindowFocus: false,
     },
   );
-  const eventsQuery = api.activityMonitor.eventsForSource.useQuery(
-    { organizationId: orgId, sourceId: sourceId ?? "", limit: 20 },
-    {
-      enabled: !!orgId && !!sourceId && canReadActivity,
-      refetchOnWindowFocus: false,
-    },
+  // The events table walks the timestamp cursor itself (see
+  // logic/eventsPager.ts), so it fetches imperatively through the utils
+  // client instead of useQuery: pages once loaded are kept and never
+  // refetched, which pins the first page's time anchor.
+  const utils = api.useUtils();
+  const fetchEventsPage = useCallback(
+    (request: PageRequest) =>
+      utils.activityMonitor.eventsForSource.fetch({
+        organizationId: orgId,
+        sourceId: sourceId ?? "",
+        limit: request.limit,
+        ...(request.beforeIso ? { beforeIso: request.beforeIso } : {}),
+      }),
+    [utils, orgId, sourceId],
   );
+  const eventsPager = useSourceEventsPager<EventRow>({
+    enabled: !!orgId && !!sourceId && canReadActivity,
+    fetchPage: fetchEventsPage,
+  });
   const [secretReveal, setSecretReveal] = useState<{
     secret: string;
     sourceName: string;
@@ -496,7 +443,7 @@ function useIngestionSourceDetailPage() {
     canReadActivity,
     sourceQuery,
     healthQuery,
-    eventsQuery,
+    eventsPager,
     secretReveal,
     setSecretReveal,
     rotateMutation,
@@ -513,7 +460,7 @@ function IngestionSourceDetailPage() {
     canReadActivity,
     sourceQuery,
     healthQuery,
-    eventsQuery,
+    eventsPager,
     secretReveal,
     setSecretReveal,
     rotateMutation,
@@ -576,7 +523,7 @@ function IngestionSourceDetailPage() {
           source={source}
           canReadActivity={canReadActivity}
           healthQuery={healthQuery}
-          eventsQuery={eventsQuery}
+          eventsPager={eventsPager}
         />
       </VStack>
 
@@ -754,128 +701,6 @@ function MetricCard({
           {value}
         </Heading>
       )}
-    </Box>
-  );
-}
-
-function EventRow({ event }: { event: EventRow }) {
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <Box
-      borderWidth="1px"
-      borderColor="border.muted"
-      borderRadius="sm"
-      padding={3}
-    >
-      <HStack gap={3} cursor="pointer" onClick={() => setExpanded((e) => !e)}>
-        <VStack align="start" gap={0} flex={1} minWidth={0}>
-          <HStack gap={2} wrap="wrap">
-            <Badge size="sm" variant="surface">
-              {event.eventType}
-            </Badge>
-            <Text fontSize="sm" fontWeight="medium">
-              {event.actor}
-            </Text>
-            <Text fontSize="sm" color="fg.muted">
-              · {event.action}
-            </Text>
-            <Text fontSize="sm" color="fg.muted">
-              {event.target ? `→ ${event.target}` : ""}
-            </Text>
-          </HStack>
-          <Text fontSize="xs" color="fg.muted">
-            {fmtRelative(event.eventTimestampIso)} · cost{" "}
-            {fmtUsd(event.costUsd)}
-            {(event.tokensInput > 0 || event.tokensOutput > 0) && (
-              <>
-                {" · "}
-                {numeral(event.tokensInput).format("0,0")} →{" "}
-                {numeral(event.tokensOutput).format("0,0")} tokens
-              </>
-            )}
-          </Text>
-        </VStack>
-        <Text fontSize="xs" color="fg.muted">
-          {expanded ? "▲" : "▼"}
-        </Text>
-      </HStack>
-      {expanded && (
-        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={3} marginTop={3}>
-          <NormalisedPanel event={event} />
-          <RawPanel event={event} />
-        </SimpleGrid>
-      )}
-    </Box>
-  );
-}
-
-function NormalisedPanel({ event }: { event: EventRow }) {
-  return (
-    <Box>
-      <Text
-        fontSize="xs"
-        fontWeight="semibold"
-        color="fg.muted"
-        marginBottom={1}
-      >
-        Normalised (OCSF)
-      </Text>
-      <Code
-        display="block"
-        padding={3}
-        fontSize="xs"
-        whiteSpace="pre-wrap"
-        wordBreak="break-all"
-        backgroundColor="bg.subtle"
-      >
-        {JSON.stringify(
-          {
-            eventId: event.eventId,
-            eventType: event.eventType,
-            actor: event.actor,
-            action: event.action,
-            target: event.target,
-            costUsd: event.costUsd,
-            tokensInput: event.tokensInput,
-            tokensOutput: event.tokensOutput,
-            eventTimestamp: event.eventTimestampIso,
-            ingestedAt: event.ingestedAtIso,
-          },
-          null,
-          2,
-        )}
-      </Code>
-    </Box>
-  );
-}
-
-function RawPanel({ event }: { event: EventRow }) {
-  let parsed: unknown = null;
-  try {
-    parsed = JSON.parse(event.rawPayload);
-  } catch {
-    // not JSON, render as text
-  }
-  return (
-    <Box>
-      <Text
-        fontSize="xs"
-        fontWeight="semibold"
-        color="fg.muted"
-        marginBottom={1}
-      >
-        Raw payload (as ingested)
-      </Text>
-      <Code
-        display="block"
-        padding={3}
-        fontSize="xs"
-        whiteSpace="pre-wrap"
-        wordBreak="break-all"
-        backgroundColor="bg.subtle"
-      >
-        {parsed != null ? JSON.stringify(parsed, null, 2) : event.rawPayload}
-      </Code>
     </Box>
   );
 }

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -566,7 +566,8 @@ function StaleTimestampCallout({
       borderRadius="md"
     >
       <Text fontSize="sm" color="amber.900">
-        <strong>Heads up:</strong> the events list shows {eventsCount} event
+        <strong>Heads up:</strong> the events table below has loaded{" "}
+        {eventsCount} event
         {eventsCount === 1 ? "" : "s"}, but the rolling
         24h&nbsp;/&nbsp;7d&nbsp;/&nbsp;30d health windows are all zero. Your
         events likely have a stale <Code fontSize="xs">startTimeUnixNano</Code>{" "}

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -192,8 +192,73 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       | upstream connection status                            |
       | "Send test event" button (push/webhook sources)       |
       | "Run poll now" button (pull sources)                  |
-      | last 50 events ingested with raw + normalised side-by-side |
+      | a paginated table of ingested events, newest first    |
     And from this page the admin can rotate the ingestSecret atomically
+
+  Rule: The events table pages through everything the source ever ingested
+
+    The server hands out events in cursor pages — newest first, a
+    timestamp cursor, no total count. The table walks that cursor, so
+    every event is reachable, not just the newest batch. Because there
+    is no total, the pager promises only what it can honour: pages
+    already visited plus the next one, and no grand-total line. Order
+    is fixed at newest-first; the table offers no sort headers and no
+    search box, because with cursor pages they could only sort or
+    search the page in hand, which would lie.
+
+    The walk overlaps each boundary and drops rows it already showed,
+    so events tied on one millisecond survive the page cut — up to the
+    server's single-fetch maximum per tied millisecond; past that the
+    walk moves on rather than looping. Pages once loaded are kept, and
+    the first page's time anchor is captured once, so walking back
+    never re-asks the server and never shows different rows.
+
+    Scenario: Events render as a table, newest first
+      Given a source has ingested events
+      When the admin opens the source's detail page
+      Then the events appear as table rows, newest first
+      And each row shows when it happened, its type, who acted,
+        the action, its target, its cost and its token usage
+      And the time reads relatively, with the exact timestamp on hover
+
+    Scenario: The table pages through more events than fit at once
+      Given a source has ingested more events than one page holds
+      When the admin moves to the next page
+      Then the following, older events are listed
+      And moving back returns to the exact rows they came from,
+        re-read from what was already loaded, not from the server
+
+    Scenario: Changing rows-per-page starts over from the first page
+      Given the admin is a few pages into the events table
+      When they pick a different rows-per-page size
+      Then the table returns to the first page at the new size
+
+    Scenario: A row opens into raw + normalised detail
+      When the admin clicks an event row
+      Then the row expands to show the normalised event
+      And for a pulled event, the raw payload as ingested sits beside it
+      And for a pushed event, whose raw body is never stored, the raw
+        panel says so instead of sitting silently empty
+      And clicking again folds the detail away
+
+    Scenario: Events sharing a timestamp are not lost at a page boundary
+      Given several events were stamped with the same millisecond
+      And fewer of them than the server's single-fetch maximum
+      And they straddle a page boundary
+      When the admin walks from one page to the next
+      Then every one of the tied events appears on exactly one page
+
+    Scenario: A failed load is an error, never an empty list
+      Given the events request fails
+      When the admin views the events section
+      Then they see an error message
+      And they do NOT see the "no events yet" setup walkthrough
+
+    Scenario: The pager offers no control it cannot honour
+      When the admin looks at the events table
+      Then there are no sortable column headers and no search box
+      And the pager shows no grand total of events
+      And only visited pages and the immediate next page can be opened
 
   Scenario: ingestSecret rotation
     When the admin clicks "Rotate secret"

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -213,6 +213,7 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
     the first page's time anchor is captured once, so walking back
     never re-asks the server and never shows different rows.
 
+    @integration
     Scenario: Events render as a table, newest first
       Given a source has ingested events
       When the admin opens the source's detail page
@@ -221,6 +222,7 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
         the action, its target, its cost and its token usage
       And the time reads relatively, with the exact timestamp on hover
 
+    @integration
     Scenario: The table pages through more events than fit at once
       Given a source has ingested more events than one page holds
       When the admin moves to the next page
@@ -228,11 +230,13 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       And moving back returns to the exact rows they came from,
         re-read from what was already loaded, not from the server
 
+    @integration
     Scenario: Changing rows-per-page starts over from the first page
       Given the admin is a few pages into the events table
       When they pick a different rows-per-page size
       Then the table returns to the first page at the new size
 
+    @integration
     Scenario: A row opens into raw + normalised detail
       When the admin clicks an event row
       Then the row expands to show the normalised event
@@ -241,6 +245,7 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
         panel says so instead of sitting silently empty
       And clicking again folds the detail away
 
+    @integration
     Scenario: Events sharing a timestamp are not lost at a page boundary
       Given several events were stamped with the same millisecond
       And fewer of them than the server's single-fetch maximum
@@ -248,12 +253,14 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       When the admin walks from one page to the next
       Then every one of the tied events appears on exactly one page
 
+    @integration
     Scenario: A failed load is an error, never an empty list
       Given the events request fails
       When the admin views the events section
       Then they see an error message
       And they do NOT see the "no events yet" setup walkthrough
 
+    @integration
     Scenario: The pager offers no control it cannot honour
       When the admin looks at the events table
       Then there are no sortable column headers and no search box

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -197,21 +197,20 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
 
   Rule: The events table pages through everything the source ever ingested
 
-    The server hands out events in cursor pages — newest first, a
-    timestamp cursor, no total count. The table walks that cursor, so
-    every event is reachable, not just the newest batch. Because there
-    is no total, the pager promises only what it can honour: pages
-    already visited plus the next one, and no grand-total line. Order
-    is fixed at newest-first; the table offers no sort headers and no
-    search box, because with cursor pages they could only sort or
-    search the page in hand, which would lie.
+    Every event the source ever ingested is reachable, not just the
+    newest batch. The admin walks pages newest-first; nothing is known
+    about how many events exist in total, so the pager promises only
+    what it can honour: pages already visited plus the next one, and no
+    grand-total line. Order is fixed at newest-first, and there are no
+    sort headers and no search box — either would only act on the page
+    in hand and quietly lie about the rest.
 
-    The walk overlaps each boundary and drops rows it already showed,
-    so events tied on one millisecond survive the page cut — up to the
-    server's single-fetch maximum per tied millisecond; past that the
-    walk moves on rather than looping. Pages once loaded are kept, and
-    the first page's time anchor is captured once, so walking back
-    never re-asks the server and never shows different rows.
+    Two honesty boundaries the scenarios below pin down: events stamped
+    on the same millisecond are never lost to a page cut, up to one
+    fetch's worth per millisecond, past which the walk moves on rather
+    than looping; and pages once seen do not change — walking back
+    shows exactly the rows the admin came from, even while new events
+    keep arriving.
 
     @integration
     Scenario: Events render as a table, newest first


### PR DESCRIPTION
## Why

The events list on an ingestion source's detail page was a card stack hard-capped at the newest 20 events — everything older was unreachable, and the layout didn't match the table idiom the rest of the app settled on (sessions, automations, traces). Admins auditing a source need to reach every event it ever ingested.

## What changed

The events section is now a `ListTable` + `Pagination` that pages through the source's whole history, newest first — with **zero backend changes**:

- **Cursor walk over the existing endpoint.** `eventsForSource` pages by a strictly-older-than timestamp cursor with no total and no id tiebreak. New pure logic (`logic/eventsPager.ts`) walks it: each next page overlaps the boundary by 1ms and drops the rows already shown, so events tied on one millisecond survive the page cut instead of being skipped forever. One sentinel row beyond the page size doubles as the has-more signal.
- **A pagination bar with no total it doesn't know.** The shared `Pagination` runs in cursor mode for the first time without a server total: it's fed rows-loaded plus one sentinel, prints no grand-total line, and only visited pages plus the immediate next one can be opened.
- **No control the cursor cannot honour.** No sort headers, no search box, no jump to an unvisited page — with cursor pages they could only sort or search the page in hand, which would lie.
- **Row expansion preserved.** Click still opens raw + normalised side by side; a pushed event's raw panel now says the body is never stored instead of sitting silently empty (push-origin events structurally have no raw payload).
- Pages once loaded are kept and never refetched, pinning the first page's time anchor so walking back lands on the exact rows left. Local `fmtRelative` gave way to the shared `formatTimeAgo`.

Spec: `specs/ai-gateway/governance/ingestion-sources.feature`, new rule "The events table pages through everything the source ever ingested" (7 scenarios, all `@integration`-bound).

## How it works

The walk's correctness boundary, stated plainly: tie recovery is exact up to one server fetch (200 rows) per tied millisecond; past that the walk skips the remainder deterministically rather than looping. An optional `beforeId` tiebreak on the server would make recovery exact — deliberately left out to keep this PR zero-backend; noted as follow-up.

## Test plan

- `logic/__tests__/eventsPager.unit.test.ts` (11 tests): boundary overlap, tie recovery (the exact skipped-sibling case), stall fallback, sentinel has-more, server-limit cap, pagination view math.
- `components/__tests__/SourceEventsTable.integration.test.tsx` (10 tests, jsdom, real pager hook against a fake server implementing the endpoint's actual strict-`<` contract): render/columns, expand raw+normalised, pushed-event raw notice, page walk + instant back without refetch, page-size reset, tied-events-across-boundary recovery, error-never-empty-state, no-sort/no-search/no-total, **regression: pager resets when the source under it changes**.
- Full governance suite green (382 unit + 30 component), typecheck and lint clean, feature-parity binds the new scenarios.

Self-review (adversarial pass) already ran on this branch; two findings were fixed on their own commits:
- stale pages when the page stays mounted across a source/org change (multi-hop history navigation) — the pager now resets when its fetch identity changes;
- the new scenarios were untagged, so the parity check skipped them — now `@integration`-bound.

Waived, recorded for the reviewer: the table's row type is a structural duplicate of the `RouterOutputs` row (convention elsewhere derives it; type-only, already flagged); `fmtUsd` carries the replaced code's formatter verbatim (no NaN guard, sub-$0.0001 flattens to `$0.0000`).

## Anything surprising?

- Browser-level proof of the UI flow is pending: no local stack was running when the proof step executed, and starting one is outside its mandate. Run the stack and re-run the browser pass before merge if screenshots are wanted on this PR.
- If more than 200 events ever share one exact millisecond on one source, the rows past the 200th of that millisecond are unreachable to the walk (skipped deterministically, never looped on). Fixing that needs the optional `beforeId` server tiebreak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a paginated, newest-first events table to ingestion-source details.
  - Browse cached event pages with configurable page sizes and navigation controls.
  - Expand rows to view normalized event details and raw payloads.
  - Added clear loading, empty, error, and missing-payload states.
  - Improved pagination reliability when events share timestamps and across source changes.

- **Documentation**
  - Updated ingestion-source specifications to document event history, pagination, and table limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->