### PR TITLE
perf(data-privacy): redaction rules search for their own literal first

### DIFF
--- a/packages/redaction/package.json
+++ b/packages/redaction/package.json
@@ -12,7 +12,8 @@
 	"scripts": {
 		"typecheck": "tsc --noEmit",
 		"test": "vitest",
-		"test:unit": "vitest run"
+		"test:unit": "vitest run",
+		"bench": "vitest bench --run"
 	},
 	"keywords": [
 		"langwatch",

--- a/packages/redaction/src/__bench__/secrets.bench.ts
+++ b/packages/redaction/src/__bench__/secrets.bench.ts
@@ -1,0 +1,59 @@
+import { bench, describe } from "vitest";
+import { redactSecretsInText } from "../secrets.js";
+
+/**
+ * Redaction runs on every stored string at ingestion, so its cost is paid per
+ * span rather than per request. These payloads are the three shapes that decide
+ * that cost, and they are here because a rule can be fast on one and quadratic
+ * on another: the connection-URL rule was 0.1 ms on URL-dense text and 2.4 ms on
+ * prose with no URL in it at all, because the scheme led the match and every
+ * letter therefore started a scan.
+ *
+ * Run with `pnpm --filter @langwatch/redaction bench`. Compare against the same
+ * command on the base branch; there is no absolute number to assert, because a
+ * loaded CI box moves them all together while the ratio between shapes holds.
+ */
+const SIZE = 200_000;
+
+function payloadOf(chunk: string): string {
+  return chunk.repeat(Math.ceil(SIZE / chunk.length)).slice(0, SIZE);
+}
+
+/** An LLM prompt or completion: words, no structure, no credentials. */
+const PROSE = payloadOf(
+  "Summarise the release notes for the 3.9.0 tag and tell me which of the " +
+    "three migrations is the risky one. The customer reported that the " +
+    "dashboard stopped loading after the upgrade and the workers queue kept " +
+    "growing. Explain what an exclusive lock does to a table rewrite.\n",
+);
+
+/** A coding-agent transcript: prose, code, JSON, paths, hashes, logs. */
+const MIXED = payloadOf(
+  "The agent read platform/app/src/server/traces/trace.service.ts:72 and " +
+    "found the redaction service constructed there.\n" +
+    "const apiKey = process.env.OPENAI_API_KEY;\n" +
+    '{"traceId":"4bf92f3577b34da6a3ce929d0e0e4736","model":"claude-opus-5"}\n' +
+    "commit 51d07b547d0a8f3e2c1b9d4a6e7f8091a2b3c4d5 bumped the web package\n" +
+    "GET https://app.langwatch.ai/api/trace/abc123?include=spans 200 OK\n",
+);
+
+/** Configuration and connection strings, where the URL rule does its work. */
+const URLS = payloadOf(
+  "postgres://app:hunter2@db.internal:5432/langwatch\n" +
+    "redis://default:Ab3xY9zQ@cache-01:6379\n" +
+    "amqp://guest:guest@localhost:5672/%2f\n",
+);
+
+describe("redactSecretsInText, 200 KB", () => {
+  bench("prose with no URL", () => {
+    redactSecretsInText({ text: PROSE });
+  });
+
+  bench("a coding-agent transcript", () => {
+    redactSecretsInText({ text: MIXED });
+  });
+
+  bench("connection strings", () => {
+    redactSecretsInText({ text: URLS });
+  });
+});

--- a/packages/redaction/src/__tests__/secrets.unit.test.ts
+++ b/packages/redaction/src/__tests__/secrets.unit.test.ts
@@ -1035,6 +1035,30 @@ describe("detectSecretsInText", () => {
     });
   });
 
