### PR TITLE
fix(langy): accept model ids that contain a slash in the per-send override

### DIFF
--- a/platform/app/src/features/errors/logic/__tests__/presentation.unit.test.ts
+++ b/platform/app/src/features/errors/logic/__tests__/presentation.unit.test.ts
@@ -431,6 +431,27 @@ describe("explainHandledError", () => {
       );
     });
 
+    it("names the model when the rejected field is the per-send modelOverride", () => {
+      // The Langy composer sends the picked model as `modelOverride`; the
+      // customer is looking at a model picker, so the card says "the model".
+      const { title, description } = explainHandledError(
+        shape({
+          code: "validation_error",
+          httpStatus: 422,
+          meta: {
+            fieldErrors: {
+              modelOverride: [
+                "modelOverride must be in 'provider/model' shape",
+              ],
+            },
+          },
+        }),
+      );
+
+      expect(title).toBe("Check your input");
+      expect(description).toBe("There's a problem with the model.");
+    });
+
     it("names them the way the screen does, not the way the schema does", () => {
       // `slug` is the wire key; the field the user is looking at is labelled
       // "URL slug". Quoting the key back reads as a different thing entirely.

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -2696,6 +2696,7 @@ const USER_VISIBLE_FIELDS: Record<string, string> = {
   url: "the URL",
   prompt: "the prompt",
   model: "the model",
+  modelOverride: "the model",
   value: "the value",
   label: "the label",
   title: "the title",

--- a/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
@@ -164,6 +164,67 @@ describe("langy turn-start rejections", () => {
     });
   });
 
+  describe("when the send carries a modelOverride", () => {
+    /** @scenario A model id that itself contains a slash is accepted */
+    it("accepts a custom-provider model whose id contains a slash and forwards it intact", async () => {
+      const result = await caller().createConversation({
+        projectId: "project_1",
+        idempotencyKey: "idem-key-0001",
+        messages: [message],
+        modelOverride: "custom/stealth/ox-alpha",
+      });
+
+      expect(result).toMatchObject({ conversationId: "c1", turnId: "t1" });
+      expect(startConversationTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ modelOverride: "custom/stealth/ox-alpha" }),
+      );
+    });
+
+    it("accepts the canonical mp_<rowId> wire form with a multi-segment model", async () => {
+      const result = await caller().createConversation({
+        projectId: "project_1",
+        idempotencyKey: "idem-key-0001",
+        messages: [message],
+        modelOverride: "mp_01jm7qk3v8/deepseek/deepseek-r1:free",
+      });
+
+      expect(result).toMatchObject({ conversationId: "c1", turnId: "t1" });
+      expect(startConversationTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelOverride: "mp_01jm7qk3v8/deepseek/deepseek-r1:free",
+        }),
+      );
+    });
+
+    /** @scenario A model reference without a provider segment is rejected as invalid input */
+    it("rejects a model without a provider segment as a validation_error naming the field", async () => {
+      const error = await caller()
+        .createConversation({
+          projectId: "project_1",
+          idempotencyKey: "idem-key-0001",
+          messages: [message],
+          modelOverride: "gpt-5-mini",
+        })
+        .catch((e: unknown) => e);
+
+      // Input-parse failures reject as BAD_REQUEST with the ZodError as the
+      // cause; the errorFormatter is what promotes them to the handled
+      // `validation_error` on the wire.
+      expect(error).toMatchObject({ code: "BAD_REQUEST" });
+
+      // The wire names the offending field, so the client card can say which
+      // value to look at instead of the anonymous fallback sentence.
+      const wire = onTheWire(error);
+      expect(wire.data.error).not.toBeNull();
+      expect(wire.data.error).toMatchObject({ code: "validation_error" });
+      expect(
+        (wire.data.error as { meta: { fieldErrors: Record<string, unknown> } })
+          .meta.fieldErrors,
+      ).toHaveProperty("modelOverride");
+      expect(startConversationTurn).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when the send carries neither idempotencyKey nor requestId", () => {
     it("rejects with a ValidationError whose meta.message survives serialization", async () => {
       const error = await caller()

--- a/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/langy.turnErrors.unit.test.ts
@@ -180,6 +180,7 @@ describe("langy turn-start rejections", () => {
       );
     });
 
+    /** @scenario A model from a named provider row is accepted with the row id in front */
     it("accepts the canonical mp_<rowId> wire form with a multi-segment model", async () => {
       const result = await caller().createConversation({
         projectId: "project_1",
@@ -214,6 +215,32 @@ describe("langy turn-start rejections", () => {
 
       // The wire names the offending field, so the client card can say which
       // value to look at instead of the anonymous fallback sentence.
+      const wire = onTheWire(error);
+      expect(wire.data.error).not.toBeNull();
+      expect(wire.data.error).toMatchObject({ code: "validation_error" });
+      expect(
+        (wire.data.error as { meta: { fieldErrors: Record<string, unknown> } })
+          .meta.fieldErrors,
+      ).toHaveProperty("modelOverride");
+      expect(startConversationTurn).not.toHaveBeenCalled();
+    });
+
+    /** @scenario A model reference with an empty segment is rejected as invalid input */
+    it("rejects a reference whose model segment is empty", async () => {
+      const error = await caller()
+        .createConversation({
+          projectId: "project_1",
+          idempotencyKey: "idem-key-0001",
+          messages: [message],
+          // THE POINT: the slash is a delimiter, not a model. Widening the
+          // pattern for aggregator ids must not let a bare delimiter through —
+          // there is no model here for the allowlist check to match.
+          modelOverride: "custom//stealth",
+        })
+        .catch((e: unknown) => e);
+
+      expect(error).toMatchObject({ code: "BAD_REQUEST" });
+
       const wire = onTheWire(error);
       expect(wire.data.error).not.toBeNull();
       expect(wire.data.error).toMatchObject({ code: "validation_error" });

--- a/platform/app/src/server/api/routers/langy.ts
+++ b/platform/app/src/server/api/routers/langy.ts
@@ -134,11 +134,15 @@ const langyTurnMessageSchema = z.object({
  * slashes and colons of its own, because custom OpenAI-compatible providers
  * accept aggregator ids like "stealth/ox-alpha" or "deepseek/deepseek-r1:free",
  * which arrive here as "custom/stealth/ox-alpha".
+ *
+ * Every slash-separated segment must be non-empty, so "custom//stealth" and
+ * "custom/stealth/" are refused: they carry a delimiter with no model behind
+ * it, and the allowlist check downstream has nothing to match them against.
  */
 const langyModelOverrideSchema = z
   .string()
   .regex(
-    /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._:/-]+$/,
+    /^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9._:-]+)+$/,
     "modelOverride must be in 'provider/model' shape",
   )
   .max(200);

--- a/platform/app/src/server/api/routers/langy.ts
+++ b/platform/app/src/server/api/routers/langy.ts
@@ -129,11 +129,16 @@ const langyTurnMessageSchema = z.object({
 /**
  * Per-send model override from the sidebar picker. Shape-validated here;
  * the value is checked against the project's Langy VK allowlist in the service.
+ *
+ * The provider segment ends at the FIRST slash; the model half may contain
+ * slashes and colons of its own, because custom OpenAI-compatible providers
+ * accept aggregator ids like "stealth/ox-alpha" or "deepseek/deepseek-r1:free",
+ * which arrive here as "custom/stealth/ox-alpha".
  */
 const langyModelOverrideSchema = z
   .string()
   .regex(
-    /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/,
+    /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._:/-]+$/,
     "modelOverride must be in 'provider/model' shape",
   )
   .max(200);

--- a/specs/langy/langy-model-selection.feature
+++ b/specs/langy/langy-model-selection.feature
@@ -35,6 +35,23 @@ Feature: Langy runs on the model the project chose
     Then the turn is accepted rather than refused
     And the model reaches the worker with its provider-prefixed id intact
 
+  # Custom OpenAI-compatible providers accept any model id, and ids from
+  # aggregators such as OpenRouter contain a slash of their own
+  # ("stealth/ox-alpha"), so the full reference carries two: the provider
+  # segment ends at the FIRST slash and the rest is the model.
+  @unit
+  Scenario: A model id that itself contains a slash is accepted
+    Given the project's model is a custom provider model named "stealth/ox-alpha"
+    When the composer sends a turn with the full id "custom/stealth/ox-alpha"
+    Then the turn is accepted rather than rejected as invalid input
+    And the full id reaches the app layer unchanged
+
+  @unit
+  Scenario: A model reference without a provider segment is rejected as invalid input
+    When the composer sends a turn with the model "gpt-5-mini"
+    Then the turn is rejected as invalid input
+    And the rejection names the model field
+
   @unit
   Scenario: Switching models mid-conversation keeps the conversation
     Given a conversation with earlier turns on one model

--- a/specs/langy/langy-model-selection.feature
+++ b/specs/langy/langy-model-selection.feature
@@ -46,11 +46,28 @@ Feature: Langy runs on the model the project chose
     Then the turn is accepted rather than rejected as invalid input
     And the full id reaches the app layer unchanged
 
+  # A project that keeps several credentials for one provider picks the row it
+  # wants, so the composer sends the row id in front of the model reference and
+  # the whole thing carries two slashes.
+  @unit
+  Scenario: A model from a named provider row is accepted with the row id in front
+    Given the project's model comes from a named provider row rather than the provider default
+    When the composer sends a turn with the row id in front of a slash-containing model id
+    Then the turn is accepted rather than rejected as invalid input
+    And the full id reaches the app layer unchanged
+
   @unit
   Scenario: A model reference without a provider segment is rejected as invalid input
     When the composer sends a turn with the model "gpt-5-mini"
     Then the turn is rejected as invalid input
     And the rejection names the model field
+
+  @unit
+  Scenario: A model reference with an empty segment is rejected as invalid input
+    When the composer sends a turn with the model "custom//stealth"
+    Then the turn is rejected as invalid input
+    And the rejection names the model field
+    And no turn is dispatched to the worker
 
   @unit
   Scenario: Switching models mid-conversation keeps the conversation


### PR DESCRIPTION
## Problem

Langy fails on the first message with a "Check your input" card (code `validation_error`) when the project's model is a custom OpenAI-compatible provider model whose id contains a slash. Model ids from aggregators such as OpenRouter have this shape: `stealth/ox-alpha`, `deepseek/deepseek-r1:free`. The full reference the composer sends is `custom/stealth/ox-alpha`.

The endpoint itself is fine: a direct call to the provider with the same key and model returns a valid completion, with streaming and tool calls.

## Root cause

`langyModelOverrideSchema` in `src/server/api/routers/langy.ts` validated `modelOverride` with a regex that allows exactly one slash. The Langy panel always sends `modelOverride`: it seeds the project's resolved default model into the picker store on load. So every send on such a project was rejected before the turn started.

The rest of the stack already supports multi-slash ids by design: `parseWireValue` splits on the first slash, the REST langy surface validates with `z.string().min(1)`, and the agent resolves a model reference by splitting at the first slash.

The rejection also degraded to the fallback sentence "Some of the values aren't valid.": `modelOverride` was not in `USER_VISIBLE_FIELDS`, so the card could not name the field.

## Fix

- The model half of the regex now accepts slashes and colons: `custom/stealth/ox-alpha` and `mp_<rowId>/deepseek/deepseek-r1:free` pass. A reference without a provider segment still fails.
- `modelOverride` is now a user-visible field labeled "the model", so a shape rejection renders "There's a problem with the model."

## Tests

- `specs/langy/langy-model-selection.feature`: two new scenarios, both bound.
- `langy.turnErrors.unit.test.ts`: multi-slash and canonical `mp_` forms are accepted and forwarded intact; a bare model id is rejected as `validation_error` with `fieldErrors.modelOverride` on the wire.
- `presentation.unit.test.ts`: the rejection copy names the model.

## QA

Dogfooded on a fresh local stack: signup, add a Custom (OpenAI-compatible) provider with an OpenRouter base URL and key, add custom model `stealth/ox-alpha`, set it as the org default, chat with Langy.

- First message answers instead of showing the validation card.
- A second turn ran 4 tool calls and the model identified itself as ox-alpha.
- The gateway metered real usage for `stealth/ox-alpha`.
- Invalid override on the live server still rejects: 400, `validation_error`, `fieldErrors.modelOverride`.
- A second custom model with a colon suffix (`nvidia/nemotron-3.5-lightning:free`) picked per-send from the composer also answered, so the colon acceptance is proven live, and switching models mid-conversation kept the conversation.

### Screenshots

Provider + default model configured, and Langy answering on the first message (this exact send failed with `validation_error` before the fix):

![settings and first reply](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7388/langy-ox-alpha/settings-and-first-reply.png)

A second turn with tool calls, the model identifies itself, and the composer pill shows the custom model:

![conversation with tool calls](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7388/langy-ox-alpha/conversation-toolcalls.png)

## Deployment Impact

App-only change: one zod regex on the Langy turn input and one entry in the client error presentation registry. No schema, migration, environment, chart, or service topology change. Rolls out with the normal app deploy and needs no operator action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for model references containing slashes and colons.
  - Preserves complete custom-provider and named-provider model IDs.

- **Bug Fixes**
  - Improved validation for missing providers and empty model segments.
  - Displays customer-facing “model” wording in validation errors.
  - Prevents invalid model selections from being submitted for processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->