### PR TITLE
fix(model-providers): tell an unreadable credential apart from no credential

### DIFF
--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -192,6 +192,7 @@ export const APP_ERROR_CODES = [
   "model_default_scope_forbidden",
   "model_not_configured",
   "model_provider_anchor_required",
+  "model_provider_credentials_unreadable",
   "model_provider_credentials_would_be_dropped",
   "model_provider_deprecated",
   "model_provider_disabled",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -651,9 +651,9 @@ const presentations = {
       "A provider added outside a project needs at least one scope, so pick the teams or projects it covers.",
   },
   model_provider_credentials_unreadable: {
-    title: "The stored credentials can't be read",
+    title: "This provider needs its credentials again",
     describe: () =>
-      "This provider holds credentials the server can no longer decrypt, so saving without new ones would replace them with nothing. Enter the credentials again to fix it.",
+      "The ones it has can no longer be used, and saving without new ones would take them away. Type the credentials again, then save.",
   },
   model_provider_credentials_would_be_dropped: {
     title: "That save would delete the stored credentials",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -650,6 +650,11 @@ const presentations = {
     describe: () =>
       "A provider added outside a project needs at least one scope, so pick the teams or projects it covers.",
   },
+  model_provider_credentials_unreadable: {
+    title: "The stored credentials can't be read",
+    describe: () =>
+      "This provider holds credentials the server can no longer decrypt, so saving without new ones would replace them with nothing. Enter the credentials again to fix it.",
+  },
   model_provider_credentials_would_be_dropped: {
     title: "That save would delete the stored credentials",
     describe: () =>

--- a/platform/app/src/server/gateway/config.materialiser.ts
+++ b/platform/app/src/server/gateway/config.materialiser.ts
@@ -16,7 +16,7 @@ import type {
   VirtualKey,
 } from "~/generated/prisma/client";
 
-import { decryptCustomKeys } from "~/server/modelProviders/customKeys";
+import { readCustomKeys } from "~/server/modelProviders/customKeys";
 import {
   type LangyMirrorTier,
   resolveLangyMirrorTier,
@@ -640,7 +640,7 @@ function geminiCredentials(
 
 export function buildCredentials(mp: ModelProvider): Record<string, unknown> {
   const provider = mp.provider;
-  const customKeys = decryptCustomKeys(mp.customKeys);
+  const customKeys = readCustomKeys(mp.customKeys).keys;
   const pick = (k: string): string =>
     typeof customKeys[k] === "string" ? (customKeys[k] as string) : "";
 
@@ -723,7 +723,7 @@ export function buildCredentials(mp: ModelProvider): Record<string, unknown> {
 
 function buildProviderSlot(mp: ModelProvider, index: number): ProviderSlot {
   const credentials = buildCredentials(mp);
-  const customKeys = decryptCustomKeys(mp.customKeys);
+  const customKeys = readCustomKeys(mp.customKeys).keys;
   // Providers whose base-URL override the gateway consumes (see mapProvider
   // in bifrost.go): "custom" and "openai" route it to Bifrost's VLLM
   // (OpenAI-compat) adapter; "anthropic" derives a per-endpoint custom

--- a/platform/app/src/server/gateway/elevenLabsCredential.service.ts
+++ b/platform/app/src/server/gateway/elevenLabsCredential.service.ts
@@ -14,7 +14,7 @@
 
 import { createLogger } from "@langwatch/observability";
 import { prisma } from "~/server/db";
-import { decryptCustomKeys } from "~/server/modelProviders/customKeys";
+import { readCustomKeys } from "~/server/modelProviders/customKeys";
 import { isElevenLabsHost } from "~/server/modelProviders/registry";
 
 const logger = createLogger("langwatch:gateway:elevenlabs-credential");
@@ -46,7 +46,7 @@ async function elevenLabsKeys(modelProviderId: string): Promise<{
   });
   if (provider?.provider !== "elevenlabs") return null;
   return {
-    keys: decryptCustomKeys(provider.customKeys),
+    keys: readCustomKeys(provider.customKeys).keys,
     organizationId: provider.organizationId,
   };
 }

--- a/platform/app/src/server/modelProviders/__tests__/customKeys.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/customKeys.unit.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const warn = vi.fn();
+vi.mock("@langwatch/observability", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: (...args: unknown[]) => warn(...args),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../utils/encryption", () => ({
+  encrypt: vi.fn((text: string) => `mock-iv:mock-encrypted-${text}:mock-tag`),
+  decrypt: vi.fn((encrypted: string) => {
+    const match = encrypted.match(/^mock-iv:mock-encrypted-(.+):mock-tag$/);
+    if (!match) throw new Error("Invalid encrypted string format");
+    return match[1]!;
+  }),
+}));
+
+import { encrypt } from "../../../utils/encryption";
+import { readCustomKeys } from "../customKeys";
+
+/**
+ * The three answers a stored credential bag can give.
+ *
+ * The middle one and the last one used to be the same answer. A caller reading
+ * only the keys cannot tell a provider that holds no credentials from one
+ * whose credentials cannot be read, and those want opposite treatment: the
+ * first is a configuration an operator chose, the second is an encryption key
+ * that changed under a row nobody has touched.
+ */
+describe("readCustomKeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given a column that holds nothing", () => {
+    it.each([null, undefined])("reads %s as absent", (raw) => {
+      expect(readCustomKeys(raw)).toEqual({ state: "absent", keys: {} });
+    });
+  });
+
+  describe("given a column that holds an encrypted bag", () => {
+    it("reads the keys back", () => {
+      const stored = encrypt(JSON.stringify({ OPENAI_API_KEY: "sk-secret" }));
+
+      expect(readCustomKeys(stored)).toEqual({
+        state: "read",
+        keys: { OPENAI_API_KEY: "sk-secret" },
+      });
+    });
+
+    it("reads an empty bag as read, not as absent", () => {
+      expect(readCustomKeys(encrypt("{}"))).toEqual({
+        state: "read",
+        keys: {},
+      });
+    });
+  });
+
+  describe("given a plaintext object from before the column was encrypted", () => {
+    it("reads it as-is", () => {
+      const plaintext = { ANTHROPIC_API_KEY: "sk-plain" };
+
+      expect(readCustomKeys(plaintext)).toEqual({
+        state: "read",
+        keys: plaintext,
+      });
+    });
+  });
+
+  describe("given a column that will not decrypt", () => {
+    it("reads as unreadable rather than as an empty bag", () => {
+      expect(readCustomKeys("not-a-value-this-secret-can-decrypt")).toEqual({
+        state: "unreadable",
+        keys: {},
+      });
+    });
+  });
+
+  describe("given a column that decrypts to something that is not JSON", () => {
+    it("reads as unreadable", () => {
+      expect(readCustomKeys(encrypt("sk-secret-not-json"))).toEqual({
+        state: "unreadable",
+        keys: {},
+      });
+    });
+
+    it("logs the error name and the length, never the decrypted text", () => {
+      const stored = encrypt("sk-secret-not-json");
+
+      readCustomKeys(stored);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      const [fields, message] = warn.mock.calls[0] as [
+        Record<string, unknown>,
+        string,
+      ];
+      expect(fields).toEqual({
+        errorName: "SyntaxError",
+        encryptedLength: stored.length,
+      });
+      expect(JSON.stringify([fields, message])).not.toContain("sk-secret");
+    });
+  });
+
+  describe("given a column that holds neither a string nor an object", () => {
+    it("reads as unreadable", () => {
+      expect(readCustomKeys(42)).toEqual({ state: "unreadable", keys: {} });
+    });
+  });
+});

--- a/platform/app/src/server/modelProviders/__tests__/customKeys.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/customKeys.unit.test.ts
@@ -111,4 +111,29 @@ describe("readCustomKeys", () => {
       expect(readCustomKeys(42)).toEqual({ state: "unreadable", keys: {} });
     });
   });
