### PR TITLE
fix(governance): a walk id keeps the events pager's latest walk from losing to a stale failure

### DIFF
--- a/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/SourceEventsTable.integration.test.tsx
@@ -317,6 +317,33 @@ describe("given React mounts the table twice, as StrictMode does in development"
     expect(screen.getAllByTestId("source-event-row")).toHaveLength(1);
     expect(screen.queryByTestId("pagination-page-2")).toBeNull();
   });
+
+  it("shows the page the second walk fetched when the first one failed", async () => {
+    // Both starts share a generation and one in-flight flag, so only a
+    // per-walk id can tell the outdated failure from the landing that
+    // actually carries rows.
+    const realServer = fakeServer([
+      makeEvent({ id: "only", ts: BASE_TS, actor: "actor-second@acme.test" }),
+    ]);
+    let shouldFailNext = true;
+    const flakyServer = vi.fn(async (req: PageRequest) => {
+      if (shouldFailNext) {
+        shouldFailNext = false;
+        throw new Error("transient");
+      }
+      return realServer(req);
+    });
+    render(
+      <StrictMode>
+        <ChakraProvider value={defaultSystem}>
+          <Harness fetchPage={flakyServer} pageSize={10} />
+        </ChakraProvider>
+      </StrictMode>,
+    );
+
+    await screen.findByText("actor-second@acme.test");
+    expect(screen.queryByText("Couldn't load this source's events")).toBeNull();
+  });
 });
 
 describe("given a page fetch fails mid-walk", () => {
@@ -331,10 +358,10 @@ describe("given a page fetch fails mid-walk", () => {
       }),
     );
     const realServer = fakeServer(twelve);
-    let failNext = false;
+    let shouldFailNext = false;
     const flakyServer = vi.fn(async (req: PageRequest) => {
-      if (failNext) {
-        failNext = false;
+      if (shouldFailNext) {
+        shouldFailNext = false;
         throw new Error("transient");
       }
       return realServer(req);
@@ -342,7 +369,7 @@ describe("given a page fetch fails mid-walk", () => {
     renderTable({ fetchPage: flakyServer, pageSize: 10 });
     await screen.findByText("actor-e00@acme.test");
 
-    failNext = true;
+    shouldFailNext = true;
     await user.click(screen.getByTestId("pagination-next"));
     await screen.findByText("Couldn't load more events");
     // The walked pages survive the failure.

--- a/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
+++ b/platform/app/ee/governance/dashboard/components/useSourceEventsPager.ts
@@ -51,14 +51,20 @@ type PagerState<R extends PagerRow> = {
   /** Bumped on every reset; a fetch started before a reset landed in a
    * world that no longer exists and its result is discarded. */
   generation: number;
+  /** The walk whose outcome still counts: the one the latest start
+   * issued. Overlapping walks share a generation, not an id. */
+  activeWalkId: number;
 };
+
+/** What a settled walk must match to still be the current one. */
+type WalkOutcome = { generation: number; walkId: number };
 
 type PagerAction<R extends PagerRow> =
   | { type: "reset" }
   | { type: "resize"; pageSize: number }
-  | { type: "fetchStart" }
-  | { type: "fetchLanded"; generation: number; rows: R[]; hasMore: boolean }
-  | { type: "fetchFailed"; generation: number; error: unknown }
+  | { type: "fetchStart"; walkId: number }
+  | ({ type: "fetchLanded"; rows: R[]; hasMore: boolean } & WalkOutcome)
+  | ({ type: "fetchFailed"; error: unknown } & WalkOutcome)
   | { type: "show"; page: number };
 
 const initPagerState = <R extends PagerRow>(
@@ -71,6 +77,7 @@ const initPagerState = <R extends PagerRow>(
   error: null,
   isFetching: false,
   generation: 0,
+  activeWalkId: 0,
 });
 
 function landFetch<R extends PagerRow>({
@@ -98,15 +105,21 @@ function landFetch<R extends PagerRow>({
 
 /**
  * A landing only counts while its walk is still the current one: same
- * generation AND a fetch still marked in flight. The second guard makes
- * a duplicated start (StrictMode's double effect run) harmless — the
- * first landing clears `isFetching`, so the echo is dropped instead of
- * appended as a phantom page.
+ * generation, and the id the latest start issued. Duplicated starts
+ * (StrictMode's double effect run) share a generation but not an id, so
+ * the newest walk wins whichever settles first — an older walk's
+ * outcome is dropped whether it succeeded or failed, instead of
+ * appending a phantom page or stranding the pager in error.
  */
-const isCurrentWalk = <R extends PagerRow>(
-  state: PagerState<R>,
-  generation: number,
-) => generation === state.generation && state.isFetching;
+const isCurrentWalk = <R extends PagerRow>({
+  state,
+  action,
+}: {
+  state: PagerState<R>;
+  action: WalkOutcome;
+}) =>
+  action.generation === state.generation &&
+  action.walkId === state.activeWalkId;
 
 function pagerReducer<R extends PagerRow>(
   state: PagerState<R>,
@@ -126,13 +139,18 @@ function pagerReducer<R extends PagerRow>(
     case "fetchStart":
       // Starting a walk is also the retry: a failure from the previous
       // attempt stops being true the moment a new fetch is in flight.
-      return { ...state, isFetching: true, error: null };
+      return {
+        ...state,
+        isFetching: true,
+        error: null,
+        activeWalkId: action.walkId,
+      };
     case "fetchLanded":
-      return isCurrentWalk(state, action.generation)
+      return isCurrentWalk({ state, action })
         ? landFetch({ state, rows: action.rows, hasMore: action.hasMore })
         : state;
     case "fetchFailed":
-      return isCurrentWalk(state, action.generation)
+      return isCurrentWalk({ state, action })
         ? { ...state, error: action.error, isFetching: false }
         : state;
     case "show":
@@ -224,9 +242,13 @@ export function useSourceEventsPager<R extends PagerRow>({
     initPagerState<R>,
   );
 
+  // Issued per walk rather than per render: two walks started from the
+  // same snapshot must still be told apart when they settle.
+  const walkIdRef = useRef(0);
   const startFetch = useCallback(
-    (snapshot: PagerState<R>) => {
-      dispatch({ type: "fetchStart" });
+    ({ snapshot }: { snapshot: PagerState<R> }) => {
+      const walkId = ++walkIdRef.current;
+      dispatch({ type: "fetchStart", walkId });
       walkOnePage({
         pageSize: snapshot.pageSize,
         displayedRows: snapshot.pages?.flat() ?? [],
@@ -236,6 +258,7 @@ export function useSourceEventsPager<R extends PagerRow>({
           dispatch({
             type: "fetchLanded",
             generation: snapshot.generation,
+            walkId,
             rows,
             hasMore,
           }),
@@ -243,6 +266,7 @@ export function useSourceEventsPager<R extends PagerRow>({
           dispatch({
             type: "fetchFailed",
             generation: snapshot.generation,
+            walkId,
             error,
           }),
       );
@@ -265,7 +289,7 @@ export function useSourceEventsPager<R extends PagerRow>({
   useEffect(() => {
     const untouched =
       state.pages === null && state.error === null && !state.isFetching;
-    if (enabled && untouched) startFetch(state);
+    if (enabled && untouched) startFetch({ snapshot: state });
   }, [enabled, state, startFetch]);
 
   const goToPage = useCallback(
@@ -274,7 +298,7 @@ export function useSourceEventsPager<R extends PagerRow>({
       if (target <= state.pages.length) {
         dispatch({ type: "show", page: target });
       } else if (target === state.pages.length + 1 && state.hasMore) {
-        startFetch(state);
+        startFetch({ snapshot: state });
       }
     },
     [state, startFetch],


### PR DESCRIPTION
# Related Issue

- Resolves #7346

Fixes #7346.

Under StrictMode the initial-load effect starts two walks sharing one generation and one `isFetching` flag. When the first walk's fetch failed before the second's succeeded, the failure passed the `isCurrentWalk` guard, cleared `isFetching`, and the subsequent success was dropped — full error alert despite a successful fetch.

## Fix

Per-walk identity in `useSourceEventsPager.ts`: `startFetch` issues a monotonic walk id from a ref, `fetchStart` records it as `activeWalkId`, and landings must match it (as well as the generation) to be absorbed. The latest start overwrites the stored id, so the newest walk wins in either settle order; the `isFetching` half of the old guard is gone — a walk settles exactly once, so an id can never land twice.

## Red first

New regression test in the StrictMode block: first fetch rejects, second resolves. On unfixed code it reproduced the exact symptom ("Couldn't load this source's events" while the second fetch had succeeded); it passes with the fix.

Also carries the cosmetic rider from the issue: `failNext` → `shouldFailNext` in the integration test.

## Verification

- Component tests: 15/15 on the file, 35/35 across `ee/governance/dashboard/`
- Unit tests: 49/49 across the dashboard logic
- `pnpm typecheck` and `pnpm typecheck:all` clean
- Zero new lint violations on touched files vs origin/main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data loading reliability when requests overlap or are retried.
  - Ensured the latest successful request is displayed after an earlier request fails.
  - Prevented outdated request results from adding duplicate pages or leaving an incorrect error state.

- **Tests**
  - Added coverage for successful retries and duplicate loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->