### PR TITLE
feat(navigation): project and scope selector search, and a phone-width chrome

### DIFF
--- a/platform/app/src/components/settings/ScopeChipPicker.tsx
+++ b/platform/app/src/components/settings/ScopeChipPicker.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   createListCollection,
   HStack,
+  Input,
   Text,
   VStack,
   Wrap,
@@ -12,6 +13,7 @@ import {
   Building2,
   CheckCheck,
   Folder,
+  Search,
   UserLock,
   Users,
 } from "lucide-react";
@@ -160,6 +162,109 @@ const ScopeIcon = ({ scopeType }: { scopeType: ScopeChipPickerScopeType }) => {
   if (scopeType === "DEPARTMENT") return <Boxes size={16} aria-hidden />;
   return <Folder size={16} aria-hidden />;
 };
+
+/**
+ * Above this many options the dropdown gains a search field: a scope
+ * list that long no longer reads at a glance, so finding beats reading.
+ */
+const SCOPE_SEARCH_THRESHOLD = 8;
+
+/**
+ * The search field pinned to the top of a long scope dropdown.
+ *
+ * Spec: specs/components/scope-chip-picker-search.feature
+ */
+function ScopeSearchField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <Box
+      position="sticky"
+      top={0}
+      zIndex={1}
+      background="bg.panel"
+      paddingX={2.5}
+      paddingY={1.5}
+      borderBottomWidth="1px"
+      borderColor="border"
+    >
+      <HStack gap={2} color="fg.muted">
+        <Search size={14} aria-hidden />
+        <Input
+          placeholder="Search scopes"
+          aria-label="Search scopes"
+          size="sm"
+          height="28px"
+          minWidth={0}
+          flex={1}
+          padding={0}
+          border={0}
+          outline="none"
+          background="transparent"
+          color="fg"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          _placeholder={{ color: "fg.subtle" }}
+          _focusVisible={{ outline: "none" }}
+        />
+      </HStack>
+    </Box>
+  );
+}
+
+/**
+ * Groups the PROJECT options under their parent team so a long project
+ * list stays organised. Projects whose team the caller did not list fall
+ * into a flat "Projects" group, which is also what every project gets
+ * when the caller passes no team data at all.
+ */
+function groupProjectOptions({
+  projectOptions,
+  availableTeams,
+  availableProjects,
+}: {
+  projectOptions: ScopeOption[];
+  availableTeams: Array<{ id: string; name: string }> | undefined;
+  availableProjects: Array<{ id: string; teamId?: string }> | undefined;
+}): {
+  teamGroups: Array<{
+    teamId: string;
+    teamName: string;
+    projects: ScopeOption[];
+  }>;
+  orphanProjects: ScopeOption[];
+} {
+  const teamNameById = new Map(
+    (availableTeams ?? []).map((t) => [t.id, t.name] as const),
+  );
+  const teamIdByProjectId = new Map(
+    (availableProjects ?? []).map((p) => [p.id, p.teamId] as const),
+  );
+  const projectsByTeam = new Map<string, ScopeOption[]>();
+  const orphanProjects: ScopeOption[] = [];
+  for (const option of projectOptions) {
+    const teamId = teamIdByProjectId.get(option.scopeId);
+    if (teamId && teamNameById.has(teamId)) {
+      const bucket = projectsByTeam.get(teamId) ?? [];
+      bucket.push(option);
+      projectsByTeam.set(teamId, bucket);
+    } else {
+      orphanProjects.push(option);
+    }
+  }
+  const teamGroups = Array.from(projectsByTeam.entries())
+    .map(([teamId, projects]) => ({
+      teamId,
+      teamName: teamNameById.get(teamId) ?? "Team",
+      projects,
+    }))
+    .sort((a, b) => a.teamName.localeCompare(b.teamName));
+  return { teamGroups, orphanProjects };
+}
 
 /**
  * Collapses redundant selections after the user picks a new scope.
@@ -511,9 +616,32 @@ export function ScopeChipPicker<
     personalScopes,
   ]);
 
+  // The search filter over a long option list. Matches an option's own
+  // label and, for a project, its parent team's name, so "platform"
+  // finds every project of the Platform team.
+  const [scopeSearch, setScopeSearch] = useState("");
+  const showSearch = options.length > SCOPE_SEARCH_THRESHOLD;
+  const visibleOptions = useMemo(() => {
+    const needle = scopeSearch.trim().toLowerCase();
+    if (!showSearch || !needle) return options;
+    const teamNameById = new Map(
+      (availableTeams ?? []).map((t) => [t.id, t.name] as const),
+    );
+    const teamIdByProjectId = new Map(
+      (availableProjects ?? []).map((p) => [p.id, p.teamId] as const),
+    );
+    return options.filter((option) => {
+      const teamName =
+        option.scopeType === "PROJECT"
+          ? teamNameById.get(teamIdByProjectId.get(option.scopeId) ?? "")
+          : undefined;
+      return `${teamName ?? ""} ${option.label}`.toLowerCase().includes(needle);
+    });
+  }, [options, scopeSearch, showSearch, availableTeams, availableProjects]);
+
   const collection = useMemo(
-    () => createListCollection({ items: options }),
-    [options],
+    () => createListCollection({ items: visibleOptions }),
+    [visibleOptions],
   );
 
   // In single-scope mode the picker represents exactly one scope, so the
@@ -589,6 +717,15 @@ export function ScopeChipPicker<
     ? false
     : !showQuickPicks || multipleMode;
 
+  // The chips-variant dropdown lists projects under their team's name;
+  // computed here so the early single-select return keeps its own copy.
+  const { teamGroups: chipTeamGroups, orphanProjects: chipOrphanProjects } =
+    groupProjectOptions({
+      projectOptions: visibleOptions.filter((o) => o.scopeType === "PROJECT"),
+      availableTeams,
+      availableProjects,
+    });
+
   if (variant === "single-select") {
     const selected = scopes[0] ?? null;
     const selectedOption = selected
@@ -598,34 +735,20 @@ export function ScopeChipPicker<
     // Group PROJECT options under their parent team so the list stays organised
     // even with many projects across teams. Non-project options (org / team /
     // department) keep their own flat groups.
-    const teamNameById = new Map(
-      (availableTeams ?? []).map((t) => [t.id, t.name] as const),
+    const { teamGroups, orphanProjects } = groupProjectOptions({
+      projectOptions: visibleOptions.filter((o) => o.scopeType === "PROJECT"),
+      availableTeams,
+      availableProjects,
+    });
+    const orgOptions = visibleOptions.filter(
+      (o) => o.scopeType === "ORGANIZATION",
     );
-    const teamIdByProjectId = new Map(
-      (availableProjects ?? []).map((p) => [p.id, p.teamId] as const),
+    const deptOptions = visibleOptions.filter(
+      (o) => o.scopeType === "DEPARTMENT",
     );
-    const projectsByTeam = new Map<string, ScopeOption[]>();
-    const orphanProjects: ScopeOption[] = [];
-    for (const option of options.filter((o) => o.scopeType === "PROJECT")) {
-      const teamId = teamIdByProjectId.get(option.scopeId);
-      if (teamId && teamNameById.has(teamId)) {
-        const bucket = projectsByTeam.get(teamId) ?? [];
-        bucket.push(option);
-        projectsByTeam.set(teamId, bucket);
-      } else {
-        orphanProjects.push(option);
-      }
-    }
-    const teamGroups = Array.from(projectsByTeam.entries())
-      .map(([teamId, projects]) => ({
-        teamId,
-        teamName: teamNameById.get(teamId) ?? "Team",
-        projects,
-      }))
-      .sort((a, b) => a.teamName.localeCompare(b.teamName));
-    const orgOptions = options.filter((o) => o.scopeType === "ORGANIZATION");
-    const deptOptions = options.filter((o) => o.scopeType === "DEPARTMENT");
-    const teamScopeOptions = options.filter((o) => o.scopeType === "TEAM");
+    const teamScopeOptions = visibleOptions.filter(
+      (o) => o.scopeType === "TEAM",
+    );
     const fallbackPlaceholder = placeholder ?? "Select an option";
 
     return (
@@ -634,6 +757,9 @@ export function ScopeChipPicker<
         <Select.Root
           collection={collection}
           value={selected ? [entryKey(selected)] : []}
+          onOpenChange={(details) => {
+            if (details.open) setScopeSearch("");
+          }}
           onValueChange={(details) => {
             const pickedValue = details.value[0];
             const option = pickedValue
@@ -667,6 +793,14 @@ export function ScopeChipPicker<
             </Select.ValueText>
           </Select.Trigger>
           <Select.Content>
+            {showSearch && (
+              <ScopeSearchField value={scopeSearch} onChange={setScopeSearch} />
+            )}
+            {visibleOptions.length === 0 && (
+              <Text paddingX={3} paddingY={2} fontSize="sm" color="fg.muted">
+                No scopes match your search.
+              </Text>
+            )}
             {orgOptions.length > 0 && (
               <Select.ItemGroup label="Organization">
                 {orgOptions.map((option) => (
@@ -800,6 +934,9 @@ export function ScopeChipPicker<
           collection={collection}
           value={selectedValues}
           multiple
+          onOpenChange={(details) => {
+            if (details.open) setScopeSearch("");
+          }}
           onValueChange={(details) => {
             const picked = new Set(details.value);
             const next = options
@@ -845,11 +982,19 @@ export function ScopeChipPicker<
             </Select.ValueText>
           </Select.Trigger>
           <Select.Content>
-            {options.some(
+            {showSearch && (
+              <ScopeSearchField value={scopeSearch} onChange={setScopeSearch} />
+            )}
+            {visibleOptions.length === 0 && (
+              <Text paddingX={3} paddingY={2} fontSize="sm" color="fg.muted">
+                No scopes match your search.
+              </Text>
+            )}
+            {visibleOptions.some(
               (o) => o.scopeType === "ORGANIZATION" && !o.personalOnly,
             ) && (
               <Select.ItemGroup label="Organization">
-                {options
+                {visibleOptions
                   .filter(
                     (o) => o.scopeType === "ORGANIZATION" && !o.personalOnly,
                   )
@@ -863,11 +1008,11 @@ export function ScopeChipPicker<
                   ))}
               </Select.ItemGroup>
             )}
-            {options.some(
+            {visibleOptions.some(
               (o) => o.scopeType === "DEPARTMENT" && !o.personalOnly,
             ) && (
               <Select.ItemGroup label="Departments">
-                {options
+                {visibleOptions
                   .filter(
                     (o) => o.scopeType === "DEPARTMENT" && !o.personalOnly,
                   )
@@ -881,9 +1026,9 @@ export function ScopeChipPicker<
                   ))}
               </Select.ItemGroup>
             )}
-            {options.some((o) => o.scopeType === "TEAM") && (
+            {visibleOptions.some((o) => o.scopeType === "TEAM") && (
               <Select.ItemGroup label="Teams">
-                {options
+                {visibleOptions
                   .filter((o) => o.scopeType === "TEAM")
                   .map((option) => (
                     <Select.Item key={option.value} item={option}>
@@ -895,23 +1040,35 @@ export function ScopeChipPicker<
                   ))}
               </Select.ItemGroup>
             )}
-            {options.some((o) => o.scopeType === "PROJECT") && (
+            {/* Projects list under their team's name so a long list stays
+                readable; projects without team data keep the flat group. */}
+            {chipTeamGroups.map((group) => (
+              <Select.ItemGroup key={group.teamId} label={group.teamName}>
+                {group.projects.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2} paddingLeft={2}>
+                      <ScopeIcon scopeType="PROJECT" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            ))}
+            {chipOrphanProjects.length > 0 && (
               <Select.ItemGroup label="Projects">
-                {options
-                  .filter((o) => o.scopeType === "PROJECT")
-                  .map((option) => (
-                    <Select.Item key={option.value} item={option}>
-                      <HStack gap={2}>
-                        <ScopeIcon scopeType="PROJECT" />
-                        <Text>{option.label}</Text>
-                      </HStack>
-                    </Select.Item>
-                  ))}
+                {chipOrphanProjects.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="PROJECT" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
               </Select.ItemGroup>
             )}
-            {options.some((o) => o.personalOnly) && (
+            {visibleOptions.some((o) => o.personalOnly) && (
               <Select.ItemGroup label="Personal projects">
-                {options
+                {visibleOptions
                   .filter((o) => o.personalOnly)
                   .map((option) => (
                     <Select.Item key={option.value} item={option}>

--- a/platform/app/src/components/settings/__tests__/ScopeChipPicker.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ScopeChipPicker.integration.test.tsx
@@ -8,7 +8,14 @@
  * the caller explicitly disallowed.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -200,6 +207,170 @@ describe("ScopeChipPicker single-select variant", () => {
       // org/team/project quick-pick buttons.
       expect(screen.queryByTestId("quick-scope-project")).toBeNull();
       expect(screen.queryByTestId("quick-scope-multiple")).toBeNull();
+    });
+  });
+});
+
+describe("ScopeChipPicker search and team grouping", () => {
+  afterEach(cleanup);
+
+  const teams = [
+    { id: "t-acme", name: "QA Shared Team" },
+    { id: "t-platform", name: "Platform Team" },
+  ];
+
+  /** Nine projects across two teams: with the org option, past the search threshold. */
+  const manyProjects = [
+    ...Array.from({ length: 7 }, (_, index) => ({
+      id: `p-qa-${index}`,
+      name: `qa-app-${index}`,
+      teamId: "t-acme",
+    })),
+    { id: "p-bill", name: "billing-svc", teamId: "t-platform" },
+    { id: "p-edge", name: "edge-router", teamId: "t-platform" },
+  ];
+
+  async function openDropdown() {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox"));
+    return user;
+  }
+
+  /** The dropdown list. Ark mirrors every label into a hidden native
+   *  `<select>`, so queries must stay inside the listbox. */
+  function listbox() {
+    return within(screen.getByRole("listbox"));
+  }
+
+  describe("given projects across two teams", () => {
+    /** @scenario Projects group under their team name */
+    it("lists each project under a group header carrying its team name", async () => {
+      renderPicker(
+        <ScopeChipPicker
+          value={[]}
+          onChange={vi.fn()}
+          organizationId="org-1"
+          organizationName="ACME Inc"
+          availableTeams={teams}
+          availableProjects={[
+            { id: "p-web", name: "web-app", teamId: "t-acme" },
+            { id: "p-bill", name: "billing-svc", teamId: "t-platform" },
+            { id: "p-lost", name: "orphan-app" },
+          ]}
+        />,
+      );
+      await openDropdown();
+
+      await waitFor(() => {
+        expect(listbox().getByText("web-app")).toBeInTheDocument();
+      });
+      const groups = listbox().getAllByRole("group");
+      const groupHolding = (label: string, item: string) =>
+        groups.some(
+          (group) =>
+            within(group).queryByText(label) !== null &&
+            within(group).queryByText(item) !== null,
+        );
+      expect(groupHolding("QA Shared Team", "web-app")).toBe(true);
+      expect(groupHolding("Platform Team", "billing-svc")).toBe(true);
+      // A project whose team is not listed keeps the flat group.
+      expect(groupHolding("Projects", "orphan-app")).toBe(true);
+    });
+  });
+
+  describe("given more than eight scopes", () => {
+    function renderCrowdedPicker(onChange = vi.fn()) {
+      renderPicker(
+        <ScopeChipPicker
+          value={[]}
+          onChange={onChange}
+          organizationId="org-1"
+          organizationName="ACME Inc"
+          availableTeams={teams}
+          availableProjects={manyProjects}
+        />,
+      );
+      return onChange;
+    }
+
+    /** @scenario A long scope list gets a search field */
+    it("shows a search field that narrows by name and team", async () => {
+      renderCrowdedPicker();
+      const user = await openDropdown();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Search scopes")).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText("Search scopes"), "platform");
+      await waitFor(() => {
+        expect(listbox().queryByText("qa-app-1")).not.toBeInTheDocument();
+      });
+      // Both Platform Team projects match through their team's name.
+      expect(listbox().getByText("billing-svc")).toBeInTheDocument();
+      expect(listbox().getByText("edge-router")).toBeInTheDocument();
+      expect(listbox().queryByText("ACME Inc")).not.toBeInTheDocument();
+    });
+
+    /** @scenario Searching does not drop scopes already selected */
+    it("keeps the selected scopes when a search picks another one", async () => {
+      const onChange = vi.fn();
+      renderPicker(
+        <ScopeChipPicker
+          value={[
+            { scopeType: "PROJECT", scopeId: "p-qa-0" },
+            { scopeType: "PROJECT", scopeId: "p-qa-1" },
+          ]}
+          onChange={onChange}
+          organizationId="org-1"
+          organizationName="ACME Inc"
+          availableTeams={teams}
+          availableProjects={manyProjects}
+        />,
+      );
+      const user = await openDropdown();
+
+      await user.type(screen.getByLabelText("Search scopes"), "billing");
+      await waitFor(() => {
+        expect(listbox().queryByText("qa-app-2")).not.toBeInTheDocument();
+      });
+      await user.click(listbox().getByText("billing-svc"));
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled();
+      });
+      const next = onChange.mock.calls.at(-1)?.[0];
+      expect(next).toEqual(
+        expect.arrayContaining([
+          { scopeType: "PROJECT", scopeId: "p-qa-0" },
+          { scopeType: "PROJECT", scopeId: "p-qa-1" },
+          { scopeType: "PROJECT", scopeId: "p-bill" },
+        ]),
+      );
+    });
+  });
+
+  describe("given eight scopes or fewer", () => {
+    /** @scenario A short scope list has no search field */
+    it("offers no search field", async () => {
+      renderPicker(
+        <ScopeChipPicker
+          value={[]}
+          onChange={vi.fn()}
+          organizationId="org-1"
+          organizationName="ACME Inc"
+          availableTeams={teams}
+          availableProjects={[
+            { id: "p-web", name: "web-app", teamId: "t-acme" },
+          ]}
+        />,
+      );
+      await openDropdown();
+
+      await waitFor(() => {
+        expect(listbox().getByText("web-app")).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText("Search scopes")).not.toBeInTheDocument();
     });
   });
 });

--- a/platform/app/src/components/settings/__tests__/ScopeChipPicker.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ScopeChipPicker.integration.test.tsx
@@ -265,16 +265,22 @@ describe("ScopeChipPicker search and team grouping", () => {
         expect(listbox().getByText("web-app")).toBeInTheDocument();
       });
       const groups = listbox().getAllByRole("group");
-      const groupHolding = (label: string, item: string) =>
+      const groupHolding = ({ label, item }: { label: string; item: string }) =>
         groups.some(
           (group) =>
             within(group).queryByText(label) !== null &&
             within(group).queryByText(item) !== null,
         );
-      expect(groupHolding("QA Shared Team", "web-app")).toBe(true);
-      expect(groupHolding("Platform Team", "billing-svc")).toBe(true);
+      expect(groupHolding({ label: "QA Shared Team", item: "web-app" })).toBe(
+        true,
+      );
+      expect(
+        groupHolding({ label: "Platform Team", item: "billing-svc" }),
+      ).toBe(true);
       // A project whose team is not listed keeps the flat group.
-      expect(groupHolding("Projects", "orphan-app")).toBe(true);
+      expect(groupHolding({ label: "Projects", item: "orphan-app" })).toBe(
+        true,
+      );
     });
   });
 