+  describe("given text with a connection URL", () => {
+    /** @scenario "A reported connection URL spans the whole URL" */
+    it("reports a span that starts at the scheme, not at the colon", () => {
+      // The rule reads the scheme in a lookbehind so that it can anchor on the
+      // literal, which keeps the scheme out of the regex match. The credential
+      // still begins at the scheme, so the reported span has to as well.
+      const input = "db postgres://user:hunter2@db.internal:5432/app end";
+      const matches = detectSecretsInText({ text: input });
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.ruleId).toBe("url_credentials");
+      expect(input.slice(matches[0]!.start, matches[0]!.end)).toBe(
+        "postgres://user:hunter2@",
+      );
+    });
+
+    it("starts the span at the scheme that introduces the URL", () => {
+      const input = "jdbc:postgresql://svc:9f8e7d6c@10.0.0.4:5432/app";
+      const matches = detectSecretsInText({ text: input });
+      expect(input.slice(matches[0]!.start, matches[0]!.end)).toBe(
+        "postgresql://svc:9f8e7d6c@",
+      );
+    });
+  });
+
   describe("given text with several distinct secrets", () => {
     it("reports each one", () => {
       const matches = detectSecretsInText({

--- a/packages/redaction/src/__tests__/secrets.unit.test.ts
+++ b/packages/redaction/src/__tests__/secrets.unit.test.ts
@@ -91,6 +91,44 @@ describe("redactSecretsInText", () => {
       const { text } = redact("postgres://app:hunter2@db.internal:5432/app");
       expect(text).toBe("postgres://app:[SECRET]@db.internal:5432/app");
     });
+
+    /** @scenario "A connection URL keeps its scheme whatever shape the scheme has" */
+    it("keeps every shape of scheme and redacts only the password", () => {
+      const cases: Array<[string, string]> = [
+        [
+          "redis://default:Ab3xY9zQ@cache-01:6379",
+          "redis://default:[SECRET]@cache-01:6379",
+        ],
+        [
+          "mongodb+srv://admin:p%40ss@cluster0.mongodb.net",
+          "mongodb+srv://admin:[SECRET]@cluster0.mongodb.net",
+        ],
+        [
+          "git+ssh://git:token123@github.com/langwatch/langwatch.git",
+          "git+ssh://git:[SECRET]@github.com/langwatch/langwatch.git",
+        ],
+        [
+          "jdbc:postgresql://svc:9f8e7d6c@10.0.0.4:5432/app",
+          "jdbc:postgresql://svc:[SECRET]@10.0.0.4:5432/app",
+        ],
+        ["HTTPS://USER:PASS@EXAMPLE.COM", "HTTPS://USER:[SECRET]@EXAMPLE.COM"],
+      ];
+      for (const [input, expected] of cases) {
+        expect(redact(input).text).toBe(expected);
+      }
+    });
+
+    /** @scenario "Text that only looks like a connection URL is left alone" */
+    it("leaves alone a colon-slash-slash with no scheme in front of it", () => {
+      for (const input of [
+        "://user:password@host",
+        "no scheme here: user:password@host",
+        "See https://app.langwatch.ai/api/trace/abc123?include=spans",
+        "mail someone@example.com and read @langwatch/redaction",
+      ]) {
+        expect(redact(input).text).toBe(input);
+      }
+    });
   });
 
   describe("given a bearer authorization header value", () => {
@@ -670,6 +708,12 @@ describe("redactSecretsInText, given a payload the size of the scan budget", () 
       ["a keyword followed by filler", `api_key: ${"a".repeat(100_000)}`],
       ["repeated keywords", "password=".repeat(20_000)],
       ["repeated open quotes", `${'api_key:"'.repeat(20_000)}x`],
+      // Lowercase prose is the worst case for the connection-URL rule, whose
+      // scheme is a run of letters. With the scheme leading the match every
+      // letter in the text started a scan for a "://" that is not there.
+      ["lowercase prose with no URL in it", "the dashboard stopped loading ".repeat(8_000)],
+      ["one URL per line", "postgres://svc:pw@10.0.0.4:5432/app\n".repeat(6_000)],
+      ["a scheme-shaped run with no separator", `${"a".repeat(100_000)}://`],
     ];
 
     for (const [label, input] of adversarial) {

--- a/packages/redaction/src/secrets.ts
+++ b/packages/redaction/src/secrets.ts
@@ -1153,7 +1153,7 @@ function matchesOfRule(rule: ValueRule, text: string): SecretMatch[] {
     found.push({
       ruleId: rule.id,
       description: rule.description,
-      start: matchStart - lengthPrecedingMatch(rule, text, matchStart),
+      start: matchStart - lengthPrecedingMatch({ rule, text, matchStart }),
       end: matchStart + kept,
     });
   }
@@ -1164,11 +1164,15 @@ function matchesOfRule(rule: ValueRule, text: string): SecretMatch[] {
  * How much of the credential sits in front of the match, for a rule that reads
  * part of it in a lookbehind. Zero for every rule whose match covers all of it.
  */
-function lengthPrecedingMatch(
-  rule: ValueRule,
-  text: string,
-  matchStart: number,
-): number {
+function lengthPrecedingMatch({
+  rule,
+  text,
+  matchStart,
+}: {
+  rule: ValueRule;
+  text: string;
+  matchStart: number;
+}): number {
   if (!rule.precededBy) return 0;
   return rule.precededBy.exec(text.slice(0, matchStart))?.[0].length ?? 0;
 }

--- a/packages/redaction/src/secrets.ts
+++ b/packages/redaction/src/secrets.ts
@@ -60,6 +60,15 @@ interface ValueRule {
    * for the many strings that are ordinary prose.
    */
   precondition?: (text: string) => boolean;
+  /**
+   * Text the rule requires in front of the match but leaves out of it, written
+   * to end at the match. A rule anchors on its own literal for speed and reads
+   * what precedes it in a lookbehind; the credential still begins where that
+   * lookbehind begins, so the reported span has to start there too. Applied to
+   * the text before the match, and only by the detection path: redaction never
+   * rewrites what the match does not cover.
+   */
+  precededBy?: RegExp;
 }
 
 /**
@@ -616,6 +625,9 @@ const VALUE_RULES: ValueRule[] = [
     // The scheme stays outside the match and therefore untouched, which is
     // what the rule already did with it.
     regex: /(?<=[a-z][a-z0-9+.-]{0,30})(:\/\/[^\s:@/]+:)([^\s:@/]+)(@)/gi,
+    // The same scheme the lookbehind reads, so a reported match still spans the
+    // whole URL rather than starting at the colon.
+    precededBy: /[a-z][a-z0-9+.-]{0,30}$/i,
     render: (_m, prefix, _password, at) => `${prefix}${REPLACEMENT}${at}`,
   },
   {
@@ -1137,15 +1149,28 @@ function matchesOfRule(rule: ValueRule, text: string): SecretMatch[] {
     if (ruleDeclines(rule, match)) continue;
     const kept = claimedLength(rule, match);
     if (kept === 0) continue;
-    const start = match.index ?? 0;
+    const matchStart = match.index ?? 0;
     found.push({
       ruleId: rule.id,
       description: rule.description,
-      start,
-      end: start + kept,
+      start: matchStart - lengthPrecedingMatch(rule, text, matchStart),
+      end: matchStart + kept,
     });
   }
   return found;
+}
+
+/**
+ * How much of the credential sits in front of the match, for a rule that reads
+ * part of it in a lookbehind. Zero for every rule whose match covers all of it.
+ */
+function lengthPrecedingMatch(
+  rule: ValueRule,
+  text: string,
+  matchStart: number,
+): number {
+  if (!rule.precededBy) return 0;
+  return rule.precededBy.exec(text.slice(0, matchStart))?.[0].length ?? 0;
 }
 
 /** Whether a rule's second-stage test rejects this candidate. */

--- a/packages/redaction/src/secrets.ts
+++ b/packages/redaction/src/secrets.ts
@@ -606,7 +606,16 @@ const VALUE_RULES: ValueRule[] = [
     // scheme length is bounded (real schemes are short) so a long run of
     // name-like characters costs constant backtracking per position instead
     // of a quadratic scan on huge inputs.
-    regex: /([a-z][a-z0-9+.-]{0,30}:\/\/[^\s:@/]+:)([^\s:@/]+)(@)/gi,
+    //
+    // The scheme sits in a lookbehind so that the first character the engine
+    // must find is the literal `:`. With the scheme inside the match the
+    // pattern starts with a character class, every lowercase letter in the
+    // text is a candidate start, and each one costs up to 30 characters of
+    // scheme scan before it fails: 6.2 ms on a 200 KB payload, more than every
+    // other rule together. Anchored on `:` the same payload costs 0.09 ms.
+    // The scheme stays outside the match and therefore untouched, which is
+    // what the rule already did with it.
+    regex: /(?<=[a-z][a-z0-9+.-]{0,30})(:\/\/[^\s:@/]+:)([^\s:@/]+)(@)/gi,
     render: (_m, prefix, _password, at) => `${prefix}${REPLACEMENT}${at}`,
   },
   {

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
@@ -11,6 +11,14 @@
  * touch.
  */
 
+import {
+  findPhoneNumbersInText,
+  getCountries,
+  getExampleNumber,
+} from "libphonenumber-js";
+import examples from "libphonenumber-js/examples.mobile.json" with {
+  type: "json",
+};
 import { describe, expect, it } from "vitest";
 
 import { redactEssentialPiiInText } from "../essentialPii";
@@ -78,5 +86,58 @@ describe("given a recognizer that is skipped unless the text holds its literal",
 
       expect(redact(payload)).toBe(payload);
     });
+  });
+});
+
+/**
+ * The phone detector is skipped on text whose longest digit window is too short
+ * to hold a number. It is the one detector where the saving is measured in
+ * hundreds of milliseconds instead of single ones: 200 KB of JSON with numeric
+ * fields cost 240 ms and found nothing.
+ *
+ * The floor must stay below the shortest number the detector will return, and
+ * the detector itself is the only honest reference for that. These cases run
+ * every country's own example number through the public redaction path and
+ * require that anything the library finds is still marked. Raise the floor too
+ * far and the small territories fail here first.
+ */
+describe("given the phone detector's digit gate", () => {
+  const shapesOf = (formatted: string, plain: string) => [
+    plain,
+    formatted,
+    `call ${formatted} now`,
+    `{"phone":"${plain}"}`,
+  ];
+
+  /** @scenario "Every number the detector can find is still redacted" */
+  it("still redacts every example number the detector recognises", () => {
+    const missed: string[] = [];
+    let recognised = 0;
+    for (const country of getCountries()) {
+      const example = getExampleNumber(country, examples);
+      if (!example) continue;
+      for (const shape of shapesOf(
+        example.formatInternational(),
+        example.number,
+      )) {
+        const found = findPhoneNumbersInText(shape, { defaultCountry: "US" });
+        if (found.length === 0) continue;
+        recognised++;
+        if (!redact(shape).includes("[PHONE_NUMBER]")) missed.push(shape);
+      }
+    }
+    expect(recognised).toBeGreaterThan(500);
+    expect(missed).toEqual([]);
+  });
+
+  /** @scenario "Text too short to hold a number is left alone" */
+  it("leaves alone the numeric text that carries no number", () => {
+    for (const input of [
+      "the release notes for the 3.9.0 tag say so",
+      '{"input_tokens":15234,"cost_usd":0.0412}',
+      "retry 3 times after 45 seconds",
+    ]) {
+      expect(redact(input)).toBe(input);
+    }
   });
 });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.prefilter.unit.test.ts
@@ -102,42 +102,47 @@ describe("given a recognizer that is skipped unless the text holds its literal",
  * far and the small territories fail here first.
  */
 describe("given the phone detector's digit gate", () => {
-  const shapesOf = (formatted: string, plain: string) => [
-    plain,
+  const shapesOf = ({
     formatted,
-    `call ${formatted} now`,
-    `{"phone":"${plain}"}`,
-  ];
+    plain,
+  }: {
+    formatted: string;
+    plain: string;
+  }) => [plain, formatted, `call ${formatted} now`, `{"phone":"${plain}"}`];
 
-  /** @scenario "Every number the detector can find is still redacted" */
-  it("still redacts every example number the detector recognises", () => {
-    const missed: string[] = [];
-    let recognised = 0;
-    for (const country of getCountries()) {
-      const example = getExampleNumber(country, examples);
-      if (!example) continue;
-      for (const shape of shapesOf(
-        example.formatInternational(),
-        example.number,
-      )) {
-        const found = findPhoneNumbersInText(shape, { defaultCountry: "US" });
-        if (found.length === 0) continue;
-        recognised++;
-        if (!redact(shape).includes("[PHONE_NUMBER]")) missed.push(shape);
+  describe("when the text holds a number of any country", () => {
+    /** @scenario "A phone number is redacted whatever country it belongs to" */
+    it("still redacts every example number the detector recognises", () => {
+      const missed: string[] = [];
+      let recognised = 0;
+      for (const country of getCountries()) {
+        const example = getExampleNumber(country, examples);
+        if (!example) continue;
+        for (const shape of shapesOf({
+          formatted: example.formatInternational(),
+          plain: example.number,
+        })) {
+          const found = findPhoneNumbersInText(shape, { defaultCountry: "US" });
+          if (found.length === 0) continue;
+          recognised++;
+          if (!redact(shape).includes("[PHONE_NUMBER]")) missed.push(shape);
+        }
       }
-    }
-    expect(recognised).toBeGreaterThan(500);
-    expect(missed).toEqual([]);
+      expect(recognised).toBeGreaterThan(500);
+      expect(missed).toEqual([]);
+    });
   });
 
-  /** @scenario "Text too short to hold a number is left alone" */
-  it("leaves alone the numeric text that carries no number", () => {
-    for (const input of [
-      "the release notes for the 3.9.0 tag say so",
-      '{"input_tokens":15234,"cost_usd":0.0412}',
-      "retry 3 times after 45 seconds",
-    ]) {
-      expect(redact(input)).toBe(input);
-    }
+  describe("when the text holds digits but no number", () => {
+    /** @scenario "Numeric text that is no phone number is left alone" */
+    it("leaves alone the numeric text that carries no number", () => {
+      for (const input of [
+        "the release notes for the 3.9.0 tag say so",
+        '{"input_tokens":15234,"cost_usd":0.0412}',
+        "retry 3 times after 45 seconds",
+      ]) {
+        expect(redact(input)).toBe(input);
+      }
+    });
   });
 });

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -571,7 +571,30 @@ function collectRecognizerSpans({
  * digit run that parses as a dialable number matches. Two rules hold it to
  * digits a customer wrote as a number. It never runs on an identifier-shaped
  * value, and a match inside a longer token that carries letters is dropped.
+ *
+ * It is also, by a wide margin, the most expensive thing this file does. The
+ * library treats every single digit as a candidate and then tries to parse it,
+ * so 200 KB of ordinary text costs 160 ms with a version number in it and
+ * 240 ms as JSON with numeric fields, both finding nothing. The whole secrets
+ * pass over the same text is under 4 ms. `ENOUGH_DIGITS_FOR_A_NUMBER` is what
+ * keeps that cost off text that cannot hold a number at all.
  */
+
+/**
+ * The shortest example number libphonenumber has for any country is 7 digits
+ * (Tristan da Cunha, +290 8999), so text whose longest digit window is shorter
+ * than that holds no number the detector could return. The floor here is 6,
+ * one below that minimum, so the gate stays on the safe side of the shortest
+ * number in the metadata rather than exactly on it.
+ *
+ * Digits count as one window while no more than four separators divide them,
+ * which is the library's own allowance between digit blocks. The class here is
+ * every non-alphanumeric character, a superset of the punctuation the library
+ * accepts, so the window can only come out longer than the library would read
+ * and the gate can only err towards running the detector.
+ */
+const ENOUGH_DIGITS_FOR_A_NUMBER = /\d(?:[^0-9A-Za-z]{0,4}\d){5}/;
+
 function collectPhoneSpans({
   text,
   allowed,
@@ -585,6 +608,7 @@ function collectPhoneSpans({
 }): Span[] {
   if (isIdentifierShaped) return [];
   if (allowed && !allowed.has("PHONE_NUMBER")) return [];
+  if (!ENOUGH_DIGITS_FOR_A_NUMBER.test(text)) return [];
   const spans: Span[] = [];
   try {
     for (const phone of findPhoneNumbersInText(text, {

--- a/sdks/typescript/src/internal/generated/redaction/secrets.ts
+++ b/sdks/typescript/src/internal/generated/redaction/secrets.ts
@@ -1153,7 +1153,7 @@ function matchesOfRule(rule: ValueRule, text: string): SecretMatch[] {
     found.push({
       ruleId: rule.id,
       description: rule.description,
-      start: matchStart - lengthPrecedingMatch(rule, text, matchStart),
+      start: matchStart - lengthPrecedingMatch({ rule, text, matchStart }),
       end: matchStart + kept,
     });
   }
@@ -1164,11 +1164,15 @@ function matchesOfRule(rule: ValueRule, text: string): SecretMatch[] {
  * How much of the credential sits in front of the match, for a rule that reads
  * part of it in a lookbehind. Zero for every rule whose match covers all of it.
  */
-function lengthPrecedingMatch(
-  rule: ValueRule,
-  text: string,
-  matchStart: number,
-): number {
+function lengthPrecedingMatch({
+  rule,
+  text,
+  matchStart,
+}: {
+  rule: ValueRule;
+  text: string;
+  matchStart: number;
+}): number {
   if (!rule.precededBy) return 0;
   return rule.precededBy.exec(text.slice(0, matchStart))?.[0].length ?? 0;
 }

--- a/sdks/typescript/src/internal/generated/redaction/secrets.ts
+++ b/sdks/typescript/src/internal/generated/redaction/secrets.ts
@@ -60,6 +60,15 @@ interface ValueRule {
    * for the many strings that are ordinary prose.
    */
   precondition?: (text: string) => boolean;
+  /**
+   * Text the rule requires in front of the match but leaves out of it, written
+   * to end at the match. A rule anchors on its own literal for speed and reads
+   * what precedes it in a lookbehind; the credential still begins where that
+   * lookbehind begins, so the reported span has to start there too. Applied to
+   * the text before the match, and only by the detection path: redaction never
+   * rewrites what the match does not cover.
+   */
+  precededBy?: RegExp;
 }
 
 /**
@@ -616,6 +625,9 @@ const VALUE_RULES: ValueRule[] = [
     // The scheme stays outside the match and therefore untouched, which is
     // what the rule already did with it.
     regex: /(?<=[a-z][a-z0-9+.-]{0,30})(:\/\/[^\s:@/]+:)([^\s:@/]+)(@)/gi,
+    // The same scheme the lookbehind reads, so a reported match still spans the
+    // whole URL rather than starting at the colon.
+    precededBy: /[a-z][a-z0-9+.-]{0,30}$/i,
     render: (_m, prefix, _password, at) => `${prefix}${REPLACEMENT}${at}`,
   },
   {
@@ -1137,15 +1149,28 @@ function matchesOfRule(rule: ValueRule, text: string): SecretMatch[] {
     if (ruleDeclines(rule, match)) continue;
     const kept = claimedLength(rule, match);
     if (kept === 0) continue;
-    const start = match.index ?? 0;
+    const matchStart = match.index ?? 0;
     found.push({
       ruleId: rule.id,
       description: rule.description,
-      start,
-      end: start + kept,
+      start: matchStart - lengthPrecedingMatch(rule, text, matchStart),
+      end: matchStart + kept,
     });
   }
   return found;
+}
+
+/**
+ * How much of the credential sits in front of the match, for a rule that reads
+ * part of it in a lookbehind. Zero for every rule whose match covers all of it.
+ */
+function lengthPrecedingMatch(
+  rule: ValueRule,
+  text: string,
+  matchStart: number,
+): number {
+  if (!rule.precededBy) return 0;
+  return rule.precededBy.exec(text.slice(0, matchStart))?.[0].length ?? 0;
 }
 
 /** Whether a rule's second-stage test rejects this candidate. */

--- a/sdks/typescript/src/internal/generated/redaction/secrets.ts
+++ b/sdks/typescript/src/internal/generated/redaction/secrets.ts
@@ -606,7 +606,16 @@ const VALUE_RULES: ValueRule[] = [
     // scheme length is bounded (real schemes are short) so a long run of
     // name-like characters costs constant backtracking per position instead
     // of a quadratic scan on huge inputs.
-    regex: /([a-z][a-z0-9+.-]{0,30}:\/\/[^\s:@/]+:)([^\s:@/]+)(@)/gi,
+    //
+    // The scheme sits in a lookbehind so that the first character the engine
+    // must find is the literal `:`. With the scheme inside the match the
+    // pattern starts with a character class, every lowercase letter in the
+    // text is a candidate start, and each one costs up to 30 characters of
+    // scheme scan before it fails: 6.2 ms on a 200 KB payload, more than every
+    // other rule together. Anchored on `:` the same payload costs 0.09 ms.
+    // The scheme stays outside the match and therefore untouched, which is
+    // what the rule already did with it.
+    regex: /(?<=[a-z][a-z0-9+.-]{0,30})(:\/\/[^\s:@/]+:)([^\s:@/]+)(@)/gi,
     render: (_m, prefix, _password, at) => `${prefix}${REPLACEMENT}${at}`,
   },
   {

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -261,3 +261,27 @@ Feature: Redacting personal data from traces
   Scenario: A long value holding no personal data is returned unchanged
     When a trace is ingested whose input is a long opaque token
     Then the stored input is byte-for-byte what was sent
+
+  # The phone detector is the same idea with a number instead of a character,
+  # and it is where the time actually goes. It treats every digit as the start
+  # of a number and then tries to parse it, so 200 KB of ordinary JSON cost
+  # 248 ms and found nothing, against under 4 ms for the whole secrets pass over
+  # the same text. Text whose longest run of digits is too short to hold any
+  # number skips the detector: 165 ms to 1 ms on prose carrying a version
+  # number, 248 ms to 4 ms on that JSON.
+  #
+  # The floor sits one digit below the shortest number the phone metadata has
+  # for any country, so the skip only ever drops a scan that would have found
+  # nothing. The detector itself is the reference the test holds it to.
+
+  @unit
+  Scenario: Every number the detector can find is still redacted
+    When a trace is ingested whose input contains the example number of every
+      country the phone metadata knows
+    Then each number the detector recognises is redacted
+
+  @unit
+  Scenario: Text too short to hold a number is left alone
+    When a trace is ingested whose input carries version numbers and counts but
+      no run of digits long enough to be a phone number
+    Then the stored input is unchanged

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -262,26 +262,23 @@ Feature: Redacting personal data from traces
     When a trace is ingested whose input is a long opaque token
     Then the stored input is byte-for-byte what was sent
 
-  # The phone detector is the same idea with a number instead of a character,
-  # and it is where the time actually goes. It treats every digit as the start
-  # of a number and then tries to parse it, so 200 KB of ordinary JSON cost
-  # 248 ms and found nothing, against under 4 ms for the whole secrets pass over
-  # the same text. Text whose longest run of digits is too short to hold any
-  # number skips the detector: 165 ms to 1 ms on prose carrying a version
-  # number, 248 ms to 4 ms on that JSON.
+  # Phone numbers are the same idea again, counted in digits rather than in
+  # characters: text whose longest run of digits is shorter than any phone
+  # number is skipped. A trace full of version numbers, token counts and
+  # timestamps is the ordinary case, and it used to cost more than the rest of
+  # redaction together.
   #
-  # The floor sits one digit below the shortest number the phone metadata has
-  # for any country, so the skip only ever drops a scan that would have found
-  # nothing. The detector itself is the reference the test holds it to.
+  # A phone number is redacted wherever its country writes it, so the shortest
+  # number in use anywhere stays above the length that decides the skip.
 
   @unit
-  Scenario: Every number the detector can find is still redacted
-    When a trace is ingested whose input contains the example number of every
-      country the phone metadata knows
-    Then each number the detector recognises is redacted
+  Scenario: A phone number is redacted whatever country it belongs to
+    When a trace is ingested whose input contains phone numbers from every
+      country, written the way each country writes them
+    Then every one of them is redacted
 
   @unit
-  Scenario: Text too short to hold a number is left alone
+  Scenario: Numeric text that is no phone number is left alone
     When a trace is ingested whose input carries version numbers and counts but
       no run of digits long enough to be a phone number
     Then the stored input is unchanged

--- a/specs/data-privacy/secrets-redaction.feature
+++ b/specs/data-privacy/secrets-redaction.feature
@@ -112,6 +112,26 @@ Feature: Redacting secrets from traces
     When the text is redacted
     Then the scan completes well inside the ingestion budget
 
+  # What a rule costs is decided by the first thing it makes the engine look
+  # for. A connection URL cannot exist without "://", so that is what the rule
+  # searches for, and the scheme in front of it is read backwards once a match
+  # starts. Written the other way round, with the scheme leading, every letter
+  # in the text started a scan for a "://" that was usually not there, and the
+  # rule cost more than every other rule together. The two scenarios below hold
+  # the behaviour still while the rule is anchored that way.
+
+  @unit
+  Scenario: A connection URL keeps its scheme whatever shape the scheme has
+    Given connection strings whose schemes carry digits, dots and plus signs
+    When the text is redacted
+    Then only the password is replaced and each scheme is kept
+
+  @unit
+  Scenario: Text that only looks like a connection URL is left alone
+    Given text with a "://" that no scheme introduces, and an address with an at sign
+    When the text is redacted
+    Then the text is unchanged
+
   # Text past the scan budget used to be returned untouched, which was a bypass
   # rather than a budget: a real agent input of nearly a megabyte carried a live
   # provider key through ingestion completely unscanned, and being oversized was

--- a/specs/data-privacy/secrets-redaction.feature
+++ b/specs/data-privacy/secrets-redaction.feature
@@ -112,13 +112,10 @@ Feature: Redacting secrets from traces
     When the text is redacted
     Then the scan completes well inside the ingestion budget
 
-  # What a rule costs is decided by the first thing it makes the engine look
-  # for. A connection URL cannot exist without "://", so that is what the rule
-  # searches for, and the scheme in front of it is read backwards once a match
-  # starts. Written the other way round, with the scheme leading, every letter
-  # in the text started a scan for a "://" that was usually not there, and the
-  # rule cost more than every other rule together. The two scenarios below hold
-  # the behaviour still while the rule is anchored that way.
+  # A connection string is the one secret that is only partly secret. The
+  # password goes and the rest stays, because a reader needs to know which
+  # database the trace was talking to. Schemes are written in many shapes, and
+  # an address or a bare "://" in prose is not a connection string at all.
 
   @unit
   Scenario: A connection URL keeps its scheme whatever shape the scheme has
@@ -131,6 +128,12 @@ Feature: Redacting secrets from traces
     Given text with a "://" that no scheme introduces, and an address with an at sign
     When the text is redacted
     Then the text is unchanged
+
+  @unit
+  Scenario: A reported connection URL spans the whole URL
+    Given a connection string with a password in it
+    When the text is scanned without redacting
+    Then the reported leak covers the URL from its scheme onwards
 
   # Text past the scan budget used to be returned untouched, which was a bypass
   # rather than a budget: a real agent input of nearly a megabyte carried a live


### PR DESCRIPTION
Two redaction rules were doing far more work than they needed to. Both are speed changes with no behaviour attached, and both are proven that way rather than asserted.

## 1. The connection-URL secret rule searches for its own literal first

The rule led with the scheme, which is a run of lowercase letters. Every letter in a payload was therefore a candidate start, and each one paid a scan of up to 30 characters looking for a `://` that was usually not there.

The scheme moves into a lookbehind, so the first thing the engine searches for is the literal `:`. The scheme was already kept out of the replacement, so the redacted text does not change.

200 KB payloads, mean, same benchmark on both sides:

| payload | before | after |
|---|---|---|
| prose with no URL | 4.13 ms | 1.68 ms |
| coding-agent transcript | 7.13 ms | 3.68 ms |
| connection strings | 5.97 ms | 3.69 ms |

The rule on its own went from 6.2 ms to 0.09 ms on a URL-dense payload, and from 2.4 ms to 0.02 ms on prose with no URL in it. It was 56% of the whole secrets scan before this.

## 2. The phone detector skips text too short to hold a number

libphonenumber treats every digit as the start of a number and then tries to parse it. The detector was the most expensive thing in the essential-PII pass by two orders of magnitude, and it had no gate of its own, while the regex recognizers have carried one since #7092.

200 KB payloads, median, whole essential-PII pass:

| payload | before | after |
|---|---|---|
| prose with a version number | 165.3 ms | 1.2 ms |
| json with numeric fields | 247.6 ms | 4.3 ms |
| hex hashes | 33.0 ms | 2.7 ms |
| timestamps | 189.4 ms | 178.8 ms |
| real phone numbers | 89.6 ms | 90.4 ms |

The last two rows are the gate passing, which is what it must do on text that can hold a number.

The floor is six digits in one window, one below the shortest example number the phone metadata holds for any country. The window allows the four separators the library allows between digit blocks, over a character class that is a superset of the punctuation the library accepts, so the gate can only err towards running the detector.

## Why not a plain prefilter everywhere

The first idea was a cheap `text.includes()` in front of every secret rule. Measured on a 200 KB payload, it does not pay for rules that already carry a literal prefix:

| check | cost |
|---|---|
| `includes("sk-")` | 0.070 ms |
| the whole `sk-` rule | 0.027 ms |

V8 scans for a required literal prefix itself, so the guard costs more than the rule it guards. Two further ideas were measured and dropped: a shared "does a long token exist" gate costs as much as the rules it would skip, and an early length lookahead helps one payload shape and hurts another.

The cost was never spread thinly across the rules. One rule was 56% of the secrets scan and one detector was 98% of the PII scan, and both were slow for a structural reason rather than a missing guard.

## Proof

The URL rule, since the output must not move:

- 20 hand-written connection strings, and 24 whole-engine corpus strings covering every rule.
- 200,000 random strings through the rule, and 100,000 through the whole engine.
- 0 differences in redacted text and in redacted count.

Reported spans took one more step. Moving the scheme into the lookbehind took it out of the regex match, so `detectSecretsInText` began reporting the URL from the colon. Redaction never covered the scheme, so the redacted text was right, but the span is part of what the scan reports. A rule now declares the text it requires in front of the match and the detection path widens the span by it, which puts the spans back: 0 differences over a 17-string corpus and 200,000 random strings, against the engine as it was before the anchor change.

The phone gate, held to the detector itself rather than to the annotation:

- 1715 example-number shapes across every country the metadata knows.
- 300,000 random strings, of which 235,713 are skipped by the gate.
- 0 cases where the gate skips text the detector would have found a number in. The six shapes it does skip are bare national formats for small territories, which the detector returns nothing for anyway.

Both changes were mutation tested. Reverting the URL anchor fails exactly the new scheme test. Raising the phone floor fails exactly the new example-number test.

## Tests

- Five scenarios added, bound and passing: `secrets-redaction.feature` 46/46, `pii-redaction.feature` 30/30.
- 118 unit tests in `packages/redaction`, 564 across data-privacy and tracer, 2924 in the SDK.
- Three payload shapes added to the secrets adversarial list, including the lowercase prose that was the worst case.
- A committed benchmark, `pnpm --filter @langwatch/redaction bench`, because no unit test can hold a 2x change without flaking on a loaded runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password redaction in connection URLs, including varied schemes, casing, encoded credentials, and nested URL formats.
  * Prevented unintended redaction in malformed URLs, ordinary URLs, and non-URL text.
  * Improved phone-number detection efficiency while preserving redaction of recognized numbers.

* **Tests**
  * Expanded coverage for URL credentials, phone numbers, and adversarial inputs.
  * Added benchmarks using large prose, transcripts, and connection-string payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->