### PR TITLE
fix(tests): give the typecheck-projects test the time its three compilers need

### DIFF
--- a/platform/app/src/test-unit-global-setup.ts
+++ b/platform/app/src/test-unit-global-setup.ts
@@ -58,6 +58,25 @@ export function resolveHardFloorMs(): number | null {
 }
 
 /**
+ * How many files the shard was given, said so that a sharded run and a whole
+ * one both read plainly.
+ *
+ * A sharded run has two counts and they are far apart: the reporter is handed
+ * the whole suite before the sequencer splits it, so `selected` is the same
+ * number on every shard while the shard itself holds a quarter of it.
+ */
+function describeFileCount({
+  selected,
+  shardSelected,
+}: {
+  selected: number;
+  shardSelected: number | null | undefined;
+}): string {
+  if (shardSelected == null) return `${selected} selected`;
+  return `${shardSelected} in this shard (of ${selected} selected)`;
+}
+
+/**
  * What the floor prints and the code it exits with, given what the shard knew
  * when it fired. Split out from the timer so the exit contract can be asserted
  * without wedging a real run.
@@ -71,12 +90,17 @@ export function hardFloorReport({
   sawFailure: boolean;
   modules: {
     selected: number;
+    shardSelected?: number | null;
     started: number;
     reported: number;
     unreportedFiles: readonly string[];
   };
 }): { exitCode: 0 | 1; lines: string[] } {
-  const { selected, started, reported, unreportedFiles } = modules;
+  const { selected, shardSelected, started, reported, unreportedFiles } =
+    modules;
+  // What this shard was given, which on a sharded run is a quarter or so of
+  // `selected`. Without it the counts below compare a shard against the suite.
+  const mine = shardSelected ?? selected;
   const exitCode = sawFailure || unreportedFiles.length > 0 ? 1 : 0;
   const minutes = Number((hardFloorMs / 60_000).toFixed(2));
 
@@ -89,12 +113,13 @@ export function hardFloorReport({
   }
   const suffix = causes.length > 0 ? ` (${causes.join(", and ")})` : "";
 
+  const counted = describeFileCount({ selected, shardSelected });
   const lines = [
     `[unit globalSetup] hard floor reached at ${minutes} min - forcing process.exit(${exitCode}) to release the CI step from a vitest finalize wedge${suffix}`,
-    `[unit globalSetup] test files: ${selected} selected, ${started} started, ${reported} reported a result`,
+    `[unit globalSetup] test files: ${counted}, ${started} started, ${reported} reported a result`,
   ];
 
-  if (started < selected) {
+  if (started < mine) {
     lines.push(
       "[unit globalSetup] the shard still had files to start, so the floor cut a run that was working rather than one that was wedged. Read that as a shard too slow for the floor, not as a hang.",
     );

--- a/platform/app/src/test-utils/__tests__/shardFailureReporter.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/shardFailureReporter.unit.test.ts
@@ -14,6 +14,7 @@ import {
   resolveHardFloorMs,
 } from "../../test-unit-global-setup";
 import ShardFailureReporter, {
+  recordShardSelection,
   resetShardState,
   shardModuleTally,
   shardSawFailure,
@@ -165,6 +166,33 @@ describe("given a shard the finalize wedge is holding open", () => {
     });
   });
 
+  describe("when the run was split into shards", () => {
+    /**
+     * The reporter is handed the whole suite before the sequencer splits it,
+     * so a shard that finished all of its own files still reports far fewer
+     * started than selected. Read against the suite, every sharded run looks
+     * like a shard cut off part way through.
+     */
+    /** @scenario "A shard is measured against its own files, not the whole suite" */
+    it("measures the shard against its own files rather than the suite", () => {
+      const reporter = new ShardFailureReporter();
+      const suite = ["a", "b", "c", "d"].map((name) =>
+        module(`src/${name}.unit.test.ts`),
+      );
+      reporter.onTestRunStart(suite);
+      // What the sequencer handed this shard out of that suite.
+      recordShardSelection(1);
+      reporter.onTestModuleQueued(module("src/a.unit.test.ts"));
+
+      const { lines } = report();
+
+      expect(lines[1]).toBe(
+        "[unit globalSetup] test files: 1 in this shard (of 4 selected), 1 started, 0 reported a result",
+      );
+      expect(lines.join("\n")).not.toContain("too slow for the floor");
+    });
+  });
+
   describe("when a file is skipped in full", () => {
     /** @scenario "A skipped file is never mistaken for one that never completed" */
     it("leaves the shard the way a passing file does", () => {
@@ -245,6 +273,7 @@ describe("given the counters behind the floor's log line", () => {
 
       expect(shardModuleTally()).toEqual({
         selected: 1,
+        shardSelected: null,
         started: 0,
         reported: 0,
         unreportedFiles: [],
@@ -264,6 +293,7 @@ describe("given the counters behind the floor's log line", () => {
 
       expect(shardModuleTally()).toEqual({
         selected: 1,
+        shardSelected: null,
         started: 1,
         reported: 0,
         unreportedFiles: ["src/a.unit.test.ts"],

--- a/platform/app/src/test-utils/__tests__/typecheckProjects.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/typecheckProjects.unit.test.ts
@@ -101,8 +101,18 @@ describe("given the repository's typecheck projects", () => {
   });
 
   describe("when the combined project replaces the two it merges", () => {
+    /**
+     * Three whole-repository programs, one per project, and the compiler
+     * builds each one before it can list what is in it. That is 26 to 36
+     * seconds on a CI runner already running the rest of the shard, so the
+     * 30-second default this suite gives a component test decided the result
+     * by the runner's mood rather than by the projects. The limit here is
+     * what the work costs, with room for a bad day.
+     */
     // @scenario "The combined project checks every file the split projects checked"
-    it("leaves no file that was checked before unchecked", () => {
+    it("leaves no file that was checked before unchecked", {
+      timeout: 180_000,
+    }, () => {
       expect(existsSync(resolve(APP_ROOT, ALL_PROJECT))).toBe(true);
 
       const combined = programFiles(ALL_PROJECT);

--- a/platform/app/src/test-utils/shardFailureReporter.ts
+++ b/platform/app/src/test-utils/shardFailureReporter.ts
@@ -34,6 +34,7 @@ const MODULE_TALLY = "__langwatchShardTestModuleTally";
 
 interface ModuleTally {
   selected: number;
+  shardSelected: number | null;
   started: number;
   reported: number;
   inFlight: Set<string>;
@@ -56,11 +57,27 @@ function moduleTally(): ModuleTally {
   const carrier = globalThis as StateCarrier;
   carrier[MODULE_TALLY] ??= {
     selected: 0,
+    shardSelected: null,
     started: 0,
     reported: 0,
     inFlight: new Set<string>(),
   };
   return carrier[MODULE_TALLY];
+}
+
+/**
+ * How many files this shard was given, which only the sequencer knows.
+ *
+ * The reporter is handed the whole suite's file list, before the sequencer
+ * splits it, so its own `selected` is the same number on all four shards.
+ * Comparing a shard's progress against that says "still had files to start"
+ * on every sharded run, whatever the shard was doing.
+ *
+ * Recorded rather than read back later because the sequencer runs once, in the
+ * same process, and nothing else is in a position to say.
+ */
+export function recordShardSelection(count: number): void {
+  moduleTally().shardSelected = count;
 }
 
 /**
@@ -88,6 +105,7 @@ export function resetShardState(): void {
  */
 export function shardModuleTally(): {
   selected: number;
+  shardSelected: number | null;
   started: number;
   reported: number;
   unreportedFiles: string[];
@@ -95,6 +113,7 @@ export function shardModuleTally(): {
   const tally = moduleTally();
   return {
     selected: tally.selected,
+    shardSelected: tally.shardSelected,
     started: tally.started,
     reported: tally.reported,
     unreportedFiles: [...tally.inFlight].sort(),
@@ -129,6 +148,8 @@ export default class ShardFailureReporter {
     tally.started = 0;
     tally.reported = 0;
     tally.inFlight.clear();
+    // `shardSelected` is deliberately left alone: the sequencer sets it, and
+    // the two run in an order vitest does not promise.
   }
 
   /**

--- a/platform/app/vitest.sequencer.ts
+++ b/platform/app/vitest.sequencer.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { BaseSequencer, type TestSpecification } from "vitest/node";
 
+import { recordShardSelection } from "./src/test-utils/shardFailureReporter";
 import {
   createWeigher,
   loadDurationManifest,
@@ -79,7 +80,12 @@ export default class WeightBalancedSequencer extends BaseSequencer {
     }
 
     // `--shard=N/M` counts from one.
-    return buckets[index - 1] ?? [];
+    const mine = buckets[index - 1] ?? [];
+    // The only place that knows how many files this shard was actually given.
+    // The reporter is handed the whole list before this runs, so without this
+    // the hard-floor would compare a shard's progress against the suite.
+    recordShardSelection(mine.length);
+    return mine;
   }
 }
 

--- a/specs/ci/unit-shard-hard-floor.feature
+++ b/specs/ci/unit-shard-hard-floor.feature
@@ -48,6 +48,13 @@ Feature: The unit shard hard floor reports what it never finished
     And it reads the gap as a shard too slow for the floor rather than a hang
 
   @unit
+  Scenario: A shard is measured against its own files, not the whole suite
+    Given a run split into shards
+    When the hard floor fires on a shard that started every file it was given
+    Then the message counts the files this shard was given
+    And it does not call the shard too slow for the floor
+
+  @unit
   Scenario: A skipped file is never mistaken for one that never completed
     Given a test file whose tests are all skipped
     When that file reports its result


### PR DESCRIPTION
`test-unit` shard 2 went red on [#7386](https://github.com/langwatch/langwatch/pull/7386) while the shard passed on the commit before it, with a source diff that the unit lane does not even run.

## One test failed, and it failed on the clock

```
❯ src/test-utils/__tests__/typecheckProjects.unit.test.ts (4 tests | 1 failed) 36629ms
     ✓ runs one project that covers the app and its tests 5ms
     ✓ is what CI runs, so local and CI check the same program 1ms
     ✓ gives each project a build info file of its own 1ms
     × leaves no file that was checked before unchecked 36445ms
```

The suite's default is `testTimeout: 30000`. That test loads three whole-repository TypeScript programs, one per project, because "the union covers both parts" cannot be checked with fewer. Fifteen minutes earlier, on the previous commit of the same PR, the same test passed at **26,193ms**. On a laptop with cold build info it takes **29.7 seconds**, which passes by 280 milliseconds.

So the limit was deciding the result by the runner's mood. It is now 180 seconds, which is what the work costs with room for a bad day.

## The shard turned red rather than slow because of it

Those 36 seconds also pushed the step past the 4-minute hard floor: 193s on the passing commit, 241s (cut) on the failing one. Main runs the same step in 127 to 181 seconds, so the floor was not the problem, this one test was. The floor then named the four files that happened to be in flight when it fired. None of them hang: each passes on its own.

## The floor's own message pointed the wrong way

It printed:

```
[unit globalSetup] test files: 2135 selected, 499 started, 495 reported a result
[unit globalSetup] the shard still had files to start, so the floor cut a run that was working
                   rather than one that was wedged. Read that as a shard too slow for the floor,
                   not as a hang.
```

That reads as a shard 23% of the way through. It was 94% of the way through. The reporter is handed the file list **before** the sequencer splits it, so `selected` is the whole lane on every shard while `started` counts only the shard's own files. `started < selected` therefore holds on every sharded run, whatever the shard is doing, and the sentence carries no information.

Reproduced by running the CI command locally with a short floor:

```
$ LANGWATCH_UNIT_HARD_FLOOR_MS=25000 pnpm test:unit --run --shard=2/4 ...
[unit globalSetup] test files: 2135 selected, 31 started, 27 reported a result
[unit globalSetup] the shard still had files to start, ...
```

The sequencer is the one place that knows what it handed the shard, so it records that, and the same command now prints:

```
[unit globalSetup] test files: 533 in this shard (of 2135 selected), 25 started, 20 reported a result
```

An unsharded run keeps the wording it had.

## Specs

`specs/ci/unit-shard-hard-floor.feature`: a shard is measured against its own files, not the whole suite. 8/8 bound.

## Testing

- New case in `shardFailureReporter.unit.test.ts` for the sharded counts. 17 unit tests green.
- The corrected line verified against a real `--shard=2/4` run, not only against the reporter.
- `typecheckProjects.unit.test.ts` green, and timed at 29.72s with cold build info against the old 30s limit, which is the margin this changes.
- `pnpm typecheck:all` clean, biome clean, feature parity `OK: 8019 bound`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hard-floor diagnostics for sharded test runs by counting only files assigned to the current shard.
  * Prevented fully started shards from being incorrectly classified as too slow.
  * Preserved existing behavior for unsharded test runs.

* **Tests**
  * Added coverage for shard-specific file counts and completion handling.
  * Updated type-check coverage timing expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->