@@ -347,6 +353,51 @@ describe("ScopeChipPicker search and team grouping", () => {
           { scopeType: "PROJECT", scopeId: "p-bill" },
         ]),
       );
+    });
+  });
+
+  describe("given the single-select variant with more than eight scopes", () => {
+    /** @scenario The single-select dropdown searches the same way */
+    it("narrows by team name and takes the picked project", async () => {
+      const onChange = vi.fn();
+      renderPicker(
+        <ScopeChipPicker
+          variant="single-select"
+          value={[]}
+          onChange={onChange}
+          organizationId="org-1"
+          organizationName="ACME Inc"
+          availableTeams={teams}
+          availableProjects={manyProjects}
+          placeholder="Select a project"
+        />,
+      );
+      const user = await openDropdown();
+
+      await user.type(screen.getByLabelText("Search scopes"), "platform");
+      await waitFor(() => {
+        expect(listbox().queryByText("qa-app-1")).not.toBeInTheDocument();
+      });
+      // Both of the team's projects match through the team's name, and
+      // they stay under a group header carrying it.
+      expect(listbox().getByText("edge-router")).toBeInTheDocument();
+      expect(
+        listbox()
+          .getAllByRole("group")
+          .some(
+            (group) =>
+              within(group).queryByText("Platform Team") !== null &&
+              within(group).queryByText("billing-svc") !== null,
+          ),
+      ).toBe(true);
+
+      await user.click(listbox().getByText("billing-svc"));
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith([
+          { scopeType: "PROJECT", scopeId: "p-bill" },
+        ]);
+      });
     });
   });
 

--- a/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
@@ -472,6 +472,43 @@ describe("the mobile chrome", () => {
       expect(screen.getByTestId("page-body")).toBeInTheDocument();
     });
 