+
+  describe("given valid JSON that is not a credential bag", () => {
+    // A caller indexing one of these throws where it expected a missing key,
+    // so none of them may read as `read`.
+    it.each([
+      "null",
+      "[]",
+      '["OPENAI_API_KEY"]',
+      '"sk-secret"',
+      "42",
+      "true",
+    ])("reads encrypted %s as unreadable", (json) => {
+      expect(readCustomKeys(encrypt(json))).toEqual({
+        state: "unreadable",
+        keys: {},
+      });
+    });
+
+    it("reads a plaintext array as unreadable", () => {
+      expect(readCustomKeys(["OPENAI_API_KEY"])).toEqual({
+        state: "unreadable",
+        keys: {},
+      });
+    });
+  });
 });

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
@@ -521,5 +521,101 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
         });
       });
     });
+
+    // A row whose stored bag will not decrypt reads back as null, exactly like
+    // a row that never had one, so every guard above waved such a save through
+    // and replaced ciphertext a restored CREDENTIALS_SECRET would have brought
+    // back.
+    describe("given a provider whose stored credentials no longer decrypt", () => {
+      // Azure again, because its schema accepts a payload that names none of
+      // its credential fields. That is what lets the save reach the guard
+      // instead of being turned back by key validation first.
+      async function createAzureRow() {
+        return await service().updateModelProvider(
+          {
+            projectId,
+            provider: "azure",
+            enabled: true,
+            customKeys: {
+              AZURE_OPENAI_API_KEY: STORED_KEY,
+              AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+            },
+            scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+          },
+          ctx(),
+        );
+      }
+
+      const CIPHERTEXT = "not-a-value-this-secret-can-decrypt";
+
+      async function corruptStoredKeys(id: string) {
+        await prisma.modelProvider.update({
+          where: { id },
+          data: { customKeys: CIPHERTEXT },
+        });
+      }
+
+      async function rawKeysOf(id: string) {
+        const row = await prisma.modelProvider.findUnique({
+          where: { id },
+          select: { customKeys: true },
+        });
+        return row?.customKeys;
+      }
+
+      describe("when the payload names no credential field", () => {
+        /** @scenario An unreadable credential is not replaced by a save that carries none */
+        it("is refused and the stored ciphertext survives", async () => {
+          const created = await createAzureRow();
+          await corruptStoredKeys(created.id);
+
+          await expect(
+            service().updateModelProvider(
+              {
+                projectId,
+                id: created.id,
+                provider: "azure",
+                enabled: true,
+                customKeys: {},
+                scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+              },
+              ctx(),
+            ),
+          ).rejects.toThrow(/cannot be read/i);
+
+          expect(await rawKeysOf(created.id)).toBe(CIPHERTEXT);
+        });
+      });
+
+      describe("when the payload carries a new credential", () => {
+        it("goes through, because that is the way back", async () => {
+          const created = await createAzureRow();
+          await corruptStoredKeys(created.id);
+
+          await service().updateModelProvider(
+            {
+              projectId,
+              id: created.id,
+              provider: "azure",
+              enabled: true,
+              customKeys: {
+                AZURE_OPENAI_API_KEY: "sk-fresh",
+                AZURE_OPENAI_ENDPOINT: "https://acme3.openai.azure.com",
+              },
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+
+          const row = await new ModelProviderRepository(
+            prisma,
+          ).findByIdWithDecryptedKeys(created.id);
+          expect(row?.customKeys).toEqual({
+            AZURE_OPENAI_API_KEY: "sk-fresh",
+            AZURE_OPENAI_ENDPOINT: "https://acme3.openai.azure.com",
+          });
+        });
+      });
+    });
   },
 );

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts
@@ -526,7 +526,7 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
     // a row that never had one, so every guard above waved such a save through
     // and replaced ciphertext a restored CREDENTIALS_SECRET would have brought
     // back.
