### PR TITLE
docs(adr): record what the realtime voice broker actually shipped (ADR-097)

### DIFF
--- a/dev/docs/adr/097-realtime-voice-session-broker.md
+++ b/dev/docs/adr/097-realtime-voice-session-broker.md
@@ -4,6 +4,8 @@
 
 **Status:** Accepted (2026-08-14)
 
+> **Implemented.** The broker shipped on 2026-08-21 in `langwatch/langwatch#7066`. The amendment below records where the build differs from the design here, and which gates and prerequisites are now closed.
+
 ## Context
 
 Realtime voice traffic does not pass through the LangWatch AI Gateway. Customers running voice agents connect straight to OpenAI, ElevenLabs or Google, so that spend carries no virtual key, no budget, and no trace. Our own voice test harness does the same: the simulator, judge, speech-to-text and text-to-speech legs route through `gateway.langwatch.ai` because they are OpenAI-shaped, while the ElevenLabs conversation itself bills a separate account.
@@ -116,6 +118,78 @@ We will not build the media relay until all four hold.
 **Neutral.** The gateway takes on one narrow vendor REST call per family, for session establishment. `agent_id` becomes part of the addressing for ElevenLabs, which is the same choice Cloudflare made. A brokered session needs a new spend record shape whose quantity is a duration, which is the unit-generic work listed as a prerequisite.
 
 **Risks worth naming.** ADR-053 Track C forbids the direct dial that even the broker's mint call performs, though that call is short, bounded and shaped exactly like the envelope Track C describes, unlike a socket. Vendor usage reporting is the single point of truth for brokered billing, so a vendor webhook outage becomes a billing gap rather than a service outage, and it must fail visibly under the existing rule that losses are never silent. ElevenLabs publishes regional residency endpoints, so brokering must preserve the region the customer selected.
