### PR TITLE
feat(governance): the nav commits the catalog direction

### DIFF
--- a/FEATURE_MAP.md
+++ b/FEATURE_MAP.md
@@ -19,7 +19,7 @@ prompt-management/   — Prompts, Prompt Playground
 library/             — Agents, Workflows, Evaluators, Datasets
 dashboards/          — Custom analytics dashboards
 triggers/            — Automations / alerts
-ai-gateway/          — Virtual Keys, Budgets, Governance, Ingestion Sources
+ai-gateway/          — Virtual Keys, Budgets, Governance, Catalog (ingestion)
 settings/            — Model Providers, Model Defaults, Project Secrets
 ```
 
@@ -87,7 +87,7 @@ Legend: ✅ present · — absent · `—` no SDK/CLI/skill/MCP by design
 | Virtual Keys | — | — | — | ✅ | — | ✅ | — | — | ✅ | ✅ |
 | Budgets | — | — | — | ✅ | — | ✅ | — | — | ✅ | ✅ |
 | Governance | — | — | — | ✅ | — | ✅ | — | — | ✅ | ✅ |
-| Ingestion Sources | — | — | — | ✅ | — | ✅ | — | — | ✅ | ✅ |
+| Catalog (ingestion) | — | — | — | ✅ | — | ✅ | — | — | ✅ | ✅ |
 | **Settings** | | | | | | | | | | |
 | Projects | — | — | ✅ | ✅ | — | ✅ | ✅ | — | ✅ | — |
 | Model Providers | ✅ | ✅ | — | ✅ | — | ✅ | ✅ | — | ✅ | ✅ |

--- a/feature-map.json
+++ b/feature-map.json
@@ -1044,8 +1044,8 @@
         },
         {
           "id": "ai-gateway.ingest",
-          "name": "Ingestion Sources",
-          "description": "OCSF-normalised event ingestion: inspect sources, tail events, check health, and recover coding-agent conversation content",
+          "name": "Catalog",
+          "description": "OCSF-normalised event ingestion (admin UI label: Catalog): inspect ingestion sources, tail events, check health, and recover coding-agent conversation content",
           "surfaces": {
             "code": {
               "sdk": {

--- a/feature-map.json
+++ b/feature-map.json
@@ -1044,8 +1044,8 @@
         },
         {
           "id": "ai-gateway.ingest",
-          "name": "Catalog",
-          "description": "OCSF-normalised event ingestion (admin UI label: Catalog): inspect ingestion sources, tail events, check health, and recover coding-agent conversation content",
+          "name": "Catalog (ingestion)",
+          "description": "OCSF-normalised event ingestion: inspect ingestion sources, tail events, check health, and recover coding-agent conversation content",
           "surfaces": {
             "code": {
               "sdk": {

--- a/platform/app/e2e/admin-ottl-dogfood.ts
+++ b/platform/app/e2e/admin-ottl-dogfood.ts
@@ -69,7 +69,7 @@ void (async () => {
     await page.goto(`${BASE_URL}/governance/tool-catalog`);
     await page.waitForLoadState("networkidle");
     await page
-      .locator('text="AI Tool Catalog"')
+      .locator('text="AI Tool Tiles"')
       .first()
       .waitFor({ state: "visible", timeout: 10_000 });
     await shoot(page, "01-tool-catalog-landing");

--- a/platform/app/e2e/full-uiqa-walkthrough.ts
+++ b/platform/app/e2e/full-uiqa-walkthrough.ts
@@ -7,7 +7,7 @@
  * Sections:
  *  A. /me portal — admin POV
  *  B. Govern → AI Gateway sub-tree (virtual-keys list, budgets, usage)
- *  C. Govern → Governance bird-eye + Tool Catalog + Anomaly Rules + Ingestion + Routing
+ *  C. Govern → Governance bird-eye + Tool Tiles + Anomaly Rules + Catalog + Routing
  *  D. Settings → Members + Teams + Roles + Audit Log
  *  E. Tile install drawer (Claude Code)
  *  F. AI Tools Portal cold visit (workspace switcher, /me/devices, /me/settings)

--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -206,7 +206,7 @@ function IngestionSourcesHeader({
     <HStack alignItems="end">
       <VStack align="start" gap={0}>
         <HStack gap={2}>
-          <Heading size="md">Ingestion Sources</Heading>
+          <Heading size="md">Catalog</Heading>
           <Badge colorPalette="purple" size="sm" variant="surface">
             Preview
           </Badge>
@@ -586,7 +586,7 @@ function IngestionSourcesPage() {
   } = useIngestionSourcesPage();
 
   return (
-    <GovernanceLayout pageTitle="Ingestion Sources · Governance · LangWatch">
+    <GovernanceLayout pageTitle="Catalog · Governance · LangWatch">
       <VStack align="stretch" gap={6} width="full" maxW="container.xl">
         <IngestionSourcesHeader
           isEnterprise={isEnterprise}

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -331,9 +331,9 @@ describe("the product sidebar", () => {
       renderSidebar("governance");
 
       expect(screen.getByText("Overview")).toBeInTheDocument();
-      expect(screen.getByText("Ingestion Sources")).toBeInTheDocument();
+      expect(screen.getByText("Catalog")).toBeInTheDocument();
       expect(screen.getByText("Anomaly Rules")).toBeInTheDocument();
-      expect(screen.getByText("Tool Catalog")).toBeInTheDocument();
+      expect(screen.getByText("Tool Tiles")).toBeInTheDocument();
       expect(screen.getByText("Departments")).toBeInTheDocument();
     });
   });

--- a/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
@@ -87,9 +87,9 @@ describe("given the governance section navigation data", () => {
         capturedItems.map((item) => ({ label: item.label, href: item.href })),
       ).toEqual([
         { label: "Overview", href: "/governance" },
-        { label: "Ingestion Sources", href: "/governance/ingestion-sources" },
+        { label: "Catalog", href: "/governance/ingestion-sources" },
         { label: "Anomaly Rules", href: "/governance/anomaly-rules" },
-        { label: "Tool Catalog", href: "/governance/tool-catalog" },
+        { label: "Tool Tiles", href: "/governance/tool-catalog" },
         { label: "Departments", href: "/governance/departments" },
       ]);
     });

--- a/platform/app/src/features/navigation/sectionNavItems.ts
+++ b/platform/app/src/features/navigation/sectionNavItems.ts
@@ -96,7 +96,7 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     icon: Eye,
   },
   {
-    label: "Ingestion Sources",
+    label: "Catalog",
     href: "/governance/ingestion-sources",
     includePath: "/governance/ingestion-sources",
     icon: PlugZap,
@@ -108,7 +108,7 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     icon: AlertTriangle,
   },
   {
-    label: "Tool Catalog",
+    label: "Tool Tiles",
     href: "/governance/tool-catalog",
     includePath: "/governance/tool-catalog",
     icon: PackageOpen,

--- a/platform/app/src/pages/governance/__tests__/delegatedViewer.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/delegatedViewer.integration.test.tsx
@@ -241,8 +241,8 @@ describe("governance pages for a delegated viewer", () => {
       expect(screen.getByText(/governance:manage/)).toBeInTheDocument();
     });
 
-    /** @scenario "The tool catalog names its own grant" */
-    it("names aiTools:manage on the tool catalog and renders no editor", () => {
+    /** @scenario "The tool tiles page names its own grant" */
+    it("names aiTools:manage on the tool tiles page and renders no editor", () => {
       renderPage(ToolCatalogPage);
 
       expect(screen.getByText(/aiTools:manage/)).toBeInTheDocument();
@@ -265,7 +265,7 @@ describe("governance pages for a delegated viewer", () => {
   });
 
   describe("when the viewer can read ingestion sources but not manage them", () => {
-    /** @scenario "Ingestion sources offers no controls a viewer cannot use" */
+    /** @scenario "The catalog offers no controls a viewer cannot use" */
     it("offers no source authoring controls", () => {
       harness.permissions = [...DELEGATED_VIEWER, "ingestionSources:view"];
       renderPage(IngestionSourcesPage);

--- a/platform/app/src/pages/governance/tool-catalog.tsx
+++ b/platform/app/src/pages/governance/tool-catalog.tsx
@@ -13,7 +13,7 @@ import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 
 /**
- * Admin AI Tool Catalog editor - Phase 7 B6+B9 wired surface.
+ * Admin AI Tool Tiles editor - Phase 7 B6+B9 wired surface.
  *
  * Two tabs per `ingestion-templates-catalog.feature` @admin-readonly
  * scenario:
@@ -48,12 +48,12 @@ function ToolCatalogPage() {
 
   if (!canManageCatalog) {
     return (
-      <GovernanceLayout pageTitle="Tool Catalog · Governance · LangWatch">
+      <GovernanceLayout pageTitle="Tool Tiles · Governance · LangWatch">
         <VStack align="stretch" gap={6} width="full">
           <ToolCatalogHeading />
           <PermissionRequiredNotice
             permission="aiTools:manage"
-            detail="The catalog and the ingestion templates stay hidden until then."
+            detail="The tiles and the ingestion templates stay hidden until then."
           />
         </VStack>
       </GovernanceLayout>
@@ -61,7 +61,7 @@ function ToolCatalogPage() {
   }
 
   return (
-    <GovernanceLayout pageTitle="Tool Catalog · Governance · LangWatch">
+    <GovernanceLayout pageTitle="Tool Tiles · Governance · LangWatch">
       <VStack align="stretch" gap={6} width="full">
         <ToolCatalogHeading />
 
@@ -119,10 +119,10 @@ function ToolCatalogHeading() {
     <HStack alignItems="end">
       <VStack align="start" gap={0}>
         <Heading as="h2" size="lg">
-          AI Tool Catalog
+          AI Tool Tiles
         </Heading>
         <Text color="fg.muted" fontSize="sm">
-          Catalog rows your members see on their <code>/me</code> portal.
+          The tiles your members see on their <code>/me</code> portal.
         </Text>
       </VStack>
       <Spacer />

--- a/specs/ai-gateway/governance/governance-home-routing.feature
+++ b/specs/ai-gateway/governance/governance-home-routing.feature
@@ -141,12 +141,12 @@ Feature: Governance home — route, nav promotion, persona detection
       sub-routes:
       | label             | href                                          |
       | Overview          | /governance                                   |
-      | Ingestion Sources | /governance/ingestion-sources                 |
+      | Catalog           | /governance/ingestion-sources                 |
       | Anomaly Rules     | /governance/anomaly-rules                     |
 
   @bdd @ui @governance-home @layout @sub-routes
   Scenario: Admin-authoring sub-routes share the GovernanceLayout chrome
-    When the admin clicks "Ingestion Sources" in the GovernanceLayout
+    When the admin clicks "Catalog" in the GovernanceLayout
       left rail and lands on "/governance/ingestion-sources"
     Then the page renders inside GovernanceLayout, the same chrome as
       the daily-use home

--- a/specs/ai-gateway/governance/persona-aware-chrome.feature
+++ b/specs/ai-gateway/governance/persona-aware-chrome.feature
@@ -158,8 +158,8 @@ Feature: AI Gateway Governance — Persona-aware chrome (sidebar + header)
   Scenario: Govern sub-nav stays put across every governance sub-route
     Given user is Persona 4 (governance admin) with both FFs on
     And the user is on "/governance" with the Govern sub-nav visible in
-        the left rail (Overview / Ingestion Sources / Anomaly Rules /
-        Tool Catalog / Departments)
+        the left rail (Overview / Catalog / Anomaly Rules /
+        Tool Tiles / Departments)
     When the user clicks a sub-nav link, or drills into a governance
         sub-route from the Overview, and lands on:
       | route                                              |

--- a/specs/ai-gateway/license-gate-governance.feature
+++ b/specs/ai-gateway/license-gate-governance.feature
@@ -91,7 +91,7 @@ Feature: AI Gateway — Enterprise license gate on governance backend
   @bdd @license-gate @ingestion-sources @cap
   Scenario: Composer-level source-type restriction still applies on non-enterprise
     Given "acme" has 0 active IngestionSources
-    When alice opens the Ingestion Sources composer
+    When alice opens the ingestion source composer
     Then only `otel_generic` is selectable in the source-type dropdown
     And the composer footer notes that other source types require Enterprise
 

--- a/specs/ai-governance/personal-portal/portal-grid.feature
+++ b/specs/ai-governance/personal-portal/portal-grid.feature
@@ -61,7 +61,7 @@ Feature: AI Tools Portal — Grid layout on /me
     And user "alice@acme.com" can manage the catalog (aiTools:manage)
     When user "alice@acme.com" loads "/me"
     Then the AI-governance getting-started banner renders
-    And it links to the tool catalog at "/governance/tool-catalog"
+    And it links to the tool tiles page at "/governance/tool-catalog"
     And no install-the-CLI affordance renders in the empty state
 
   Scenario: team-scoped entries override org-scoped entries by slug

--- a/specs/ai-governance/rbac/delegated-governance-viewer.feature
+++ b/specs/ai-governance/rbac/delegated-governance-viewer.feature
@@ -65,17 +65,17 @@ Feature: Delegated governance viewer reaches the Governance pages
     And no rule row offers an edit or archive control
 
   @integration @rbac
-  Scenario: Ingestion sources offers no controls a viewer cannot use
+  Scenario: The catalog offers no controls a viewer cannot use
     Given sam holds `ingestionSources:view` and not `ingestionSources:manage`
-    When sam opens the ingestion sources page
+    When sam opens the catalog page (the ingestion-sources route)
     Then there is no control to add a source
     And no source row offers an edit, rotate, or archive control
 
   @integration @rbac
-  Scenario: The tool catalog names its own grant
-    Given sam opens the tool catalog page
+  Scenario: The tool tiles page names its own grant
+    Given sam opens the tool tiles page
     Then the page names `aiTools:manage`
-    And no catalog editor is rendered
+    And no tiles editor is rendered
 
   @regression @rbac
   Scenario: An org admin still sees every panel on the overview

--- a/tests/agentic-e2e/tests/navigation/shared-section-layout.spec.ts
+++ b/tests/agentic-e2e/tests/navigation/shared-section-layout.spec.ts
@@ -107,7 +107,7 @@ test("complex product areas share one local navigation layout", async ({
     name: "AI Governance navigation",
   });
   await governanceNavigation
-    .getByRole("link", { name: "Ingestion Sources", exact: true })
+    .getByRole("link", { name: "Catalog", exact: true })
     .click();
   await expect(page).toHaveURL("/governance/ingestion-sources");
 
@@ -120,7 +120,7 @@ test("complex product areas share one local navigation layout", async ({
       .getByRole("link", { name: "Overview", exact: true })
       .evaluate((element) => getComputedStyle(element).backgroundColor);
     const activeBackground = await governanceNavigation
-      .getByRole("link", { name: "Ingestion Sources", exact: true })
+      .getByRole("link", { name: "Catalog", exact: true })
       .evaluate((element) => getComputedStyle(element).backgroundColor);
     expect(overviewBackground).not.toBe(activeBackground);
   }).toPass({ timeout: 15_000 });


### PR DESCRIPTION
# Related Issue

- Resolves #7353

Closes #7353. First PR of the governance catalog restructure stack — the naming foundation, nothing else.

## What changed

Two nav entries and the headings/pins that carry them:

- **Ingestion Sources → Catalog** — in the target structure the catalog is the governance procurement surface and sources become one tab inside it (PR 2).
- **Tool Catalog → Tool Tiles** — that page is the member-portal tile publisher, not a catalog; freeing the word prevents a `Catalog` / `Tool Catalog` menu that reads as one feature.

## What deliberately did not change

- **URLs, hrefs, permissions, feature flags, component names.** `/governance/ingestion-sources` and `/governance/tool-catalog` keep working; the label changed, the bookmark did not. The route move + redirect ships with the tab shell in PR 2.
- **Entity-noun copy.** "Ingestion source not found", "Connect an ingestion source", the home-page "Ingestion sources" health card — a Catalog page containing ingestion sources keeps those true, so they keep their wording.
- **SDK CLI prose** that names the tool catalog (`wrapper.ts`, `ingest/list.ts`) — release-bearing, deferred to the fold-in PR and noted on the issue.
- **Icons** — swap rides with PR 2 when the page earns catalog content.

## Surface

`sectionNavItems.ts` is already the single source both the sidebar and `GovernanceLayout` render from, so the rename is one data edit plus: page headings/titles, the two nav integration tests, the `delegatedViewer` scenario docstrings, the e2e heading locator (`admin-ottl-dogfood.ts`), six spec-file lines, and the feature-map registry entries. 14 files, 33/33 lines — pure rename symmetry.

## Verification

- Red-first: label expectations updated in `sectionNavParity` + `ProductSidebar` tests, observed failing on the old labels, then the source edit turned them green (38/38 across the three touched test files).
- `pnpm typecheck` and `pnpm typecheck:all` clean; `check:feature-parity` passes (7884 scenarios still bound — the renamed scenarios stayed matched to their docstrings).
- Full unit suite: 30k+ tests pass. Three server-route test files failed on first run from an unbuilt `@langwatch/mcp-server` in this worktree (environmental, files untouched by this diff); after building the package all pass.
- The linter reports no new violations on touched files (2 pre-existing complexity notes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Renamed the Governance navigation item from **Ingestion Sources** to **Catalog**.
  * Renamed **Tool Catalog** to **Tool Tiles** across page titles, headings, notices, and navigation.
  * Clarified Catalog capabilities, including inspecting ingestion sources, monitoring events, checking health, and recovering conversation content.
  * Updated access messaging for tool tiles and ingestion templates.
* **Tests**
  * Updated navigation, routing, and governance scenarios to reflect the new terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->