### PR TITLE
fix(cli): the session-context hook follows a native worktree switch

### DIFF
--- a/docs/integration/tools/integrations/claude-code.mdx
+++ b/docs/integration/tools/integrations/claude-code.mdx
@@ -122,6 +122,20 @@ Open your personal page at `/me`, or open the project you pinned Claude Code to.
 
 Your agent can read all of this back. See [Explore your usage with your own agent](/ai-governance/explore-your-usage-with-your-own-agent).
 
+### Attribute sessions to pull requests
+
+LangWatch joins a session to a pull request through the repository and branch the session reports. The session reports the directory it is working in, read at the start of the session and again after every turn. Two rules follow from how Claude Code tracks that directory:
+
+- A `cd` inside the Bash tool does not move the session. The session still reports the directory it was launched in.
+- A native switch with the EnterWorktree tool does move the session. From then on it reports the repository and branch of the worktree it entered.
+
+So to get a session attributed to the pull request it works on, either start Claude Code inside a checkout of that branch, or have the session switch natively:
+
+1. Create a worktree for the branch: `git -C <repo> fetch origin <branch> && git -C <repo> worktree add .claude/worktrees/<name> <branch>`
+2. Ask the session to call the EnterWorktree tool with that worktree's path.
+
+A long-lived session that picks up several pull requests should switch this way each time it moves to the next one. Work done from a directory outside any checkout, for example reviewing with `gh` commands from a home directory, attaches to no repository and no pull request, and its token cost cannot be attributed. The per pull request rollup is available over the API as [Get pull request coding agent usage](/api-reference/coding-agents/get-pull-request-coding-agent-usage).
+
 ## Content and privacy
 
 The setup that `langwatch claude` and `langwatch instrument claude` write turns on the four Claude Code content flags, because the content is what makes a trace worth reading:

--- a/docs/integration/tools/integrations/openai-codex.mdx
+++ b/docs/integration/tools/integrations/openai-codex.mdx
@@ -126,6 +126,10 @@ Open your personal page at `/me`, or open the project you pinned Codex to.
 
 Your agent can read all of this back. See [Explore your usage with your own agent](/ai-governance/explore-your-usage-with-your-own-agent).
 
+### Attribute sessions to pull requests
+
+LangWatch joins a session to a pull request through the repository and branch the session reports. Codex records the directory once, when the session starts, so the attribution follows the directory `codex` was started in. A `cd` inside the session does not change it. To get a session attributed to the pull request it works on, start `codex` inside a checkout of that branch. A session started outside any checkout, for example a home directory, attaches to no repository and no pull request. The per pull request rollup is available over the API as [Get pull request coding agent usage](/api-reference/coding-agents/get-pull-request-coding-agent-usage).
+
 ## Content and privacy
 
 Content reaches LangWatch on one path only, and you can turn that path off. Codex's own OpenTelemetry export carries no conversation content; the `notify` program LangWatch installs does send it. Read both parts below before you decide.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -32074,6 +32074,20 @@ Open your personal page at `/me`, or open the project you pinned Claude Code to.
 
 Your agent can read all of this back. See [Explore your usage with your own agent](/ai-governance/explore-your-usage-with-your-own-agent).
 
+### Attribute sessions to pull requests
+
+LangWatch joins a session to a pull request through the repository and branch the session reports. The session reports the directory it is working in, read at the start of the session and again after every turn. Two rules follow from how Claude Code tracks that directory:
+
+- A `cd` inside the Bash tool does not move the session. The session still reports the directory it was launched in.
+- A native switch with the EnterWorktree tool does move the session. From then on it reports the repository and branch of the worktree it entered.
+
+So to get a session attributed to the pull request it works on, either start Claude Code inside a checkout of that branch, or have the session switch natively:
+
+1. Create a worktree for the branch: `git -C <repo> fetch origin <branch> && git -C <repo> worktree add .claude/worktrees/<name> <branch>`
+2. Ask the session to call the EnterWorktree tool with that worktree's path.
+
+A long-lived session that picks up several pull requests should switch this way each time it moves to the next one. Work done from a directory outside any checkout, for example reviewing with `gh` commands from a home directory, attaches to no repository and no pull request, and its token cost cannot be attributed. The per pull request rollup is available over the API as [Get pull request coding agent usage](/api-reference/coding-agents/get-pull-request-coding-agent-usage).
+
 ## Content and privacy
 
 The setup that `langwatch claude` and `langwatch instrument claude` write turns on the four Claude Code content flags, because the content is what makes a trace worth reading:
@@ -32642,6 +32656,10 @@ Open your personal page at `/me`, or open the project you pinned Codex to.
 - **Content**: the prompt of each turn, each tool call with its result, and the answer of the model.
 
 Your agent can read all of this back. See [Explore your usage with your own agent](/ai-governance/explore-your-usage-with-your-own-agent).
+
+### Attribute sessions to pull requests
+
+LangWatch joins a session to a pull request through the repository and branch the session reports. Codex records the directory once, when the session starts, so the attribution follows the directory `codex` was started in. A `cd` inside the session does not change it. To get a session attributed to the pull request it works on, start `codex` inside a checkout of that branch. A session started outside any checkout, for example a home directory, attaches to no repository and no pull request. The per pull request rollup is available over the API as [Get pull request coding agent usage](/api-reference/coding-agents/get-pull-request-coding-agent-usage).
 
 ## Content and privacy
 

--- a/sdks/typescript/src/cli/commands/ingestion/__tests__/hook-harness.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/__tests__/hook-harness.ts
@@ -96,6 +96,8 @@ export interface RunHookOptions {
   readInput?: () => Promise<string>;
   env?: NodeJS.ProcessEnv;
   git?: Record<string, string>;
+  /** Full control over git answers, for runs where the directory matters. */
+  runGit?: GitRunner;
   fetchImpl?: typeof fetch;
   now?: number;
   tool?: string;
@@ -185,6 +187,7 @@ export const installHookHarness = (): HookHarness => {
       readInput,
       env = {},
       git = WORKTREE_GIT,
+      runGit,
       fetchImpl = collector(),
       now = NOW,
       tool = "claude-code",
@@ -203,7 +206,7 @@ export const installHookHarness = (): HookHarness => {
             Promise.resolve(
               typeof input === "string" ? input : JSON.stringify(input),
             )),
-        runGit: gitRunner(git),
+        runGit: runGit ?? gitRunner(git),
         fetchImpl,
         now: () => now,
         stateDir,

--- a/sdks/typescript/src/cli/commands/ingestion/__tests__/hook.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/__tests__/hook.unit.test.ts
@@ -82,6 +82,57 @@ describe("the session context hook", () => {
       expect(attributes).not.toHaveProperty("vcs.ref.head.name");
       expect(attributes).not.toHaveProperty("vcs.worktree.name");
     });
+
+    /** @scenario "A native worktree switch changes the reported checkout" */
+    it("reports the payload's cwd over the launch directory variable", async () => {
+      const byDirectory: Record<string, Record<string, string>> = {
+        "/launch/checkout": {
+          "remote get-url origin": "git@github.com:langwatch/langwatch.git",
+          "branch --show-current": "main",
+          "rev-parse --git-dir": "/launch/checkout/.git",
+          "rev-parse --git-common-dir": "/launch/checkout/.git",
+        },
+        "/repo/worktrees/pr-123": {
+          "remote get-url origin": "git@github.com:langwatch/langwatch.git",
+          "branch --show-current": "fix/the-pr-branch",
+          "rev-parse --git-dir": "/repo/.git/worktrees/pr-123",
+          "rev-parse --git-common-dir": "/repo/.git",
+          "rev-parse --show-toplevel": "/repo/worktrees/pr-123",
+        },
+      };
+      await hook.runHook({
+        input: { session_id: SESSION_ID, cwd: "/repo/worktrees/pr-123" },
+        env: { CLAUDE_PROJECT_DIR: "/launch/checkout" },
+        runGit: ({ args, cwd }) => byDirectory[cwd]?.[args.join(" ")] ?? null,
+      });
+
+      expect(attributesOf(posted[0]!)).toMatchObject({
+        "vcs.ref.head.name": "fix/the-pr-branch",
+        "vcs.worktree.name": "pr-123",
+      });
+    });
+
+    /** @scenario "A payload with no cwd falls back to the launch directory" */
+    it("reads the launch directory variable when the payload has no cwd", async () => {
+      await hook.runHook({
+        input: { session_id: SESSION_ID },
+        env: { CLAUDE_PROJECT_DIR: "/launch/checkout" },
+        runGit: ({ args, cwd }) =>
+          cwd === "/launch/checkout"
+            ? {
+                "remote get-url origin":
+                  "git@github.com:langwatch/langwatch.git",
+                "branch --show-current": "main",
+                "rev-parse --git-dir": "/launch/checkout/.git",
+                "rev-parse --git-common-dir": "/launch/checkout/.git",
+              }[args.join(" ")] ?? null
+            : null,
+      });
+
+      expect(attributesOf(posted[0]!)).toMatchObject({
+        "vcs.ref.head.name": "main",
+      });
+    });
   });
 
   describe("given a session claude holds a name for", () => {

--- a/sdks/typescript/src/cli/commands/ingestion/hook.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/hook.ts
@@ -84,9 +84,13 @@ import {
  * `CLAUDE_PROJECT_DIR` in its environment, and reading either would report the
  * wrong session, on the wrong checkout, under the wrong agent.
  *
- * `projectDirVar` matters because a session can `cd` away from where it
- * started: Claude Code exports the root it was launched in, so that beats the
- * payload's `cwd`. Codex and opencode publish no such variable, and their
+ * The payload's `cwd` beats `projectDirVar`. Claude Code's payload `cwd` is
+ * the harness's own working directory: a `cd` inside the Bash tool never moves
+ * it, and a native worktree switch (EnterWorktree) does. `CLAUDE_PROJECT_DIR`
+ * stays pinned to the directory the session was launched in, so preferring it
+ * would keep reporting the launch checkout after the session moved into a
+ * worktree to work on another branch. It remains the fallback for a payload
+ * with no `cwd`. Codex and opencode publish no such variable, and their
  * payload `cwd` is already the session's own directory.
  */
 const TOOLS: Record<
@@ -227,7 +231,7 @@ async function runHook({
   });
 
   const projectDir = spec.projectDirVar ? env[spec.projectDirVar] : undefined;
-  const directory = firstNonEmpty(projectDir, input.cwd) ?? process.cwd();
+  const directory = firstNonEmpty(input.cwd, projectDir) ?? process.cwd();
   // The session's own name, as claude itself holds it. The SessionStart
   // payload carries it at start; the live registry is what makes a
   // mid-session /rename observable from the Stop hook, which runs after

--- a/specs/ai-governance/cli-wrappers/session-context-hook.feature
+++ b/specs/ai-governance/cli-wrappers/session-context-hook.feature
@@ -158,6 +158,18 @@ Rule: The hook reports the git identity of the session
     Then a new record is posted with the new branch
 
   @unit
+  Scenario: A native worktree switch changes the reported checkout
+    Given a Claude Code session launched in one checkout
+    When a Stop invocation's payload cwd names a different worktree of the repository
+    Then the record reports the worktree the payload names, not the launch directory
+
+  @unit
+  Scenario: A payload with no cwd falls back to the launch directory
+    Given a Claude Code invocation whose payload carries only the session id
+    When the hook runs with CLAUDE_PROJECT_DIR set
+    Then the record reports the git identity of that directory
+
+  @unit
   Scenario: Two agents reporting the same session id keep separate fingerprints
     Given a session id already reported for one agent
     When another agent reports the same session id


### PR DESCRIPTION
## What

`langwatch ingest hook claude-code` preferred `CLAUDE_PROJECT_DIR` over the hook payload's `cwd`. `CLAUDE_PROJECT_DIR` stays pinned to the directory the session was launched in, so a session that moved into a worktree with the native EnterWorktree tool kept reporting the launch checkout, on the launch branch, for its whole life.

## Why it matters

Pull-request attribution joins a session to a pull request through the repository and branch the session reports. Agent sessions that pick up a pull request in a worktree never reported that branch, so their sessions and token cost never attached to any pull request.

## How

The payload's `cwd` is the harness's own working directory: a `cd` inside the Bash tool never moves it (verified against Claude Code 2.1.238, the Stop payload keeps the launch directory after `cd /tmp`), and a native EnterWorktree switch does move it (verified, the Stop payload carries the worktree path). So the hook now prefers the payload's `cwd` and keeps `CLAUDE_PROJECT_DIR` only as the fallback for a payload with no `cwd`. Codex and opencode already used the payload's `cwd` and are unchanged.

## Verified end to end

On the agents box, a session launched in a non-git workspace directory, switched natively into a nested-clone worktree checked out on an open PR's branch, posted:

```
github.com/langwatch/langwatch@issue7391/inventory-unification#pr-7394
```

and the platform created the branch-to-PR mapping for PR 7394 from it.

## Spec

`specs/ai-governance/cli-wrappers/session-context-hook.feature`:
- "A native worktree switch changes the reported checkout" (@unit, bound)
- "A payload with no cwd falls back to the launch directory" (@unit, bound)

## Tests

- `sdks/typescript`: ingestion suite 74/74, feature parity green.

https://claude.ai/code/session_01BUKKUiZbSBHmrLK9JJj4Ba


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session context now uses the payload’s checkout directory when available, ensuring branch and worktree details are reported correctly.
  * Falls back to the configured project directory when no checkout directory is provided.

* **Documentation**
  * Added guidance on attributing Claude Code and Codex sessions to repositories and pull requests, including worktree setup and directory behavior.

* **Tests**
  * Added coverage for payload-provided and fallback checkout directory scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->