+
+## Amendment (2026-08-21): the broker as built
+
+The broker shipped in `langwatch/langwatch#7066`. Both mints, the client usage report and the vendor post-call webhook are live, and voice spend lands on a virtual key. This section records where the build differs from the design above. Everything not named here holds as written.
+
+### The ElevenLabs post-call webhook is served by the gateway
+
+The webhook is `POST /v1/convai/webhook/{model_provider_id}` on the gateway. That is the URL a customer registers in their own ElevenLabs workspace. The control plane keeps its own route mounted and unchanged, as the target the gateway relays to.
+
+A webhook must be reachable from the vendor's network, so whatever serves it has to be public. The gateway is public by design. The LangWatch app is the admin UI, and self-hosted installs commonly keep it behind a VPN or an access proxy, so serving the webhook there would force a public hole in the admin surface. The route sits under the `/v1` prefix the gateway chart already publishes, so a self-hosted install that already exposes the gateway gets voice billing with no ingress change. Voice then needs one public component.
+
+The gateway verifies nothing and reads nothing. It relays the raw request bytes and the `ElevenLabs-Signature` header exactly as received, because the vendor signs those bytes and any re-encoding would fail every delivery. The control plane holds the per-tenant secret and remains the only verifier. Its status is relayed unchanged, so a 404 for a provider id with no webhook configured keeps provider ids unprobeable.
+
+A relay that cannot reach the control plane answers 502. Acknowledging a delivery the gateway never passed on would tell the vendor the report landed, and the count of consecutive failures is the only signal that the relay is broken. The reconciler below reads the same numbers back from the vendor, so the refusal loses no billing data.
+
+### The route decides the vendor
+
+Each mint route states its own providers through the surface descriptor added in `langwatch/langwatch#7049`, and the credential chain is trimmed to those providers before the model is resolved. `Surface` moved off `PassthroughRequest` onto `Request` so a mint can carry it alongside the raw-forward routes. There is no fallback walk, and the model string never selects the vendor. A session credential is bound to one vendor account, so a second credential would sign for an agent that does not exist there and the caller would get a URL that only fails once the socket opens.
+
+### Gate 3 and all three prerequisites are closed
+
+Prerequisite 1 is done. `langwatch/langwatch#6934` closed on 2026-08-16, so character-priced and second-priced audio calls debit.
+
+Prerequisite 2 is done. The spend quantity vocabulary carries `input_chars` and `audio_ms` beside the token classes, so a voice session can state the duration it was charged for.
+
+Prerequisite 3 and **gate 3** are done. Per-key concurrency limits shipped as `realtime.maxOpenSessions` on the virtual key. The open count and the session insert run in one Postgres transaction behind an advisory lock keyed on the project and the key, so two mints racing on the same key cannot both read a count of zero. Past the limit the mint answers 429 `realtime_session_limit`, and the refusal is written as a failed spend row so a blocked call stays visible. The limit is read inside that transaction rather than carried on the gateway config bundle, so an edit applies to the next mint instead of waiting on the config cache.
+
+Gates 1, 2 and 4 are unchanged, so the media relay stays unbuilt.
+
+### An OpenAI ephemeral secret authenticates a server-side socket
+
+Measured against the live API on 2026-08-16. An `ek_` client secret opens a server-side websocket both as an `Authorization: Bearer` header and as the GA `openai-insecure-api-key.<secret>` subprotocol, and both reach `session.created`. Only the deprecated `openai-beta.realtime-v1` subprotocol is refused, and the vendor's error names the beta API rather than the credential. This was the open question the OpenAI arm of the decision rested on.
+
+The negative consequence recorded above, that OpenAI usage under a broker depends on the vendor's usage API or the SDK, is narrower as built. The client posts what its own socket reported in `response.done` to `POST /v1/realtime/sessions/{id}/usage`, and that closes the session's spend record.
+
+### The webhook signature is checked against the vendor's published verifier, and never against a live delivery
+
+The ElevenLabs workspace key available for this work lacks the `webhooks_write` scope, so no webhook could be registered and no vendor-signed delivery was ever received. The implementation was read against the verifier ElevenLabs ships in `@elevenlabs/elevenlabs-js@2.64.0` and matches it on every point that decides accept or reject: `t=<unix>,v0=<hex>`, HMAC-SHA256 over the timestamp, a literal dot, then the raw body, in lowercase hex. Our tolerance is two-sided over 30 minutes where the vendor's bounds only the past.
+
+Read that as verified against the vendor's code. It is weaker evidence than a live delivery and stronger than the documentation.
+
+### The reconciler makes the webhook optional
+
+A control-plane worker polls sessions still open two minutes after their mint, at most 25 per tick on a 60 second tick, and reads each conversation back from the vendor by the id recorded at the mint.
+
+The ElevenLabs post-call webhook is one slot per workspace, and a customer may already be using it for something else. Without the poller, giving up that slot would be a precondition for billing voice at all. With it, the webhook is an optimization: a fully private install with no inbound path still bills every call, because the poller is outbound only.
+
+A session with no recorded conversation id is left alone. It settles as cost unknown when its grace expires, which is visible, rather than being charged whatever conversation happened to be nearby.
+
+### A settled session emits a span
+
+Budgets and the ledger read `gateway_spend`. The Usage page and the trace explorer read `trace_summaries`. A brokered call runs client to vendor, so the only span the gateway can emit is the mint, and a mint happens before the call has cost anything. The first dogfood run billed a call correctly and showed $0.00 on the Usage page.
+
+The settlement now writes a `realtime.session.settled` span into the trace the mint opened, from `closeAndConfirmRealtimeSession` in the control plane. That is the one funnel the webhook, the reconciler and the client usage report all pass through, so both vendors converge on it.
+
+Emission is gated on the conditional close. The session row moves to CLOSED only while it is still open, and the span is written only by the update that won that move. A resent webhook, a retried client report, and a late confirmation superseding a settled record all find the row closed and add nothing. The span id is derived from the session id, so a write that got past the gate would land on the same span rather than a second one. A settlement with an unknown cost writes no span, so a call never appears at zero.
+
+### Further decisions the build had to make
+
+**The mint admits and does not confirm.** The spend interceptor confirms on any successful dispatch for every other request type. For a mint that would close the record at zero dollars before the call started, and leave the settlement sweeper nothing to settle, so `realtime_session` defers its outcome. A refused or errored mint still emits a failure, because a session that never opened has no later report coming.
+
+**The session booking fails closed**, against the budget fail-open doctrine. A budget precheck that cannot reach the control plane lets one bounded request through and reconciles afterwards. A voice session is neither bounded nor self-reporting, so an unbooked session is spend no ledger will ever see and a cap slot the next mint cannot count against. The mint already depends on the control plane to resolve the virtual key, so refusing costs no availability the caller had.
+
+**Guardrails do not run on a mint**, and the response says so on `X-LangWatch-Guardrails-Not-Applied: realtime_session`. The body is a session declaration rather than a prompt, and the conversation never reaches the gateway.
+
+**A post-call report is matched exactly or not at all.** The conversation id recorded at the mint, then the session id a conversation echoed back, then the one session open for that credential in the window. Two candidates is a miss, and an unmatched call settles visibly as cost unknown, because charging a call to the wrong session is a wrong bill that reads as a right one.
+
+**Regional residency is preserved.** A customer on an ElevenLabs residency endpoint sets `ELEVENLABS_BASE_URL` on the provider, and both the mint and the reconciler go there. The value is restricted to HTTPS on `elevenlabs.io` on write and again on read, because both paths send the customer's `xi-api-key` to that host.
+
+**Adapter support.** `langwatch/scenario#935` teaches the two realtime voice adapters to mint through the gateway, using the environment variables they already read for chat.
+
+**Doc changes.** The `docs/ai-gateway/api/audio.mdx` block this ADR listed no longer tells customers to connect directly to the provider. Realtime voice has its own page at `docs/ai-gateway/api/realtime.mdx`.
 
 ## References
 

