### PR TITLE
fix(governance): one projection hold per ingestion-key rotation, and a spinner while the wrapper sets up

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -212,3 +212,18 @@ regexes = [
   '''^hunter2-signing$''',
   '''^tok-live-abc123$''',
 ]
+
+# `ik-lw-fresh1234567890_secret`, the stand-in ingestion token an earlier commit
+# on the ingest-key rotation branch handed the mocked `apiKeys.create`. The tip
+# spells it `ik-lw-fake-token`, which no rule fires on, but gitleaks scans the
+# whole commit range on a pull request, so the earlier commit still needs naming
+# here. The value was invented for a mock return, reaches no provider, and
+# authenticates nothing.
+#
+# Scoped by VALUE and ANCHORED, for the reason given above the block before it:
+# a substring allowlist would also permit a real token that merely starts with
+# this prefix.
+[[allowlists]]
+description = "Stand-in ingestion token in the ingest-key rotation test, issued by nobody"
+targetRules = ["generic-api-key"]
+regexes = ['''^ik-lw-fresh1234567890_secret$''']

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
@@ -44,7 +44,7 @@ describe("IngestionKeyService.ensureForProject", () => {
     vi.clearAllMocks();
     service = IngestionKeyService.create({} as never);
     apiKeys.create.mockResolvedValue({
-      token: "ik-lw-fresh1234567890_secret",
+      token: "ik-lw-fake-token",
       apiKey: { id: "ak_new" },
     });
   });

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * The hard-cut rotation's latency contract: one request, one projection
+ * hold. The revoke of the prior key rides the same per-organization FIFO
+ * ledger queue as the mint that follows, so only the mint's final grant
+ * attach needs to hold for the projection.
+ *
+ * Feature: specs/api-keys/ingest-key-rotation-latency.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiKeys = vi.hoisted(() => ({
+  create: vi.fn(),
+  revoke: vi.fn(),
+}));
+const apiKeyRepo = vi.hoisted(() => ({
+  findIngestKey: vi.fn(),
+}));
+
+vi.mock("~/server/api-key/api-key.service", () => ({
+  ApiKeyService: { create: () => apiKeys },
+}));
+vi.mock("~/server/api-key/api-key.repository", () => ({
+  ApiKeyRepository: { create: () => apiKeyRepo },
+}));
+vi.mock("../personalWorkspace.service", () => ({
+  PersonalWorkspaceService: class {},
+}));
+
+import { IngestionKeyService } from "../ingestionKey.service";
+
+const MINT_PARAMS = {
+  callerUserId: "user_1",
+  ownerUserId: "user_1",
+  organizationId: "org_1",
+  projectId: "project_1",
+  sourceType: "claude_code",
+} as const;
+
+describe("IngestionKeyService.ensureForProject", () => {
+  let service: IngestionKeyService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = IngestionKeyService.create({} as never);
+    apiKeys.create.mockResolvedValue({
+      token: "ik-lw-fresh1234567890_secret",
+      apiKey: { id: "ak_new" },
+    });
+  });
+
+  describe("when a prior key exists for the project and source type", () => {
+    /** @scenario "A hard-cut rotation holds once, on the new key's grants" */
+    it("revokes it without a projection hold of its own", async () => {
+      apiKeyRepo.findIngestKey.mockResolvedValue({ id: "ak_prior" });
+
+      await service.ensureForProject(MINT_PARAMS);
+
+      expect(apiKeys.revoke).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "ak_prior", awaitProjection: false }),
+      );
+      // The mint that follows is the chain's one awaited write.
+      expect(apiKeys.revoke).toHaveBeenCalledBefore(apiKeys.create);
+      expect(apiKeys.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when no prior key exists", () => {
+    it("mints without revoking anything", async () => {
+      apiKeyRepo.findIngestKey.mockResolvedValue(null);
+
+      const issued = await service.ensureForProject(MINT_PARAMS);
+
+      expect(apiKeys.revoke).not.toHaveBeenCalled();
+      expect(issued.apiKeyId).toBe("ak_new");
+    });
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
@@ -50,7 +50,7 @@ describe("IngestionKeyService.ensureForProject", () => {
   });
 
   describe("when a prior key exists for the project and source type", () => {
-    /** @scenario "A hard-cut rotation holds once, on the new key's grants" */
+    /** @scenario "Rotating a key answers without waiting on the old key's cleanup" */
     it("revokes it without a projection hold of its own", async () => {
       apiKeyRepo.findIngestKey.mockResolvedValue({ id: "ak_prior" });
 

--- a/platform/app/ee/governance/services/ingestionKey.service.ts
+++ b/platform/app/ee/governance/services/ingestionKey.service.ts
@@ -111,6 +111,12 @@ export class IngestionKeyService {
         callerUserId,
         callerIsAdmin: true,
         organizationId,
+        // The mint below ends with an awaited grant attach on the same
+        // organization's FIFO ledger queue, so that single wait proves this
+        // revoke's writes landed too. Waiting here as well made a rotation
+        // stack fold pickup cycles: the CLI's first `langwatch claude` after
+        // a logout sat well over twenty seconds on this one request.
+        awaitProjection: false,
       });
     }
 

--- a/platform/app/ee/governance/services/ingestionKey.service.ts
+++ b/platform/app/ee/governance/services/ingestionKey.service.ts
@@ -111,11 +111,12 @@ export class IngestionKeyService {
         callerUserId,
         callerIsAdmin: true,
         organizationId,
-        // The mint below ends with an awaited grant attach on the same
-        // organization's FIFO ledger queue, so that single wait proves this
-        // revoke's writes landed too. Waiting here as well made a rotation
-        // stack fold pickup cycles: the CLI's first `langwatch claude` after
-        // a logout sat well over twenty seconds on this one request.
+        // The prior key is dead the moment its row is revoked, and its
+        // private role is named after that key id, so the mint below never
+        // waits for the name. Holding here for the role deletion to project
+        // only added a fold pickup cycle to a rotation that already waits
+        // for the new key's own writes: the CLI's first `langwatch claude`
+        // after a logout sat well over twenty seconds on this one request.
         awaitProjection: false,
       });
     }

--- a/platform/app/src/server/api-key/__tests__/api-key.service.safety.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.safety.unit.test.ts
@@ -220,7 +220,7 @@ describe("ApiKeyService — safety invariants (mocked)", () => {
         );
       });
 
-      /** @scenario "A restricted key's private role lands before its binding attaches" */
+      /** @scenario "A new restricted key is usable the moment it is returned" */
       it("finishes the role definition before attaching the binding", async () => {
         const order: string[] = [];
         ledger.defineRole.mockImplementation(async () => {

--- a/platform/app/src/server/api-key/__tests__/api-key.service.safety.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.safety.unit.test.ts
@@ -219,6 +219,31 @@ describe("ApiKeyService — safety invariants (mocked)", () => {
           }),
         );
       });
+
+      /** @scenario "A restricted key's private role rides the grant attach's hold" */
+      it("defines the private role without its own projection hold", async () => {
+        await service.create({
+          name: "Restricted Key",
+          userId: USER_ID,
+          organizationId: ORG_ID,
+          permissionMode: "restricted",
+          permissions: ["traces:view"],
+          bindings: [
+            { role: "CUSTOM", scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          ],
+        });
+
+        // The attach that follows holds for its projection (writer default),
+        // and the organization's ledger queue is FIFO, so that one hold
+        // proves the role definition landed too.
+        expect(ledger.defineRole).toHaveBeenCalledWith(
+          expect.objectContaining({ awaitProjection: false }),
+        );
+        expect(ledger.attachBindings).toHaveBeenCalledTimes(1);
+        expect(
+          ledger.attachBindings.mock.calls[0]![0].awaitProjection,
+        ).toBeUndefined();
+      });
     });
 
     describe("when permissions arrive in arbitrary order", () => {

--- a/platform/app/src/server/api-key/__tests__/api-key.service.safety.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.safety.unit.test.ts
@@ -220,8 +220,19 @@ describe("ApiKeyService — safety invariants (mocked)", () => {
         );
       });
 
-      /** @scenario "A restricted key's private role rides the grant attach's hold" */
-      it("defines the private role without its own projection hold", async () => {
+      /** @scenario "A restricted key's private role lands before its binding attaches" */
+      it("finishes the role definition before attaching the binding", async () => {
+        const order: string[] = [];
+        ledger.defineRole.mockImplementation(async () => {
+          // The writer holds for the role projection inside this call.
+          await Promise.resolve();
+          order.push("defineRole");
+        });
+        ledger.attachBindings.mockImplementation(async () => {
+          order.push("attachBindings");
+          return { attached: [], duplicates: [] };
+        });
+
         await service.create({
           name: "Restricted Key",
           userId: USER_ID,
@@ -233,16 +244,10 @@ describe("ApiKeyService — safety invariants (mocked)", () => {
           ],
         });
 
-        // The attach that follows holds for its projection (writer default),
-        // and the organization's ledger queue is FIFO, so that one hold
-        // proves the role definition landed too.
-        expect(ledger.defineRole).toHaveBeenCalledWith(
-          expect.objectContaining({ awaitProjection: false }),
-        );
-        expect(ledger.attachBindings).toHaveBeenCalledTimes(1);
-        expect(
-          ledger.attachBindings.mock.calls[0]![0].awaitProjection,
-        ).toBeUndefined();
+        // The binding row carries a foreign key to the role row, so the role
+        // has to be projected first. Command jobs are grouped per command
+        // name, so the attach cannot stand in for the definition's hold.
+        expect(order).toEqual(["defineRole", "attachBindings"]);
       });
     });
 

--- a/platform/app/src/server/api-key/__tests__/api-key.service.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.unit.test.ts
@@ -539,6 +539,44 @@ describe("ApiKeyService", () => {
       });
     });
 
+    describe("when the caller leaves the projection hold to a later write", () => {
+      /** @scenario "A hard-cut rotation holds once, on the new key's grants" */
+      it("passes the skipped hold through to the role deletion", async () => {
+        const keyWithCustomRole = {
+          ...existingKey,
+          roleBindings: [
+            {
+              id: "rb_1",
+              customRoleId: "cr_1",
+              role: "CUSTOM",
+              scopeType: "ORGANIZATION",
+              scopeId: "org_1",
+            },
+          ],
+        };
+        prisma.apiKey.findUnique.mockResolvedValue(keyWithCustomRole);
+        prisma._mockTx.apiKey.findUnique.mockResolvedValue(keyWithCustomRole);
+        prisma._mockTx.apiKey.update.mockResolvedValue({
+          ...existingKey,
+          revokedAt: new Date(),
+        });
+
+        const revoked = await service.revoke({
+          id: "ak_1",
+          callerUserId: "user_1",
+          callerIsAdmin: false,
+          organizationId: "org_1",
+          awaitProjection: false,
+        });
+
+        // The key row itself is revoked imperatively either way.
+        expect(revoked.revokedAt).not.toBeNull();
+        expect(ledger.deleteRole).toHaveBeenCalledWith(
+          expect.objectContaining({ roleId: "cr_1", awaitProjection: false }),
+        );
+      });
+    });
+
     describe("when revoking a key with multiple bindings sharing one CustomRole", () => {
       it("deduplicates and deletes the CustomRole once", async () => {
         const keyWithSharedRole = {

--- a/platform/app/src/server/api-key/__tests__/api-key.service.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.unit.test.ts
@@ -540,7 +540,7 @@ describe("ApiKeyService", () => {
     });
 
     describe("when the caller leaves the projection hold to a later write", () => {
-      /** @scenario "A hard-cut rotation holds once, on the new key's grants" */
+      /** @scenario "Rotating a key answers without waiting on the old key's cleanup" */
       it("passes the skipped hold through to the role deletion", async () => {
         const keyWithCustomRole = {
           ...existingKey,

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -973,7 +973,7 @@ export class ApiKeyService {
     callerUserId,
     callerIsAdmin,
     organizationId,
-    awaitProjection,
+    awaitProjection = true,
   }: {
     id: string;
     /**
@@ -1025,7 +1025,7 @@ export class ApiKeyService {
           userId: callerUserId,
           fallback: "apiKeyService",
         }),
-        ...(awaitProjection !== undefined ? { awaitProjection } : {}),
+        awaitProjection,
       });
     }
 

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -333,6 +333,12 @@ export class ApiKeyService {
           kind: CUSTOM_ROLE_KIND.SYSTEM_API_KEY,
         },
         actor,
+        // A restricted key ALWAYS attaches a CUSTOM binding right after this
+        // (validated above), and that attach awaits its own projection. The
+        // organization's ledger queue is FIFO, so the binding row landing
+        // proves the role row landed first — waiting here too would spend a
+        // second full fold pickup cycle on the same request for nothing.
+        awaitProjection: false,
       });
       effectiveBindings = effectiveBindings.map((b) =>
         b.role === TeamUserRole.CUSTOM
@@ -967,6 +973,7 @@ export class ApiKeyService {
     callerUserId,
     callerIsAdmin,
     organizationId,
+    awaitProjection,
   }: {
     id: string;
     /**
@@ -976,6 +983,15 @@ export class ApiKeyService {
     callerUserId: string | null;
     callerIsAdmin: boolean;
     organizationId: string;
+    /**
+     * Whether the ledger writes hold for their projections. The key row
+     * itself is revoked imperatively either way, so the key is dead on the
+     * next read regardless. A caller that follows this revoke with an
+     * awaited write on the same organization's queue (the hard-cut
+     * ingestion-key rotation re-mints right after) turns this off and rides
+     * that later wait instead of stacking fold cycles on one request.
+     */
+    awaitProjection?: boolean;
   }): Promise<ApiKey> {
     const apiKey = await this.repo.findById({ id });
     if (!apiKey) throw new ApiKeyNotFoundError(id);
@@ -1009,6 +1025,7 @@ export class ApiKeyService {
           userId: callerUserId,
           fallback: "apiKeyService",
         }),
+        ...(awaitProjection !== undefined ? { awaitProjection } : {}),
       });
     }
 

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -333,12 +333,6 @@ export class ApiKeyService {
           kind: CUSTOM_ROLE_KIND.SYSTEM_API_KEY,
         },
         actor,
-        // A restricted key ALWAYS attaches a CUSTOM binding right after this
-        // (validated above), and that attach awaits its own projection. The
-        // organization's ledger queue is FIFO, so the binding row landing
-        // proves the role row landed first — waiting here too would spend a
-        // second full fold pickup cycle on the same request for nothing.
-        awaitProjection: false,
       });
       effectiveBindings = effectiveBindings.map((b) =>
         b.role === TeamUserRole.CUSTOM
@@ -984,12 +978,12 @@ export class ApiKeyService {
     callerIsAdmin: boolean;
     organizationId: string;
     /**
-     * Whether the ledger writes hold for their projections. The key row
-     * itself is revoked imperatively either way, so the key is dead on the
-     * next read regardless. A caller that follows this revoke with an
-     * awaited write on the same organization's queue (the hard-cut
-     * ingestion-key rotation re-mints right after) turns this off and rides
-     * that later wait instead of stacking fold cycles on one request.
+     * Whether the deletion of the key's private role holds for its
+     * projection. The key row itself is revoked imperatively either way, so
+     * the key is dead on the next read regardless, and the retired role is
+     * named after the key id, so no later mint waits for that name to come
+     * free. A caller that only needs the credential dead (the hard-cut
+     * ingestion-key rotation) turns this off and saves a fold pickup cycle.
      */
     awaitProjection?: boolean;
   }): Promise<ApiKey> {

--- a/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.ledger.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.ledger.unit.test.ts
@@ -355,6 +355,43 @@ describe("given an organization whose genesis import has landed", () => {
     expect(db.auditLog.createMany).not.toHaveBeenCalled();
   });
 
+  describe("when a caller leaves the projection hold to a later write", () => {
+    /** @scenario "Defining a role can leave the hold to a later write" */
+    it("appends the definition without polling for the role row", async () => {
+      const { writer, db, sent } = harness({ onLedger: true });
+
+      await writer.defineRole({
+        organizationId: ORG_ID,
+        roleId: "role_1",
+        name: "Auditor",
+        permissions: ["traces:read"],
+        kind: "custom",
+        actor: ACTOR,
+        awaitProjection: false,
+      });
+
+      expect(sent.map((command) => command.verb)).toEqual(["defineRoles"]);
+      expect(db.customRole.findFirst).not.toHaveBeenCalled();
+      expect(bumpAuthzEpoch).toHaveBeenCalledWith({ organizationId: ORG_ID });
+    });
+
+    /** @scenario "Deleting a role can leave the hold to a later write" */
+    it("appends the deletion without polling for the row's disappearance", async () => {
+      const { writer, db, sent } = harness({ onLedger: true });
+
+      await writer.deleteRole({
+        organizationId: ORG_ID,
+        roleId: "role_1",
+        actor: ACTOR,
+        awaitProjection: false,
+      });
+
+      expect(sent.map((command) => command.verb)).toEqual(["deleteRole"]);
+      expect(db.customRole.count).not.toHaveBeenCalled();
+      expect(bumpAuthzEpoch).toHaveBeenCalledWith({ organizationId: ORG_ID });
+    });
+  });
+
   /** @scenario "Completing the genesis import moves an organization's writes onto the ledger" */
   it("emits the offboard command and deletes no binding row itself", async () => {
     const { writer, db, sent } = harness({ onLedger: true });

--- a/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.ledger.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.ledger.unit.test.ts
@@ -355,27 +355,8 @@ describe("given an organization whose genesis import has landed", () => {
     expect(db.auditLog.createMany).not.toHaveBeenCalled();
   });
 
-  describe("when a caller leaves the projection hold to a later write", () => {
-    /** @scenario "Defining a role can leave the hold to a later write" */
-    it("appends the definition without polling for the role row", async () => {
-      const { writer, db, sent } = harness({ onLedger: true });
-
-      await writer.defineRole({
-        organizationId: ORG_ID,
-        roleId: "role_1",
-        name: "Auditor",
-        permissions: ["traces:read"],
-        kind: "custom",
-        actor: ACTOR,
-        awaitProjection: false,
-      });
-
-      expect(sent.map((command) => command.verb)).toEqual(["defineRoles"]);
-      expect(db.customRole.findFirst).not.toHaveBeenCalled();
-      expect(bumpAuthzEpoch).toHaveBeenCalledWith({ organizationId: ORG_ID });
-    });
-
-    /** @scenario "Deleting a role can leave the hold to a later write" */
+  describe("when a caller only needs the role retired", () => {
+    /** @scenario "Deleting a role that nothing reads again can skip the hold" */
     it("appends the deletion without polling for the row's disappearance", async () => {
       const { writer, db, sent } = harness({ onLedger: true });
 

--- a/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.ledger.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.ledger.unit.test.ts
@@ -356,7 +356,7 @@ describe("given an organization whose genesis import has landed", () => {
   });
 
   describe("when a caller only needs the role retired", () => {
-    /** @scenario "Deleting a role that nothing reads again can skip the hold" */
+    /** @scenario "Retiring the old key's private role does not hold the answer" */
     it("appends the deletion without polling for the row's disappearance", async () => {
       const { writer, db, sent } = harness({ onLedger: true });
 

--- a/platform/app/src/server/app-layer/authz/ledger.ts
+++ b/platform/app/src/server/app-layer/authz/ledger.ts
@@ -1279,7 +1279,6 @@ export class GrantsLedgerWriter {
     permissions,
     kind,
     actor,
-    awaitProjection = true,
   }: {
     organizationId: string;
     roleId: string;
@@ -1288,16 +1287,6 @@ export class GrantsLedgerWriter {
     permissions: string[];
     kind: "custom" | "system_api_key";
     actor: LedgerActor;
-    /**
-     * Whether to hold for the projection to land the role row. On by
-     * default: a caller that just defined a role usually reads it next. A
-     * caller that follows this write with ANOTHER write on the same
-     * organization's queue and awaits THAT one turns it off — the queue is
-     * per-organization FIFO, so the later write's projection landing proves
-     * this one landed too, and each skipped wait saves a full fold pickup
-     * cycle on the request.
-     */
-    awaitProjection?: boolean;
   }): Promise<void> {
     const occurredAtMs = this.now();
     if (!(await this.onLedger(organizationId))) {
@@ -1328,28 +1317,31 @@ export class GrantsLedgerWriter {
       ],
       actor,
     });
-    if (awaitProjection) {
-      await this.awaitProjection({
-        what: `definition of role ${roleId}`,
-        organizationId,
-        // The COMPAT head, like every other read-your-writes check here: that
-        // is the table `deleteRole` polls, the table the resolver reads, and
-        // the table every consumer of a freshly defined role reads. `Role` is
-        // the future head, written by the same `store()` — polling it would
-        // return before the row the caller is about to look for exists.
-        check: async () => {
-          const row = await this.prisma.customRole.findFirst({
-            where: { id: roleId, organizationId },
-            select: { name: true, permissions: true },
-          });
-          return (
-            row != null &&
-            row.name === name &&
-            samePermissions({ stored: row.permissions, wanted: permissions })
-          );
-        },
-      });
-    }
+    // Always held. A role row is a foreign key target: the grant attach that
+    // normally follows writes a compat RoleBinding pointing at this role, and
+    // that write fails if the role row is not there yet. Commands are queued
+    // per command name, not per organization, so `attachGrants` can be picked
+    // up before `defineRoles` and cannot stand in for this hold.
+    await this.awaitProjection({
+      what: `definition of role ${roleId}`,
+      organizationId,
+      // The COMPAT head, like every other read-your-writes check here: that
+      // is the table `deleteRole` polls, the table the resolver reads, and
+      // the table every consumer of a freshly defined role reads. `Role` is
+      // the future head, written by the same `store()` — polling it would
+      // return before the row the caller is about to look for exists.
+      check: async () => {
+        const row = await this.prisma.customRole.findFirst({
+          where: { id: roleId, organizationId },
+          select: { name: true, permissions: true },
+        });
+        return (
+          row != null &&
+          row.name === name &&
+          samePermissions({ stored: row.permissions, wanted: permissions })
+        );
+      },
+    });
     await bumpAuthzEpoch({ organizationId });
   }
 
@@ -1439,7 +1431,15 @@ export class GrantsLedgerWriter {
     organizationId: string;
     roleId: string;
     actor: LedgerActor;
-    /** Same contract as `defineRole`'s parameter of this name. */
+    /**
+     * Whether to hold for the projection to drop the role row. On by
+     * default: a caller that deletes a role usually needs the name free
+     * again straight away. A caller that only retires a role nothing reads
+     * any more turns it off and saves a full fold pickup cycle on the
+     * request; the append is durable either way and the fold converges.
+     * Nothing here depends on the ordering of other commands, which the
+     * queue does not give: command jobs are grouped per command name.
+     */
     awaitProjection?: boolean;
   }): Promise<void> {
     if (!(await this.onLedger(organizationId))) {

--- a/platform/app/src/server/app-layer/authz/ledger.ts
+++ b/platform/app/src/server/app-layer/authz/ledger.ts
@@ -1279,6 +1279,7 @@ export class GrantsLedgerWriter {
     permissions,
     kind,
     actor,
+    awaitProjection = true,
   }: {
     organizationId: string;
     roleId: string;
@@ -1287,6 +1288,16 @@ export class GrantsLedgerWriter {
     permissions: string[];
     kind: "custom" | "system_api_key";
     actor: LedgerActor;
+    /**
+     * Whether to hold for the projection to land the role row. On by
+     * default: a caller that just defined a role usually reads it next. A
+     * caller that follows this write with ANOTHER write on the same
+     * organization's queue and awaits THAT one turns it off — the queue is
+     * per-organization FIFO, so the later write's projection landing proves
+     * this one landed too, and each skipped wait saves a full fold pickup
+     * cycle on the request.
+     */
+    awaitProjection?: boolean;
   }): Promise<void> {
     const occurredAtMs = this.now();
     if (!(await this.onLedger(organizationId))) {
@@ -1317,26 +1328,28 @@ export class GrantsLedgerWriter {
       ],
       actor,
     });
-    await this.awaitProjection({
-      what: `definition of role ${roleId}`,
-      organizationId,
-      // The COMPAT head, like every other read-your-writes check here: that
-      // is the table `deleteRole` polls, the table the resolver reads, and
-      // the table every consumer of a freshly defined role reads. `Role` is
-      // the future head, written by the same `store()` — polling it would
-      // return before the row the caller is about to look for exists.
-      check: async () => {
-        const row = await this.prisma.customRole.findFirst({
-          where: { id: roleId, organizationId },
-          select: { name: true, permissions: true },
-        });
-        return (
-          row != null &&
-          row.name === name &&
-          samePermissions({ stored: row.permissions, wanted: permissions })
-        );
-      },
-    });
+    if (awaitProjection) {
+      await this.awaitProjection({
+        what: `definition of role ${roleId}`,
+        organizationId,
+        // The COMPAT head, like every other read-your-writes check here: that
+        // is the table `deleteRole` polls, the table the resolver reads, and
+        // the table every consumer of a freshly defined role reads. `Role` is
+        // the future head, written by the same `store()` — polling it would
+        // return before the row the caller is about to look for exists.
+        check: async () => {
+          const row = await this.prisma.customRole.findFirst({
+            where: { id: roleId, organizationId },
+            select: { name: true, permissions: true },
+          });
+          return (
+            row != null &&
+            row.name === name &&
+            samePermissions({ stored: row.permissions, wanted: permissions })
+          );
+        },
+      });
+    }
     await bumpAuthzEpoch({ organizationId });
   }
 
@@ -1421,10 +1434,13 @@ export class GrantsLedgerWriter {
     organizationId,
     roleId,
     actor,
+    awaitProjection = true,
   }: {
     organizationId: string;
     roleId: string;
     actor: LedgerActor;
+    /** Same contract as `defineRole`'s parameter of this name. */
+    awaitProjection?: boolean;
   }): Promise<void> {
     if (!(await this.onLedger(organizationId))) {
       // The pre-ledger role delete. `deleteMany` rather than `delete` keeps
@@ -1451,16 +1467,18 @@ export class GrantsLedgerWriter {
       actor,
       occurredAtMs: this.now(),
     });
-    await this.awaitProjection({
-      what: `deletion of role ${roleId}`,
-      organizationId,
-      check: async () => {
-        const present = await this.prisma.customRole.count({
-          where: { id: roleId, organizationId },
-        });
-        return present === 0;
-      },
-    });
+    if (awaitProjection) {
+      await this.awaitProjection({
+        what: `deletion of role ${roleId}`,
+        organizationId,
+        check: async () => {
+          const present = await this.prisma.customRole.count({
+            where: { id: roleId, organizationId },
+          });
+          return present === 0;
+        },
+      });
+    }
     await bumpAuthzEpoch({ organizationId });
   }
 

--- a/platform/app/src/server/role/repositories/role.repository.ts
+++ b/platform/app/src/server/role/repositories/role.repository.ts
@@ -253,16 +253,9 @@ export class RoleRepository {
   async create({
     params,
     actor,
-    awaitProjection = true,
   }: {
     params: CreateRoleParams;
     actor: LedgerActor;
-    /**
-     * Passed through to the ledger writer. A caller whose next step is
-     * another awaited write on the same organization's queue turns it off;
-     * see `GrantsLedgerWriter.defineRole` for the ordering argument.
-     */
-    awaitProjection?: boolean;
   }): Promise<CustomRole> {
     const roleId = nanoid();
     await this.assertNameFree({
@@ -283,7 +276,6 @@ export class RoleRepository {
       permissions: params.permissions as string[],
       kind: kind as "custom" | "system_api_key",
       actor,
-      awaitProjection,
     });
     const now = new Date();
     return {
@@ -412,7 +404,7 @@ export class RoleRepository {
     apiKeyId: string;
     organizationId: string;
     actor: LedgerActor;
-    /** Same contract as `create`'s parameter of this name. */
+    /** Same contract as `GrantsLedgerWriter.deleteRole`'s parameter of this name. */
     awaitProjection?: boolean;
   }) {
     if (roleIds.length === 0) return;

--- a/platform/app/src/server/role/repositories/role.repository.ts
+++ b/platform/app/src/server/role/repositories/role.repository.ts
@@ -253,7 +253,7 @@ export class RoleRepository {
   async create({
     params,
     actor,
-    awaitProjection,
+    awaitProjection = true,
   }: {
     params: CreateRoleParams;
     actor: LedgerActor;
@@ -283,7 +283,7 @@ export class RoleRepository {
       permissions: params.permissions as string[],
       kind: kind as "custom" | "system_api_key",
       actor,
-      ...(awaitProjection !== undefined ? { awaitProjection } : {}),
+      awaitProjection,
     });
     const now = new Date();
     return {
@@ -406,7 +406,7 @@ export class RoleRepository {
     apiKeyId,
     organizationId,
     actor,
-    awaitProjection,
+    awaitProjection = true,
   }: {
     roleIds: string[];
     apiKeyId: string;
@@ -451,7 +451,7 @@ export class RoleRepository {
         organizationId,
         roleId,
         actor,
-        ...(awaitProjection !== undefined ? { awaitProjection } : {}),
+        awaitProjection,
       });
     }
   }

--- a/platform/app/src/server/role/repositories/role.repository.ts
+++ b/platform/app/src/server/role/repositories/role.repository.ts
@@ -253,9 +253,16 @@ export class RoleRepository {
   async create({
     params,
     actor,
+    awaitProjection,
   }: {
     params: CreateRoleParams;
     actor: LedgerActor;
+    /**
+     * Passed through to the ledger writer. A caller whose next step is
+     * another awaited write on the same organization's queue turns it off;
+     * see `GrantsLedgerWriter.defineRole` for the ordering argument.
+     */
+    awaitProjection?: boolean;
   }): Promise<CustomRole> {
     const roleId = nanoid();
     await this.assertNameFree({
@@ -276,6 +283,7 @@ export class RoleRepository {
       permissions: params.permissions as string[],
       kind: kind as "custom" | "system_api_key",
       actor,
+      ...(awaitProjection !== undefined ? { awaitProjection } : {}),
     });
     const now = new Date();
     return {
@@ -398,11 +406,14 @@ export class RoleRepository {
     apiKeyId,
     organizationId,
     actor,
+    awaitProjection,
   }: {
     roleIds: string[];
     apiKeyId: string;
     organizationId: string;
     actor: LedgerActor;
+    /** Same contract as `create`'s parameter of this name. */
+    awaitProjection?: boolean;
   }) {
     if (roleIds.length === 0) return;
     // Revoke this api key's CUSTOM grants on these roles FIRST. The
@@ -436,7 +447,12 @@ export class RoleRepository {
         this.prisma.teamUser.count({ where: { assignedRoleId: roleId } }),
       ]);
       if (holders > 0 || assignedUsers > 0) continue;
-      await this.writer.deleteRole({ organizationId, roleId, actor });
+      await this.writer.deleteRole({
+        organizationId,
+        roleId,
+        actor,
+        ...(awaitProjection !== undefined ? { awaitProjection } : {}),
+      });
     }
   }
 

--- a/sdks/typescript/src/cli/utils/governance/__tests__/wrapper.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/wrapper.unit.test.ts
@@ -556,7 +556,7 @@ describe("withTelemetrySetupSpinner", () => {
 	});
 
 	describe("when the setup step is in flight", () => {
-		/** @scenario "Mode resolution runs behind a spinner" */
+		/** @scenario "Telemetry setup shows a spinner while it runs" */
 		it("spins while it runs and is gone before the result reaches the caller", async () => {
 			const result = await withTelemetrySetupSpinner({
 				tool: "claude",

--- a/sdks/typescript/src/cli/utils/governance/__tests__/wrapper.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/wrapper.unit.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSpinner } from "../../spinner";
 import type { GovernanceConfig } from "../config";
 import { envForTool } from "../tool-env";
 import {
 	buildShellReapply,
 	preflightWrapper,
 	shouldForgetGatewayPin,
+	withTelemetrySetupSpinner,
 } from "../wrapper";
+
+const spinner = vi.hoisted(() => ({
+	start: vi.fn(),
+	stop: vi.fn(),
+}));
+vi.mock("../../spinner", () => ({
+	createSpinner: vi.fn(() => spinner),
+}));
 
 const cfg: GovernanceConfig = {
 	gateway_url: "http://gw.example.com",
@@ -536,6 +546,53 @@ describe("shouldForgetGatewayPin", () => {
 			expect(
 				shouldForgetGatewayPin({ pinnedMode: "ingestion", retryable: false }),
 			).toBe(false);
+		});
+	});
+});
+
+describe("withTelemetrySetupSpinner", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("when the setup step is in flight", () => {
+		/** @scenario "Mode resolution runs behind a spinner" */
+		it("spins while it runs and is gone before the result reaches the caller", async () => {
+			const result = await withTelemetrySetupSpinner({
+				tool: "claude",
+				run: async () => {
+					expect(spinner.start).toHaveBeenCalledTimes(1);
+					expect(spinner.stop).not.toHaveBeenCalled();
+					return "resolved-mode";
+				},
+			});
+
+			expect(result).toBe("resolved-mode");
+			expect(spinner.stop).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(createSpinner)).toHaveBeenCalledWith(
+				expect.objectContaining({
+					text: expect.stringContaining("claude"),
+					// ora's default flips stdin to raw mode and swallows Ctrl+C;
+					// the wait must stay killable.
+					discardStdin: false,
+				}),
+			);
+		});
+	});
+
+	describe("when the setup step fails", () => {
+		/** @scenario "The spinner is gone before an error is reported" */
+		it("stops the spinner before the failure surfaces", async () => {
+			await expect(
+				withTelemetrySetupSpinner({
+					tool: "claude",
+					run: async () => {
+						throw new Error("mint failed");
+					},
+				}),
+			).rejects.toThrow("mint failed");
+
+			expect(spinner.stop).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/sdks/typescript/src/cli/utils/governance/wrapper.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper.ts
@@ -16,6 +16,7 @@
 
 import { spawn } from "node:child_process";
 import { normalizeEndpoint } from "../../../internal/endpoint";
+import { createSpinner } from "../spinner";
 import { lwTag } from "./brand";
 import { checkBudget, renderBudgetExceeded } from "./budget";
 import { updateLangwatchClaudePlugin } from "./claude-plugin";
@@ -310,6 +311,35 @@ export function buildShellReapply(args: {
 }
 
 /**
+ * Run one setup step behind a spinner. Mode resolution can reach the
+ * control plane (confirming the cached ingest key is live, minting a fresh
+ * one after a logout), and that used to happen in silence long enough to
+ * read as a hang. The spinner is stopped before the result — or the error —
+ * reaches the caller, so everything printed after it lands on a clean line.
+ *
+ * discardStdin:false for the same reason login-flow sets it: ora's default
+ * flips stdin to raw mode and swallows Ctrl+C, making the wait unkillable.
+ */
+export async function withTelemetrySetupSpinner<T>({
+	tool,
+	run,
+}: {
+	tool: string;
+	run: () => Promise<T>;
+}): Promise<T> {
+	const spinner = createSpinner({
+		text: `Setting up telemetry for ${tool}...`,
+		discardStdin: false,
+	});
+	spinner.start();
+	try {
+		return await run();
+	} finally {
+		spinner.stop();
+	}
+}
+
+/**
  * Run the named tool routed through the gateway. Inherits stdio so
  * the user gets the same interactive UX they'd have invoking the
  * tool directly. Exits the parent process with the child's exit
@@ -417,9 +447,12 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 	const toolEnv = envForTool(cfg, tool);
 	const gatewayVars = toolEnv.vars;
 	const gatewayClears = toolEnv.clears ?? [];
+	const resolveModeWithFeedback = (
+		...args: Parameters<typeof resolveWrapperMode>
+	) => withTelemetrySetupSpinner({ tool, run: () => resolveWrapperMode(...args) });
 	let modeResult;
 	try {
-		modeResult = await resolveWrapperMode(
+		modeResult = await resolveModeWithFeedback(
 			cfg,
 			tool,
 			gatewayVars,
@@ -448,7 +481,7 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 			// derived from the expired session.
 			const refreshedEnv = envForTool(cfg, tool);
 			try {
-				modeResult = await resolveWrapperMode(
+				modeResult = await resolveModeWithFeedback(
 					cfg,
 					tool,
 					refreshedEnv.vars,

--- a/sdks/typescript/src/cli/utils/governance/wrapper.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper.ts
@@ -311,11 +311,12 @@ export function buildShellReapply(args: {
 }
 
 /**
- * Run one setup step behind a spinner. Mode resolution can reach the
- * control plane (confirming the cached ingest key is live, minting a fresh
- * one after a logout), and that used to happen in silence long enough to
- * read as a hang. The spinner is stopped before the result — or the error —
- * reaches the caller, so everything printed after it lands on a clean line.
+ * Run one telemetry setup step behind a spinner. Setting a tool up can
+ * reach the control plane (confirming the cached ingest key is live, minting
+ * a fresh one after a logout), and that used to happen in silence long
+ * enough to read as a hang. The spinner is stopped before the result, or the
+ * error, reaches the caller, so everything printed after it lands on a clean
+ * line.
  *
  * discardStdin:false for the same reason login-flow sets it: ora's default
  * flips stdin to raw mode and swallows Ctrl+C, making the wait unkillable.
@@ -447,18 +448,19 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 	const toolEnv = envForTool(cfg, tool);
 	const gatewayVars = toolEnv.vars;
 	const gatewayClears = toolEnv.clears ?? [];
-	const resolveModeWithFeedback = (
-		...args: Parameters<typeof resolveWrapperMode>
-	) => withTelemetrySetupSpinner({ tool, run: () => resolveWrapperMode(...args) });
 	let modeResult;
 	try {
-		modeResult = await resolveModeWithFeedback(
-			cfg,
+		modeResult = await withTelemetrySetupSpinner({
 			tool,
-			gatewayVars,
-			gatewayClears,
-			pathChoice.mode,
-		);
+			run: () =>
+				resolveWrapperMode(
+					cfg,
+					tool,
+					gatewayVars,
+					gatewayClears,
+					pathChoice.mode,
+				),
+		});
 	} catch (err) {
 		// Direct-OTLP setup can fail at mint time: an expired device session,
 		// no personal workspace yet, an unreachable control plane. None of
@@ -481,13 +483,17 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 			// derived from the expired session.
 			const refreshedEnv = envForTool(cfg, tool);
 			try {
-				modeResult = await resolveModeWithFeedback(
-					cfg,
+				modeResult = await withTelemetrySetupSpinner({
 					tool,
-					refreshedEnv.vars,
-					refreshedEnv.clears ?? [],
-					"ingestion",
-				);
+					run: () =>
+						resolveWrapperMode(
+							cfg,
+							tool,
+							refreshedEnv.vars,
+							refreshedEnv.clears ?? [],
+							"ingestion",
+						),
+				});
 			} catch (err2) {
 				process.stderr.write(
 					`${lwTag()} still could not set up direct OTLP telemetry for ` +
@@ -497,7 +503,8 @@ export async function runWrapped(tool: string, args: string[]): Promise<never> {
 			}
 		} else {
 			process.stderr.write(
-				`mode resolution failed: ${(err as Error).message}\n`,
+				`${lwTag()} could not set up telemetry for ${tool}: ` +
+					`${(err as Error).message}\n`,
 			);
 			process.exit(2);
 		}

--- a/specs/ai-governance/cli-wrappers/wrapper-setup-feedback.feature
+++ b/specs/ai-governance/cli-wrappers/wrapper-setup-feedback.feature
@@ -9,14 +9,14 @@ Feature: The wrapper shows progress while it sets up telemetry
   Rule: network setup is never silent
 
     @unit
-    Scenario: Mode resolution runs behind a spinner
-      Given `langwatch claude` resolving its telemetry mode
-      When the resolution is in flight
-      Then a spinner says telemetry is being set up
+    Scenario: Telemetry setup shows a spinner while it runs
+      Given `langwatch claude` setting up telemetry for the tool
+      When the setup is in flight
+      Then a spinner says telemetry is being set up for that tool
       And the spinner is gone before the wrapper prints its feedback lines
 
     @unit
     Scenario: The spinner is gone before an error is reported
-      Given `langwatch claude` resolving its telemetry mode
-      When the resolution fails
+      Given `langwatch claude` setting up telemetry for the tool
+      When the setup fails
       Then the spinner is stopped before the failure is printed

--- a/specs/ai-governance/cli-wrappers/wrapper-setup-feedback.feature
+++ b/specs/ai-governance/cli-wrappers/wrapper-setup-feedback.feature
@@ -1,0 +1,22 @@
+Feature: The wrapper shows progress while it sets up telemetry
+
+  Between the path choice and the launch, `langwatch <tool>` can reach the
+  control plane: it confirms the cached ingest key is still live, and after
+  a logout it mints a fresh one. That work used to run in silence right
+  after the "langwatch saved" line, long enough to read as a hang and make
+  the user reach for Ctrl+C.
+
+  Rule: network setup is never silent
+
+    @unit
+    Scenario: Mode resolution runs behind a spinner
+      Given `langwatch claude` resolving its telemetry mode
+      When the resolution is in flight
+      Then a spinner says telemetry is being set up
+      And the spinner is gone before the wrapper prints its feedback lines
+
+    @unit
+    Scenario: The spinner is gone before an error is reported
+      Given `langwatch claude` resolving its telemetry mode
+      When the resolution fails
+      Then the spinner is stopped before the failure is printed

--- a/specs/api-keys/ingest-key-rotation-latency.feature
+++ b/specs/api-keys/ingest-key-rotation-latency.feature
@@ -1,0 +1,50 @@
+Feature: An ingestion-key rotation answers within one convergence window
+
+  Rotating an ingestion key rides the grants ledger: revoke the prior key's
+  bindings, delete its private role, define the new key's role, attach the
+  new key's binding. Every one of those writes used to hold the request
+  until the grants projection landed it, and the organization's ledger
+  queue delivers writes in order, so one rotation stacked up to four full
+  fold pickup cycles. The first `langwatch claude` after a logout sat well
+  over twenty seconds on that one mint request, with no feedback.
+
+  Only the last write of a chain needs the hold. The queue is FIFO per
+  organization, so the final write's projection landing proves every
+  earlier write of the same request landed too. The intermediate writes
+  stay durable either way; skipping their holds changes when the request
+  answers, never what the fold applies.
+
+  Background:
+    Given an organization whose writes ride the grants ledger
+
+  Rule: a request chains its ledger writes behind one hold, not one each
+
+    @unit
+    Scenario: Defining a role can leave the hold to a later write
+      Given a caller that follows the role definition with an awaited write
+        on the same organization's queue
+      When the role is defined without its own projection hold
+      Then the definition command is still appended
+      And the request does not poll for the role row
+
+    @unit
+    Scenario: Deleting a role can leave the hold to a later write
+      Given a caller that follows the role deletion with an awaited write
+        on the same organization's queue
+      When the role is deleted without its own projection hold
+      Then the deletion command is still appended
+      And the request does not poll for the role row's disappearance
+
+    @unit
+    Scenario: A restricted key's private role rides the grant attach's hold
+      Given a restricted API key create with custom permissions
+      When the key is created
+      Then the private role definition carries no projection hold of its own
+      And the grant attach that follows it holds as before
+
+    @unit
+    Scenario: A hard-cut rotation holds once, on the new key's grants
+      Given a live ingestion key for the same project and source type
+      When the key is rotated
+      Then the prior key's revocation carries no projection hold of its own
+      And the prior key is revoked on the key row itself either way

--- a/specs/api-keys/ingest-key-rotation-latency.feature
+++ b/specs/api-keys/ingest-key-rotation-latency.feature
@@ -3,44 +3,37 @@ Feature: An ingestion-key rotation answers within one convergence window
   Rotating an ingestion key rides the grants ledger: revoke the prior key's
   bindings, delete its private role, define the new key's role, attach the
   new key's binding. Every one of those writes used to hold the request
-  until the grants projection landed it, and the organization's ledger
-  queue delivers writes in order, so one rotation stacked up to four full
-  fold pickup cycles. The first `langwatch claude` after a logout sat well
-  over twenty seconds on that one mint request, with no feedback.
+  until the grants projection landed it, so one rotation stacked several
+  full fold pickup cycles. The first `langwatch claude` after a logout sat
+  well over twenty seconds on that one mint request, with no feedback.
 
-  Only the last write of a chain needs the hold. The queue is FIFO per
-  organization, so the final write's projection landing proves every
-  earlier write of the same request landed too. The intermediate writes
-  stay durable either way; skipping their holds changes when the request
-  answers, never what the fold applies.
+  A hold earns its place only where the request, or the write after it,
+  reads what the fold wrote. Deleting the prior key's private role is not
+  such a write: the key row is revoked imperatively, so the credential is
+  dead on the next read, and the role is named after that key id, so the
+  new key's role never waits for the name. Defining the new key's role is
+  such a write: the binding attached right after carries a foreign key to
+  the role row. Commands are queued per command name rather than per
+  organization, so no ordering between two different commands can stand in
+  for a hold.
 
   Background:
     Given an organization whose writes ride the grants ledger
 
-  Rule: a request chains its ledger writes behind one hold, not one each
+  Rule: a request holds where a later read needs the fold, and nowhere else
 
     @unit
-    Scenario: Defining a role can leave the hold to a later write
-      Given a caller that follows the role definition with an awaited write
-        on the same organization's queue
-      When the role is defined without its own projection hold
-      Then the definition command is still appended
-      And the request does not poll for the role row
-
-    @unit
-    Scenario: Deleting a role can leave the hold to a later write
-      Given a caller that follows the role deletion with an awaited write
-        on the same organization's queue
+    Scenario: Deleting a role that nothing reads again can skip the hold
+      Given a caller that only needs the role retired
       When the role is deleted without its own projection hold
       Then the deletion command is still appended
       And the request does not poll for the role row's disappearance
 
     @unit
-    Scenario: A restricted key's private role rides the grant attach's hold
+    Scenario: A restricted key's private role lands before its binding attaches
       Given a restricted API key create with custom permissions
       When the key is created
-      Then the private role definition carries no projection hold of its own
-      And the grant attach that follows it holds as before
+      Then the private role definition finishes before the binding attaches
 
     @unit
     Scenario: A hard-cut rotation holds once, on the new key's grants

--- a/specs/api-keys/ingest-key-rotation-latency.feature
+++ b/specs/api-keys/ingest-key-rotation-latency.feature
@@ -1,43 +1,35 @@
-Feature: An ingestion-key rotation answers within one convergence window
+Feature: An ingestion-key rotation answers as soon as the new key works
 
-  Rotating an ingestion key rides the grants ledger: revoke the prior key's
-  bindings, delete its private role, define the new key's role, attach the
-  new key's binding. Every one of those writes used to hold the request
-  until the grants projection landed it, so one rotation stacked several
-  full fold pickup cycles. The first `langwatch claude` after a logout sat
-  well over twenty seconds on that one mint request, with no feedback.
+  The first `langwatch claude` after a logout rotates the project's ingestion
+  key. That request used to sit in silence well over twenty seconds before it
+  handed the token back, long enough that the user reached for Ctrl+C.
 
-  A hold earns its place only where the request, or the write after it,
-  reads what the fold wrote. Deleting the prior key's private role is not
-  such a write: the key row is revoked imperatively, so the credential is
-  dead on the next read, and the role is named after that key id, so the
-  new key's role never waits for the name. Defining the new key's role is
-  such a write: the binding attached right after carries a foreign key to
-  the role row. Commands are queued per command name rather than per
-  organization, so no ordering between two different commands can stand in
-  for a hold.
+  A rotation does two things: it retires the credential that was there, and it
+  issues the one that replaces it. The user waits for the second. Waiting for
+  the cleanup of the first buys the user nothing, because the old token is
+  already refused by then.
 
   Background:
     Given an organization whose writes ride the grants ledger
 
-  Rule: a request holds where a later read needs the fold, and nowhere else
+  Rule: a rotation answers on the new key, not on the cleanup of the old one
 
     @unit
-    Scenario: Deleting a role that nothing reads again can skip the hold
-      Given a caller that only needs the role retired
-      When the role is deleted without its own projection hold
-      Then the deletion command is still appended
-      And the request does not poll for the role row's disappearance
+    Scenario: Retiring the old key's private role does not hold the answer
+      Given a role that nothing reads again once it is retired
+      When the role is retired
+      Then the retirement is recorded
+      And the caller is not held until it takes effect
 
     @unit
-    Scenario: A restricted key's private role lands before its binding attaches
+    Scenario: A new restricted key is usable the moment it is returned
       Given a restricted API key create with custom permissions
       When the key is created
-      Then the private role definition finishes before the binding attaches
+      Then its private permissions exist before the key is granted them
 
     @unit
-    Scenario: A hard-cut rotation holds once, on the new key's grants
+    Scenario: Rotating a key answers without waiting on the old key's cleanup
       Given a live ingestion key for the same project and source type
       When the key is rotated
-      Then the prior key's revocation carries no projection hold of its own
-      And the prior key is revoked on the key row itself either way
+      Then the old token is refused from that moment on
+      And the request is not held until the old key's cleanup takes effect


### PR DESCRIPTION
## The problem

The first `langwatch claude` after a logout sits in silence right after the "langwatch saved" line, long enough that the user reaches for Ctrl+C. Measured against production: the ingestion-key mint request alone takes **14.9 seconds** on a fresh mint, and more after a logout.

The stall is the grants ledger's read-your-writes hold, stacked. A rotation makes these ledger writes in one request:

1. revoke the prior key's bindings (never held)
2. delete its private role
3. define the new key's role
4. attach the new key's binding

Writes 2, 3 and 4 each held the request until the grants projection landed the row, and each hold pays a full fold pickup cycle (the fold's fallback poll is 5 seconds).

## The fix

A hold earns its place only where the request, or the write right after it, reads what the fold wrote.

- `deleteRole` gains the `awaitProjection` option `attachBindings` already had. Default stays `true`; every existing caller keeps its hold.
- The hard-cut rotation (`IngestionKeyService.ensureForProject`) revokes the prior key without a hold. The prior key's row is revoked imperatively, so the credential is dead on the next read regardless, and the retired role is named after that key id (`apikey:<id>`), so the new key's role never waits for the name to come free.
- `defineRole` keeps its hold. The private role is a foreign key target for the binding attached right after it, so the role row has to be projected first.
- The wrapper shows a spinner ("Setting up telemetry for claude...") while it sets the tool up against the control plane. It stops before any feedback or error prints, and leaves stdin cooked so Ctrl+C still works (same trap login-flow documents).

Net effect: one fewer projection hold per rotation, plus visible progress while the rest runs.

## Why not skip the role definition's hold too

The first version of this PR skipped it, on the argument that the organization's ledger queue is FIFO so the grant attach's hold covers the role definition as well. That argument is wrong, and CodeRabbit caught it. `QueueManager.buildGroupKey` builds a command job's group key as `${tenantId}/command/${cmdName}/${aggregateType}:${aggregateId}` unless the command opts into `serializeByAggregate`, which the authz-grants pipeline does not. `defineRoles` and `attachGrants` therefore sit in different queue groups with no ordering between them, and the attach can be picked up first. The binding row carries a foreign key to `CustomRole`, so that ordering would make the compat binding write fail and the attach's own hold spin to its timeout.

Making the premise true is possible: registering the authz-grants commands with `serializeByAggregate` would put every command for one organization in one FIFO group, which is what the pipeline docstring already claims it does. That changes queue behavior for the whole authz pipeline, including the migration backfill, so it belongs in its own change rather than riding a latency fix.

## Why the fold is slow at all

The remaining holds still cost about 5 to 7 seconds each in production, which points at the fold consumer riding its 5 second BRPOP fallback instead of the push wake signal. That is a separate investigation on the queue side; this PR removes one hold and the silence.

## Specs and tests

- `specs/api-keys/ingest-key-rotation-latency.feature` (3 scenarios) and `specs/ai-governance/cli-wrappers/wrapper-setup-feedback.feature` (2 scenarios), all bound.
- Ledger: a deletion without a hold still appends its command and never polls.
- API key service: the restricted create finishes the role definition before it attaches the binding (order assertion, so the foreign key ordering is pinned); a revoke with the hold skipped threads it to the role deletion and still revokes the key row.
- Ingestion key rotation: the revoke of the prior key carries `awaitProjection: false` and precedes the mint.
- Wrapper: the spinner starts before the step, is stopped before the result or the error surfaces, and is created with `discardStdin: false`.

## Checks run

- `pnpm typecheck:all` (app) and `pnpm typecheck` (TypeScript SDK): clean
- platform suites for every touched directory: 903 tests green; SDK governance suite: 716 green
- biome new-violations gate against the merge base: 0 new
- feature parity: whole repo OK, both new files fully bound


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reduced delays during ingestion-key rotation by avoiding unnecessary authorization projection waits.
  * Ensured replacement keys are usable before rotation completes, while retired keys are refused immediately.
  * Preserved authorization consistency by completing required permission setup before restricted-key binding.
  * Added spinner feedback during CLI telemetry setup, including retries and failures.

* **Bug Fixes**
  * Ensured CLI spinners stop before success or error messages appear.

* **Tests**
  * Added coverage for key rotation, API-key revocation, authorization updates, and CLI setup feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->