+    /** @scenario The overlay keeps the keyboard inside it */
+    it("marks the page behind it inert and wraps Tab inside itself", async () => {
+      const user = userEvent.setup();
+      renderShell();
+
+      await user.click(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+
+      // Everything the shell renders under the overlay is inert, so the
+      // page behind carries no tab stop and no reader can reach it.
+      const overlay = screen.getByTestId("mobile-menu-overlay");
+      expect(
+        screen.getByTestId("page-body").closest("[inert]"),
+      ).toBeInTheDocument();
+      expect(overlay.closest("[inert]")).toBeNull();
+
+      const focusable = Array.from(
+        overlay.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      const last = focusable.at(-1);
+      const first = focusable[0];
+      expect(last).toBeDefined();
+      last?.focus();
+
+      await user.tab();
+      expect(first).toHaveFocus();
+
+      await user.tab({ shift: true });
+      expect(last).toHaveFocus();
+    });
+
     /** @scenario Escape closes the overlay and returns focus to the menu button */
     it("closes on Escape and moves focus back to the menu button", async () => {
       const user = userEvent.setup();

--- a/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
@@ -509,6 +509,34 @@ describe("the mobile chrome", () => {
       expect(last).toHaveFocus();
     });
 
+    /** @scenario Escape closes only the menu on top */
+    it("leaves Escape to the menu the overlay opened", async () => {
+      mockOrganizations = [orgA, orgB];
+      const user = userEvent.setup();
+      renderShell();
+
+      await user.click(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "Switch organization" }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Beta Corp")).toBeInTheDocument();
+      });
+
+      await user.keyboard("{Escape}");
+
+      await waitFor(() => {
+        expect(screen.queryByText("Beta Corp")).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+    });
+
     /** @scenario Escape closes the overlay and returns focus to the menu button */
     it("closes on Escape and moves focus back to the menu button", async () => {
       const user = userEvent.setup();

--- a/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
@@ -405,7 +405,7 @@ describe("the mobile chrome", () => {
     });
 
     /** @scenario Navigating from the overlay closes it */
-    it("closes the overlay when the page underneath changes", async () => {
+    it("closes the overlay when a page is opened from it", async () => {
       const user = userEvent.setup();
       const view = renderShell();
 
@@ -415,6 +415,14 @@ describe("the mobile chrome", () => {
       await waitFor(() => {
         expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
       });
+
+      // Tap a real entry. jsdom cannot follow the anchor, so the route
+      // change the tap causes is applied to the mocked pathname by hand.
+      const overlay = within(screen.getByTestId("mobile-menu-overlay"));
+      const entry = overlay.getByRole("link", { name: /Analytics/ });
+      expect(entry).toHaveAttribute("href", "/demo/analytics");
+      entry.addEventListener("click", (event) => event.preventDefault());
+      await user.click(entry);
 
       mockNavPathname = "/demo/analytics";
       view.rerender(
@@ -431,6 +439,60 @@ describe("the mobile chrome", () => {
         ).not.toBeInTheDocument();
       });
       expect(screen.getByTestId("page-body")).toBeInTheDocument();
+    });
+
+    /** @scenario The close button dismisses the overlay without navigating */
+    it("closes when the close button is tapped and stays on the page", async () => {
+      const user = userEvent.setup();
+      renderShell();
+
+      await user.click(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("dialog", { name: "Navigation menu" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Close navigation menu" }),
+      ).toHaveFocus();
+
+      await user.click(
+        screen.getByRole("button", { name: "Close navigation menu" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("mobile-menu-overlay"),
+        ).not.toBeInTheDocument();
+      });
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("page-body")).toBeInTheDocument();
+    });
+
+    /** @scenario Escape closes the overlay and returns focus to the menu button */
+    it("closes on Escape and moves focus back to the menu button", async () => {
+      const user = userEvent.setup();
+      renderShell();
+
+      const menuButton = screen.getByRole("button", {
+        name: "Open navigation menu",
+      });
+      await user.click(menuButton);
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+
+      await user.keyboard("{Escape}");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("mobile-menu-overlay"),
+        ).not.toBeInTheDocument();
+      });
+      expect(menuButton).toHaveFocus();
     });
   });
 

--- a/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/MobileShell.integration.test.tsx
@@ -1,0 +1,463 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The navigation-v2 chrome on a phone-width viewport: the compact bar
+ * with the scope and the menu button, and the full-screen menu overlay,
+ * mounted through the real DashboardLayout dispatcher with the device
+ * on the product-switcher mode and the viewport mocked to phone width.
+ *
+ * Spec: specs/navigation/mobile-chrome.feature
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/[project]";
+let mockGovernanceFlagEnabled = true;
+const pushMock = vi.fn().mockResolvedValue(true);
+
+const teamA = {
+  id: "team_1",
+  name: "Core",
+  slug: "core",
+  isPersonal: false,
+  ownerUserId: null,
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  projects: [
+    { id: "project_1", slug: "demo", name: "Demo", isPersonal: false },
+    {
+      id: "project_2",
+      slug: "support-bot",
+      name: "Support Bot",
+      isPersonal: false,
+    },
+  ],
+};
+/** The reader's own workspace, which is what the Me pages resolve. */
+const personalTeam = {
+  id: "team_personal",
+  name: "Ada's Workspace",
+  slug: "personal-ada",
+  isPersonal: true,
+  ownerUserId: "user_1",
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  projects: [
+    {
+      id: "project_personal",
+      slug: "personal-ada-abc123",
+      name: "Personal Workspace",
+      isPersonal: true,
+    },
+  ],
+};
+const orgA = {
+  id: "org_1",
+  name: "ACME",
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  teams: [teamA, personalTeam],
+};
+/** The team the page being rendered resolves to. */
+let mockAmbientTeam: {
+  id: string;
+  name: string;
+  slug: string;
+  isPersonal: boolean;
+  ownerUserId: string | null;
+  members: Array<{ userId: string; role: string }>;
+  projects: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    isPersonal: boolean;
+  }>;
+} = teamA;
+const orgB = {
+  id: "org_2",
+  name: "Beta Corp",
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  teams: [
+    {
+      id: "team_2",
+      name: "Beta",
+      slug: "beta",
+      isPersonal: false,
+      ownerUserId: null,
+      members: [{ userId: "user_1", role: "ADMIN" }],
+      projects: [
+        {
+          id: "project_3",
+          slug: "beta-app",
+          name: "Beta App",
+          isPersonal: false,
+        },
+      ],
+    },
+  ],
+};
+let mockOrganizations: unknown[] = [orgA];
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    pathname: mockPathname,
+    query: {},
+    asPath: mockPathname,
+    push: pushMock,
+    replace: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+  }),
+}));
+
+vi.mock("~/utils/compat/next-head", () => ({
+  default: () => null,
+}));
+
+let mockIsMobile = true;
+vi.mock("~/features/navigation/shell/useIsMobileViewport", () => ({
+  useIsMobileViewport: () => mockIsMobile,
+}));
+
+let mockNavPathname = "/demo";
+vi.mock("~/utils/compat/next-navigation", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  usePathname: () => mockNavPathname,
+}));
+
+vi.mock("~/hooks/useRequiredSession", () => ({
+  useRequiredSession: () => ({
+    data: {
+      user: { id: "user_1", name: "Ada", email: "ada@acme.test" },
+    },
+  }),
+}));
+
+// Only the hook is stubbed. The access helpers beside it are pure, and the
+// fixture holds the membership rows they read, so the real ones answer.
+vi.mock("~/hooks/useOrganizationTeamProject", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useOrganizationTeamProject: () => ({
+    isLoading: false,
+    organization: mockOrganizations[0],
+    organizations: mockOrganizations,
+    team: mockAmbientTeam,
+    project: mockAmbientTeam.projects[0],
+    organizationRole: "ADMIN",
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useLiteMemberGuard", () => ({
+  useLiteMemberGuard: () => ({ isLiteMember: false }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", async () => {
+  const actual = await vi.importActual<object>("~/hooks/useFeatureFlag");
+  return {
+    ...actual,
+    useFeatureFlag: (flag: string) => ({
+      enabled:
+        flag === "release_ui_ai_governance_enabled"
+          ? mockGovernanceFlagEnabled
+          : true,
+      isLoading: false,
+    }),
+  };
+});
+
+const trackEventMock = vi.fn();
+vi.mock("~/utils/tracking", () => ({
+  trackEvent: (...args: unknown[]) => trackEventMock(...args),
+}));
+
+vi.mock("~/components/LoadingScreen", () => ({
+  LoadingScreen: () => <div data-testid="loading-screen" />,
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({
+    data: {
+      NODE_ENV: "test",
+      IS_SAAS: true,
+      HAS_LANGWATCH_NLP_SERVICE: true,
+      HAS_LANGEVALS_ENDPOINT: true,
+    },
+  }),
+}));
+
+vi.mock("~/hooks/usePlanManagementUrl", () => ({
+  usePlanManagementUrl: () => ({ url: "" }),
+}));
+
+vi.mock("~/hooks/usePostHogIdentify", () => ({
+  usePostHogIdentify: () => undefined,
+}));
+
+vi.mock("~/hooks/useOrgQueryParamSelection", () => ({
+  useOrgQueryParamSelection: () => undefined,
+}));
+
+vi.mock("~/hooks/useSavedViews", () => ({
+  SavedViewsProvider: ({ children }: PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn(), closeDrawer: vi.fn() }),
+}));
+
+vi.mock("~/hooks/useOpsPermission", () => ({
+  useOpsPermission: () => ({ hasAccess: false }),
+}));
+
+vi.mock("~/features/langy/stores/langyStore", () => ({
+  useLangyStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      dockShifted: false,
+      claimDockShell: () => undefined,
+      releaseDockShell: () => undefined,
+    }),
+}));
+
+vi.mock("~/utils/crispBubblePolicy", () => ({
+  toggleSupportChat: vi.fn(),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    limits: {
+      getUsage: { useQuery: () => ({ data: undefined }) },
+    },
+    user: {
+      getSsoStatus: { useQuery: () => ({ data: undefined }) },
+      isAdmin: { useQuery: () => ({ data: { isAdmin: false } }) },
+    },
+    governance: {
+      recordWorkspaceView: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+    annotation: {
+      getPendingItemsCount: { useQuery: () => ({ data: 0 }) },
+    },
+    personalWorkspaceFeatures: {
+      get: { useQuery: () => ({ data: undefined }) },
+    },
+    ops: {
+      getBadgeCounts: { useQuery: () => ({ data: undefined }) },
+      getDashboardSnapshot: { useQuery: () => ({ data: undefined }) },
+    },
+    featureFlag: {
+      isEnabledForEachOrganization: {
+        useQuery: (input: { flag: string }) => ({
+          data: {
+            enabledByOrganizationId: {
+              org_1: true,
+              org_2:
+                input.flag === "release_ui_ai_governance_enabled"
+                  ? mockGovernanceFlagEnabled
+                  : true,
+            },
+          },
+        }),
+      },
+    },
+  },
+}));
+
+const commandBarOpenMock = vi.fn();
+vi.mock("~/features/command-bar", () => ({
+  CommandBarTrigger: () => null,
+  useCommandBar: () => ({ open: commandBarOpenMock }),
+}));
+
+vi.mock("~/features/traces-v2/components/GlobalTraceV2DrawerMount", () => ({
+  GlobalTraceV2DrawerMount: () => null,
+}));
+
+vi.mock("~/components/CurrentDrawer", () => ({ CurrentDrawer: () => null }));
+vi.mock("~/components/AnnouncementBanner", () => ({
+  AnnouncementBanner: () => null,
+}));
+vi.mock("~/components/UpgradeModal", () => ({
+  GlobalUpgradeModal: () => null,
+}));
+vi.mock("~/components/SavedViewsBar", () => ({
+  SavedViewsBar: () => null,
+}));
+vi.mock("~/components/governance/AdminViewingAsBanner", () => ({
+  AdminViewingAsBanner: () => null,
+}));
+vi.mock("../../../../ee/admin/ImpersonationBanner", () => ({
+  ImpersonationBanner: () => null,
+}));
+vi.mock("../../../../ee/admin/ImpersonationSwitchBackMenuItem", () => ({
+  ImpersonationSwitchBackMenuItem: () => null,
+}));
+vi.mock("~/components/sidebar/PresenceMenuItem", () => ({
+  PresenceMenuItem: () => null,
+}));
+
+import { useNavigationModeStore } from "~/features/navigation/navigationModeStore";
+import {
+  DashboardLayout,
+  type DashboardLayoutProps,
+} from "../../../components/DashboardLayout";
+
+function renderShell(props: Partial<DashboardLayoutProps> = {}) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <DashboardLayout {...props}>
+        <div data-testid="page-body" />
+      </DashboardLayout>
+    </ChakraProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockIsMobile = true;
+  mockNavPathname = "/demo";
+  mockPathname = "/[project]";
+  mockGovernanceFlagEnabled = true;
+  mockOrganizations = [orgA];
+  mockAmbientTeam = teamA;
+  pushMock.mockClear();
+  trackEventMock.mockReset();
+  commandBarOpenMock.mockReset();
+  localStorage.clear();
+  useNavigationModeStore.setState({ storedMode: "product-switcher" });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the mobile chrome", () => {
+  describe("when an LLM Ops page renders at phone width", () => {
+    /** @scenario The mobile top bar holds the scope and the menu button only */
+    it("shows the logo, the product selector, the project selector and the menu button, with no sidebar", () => {
+      renderShell();
+
+      expect(
+        screen.getByRole("button", { name: "Switch product" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Switch project" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("product-sidebar")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("shell-product-cluster"),
+      ).not.toBeInTheDocument();
+    });
+
+    /** @scenario LLM Ops keeps the organization out of the mobile bar */
+    it("keeps the organization control out of the bar and offers it in the overlay", async () => {
+      mockOrganizations = [orgA, orgB];
+      renderShell();
+
+      expect(
+        screen.queryByRole("button", { name: "Switch organization" }),
+      ).not.toBeInTheDocument();
+
+      const user = userEvent.setup();
+      await user.click(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("button", { name: "Switch organization" }),
+      ).toBeInTheDocument();
+    });
+
+    /** @scenario The menu button opens the navigation overlay */
+    it("opens a full-screen overlay carrying the product's pages and the account controls", async () => {
+      const user = userEvent.setup();
+      renderShell();
+
+      await user.click(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+      const overlay = within(screen.getByTestId("mobile-menu-overlay"));
+      expect(overlay.getByLabelText("Quick Search")).toBeInTheDocument();
+      expect(overlay.getByText("Trace Explorer")).toBeInTheDocument();
+      expect(
+        overlay.getByRole("button", { name: "Open user menu for Ada" }),
+      ).toBeInTheDocument();
+      expect(
+        overlay.getByRole("button", { name: "Close navigation menu" }),
+      ).toBeInTheDocument();
+    });
+
+    /** @scenario Navigating from the overlay closes it */
+    it("closes the overlay when the page underneath changes", async () => {
+      const user = userEvent.setup();
+      const view = renderShell();
+
+      await user.click(
+        screen.getByRole("button", { name: "Open navigation menu" }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("mobile-menu-overlay")).toBeInTheDocument();
+      });
+
+      mockNavPathname = "/demo/analytics";
+      view.rerender(
+        <ChakraProvider value={defaultSystem}>
+          <DashboardLayout>
+            <div data-testid="page-body" />
+          </DashboardLayout>
+        </ChakraProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("mobile-menu-overlay"),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("page-body")).toBeInTheDocument();
+    });
+  });
+
+  describe("when a Gateway page renders at phone width", () => {
+    /** @scenario An organization product shows the organization in the mobile bar */
+    it("shows the organization and no project selector", () => {
+      mockPathname = "/gateway/virtual-keys";
+      renderShell();
+
+      // A single organization reads as plain text, same as on desktop.
+      expect(screen.getByText("ACME")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Switch project" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the viewport is desktop-width", () => {
+    /** @scenario Tablet and desktop widths keep the sidebar chrome */
+    it("keeps the sidebar and offers no menu button", () => {
+      mockIsMobile = false;
+      renderShell();
+
+      expect(screen.getByTestId("product-sidebar")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Open navigation menu" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -549,7 +549,10 @@ describe("the product-switcher top bar", () => {
       renderShell();
       await openProjectPicker();
 
-      expect(screen.getByPlaceholderText("Search projects")).toHaveFocus();
+      // The field carries its own accessible name, not only a placeholder.
+      expect(
+        screen.getByRole("combobox", { name: "Search projects" }),
+      ).toHaveFocus();
       await waitFor(() => {
         expect(screen.getByText("Edge Router")).toBeInTheDocument();
       });

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -519,10 +525,7 @@ describe("the product-switcher top bar", () => {
     });
 
     async function openProjectPicker() {
-      // Ark's combobox input is machine-controlled, so zero-delay typing
-      // outruns the re-render and drops characters; a small delay types
-      // the way a person does.
-      const user = userEvent.setup({ delay: 20 });
+      const user = userEvent.setup();
       await user.click(screen.getByRole("button", { name: "Switch project" }));
       await waitFor(() => {
         expect(
@@ -532,25 +535,33 @@ describe("the product-switcher top bar", () => {
       return user;
     }
 
+    // Ark's combobox input is machine-controlled, so per-character typing
+    // races the re-render and drops characters on a slow runner; one
+    // change event with the whole query is deterministic.
+    function searchFor(text: string) {
+      fireEvent.change(screen.getByPlaceholderText("Search projects"), {
+        target: { value: text },
+      });
+    }
+
     /** @scenario A large project list opens with a focused search field */
     it("opens with a focused search field that filters by project and team name", async () => {
       renderShell();
-      const user = await openProjectPicker();
+      await openProjectPicker();
 
       expect(screen.getByPlaceholderText("Search projects")).toHaveFocus();
       await waitFor(() => {
         expect(screen.getByText("Edge Router")).toBeInTheDocument();
       });
 
-      await user.keyboard("router");
+      searchFor("router");
       await waitFor(() => {
         expect(screen.queryByText("Core App 1")).not.toBeInTheDocument();
       });
       expect(screen.getByText("Edge Router")).toBeInTheDocument();
 
       // Team names match too: "platform" is the team, not a project name.
-      await user.clear(screen.getByPlaceholderText("Search projects"));
-      await user.keyboard("platform");
+      searchFor("platform");
       await waitFor(() => {
         expect(screen.getByText("Billing Sync")).toBeInTheDocument();
       });
@@ -563,7 +574,7 @@ describe("the product-switcher top bar", () => {
       renderShell();
       const user = await openProjectPicker();
 
-      await user.keyboard("billing");
+      searchFor("billing");
       await waitFor(() => {
         expect(screen.getByText("Billing Sync")).toBeInTheDocument();
       });
@@ -579,12 +590,12 @@ describe("the product-switcher top bar", () => {
     /** @scenario Creating a project stays available while the list is unfiltered */
     it("keeps the per-team create entries while nothing is typed and drops them while searching", async () => {
       renderShell();
-      const user = await openProjectPicker();
+      await openProjectPicker();
 
       // One create entry per team the user can create in (org admin: both).
       expect(screen.getAllByText("New Project")).toHaveLength(2);
 
-      await user.keyboard("core");
+      searchFor("core");
       await waitFor(() => {
         expect(screen.queryByText("New Project")).not.toBeInTheDocument();
       });

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -60,7 +60,20 @@ const orgA = {
   teams: [teamA, personalTeam],
 };
 /** The team the page being rendered resolves to. */
-let mockAmbientTeam: typeof teamA | typeof personalTeam = teamA;
+let mockAmbientTeam: {
+  id: string;
+  name: string;
+  slug: string;
+  isPersonal: boolean;
+  ownerUserId: string | null;
+  members: Array<{ userId: string; role: string }>;
+  projects: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    isPersonal: boolean;
+  }>;
+} = teamA;
 const orgB = {
   id: "org_2",
   name: "Beta Corp",
@@ -85,6 +98,50 @@ const orgB = {
   ],
 };
 let mockOrganizations: unknown[] = [orgA];
+
+/** Two teams and eleven projects: past the search threshold. */
+const crowdedTeamCore = {
+  id: "team_core",
+  name: "Core",
+  slug: "crowded-core",
+  isPersonal: false,
+  ownerUserId: null,
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  projects: Array.from({ length: 9 }, (_, index) => ({
+    id: `project_core_${index}`,
+    slug: `core-app-${index}`,
+    name: `Core App ${index}`,
+    isPersonal: false,
+  })),
+};
+const crowdedTeamPlatform = {
+  id: "team_platform",
+  name: "Platform",
+  slug: "crowded-platform",
+  isPersonal: false,
+  ownerUserId: null,
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  projects: [
+    {
+      id: "project_router",
+      slug: "edge-router",
+      name: "Edge Router",
+      isPersonal: false,
+    },
+    {
+      id: "project_billing",
+      slug: "billing-sync",
+      name: "Billing Sync",
+      isPersonal: false,
+    },
+  ],
+};
+const crowdedOrg = {
+  id: "org_1",
+  name: "ACME",
+  members: [{ userId: "user_1", role: "ADMIN" }],
+  teams: [crowdedTeamCore, crowdedTeamPlatform, personalTeam],
+};
 
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
@@ -452,6 +509,101 @@ describe("the product-switcher top bar", () => {
       await waitFor(() => {
         expect(screen.getByText("Support Bot")).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("when the organization holds more than eight projects", () => {
+    beforeEach(() => {
+      mockOrganizations = [crowdedOrg];
+      mockAmbientTeam = crowdedTeamCore;
+    });
+
+    async function openProjectPicker() {
+      // Ark's combobox input is machine-controlled, so zero-delay typing
+      // outruns the re-render and drops characters; a small delay types
+      // the way a person does.
+      const user = userEvent.setup({ delay: 20 });
+      await user.click(screen.getByRole("button", { name: "Switch project" }));
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Search projects"),
+        ).toBeInTheDocument();
+      });
+      return user;
+    }
+
+    /** @scenario A large project list opens with a focused search field */
+    it("opens with a focused search field that filters by project and team name", async () => {
+      renderShell();
+      const user = await openProjectPicker();
+
+      expect(screen.getByPlaceholderText("Search projects")).toHaveFocus();
+      await waitFor(() => {
+        expect(screen.getByText("Edge Router")).toBeInTheDocument();
+      });
+
+      await user.keyboard("router");
+      await waitFor(() => {
+        expect(screen.queryByText("Core App 1")).not.toBeInTheDocument();
+      });
+      expect(screen.getByText("Edge Router")).toBeInTheDocument();
+
+      // Team names match too: "platform" is the team, not a project name.
+      await user.clear(screen.getByPlaceholderText("Search projects"));
+      await user.keyboard("platform");
+      await waitFor(() => {
+        expect(screen.getByText("Billing Sync")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Edge Router")).toBeInTheDocument();
+      expect(screen.queryByText("Core App 1")).not.toBeInTheDocument();
+    });
+
+    /** @scenario The project search answers the keyboard */
+    it("moves with the arrow keys and opens the highlighted project on Enter", async () => {
+      renderShell();
+      const user = await openProjectPicker();
+
+      await user.keyboard("billing");
+      await waitFor(() => {
+        expect(screen.getByText("Billing Sync")).toBeInTheDocument();
+      });
+      await user.keyboard("{ArrowDown}{Enter}");
+
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith(
+          expect.stringContaining("billing-sync"),
+        );
+      });
+    });
+
+    /** @scenario Creating a project stays available while the list is unfiltered */
+    it("keeps the per-team create entries while nothing is typed and drops them while searching", async () => {
+      renderShell();
+      const user = await openProjectPicker();
+
+      // One create entry per team the user can create in (org admin: both).
+      expect(screen.getAllByText("New Project")).toHaveLength(2);
+
+      await user.keyboard("core");
+      await waitFor(() => {
+        expect(screen.queryByText("New Project")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when the organization holds eight projects or fewer", () => {
+    /** @scenario A short project list stays a plain menu */
+    it("lists the projects with no search field", async () => {
+      renderShell();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: "Switch project" }));
+      await waitFor(() => {
+        expect(screen.getByText("Support Bot")).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByPlaceholderText("Search projects"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/platform/app/src/features/navigation/shell/MobileShell.tsx
+++ b/platform/app/src/features/navigation/shell/MobileShell.tsx
@@ -1,0 +1,186 @@
+import { Box, HStack, IconButton, Spacer, Text } from "@chakra-ui/react";
+import { Menu as MenuIcon, Settings as SettingsIcon, X } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+import { AppHeaderUserMenu } from "~/components/AppHeaderUserMenu";
+import { LogoIcon } from "~/components/icons/LogoIcon";
+import { SideMenuDensityProvider } from "~/components/sidebar/sideMenuDensity";
+import { Link } from "~/components/ui/link";
+import { APP_HEADER_HEIGHT } from "~/features/langy/logic/langyPanelLayout";
+import { usePathname } from "~/utils/compat/next-navigation";
+import type { ProductId } from "../products";
+import { OrganizationSelect } from "./OrganizationSelect";
+import { ProductScopeControl } from "./ProductScopeControl";
+import { SidebarContent } from "./ProductSidebar";
+import { ProductSwitcherMenu } from "./ProductSwitcherMenu";
+import type { NavigationV2ShellReadyState } from "./useNavigationV2ShellState";
+
+const LOGO_HEIGHT = 24;
+
+/**
+ * The navigation-v2 chrome on a phone-width viewport: one compact bar
+ * with the logo, the product selector, the product's own scope control
+ * and a menu button; the page below it takes the rest of the screen.
+ * The menu button opens a full-screen overlay carrying the organization
+ * and project selectors, the product's pages and the account controls.
+ *
+ * Spec: specs/navigation/mobile-chrome.feature
+ */
+export function MobileShell({
+  state,
+  children,
+}: {
+  state: NavigationV2ShellReadyState;
+  children: ReactNode;
+}) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const pathname = usePathname();
+
+  // A tap on any menu entry navigates, and the new page is the reason
+  // the menu was opened, so the overlay stands down on its own.
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
+
+  return (
+    <>
+      <MobileTopBar
+        activeProductId={state.activeProductId}
+        isMenuOpen={false}
+        onMenuToggle={() => setIsMenuOpen(true)}
+      />
+      <Box
+        width="full"
+        background="bg.surface"
+        borderTopWidth="1px"
+        borderColor="border"
+        minHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
+        maxHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
+        overflow="auto"
+        display="flex"
+        position="relative"
+      >
+        {children}
+      </Box>
+      {isMenuOpen && (
+        <MobileMenuOverlay state={state} onClose={() => setIsMenuOpen(false)} />
+      )}
+    </>
+  );
+}
+
+/**
+ * The compact bar: logo, product, the product's own scope, and the menu
+ * button. LLM Ops keeps the organization out of the bar so the project
+ * chip has the room; the organization-wide products carry the
+ * organization control instead. The same bar heads the overlay, where
+ * the button becomes the way to close it.
+ */
+function MobileTopBar({
+  activeProductId,
+  isMenuOpen,
+  onMenuToggle,
+}: {
+  activeProductId: ProductId | null;
+  isMenuOpen: boolean;
+  onMenuToggle: () => void;
+}) {
+  const showsOwnScope =
+    activeProductId === "llm-ops" || activeProductId === "me";
+
+  return (
+    <HStack
+      width="full"
+      height={`${APP_HEADER_HEIGHT}px`}
+      paddingX={3}
+      gap={1}
+      background="bg.page"
+      justifyContent="space-between"
+      overflow="hidden"
+    >
+      <HStack gap={2} minWidth={0} flex={1} alignItems="center">
+        <Link href="/" display="flex" alignItems="center" flexShrink={0}>
+          <LogoIcon width={LOGO_HEIGHT * (38 / 52)} height={LOGO_HEIGHT} />
+        </Link>
+        {activeProductId ? (
+          <ProductSwitcherMenu activeProductId={activeProductId} />
+        ) : (
+          <HStack gap={2} paddingX={1} flexShrink={0}>
+            <SettingsIcon size={14} color="var(--chakra-colors-fg-muted)" />
+            <Text fontSize="13px" fontWeight="medium">
+              Settings
+            </Text>
+          </HStack>
+        )}
+        {showsOwnScope ? (
+          <ProductScopeControl activeProductId={activeProductId} />
+        ) : (
+          <OrganizationSelect activeProductId={activeProductId} />
+        )}
+      </HStack>
+      <IconButton
+        aria-label={
+          isMenuOpen ? "Close navigation menu" : "Open navigation menu"
+        }
+        variant="ghost"
+        size="sm"
+        onClick={onMenuToggle}
+      >
+        {isMenuOpen ? <X size={20} /> : <MenuIcon size={20} />}
+      </IconButton>
+    </HStack>
+  );
+}
+
+/**
+ * The full-screen menu: the same bar on top with the close button, the
+ * organization and the product scope side by side under it (so a
+ * multi-organization user can switch both from here), then the
+ * product's pages and the pinned bottom block the desktop sidebar
+ * carries.
+ */
+function MobileMenuOverlay({
+  state,
+  onClose,
+}: {
+  state: NavigationV2ShellReadyState;
+  onClose: () => void;
+}) {
+  return (
+    <Box
+      data-testid="mobile-menu-overlay"
+      position="fixed"
+      inset={0}
+      zIndex={1300}
+      background="bg.page"
+      display="flex"
+      flexDirection="column"
+    >
+      <MobileTopBar
+        activeProductId={state.activeProductId}
+        isMenuOpen
+        onMenuToggle={onClose}
+      />
+      <HStack
+        paddingX={4}
+        paddingY={2}
+        gap={2}
+        borderBottomWidth="1px"
+        borderColor="border"
+      >
+        <OrganizationSelect activeProductId={state.activeProductId} />
+        <ProductScopeControl activeProductId={state.activeProductId} />
+        <Spacer />
+        <AppHeaderUserMenu showPresenceMenuItem={state.showPresenceMenuItem} />
+      </HStack>
+      <Box flex={1} minHeight={0}>
+        <SideMenuDensityProvider density="compact">
+          <SidebarContent
+            surface={state.activeProductId ?? "settings"}
+            showExpanded
+            fullWidth
+          />
+        </SideMenuDensityProvider>
+      </Box>
+    </Box>
+  );
+}

--- a/platform/app/src/features/navigation/shell/MobileShell.tsx
+++ b/platform/app/src/features/navigation/shell/MobileShell.tsx
@@ -1,6 +1,12 @@
 import { Box, HStack, IconButton, Spacer, Text } from "@chakra-ui/react";
 import { Menu as MenuIcon, Settings as SettingsIcon, X } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { AppHeaderUserMenu } from "~/components/AppHeaderUserMenu";
 import { LogoIcon } from "~/components/icons/LogoIcon";
 import { SideMenuDensityProvider } from "~/components/sidebar/sideMenuDensity";
@@ -33,6 +39,7 @@ export function MobileShell({
   children: ReactNode;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const pathname = usePathname();
 
   // A tap on any menu entry navigates, and the new page is the reason
@@ -41,12 +48,18 @@ export function MobileShell({
     setIsMenuOpen(false);
   }, [pathname]);
 
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+    menuButtonRef.current?.focus();
+  };
+
   return (
     <>
       <MobileTopBar
         activeProductId={state.activeProductId}
         isMenuOpen={false}
-        onMenuToggle={() => setIsMenuOpen(true)}
+        onMenuButtonPress={() => setIsMenuOpen(true)}
+        menuButtonRef={menuButtonRef}
       />
       <Box
         width="full"
@@ -61,9 +74,7 @@ export function MobileShell({
       >
         {children}
       </Box>
-      {isMenuOpen && (
-        <MobileMenuOverlay state={state} onClose={() => setIsMenuOpen(false)} />
-      )}
+      {isMenuOpen && <MobileMenuOverlay state={state} onClose={closeMenu} />}
     </>
   );
 }
@@ -78,11 +89,13 @@ export function MobileShell({
 function MobileTopBar({
   activeProductId,
   isMenuOpen,
-  onMenuToggle,
+  onMenuButtonPress,
+  menuButtonRef,
 }: {
   activeProductId: ProductId | null;
   isMenuOpen: boolean;
-  onMenuToggle: () => void;
+  onMenuButtonPress: () => void;
+  menuButtonRef?: RefObject<HTMLButtonElement | null>;
 }) {
   const showsOwnScope =
     activeProductId === "llm-ops" || activeProductId === "me";
@@ -118,12 +131,13 @@ function MobileTopBar({
         )}
       </HStack>
       <IconButton
+        ref={menuButtonRef}
         aria-label={
           isMenuOpen ? "Close navigation menu" : "Open navigation menu"
         }
         variant="ghost"
         size="sm"
-        onClick={onMenuToggle}
+        onClick={onMenuButtonPress}
       >
         {isMenuOpen ? <X size={20} /> : <MenuIcon size={20} />}
       </IconButton>
@@ -145,9 +159,27 @@ function MobileMenuOverlay({
   state: NavigationV2ShellReadyState;
   onClose: () => void;
 }) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // The overlay is a modal: it takes focus on open, and Escape closes
+  // it the way the close button does.
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   return (
     <Box
       data-testid="mobile-menu-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Navigation menu"
       position="fixed"
       inset={0}
       zIndex={1300}
@@ -158,7 +190,8 @@ function MobileMenuOverlay({
       <MobileTopBar
         activeProductId={state.activeProductId}
         isMenuOpen
-        onMenuToggle={onClose}
+        onMenuButtonPress={onClose}
+        menuButtonRef={closeButtonRef}
       />
       <HStack
         paddingX={4}
@@ -177,7 +210,7 @@ function MobileMenuOverlay({
           <SidebarContent
             surface={state.activeProductId ?? "settings"}
             showExpanded
-            fullWidth
+            isFullWidth
           />
         </SideMenuDensityProvider>
       </Box>

--- a/platform/app/src/features/navigation/shell/MobileShell.tsx
+++ b/platform/app/src/features/navigation/shell/MobileShell.tsx
@@ -40,6 +40,7 @@ export function MobileShell({
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const shouldRestoreFocus = useRef(false);
   const pathname = usePathname();
 
   // A tap on any menu entry navigates, and the new page is the reason
@@ -48,9 +49,18 @@ export function MobileShell({
     setIsMenuOpen(false);
   }, [pathname]);
 
-  const closeMenu = () => {
-    setIsMenuOpen(false);
+  // The bar is inert while the menu covers it, and an inert element
+  // takes no focus, so the button gets it back only after the render
+  // that lifts the inert.
+  useEffect(() => {
+    if (isMenuOpen || !shouldRestoreFocus.current) return;
+    shouldRestoreFocus.current = false;
     menuButtonRef.current?.focus();
+  }, [isMenuOpen]);
+
+  const closeMenu = () => {
+    shouldRestoreFocus.current = true;
+    setIsMenuOpen(false);
   };
 
   return (
@@ -174,14 +184,22 @@ function MobileMenuOverlay({
   }, []);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      const overlay = overlayRef.current;
+      // A menu the overlay opens portals its list out of this box and
+      // takes the focus with it. While it holds the keyboard the keys
+      // are its own: Escape closes that menu, not the whole overlay.
+      if (ownsKeyboardElsewhere(overlay)) return;
       if (event.key === "Escape") {
         onClose();
         return;
       }
-      if (event.key === "Tab") trapTab({ event, overlay: overlayRef.current });
+      if (event.key === "Tab") trapTab({ event, overlay });
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    // Capture phase: a menu that answers this key restores focus to its
+    // own trigger while it handles it, so by the bubble phase the focus
+    // no longer says who owned the key.
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [onClose]);
 
   return (
@@ -233,10 +251,19 @@ const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
+ * True while a real element outside the overlay holds the focus, which
+ * is what an open portaled menu looks like. An empty focus (the body,
+ * or nothing) is not somebody else's keyboard.
+ */
+function ownsKeyboardElsewhere(overlay: HTMLElement | null) {
+  const active = document.activeElement;
+  if (!overlay || !active || active === document.body) return false;
+  return !overlay.contains(active);
+}
+
+/**
  * Keeps Tab and Shift+Tab inside the open menu: the last entry wraps to
- * the first and back. A menu the overlay opens portals its list outside
- * this box and drives its own keyboard, so focus that already left is
- * left where it is.
+ * the first and back.
  */
 function trapTab({
   event,

--- a/platform/app/src/features/navigation/shell/MobileShell.tsx
+++ b/platform/app/src/features/navigation/shell/MobileShell.tsx
@@ -55,24 +55,29 @@ export function MobileShell({
 
   return (
     <>
-      <MobileTopBar
-        activeProductId={state.activeProductId}
-        isMenuOpen={false}
-        onMenuButtonPress={() => setIsMenuOpen(true)}
-        menuButtonRef={menuButtonRef}
-      />
-      <Box
-        width="full"
-        background="bg.surface"
-        borderTopWidth="1px"
-        borderColor="border"
-        minHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
-        maxHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
-        overflow="auto"
-        display="flex"
-        position="relative"
-      >
-        {children}
+      {/* While the menu covers the screen the page behind it is inert:
+          out of the tab order and out of the accessibility tree, so the
+          modal keeps both the focus and the reader. */}
+      <Box inert={isMenuOpen ? true : undefined}>
+        <MobileTopBar
+          activeProductId={state.activeProductId}
+          isMenuOpen={false}
+          onMenuButtonPress={() => setIsMenuOpen(true)}
+          menuButtonRef={menuButtonRef}
+        />
+        <Box
+          width="full"
+          background="bg.surface"
+          borderTopWidth="1px"
+          borderColor="border"
+          minHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
+          maxHeight={`calc(100vh - ${APP_HEADER_HEIGHT}px)`}
+          overflow="auto"
+          display="flex"
+          position="relative"
+        >
+          {children}
+        </Box>
       </Box>
       {isMenuOpen && <MobileMenuOverlay state={state} onClose={closeMenu} />}
     </>
@@ -159,6 +164,7 @@ function MobileMenuOverlay({
   state: NavigationV2ShellReadyState;
   onClose: () => void;
 }) {
+  const overlayRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   // The overlay is a modal: it takes focus on open, and Escape closes
@@ -168,7 +174,11 @@ function MobileMenuOverlay({
   }, []);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key === "Tab") trapTab({ event, overlay: overlayRef.current });
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
@@ -176,6 +186,7 @@ function MobileMenuOverlay({
 
   return (
     <Box
+      ref={overlayRef}
       data-testid="mobile-menu-overlay"
       role="dialog"
       aria-modal="true"
@@ -216,4 +227,39 @@ function MobileMenuOverlay({
       </Box>
     </Box>
   );
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Keeps Tab and Shift+Tab inside the open menu: the last entry wraps to
+ * the first and back. A menu the overlay opens portals its list outside
+ * this box and drives its own keyboard, so focus that already left is
+ * left where it is.
+ */
+function trapTab({
+  event,
+  overlay,
+}: {
+  event: KeyboardEvent;
+  overlay: HTMLElement | null;
+}) {
+  const active = document.activeElement;
+  if (!overlay || !active || !overlay.contains(active)) return;
+
+  const focusable = Array.from(
+    overlay.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  );
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) return;
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
 }

--- a/platform/app/src/features/navigation/shell/NavigationV2Shell.tsx
+++ b/platform/app/src/features/navigation/shell/NavigationV2Shell.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/features/langy/logic/langyPanelLayout";
 import Head from "~/utils/compat/next-head";
 import { ICON_RAIL_WIDTH, IconRail } from "./IconRail";
+import { MobileShell } from "./MobileShell";
 import { ProductSidebar } from "./ProductSidebar";
 import { ShellTopBar } from "./ShellTopBar";
 import { shellContentMaxWidth } from "./shellLayout";
@@ -56,6 +57,22 @@ export const NavigationV2Shell = ({
   if (state.status === "loading") return <LoadingScreen />;
 
   const isIconRail = mode === "icon-rail";
+
+  // A phone has room for the page or the chrome, not both: one compact
+  // bar and a full-screen menu replace the sidebar and the rail in both
+  // modes. Spec: specs/navigation/mobile-chrome.feature
+  if (state.isMobile) {
+    return (
+      <Box width="full" minHeight="100vh" background="bg.page">
+        <ShellHead pageTitle={pageTitle} state={state} />
+        <MobileShell state={state}>
+          <DashboardPageBody personalScope={personalScope} {...props}>
+            {children}
+          </DashboardPageBody>
+        </MobileShell>
+      </Box>
+    );
+  }
 
   return (
     <Box

--- a/platform/app/src/features/navigation/shell/ProductScopeControl.tsx
+++ b/platform/app/src/features/navigation/shell/ProductScopeControl.tsx
@@ -7,6 +7,10 @@ import { useWorkspaceData } from "~/components/useWorkspaceData";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
 import type { ProductId } from "../products";
+import {
+  type ProjectPickGroup,
+  ProjectSwitcherCombobox,
+} from "./ProjectSwitcherCombobox";
 
 function ScopeDivider() {
   return (
@@ -49,10 +53,18 @@ function MeScopeChip() {
 }
 
 /**
+ * Above this many projects the plain menu turns into a searchable
+ * combobox: the list no longer fits a screen, so finding beats reading.
+ */
+const PROJECT_SEARCH_THRESHOLD = 8;
+
+/**
  * The LLM Ops scope: the current project as a chip, opening a menu with
  * the organization's projects (and a per-team create entry where the
  * user can create one). Organization choice lives in its own control,
- * so this menu stays within the current organization.
+ * so this menu stays within the current organization. Past
+ * PROJECT_SEARCH_THRESHOLD projects the menu becomes a combobox that
+ * opens with a focused search field.
  */
 function ProjectScopeMenu() {
   const { organization, project } = useOrganizationTeamProject({
@@ -77,75 +89,118 @@ function ProjectScopeMenu() {
       (group) => group.projects.length > 0 || group.team.canCreateProject,
     );
 
+  const projectCount = groups.reduce(
+    (count, group) => count + group.projects.length,
+    0,
+  );
+  const showTeamHeaders = orgTeams.length > 1;
+
   return (
     <>
       <ScopeDivider />
-      <Menu.Root>
-        <Menu.Trigger asChild>
-          <Button
-            variant="ghost"
-            aria-label="Switch project"
-            fontSize="13px"
-            fontWeight="normal"
-            paddingX={2}
-            height="32px"
-            color="fg"
-            gap={2}
-            _hover={{ backgroundColor: "bg.muted" }}
-          >
-            <ProjectAvatar name={project.name} />
-            <Text whiteSpace="nowrap">{project.name}</Text>
-            <ChevronsUpDown size={12} color="var(--chakra-colors-fg-muted)" />
-          </Button>
-        </Menu.Trigger>
-        <Portal>
-          <Menu.Content minWidth="240px">
-            {groups.map(({ team, projects: teamProjects }) => (
-              <Menu.ItemGroup
-                key={team.teamId}
-                title={orgTeams.length > 1 ? team.label : "Projects"}
-              >
-                {teamProjects.map((candidate) => (
-                  <Menu.Item
-                    key={candidate.projectId}
-                    value={candidate.projectId}
-                    fontSize="13px"
-                    asChild
-                  >
-                    <Link
-                      href={candidate.href}
-                      _hover={{ textDecoration: "none" }}
-                    >
-                      <HStack gap={2} width="full">
-                        <ProjectAvatar name={candidate.label} />
-                        <Text flex={1}>{candidate.label}</Text>
-                        {candidate.projectId === project.id && (
-                          <Check size={13} aria-label="Current project" />
-                        )}
-                      </HStack>
-                    </Link>
-                  </Menu.Item>
-                ))}
-                {team.canCreateProject && (
-                  <Menu.Item
-                    value={`new-project-${team.teamId}`}
-                    fontSize="13px"
-                    onClick={() =>
-                      onCreateProjectForTeam?.({
-                        teamId: team.teamId,
-                        orgId: team.orgId,
-                      })
-                    }
-                  >
-                    <Plus size={13} /> New Project
-                  </Menu.Item>
-                )}
-              </Menu.ItemGroup>
-            ))}
-          </Menu.Content>
-        </Portal>
-      </Menu.Root>
+      {projectCount > PROJECT_SEARCH_THRESHOLD ? (
+        <ProjectSwitcherCombobox
+          groups={groups}
+          currentProjectId={project.id}
+          currentProjectName={project.name}
+          showTeamHeaders={showTeamHeaders}
+          onCreateProjectForTeam={onCreateProjectForTeam}
+        />
+      ) : (
+        <ProjectMenu
+          groups={groups}
+          currentProjectId={project.id}
+          currentProjectName={project.name}
+          showTeamHeaders={showTeamHeaders}
+          onCreateProjectForTeam={onCreateProjectForTeam}
+        />
+      )}
     </>
+  );
+}
+
+/** The plain project menu, for a list short enough to read whole. */
+function ProjectMenu({
+  groups,
+  currentProjectId,
+  currentProjectName,
+  showTeamHeaders,
+  onCreateProjectForTeam,
+}: {
+  groups: ProjectPickGroup[];
+  currentProjectId: string;
+  currentProjectName: string;
+  showTeamHeaders: boolean;
+  onCreateProjectForTeam:
+    | (({ teamId, orgId }: { teamId: string; orgId: string }) => void)
+    | undefined;
+}) {
+  return (
+    <Menu.Root>
+      <Menu.Trigger asChild>
+        <Button
+          variant="ghost"
+          aria-label="Switch project"
+          fontSize="13px"
+          fontWeight="normal"
+          paddingX={2}
+          height="32px"
+          color="fg"
+          gap={2}
+          _hover={{ backgroundColor: "bg.muted" }}
+        >
+          <ProjectAvatar name={currentProjectName} />
+          <Text whiteSpace="nowrap">{currentProjectName}</Text>
+          <ChevronsUpDown size={12} color="var(--chakra-colors-fg-muted)" />
+        </Button>
+      </Menu.Trigger>
+      <Portal>
+        <Menu.Content minWidth="240px">
+          {groups.map(({ team, projects: teamProjects }) => (
+            <Menu.ItemGroup
+              key={team.teamId}
+              title={showTeamHeaders ? team.label : "Projects"}
+            >
+              {teamProjects.map((candidate) => (
+                <Menu.Item
+                  key={candidate.projectId}
+                  value={candidate.projectId}
+                  fontSize="13px"
+                  asChild
+                >
+                  <Link
+                    href={candidate.href}
+                    _hover={{ textDecoration: "none" }}
+                  >
+                    <HStack gap={2} width="full">
+                      <ProjectAvatar name={candidate.label} />
+                      <Text flex={1}>{candidate.label}</Text>
+                      {candidate.projectId === currentProjectId && (
+                        <Check size={13} aria-label="Current project" />
+                      )}
+                    </HStack>
+                  </Link>
+                </Menu.Item>
+              ))}
+              {team.canCreateProject && (
+                <Menu.Item
+                  value={`new-project-${team.teamId}`}
+                  fontSize="13px"
+                  onClick={() =>
+                    onCreateProjectForTeam?.({
+                      teamId: team.teamId,
+                      orgId: team.orgId,
+                    })
+                  }
+                >
+                  <Plus size={13} /> New Project
+                </Menu.Item>
+              )}
+            </Menu.ItemGroup>
+          ))}
+        </Menu.Content>
+      </Portal>
+    </Menu.Root>
   );
 }
 

--- a/platform/app/src/features/navigation/shell/ProductScopeControl.tsx
+++ b/platform/app/src/features/navigation/shell/ProductScopeControl.tsx
@@ -7,10 +7,8 @@ import { useWorkspaceData } from "~/components/useWorkspaceData";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
 import type { ProductId } from "../products";
-import {
-  type ProjectPickGroup,
-  ProjectSwitcherCombobox,
-} from "./ProjectSwitcherCombobox";
+import { ProjectSwitcherCombobox } from "./ProjectSwitcherCombobox";
+import type { ProjectPickGroup } from "./projectPickItems";
 
 function ScopeDivider() {
   return (

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -291,11 +291,11 @@ function ProductSidebarBody({
 export function SidebarContent({
   surface,
   showExpanded,
-  fullWidth = false,
+  isFullWidth = false,
 }: {
   surface: SidebarSurface;
   showExpanded: boolean;
-  fullWidth?: boolean;
+  isFullWidth?: boolean;
 }) {
   const scrollRegionRef = useRef<HTMLDivElement>(null);
   // Keyed by surface: each product's menu keeps its own place, and moving
@@ -309,7 +309,7 @@ export function SidebarContent({
       gap={0}
       height="100%"
       align="start"
-      width={fullWidth ? "full" : SHELL_SIDEBAR_WIDTH_EXPANDED}
+      width={isFullWidth ? "full" : SHELL_SIDEBAR_WIDTH_EXPANDED}
       justifyContent="space-between"
     >
       {/* The way back out of Settings sits above the scroll region, so a

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -286,14 +286,16 @@ function ProductSidebarBody({
  * Search, the surface's own pages, and the bottom block pinned under
  * them. Laid out at the expanded width whatever the column is showing,
  * so a collapsing column slides the same content out of view instead of
- * reflowing it.
+ * reflowing it. The mobile menu reuses it at the full viewport width.
  */
-function SidebarContent({
+export function SidebarContent({
   surface,
   showExpanded,
+  fullWidth = false,
 }: {
   surface: SidebarSurface;
   showExpanded: boolean;
+  fullWidth?: boolean;
 }) {
   const scrollRegionRef = useRef<HTMLDivElement>(null);
   // Keyed by surface: each product's menu keeps its own place, and moving
@@ -307,7 +309,7 @@ function SidebarContent({
       gap={0}
       height="100%"
       align="start"
-      width={SHELL_SIDEBAR_WIDTH_EXPANDED}
+      width={fullWidth ? "full" : SHELL_SIDEBAR_WIDTH_EXPANDED}
       justifyContent="space-between"
     >
       {/* The way back out of Settings sits above the scroll region, so a

--- a/platform/app/src/features/navigation/shell/ProjectSwitcherCombobox.tsx
+++ b/platform/app/src/features/navigation/shell/ProjectSwitcherCombobox.tsx
@@ -1,0 +1,362 @@
+import {
+  Box,
+  Button,
+  Combobox,
+  createListCollection,
+  HStack,
+  Portal,
+  Text,
+} from "@chakra-ui/react";
+import { Check, ChevronsUpDown, Plus, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ProjectAvatar } from "~/components/ProjectAvatar";
+import { useRouter } from "~/utils/compat/next-router";
+
+/**
+ * A team and the projects the picker offers under it. The same shape
+ * `ProjectScopeMenu` builds for the plain menu, so the two render paths
+ * cannot drift on what they offer.
+ */
+export interface ProjectPickGroup {
+  team: {
+    teamId: string;
+    orgId: string;
+    label: string;
+    canCreateProject?: boolean;
+  };
+  projects: Array<{
+    projectId: string;
+    label: string;
+    href: string;
+  }>;
+}
+
+interface ProjectPickItem {
+  value: string;
+  label: string;
+  teamId: string;
+  href: string | null;
+  /** What the filter matches against: the team name plus the project name. */
+  searchText: string;
+  kind: "project" | "new-project";
+}
+
+function toPickItems(groups: ProjectPickGroup[]): ProjectPickItem[] {
+  return groups.flatMap((group) => [
+    ...group.projects.map((project) => ({
+      value: project.projectId,
+      label: project.label,
+      teamId: group.team.teamId,
+      href: project.href,
+      searchText: `${group.team.label} ${project.label}`.toLowerCase(),
+      kind: "project" as const,
+    })),
+    ...(group.team.canCreateProject
+      ? [
+          {
+            value: `new-project:${group.team.teamId}`,
+            label: "New Project",
+            teamId: group.team.teamId,
+            href: null,
+            searchText: "",
+            kind: "new-project" as const,
+          },
+        ]
+      : []),
+  ]);
+}
+
+/**
+ * The items the popup offers for a query, grouped for rendering and flat
+ * for the collection the keyboard walks. A running search hides the
+ * create entries: they match no project, and a list of results is not
+ * the place to start a different action from.
+ */
+function useProjectPickItems({
+  groups,
+  query,
+}: {
+  groups: ProjectPickGroup[];
+  query: string;
+}) {
+  const allItems = useMemo(() => toPickItems(groups), [groups]);
+
+  const filteredItems = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return allItems;
+    return allItems.filter(
+      (item) => item.kind === "project" && item.searchText.includes(needle),
+    );
+  }, [allItems, query]);
+
+  const collection = useMemo(
+    () =>
+      createListCollection({
+        items: filteredItems,
+        itemToValue: (item) => item.value,
+        itemToString: (item) => item.label,
+      }),
+    [filteredItems],
+  );
+
+  const visibleGroups = useMemo(
+    () =>
+      groups
+        .map((group) => ({
+          team: group.team,
+          items: filteredItems.filter(
+            (item) => item.teamId === group.team.teamId,
+          ),
+        }))
+        .filter((group) => group.items.length > 0),
+    [groups, filteredItems],
+  );
+
+  return { allItems, collection, visibleGroups };
+}
+
+/**
+ * The project switch chip for an organization with a long project list:
+ * a combobox whose popup opens with a focused search field, filters by
+ * project and team name as the user types, and answers the arrow keys
+ * and Enter. Grouped by team, with the per-team create entry kept while
+ * the list is unfiltered.
+ *
+ * Spec: specs/navigation/product-switcher-navigation.feature
+ */
+export function ProjectSwitcherCombobox({
+  groups,
+  currentProjectId,
+  currentProjectName,
+  showTeamHeaders,
+  onCreateProjectForTeam,
+}: {
+  groups: ProjectPickGroup[];
+  currentProjectId: string;
+  currentProjectName: string;
+  showTeamHeaders: boolean;
+  onCreateProjectForTeam:
+    | (({ teamId, orgId }: { teamId: string; orgId: string }) => void)
+    | undefined;
+}) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const { allItems, collection, visibleGroups } = useProjectPickItems({
+    groups,
+    query,
+  });
+
+  const pick = (value: string) => {
+    const outcome = resolvePickOutcome({
+      value,
+      allItems,
+      groups,
+      currentProjectId,
+    });
+    if (outcome?.kind === "create") onCreateProjectForTeam?.(outcome.team);
+    if (outcome?.kind === "open") void router.push(outcome.href);
+  };
+
+  return (
+    <Combobox.Root
+      collection={collection}
+      value={[currentProjectId]}
+      openOnClick
+      selectionBehavior="clear"
+      onValueChange={(details) => {
+        const next = details.value?.[0];
+        if (next) pick(next);
+      }}
+      onInputValueChange={(details) => setQuery(details.inputValue)}
+      onOpenChange={(details) => {
+        if (details.open) setQuery("");
+      }}
+      positioning={{ placement: "bottom-start", gutter: 4 }}
+      width="auto"
+    >
+      {/* Ark positions the listbox against the CONTROL, so the trigger
+          must live inside one that generates a layout box. */}
+      <Combobox.Control display="inline-flex" width="auto" minWidth={0}>
+        <Combobox.Trigger asChild>
+          <Button
+            variant="ghost"
+            aria-label="Switch project"
+            fontSize="13px"
+            fontWeight="normal"
+            paddingX={2}
+            height="32px"
+            color="fg"
+            gap={2}
+            _hover={{ backgroundColor: "bg.muted" }}
+          >
+            <ProjectAvatar name={currentProjectName} />
+            <Text whiteSpace="nowrap">{currentProjectName}</Text>
+            <ChevronsUpDown size={12} color="var(--chakra-colors-fg-muted)" />
+          </Button>
+        </Combobox.Trigger>
+      </Combobox.Control>
+      <ProjectComboboxPopup
+        visibleGroups={visibleGroups}
+        showTeamHeaders={showTeamHeaders}
+        currentProjectId={currentProjectId}
+      />
+    </Combobox.Root>
+  );
+}
+
+/**
+ * What picking a value means: opening a project, starting the create
+ * flow for a team, or nothing (the current project, or a value that
+ * left the list between render and pick).
+ */
+function resolvePickOutcome({
+  value,
+  allItems,
+  groups,
+  currentProjectId,
+}: {
+  value: string;
+  allItems: ProjectPickItem[];
+  groups: ProjectPickGroup[];
+  currentProjectId: string;
+}):
+  | { kind: "create"; team: { teamId: string; orgId: string } }
+  | { kind: "open"; href: string }
+  | null {
+  const item = allItems.find((candidate) => candidate.value === value);
+  if (!item) return null;
+  if (item.kind === "new-project") {
+    const team = groups.find((g) => g.team.teamId === item.teamId)?.team;
+    return team
+      ? { kind: "create", team: { teamId: team.teamId, orgId: team.orgId } }
+      : null;
+  }
+  if (item.value === currentProjectId || !item.href) return null;
+  return { kind: "open", href: item.href };
+}
+
+/** The portaled popup: the search field, the empty state and the groups. */
+function ProjectComboboxPopup({
+  visibleGroups,
+  showTeamHeaders,
+  currentProjectId,
+}: {
+  visibleGroups: Array<{
+    team: ProjectPickGroup["team"];
+    items: ProjectPickItem[];
+  }>;
+  showTeamHeaders: boolean;
+  currentProjectId: string;
+}) {
+  return (
+    <Portal>
+      <Combobox.Positioner>
+        <Combobox.Content
+          minWidth="260px"
+          maxHeight="360px"
+          overflowY="auto"
+          padding={0}
+        >
+          <ProjectSearchHeader />
+          <Combobox.Empty
+            paddingX={3}
+            paddingY={2}
+            color="fg.muted"
+            fontSize="13px"
+          >
+            No projects match your search.
+          </Combobox.Empty>
+          <Box padding={1}>
+            {visibleGroups.map((group) => (
+              <Combobox.ItemGroup key={group.team.teamId}>
+                <Combobox.ItemGroupLabel
+                  paddingX={2}
+                  paddingTop={2}
+                  paddingBottom={1}
+                  color="fg.muted"
+                  fontSize="11px"
+                  fontWeight="600"
+                >
+                  {showTeamHeaders ? group.team.label : "Projects"}
+                </Combobox.ItemGroupLabel>
+                {group.items.map((item) => (
+                  <ProjectItemRow
+                    key={item.value}
+                    item={item}
+                    isCurrent={item.value === currentProjectId}
+                  />
+                ))}
+              </Combobox.ItemGroup>
+            ))}
+          </Box>
+        </Combobox.Content>
+      </Combobox.Positioner>
+    </Portal>
+  );
+}
+
+/** The focused search field pinned to the top of the popup. */
+function ProjectSearchHeader() {
+  return (
+    <Box
+      position="sticky"
+      top={0}
+      zIndex={1}
+      background="bg.panel"
+      paddingX={2.5}
+      paddingY={1.5}
+      borderBottomWidth="1px"
+      borderColor="border"
+    >
+      <HStack gap={2} color="fg.muted">
+        <Search size={14} aria-hidden />
+        <Combobox.Input
+          autoFocus
+          placeholder="Search projects"
+          height="28px"
+          minWidth={0}
+          flex={1}
+          padding={0}
+          border={0}
+          outline="none"
+          background="transparent"
+          fontSize="13px"
+          color="fg"
+          _placeholder={{ color: "fg.subtle" }}
+          _focusVisible={{ outline: "none" }}
+        />
+      </HStack>
+    </Box>
+  );
+}
+
+function ProjectItemRow({
+  item,
+  isCurrent,
+}: {
+  item: ProjectPickItem;
+  isCurrent: boolean;
+}) {
+  return (
+    <Combobox.Item
+      item={item}
+      borderRadius="md"
+      paddingX={2}
+      paddingY={1.5}
+      fontSize="13px"
+      _highlighted={{ background: "bg.subtle" }}
+    >
+      <HStack gap={2} width="full">
+        {item.kind === "new-project" ? (
+          <Plus size={13} aria-hidden />
+        ) : (
+          <ProjectAvatar name={item.label} />
+        )}
+        <Combobox.ItemText flex={1} truncate>
+          {item.label}
+        </Combobox.ItemText>
+        {isCurrent && <Check size={13} aria-label="Current project" />}
+      </HStack>
+    </Combobox.Item>
+  );
+}

--- a/platform/app/src/features/navigation/shell/ProjectSwitcherCombobox.tsx
+++ b/platform/app/src/features/navigation/shell/ProjectSwitcherCombobox.tsx
@@ -1,119 +1,14 @@
-import {
-  Box,
-  Button,
-  Combobox,
-  createListCollection,
-  HStack,
-  Portal,
-  Text,
-} from "@chakra-ui/react";
-import { Check, ChevronsUpDown, Plus, Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Button, Combobox, Text } from "@chakra-ui/react";
+import { ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
 import { ProjectAvatar } from "~/components/ProjectAvatar";
 import { useRouter } from "~/utils/compat/next-router";
-
-/**
- * A team and the projects the picker offers under it. The same shape
- * `ProjectScopeMenu` builds for the plain menu, so the two render paths
- * cannot drift on what they offer.
- */
-export interface ProjectPickGroup {
-  team: {
-    teamId: string;
-    orgId: string;
-    label: string;
-    canCreateProject?: boolean;
-  };
-  projects: Array<{
-    projectId: string;
-    label: string;
-    href: string;
-  }>;
-}
-
-interface ProjectPickItem {
-  value: string;
-  label: string;
-  teamId: string;
-  href: string | null;
-  /** What the filter matches against: the team name plus the project name. */
-  searchText: string;
-  kind: "project" | "new-project";
-}
-
-function toPickItems(groups: ProjectPickGroup[]): ProjectPickItem[] {
-  return groups.flatMap((group) => [
-    ...group.projects.map((project) => ({
-      value: project.projectId,
-      label: project.label,
-      teamId: group.team.teamId,
-      href: project.href,
-      searchText: `${group.team.label} ${project.label}`.toLowerCase(),
-      kind: "project" as const,
-    })),
-    ...(group.team.canCreateProject
-      ? [
-          {
-            value: `new-project:${group.team.teamId}`,
-            label: "New Project",
-            teamId: group.team.teamId,
-            href: null,
-            searchText: "",
-            kind: "new-project" as const,
-          },
-        ]
-      : []),
-  ]);
-}
-
-/**
- * The items the popup offers for a query, grouped for rendering and flat
- * for the collection the keyboard walks. A running search hides the
- * create entries: they match no project, and a list of results is not
- * the place to start a different action from.
- */
-function useProjectPickItems({
-  groups,
-  query,
-}: {
-  groups: ProjectPickGroup[];
-  query: string;
-}) {
-  const allItems = useMemo(() => toPickItems(groups), [groups]);
-
-  const filteredItems = useMemo(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) return allItems;
-    return allItems.filter(
-      (item) => item.kind === "project" && item.searchText.includes(needle),
-    );
-  }, [allItems, query]);
-
-  const collection = useMemo(
-    () =>
-      createListCollection({
-        items: filteredItems,
-        itemToValue: (item) => item.value,
-        itemToString: (item) => item.label,
-      }),
-    [filteredItems],
-  );
-
-  const visibleGroups = useMemo(
-    () =>
-      groups
-        .map((group) => ({
-          team: group.team,
-          items: filteredItems.filter(
-            (item) => item.teamId === group.team.teamId,
-          ),
-        }))
-        .filter((group) => group.items.length > 0),
-    [groups, filteredItems],
-  );
-
-  return { allItems, collection, visibleGroups };
-}
+import { ProjectComboboxPopup } from "./ProjectSwitcherComboboxPopup";
+import {
+  type ProjectPickGroup,
+  resolvePickOutcome,
+  useProjectPickItems,
+} from "./projectPickItems";
 
 /**
  * The project switch chip for an organization with a long project list:
@@ -174,27 +69,7 @@ export function ProjectSwitcherCombobox({
       positioning={{ placement: "bottom-start", gutter: 4 }}
       width="auto"
     >
-      {/* Ark positions the listbox against the CONTROL, so the trigger
-          must live inside one that generates a layout box. */}
-      <Combobox.Control display="inline-flex" width="auto" minWidth={0}>
-        <Combobox.Trigger asChild>
-          <Button
-            variant="ghost"
-            aria-label="Switch project"
-            fontSize="13px"
-            fontWeight="normal"
-            paddingX={2}
-            height="32px"
-            color="fg"
-            gap={2}
-            _hover={{ backgroundColor: "bg.muted" }}
-          >
-            <ProjectAvatar name={currentProjectName} />
-            <Text whiteSpace="nowrap">{currentProjectName}</Text>
-            <ChevronsUpDown size={12} color="var(--chakra-colors-fg-muted)" />
-          </Button>
-        </Combobox.Trigger>
-      </Combobox.Control>
+      <ProjectComboboxTrigger currentProjectName={currentProjectName} />
       <ProjectComboboxPopup
         visibleGroups={visibleGroups}
         showTeamHeaders={showTeamHeaders}
@@ -204,159 +79,33 @@ export function ProjectSwitcherCombobox({
   );
 }
 
-/**
- * What picking a value means: opening a project, starting the create
- * flow for a team, or nothing (the current project, or a value that
- * left the list between render and pick).
- */
-function resolvePickOutcome({
-  value,
-  allItems,
-  groups,
-  currentProjectId,
+/** The chip that opens the popup, styled the same as the plain menu's. */
+function ProjectComboboxTrigger({
+  currentProjectName,
 }: {
-  value: string;
-  allItems: ProjectPickItem[];
-  groups: ProjectPickGroup[];
-  currentProjectId: string;
-}):
-  | { kind: "create"; team: { teamId: string; orgId: string } }
-  | { kind: "open"; href: string }
-  | null {
-  const item = allItems.find((candidate) => candidate.value === value);
-  if (!item) return null;
-  if (item.kind === "new-project") {
-    const team = groups.find((g) => g.team.teamId === item.teamId)?.team;
-    return team
-      ? { kind: "create", team: { teamId: team.teamId, orgId: team.orgId } }
-      : null;
-  }
-  if (item.value === currentProjectId || !item.href) return null;
-  return { kind: "open", href: item.href };
-}
-
-/** The portaled popup: the search field, the empty state and the groups. */
-function ProjectComboboxPopup({
-  visibleGroups,
-  showTeamHeaders,
-  currentProjectId,
-}: {
-  visibleGroups: Array<{
-    team: ProjectPickGroup["team"];
-    items: ProjectPickItem[];
-  }>;
-  showTeamHeaders: boolean;
-  currentProjectId: string;
+  currentProjectName: string;
 }) {
   return (
-    <Portal>
-      <Combobox.Positioner>
-        <Combobox.Content
-          minWidth="260px"
-          maxHeight="360px"
-          overflowY="auto"
-          padding={0}
-        >
-          <ProjectSearchHeader />
-          <Combobox.Empty
-            paddingX={3}
-            paddingY={2}
-            color="fg.muted"
-            fontSize="13px"
-          >
-            No projects match your search.
-          </Combobox.Empty>
-          <Box padding={1}>
-            {visibleGroups.map((group) => (
-              <Combobox.ItemGroup key={group.team.teamId}>
-                <Combobox.ItemGroupLabel
-                  paddingX={2}
-                  paddingTop={2}
-                  paddingBottom={1}
-                  color="fg.muted"
-                  fontSize="11px"
-                  fontWeight="600"
-                >
-                  {showTeamHeaders ? group.team.label : "Projects"}
-                </Combobox.ItemGroupLabel>
-                {group.items.map((item) => (
-                  <ProjectItemRow
-                    key={item.value}
-                    item={item}
-                    isCurrent={item.value === currentProjectId}
-                  />
-                ))}
-              </Combobox.ItemGroup>
-            ))}
-          </Box>
-        </Combobox.Content>
-      </Combobox.Positioner>
-    </Portal>
-  );
-}
-
-/** The focused search field pinned to the top of the popup. */
-function ProjectSearchHeader() {
-  return (
-    <Box
-      position="sticky"
-      top={0}
-      zIndex={1}
-      background="bg.panel"
-      paddingX={2.5}
-      paddingY={1.5}
-      borderBottomWidth="1px"
-      borderColor="border"
-    >
-      <HStack gap={2} color="fg.muted">
-        <Search size={14} aria-hidden />
-        <Combobox.Input
-          autoFocus
-          placeholder="Search projects"
-          height="28px"
-          minWidth={0}
-          flex={1}
-          padding={0}
-          border={0}
-          outline="none"
-          background="transparent"
+    // Ark positions the listbox against the CONTROL, so the trigger
+    // must live inside one that generates a layout box.
+    <Combobox.Control display="inline-flex" width="auto" minWidth={0}>
+      <Combobox.Trigger asChild>
+        <Button
+          variant="ghost"
+          aria-label="Switch project"
           fontSize="13px"
+          fontWeight="normal"
+          paddingX={2}
+          height="32px"
           color="fg"
-          _placeholder={{ color: "fg.subtle" }}
-          _focusVisible={{ outline: "none" }}
-        />
-      </HStack>
-    </Box>
-  );
-}
-
-function ProjectItemRow({
-  item,
-  isCurrent,
-}: {
-  item: ProjectPickItem;
-  isCurrent: boolean;
-}) {
-  return (
-    <Combobox.Item
-      item={item}
-      borderRadius="md"
-      paddingX={2}
-      paddingY={1.5}
-      fontSize="13px"
-      _highlighted={{ background: "bg.subtle" }}
-    >
-      <HStack gap={2} width="full">
-        {item.kind === "new-project" ? (
-          <Plus size={13} aria-hidden />
-        ) : (
-          <ProjectAvatar name={item.label} />
-        )}
-        <Combobox.ItemText flex={1} truncate>
-          {item.label}
-        </Combobox.ItemText>
-        {isCurrent && <Check size={13} aria-label="Current project" />}
-      </HStack>
-    </Combobox.Item>
+          gap={2}
+          _hover={{ backgroundColor: "bg.muted" }}
+        >
+          <ProjectAvatar name={currentProjectName} />
+          <Text whiteSpace="nowrap">{currentProjectName}</Text>
+          <ChevronsUpDown size={12} color="var(--chakra-colors-fg-muted)" />
+        </Button>
+      </Combobox.Trigger>
+    </Combobox.Control>
   );
 }

--- a/platform/app/src/features/navigation/shell/ProjectSwitcherComboboxPopup.tsx
+++ b/platform/app/src/features/navigation/shell/ProjectSwitcherComboboxPopup.tsx
@@ -1,0 +1,134 @@
+import { Box, Combobox, HStack, Portal } from "@chakra-ui/react";
+import { Check, Plus, Search } from "lucide-react";
+import { ProjectAvatar } from "~/components/ProjectAvatar";
+import type { ProjectPickGroup, ProjectPickItem } from "./projectPickItems";
+
+/**
+ * The portaled popup of the project switcher combobox: the search field,
+ * the empty state and the team groups.
+ */
+export function ProjectComboboxPopup({
+  visibleGroups,
+  showTeamHeaders,
+  currentProjectId,
+}: {
+  visibleGroups: Array<{
+    team: ProjectPickGroup["team"];
+    items: ProjectPickItem[];
+  }>;
+  showTeamHeaders: boolean;
+  currentProjectId: string;
+}) {
+  return (
+    <Portal>
+      <Combobox.Positioner>
+        <Combobox.Content
+          minWidth="260px"
+          maxHeight="360px"
+          overflowY="auto"
+          padding={0}
+        >
+          <ProjectSearchHeader />
+          <Combobox.Empty
+            paddingX={3}
+            paddingY={2}
+            color="fg.muted"
+            fontSize="13px"
+          >
+            No projects match your search.
+          </Combobox.Empty>
+          <Box padding={1}>
+            {visibleGroups.map((group) => (
+              <Combobox.ItemGroup key={group.team.teamId}>
+                <Combobox.ItemGroupLabel
+                  paddingX={2}
+                  paddingTop={2}
+                  paddingBottom={1}
+                  color="fg.muted"
+                  fontSize="11px"
+                  fontWeight="600"
+                >
+                  {showTeamHeaders ? group.team.label : "Projects"}
+                </Combobox.ItemGroupLabel>
+                {group.items.map((item) => (
+                  <ProjectItemRow
+                    key={item.value}
+                    item={item}
+                    isCurrent={item.value === currentProjectId}
+                  />
+                ))}
+              </Combobox.ItemGroup>
+            ))}
+          </Box>
+        </Combobox.Content>
+      </Combobox.Positioner>
+    </Portal>
+  );
+}
+
+/** The focused search field pinned to the top of the popup. */
+function ProjectSearchHeader() {
+  return (
+    <Box
+      position="sticky"
+      top={0}
+      zIndex={1}
+      background="bg.panel"
+      paddingX={2.5}
+      paddingY={1.5}
+      borderBottomWidth="1px"
+      borderColor="border"
+    >
+      <HStack gap={2} color="fg.muted">
+        <Search size={14} aria-hidden />
+        <Combobox.Input
+          autoFocus
+          aria-label="Search projects"
+          placeholder="Search projects"
+          height="28px"
+          minWidth={0}
+          flex={1}
+          padding={0}
+          border={0}
+          outline="none"
+          background="transparent"
+          fontSize="13px"
+          color="fg"
+          _placeholder={{ color: "fg.subtle" }}
+          _focusVisible={{ outline: "none" }}
+        />
+      </HStack>
+    </Box>
+  );
+}
+
+function ProjectItemRow({
+  item,
+  isCurrent,
+}: {
+  item: ProjectPickItem;
+  isCurrent: boolean;
+}) {
+  return (
+    <Combobox.Item
+      item={item}
+      borderRadius="md"
+      paddingX={2}
+      paddingY={1.5}
+      fontSize="13px"
+      _highlighted={{ background: "bg.subtle" }}
+    >
+      <HStack gap={2} width="full">
+        {item.kind === "new-project" ? (
+          <Plus size={13} aria-hidden />
+        ) : (
+          <ProjectAvatar name={item.label} />
+        )}
+        <Combobox.ItemText flex={1} truncate>
+          {item.label}
+        </Combobox.ItemText>
+        {isCurrent && <Check size={13} aria-label="Current project" />}
+      </HStack>
+    </Combobox.Item>
+  );
+}

--- a/platform/app/src/features/navigation/shell/projectPickItems.ts
+++ b/platform/app/src/features/navigation/shell/projectPickItems.ts
@@ -1,0 +1,136 @@
+import { createListCollection } from "@chakra-ui/react";
+import { useMemo } from "react";
+
+/**
+ * A team and the projects the picker offers under it. The same shape
+ * `ProjectScopeMenu` builds for the plain menu, so the two render paths
+ * cannot drift on what they offer.
+ */
+export interface ProjectPickGroup {
+  team: {
+    teamId: string;
+    orgId: string;
+    label: string;
+    canCreateProject?: boolean;
+  };
+  projects: Array<{
+    projectId: string;
+    label: string;
+    href: string;
+  }>;
+}
+
+export interface ProjectPickItem {
+  value: string;
+  label: string;
+  teamId: string;
+  href: string | null;
+  /** What the filter matches against: the team name plus the project name. */
+  searchText: string;
+  kind: "project" | "new-project";
+}
+
+function toPickItems(groups: ProjectPickGroup[]): ProjectPickItem[] {
+  return groups.flatMap((group) => [
+    ...group.projects.map((project) => ({
+      value: project.projectId,
+      label: project.label,
+      teamId: group.team.teamId,
+      href: project.href,
+      searchText: `${group.team.label} ${project.label}`.toLowerCase(),
+      kind: "project" as const,
+    })),
+    ...(group.team.canCreateProject
+      ? [
+          {
+            value: `new-project:${group.team.teamId}`,
+            label: "New Project",
+            teamId: group.team.teamId,
+            href: null,
+            searchText: "",
+            kind: "new-project" as const,
+          },
+        ]
+      : []),
+  ]);
+}
+
+/**
+ * The items the popup offers for a query, grouped for rendering and flat
+ * for the collection the keyboard walks. A running search hides the
+ * create entries: they match no project, and a list of results is not
+ * the place to start a different action from.
+ */
+export function useProjectPickItems({
+  groups,
+  query,
+}: {
+  groups: ProjectPickGroup[];
+  query: string;
+}) {
+  const allItems = useMemo(() => toPickItems(groups), [groups]);
+
+  const filteredItems = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return allItems;
+    return allItems.filter(
+      (item) => item.kind === "project" && item.searchText.includes(needle),
+    );
+  }, [allItems, query]);
+
+  const collection = useMemo(
+    () =>
+      createListCollection({
+        items: filteredItems,
+        itemToValue: (item) => item.value,
+        itemToString: (item) => item.label,
+      }),
+    [filteredItems],
+  );
+
+  const visibleGroups = useMemo(
+    () =>
+      groups
+        .map((group) => ({
+          team: group.team,
+          items: filteredItems.filter(
+            (item) => item.teamId === group.team.teamId,
+          ),
+        }))
+        .filter((group) => group.items.length > 0),
+    [groups, filteredItems],
+  );
+
+  return { allItems, collection, visibleGroups };
+}
+
+/**
+ * What picking a value means: opening a project, starting the create
+ * flow for a team, or nothing (the current project, or a value that
+ * left the list between render and pick).
+ */
+export function resolvePickOutcome({
+  value,
+  allItems,
+  groups,
+  currentProjectId,
+}: {
+  value: string;
+  allItems: ProjectPickItem[];
+  groups: ProjectPickGroup[];
+  currentProjectId: string;
+}):
+  | { kind: "create"; team: { teamId: string; orgId: string } }
+  | { kind: "open"; href: string }
+  | null {
+  const item = allItems.find((candidate) => candidate.value === value);
+  if (!item) return null;
+  if (item.kind === "new-project") {
+    const team = groups.find((g) => g.team.teamId === item.teamId)?.team;
+    return team
+      ? { kind: "create", team: { teamId: team.teamId, orgId: team.orgId } }
+      : null;
+  }
+  if (item.value === currentProjectId || !item.href) return null;
+  return { kind: "open", href: item.href };
+}

--- a/platform/app/src/features/navigation/shell/useIsMobileViewport.ts
+++ b/platform/app/src/features/navigation/shell/useIsMobileViewport.ts
@@ -1,0 +1,16 @@
+import { useBreakpointValue } from "@chakra-ui/react";
+
+/**
+ * Whether the viewport is phone-width, which is where the navigation-v2
+ * shells trade the sidebar chrome for the compact mobile bar and its
+ * full-screen menu. Below Chakra's `md` breakpoint the sidebar has no
+ * room to earn; between `md` and `lg` the compact hover-expanded
+ * sidebar still works.
+ *
+ * Spec: specs/navigation/mobile-chrome.feature
+ */
+export function useIsMobileViewport(): boolean {
+  return (
+    useBreakpointValue({ base: true, md: false }, { fallback: "md" }) === true
+  );
+}

--- a/platform/app/src/features/navigation/shell/useNavigationV2ShellState.ts
+++ b/platform/app/src/features/navigation/shell/useNavigationV2ShellState.ts
@@ -19,6 +19,7 @@ import {
   SHELL_SIDEBAR_WIDTH_COMPACT,
   SHELL_SIDEBAR_WIDTH_EXPANDED,
 } from "./shellLayout";
+import { useIsMobileViewport } from "./useIsMobileViewport";
 
 type OrganizationTeamProject = ReturnType<typeof useOrganizationTeamProject>;
 type AppSession = ReturnType<typeof useRequiredSession>["data"];
@@ -34,6 +35,8 @@ export interface NavigationV2ShellReadyState {
   isSettingsRoute: boolean;
   isDevelopment: boolean;
   isCompactSidebar: boolean;
+  /** Phone-width viewport: the mobile bar + menu replace the sidebar chrome. */
+  isMobile: boolean;
   /**
    * Width of the sidebar column, and with it the left edge of the
    * content column. The top bar and the content cap both read it here,
@@ -71,6 +74,7 @@ export function useNavigationV2ShellState({
     { base: true, lg: false },
     { fallback: "lg" },
   );
+  const isMobile = useIsMobileViewport();
   const router = useRouter();
 
   useOrgQueryParamSelection();
@@ -116,6 +120,7 @@ export function useNavigationV2ShellState({
     pathname: router.pathname,
     isDevelopment: publicEnv.data?.NODE_ENV === "development",
     isCompactSidebar: isSmallScreen === true,
+    isMobile,
     langyDockInset,
   });
 }
@@ -128,6 +133,7 @@ function toReadyState({
   pathname,
   isDevelopment,
   isCompactSidebar,
+  isMobile,
   langyDockInset,
 }: {
   user: SessionUser;
@@ -136,6 +142,7 @@ function toReadyState({
   pathname: string;
   isDevelopment: boolean;
   isCompactSidebar: boolean;
+  isMobile: boolean;
   langyDockInset: number;
 }): NavigationV2ShellReadyState {
   return {
@@ -147,6 +154,7 @@ function toReadyState({
     isSettingsRoute: route.isSettingsRoute,
     isDevelopment,
     isCompactSidebar,
+    isMobile,
     menuWidth: isCompactSidebar
       ? SHELL_SIDEBAR_WIDTH_COMPACT
       : SHELL_SIDEBAR_WIDTH_EXPANDED,

--- a/specs/components/scope-chip-picker-search.feature
+++ b/specs/components/scope-chip-picker-search.feature
@@ -1,0 +1,36 @@
+Feature: Scope picker search and team grouping
+  As a user scoping a resource in an organization with many teams and projects
+  I want the scope dropdown to group projects under their team and to be searchable
+  So that I can find the right scope without reading one long flat list
+
+  `ScopeChipPicker` is the shared scope selector (see
+  dev/docs/best_practices/scope-selector-and-badges.md). Both of its
+  dropdown variants gain a search field when the option list is long,
+  and the multi-select dropdown groups project options under their team
+  name the way the single-select variant already does.
+
+  @integration
+  Scenario: Projects group under their team name
+    Given my organization has two teams with projects in each
+    When I open the scope dropdown
+    Then each project lists under a group header carrying its team name
+    And a project whose team is not listed falls under a plain "Projects" group
+
+  @integration
+  Scenario: A long scope list gets a search field
+    Given the picker offers more than eight scopes
+    When I open the scope dropdown
+    Then a search field sits at the top of the list
+    And typing narrows the options to those whose name or team matches
+
+  @integration
+  Scenario: A short scope list has no search field
+    Given the picker offers eight scopes or fewer
+    When I open the scope dropdown
+    Then the options list has no search field
+
+  @integration
+  Scenario: Searching does not drop scopes already selected
+    Given two scopes are selected
+    When I search for a third scope and select it
+    Then all three scopes stay selected

--- a/specs/components/scope-chip-picker-search.feature
+++ b/specs/components/scope-chip-picker-search.feature
@@ -24,6 +24,12 @@ Feature: Scope picker search and team grouping
     And typing narrows the options to those whose name or team matches
 
   @integration
+  Scenario: The single-select dropdown searches the same way
+    Given the single-select picker offers more than eight scopes
+    When I search by a team name and pick one of its projects
+    Then the picker takes that project as the chosen scope
+
+  @integration
   Scenario: A short scope list has no search field
     Given the picker offers eight scopes or fewer
     When I open the scope dropdown

--- a/specs/navigation/mobile-chrome.feature
+++ b/specs/navigation/mobile-chrome.feature
@@ -65,6 +65,14 @@ Feature: Mobile chrome
     And tabbing past the last entry returns to the first one
 
   @integration
+  Scenario: Escape closes only the menu on top
+    Given the navigation overlay is open
+    And I opened the organization menu from it
+    When I press Escape
+    Then the organization menu closes
+    And the overlay stays open
+
+  @integration
   Scenario: Tablet and desktop widths keep the sidebar chrome
     Given I am on an LLM Ops page on a desktop-width viewport
     Then the sidebar renders and no menu button shows

--- a/specs/navigation/mobile-chrome.feature
+++ b/specs/navigation/mobile-chrome.feature
@@ -59,6 +59,12 @@ Feature: Mobile chrome
     And the menu button holds focus
 
   @integration
+  Scenario: The overlay keeps the keyboard inside it
+    Given the navigation overlay is open
+    Then the page behind it is inert
+    And tabbing past the last entry returns to the first one
+
+  @integration
   Scenario: Tablet and desktop widths keep the sidebar chrome
     Given I am on an LLM Ops page on a desktop-width viewport
     Then the sidebar renders and no menu button shows

--- a/specs/navigation/mobile-chrome.feature
+++ b/specs/navigation/mobile-chrome.feature
@@ -45,6 +45,20 @@ Feature: Mobile chrome
     Then the overlay closes and the page shows
 
   @integration
+  Scenario: The close button dismisses the overlay without navigating
+    Given the navigation overlay is open
+    When I tap the close button
+    Then the overlay closes
+    And I stay on the same page
+
+  @integration
+  Scenario: Escape closes the overlay and returns focus to the menu button
+    Given the navigation overlay is open
+    When I press Escape
+    Then the overlay closes
+    And the menu button holds focus
+
+  @integration
   Scenario: Tablet and desktop widths keep the sidebar chrome
     Given I am on an LLM Ops page on a desktop-width viewport
     Then the sidebar renders and no menu button shows

--- a/specs/navigation/mobile-chrome.feature
+++ b/specs/navigation/mobile-chrome.feature
@@ -1,0 +1,50 @@
+Feature: Mobile chrome
+  As a user opening LangWatch on a phone
+  I want a top bar with only the scope and a menu button
+  So that the page keeps the screen and navigation stays one tap away
+
+  On viewports narrower than the tablet breakpoint the navigation-v2
+  shells replace the sidebar and the desktop top bar with a single
+  compact bar: the logo, the product selector, the product's own scope
+  control, and a menu button on the right. The menu button opens a
+  full-screen overlay that carries the organization and project
+  selectors, the product's pages, and the account controls, so nothing
+  the desktop chrome offers becomes unreachable.
+
+  @integration
+  Scenario: The mobile top bar holds the scope and the menu button only
+    Given I am on an LLM Ops page on a phone-width viewport
+    Then the top bar shows the logo, the product selector and the project selector
+    And a menu button sits on the right
+    And the sidebar is not rendered
+
+  @integration
+  Scenario: LLM Ops keeps the organization out of the mobile bar
+    Given I belong to two organizations
+    And I am on an LLM Ops page on a phone-width viewport
+    Then the top bar shows the project selector and no organization control
+    And the navigation overlay offers the organization selector
+
+  @integration
+  Scenario: An organization product shows the organization in the mobile bar
+    Given I am on a Gateway page on a phone-width viewport
+    Then the top bar shows the organization control
+    And no project selector renders
+
+  @integration
+  Scenario: The menu button opens the navigation overlay
+    Given I am on an LLM Ops page on a phone-width viewport
+    When I tap the menu button
+    Then an overlay covers the screen with the product's pages
+    And the overlay carries the account controls
+
+  @integration
+  Scenario: Navigating from the overlay closes it
+    Given the navigation overlay is open
+    When I open a page from it
+    Then the overlay closes and the page shows
+
+  @integration
+  Scenario: Tablet and desktop widths keep the sidebar chrome
+    Given I am on an LLM Ops page on a desktop-width viewport
+    Then the sidebar renders and no menu button shows

--- a/specs/navigation/product-switcher-navigation.feature
+++ b/specs/navigation/product-switcher-navigation.feature
@@ -116,3 +116,29 @@ Feature: Product switcher navigation
     When I open one of its pages
     Then the page renders as a project page in the LLM Ops product
     And it does not render as the personal or the settings surface
+
+  @integration
+  Scenario: A large project list opens with a focused search field
+    Given my organization holds more than eight projects
+    When I open the project menu
+    Then a search field sits at the top of the menu and holds the focus
+    And typing narrows the list to projects whose name or team matches
+
+  @integration
+  Scenario: A short project list stays a plain menu
+    Given my organization holds eight projects or fewer
+    When I open the project menu
+    Then the menu lists the projects with no search field
+
+  @integration
+  Scenario: The project search answers the keyboard
+    Given my organization holds more than eight projects
+    And the project menu is open
+    When I move down the list with the arrow keys and press Enter
+    Then the highlighted project opens
+
+  @integration
+  Scenario: Creating a project stays available while the list is unfiltered
+    Given my organization holds more than eight projects
+    When I open the project menu without typing
+    Then each team I can create a project in offers "New Project"


### PR DESCRIPTION
Three changes to how you find and reach things: search in the project selector, search and team grouping in the scope selector, and a phone-width chrome for the navigation-v2 shells.

## Project selector search

An organization with more than eight projects gets a different project menu in the top bar: a combobox that opens with a focused search field. Type to filter by project or team name, move with the arrow keys, press Enter to open. The list stays grouped by team, and the per-team "New Project" entries stay while the list is unfiltered. Eight projects or fewer keep the plain menu they have today.

![Project selector with search](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/project-selector-search-open.png?raw=true)

![Filtered by "class"](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/project-selector-search-filtered.png?raw=true)

The popup is a Chakra `Combobox` (Ark), so the keyboard support and the aria wiring come from the component instead of a hand-rolled menu + input.

## Scope selector: team grouping and search

The shared `ScopeChipPicker` (API keys, virtual keys, budgets, routing policies, model providers, data retention, data privacy) had one flat "Projects" group in its multi-select dropdown, so with many projects the list was hard to read. It now groups projects under a gray header with their team's name, the way the single-select variant already did. Projects whose team is not known keep the flat group, so callers that pass no team data see no change.

Past eight options the dropdown also gains a search field, pinned to the top. It matches the option's own name and, for projects, the parent team's name, so "shared" finds every project of the QA Shared Team. Selections made before a search survive it.

![Scope selector grouped by team](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/scope-picker-grouped.png?raw=true)

![Scope search matches team names](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/scope-picker-search.png?raw=true)

I checked every surface that renders a scope selection: all of them already go through `ScopeChipPicker`, so this one change covers API keys, virtual keys and the rest. The remaining `scopeType` code outside it is read-side badges and one budget period dropdown, nothing to migrate.

## Mobile chrome

Below the tablet breakpoint the navigation-v2 shells replace the sidebar with one compact bar: the logo, the product selector, the product's own scope, and a menu button. LLM Ops shows the project selector and keeps the organization out of the bar; Gateway, Governance and Settings show the organization control instead.

![Mobile top bar](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/mobile-top-bar.png?raw=true)

The menu button opens a full-screen overlay: the organization and project selectors side by side (so a multi-organization user can switch both from here), the account menu, Quick Search, the product's pages, and the pinned bottom block from the desktop sidebar. Opening any page closes the overlay.

![Mobile menu open](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/mobile-menu-open.png?raw=true)

![Gateway on mobile](https://github.com/langwatch/pr-screenshots/blob/main/selector-search-mobile/mobile-gateway-bar.png?raw=true)

The overlay is a modal: it takes focus when it opens, the page behind it is inert, Tab wraps inside it, Escape closes it and the menu button gets the focus back. A menu opened from inside the overlay (organization, project, account) keeps its own keys, so the first Escape closes that menu and the second closes the overlay.

Tablet width (`md` to `lg`) keeps the compact hover-expanded sidebar; desktop keeps everything as it is. The legacy chrome is untouched.

## Specs

- `specs/navigation/product-switcher-navigation.feature`: four new scenarios for the project search. 19/19 bound.
- `specs/components/scope-chip-picker-search.feature` (new): 5/5 bound.
- `specs/navigation/mobile-chrome.feature` (new): 10/10 bound.

## Testing

- `ProductSwitcherShell.integration.test.tsx`: search opens focused, filters by project and team name, arrow keys + Enter open the highlighted project, create entries stay while unfiltered and hide while searching, short lists keep the plain menu. 18/18.
- `ScopeChipPicker.integration.test.tsx`: team grouping with an orphan fallback, search field past eight options, team-name matching, selection survival across a search, the same search in the single-select variant, no field for short lists. 12/12.
- `MobileShell.integration.test.tsx` (new): the bar's contents per product, the overlay's contents, close-on-navigation, close button, Escape, focus containment, Escape layering, desktop keeps the sidebar. 10/10.
- Browser QA on the dogfood account for all three features; the screenshots above are from it. Keyboard verified end to end (typed a filter, ArrowDown, Enter, landed on the project). The mobile overlay was checked in a real browser for focus, inert, Tab wrap, Escape layering and focus restore. Two faults came out of that pass which jsdom cannot show: a menu opened from the overlay restores focus to its own trigger while it answers Escape, so the overlay read the key too late and closed with it, and an inert element takes no focus, so the menu button had to get the focus back one render later.
- `pnpm typecheck:all` clean, biome clean (the two pre-existing `ScopeChipPicker` complexity warnings keep their merge-base count), feature parity `OK: 8037 bound`.

One note on the tests: Ark's combobox input is machine-controlled, so per-character `userEvent` typing races the re-render and drops characters on a slow runner; the tests set the query with a single change event instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable project and scope pickers for larger lists, with team grouping, keyboard navigation, and project/team name filtering.
  * Added mobile navigation with compact controls, a full-screen menu overlay, focus management, and automatic dismissal after navigation.
  * Added “New Project” actions within project menus.
* **Bug Fixes**
  * Improved handling of orphan projects and preserved existing selections during filtering.
* **Tests**
  * Added integration coverage for mobile navigation, project switching, grouping, searching, and responsive menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->