--- a/dev/docs/adr/097-realtime-voice-session-broker.md
+++ b/dev/docs/adr/097-realtime-voice-session-broker.md
@@ -153,6 +153,8 @@ Measured against the live API on 2026-08-16. An `ek_` client secret opens a serv
 
 The negative consequence recorded above, that OpenAI usage under a broker depends on the vendor's usage API or the SDK, is narrower as built. The client posts what its own socket reported in `response.done` to `POST /v1/realtime/sessions/{id}/usage`, and that closes the session's spend record.
 
+That figure is taken as reported. The report is bound to the session's own project and virtual key and a second report on a closed session is a no-op, so it cannot be replayed or written by another key, but nothing checks it against the vendor. An OpenAI session bills what its client says it used, and a session that reports nothing settles as cost unknown at the grace. The socket does not pass through the gateway, so there is no second reading to compare against until OpenAI exposes one.
+
 ### The webhook signature is checked against the vendor's published verifier, and never against a live delivery
 
 The ElevenLabs workspace key available for this work lacks the `webhooks_write` scope, so no webhook could be registered and no vendor-signed delivery was ever received. The implementation was read against the verifier ElevenLabs ships in `@elevenlabs/elevenlabs-js@2.64.0` and matches it on every point that decides accept or reject: `t=<unix>,v0=<hex>`, HMAC-SHA256 over the timestamp, a literal dot, then the raw body, in lowercase hex. Our tolerance is two-sided over 30 minutes where the vendor's bounds only the past.
@@ -161,7 +163,7 @@ Read that as verified against the vendor's code. It is weaker evidence than a li
 
 ### The reconciler makes the webhook optional
 
-A control-plane worker polls sessions still open two minutes after their mint, at most 25 per tick on a 60 second tick, and reads each conversation back from the vendor by the id recorded at the mint.
+A control-plane worker polls sessions still open two minutes after their mint, at most 25 per tick on a 60-second tick, and reads each conversation back from the vendor by the id recorded at the mint.
 
 The ElevenLabs post-call webhook is one slot per workspace, and a customer may already be using it for something else. Without the poller, giving up that slot would be a precondition for billing voice at all. With it, the webhook is an optimization: a fully private install with no inbound path still bills every call, because the poller is outbound only.
 
