### PR TITLE
ci(pr-auto-approve): route PR evaluation through LangWatch AI Gateway

### DIFF
--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -322,7 +322,11 @@ jobs:
         id: llm
         if: steps.pr-data.outputs.oversized == 'false' && steps.path-check.outputs.blocked == 'false'
         env:
-          OPENAI_API_KEY: ${{ secrets.LOW_RISK_OPENAI_API_KEY }}
+          # OpenAI traffic rides the LangWatch AI Gateway: the key is a
+          # gateway virtual key, and the base URL env vars point the
+          # openai and langchain client families at it.
+          OPENAI_API_KEY: ${{ secrets.LOW_RISK_GATEWAY_VIRTUAL_KEY }}
+          OPENAI_BASE_URL: https://gateway.langwatch.ai/v1
         run: |
           POLICY=$(cat dev/docs/LOW_RISK_PULL_REQUESTS.md)
           PR_TITLE=$(cat /tmp/pr_title.txt)
@@ -365,7 +369,7 @@ jobs:
               ]
             }')
 
-          RESPONSE=$(curl -s --max-time 60 https://api.openai.com/v1/chat/completions \
+          RESPONSE=$(curl -s --max-time 60 "$OPENAI_BASE_URL/chat/completions" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $OPENAI_API_KEY" \
             -d "$PAYLOAD")


### PR DESCRIPTION
## Reviewer cockpit

**Scariest thing:** this PR edits `.github/workflows/`, which is a restricted path in `pr-auto-approve.yml` itself (`RESTRICTED_PATTERN`, line 302). So on **this** PR the `Evaluate PR with OpenAI` step is skipped by design and the change is **not** exercised here. Real proof only arrives on the next unrelated PR.

**Start here:** `.github/workflows/pr-auto-approve.yml`, the `Evaluate PR with OpenAI` step (env block + the `curl` target).

## Why

The `evaluate` job has been failing. Verbatim error from run 32378375992:

```
"message": "You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
"type": "insufficient_quota",
"code": "credit_balance_exhausted"
```

The step called `api.openai.com` directly with `LOW_RISK_OPENAI_API_KEY`, an account that is out of credits.

## What changed

Adopt the LangWatch AI Gateway pattern the SDK workflows already use, instead of topping up a second billing account:

- `sdk-python-ci.yml:126-128`
- `sdk-javascript-ci.yml:150-152`

Three changes, all inside the one step:

1. `OPENAI_API_KEY` now reads `secrets.LOW_RISK_GATEWAY_VIRTUAL_KEY` (a gateway virtual key) instead of `secrets.LOW_RISK_OPENAI_API_KEY`.
2. Added `OPENAI_BASE_URL: https://gateway.langwatch.ai/v1` (bare literal, same as the SDK workflows).
3. The `curl` target changed from the hardcoded `https://api.openai.com/v1/chat/completions` to `"$OPENAI_BASE_URL/chat/completions"`.

The old secret is left in place so a revert is a one-line change.

## How it works

The request body is unchanged, including `model: gpt-5-mini` and `response_format: {type: json_schema, strict: true}`. That is safe because the gateway does not rewrite bodies on the OpenAI lane:

- `services/aigateway/adapters/providers/param_policy.go:12-16` — "Raw-forward lanes (OpenAI, Azure, vLLM) pass the body through byte-identical and are never consulted here."
- `param_policy.go:52-55` — `policyLaneFor` returns `("", false)` for OpenAI-compatible providers.
- `param_policy.go:541-545` — `applyParamPolicy` returns immediately when that lookup fails, skipping the whole `response_format` policy table.
- `bifrost_parser.go:199-206` — `isOpenAICompatibleProvider` is a closed switch over `OpenAI, Azure, VLLM`.
- `bifrost_parser.go:234-241` — `gpt-5-mini` maps to the OpenAI provider.

## Test plan

**Proven:**
- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-auto-approve.yml'))"` exits 0.
- Diff is exactly the three changes above: `git diff --stat` → `1 file changed, 6 insertions(+), 2 deletions(-)`.
- The secret exists: `gh secret list --repo langwatch/langwatch` lists `LOW_RISK_GATEWAY_VIRTUAL_KEY` (created 2026-08-20T15:39:51Z).
- `gpt-5-mini` is routable on the gateway: `config_wire_test.go:188-198`; `docs/ai-gateway/api/models.mdx:26`.

**Claimed, not proven:**
- That a live PR evaluation succeeds through the gateway. It **cannot** be proven on this PR (restricted path, see cockpit). No gateway test covers `json_schema` on the OpenAI lane — the passthrough argument above is a code read, not a test.

**How to actually prove it:** after merge, open any PR that does not touch `.github/workflows/` and confirm the `evaluate` job reaches a verdict instead of erroring.

## Human verification

<!-- no-ui-surface -->
Backend/CI-only change: one GitHub Actions workflow file. No UI surface, so no
screenshot or recording applies.

To verify by hand:
1. `gh secret list --repo langwatch/langwatch | grep LOW_RISK_GATEWAY_VIRTUAL_KEY`
   — confirms the key this workflow now reads exists.
2. Read the diff: the request body is byte-identical; only the credential and
   the endpoint change.
3. After merge, open any PR that does NOT touch `.github/workflows/` and read
   the `evaluate` job. A verdict there is the real proof.

## How I can prove I was successful

**Proven**
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-auto-approve.yml'))"` exits 0.
- `git diff --stat origin/main HEAD` → `1 file changed, 6 insertions(+), 2 deletions(-)`.
- `gh pr view 7343 --json files` → exactly one file.
- Secret `LOW_RISK_GATEWAY_VIRTUAL_KEY` exists (created 2026-08-20T15:39:51Z).
- `gpt-5-mini` is routable on the gateway: `config_wire_test.go:188-198`, `docs/ai-gateway/api/models.mdx:26`.
- Gateway raw-forwards the OpenAI lane: `param_policy.go:12-16`, `:52-55`, `:541-545`; `bifrost_parser.go:199-206`.
- CI on this PR: 86/86 check-runs collected, zero non-success after dedupe by `started_at`.

**Claimed, not proven**
- No live call has been made through the gateway with this key. The virtual key's
  authorisation for `gpt-5-mini` is unverified from outside the LangWatch project.
- No test in the repo exercises `response_format: json_schema` on the OpenAI lane.
- This PR touches `.github/workflows/`, which is a restricted path
  (`pr-auto-approve.yml:302`), so its own `evaluate` step is skipped. Green here
  means "nothing broke", not "the gateway works".

## Anything surprising?

- No repo variable is used: `gh variable list --repo langwatch/langwatch` is empty, so the URL is a bare literal matching the SDK workflows.
- If the virtual key is not authorised for `gpt-5-mini`, this trades a quota error for an auth error. The first post-merge PR is the check.

