### PR TITLE
fix(build): anchor the npm pack filters, and run them where they can fail

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1375,6 +1375,42 @@ jobs:
       - name: Test guard-deployment-impact.ts
         run: node --test --experimental-strip-types .github/scripts/guard-deployment-impact.test.ts
 
+  # The npm artifact's staging filters, run over the real tree.
+  #
+  # dev/scripts/pack-npm.sh decides what every `npx @langwatch/server` user
+  # receives. Its filters are rsync patterns, and a pattern that is broader than
+  # it means to be drops application source: twice already the published server
+  # died at first boot ~20 minutes in on exactly that. The guard inside the
+  # script compares what git tracks against what staging kept, and `--check-filters`
+  # runs it without a build and without packing, in about ten seconds.
+  #
+  # It used to run only inside npx-server-smoke, which does not run on main and
+  # whose path filter names none of the trees the guard reads. A `.gitignore`
+  # added under dev/scripts therefore merged green and turned every branch that
+  # merged main red.
+  #
+  # No `if:` gate, on purpose. The guard reads every tree `files` in the root
+  # package.json names, and a path filter listing them would be a second copy of
+  # that list, stale the day someone edits it. A minute on an unrelated pull
+  # request is the cheaper mistake.
+  pack-filters:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # Drops docs/ + assets/ media. See LEAN CHECKOUT at the top of this file.
+          # None of it is in the package's `files`.
+          sparse-checkout: |
+            /*
+            !/docs/media/
+            !/docs/images/
+            !/assets/
+          sparse-checkout-cone-mode: false
+
+      - name: Check the npm pack filters
+        run: bash dev/scripts/pack-npm.sh --check-filters
+
   ci-self-test:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
@@ -1500,7 +1536,7 @@ jobs:
           path: vitest.durations.json
 
   langwatch-app-complete:
-    needs: [changes, typecheck, test-unit, test-component, test-integration, lint, ast-grep, feature-parity, openapi-completeness, build, ci-scripts-test, ci-self-test]
+    needs: [changes, typecheck, test-unit, test-component, test-integration, lint, ast-grep, feature-parity, openapi-completeness, build, ci-scripts-test, ci-self-test, pack-filters]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -7,7 +7,13 @@
 # Trigger policy:
 # - workflow_dispatch (manual, with optional `port_base` input)
 # - nightly schedule (04:00 UTC)
-# - push to non-main branches when key files change (PR validation)
+# - push, on any branch INCLUDING main, when key files change
+#
+# main was excluded from the push trigger for as long as this file has existed,
+# which left the nightly as its only cover. A defect that lands after the
+# nightly sits on main for up to a day while main reads green, and every branch
+# that merges main in that window goes red on work it did not do. The
+# concurrency block below already assumed a per-commit run on main.
 #
 # This workflow is intentionally not in the langwatch-app-complete required
 # checks — postgres/clickhouse/uv downloads are heavy and flaky-prone. Treat
@@ -25,8 +31,6 @@ on:
   schedule:
     - cron: "0 4 * * *"
   push:
-    branches-ignore:
-      - main
     paths:
       - "package.json"
       - "pnpm-workspace.yaml"

--- a/dev/scripts/pack-npm.sh
+++ b/dev/scripts/pack-npm.sh
@@ -39,15 +39,32 @@ cd "$ROOT"
 # seconds on every pull request instead of only inside the npx smoke matrix.
 # The expensive half is skipped: packing, and the staged-versus-tarball guard
 # that needs a tarball.
+#
+# `--stage-to DIR` stages into DIR and leaves it there. The filters decide what
+# every npm user receives and their verdict is otherwise only visible in a
+# temporary directory this script deletes on the way out, so this is how a
+# person, or a test, reads what actually survived.
 CHECK_FILTERS_ONLY=0
+STAGE_TO=""
 PACK_ARGS=()
+prev_arg=""
 for arg in "$@"; do
-  if [ "$arg" = "--check-filters" ]; then
-    CHECK_FILTERS_ONLY=1
-  else
-    PACK_ARGS+=("$arg")
+  if [ "$prev_arg" = "--stage-to" ]; then
+    STAGE_TO="$arg"
+    prev_arg=""
+    continue
   fi
+  case "$arg" in
+    --check-filters) CHECK_FILTERS_ONLY=1 ;;
+    --stage-to) prev_arg="--stage-to" ;;
+    --stage-to=*) STAGE_TO="${arg#--stage-to=}" ;;
+    *) PACK_ARGS+=("$arg") ;;
+  esac
 done
+if [ "$prev_arg" = "--stage-to" ]; then
+  echo "✗ --stage-to needs a directory" >&2
+  exit 1
+fi
 set -- ${PACK_ARGS[@]+"${PACK_ARGS[@]}"}
 
 # The CLI bundle is the package's entrypoint; packing without it produces a
@@ -61,8 +78,13 @@ if [ ! -f "pnpm-lock.yaml" ]; then
   exit 1
 fi
 
-STAGE="$(mktemp -d "${TMPDIR:-/tmp}/langwatch-pack.XXXXXX")"
-trap 'rm -rf "$STAGE"' EXIT
+if [ -n "$STAGE_TO" ]; then
+  mkdir -p "$STAGE_TO"
+  STAGE="$(cd "$STAGE_TO" && pwd)"
+else
+  STAGE="$(mktemp -d "${TMPDIR:-/tmp}/langwatch-pack.XXXXXX")"
+  trap 'rm -rf "$STAGE"' EXIT
+fi
 APP="$STAGE/app"
 mkdir -p "$APP"
 
@@ -140,6 +162,13 @@ EXCLUDES=(
   --exclude=.DS_Store
   --exclude=.vscode
   --exclude=.idea
+  # Editor and merge leftovers. npm-packlist drops `*.orig`, `.*.swp` and
+  # `._*` at every depth whatever the manifest says, so a working tree holding
+  # one would stage a file the tarball then refuses, and the staged-versus-
+  # tarball guard below would fail the pack.
+  --exclude=*.orig
+  --exclude=.*.swp
+  --exclude=._*
   # EVERY dotenv variant, not just `.env` and `*.local`. This tarball is
   # PUBLIC, and the working tree carries dotenv files that are gitignored but
   # very much present: haven writes platform/app/.env.portless (mode 0600, with
@@ -291,12 +320,28 @@ if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
   # Ignore files are on the list because an ignore file inside the package
   # gets a second say over what npm publishes, which is the whole reason the
   # staging tree strips them. Key material and dotenv files are on it because
-  # the secrets check below refuses to publish them at all.
+  # the secrets check below refuses to publish them at all. The build-output
+  # and editor directories are on it because nothing under them is source, even
+  # on the day somebody commits one by accident.
+  #
+  # Tests, notebooks and containers.
   not_application_source='(^|/)(__tests__|tests?|notebooks)/'
-  not_application_source="$not_application_source"'|(^|/)\.(git|npm|docker)ignore$'
   not_application_source="$not_application_source"'|(^|/)Dockerfile(\.|$)'
+  # Ignore files, registry auth, dotenv and key material.
+  not_application_source="$not_application_source"'|(^|/)\.(git|npm|docker)ignore$'
   not_application_source="$not_application_source"'|(^|/)\.npmrc$|(^|/)\.env($|\.)'
   not_application_source="$not_application_source"'|\.(pem|key|p12|pfx)$'
+  # Build output, tool caches and editor state.
+  not_application_source="$not_application_source"'|(^|/)(node_modules|coverage'
+  not_application_source="$not_application_source"'|test-results|playwright-report|blob-report'
+  not_application_source="$not_application_source"'|__pycache__|\.pytest_cache|\.venv'
+  not_application_source="$not_application_source"'|\.github|\.vscode|\.idea'
+  not_application_source="$not_application_source"'|\.next|\.turbo|\.vercel|\.pnpm-store)/'
+  # The bundle source maps the filters re-include are build output, so no
+  # tracked path can reach this rule and the re-include stays asserted by the
+  # staged-versus-tarball guard after the pack.
+  not_application_source="$not_application_source"'|\.(log|map|tsbuildinfo|orig|swp)$'
+  not_application_source="$not_application_source"'|(^|/)(\.DS_Store|\._[^/]*)$'
 
   staged_list="$(mktemp)"
   all_tracked="$(mktemp)"

--- a/dev/scripts/pack-npm.sh
+++ b/dev/scripts/pack-npm.sh
@@ -46,6 +46,7 @@ cd "$ROOT"
 # person, or a test, reads what actually survived.
 CHECK_FILTERS_ONLY=0
 STAGE_TO=""
+STAGE_TO_GIVEN=0
 PACK_ARGS=()
 prev_arg=""
 for arg in "$@"; do
@@ -56,12 +57,15 @@ for arg in "$@"; do
   fi
   case "$arg" in
     --check-filters) CHECK_FILTERS_ONLY=1 ;;
-    --stage-to) prev_arg="--stage-to" ;;
-    --stage-to=*) STAGE_TO="${arg#--stage-to=}" ;;
+    --stage-to) prev_arg="--stage-to"; STAGE_TO_GIVEN=1 ;;
+    --stage-to=*) STAGE_TO="${arg#--stage-to=}"; STAGE_TO_GIVEN=1 ;;
     *) PACK_ARGS+=("$arg") ;;
   esac
 done
-if [ "$prev_arg" = "--stage-to" ]; then
+# Tracked separately from the value, so `--stage-to=` and `--stage-to ""` are
+# refused rather than falling back to the temporary directory and quietly
+# ignoring the mode the caller asked for.
+if [ "$STAGE_TO_GIVEN" -eq 1 ] && [ -z "$STAGE_TO" ]; then
   echo "✗ --stage-to needs a directory" >&2
   exit 1
 fi
@@ -79,7 +83,16 @@ if [ ! -f "pnpm-lock.yaml" ]; then
 fi
 
 if [ -n "$STAGE_TO" ]; then
+  # An empty directory only. `rsync -a` adds and overwrites but never deletes,
+  # so anything already sitting there would read as staged and, on a full pack,
+  # ship: the published manifest lists `app`, so the whole preserved tree goes
+  # out. Refusing is the safe half of the choice, because the alternative is
+  # this script deleting a directory a caller named.
   mkdir -p "$STAGE_TO"
+  if [ -n "$(ls -A "$STAGE_TO" 2>/dev/null)" ]; then
+    echo "✗ --stage-to needs an empty directory, and $STAGE_TO is not empty" >&2
+    exit 1
+  fi
   STAGE="$(cd "$STAGE_TO" && pwd)"
 else
   STAGE="$(mktemp -d "${TMPDIR:-/tmp}/langwatch-pack.XXXXXX")"

--- a/dev/scripts/pack-npm.sh
+++ b/dev/scripts/pack-npm.sh
@@ -34,9 +34,25 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
 
+# `--check-filters` stages the tree, runs the source-completeness guard, and
+# stops. No build output is needed and no tarball is produced, so it runs in
+# seconds on every pull request instead of only inside the npx smoke matrix.
+# The expensive half is skipped: packing, and the staged-versus-tarball guard
+# that needs a tarball.
+CHECK_FILTERS_ONLY=0
+PACK_ARGS=()
+for arg in "$@"; do
+  if [ "$arg" = "--check-filters" ]; then
+    CHECK_FILTERS_ONLY=1
+  else
+    PACK_ARGS+=("$arg")
+  fi
+done
+set -- ${PACK_ARGS[@]+"${PACK_ARGS[@]}"}
+
 # The CLI bundle is the package's entrypoint; packing without it produces a
 # tarball whose `bin` dangles and which fails at `npx` time, not at pack time.
-if [ ! -f "packages/server/dist/cli.cjs" ]; then
+if [ "$CHECK_FILTERS_ONLY" -eq 0 ] && [ ! -f "packages/server/dist/cli.cjs" ]; then
   echo "✗ packages/server/dist/cli.cjs missing — run 'pnpm build:cli' first" >&2
   exit 1
 fi
@@ -52,6 +68,10 @@ mkdir -p "$APP"
 
 # Trimming that used to live in the two .npmignore files. Stated once, here,
 # where it is visible next to the copy that applies it.
+#
+# Everything in this array is matched by rsync at EVERY depth of every shipped
+# tree, so a name only belongs here when that is what it means. A path that
+# names one location goes in ANCHORED_EXCLUDES below instead.
 EXCLUDES=(
   --exclude=node_modules
   # No ignore files in the staged tree. npm/pnpm pack honours a .gitignore
@@ -92,9 +112,15 @@ EXCLUDES=(
   # checkout does not even have.
   #
   # Every remaining bare name here was checked against the shipped trees for
-  # the same collision: `test`/`tests` match only genuine test directories,
-  # and `notebooks`/`coverage` match nothing in source.
-  --exclude=Dockerfile*
+  # the same collision: `test`, `tests` and `notebooks` match only genuine
+  # test and notebook directories (`notebooks` drops services/langevals/
+  # notebooks, which is what it is for), and `coverage` matches nothing.
+  #
+  # `Dockerfile` and `Dockerfile.<target>` rather than `Dockerfile*`: the star
+  # form also matches any source file whose name merely starts with the word,
+  # and every container file in the repo uses one of these two spellings.
+  --exclude=Dockerfile
+  --exclude=Dockerfile.*
   --exclude=.dockerignore
   --exclude=.github
   # The server bundles' source maps, re-included ahead of the blanket *.map
@@ -141,25 +167,59 @@ EXCLUDES=(
   # disables that protection for every nested one. .npmrc is where
   # `npm config set --location=project` and most CI setups write registry auth.
   --exclude=.npmrc
-  # Debug logs routinely carry registry URLs and, on auth failure, token
-  # fragments.
+  # Logs. Debug logs routinely carry registry URLs and, on auth failure, token
+  # fragments, and `pnpm dev:app` tees the whole dev server into server.log.
+  # The tarball is public, so every log is stripped wherever it sits rather
+  # than only the two filenames that were named here before. No tracked file
+  # in any shipped tree ends in `.log`, and the guard below fails loudly if one
+  # ever does.
+  --exclude=*.log
   --exclude=*-debug.log*
   --exclude=.vercel
   --exclude=.next
   --exclude=.turbo
   --exclude=.pnpm-store
-  # The quickwit dev binary (platform/app/quickwit*) is a local download, not
-  # source — no tracked path anywhere contains the name (the old .npmignore's
-  # `!elastic/quickwit` re-include referenced a directory that no longer
-  # exists), so the bare-name exclude collides with nothing.
-  --exclude=quickwit
-  --exclude=quickwit-*
-  --exclude=.sentryclirc
-  --exclude=server.log
-  --exclude=licenses.json
-  --exclude=prisma/db.sqlite*
-  --exclude=e2e/auth.json
 )
+
+# Working-tree artifacts that live at ONE known path. Each is written from the
+# repository root and is anchored there, so it cannot reach a file of the same
+# name somewhere else.
+#
+# A bare name would have been shorter and is what these used to be, but rsync
+# matches a bare name against every path component, so `--exclude=licenses.json`
+# also silently drops a source data file of that name in any shipped tree, and
+# `--exclude=quickwit` drops a source directory called that at any depth. The
+# old .npmignore carried a `!elastic/quickwit` re-include, so such a directory
+# has existed here before. That is the same class as the `--exclude=reports`
+# failure recorded above, which reached npm and killed the published server at
+# first boot.
+ANCHORED_EXCLUDES=(
+  # A local download, not source.
+  platform/app/quickwit
+  platform/app/quickwit-*
+  platform/app/.sentryclirc
+  # `pnpm licenses` writes this report.
+  platform/app/licenses.json
+  platform/app/prisma/db.sqlite*
+  platform/app/e2e/auth.json
+)
+
+# Rewrite ANCHORED_EXCLUDES into rsync patterns for one `files` entry, into the
+# global `anchored` array. rsync anchors a leading-slash pattern at the top of
+# the transfer, and this script copies one entry at a time with the entry
+# itself as that top, so `platform/app/licenses.json` becomes `/app/licenses.json`
+# while the entry is `platform/app` and disappears entirely for every other
+# entry.
+anchored=()
+anchored_patterns_for() {
+  local entry="$1" path
+  anchored=()
+  for path in "${ANCHORED_EXCLUDES[@]}"; do
+    case "$path" in
+      "$entry"/*) anchored+=("--exclude=/${entry##*/}/${path#"$entry"/}") ;;
+    esac
+  done
+}
 
 # Everything `files` lists, copied into app/ so the workspace root sits one
 # level below the package root.