-    describe("given a provider whose stored credentials no longer decrypt", () => {
+    describe("given a provider whose stored credentials can no longer be used", () => {
       // Azure again, because its schema accepts a payload that names none of
       // its credential fields. That is what lets the save reach the guard
       // instead of being turned back by key validation first.
@@ -548,7 +548,7 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
 
       const CIPHERTEXT = "not-a-value-this-secret-can-decrypt";
 
-      async function corruptStoredKeys(id: string) {
+      async function makeUnusable(id: string) {
         await prisma.modelProvider.update({
           where: { id },
           data: { customKeys: CIPHERTEXT },
@@ -563,26 +563,53 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
         return row?.customKeys;
       }
 
-      describe("when the payload names no credential field", () => {
-        /** @scenario An unreadable credential is not replaced by a save that carries none */
-        it("is refused and the stored ciphertext survives", async () => {
+      async function refusal(id: string, customKeys: Record<string, unknown>) {
+        try {
+          await service().updateModelProvider(
+            {
+              projectId,
+              id,
+              provider: "azure",
+              enabled: true,
+              customKeys,
+              scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+            },
+            ctx(),
+          );
+        } catch (error) {
+          return error as { code?: string };
+        }
+        return undefined;
+      }
+
+      describe.each([
+        {
+          name: "names no credential field",
+          customKeys: {},
+        },
+        {
+          name: "sends every credential field empty",
+          customKeys: { AZURE_OPENAI_API_KEY: "", AZURE_OPENAI_ENDPOINT: "" },
+        },
+        {
+          // What the drawer actually sends. It renders the masked placeholder
+          // for the secret fields of an enabled row it found no credentials
+          // on, so the ordinary save names every field and carries none.
+          name: "sends the masked placeholder back",
+          customKeys: {
+            AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            AZURE_OPENAI_ENDPOINT: "",
+          },
+        },
+      ])("when a save $name", ({ customKeys }) => {
+        /** @scenario A provider with unusable credentials refuses a save that brings no replacement */
+        it("is refused and the stored value survives", async () => {
           const created = await createAzureRow();
-          await corruptStoredKeys(created.id);
+          await makeUnusable(created.id);
 
-          await expect(
-            service().updateModelProvider(
-              {
-                projectId,
-                id: created.id,
-                provider: "azure",
-                enabled: true,
-                customKeys: {},
-                scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
-              },
-              ctx(),
-            ),
-          ).rejects.toThrow(/cannot be read/i);
+          const error = await refusal(created.id, customKeys);
 
+          expect(error?.code).toBe("model_provider_credentials_unreadable");
           expect(await rawKeysOf(created.id)).toBe(CIPHERTEXT);
         });
       });
@@ -590,7 +617,7 @@ describe.skipIf(!hasDatabase || !hasCredentialsSecret)(
       describe("when the payload carries a new credential", () => {
         it("goes through, because that is the way back", async () => {
           const created = await createAzureRow();
-          await corruptStoredKeys(created.id);
+          await makeUnusable(created.id);
 
           await service().updateModelProvider(
             {

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
@@ -165,41 +165,58 @@ describe("ModelProviderRepository", () => {
     });
   });
 
-  describe("decryptCustomKeys", () => {
-    describe("when given an encrypted string", () => {
+  describe("withDecryptedKeys", () => {
+    describe("when the row holds an encrypted string", () => {
       it("round-trips correctly with encryptCustomKeys", () => {
         const original = {
           OPENAI_API_KEY: "sk-secret123",
           BASE_URL: "https://api.openai.com",
         };
         const encrypted = (repository as any).encryptCustomKeys(original);
-        const decrypted = (repository as any).decryptCustomKeys(encrypted);
+        const row = (repository as any).withDecryptedKeys(
+          createModelProvider({ customKeys: encrypted }),
+        );
 
-        expect(decrypted).toEqual(original);
+        expect(row.customKeys).toEqual(original);
+        expect(row.customKeysUnreadable).toBe(false);
       });
     });
 
-    describe("when given a plaintext object (migration compatibility)", () => {
+    describe("when the row holds a plaintext object (migration compatibility)", () => {
       it("returns the object as-is", () => {
         const plaintext = { OPENAI_API_KEY: "sk-secret123" };
-        const result = (repository as any).decryptCustomKeys(plaintext);
+        const row = (repository as any).withDecryptedKeys(
+          createModelProvider({ customKeys: plaintext }),
+        );
 
-        expect(result).toEqual(plaintext);
+        expect(row.customKeys).toEqual(plaintext);
+        expect(row.customKeysUnreadable).toBe(false);
         expect(decrypt).not.toHaveBeenCalled();
       });
     });
 
-    describe("when given null", () => {
-      it("returns null", () => {
-        const result = (repository as any).decryptCustomKeys(null);
-        expect(result).toBeNull();
+    describe("when the row holds nothing", () => {
+      it("reads back as null and readable", () => {
+        const row = (repository as any).withDecryptedKeys(
+          createModelProvider({ customKeys: null }),
+        );
+
+        expect(row.customKeys).toBeNull();
+        expect(row.customKeysUnreadable).toBe(false);
       });
     });
 
-    describe("when given undefined", () => {
-      it("returns null", () => {
-        const result = (repository as any).decryptCustomKeys(undefined);
-        expect(result).toBeNull();
+    describe("when the row holds something that will not decrypt", () => {
+      // The row still holds ciphertext. Reading it back as null keeps the
+      // providers list loading, and the flag is what stops a write path from
+      // treating it as a row that never had credentials.
+      it("reads back as null and unreadable", () => {
+        const row = (repository as any).withDecryptedKeys(
+          createModelProvider({ customKeys: "not-an-encrypted-value" }),
+        );
+
+        expect(row.customKeys).toBeNull();
+        expect(row.customKeysUnreadable).toBe(true);
       });
     });
   });

--- a/platform/app/src/server/modelProviders/__tests__/modelProvider.service.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/modelProvider.service.unit.test.ts
@@ -80,6 +80,29 @@ describe("ModelProviderService business logic", () => {
         });
         expect(result).toEqual({ OPENAI_API_KEY: "new-key" });
       });
+
+      it("drops a masked field with nothing behind it", () => {
+        // The drawer shows the placeholder for the secret fields of an enabled
+        // row it found no credentials on, so this payload is the ordinary save
+        // from such a row. Storing the placeholder would give the provider a
+        // credential that was never real.
+        const result = mergeStoredCustomKeys({
+          incoming: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            OPENAI_BASE_URL: "https://new-url.com",
+          },
+          stored: null,
+        });
+        expect(result).toEqual({ OPENAI_BASE_URL: "https://new-url.com" });
+      });
+
+      it("drops a masked field the stored row does not have", () => {
+        const result = mergeStoredCustomKeys({
+          incoming: { OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER },
+          stored: { OPENAI_BASE_URL: "https://old-url.com" },
+        });
+        expect(result).toEqual({});
+      });
     });
 
     describe("when a field comes back masked", () => {

--- a/platform/app/src/server/modelProviders/credentialMerge.ts
+++ b/platform/app/src/server/modelProviders/credentialMerge.ts
@@ -30,6 +30,13 @@ export const isSecretCredential = isSecretCredentialField;
  *
  * Clearing a secret on purpose still works: the field is sent empty, which
  * names it, and an empty value replaces the stored one.
+ *
+ * A placeholder with nothing behind it is dropped rather than stored as a
+ * literal value, the same rule the extra-header merge follows. The drawer
+ * shows the placeholder for a secret field whenever the row is enabled and
+ * carries no readable credentials, so a save from there would otherwise store
+ * `HAS_KEY...` as the API key and the provider would fail on every request
+ * with a credential that was never real.
  */
 export function mergeStoredCustomKeys({
   incoming,
@@ -38,7 +45,16 @@ export function mergeStoredCustomKeys({
   incoming: Record<string, unknown> | null;
   stored: Record<string, unknown> | null;
 }): Record<string, unknown> {
-  if (!stored) return incoming ?? {};
+  // A masked field carries no value of its own. Either the stored one comes
+  // back through `preserved` below, or there is nothing behind it and the
+  // placeholder must not be stored as though it were a credential.
+  const edited = Object.fromEntries(
+    Object.entries(incoming ?? {}).filter(
+      ([, value]) => value !== MASKED_KEY_PLACEHOLDER,
+    ),
+  );
+
+  if (!stored) return edited;
 
   const preserved = Object.entries(stored).filter(([key, value]) => {
     if (incoming && key in incoming) {
@@ -47,5 +63,5 @@ export function mergeStoredCustomKeys({
     return isSecretCredential(key) && value !== "" && value != null;
   });
 
-  return { ...(incoming ?? {}), ...Object.fromEntries(preserved) };
+  return { ...edited, ...Object.fromEntries(preserved) };
 }

--- a/platform/app/src/server/modelProviders/customKeys.ts
+++ b/platform/app/src/server/modelProviders/customKeys.ts
@@ -28,6 +28,16 @@ const ABSENT: CustomKeysRead = { state: "absent", keys: {} };
 const UNREADABLE: CustomKeysRead = { state: "unreadable", keys: {} };
 
 /**
+ * A credential bag is a plain object. `JSON.parse` also answers null, arrays,
+ * numbers and strings for perfectly valid JSON, and a caller that indexes one
+ * of those throws where it expected a missing key, so anything else reads as
+ * unreadable.
+ */
+function isKeyBag(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
  * Reads a ModelProvider's `customKeys` column.
  *
  * The column holds either an encrypted JSON string or, on rows written before
@@ -44,7 +54,7 @@ const UNREADABLE: CustomKeysRead = { state: "unreadable", keys: {} };
 export function readCustomKeys(raw: unknown): CustomKeysRead {
   if (raw === null || raw === undefined) return ABSENT;
   if (typeof raw === "object") {
-    return { state: "read", keys: raw as Record<string, unknown> };
+    return isKeyBag(raw) ? { state: "read", keys: raw } : UNREADABLE;
   }
   if (typeof raw !== "string") return UNREADABLE;
   return parseDecrypted(raw);
@@ -60,10 +70,8 @@ function parseDecrypted(raw: string): CustomKeysRead {
     return UNREADABLE;
   }
   try {
-    return {
-      state: "read",
-      keys: JSON.parse(plaintext) as Record<string, unknown>,
-    };
+    const parsed: unknown = JSON.parse(plaintext);
+    return isKeyBag(parsed) ? { state: "read", keys: parsed } : UNREADABLE;
   } catch (error) {
     // The error NAME only, never the error itself. A SyntaxError from
     // JSON.parse quotes the input it choked on, and the input here is the

--- a/platform/app/src/server/modelProviders/customKeys.ts
+++ b/platform/app/src/server/modelProviders/customKeys.ts
@@ -4,39 +4,66 @@ import { decrypt } from "~/utils/encryption";
 const logger = createLogger("langwatch:modelProviders:customKeys");
 
 /**
- * Reads a ModelProvider's `customKeys` column into a plain map.
+ * How a ModelProvider's `customKeys` column read back.
  *
- * The column holds either an encrypted JSON string or, on rows written
- * before encryption, the object itself. A value that will not decrypt or
- * parse reads as no keys at all: a provider whose secrets cannot be read
- * serves nothing, and throwing here would take an unrelated request down
- * with it.
+ * `keys` is empty for every state except `read`, so a caller that fails closed
+ * on missing credentials can use it and ignore the rest. `state` is there for
+ * the callers that must act differently, because the three are not the same
+ * thing:
  *
- * The empty map is logged because callers cannot tell it apart from a
- * provider that simply has no custom keys, and the two have very different
- * consequences on the voice path: the webhook answers 404 and the reconciler
- * skips the session, so the call settles as cost-unknown with no other
- * signal that anything went wrong. `decrypt` logs its own failures; a parse
- * failure had none.
+ * - `absent`: the column is null. The row stores no credentials, which is a
+ *   configuration an operator can choose.
+ * - `read`: the column decrypted and parsed. `keys` may still be empty, which
+ *   is also a configuration an operator can choose.
+ * - `unreadable`: the column holds a value that would not decrypt or parse.
+ *   The credentials exist and cannot be used, which is an infrastructure
+ *   failure, usually CREDENTIALS_SECRET changing after the row was written.
  */
-export function decryptCustomKeys(raw: unknown): Record<string, unknown> {
-  if (raw === null || raw === undefined) return {};
-  if (typeof raw === "object") return raw as Record<string, unknown>;
-  if (typeof raw !== "string") return {};
+export interface CustomKeysRead {
+  state: "absent" | "read" | "unreadable";
+  keys: Record<string, unknown>;
+}
+
+const ABSENT: CustomKeysRead = { state: "absent", keys: {} };
+const UNREADABLE: CustomKeysRead = { state: "unreadable", keys: {} };
+
+/**
+ * Reads a ModelProvider's `customKeys` column.
+ *
+ * The column holds either an encrypted JSON string or, on rows written before
+ * encryption, the object itself.
+ *
+ * Nothing here throws. A provider whose secrets cannot be read serves nothing,
+ * and throwing would take an unrelated request down with it, so the failure is
+ * reported in `state` instead. Reporting it matters because an empty bag and
+ * an unreadable one look identical to a caller that only reads `keys`: on the
+ * voice path the webhook answers 404 and the reconciler skips the session, so
+ * the call settles as cost-unknown with no other signal that anything went
+ * wrong. `decrypt` logs its own failures; a parse failure had none.
+ */
+export function readCustomKeys(raw: unknown): CustomKeysRead {
+  if (raw === null || raw === undefined) return ABSENT;
+  if (typeof raw === "object") {
+    return { state: "read", keys: raw as Record<string, unknown> };
+  }
+  if (typeof raw !== "string") return UNREADABLE;
   return parseDecrypted(raw);
 }
 
-/** Decrypts one stored value and reads it as JSON, or answers no keys. */
-function parseDecrypted(raw: string): Record<string, unknown> {
+/** Decrypts one stored value and reads it as JSON. */
+function parseDecrypted(raw: string): CustomKeysRead {
   let plaintext: string;
   try {
     plaintext = decrypt(raw);
   } catch {
     // decrypt logs its own failures.
-    return {};
+    return UNREADABLE;
   }
   try {
-    return JSON.parse(plaintext) as Record<string, unknown>;
+    return {
+      state: "read",
+      keys: JSON.parse(plaintext) as Record<string, unknown>,
+    };
   } catch (error) {
     // The error NAME only, never the error itself. A SyntaxError from
     // JSON.parse quotes the input it choked on, and the input here is the
@@ -47,8 +74,8 @@ function parseDecrypted(raw: string): Record<string, unknown> {
         errorName: error instanceof Error ? error.name : "unknown",
         encryptedLength: raw.length,
       },
-      "a model provider's custom keys decrypted to something that is not JSON; reading it as no keys",
+      "a model provider's custom keys decrypted to something that is not JSON; reading it as unreadable",
     );
-    return {};
+    return UNREADABLE;
   }
 }

--- a/platform/app/src/server/modelProviders/errors.ts
+++ b/platform/app/src/server/modelProviders/errors.ts
@@ -261,3 +261,30 @@ export class ModelProviderCredentialsWouldBeDroppedError extends HandledError {
     this.name = "ModelProviderCredentialsWouldBeDroppedError";
   }
 }
+
+/**
+ * A save would replace credentials the server holds but cannot read.
+ *
+ * Separate from `ModelProviderCredentialsWouldBeDroppedError` because the
+ * advice differs. There the stored value is fine and the save just has to stop
+ * leaving it out; here the stored value will not decrypt, usually because
+ * CREDENTIALS_SECRET changed after the row was written, so the only way
+ * forward is a new credential. Letting the save through would overwrite
+ * ciphertext that restoring the old secret would have recovered.
+ */
+export class ModelProviderCredentialsUnreadableError extends HandledError {
+  declare readonly code: "model_provider_credentials_unreadable";
+
+  constructor({ provider }: { provider: string }) {
+    super(
+      "model_provider_credentials_unreadable",
+      "The credentials stored for this provider cannot be read, so this save would replace them with nothing. Send new credentials with it.",
+      {
+        meta: { provider },
+        httpStatus: 400,
+        fault: "customer",
+      },
+    );
+    this.name = "ModelProviderCredentialsUnreadableError";
+  }
+}

--- a/platform/app/src/server/modelProviders/errors.ts
+++ b/platform/app/src/server/modelProviders/errors.ts
@@ -278,7 +278,7 @@ export class ModelProviderCredentialsUnreadableError extends HandledError {
   constructor({ provider }: { provider: string }) {
     super(
       "model_provider_credentials_unreadable",
-      "The credentials stored for this provider cannot be read, so this save would replace them with nothing. Send new credentials with it.",
+      "The credentials stored for this provider cannot be read, so this save would replace them with nothing. Type a new credential and save again.",
       {
         meta: { provider },
         httpStatus: 400,

--- a/platform/app/src/server/modelProviders/modelProvider.repository.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.repository.ts
@@ -6,9 +6,10 @@ import type {
 } from "~/generated/prisma/client";
 import { Prisma } from "~/generated/prisma/client";
 import { KSUID_RESOURCES } from "../../utils/constants";
-import { decrypt, encrypt } from "../../utils/encryption";
+import { encrypt } from "../../utils/encryption";
 import { resolveSingleOrganizationForScopes } from "../scopes/resolveOrganizationForScope";
 import { resolveScopeChain } from "../scopes/resolveScopeChain";
+import { readCustomKeys } from "./customKeys";
 import type { CustomModelsInput } from "./customModel.schema";
 
 /**
@@ -19,6 +20,15 @@ import type { CustomModelsInput } from "./customModel.schema";
  */
 export type ModelProviderWithScopes = ModelProvider & {
   scopes: ModelProviderScope[];
+  /**
+   * True when the row holds credentials that will not decrypt or parse.
+   *
+   * `customKeys` reads back as null in that case, the same as a row that holds
+   * none, and this flag is the only thing that separates them. A write path
+   * must not treat the two alike: one row has nothing to lose and the other
+   * still holds ciphertext that a restored CREDENTIALS_SECRET would recover.
+   */
+  customKeysUnreadable?: boolean;
 };
 
 export type ScopeInput = {
@@ -454,56 +464,26 @@ export class ModelProviderRepository {
   }
 
   /**
-   * Decrypts customKeys after reading from the database.
-   * Handles the migration transition where some rows may still have plaintext JSON objects.
-   *
-   * @returns Decrypted object, or null if input is null/undefined or undecryptable.
-   *
-   * Undecryptable rows (typically: CREDENTIALS_SECRET rotated since the row
-   * was written) used to throw and crash the whole `getAllForProject` query —
-   * blocking the entire UI behind a 500 response. We now log a warning and
-   * return null so the provider is treated as keyless, the user can re-enter
-   * keys, and the rest of the providers list still loads.
-   */
-  private decryptCustomKeys(
-    customKeys: unknown,
-  ): Record<string, unknown> | null {
-    if (customKeys === null || customKeys === undefined) return null;
-
-    // Plaintext object (migration compatibility): return as-is
-    if (typeof customKeys === "object") {
-      return customKeys as Record<string, unknown>;
-    }
-
-    // Encrypted string: decrypt and parse
-    if (typeof customKeys === "string") {
-      try {
-        const decrypted = decrypt(customKeys);
-        return JSON.parse(decrypted) as Record<string, unknown>;
-      } catch (err) {
-        console.warn(
-          "[ModelProviderRepository] dropping unreadable customKeys (likely CREDENTIALS_SECRET rotated since row was written):",
-          err instanceof Error ? err.message : String(err),
-        );
-        return null;
-      }
-    }
-
-    return null;
-  }
-
-  /**
    * Returns a copy of the ModelProvider with decrypted customKeys.
    * Preserves the `scopes` relation as-is.
+   *
+   * A row whose credentials will not decrypt (typically CREDENTIALS_SECRET
+   * changed after the row was written) reads back with `customKeys: null` so
+   * the providers list still loads and the operator can enter new keys, rather
+   * than the whole query throwing and blocking the UI behind a 500. That makes
+   * it look exactly like a row that stores no credentials, so
+   * `customKeysUnreadable` carries the difference for the callers that have to
+   * act on it.
    */
   private withDecryptedKeys(
     provider: ModelProviderWithScopes,
   ): ModelProviderWithScopes {
+    const read = readCustomKeys(provider.customKeys);
     return {
       ...provider,
-      customKeys: this.decryptCustomKeys(
-        provider.customKeys,
-      ) as Prisma.JsonValue | null,
+      customKeys:
+        read.state === "read" ? (read.keys as Prisma.JsonValue) : null,
+      customKeysUnreadable: read.state === "unreadable",
     };
   }
 }

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -11,6 +11,7 @@ import type { CustomModelsInput } from "./customModel.schema";
 import { toLegacyCompatibleCustomModels } from "./customModel.schema";
 import {
   ModelProviderAnchorRequiredError,
+  ModelProviderCredentialsUnreadableError,
   ModelProviderCredentialsWouldBeDroppedError,
   ModelProviderDeprecatedError,
   ModelProviderNotFoundError,
@@ -1465,6 +1466,7 @@ export class ModelProviderService {
     existingProvider: {
       id: string;
       customKeys: unknown;
+      customKeysUnreadable?: boolean;
       extraHeaders: unknown;
     },
     data: {
@@ -1492,6 +1494,7 @@ export class ModelProviderService {
         provider: data.provider,
         validatedKeys,
         existingKeys,
+        existingUnreadable: existingProvider.customKeysUnreadable === true,
       });
       customKeysToSave = mergeStoredCustomKeys({
         incoming: validatedKeys,
@@ -1577,13 +1580,13 @@ export class ModelProviderService {
     provider,
     validatedKeys,
     existingKeys,
+    existingUnreadable,
   }: {
     provider: string;
     validatedKeys: Record<string, unknown> | null;
     existingKeys: Record<string, unknown> | null;
+    existingUnreadable: boolean;
   }): void {
-    if (!existingKeys) return;
-
     const definition =
       modelProviders[provider as keyof typeof modelProviders] ?? undefined;
     const schemaKeys = new Set([
@@ -1591,6 +1594,22 @@ export class ModelProviderService {
       "MANAGED",
     ]);
     if (schemaKeys.size === 1) return; // unknown provider: nothing to judge against
+
+    const incomingCredentials = Object.keys(validatedKeys ?? {}).filter((key) =>
+      schemaKeys.has(key),
+    );
+    if (incomingCredentials.length > 0) return;
+
+    // A row whose stored credentials will not decrypt reads back as keyless,
+    // so without this branch the same save that is refused on a readable row
+    // goes through here and replaces ciphertext that a restored
+    // CREDENTIALS_SECRET would have recovered. Sending a credential is the way
+    // out, and it is already allowed by the check above.
+    if (existingUnreadable) {
+      throw new ModelProviderCredentialsUnreadableError({ provider });
+    }
+
+    if (!existingKeys) return;
 
     // Only a credential that actually holds something is worth protecting. A
     // field already sitting empty has nothing to lose, and counting it would
@@ -1600,11 +1619,6 @@ export class ModelProviderService {
         schemaKeys.has(key) && typeof value === "string" && value !== "",
     );
     if (storedCredentials.length === 0) return;
-
-    const incomingCredentials = Object.keys(validatedKeys ?? {}).filter((key) =>
-      schemaKeys.has(key),
-    );
-    if (incomingCredentials.length > 0) return;
 
     throw new ModelProviderCredentialsWouldBeDroppedError({ provider });
   }

--- a/platform/app/src/server/modelProviders/modelProvider.service.ts
+++ b/platform/app/src/server/modelProviders/modelProvider.service.ts
@@ -1595,19 +1595,35 @@ export class ModelProviderService {
     ]);
     if (schemaKeys.size === 1) return; // unknown provider: nothing to judge against
 
-    const incomingCredentials = Object.keys(validatedKeys ?? {}).filter((key) =>
-      schemaKeys.has(key),
+    const incomingCredentials = Object.entries(validatedKeys ?? {}).filter(
+      ([key]) => schemaKeys.has(key),
     );
-    if (incomingCredentials.length > 0) return;
 
     // A row whose stored credentials will not decrypt reads back as keyless,
     // so without this branch the same save that is refused on a readable row
     // goes through here and replaces ciphertext that a restored
-    // CREDENTIALS_SECRET would have recovered. Sending a credential is the way
-    // out, and it is already allowed by the check above.
+    // CREDENTIALS_SECRET would have recovered.
+    //
+    // Naming a field is enough on a readable row, where an empty value is a
+    // deliberate clear of something the customer could see. Here it is not: the
+    // drawer renders the masked placeholder for every secret field of an
+    // enabled row it found no credentials on, and empty for the rest, so the
+    // ordinary save carries a full set of field names and no credential at
+    // all. Only a value that could serve a request counts.
     if (existingUnreadable) {
-      throw new ModelProviderCredentialsUnreadableError({ provider });
+      const replacement = incomingCredentials.some(
+        ([, value]) =>
+          typeof value === "string" &&
+          value !== "" &&
+          value !== MASKED_KEY_PLACEHOLDER,
+      );
+      if (!replacement) {
+        throw new ModelProviderCredentialsUnreadableError({ provider });
+      }
+      return;
     }
+
+    if (incomingCredentials.length > 0) return;
 
     if (!existingKeys) return;
 

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -148,6 +148,17 @@ Feature: Model Provider Configuration
     Then the save is rejected with an error the customer can act on
     And the stored API key and endpoint are preserved
 
+  # A row whose stored credentials will not decrypt reads back with none, so
+  # the guard above cannot see them. The row still holds ciphertext that
+  # restoring the old encryption secret would recover, and a save that carries
+  # no replacement would overwrite it for good.
+  @integration
+  Scenario: An unreadable credential is not replaced by a save that carries none
+    Given I have a provider whose stored credentials no longer decrypt
+    When a save carries no credential for the provider
+    Then the save is rejected with an error that names the unreadable credential
+    And the stored value is left exactly as it was
+
   # A save that names one credential is editing that one. An API key is never
   # shown back, so nobody can send one they did not type, and leaving it out
   # asks for nothing rather than asking for its removal.

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -148,16 +148,16 @@ Feature: Model Provider Configuration
     Then the save is rejected with an error the customer can act on
     And the stored API key and endpoint are preserved
 
-  # A row whose stored credentials will not decrypt reads back with none, so
-  # the guard above cannot see them. The row still holds ciphertext that
-  # restoring the old encryption secret would recover, and a save that carries
-  # no replacement would overwrite it for good.
+  # A provider whose credentials can no longer be used shows the same empty
+  # fields as one that never had any, so the guard above cannot see them and
+  # the ordinary save would take them away. They can still come back, so the
+  # save has to bring a replacement.
   @integration
-  Scenario: An unreadable credential is not replaced by a save that carries none
-    Given I have a provider whose stored credentials no longer decrypt
-    When a save carries no credential for the provider
-    Then the save is rejected with an error that names the unreadable credential
-    And the stored value is left exactly as it was
+  Scenario: A provider with unusable credentials refuses a save that brings no replacement
+    Given I have a provider whose stored credentials can no longer be used
+    When a save carries no new credential for the provider
+    Then the save is rejected with an error the customer can act on
+    And the stored credentials are unchanged
 
   # A save that names one credential is editing that one. An API key is never
   # shown back, so nobody can send one they did not type, and leaving it out


### PR DESCRIPTION
## What was reported, and what is true

`decryptCustomKeys` in `platform/app/src/server/modelProviders/customKeys.ts`
returned `{}` for four different inputs: a null column, a value that is neither
a string nor an object, a value that will not decrypt, and a value that
decrypts to something that is not JSON. Its own docstring said callers cannot
tell those apart. That is confirmed.

Three states matter, and they are not the same thing:

- **absent**: the column is null. The row holds no credentials, which is a
  configuration an operator can choose (`scripts/dogfood/governance/setup-test-provider.ts`
  creates exactly that).
- **read**: the column decrypted and parsed. The bag may still be empty.
- **unreadable**: the column holds a value that will not decrypt or parse. The
  credentials exist and cannot be used. This is an infrastructure failure,
  almost always `CREDENTIALS_SECRET` changing after the row was written.

## Every caller, and which one was exposed

| caller | what it does with the answer | exposed |
| --- | --- | --- |
| `gateway/config.materialiser.ts` `buildCredentials` | builds `api_key` from the bag | no |
| `gateway/config.materialiser.ts` `buildProviderSlot` | resolves `base_url` from the bag | no |
| `gateway/elevenLabsCredential.service.ts` | reads the webhook secret and the API key | no |
| `modelProviders/modelProvider.repository.ts` (its own private copy) | feeds every read path, and the update path | **yes** |

The two gateway callers fail closed on an empty bag, and an enabled row with no
stored credentials produces the same dead slot, so their behaviour is already
correct for both states. The ElevenLabs webhook answers 404 and the reconciler
skips the session either way. A 500 on the unreadable case was considered so
the vendor would retry, and rejected: it would tell a caller that an id exists,
which is what the 404 is there to prevent, and vendor retries are not
guaranteed. None of them changed behaviour here.

## The two defects that are real

### 1. A second copy of the rule, and it leaks the credential into the log

`ModelProviderRepository` carried its own private `decryptCustomKeys`. Its
`catch` covered `JSON.parse` as well as `decrypt`, and it logged
`err.message`:

```ts
const decrypted = decrypt(customKeys);
return JSON.parse(decrypted) as Record<string, unknown>;
} catch (err) {
  console.warn(
    "[ModelProviderRepository] dropping unreadable customKeys ...",
    err instanceof Error ? err.message : String(err),
  );
```

A `SyntaxError` from `JSON.parse` quotes the input it choked on, and that input
is the decrypted provider key. So a row that decrypts to something malformed
writes the credential into the log line that exists to warn that the credential
could not be read. That is the same defect the shared helper was written to
remove; the copy still had it.

The copy is deleted. The repository reads through the shared helper, which logs
the error name and the input length only.

### 2. A save from the drawer replaced a credential the server could not read

`withDecryptedKeys` reads an unreadable row back as `customKeys: null`, which
is what keeps the providers list loading instead of throwing a 500. That makes
it look exactly like a row that never had credentials, and
`assertKeepsStoredCredentials` opened with `if (!existingKeys) return;`.

So a save that brings no credential:

- on a **readable** row is refused with `ModelProviderCredentialsWouldBeDroppedError`
- on an **unreadable** row went through, and `mergeStoredCustomKeys` replaced
  the stored ciphertext with whatever the payload carried

"Brings no credential" is three payloads, not one, and the drawer sends the
worst of them. `buildCustomKeyState` renders `MASKED_KEY_PLACEHOLDER` for every
secret field of an enabled row it found no credentials on, and empty for the
rest, so the ordinary save names the full set of fields and carries nothing.
The guard now asks for a value that could serve a request: a non-empty string
that is not the placeholder. Readable rows keep the naming rule, so clearing a
credential on purpose still works.

The row still held ciphertext that restoring the old `CREDENTIALS_SECRET` would
have recovered. A bad deploy that sets the wrong secret makes every provider in
the instance read as keyless, and each drawer save during that window destroys
one for good.

The guard now covers it, with its own error, because the advice differs: for a
readable row the stored value is fine and the save has to stop leaving it out;
for an unreadable row only a new credential moves it forward. A save that
carries a credential still goes through, which is the way back.

### 3. The placeholder was stored as though it were a credential

`mergeStoredCustomKeys` returned `incoming` unchanged when the row had nothing
stored, and kept an unmatched masked field in the other branch, so a save
carrying `MASKED_KEY_PLACEHOLDER` for a key with nothing behind it stored
`HAS_KEY...` as the API key. The provider then failed every request with a
credential that was never real. This was live for env-var-backed rows too, not
only unreadable ones, since those also read back with no `customKeys`.

A placeholder with no stored value behind it is dropped now, which is the rule
`mergeExtraHeaders` next to it already followed.

### 4. Not every JSON value is a credential bag

`readCustomKeys` returned whatever `JSON.parse` gave it. `null`, arrays and
every scalar are valid JSON, and `buildCredentials` indexes the result, so a
stored `"null"` threw in the gateway config materialiser instead of reading as
no credentials. Only a plain non-null non-array object reads as credentials.

## Shape of the fix

`decryptCustomKeys` becomes `readCustomKeys` and answers
`{ state: "absent" | "read" | "unreadable", keys }`. `keys` is empty for every
state except `read`, so a caller that fails closed can use it and ignore the
rest; `state` is there for the callers that must act. The rename puts every
call site through review once.

The repository carries the difference forward as `customKeysUnreadable` on the
row, because `customKeys: null` cannot say it.

## Tests

- `modelProviders/__tests__/customKeys.unit.test.ts`: the three states, valid
  JSON that is not a bag (encrypted `null`, `[]`, an array of strings, a
  string, a number, a boolean, and a plaintext array), and an assertion that
  the malformed-JSON warning carries the error name and the input length and
  never the decrypted text.
- `modelProviders/__tests__/modelProvider.service.unit.test.ts`: a masked field
  with nothing behind it is dropped rather than stored, in both merge branches.
- `modelProviders/__tests__/modelProvider.repository.unit.test.ts`: rewritten
  from the deleted private method onto `withDecryptedKeys`, including a row
  that reads back null and unreadable.
- `modelProviders/__tests__/modelProvider.credentialPreservation.integration.test.ts`:
  real Postgres. A row is made unreadable in place, then a table over the three
  payloads that bring no replacement (absent, empty, masked) asserts each is
  refused with `code === "model_provider_credentials_unreadable"` and the stored
  value is read back raw and asserted unchanged. A fourth case saves a new
  credential and asserts it lands.

Both fixes were proven by breaking them:

- making `readCustomKeys` answer `read` instead of `unreadable` fails 4 unit
  tests
- removing the guard branch makes the integration test report
  `promise resolved "{ …(23) }" instead of rejecting`, which is the bug
- relaxing the guard back to "a credential field is named" fails the empty and
  masked rows of the table
- reverting the placeholder drop fails 2 merge unit tests
- accepting any `JSON.parse` result fails 6 helper unit tests

Also run: 766 unit tests across `src/server/modelProviders` and
`src/features/errors` pass, the feature-parity check binds the new scenario, and
biome reports the same 7 diagnostics on the service file before and after.

## Deployment Impact

- Env vars: none added, changed or removed.
- Helm values: none.
- Vanilla install: unaffected.
- BYOC dataplane: unaffected.
- Database migrations: none. `customKeysUnreadable` is derived at read time and
  is not a column.
- Gateway: no wire change. The config payload is byte-identical.
- Behaviour change an operator can see: a provider whose stored credentials can
  no longer be used refuses a save that brings no replacement, and says "This
  provider needs its credentials again". Typing the credentials and saving works
  as before. A save that would have stored the masked placeholder as a
  credential now stores nothing for that field, which is what the field always
  meant.
- Rollback: revert the commit. Nothing persists that an older build cannot read.
