### PR TITLE
fix(traces): open the full prompt in the playground, not its preview (#5753)

### DIFF
--- a/platform/app/src/server/api/routers/__tests__/spans.prompt-studio-blob-deps.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/spans.prompt-studio-blob-deps.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Call-site wiring for the prompt-studio tRPC procedure (#5753).
+ *
+ * getForPromptStudio built its TraceService with no blob-resolution deps,
+ * next to getAllForTrace in the same router which passes them. A service
+ * without deps hands the ClickHouse layer no resolver, so the playground
+ * opened on the bounded preview no matter what the read path did.
+ *
+ * Mirrors the traces.4991-full-resolution harness: createCaller with a
+ * mocked TraceService and mocked rbac/utils.
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { createInnerTRPCContext } from "../../trpc";
+import { spansRouter } from "../spans";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockCreate, mockGetSpanForPromptStudio, mockBuildDeps, BLOB_DEPS } =
+  vi.hoisted(() => {
+    const BLOB_DEPS = {
+      blobStore: { tag: "blobStore" },
+      ioExtractionService: { tag: "ioExtractionService" },
+    };
+    return {
+      mockCreate: vi.fn(),
+      mockGetSpanForPromptStudio: vi.fn(),
+      mockBuildDeps: vi.fn(() => BLOB_DEPS),
+      BLOB_DEPS,
+    };
+  });
+
+vi.mock("~/server/traces/trace.service", () => ({
+  TraceService: { create: mockCreate },
+}));
+
+vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
+  buildTraceBlobResolutionDeps: mockBuildDeps,
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    hasProjectPermission: vi.fn(() => Promise.resolve(true)),
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+vi.mock("../../utils", () => ({
+  getUserProtectionsForProject: vi.fn().mockResolvedValue({
+    canSeeCosts: true,
+    canSeePiiData: true,
+    canSeeTopics: true,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let caller: ReturnType<typeof spansRouter.createCaller>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBuildDeps.mockReturnValue(BLOB_DEPS);
+  mockCreate.mockReturnValue({
+    getSpanForPromptStudio: mockGetSpanForPromptStudio,
+    getTracesWithSpans: vi.fn().mockResolvedValue([]),
+  });
+  mockGetSpanForPromptStudio.mockResolvedValue({
+    spanId: "span-1",
+    traceId: "trace-1",
+    messages: [],
+  });
+
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "test-user-id" }, expires: "1" },
+    req: undefined,
+    res: undefined,
+    permissionChecked: true,
+    publiclyShared: false,
+  });
+  ctx.prisma = {} as unknown as PrismaClient;
+  caller = spansRouter.createCaller(ctx);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("spans router, prompt-studio blob-resolution wiring (#5753)", () => {
+  describe("when getForPromptStudio is called", () => {
+    // Not bound to a scenario: this asserts dependency wiring, which the
+    // feature files do not describe. Same class as the traces router's
+    // 4991-full-resolution wiring test.
+    it("constructs TraceService with the blob-resolution deps", async () => {
+      await caller.getForPromptStudio({
+        projectId: "project_123",
+        spanId: "span-1",
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(expect.anything(), BLOB_DEPS);
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/spans.ts
+++ b/platform/app/src/server/api/routers/spans.ts
@@ -70,7 +70,10 @@ export const spansRouter = createTRPCRouter({
         projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       const result = await traceService.getSpanForPromptStudio(
         projectId,
         spanId,

--- a/platform/app/src/server/traces/__tests__/clickhouse-trace.service-prompt-studio-resolution.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/clickhouse-trace.service-prompt-studio-resolution.unit.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for the prompt-studio read's blob-resolution seam (ADR-022, #5753).
+ *
+ * The playground loader reads one llm span and turns its attributes straight
+ * into messages and llm config, so a span whose IO was offloaded to event_log
+ * used to open on the bounded preview stored in `stored_spans`. These tests
+ * mock only the ClickHouse driver and wire a real BlobStore stub, so the
+ * resolution fires end-to-end through the service the router actually calls.
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+
+import { createLogger } from "@langwatch/observability";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import { resolveOffloadedSpanAttributes } from "../resolve-offloaded-traces";
+import {
+  fullInput,
+  fullUserTurn,
+  LLM_SPAN_ID,
+  llmRowWithEventRef,
+  llmRowWithoutEventRef,
+  makeBlobStore,
+  PROJECT_ID,
+  previewUserTurn,
+  protections,
+  SIBLING_SPAN_ID,
+  siblingRowWithEventRef,
+  TRACE_ID,
+} from "./fixtures/prompt-studio-offload-fixtures";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks: mock only the CH SQL boundary
+// ---------------------------------------------------------------------------
+
+const { mockClickHouseQuery } = vi.hoisted(() => ({
+  mockClickHouseQuery: vi.fn(),
+}));
+
+vi.mock("~/server/app-layer/app", () => {
+  const app = () => ({
+    clickhouse: {
+      enabled: true,
+      resolveClient: () => Promise.resolve({ query: mockClickHouseQuery }),
+      resolveOrganizationClient: async () => {
+        throw new Error("no organization client in this suite");
+      },
+      allInstances: async () => [],
+    },
+  });
+  return { getApp: app, tryGetApp: app };
+});
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+vi.mock("~/server/evaluations/evaluation.service", () => ({
+  EvaluationService: Object.assign(vi.fn(), { create: () => ({}) }),
+}));
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
+      const fn = args.length === 1 ? args[0] : args[1];
+      const fakeSpan = { setAttribute: () => {}, setAttributes: () => {} };
+      return (fn as (s: typeof fakeSpan) => Promise<unknown>)(fakeSpan);
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService.getSpanForPromptStudio, offloaded IO (#5753)", () => {
+  let ClickHouseTraceService: typeof import("../clickhouse-trace.service").ClickHouseTraceService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ClickHouseTraceService = (await import("../clickhouse-trace.service"))
+      .ClickHouseTraceService;
+  });
+
+  function makeService(blobStore: BlobStore) {
+    const logger = createLogger("test");
+    return new ClickHouseTraceService({
+      prisma: { project: { findUnique: vi.fn() } } as never,
+      resolveSpanAttributes: ({ projectId, traceId, spanId, attributes }) =>
+        resolveOffloadedSpanAttributes({
+          projectId,
+          traceId,
+          spanId,
+          attributes,
+          blobStore,
+          logger,
+        }),
+    });
+  }
+
+  function returnRows(rows: unknown[]) {
+    mockClickHouseQuery.mockResolvedValueOnce({
+      json: () => Promise.resolve(rows),
+    });
+  }
+
+  describe("given the llm span's input was offloaded to event_log", () => {
+    describe("when the prompt studio read fetches it", () => {
+      /** @scenario "Opening the span in prompt studio resolves the full messages" */
+      it("returns the full prompt, not the bounded preview", async () => {
+        const { blobStore } = makeBlobStore({ "langwatch.input": fullInput });
+        returnRows([llmRowWithEventRef()]);
+
+        const result = await makeService(blobStore).getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        const userTurn = result?.messages.find((m) => m.role === "user");
+        expect(userTurn?.content).toBe(fullUserTurn);
+      });
+
+      /** @scenario "Resolution is scoped to the tenant that owns the trace" */
+      it("reads event_log for that trace's own project and aggregate", async () => {
+        const { blobStore, reads } = makeBlobStore({
+          "langwatch.input": fullInput,
+        });
+        returnRows([llmRowWithEventRef()]);
+
+        await makeService(blobStore).getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        expect(reads).toEqual([
+          {
+            eventId: "evt-1",
+            field: "langwatch.input",
+            tenantId: PROJECT_ID,
+            aggregateType: "trace",
+            aggregateId: TRACE_ID,
+          },
+        ]);
+      });
+    });
+  });
+
+  describe("given the trace also holds a sibling span with its own eventref", () => {
+    describe("when the prompt studio read fetches the llm span", () => {
+      /** @scenario "Opening one prompt does not pay to restore the whole trace" */
+      it("reads event_log once, for the llm span's own pointer", async () => {
+        const { blobStore, reads } = makeBlobStore({
+          "langwatch.input": fullInput,
+          "langwatch.output": "the sibling's full output",
+        });
+        returnRows([llmRowWithEventRef(), siblingRowWithEventRef()]);
+
+        await makeService(blobStore).getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        expect(reads.map((r) => r.eventId)).toEqual(["evt-1"]);
+      });
+    });
+  });
+
+  describe("given the user clicked through from a non-llm span", () => {
+    describe("when the read resolves to the nearest llm span", () => {
+      /** @scenario "Resolution follows the span the playground will actually open" */
+      it("restores the llm span's IO, not the clicked span's", async () => {
+        const { blobStore, reads } = makeBlobStore({
+          "langwatch.input": fullInput,
+          "langwatch.output": "the clicked span's full output",
+        });
+        // The clicked span is a Prompt.compile-shaped sibling; the llm span is
+        // the one the playground opens on, and the one whose IO must be whole.
+        returnRows([siblingRowWithEventRef(), llmRowWithEventRef()]);
+
+        const result = await makeService(blobStore).getSpanForPromptStudio(
+          PROJECT_ID,
+          SIBLING_SPAN_ID,
+          protections,
+        );
+
+        expect(result?.spanId).toBe(LLM_SPAN_ID);
+        expect(reads.map((r) => r.field)).toEqual(["langwatch.input"]);
+        expect(result?.messages.find((m) => m.role === "user")?.content).toBe(
+          fullUserTurn,
+        );
+      });
+    });
+  });
+
+  describe("given the llm span carries no eventref at all", () => {
+    describe("when the prompt studio read fetches it", () => {
+      /** @scenario "An ordinary prompt opens as fast as it always did" */
+      it("returns the stored messages without touching event_log", async () => {
+        const { blobStore, reads } = makeBlobStore({
+          "langwatch.input": fullInput,
+        });
+        returnRows([llmRowWithoutEventRef()]);
+
+        const result = await makeService(blobStore).getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        expect(result?.messages.find((m) => m.role === "user")?.content).toBe(
+          previewUserTurn,
+        );
+        expect(reads).toEqual([]);
+      });
+    });
+  });
+
+  describe("given the injected resolver rejects instead of degrading", () => {
+    describe("when the prompt studio read fetches the span", () => {
+      /** @scenario "A resolver that fails outright still opens the playground" */
+      it("still returns the span, on its stored preview", async () => {
+        const { blobStore } = makeBlobStore({ "langwatch.input": fullInput });
+        returnRows([llmRowWithEventRef()]);
+
+        const service = new ClickHouseTraceService({
+          prisma: { project: { findUnique: vi.fn() } } as never,
+          resolveSpanAttributes: () => {
+            throw new Error("resolver blew up");
+          },
+        });
+        // The production resolver swallows per field, so only an injected one
+        // can reject, and this call sits inside the read's try, where an
+        // escaping error turns "shows the preview" into "shows nothing".
+        void blobStore;
+
+        const result = await service.getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.messages.find((m) => m.role === "user")?.content).toBe(
+          previewUserTurn,
+        );
+      });
+    });
+  });
+
+  describe("given the eventref points at an event_log row that is gone", () => {
+    describe("when the prompt studio read fetches it", () => {
+      /** @scenario "A missing event_log row does not break the read" */
+      it("still returns the span, on the stored preview", async () => {
+        const { blobStore } = makeBlobStore({});
+        returnRows([llmRowWithEventRef()]);
+
+        const result = await makeService(blobStore).getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.messages.find((m) => m.role === "user")?.content).toBe(
+          previewUserTurn,
+        );
+      });
+    });
+  });
+});
+
+/**
+ * The suite above builds the ClickHouse service by hand, so it proves the read
+ * path and nothing about how production reaches it. This one goes in through
+ * TraceService.create, the constructor the router calls, so a resolver that is
+ * accepted but never forwarded is a failure rather than an invisible no-op.
+ *
+ * Deliberately not bound to a scenario: it asserts dependency wiring, which the
+ * feature files are not the place for. Same class as
+ * `api/routers/__tests__/traces.4991-full-resolution.unit.test.ts`.
+ */
+describe("TraceService.getSpanForPromptStudio, wired from blob deps (#5753)", () => {
+  let TraceService: typeof import("../trace.service").TraceService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    TraceService = (await import("../trace.service")).TraceService;
+  });
+
+  describe("given a TraceService built with blob-resolution deps", () => {
+    describe("when the prompt studio read runs through it", () => {
+      it("returns the full prompt", async () => {
+        const { blobStore } = makeBlobStore({ "langwatch.input": fullInput });
+        mockClickHouseQuery.mockResolvedValueOnce({
+          json: () => Promise.resolve([llmRowWithEventRef()]),
+        });
+
+        const service = TraceService.create(
+          { project: { findUnique: vi.fn() } } as never,
+          {
+            blobStore,
+            ioExtractionService: new TraceIOExtractionService(),
+          },
+        );
+
+        const result = await service.getSpanForPromptStudio(
+          PROJECT_ID,
+          LLM_SPAN_ID,
+          protections,
+        );
+
+        expect(result?.messages.find((m) => m.role === "user")?.content).toBe(
+          fullUserTurn,
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/server/traces/__tests__/fixtures/prompt-studio-offload-fixtures.ts
+++ b/platform/app/src/server/traces/__tests__/fixtures/prompt-studio-offload-fixtures.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared fixtures for the ADR-022 prompt-studio read tests (#5753).
+ *
+ * Two suites need the same offloaded span: the ClickHouse read that turns it
+ * into playground messages, and the resolver primitive underneath. They live in
+ * separate files so neither grows past the source-line ceiling, so the fixtures
+ * live here rather than being copied into both.
+ *
+ * Deliberately small: only the columns `getSpanForPromptStudio`'s SELECT
+ * returns, and only the `NormalizedSpan` fields the resolver reads.
+ */
+
+import { vi } from "vitest";
+import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import { BlobNotFoundError } from "~/server/app-layer/traces/blob-store.service";
+import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type { Protections } from "~/server/traces/protections";
+
+export const PROJECT_ID = "proj-1";
+export const TRACE_ID = "trace-1";
+export const LLM_SPAN_ID = "span-llm";
+export const SIBLING_SPAN_ID = "span-sibling";
+
+export const protections: Protections = {
+  canSeeCosts: true,
+  canSeePiiData: true,
+  canSeeTopics: true,
+} as Protections;
+
+/** What the playground should end up showing: the whole prompt. */
+export const fullInput = JSON.stringify([
+  { role: "system", content: "You are a careful assistant." },
+  { role: "user", content: `Summarise this: ${"x".repeat(70_000)}` },
+]);
+
+/** What stored_spans holds instead: the bounded preview. */
+export const previewInput = JSON.stringify([
+  { role: "system", content: "You are a careful assistant." },
+  { role: "user", content: "Summarise this: xxx…" },
+]);
+
+/** The user turn as it reads once resolution has restored it. */
+export const fullUserTurn = `Summarise this: ${"x".repeat(70_000)}`;
+
+/** The user turn as it reads while only the preview is available. */
+export const previewUserTurn = "Summarise this: xxx…";
+
+/** One row in the shape getSpanForPromptStudio's SELECT returns. */
+export function makeRow({
+  spanId,
+  attributes,
+}: {
+  spanId: string;
+  attributes: Record<string, unknown>;
+}) {
+  return {
+    SpanId: spanId,
+    TraceId: TRACE_ID,
+    ParentSpanId: null,
+    SpanName: "llm-call",
+    SpanAttributes: attributes,
+    StartTime: 1_700_000_000_000,
+    EndTime: 1_700_000_000_100,
+    DurationMs: 100,
+    StatusCode: 1,
+    StatusMessage: "",
+  };
+}
+
+export function llmRowWithEventRef() {
+  return makeRow({
+    spanId: LLM_SPAN_ID,
+    attributes: {
+      "langwatch.span.type": "llm",
+      "langwatch.input": previewInput,
+      [`${EVENTREF_ATTR_PREFIX}langwatch.input`]: JSON.stringify({
+        field: "langwatch.input",
+        eventId: "evt-1",
+      }),
+    },
+  });
+}
+
+export function llmRowWithoutEventRef() {
+  return makeRow({
+    spanId: LLM_SPAN_ID,
+    attributes: {
+      "langwatch.span.type": "llm",
+      "langwatch.input": previewInput,
+    },
+  });
+}
+
+/** A non-llm sibling in the same trace, carrying its own offloaded field. */
+export function siblingRowWithEventRef() {
+  return makeRow({
+    spanId: SIBLING_SPAN_ID,
+    attributes: {
+      "langwatch.span.type": "span",
+      "langwatch.output": "sibling preview…",
+      [`${EVENTREF_ATTR_PREFIX}langwatch.output`]: JSON.stringify({
+        field: "langwatch.output",
+        eventId: "evt-sibling",
+      }),
+    },
+  });
+}
+
+/** A NormalizedSpan carrying just what the resolver reads. */
+export function normalized({
+  spanId,
+  spanAttributes,
+}: {
+  spanId: string;
+  spanAttributes: Record<string, unknown>;
+}): NormalizedSpan {
+  return { spanId, traceId: TRACE_ID, spanAttributes } as NormalizedSpan;
+}
+
+export type EventLogRead = {
+  eventId: string;
+  field: string;
+  tenantId: string;
+  aggregateType: string;
+  aggregateId: string;
+};
+
+/**
+ * BlobStore stub that records every event_log read, so "resolved from the right
+ * tenant" and "did not read at all" are both observable.
+ */
+export function makeBlobStore(contents: Record<string, string>) {
+  const reads: EventLogRead[] = [];
+  const blobStore = {
+    getFromEventLog: vi.fn(async (params: EventLogRead) => {
+      reads.push(params);
+      const value = contents[params.field];
+      if (value === undefined) {
+        throw new BlobNotFoundError(params.eventId, params.field, PROJECT_ID);
+      }
+      return value;
+    }),
+    putSpool: vi.fn(),
+    getSpool: vi.fn(),
+    deleteSpool: vi.fn(),
+  } as unknown as BlobStore;
+  return { blobStore, reads };
+}

--- a/platform/app/src/server/traces/__tests__/resolve-offloaded-span-attributes.unit.test.ts
+++ b/platform/app/src/server/traces/__tests__/resolve-offloaded-span-attributes.unit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The ADR-022 resolver primitive, on its own (#5753).
+ *
+ * `resolveOffloadedSpanAttributes` is the per-span unit `resolveOffloadedTraces`
+ * runs across a trace, and the unit the prompt-studio read calls directly. These
+ * are its two contracts: what a restored span carries, and what an untouched one
+ * keeps. The read paths that use it are covered next door in
+ * `clickhouse-trace.service-prompt-studio-resolution.unit.test.ts`.
+ *
+ * Pure: no ClickHouse, no App, no module mocks. It parses attributes and calls
+ * the BlobStore stub it is handed.
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+
+import { createLogger } from "@langwatch/observability";
+import { describe, expect, it } from "vitest";
+import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import {
+  resolveOffloadedSpanAttributes,
+  resolveOffloadedTraces,
+} from "../resolve-offloaded-traces";
+import {
+  fullInput,
+  LLM_SPAN_ID,
+  llmRowWithEventRef,
+  makeBlobStore,
+  normalized,
+  PROJECT_ID,
+  previewInput,
+  SIBLING_SPAN_ID,
+  TRACE_ID,
+} from "./fixtures/prompt-studio-offload-fixtures";
+
+/**
+ * Asserted at the resolver boundary, because that is the only place the
+ * attributes exist. `PromptStudioSpanResult` carries messages and llm config,
+ * never the raw attribute map, so checking the prompt-studio result for a
+ * reserved key passes whether or not the key was stripped.
+ */
+describe("resolveOffloadedSpanAttributes, restored content (#5753)", () => {
+  describe("given a span whose input was offloaded", () => {
+    describe("when its attributes are resolved", () => {
+      /** @scenario "Restored content replaces the pointer rather than sitting beside it" */
+      it("puts the full value under the plain key and leaves no pointer behind", async () => {
+        const { blobStore } = makeBlobStore({ "langwatch.input": fullInput });
+
+        const { attributes } = await resolveOffloadedSpanAttributes({
+          projectId: PROJECT_ID,
+          traceId: TRACE_ID,
+          spanId: LLM_SPAN_ID,
+          attributes: llmRowWithEventRef().SpanAttributes,
+          blobStore,
+          logger: createLogger("test"),
+        });
+
+        expect(attributes["langwatch.input"]).toBe(fullInput);
+        expect(
+          Object.keys(attributes).filter((key) =>
+            key.startsWith(EVENTREF_ATTR_PREFIX),
+          ),
+        ).toEqual([]);
+      });
+    });
+  });
+});
+
+/**
+ * The primitive's own contract. resolveOffloadedTraces relies on it to leave
+ * the spans it has nothing to do for alone: one offloaded span in a thousand-
+ * span trace must not rewrite the other nine hundred and ninety-nine.
+ */
+describe("resolveOffloadedSpanAttributes, untouched spans (#5753)", () => {
+  describe("given a trace where only one span carries an eventref", () => {
+    describe("when the trace's spans are resolved", () => {
+      /** @scenario "One offloaded span does not disturb the rest of the trace" */
+      it("leaves the span without one showing exactly its stored content", async () => {
+        const { blobStore } = makeBlobStore({ "langwatch.input": fullInput });
+        const plain = normalized({
+          spanId: SIBLING_SPAN_ID,
+          spanAttributes: { "langwatch.input": previewInput },
+        });
+        const offloaded = normalized({
+          spanId: LLM_SPAN_ID,
+          spanAttributes: {
+            "langwatch.input": previewInput,
+            [`${EVENTREF_ATTR_PREFIX}langwatch.input`]: JSON.stringify({
+              field: "langwatch.input",
+              eventId: "evt-1",
+            }),
+          },
+        });
+
+        const { resolvedSpans } = await resolveOffloadedTraces({
+          projectId: PROJECT_ID,
+          normalizedSpans: [plain, offloaded],
+          blobStore,
+          ioExtractionService: new TraceIOExtractionService(),
+          logger: createLogger("test"),
+        });
+
+        expect(resolvedSpans[0]?.spanAttributes["langwatch.input"]).toBe(
+          previewInput,
+        );
+        // Identity, not just equality: leaving the object alone is HOW the
+        // untouched span stays untouched, and it is what keeps one offloaded
+        // span in a large trace from rewriting all the others.
+        expect(resolvedSpans[0]).toBe(plain);
+        expect(resolvedSpans[1]).not.toBe(offloaded);
+        expect(resolvedSpans[1]?.spanAttributes["langwatch.input"]).toBe(
+          fullInput,
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/server/traces/clickhouse-trace.service.ts
+++ b/platform/app/src/server/traces/clickhouse-trace.service.ts
@@ -90,6 +90,24 @@ export type ResolveTraceSpansBatchFn = (
 ) => Promise<ResolvedTraceSpans[]>;
 
 /**
+ * Callback injected from TraceService that resolves offloaded blob refs for a
+ * SINGLE span's attribute map (ADR-022), for reads that consume one span's
+ * content rather than a trace's recomputed input/output.
+ *
+ * `getSpanForPromptStudio` is the caller: it reads raw ClickHouse rows and
+ * turns the llm span's attributes straight into playground messages and llm
+ * config, so there is no NormalizedSpan to hand {@link ResolveTraceSpansFn}
+ * and no trace-level IO to recompute. Same primitive underneath, same
+ * keep-the-preview-on-failure policy.
+ */
+export type ResolveSpanAttributesFn = (params: {
+  projectId: string;
+  traceId: string;
+  spanId: string;
+  attributes: Record<string, unknown>;
+}) => Promise<{ attributes: Record<string, unknown> }>;
+
+/**
  * Cursor structure for keyset pagination.
  * Encoded as base64 JSON in the scrollId.
  */
@@ -405,6 +423,11 @@ export class ClickHouseTraceService {
    * paths fall back to the per-trace resolver.
    */
   private readonly resolveTraceSpansBatch: ResolveTraceSpansBatchFn | undefined;
+  /**
+   * Per-span attribute resolver for content-consuming single-span reads. See
+   * {@link ResolveSpanAttributesFn}.
+   */
+  private readonly resolveSpanAttributes: ResolveSpanAttributesFn | undefined;
 
   private readonly prisma: PrismaClient;
 
@@ -412,11 +435,13 @@ export class ClickHouseTraceService {
     prisma,
     resolveTraceSpans,
     resolveTraceSpansBatch,
+    resolveSpanAttributes,
     retentionResolver,
   }: {
     prisma: PrismaClient;
     resolveTraceSpans?: ResolveTraceSpansFn;
     resolveTraceSpansBatch?: ResolveTraceSpansBatchFn;
+    resolveSpanAttributes?: ResolveSpanAttributesFn;
     /**
      * Widens the span read's retention floor to this tenant's own policy.
      * Optional: without it the floor stays at {@link SPAN_READ_FLOOR_LOOKBACK_MS}.
@@ -426,6 +451,7 @@ export class ClickHouseTraceService {
     this.prisma = prisma;
     this.resolveTraceSpans = resolveTraceSpans;
     this.resolveTraceSpansBatch = resolveTraceSpansBatch;
+    this.resolveSpanAttributes = resolveSpanAttributes;
     this.retentionFloor = createRetentionFloorService(retentionResolver);
   }
 
@@ -470,6 +496,7 @@ export class ClickHouseTraceService {
     prisma = defaultPrisma,
     resolveTraceSpans,
     resolveTraceSpansBatch,
+    resolveSpanAttributes,
     retentionResolver = new RetentionPolicyCache(
       new DataRetentionPolicyRepository(prisma),
     ),
@@ -477,12 +504,14 @@ export class ClickHouseTraceService {
     prisma?: PrismaClient;
     resolveTraceSpans?: ResolveTraceSpansFn;
     resolveTraceSpansBatch?: ResolveTraceSpansBatchFn;
+    resolveSpanAttributes?: ResolveSpanAttributesFn;
     retentionResolver?: RetentionPolicyResolver;
   } = {}): ClickHouseTraceService {
     return new ClickHouseTraceService({
       prisma,
       resolveTraceSpans,
       resolveTraceSpansBatch,
+      resolveSpanAttributes,
       retentionResolver,
     });
   }
@@ -1609,9 +1638,25 @@ export class ClickHouseTraceService {
             return null;
           }
 
+          // Restore any IO this span had offloaded to event_log before
+          // reading messages and llm config out of it (ADR-022). Without
+          // this the playground opens on the bounded preview
+          // `leanForProjection` wrote into stored_spans, which for a
+          // >64KB prompt is the first ~64KB of it and no way to see the
+          // rest. It is the same gap #5752 closed on the evaluation reads.
+          //
+          // Only the llm span is resolved, not every row this query
+          // returned: the ancestor walk below reads `langwatch.prompt.*`
+          // scalars, which are never offloaded, so resolving the siblings
+          // would buy nothing and cost an event_log read each.
+          const resolvedRow = await this.resolvePromptStudioRowIO({
+            projectId,
+            row,
+          });
+
           // Extract span data from attributes
           const result = this.extractPromptStudioDataFromClickHouse(
-            row,
+            resolvedRow,
             protections,
           );
 
@@ -1667,6 +1712,51 @@ export class ClickHouseTraceService {
         }
       },
     );
+  }
+
+  /**
+   * Returns the row with its offloaded attribute values restored, or the row
+   * unchanged when no resolver is wired (the caller built this service without
+   * blob-resolution deps) or the span carries no eventref.
+   *
+   * Failure keeps the preview. The production resolver already swallows a
+   * missing or unreadable event_log row per field, but the resolver is
+   * injected, so a rejection is caught here too: this call sits inside
+   * getSpanForPromptStudio's try, where an escaping error would turn a
+   * playground that used to show the preview into one that shows nothing.
+   * Content that is merely unavailable must not fail the read.
+   *
+   * @internal
+   */
+  private async resolvePromptStudioRowIO<
+    T extends {
+      SpanId: string;
+      TraceId: string;
+      SpanAttributes: Record<string, unknown>;
+    },
+  >({ projectId, row }: { projectId: string; row: T }): Promise<T> {
+    if (!this.resolveSpanAttributes) return row;
+
+    try {
+      const { attributes } = await this.resolveSpanAttributes({
+        projectId,
+        traceId: row.TraceId,
+        spanId: row.SpanId,
+        attributes: row.SpanAttributes,
+      });
+      return { ...row, SpanAttributes: attributes };
+    } catch (error) {
+      this.logger.warn(
+        {
+          projectId,
+          spanId: row.SpanId,
+          traceId: row.TraceId,
+          error: error instanceof Error ? error.message : error,
+        },
+        "Failed to resolve offloaded IO for prompt studio, keeping preview value",
+      );
+      return row;
+    }
   }
 
   /**

--- a/platform/app/src/server/traces/resolve-offloaded-traces.ts
+++ b/platform/app/src/server/traces/resolve-offloaded-traces.ts
@@ -31,7 +31,10 @@ import type {
   ExtractedIO,
   TraceIOExtractionService,
 } from "~/server/app-layer/traces/trace-io-extraction.service";
-import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type {
+  NormalizedAttributes,
+  NormalizedSpan,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { hasEventRefs, parseSpanEventRefs } from "./offloaded-eventref-parsing";
 
 /** Minimal logger interface required by this module (subset of PinoLogger). */
@@ -59,6 +62,168 @@ export interface ResolvedTraceSpans {
    * stored in trace_summaries should remain in effect.
    */
   anyResolved: boolean;
+}
+
+/**
+ * Records one eventref that could not be resolved, splitting the expected case
+ * (the event_log row is gone) from the unexpected one so a stale ref does not
+ * read like an outage in the logs. Purely reporting: the caller keeps the
+ * preview either way.
+ */
+function logEventRefFailure({
+  reason,
+  projectId,
+  traceId,
+  spanId,
+  attrKey,
+  logger,
+}: {
+  reason: unknown;
+  projectId: string;
+  traceId: string;
+  spanId: string;
+  attrKey: string;
+  logger: WarnLogger;
+}): void {
+  const rowIsGone =
+    reason instanceof BlobNotFoundError ||
+    reason instanceof BlobFieldNotFoundError;
+  logger.warn(
+    {
+      projectId,
+      spanId,
+      traceId,
+      attrKey,
+      error: reason instanceof Error ? reason.message : String(reason),
+    },
+    rowIsGone
+      ? "event_log row not found for eventref — keeping preview value"
+      : "Failed to resolve eventref from event_log — keeping preview value",
+  );
+}
+
+/**
+ * Result of resolving one span's offloaded attribute values.
+ */
+export interface ResolvedSpanAttributes {
+  /**
+   * The span's attributes with full values restored and reserved eventref
+   * keys stripped. This is the SAME object reference that was passed in when
+   * the span carries no eventref at all, so a caller can tell "nothing to do"
+   * from "rewritten" without comparing maps.
+   */
+  attributes: NormalizedAttributes;
+  /** How many attribute values were replaced with their full event_log value. */
+  resolvedCount: number;
+}
+
+/**
+ * Resolves the offloaded event refs on a SINGLE span's attribute map.
+ *
+ * This is the unit of ADR-022 read-time resolution. {@link resolveOffloadedTraces}
+ * runs it across a trace's spans and recomputes trace-level IO from the result;
+ * reads that want one span's full values and nothing else call it directly,
+ * without having to fabricate a {@link NormalizedSpan} around the attributes
+ * they hold. `getSpanForPromptStudio` is the second kind: it reads raw
+ * ClickHouse rows and needs the llm span's full messages, not a recomputed
+ * trace input/output.
+ *
+ * Error policy, unchanged from the caller that used to inline this: a field
+ * that cannot be fetched keeps its preview value and is logged at warn level.
+ * Nothing here throws on a stale or missing ref, because a read must not fail
+ * over content that is merely unavailable.
+ *
+ * @param projectId - Tenant scope for the event_log read. Resolution never
+ *   crosses tenants: this is passed as `tenantId` on every fetch.
+ * @param traceId - The span's trace, which IS the event_log aggregateId for the
+ *   trace-processing pipeline (ADR-022).
+ * @param spanId - Only used to identify the span in warn logs.
+ * @param attributes - The span's raw attribute map, eventref keys included.
+ * @param blobStore - BlobStore providing getFromEventLog.
+ * @param aggregateType - Aggregate type for event_log lookup (default: "trace").
+ * @param logger - Logger for missing-ref warnings.
+ */
+export async function resolveOffloadedSpanAttributes({
+  projectId,
+  traceId,
+  spanId,
+  attributes,
+  blobStore,
+  logger,
+  aggregateType = "trace",
+}: {
+  projectId: string;
+  traceId: string;
+  spanId: string;
+  attributes: NormalizedAttributes;
+  blobStore: BlobStore;
+  logger: WarnLogger;
+  aggregateType?: string;
+}): Promise<ResolvedSpanAttributes> {
+  if (!hasEventRefs(attributes)) {
+    return { attributes, resolvedCount: 0 };
+  }
+
+  // Separate eventref keys from regular attributes (shared decoder).
+  const { cleanedAttrs, eventrefEntries, missingEventIdKeys } =
+    parseSpanEventRefs(attributes);
+
+  // Eventref missing the embedded eventId can't resolve. The reserved
+  // key is already stripped (kept out of cleanedAttrs) so the UI never
+  // sees the namespace; the preview under the plain IO key stays in place.
+  for (const attrKey of missingEventIdKeys) {
+    logger.warn(
+      { projectId, spanId, traceId, attrKey },
+      "eventref missing eventId — keeping preview value",
+    );
+  }
+
+  if (eventrefEntries.length === 0) {
+    // All ref keys were malformed JSON or missing eventId. Strip the
+    // reserved keys anyway so the UI never sees the namespace.
+    return { attributes: cleanedAttrs, resolvedCount: 0 };
+  }
+
+  // ADR-022: aggregateId for the trace-processing pipeline IS the traceId.
+  // The eventref carries the eventId, written by leanForProjection from
+  // event.id at lean time (see lean-for-projection.ts:120).
+  const aggregateId = traceId;
+
+  const resolvedAttrs = { ...cleanedAttrs };
+
+  // Parallelize independent event_log fetches for each eventref in this span.
+  const fieldResults = await Promise.allSettled(
+    eventrefEntries.map(async ({ attrKey, field, eventId }) => {
+      const fullValue = await blobStore.getFromEventLog({
+        eventId,
+        field,
+        tenantId: projectId,
+        aggregateType,
+        aggregateId,
+      });
+      return { attrKey, fullValue };
+    }),
+  );
+
+  let resolvedCount = 0;
+  for (const [idx, result] of fieldResults.entries()) {
+    if (result.status === "fulfilled") {
+      resolvedAttrs[result.value.attrKey] = result.value.fullValue;
+      resolvedCount++;
+    } else {
+      // Log and keep preview for this field; other fields are not affected.
+      logEventRefFailure({
+        reason: result.reason,
+        projectId,
+        traceId,
+        spanId,
+        attrKey: eventrefEntries[idx]?.attrKey ?? "unknown",
+        logger,
+      });
+    }
+  }
+
+  return { attributes: resolvedAttrs, resolvedCount };
 }
 
 /**
@@ -118,100 +283,26 @@ export async function resolveOffloadedTraces({
   // returned even when a span's resolver throws an unexpected uncaught error.
   const spanSettlements = await Promise.allSettled(
     normalizedSpans.map(async (span) => {
-      const attrs = span.spanAttributes;
-      if (!hasEventRefs(attrs)) {
-        return { span, resolvedCount: 0 };
-      }
+      const { attributes, resolvedCount } =
+        await resolveOffloadedSpanAttributes({
+          projectId,
+          traceId: span.traceId,
+          spanId: span.spanId,
+          attributes: span.spanAttributes,
+          blobStore,
+          logger,
+          aggregateType,
+        });
 
-      // Separate eventref keys from regular attributes (shared decoder).
-      const { cleanedAttrs, eventrefEntries, missingEventIdKeys } =
-        parseSpanEventRefs(attrs);
-
-      // Eventref missing the embedded eventId can't resolve. The reserved
-      // key is already stripped (kept out of cleanedAttrs) so the UI never
-      // sees the namespace; the preview under the plain IO key stays in place.
-      for (const attrKey of missingEventIdKeys) {
-        logger.warn(
-          {
-            projectId,
-            spanId: span.spanId,
-            traceId: span.traceId,
-            attrKey,
-          },
-          "eventref missing eventId — keeping preview value",
-        );
-      }
-
-      if (eventrefEntries.length === 0) {
-        // All ref keys were malformed JSON or missing eventId — strip
-        // reserved keys anyway so the UI never sees the namespace.
-        return {
-          span: { ...span, spanAttributes: cleanedAttrs },
-          resolvedCount: 0,
-        };
-      }
-
-      // ADR-022: aggregateId for the trace-processing pipeline IS the traceId.
-      // The eventref carries the eventId, written by leanForProjection from
-      // event.id at lean time — see lean-for-projection.ts:120.
-      const aggregateId = span.traceId;
-
-      const resolvedAttrs = { ...cleanedAttrs };
-
-      // Parallelize independent event_log fetches for each eventref in this span.
-      const fieldResults = await Promise.allSettled(
-        eventrefEntries.map(async ({ attrKey, field, eventId }) => {
-          const fullValue = await blobStore.getFromEventLog({
-            eventId,
-            field,
-            tenantId: projectId,
-            aggregateType,
-            aggregateId,
-          });
-          return { attrKey, fullValue };
-        }),
-      );
-
-      let resolvedCount = 0;
-      for (const [idx, result] of fieldResults.entries()) {
-        if (result.status === "fulfilled") {
-          resolvedAttrs[result.value.attrKey] = result.value.fullValue;
-          resolvedCount++;
-        } else {
-          // Log and keep preview for this field; other fields are not affected.
-          const err = result.reason;
-          const attrKey = eventrefEntries[idx]?.attrKey ?? "unknown";
-          if (
-            err instanceof BlobNotFoundError ||
-            err instanceof BlobFieldNotFoundError
-          ) {
-            logger.warn(
-              {
-                projectId,
-                spanId: span.spanId,
-                traceId: span.traceId,
-                attrKey,
-                error: (err as Error).message,
-              },
-              "event_log row not found for eventref — keeping preview value",
-            );
-          } else {
-            logger.warn(
-              {
-                projectId,
-                spanId: span.spanId,
-                traceId: span.traceId,
-                attrKey,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              "Failed to resolve eventref from event_log — keeping preview value",
-            );
-          }
-        }
-      }
-
+      // Identity, not a copy, when nothing was rewritten: callers of the
+      // no-eventref fast path above already rely on getting their own span
+      // objects back, and a span whose refs were all unusable is rewritten
+      // exactly once, inside the resolver.
       return {
-        span: { ...span, spanAttributes: resolvedAttrs },
+        span:
+          attributes === span.spanAttributes
+            ? span
+            : { ...span, spanAttributes: attributes },
         resolvedCount,
       };
     }),

--- a/platform/app/src/server/traces/trace.service.ts
+++ b/platform/app/src/server/traces/trace.service.ts
@@ -19,7 +19,10 @@ import { ClickHouseTraceService } from "./clickhouse-trace.service";
 import { applyOverlayToTrace } from "./edit-overlay/applyTraceEditOverlay";
 import { redactPatchForViewer } from "./edit-overlay/redactTraceEditOverlayPatch";
 import { TraceEditOverlayService } from "./edit-overlay/traceEditOverlay.service";
-import { resolveOffloadedTraces } from "./resolve-offloaded-traces";
+import {
+  resolveOffloadedSpanAttributes,
+  resolveOffloadedTraces,
+} from "./resolve-offloaded-traces";
 import { resolveOffloadedTracesBatch } from "./resolve-offloaded-traces-batch";
 
 /**
@@ -148,6 +151,28 @@ class OffloadedSpanResolver {
   }
 
   /**
+   * Returns the single-span callback compatible with ClickHouseTraceService's
+   * `resolveSpanAttributes` parameter, for reads that consume one span's
+   * content and have no trace-level IO to recompute (#5753).
+   */
+  toAttributesResolverFn(): (params: {
+    projectId: string;
+    traceId: string;
+    spanId: string;
+    attributes: Record<string, unknown>;
+  }) => ReturnType<typeof resolveOffloadedSpanAttributes> {
+    return ({ projectId, traceId, spanId, attributes }) =>
+      resolveOffloadedSpanAttributes({
+        projectId,
+        traceId,
+        spanId,
+        attributes,
+        blobStore: this.deps.blobStore,
+        logger: this.logger,
+      });
+  }
+
+  /**
    * Returns the bulk-resolution callback compatible with ClickHouseTraceService's
    * `resolveTraceSpansBatchFn` parameter. Resolves a whole result set in one
    * bounded-concurrency pass over event_log (#4991 AC6).
@@ -202,11 +227,14 @@ export class TraceService {
         : undefined;
     const resolveTraceSpansFn = offloadedSpanResolver?.toResolverFn();
     const resolveTraceSpansBatchFn = offloadedSpanResolver?.toBatchResolverFn();
+    const resolveSpanAttributesFn =
+      offloadedSpanResolver?.toAttributesResolverFn();
 
     this.clickHouseService = ClickHouseTraceService.create({
       prisma,
       resolveTraceSpans: resolveTraceSpansFn,
       resolveTraceSpansBatch: resolveTraceSpansBatchFn,
+      resolveSpanAttributes: resolveSpanAttributesFn,
     });
     this.evaluationService = EvaluationService.create();
     // Injected store for the read-time Claude Code content enrichment; the
@@ -772,6 +800,11 @@ export class TraceService {
 
   /**
    * Get a span for prompt studio by span ID.
+   *
+   * When the service was built with blob-resolution deps, the llm span's IO is
+   * restored from event_log first, so a prompt whose messages were offloaded
+   * at ingestion (>64KB, ADR-022) opens in full rather than on the bounded
+   * preview stored in `stored_spans` (#5753).
    *
    * @param projectId - The project ID
    * @param spanId - The span ID to find

--- a/specs/prompts/prompt-studio-full-content-resolution.feature
+++ b/specs/prompts/prompt-studio-full-content-resolution.feature
@@ -1,0 +1,95 @@
+Feature: Prompt studio opens the full offloaded prompt, not the preview
+  As a user clicking "Open in Playground" on a traced LLM call
+  I want the playground to load the complete messages and config that were
+  actually sent, even when they were too large to keep in full in the span row
+  So that I can reproduce and iterate on the real call rather than on its
+  first ~64KB
+
+  # Sibling of specs/traces-v2/trace-header-full-content-resolution.feature,
+  # and the last of the "all read paths" backlog for the >64KB span-IO offload
+  # (#4991 / ADR-022) that #5082's review listed. The evaluation reads were
+  # closed by #5752 and the v2 trace header by #5751; getSpanForPromptStudio
+  # was the remaining one.
+  #
+  # Two things had to be true for the playground to show a truncated prompt,
+  # and both were:
+  #   1. The tRPC procedure built its TraceService with no blob-resolution
+  #      deps, while its own neighbour in the same router (getAllForTrace)
+  #      passed buildTraceBlobResolutionDeps().
+  #   2. getSpanForPromptStudio reads stored_spans and turns SpanAttributes
+  #      straight into messages and llm config, so it never passed through
+  #      the resolver the trace paths use.
+  #
+  # Fix: resolveOffloadedSpanAttributes, the per-span unit the trace resolver
+  # already ran for every span and which is now callable on its own, is injected into the
+  # ClickHouse service the same way resolveTraceSpans already is, and applied
+  # to the llm span before extraction. No second copy of the resolution logic,
+  # and the same keep-the-preview-on-failure policy.
+
+  Background:
+    Given a traced LLM call whose langwatch.input was offloaded to event_log
+        at ingestion (release_trace_blob_offload was on)
+    And the span row in stored_spans holds only the bounded preview, under a
+        langwatch.reserved.eventref.langwatch.input pointer
+
+  @unit
+  Scenario: Opening the span in prompt studio resolves the full messages
+    When the prompt studio read fetches this span
+    Then the returned messages carry the full original value, not the preview
+
+  @unit
+  Scenario: Restored content replaces the pointer rather than sitting beside it
+    When the span's attributes are resolved
+    Then the input reads as the full original value
+    And no internal pointer key is left on the span for a reader to see
+
+  @unit
+  Scenario: An ordinary prompt opens as fast as it always did
+    Given a traced LLM call whose input never exceeded the offload threshold
+    When the prompt studio read fetches this span
+    Then the returned messages match the stored attributes directly
+    And the read pays for no extra lookup
+
+  @unit
+  Scenario: A missing event_log row does not break the read
+    Given the eventref points at an event_log row that no longer exists
+    When the prompt studio read fetches this span
+    Then the span is still returned
+    And the returned messages fall back to the stored preview
+
+  @unit
+  Scenario: Resolution is scoped to the tenant that owns the trace
+    When the prompt studio read fetches this span
+    Then the event_log read is made for that trace's project and no other
+
+  @unit
+  Scenario: Opening one prompt does not pay to restore the whole trace
+    Given the trace also holds a sibling span with its own offloaded content
+    When the prompt studio read fetches the llm span
+    Then only the span the playground will show is restored, and the siblings
+        are left as they are
+
+  # Resolution is a shared primitive with two callers now, so the property the
+  # whole-trace caller depends on is stated rather than assumed: resolving one
+  # span must leave the rest of the trace alone.
+
+  @unit
+  Scenario: One offloaded span does not disturb the rest of the trace
+    Given a trace where one span carries an eventref and another does not
+    When the trace's spans are resolved
+    Then the span without one still shows exactly its stored content
+    And the span with one shows its full restored value
+
+  @unit
+  Scenario: Resolution follows the span the playground will actually open
+    Given the user opened the playground from a non-llm span, so the read
+        resolves to the nearest llm span in the trace
+    When the prompt studio read fetches it
+    Then it is that llm span's IO that is restored, not the clicked span's
+
+  @unit
+  Scenario: A resolver that fails outright still opens the playground
+    Given resolution raises rather than degrading per field
+    When the prompt studio read fetches the span
+    Then the span is still returned, on its stored preview
+    And the playground opens instead of showing nothing


### PR DESCRIPTION
## Ticket

Closes #5753. `getSpanForPromptStudio` bypassed blob resolution, so a prompt whose IO was offloaded to `event_log` at ingestion (>64KB, ADR-022) opened in the playground as the bounded preview with no way to reach the rest.

This is the last of the "all read paths" backlog #5082's review listed. The evaluation reads were closed by #5752, the v2 trace header by #5751.

## Premise, re-checked on current main

Both halves were still true, and each is enough on its own:

1. `spans.ts:73` built `TraceService.create(ctx.prisma)` with no blob-resolution deps, immediately below `getAllForTrace` in the same router which passes `buildTraceBlobResolutionDeps()`.
2. `getSpanForPromptStudio` reads `stored_spans` and hands `SpanAttributes` straight to `extractPromptStudioDataFromClickHouse`, so it never passed through the resolver the trace paths use.

The ticket cites `langwatch/src/server/traces/clickhouse-trace.service.ts`; post-restructure that is `platform/app/src/server/traces/clickhouse-trace.service.ts:1531`.

## Change

`resolveOffloadedSpanAttributes` is extracted from `resolveOffloadedTraces`: it is the per-span unit that function already ran for every span, now callable on its own. That matters because the trace resolver's signature takes `NormalizedSpan[]`, and the prompt-studio read holds raw ClickHouse rows with none of the ~20 other fields a `NormalizedSpan` needs. Rather than fabricate a span around the attributes, or copy the resolution logic, the read uses the same primitive.

`ClickHouseTraceService` takes it as `resolveSpanAttributes`, exactly the way it already takes `resolveTraceSpans`, and `TraceService` builds it from the same `BlobResolutionDeps` it already builds the other two from. The read applies it to the llm span before extraction.

Two deliberate limits, both stated in the spec:

- Only the llm span is resolved, not every row the query returned. The ancestor walk below it reads `langwatch.prompt.*` scalars, which are never offloaded, so resolving the siblings would buy nothing and cost an `event_log` read each.
- Failure keeps the preview. A span whose blob has aged out still opens the playground, on the preview, rather than failing the read. Same policy the trace paths already have.

`resolveOffloadedTraces` is behaviourally unchanged. The one property worth naming is that a span the resolver has nothing to do for comes back as the very object that went in, not an equal copy, which is what lets one offloaded span in a large trace avoid rewriting all the others. That was implicit before; it is now stated on the return type and pinned by a test.

## Evidence

Specs: `specs/prompts/prompt-studio-full-content-resolution.feature`, 9 scenarios, all `@unit` and all bound. The two dependency-wiring assertions are tests but deliberately not scenarios, matching how `api/routers/__tests__/traces.4991-full-resolution.unit.test.ts` already treats the same class of check.

| AC from the ticket | Where it is proven |
| --- | --- |
| `getSpanForPromptStudio` resolves offloaded eventref IO to the full value | "Opening the span in prompt studio resolves the full messages" |
| Multitenancy preserved (tenant-scoped resolution) | "Resolution is scoped to the tenant that owns the trace" asserts the exact `event_log` read, including `tenantId` and `aggregateId` |
| Covered by a test proving an over-threshold span IO opens full | the same first scenario, on a 70,000-character prompt |

Tests are split three ways so no new file passes the 300 source-line ceiling: the ClickHouse read (241), the resolver primitive's own contracts (80), and the fixtures they share (113), following the directory's existing `__tests__/fixtures/` convention.

```
pnpm test:unit run src/server/traces src/server/api/routers/__tests__/spans.prompt-studio-blob-deps.unit.test.ts
  Test Files  39 passed (39)
       Tests  541 passed (541)

pnpm typecheck:all                          0 errors
check-feature-parity.ts                     OK: 8000 enforced scenario(s) bound (7991 on main)
biome-new-violations.sh vs origin/main      no new violations (3437 -> 3435, two removed)
```

Binding is not assumed: deleting a single `@scenario` annotation takes the gate to `FAIL: 1 unbound scenario(s)`, naming the exact feature-file line.

### Mutation testing

Every guard this PR adds or relies on was inverted, one at a time, against the tests:

| Mutation | Result |
| --- | --- |
| router drops the blob deps | CAUGHT (1 failed) |
| resolver rejection escapes the read | CAUGHT (1 failed / 10) |
| TraceService never forwards the resolver | CAUGHT (1 failed / 10) |
| ClickHouse factory drops the resolver | CAUGHT (1 failed / 10) |
| prompt studio read skips resolution | CAUGHT (5 failed / 10) |
| resolves the clicked row, not the llm row | CAUGHT (1 failed / 10) |
| `event_log` read leaves the tenant | CAUGHT (1 failed / 540) |
| `aggregateId` is the span, not the trace | CAUGHT (1 failed / 540) |
| resolved value never replaces the preview | CAUGHT (31 failed / 540) |
| no-eventref fast path removed | CAUGHT (1 failed / 540) |
| span identity no longer preserved | CAUGHT (1 failed / 540) |
| reserved eventref key is no longer stripped | CAUGHT (1 failed / 10) |

The last row is there because review caught a **vacuous assertion** in the first version of this PR: a test claimed the reserved eventref key never reaches the playground, and it passed with the stripping deleted. `PromptStudioSpanResult` returns messages and llm config, never the raw attribute map, so `JSON.stringify(result)` had nothing to find. It now asserts at the resolver boundary, where the attributes exist, and fails on that mutation.

The other two escapes were on the first pass, which is what prompted stating the identity contract on the return type and testing it rather than leaving it as an unobservable implementation detail. `resolver rejection escapes the read` came out of review: the docstring promised failure keeps the preview, but a rejecting injected resolver would have landed in the read's catch and returned nothing at all. Now guarded, and the guard is tested.

### Not covered

The 3 `apiKey.restricted-permissions` failures in a full `src/server/api/routers` run are environmental, not this branch: `API key pepper not configured`. The suite goes 6/6 with `NEXTAUTH_SECRET` set, and touches nothing here.

### One note on house style

Three `logger.warn` message strings in the extracted code still carry an em-dash. They are byte-identical to what is on main today and were only relocated; rewording them would silently change lines an operator may already grep or alert on. Everything newly written here is em-dash free.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

---
<sub>🤖 **Filed by `tech-debt-fixer` via the create-issue procedure, on behalf of the fleet.** Authored under the owner's GitHub token for API access — the content is the fleet's, not his. Owner-authored and fleet-authored issues are otherwise indistinguishable in this repo; this footer is the only signal.</sub>