@@ -175,7 +177,7 @@ The settlement now writes a `realtime.session.settled` span into the trace the m
 
 Emission is gated on the conditional close. The session row moves to CLOSED only while it is still open, and the span is written only by the update that won that move. A resent webhook, a retried client report, and a late confirmation superseding a settled record all find the row closed and add nothing. The span id is derived from the session id, so a write that got past the gate would land on the same span rather than a second one. A settlement with an unknown cost writes no span, so a call never appears at zero.
 
-### Further decisions the build had to make
+### Properties of the broker the design did not state
 
 **The mint admits and does not confirm.** The spend interceptor confirms on any successful dispatch for every other request type. For a mint that would close the record at zero dollars before the call started, and leave the settlement sweeper nothing to settle, so `realtime_session` defers its outcome. A refused or errored mint still emits a failure, because a session that never opened has no later report coming.
 
@@ -187,22 +189,19 @@ Emission is gated on the conditional close. The session row moves to CLOSED only
 
 **Regional residency is preserved.** A customer on an ElevenLabs residency endpoint sets `ELEVENLABS_BASE_URL` on the provider, and both the mint and the reconciler go there. The value is restricted to HTTPS on `elevenlabs.io` on write and again on read, because both paths send the customer's `xi-api-key` to that host.
 
