### PR TITLE
fix(traces): read the Vercel AI SDK's own metadata channel, and stop telling ADK users to break their trace

### DIFF
--- a/dev/scripts/dogfood/multimodal/python/anthropic_official.py
+++ b/dev/scripts/dogfood/multimodal/python/anthropic_official.py
@@ -3,8 +3,8 @@
     uv run --with langwatch --with anthropic --with openinference-instrumentation-anthropic python anthropic_official.py image
     uv run --with langwatch --with anthropic --with openinference-instrumentation-anthropic python anthropic_official.py pdf
 
-An image rides an `image` content block carrying base64 source data. A
-document rides a `document` content block the same way, with media type
+An image goes in an `image` content block with a base64 source. A
+document goes in a `document` content block the same way, with media type
 application/pdf. `AnthropicInstrumentor` patches the client globally, so a
 plain `client.messages.create` call is enough to produce a span.
 """

--- a/dev/scripts/dogfood/multimodal/python/azure_openai.py
+++ b/dev/scripts/dogfood/multimodal/python/azure_openai.py
@@ -3,7 +3,7 @@
     uv run --with langwatch --with openai python azure_openai.py image
 
 Image only: the deployment below is a Chat Completions model, and the
-picture rides the same `image_url` data-URL part the OpenAI cell uses. The
+picture goes in the same `image_url` data-URL part the OpenAI cell uses. The
 deployment name is an Azure resource setting, not a model id, so it is read
 from AZURE_OPENAI_DEPLOYMENT with a fallback that matches this project's
 Azure resource.

--- a/dev/scripts/dogfood/multimodal/python/google_adk.py
+++ b/dev/scripts/dogfood/multimodal/python/google_adk.py
@@ -3,7 +3,7 @@
     uv run --with langwatch --with google-adk --with "openinference-instrumentation-google-adk>=0.1.11" python google_adk.py image
     uv run --with langwatch --with google-adk --with "openinference-instrumentation-google-adk>=0.1.11" python google_adk.py pdf
 
-An image or a PDF rides a `Part.from_bytes` inline data block next to the
+An image or a PDF goes in a `Part.from_bytes` inline data block next to the
 text question, inside one user `Content` message. `GoogleADKInstrumentor`
 patches ADK globally, so the run through `Runner.run` is enough to produce a
 span. ADK talks to the Gemini Developer API through `GOOGLE_API_KEY`, so the

--- a/dev/scripts/dogfood/multimodal/python/langgraph_openai.py
+++ b/dev/scripts/dogfood/multimodal/python/langgraph_openai.py
@@ -4,7 +4,7 @@ LangChain callback handler.
     uv run --with langwatch --with langchain --with langgraph --with langchain-openai python langgraph_openai.py
 
 Image only. The callback is passed into the node's `RunnableConfig`, so the
-model call becomes a span nested under the trace. The image rides an
+model call becomes a span nested under the trace. The image goes in an
 `image_url` content block, the shape Chat Completions accepts.
 """
 

--- a/dev/scripts/dogfood/multimodal/python/openai_official.py
+++ b/dev/scripts/dogfood/multimodal/python/openai_official.py
@@ -3,7 +3,7 @@
     uv run --with langwatch --with openai python openai_official.py image
     uv run --with langwatch --with openai python openai_official.py pdf
 
