### PR TITLE
fix(release): infra/clickhouse-serverless changes now cut a release

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "charts/clickhouse-serverless": "0.3.0",
+  "infra/clickhouse-serverless": "0.3.0",
   "sdks/go": "0.3.0",
   "sdks/typescript": "1.7.0",
   "sdks/python": "1.2.0",

--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "charts/clickhouse-serverless": "0.3.0",
+  "infra/clickhouse-serverless": "0.3.0",
   "sdks/go": "0.3.0",
   "sdks/typescript": "1.12.0",
   "sdks/python": "1.3.1",

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -23,6 +23,21 @@
         "values.yaml"
       ]
     },
+    "infra/clickhouse-serverless": {
+      "release-type": "simple",
+      "package-name": "clickhouse-serverless-image",
+      "prerelease": false,
+      "component": "clickhouse-serverless-image",
+      "include-component-in-tag": true,
+      "tag-separator": "@",
+      "changelog-sections": [
+        {"type": "feat",     "section": "Features"},
+        {"type": "fix",      "section": "Bug Fixes"},
+        {"type": "chore",    "section": "Miscellaneous",    "hidden": false},
+        {"type": "docs",     "section": "Documentation",    "hidden": false},
+        {"type": "refactor", "section": "Code Refactoring", "hidden": false}
+      ]
+    },
     "sdks/go": {
       "release-type": "go",
       "package-name": "langwatch-go",
@@ -303,6 +318,7 @@
         "mcp/typescript",
         "services/langevals",
         "charts/clickhouse-serverless",
+        "infra/clickhouse-serverless",
         "sdks/python",
         "skills",
         "plugins/langwatch",
@@ -418,5 +434,13 @@
   },
   "bootstrap-sha": "HEAD",
   "separate-pull-requests": true,
-  "draft-pull-request": true
+  "draft-pull-request": true,
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "clickhouse-serverless",
+      "components": ["clickhouse-serverless", "clickhouse-serverless-image"],
+      "merge": false
+    }
+  ]
 }

--- a/infra/clickhouse-serverless/.release-please-shim
+++ b/infra/clickhouse-serverless/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker (v1) — next: 0.3.0


### PR DESCRIPTION
# Related Issue

- Resolves #7349

## Motivation

Flagged in review of #7331: the chart's pinned image tag (`values.yaml`
`tag: "0.3.0"`) is undeliverable by the current release-please setup.
`clickhouse-serverless` is rooted at `charts/clickhouse-serverless`; the
image's actual source is `infra/clickhouse-serverless/`. A PR touching
only the Go source cuts no release, so
`publish-docker-clickhouse-serverless.yml` (gated on a
`clickhouse-serverless@v*` tag) never fires and the pin never advances.

This isn't hypothetical — it's already happened twice since `v0.3.0`
(2026-08-07): 85bdcaa1ac and 269a56ec79 both touch
`infra/clickhouse-serverless/{Dockerfile,go.mod}`, and `v0.4.0` does
not exist.

Fixes #7349.

## Change

- New release-please package `infra/clickhouse-serverless` (simple,
  component `clickhouse-serverless-image`).
- Linked to `charts/clickhouse-serverless` via the `linked-versions`
  plugin, `merge: false` — versions stay in sync, each package keeps
  its own release PR (sidesteps googleapis/release-please#2306 /
  #2712, both open bugs in the combined-PR title path).
- `infra/clickhouse-serverless` added to the root `.` package's
  `exclude-paths`.
- Manifest seeded at `0.3.0`, matching the chart's current version.

## Verification

- Both edited files formally validated against release-please's own
  upstream JSON schemas (`schemas/config.json`, `schemas/manifest.json`)
  via python jsonschema — both pass.
- `jq .` round-trip: both files valid JSON.
- Manifest package keys and config package keys diffed — exact match.
- Confirmed `publish-docker-clickhouse-serverless.yml`'s tag-prefix
  gate needs no change: linked-versions force-bumps the chart package
  too on a Go-only change, producing the `clickhouse-serverless@v*`
  tag the gate already matches.
- `.github/scripts/guard-breaking-change-scope.ts` reads
  `config.packages` generically — new package picked up automatically,
  no companion change needed.

Note: `merge: false` cannot be exercised end-to-end offline — it is
verified by reading the early-return guard in the plugin's source
(`src/plugins/linked-versions.ts`), and will be proven live by the next
Go-touching PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added release tracking for the ClickHouse Serverless infrastructure package.
  * Configured independent versioning and coordinated releases with the existing ClickHouse Serverless chart.
  * Marked the package for its next release, version 0.3.0.
  * Release management updates help ensure package changes are versioned and published consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->