-**Adapter support.** `langwatch/scenario#935` teaches the two realtime voice adapters to mint through the gateway, using the environment variables they already read for chat.
-
-**Doc changes.** The `docs/ai-gateway/api/audio.mdx` block this ADR listed no longer tells customers to connect directly to the provider. Realtime voice has its own page at `docs/ai-gateway/api/realtime.mdx`.
-
 ## References
 
 - Related Nexus pages (internal wiki): `gateway-spend-command-pipeline-adr`, `skai-gateway-replacement-adr`, `bench-gateway-kong`, `feature-ai-gateway`, `feature-gateway-virtual-keys`, `feature-voice-agent-testing`, `pain-voice-agent-testing-cost`
 - Repo ADRs: [053-tenant-aware-egress-and-workload-isolation.md](./053-tenant-aware-egress-and-workload-isolation.md) (Proposed), [017-gateway-trace-payload-capture.md](./017-gateway-trace-payload-capture.md) (Accepted, and not the regime running in code), [016-scoped-model-providers.md](./016-scoped-model-providers.md), [021-multi-scope-targeting-and-tenancy.md](./021-multi-scope-targeting-and-tenancy.md), [018-governance-unified-observability-substrate.md](./018-governance-unified-observability-substrate.md)
 - Scenario ADRs, in the `langwatch/scenario` repository: [docs/adr/002-voice-provider-state.md](https://github.com/langwatch/scenario/blob/main/docs/adr/002-voice-provider-state.md) (Proposed), [docs/adr/003-voice-internal-design.md](https://github.com/langwatch/scenario/blob/main/docs/adr/003-voice-internal-design.md) (Accepted)
 - Shipped audio support: `langwatch/langwatch#6168`, [specs/ai-gateway/audio-endpoints.feature](../../../specs/ai-gateway/audio-endpoints.feature), [docs/ai-gateway/api/audio.mdx](../../../docs/ai-gateway/api/audio.mdx)
+- The broker as built: `langwatch/langwatch#7066`, [specs/ai-gateway/realtime-sessions.feature](../../../specs/ai-gateway/realtime-sessions.feature), [docs/ai-gateway/api/realtime.mdx](../../../docs/ai-gateway/api/realtime.mdx), and `langwatch/scenario#935` for the two voice adapters that mint through it
 - Vendor documentation: OpenAI Realtime websocket and costs guides, ElevenLabs Conversational AI websocket and authentication references, Google Gemini Live API and session management, Deepgram Voice Agent reference, Azure Voice Live how-to
 - Competitor realtime support: Cloudflare AI Gateway realtime websockets, LiteLLM `/v1/realtime`, Portkey realtime API, Helicone realtime integration, Kong voice AI observability cookbook
 
 ### Doc changes this decision requires when it lands
 
-- `docs/ai-gateway/api/audio.mdx`, the "Not yet supported" block, currently tells customers to connect directly to the provider.
+- `docs/ai-gateway/api/audio.mdx`, the "Not yet supported" block, currently tells customers to connect directly to the provider. Done on 2026-08-21: the block now points at `docs/ai-gateway/api/realtime.mdx`.
 - `bench-gateway-kong`, whose LangWatch route-type column predates `#6168`.
 
 ### Resolutions (2026-08-14)


### PR DESCRIPTION
`dev/docs/adr/097-realtime-voice-session-broker.md` still reads as the pre-build design. The broker shipped in #7066 and that PR did not touch the ADR. Two parts of the design changed during implementation, so an engineer reading the ADR today would build the wrong thing.

This keeps the original design text intact and adds a dated amendment, the same shape ADR-007 and ADR-015 use for post-implementation changes. Documentation only.

## What changed against the design

**The ElevenLabs post-call webhook is served by the gateway.** It is `POST /v1/convai/webhook/{model_provider_id}`, under the `/v1` prefix the gateway chart already publishes, so a self-hosted install needs no ingress change and voice needs one public component. The gateway relays the raw request bytes and the `ElevenLabs-Signature` header exactly as received and verifies nothing. The control plane holds the per-tenant secret and stays the only verifier, and its status is relayed unchanged so a 404 keeps provider ids unprobeable. A relay that cannot reach the control plane answers 502 rather than a manufactured acknowledgement.

**The route decides the vendor.** Each mint route states its own providers through the surface descriptor added in #7049, and the credential chain is trimmed to those providers before the model is resolved. `Surface` moved off `PassthroughRequest` onto `Request` so a mint can carry it. The ADR did not describe a competing mechanism, so this is recorded as an addition rather than a correction.

## What the amendment also records

- **Gate 3 and all three prerequisites are closed.** Per-key concurrency shipped as `realtime.maxOpenSessions` on the virtual key, counted and inserted in one Postgres transaction behind an advisory lock keyed on the project and the key. Past the limit the mint answers 429 `realtime_session_limit` and the refusal is written as a failed spend row. Prerequisite 1 closed with #6934 on 2026-08-16; prerequisite 2 is the `input_chars` and `audio_ms` quantities in the spend vocabulary. Gates 1, 2 and 4 are unchanged, so the media relay stays unbuilt.
- **An OpenAI `ek_` secret authenticates a server-side websocket**, as an `Authorization: Bearer` header and as the GA subprotocol. Only the deprecated `openai-beta.realtime-v1` subprotocol is refused. This closes the open question the OpenAI arm rested on, and narrows the ADR's negative consequence about OpenAI usage: the client posts what `response.done` reported to `POST /v1/realtime/sessions/{id}/usage`.
- **The webhook signature is checked against the vendor's published verifier, and never against a live delivery.** The workspace API key lacks the `webhooks_write` scope, so no webhook could be registered and no vendor-signed delivery was ever received. The amendment states that qualifier plainly instead of claiming the format is verified.
- **The reconciler makes the webhook optional.** A control-plane worker polls sessions still open two minutes after their mint, at most 25 per tick on a 60 second tick. The workspace webhook is one slot per workspace, so without the poller giving up that slot would be a precondition for billing voice at all.
- **A settled session emits a span**, so the Usage page and the trace explorer agree with `gateway_spend`. Emission is gated on the conditional close, so a resent webhook, a retried client report and a late confirmation after a settle all find the row closed and add nothing.
- Four further build decisions: the mint admits and does not confirm, the session booking fails closed, guardrails do not run on a mint, and a post-call report is matched exactly or not at all.

Every claim was checked against the merged code, not against the PR description.

## Deployment Impact

Documentation only. One file changes, `dev/docs/adr/097-realtime-voice-session-broker.md`. Nothing deploys.

**Environment variables.** None added or changed.

**Database.** No migrations.

**Helm values.** None added or changed.

**Vanilla install.** No effect.

**BYOC dataplane.** No effect.

**Rollback.** Revert the commit. No runtime state is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated realtime voice session documentation to reflect the broker’s shipped capabilities.
  * Added guidance on authentication, usage billing, concurrency controls, webhook processing, session matching, regional endpoint validation, and Scenario adapter support.
  * Clarified settlement behavior, guardrail handling, and fail-closed booking for safer session management.
  * Noted that media relay functionality is not yet available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->