-An image rides an `image_url` part carrying a data URL. A document rides a
+An image goes in an `image_url` part, as a data URL. A document goes in a
 `file` part carrying `file_data`, which is the shape Chat Completions accepts
 for PDFs.
 """

--- a/dev/scripts/dogfood/multimodal/python/strands_bedrock.py
+++ b/dev/scripts/dogfood/multimodal/python/strands_bedrock.py
@@ -5,7 +5,7 @@
 
 Strands turns on its own OpenTelemetry instrumentation as soon as a global
 tracer provider exists, so `langwatch.setup()` is enough on its own; no
-separate instrumentor is needed. The attachment rides a native Bedrock
+separate instrumentor is needed. The attachment goes in a native Bedrock
 Converse content block, an `image` block for a picture or a `document`
 block for a PDF, both carrying raw bytes rather than base64 text. The model
 is Claude Haiku 4.5 through the EU cross-region inference profile, which

--- a/dev/scripts/dogfood/multimodal/typescript/vercel-ai.ts
+++ b/dev/scripts/dogfood/multimodal/typescript/vercel-ai.ts
@@ -4,7 +4,7 @@
  *   node vercel-ai.ts image
  *   node vercel-ai.ts pdf
  *
- * An image and a PDF both ride an AI SDK `file` part inside one user
+ * An image and a PDF both go in an AI SDK `file` part inside one user
  * message. `experimental_telemetry` turns on tracing for this call, and
  * `setupObservability()` points the OpenTelemetry exporter at LangWatch.
  * Model traffic goes through the OpenAI-shaped chat completions path so the

--- a/docs/integration/python/integrations/google-ai.mdx
+++ b/docs/integration/python/integrations/google-ai.mdx
@@ -51,10 +51,6 @@ from google.genai import types
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 import os
 
-<Info>
-The LangWatch API key is configured by default via the `LANGWATCH_API_KEY` environment variable.
-</Info>
-
 # Initialize LangWatch with the Google ADK instrumentor
 langwatch.setup(
     instrumentors=[GoogleADKInstrumentor()]
@@ -106,17 +102,21 @@ if __name__ == "__main__":
 
 **That's it!** All Google ADK agent activity will now be traced and sent to your LangWatch dashboard automatically.
 
-### Optional: Using Decorators for Additional Context
+The LangWatch API key comes from the `LANGWATCH_API_KEY` environment variable.
 
-If you want to add additional context or metadata to your traces, you can optionally use the `@langwatch.trace()` decorator:
+### Optional: Add metadata with a decorator
+
+To attach metadata to the trace, wrap the call in `@langwatch.trace()` and run
+the agent with **`Runner.run_async`**:
 
 ```python
+import asyncio
+
 import langwatch
 from google.adk import Agent, Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-import os
 
 langwatch.setup(
     instrumentors=[GoogleADKInstrumentor()]
@@ -125,27 +125,47 @@ langwatch.setup(
 # ... agent setup code ...
 
 @langwatch.trace(name="Google ADK Agent Run")
-def run_agent_interaction(user_message: str):
+async def run_agent_interaction(user_message: str):
     # Update the current trace with additional metadata
     current_trace = langwatch.get_current_trace()
     if current_trace:
         current_trace.update(
             metadata={
                 "user_id": "user_123",
-                "session_id": "session_abc",
-                "agent_name": "hello_agent",
-                "model": "gemini-2.0-flash"
+                "thread_id": "session_abc",
+                "labels": ["hello_agent"],
             }
         )
-    
+
     user_msg = types.Content(role="user", parts=[types.Part(text=user_message)])
-    
-    for event in runner.run(user_id="demo-user", session_id="demo-session", new_message=user_msg):
+
+    async for event in runner.run_async(
+        user_id="demo-user", session_id="demo-session", new_message=user_msg
+    ):
         if event.is_final_response():
             return event.content.parts[0].text
-    
+
     return "No response generated"
+
+
+asyncio.run(run_agent_interaction("hi"))
 ```
+
+<Warning>
+Use `run_async` under the decorator, not the synchronous `Runner.run`.
+
+`Runner.run` starts a new Python thread and calls `asyncio.run` inside it.
+OpenTelemetry keeps the active trace in a context variable, and a new thread
+starts with an empty one, so the agent spans open a **second, separate trace**.
+The metadata you set stays on the wrapper trace and the agent trace gets none
+of it.
+
+`run_async` stays on the caller's task, so the wrapper span is the parent of
+`invocation`, `agent_run` and `call_llm`, and all of it is one trace.
+
+If you have to keep the synchronous `Runner.run`, drop the decorator and let
+the instrumentor own the trace.
+</Warning>
 
 ## How it Works
 
@@ -157,7 +177,7 @@ def run_agent_interaction(user_message: str):
     - Model completions
     - Session management
 
-3.  **Optional Decorators**: You can optionally use `@langwatch.trace()` to add additional context and metadata to your traces, but it's not required for basic functionality.
+3.  **Optional Decorators**: You can optionally use `@langwatch.trace()` to add additional context and metadata to your traces, but it's not required for basic functionality. The decorator parents the agent spans only over `Runner.run_async`.
 
 With this setup, LangWatch traces all agent interactions, tool calls, and model completions.
 
@@ -166,7 +186,7 @@ With this setup, LangWatch traces all agent interactions, tool calls, and model 
 
 - You do **not** need to set any OpenTelemetry environment variables or configure exporters manually. `langwatch.setup()` handles it.
 - You can combine Google ADK instrumentation with other instrumentors (e.g., OpenAI, LangChain) by adding them to the `instrumentors` list.
-- The `@langwatch.trace()` decorator is **optional** - the OpenInference instrumentor will capture all ADK activity automatically.
+- The `@langwatch.trace()` decorator is **optional** - the OpenInference instrumentor will capture all ADK activity automatically. Use it with `Runner.run_async`, never with the synchronous `Runner.run`.
 - For advanced configuration (custom attributes, endpoint, etc.), see the [Python integration guide](/integration/python/guide).
 
 ## Troubleshooting
@@ -175,48 +195,5 @@ With this setup, LangWatch traces all agent interactions, tool calls, and model 
 - If you see no traces in LangWatch, check that the instrumentor is included in `langwatch.setup()` and that your agent code is being executed.
 - Ensure you have the correct Google API key set for Gemini access.
 - **`AttributeError: module 'google.adk.flows.llm_flows.functions' has no attribute 'trace_tool_call'`** on `langwatch.setup()`: your `openinference-instrumentation-google-adk` is too old for your Google ADK version. ADK 1.32 removed that symbol; the fix shipped in instrumentor 0.1.11. Run `pip install -U "openinference-instrumentation-google-adk>=0.1.11"`. If it still fails, confirm the upgrade actually applied in the running interpreter with `pip show openinference-instrumentation-google-adk`.
-
-## Interoperability with LangWatch SDK
-
-You can use this integration together with the LangWatch Python SDK to add additional attributes to the trace:
-
-```python
-import langwatch
-from google.adk import Agent, Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai import types
-from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-
-langwatch.setup(
-    instrumentors=[GoogleADKInstrumentor()]
-)
-
-@langwatch.trace(name="Custom ADK Agent")
-def my_custom_agent(input_message: str):
-    # Your ADK agent code here
-    agent = Agent(
-        name="custom_agent",
-        model="gemini-2.0-flash",
-        instruction="Your custom instructions",
-        tools=[your_custom_tools]
-    )
-    
-    # Update the current trace with additional metadata
-    current_trace = langwatch.get_current_trace()
-    if current_trace:
-        current_trace.update(
-            metadata={
-                "user_id": "user_123",
-                "session_id": "session_abc",
-                "agent_name": "custom_agent",
-                "model": "gemini-2.0-flash"
-            }
-        )
-    
-    # Run your agent
-    # ... agent execution code ...
-    
-    return "Agent response"
-```
-
-This approach allows you to combine the automatic tracing capabilities of Google ADK with the rich metadata and custom attributes provided by LangWatch. 
+- **One agent run shows up as two traces, one of them empty except for your decorator span**: you wrapped the synchronous `Runner.run`. Switch to `Runner.run_async`, or drop the decorator. See the warning above.
+- **The metadata you set with `trace.update()` is on a trace with no agent spans**: same cause, same fix. 

--- a/docs/integration/python/integrations/google-ai.mdx
+++ b/docs/integration/python/integrations/google-ai.mdx
@@ -43,6 +43,11 @@ The [OpenInference Google ADK instrumentor](https://github.com/Arize-ai/openinfe
 
 Here's the simplest way to instrument your application:
 
+<Info>
+Set `LANGWATCH_API_KEY` in the environment before you run this. Without it the
+SDK sends nothing.
+</Info>
+
 ```python
 import langwatch
 from google.adk import Agent, Runner
@@ -101,8 +106,6 @@ if __name__ == "__main__":
 ```
 
 **That's it!** All Google ADK agent activity will now be traced and sent to your LangWatch dashboard automatically.
-
-The LangWatch API key comes from the `LANGWATCH_API_KEY` environment variable.
 
 ### Optional: Add metadata with a decorator
 

--- a/docs/integration/python/tutorials/capturing-audio.mdx
+++ b/docs/integration/python/tutorials/capturing-audio.mdx
@@ -6,9 +6,7 @@ icon: python
 keywords: langwatch, python, audio, voice, realtime, speech, multimodal, tracing
 ---
 
-LangWatch captures a recording as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the audio the way your model provider expects, keep the call inside a trace, and the recording plays on the trace.
-
-This page lists the audio shapes LangWatch understands, what happens to the bytes, and where the player appears in the product.
+Send the audio the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the recording out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the audio with the model call
 
@@ -16,7 +14,7 @@ The example below uses `langwatch.setup()` and a `@langwatch.trace()` entry poin
 
 ### OpenAI
 
-A recording rides an `input_audio` part carrying raw base64 and a format.
+Put the recording in an `input_audio` part, as raw base64 with a format.
 
 ```python
 import base64
@@ -33,7 +31,7 @@ def transcribe(prompt: str, path: str) -> str:
 
     encoded = base64.b64encode(open(path, "rb").read()).decode("utf-8")
     completion = client.chat.completions.create(
-        model="gpt-4o-audio-preview",
+        model="gpt-audio-mini",
         messages=[
             {
                 "role": "user",
@@ -55,7 +53,7 @@ transcribe("What does the caller ask for?", "call.wav")
 
 ### Google Gemini and Vertex
 
-A recording rides an inline data part with an audio media type. The rest of the agent setup does not change.
+Put the recording in an inline data part with an audio media type. The rest of the agent setup does not change.
 
 ```python
 import asyncio
@@ -109,10 +107,11 @@ transcribe("What does the caller ask for?", "call.wav")
 ```
 
 <Note>
-  The instrumentor makes the trace for this call. Do not add a
-  `@langwatch.trace()` wrapper around `Runner.run`: it crosses a
-  sync-to-async boundary that does not carry the trace context, so the
-  wrapper lands in a separate trace.
+  The instrumentor makes the trace for this call, so no `@langwatch.trace()`
+  wrapper is needed. If you add one to attach metadata, switch the run to
+  `Runner.run_async`: the synchronous `Runner.run` starts its own thread, which
+  begins with an empty OpenTelemetry context, and the agent spans open a second
+  trace. See the [Google ADK integration](/integration/python/integrations/google-ai).
 </Note>
 
 
@@ -129,13 +128,13 @@ Send any of these and the recording is captured.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 
-When a message carries both a recording and text, the text is treated as the transcript of that recording and the two are shown as one unit.
+When a message holds both a recording and text, LangWatch treats the text as the transcript of that recording and shows the two together.
 
 ## What happens to the bytes
 
-LangWatch moves the recording out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the recording out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. A recording captured by a simulation and by the trace of the same call is one stored object, not two.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, a recording captured by a simulation and by the trace of the same call is one stored object, not two.
 
 Raw, header-less audio does not play in a browser on its own. LangWatch wraps `pcm16` and G.711 payloads into a WAV container when it stores them, so the reference plays everywhere without a conversion step of your own.
 
@@ -143,19 +142,15 @@ Raw, header-less audio does not play in a browser on its own. LangWatch wraps `p
 
 Open the trace and the Summary tab shows a player under the input. The Conversation tab shows a player in the message it belongs to, next to the transcript. A turn that recorded no transcript still shows its player. The Trace tab shows the full message payload.
 
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no player, ask LangWatch to turn it on for your project.
-</Note>
-
 ## Testing voice agents
 
-Capturing the audio of a live call tells you what happened. To drive a call on purpose, and score it, use Scenario. It synthesizes a caller, speaks to your agent over its real transport, and judges the conversation with the same `scenario.run()` and the same judge you use for text.
+You see what happened on a call once it has run. To drive a call on purpose and score it, use Scenario: it synthesizes a caller, speaks to your agent over its real transport, and scores the conversation with `scenario.run()`.
 
 <Frame caption="Voice agent testing in Scenario, with the simulated call, its per-turn audio and the judge verdict">
   <img src="/images/scenario-voice.webp" alt="LangWatch voice agent testing" />
 </Frame>
 
-Scenario carries adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can inject background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
+Scenario has adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can add background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
 
 ## Related
 

--- a/docs/integration/python/tutorials/capturing-audio.mdx
+++ b/docs/integration/python/tutorials/capturing-audio.mdx
@@ -10,7 +10,7 @@ Send the audio the way your model provider expects and keep the call inside a tr
 
 ## Send the audio with the model call
 
-The example below uses `langwatch.setup()` and a `@langwatch.trace()` entry point. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
+Both examples below call `langwatch.setup()`. The OpenAI one runs inside a `@langwatch.trace()` entry point; the Google ADK one lets the instrumentor make the trace. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
 
 ### OpenAI
 
@@ -121,10 +121,12 @@ Send any of these and the recording is captured.
 
 | Source | Shape |
 |---|---|
-| OpenAI Realtime | `{"type": "input_audio", "input_audio": {"data": "<base64>", "format": "wav"}}` |
+| OpenAI | `{"type": "input_audio", "input_audio": {"data": "<base64>", "format": "wav"}}` |
 | OpenAI | `{"type": "file", "file": {"filename": "call.wav", "file_data": "<base64>"}}` |
 | Google Gemini and Vertex | `{"inline_data": {"mime_type": "audio/wav", "data": "..."}}` |
 | AG-UI | `{"type": "audio", "source": {"type": "data", "value": "...", "mimeType": "audio/wav"}}` |
+
+An OpenAI Realtime session sends its turns in the same `input_audio` shape.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 

--- a/docs/integration/python/tutorials/capturing-documents.mdx
+++ b/docs/integration/python/tutorials/capturing-documents.mdx
@@ -6,9 +6,7 @@ icon: python
 keywords: langwatch, python, documents, pdf, files, attachments, multimodal, tracing
 ---
 
-LangWatch captures a document as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the file the way your model provider expects, keep the call inside a trace, and the attachment is on the trace.
-
-This page lists the document shapes LangWatch understands, what happens to the bytes, and where the attachment appears in the product.
+Send the file the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the document out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the document with the model call
 
@@ -16,7 +14,7 @@ The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry 
 
 ### OpenAI
 
-A document rides a `file` part carrying `file_data`. That is the shape Chat Completions accepts for PDF files.
+Put the document in a `file` part, as `file_data`. That is the shape Chat Completions accepts for PDF files.
 
 ```python
 import base64
@@ -64,7 +62,7 @@ read_invoice("What is the invoice number and the total due?", "invoice.pdf")
 
 ### Anthropic
 
-A document rides a `document` content block with a base64 source.
+Put the document in a `document` content block with a base64 source.
 
 ```python
 import base64
@@ -108,7 +106,7 @@ read_invoice("What is the invoice number and the total due?", "invoice.pdf")
 
 ### Google Gemini and Vertex
 
-A document rides an inline data part with the PDF media type. The rest of the agent setup does not change.
+Put the document in an inline data part with the PDF media type. The rest of the agent setup does not change.
 
 ```python
 import asyncio
@@ -162,10 +160,11 @@ ask("What is the invoice number and the total due?", "invoice.pdf")
 ```
 
 <Note>
-  The instrumentor makes the trace for this call. Do not add a
-  `@langwatch.trace()` wrapper around `Runner.run`: it crosses a
-  sync-to-async boundary that does not carry the trace context, so the
-  wrapper lands in a separate trace.
+  The instrumentor makes the trace for this call, so no `@langwatch.trace()`
+  wrapper is needed. If you add one to attach metadata, switch the run to
+  `Runner.run_async`: the synchronous `Runner.run` starts its own thread, which
+  begins with an empty OpenTelemetry context, and the agent spans open a second
+  trace. See the [Google ADK integration](/integration/python/integrations/google-ai).
 </Note>
 
 
@@ -181,29 +180,25 @@ Send any of these and the attachment is captured.
 | Google Gemini and Vertex | `{"inline_data": {"mime_type": "application/pdf", "data": "..."}}` |
 | AG-UI | `{"type": "document", "source": {"type": "data", "value": "...", "mimeType": "application/pdf"}}` |
 
-A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, carries no bytes. It is passed through as it is and no attachment is stored.
+A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, holds no bytes. LangWatch passes it through unchanged and stores no attachment.
 
 ## What happens to the bytes
 
-LangWatch moves the document out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the document out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same contract sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same contract sent on ten traces costs one stored object.
 
 On read, LangWatch serves PDF files with their original media type, along with images, audio and video. Every other document type, such as CSV, JSON, Markdown and plain text, is served as a download.
 
 ## Where the document appears
 
-A paperclip sits next to the input preview on the trace list, so a run that carried a file is recognisable without opening it.
+The trace list draws a paperclip next to the input preview, so you can spot a run with a file without opening it.
 
-Open the trace and the Summary tab shows an attachment chip. The chip carries the filename, or the media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
+Open the trace and the Summary tab shows an attachment chip, named after the file, or after its media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
 
 <Frame caption="The trace drawer Summary tab, with an application/pdf attachment chip below the input text and the model answer reading the invoice number and total from the file">
   <img src="/images/integration/multimodal/trace-drawer-pdf.png" alt="LangWatch trace drawer showing a PDF attachment chip below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no attachment, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 

--- a/docs/integration/python/tutorials/capturing-documents.mdx
+++ b/docs/integration/python/tutorials/capturing-documents.mdx
@@ -10,7 +10,7 @@ Send the file the way your model provider expects and keep the call inside a tra
 
 ## Send the document with the model call
 
-The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry point. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
+The examples below all call `langwatch.setup()`. The OpenAI and Anthropic ones run inside a `@langwatch.trace()` entry point; the Google ADK one lets the instrumentor make the trace. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
 
 ### OpenAI
 

--- a/docs/integration/python/tutorials/capturing-images.mdx
+++ b/docs/integration/python/tutorials/capturing-images.mdx
@@ -6,9 +6,7 @@ icon: python
 keywords: langwatch, python, images, multimodal, vision, attachments, tracing
 ---
 
-LangWatch captures an image as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the image the way your model provider expects, keep the call inside a trace, and the picture is on the trace.
-
-This page lists the image shapes LangWatch understands, what happens to the bytes, and where the picture appears in the product.
+Send the image the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the image out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the image with the model call
 
@@ -16,7 +14,7 @@ The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry 
 
 ### OpenAI
 
-An image rides an `image_url` part carrying a data URL.
+Put the image in an `image_url` part, as a data URL.
 
 ```python
 import base64
@@ -59,7 +57,7 @@ describe("What does this image show?", "shapes.png")
 
 ### Anthropic
 
-An image rides an `image` content block with a base64 source.
+Put the image in an `image` content block with a base64 source.
 
 ```python
 import base64
@@ -105,7 +103,7 @@ Anthropic's hosted form, `{"type": "url", "url": "https://..."}`, is understood 
 
 ### Google Gemini and Vertex
 
-An image rides an inline data part. `Part.from_bytes` builds it for you. The rest of the agent setup does not change.
+Put the image in an inline data part. `Part.from_bytes` builds one for you. The rest of the agent setup does not change.
 
 ```python
 import asyncio
@@ -159,10 +157,11 @@ describe("What does this image show?", "shapes.png")
 ```
 
 <Note>
-  The instrumentor makes the trace for this call. Do not add a
-  `@langwatch.trace()` wrapper around `Runner.run`: it crosses a
-  sync-to-async boundary that does not carry the trace context, so the
-  wrapper lands in a separate trace.
+  The instrumentor makes the trace for this call, so no `@langwatch.trace()`
+  wrapper is needed. If you add one to attach metadata, switch the run to
+  `Runner.run_async`: the synchronous `Runner.run` starts its own thread, which
+  begins with an empty OpenTelemetry context, and the agent spans open a second
+  trace. See the [Google ADK integration](/integration/python/integrations/google-ai).
 </Note>
 
 
@@ -179,19 +178,19 @@ Send any of these and the picture is captured. The list covers the shapes the ma
 | Google Gemini and Vertex | `{"inline_data": {"mime_type": "image/png", "data": "..."}}` |
 | AG-UI | `{"type": "image", "source": {"type": "data", "value": "...", "mimeType": "image/png"}}` |
 
-Always set the media type. A part that carries bytes with no media type stays inline in the trace instead of moving into storage, because those bytes would come back as a plain download and not as a picture.
+Always set the media type. Without one, LangWatch leaves the bytes inline in the trace instead of storing them, because it cannot serve them back as a picture.
 
 ## What happens to the bytes
 
-LangWatch moves the image out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the image out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same picture sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same picture sent on ten traces costs one stored object.
 
 On read, LangWatch serves the original media type for images, audio, video and PDF files. Anything else is served as a download.
 
 ## Where the image appears
 
-A thumbnail sits next to the input preview on the trace list, so a run that carried a picture is recognisable without opening it.
+The trace list draws a thumbnail next to the input preview, so you can spot a run with a picture without opening it.
 
 <Frame caption="Trace list rows showing image thumbnails next to the input text, and a paperclip on the row whose attachment is a document">
   <img src="/images/integration/multimodal/trace-list-thumbnails.png" alt="LangWatch trace list with image thumbnails on the input previews" />
@@ -202,10 +201,6 @@ Open the trace and the Summary tab shows the picture inline under the question. 
 <Frame caption="The trace drawer Summary tab, with the captured picture rendered inline below the input text and the model answer below it">
   <img src="/images/integration/multimodal/trace-drawer-image.png" alt="LangWatch trace drawer showing a captured image below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no picture, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 

--- a/docs/integration/python/tutorials/capturing-images.mdx
+++ b/docs/integration/python/tutorials/capturing-images.mdx
@@ -10,7 +10,7 @@ Send the image the way your model provider expects and keep the call inside a tr
 
 ## Send the image with the model call
 
-The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry point. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
+The examples below all call `langwatch.setup()`. The OpenAI and Anthropic ones run inside a `@langwatch.trace()` entry point; the Google ADK one lets the instrumentor make the trace. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
 
 ### OpenAI
 

--- a/docs/integration/typescript/integrations/vercel-ai-sdk.mdx
+++ b/docs/integration/typescript/integrations/vercel-ai-sdk.mdx
@@ -62,6 +62,44 @@ console.log(await main("Hey, tell me a joke"));
 
 The Vercel AI SDK automatically sends traces to LangWatch when `experimental_telemetry.isEnabled` is set to `true`. For Next.js applications, configure OpenTelemetry in your `instrumentation.ts` file using `LangWatchExporter`.
 
+## Metadata
+
+Pass `experimental_telemetry.metadata` to tag the call. LangWatch reads these
+keys from it:
+
+| Key | What it does |
+|---|---|
+| `labels` | An array of labels. Filter the trace list by them. |
+| `thread_id` | Groups the call into a conversation with every other call that sends the same id. |
+| `user_id` | The end user the call belongs to. |
+| `customer_id` | The customer or tenant the call belongs to. |
+
+Any other key becomes custom metadata on the trace, filterable by its own name.
+
+```typescript
+const response = await generateText({
+  model: openai("gpt-5-mini"),
+  prompt: message,
+  experimental_telemetry: {
+    isEnabled: true,
+    metadata: {
+      labels: ["checkout", "beta"],
+      thread_id: "conversation-8f21",
+      user_id: "user-42",
+      tenant: "eu-west",
+    },
+  },
+});
+```
+
+The AI SDK accepts strings, numbers, booleans and arrays of them as metadata
+values. It does not accept a nested object, so flatten anything deeper into
+separate keys.
+
+Setting the same key as a span attribute overrides the value you pass here. See
+[Capturing Metadata and Attributes](/integration/typescript/tutorials/capturing-metadata)
+for the attribute names.
+
 ## Related
 
 - [Capturing RAG](/integration/typescript/tutorials/capturing-rag) - Learn how to capture RAG data from retrievers and tools

--- a/docs/integration/typescript/integrations/vercel-ai-sdk.mdx
+++ b/docs/integration/typescript/integrations/vercel-ai-sdk.mdx
@@ -92,11 +92,16 @@ const response = await generateText({
 });
 ```
 
-The AI SDK accepts strings, numbers, booleans and arrays of them as metadata
-values. It does not accept a nested object, so flatten anything deeper into
-separate keys.
+`experimental_telemetry` is the AI SDK's own experimental API, and its shape
+can change between AI SDK versions.
 
-Setting the same key as a span attribute overrides the value you pass here. See
+It accepts strings, numbers, booleans and arrays of them as metadata values. It
+does not accept a nested object, so flatten anything deeper into separate keys.
+A `null` inside a `labels` array is dropped.
+
+A `thread_id`, `user_id`, `customer_id` or `metadata.<key>` you also set as a
+span attribute wins over the one you pass here. Labels are the exception: the
+two sets are combined, so the trace keeps both. See
 [Capturing Metadata and Attributes](/integration/typescript/tutorials/capturing-metadata)
 for the attribute names.
 

--- a/docs/integration/typescript/tutorials/capturing-audio.mdx
+++ b/docs/integration/typescript/tutorials/capturing-audio.mdx
@@ -89,11 +89,13 @@ Send any of these and the recording is captured.
 
 | Source | Shape |
 |---|---|
-| OpenAI Realtime | `{ type: "input_audio", input_audio: { data: "<base64>", format: "wav" } }` |
+| OpenAI | `{ type: "input_audio", input_audio: { data: "<base64>", format: "wav" } }` |
 | Vercel AI SDK | `{ type: "file", mediaType: "audio/wav", data: "<base64>" }` |
 | OpenAI | `{ type: "file", file: { filename: "call.wav", file_data: "<base64>" } }` |
 | Google Gemini and Vertex | `{ inlineData: { mimeType: "audio/wav", data: "..." } }` |
 | AG-UI | `{ type: "audio", source: { type: "data", value: "...", mimeType: "audio/wav" } }` |
+
+An OpenAI Realtime session sends its turns in the same `input_audio` shape.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 

--- a/docs/integration/typescript/tutorials/capturing-audio.mdx
+++ b/docs/integration/typescript/tutorials/capturing-audio.mdx
@@ -6,9 +6,7 @@ icon: square-js
 keywords: langwatch, typescript, javascript, audio, voice, realtime, speech, multimodal, tracing
 ---
 
-LangWatch captures a recording as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the audio the way your model provider expects, keep the call inside a trace, and the recording plays on the trace.
-
-This page lists the audio shapes LangWatch understands, what happens to the bytes, and where the player appears in the product.
+Send the audio the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the recording out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the audio with the model call
 
@@ -16,7 +14,7 @@ The examples below use `setupObservability()`. Read [Integration Guide](/integra
 
 ### Vercel AI SDK
 
-A recording rides a `file` part inside the user message, the same part an image uses. Only the media type changes.
+Put the recording in a `file` part inside the user message. `mediaType` is what tells LangWatch and the provider what the bytes are.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -28,8 +26,8 @@ setupObservability({ serviceName: "voice-service" });
 
 const data = readFileSync("call.wav").toString("base64");
 
-const result = await generateText({
-  model: openai.chat("gpt-4o-audio-preview"),
+const { text } = await generateText({
+  model: openai.chat("gpt-audio-mini"),
   messages: [
     {
       role: "user",
@@ -41,11 +39,13 @@ const result = await generateText({
   ],
   experimental_telemetry: { isEnabled: true },
 });
+
+console.log(text);
 ```
 
 ### OpenAI SDK
 
-A recording rides an `input_audio` part carrying raw base64 and a format.
+Put the recording in an `input_audio` part, as raw base64 with a format.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -64,7 +64,7 @@ const transcribe = async (prompt: string, path: string): Promise<string> => {
 
     const encoded = readFileSync(path).toString("base64");
     const completion = await client.chat.completions.create({
-      model: "gpt-4o-audio-preview",
+      model: "gpt-audio-mini",
       messages: [
         {
           role: "user",
@@ -97,13 +97,13 @@ Send any of these and the recording is captured.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 
-When a message carries both a recording and text, the text is treated as the transcript of that recording and the two are shown as one unit.
+When a message holds both a recording and text, LangWatch treats the text as the transcript of that recording and shows the two together.
 
 ## What happens to the bytes
 
-LangWatch moves the recording out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the recording out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. A recording captured by a simulation and by the trace of the same call is one stored object, not two.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, a recording captured by a simulation and by the trace of the same call is one stored object, not two.
 
 Raw, header-less audio does not play in a browser on its own. LangWatch wraps `pcm16` and G.711 payloads into a WAV container when it stores them, so the reference plays everywhere without a conversion step of your own.
 
@@ -111,19 +111,15 @@ Raw, header-less audio does not play in a browser on its own. LangWatch wraps `p
 
 Open the trace and the Summary tab shows a player under the input. The Conversation tab shows a player in the message it belongs to, next to the transcript. A turn that recorded no transcript still shows its player. The Trace tab shows the full message payload.
 
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no player, ask LangWatch to turn it on for your project.
-</Note>
-
 ## Testing voice agents
 
-Capturing the audio of a live call tells you what happened. To drive a call on purpose, and score it, use Scenario. It synthesizes a caller, speaks to your agent over its real transport, and judges the conversation with the same `scenario.run()` and the same judge you use for text.
+You see what happened on a call once it has run. To drive a call on purpose and score it, use Scenario: it synthesizes a caller, speaks to your agent over its real transport, and scores the conversation with `scenario.run()`.
 
 <Frame caption="Voice agent testing in Scenario, with the simulated call, its per-turn audio and the judge verdict">
   <img src="/images/scenario-voice.webp" alt="LangWatch voice agent testing" />
 </Frame>
 
-Scenario carries adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can inject background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
+Scenario has adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can add background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
 
 ## Related
 

--- a/docs/integration/typescript/tutorials/capturing-documents.mdx
+++ b/docs/integration/typescript/tutorials/capturing-documents.mdx
@@ -6,9 +6,7 @@ icon: square-js
 keywords: langwatch, typescript, javascript, documents, pdf, files, attachments, multimodal, tracing
 ---
 
-LangWatch captures a document as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the file the way your model provider expects, keep the call inside a trace, and the attachment is on the trace.
-
-This page lists the document shapes LangWatch understands, what happens to the bytes, and where the attachment appears in the product.
+Send the file the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the document out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the document with the model call
 
@@ -16,7 +14,7 @@ The examples below use `setupObservability()`. Read [Integration Guide](/integra
 
 ### Vercel AI SDK
 
-A document rides a `file` part inside the user message, the same part an image uses. Only the media type changes.
+Put the document in a `file` part inside the user message. `mediaType` is what tells LangWatch and the provider what the bytes are.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -28,7 +26,7 @@ setupObservability({ serviceName: "invoice-service" });
 
 const data = readFileSync("invoice.pdf").toString("base64");
 
-const result = await generateText({
+const { text } = await generateText({
   model: openai.chat("gpt-5-mini"),
   messages: [
     {
@@ -46,11 +44,13 @@ const result = await generateText({
   ],
   experimental_telemetry: { isEnabled: true },
 });
+
+console.log(text);
 ```
 
 ### OpenAI SDK
 
-A document rides a `file` part carrying `file_data`. That is the shape Chat Completions accepts for PDF files.
+Put the document in a `file` part, as `file_data`. That is the shape Chat Completions accepts for PDF files.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -109,29 +109,25 @@ Send any of these and the attachment is captured.
 | Google Gemini and Vertex | `{ inlineData: { mimeType: "application/pdf", data: "..." } }` |
 | AG-UI | `{ type: "document", source: { type: "data", value: "...", mimeType: "application/pdf" } }` |
 
-A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, carries no bytes. It is passed through as it is and no attachment is stored.
+A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, holds no bytes. LangWatch passes it through unchanged and stores no attachment.
 
 ## What happens to the bytes
 
-LangWatch moves the document out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the document out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same contract sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same contract sent on ten traces costs one stored object.
 
 On read, LangWatch serves PDF files with their original media type, along with images, audio and video. Every other document type, such as CSV, JSON, Markdown and plain text, is served as a download.
 
 ## Where the document appears
 
-A paperclip sits next to the input preview on the trace list, so a run that carried a file is recognisable without opening it.
+The trace list draws a paperclip next to the input preview, so you can spot a run with a file without opening it.
 
-Open the trace and the Summary tab shows an attachment chip. The chip carries the filename, or the media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
+Open the trace and the Summary tab shows an attachment chip, named after the file, or after its media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
 
 <Frame caption="The trace drawer Summary tab, with an application/pdf attachment chip below the input text and the model answer reading the invoice number and total from the file">
   <img src="/images/integration/multimodal/trace-drawer-pdf.png" alt="LangWatch trace drawer showing a PDF attachment chip below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no attachment, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 

--- a/docs/integration/typescript/tutorials/capturing-images.mdx
+++ b/docs/integration/typescript/tutorials/capturing-images.mdx
@@ -6,9 +6,7 @@ icon: square-js
 keywords: langwatch, typescript, javascript, images, multimodal, vision, attachments, tracing
 ---
 
-LangWatch captures an image as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the image the way your model provider expects, keep the call inside a trace, and the picture is on the trace.
-
-This page lists the image shapes LangWatch understands, what happens to the bytes, and where the picture appears in the product.
+Send the image the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the image out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the image with the model call
 
@@ -16,7 +14,7 @@ The examples below use `setupObservability()`. Read [Integration Guide](/integra
 
 ### Vercel AI SDK
 
-An image rides a `file` part inside the user message. `experimental_telemetry` turns tracing on for the call.
+Put the image in a `file` part inside the user message. `experimental_telemetry` turns tracing on for the call.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -28,7 +26,7 @@ setupObservability({ serviceName: "image-service" });
 
 const data = readFileSync("shapes.png").toString("base64");
 
-const result = await generateText({
+const { text } = await generateText({
   model: openai.chat("gpt-5-mini"),
   messages: [
     {
@@ -41,11 +39,13 @@ const result = await generateText({
   ],
   experimental_telemetry: { isEnabled: true },
 });
+
+console.log(text);
 ```
 
 ### OpenAI SDK
 
-An image rides an `image_url` part carrying a data URL.
+Put the image in an `image_url` part, as a data URL.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -100,19 +100,19 @@ Send any of these and the picture is captured. The list covers the shapes the ma
 | Google Gemini and Vertex | `{ inlineData: { mimeType: "image/png", data: "..." } }` |
 | AG-UI | `{ type: "image", source: { type: "data", value: "...", mimeType: "image/png" } }` |
 
-Always set the media type. A part that carries bytes with no media type stays inline in the trace instead of moving into storage, because those bytes would come back as a plain download and not as a picture.
+Always set the media type. Without one, LangWatch leaves the bytes inline in the trace instead of storing them, because it cannot serve them back as a picture.
 
 ## What happens to the bytes
 
-LangWatch moves the image out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the image out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same picture sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same picture sent on ten traces costs one stored object.
 
 On read, LangWatch serves the original media type for images, audio, video and PDF files. Anything else is served as a download.
 
 ## Where the image appears
 
-A thumbnail sits next to the input preview on the trace list, so a run that carried a picture is recognisable without opening it.
+The trace list draws a thumbnail next to the input preview, so you can spot a run with a picture without opening it.
 
 <Frame caption="Trace list rows showing image thumbnails next to the input text, and a paperclip on the row whose attachment is a document">
   <img src="/images/integration/multimodal/trace-list-thumbnails.png" alt="LangWatch trace list with image thumbnails on the input previews" />
@@ -123,10 +123,6 @@ Open the trace and the Summary tab shows the picture inline under the question. 
 <Frame caption="The trace drawer Summary tab, with the captured picture rendered inline below the input text and the model answer below it">
   <img src="/images/integration/multimodal/trace-drawer-image.png" alt="LangWatch trace drawer showing a captured image below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no picture, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -20554,10 +20554,6 @@ from google.genai import types
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 import os
 
-<Info>
-The LangWatch API key is configured by default via the `LANGWATCH_API_KEY` environment variable.
-</Info>
-
 # Initialize LangWatch with the Google ADK instrumentor
 langwatch.setup(
     instrumentors=[GoogleADKInstrumentor()]
@@ -20609,17 +20605,21 @@ if __name__ == "__main__":
 
 **That's it!** All Google ADK agent activity will now be traced and sent to your LangWatch dashboard automatically.
 
-### Optional: Using Decorators for Additional Context
+The LangWatch API key comes from the `LANGWATCH_API_KEY` environment variable.
 
-If you want to add additional context or metadata to your traces, you can optionally use the `@langwatch.trace()` decorator:
+### Optional: Add metadata with a decorator
+
+To attach metadata to the trace, wrap the call in `@langwatch.trace()` and run
+the agent with **`Runner.run_async`**:
 
 ```python
+import asyncio
+
 import langwatch
 from google.adk import Agent, Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-import os
 
 langwatch.setup(
     instrumentors=[GoogleADKInstrumentor()]
@@ -20628,27 +20628,47 @@ langwatch.setup(
 # ... agent setup code ...
 
 @langwatch.trace(name="Google ADK Agent Run")
-def run_agent_interaction(user_message: str):
+async def run_agent_interaction(user_message: str):
     # Update the current trace with additional metadata
     current_trace = langwatch.get_current_trace()
     if current_trace:
         current_trace.update(
             metadata={
                 "user_id": "user_123",
-                "session_id": "session_abc",
-                "agent_name": "hello_agent",
-                "model": "gemini-2.0-flash"
+                "thread_id": "session_abc",
+                "labels": ["hello_agent"],
             }
         )
 
     user_msg = types.Content(role="user", parts=[types.Part(text=user_message)])
 
-    for event in runner.run(user_id="demo-user", session_id="demo-session", new_message=user_msg):
+    async for event in runner.run_async(
+        user_id="demo-user", session_id="demo-session", new_message=user_msg
+    ):
         if event.is_final_response():
             return event.content.parts[0].text
 
     return "No response generated"
+
+
+asyncio.run(run_agent_interaction("hi"))
 ```
+
+<Warning>
+Use `run_async` under the decorator, not the synchronous `Runner.run`.
+
+`Runner.run` starts a new Python thread and calls `asyncio.run` inside it.
+OpenTelemetry keeps the active trace in a context variable, and a new thread
+starts with an empty one, so the agent spans open a **second, separate trace**.
+The metadata you set stays on the wrapper trace and the agent trace gets none
+of it.
+
+`run_async` stays on the caller's task, so the wrapper span is the parent of
+`invocation`, `agent_run` and `call_llm`, and all of it is one trace.
+
+If you have to keep the synchronous `Runner.run`, drop the decorator and let
+the instrumentor own the trace.
+</Warning>
 
 ## How it Works
 
@@ -20660,7 +20680,7 @@ def run_agent_interaction(user_message: str):
     - Model completions
     - Session management
 
-3.  **Optional Decorators**: You can optionally use `@langwatch.trace()` to add additional context and metadata to your traces, but it's not required for basic functionality.
+3.  **Optional Decorators**: You can optionally use `@langwatch.trace()` to add additional context and metadata to your traces, but it's not required for basic functionality. The decorator parents the agent spans only over `Runner.run_async`.
 
 With this setup, LangWatch traces all agent interactions, tool calls, and model completions.
 
@@ -20669,7 +20689,7 @@ With this setup, LangWatch traces all agent interactions, tool calls, and model 
 
 - You do **not** need to set any OpenTelemetry environment variables or configure exporters manually. `langwatch.setup()` handles it.
 - You can combine Google ADK instrumentation with other instrumentors (e.g., OpenAI, LangChain) by adding them to the `instrumentors` list.
-- The `@langwatch.trace()` decorator is **optional** - the OpenInference instrumentor will capture all ADK activity automatically.
+- The `@langwatch.trace()` decorator is **optional** - the OpenInference instrumentor will capture all ADK activity automatically. Use it with `Runner.run_async`, never with the synchronous `Runner.run`.
 - For advanced configuration (custom attributes, endpoint, etc.), see the [Python integration guide](/integration/python/guide).
 
 ## Troubleshooting
@@ -20678,51 +20698,8 @@ With this setup, LangWatch traces all agent interactions, tool calls, and model 
 - If you see no traces in LangWatch, check that the instrumentor is included in `langwatch.setup()` and that your agent code is being executed.
 - Ensure you have the correct Google API key set for Gemini access.
 - **`AttributeError: module 'google.adk.flows.llm_flows.functions' has no attribute 'trace_tool_call'`** on `langwatch.setup()`: your `openinference-instrumentation-google-adk` is too old for your Google ADK version. ADK 1.32 removed that symbol; the fix shipped in instrumentor 0.1.11. Run `pip install -U "openinference-instrumentation-google-adk>=0.1.11"`. If it still fails, confirm the upgrade actually applied in the running interpreter with `pip show openinference-instrumentation-google-adk`.
-
-## Interoperability with LangWatch SDK
-
-You can use this integration together with the LangWatch Python SDK to add additional attributes to the trace:
-
-```python
-import langwatch
-from google.adk import Agent, Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai import types
-from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-
-langwatch.setup(
-    instrumentors=[GoogleADKInstrumentor()]
-)
-
-@langwatch.trace(name="Custom ADK Agent")
-def my_custom_agent(input_message: str):
-    # Your ADK agent code here
-    agent = Agent(
-        name="custom_agent",
-        model="gemini-2.0-flash",
-        instruction="Your custom instructions",
-        tools=[your_custom_tools]
-    )
-
-    # Update the current trace with additional metadata
-    current_trace = langwatch.get_current_trace()
-    if current_trace:
-        current_trace.update(
-            metadata={
-                "user_id": "user_123",
-                "session_id": "session_abc",
-                "agent_name": "custom_agent",
-                "model": "gemini-2.0-flash"
-            }
-        )
-
-    # Run your agent
-    # ... agent execution code ...
-
-    return "Agent response"
-```
-
-This approach allows you to combine the automatic tracing capabilities of Google ADK with the rich metadata and custom attributes provided by LangWatch.
+- **One agent run shows up as two traces, one of them empty except for your decorator span**: you wrapped the synchronous `Runner.run`. Switch to `Runner.run_async`, or drop the decorator. See the warning above.
+- **The metadata you set with `trace.update()` is on a trace with no agent spans**: same cause, same fix.
 
 ---
 
@@ -22845,9 +22822,7 @@ icon: python
 keywords: langwatch, python, audio, voice, realtime, speech, multimodal, tracing
 ---
 
-LangWatch captures a recording as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the audio the way your model provider expects, keep the call inside a trace, and the recording plays on the trace.
-
-This page lists the audio shapes LangWatch understands, what happens to the bytes, and where the player appears in the product.
+Send the audio the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the recording out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the audio with the model call
 
@@ -22855,7 +22830,7 @@ The example below uses `langwatch.setup()` and a `@langwatch.trace()` entry poin
 
 ### OpenAI
 
-A recording rides an `input_audio` part carrying raw base64 and a format.
+Put the recording in an `input_audio` part, as raw base64 with a format.
 
 ```python
 import base64
@@ -22872,7 +22847,7 @@ def transcribe(prompt: str, path: str) -> str:
 
     encoded = base64.b64encode(open(path, "rb").read()).decode("utf-8")
     completion = client.chat.completions.create(
-        model="gpt-4o-audio-preview",
+        model="gpt-audio-mini",
         messages=[
             {
                 "role": "user",
@@ -22894,7 +22869,7 @@ transcribe("What does the caller ask for?", "call.wav")
 
 ### Google Gemini and Vertex
 
-A recording rides an inline data part with an audio media type. The rest of the agent setup does not change.
+Put the recording in an inline data part with an audio media type. The rest of the agent setup does not change.
 
 ```python
 import asyncio
@@ -22948,10 +22923,11 @@ transcribe("What does the caller ask for?", "call.wav")
 ```
 
 <Note>
-  The instrumentor makes the trace for this call. Do not add a
-  `@langwatch.trace()` wrapper around `Runner.run`: it crosses a
-  sync-to-async boundary that does not carry the trace context, so the
-  wrapper lands in a separate trace.
+  The instrumentor makes the trace for this call, so no `@langwatch.trace()`
+  wrapper is needed. If you add one to attach metadata, switch the run to
+  `Runner.run_async`: the synchronous `Runner.run` starts its own thread, which
+  begins with an empty OpenTelemetry context, and the agent spans open a second
+  trace. See the [Google ADK integration](/integration/python/integrations/google-ai).
 </Note>
 
 
@@ -22968,13 +22944,13 @@ Send any of these and the recording is captured.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 
-When a message carries both a recording and text, the text is treated as the transcript of that recording and the two are shown as one unit.
+When a message holds both a recording and text, LangWatch treats the text as the transcript of that recording and shows the two together.
 
 ## What happens to the bytes
 
-LangWatch moves the recording out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the recording out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. A recording captured by a simulation and by the trace of the same call is one stored object, not two.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, a recording captured by a simulation and by the trace of the same call is one stored object, not two.
 
 Raw, header-less audio does not play in a browser on its own. LangWatch wraps `pcm16` and G.711 payloads into a WAV container when it stores them, so the reference plays everywhere without a conversion step of your own.
 
@@ -22982,19 +22958,15 @@ Raw, header-less audio does not play in a browser on its own. LangWatch wraps `p
 
 Open the trace and the Summary tab shows a player under the input. The Conversation tab shows a player in the message it belongs to, next to the transcript. A turn that recorded no transcript still shows its player. The Trace tab shows the full message payload.
 
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no player, ask LangWatch to turn it on for your project.
-</Note>
-
 ## Testing voice agents
 
-Capturing the audio of a live call tells you what happened. To drive a call on purpose, and score it, use Scenario. It synthesizes a caller, speaks to your agent over its real transport, and judges the conversation with the same `scenario.run()` and the same judge you use for text.
+You see what happened on a call once it has run. To drive a call on purpose and score it, use Scenario: it synthesizes a caller, speaks to your agent over its real transport, and scores the conversation with `scenario.run()`.
 
 <Frame caption="Voice agent testing in Scenario, with the simulated call, its per-turn audio and the judge verdict">
   <img src="/images/scenario-voice.webp" alt="LangWatch voice agent testing" />
 </Frame>
 
-Scenario carries adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can inject background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
+Scenario has adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can add background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
 
 ## Related
 
@@ -23014,9 +22986,7 @@ icon: python
 keywords: langwatch, python, documents, pdf, files, attachments, multimodal, tracing
 ---
 
-LangWatch captures a document as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the file the way your model provider expects, keep the call inside a trace, and the attachment is on the trace.
-
-This page lists the document shapes LangWatch understands, what happens to the bytes, and where the attachment appears in the product.
+Send the file the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the document out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the document with the model call
 
@@ -23024,7 +22994,7 @@ The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry 
 
 ### OpenAI
 
-A document rides a `file` part carrying `file_data`. That is the shape Chat Completions accepts for PDF files.
+Put the document in a `file` part, as `file_data`. That is the shape Chat Completions accepts for PDF files.
 
 ```python
 import base64
@@ -23072,7 +23042,7 @@ read_invoice("What is the invoice number and the total due?", "invoice.pdf")
 
 ### Anthropic
 
-A document rides a `document` content block with a base64 source.
+Put the document in a `document` content block with a base64 source.
 
 ```python
 import base64
@@ -23116,7 +23086,7 @@ read_invoice("What is the invoice number and the total due?", "invoice.pdf")
 
 ### Google Gemini and Vertex
 
-A document rides an inline data part with the PDF media type. The rest of the agent setup does not change.
+Put the document in an inline data part with the PDF media type. The rest of the agent setup does not change.
 
 ```python
 import asyncio
@@ -23170,10 +23140,11 @@ ask("What is the invoice number and the total due?", "invoice.pdf")
 ```
 
 <Note>
-  The instrumentor makes the trace for this call. Do not add a
-  `@langwatch.trace()` wrapper around `Runner.run`: it crosses a
-  sync-to-async boundary that does not carry the trace context, so the
-  wrapper lands in a separate trace.
+  The instrumentor makes the trace for this call, so no `@langwatch.trace()`
+  wrapper is needed. If you add one to attach metadata, switch the run to
+  `Runner.run_async`: the synchronous `Runner.run` starts its own thread, which
+  begins with an empty OpenTelemetry context, and the agent spans open a second
+  trace. See the [Google ADK integration](/integration/python/integrations/google-ai).
 </Note>
 
 
@@ -23189,29 +23160,25 @@ Send any of these and the attachment is captured.
 | Google Gemini and Vertex | `{"inline_data": {"mime_type": "application/pdf", "data": "..."}}` |
 | AG-UI | `{"type": "document", "source": {"type": "data", "value": "...", "mimeType": "application/pdf"}}` |
 
-A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, carries no bytes. It is passed through as it is and no attachment is stored.
+A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, holds no bytes. LangWatch passes it through unchanged and stores no attachment.
 
 ## What happens to the bytes
 
-LangWatch moves the document out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the document out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same contract sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same contract sent on ten traces costs one stored object.
 
 On read, LangWatch serves PDF files with their original media type, along with images, audio and video. Every other document type, such as CSV, JSON, Markdown and plain text, is served as a download.
 
 ## Where the document appears
 
-A paperclip sits next to the input preview on the trace list, so a run that carried a file is recognisable without opening it.
+The trace list draws a paperclip next to the input preview, so you can spot a run with a file without opening it.
 
-Open the trace and the Summary tab shows an attachment chip. The chip carries the filename, or the media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
+Open the trace and the Summary tab shows an attachment chip, named after the file, or after its media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
 
 <Frame caption="The trace drawer Summary tab, with an application/pdf attachment chip below the input text and the model answer reading the invoice number and total from the file">
   <img src="/images/integration/multimodal/trace-drawer-pdf.png" alt="LangWatch trace drawer showing a PDF attachment chip below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no attachment, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 
@@ -23473,9 +23440,7 @@ icon: python
 keywords: langwatch, python, images, multimodal, vision, attachments, tracing
 ---
 
-LangWatch captures an image as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the image the way your model provider expects, keep the call inside a trace, and the picture is on the trace.
-
-This page lists the image shapes LangWatch understands, what happens to the bytes, and where the picture appears in the product.
+Send the image the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the image out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the image with the model call
 
@@ -23483,7 +23448,7 @@ The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry 
 
 ### OpenAI
 
-An image rides an `image_url` part carrying a data URL.
+Put the image in an `image_url` part, as a data URL.
 
 ```python
 import base64
@@ -23526,7 +23491,7 @@ describe("What does this image show?", "shapes.png")
 
 ### Anthropic
 
-An image rides an `image` content block with a base64 source.
+Put the image in an `image` content block with a base64 source.
 
 ```python
 import base64
@@ -23572,7 +23537,7 @@ Anthropic's hosted form, `{"type": "url", "url": "https://..."}`, is understood 
 
 ### Google Gemini and Vertex
 
-An image rides an inline data part. `Part.from_bytes` builds it for you. The rest of the agent setup does not change.
+Put the image in an inline data part. `Part.from_bytes` builds one for you. The rest of the agent setup does not change.
 
 ```python
 import asyncio
@@ -23626,10 +23591,11 @@ describe("What does this image show?", "shapes.png")
 ```
 
 <Note>
-  The instrumentor makes the trace for this call. Do not add a
-  `@langwatch.trace()` wrapper around `Runner.run`: it crosses a
-  sync-to-async boundary that does not carry the trace context, so the
-  wrapper lands in a separate trace.
+  The instrumentor makes the trace for this call, so no `@langwatch.trace()`
+  wrapper is needed. If you add one to attach metadata, switch the run to
+  `Runner.run_async`: the synchronous `Runner.run` starts its own thread, which
+  begins with an empty OpenTelemetry context, and the agent spans open a second
+  trace. See the [Google ADK integration](/integration/python/integrations/google-ai).
 </Note>
 
 
@@ -23646,19 +23612,19 @@ Send any of these and the picture is captured. The list covers the shapes the ma
 | Google Gemini and Vertex | `{"inline_data": {"mime_type": "image/png", "data": "..."}}` |
 | AG-UI | `{"type": "image", "source": {"type": "data", "value": "...", "mimeType": "image/png"}}` |
 
-Always set the media type. A part that carries bytes with no media type stays inline in the trace instead of moving into storage, because those bytes would come back as a plain download and not as a picture.
+Always set the media type. Without one, LangWatch leaves the bytes inline in the trace instead of storing them, because it cannot serve them back as a picture.
 
 ## What happens to the bytes
 
-LangWatch moves the image out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the image out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same picture sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same picture sent on ten traces costs one stored object.
 
 On read, LangWatch serves the original media type for images, audio, video and PDF files. Anything else is served as a download.
 
 ## Where the image appears
 
-A thumbnail sits next to the input preview on the trace list, so a run that carried a picture is recognisable without opening it.
+The trace list draws a thumbnail next to the input preview, so you can spot a run with a picture without opening it.
 
 <Frame caption="Trace list rows showing image thumbnails next to the input text, and a paperclip on the row whose attachment is a document">
   <img src="/images/integration/multimodal/trace-list-thumbnails.png" alt="LangWatch trace list with image thumbnails on the input previews" />
@@ -23669,10 +23635,6 @@ Open the trace and the Summary tab shows the picture inline under the question. 
 <Frame caption="The trace drawer Summary tab, with the captured picture rendered inline below the input text and the model answer below it">
   <img src="/images/integration/multimodal/trace-drawer-image.png" alt="LangWatch trace drawer showing a captured image below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no picture, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 
@@ -26024,6 +25986,44 @@ console.log(await main("Hey, tell me a joke"));
 
 The Vercel AI SDK automatically sends traces to LangWatch when `experimental_telemetry.isEnabled` is set to `true`. For Next.js applications, configure OpenTelemetry in your `instrumentation.ts` file using `LangWatchExporter`.
 
+## Metadata
+
+Pass `experimental_telemetry.metadata` to tag the call. LangWatch reads these
+keys from it:
+
+| Key | What it does |
+|---|---|
+| `labels` | An array of labels. Filter the trace list by them. |
+| `thread_id` | Groups the call into a conversation with every other call that sends the same id. |
+| `user_id` | The end user the call belongs to. |
+| `customer_id` | The customer or tenant the call belongs to. |
+
+Any other key becomes custom metadata on the trace, filterable by its own name.
+
+```typescript
+const response = await generateText({
+  model: openai("gpt-5-mini"),
+  prompt: message,
+  experimental_telemetry: {
+    isEnabled: true,
+    metadata: {
+      labels: ["checkout", "beta"],
+      thread_id: "conversation-8f21",
+      user_id: "user-42",
+      tenant: "eu-west",
+    },
+  },
+});
+```
+
+The AI SDK accepts strings, numbers, booleans and arrays of them as metadata
+values. It does not accept a nested object, so flatten anything deeper into
+separate keys.
+
+Setting the same key as a span attribute overrides the value you pass here. See
+[Capturing Metadata and Attributes](/integration/typescript/tutorials/capturing-metadata)
+for the attribute names.
+
 ## Related
 
 - [Capturing RAG](/integration/typescript/tutorials/capturing-rag) - Learn how to capture RAG data from retrievers and tools
@@ -26042,9 +26042,7 @@ icon: square-js
 keywords: langwatch, typescript, javascript, audio, voice, realtime, speech, multimodal, tracing
 ---
 
-LangWatch captures a recording as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the audio the way your model provider expects, keep the call inside a trace, and the recording plays on the trace.
-
-This page lists the audio shapes LangWatch understands, what happens to the bytes, and where the player appears in the product.
+Send the audio the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the recording out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the audio with the model call
 
@@ -26052,7 +26050,7 @@ The examples below use `setupObservability()`. Read [Integration Guide](/integra
 
 ### Vercel AI SDK
 
-A recording rides a `file` part inside the user message, the same part an image uses. Only the media type changes.
+Put the recording in a `file` part inside the user message. `mediaType` is what tells LangWatch and the provider what the bytes are.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -26064,8 +26062,8 @@ setupObservability({ serviceName: "voice-service" });
 
 const data = readFileSync("call.wav").toString("base64");
 
-const result = await generateText({
-  model: openai.chat("gpt-4o-audio-preview"),
+const { text } = await generateText({
+  model: openai.chat("gpt-audio-mini"),
   messages: [
     {
       role: "user",
@@ -26077,11 +26075,13 @@ const result = await generateText({
   ],
   experimental_telemetry: { isEnabled: true },
 });
+
+console.log(text);
 ```
 
 ### OpenAI SDK
 
-A recording rides an `input_audio` part carrying raw base64 and a format.
+Put the recording in an `input_audio` part, as raw base64 with a format.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -26100,7 +26100,7 @@ const transcribe = async (prompt: string, path: string): Promise<string> => {
 
     const encoded = readFileSync(path).toString("base64");
     const completion = await client.chat.completions.create({
-      model: "gpt-4o-audio-preview",
+      model: "gpt-audio-mini",
       messages: [
         {
           role: "user",
@@ -26133,13 +26133,13 @@ Send any of these and the recording is captured.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 
-When a message carries both a recording and text, the text is treated as the transcript of that recording and the two are shown as one unit.
+When a message holds both a recording and text, LangWatch treats the text as the transcript of that recording and shows the two together.
 
 ## What happens to the bytes
 
-LangWatch moves the recording out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the recording out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. A recording captured by a simulation and by the trace of the same call is one stored object, not two.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, a recording captured by a simulation and by the trace of the same call is one stored object, not two.
 
 Raw, header-less audio does not play in a browser on its own. LangWatch wraps `pcm16` and G.711 payloads into a WAV container when it stores them, so the reference plays everywhere without a conversion step of your own.
 
@@ -26147,19 +26147,15 @@ Raw, header-less audio does not play in a browser on its own. LangWatch wraps `p
 
 Open the trace and the Summary tab shows a player under the input. The Conversation tab shows a player in the message it belongs to, next to the transcript. A turn that recorded no transcript still shows its player. The Trace tab shows the full message payload.
 
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no player, ask LangWatch to turn it on for your project.
-</Note>
-
 ## Testing voice agents
 
-Capturing the audio of a live call tells you what happened. To drive a call on purpose, and score it, use Scenario. It synthesizes a caller, speaks to your agent over its real transport, and judges the conversation with the same `scenario.run()` and the same judge you use for text.
+You see what happened on a call once it has run. To drive a call on purpose and score it, use Scenario: it synthesizes a caller, speaks to your agent over its real transport, and scores the conversation with `scenario.run()`.
 
 <Frame caption="Voice agent testing in Scenario, with the simulated call, its per-turn audio and the judge verdict">
   <img src="/images/scenario-voice.webp" alt="LangWatch voice agent testing" />
 </Frame>
 
-Scenario carries adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can inject background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
+Scenario has adapters for Pipecat, Twilio, ElevenLabs, OpenAI Realtime and Gemini Live, and it can add background noise, phone-quality degradation and interruptions. See [Voice Agent Testing](/agent-simulations/voice-agents) for the setup.
 
 ## Related
 
@@ -26179,9 +26175,7 @@ icon: square-js
 keywords: langwatch, typescript, javascript, documents, pdf, files, attachments, multimodal, tracing
 ---
 
-LangWatch captures a document as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the file the way your model provider expects, keep the call inside a trace, and the attachment is on the trace.
-
-This page lists the document shapes LangWatch understands, what happens to the bytes, and where the attachment appears in the product.
+Send the file the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the document out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the document with the model call
 
@@ -26189,7 +26183,7 @@ The examples below use `setupObservability()`. Read [Integration Guide](/integra
 
 ### Vercel AI SDK
 
-A document rides a `file` part inside the user message, the same part an image uses. Only the media type changes.
+Put the document in a `file` part inside the user message. `mediaType` is what tells LangWatch and the provider what the bytes are.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -26201,7 +26195,7 @@ setupObservability({ serviceName: "invoice-service" });
 
 const data = readFileSync("invoice.pdf").toString("base64");
 
-const result = await generateText({
+const { text } = await generateText({
   model: openai.chat("gpt-5-mini"),
   messages: [
     {
@@ -26219,11 +26213,13 @@ const result = await generateText({
   ],
   experimental_telemetry: { isEnabled: true },
 });
+
+console.log(text);
 ```
 
 ### OpenAI SDK
 
-A document rides a `file` part carrying `file_data`. That is the shape Chat Completions accepts for PDF files.
+Put the document in a `file` part, as `file_data`. That is the shape Chat Completions accepts for PDF files.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -26282,29 +26278,25 @@ Send any of these and the attachment is captured.
 | Google Gemini and Vertex | `{ inlineData: { mimeType: "application/pdf", data: "..." } }` |
 | AG-UI | `{ type: "document", source: { type: "data", value: "...", mimeType: "application/pdf" } }` |
 
-A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, carries no bytes. It is passed through as it is and no attachment is stored.
+A part that names only a provider-hosted file, such as an OpenAI `file_id` with no `file_data`, holds no bytes. LangWatch passes it through unchanged and stores no attachment.
 
 ## What happens to the bytes
 
-LangWatch moves the document out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the document out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same contract sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same contract sent on ten traces costs one stored object.
 
 On read, LangWatch serves PDF files with their original media type, along with images, audio and video. Every other document type, such as CSV, JSON, Markdown and plain text, is served as a download.
 
 ## Where the document appears
 
-A paperclip sits next to the input preview on the trace list, so a run that carried a file is recognisable without opening it.
+The trace list draws a paperclip next to the input preview, so you can spot a run with a file without opening it.
 
-Open the trace and the Summary tab shows an attachment chip. The chip carries the filename, or the media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
+Open the trace and the Summary tab shows an attachment chip, named after the file, or after its media type when the message sends no filename. Click it to open the file. The Conversation tab shows the same chip in the message it belongs to, and the Trace tab shows the full message payload.
 
 <Frame caption="The trace drawer Summary tab, with an application/pdf attachment chip below the input text and the model answer reading the invoice number and total from the file">
   <img src="/images/integration/multimodal/trace-drawer-pdf.png" alt="LangWatch trace drawer showing a PDF attachment chip below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no attachment, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 
@@ -26324,9 +26316,7 @@ icon: square-js
 keywords: langwatch, typescript, javascript, images, multimodal, vision, attachments, tracing
 ---
 
-LangWatch captures an image as soon as it appears in the messages of a traced model call. There is no extra API to call and no separate upload step. Send the image the way your model provider expects, keep the call inside a trace, and the picture is on the trace.
-
-This page lists the image shapes LangWatch understands, what happens to the bytes, and where the picture appears in the product.
+Send the image the way your model provider expects and keep the call inside a trace. There is no upload step and no extra API call: LangWatch reads the image out of the messages at ingestion, stores it, and leaves a reference in its place.
 
 ## Send the image with the model call
 
@@ -26334,7 +26324,7 @@ The examples below use `setupObservability()`. Read [Integration Guide](/integra
 
 ### Vercel AI SDK
 
-An image rides a `file` part inside the user message. `experimental_telemetry` turns tracing on for the call.
+Put the image in a `file` part inside the user message. `experimental_telemetry` turns tracing on for the call.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -26346,7 +26336,7 @@ setupObservability({ serviceName: "image-service" });
 
 const data = readFileSync("shapes.png").toString("base64");
 
-const result = await generateText({
+const { text } = await generateText({
   model: openai.chat("gpt-5-mini"),
   messages: [
     {
@@ -26359,11 +26349,13 @@ const result = await generateText({
   ],
   experimental_telemetry: { isEnabled: true },
 });
+
+console.log(text);
 ```
 
 ### OpenAI SDK
 
-An image rides an `image_url` part carrying a data URL.
+Put the image in an `image_url` part, as a data URL.
 
 ```typescript
 import { readFileSync } from "node:fs";
@@ -26418,19 +26410,19 @@ Send any of these and the picture is captured. The list covers the shapes the ma
 | Google Gemini and Vertex | `{ inlineData: { mimeType: "image/png", data: "..." } }` |
 | AG-UI | `{ type: "image", source: { type: "data", value: "...", mimeType: "image/png" } }` |
 
-Always set the media type. A part that carries bytes with no media type stays inline in the trace instead of moving into storage, because those bytes would come back as a plain download and not as a picture.
+Always set the media type. Without one, LangWatch leaves the bytes inline in the trace instead of storing them, because it cannot serve them back as a picture.
 
 ## What happens to the bytes
 
-LangWatch moves the image out of the span at the ingestion edge. The bytes go into content-addressed object storage and the message part is rewritten to a short `/api/files/<projectId>/<id>` reference, so the trace itself stays small and fast to query.
+LangWatch moves the image out of the span at ingestion. The bytes go into content-addressed object storage and the message part becomes a `/api/files/<projectId>/<id>` reference, around 60 characters where the base64 was.
 
-Storage is addressed by SHA-256, so identical bytes are stored once. The same picture sent on ten traces costs one stored object.
+Storage is addressed by SHA-256, so identical bytes are stored once. For example, the same picture sent on ten traces costs one stored object.
 
 On read, LangWatch serves the original media type for images, audio, video and PDF files. Anything else is served as a download.
 
 ## Where the image appears
 
-A thumbnail sits next to the input preview on the trace list, so a run that carried a picture is recognisable without opening it.
+The trace list draws a thumbnail next to the input preview, so you can spot a run with a picture without opening it.
 
 <Frame caption="Trace list rows showing image thumbnails next to the input text, and a paperclip on the row whose attachment is a document">
   <img src="/images/integration/multimodal/trace-list-thumbnails.png" alt="LangWatch trace list with image thumbnails on the input previews" />
@@ -26441,10 +26433,6 @@ Open the trace and the Summary tab shows the picture inline under the question. 
 <Frame caption="The trace drawer Summary tab, with the captured picture rendered inline below the input text and the model answer below it">
   <img src="/images/integration/multimodal/trace-drawer-image.png" alt="LangWatch trace drawer showing a captured image below the input question" />
 </Frame>
-
-<Note>
-Attachment capture is enabled per project. If your traces show the message text but no picture, ask LangWatch to turn it on for your project.
-</Note>
 
 ## Related
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -20546,6 +20546,11 @@ The [OpenInference Google ADK instrumentor](https://github.com/Arize-ai/openinfe
 
 Here's the simplest way to instrument your application:
 
+<Info>
+Set `LANGWATCH_API_KEY` in the environment before you run this. Without it the
+SDK sends nothing.
+</Info>
+
 ```python
 import langwatch
 from google.adk import Agent, Runner
@@ -20604,8 +20609,6 @@ if __name__ == "__main__":
 ```
 
 **That's it!** All Google ADK agent activity will now be traced and sent to your LangWatch dashboard automatically.
-
-The LangWatch API key comes from the `LANGWATCH_API_KEY` environment variable.
 
 ### Optional: Add metadata with a decorator
 
@@ -22826,7 +22829,7 @@ Send the audio the way your model provider expects and keep the call inside a tr
 
 ## Send the audio with the model call
 
-The example below uses `langwatch.setup()` and a `@langwatch.trace()` entry point. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
+Both examples below call `langwatch.setup()`. The OpenAI one runs inside a `@langwatch.trace()` entry point; the Google ADK one lets the instrumentor make the trace. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
 
 ### OpenAI
 
@@ -22937,10 +22940,12 @@ Send any of these and the recording is captured.
 
 | Source | Shape |
 |---|---|
-| OpenAI Realtime | `{"type": "input_audio", "input_audio": {"data": "<base64>", "format": "wav"}}` |
+| OpenAI | `{"type": "input_audio", "input_audio": {"data": "<base64>", "format": "wav"}}` |
 | OpenAI | `{"type": "file", "file": {"filename": "call.wav", "file_data": "<base64>"}}` |
 | Google Gemini and Vertex | `{"inline_data": {"mime_type": "audio/wav", "data": "..."}}` |
 | AG-UI | `{"type": "audio", "source": {"type": "data", "value": "...", "mimeType": "audio/wav"}}` |
+
+An OpenAI Realtime session sends its turns in the same `input_audio` shape.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 
@@ -22990,7 +22995,7 @@ Send the file the way your model provider expects and keep the call inside a tra
 
 ## Send the document with the model call
 
-The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry point. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
+The examples below all call `langwatch.setup()`. The OpenAI and Anthropic ones run inside a `@langwatch.trace()` entry point; the Google ADK one lets the instrumentor make the trace. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
 
 ### OpenAI
 
@@ -23444,7 +23449,7 @@ Send the image the way your model provider expects and keep the call inside a tr
 
 ## Send the image with the model call
 
-The examples below all use `langwatch.setup()` and a `@langwatch.trace()` entry point. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
+The examples below all call `langwatch.setup()`. The OpenAI and Anthropic ones run inside a `@langwatch.trace()` entry point; the Google ADK one lets the instrumentor make the trace. Read [Integration Guide](/integration/python/guide) first if you have not set that up yet.
 
 ### OpenAI
 
@@ -26016,11 +26021,16 @@ const response = await generateText({
 });
 ```
 
-The AI SDK accepts strings, numbers, booleans and arrays of them as metadata
-values. It does not accept a nested object, so flatten anything deeper into
-separate keys.
+`experimental_telemetry` is the AI SDK's own experimental API, and its shape
+can change between AI SDK versions.
 
-Setting the same key as a span attribute overrides the value you pass here. See
+It accepts strings, numbers, booleans and arrays of them as metadata values. It
+does not accept a nested object, so flatten anything deeper into separate keys.
+A `null` inside a `labels` array is dropped.
+
+A `thread_id`, `user_id`, `customer_id` or `metadata.<key>` you also set as a
+span attribute wins over the one you pass here. Labels are the exception: the
+two sets are combined, so the trace keeps both. See
 [Capturing Metadata and Attributes](/integration/typescript/tutorials/capturing-metadata)
 for the attribute names.
 
@@ -26125,11 +26135,13 @@ Send any of these and the recording is captured.
 
 | Source | Shape |
 |---|---|
-| OpenAI Realtime | `{ type: "input_audio", input_audio: { data: "<base64>", format: "wav" } }` |
+| OpenAI | `{ type: "input_audio", input_audio: { data: "<base64>", format: "wav" } }` |
 | Vercel AI SDK | `{ type: "file", mediaType: "audio/wav", data: "<base64>" }` |
 | OpenAI | `{ type: "file", file: { filename: "call.wav", file_data: "<base64>" } }` |
 | Google Gemini and Vertex | `{ inlineData: { mimeType: "audio/wav", data: "..." } }` |
 | AG-UI | `{ type: "audio", source: { type: "data", value: "...", mimeType: "audio/wav" } }` |
+
+An OpenAI Realtime session sends its turns in the same `input_audio` shape.
 
 The `format` field accepts `wav`, `mp3`, `flac`, `ogg` and `webm`. A raw format such as `pcm16` is accepted too, see the next section.
 

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
@@ -275,6 +275,19 @@ describe("TraceAttributeAccumulationService and the Vercel AI SDK metadata chann
       );
       expect(result["langwatch.user_id"]).toBe("explicit-user");
     });
+
+    /** @scenario "An explicit custom metadata attribute wins over the Vercel channel" */
+    it("keeps the explicit custom metadata value", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: {
+            "metadata.tenant": "explicit",
+            "ai.telemetry.metadata.tenant": "vercel",
+          },
+        }),
+      );
+      expect(result["metadata.tenant"]).toBe("explicit");
+    });
   });
 
   describe("when a span carries Vercel telemetry keys that are not metadata", () => {

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
@@ -156,3 +156,142 @@ describe("TraceAttributeAccumulationService.extractAttributes", () => {
     });
   });
 });
+
+/**
+ * The Vercel AI SDK flattens `experimental_telemetry.metadata` onto every span
+ * it emits as `ai.telemetry.metadata.<key>`. The trace summary read
+ * `langwatch.*`, `gen_ai.*` and `tag.tags` only, so a Vercel AI call tagged
+ * through the SDK's own metadata channel reached the product with no labels,
+ * no user, no conversation and no custom keys.
+ */
+describe("TraceAttributeAccumulationService and the Vercel AI SDK metadata channel", () => {
+  describe("when a span carries ai.telemetry.metadata.labels", () => {
+    /** @scenario "Labels passed to experimental_telemetry reach the trace" */
+    it("folds them into langwatch.labels", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: {
+            "ai.telemetry.metadata.labels": ["checkout", "beta"],
+          },
+        }),
+      );
+      expect(JSON.parse(result["langwatch.labels"]!)).toEqual([
+        "checkout",
+        "beta",
+      ]);
+    });
+
+    /** @scenario "Vercel labels join labels sent by another span of the same trace" */
+    it("unions them with langwatch.labels without duplicates", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: {
+            "langwatch.labels": ["prod", "checkout"],
+            "ai.telemetry.metadata.labels": ["checkout"],
+          },
+        }),
+      );
+      expect(JSON.parse(result["langwatch.labels"]!).sort()).toEqual([
+        "checkout",
+        "prod",
+      ]);
+    });
+  });
+
+  describe("when a span carries the identity metadata keys", () => {
+    /** @scenario "A user id passed to experimental_telemetry identifies the trace" */
+    it("fills the trace user id", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "ai.telemetry.metadata.user_id": "user-42" },
+        }),
+      );
+      expect(result["langwatch.user_id"]).toBe("user-42");
+    });
+
+    /** @scenario "A thread id passed to experimental_telemetry groups the conversation" */
+    it("fills the conversation id", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "ai.telemetry.metadata.thread_id": "thread-9" },
+        }),
+      );
+      expect(result["gen_ai.conversation.id"]).toBe("thread-9");
+    });
+
+    /** @scenario "A customer id passed to experimental_telemetry reaches the trace" */
+    it("fills the customer id", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "ai.telemetry.metadata.customer_id": "acme" },
+        }),
+      );
+      expect(result["langwatch.customer_id"]).toBe("acme");
+    });
+
+    /** @scenario "The camelCase spelling of an identity key is accepted" */
+    it("accepts the camelCase spelling", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "ai.telemetry.metadata.threadId": "thread-9" },
+        }),
+      );
+      expect(result["gen_ai.conversation.id"]).toBe("thread-9");
+    });
+  });
+
+  describe("when a span carries a metadata key that is not reserved", () => {
+    /** @scenario "A key that is not reserved becomes custom trace metadata" */
+    it("keeps it as custom trace metadata", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "ai.telemetry.metadata.tenant": "eu-west" },
+        }),
+      );
+      expect(result["metadata.tenant"]).toBe("eu-west");
+    });
+
+    /** @scenario "A non-string value keeps its own shape in custom metadata" */
+    it("writes a number as its own text", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "ai.telemetry.metadata.retry_count": 3 },
+        }),
+      );
+      expect(result["metadata.retry_count"]).toBe("3");
+    });
+  });
+
+  describe("when the same value arrives on both channels", () => {
+    /** @scenario "An explicit LangWatch attribute wins over the Vercel channel" */
+    it("keeps the explicit LangWatch value", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: {
+            "langwatch.user.id": "explicit-user",
+            "ai.telemetry.metadata.user_id": "vercel-user",
+          },
+        }),
+      );
+      expect(result["langwatch.user_id"]).toBe("explicit-user");
+    });
+  });
+
+  describe("when a span carries Vercel telemetry keys that are not metadata", () => {
+    /** @scenario "The Vercel telemetry keys that are not metadata are left alone" */
+    it("leaves them out of trace metadata", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: {
+            "ai.telemetry.functionId": "checkout-flow",
+            "ai.model.id": "gpt-5-mini",
+          },
+        }),
+      );
+      expect(result["metadata.functionId"]).toBeUndefined();
+      expect(
+        Object.keys(result).filter((key) => key.startsWith("metadata.")),
+      ).toEqual([]);
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-io-accumulation.service.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-io-accumulation.service.unit.test.ts
@@ -370,7 +370,7 @@ describe("TraceIOAccumulationService: media refs", () => {
   });
 
   /**
-   * A span the way the wire records it: the picture rides the span attribute,
+   * A span the way the wire records it: the picture is on the span attribute,
    * and what the extraction service reports about the span is a separate
    * question. Instrumentation for several SDKs reports the text alone.
    */

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-attribute-accumulation.service.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-attribute-accumulation.service.ts
@@ -29,6 +29,46 @@ const VERCEL_RESERVED_METADATA: Readonly<Record<string, string>> = {
   customerId: "langwatch.customer_id",
 };
 
+/** The metadata name behind a Vercel telemetry key, or null for any other key. */
+const vercelMetadataName = (key: string): string | null =>
+  key.startsWith(VERCEL_METADATA_PREFIX)
+    ? key.slice(VERCEL_METADATA_PREFIX.length) || null
+    : null;
+
+/** Labels as an array, whether they arrive as one or as a JSON string. */
+const labelList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((label): label is string => typeof label === "string")
+    : parseJsonStringArray(typeof value === "string" ? value : void 0);
+
+const unionLabelsInto = (
+  result: Record<string, string>,
+  labels: string[],
+): void => {
+  if (labels.length === 0) return;
+  const existing = parseJsonStringArray(result[ATTR_KEYS.LANGWATCH_LABELS]);
+  result[ATTR_KEYS.LANGWATCH_LABELS] = JSON.stringify([
+    ...new Set([...existing, ...labels]),
+  ]);
+};
+
+/** Writes the value only when the key has no value yet, so an explicit one wins. */
+const fillIfEmpty = (
+  result: Record<string, string>,
+  key: string,
+  value: unknown,
+): void => {
+  if (result[key]) return;
+  if (typeof value === "string" && value.length > 0) result[key] = value;
+};
+
+const attributeText = (value: unknown): string =>
+  typeof value === "string"
+    ? value
+    : typeof value === "object"
+      ? JSON.stringify(value)
+      : String(value);
+
 export const RESOURCE_ATTR_MAPPINGS = [
   ["telemetry.sdk.name", "sdk.name"],
   ["telemetry.sdk.version", "sdk.version"],
@@ -313,41 +353,21 @@ export class TraceAttributeAccumulationService {
     result: Record<string, string>,
   ): void {
     for (const [key, value] of Object.entries(spanAttrs)) {
-      if (!key.startsWith(VERCEL_METADATA_PREFIX)) continue;
-      if (value === null || value === undefined) continue;
-
-      const name = key.slice(VERCEL_METADATA_PREFIX.length);
-      if (!name) continue;
+      const name = vercelMetadataName(key);
+      if (!name || value === null || value === undefined) continue;
 
       if (name === "labels" || name === "tags") {
-        const labels = Array.isArray(value)
-          ? value.filter((label): label is string => typeof label === "string")
-          : parseJsonStringArray(typeof value === "string" ? value : void 0);
-        if (labels.length === 0) continue;
-        const existing = parseJsonStringArray(
-          result[ATTR_KEYS.LANGWATCH_LABELS],
-        );
-        result[ATTR_KEYS.LANGWATCH_LABELS] = JSON.stringify([
-          ...new Set([...existing, ...labels]),
-        ]);
+        unionLabelsInto(result, labelList(value));
         continue;
       }
 
       const reserved = VERCEL_RESERVED_METADATA[name];
       if (reserved) {
-        if (result[reserved]) continue;
-        if (typeof value === "string" && value.length > 0) {
-          result[reserved] = value;
-        }
+        fillIfEmpty(result, reserved, value);
         continue;
       }
 
-      result[`metadata.${name}`] =
-        typeof value === "string"
-          ? value
-          : typeof value === "object"
-            ? JSON.stringify(value)
-            : String(value);
+      result[`metadata.${name}`] = attributeText(value);
     }
   }
 

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-attribute-accumulation.service.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-attribute-accumulation.service.ts
@@ -8,6 +8,27 @@ import type { NormalizedSpan } from "../../schemas/spans";
 import type { TraceOriginService } from "./trace-origin.service";
 import { parseJsonStringArray, stringAttr } from "./trace-summary.utils";
 
+/**
+ * The prefix the Vercel AI SDK writes `experimental_telemetry.metadata` under.
+ * It flattens the object one attribute per entry, so a `{ labels, user_id }`
+ * metadata object arrives as two separate span attributes.
+ */
+const VERCEL_METADATA_PREFIX = "ai.telemetry.metadata.";
+
+/**
+ * Metadata names that identify a trace rather than describe it, and the
+ * trace-summary key each one fills. Both spellings are accepted because the
+ * REST collector accepts both and callers copy whichever they already use.
+ */
+const VERCEL_RESERVED_METADATA: Readonly<Record<string, string>> = {
+  thread_id: "gen_ai.conversation.id",
+  threadId: "gen_ai.conversation.id",
+  user_id: "langwatch.user_id",
+  userId: "langwatch.user_id",
+  customer_id: "langwatch.customer_id",
+  customerId: "langwatch.customer_id",
+};
+
 export const RESOURCE_ATTR_MAPPINGS = [
   ["telemetry.sdk.name", "sdk.name"],
   ["telemetry.sdk.version", "sdk.version"],
@@ -254,6 +275,8 @@ export class TraceAttributeAccumulationService {
       ]);
     }
 
+    this.applyVercelTelemetryMetadata(spanAttrs, result);
+
     const promptId = stringAttr(spanAttrs, "langwatch.prompt.id");
     if (promptId?.includes(":")) {
       result["langwatch.prompt.id"] = promptId;
@@ -269,6 +292,63 @@ export class TraceAttributeAccumulationService {
     }
 
     return result;
+  }
+
+  /**
+   * Folds the Vercel AI SDK's metadata channel into the keys the trace
+   * summary already reads.
+   *
+   * `experimental_telemetry: { metadata: {...} }` is flattened by the AI SDK
+   * onto every span it emits, one `ai.telemetry.metadata.<key>` attribute per
+   * entry. It is the only metadata channel the AI SDK gives a caller, so the
+   * reserved names below get the same treatment they get on every other
+   * channel, and anything else becomes custom trace metadata.
+   *
+   * A value the caller set explicitly through `langwatch.*` (or through a
+   * resource attribute) always wins: this only fills a key that is still
+   * empty.
+   */
+  private applyVercelTelemetryMetadata(
+    spanAttrs: NormalizedSpan["spanAttributes"],
+    result: Record<string, string>,
+  ): void {
+    for (const [key, value] of Object.entries(spanAttrs)) {
+      if (!key.startsWith(VERCEL_METADATA_PREFIX)) continue;
+      if (value === null || value === undefined) continue;
+
+      const name = key.slice(VERCEL_METADATA_PREFIX.length);
+      if (!name) continue;
+
+      if (name === "labels" || name === "tags") {
+        const labels = Array.isArray(value)
+          ? value.filter((label): label is string => typeof label === "string")
+          : parseJsonStringArray(typeof value === "string" ? value : void 0);
+        if (labels.length === 0) continue;
+        const existing = parseJsonStringArray(
+          result[ATTR_KEYS.LANGWATCH_LABELS],
+        );
+        result[ATTR_KEYS.LANGWATCH_LABELS] = JSON.stringify([
+          ...new Set([...existing, ...labels]),
+        ]);
+        continue;
+      }
+
+      const reserved = VERCEL_RESERVED_METADATA[name];
+      if (reserved) {
+        if (result[reserved]) continue;
+        if (typeof value === "string" && value.length > 0) {
+          result[reserved] = value;
+        }
+        continue;
+      }
+
+      result[`metadata.${name}`] =
+        typeof value === "string"
+          ? value
+          : typeof value === "object"
+            ? JSON.stringify(value)
+            : String(value);
+    }
   }
 
   accumulateAttributes({

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
@@ -135,7 +135,7 @@ export function extractIOFromLogRecord(data: LogRecordReceivedEventData): {
         return { input: null, output: responseText };
       }
     }
-    // LIGHT path: without OTEL_LOG_RAW_API_BODIES the reply text rides an
+    // LIGHT path: without OTEL_LOG_RAW_API_BODIES the reply text arrives on an
     // `assistant_response` event (attribute `response`) and no
     // api_response_body exists in the session — the two events are
     // per-session alternatives carrying the same reply text, so accepting

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -228,7 +228,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: false,
     description:
-      "Externalizes inline media (audio, images, files) from span content into the content-addressed stored-objects store at the ingestion edge, replacing base64 payloads with /api/files references. Off = media rides inline through the pipeline as before. Note: stored media is not yet covered by retention deletion; enable knowingly.",
+      "Externalizes inline media (audio, images, files) from span content into the content-addressed stored-objects store at the ingestion edge, replacing base64 payloads with /api/files references. Off = media stays inline through the pipeline as before. Note: stored media is not yet covered by retention deletion; enable knowingly.",
   },
   {
     key: "release_ui_ai_governance_enabled",

--- a/platform/app/src/server/stored-objects/__tests__/trace-media-extraction.integration.test.ts
+++ b/platform/app/src/server/stored-objects/__tests__/trace-media-extraction.integration.test.ts
@@ -610,7 +610,7 @@ describe("trace media extraction at the ingestion edge", () => {
     });
 
     /** @scenario "The same bytes in two attributes of one span are stored once" */
-    it("stores one object when the same image rides two attributes of one span", async () => {
+    it("stores one object when the same image is on two attributes of one span", async () => {
       // What a managed-prompt run produces: the engine compiles the prompt from
       // the dataset value (prompt variables), then sends the message built from
       // it. The same picture legitimately appears twice in one span.

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -179,7 +179,7 @@ func TestRewriteRehomesSystemAttachmentToUser(t *testing.T) {
 	assert.Equal(t, "You are a vision grader. Image:", strings.TrimSpace(systemText),
 		"the system message keeps only the text before the image, not the image link")
 	assert.Equal(t, "user", out[1].Role)
-	firstPartOfType(t, out[1], "image_url") // the image moved to the user message
+	firstPartOfType(t, out[1], "image_url")
 }
 
 // @scenario "An unreachable attachment URL fails the run with a clear message naming the URL"

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -179,7 +179,7 @@ func TestRewriteRehomesSystemAttachmentToUser(t *testing.T) {
 	assert.Equal(t, "You are a vision grader. Image:", strings.TrimSpace(systemText),
 		"the system message keeps only the text before the image, not the image link")
 	assert.Equal(t, "user", out[1].Role)
-	firstPartOfType(t, out[1], "image_url") // the image rode into the user message
+	firstPartOfType(t, out[1], "image_url") // the image moved to the user message
 }
 
 // @scenario "An unreachable attachment URL fails the run with a clear message naming the URL"

--- a/specs/trace-processing/trace-media-blob-extraction.feature
+++ b/specs/trace-processing/trace-media-blob-extraction.feature
@@ -100,7 +100,7 @@ Feature: Trace media blob extraction at the ingestion edge
 
   @integration
   Scenario: Media carried on span events is externalized like span attributes
-    Given a span whose gen_ai prompt rides in a span event attribute containing an inline image
+    Given a span whose gen_ai prompt is in a span event attribute containing an inline image
     When the span is ingested
     Then the event attribute is rewritten to reference the stored object
 

--- a/specs/trace-processing/trace-media-blob-extraction.feature
+++ b/specs/trace-processing/trace-media-blob-extraction.feature
@@ -100,7 +100,7 @@ Feature: Trace media blob extraction at the ingestion edge
 
   @integration
   Scenario: Media carried on span events is externalized like span attributes
-    Given a span whose gen_ai prompt is in a span event attribute containing an inline image
+    Given an instrumentation that records the prompt on a span event, with an inline image in it
     When the span is ingested
     Then the event attribute is rewritten to reference the stored object
 

--- a/specs/trace-processing/vercel-ai-telemetry-metadata.feature
+++ b/specs/trace-processing/vercel-ai-telemetry-metadata.feature
@@ -92,6 +92,13 @@ Feature: Vercel AI SDK telemetry metadata reaches the trace summary
     When the trace summary is built
     Then the trace user id is "explicit-user"
 
+  @unit
+  Scenario: An explicit custom metadata attribute wins over the Vercel channel
+    Given a span with the metadata attribute "tenant" set to "explicit"
+    And the same span with ai.telemetry.metadata.tenant = "vercel"
+    When the trace summary is built
+    Then the trace metadata key "tenant" is "explicit"
+
   # ─── Not a metadata key ────────────────────────────────────────────
 
   @unit

--- a/specs/trace-processing/vercel-ai-telemetry-metadata.feature
+++ b/specs/trace-processing/vercel-ai-telemetry-metadata.feature
@@ -1,0 +1,101 @@
+# The Vercel AI SDK has its own metadata channel.
+#
+# `generateText({ experimental_telemetry: { isEnabled: true, metadata: {...} } })`
+# flattens every entry onto the spans it emits as `ai.telemetry.metadata.<key>`,
+# one attribute per key. That is the only metadata channel a Vercel AI SDK user
+# has without dropping to raw OpenTelemetry, and it is how the SDK's own
+# documentation tells people to tag a call.
+#
+# The trace summary is built from span attributes and reads `langwatch.*`,
+# `gen_ai.*` and `tag.tags`. It did not read `ai.telemetry.metadata.*`, so a
+# Vercel AI call tagged with labels, a user id or a thread id arrived with none
+# of them: the labels facet stayed empty, the call joined no conversation, and
+# custom keys were dropped. The legacy collector mapper has understood this
+# shape since the Vercel integration shipped, which is what made the gap hard
+# to see: the same payload behaved differently on the two read paths.
+#
+# The reserved names are the same ones every other channel uses, so a value the
+# customer set explicitly through `langwatch.*` always wins over the same value
+# arriving through the Vercel channel.
+
+Feature: Vercel AI SDK telemetry metadata reaches the trace summary
+  As a developer tracing an application built on the Vercel AI SDK
+  I want the metadata I pass to experimental_telemetry to reach my traces
+  So that I can filter by label, group by conversation and find a user's calls
+  without writing OpenTelemetry attributes by hand.
+
+  Background:
+    Given a project that receives spans over OTLP
+
+  # ─── Labels ────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: Labels passed to experimental_telemetry reach the trace
+    Given a span with ai.telemetry.metadata.labels = ["checkout", "beta"]
+    When the trace summary is built
+    Then the trace has the labels "checkout" and "beta"
+
+  @unit
+  Scenario: Vercel labels join labels sent by another span of the same trace
+    Given a span with ai.telemetry.metadata.labels = ["checkout"]
+    And another span of the same trace with langwatch.labels = ["prod"]
+    When the trace summary is built
+    Then the trace has the labels "checkout" and "prod"
+    And each label appears once
+
+  # ─── Trace identity ────────────────────────────────────────────────
+
+  @unit
+  Scenario: A user id passed to experimental_telemetry identifies the trace
+    Given a span with ai.telemetry.metadata.user_id = "user-42"
+    When the trace summary is built
+    Then the trace user id is "user-42"
+
+  @unit
+  Scenario: A thread id passed to experimental_telemetry groups the conversation
+    Given a span with ai.telemetry.metadata.thread_id = "thread-9"
+    When the trace summary is built
+    Then the trace conversation id is "thread-9"
+
+  @unit
+  Scenario: A customer id passed to experimental_telemetry reaches the trace
+    Given a span with ai.telemetry.metadata.customer_id = "acme"
+    When the trace summary is built
+    Then the trace customer id is "acme"
+
+  @unit
+  Scenario: The camelCase spelling of an identity key is accepted
+    Given a span with ai.telemetry.metadata.threadId = "thread-9"
+    When the trace summary is built
+    Then the trace conversation id is "thread-9"
+
+  # ─── Custom keys ───────────────────────────────────────────────────
+
+  @unit
+  Scenario: A key that is not reserved becomes custom trace metadata
+    Given a span with ai.telemetry.metadata.tenant = "eu-west"
+    When the trace summary is built
+    Then the trace metadata key "tenant" is "eu-west"
+
+  @unit
+  Scenario: A non-string value keeps its own shape in custom metadata
+    Given a span with ai.telemetry.metadata.retry_count = 3
+    When the trace summary is built
+    Then the trace metadata key "retry_count" is "3"
+
+  # ─── Precedence ────────────────────────────────────────────────────
+
+  @unit
+  Scenario: An explicit LangWatch attribute wins over the Vercel channel
+    Given a span with langwatch.user.id = "explicit-user"
+    And the same span with ai.telemetry.metadata.user_id = "vercel-user"
+    When the trace summary is built
+    Then the trace user id is "explicit-user"
+
+  # ─── Not a metadata key ────────────────────────────────────────────
+
+  @unit
+  Scenario: The Vercel telemetry keys that are not metadata are left alone
+    Given a span with ai.telemetry.functionId = "checkout-flow"
+    When the trace summary is built
+    Then the trace has no custom metadata key "functionId"


### PR DESCRIPTION
Follow-ups from the multimodal capture review (#7339). Two of them were reported
as small notes at the bottom of that PR; both turned out to be worth a fix.

## 1. The Vercel AI SDK's own metadata channel never reached the trace

`generateText({ experimental_telemetry: { isEnabled: true, metadata: {...} } })`
is the only metadata channel the AI SDK gives a caller. It flattens the object
onto every span it emits, one `ai.telemetry.metadata.<key>` attribute per entry.

The trace summary is built from span attributes and read `langwatch.*`,
`gen_ai.*` and `tag.tags`. It did not read `ai.telemetry.metadata.*`, so a
Vercel AI call tagged through the SDK's own channel arrived with **none** of it:
the labels facet stayed empty, the call joined no conversation, the user id was
lost and custom keys were dropped.

The legacy collector mapper (`otel.traces.ts`) has understood this shape since
the Vercel integration shipped, and has a test for it. That is what made the gap
hard to see: the same payload behaved differently on the two read paths, and the
one the trace list reads was the one that ignored it.

`TraceAttributeAccumulationService` now folds the channel into the keys it
already reads:

| Metadata key | Where it lands |
|---|---|
| `labels` | `langwatch.labels`, unioned with any labels from another span |
| `thread_id` / `threadId` | `gen_ai.conversation.id` |
| `user_id` / `userId` | `langwatch.user_id` |
| `customer_id` / `customerId` | `langwatch.customer_id` |
| anything else | `metadata.<key>` |

A value set explicitly through `langwatch.*` still wins, so nothing that works
today changes. Keys under `ai.telemetry.` that are not metadata (`functionId`,
`ai.model.id`) are left where they are.

Checked against a real run, not only the tests: the dogfood cell sends
`metadata: { labels: ["multimodal-dogfood", "vercel-ai", kind] }`, and the three
labels reach the trace summary and the trace list.

![trace list labels](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7368/vercel/trace-list-labels.png)

`docs/integration/typescript/integrations/vercel-ai-sdk.mdx` gains the table and
an example, since the page never said what the metadata object accepts.

## 2. Our Google ADK docs told people to break their own trace

`google-ai.mdx` showed `@langwatch/trace()` wrapped around `runner.run` twice,
presented as the way to attach metadata to an ADK trace. It produces two traces.

`Runner.run` starts a new Python thread and calls `asyncio.run` inside it
(`google/adk/runners.py`, `create_thread` is a plain `threading.Thread`).
OpenTelemetry keeps the active span in a context variable, and a new thread
starts with an empty one, so the agent spans open a second, separate trace. The
metadata stays on the wrapper trace and the agent trace gets none of it.

Measured with an in-memory exporter on a real ADK run, one agent turn each:

```
== sync Runner.run under a wrapper: 2 trace(s) ==
  2c0deecbfd410889aa905e1956bd86df  ['wrapper around Runner.run']
  51b21f041dc465ae050f57adb694834d  ['call_llm', 'agent_run [probe_agent]', 'invocation [adk-context-probe]']

== Runner.run_async under a wrapper: 1 trace(s) ==
  6690e49ac5445d8ba61935640741f49a  ['wrapper around Runner.run_async', 'invocation [adk-context-probe]', 'call_llm', 'agent_run [probe_agent]']
```

`run_async` stays on the caller's task, so the wrapper is the parent and it is
one trace. The page now shows `run_async` under the decorator, states why, and
carries two troubleshooting entries for the symptom (two traces, one of them
holding only your decorator span). The three multimodal tutorials that repeated
the old note say the same thing.

The page also had an `<Info>` component inside a Python code fence, which
rendered as Python. Removed.

## 3. The docs writing rules, and a sweep of the pages against them

"An image rides an `image_url` part carrying a data URL" shipped thirteen times
across the six multimodal tutorials. It is the shape rule 17 of the docs writing
rules already bans (an artifact as the subject of a verb that belongs to the
reader), with a physical verb instead of a cognitive one, which the wording did
not reach. The rule is extended and `rides` is banned outright, on the wiki page
with a dated changelog entry.

Re-reading the guide in full turned up two more misses on pages that had never
been checked against all of it:

- **Rule 12**: every page's body opener restated its frontmatter `description`,
  which Mintlify already prints as the page lede. Openers now add the mechanism.
- **Rule 11**: every page ended with a note telling the reader to ask LangWatch
  to switch attachment capture on for their project. That is a rollout gate
  described in customer words, and rule 11 says to write near-future-looking and
  describe the feature as available. The notes are gone.

Also in that sweep: the narrator sentence ("This page lists ...") is cut, the
Vercel examples now use the result they were assigning and discarding, the
cross-page comparisons ("the same part an image uses") are replaced so each page
stands alone, and `gpt-4o-audio-preview` becomes `gpt-audio-mini`.

`rides` is out of the dogfood scripts, the fold service, the specs and the
feature-flag description too.

## Verification

- 8 new unit tests over the Vercel channel. 7 of the 8 fail with the fold
  change reverted; the eighth is the negative case that must pass either way.
- `specs/trace-processing/vercel-ai-telemetry-metadata.feature`, 10/10 scenarios
  bound.
- The ADK claim is measured, not read: the transcript above comes from a real
  Gemini run through both entry points.
- `pnpm typecheck:all` and the projections unit lane are green.

## Deployment Impact

None. No chart value, environment variable, migration or operator action. The
fold change only fills trace-summary keys that were empty before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing Vercel AI SDK telemetry metadata, including labels, identity fields, custom metadata, and precedence handling.
  * Added documentation for configuring Vercel AI SDK metadata.

* **Documentation**
  * Clarified multimodal capture for images, documents, and audio, including ingestion, deduplication, storage, and trace visibility.
  * Updated Google ADK guidance to recommend asynchronous runs when preserving trace relationships.
  * Refreshed provider examples and supported model usage.

* **Tests**
  * Added coverage for Vercel AI SDK telemetry metadata mapping and merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->