@@ -171,9 +231,11 @@ EXCLUDES=(
 #
 # A while-read loop rather than mapfile: mapfile is bash 4+, and macOS still
 # ships bash 3.2, so a local `pnpm pack:npm` would die on it.
+FILES_ENTRIES=()
 while IFS= read -r entry; do
   [ -n "$entry" ] || continue
   entry="${entry%/}"
+  FILES_ENTRIES+=("$entry")
   # npm skips a `files` entry that doesn't exist rather than failing, so this
   # matches it. Warn loudly though: a silently-skipped entry is how a stale
   # list goes unnoticed (packages/server/templates/ sat here for a long time
@@ -183,7 +245,9 @@ while IFS= read -r entry; do
     continue
   fi
   mkdir -p "$APP/$(dirname "$entry")"
-  rsync -a "${EXCLUDES[@]}" "$ROOT/$entry" "$APP/$(dirname "$entry")/"
+  anchored_patterns_for "$entry"
+  rsync -a ${anchored[@]+"${anchored[@]}"} "${EXCLUDES[@]}" \
+    "$ROOT/$entry" "$APP/$(dirname "$entry")/"
 done < <(node -p "require('./package.json').files.join('\n')")
 
 # The workspace root's own manifest. pnpm resolves the lockfile's `.` importer
@@ -206,7 +270,71 @@ node -e '
 cp "$ROOT/README.md" "$STAGE/README.md"
 cp "$ROOT/LICENSE.md" "$STAGE/LICENSE.md"
 
+# Guard: the staging filters must not drop application source.
+#
+# Two exclusion bugs in this script have already shipped a tarball that looked
+# fine and died at first boot ~20 minutes in: a .gitignore in the staged tree
+# stripping dist/, and an rsync `--exclude=reports` matching the name at any
+# depth and taking src/server/app-layer/reports with it. Comparing what git
+# tracks against what staging kept costs a second and catches the class.
+#
+# Across every tree `files` names, not a chosen subset of them. The subset this
+# guard used to read was complete only while no over-broad pattern happened to
+# land outside it, which is not a property anyone can maintain.
+#
+# Only when packing from a git checkout, because a published tree has no index.
+if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  # The file classes the filters above drop ON PURPOSE. Naming them here is
+  # what keeps this guard a statement of intent rather than a second copy of
+  # EXCLUDES: add a class only when shipping it would be wrong.
+  #
+  # Ignore files are on the list because an ignore file inside the package
+  # gets a second say over what npm publishes, which is the whole reason the
+  # staging tree strips them. Key material and dotenv files are on it because
+  # the secrets check below refuses to publish them at all.
+  not_application_source='(^|/)(__tests__|tests?|notebooks)/'
+  not_application_source="$not_application_source"'|(^|/)\.(git|npm|docker)ignore$'
+  not_application_source="$not_application_source"'|(^|/)Dockerfile(\.|$)'
+  not_application_source="$not_application_source"'|(^|/)\.npmrc$|(^|/)\.env($|\.)'
+  not_application_source="$not_application_source"'|\.(pem|key|p12|pfx)$'
+
+  staged_list="$(mktemp)"
+  all_tracked="$(mktemp)"
+  tracked="$(mktemp)"
+  (cd "$APP" && find . \( -type f -o -type l \)) | sed 's|^\./||' | sort > "$staged_list"
+  # -c core.quotePath=false: git quotes non-ASCII paths by default, which would
+  # never match the staged listing and would read as missing source.
+  git -C "$ROOT" -c core.quotePath=false ls-files -- \
+    ${FILES_ENTRIES[@]+"${FILES_ENTRIES[@]}"} | sort > "$all_tracked"
+  # `|| true` on both: a grep that filters everything exits 1 and would abort
+  # the script under `set -e`.
+  { grep -vE "$not_application_source" "$all_tracked" || true; } > "$tracked"
+  # `.env.example` is tracked documentation, and the filters re-include it ahead
+  # of the dotenv excludes. The dotenv exemption above would otherwise stop this
+  # guard from proving that ordering still holds, so put it back.
+  { grep -E '(^|/)\.env\.example$' "$all_tracked" || true; } >> "$tracked"
+  sort -u -o "$tracked" "$tracked"
+
+  missing="$(comm -23 "$tracked" "$staged_list")"
+  rm -f "$staged_list" "$all_tracked" "$tracked"
+  if [ -n "$missing" ]; then
+    echo "✗ staging dropped application source the repo tracks:" >&2
+    printf '%s\n' "$missing" | head -20 >&2 || true
+    echo "  Either an EXCLUDES pattern is broader than it means to be, since a" >&2
+    echo "  bare name there matches at every depth, or these files are meant to" >&2
+    echo "  stay out and belong in the exemptions right above this check." >&2
+    exit 1
+  fi
+  echo "→ verified: staging keeps every tracked source file across the shipped trees"
+fi
+
 echo "→ staged $(du -sh "$STAGE" | cut -f1) at $STAGE"
+
+if [ "$CHECK_FILTERS_ONLY" -eq 1 ]; then
+  echo "→ --check-filters: staging verified, stopping before the pack"
+  exit 0
+fi
+
 echo "→ running: pnpm pack $*"
 cd "$STAGE"
 # Always pack to an explicit destination OUTSIDE the staging dir, because the
@@ -228,17 +356,10 @@ case " $* " in
     ;;
 esac
 
-# Assert the tarball still carries what the staging tree put in it.
+# Find the tarball that `pnpm pack` just wrote.
 #
-# Packing applies its own filtering on top of the staged allowlist, so a file
-# can be staged correctly and still not ship — which is how the prebuilt vite
-# client went missing once already (a .gitignore inside langwatch/ listing
-# `/dist`). The failure surfaces ~25 minutes later as an end-user boot that
-# silently rebuilds and times out, so check it here where the cause is
-# obvious. Only asserted when the source actually had a build to ship: a
-# dev-checkout pack with no dist/ is legitimate.
 # `|| true` on both: under `set -e` + `pipefail` a glob that matches nothing
-# makes ls fail, which would abort the script here — silently, since packing
+# makes ls fail, which would abort the script here, silently, since packing
 # has already succeeded by this point.
 # Default matches the default supplied to `pnpm pack` above. Both spellings of
 # the flag are read, so `--pack-destination=DIR` cannot leave dest pointing at
@@ -258,67 +379,39 @@ if [ -z "$tarball" ]; then
   exit 1
 fi
 
-if [ -f "$ROOT/platform/app/dist/client/index.html" ]; then
-  # List once into a file rather than piping into `grep -q`. grep -q exits at
-  # the first match, which SIGPIPEs tar; under `pipefail` that non-zero tar
-  # fails the pipeline even though the match succeeded, so the check reported
-  # the file missing when it was present. It fired on linux and not macos —
-  # the race depends on how much tar writes before grep exits, which is
-  # exactly the kind of check that must not be timing-dependent.
-  listing="$(mktemp)"
-  tar -tzf "$tarball" > "$listing"
-  if ! grep -qx "package/app/platform/app/dist/client/index.html" "$listing"; then
-    rm -f "$listing"
-    echo "✗ the repo has a built platform/app/dist/client but the tarball does not ship it." >&2
-    echo "  Something filtered it out after staging — check for an ignore file in the staged tree." >&2
-    exit 1
-  fi
-  rm -f "$listing"
-  echo "→ verified: tarball ships the prebuilt platform/app/dist/client"
-fi
-
-# Assert no application source went missing.
+# Assert the tarball carries everything the staging tree put in it.
 #
-# Two separate exclusion bugs in this script have already shipped a tarball
-# that looked fine and died at first boot ~20 minutes in: a .gitignore in the
-# staged tree stripping dist/, and an rsync `--exclude=reports` matching the
-# name at any depth and taking src/server/app-layer/reports with it. Both were
-# invisible until the smoke job ran the whole stack. Comparing what git tracks
-# against what the tarball carries costs a second and catches the entire class.
+# Packing applies its own filtering on top of the staged allowlist, so a file
+# can be staged correctly and still not ship. That is how the prebuilt vite
+# client went missing once already (a .gitignore inside the app listing
+# `/dist`). The failure surfaces ~25 minutes later as an end-user boot that
+# silently rebuilds and times out.
 #
-# Only when packing from a git checkout — a published tree has no index.
-if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
-  in_tar="$(mktemp)"
-  tracked="$(mktemp)"
-  tar -tzf "$tarball" | sed 's|^package/app/||' | sort > "$in_tar"
-  # Every shipped SOURCE tree, not just the app's: a bare name in EXCLUDES
-  # matches at any depth in all of them, and the guard being complete for the
-  # others was previously true only by accident (none happened to contain a
-  # dir named like an exclude). Runtime source only: tests, fixtures and the
-  # secret-shaped names the excludes above deliberately strip are filtered.
-  # -c core.quotePath=false: git quotes non-ASCII paths by default, which
-  # would never match the tar listing and read as missing source. The
-  # `|| true` keeps a fully-filtered grep (exit 1) from aborting the script
-  # under pipefail after the pack already succeeded.
-  git -C "$ROOT" -c core.quotePath=false ls-files \
-      platform/app/src platform/app/ee \
-      mcp/typescript/src \
-      packages/authz/src packages/authz-server/src \
-      packages/handled-error/src packages/langy/src \
-      packages/system-migrations/src \
-      skills dev/scripts \
-    | { grep -vE '__tests__|\.test\.|\.spec\.|(^|/)tests?/|(^|/)\.npmrc$|\.env\.example$' || true; } | sort > "$tracked"
-  missing="$(comm -23 "$tracked" "$in_tar")"
-  rm -f "$in_tar" "$tracked"
-  if [ -n "$missing" ]; then
-    echo "✗ the tarball is missing application source the repo tracks:" >&2
-    printf '%s\n' "$missing" | head -20 >&2 || true
-    echo "  An exclude pattern in this script is too broad — a bare name in" >&2
-    echo "  EXCLUDES matches at every depth, not just where it was meant." >&2
-    exit 1
-  fi
-  echo "→ verified: tarball ships every tracked source file across the shipped trees"
+# Whatever survived staging IS the package, so this comparison needs no
+# exemption list at all. That is what separates it from the guard before the
+# pack: this one answers "did packing lose something", that one answers "did
+# the filters keep the right things", and a single check that answered both
+# reported a deliberate strip as a too-broad exclude pattern.
+staged_all="$(mktemp)"
+in_tar="$(mktemp)"
+(cd "$STAGE" && find . \( -type f -o -type l \)) \
+  | sed 's|^\./||' | grep -v '\.tgz$' | sort > "$staged_all"
+# List once into a file rather than piping into `grep -q`. grep -q exits at the
+# first match, which SIGPIPEs tar; under `pipefail` that non-zero tar fails the
+# pipeline even though the match succeeded. It fires on linux and not macos,
+# because the race depends on how much tar writes before grep exits.
+tar -tzf "$tarball" | grep -v '/$' | sed 's|^package/||' | sort > "$in_tar"
+lost="$(comm -23 "$staged_all" "$in_tar")"
+rm -f "$staged_all" "$in_tar"
+if [ -n "$lost" ]; then
+  echo "✗ packing dropped files the staging tree carried:" >&2
+  printf '%s\n' "$lost" | head -20 >&2 || true
+  echo "  npm applies its own filtering on top of staging. Check for an ignore" >&2
+  echo "  file that reached the staged tree, and for npm's own always-excluded" >&2
+  echo "  names at the package root." >&2
+  exit 1
 fi
+echo "→ verified: the tarball carries every staged file"
 
 # The lockfile is the whole reason for the staged layout (npm strips one at
 # the package ROOT), so its presence is asserted on every pack — not only in

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
 		"typecheck": "tsc --noEmit",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"test:invariants": "vitest run test/workspace-invariants.test.ts"
+		"test:invariants": "vitest run test/workspace-invariants.test.ts test/pack-npm-filters.test.ts"
 	},
 	"dependencies": {
 		"chalk": "^6.0.0",

--- a/packages/server/test/pack-npm-filters.test.ts
+++ b/packages/server/test/pack-npm-filters.test.ts
@@ -92,10 +92,13 @@ function buildFixture(trackedPaths: string[]): string {
 	return root;
 }
 
-function runCheck(
-	root: string,
-	extraArgs: string[] = [],
-): { code: number; output: string } {
+function runCheck({
+	root,
+	extraArgs = [],
+}: {
+	root: string;
+	extraArgs?: string[];
+}): { code: number; output: string } {
 	const args = [
 		join(root, "dev", "scripts", "pack-npm.sh"),
 		"--check-filters",
@@ -122,7 +125,13 @@ function runCheck(
 }
 
 /** Whether a repo-relative path survived into the staged tree. */
-function staged(stageDir: string, relPath: string): boolean {
+function staged({
+	stageDir,
+	relPath,
+}: {
+	stageDir: string;
+	relPath: string;
+}): boolean {
 	return existsSync(join(stageDir, "app", relPath));
 }
 
@@ -141,11 +150,11 @@ describe("npm pack staging filters", () => {
 		const root = buildFixture(collisions);
 		const stageDir = join(root, "_stage");
 
-		const { code } = runCheck(root, ["--stage-to", stageDir]);
+		const { code } = runCheck({ root, extraArgs: ["--stage-to", stageDir] });
 
 		expect(code).toBe(0);
 		for (const relPath of collisions) {
-			expect(staged(stageDir, relPath)).toBe(true);
+			expect(staged({ stageDir, relPath })).toBe(true);
 		}
 	});
 
@@ -164,7 +173,7 @@ describe("npm pack staging filters", () => {
 			"packages/api/tests/integration.test.ts",
 		]);
 
-		const { code, output } = runCheck(root);
+		const { code, output } = runCheck({ root });
 		expect(output).toContain("staging keeps every tracked source file");
 		expect(code).toBe(0);
 	});
@@ -181,11 +190,15 @@ describe("npm pack staging filters", () => {
 		]);
 		const stageDir = join(root, "_stage");
 
-		const { code } = runCheck(root, ["--stage-to", stageDir]);
+		const { code } = runCheck({ root, extraArgs: ["--stage-to", stageDir] });
 
 		expect(code).toBe(0);
-		expect(staged(stageDir, "platform/app/.env.example")).toBe(true);
-		expect(staged(stageDir, "platform/app/.env.staging")).toBe(false);
+		expect(staged({ stageDir, relPath: "platform/app/.env.example" })).toBe(
+			true,
+		);
+		expect(staged({ stageDir, relPath: "platform/app/.env.staging" })).toBe(
+			false,
+		);
 	});
 
 	it("still strips the artifacts the app root writes", () => {
@@ -203,10 +216,13 @@ describe("npm pack staging filters", () => {
 		const root = buildFixture(artifacts);
 		const stageDir = join(root, "_stage");
 
-		const { code, output } = runCheck(root, ["--stage-to", stageDir]);
+		const { code, output } = runCheck({
+			root,
+			extraArgs: ["--stage-to", stageDir],
+		});
 
 		for (const relPath of artifacts) {
-			expect(staged(stageDir, relPath)).toBe(false);
+			expect(staged({ stageDir, relPath })).toBe(false);
 		}
 		// Everything but the log is outside the guard's exemptions, so the guard
 		// names each one it dropped. That is the failing half of the guard, which
@@ -216,5 +232,35 @@ describe("npm pack staging filters", () => {
 		for (const named of artifacts.filter((p) => !p.endsWith(".log"))) {
 			expect(output).toContain(named);
 		}
+	});
+
+	describe("--stage-to", () => {
+		it.each([["--stage-to", ""], ["--stage-to="]])(
+			"refuses %s with no directory",
+			(...extraArgs: string[]) => {
+				const root = buildFixture(["platform/app/src/server/config.ts"]);
+
+				const { code, output } = runCheck({ root, extraArgs });
+
+				expect(code).toBe(1);
+				expect(output).toContain("--stage-to needs a directory");
+			},
+		);
+
+		it("refuses a directory that already holds something", () => {
+			// rsync adds and overwrites but never deletes, so a stale file left in
+			// the directory would read as staged and, on a full pack, ship.
+			const root = buildFixture(["platform/app/src/server/config.ts"]);
+			const stageDir = join(root, "_stage");
+			write({ root: stageDir, relPath: "leftover.txt" });
+
+			const { code, output } = runCheck({
+				root,
+				extraArgs: ["--stage-to", stageDir],
+			});
+
+			expect(code).toBe(1);
+			expect(output).toContain("needs an empty directory");
+		});
 	});
 });

--- a/packages/server/test/pack-npm-filters.test.ts
+++ b/packages/server/test/pack-npm-filters.test.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -37,7 +44,15 @@ afterEach(() => {
 	fixture = undefined;
 });
 
-function write(root: string, relPath: string, content = "x\n"): void {
+function write({
+	root,
+	relPath,
+	content = "x\n",
+}: {
+	root: string;
+	relPath: string;
+	content?: string;
+}): void {
 	const full = join(root, relPath);
 	mkdirSync(dirname(full), { recursive: true });
 	writeFileSync(full, content);
@@ -53,10 +68,7 @@ function buildFixture(trackedPaths: string[]): string {
 	fixture = root;
 
 	mkdirSync(join(root, "dev", "scripts"), { recursive: true });
-	writeFileSync(
-		join(root, "dev", "scripts", "pack-npm.sh"),
-		execFileSync("cat", [scriptPath], { encoding: "utf8" }),
-	);
+	copyFileSync(scriptPath, join(root, "dev", "scripts", "pack-npm.sh"));
 	writeFileSync(
 		join(root, "package.json"),
 		`${JSON.stringify(
@@ -73,23 +85,35 @@ function buildFixture(trackedPaths: string[]): string {
 	writeFileSync(join(root, "README.md"), "fixture\n");
 	writeFileSync(join(root, "LICENSE.md"), "fixture\n");
 
-	for (const relPath of trackedPaths) write(root, relPath);
+	for (const relPath of trackedPaths) write({ root, relPath });
 
 	execFileSync("git", ["init", "-q"], { cwd: root });
 	execFileSync("git", ["add", "-A"], { cwd: root });
 	return root;
 }
 
-function runCheck(root: string): { code: number; output: string } {
+function runCheck(
+	root: string,
+	extraArgs: string[] = [],
+): { code: number; output: string } {
+	const args = [
+		join(root, "dev", "scripts", "pack-npm.sh"),
+		"--check-filters",
+		...extraArgs,
+	];
 	try {
-		const output = execFileSync(
-			"bash",
-			[join(root, "dev", "scripts", "pack-npm.sh"), "--check-filters"],
-			{ cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-		);
+		const output = execFileSync("bash", args, {
+			cwd: root,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
 		return { code: 0, output };
 	} catch (error) {
-		const failure = error as { status?: number; stdout?: string; stderr?: string };
+		const failure = error as {
+			status?: number;
+			stdout?: string;
+			stderr?: string;
+		};
 		return {
 			code: failure.status ?? 1,
 			output: `${failure.stdout ?? ""}${failure.stderr ?? ""}`,
@@ -97,23 +121,32 @@ function runCheck(root: string): { code: number; output: string } {
 	}
 }
 
+/** Whether a repo-relative path survived into the staged tree. */
+function staged(stageDir: string, relPath: string): boolean {
+	return existsSync(join(stageDir, "app", relPath));
+}
+
 describe("npm pack staging filters", () => {
 	it("keeps source whose name collides with a working-tree artifact", () => {
 		// Each of these shares a name with something the script strips from the
 		// app root. A bare-name pattern removes all of them; an anchored one
 		// reaches only the app root copy.
-		const root = buildFixture([
+		const collisions = [
 			"platform/app/src/server/licenses.json",
 			"platform/app/src/server/quickwit/index.ts",
 			"packages/api/src/licenses.json",
 			"packages/api/src/quickwit-client.ts",
 			"platform/app/src/server/reports/report-chart.service.ts",
-		]);
+		];
+		const root = buildFixture(collisions);
+		const stageDir = join(root, "_stage");
 
-		const { code, output } = runCheck(root);
-		expect(output).not.toContain("licenses.json");
-		expect(output).not.toContain("quickwit");
+		const { code } = runCheck(root, ["--stage-to", stageDir]);
+
 		expect(code).toBe(0);
+		for (const relPath of collisions) {
+			expect(staged(stageDir, relPath)).toBe(true);
+		}
 	});
 
 	it("passes when a shipped tree tracks an ignore file", () => {
@@ -137,41 +170,51 @@ describe("npm pack staging filters", () => {
 	});
 
 	it("ships .env.example and no other dotenv file", () => {
+		// `.env.example` is tracked documentation, and the re-include that keeps
+		// it has to be read before the excludes that would take it. The staged
+		// tree is what says whether that ordering still holds, because the guard
+		// exempts every other dotenv file and so cannot report one.
 		const root = buildFixture([
 			"platform/app/.env.example",
+			"platform/app/.env.staging",
 			"platform/app/src/server/config.ts",
 		]);
+		const stageDir = join(root, "_stage");
 
-		const { code } = runCheck(root);
+		const { code } = runCheck(root, ["--stage-to", stageDir]);
+
 		expect(code).toBe(0);
+		expect(staged(stageDir, "platform/app/.env.example")).toBe(true);
+		expect(staged(stageDir, "platform/app/.env.staging")).toBe(false);
 	});
 
 	it("still strips the artifacts the app root writes", () => {
 		// The inverse probe. These paths are never tracked in the real repository
 		// (they are what a working tree accumulates), so tracking them here is
-		// what makes the guard report each one it dropped, which is the only way
-		// to read rsync's verdict from the outside.
-		const root = buildFixture([
+		// what puts them in front of the filters at all.
+		const artifacts = [
 			"platform/app/licenses.json",
 			"platform/app/quickwit",
 			"platform/app/.sentryclirc",
 			"platform/app/prisma/db.sqlite3",
 			"platform/app/e2e/auth.json",
 			"platform/app/src/server/stray.log",
-		]);
+		];
+		const root = buildFixture(artifacts);
+		const stageDir = join(root, "_stage");
 
-		const { code, output } = runCheck(root);
+		const { code, output } = runCheck(root, ["--stage-to", stageDir]);
+
+		for (const relPath of artifacts) {
+			expect(staged(stageDir, relPath)).toBe(false);
+		}
+		// Everything but the log is outside the guard's exemptions, so the guard
+		// names each one it dropped. That is the failing half of the guard, which
+		// nothing else here exercises.
 		expect(code).toBe(1);
 		expect(output).toContain("staging dropped application source");
-		for (const dropped of [
-			"platform/app/licenses.json",
-			"platform/app/quickwit",
-			"platform/app/.sentryclirc",
-			"platform/app/prisma/db.sqlite3",
-			"platform/app/e2e/auth.json",
-			"platform/app/src/server/stray.log",
-		]) {
-			expect(output).toContain(dropped);
+		for (const named of artifacts.filter((p) => !p.endsWith(".log"))) {
+			expect(output).toContain(named);
 		}
 	});
 });

--- a/packages/server/test/pack-npm-filters.test.ts
+++ b/packages/server/test/pack-npm-filters.test.ts
@@ -1,0 +1,177 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * What the npm artifact's staging filters keep and drop.
+ *
+ * dev/scripts/pack-npm.sh copies the `files` list into a staging tree with a
+ * set of rsync patterns, and rsync matches a pattern without a slash against
+ * EVERY path component. A working-tree artifact named there by its bare name
+ * therefore also removes any source file or directory that happens to share
+ * the name, anywhere in any shipped tree. That has reached npm twice: once as
+ * `--exclude=reports`, which took src/server/app-layer/reports with it and
+ * killed the published server at first boot inside the ClickHouse migration.
+ *
+ * The script is run for real against a small fixture repository rather than
+ * having its patterns re-read here, so the assertions are about rsync's own
+ * matching and not about a second reading of it.
+ */
+
+const scriptPath = join(
+	__dirname,
+	"..",
+	"..",
+	"..",
+	"dev",
+	"scripts",
+	"pack-npm.sh",
+);
+
+let fixture: string | undefined;
+
+afterEach(() => {
+	if (fixture) rmSync(fixture, { recursive: true, force: true });
+	fixture = undefined;
+});
+
+function write(root: string, relPath: string, content = "x\n"): void {
+	const full = join(root, relPath);
+	mkdirSync(dirname(full), { recursive: true });
+	writeFileSync(full, content);
+}
+
+/**
+ * A repository the pack script can run against: the real script at the path it
+ * resolves its root from, a root manifest whose `files` names the trees below,
+ * a lockfile, and a git index for the guard to compare against.
+ */
+function buildFixture(trackedPaths: string[]): string {
+	const root = mkdtempSync(join(tmpdir(), "pack-filters-"));
+	fixture = root;
+
+	mkdirSync(join(root, "dev", "scripts"), { recursive: true });
+	writeFileSync(
+		join(root, "dev", "scripts", "pack-npm.sh"),
+		execFileSync("cat", [scriptPath], { encoding: "utf8" }),
+	);
+	writeFileSync(
+		join(root, "package.json"),
+		`${JSON.stringify(
+			{
+				name: "@langwatch/server",
+				version: "0.0.0",
+				files: ["platform/app/", "packages/api/", "dev/scripts/"],
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	writeFileSync(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+	writeFileSync(join(root, "README.md"), "fixture\n");
+	writeFileSync(join(root, "LICENSE.md"), "fixture\n");
+
+	for (const relPath of trackedPaths) write(root, relPath);
+
+	execFileSync("git", ["init", "-q"], { cwd: root });
+	execFileSync("git", ["add", "-A"], { cwd: root });
+	return root;
+}
+
+function runCheck(root: string): { code: number; output: string } {
+	try {
+		const output = execFileSync(
+			"bash",
+			[join(root, "dev", "scripts", "pack-npm.sh"), "--check-filters"],
+			{ cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		);
+		return { code: 0, output };
+	} catch (error) {
+		const failure = error as { status?: number; stdout?: string; stderr?: string };
+		return {
+			code: failure.status ?? 1,
+			output: `${failure.stdout ?? ""}${failure.stderr ?? ""}`,
+		};
+	}
+}
+
+describe("npm pack staging filters", () => {
+	it("keeps source whose name collides with a working-tree artifact", () => {
+		// Each of these shares a name with something the script strips from the
+		// app root. A bare-name pattern removes all of them; an anchored one
+		// reaches only the app root copy.
+		const root = buildFixture([
+			"platform/app/src/server/licenses.json",
+			"platform/app/src/server/quickwit/index.ts",
+			"packages/api/src/licenses.json",
+			"packages/api/src/quickwit-client.ts",
+			"platform/app/src/server/reports/report-chart.service.ts",
+		]);
+
+		const { code, output } = runCheck(root);
+		expect(output).not.toContain("licenses.json");
+		expect(output).not.toContain("quickwit");
+		expect(code).toBe(0);
+	});
+
+	it("passes when a shipped tree tracks an ignore file", () => {
+		// Ignore files are stripped at every depth on purpose, because one inside
+		// the package gets a second say over what npm publishes. The guard has to
+		// know that, or a tracked .gitignore anywhere reads as lost source: one
+		// added under dev/scripts turned every branch that merged main red.
+		const root = buildFixture([
+			"dev/scripts/dogfood/multimodal/.gitignore",
+			"platform/app/.gitignore",
+			"packages/api/.npmignore",
+			"platform/app/Dockerfile",
+			"platform/app/.dockerignore",
+			"packages/api/src/__tests__/unit.test.ts",
+			"packages/api/tests/integration.test.ts",
+		]);
+
+		const { code, output } = runCheck(root);
+		expect(output).toContain("staging keeps every tracked source file");
+		expect(code).toBe(0);
+	});
+
+	it("ships .env.example and no other dotenv file", () => {
+		const root = buildFixture([
+			"platform/app/.env.example",
+			"platform/app/src/server/config.ts",
+		]);
+
+		const { code } = runCheck(root);
+		expect(code).toBe(0);
+	});
+
+	it("still strips the artifacts the app root writes", () => {
+		// The inverse probe. These paths are never tracked in the real repository
+		// (they are what a working tree accumulates), so tracking them here is
+		// what makes the guard report each one it dropped, which is the only way
+		// to read rsync's verdict from the outside.
+		const root = buildFixture([
+			"platform/app/licenses.json",
+			"platform/app/quickwit",
+			"platform/app/.sentryclirc",
+			"platform/app/prisma/db.sqlite3",
+			"platform/app/e2e/auth.json",
+			"platform/app/src/server/stray.log",
+		]);
+
+		const { code, output } = runCheck(root);
+		expect(code).toBe(1);
+		expect(output).toContain("staging dropped application source");
+		for (const dropped of [
+			"platform/app/licenses.json",
+			"platform/app/quickwit",
+			"platform/app/.sentryclirc",
+			"platform/app/prisma/db.sqlite3",
+			"platform/app/e2e/auth.json",
+			"platform/app/src/server/stray.log",
+		]) {
+			expect(output).toContain(dropped);
+		}
+	});
+});


### PR DESCRIPTION
## What this fixes

Two problems in the npm packing path, found because every branch that merged
main went red on a check main itself had never run.

### 1. rsync patterns that match more than they mean

`dev/scripts/pack-npm.sh` copies the `files` trees into a staging tree with
rsync `--exclude` patterns. rsync matches a pattern that has no slash against
**every path component**, not just the root. Six working tree artifacts were
named there by their bare name:

`quickwit`, `quickwit-*`, `licenses.json`, `server.log`, `.sentryclirc`,
`prisma/db.sqlite*`, `e2e/auth.json`

Measured against the current tree, with decoy files and the real script:

| path | before | after |
| --- | --- | --- |
| `platform/app/src/server/licenses.json` | dropped | ships |
| `packages/api/src/licenses.json` | dropped | ships |
| `platform/app/src/server/quickwit/keep.ts` | dropped | ships |
| `platform/app/licenses.json` | dropped | dropped |
| `platform/app/quickwit` | dropped | dropped |

This is the same class as `--exclude=reports`, which took
`src/server/app-layer/reports` with it and killed the published server at first
boot inside the ClickHouse migration. Those six now live in `ANCHORED_EXCLUDES`,
written from the repository root and rewritten per `files` entry into a pattern
anchored at that entry.

Two more entries had the same ambiguity and were tightened:

- `Dockerfile*` becomes `Dockerfile` and `Dockerfile.*`. The star form also
  matches any source file whose name merely starts with the word. Every
  container file in the repo uses one of the two exact spellings.
- `server.log` becomes `*.log`. The tarball is public, so a stray log should
  not ship from anywhere, and no tracked file in any shipped tree ends in
  `.log`.

Three names were missing rather than too broad. npm-packlist drops `*.orig`,
`.*.swp` and `._*` at every depth whatever the manifest says, so a working tree
holding one staged a file the tarball then refused. They are excluded at
staging now, which keeps the two in agreement.

### 2. A guard that reported the wrong cause

The guard compared what git tracks against the tarball and printed:

```
✗ the tarball is missing application source the repo tracks:
dev/scripts/dogfood/multimodal/.gitignore
  An exclude pattern in this script is too broad
```

That diagnosis was wrong. `--exclude=.gitignore` means every depth on purpose,
because an ignore file inside the package gets a second say over what npm
publishes. The guard's exemption list just did not name ignore files, so a
`.gitignore` added under `dev/scripts` read as lost source.

The single check was answering two questions at once. It is now two, one cause
each:

- **staging against git**: did the filters keep the right things. Needs an
  exemption list, and names it next to the check.
- **tarball against staging**: did packing lose something. Needs no exemption
  list at all, because whatever survived staging is the package. This replaces
  the one-off `dist/client/index.html` assertion, which it covers exactly.

The first guard now reads every tree the root `files` list names, instead of a
hand-picked subset of nine. The subset was complete only while no over-broad
pattern happened to land outside it. Its exemption list names every class the
filters drop on purpose: tests, notebooks, container files, ignore files,
registry auth, dotenv and key material, build output, tool caches and editor
state. Anything not on that list must ship.

### 3. A check that could not run where it fails

`npx-server-smoke` carries `push: branches-ignore: [main]`, and has since the
workflow was created. Its nightly `schedule` does run on main, so the gap is a
window rather than a hole: run 32446411869 passed on main at 04:17 UTC on
2026-08-21, and the offending commit landed at 04:54 UTC. Main then read green
for the rest of the day while every branch that merged it went red.

Two changes:

- `npx-server-smoke` runs on push to main again. Its own concurrency block
  already said "every commit that lands on main has to keep its own
  validation", which the trigger made impossible.
- The fast half of the guard now runs on every pull request and every merge, as
  a new `pack-filters` job in `langwatch-app-ci`. `pack-npm.sh --check-filters`
  stages the tree, runs the source guard and stops: no build, no tarball, about
  ten seconds. That is what would have caught this commit, because the smoke
  path filter names none of the trees the guard reads.

The `pack-filters` job has no path gate on purpose. The guard reads every tree
`files` names, and a path filter listing them is a second copy of that list
which goes stale the day someone edits it.

## Tests

`pack-npm.sh --stage-to DIR` stages into a directory and leaves it there. The
filters decide what every npm user receives and their verdict was otherwise
only visible in a temporary directory the script deletes, so a person debugging
a missing file had nothing to look at. It refuses an empty value and a
directory that already holds something: rsync adds and overwrites but never
deletes, and the published manifest lists `app`, so a stale file would ship.
Refusing rather than clearing, because the alternative is this script deleting
a directory a caller named.

`packages/server/test/pack-npm-filters.test.ts` runs the real script against a
small fixture repository and asserts on the staged tree, so the assertions are
about rsync's own matching:

- source whose name collides with an app root artifact reaches the package
- a tracked ignore file anywhere does not fail the guard
- `.env.example` reaches the package and `.env.staging` does not
- the artifacts at the app root are still stripped, and the guard names each
  one it dropped

Every fix was proven by breaking it:

- restoring the bare-name excludes fails `keeps source whose name collides with
  a working-tree artifact` and `still strips the artifacts the app root writes`
- removing the ignore-file exemption fails `passes when a shipped tree tracks an
  ignore file`
- removing the `--include=.env.example` rule fails `ships .env.example and no
  other dotenv file`

The tests join `test:invariants`, which the required `lint` job already runs.

Verified locally by running the real check, not by reading the glob:
`pack-npm.sh --check-filters` in 10.7s and a full `pack-npm.sh` producing a
22 MB tarball with all four assertions green.

## Deployment Impact

None. This changes build tooling and CI only.

- Env vars: none added, changed or removed.
- Helm values: none.
- Vanilla install: unaffected.
- BYOC dataplane: unaffected.
- Database migrations: none.
- Rollback: revert the commit. The published artifact's contents are unchanged
  by this PR, since no file it now keeps exists in the tree today.
