### PR TITLE
feat(authz): the ADR-110 authz-engine migration — every legacy table stated, proven, and finishing is the switch

### DIFF
--- a/packages/authz-server/src/authz-migration.repository.ts
+++ b/packages/authz-server/src/authz-migration.repository.ts
@@ -157,6 +157,22 @@ export type ProjectCredentialFact = {
 };
 
 
+/** One non-RESOURCE `Grant` head row, as the authz-engine migration's proof
+ *  reads it. Columns as stored, uppercase spellings kept. */
+export type GrantHeadRow = {
+  id: string;
+  principalType: string;
+  principalId: string | null;
+  roleKey: string | null;
+  legacyRole: string | null;
+  /** Which writer emitted the fact — what tells the migration's sweep and
+   *  completeness check a row is theirs to own. */
+  source: string;
+  scopeType: string;
+  scopeId: string;
+  revoked: boolean;
+};
+
 /** One RESOURCE-scope `Grant` head row, re-read for the import proof.
  *  Columns as stored: `principalType` and `resourceKind` keep the database's
  *  uppercase spellings, and the proof is where they meet the source row's. */

--- a/packages/authz-server/src/authz-migration.repository.ts
+++ b/packages/authz-server/src/authz-migration.repository.ts
@@ -162,6 +162,9 @@ export type ProjectCredentialFact = {
  *  uppercase spellings, and the proof is where they meet the source row's. */
 export type ResourceGrantRow = {
   grantId: string;
+  /** Which writer emitted the fact — what tells the migration's sweep and
+   *  completeness check a row is theirs to own. */
+  source: string;
   token: string | null;
   resourceKind: string | null;
   /** The RESOURCE scope's id: the shared resource itself. */

--- a/packages/authz-server/src/index.ts
+++ b/packages/authz-server/src/index.ts
@@ -41,6 +41,7 @@ export type {
   AuthzMigrationRepository,
   ExistingTeamBinding,
   ExternalMemberFact,
+  GrantHeadRow,
   LegacyBindingRow,
   LegacyRoleRow,
   LegacyTeamRow,

--- a/platform/app/src/server/api-key/__tests__/legacy-grant-mint.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/legacy-grant-mint.unit.test.ts
@@ -328,12 +328,29 @@ describe("genesisImportMoment()", () => {
     findUnique.mockReset();
   });
 
-  describe("given an organization parked for weeks before it migrated", () => {
+  describe("given an organization parked for weeks before it finalized", () => {
     /** @scenario "A key born during a parked genesis import still mints once the organization migrates" */
-    it("uses the migrated transition's own time, not the parked row's first appearance", async () => {
+    it("uses the finalized transition's own time, not the parked row's first appearance", async () => {
       // The row first appeared weeks earlier as `parked`; `createdAt` still
       // reflects that, but `occurredAt` has since been overwritten with the
-      // `migrated` transition's own business time.
+      // `finalized` transition's own business time.
+      findUnique.mockResolvedValue({
+        status: "finalized",
+        createdAt: new Date("2024-05-01T00:00:00.000Z"),
+        occurredAt: new Date("2024-06-01T00:00:00.000Z"),
+      });
+
+      const moment = await genesisImportMoment({
+        organizationId: "org_1",
+        prisma,
+      });
+
+      expect(moment).toEqual(new Date("2024-06-01T00:00:00.000Z"));
+    });
+  });
+
+  describe("given an organization that is held rather than finalized", () => {
+    it("reports no cutover moment: a held organization's writes are still legacy", async () => {
       findUnique.mockResolvedValue({
         status: "migrated",
         createdAt: new Date("2024-05-01T00:00:00.000Z"),
@@ -345,7 +362,7 @@ describe("genesisImportMoment()", () => {
         prisma,
       });
 
-      expect(moment).toEqual(new Date("2024-06-01T00:00:00.000Z"));
+      expect(moment).toBeNull();
     });
   });
 

--- a/platform/app/src/server/api-key/legacy-grant-mint.ts
+++ b/platform/app/src/server/api-key/legacy-grant-mint.ts
@@ -131,14 +131,19 @@ function sweepGuard(): void {
 }
 
 /**
- * The statuses that mean this organization's genesis import actually cut it
+ * The statuses that mean this organization's migration actually cut it
  * over — mirrors `ON_ENGINE_STATUSES` in engine-gate.ts (kept as its
  * own literal here rather than imported: that gate answers a present-tense
  * "is this organization on the ledger today", this answers "when did it get
  * there", and the two must not be forced to share a type only one of them
  * needs).
+ *
+ * `finalized` only, matching the gate: `migrated` is the HELD state — the
+ * organization's writes are still imperative legacy rows, so a key created
+ * while held belongs to the legacy era and the next migration pass adopts
+ * its bindings; there is no ledger era to date it against yet.
  */
-const CUTOVER_STATUSES: readonly string[] = ["migrated", "finalized"];
+const CUTOVER_STATUSES: readonly string[] = ["finalized"];
 
 /**
  * The moment this organization's genesis import actually cut it over onto the

--- a/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
@@ -57,7 +57,7 @@ function buildPrisma({ onEngine }: { onEngine: boolean | undefined }) {
   const roleBindingFindMany = vi.fn().mockResolvedValue([]);
   const migrationStateFindUnique = vi
     .fn()
-    .mockResolvedValue(onEngine ? { status: "migrated" } : null);
+    .mockResolvedValue(onEngine ? { status: "finalized" } : null);
 
   const prisma = {
     project: {

--- a/platform/app/src/server/api/__tests__/rbac.legacy-fallback.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.legacy-fallback.unit.test.ts
@@ -63,6 +63,10 @@ describe("legacy TeamUser fallback at the resolver seam", () => {
   describe.each([
     "pending",
     "parked",
+    // Held: the work landed but the proof found the projection behind or
+    // disagreeing. The ops page promises such an organization behaves
+    // exactly as before, so it reads legacy like the others.
+    "migrated",
   ] as const)("when the organization's migration is %s", (status) => {
     /** @scenario "An organization that has not finalized reads from legacy" */
     it("answers from the legacy row, whatever the migration is doing", async () => {
@@ -81,15 +85,14 @@ describe("legacy TeamUser fallback at the resolver seam", () => {
     });
   });
 
-  describe("when the migration has finished", () => {
+  describe("when the migration has finalized", () => {
     // Finishing IS the switch (ADR-110), so the engine answers and the legacy
-    // rows are not consulted at all. This is the half the old four-state
-    // matrix could not express: it predated a world where any status moved the
-    // organization off this path.
+    // rows are not consulted at all. Only `finalized` finishes: `migrated`
+    // is the held state and reads legacy above.
     /** @scenario "A cut-over organization is decided by the engine" */
     it("stops consulting the legacy row", async () => {
       mockPrisma.systemMigrationTenantState.findUnique.mockResolvedValue({
-        status: "migrated",
+        status: "finalized",
       });
 
       await resolveTeamPermission(

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -20,11 +20,12 @@ import type {
   RoleHeadRow,
   ShareLinkFactRow,
 } from "@langwatch/authz-server";
+import { PRINCIPAL_TO_DB } from "@langwatch/authz-server";
 import { describe, expect, it } from "vitest";
+import type { GrantHeadRow } from "../authz-engine.check";
 import {
   AuthzEngineMigration,
   type AuthzEngineMigrationStore,
-  type GrantHeadRow,
 } from "../authz-engine.migration";
 
 const ORG_ID = "org_acme";
@@ -36,7 +37,6 @@ type Sent = {
     | "attachGrant"
     | "defineRole"
     | "changeGrantRole"
-    | "changeRolePermissions"
     | "revokeGrant"
     | "deleteRole";
   commandId: string;
@@ -52,15 +52,21 @@ type Data = {
   shareLinks?: ShareLinkFactRow[];
   externalMembers?: ExternalMemberFact[];
   credentials?: ProjectCredentialFact[];
+  groupMemberships?: Array<{ userId: string; groupId: string }>;
   grantHeads?: GrantHeadRow[];
   roleHeads?: RoleHeadRow[];
   resourceRows?: ResourceGrantRow[];
 };
 
-function harness(data: Data = {}) {
+type Ledger = ConstructorParameters<typeof AuthzEngineMigration>[0]["ledger"];
+
+function harness(
+  data: Data = {},
+  options: { wrapLedger?: (ledger: Ledger) => Ledger } = {},
+) {
   const sent: Sent[] = [];
   const seeded: ResourceGrantUsageSeed[][] = [];
-  const reads = { heads: 0 };
+  const reads = { grantHeads: 0, roleHeads: 0, resourceRows: 0 };
   const store: AuthzEngineMigrationStore = {
     findOrganizationCreatedAtMs: async () =>
       data.organizationCreatedAtMs === undefined
@@ -73,12 +79,19 @@ function harness(data: Data = {}) {
     findShareLinkRows: async () => data.shareLinks ?? [],
     findExternalMemberFacts: async () => data.externalMembers ?? [],
     findProjectCredentialFacts: async () => data.credentials ?? [],
+    findGroupMemberships: async () => data.groupMemberships ?? [],
     findGrantHeadRows: async () => {
-      reads.heads += 1;
+      reads.grantHeads += 1;
       return data.grantHeads ?? [];
     },
-    findRoleHeads: async () => data.roleHeads ?? [],
-    findResourceGrantRows: async () => data.resourceRows ?? [],
+    findRoleHeads: async () => {
+      reads.roleHeads += 1;
+      return data.roleHeads ?? [];
+    },
+    findResourceGrantRows: async () => {
+      reads.resourceRows += 1;
+      return data.resourceRows ?? [];
+    },
     seedResourceGrantUsage: async ({ seeds }) => {
       seeded.push([...seeds]);
     },
@@ -91,16 +104,16 @@ function harness(data: Data = {}) {
     }: { commandId: string } & Record<string, unknown>) => {
       sent.push({ kind, commandId, payload });
     };
+  const recording: Ledger = {
+    attachGrant: record("attachGrant"),
+    defineRole: record("defineRole"),
+    changeGrantRole: record("changeGrantRole"),
+    revokeGrant: record("revokeGrant"),
+    deleteRole: record("deleteRole"),
+  };
   const migration = new AuthzEngineMigration({
     store,
-    ledger: {
-      attachGrant: record("attachGrant"),
-      defineRole: record("defineRole"),
-      changeGrantRole: record("changeGrantRole"),
-      changeRolePermissions: record("changeRolePermissions"),
-      revokeGrant: record("revokeGrant"),
-      deleteRole: record("deleteRole"),
-    },
+    ledger: options.wrapLedger ? options.wrapLedger(recording) : recording,
     now: () => NOW,
   });
   return { migration, sent, seeded, reads };
@@ -151,20 +164,13 @@ function shareLink(
 }
 
 /** The head row a folded attach of `fact` would produce — for tests that
- *  start from a converged projection. */
+ *  start from a converged projection. Spelled through the same mapping the
+ *  production check compares against, so the fixture cannot drift from what
+ *  a real fold writes. */
 function foldedHead(fact: GrantFact): GrantHeadRow {
-  const stored: Record<string, string> = {
-    user: "USER",
-    group: "GROUP",
-    apiKey: "API_KEY",
-    team: "TEAM",
-    project: "PROJECT",
-    organization: "ORGANIZATION",
-    anyone: "ANYONE",
-  };
   return {
     id: fact.grantId,
-    principalType: stored[fact.principal.type] ?? fact.principal.type,
+    principalType: PRINCIPAL_TO_DB[fact.principal.type],
     principalId: fact.principal.id,
     roleKey: fact.roleKey,
     legacyRole: fact.legacyRole ?? null,
@@ -347,7 +353,7 @@ describe("given an organization with legacy access rows", () => {
 
       await migration.migrateTenant({ tenantId: ORG_ID });
 
-      expect(reads.heads).toBe(1);
+      expect(reads).toEqual({ grantHeads: 1, roleHeads: 1, resourceRows: 1 });
     });
 
     /** @scenario "A projection that has not caught up holds the organization" */
@@ -408,13 +414,17 @@ describe("given an organization with legacy access rows", () => {
           field: "roleKey",
         }),
       );
-      // And the drift is repaired for the next pass, as a proper role change.
+      // And the drift is repaired for the next pass, as a proper role change
+      // stamped with TODAY'S business time — the head's upsert guard refuses
+      // an event that is not strictly newer than the row, so a repair pinned
+      // to the legacy createdAt would be permanently inert.
       expect(
         sent.some(
           (entry) =>
             entry.kind === "changeGrantRole" &&
             entry.payload.grantId === "binding_1" &&
-            entry.payload.to === "member",
+            entry.payload.to === "member" &&
+            entry.payload.occurredAtMs === NOW,
         ),
       ).toBe(true);
     });
@@ -473,35 +483,90 @@ describe("given an organization with legacy access rows", () => {
     });
 
     /** @scenario "A pass that failed partway is safe to repeat" */
-    it("restates every fact under the command id the first attempt used", async () => {
-      const data: Data = {
-        bindings: [binding()],
-        organizationCreatedAtMs: null,
-      };
-      const failing = harness(data);
-      let calls = 0;
-      const ledgerAttach = failing.migration as unknown as {
-        deps: { ledger: { attachGrant: (args: unknown) => Promise<void> } };
-      };
-      const original = ledgerAttach.deps.ledger.attachGrant;
-      ledgerAttach.deps.ledger.attachGrant = async (args) => {
-        calls += 1;
-        if (calls === 1) throw new Error("queue hiccup");
-        return original(args);
-      };
+    it("restates every fact under the command id the failed attempt used", async () => {
+      const attempted: string[] = [];
+      let failFirst = true;
+      const { migration, sent } = harness(
+        { bindings: [binding()], organizationCreatedAtMs: null },
+        {
+          wrapLedger: (ledger) => ({
+            ...ledger,
+            attachGrant: async (args) => {
+              attempted.push(args.commandId);
+              if (failFirst) {
+                failFirst = false;
+                throw new Error("queue hiccup");
+              }
+              return ledger.attachGrant(args);
+            },
+          }),
+        },
+      );
 
       await expect(
-        failing.migration.migrateTenant({ tenantId: ORG_ID }),
+        migration.migrateTenant({ tenantId: ORG_ID }),
       ).rejects.toThrow("queue hiccup");
 
-      const retry = await failing.migration.migrateTenant({ tenantId: ORG_ID });
+      const retry = await migration.migrateTenant({ tenantId: ORG_ID });
       expect(retry.status).toBe("migrated");
-      const commandIds = failing.sent
-        .filter((entry) => entry.kind === "attachGrant")
-        .map((entry) => entry.commandId);
-      // The retry's command id equals what the failed attempt would have
-      // sent, so the event store dedupes rather than duplicating.
-      expect(new Set(commandIds).size).toBe(1);
+      // The retry sends the exact command id the failed attempt tried, so
+      // the event store dedupes rather than duplicating.
+      expect(attempted).toHaveLength(2);
+      expect(attempted[1]).toBe(attempted[0]);
+      expect(sent.filter((entry) => entry.kind === "attachGrant")).toHaveLength(
+        1,
+      );
+    });
+
+    /** @scenario "Re-running the migration states the same facts" */
+    it("appends a changed legacy row under a NEW command id", async () => {
+      // Content is part of the key: identity alone would let the first
+      // pass's dedupe silently swallow a row edited between passes.
+      const before = harness({
+        bindings: [binding({ role: "MEMBER" })],
+        organizationCreatedAtMs: null,
+      });
+      const after = harness({
+        bindings: [binding({ role: "ADMIN" })],
+        organizationCreatedAtMs: null,
+      });
+
+      await before.migration.migrateTenant({ tenantId: ORG_ID });
+      await after.migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(before.sent[0]?.commandId).not.toBe(after.sent[0]?.commandId);
+    });
+
+    it("aborts between chunks, parking the organization with sends stopped", async () => {
+      const controller = new AbortController();
+      const manyBindings = Array.from({ length: 150 }, (_, index) =>
+        binding({ id: `binding_${index}` }),
+      );
+      const { migration, sent } = harness(
+        { bindings: manyBindings, organizationCreatedAtMs: null },
+        {
+          wrapLedger: (ledger) => ({
+            ...ledger,
+            attachGrant: async (args) => {
+              controller.abort();
+              return ledger.attachGrant(args);
+            },
+          }),
+        },
+      );
+
+      await expect(
+        migration.migrateTenant({
+          tenantId: ORG_ID,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow("parked for retry");
+
+      // The first chunk of 100 was already in flight; the second never
+      // started — the abort boundary is the chunk.
+      expect(sent.filter((entry) => entry.kind === "attachGrant")).toHaveLength(
+        100,
+      );
     });
 
     /** @scenario "A row deleted on the legacy side is revoked, not left behind" */
@@ -559,16 +624,432 @@ describe("given an organization with legacy access rows", () => {
   });
 
   describe("when share links carry a view budget", () => {
-    it("hands the budget over on every pass", async () => {
+    it("hands the budget over on every pass, not just the first", async () => {
       const { migration, seeded } = harness({
         shareLinks: [shareLink({ maxViews: 10, viewCount: 3 })],
       });
 
       await migration.migrateTenant({ tenantId: ORG_ID });
+      await migration.migrateTenant({ tenantId: ORG_ID });
 
-      expect(seeded).toEqual([
-        [{ grantId: "share_1", projectId: "project_1", viewCount: 3 }],
+      // Legacy keeps counting while the organization is held; re-seeding
+      // every pass is what lets the proof heal.
+      const seed = [
+        { grantId: "share_1", projectId: "project_1", viewCount: 3 },
+      ];
+      expect(seeded).toEqual([seed, seed]);
+    });
+
+    it("refuses to finalize a link whose view budget grew back", async () => {
+      const row = shareLink({ maxViews: 10, viewCount: 3 });
+      const { migration } = harness({
+        shareLinks: [row],
+        organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: row.id,
+            source: "migration",
+            token: row.token,
+            resourceKind: "TRACE",
+            resourceId: row.resourceId,
+            projectId: row.projectId,
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: 10,
+            // The head counts MORE spent views than legacy remembers: a
+            // budget that grew back, which nothing legitimate produces.
+            viewCount: 5,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as {
+        diffs: Array<{ kind: string; id: string; field?: string }>;
+      };
+      expect(report.diffs).toContainEqual(
+        expect.objectContaining({
+          kind: "resource_changed",
+          id: row.id,
+          field: "viewCount",
+        }),
+      );
+    });
+
+    it("treats a head behind the legacy view count as lag, not disagreement", async () => {
+      // Views land legacy-side between passes and the monotonic seed raises
+      // the usage row next pass — outstanding, so the organization heals
+      // instead of re-holding forever on an actively-viewed link.
+      const row = shareLink({ maxViews: 10, viewCount: 3 });
+      const { migration } = harness({
+        shareLinks: [row],
+        organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: row.id,
+            source: "migration",
+            token: row.token,
+            resourceKind: "TRACE",
+            resourceId: row.resourceId,
+            projectId: row.projectId,
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: 10,
+            viewCount: 1,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as {
+        totalDiffs: number;
+        outstandingSample: string[];
+      };
+      expect(report.totalDiffs).toBe(0);
+      expect(report.outstandingSample).toContain(row.id);
+    });
+
+    /** @scenario "A row deleted on the legacy side is revoked, not left behind" */
+    it("revokes a deleted share link's live resource head", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: "share_orphan",
+            source: "migration",
+            token: "token_orphan",
+            resourceKind: "TRACE",
+            resourceId: "trace_1",
+            projectId: "project_1",
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: null,
+            viewCount: 0,
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(
+        sent.filter(
+          (entry) =>
+            entry.kind === "revokeGrant" &&
+            entry.payload.grantId === "share_orphan",
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("finalizes a link whose head matches field for field", async () => {
+      const row = shareLink({ maxViews: 10, viewCount: 3 });
+      const { migration } = harness({
+        shareLinks: [row],
+        organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: row.id,
+            source: "migration",
+            token: row.token,
+            resourceKind: "TRACE",
+            resourceId: row.resourceId,
+            projectId: row.projectId,
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: 10,
+            viewCount: 3,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("finalized");
+    });
+  });
+
+  describe("when the heads disagree with legacy in other directions", () => {
+    /** @scenario "The check that precedes finalizing is proven, not assumed" */
+    it("holds when a stated grant's head is revoked while legacy still holds the row", async () => {
+      const row = binding();
+      const { migration } = harness({
+        bindings: [row],
+        organizationCreatedAtMs: null,
+        grantHeads: [
+          {
+            ...foldedHead({
+              grantId: row.id,
+              principal: { type: "user", id: "user_1" },
+              roleKey: "member",
+              scope: { type: "PROJECT", id: "project_1" },
+              source: "migration",
+              occurredAtMs: CREATED,
+            }),
+            revoked: true,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as {
+        diffs: Array<{ kind: string; id: string }>;
+      };
+      expect(report.diffs).toContainEqual(
+        expect.objectContaining({ kind: "grant_revoked", id: row.id }),
+      );
+    });
+
+    /** @scenario "The check that precedes finalizing is proven, not assumed" */
+    it("repairs a role whose head permissions drifted, and names the drift", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        roles: [
+          {
+            id: "role_1",
+            name: "Auditor",
+            description: null,
+            permissions: ["traces:view", "traces:share"],
+            kind: "custom",
+            createdAtMs: CREATED,
+          },
+        ],
+        roleHeads: [
+          {
+            id: "role_1",
+            name: "Auditor",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      // Repaired by restating the role WHOLE at today's business time, so
+      // the head's strictly-newer guard admits it.
+      expect(
+        sent.some(
+          (entry) =>
+            entry.kind === "defineRole" &&
+            entry.commandId.startsWith("authz-engine:redefine:role_1:") &&
+            (entry.payload.role as RoleFact).permissions.join(",") ===
+              "traces:view,traces:share" &&
+            (entry.payload.role as RoleFact).occurredAtMs === NOW,
+        ),
+      ).toBe(true);
+      const report = outcome.report as {
+        diffs: Array<{ kind: string; field?: string }>;
+      };
+      expect(report.diffs).toContainEqual(
+        expect.objectContaining({ kind: "role_changed", field: "permissions" }),
+      );
+    });
+
+    it("holds on a renamed role head and names the field", async () => {
+      const { migration } = harness({
+        organizationCreatedAtMs: null,
+        roles: [
+          {
+            id: "role_1",
+            name: "Auditor",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+            createdAtMs: CREATED,
+          },
+        ],
+        roleHeads: [
+          {
+            id: "role_1",
+            name: "Inspector",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as {
+        diffs: Array<{ kind: string; field?: string }>;
+      };
+      expect(report.diffs).toContainEqual(
+        expect.objectContaining({ kind: "role_changed", field: "name" }),
+      );
+    });
+
+    /** @scenario "A row deleted on the legacy side is revoked, not left behind" */
+    it("deletes role heads whose legacy row is gone, whatever their kind", async () => {
+      // The migration only runs before an organization finalizes, and until
+      // then every role head — system_api_key included — mirrors a legacy
+      // CustomRole row; a head with no such row is stale whatever its kind.
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        roleHeads: [
+          {
+            id: "role_gone",
+            name: "Retired",
+            description: null,
+            permissions: [],
+            kind: "custom",
+          },
+          {
+            id: "role_system",
+            name: "API key role",
+            description: null,
+            permissions: [],
+            kind: "system_api_key",
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const deletions = sent.filter((entry) => entry.kind === "deleteRole");
+      expect(deletions.map((entry) => entry.payload.roleId).sort()).toEqual([
+        "role_gone",
+        "role_system",
       ]);
+    });
+  });
+
+  describe("when legacy rows cannot be expressed as grants", () => {
+    /** @scenario "Every legacy table is a source of facts" */
+    it("skips a binding naming no principal, on both the state and the check side", async () => {
+      const { migration, sent } = harness({
+        bindings: [binding({ userId: null, groupId: null, apiKeyId: null })],
+        organizationCreatedAtMs: null,
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(sent.filter((entry) => entry.kind === "attachGrant")).toHaveLength(
+        0,
+      );
+      // Nothing stated means nothing outstanding: the row holds nothing up.
+      expect(outcome.status).toBe("finalized");
+    });
+
+    /** @scenario "Team membership is stated directly, not promoted first" */
+    it("never states a CUSTOM membership row: the legacy fallback denies that shape", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        teamRows: [
+          {
+            userId: "user_1",
+            teamId: "team_1",
+            role: "CUSTOM",
+            customRoleId: "role_1",
+            createdAtMs: CREATED,
+          },
+          {
+            userId: "user_2",
+            teamId: "team_1",
+            role: "CUSTOM",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent)).toHaveLength(0);
+    });
+
+    /** @scenario "Team membership is stated directly, not promoted first" */
+    it("suppresses a membership beside a binding of ANY role, matching the resolver", async () => {
+      // Legacy suppresses its fallback on any binding at the scopes in
+      // play, whatever role it carries — keying the suppression on role
+      // stated an extra admin grant legacy never answers.
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        teamRows: [
+          {
+            userId: "user_1",
+            teamId: "team_1",
+            role: "ADMIN",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+        bindings: [
+          binding({
+            id: "binding_team",
+            scopeType: "TEAM",
+            scopeId: "team_1",
+            role: "VIEWER",
+          }),
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const teamFacts = attachedFacts(sent).filter(
+        (fact) => fact.scope.type === "TEAM",
+      );
+      expect(teamFacts.map((fact) => fact.grantId)).toEqual(["binding_team"]);
+    });
+
+    /** @scenario "Team membership is stated directly, not promoted first" */
+    it("counts a binding held through a group as suppressing too", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        teamRows: [
+          {
+            userId: "user_1",
+            teamId: "team_1",
+            role: "MEMBER",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+        groupMemberships: [{ userId: "user_1", groupId: "group_1" }],
+        bindings: [
+          binding({
+            id: "binding_group",
+            userId: null,
+            groupId: "group_1",
+            scopeType: "TEAM",
+            scopeId: "team_1",
+            role: "VIEWER",
+          }),
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const teamFacts = attachedFacts(sent).filter(
+        (fact) => fact.scope.type === "TEAM" && fact.principal.type === "user",
+      );
+      expect(teamFacts).toHaveLength(0);
+    });
+
+    /** @scenario "The organization member floor is stated once" */
+    it("does not double-grant an ADMIN who already holds a binding", async () => {
+      const { migration, sent } = harness({
+        members: [member("user_admin", "ADMIN")],
+        bindings: [binding({ userId: "user_admin" })],
+        organizationCreatedAtMs: null,
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const facts = attachedFacts(sent);
+      expect(facts.some((fact) => fact.roleKey === "legacy-admin")).toBe(false);
     });
   });
 });

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -9,6 +9,7 @@
 import type {
   ExternalMemberFact,
   GrantFact,
+  GrantHeadRow,
   LegacyBindingRow,
   LegacyRoleRow,
   LegacyTeamRow,
@@ -22,7 +23,6 @@ import type {
 } from "@langwatch/authz-server";
 import { PRINCIPAL_TO_DB } from "@langwatch/authz-server";
 import { describe, expect, it } from "vitest";
-import type { GrantHeadRow } from "../authz-engine.check";
 import {
   AuthzEngineMigration,
   type AuthzEngineMigrationStore,
@@ -943,6 +943,42 @@ describe("given an organization with legacy access rows", () => {
       expect(outcome.status).toBe("finalized");
     });
 
+    /** @scenario "Every legacy table is a source of facts" */
+    it("leaves an earlier import of a principal-less binding alone, and finalizes anyway", async () => {
+      const retained = binding({
+        id: "binding_retained",
+        userId: null,
+        groupId: null,
+        apiKeyId: null,
+      });
+      const { migration, sent } = harness({
+        bindings: [retained],
+        organizationCreatedAtMs: null,
+        // A head an earlier import wrote for the row this pass declines to
+        // express. Legacy still HAS the row, so the sweep must not revoke
+        // it — and the check must not count it outstanding either, because
+        // no later pass could ever clear that.
+        grantHeads: [
+          {
+            id: retained.id,
+            principalType: "USER",
+            principalId: null,
+            roleKey: "member",
+            legacyRole: null,
+            source: "genesis-import",
+            scopeType: "PROJECT",
+            scopeId: "project_1",
+            revoked: false,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(sent.filter((entry) => entry.kind === "revokeGrant")).toEqual([]);
+      expect(outcome.status).toBe("finalized");
+    });
+
     /** @scenario "Team membership is stated directly, not promoted first" */
     it("never states a CUSTOM membership row: the legacy fallback denies that shape", async () => {
       const { migration, sent } = harness({
@@ -1048,6 +1084,24 @@ describe("given an organization with legacy access rows", () => {
 
       await migration.migrateTenant({ tenantId: ORG_ID });
 
+      const facts = attachedFacts(sent);
+      expect(facts.some((fact) => fact.roleKey === "legacy-admin")).toBe(false);
+    });
+
+    /** @scenario "The organization member floor is stated once" */
+    it("reads a group-held binding as a binding, the way the legacy resolver does", async () => {
+      const { migration, sent } = harness({
+        members: [member("user_admin", "ADMIN")],
+        bindings: [binding({ userId: null, groupId: "group_1" })],
+        groupMemberships: [{ userId: "user_admin", groupId: "group_1" }],
+        organizationCreatedAtMs: null,
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      // The admin's only binding is held through a group. The resolver
+      // counts it, so the fallback is suppressed here too — the same
+      // predicate the team-membership suppression uses.
       const facts = attachedFacts(sent);
       expect(facts.some((fact) => fact.roleKey === "legacy-admin")).toBe(false);
     });

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -56,14 +56,14 @@ type Data = {
   grantHeads?: GrantHeadRow[];
   roleHeads?: RoleHeadRow[];
   resourceRows?: ResourceGrantRow[];
+  /** Wraps the recording ledger, for tests that need to observe or fail a
+   *  send rather than only read what was sent. */
+  wrapLedger?: (ledger: Ledger) => Ledger;
 };
 
 type Ledger = ConstructorParameters<typeof AuthzEngineMigration>[0]["ledger"];
 
-function harness(
-  data: Data = {},
-  options: { wrapLedger?: (ledger: Ledger) => Ledger } = {},
-) {
+function harness(data: Data = {}) {
   const sent: Sent[] = [];
   const seeded: ResourceGrantUsageSeed[][] = [];
   const reads = { grantHeads: 0, roleHeads: 0, resourceRows: 0 };
@@ -113,7 +113,7 @@ function harness(
   };
   const migration = new AuthzEngineMigration({
     store,
-    ledger: options.wrapLedger ? options.wrapLedger(recording) : recording,
+    ledger: data.wrapLedger ? data.wrapLedger(recording) : recording,
     now: () => NOW,
   });
   return { migration, sent, seeded, reads };
@@ -125,7 +125,13 @@ function attachedFacts(sent: Sent[]): GrantFact[] {
     .map((entry) => entry.payload.grant as GrantFact);
 }
 
-function member(userId: string, role = "MEMBER"): OrganizationMemberFact {
+function member({
+  userId,
+  role = "MEMBER",
+}: {
+  userId: string;
+  role?: string;
+}): OrganizationMemberFact {
   return { userId, role, createdAtMs: CREATED };
 }
 
@@ -187,9 +193,9 @@ describe("given an organization with legacy access rows", () => {
     it("states every legacy table's rows as facts", async () => {
       const { migration, sent } = harness({
         members: [
-          member("user_member"),
-          member("user_admin", "ADMIN"),
-          member("user_external", "EXTERNAL"),
+          member({ userId: "user_member" }),
+          member({ userId: "user_admin", role: "ADMIN" }),
+          member({ userId: "user_external", role: "EXTERNAL" }),
         ],
         externalMembers: [{ userId: "user_external", createdAtMs: CREATED }],
         teamRows: [
@@ -322,7 +328,7 @@ describe("given an organization with legacy access rows", () => {
     /** @scenario "The organization member floor is stated once" */
     it("floors an unbound member with the organization grant and nothing else", async () => {
       const { migration, sent } = harness({
-        members: [member("user_lonely")],
+        members: [member({ userId: "user_lonely" })],
       });
 
       await migration.migrateTenant({ tenantId: ORG_ID });
@@ -459,7 +465,7 @@ describe("given an organization with legacy access rows", () => {
     /** @scenario "Re-running the migration states the same facts" */
     it("derives the same ids and the same command ids", async () => {
       const data: Data = {
-        members: [member("user_1")],
+        members: [member({ userId: "user_1" })],
         teamRows: [
           {
             userId: "user_1",
@@ -486,22 +492,21 @@ describe("given an organization with legacy access rows", () => {
     it("restates every fact under the command id the failed attempt used", async () => {
       const attempted: string[] = [];
       let failFirst = true;
-      const { migration, sent } = harness(
-        { bindings: [binding()], organizationCreatedAtMs: null },
-        {
-          wrapLedger: (ledger) => ({
-            ...ledger,
-            attachGrant: async (args) => {
-              attempted.push(args.commandId);
-              if (failFirst) {
-                failFirst = false;
-                throw new Error("queue hiccup");
-              }
-              return ledger.attachGrant(args);
-            },
-          }),
-        },
-      );
+      const { migration, sent } = harness({
+        bindings: [binding()],
+        organizationCreatedAtMs: null,
+        wrapLedger: (ledger) => ({
+          ...ledger,
+          attachGrant: async (args) => {
+            attempted.push(args.commandId);
+            if (failFirst) {
+              failFirst = false;
+              throw new Error("queue hiccup");
+            }
+            return ledger.attachGrant(args);
+          },
+        }),
+      });
 
       await expect(
         migration.migrateTenant({ tenantId: ORG_ID }),
@@ -542,18 +547,17 @@ describe("given an organization with legacy access rows", () => {
       const manyBindings = Array.from({ length: 150 }, (_, index) =>
         binding({ id: `binding_${index}` }),
       );
-      const { migration, sent } = harness(
-        { bindings: manyBindings, organizationCreatedAtMs: null },
-        {
-          wrapLedger: (ledger) => ({
-            ...ledger,
-            attachGrant: async (args) => {
-              controller.abort();
-              return ledger.attachGrant(args);
-            },
-          }),
-        },
-      );
+      const { migration, sent } = harness({
+        bindings: manyBindings,
+        organizationCreatedAtMs: null,
+        wrapLedger: (ledger) => ({
+          ...ledger,
+          attachGrant: async (args) => {
+            controller.abort();
+            return ledger.attachGrant(args);
+          },
+        }),
+      });
 
       await expect(
         migration.migrateTenant({
@@ -1077,7 +1081,7 @@ describe("given an organization with legacy access rows", () => {
     /** @scenario "The organization member floor is stated once" */
     it("does not double-grant an ADMIN who already holds a binding", async () => {
       const { migration, sent } = harness({
-        members: [member("user_admin", "ADMIN")],
+        members: [member({ userId: "user_admin", role: "ADMIN" })],
         bindings: [binding({ userId: "user_admin" })],
         organizationCreatedAtMs: null,
       });
@@ -1091,7 +1095,7 @@ describe("given an organization with legacy access rows", () => {
     /** @scenario "The organization member floor is stated once" */
     it("reads a group-held binding as a binding, the way the legacy resolver does", async () => {
       const { migration, sent } = harness({
-        members: [member("user_admin", "ADMIN")],
+        members: [member({ userId: "user_admin", role: "ADMIN" })],
         bindings: [binding({ userId: null, groupId: "group_1" })],
         groupMemberships: [{ userId: "user_admin", groupId: "group_1" }],
         organizationCreatedAtMs: null,

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -1,0 +1,574 @@
+/**
+ * The ADR-110 authz-engine migration: every legacy table stated as facts,
+ * the deny direction reconciled, and the one-read check that decides
+ * finalized against held.
+ *
+ * @see specs/migration/authz-grants-rollout.feature
+ */
+
+import type {
+  ExternalMemberFact,
+  GrantFact,
+  LegacyBindingRow,
+  LegacyRoleRow,
+  LegacyTeamRow,
+  OrganizationMemberFact,
+  ProjectCredentialFact,
+  ResourceGrantRow,
+  ResourceGrantUsageSeed,
+  RoleFact,
+  RoleHeadRow,
+  ShareLinkFactRow,
+} from "@langwatch/authz-server";
+import { describe, expect, it } from "vitest";
+import {
+  AuthzEngineMigration,
+  type AuthzEngineMigrationStore,
+  type GrantHeadRow,
+} from "../authz-engine.migration";
+
+const ORG_ID = "org_acme";
+const NOW = 1_800_000_000_000;
+const CREATED = 1_700_000_000_000;
+
+type Sent = {
+  kind:
+    | "attachGrant"
+    | "defineRole"
+    | "changeGrantRole"
+    | "changeRolePermissions"
+    | "revokeGrant"
+    | "deleteRole";
+  commandId: string;
+  payload: Record<string, unknown>;
+};
+
+type Data = {
+  organizationCreatedAtMs?: number | null;
+  roles?: LegacyRoleRow[];
+  bindings?: LegacyBindingRow[];
+  members?: OrganizationMemberFact[];
+  teamRows?: LegacyTeamRow[];
+  shareLinks?: ShareLinkFactRow[];
+  externalMembers?: ExternalMemberFact[];
+  credentials?: ProjectCredentialFact[];
+  grantHeads?: GrantHeadRow[];
+  roleHeads?: RoleHeadRow[];
+  resourceRows?: ResourceGrantRow[];
+};
+
+function harness(data: Data = {}) {
+  const sent: Sent[] = [];
+  const seeded: ResourceGrantUsageSeed[][] = [];
+  const reads = { heads: 0 };
+  const store: AuthzEngineMigrationStore = {
+    findOrganizationCreatedAtMs: async () =>
+      data.organizationCreatedAtMs === undefined
+        ? CREATED
+        : data.organizationCreatedAtMs,
+    findLegacyRoleRows: async () => data.roles ?? [],
+    findLegacyBindingRows: async () => data.bindings ?? [],
+    findOrganizationMembers: async () => data.members ?? [],
+    findLegacyTeamRows: async () => data.teamRows ?? [],
+    findShareLinkRows: async () => data.shareLinks ?? [],
+    findExternalMemberFacts: async () => data.externalMembers ?? [],
+    findProjectCredentialFacts: async () => data.credentials ?? [],
+    findGrantHeadRows: async () => {
+      reads.heads += 1;
+      return data.grantHeads ?? [];
+    },
+    findRoleHeads: async () => data.roleHeads ?? [],
+    findResourceGrantRows: async () => data.resourceRows ?? [],
+    seedResourceGrantUsage: async ({ seeds }) => {
+      seeded.push([...seeds]);
+    },
+  };
+  const record =
+    (kind: Sent["kind"]) =>
+    async ({
+      commandId,
+      ...payload
+    }: { commandId: string } & Record<string, unknown>) => {
+      sent.push({ kind, commandId, payload });
+    };
+  const migration = new AuthzEngineMigration({
+    store,
+    ledger: {
+      attachGrant: record("attachGrant"),
+      defineRole: record("defineRole"),
+      changeGrantRole: record("changeGrantRole"),
+      changeRolePermissions: record("changeRolePermissions"),
+      revokeGrant: record("revokeGrant"),
+      deleteRole: record("deleteRole"),
+    },
+    now: () => NOW,
+  });
+  return { migration, sent, seeded, reads };
+}
+
+function attachedFacts(sent: Sent[]): GrantFact[] {
+  return sent
+    .filter((entry) => entry.kind === "attachGrant")
+    .map((entry) => entry.payload.grant as GrantFact);
+}
+
+function member(userId: string, role = "MEMBER"): OrganizationMemberFact {
+  return { userId, role, createdAtMs: CREATED };
+}
+
+function binding(overrides: Partial<LegacyBindingRow> = {}): LegacyBindingRow {
+  return {
+    id: "binding_1",
+    userId: "user_1",
+    groupId: null,
+    apiKeyId: null,
+    role: "MEMBER",
+    customRoleId: null,
+    scopeType: "PROJECT",
+    scopeId: "project_1",
+    createdAtMs: CREATED,
+    ...overrides,
+  };
+}
+
+function shareLink(
+  overrides: Partial<ShareLinkFactRow> = {},
+): ShareLinkFactRow {
+  return {
+    id: "share_1",
+    token: "token_1",
+    resourceType: "TRACE",
+    resourceId: "trace_1",
+    projectId: "project_1",
+    userId: "user_1",
+    visibility: "PUBLIC",
+    expiresAtMs: null,
+    maxViews: null,
+    viewCount: 0,
+    createdAtMs: CREATED,
+    ...overrides,
+  };
+}
+
+/** The head row a folded attach of `fact` would produce — for tests that
+ *  start from a converged projection. */
+function foldedHead(fact: GrantFact): GrantHeadRow {
+  const stored: Record<string, string> = {
+    user: "USER",
+    group: "GROUP",
+    apiKey: "API_KEY",
+    team: "TEAM",
+    project: "PROJECT",
+    organization: "ORGANIZATION",
+    anyone: "ANYONE",
+  };
+  return {
+    id: fact.grantId,
+    principalType: stored[fact.principal.type] ?? fact.principal.type,
+    principalId: fact.principal.id,
+    roleKey: fact.roleKey,
+    legacyRole: fact.legacyRole ?? null,
+    source: "migration",
+    scopeType: fact.scope.type,
+    scopeId: fact.scope.id,
+    revoked: false,
+  };
+}
+
+describe("given an organization with legacy access rows", () => {
+  describe("when the migration states its facts", () => {
+    /** @scenario "Every legacy table is a source of facts" */
+    it("states every legacy table's rows as facts", async () => {
+      const { migration, sent } = harness({
+        members: [
+          member("user_member"),
+          member("user_admin", "ADMIN"),
+          member("user_external", "EXTERNAL"),
+        ],
+        externalMembers: [{ userId: "user_external", createdAtMs: CREATED }],
+        teamRows: [
+          {
+            userId: "user_member",
+            teamId: "team_1",
+            role: "MEMBER",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+        bindings: [binding()],
+        roles: [
+          {
+            id: "role_1",
+            name: "Auditor",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+            createdAtMs: CREATED,
+          },
+        ],
+        shareLinks: [shareLink()],
+        credentials: [{ projectId: "project_1", createdAtMs: CREATED }],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const facts = attachedFacts(sent);
+      const roleKeys = facts.map((fact) => fact.roleKey);
+      // The member floor, once, as the organization's own principal.
+      expect(
+        facts.filter((fact) => fact.principal.type === "organization"),
+      ).toHaveLength(1);
+      // The unbound ADMIN's fallback fact, under its dormant key.
+      expect(roleKeys).toContain("legacy-admin");
+      // The EXTERNAL membership's cap.
+      expect(roleKeys).toContain("lite-member");
+      // The team membership, at TEAM scope.
+      expect(
+        facts.some(
+          (fact) =>
+            fact.scope.type === "TEAM" && fact.principal.id === "user_member",
+        ),
+      ).toBe(true);
+      // The binding, adopting its row id.
+      expect(facts.some((fact) => fact.grantId === "binding_1")).toBe(true);
+      // The custom role, adopting its row id.
+      expect(
+        sent.some(
+          (entry) =>
+            entry.kind === "defineRole" &&
+            (entry.payload.role as RoleFact).roleId === "role_1",
+        ),
+      ).toBe(true);
+      // The share link, as a RESOURCE fact keeping its id and token.
+      const resource = facts.find((fact) => fact.grantId === "share_1");
+      expect(resource?.scope.type).toBe("RESOURCE");
+      expect(resource?.resource?.token).toBe("token_1");
+      // The project credential, with the project itself as principal.
+      expect(
+        facts.some(
+          (fact) =>
+            fact.principal.type === "project" &&
+            fact.scope.type === "PROJECT" &&
+            fact.scope.id === "project_1",
+        ),
+      ).toBe(true);
+      // Every fact carries the migration's source.
+      expect(new Set(facts.map((fact) => fact.source))).toEqual(
+        new Set(["migration"]),
+      );
+    });
+
+    /** @scenario "Team membership is stated directly, not promoted first" */
+    it("states memberships as grants and writes no binding row", async () => {
+      const { migration, sent } = harness({
+        teamRows: [
+          {
+            userId: "user_1",
+            teamId: "team_1",
+            role: "ADMIN",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const teamFacts = attachedFacts(sent).filter(
+        (fact) => fact.scope.type === "TEAM",
+      );
+      expect(teamFacts).toHaveLength(1);
+      expect(teamFacts[0]?.roleKey).toBe("admin");
+      // Derived identity, not a minted binding row: the id is a grant KSUID.
+      expect(teamFacts[0]?.grantId).toMatch(/^grant_/);
+    });
+
+    /** @scenario "Team membership is stated directly, not promoted first" */
+    it("does not restate a membership a team binding already carries", async () => {
+      const { migration, sent } = harness({
+        teamRows: [
+          {
+            userId: "user_1",
+            teamId: "team_1",
+            role: "MEMBER",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+        bindings: [
+          binding({
+            id: "binding_team",
+            scopeType: "TEAM",
+            scopeId: "team_1",
+            role: "MEMBER",
+          }),
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const teamFacts = attachedFacts(sent).filter(
+        (fact) => fact.scope.type === "TEAM",
+      );
+      expect(teamFacts.map((fact) => fact.grantId)).toEqual(["binding_team"]);
+    });
+
+    /** @scenario "The organization member floor is stated once" */
+    it("floors an unbound member with the organization grant and nothing else", async () => {
+      const { migration, sent } = harness({
+        members: [member("user_lonely")],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const facts = attachedFacts(sent);
+      expect(facts).toHaveLength(1);
+      expect(facts[0]?.principal).toEqual({
+        type: "organization",
+        id: ORG_ID,
+      });
+      expect(facts[0]?.roleKey).toBe("member");
+    });
+
+    /** @scenario "An imported grant keeps the time it was originally made" */
+    it("carries the legacy row's own time as the fact's business time", async () => {
+      const { migration, sent } = harness({ bindings: [binding()] });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent)[0]?.occurredAtMs).toBe(CREATED);
+    });
+  });
+
+  describe("when the pass checks the projection", () => {
+    /** @scenario "The migration states its facts and checks once" */
+    it("reads the projection once and does not poll", async () => {
+      const { migration, reads } = harness({ bindings: [binding()] });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(reads.heads).toBe(1);
+    });
+
+    /** @scenario "A projection that has not caught up holds the organization" */
+    it("holds the organization with the outstanding count", async () => {
+      const { migration } = harness({
+        bindings: [binding()],
+        organizationCreatedAtMs: null,
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as { outstanding: number };
+      expect(report.outstanding).toBe(1);
+    });
+
+    /** @scenario "A held organization names what is outstanding" */
+    it("names the outstanding ids in the held report", async () => {
+      const { migration } = harness({ bindings: [binding()] });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      const report = outcome.report as { outstandingSample: string[] };
+      expect(report.outstandingSample).toContain("binding_1");
+    });
+
+    /** @scenario "The check that precedes finalizing is proven, not assumed" */
+    it("does not finalize a projection that disagrees, and names the disagreement", async () => {
+      const drifted = binding();
+      const { migration, sent } = harness({
+        bindings: [drifted],
+        organizationCreatedAtMs: null,
+        grantHeads: [
+          {
+            ...foldedHead({
+              grantId: drifted.id,
+              principal: { type: "user", id: "user_1" },
+              roleKey: "member",
+              scope: { type: "PROJECT", id: "project_1" },
+              source: "migration",
+              occurredAtMs: CREATED,
+            }),
+            roleKey: "admin",
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as {
+        diffs: Array<{ kind: string; id: string; field?: string }>;
+      };
+      expect(report.diffs).toContainEqual(
+        expect.objectContaining({
+          kind: "grant_changed",
+          id: "binding_1",
+          field: "roleKey",
+        }),
+      );
+      // And the drift is repaired for the next pass, as a proper role change.
+      expect(
+        sent.some(
+          (entry) =>
+            entry.kind === "changeGrantRole" &&
+            entry.payload.grantId === "binding_1" &&
+            entry.payload.to === "member",
+        ),
+      ).toBe(true);
+    });
+
+    // "An organization reads from the projection the moment it finalizes"
+    // stays @integration — the moment itself is the engine gate's read, which
+    // this unit harness cannot honestly observe. What it CAN pin is the
+    // precondition: a projection holding exactly what legacy holds finalizes.
+    it("finalizes when the projection holds exactly what legacy holds", async () => {
+      const row = binding();
+      const fact: GrantFact = {
+        grantId: row.id,
+        principal: { type: "user", id: "user_1" },
+        roleKey: "member",
+        scope: { type: "PROJECT", id: "project_1" },
+        source: "migration",
+        occurredAtMs: CREATED,
+      };
+      const { migration } = harness({
+        bindings: [row],
+        organizationCreatedAtMs: null,
+        grantHeads: [foldedHead(fact)],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("finalized");
+    });
+  });
+
+  describe("when the migration runs again", () => {
+    /** @scenario "Re-running the migration states the same facts" */
+    it("derives the same ids and the same command ids", async () => {
+      const data: Data = {
+        members: [member("user_1")],
+        teamRows: [
+          {
+            userId: "user_1",
+            teamId: "team_1",
+            role: "MEMBER",
+            customRoleId: null,
+            createdAtMs: CREATED,
+          },
+        ],
+        bindings: [binding()],
+      };
+      const first = harness(data);
+      const second = harness(data);
+
+      await first.migration.migrateTenant({ tenantId: ORG_ID });
+      await second.migration.migrateTenant({ tenantId: ORG_ID });
+
+      const ids = (sent: Sent[]) =>
+        sent.map((entry) => `${entry.kind}:${entry.commandId}`).sort();
+      expect(ids(second.sent)).toEqual(ids(first.sent));
+    });
+
+    /** @scenario "A pass that failed partway is safe to repeat" */
+    it("restates every fact under the command id the first attempt used", async () => {
+      const data: Data = {
+        bindings: [binding()],
+        organizationCreatedAtMs: null,
+      };
+      const failing = harness(data);
+      let calls = 0;
+      const ledgerAttach = failing.migration as unknown as {
+        deps: { ledger: { attachGrant: (args: unknown) => Promise<void> } };
+      };
+      const original = ledgerAttach.deps.ledger.attachGrant;
+      ledgerAttach.deps.ledger.attachGrant = async (args) => {
+        calls += 1;
+        if (calls === 1) throw new Error("queue hiccup");
+        return original(args);
+      };
+
+      await expect(
+        failing.migration.migrateTenant({ tenantId: ORG_ID }),
+      ).rejects.toThrow("queue hiccup");
+
+      const retry = await failing.migration.migrateTenant({ tenantId: ORG_ID });
+      expect(retry.status).toBe("migrated");
+      const commandIds = failing.sent
+        .filter((entry) => entry.kind === "attachGrant")
+        .map((entry) => entry.commandId);
+      // The retry's command id equals what the failed attempt would have
+      // sent, so the event store dedupes rather than duplicating.
+      expect(new Set(commandIds).size).toBe(1);
+    });
+
+    /** @scenario "A row deleted on the legacy side is revoked, not left behind" */
+    it("revokes a migration-owned head fact whose legacy row is gone", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        grantHeads: [
+          foldedHead({
+            grantId: "grant_orphan",
+            principal: { type: "user", id: "user_gone" },
+            roleKey: "member",
+            scope: { type: "PROJECT", id: "project_1" },
+            source: "migration",
+            occurredAtMs: CREATED,
+          }),
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(
+        sent.filter(
+          (entry) =>
+            entry.kind === "revokeGrant" &&
+            entry.payload.grantId === "grant_orphan",
+        ),
+      ).toHaveLength(1);
+    });
+
+    /** @scenario "A row deleted on the legacy side is revoked, not left behind" */
+    it("leaves live-write facts alone: only migration-owned sources reconcile", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        grantHeads: [
+          {
+            ...foldedHead({
+              grantId: "grant_live",
+              principal: { type: "user", id: "user_live" },
+              roleKey: "member",
+              scope: { type: "PROJECT", id: "project_1" },
+              source: "grants-service",
+              occurredAtMs: CREATED,
+            }),
+            source: "grants-service",
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(sent.filter((entry) => entry.kind === "revokeGrant")).toHaveLength(
+        0,
+      );
+    });
+  });
+
+  describe("when share links carry a view budget", () => {
+    it("hands the budget over on every pass", async () => {
+      const { migration, seeded } = harness({
+        shareLinks: [shareLink({ maxViews: 10, viewCount: 3 })],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(seeded).toEqual([
+        [{ grantId: "share_1", projectId: "project_1", viewCount: 3 }],
+      ]);
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/__tests__/engine-gate.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/engine-gate.unit.test.ts
@@ -42,7 +42,7 @@ describe("the authz engine gate", () => {
 
   describe("when the organization has an authz migration state row", () => {
     it("asks about the authz migration, not any other", async () => {
-      const { findUnique, prisma } = stateTable("migrated");
+      const { findUnique, prisma } = stateTable("finalized");
 
       await organizationOnAuthzEngine({ organizationId: ORG_ID, prisma });
 
@@ -55,7 +55,7 @@ describe("the authz engine gate", () => {
     });
 
     it.each([
-      ["migrated", true],
+      ["migrated", false],
       ["finalized", true],
       ["pending", false],
       ["parked", false],
@@ -143,7 +143,7 @@ describe("the authz engine gate", () => {
 
   describe("when the same organization is asked about repeatedly", () => {
     it("reads the row once inside the cache window", async () => {
-      const { findUnique, prisma } = stateTable("migrated");
+      const { findUnique, prisma } = stateTable("finalized");
 
       await organizationOnAuthzEngine({ organizationId: ORG_ID, prisma });
       await organizationOnAuthzEngine({ organizationId: ORG_ID, prisma });
@@ -153,13 +153,13 @@ describe("the authz engine gate", () => {
     });
 
     it("keeps one organization's answer out of another's", async () => {
-      const { prisma: migrated } = stateTable("migrated");
+      const { prisma: finalized } = stateTable("finalized");
       const { prisma: pending } = stateTable("pending");
 
       await expect(
         organizationOnAuthzEngine({
           organizationId: "org_a",
-          prisma: migrated,
+          prisma: finalized,
         }),
       ).resolves.toBe(true);
       await expect(
@@ -175,7 +175,7 @@ describe("the authz engine gate", () => {
       vi.setSystemTime(new Date("2026-08-18T09:00:00.000Z"));
       const findUnique = vi
         .fn()
-        .mockResolvedValueOnce({ status: "migrated" })
+        .mockResolvedValueOnce({ status: "finalized" })
         .mockResolvedValue({ status: "rolled_back" });
       const prisma = {
         systemMigrationTenantState: { findUnique },
@@ -205,7 +205,7 @@ describe("the authz engine gate", () => {
       const findUnique = vi
         .fn()
         .mockResolvedValueOnce(null)
-        .mockResolvedValue({ status: "migrated" });
+        .mockResolvedValue({ status: "finalized" });
       const prisma = {
         systemMigrationTenantState: { findUnique },
       } as unknown as Pick<PrismaClient, "systemMigrationTenantState">;

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -1,0 +1,319 @@
+/**
+ * The authz-engine migration's proof (ADR-110): the heads the fold wrote,
+ * compared against the facts this pass assembled. Pure functions over one
+ * projection read — what they cannot see is `outstanding` (stated but not
+ * folded); what they see and disagree with is a named diff. The migration
+ * itself lives in ./authz-engine.migration.ts; the facts in
+ * ./authz-engine.facts.ts.
+ *
+ * @see specs/migration/authz-grants-rollout.feature
+ */
+import { createHash } from "node:crypto";
+import type {
+  GrantFact,
+  ResourceGrantRow,
+  RoleFact,
+  RoleHeadRow,
+} from "@langwatch/authz-server";
+import {
+  PRINCIPAL_TO_DB,
+  shareVisibilityAudience,
+} from "@langwatch/authz-server";
+import {
+  type ExpectedFacts,
+  type ExpectedShareLink,
+  isMigrationOwned,
+  permissionStrings,
+} from "./authz-engine.facts";
+
+/** One non-resource Grant head row, as the proof reads it. */
+export type GrantHeadRow = {
+  id: string;
+  principalType: string;
+  principalId: string | null;
+  roleKey: string | null;
+  legacyRole: string | null;
+  source: string;
+  scopeType: string;
+  scopeId: string;
+  revoked: boolean;
+};
+
+/** One named disagreement between a head and the legacy row it mirrors.
+ *  Missing and extra rows are not diffs: they are `outstanding` — the fold
+ *  has not caught up with what this pass stated or revoked. */
+export type AuthzEngineDiff = {
+  kind: "grant_revoked" | "grant_changed" | "role_changed" | "resource_changed";
+  id: string;
+  field?: string;
+  expected?: string | null;
+  actual?: string | null;
+};
+
+export type HeadState = {
+  grantRows: GrantHeadRow[];
+  roleHeads: RoleHeadRow[];
+  resourceRows: ResourceGrantRow[];
+};
+
+export type CheckResult = { outstanding: string[]; diffs: AuthzEngineDiff[] };
+
+export function checkGrantHeads({
+  expected,
+  heads,
+}: {
+  expected: ExpectedFacts;
+  heads: HeadState;
+}): CheckResult {
+  const outstanding: string[] = [];
+  const diffs: AuthzEngineDiff[] = [];
+  const headById = new Map(heads.grantRows.map((row) => [row.id, row]));
+  for (const fact of expected.nonResourceFacts) {
+    const head = headById.get(fact.grantId);
+    if (!head) {
+      outstanding.push(fact.grantId);
+      continue;
+    }
+    if (head.revoked) {
+      diffs.push({ kind: "grant_revoked", id: fact.grantId });
+      continue;
+    }
+    diffs.push(...grantDiffs({ fact, head }));
+  }
+  // Stale rows revoked this pass, not yet folded: outstanding, never a diff.
+  outstanding.push(
+    ...heads.grantRows
+      .filter(
+        (row) =>
+          !row.revoked &&
+          isMigrationOwned(row.source) &&
+          !expected.grantIds.has(row.id),
+      )
+      .map((row) => row.id),
+  );
+  return { outstanding, diffs };
+}
+
+export function checkRoleHeads({
+  expected,
+  heads,
+}: {
+  expected: ExpectedFacts;
+  heads: HeadState;
+}): CheckResult {
+  const outstanding: string[] = [];
+  const diffs: AuthzEngineDiff[] = [];
+  const headById = new Map(heads.roleHeads.map((head) => [head.id, head]));
+  const expectedRoleIds = new Set(expected.roles.map((role) => role.roleId));
+  for (const role of expected.roles) {
+    const head = headById.get(role.roleId);
+    if (!head) {
+      outstanding.push(role.roleId);
+      continue;
+    }
+    diffs.push(...roleDiffs({ role, head }));
+  }
+  for (const head of heads.roleHeads) {
+    if (!expectedRoleIds.has(head.id)) {
+      outstanding.push(head.id);
+    }
+  }
+  return { outstanding, diffs };
+}
+
+export function checkResourceHeads({
+  organizationId,
+  expected,
+  heads,
+}: {
+  organizationId: string;
+  expected: ExpectedFacts;
+  heads: HeadState;
+}): CheckResult {
+  const outstanding: string[] = [];
+  const diffs: AuthzEngineDiff[] = [];
+  const headById = new Map(heads.resourceRows.map((row) => [row.grantId, row]));
+  const expectedLinkIds = new Set(
+    expected.shareLinks.map((link) => link.row.id),
+  );
+  for (const link of expected.shareLinks) {
+    const head = headById.get(link.row.id);
+    if (!head) {
+      outstanding.push(link.row.id);
+      continue;
+    }
+    const result = resourceDiffs({ organizationId, link, head });
+    outstanding.push(...result.outstanding);
+    diffs.push(...result.diffs);
+  }
+  for (const row of heads.resourceRows) {
+    // Only rows the migration owns: a live-write row (a ledger-first share
+    // whose compat write was stepped over) is not this migration's to hold
+    // an organization on, and never its to revoke.
+    if (isMigrationOwned(row.source) && !expectedLinkIds.has(row.grantId)) {
+      outstanding.push(row.grantId);
+    }
+  }
+  return { outstanding, diffs };
+}
+
+export function roleDrifted({
+  role,
+  head,
+}: {
+  role: RoleFact;
+  head: RoleHeadRow;
+}): boolean {
+  return (
+    head.name !== role.name ||
+    (head.description ?? null) !== (role.description ?? null) ||
+    permissionStrings(head.permissions).join(",") !==
+      role.permissions.join(",") ||
+    (head.kind === "system_api_key" ? "system_api_key" : "custom") !== role.kind
+  );
+}
+
+/** Field equality for one stated fact against its head row — against what
+ *  the migration SAID, since that is what the head is supposed to hold. */
+function grantDiffs({
+  fact,
+  head,
+}: {
+  fact: GrantFact;
+  head: GrantHeadRow;
+}): AuthzEngineDiff[] {
+  const compared: Array<[string, string | null, string | null]> = [
+    ["principalType", PRINCIPAL_TO_DB[fact.principal.type], head.principalType],
+    ["principalId", fact.principal.id, head.principalId],
+    ["roleKey", fact.roleKey, head.roleKey],
+    ["legacyRole", fact.legacyRole ?? null, head.legacyRole],
+    ["scopeType", fact.scope.type, head.scopeType],
+    ["scopeId", fact.scope.id, head.scopeId],
+  ];
+  return compared.flatMap(([field, expected, actual]) =>
+    expected === actual
+      ? []
+      : [
+          {
+            kind: "grant_changed" as const,
+            id: fact.grantId,
+            field,
+            expected,
+            actual,
+          },
+        ],
+  );
+}
+
+function roleDiffs({
+  role,
+  head,
+}: {
+  role: RoleFact;
+  head: RoleHeadRow;
+}): AuthzEngineDiff[] {
+  const compared: Array<[string, string | null, string | null]> = [
+    ["name", role.name, head.name],
+    ["description", role.description ?? null, head.description],
+    [
+      "permissions",
+      role.permissions.join(","),
+      permissionStrings(head.permissions).join(","),
+    ],
+    [
+      "kind",
+      role.kind,
+      head.kind === "system_api_key" ? "system_api_key" : "custom",
+    ],
+  ];
+  return compared.flatMap(([field, expected, actual]) =>
+    expected === actual
+      ? []
+      : [
+          {
+            kind: "role_changed" as const,
+            id: role.roleId,
+            field,
+            expected,
+            actual,
+          },
+        ],
+  );
+}
+
+/**
+ * Field equality for one imported link against its RESOURCE head row, and
+ * the id when its head lags. The stored spellings differ (the head keeps
+ * the database's uppercase), so the comparison is against what the import
+ * said, mapped to that spelling.
+ *
+ * The view budget cuts both ways and the two directions mean different
+ * things. A head BEHIND the legacy count is convergence lag — views land
+ * legacy-side between passes and the monotonic seed raises the usage row
+ * next pass — so it is `outstanding`, not a disagreement; reporting it as
+ * one made an actively-viewed link re-hold the organization forever. A
+ * head AHEAD of the legacy count is a budget that grew back, which nothing
+ * legitimate produces, so that is the named diff.
+ *
+ * Tokens are bearer credentials and the report is persisted and rendered
+ * on the ops page, so a token disagreement reports fingerprints, never the
+ * values.
+ */
+function resourceDiffs({
+  organizationId,
+  link,
+  head,
+}: {
+  organizationId: string;
+  link: ExpectedShareLink;
+  head: ResourceGrantRow;
+}): CheckResult {
+  const { row } = link;
+  const principal = shareVisibilityAudience({
+    visibility: row.visibility,
+    organizationId,
+    projectId: row.projectId,
+  });
+  const compared: Array<[string, string | null, string | null]> = [
+    ["token", tokenFingerprint(row.token), tokenFingerprint(head.token)],
+    ["kind", row.resourceType, (head.resourceKind ?? "").toUpperCase() || null],
+    ["resourceId", row.resourceId, head.resourceId],
+    ["projectId", row.projectId, head.projectId],
+    ["principalType", PRINCIPAL_TO_DB[principal.type], head.principalType],
+    ["principalId", principal.id, head.principalId],
+    ["expiresAt", numberField(row.expiresAtMs), numberField(head.expiresAtMs)],
+    ["maxViews", numberField(row.maxViews), numberField(head.maxViews)],
+  ];
+  if (head.viewCount > row.viewCount) {
+    compared.push([
+      "viewCount",
+      numberField(row.viewCount),
+      numberField(head.viewCount),
+    ]);
+  }
+  return {
+    outstanding: head.viewCount < row.viewCount ? [row.id] : [],
+    diffs: compared.flatMap(([field, expected, actual]) =>
+      expected === actual
+        ? []
+        : [
+            {
+              kind: "resource_changed" as const,
+              id: row.id,
+              field,
+              expected,
+              actual,
+            },
+          ],
+    ),
+  };
+}
+
+function tokenFingerprint(token: string | null): string | null {
+  if (token === null) return null;
+  return createHash("sha256").update(token).digest("hex").slice(0, 12);
+}
+
+function numberField(value: number | null): string | null {
+  return value === null ? null : String(value);
+}

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -11,6 +11,7 @@
 import { createHash } from "node:crypto";
 import type {
   GrantFact,
+  GrantHeadRow,
   ResourceGrantRow,
   RoleFact,
   RoleHeadRow,
@@ -25,19 +26,6 @@ import {
   isMigrationOwned,
   permissionStrings,
 } from "./authz-engine.facts";
-
-/** One non-resource Grant head row, as the proof reads it. */
-export type GrantHeadRow = {
-  id: string;
-  principalType: string;
-  principalId: string | null;
-  roleKey: string | null;
-  legacyRole: string | null;
-  source: string;
-  scopeType: string;
-  scopeId: string;
-  revoked: boolean;
-};
 
 /** One named disagreement between a head and the legacy row it mirrors.
  *  Missing and extra rows are not diffs: they are `outstanding` — the fold
@@ -81,13 +69,18 @@ export function checkGrantHeads({
     diffs.push(...grantDiffs({ fact, head }));
   }
   // Stale rows revoked this pass, not yet folded: outstanding, never a diff.
+  // The guard matches the sweep's exactly, `retainedGrantIds` included — a
+  // row the sweep deliberately did NOT revoke is never going to disappear
+  // from the head, so counting it outstanding would hold the organization
+  // for a condition no later pass can clear.
   outstanding.push(
     ...heads.grantRows
       .filter(
         (row) =>
           !row.revoked &&
           isMigrationOwned(row.source) &&
-          !expected.grantIds.has(row.id),
+          !expected.grantIds.has(row.id) &&
+          !expected.retainedGrantIds.has(row.id),
       )
       .map((row) => row.id),
   );

--- a/platform/app/src/server/app-layer/authz/authz-engine.facts.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.facts.ts
@@ -1,0 +1,439 @@
+/**
+ * The authz-engine migration's fact assembly (ADR-110): every legacy table
+ * translated into the grant and role facts the ledger states. Pure — no
+ * store, no ledger, no clock — which is what keeps each pass's expected
+ * state a function of the legacy rows it read. The migration itself lives
+ * in ./authz-engine.migration.ts; the proof over these facts in
+ * ./authz-engine.check.ts.
+ *
+ * @see specs/migration/authz-grants-rollout.feature
+ */
+
+import { roleKeyForTeamRole } from "@langwatch/authz";
+import type {
+  ExternalMemberFact,
+  GrantFact,
+  LedgerPrincipal,
+  LegacyBindingRow,
+  LegacyRoleRow,
+  LegacyTeamRow,
+  OrganizationMemberFact,
+  ProjectCredentialFact,
+  RoleFact,
+  ShareLinkFactRow,
+} from "@langwatch/authz-server";
+import {
+  SHARE_LINK_PERMISSION,
+  shareVisibilityAudience,
+} from "@langwatch/authz-server";
+import { deriveGrantId } from "@langwatch/authz-server/migration";
+
+/**
+ * The sources this migration owns in the Grant head — its own, plus the
+ * three-stage rollout's it replaces (ADR-110 collapsed genesis-import,
+ * backfill-b and cutover-import into this one migration; rows they wrote
+ * are this migration's to reconcile and to prove).
+ */
+export const MIGRATION_OWNED_SOURCES = [
+  "migration",
+  "genesis-import",
+  "backfill-b",
+  "cutover-import",
+] as const;
+
+export function isMigrationOwned(source: string): boolean {
+  return (MIGRATION_OWNED_SOURCES as readonly string[]).includes(source);
+}
+
+export type ExpectedShareLink = { row: ShareLinkFactRow; fact: GrantFact };
+
+export type ExpectedFacts = {
+  roles: RoleFact[];
+  bindingFacts: GrantFact[];
+  teamFacts: GrantFact[];
+  organizationFacts: GrantFact[];
+  credentialFacts: GrantFact[];
+  shareLinks: ExpectedShareLink[];
+  /** Every non-resource fact, for the proof's walk. */
+  nonResourceFacts: GrantFact[];
+  /** Every expected id, resource included, for the deny sweep. */
+  grantIds: Set<string>;
+  /** Ids of legacy rows the migration READ but chose not to express (a
+   *  binding naming no principal). Legacy still HAS these rows, so the
+   *  deny sweep must not treat an earlier import of one as stale. */
+  retainedGrantIds: Set<string>;
+};
+
+export function assembleFacts({
+  organizationId,
+  inventory,
+}: {
+  organizationId: string;
+  inventory: {
+    organizationCreatedAtMs: number | null;
+    roleRows: LegacyRoleRow[];
+    bindingRows: LegacyBindingRow[];
+    members: OrganizationMemberFact[];
+    teamRows: LegacyTeamRow[];
+    shareLinkRows: ShareLinkFactRow[];
+    externalMembers: ExternalMemberFact[];
+    credentials: ProjectCredentialFact[];
+    groupMemberships: Array<{ userId: string; groupId: string }>;
+  };
+}): ExpectedFacts {
+  const roles = inventory.roleRows
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(legacyRoleToFact);
+  const bindingFacts = inventory.bindingRows
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .flatMap((row) => {
+      const fact = bindingToFact({ row });
+      return fact ? [fact] : [];
+    });
+  const teamFacts = teamMembershipFacts({
+    organizationId,
+    teamRows: inventory.teamRows,
+    bindingRows: inventory.bindingRows,
+    groupMemberships: inventory.groupMemberships,
+  });
+  const organizationFacts = organizationLevelFacts({
+    organizationId,
+    members: inventory.members,
+    externalMembers: inventory.externalMembers,
+    bindingRows: inventory.bindingRows,
+    organizationCreatedAtMs: inventory.organizationCreatedAtMs,
+  });
+  const credentialFacts = inventory.credentials
+    .slice()
+    .sort((a, b) => a.projectId.localeCompare(b.projectId))
+    .map((credential) => credentialToFact({ organizationId, credential }));
+  const shareLinks = inventory.shareLinkRows
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(
+      (row): ExpectedShareLink => ({
+        row,
+        fact: shareLinkToFact({ organizationId, row }),
+      }),
+    );
+
+  const nonResourceFacts = [
+    ...bindingFacts,
+    ...teamFacts,
+    ...organizationFacts,
+    ...credentialFacts,
+  ];
+  return {
+    roles,
+    bindingFacts,
+    teamFacts,
+    organizationFacts,
+    credentialFacts,
+    shareLinks,
+    nonResourceFacts,
+    grantIds: new Set([
+      ...nonResourceFacts.map((fact) => fact.grantId),
+      ...shareLinks.map((link) => link.row.id),
+    ]),
+    retainedGrantIds: new Set(
+      inventory.bindingRows
+        .filter((row) => bindingPrincipal(row) === null)
+        .map((row) => row.id),
+    ),
+  };
+}
+
+/**
+ * A CustomRole as the ledger defines it, adopting the row's own id. The
+ * stored permissions column is jsonb: anything that is not an array of
+ * strings imports as the empty list, which grants nothing.
+ */
+function legacyRoleToFact(row: LegacyRoleRow): RoleFact {
+  return {
+    roleId: row.id,
+    name: row.name,
+    ...(row.description === null ? {} : { description: row.description }),
+    permissions: permissionStrings(row.permissions),
+    kind: row.kind === "system_api_key" ? "system_api_key" : "custom",
+    occurredAtMs: row.createdAtMs,
+  };
+}
+
+export function permissionStrings(stored: unknown): string[] {
+  return Array.isArray(stored)
+    ? stored.filter(
+        (entry): entry is string => typeof entry === "string" && entry !== "",
+      )
+    : [];
+}
+
+/**
+ * A RoleBinding as the ledger attaches it. The grant id IS the row id. A row
+ * naming no principal cannot be expressed as a grant and is skipped; the
+ * proof does not expect it either, so it holds nothing up.
+ *
+ * A custom key erases which legacy `role` column value the row carried, so
+ * it travels as `legacyRole`: the legacy resolver falls back to that column
+ * whenever the custom role's permission list is empty, and dropping it would
+ * turn an ADMIN with an empty custom role into a viewer.
+ */
+function bindingToFact({ row }: { row: LegacyBindingRow }): GrantFact | null {
+  const principal = bindingPrincipal(row);
+  if (!principal) return null;
+  return {
+    grantId: row.id,
+    principal,
+    roleKey:
+      row.customRoleId === null
+        ? roleKeyForTeamRole(row.role)
+        : `custom:${row.customRoleId}`,
+    ...(row.customRoleId === null ? {} : { legacyRole: row.role }),
+    scope: { type: row.scopeType, id: row.scopeId },
+    source: "migration",
+    occurredAtMs: row.createdAtMs,
+  };
+}
+
+function bindingPrincipal(row: LegacyBindingRow): LedgerPrincipal | null {
+  if (row.userId !== null) return { type: "user", id: row.userId };
+  if (row.groupId !== null) return { type: "group", id: row.groupId };
+  if (row.apiKeyId !== null) return { type: "apiKey", id: row.apiKeyId };
+  return null;
+}
+
+/**
+ * Team memberships stated DIRECTLY (ADR-110), never promoted into binding
+ * rows first — and only where the legacy resolver actually grants from
+ * them. Its predicate, mirrored exactly:
+ *
+ * - A membership is suppressed when the user holds ANY binding at the
+ *   scopes in play (the organization, or the membership's own team) —
+ *   directly or through a group. The resolver counts a binding of any role
+ *   there, so the suppression must not key on role: keeping a role in the
+ *   key stated an EXTRA grant beside a differing-role binding, a union the
+ *   legacy path never answers.
+ * - A `CUSTOM` membership row is never stated: the resolver's fallback
+ *   denies that shape outright ("leave those to the binding path"), with
+ *   or without an assigned role, so a fact for it would grant access
+ *   legacy refuses.
+ */
+function teamMembershipFacts({
+  organizationId,
+  teamRows,
+  bindingRows,
+  groupMemberships,
+}: {
+  organizationId: string;
+  teamRows: LegacyTeamRow[];
+  bindingRows: LegacyBindingRow[];
+  groupMemberships: Array<{ userId: string; groupId: string }>;
+}): GrantFact[] {
+  const groupsByUser = new Map<string, Set<string>>();
+  for (const membership of groupMemberships) {
+    const groups = groupsByUser.get(membership.userId) ?? new Set<string>();
+    groups.add(membership.groupId);
+    groupsByUser.set(membership.userId, groups);
+  }
+  const covers = ({
+    row,
+    userId,
+  }: {
+    row: LegacyBindingRow;
+    userId: string;
+  }): boolean => {
+    if (row.userId === userId) return true;
+    return (
+      row.groupId !== null &&
+      (groupsByUser.get(userId)?.has(row.groupId) ?? false)
+    );
+  };
+  const suppressed = ({ userId, teamId }: { userId: string; teamId: string }) =>
+    bindingRows.some((row) => {
+      const inPlay =
+        (row.scopeType === "ORGANIZATION" && row.scopeId === organizationId) ||
+        (row.scopeType === "TEAM" && row.scopeId === teamId);
+      return inPlay && covers({ row, userId });
+    });
+  return teamRows
+    .slice()
+    .sort(
+      (a, b) =>
+        a.teamId.localeCompare(b.teamId) || a.userId.localeCompare(b.userId),
+    )
+    .flatMap((row) => {
+      if (row.role === "CUSTOM") return [];
+      if (suppressed(row)) return [];
+      const principal = { type: "user" as const, id: row.userId };
+      const scope = { type: "TEAM" as const, id: row.teamId };
+      return [
+        {
+          grantId: deriveGrantId({
+            organizationId,
+            principal,
+            scope,
+            occurredAtMs: row.createdAtMs,
+          }),
+          principal,
+          roleKey: roleKeyForTeamRole(row.role),
+          scope,
+          source: "migration" as const,
+          occurredAtMs: row.createdAtMs,
+        },
+      ];
+    });
+}
+
+/**
+ * The facts the legacy schema inferred instead of storing.
+ *
+ * The floor: one org-scoped `member` grant whose principal is the
+ * organization's membership itself, so a member holding no binding anywhere
+ * holds exactly the floor and nothing beyond it.
+ *
+ * The legacy-admin fallback: an ADMIN with no binding anywhere is served
+ * today by the resolver's fallback. `legacy-admin`, NOT `admin`, and the
+ * difference is load-bearing: `admin` would grant the full admin bag where
+ * the fallback grants a narrower one; the untranslatable key keeps the fact
+ * dormant until the contract gives it the bag the fallback actually grants.
+ *
+ * Lite members: `OrganizationUser.role = EXTERNAL`, the org-scoped cap the
+ * legacy schema kept as a membership column.
+ */
+function organizationLevelFacts({
+  organizationId,
+  members,
+  externalMembers,
+  bindingRows,
+  organizationCreatedAtMs,
+}: {
+  organizationId: string;
+  members: OrganizationMemberFact[];
+  externalMembers: ExternalMemberFact[];
+  bindingRows: LegacyBindingRow[];
+  organizationCreatedAtMs: number | null;
+}): GrantFact[] {
+  const scope = { type: "ORGANIZATION" as const, id: organizationId };
+  const facts: GrantFact[] = [];
+
+  if (organizationCreatedAtMs !== null) {
+    const principal = { type: "organization" as const, id: organizationId };
+    facts.push({
+      grantId: deriveGrantId({
+        organizationId,
+        principal,
+        scope,
+        occurredAtMs: organizationCreatedAtMs,
+      }),
+      principal,
+      roleKey: "member",
+      scope,
+      source: "migration",
+      occurredAtMs: organizationCreatedAtMs,
+    });
+  }
+
+  const boundUserIds = new Set(
+    bindingRows.flatMap((row) => (row.userId === null ? [] : [row.userId])),
+  );
+  for (const member of members
+    .slice()
+    .sort((a, b) => a.userId.localeCompare(b.userId))) {
+    if (member.role !== "ADMIN" || boundUserIds.has(member.userId)) continue;
+    const principal = { type: "user" as const, id: member.userId };
+    facts.push({
+      grantId: deriveGrantId({
+        organizationId,
+        principal,
+        scope,
+        occurredAtMs: member.createdAtMs,
+      }),
+      principal,
+      roleKey: "legacy-admin",
+      scope,
+      source: "migration",
+      occurredAtMs: member.createdAtMs,
+    });
+  }
+
+  for (const member of externalMembers
+    .slice()
+    .sort((a, b) => a.userId.localeCompare(b.userId))) {
+    const principal = { type: "user" as const, id: member.userId };
+    facts.push({
+      grantId: deriveGrantId({
+        organizationId,
+        principal,
+        scope,
+        occurredAtMs: member.createdAtMs,
+      }),
+      principal,
+      roleKey: "lite-member",
+      scope,
+      source: "migration",
+      occurredAtMs: member.createdAtMs,
+    });
+  }
+  return facts;
+}
+
+/** The legacy per-project credential (`Project.apiKey`): the PROJECT itself
+ *  is the principal — that key authenticates as the project and names no
+ *  user or key row at all. */
+function credentialToFact({
+  organizationId,
+  credential,
+}: {
+  organizationId: string;
+  credential: ProjectCredentialFact;
+}): GrantFact {
+  const principal = { type: "project" as const, id: credential.projectId };
+  const scope = { type: "PROJECT" as const, id: credential.projectId };
+  return {
+    grantId: deriveGrantId({
+      organizationId,
+      principal,
+      scope,
+      occurredAtMs: credential.createdAtMs,
+    }),
+    principal,
+    roleKey: "admin",
+    scope,
+    source: "migration",
+    occurredAtMs: credential.createdAtMs,
+  };
+}
+
+/** A share link as the ledger attaches it, adopting the row's own id so the
+ *  token a customer already circulated keeps resolving to it. Resource facts
+ *  carry no role: their single permission is in the terms. */
+function shareLinkToFact({
+  organizationId,
+  row,
+}: {
+  organizationId: string;
+  row: ShareLinkFactRow;
+}): GrantFact {
+  return {
+    grantId: row.id,
+    principal: shareVisibilityAudience({
+      visibility: row.visibility,
+      organizationId,
+      projectId: row.projectId,
+    }),
+    roleKey: null,
+    scope: { type: "RESOURCE", id: row.resourceId },
+    resource: {
+      kind: row.resourceType === "THREAD" ? "thread" : "trace",
+      projectId: row.projectId,
+      token: row.token,
+      permission: SHARE_LINK_PERMISSION,
+      ...(row.userId === null ? {} : { createdByUserId: row.userId }),
+      ...(row.expiresAtMs === null ? {} : { expiresAtMs: row.expiresAtMs }),
+      ...(row.maxViews === null ? {} : { maxViews: row.maxViews }),
+    },
+    source: "migration",
+    occurredAtMs: row.createdAtMs,
+  };
+}

--- a/platform/app/src/server/app-layer/authz/authz-engine.facts.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.facts.ts
@@ -45,6 +45,41 @@ export function isMigrationOwned(source: string): boolean {
   return (MIGRATION_OWNED_SOURCES as readonly string[]).includes(source);
 }
 
+/** Whether one binding row covers one user — named directly, or held
+ *  through a group the user belongs to. */
+export type BindingCoverage = (args: {
+  row: LegacyBindingRow;
+  userId: string;
+}) => boolean;
+
+/**
+ * The coverage predicate, built once per organization from its group
+ * memberships. The legacy resolver reads a group-held binding exactly like a
+ * user-held one, so every rule phrased as "this user already holds a
+ * binding" — the team-membership suppression AND the admin fallback — has to
+ * read them the same way. Two predicates that disagree would state a fact on
+ * one path that the other suppresses.
+ */
+function bindingCoverage({
+  groupMemberships,
+}: {
+  groupMemberships: Array<{ userId: string; groupId: string }>;
+}): BindingCoverage {
+  const groupsByUser = new Map<string, Set<string>>();
+  for (const membership of groupMemberships) {
+    const groups = groupsByUser.get(membership.userId) ?? new Set<string>();
+    groups.add(membership.groupId);
+    groupsByUser.set(membership.userId, groups);
+  }
+  return ({ row, userId }) => {
+    if (row.userId === userId) return true;
+    return (
+      row.groupId !== null &&
+      (groupsByUser.get(userId)?.has(row.groupId) ?? false)
+    );
+  };
+}
+
 export type ExpectedShareLink = { row: ShareLinkFactRow; fact: GrantFact };
 
 export type ExpectedFacts = {
@@ -92,17 +127,24 @@ export function assembleFacts({
       const fact = bindingToFact({ row });
       return fact ? [fact] : [];
     });
+  // One coverage predicate for both suppression rules below: a user is
+  // "already bound" identically whether the binding names them or a group
+  // they belong to, and the two rules must never disagree about that.
+  const covers = bindingCoverage({
+    groupMemberships: inventory.groupMemberships,
+  });
   const teamFacts = teamMembershipFacts({
     organizationId,
     teamRows: inventory.teamRows,
     bindingRows: inventory.bindingRows,
-    groupMemberships: inventory.groupMemberships,
+    covers,
   });
   const organizationFacts = organizationLevelFacts({
     organizationId,
     members: inventory.members,
     externalMembers: inventory.externalMembers,
     bindingRows: inventory.bindingRows,
+    covers,
     organizationCreatedAtMs: inventory.organizationCreatedAtMs,
   });
   const credentialFacts = inventory.credentials
@@ -223,32 +265,13 @@ function teamMembershipFacts({
   organizationId,
   teamRows,
   bindingRows,
-  groupMemberships,
+  covers,
 }: {
   organizationId: string;
   teamRows: LegacyTeamRow[];
   bindingRows: LegacyBindingRow[];
-  groupMemberships: Array<{ userId: string; groupId: string }>;
+  covers: BindingCoverage;
 }): GrantFact[] {
-  const groupsByUser = new Map<string, Set<string>>();
-  for (const membership of groupMemberships) {
-    const groups = groupsByUser.get(membership.userId) ?? new Set<string>();
-    groups.add(membership.groupId);
-    groupsByUser.set(membership.userId, groups);
-  }
-  const covers = ({
-    row,
-    userId,
-  }: {
-    row: LegacyBindingRow;
-    userId: string;
-  }): boolean => {
-    if (row.userId === userId) return true;
-    return (
-      row.groupId !== null &&
-      (groupsByUser.get(userId)?.has(row.groupId) ?? false)
-    );
-  };
   const suppressed = ({ userId, teamId }: { userId: string; teamId: string }) =>
     bindingRows.some((row) => {
       const inPlay =
@@ -306,12 +329,14 @@ function organizationLevelFacts({
   members,
   externalMembers,
   bindingRows,
+  covers,
   organizationCreatedAtMs,
 }: {
   organizationId: string;
   members: OrganizationMemberFact[];
   externalMembers: ExternalMemberFact[];
   bindingRows: LegacyBindingRow[];
+  covers: BindingCoverage;
   organizationCreatedAtMs: number | null;
 }): GrantFact[] {
   const scope = { type: "ORGANIZATION" as const, id: organizationId };
@@ -334,13 +359,14 @@ function organizationLevelFacts({
     });
   }
 
-  const boundUserIds = new Set(
-    bindingRows.flatMap((row) => (row.userId === null ? [] : [row.userId])),
-  );
   for (const member of members
     .slice()
     .sort((a, b) => a.userId.localeCompare(b.userId))) {
-    if (member.role !== "ADMIN" || boundUserIds.has(member.userId)) continue;
+    if (member.role !== "ADMIN") continue;
+    // "No binding anywhere" reads group-held bindings too — the same
+    // predicate the team-membership suppression uses.
+    if (bindingRows.some((row) => covers({ row, userId: member.userId })))
+      continue;
     const principal = { type: "user" as const, id: member.userId };
     facts.push({
       grantId: deriveGrantId({

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -57,6 +57,7 @@ import { createHash } from "node:crypto";
 import type {
   ExternalMemberFact,
   GrantFact,
+  GrantHeadRow,
   GrantsLedgerActor,
   LegacyBindingRow,
   LegacyRoleRow,
@@ -78,7 +79,6 @@ import {
   checkGrantHeads,
   checkResourceHeads,
   checkRoleHeads,
-  type GrantHeadRow,
   type HeadState,
   roleDrifted,
 } from "./authz-engine.check";
@@ -415,7 +415,17 @@ export class AuthzEngineMigration implements SystemMigration {
     await this.each(staleGrants, signal, (grantId) =>
       this.deps.ledger.revokeGrant({
         organizationId,
-        commandId: `authz-engine:deny:grant:${grantId}`,
+        // The pass's business time is in the key for the reason the repair
+        // keys carry it: a legacy row deleted, restored under the same id,
+        // then deleted again would otherwise collide with the first deny's
+        // idempotency key and be swallowed, leaving a live head with no
+        // legacy row behind it. A live head is the only sweep candidate, so
+        // a re-appended deny costs at most one event while the fold lags.
+        commandId: contentCommandId({
+          kind: "deny:grant",
+          id: grantId,
+          content: { occurredAtMs },
+        }),
         grantId,
         reason: "authz-engine reconciliation: legacy row no longer exists",
         actor: ACTOR,
@@ -435,7 +445,11 @@ export class AuthzEngineMigration implements SystemMigration {
     await this.each(staleRoles, signal, (roleId) =>
       this.deps.ledger.deleteRole({
         organizationId,
-        commandId: `authz-engine:deny:role:${roleId}`,
+        commandId: contentCommandId({
+          kind: "deny:role",
+          id: roleId,
+          content: { occurredAtMs },
+        }),
         roleId,
         actor: ACTOR,
         occurredAtMs,

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -335,18 +335,21 @@ export class AuthzEngineMigration implements SystemMigration {
     expected: ExpectedFacts;
     signal?: AbortSignal;
   }): Promise<void> {
-    await this.each(expected.roles, signal, (role) =>
-      this.deps.ledger.defineRole({
-        organizationId,
-        commandId: contentCommandId({
-          kind: "role",
-          id: role.roleId,
-          content: role,
+    await this.each({
+      items: expected.roles,
+      signal,
+      send: (role) =>
+        this.deps.ledger.defineRole({
+          organizationId,
+          commandId: contentCommandId({
+            kind: "role",
+            id: role.roleId,
+            content: role,
+          }),
+          role,
+          actor: ACTOR,
         }),
-        role,
-        actor: ACTOR,
-      }),
-    );
+    });
     const grants = [
       ...expected.bindingFacts,
       ...expected.teamFacts,
@@ -354,17 +357,20 @@ export class AuthzEngineMigration implements SystemMigration {
       ...expected.credentialFacts,
       ...expected.shareLinks.map((link) => link.fact),
     ];
-    await this.each(grants, signal, (fact) =>
-      this.deps.ledger.attachGrant({
-        organizationId,
-        commandId: contentCommandId({
-          kind: "grant",
-          id: fact.grantId,
-          content: fact,
+    await this.each({
+      items: grants,
+      signal,
+      send: (fact) =>
+        this.deps.ledger.attachGrant({
+          organizationId,
+          commandId: contentCommandId({
+            kind: "grant",
+            id: fact.grantId,
+            content: fact,
+          }),
+          grant: { ...fact, actor: ACTOR },
         }),
-        grant: { ...fact, actor: ACTOR },
-      }),
-    );
+    });
   }
 
   /**
@@ -412,26 +418,29 @@ export class AuthzEngineMigration implements SystemMigration {
         )
         .map((row) => row.grantId),
     ].sort();
-    await this.each(staleGrants, signal, (grantId) =>
-      this.deps.ledger.revokeGrant({
-        organizationId,
-        // The pass's business time is in the key for the reason the repair
-        // keys carry it: a legacy row deleted, restored under the same id,
-        // then deleted again would otherwise collide with the first deny's
-        // idempotency key and be swallowed, leaving a live head with no
-        // legacy row behind it. A live head is the only sweep candidate, so
-        // a re-appended deny costs at most one event while the fold lags.
-        commandId: contentCommandId({
-          kind: "deny:grant",
-          id: grantId,
-          content: { occurredAtMs },
+    await this.each({
+      items: staleGrants,
+      signal,
+      send: (grantId) =>
+        this.deps.ledger.revokeGrant({
+          organizationId,
+          // The pass's business time is in the key for the reason the repair
+          // keys carry it: a legacy row deleted, restored under the same id,
+          // then deleted again would otherwise collide with the first deny's
+          // idempotency key and be swallowed, leaving a live head with no
+          // legacy row behind it. A live head is the only sweep candidate, so
+          // a re-appended deny costs at most one event while the fold lags.
+          commandId: contentCommandId({
+            kind: "deny:grant",
+            id: grantId,
+            content: { occurredAtMs },
+          }),
+          grantId,
+          reason: "authz-engine reconciliation: legacy row no longer exists",
+          actor: ACTOR,
+          occurredAtMs,
         }),
-        grantId,
-        reason: "authz-engine reconciliation: legacy row no longer exists",
-        actor: ACTOR,
-        occurredAtMs,
-      }),
-    );
+    });
 
     const expectedRoleIds = new Set(expected.roles.map((role) => role.roleId));
     const staleRoles = heads.roleHeads
@@ -442,19 +451,22 @@ export class AuthzEngineMigration implements SystemMigration {
       .filter((head) => !expectedRoleIds.has(head.id))
       .map((head) => head.id)
       .sort();
-    await this.each(staleRoles, signal, (roleId) =>
-      this.deps.ledger.deleteRole({
-        organizationId,
-        commandId: contentCommandId({
-          kind: "deny:role",
-          id: roleId,
-          content: { occurredAtMs },
+    await this.each({
+      items: staleRoles,
+      signal,
+      send: (roleId) =>
+        this.deps.ledger.deleteRole({
+          organizationId,
+          commandId: contentCommandId({
+            kind: "deny:role",
+            id: roleId,
+            content: { occurredAtMs },
+          }),
+          roleId,
+          actor: ACTOR,
+          occurredAtMs,
         }),
-        roleId,
-        actor: ACTOR,
-        occurredAtMs,
-      }),
-    );
+    });
   }
 
   /**
@@ -498,21 +510,24 @@ export class AuthzEngineMigration implements SystemMigration {
       if (fact.roleKey.startsWith("custom:")) return [];
       return [{ grantId: fact.grantId, from: head.roleKey, to: fact.roleKey }];
     });
-    await this.each(rekeys, signal, (rekey) =>
-      this.deps.ledger.changeGrantRole({
-        organizationId,
-        commandId: contentCommandId({
-          kind: "rekey",
-          id: rekey.grantId,
-          content: { to: rekey.to, occurredAtMs },
+    await this.each({
+      items: rekeys,
+      signal,
+      send: (rekey) =>
+        this.deps.ledger.changeGrantRole({
+          organizationId,
+          commandId: contentCommandId({
+            kind: "rekey",
+            id: rekey.grantId,
+            content: { to: rekey.to, occurredAtMs },
+          }),
+          grantId: rekey.grantId,
+          from: rekey.from,
+          to: rekey.to,
+          actor: ACTOR,
+          occurredAtMs,
         }),
-        grantId: rekey.grantId,
-        from: rekey.from,
-        to: rekey.to,
-        actor: ACTOR,
-        occurredAtMs,
-      }),
-    );
+    });
 
     // A drifted role is restated WHOLE: `defineRole` at today's business
     // time wins the head's strictly-newer guard and carries every field —
@@ -525,18 +540,21 @@ export class AuthzEngineMigration implements SystemMigration {
       if (!head || !roleDrifted({ role, head })) return [];
       return [{ ...role, occurredAtMs }];
     });
-    await this.each(redefines, signal, (role) =>
-      this.deps.ledger.defineRole({
-        organizationId,
-        commandId: contentCommandId({
-          kind: "redefine",
-          id: role.roleId,
-          content: role,
+    await this.each({
+      items: redefines,
+      signal,
+      send: (role) =>
+        this.deps.ledger.defineRole({
+          organizationId,
+          commandId: contentCommandId({
+            kind: "redefine",
+            id: role.roleId,
+            content: role,
+          }),
+          role,
+          actor: ACTOR,
         }),
-        role,
-        actor: ACTOR,
-      }),
-    );
+    });
   }
 
   /**
@@ -570,11 +588,15 @@ export class AuthzEngineMigration implements SystemMigration {
 
   /** Bounded fan-out, aborted between chunks — the runner will not
    *  interrupt an in-flight send, so the boundary is the chunk. */
-  private async each<T>(
-    items: readonly T[],
-    signal: AbortSignal | undefined,
-    send: (item: T) => Promise<void>,
-  ): Promise<void> {
+  private async each<T>({
+    items,
+    signal,
+    send,
+  }: {
+    items: readonly T[];
+    signal: AbortSignal | undefined;
+    send: (item: T) => Promise<void>;
+  }): Promise<void> {
     for (let i = 0; i < items.length; i += SEND_CONCURRENCY) {
       if (signal?.aborted) {
         throw new Error(

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -35,16 +35,29 @@
  * itself and a derived fact — whose legacy representation is the membership
  * or credential row it came from — creates no binding row at all.
  *
+ * Two disagreements are named rather than repaired, deliberately — each
+ * holds the organization with a diff an operator reads, and both fail
+ * toward LESS access, never more:
+ *
+ * - A DERIVED fact whose head was revoked and whose legacy source came back
+ *   (a membership toggled off and on) re-derives the id of the revoked
+ *   head; the restated attach dedupes and would lose the head's guard
+ *   anyway, so the check reports `grant_revoked` each pass. Remediation is
+ *   the operator's (a projection replay, or withdrawing enrollment until
+ *   the toggle settles).
+ * - A `custom:<id>` role reassignment cannot be repaired by
+ *   `changeGrantRole`, because that event clears `legacyRole` (the
+ *   escalation rule in the projection) while the expected fact still
+ *   carries it; the check names the `legacyRole` disagreement instead.
+ *
  * @see specs/migration/authz-grants-rollout.feature
  * @see dev/docs/adr/110-grant-aggregates-are-grants.md
  */
 import { createHash } from "node:crypto";
-import { roleKeyForTeamRole } from "@langwatch/authz";
 import type {
   ExternalMemberFact,
   GrantFact,
   GrantsLedgerActor,
-  LedgerPrincipal,
   LegacyBindingRow,
   LegacyRoleRow,
   LegacyTeamRow,
@@ -56,19 +69,24 @@ import type {
   RoleHeadRow,
   ShareLinkFactRow,
 } from "@langwatch/authz-server";
-import {
-  PRINCIPAL_TO_DB,
-  SHARE_LINK_PERMISSION,
-  shareVisibilityAudience,
-} from "@langwatch/authz-server";
-import {
-  bindingIdentityKey,
-  deriveGrantId,
-} from "@langwatch/authz-server/migration";
 import type {
   SystemMigration,
   TenantMigrationOutcome,
 } from "@langwatch/system-migrations";
+import {
+  type AuthzEngineDiff,
+  checkGrantHeads,
+  checkResourceHeads,
+  checkRoleHeads,
+  type GrantHeadRow,
+  type HeadState,
+  roleDrifted,
+} from "./authz-engine.check";
+import {
+  assembleFacts,
+  type ExpectedFacts,
+  isMigrationOwned,
+} from "./authz-engine.facts";
 import { AUTHZ_ENGINE_MIGRATION_NAME } from "./migration-name";
 
 /** The system actor on every fact this migration authors: no human did it. */
@@ -86,50 +104,6 @@ const SEND_CONCURRENCY = 100;
 /** A held report names a SAMPLE, not the world: the count is the size of the
  *  problem, the sample is enough to find it. */
 const MAX_REPORTED = 50;
-
-/**
- * The sources this migration owns in the Grant head — its own, plus the
- * three-stage rollout's it replaces (ADR-110 collapsed genesis-import,
- * backfill-b and cutover-import into this one migration; rows they wrote
- * are this migration's to reconcile and to prove).
- */
-export const MIGRATION_OWNED_SOURCES = [
-  "migration",
-  "genesis-import",
-  "backfill-b",
-  "cutover-import",
-] as const;
-
-/** One non-resource Grant head row, as the proof reads it. */
-export type GrantHeadRow = {
-  id: string;
-  principalType: string;
-  principalId: string | null;
-  roleKey: string | null;
-  legacyRole: string | null;
-  source: string;
-  scopeType: string;
-  scopeId: string;
-  revoked: boolean;
-};
-
-/** One named disagreement between a head and the legacy row it mirrors. */
-export type AuthzEngineDiff = {
-  kind:
-    | "grant_missing"
-    | "grant_revoked"
-    | "grant_changed"
-    | "grant_extra"
-    | "role_missing"
-    | "role_changed"
-    | "role_extra"
-    | "resource_missing"
-    | "resource_changed";
-  id: string;
-  field?: string;
-  expected?: string | null;
-  actual?: string | null;
-};
 
 /**
  * The legacy inventory and the head reads, all on the Prisma migration
@@ -162,6 +136,9 @@ export interface AuthzEngineMigrationStore {
   findProjectCredentialFacts(args: {
     organizationId: string;
   }): Promise<ProjectCredentialFact[]>;
+  findGroupMemberships(args: {
+    organizationId: string;
+  }): Promise<Array<{ userId: string; groupId: string }>>;
 
   findRoleHeads(args: { organizationId: string }): Promise<RoleHeadRow[]>;
   findGrantHeadRows(args: { organizationId: string }): Promise<GrantHeadRow[]>;
@@ -198,14 +175,6 @@ export interface AuthzEngineLedger {
     grantId: string;
     from: string | null;
     to: string;
-    actor: GrantsLedgerActor;
-    occurredAtMs: number;
-  }): Promise<void>;
-  changeRolePermissions(args: {
-    organizationId: string;
-    commandId: string;
-    roleId: string;
-    permissions: string[];
     actor: GrantsLedgerActor;
     occurredAtMs: number;
   }): Promise<void>;
@@ -268,7 +237,8 @@ export class AuthzEngineMigration implements SystemMigration {
     const heads = await this.readHeads(organizationId);
 
     await this.state({ organizationId, expected, signal });
-    await this.reconcile({ organizationId, expected, heads, signal });
+    await this.reconcileStale({ organizationId, expected, heads, signal });
+    await this.repairDrift({ organizationId, expected, heads, signal });
     // The budget handover rides every pass, monotonically upward: legacy
     // keeps counting views while the organization is held, and the proof
     // compares counts exactly, so re-seeding is what lets it heal.
@@ -321,6 +291,7 @@ export class AuthzEngineMigration implements SystemMigration {
       shareLinkRows,
       externalMembers,
       credentials,
+      groupMemberships,
     ] = await Promise.all([
       this.deps.store.findOrganizationCreatedAtMs({ organizationId }),
       this.deps.store.findLegacyRoleRows({ organizationId }),
@@ -330,6 +301,7 @@ export class AuthzEngineMigration implements SystemMigration {
       this.deps.store.findShareLinkRows({ organizationId }),
       this.deps.store.findExternalMemberFacts({ organizationId }),
       this.deps.store.findProjectCredentialFacts({ organizationId }),
+      this.deps.store.findGroupMemberships({ organizationId }),
     ]);
     return {
       organizationCreatedAtMs,
@@ -340,6 +312,7 @@ export class AuthzEngineMigration implements SystemMigration {
       shareLinkRows,
       externalMembers,
       credentials,
+      groupMemberships,
     };
   }
 
@@ -365,7 +338,11 @@ export class AuthzEngineMigration implements SystemMigration {
     await this.each(expected.roles, signal, (role) =>
       this.deps.ledger.defineRole({
         organizationId,
-        commandId: contentCommandId("role", role.roleId, role),
+        commandId: contentCommandId({
+          kind: "role",
+          id: role.roleId,
+          content: role,
+        }),
         role,
         actor: ACTOR,
       }),
@@ -380,33 +357,25 @@ export class AuthzEngineMigration implements SystemMigration {
     await this.each(grants, signal, (fact) =>
       this.deps.ledger.attachGrant({
         organizationId,
-        commandId: contentCommandId("grant", fact.grantId, fact),
+        commandId: contentCommandId({
+          kind: "grant",
+          id: fact.grantId,
+          content: fact,
+        }),
         grant: { ...fact, actor: ACTOR },
       }),
     );
   }
 
   /**
-   * The deny direction, plus drift repair — both diffs of the heads against
-   * the rows this pass just read.
-   *
-   * A legacy row deleted while the organization was off the engine has no
-   * event of its own (legacy deletes are imperative row-deletes), so any
-   * migration-owned head fact whose legacy row is gone gets a compensating
-   * revocation. Safe without waiting on the projection: it only ever names
-   * ids the head ALREADY carries, so a fact stated moments ago is simply
-   * not a candidate.
-   *
-   * Drift repair covers the two legacy mutations that happen in place: a
-   * binding's role reassignment and a custom role's permission edit. Both
-   * are stated as their proper change events with today's business time —
-   * a restated `attach`/`define` cannot carry them, because the head's
-   * upsert guard refuses an event that is not strictly newer than the row,
-   * and an adopted fact's business time is pinned to the legacy row's
-   * createdAt. Anything else that drifts is not repaired here; the proof
-   * names it and the organization stays held for an operator to read.
+   * The deny direction: a legacy row deleted while the organization was off
+   * the engine has no event of its own (legacy deletes are imperative
+   * row-deletes), so any migration-owned head fact whose legacy row is gone
+   * gets a compensating revocation. Safe without waiting on the projection:
+   * it only ever names ids the head ALREADY carries, so a fact stated
+   * moments ago is simply not a candidate.
    */
-  private async reconcile({
+  private async reconcileStale({
     organizationId,
     expected,
     heads,
@@ -417,16 +386,32 @@ export class AuthzEngineMigration implements SystemMigration {
     heads: HeadState;
     signal?: AbortSignal;
   }): Promise<void> {
-    const { grantRows: headRows, roleHeads } = heads;
     const occurredAtMs = this.deps.now();
 
-    const ownedLive = headRows.filter(
-      (row) => isMigrationOwned(row.source) && !row.revoked,
-    );
-    const staleGrants = ownedLive
-      .filter((row) => !expected.grantIds.has(row.id))
-      .map((row) => row.id)
-      .sort();
+    // Both heads: the non-resource rows, and the RESOURCE tier — a share
+    // link deleted legacy-side is a live bearer token until this revokes
+    // it, and `findResourceGrantRows` already fences on live rows, so no
+    // already-revoked row can be re-revoked. A row legacy still HAS but the
+    // migration chose not to express (`retainedGrantIds`) is not stale —
+    // revoking it would delete a legacy row through the compat head, the
+    // one change the migration promises not to make.
+    const staleGrants = [
+      ...heads.grantRows
+        .filter(
+          (row) =>
+            isMigrationOwned(row.source) &&
+            !row.revoked &&
+            !expected.grantIds.has(row.id) &&
+            !expected.retainedGrantIds.has(row.id),
+        )
+        .map((row) => row.id),
+      ...heads.resourceRows
+        .filter(
+          (row) =>
+            isMigrationOwned(row.source) && !expected.grantIds.has(row.grantId),
+        )
+        .map((row) => row.grantId),
+    ].sort();
     await this.each(staleGrants, signal, (grantId) =>
       this.deps.ledger.revokeGrant({
         organizationId,
@@ -439,8 +424,12 @@ export class AuthzEngineMigration implements SystemMigration {
     );
 
     const expectedRoleIds = new Set(expected.roles.map((role) => role.roleId));
-    const staleRoles = roleHeads
-      .filter((head) => head.kind === "custom" && !expectedRoleIds.has(head.id))
+    const staleRoles = heads.roleHeads
+      // Every kind: the migration only runs before an organization
+      // finalizes, and until then every role head — `system_api_key`
+      // included — mirrors a legacy CustomRole row, so a head with no such
+      // row is stale whatever its kind.
+      .filter((head) => !expectedRoleIds.has(head.id))
       .map((head) => head.id)
       .sort();
     await this.each(staleRoles, signal, (roleId) =>
@@ -452,18 +441,57 @@ export class AuthzEngineMigration implements SystemMigration {
         occurredAtMs,
       }),
     );
+  }
 
-    const headById = new Map(headRows.map((row) => [row.id, row]));
+  /**
+   * Drift repair, covering the in-place legacy mutations: a binding's role
+   * reassignment (onto a BUILT-IN key) and any edit to a custom role. Both
+   * are stated with today's business time — a restated fact cannot carry
+   * them, because the head's upsert guard refuses an event that is not
+   * strictly newer than the row, and an adopted fact's business time is
+   * pinned to the legacy row's createdAt.
+   *
+   * The pass's `occurredAtMs` is part of every repair's command id: a
+   * repair whose target oscillates back to a value it held before would
+   * otherwise collide with the first repair's idempotency key and be
+   * swallowed at the event store forever. A retried held pass re-appends
+   * the repair instead, which is harmless — the change events are
+   * state-setting and tie-tolerant.
+   *
+   * A reassignment onto a `custom:<id>` key is NOT repaired: the change
+   * event clears `legacyRole` (the projection's escalation rule) while the
+   * expected fact still carries it, so that repair could never converge —
+   * the proof names the disagreement instead (see the module header).
+   */
+  private async repairDrift({
+    organizationId,
+    expected,
+    heads,
+    signal,
+  }: {
+    organizationId: string;
+    expected: ExpectedFacts;
+    heads: HeadState;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const occurredAtMs = this.deps.now();
+
+    const headById = new Map(heads.grantRows.map((row) => [row.id, row]));
     const rekeys = expected.nonResourceFacts.flatMap((fact) => {
       const head = headById.get(fact.grantId);
       if (!head || head.revoked) return [];
       if (fact.roleKey === null || head.roleKey === fact.roleKey) return [];
+      if (fact.roleKey.startsWith("custom:")) return [];
       return [{ grantId: fact.grantId, from: head.roleKey, to: fact.roleKey }];
     });
     await this.each(rekeys, signal, (rekey) =>
       this.deps.ledger.changeGrantRole({
         organizationId,
-        commandId: contentCommandId("rekey", rekey.grantId, rekey.to),
+        commandId: contentCommandId({
+          kind: "rekey",
+          id: rekey.grantId,
+          content: { to: rekey.to, occurredAtMs },
+        }),
         grantId: rekey.grantId,
         from: rekey.from,
         to: rekey.to,
@@ -472,26 +500,27 @@ export class AuthzEngineMigration implements SystemMigration {
       }),
     );
 
-    const roleHeadById = new Map(roleHeads.map((head) => [head.id, head]));
-    const reperms = expected.roles.flatMap((role) => {
+    // A drifted role is restated WHOLE: `defineRole` at today's business
+    // time wins the head's strictly-newer guard and carries every field —
+    // name, description, permissions, kind — in one mechanism.
+    const roleHeadById = new Map(
+      heads.roleHeads.map((head) => [head.id, head]),
+    );
+    const redefines = expected.roles.flatMap((role) => {
       const head = roleHeadById.get(role.roleId);
-      if (!head) return [];
-      const headPermissions = permissionStrings(head.permissions);
-      if (headPermissions.join(",") === role.permissions.join(",")) return [];
-      return [{ roleId: role.roleId, permissions: role.permissions }];
+      if (!head || !roleDrifted({ role, head })) return [];
+      return [{ ...role, occurredAtMs }];
     });
-    await this.each(reperms, signal, (reperm) =>
-      this.deps.ledger.changeRolePermissions({
+    await this.each(redefines, signal, (role) =>
+      this.deps.ledger.defineRole({
         organizationId,
-        commandId: contentCommandId(
-          "reperm",
-          reperm.roleId,
-          reperm.permissions,
-        ),
-        roleId: reperm.roleId,
-        permissions: reperm.permissions,
+        commandId: contentCommandId({
+          kind: "redefine",
+          id: role.roleId,
+          content: role,
+        }),
+        role,
         actor: ACTOR,
-        occurredAtMs,
       }),
     );
   }
@@ -512,62 +541,17 @@ export class AuthzEngineMigration implements SystemMigration {
     expected: ExpectedFacts;
     heads: HeadState;
   }): { outstanding: string[]; diffs: AuthzEngineDiff[] } {
-    const { grantRows: headRows, roleHeads, resourceRows } = heads;
-    const outstanding: string[] = [];
-    const diffs: AuthzEngineDiff[] = [];
-
-    const headById = new Map(headRows.map((row) => [row.id, row]));
-    for (const fact of expected.nonResourceFacts) {
-      const head = headById.get(fact.grantId);
-      if (!head) {
-        outstanding.push(fact.grantId);
-        continue;
-      }
-      if (head.revoked) {
-        diffs.push({ kind: "grant_revoked", id: fact.grantId });
-        continue;
-      }
-      diffs.push(...grantDiffs({ fact, head }));
-    }
-    for (const row of headRows) {
-      if (row.revoked || !isMigrationOwned(row.source)) continue;
-      // Revoked this pass, not yet folded: outstanding, never a diff.
-      if (!expected.grantIds.has(row.id)) outstanding.push(row.id);
-    }
-
-    const roleHeadById = new Map(roleHeads.map((head) => [head.id, head]));
-    const expectedRoleIds = new Set(expected.roles.map((role) => role.roleId));
-    for (const role of expected.roles) {
-      const head = roleHeadById.get(role.roleId);
-      if (!head) {
-        outstanding.push(role.roleId);
-        continue;
-      }
-      diffs.push(...roleDiffs({ role, head }));
-    }
-    for (const head of roleHeads) {
-      if (head.kind === "custom" && !expectedRoleIds.has(head.id)) {
-        outstanding.push(head.id);
-      }
-    }
-
-    const resourceById = new Map(resourceRows.map((row) => [row.grantId, row]));
-    const expectedLinkIds = new Set(
-      expected.shareLinks.map((link) => link.row.id),
-    );
-    for (const link of expected.shareLinks) {
-      const head = resourceById.get(link.row.id);
-      if (!head) {
-        outstanding.push(link.row.id);
-        continue;
-      }
-      diffs.push(...resourceDiffs({ organizationId, link, head }));
-    }
-    for (const row of resourceRows) {
-      if (!expectedLinkIds.has(row.grantId)) outstanding.push(row.grantId);
-    }
-
-    return { outstanding: outstanding.sort(), diffs };
+    const grants = checkGrantHeads({ expected, heads });
+    const roles = checkRoleHeads({ expected, heads });
+    const resources = checkResourceHeads({ organizationId, expected, heads });
+    return {
+      outstanding: [
+        ...grants.outstanding,
+        ...roles.outstanding,
+        ...resources.outstanding,
+      ].sort(),
+      diffs: [...grants.diffs, ...roles.diffs, ...resources.diffs],
+    };
   }
 
   /** Bounded fan-out, aborted between chunks — the runner will not
@@ -588,101 +572,6 @@ export class AuthzEngineMigration implements SystemMigration {
   }
 }
 
-type HeadState = {
-  grantRows: GrantHeadRow[];
-  roleHeads: RoleHeadRow[];
-  resourceRows: ResourceGrantRow[];
-};
-
-type ExpectedShareLink = { row: ShareLinkFactRow; fact: GrantFact };
-
-type ExpectedFacts = {
-  roles: RoleFact[];
-  bindingFacts: GrantFact[];
-  teamFacts: GrantFact[];
-  organizationFacts: GrantFact[];
-  credentialFacts: GrantFact[];
-  shareLinks: ExpectedShareLink[];
-  /** Every non-resource fact, for the proof's walk. */
-  nonResourceFacts: GrantFact[];
-  /** Every expected id, resource included, for the deny sweep. */
-  grantIds: Set<string>;
-};
-
-function assembleFacts({
-  organizationId,
-  inventory,
-}: {
-  organizationId: string;
-  inventory: {
-    organizationCreatedAtMs: number | null;
-    roleRows: LegacyRoleRow[];
-    bindingRows: LegacyBindingRow[];
-    members: OrganizationMemberFact[];
-    teamRows: LegacyTeamRow[];
-    shareLinkRows: ShareLinkFactRow[];
-    externalMembers: ExternalMemberFact[];
-    credentials: ProjectCredentialFact[];
-  };
-}): ExpectedFacts {
-  const roles = inventory.roleRows
-    .slice()
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .map(legacyRoleToFact);
-  const bindingFacts = inventory.bindingRows
-    .slice()
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .flatMap((row) => {
-      const fact = bindingToFact({ row });
-      return fact ? [fact] : [];
-    });
-  const teamFacts = teamMembershipFacts({
-    organizationId,
-    teamRows: inventory.teamRows,
-    bindingRows: inventory.bindingRows,
-  });
-  const organizationFacts = organizationLevelFacts({
-    organizationId,
-    members: inventory.members,
-    externalMembers: inventory.externalMembers,
-    bindingRows: inventory.bindingRows,
-    organizationCreatedAtMs: inventory.organizationCreatedAtMs,
-  });
-  const credentialFacts = inventory.credentials
-    .slice()
-    .sort((a, b) => a.projectId.localeCompare(b.projectId))
-    .map((credential) => credentialToFact({ organizationId, credential }));
-  const shareLinks = inventory.shareLinkRows
-    .slice()
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .map(
-      (row): ExpectedShareLink => ({
-        row,
-        fact: shareLinkToFact({ organizationId, row }),
-      }),
-    );
-
-  const nonResourceFacts = [
-    ...bindingFacts,
-    ...teamFacts,
-    ...organizationFacts,
-    ...credentialFacts,
-  ];
-  return {
-    roles,
-    bindingFacts,
-    teamFacts,
-    organizationFacts,
-    credentialFacts,
-    shareLinks,
-    nonResourceFacts,
-    grantIds: new Set([
-      ...nonResourceFacts.map((fact) => fact.grantId),
-      ...shareLinks.map((link) => link.row.id),
-    ]),
-  };
-}
-
 /**
  * A command id derived from the fact's identity AND its content. Identity
  * alone is not enough: the event store dedupes on the idempotency key, so a
@@ -690,414 +579,18 @@ function assembleFacts({
  * key and be silently swallowed. Content in the key means the same fact
  * always dedupes and a changed one always appends.
  */
-function contentCommandId(kind: string, id: string, content: unknown): string {
+function contentCommandId({
+  kind,
+  id,
+  content,
+}: {
+  kind: string;
+  id: string;
+  content: unknown;
+}): string {
   const digest = createHash("sha256")
     .update(JSON.stringify(content))
     .digest("hex")
     .slice(0, 16);
   return `authz-engine:${kind}:${id}:${digest}`;
-}
-
-function isMigrationOwned(source: string): boolean {
-  return (MIGRATION_OWNED_SOURCES as readonly string[]).includes(source);
-}
-
-/**
- * A CustomRole as the ledger defines it, adopting the row's own id. The
- * stored permissions column is jsonb: anything that is not an array of
- * strings imports as the empty list, which grants nothing.
- */
-function legacyRoleToFact(row: LegacyRoleRow): RoleFact {
-  return {
-    roleId: row.id,
-    name: row.name,
-    ...(row.description === null ? {} : { description: row.description }),
-    permissions: permissionStrings(row.permissions),
-    kind: row.kind === "system_api_key" ? "system_api_key" : "custom",
-    occurredAtMs: row.createdAtMs,
-  };
-}
-
-function permissionStrings(stored: unknown): string[] {
-  return Array.isArray(stored)
-    ? stored.filter(
-        (entry): entry is string => typeof entry === "string" && entry !== "",
-      )
-    : [];
-}
-
-/**
- * A RoleBinding as the ledger attaches it. The grant id IS the row id. A row
- * naming no principal cannot be expressed as a grant and is skipped; the
- * proof does not expect it either, so it holds nothing up.
- *
- * A custom key erases which legacy `role` column value the row carried, so
- * it travels as `legacyRole`: the legacy resolver falls back to that column
- * whenever the custom role's permission list is empty, and dropping it would
- * turn an ADMIN with an empty custom role into a viewer.
- */
-function bindingToFact({ row }: { row: LegacyBindingRow }): GrantFact | null {
-  const principal = bindingPrincipal(row);
-  if (!principal) return null;
-  return {
-    grantId: row.id,
-    principal,
-    roleKey:
-      row.customRoleId === null
-        ? roleKeyForTeamRole(row.role)
-        : `custom:${row.customRoleId}`,
-    ...(row.customRoleId === null ? {} : { legacyRole: row.role }),
-    scope: { type: row.scopeType, id: row.scopeId },
-    source: "migration",
-    occurredAtMs: row.createdAtMs,
-  };
-}
-
-function bindingPrincipal(row: LegacyBindingRow): LedgerPrincipal | null {
-  if (row.userId !== null) return { type: "user", id: row.userId };
-  if (row.groupId !== null) return { type: "group", id: row.groupId };
-  if (row.apiKeyId !== null) return { type: "apiKey", id: row.apiKeyId };
-  return null;
-}
-
-/**
- * Team memberships stated DIRECTLY (ADR-110), never promoted into binding
- * rows first. A membership a TEAM-scoped binding already carries — same
- * identity the database's partial unique indexes use, role normalized
- * through the same mapping on both sides — is that binding's fact, not a
- * second one.
- */
-function teamMembershipFacts({
-  organizationId,
-  teamRows,
-  bindingRows,
-}: {
-  organizationId: string;
-  teamRows: LegacyTeamRow[];
-  bindingRows: LegacyBindingRow[];
-}): GrantFact[] {
-  const bound = new Set(
-    bindingRows
-      .filter((row) => row.scopeType === "TEAM" && row.userId !== null)
-      .map((row) =>
-        bindingIdentityKey({
-          principal: { userId: row.userId },
-          scopeType: "TEAM",
-          scopeId: row.scopeId,
-          role:
-            row.customRoleId === null ? roleKeyForTeamRole(row.role) : row.role,
-          customRoleId: row.customRoleId,
-        }),
-      ),
-  );
-  return teamRows
-    .slice()
-    .sort(
-      (a, b) =>
-        a.teamId.localeCompare(b.teamId) || a.userId.localeCompare(b.userId),
-    )
-    .flatMap((row) => {
-      const key = bindingIdentityKey({
-        principal: { userId: row.userId },
-        scopeType: "TEAM",
-        scopeId: row.teamId,
-        role:
-          row.customRoleId === null ? roleKeyForTeamRole(row.role) : row.role,
-        customRoleId: row.customRoleId,
-      });
-      if (bound.has(key)) return [];
-      const principal = { type: "user" as const, id: row.userId };
-      const scope = { type: "TEAM" as const, id: row.teamId };
-      return [
-        {
-          grantId: deriveGrantId({
-            organizationId,
-            principal,
-            scope,
-            occurredAtMs: row.createdAtMs,
-          }),
-          principal,
-          roleKey:
-            row.customRoleId === null
-              ? roleKeyForTeamRole(row.role)
-              : `custom:${row.customRoleId}`,
-          ...(row.customRoleId === null ? {} : { legacyRole: row.role }),
-          scope,
-          source: "migration" as const,
-          occurredAtMs: row.createdAtMs,
-        },
-      ];
-    });
-}
-
-/**
- * The facts the legacy schema inferred instead of storing.
- *
- * The floor: one org-scoped `member` grant whose principal is the
- * organization's membership itself, so a member holding no binding anywhere
- * holds exactly the floor and nothing beyond it.
- *
- * The legacy-admin fallback: an ADMIN with no binding anywhere is served
- * today by the resolver's fallback. `legacy-admin`, NOT `admin`, and the
- * difference is load-bearing: `admin` would grant the full admin bag where
- * the fallback grants a narrower one; the untranslatable key keeps the fact
- * dormant until the contract gives it the bag the fallback actually grants.
- *
- * Lite members: `OrganizationUser.role = EXTERNAL`, the org-scoped cap the
- * legacy schema kept as a membership column.
- */
-function organizationLevelFacts({
-  organizationId,
-  members,
-  externalMembers,
-  bindingRows,
-  organizationCreatedAtMs,
-}: {
-  organizationId: string;
-  members: OrganizationMemberFact[];
-  externalMembers: ExternalMemberFact[];
-  bindingRows: LegacyBindingRow[];
-  organizationCreatedAtMs: number | null;
-}): GrantFact[] {
-  const scope = { type: "ORGANIZATION" as const, id: organizationId };
-  const facts: GrantFact[] = [];
-
-  if (organizationCreatedAtMs !== null) {
-    const principal = { type: "organization" as const, id: organizationId };
-    facts.push({
-      grantId: deriveGrantId({
-        organizationId,
-        principal,
-        scope,
-        occurredAtMs: organizationCreatedAtMs,
-      }),
-      principal,
-      roleKey: "member",
-      scope,
-      source: "migration",
-      occurredAtMs: organizationCreatedAtMs,
-    });
-  }
-
-  const boundUserIds = new Set(
-    bindingRows.flatMap((row) => (row.userId === null ? [] : [row.userId])),
-  );
-  for (const member of members
-    .slice()
-    .sort((a, b) => a.userId.localeCompare(b.userId))) {
-    if (member.role !== "ADMIN" || boundUserIds.has(member.userId)) continue;
-    const principal = { type: "user" as const, id: member.userId };
-    facts.push({
-      grantId: deriveGrantId({
-        organizationId,
-        principal,
-        scope,
-        occurredAtMs: member.createdAtMs,
-      }),
-      principal,
-      roleKey: "legacy-admin",
-      scope,
-      source: "migration",
-      occurredAtMs: member.createdAtMs,
-    });
-  }
-
-  for (const member of externalMembers
-    .slice()
-    .sort((a, b) => a.userId.localeCompare(b.userId))) {
-    const principal = { type: "user" as const, id: member.userId };
-    facts.push({
-      grantId: deriveGrantId({
-        organizationId,
-        principal,
-        scope,
-        occurredAtMs: member.createdAtMs,
-      }),
-      principal,
-      roleKey: "lite-member",
-      scope,
-      source: "migration",
-      occurredAtMs: member.createdAtMs,
-    });
-  }
-  return facts;
-}
-
-/** The legacy per-project credential (`Project.apiKey`): the PROJECT itself
- *  is the principal — that key authenticates as the project and names no
- *  user or key row at all. */
-function credentialToFact({
-  organizationId,
-  credential,
-}: {
-  organizationId: string;
-  credential: ProjectCredentialFact;
-}): GrantFact {
-  const principal = { type: "project" as const, id: credential.projectId };
-  const scope = { type: "PROJECT" as const, id: credential.projectId };
-  return {
-    grantId: deriveGrantId({
-      organizationId,
-      principal,
-      scope,
-      occurredAtMs: credential.createdAtMs,
-    }),
-    principal,
-    roleKey: "admin",
-    scope,
-    source: "migration",
-    occurredAtMs: credential.createdAtMs,
-  };
-}
-
-/** A share link as the ledger attaches it, adopting the row's own id so the
- *  token a customer already circulated keeps resolving to it. Resource facts
- *  carry no role: their single permission is in the terms. */
-function shareLinkToFact({
-  organizationId,
-  row,
-}: {
-  organizationId: string;
-  row: ShareLinkFactRow;
-}): GrantFact {
-  return {
-    grantId: row.id,
-    principal: shareVisibilityAudience({
-      visibility: row.visibility,
-      organizationId,
-      projectId: row.projectId,
-    }),
-    roleKey: null,
-    scope: { type: "RESOURCE", id: row.resourceId },
-    resource: {
-      kind: row.resourceType === "THREAD" ? "thread" : "trace",
-      projectId: row.projectId,
-      token: row.token,
-      permission: SHARE_LINK_PERMISSION,
-      ...(row.userId === null ? {} : { createdByUserId: row.userId }),
-      ...(row.expiresAtMs === null ? {} : { expiresAtMs: row.expiresAtMs }),
-      ...(row.maxViews === null ? {} : { maxViews: row.maxViews }),
-    },
-    source: "migration",
-    occurredAtMs: row.createdAtMs,
-  };
-}
-
-/** Field equality for one stated fact against its head row — against what
- *  the migration SAID, since that is what the head is supposed to hold. */
-function grantDiffs({
-  fact,
-  head,
-}: {
-  fact: GrantFact;
-  head: GrantHeadRow;
-}): AuthzEngineDiff[] {
-  const compared: Array<[string, string | null, string | null]> = [
-    ["principalType", PRINCIPAL_TO_DB[fact.principal.type], head.principalType],
-    ["principalId", fact.principal.id, head.principalId],
-    ["roleKey", fact.roleKey, head.roleKey],
-    ["legacyRole", fact.legacyRole ?? null, head.legacyRole],
-    ["scopeType", fact.scope.type, head.scopeType],
-    ["scopeId", fact.scope.id, head.scopeId],
-  ];
-  return compared.flatMap(([field, expected, actual]) =>
-    expected === actual
-      ? []
-      : [
-          {
-            kind: "grant_changed" as const,
-            id: fact.grantId,
-            field,
-            expected,
-            actual,
-          },
-        ],
-  );
-}
-
-function roleDiffs({
-  role,
-  head,
-}: {
-  role: RoleFact;
-  head: RoleHeadRow;
-}): AuthzEngineDiff[] {
-  const compared: Array<[string, string | null, string | null]> = [
-    ["name", role.name, head.name],
-    ["description", role.description ?? null, head.description],
-    [
-      "permissions",
-      role.permissions.join(","),
-      permissionStrings(head.permissions).join(","),
-    ],
-    [
-      "kind",
-      role.kind,
-      head.kind === "system_api_key" ? "system_api_key" : "custom",
-    ],
-  ];
-  return compared.flatMap(([field, expected, actual]) =>
-    expected === actual
-      ? []
-      : [
-          {
-            kind: "role_changed" as const,
-            id: role.roleId,
-            field,
-            expected,
-            actual,
-          },
-        ],
-  );
-}
-
-/** Field equality for one imported link against its RESOURCE head row. The
- *  stored spellings differ (the head keeps the database's uppercase), so the
- *  comparison is against what the import said, mapped to that spelling. */
-function resourceDiffs({
-  organizationId,
-  link,
-  head,
-}: {
-  organizationId: string;
-  link: ExpectedShareLink;
-  head: ResourceGrantRow;
-}): AuthzEngineDiff[] {
-  const { row } = link;
-  const principal = shareVisibilityAudience({
-    visibility: row.visibility,
-    organizationId,
-    projectId: row.projectId,
-  });
-  const compared: Array<[string, string | null, string | null]> = [
-    ["token", row.token, head.token],
-    ["kind", row.resourceType, (head.resourceKind ?? "").toUpperCase() || null],
-    ["resourceId", row.resourceId, head.resourceId],
-    ["projectId", row.projectId, head.projectId],
-    ["principalType", PRINCIPAL_TO_DB[principal.type], head.principalType],
-    ["principalId", principal.id, head.principalId],
-    ["expiresAt", numberField(row.expiresAtMs), numberField(head.expiresAtMs)],
-    ["maxViews", numberField(row.maxViews), numberField(head.maxViews)],
-    // The view budget is part of the link, not decoration on it: a link
-    // reproduced with the right cap and no views spent is a link the
-    // migration refilled. Compared so that never passes silently.
-    ["viewCount", numberField(row.viewCount), numberField(head.viewCount)],
-  ];
-  return compared.flatMap(([field, expected, actual]) =>
-    expected === actual
-      ? []
-      : [
-          {
-            kind: "resource_changed" as const,
-            id: row.id,
-            field,
-            expected,
-            actual,
-          },
-        ],
-  );
-}
-
-function numberField(value: number | null): string | null {
-  return value === null ? null : String(value);
 }

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -1,0 +1,1103 @@
+/**
+ * ADR-110 — the one migration that moves an organization onto the grants
+ * engine. Every legacy table is a source of facts; the migration states each
+ * row as an event, checks once that the projection agrees with what it
+ * stated, and finishing IS the switch: the moment this returns `finalized`
+ * the engine gate answers permission checks from the projection
+ * (engine-gate.ts reads this migration's status and nothing else).
+ *
+ * Adoption, not re-creation. A fact with a legacy row of its own — a
+ * RoleBinding, a CustomRole, a ShareLink — keeps that row's id, because the
+ * id is the upstream identity the REST surface already returns to customers.
+ * A fact the legacy schema only INFERRED — the org-member floor, the
+ * legacy-admin fallback, a lite member, a team membership with no binding, a
+ * project credential — derives its id from its content (`deriveGrantId`), so
+ * every pass derives the same id for the same fact.
+ *
+ * Idempotent by construction, not by bookkeeping: each pass re-reads the
+ * legacy tables, restates every fact (command ids are content-derived, so a
+ * restated fact dedupes at the event store and a CHANGED one appends), emits
+ * compensating revocations for facts whose legacy row is gone, and proves
+ * the heads against the rows it just read. Nothing here consults `previous`;
+ * there is no partial state a failed pass could leave behind that the next
+ * full pass does not simply redo.
+ *
+ * The migration does not wait (ADR-110): it cannot write the projection —
+ * it can only state events — so it checks once and reports. A projection
+ * that has not caught up is a HELD organization (`migrated`), not an error:
+ * the next pass revisits it and the check heals as the fold drains. A head
+ * that disagrees with legacy on a field is also held, with the disagreement
+ * named in the report.
+ *
+ * Nothing legacy changes before an organization finalizes: the projection's
+ * compat writes are update-only for migration-sourced facts (see
+ * authz-grants-write.prisma.repository.ts), so an adopted row converges onto
+ * itself and a derived fact — whose legacy representation is the membership
+ * or credential row it came from — creates no binding row at all.
+ *
+ * @see specs/migration/authz-grants-rollout.feature
+ * @see dev/docs/adr/110-grant-aggregates-are-grants.md
+ */
+import { createHash } from "node:crypto";
+import { roleKeyForTeamRole } from "@langwatch/authz";
+import type {
+  ExternalMemberFact,
+  GrantFact,
+  GrantsLedgerActor,
+  LedgerPrincipal,
+  LegacyBindingRow,
+  LegacyRoleRow,
+  LegacyTeamRow,
+  OrganizationMemberFact,
+  ProjectCredentialFact,
+  ResourceGrantRow,
+  ResourceGrantUsageSeed,
+  RoleFact,
+  RoleHeadRow,
+  ShareLinkFactRow,
+} from "@langwatch/authz-server";
+import {
+  PRINCIPAL_TO_DB,
+  SHARE_LINK_PERMISSION,
+  shareVisibilityAudience,
+} from "@langwatch/authz-server";
+import {
+  bindingIdentityKey,
+  deriveGrantId,
+} from "@langwatch/authz-server/migration";
+import type {
+  SystemMigration,
+  TenantMigrationOutcome,
+} from "@langwatch/system-migrations";
+import { AUTHZ_ENGINE_MIGRATION_NAME } from "./migration-name";
+
+/** The system actor on every fact this migration authors: no human did it. */
+export const AUTHZ_ENGINE_ACTOR_ID = "system:authz-engine" as const;
+
+const ACTOR: GrantsLedgerActor = {
+  type: "system",
+  id: AUTHZ_ENGINE_ACTOR_ID,
+};
+
+/** Commands in flight at once. Sends are queue enqueues, so this bounds
+ *  memory and connection pressure, not throughput. */
+const SEND_CONCURRENCY = 100;
+
+/** A held report names a SAMPLE, not the world: the count is the size of the
+ *  problem, the sample is enough to find it. */
+const MAX_REPORTED = 50;
+
+/**
+ * The sources this migration owns in the Grant head — its own, plus the
+ * three-stage rollout's it replaces (ADR-110 collapsed genesis-import,
+ * backfill-b and cutover-import into this one migration; rows they wrote
+ * are this migration's to reconcile and to prove).
+ */
+export const MIGRATION_OWNED_SOURCES = [
+  "migration",
+  "genesis-import",
+  "backfill-b",
+  "cutover-import",
+] as const;
+
+/** One non-resource Grant head row, as the proof reads it. */
+export type GrantHeadRow = {
+  id: string;
+  principalType: string;
+  principalId: string | null;
+  roleKey: string | null;
+  legacyRole: string | null;
+  source: string;
+  scopeType: string;
+  scopeId: string;
+  revoked: boolean;
+};
+
+/** One named disagreement between a head and the legacy row it mirrors. */
+export type AuthzEngineDiff = {
+  kind:
+    | "grant_missing"
+    | "grant_revoked"
+    | "grant_changed"
+    | "grant_extra"
+    | "role_missing"
+    | "role_changed"
+    | "role_extra"
+    | "resource_missing"
+    | "resource_changed";
+  id: string;
+  field?: string;
+  expected?: string | null;
+  actual?: string | null;
+};
+
+/**
+ * The legacy inventory and the head reads, all on the Prisma migration
+ * repository. Inventory reads are deliberately unfenced — this repository's
+ * job is what the organization HAS; the head reads fence on live rows
+ * themselves.
+ */
+export interface AuthzEngineMigrationStore {
+  findOrganizationCreatedAtMs(args: {
+    organizationId: string;
+  }): Promise<number | null>;
+  findLegacyRoleRows(args: {
+    organizationId: string;
+  }): Promise<LegacyRoleRow[]>;
+  findLegacyBindingRows(args: {
+    organizationId: string;
+  }): Promise<LegacyBindingRow[]>;
+  findOrganizationMembers(args: {
+    organizationId: string;
+  }): Promise<OrganizationMemberFact[]>;
+  findLegacyTeamRows(args: {
+    organizationId: string;
+  }): Promise<LegacyTeamRow[]>;
+  findShareLinkRows(args: {
+    organizationId: string;
+  }): Promise<ShareLinkFactRow[]>;
+  findExternalMemberFacts(args: {
+    organizationId: string;
+  }): Promise<ExternalMemberFact[]>;
+  findProjectCredentialFacts(args: {
+    organizationId: string;
+  }): Promise<ProjectCredentialFact[]>;
+
+  findRoleHeads(args: { organizationId: string }): Promise<RoleHeadRow[]>;
+  findGrantHeadRows(args: { organizationId: string }): Promise<GrantHeadRow[]>;
+  findResourceGrantRows(args: {
+    organizationId: string;
+  }): Promise<ResourceGrantRow[]>;
+  seedResourceGrantUsage(args: {
+    organizationId: string;
+    seeds: readonly ResourceGrantUsageSeed[];
+  }): Promise<void>;
+}
+
+/**
+ * The migration's door into the ledger — one command, one entity (ADR-110).
+ * A send while the queue is unavailable throws `AuthzLedgerUnavailableError`,
+ * which parks the organization naming the queue as the cause; the runner
+ * retries on a later pass.
+ */
+export interface AuthzEngineLedger {
+  attachGrant(args: {
+    organizationId: string;
+    commandId: string;
+    grant: GrantFact & { actor: GrantsLedgerActor };
+  }): Promise<void>;
+  defineRole(args: {
+    organizationId: string;
+    commandId: string;
+    role: RoleFact;
+    actor: GrantsLedgerActor;
+  }): Promise<void>;
+  changeGrantRole(args: {
+    organizationId: string;
+    commandId: string;
+    grantId: string;
+    from: string | null;
+    to: string;
+    actor: GrantsLedgerActor;
+    occurredAtMs: number;
+  }): Promise<void>;
+  changeRolePermissions(args: {
+    organizationId: string;
+    commandId: string;
+    roleId: string;
+    permissions: string[];
+    actor: GrantsLedgerActor;
+    occurredAtMs: number;
+  }): Promise<void>;
+  revokeGrant(args: {
+    organizationId: string;
+    commandId: string;
+    grantId: string;
+    reason: string;
+    actor: GrantsLedgerActor;
+    occurredAtMs: number;
+  }): Promise<void>;
+  deleteRole(args: {
+    organizationId: string;
+    commandId: string;
+    roleId: string;
+    actor: GrantsLedgerActor;
+    occurredAtMs: number;
+  }): Promise<void>;
+}
+
+export type AuthzEngineMigrationDeps = {
+  store: AuthzEngineMigrationStore;
+  ledger: AuthzEngineLedger;
+  now: () => number;
+};
+
+export class AuthzEngineMigration implements SystemMigration {
+  readonly name = AUTHZ_ENGINE_MIGRATION_NAME;
+  readonly title = "Authorization engine";
+  readonly description =
+    "Turns each organization's existing access into the authorization " +
+    "engine's own records, verifies the engine gives the same answers, and " +
+    "then has the engine answer permission checks for that organization.";
+  // Finalizing changes who answers permission checks for the organization,
+  // so an operator action on it takes the typed destructive confirmation.
+  readonly requiresOperatorConfirmation = true;
+  // Cloud soaks first (per-organization enrollment); a later release flips
+  // this once it has. Flipping it IS the self-hosted release act.
+  readonly runsAutomaticallyOnSelfHosted = false;
+
+  constructor(private readonly deps: AuthzEngineMigrationDeps) {}
+
+  async migrateTenant({
+    tenantId,
+    signal,
+  }: {
+    tenantId: string;
+    signal?: AbortSignal;
+  }): Promise<TenantMigrationOutcome> {
+    const organizationId = tenantId;
+    const inventory = await this.readInventory(organizationId);
+    const expected = assembleFacts({ organizationId, inventory });
+
+    // The projection, read ONCE per pass (the spec's own words) — before
+    // anything is stated, so nothing here waits on a fold. Reconcile and the
+    // check both walk this read: what this pass states is invisible to it by
+    // construction, lands as `outstanding`, and the NEXT pass sees it folded
+    // and finalizes. Holding a first pass to finalize a later one is the
+    // design, not a shortcut.
+    const heads = await this.readHeads(organizationId);
+
+    await this.state({ organizationId, expected, signal });
+    await this.reconcile({ organizationId, expected, heads, signal });
+    // The budget handover rides every pass, monotonically upward: legacy
+    // keeps counting views while the organization is held, and the proof
+    // compares counts exactly, so re-seeding is what lets it heal.
+    await this.deps.store.seedResourceGrantUsage({
+      organizationId,
+      seeds: expected.shareLinks.map((link) => ({
+        grantId: link.row.id,
+        projectId: link.row.projectId,
+        viewCount: link.row.viewCount,
+      })),
+    });
+
+    const { outstanding, diffs } = this.check({
+      organizationId,
+      expected,
+      heads,
+    });
+
+    const counts = {
+      roles: expected.roles.length,
+      bindings: expected.bindingFacts.length,
+      teamMemberships: expected.teamFacts.length,
+      organizationFacts: expected.organizationFacts.length,
+      projectCredentials: expected.credentialFacts.length,
+      shareLinks: expected.shareLinks.length,
+    };
+    if (outstanding.length > 0 || diffs.length > 0) {
+      return {
+        status: "migrated",
+        report: {
+          kind: "authz_engine_held",
+          ...counts,
+          outstanding: outstanding.length,
+          outstandingSample: outstanding.slice(0, MAX_REPORTED),
+          totalDiffs: diffs.length,
+          diffs: diffs.slice(0, MAX_REPORTED),
+        },
+      };
+    }
+    return { status: "finalized", report: { kind: "authz_engine", ...counts } };
+  }
+
+  private async readInventory(organizationId: string) {
+    const [
+      organizationCreatedAtMs,
+      roleRows,
+      bindingRows,
+      members,
+      teamRows,
+      shareLinkRows,
+      externalMembers,
+      credentials,
+    ] = await Promise.all([
+      this.deps.store.findOrganizationCreatedAtMs({ organizationId }),
+      this.deps.store.findLegacyRoleRows({ organizationId }),
+      this.deps.store.findLegacyBindingRows({ organizationId }),
+      this.deps.store.findOrganizationMembers({ organizationId }),
+      this.deps.store.findLegacyTeamRows({ organizationId }),
+      this.deps.store.findShareLinkRows({ organizationId }),
+      this.deps.store.findExternalMemberFacts({ organizationId }),
+      this.deps.store.findProjectCredentialFacts({ organizationId }),
+    ]);
+    return {
+      organizationCreatedAtMs,
+      roleRows,
+      bindingRows,
+      members,
+      teamRows,
+      shareLinkRows,
+      externalMembers,
+      credentials,
+    };
+  }
+
+  private async readHeads(organizationId: string): Promise<HeadState> {
+    const [grantRows, roleHeads, resourceRows] = await Promise.all([
+      this.deps.store.findGrantHeadRows({ organizationId }),
+      this.deps.store.findRoleHeads({ organizationId }),
+      this.deps.store.findResourceGrantRows({ organizationId }),
+    ]);
+    return { grantRows, roleHeads, resourceRows };
+  }
+
+  /** Roles before grants: a custom binding's roleKey names its role. */
+  private async state({
+    organizationId,
+    expected,
+    signal,
+  }: {
+    organizationId: string;
+    expected: ExpectedFacts;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    await this.each(expected.roles, signal, (role) =>
+      this.deps.ledger.defineRole({
+        organizationId,
+        commandId: contentCommandId("role", role.roleId, role),
+        role,
+        actor: ACTOR,
+      }),
+    );
+    const grants = [
+      ...expected.bindingFacts,
+      ...expected.teamFacts,
+      ...expected.organizationFacts,
+      ...expected.credentialFacts,
+      ...expected.shareLinks.map((link) => link.fact),
+    ];
+    await this.each(grants, signal, (fact) =>
+      this.deps.ledger.attachGrant({
+        organizationId,
+        commandId: contentCommandId("grant", fact.grantId, fact),
+        grant: { ...fact, actor: ACTOR },
+      }),
+    );
+  }
+
+  /**
+   * The deny direction, plus drift repair — both diffs of the heads against
+   * the rows this pass just read.
+   *
+   * A legacy row deleted while the organization was off the engine has no
+   * event of its own (legacy deletes are imperative row-deletes), so any
+   * migration-owned head fact whose legacy row is gone gets a compensating
+   * revocation. Safe without waiting on the projection: it only ever names
+   * ids the head ALREADY carries, so a fact stated moments ago is simply
+   * not a candidate.
+   *
+   * Drift repair covers the two legacy mutations that happen in place: a
+   * binding's role reassignment and a custom role's permission edit. Both
+   * are stated as their proper change events with today's business time —
+   * a restated `attach`/`define` cannot carry them, because the head's
+   * upsert guard refuses an event that is not strictly newer than the row,
+   * and an adopted fact's business time is pinned to the legacy row's
+   * createdAt. Anything else that drifts is not repaired here; the proof
+   * names it and the organization stays held for an operator to read.
+   */
+  private async reconcile({
+    organizationId,
+    expected,
+    heads,
+    signal,
+  }: {
+    organizationId: string;
+    expected: ExpectedFacts;
+    heads: HeadState;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const { grantRows: headRows, roleHeads } = heads;
+    const occurredAtMs = this.deps.now();
+
+    const ownedLive = headRows.filter(
+      (row) => isMigrationOwned(row.source) && !row.revoked,
+    );
+    const staleGrants = ownedLive
+      .filter((row) => !expected.grantIds.has(row.id))
+      .map((row) => row.id)
+      .sort();
+    await this.each(staleGrants, signal, (grantId) =>
+      this.deps.ledger.revokeGrant({
+        organizationId,
+        commandId: `authz-engine:deny:grant:${grantId}`,
+        grantId,
+        reason: "authz-engine reconciliation: legacy row no longer exists",
+        actor: ACTOR,
+        occurredAtMs,
+      }),
+    );
+
+    const expectedRoleIds = new Set(expected.roles.map((role) => role.roleId));
+    const staleRoles = roleHeads
+      .filter((head) => head.kind === "custom" && !expectedRoleIds.has(head.id))
+      .map((head) => head.id)
+      .sort();
+    await this.each(staleRoles, signal, (roleId) =>
+      this.deps.ledger.deleteRole({
+        organizationId,
+        commandId: `authz-engine:deny:role:${roleId}`,
+        roleId,
+        actor: ACTOR,
+        occurredAtMs,
+      }),
+    );
+
+    const headById = new Map(headRows.map((row) => [row.id, row]));
+    const rekeys = expected.nonResourceFacts.flatMap((fact) => {
+      const head = headById.get(fact.grantId);
+      if (!head || head.revoked) return [];
+      if (fact.roleKey === null || head.roleKey === fact.roleKey) return [];
+      return [{ grantId: fact.grantId, from: head.roleKey, to: fact.roleKey }];
+    });
+    await this.each(rekeys, signal, (rekey) =>
+      this.deps.ledger.changeGrantRole({
+        organizationId,
+        commandId: contentCommandId("rekey", rekey.grantId, rekey.to),
+        grantId: rekey.grantId,
+        from: rekey.from,
+        to: rekey.to,
+        actor: ACTOR,
+        occurredAtMs,
+      }),
+    );
+
+    const roleHeadById = new Map(roleHeads.map((head) => [head.id, head]));
+    const reperms = expected.roles.flatMap((role) => {
+      const head = roleHeadById.get(role.roleId);
+      if (!head) return [];
+      const headPermissions = permissionStrings(head.permissions);
+      if (headPermissions.join(",") === role.permissions.join(",")) return [];
+      return [{ roleId: role.roleId, permissions: role.permissions }];
+    });
+    await this.each(reperms, signal, (reperm) =>
+      this.deps.ledger.changeRolePermissions({
+        organizationId,
+        commandId: contentCommandId(
+          "reperm",
+          reperm.roleId,
+          reperm.permissions,
+        ),
+        roleId: reperm.roleId,
+        permissions: reperm.permissions,
+        actor: ACTOR,
+        occurredAtMs,
+      }),
+    );
+  }
+
+  /**
+   * The check, over the pass's one projection read (ADR-110: the migration
+   * does not wait). What that read cannot see is `outstanding` — facts this
+   * pass stated, and revocations it sent; a later pass sees them folded.
+   * What it sees and disagrees with is a `diff`, named so an operator can
+   * act on it.
+   */
+  private check({
+    organizationId,
+    expected,
+    heads,
+  }: {
+    organizationId: string;
+    expected: ExpectedFacts;
+    heads: HeadState;
+  }): { outstanding: string[]; diffs: AuthzEngineDiff[] } {
+    const { grantRows: headRows, roleHeads, resourceRows } = heads;
+    const outstanding: string[] = [];
+    const diffs: AuthzEngineDiff[] = [];
+
+    const headById = new Map(headRows.map((row) => [row.id, row]));
+    for (const fact of expected.nonResourceFacts) {
+      const head = headById.get(fact.grantId);
+      if (!head) {
+        outstanding.push(fact.grantId);
+        continue;
+      }
+      if (head.revoked) {
+        diffs.push({ kind: "grant_revoked", id: fact.grantId });
+        continue;
+      }
+      diffs.push(...grantDiffs({ fact, head }));
+    }
+    for (const row of headRows) {
+      if (row.revoked || !isMigrationOwned(row.source)) continue;
+      // Revoked this pass, not yet folded: outstanding, never a diff.
+      if (!expected.grantIds.has(row.id)) outstanding.push(row.id);
+    }
+
+    const roleHeadById = new Map(roleHeads.map((head) => [head.id, head]));
+    const expectedRoleIds = new Set(expected.roles.map((role) => role.roleId));
+    for (const role of expected.roles) {
+      const head = roleHeadById.get(role.roleId);
+      if (!head) {
+        outstanding.push(role.roleId);
+        continue;
+      }
+      diffs.push(...roleDiffs({ role, head }));
+    }
+    for (const head of roleHeads) {
+      if (head.kind === "custom" && !expectedRoleIds.has(head.id)) {
+        outstanding.push(head.id);
+      }
+    }
+
+    const resourceById = new Map(resourceRows.map((row) => [row.grantId, row]));
+    const expectedLinkIds = new Set(
+      expected.shareLinks.map((link) => link.row.id),
+    );
+    for (const link of expected.shareLinks) {
+      const head = resourceById.get(link.row.id);
+      if (!head) {
+        outstanding.push(link.row.id);
+        continue;
+      }
+      diffs.push(...resourceDiffs({ organizationId, link, head }));
+    }
+    for (const row of resourceRows) {
+      if (!expectedLinkIds.has(row.grantId)) outstanding.push(row.grantId);
+    }
+
+    return { outstanding: outstanding.sort(), diffs };
+  }
+
+  /** Bounded fan-out, aborted between chunks — the runner will not
+   *  interrupt an in-flight send, so the boundary is the chunk. */
+  private async each<T>(
+    items: readonly T[],
+    signal: AbortSignal | undefined,
+    send: (item: T) => Promise<void>,
+  ): Promise<void> {
+    for (let i = 0; i < items.length; i += SEND_CONCURRENCY) {
+      if (signal?.aborted) {
+        throw new Error(
+          "authz-engine migration aborted; organization parked for retry",
+        );
+      }
+      await Promise.all(items.slice(i, i + SEND_CONCURRENCY).map(send));
+    }
+  }
+}
+
+type HeadState = {
+  grantRows: GrantHeadRow[];
+  roleHeads: RoleHeadRow[];
+  resourceRows: ResourceGrantRow[];
+};
+
+type ExpectedShareLink = { row: ShareLinkFactRow; fact: GrantFact };
+
+type ExpectedFacts = {
+  roles: RoleFact[];
+  bindingFacts: GrantFact[];
+  teamFacts: GrantFact[];
+  organizationFacts: GrantFact[];
+  credentialFacts: GrantFact[];
+  shareLinks: ExpectedShareLink[];
+  /** Every non-resource fact, for the proof's walk. */
+  nonResourceFacts: GrantFact[];
+  /** Every expected id, resource included, for the deny sweep. */
+  grantIds: Set<string>;
+};
+
+function assembleFacts({
+  organizationId,
+  inventory,
+}: {
+  organizationId: string;
+  inventory: {
+    organizationCreatedAtMs: number | null;
+    roleRows: LegacyRoleRow[];
+    bindingRows: LegacyBindingRow[];
+    members: OrganizationMemberFact[];
+    teamRows: LegacyTeamRow[];
+    shareLinkRows: ShareLinkFactRow[];
+    externalMembers: ExternalMemberFact[];
+    credentials: ProjectCredentialFact[];
+  };
+}): ExpectedFacts {
+  const roles = inventory.roleRows
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(legacyRoleToFact);
+  const bindingFacts = inventory.bindingRows
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .flatMap((row) => {
+      const fact = bindingToFact({ row });
+      return fact ? [fact] : [];
+    });
+  const teamFacts = teamMembershipFacts({
+    organizationId,
+    teamRows: inventory.teamRows,
+    bindingRows: inventory.bindingRows,
+  });
+  const organizationFacts = organizationLevelFacts({
+    organizationId,
+    members: inventory.members,
+    externalMembers: inventory.externalMembers,
+    bindingRows: inventory.bindingRows,
+    organizationCreatedAtMs: inventory.organizationCreatedAtMs,
+  });
+  const credentialFacts = inventory.credentials
+    .slice()
+    .sort((a, b) => a.projectId.localeCompare(b.projectId))
+    .map((credential) => credentialToFact({ organizationId, credential }));
+  const shareLinks = inventory.shareLinkRows
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(
+      (row): ExpectedShareLink => ({
+        row,
+        fact: shareLinkToFact({ organizationId, row }),
+      }),
+    );
+
+  const nonResourceFacts = [
+    ...bindingFacts,
+    ...teamFacts,
+    ...organizationFacts,
+    ...credentialFacts,
+  ];
+  return {
+    roles,
+    bindingFacts,
+    teamFacts,
+    organizationFacts,
+    credentialFacts,
+    shareLinks,
+    nonResourceFacts,
+    grantIds: new Set([
+      ...nonResourceFacts.map((fact) => fact.grantId),
+      ...shareLinks.map((link) => link.row.id),
+    ]),
+  };
+}
+
+/**
+ * A command id derived from the fact's identity AND its content. Identity
+ * alone is not enough: the event store dedupes on the idempotency key, so a
+ * legacy row edited between two passes would restate under the first pass's
+ * key and be silently swallowed. Content in the key means the same fact
+ * always dedupes and a changed one always appends.
+ */
+function contentCommandId(kind: string, id: string, content: unknown): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify(content))
+    .digest("hex")
+    .slice(0, 16);
+  return `authz-engine:${kind}:${id}:${digest}`;
+}
+
+function isMigrationOwned(source: string): boolean {
+  return (MIGRATION_OWNED_SOURCES as readonly string[]).includes(source);
+}
+
+/**
+ * A CustomRole as the ledger defines it, adopting the row's own id. The
+ * stored permissions column is jsonb: anything that is not an array of
+ * strings imports as the empty list, which grants nothing.
+ */
+function legacyRoleToFact(row: LegacyRoleRow): RoleFact {
+  return {
+    roleId: row.id,
+    name: row.name,
+    ...(row.description === null ? {} : { description: row.description }),
+    permissions: permissionStrings(row.permissions),
+    kind: row.kind === "system_api_key" ? "system_api_key" : "custom",
+    occurredAtMs: row.createdAtMs,
+  };
+}
+
+function permissionStrings(stored: unknown): string[] {
+  return Array.isArray(stored)
+    ? stored.filter(
+        (entry): entry is string => typeof entry === "string" && entry !== "",
+      )
+    : [];
+}
+
+/**
+ * A RoleBinding as the ledger attaches it. The grant id IS the row id. A row
+ * naming no principal cannot be expressed as a grant and is skipped; the
+ * proof does not expect it either, so it holds nothing up.
+ *
+ * A custom key erases which legacy `role` column value the row carried, so
+ * it travels as `legacyRole`: the legacy resolver falls back to that column
+ * whenever the custom role's permission list is empty, and dropping it would
+ * turn an ADMIN with an empty custom role into a viewer.
+ */
+function bindingToFact({ row }: { row: LegacyBindingRow }): GrantFact | null {
+  const principal = bindingPrincipal(row);
+  if (!principal) return null;
+  return {
+    grantId: row.id,
+    principal,
+    roleKey:
+      row.customRoleId === null
+        ? roleKeyForTeamRole(row.role)
+        : `custom:${row.customRoleId}`,
+    ...(row.customRoleId === null ? {} : { legacyRole: row.role }),
+    scope: { type: row.scopeType, id: row.scopeId },
+    source: "migration",
+    occurredAtMs: row.createdAtMs,
+  };
+}
+
+function bindingPrincipal(row: LegacyBindingRow): LedgerPrincipal | null {
+  if (row.userId !== null) return { type: "user", id: row.userId };
+  if (row.groupId !== null) return { type: "group", id: row.groupId };
+  if (row.apiKeyId !== null) return { type: "apiKey", id: row.apiKeyId };
+  return null;
+}
+
+/**
+ * Team memberships stated DIRECTLY (ADR-110), never promoted into binding
+ * rows first. A membership a TEAM-scoped binding already carries — same
+ * identity the database's partial unique indexes use, role normalized
+ * through the same mapping on both sides — is that binding's fact, not a
+ * second one.
+ */
+function teamMembershipFacts({
+  organizationId,
+  teamRows,
+  bindingRows,
+}: {
+  organizationId: string;
+  teamRows: LegacyTeamRow[];
+  bindingRows: LegacyBindingRow[];
+}): GrantFact[] {
+  const bound = new Set(
+    bindingRows
+      .filter((row) => row.scopeType === "TEAM" && row.userId !== null)
+      .map((row) =>
+        bindingIdentityKey({
+          principal: { userId: row.userId },
+          scopeType: "TEAM",
+          scopeId: row.scopeId,
+          role:
+            row.customRoleId === null ? roleKeyForTeamRole(row.role) : row.role,
+          customRoleId: row.customRoleId,
+        }),
+      ),
+  );
+  return teamRows
+    .slice()
+    .sort(
+      (a, b) =>
+        a.teamId.localeCompare(b.teamId) || a.userId.localeCompare(b.userId),
+    )
+    .flatMap((row) => {
+      const key = bindingIdentityKey({
+        principal: { userId: row.userId },
+        scopeType: "TEAM",
+        scopeId: row.teamId,
+        role:
+          row.customRoleId === null ? roleKeyForTeamRole(row.role) : row.role,
+        customRoleId: row.customRoleId,
+      });
+      if (bound.has(key)) return [];
+      const principal = { type: "user" as const, id: row.userId };
+      const scope = { type: "TEAM" as const, id: row.teamId };
+      return [
+        {
+          grantId: deriveGrantId({
+            organizationId,
+            principal,
+            scope,
+            occurredAtMs: row.createdAtMs,
+          }),
+          principal,
+          roleKey:
+            row.customRoleId === null
+              ? roleKeyForTeamRole(row.role)
+              : `custom:${row.customRoleId}`,
+          ...(row.customRoleId === null ? {} : { legacyRole: row.role }),
+          scope,
+          source: "migration" as const,
+          occurredAtMs: row.createdAtMs,
+        },
+      ];
+    });
+}
+
+/**
+ * The facts the legacy schema inferred instead of storing.
+ *
+ * The floor: one org-scoped `member` grant whose principal is the
+ * organization's membership itself, so a member holding no binding anywhere
+ * holds exactly the floor and nothing beyond it.
+ *
+ * The legacy-admin fallback: an ADMIN with no binding anywhere is served
+ * today by the resolver's fallback. `legacy-admin`, NOT `admin`, and the
+ * difference is load-bearing: `admin` would grant the full admin bag where
+ * the fallback grants a narrower one; the untranslatable key keeps the fact
+ * dormant until the contract gives it the bag the fallback actually grants.
+ *
+ * Lite members: `OrganizationUser.role = EXTERNAL`, the org-scoped cap the
+ * legacy schema kept as a membership column.
+ */
+function organizationLevelFacts({
+  organizationId,
+  members,
+  externalMembers,
+  bindingRows,
+  organizationCreatedAtMs,
+}: {
+  organizationId: string;
+  members: OrganizationMemberFact[];
+  externalMembers: ExternalMemberFact[];
+  bindingRows: LegacyBindingRow[];
+  organizationCreatedAtMs: number | null;
+}): GrantFact[] {
+  const scope = { type: "ORGANIZATION" as const, id: organizationId };
+  const facts: GrantFact[] = [];
+
+  if (organizationCreatedAtMs !== null) {
+    const principal = { type: "organization" as const, id: organizationId };
+    facts.push({
+      grantId: deriveGrantId({
+        organizationId,
+        principal,
+        scope,
+        occurredAtMs: organizationCreatedAtMs,
+      }),
+      principal,
+      roleKey: "member",
+      scope,
+      source: "migration",
+      occurredAtMs: organizationCreatedAtMs,
+    });
+  }
+
+  const boundUserIds = new Set(
+    bindingRows.flatMap((row) => (row.userId === null ? [] : [row.userId])),
+  );
+  for (const member of members
+    .slice()
+    .sort((a, b) => a.userId.localeCompare(b.userId))) {
+    if (member.role !== "ADMIN" || boundUserIds.has(member.userId)) continue;
+    const principal = { type: "user" as const, id: member.userId };
+    facts.push({
+      grantId: deriveGrantId({
+        organizationId,
+        principal,
+        scope,
+        occurredAtMs: member.createdAtMs,
+      }),
+      principal,
+      roleKey: "legacy-admin",
+      scope,
+      source: "migration",
+      occurredAtMs: member.createdAtMs,
+    });
+  }
+
+  for (const member of externalMembers
+    .slice()
+    .sort((a, b) => a.userId.localeCompare(b.userId))) {
+    const principal = { type: "user" as const, id: member.userId };
+    facts.push({
+      grantId: deriveGrantId({
+        organizationId,
+        principal,
+        scope,
+        occurredAtMs: member.createdAtMs,
+      }),
+      principal,
+      roleKey: "lite-member",
+      scope,
+      source: "migration",
+      occurredAtMs: member.createdAtMs,
+    });
+  }
+  return facts;
+}
+
+/** The legacy per-project credential (`Project.apiKey`): the PROJECT itself
+ *  is the principal — that key authenticates as the project and names no
+ *  user or key row at all. */
+function credentialToFact({
+  organizationId,
+  credential,
+}: {
+  organizationId: string;
+  credential: ProjectCredentialFact;
+}): GrantFact {
+  const principal = { type: "project" as const, id: credential.projectId };
+  const scope = { type: "PROJECT" as const, id: credential.projectId };
+  return {
+    grantId: deriveGrantId({
+      organizationId,
+      principal,
+      scope,
+      occurredAtMs: credential.createdAtMs,
+    }),
+    principal,
+    roleKey: "admin",
+    scope,
+    source: "migration",
+    occurredAtMs: credential.createdAtMs,
+  };
+}
+
+/** A share link as the ledger attaches it, adopting the row's own id so the
+ *  token a customer already circulated keeps resolving to it. Resource facts
+ *  carry no role: their single permission is in the terms. */
+function shareLinkToFact({
+  organizationId,
+  row,
+}: {
+  organizationId: string;
+  row: ShareLinkFactRow;
+}): GrantFact {
+  return {
+    grantId: row.id,
+    principal: shareVisibilityAudience({
+      visibility: row.visibility,
+      organizationId,
+      projectId: row.projectId,
+    }),
+    roleKey: null,
+    scope: { type: "RESOURCE", id: row.resourceId },
+    resource: {
+      kind: row.resourceType === "THREAD" ? "thread" : "trace",
+      projectId: row.projectId,
+      token: row.token,
+      permission: SHARE_LINK_PERMISSION,
+      ...(row.userId === null ? {} : { createdByUserId: row.userId }),
+      ...(row.expiresAtMs === null ? {} : { expiresAtMs: row.expiresAtMs }),
+      ...(row.maxViews === null ? {} : { maxViews: row.maxViews }),
+    },
+    source: "migration",
+    occurredAtMs: row.createdAtMs,
+  };
+}
+
+/** Field equality for one stated fact against its head row — against what
+ *  the migration SAID, since that is what the head is supposed to hold. */
+function grantDiffs({
+  fact,
+  head,
+}: {
+  fact: GrantFact;
+  head: GrantHeadRow;
+}): AuthzEngineDiff[] {
+  const compared: Array<[string, string | null, string | null]> = [
+    ["principalType", PRINCIPAL_TO_DB[fact.principal.type], head.principalType],
+    ["principalId", fact.principal.id, head.principalId],
+    ["roleKey", fact.roleKey, head.roleKey],
+    ["legacyRole", fact.legacyRole ?? null, head.legacyRole],
+    ["scopeType", fact.scope.type, head.scopeType],
+    ["scopeId", fact.scope.id, head.scopeId],
+  ];
+  return compared.flatMap(([field, expected, actual]) =>
+    expected === actual
+      ? []
+      : [
+          {
+            kind: "grant_changed" as const,
+            id: fact.grantId,
+            field,
+            expected,
+            actual,
+          },
+        ],
+  );
+}
+
+function roleDiffs({
+  role,
+  head,
+}: {
+  role: RoleFact;
+  head: RoleHeadRow;
+}): AuthzEngineDiff[] {
+  const compared: Array<[string, string | null, string | null]> = [
+    ["name", role.name, head.name],
+    ["description", role.description ?? null, head.description],
+    [
+      "permissions",
+      role.permissions.join(","),
+      permissionStrings(head.permissions).join(","),
+    ],
+    [
+      "kind",
+      role.kind,
+      head.kind === "system_api_key" ? "system_api_key" : "custom",
+    ],
+  ];
+  return compared.flatMap(([field, expected, actual]) =>
+    expected === actual
+      ? []
+      : [
+          {
+            kind: "role_changed" as const,
+            id: role.roleId,
+            field,
+            expected,
+            actual,
+          },
+        ],
+  );
+}
+
+/** Field equality for one imported link against its RESOURCE head row. The
+ *  stored spellings differ (the head keeps the database's uppercase), so the
+ *  comparison is against what the import said, mapped to that spelling. */
+function resourceDiffs({
+  organizationId,
+  link,
+  head,
+}: {
+  organizationId: string;
+  link: ExpectedShareLink;
+  head: ResourceGrantRow;
+}): AuthzEngineDiff[] {
+  const { row } = link;
+  const principal = shareVisibilityAudience({
+    visibility: row.visibility,
+    organizationId,
+    projectId: row.projectId,
+  });
+  const compared: Array<[string, string | null, string | null]> = [
+    ["token", row.token, head.token],
+    ["kind", row.resourceType, (head.resourceKind ?? "").toUpperCase() || null],
+    ["resourceId", row.resourceId, head.resourceId],
+    ["projectId", row.projectId, head.projectId],
+    ["principalType", PRINCIPAL_TO_DB[principal.type], head.principalType],
+    ["principalId", principal.id, head.principalId],
+    ["expiresAt", numberField(row.expiresAtMs), numberField(head.expiresAtMs)],
+    ["maxViews", numberField(row.maxViews), numberField(head.maxViews)],
+    // The view budget is part of the link, not decoration on it: a link
+    // reproduced with the right cap and no views spent is a link the
+    // migration refilled. Compared so that never passes silently.
+    ["viewCount", numberField(row.viewCount), numberField(head.viewCount)],
+  ];
+  return compared.flatMap(([field, expected, actual]) =>
+    expected === actual
+      ? []
+      : [
+          {
+            kind: "resource_changed" as const,
+            id: row.id,
+            field,
+            expected,
+            actual,
+          },
+        ],
+  );
+}
+
+function numberField(value: number | null): string | null {
+  return value === null ? null : String(value);
+}

--- a/platform/app/src/server/app-layer/authz/engine-gate.ts
+++ b/platform/app/src/server/app-layer/authz/engine-gate.ts
@@ -51,15 +51,17 @@ export function setAuthzEngineGateFailureReporter(
 }
 
 /**
- * The statuses that mean this organization's whole grant history is in the
- * event log and its projection is fed — so the engine can both answer and be
- * written to. Anything else (absent, pending, parked) means the history is
- * not there, and the organization stays on the legacy path.
+ * Only `finalized` moves an organization onto the engine. `migrated` is the
+ * HELD state (the runner's own contract): the work landed but the
+ * migration's proof found the projection behind or disagreeing, and the ops
+ * page promises the operator such an organization "stays on its legacy
+ * path, behaving exactly as before". Reads from a half-fed projection would
+ * deny access the customer holds; writes fork on this same predicate, and a
+ * held organization's imperative legacy writes are what the next pass
+ * restates, rekeys or revokes — that loop is how it heals into `finalized`.
+ * Anything else (absent, pending, parked, rolled back) is legacy too.
  */
-const ON_ENGINE_STATUSES: readonly MigrationTenantStatus[] = [
-  "migrated",
-  "finalized",
-];
+const ON_ENGINE_STATUSES: readonly MigrationTenantStatus[] = ["finalized"];
 
 /**
  * One bound for both directions. The negative one is what lets a finishing

--- a/platform/app/src/server/app-layer/authz/engine-gate.ts
+++ b/platform/app/src/server/app-layer/authz/engine-gate.ts
@@ -157,13 +157,13 @@ export async function organizationOnAuthzEngine({
 
 /**
  * Drop one organization's cached answer, so the next check re-reads. Intended
- * to be called the moment a migration finalizes an organization, so the switch
- * is immediate on the pod that ran it while every other pod converges on the
- * TTL. NOT wired yet: the ADR-110 one-shot migration is not registered
- * (`registeredMigrations()` is empty), so nothing calls this today — until it
- * lands, a finalized organization waits out the full TTL even on its own pod.
- * Pod-local by design — cross-pod invalidation would need a bus and would buy
- * sixty seconds.
+ * for a caller that has just changed the stored status and needs its own pod
+ * to re-read it. Nothing calls it in production BY DESIGN: the migration
+ * returns `finalized` before the runner persists the status, so a call from
+ * there would re-cache the old answer; every pod — the finalizing one
+ * included — converges on the TTL instead, the same sixty-second bound
+ * ADR-110 documents for rollback. Pod-local — cross-pod invalidation would
+ * need a bus and would buy sixty seconds.
  */
 export function invalidateAuthzEngineGate({
   organizationId,

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/access-listing.cutover.repository.unit.test.ts
@@ -54,7 +54,7 @@ const repositoryFor = (onEngineByOrg: Record<string, boolean>) => {
       where: { migrationName_tenantId: { tenantId: string } };
     }) =>
       onEngineByOrg[where.migrationName_tenantId.tenantId] === true
-        ? { status: "migrated" }
+        ? { status: "finalized" }
         : null,
   );
   const prisma = {
@@ -257,7 +257,7 @@ describe("CutoverAwareAccessListingRepository", () => {
       const grants = spyRepository("grants");
       const findUnique = vi
         .fn()
-        .mockResolvedValueOnce({ status: "migrated" })
+        .mockResolvedValueOnce({ status: "finalized" })
         .mockResolvedValue(null);
       const prisma = {
         systemMigrationTenantState: { findUnique },
@@ -304,7 +304,7 @@ describe("CutoverAwareAccessListingRepository", () => {
         systemMigrationTenantState: {
           findUnique: vi
             .fn()
-            .mockResolvedValue(onEngine ? { status: "migrated" } : null),
+            .mockResolvedValue(onEngine ? { status: "finalized" } : null),
         },
         grant: { findMany: grantFindMany },
         roleBinding: { findMany: roleBindingFindMany },

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-grants-write.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-grants-write.repository.unit.test.ts
@@ -15,6 +15,7 @@
  */
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import type { GrantProjectionWrite } from "~/server/event-sourcing/pipelines/authz-grants/projections/authzGrantsWrite.projection";
+import { MIGRATION_OWNED_SOURCES } from "../../authz-engine.facts";
 import { PrismaAuthzGrantsWriteRepository } from "../authz-grants-write.prisma.repository";
 
 const ORG = "org_acme";
@@ -301,12 +302,18 @@ describe("PrismaAuthzGrantsWriteRepository", () => {
     // while a derived fact (a team membership, the org floor) matches no
     // row and must not be given one. Update-only is what makes both true.
     /** @scenario "Nothing legacy changes before an organization finalizes" */
-    it("updates the compat binding in place and never creates one", async () => {
+    // All four owned sources take the update-only path: the three-stage
+    // rollout's rows are this migration's too, and a check regressed to
+    // `source === "migration"` would silently resume minting bindings for
+    // them.
+    it.each(
+      MIGRATION_OWNED_SOURCES,
+    )("updates the compat binding in place and never creates one (%s)", async (source) => {
       const { repository, prisma } = build();
 
       await repository.append({
         kind: "grant.upsert",
-        row: grantRow({ source: "migration" }),
+        row: grantRow({ source }),
       } as GrantProjectionWrite);
 
       expect(prisma.roleBinding.upsert).not.toHaveBeenCalled();

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-grants-write.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-grants-write.repository.unit.test.ts
@@ -62,6 +62,7 @@ function build() {
     },
     shareLink: {
       upsert: vi.fn().mockResolvedValue(undefined),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
     },
     $executeRaw: executeRaw,
@@ -73,7 +74,7 @@ function build() {
     grant: { updateMany: Mock; findUnique: Mock };
     roleBinding: { upsert: Mock; updateMany: Mock; deleteMany: Mock };
     customRole: { upsert: Mock; updateMany: Mock; deleteMany: Mock };
-    shareLink: { upsert: Mock; deleteMany: Mock };
+    shareLink: { upsert: Mock; updateMany: Mock; deleteMany: Mock };
   };
   return {
     prisma: mocks,
@@ -291,6 +292,70 @@ describe("PrismaAuthzGrantsWriteRepository", () => {
           row: grantRow(),
         } as GrantProjectionWrite),
       ).rejects.toThrow("connection lost");
+    });
+  });
+
+  describe("given a migration-sourced grant fact", () => {
+    // ADR-110: nothing legacy changes before an organization finalizes. An
+    // adopted binding converges onto the row it was read from — an update —
+    // while a derived fact (a team membership, the org floor) matches no
+    // row and must not be given one. Update-only is what makes both true.
+    /** @scenario "Nothing legacy changes before an organization finalizes" */
+    it("updates the compat binding in place and never creates one", async () => {
+      const { repository, prisma } = build();
+
+      await repository.append({
+        kind: "grant.upsert",
+        row: grantRow({ source: "migration" }),
+      } as GrantProjectionWrite);
+
+      expect(prisma.roleBinding.upsert).not.toHaveBeenCalled();
+      expect(prisma.roleBinding.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: ORG, id: "grant_1" },
+        }),
+      );
+    });
+
+    /** @scenario "Nothing legacy changes before an organization finalizes" */
+    it("updates the compat share link in place and never creates one", async () => {
+      const { repository, prisma } = build();
+
+      await repository.append({
+        kind: "grant.upsert",
+        row: grantRow({
+          source: "migration",
+          principalType: "ANYONE",
+          principalId: null,
+          roleKey: null,
+          scopeType: "RESOURCE",
+          scopeId: "trace_1",
+          token: "token_1",
+          permission: "traces:view",
+          resourceKind: "TRACE",
+          projectId: "project_1",
+        }),
+      } as GrantProjectionWrite);
+
+      expect(prisma.shareLink.upsert).not.toHaveBeenCalled();
+      expect(prisma.shareLink.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { projectId: "project_1", id: "grant_1" },
+        }),
+      );
+    });
+
+    /** A live write keeps the create path: only the migration is dark. */
+    it("still creates compat rows for live-write sources", async () => {
+      const { repository, prisma } = build();
+
+      await repository.append({
+        kind: "grant.upsert",
+        row: grantRow({ source: "grants-service" }),
+      } as GrantProjectionWrite);
+
+      expect(prisma.roleBinding.upsert).toHaveBeenCalled();
+      expect(prisma.roleBinding.updateMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.cutover.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.cutover.repository.unit.test.ts
@@ -36,7 +36,7 @@ const repositoryFor = (onEngine: boolean) => {
     systemMigrationTenantState: {
       findUnique: vi
         .fn()
-        .mockResolvedValue(onEngine ? { status: "migrated" } : null),
+        .mockResolvedValue(onEngine ? { status: "finalized" } : null),
     },
   } as unknown as Prisma.TransactionClient;
   return {
@@ -208,7 +208,7 @@ describe("CutoverAwareAuthzReadRepository", () => {
 
   describe("when several calls ask about the same organization", () => {
     it("reads the projection once, because the gate caches the answer", async () => {
-      const findUnique = vi.fn().mockResolvedValue({ status: "migrated" });
+      const findUnique = vi.fn().mockResolvedValue({ status: "finalized" });
       const prisma = {
         systemMigrationTenantState: { findUnique },
       } as unknown as Prisma.TransactionClient;
@@ -235,7 +235,7 @@ describe("CutoverAwareAuthzReadRepository", () => {
     const gateFlippingAfterFirstRead = () => {
       const findUnique = vi
         .fn()
-        .mockResolvedValueOnce({ status: "migrated" })
+        .mockResolvedValueOnce({ status: "finalized" })
         .mockResolvedValue(null);
       const prisma = {
         systemMigrationTenantState: { findUnique },

--- a/platform/app/src/server/app-layer/authz/repositories/authz-grants-write.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-grants-write.prisma.repository.ts
@@ -43,7 +43,7 @@ import type {
   GrantProjectionWrite,
   GrantProjectionWriteStore,
 } from "~/server/event-sourcing/pipelines/authz-grants/projections/authzGrantsWrite.projection";
-import { MIGRATION_OWNED_SOURCES } from "../authz-engine.migration";
+import { MIGRATION_OWNED_SOURCES } from "../authz-engine.facts";
 
 const logger = createLogger("langwatch:authz:projection-compat");
 

--- a/platform/app/src/server/app-layer/authz/repositories/authz-grants-write.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-grants-write.prisma.repository.ts
@@ -43,6 +43,7 @@ import type {
   GrantProjectionWrite,
   GrantProjectionWriteStore,
 } from "~/server/event-sourcing/pipelines/authz-grants/projections/authzGrantsWrite.projection";
+import { MIGRATION_OWNED_SOURCES } from "../authz-engine.migration";
 
 const logger = createLogger("langwatch:authz:projection-compat");
 
@@ -128,6 +129,10 @@ function reportMissedRow(write: GrantProjectionWrite, result: unknown): void {
     { write: write.kind, occurredAt: write.occurredAt },
     "authz projection write matched no row; the grant it names is absent or newer",
   );
+}
+
+function isMigrationOwnedSource(source: string): boolean {
+  return (MIGRATION_OWNED_SOURCES as readonly string[]).includes(source);
 }
 
 /** Prisma's codes for "a unique or foreign key says no". */
@@ -283,27 +288,51 @@ export class PrismaAuthzGrantsWriteRepository
     grant: ReturnType<typeof grantRowToFact>,
     organizationId: string,
   ): Promise<void> {
+    // UPDATE-only for migration-sourced facts (ADR-110: nothing legacy
+    // changes before an organization finalizes). An adopted binding or link
+    // converges onto the very row it was read from — a byte-identical
+    // update — while a fact the legacy schema only inferred (a team
+    // membership, the org floor, a project credential) has no row here and
+    // must not be given one: its legacy representation is the membership or
+    // credential row it came from, and minting a binding for it would be
+    // exactly the visible change the migration promises not to make.
+    const migrationSourced = isMigrationOwnedSource(grant.source);
+
     const binding = grantFactToCompatBinding({ grant, organizationId });
     if (binding) {
       const { id, ...rest } = binding;
-      await this.prisma.roleBinding.upsert({
-        where: { organizationId, id },
-        create: binding,
-        update: rest,
-      });
+      if (migrationSourced) {
+        await this.prisma.roleBinding.updateMany({
+          where: { organizationId, id },
+          data: rest,
+        });
+      } else {
+        await this.prisma.roleBinding.upsert({
+          where: { organizationId, id },
+          create: binding,
+          update: rest,
+        });
+      }
     }
 
     const link = grantFactToCompatShareLink({ grant, organizationId });
     if (link) {
       const { id, ...rest } = link;
-      await this.prisma.shareLink.upsert({
-        where: { projectId: link.projectId, id },
-        create: link,
-        // `viewCount` is named in neither branch: the create leans on the
-        // column default and the update leaves the running total alone, so a
-        // re-applied attach cannot reset a link's accounting.
-        update: rest,
-      });
+      if (migrationSourced) {
+        await this.prisma.shareLink.updateMany({
+          where: { projectId: link.projectId, id },
+          data: rest,
+        });
+      } else {
+        await this.prisma.shareLink.upsert({
+          where: { projectId: link.projectId, id },
+          create: link,
+          // `viewCount` is named in neither branch: the create leans on the
+          // column default and the update leaves the running total alone, so a
+          // re-applied attach cannot reset a link's accounting.
+          update: rest,
+        });
+      }
     }
   }
 

--- a/platform/app/src/server/app-layer/authz/repositories/authz-grants-write.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-grants-write.prisma.repository.ts
@@ -43,7 +43,7 @@ import type {
   GrantProjectionWrite,
   GrantProjectionWriteStore,
 } from "~/server/event-sourcing/pipelines/authz-grants/projections/authzGrantsWrite.projection";
-import { MIGRATION_OWNED_SOURCES } from "../authz-engine.facts";
+import { isMigrationOwned } from "../authz-engine.facts";
 
 const logger = createLogger("langwatch:authz:projection-compat");
 
@@ -129,10 +129,6 @@ function reportMissedRow(write: GrantProjectionWrite, result: unknown): void {
     { write: write.kind, occurredAt: write.occurredAt },
     "authz projection write matched no row; the grant it names is absent or newer",
   );
-}
-
-function isMigrationOwnedSource(source: string): boolean {
-  return (MIGRATION_OWNED_SOURCES as readonly string[]).includes(source);
 }
 
 /** Prisma's codes for "a unique or foreign key says no". */
@@ -296,7 +292,7 @@ export class PrismaAuthzGrantsWriteRepository
     // must not be given one: its legacy representation is the membership or
     // credential row it came from, and minting a binding for it would be
     // exactly the visible change the migration promises not to make.
-    const migrationSourced = isMigrationOwnedSource(grant.source);
+    const migrationSourced = isMigrationOwned(grant.source);
 
     const binding = grantFactToCompatBinding({ grant, organizationId });
     if (binding) {

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -4,6 +4,7 @@ import type {
   AuthzMigrationRepository,
   ExistingTeamBinding,
   ExternalMemberFact,
+  GrantHeadRow,
   LegacyBindingRow,
   LegacyRoleRow,
   LegacyTeamRow,
@@ -18,7 +19,7 @@ import type {
 } from "@langwatch/authz-server";
 import type { TenantMigrationStatus } from "@langwatch/system-migrations";
 import { Prisma, type PrismaClient } from "~/generated/prisma/client";
-import type { GrantHeadRow } from "../authz-engine.check";
+
 import { queryOrganizationOnAuthzEngine } from "../engine-gate";
 
 /**

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -18,7 +18,7 @@ import type {
 } from "@langwatch/authz-server";
 import type { TenantMigrationStatus } from "@langwatch/system-migrations";
 import { Prisma, type PrismaClient } from "~/generated/prisma/client";
-import type { GrantHeadRow } from "../authz-engine.migration";
+import type { GrantHeadRow } from "../authz-engine.check";
 import { queryOrganizationOnAuthzEngine } from "../engine-gate";
 
 /**
@@ -230,6 +230,20 @@ export class PrismaAuthzMigrationRepository
       customRoleId: row.assignedRoleId,
       createdAtMs: row.createdAt.getTime(),
     }));
+  }
+
+  /** Every (userId, groupId) membership in the organization — what lets the
+   *  migration mirror the legacy fallback's suppression predicate, which
+   *  counts bindings held THROUGH a group as bindings the user holds. */
+  async findGroupMemberships({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<Array<{ userId: string; groupId: string }>> {
+    return this.prisma.groupMembership.findMany({
+      where: { group: { organizationId } },
+      select: { userId: true, groupId: true },
+    });
   }
 
   async findExistingTeamBindings({
@@ -490,6 +504,7 @@ export class PrismaAuthzMigrationRepository
       where: { organizationId, scopeType: "RESOURCE", revokedAt: null },
       select: {
         id: true,
+        source: true,
         token: true,
         resourceKind: true,
         scopeId: true,
@@ -513,6 +528,7 @@ export class PrismaAuthzMigrationRepository
     );
     return rows.map((row) => ({
       grantId: row.id,
+      source: row.source,
       token: row.token,
       resourceKind: row.resourceKind,
       resourceId: row.scopeId,

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -18,6 +18,7 @@ import type {
 } from "@langwatch/authz-server";
 import type { TenantMigrationStatus } from "@langwatch/system-migrations";
 import { Prisma, type PrismaClient } from "~/generated/prisma/client";
+import type { GrantHeadRow } from "../authz-engine.migration";
 import { queryOrganizationOnAuthzEngine } from "../engine-gate";
 
 /**
@@ -149,6 +150,42 @@ export class PrismaAuthzMigrationRepository
       select: { id: true },
     });
     return rows.map((row) => row.id);
+  }
+
+  /** Every non-resource Grant head row, revoked included — the ADR-110
+   *  proof needs both directions: a live row to compare and a revoked one to
+   *  recognize as already denied. Resource rows have their own read
+   *  (`findResourceGrantRows`), which carries the tier's extra columns. */
+  async findGrantHeadRows({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<GrantHeadRow[]> {
+    const rows = await this.prisma.grant.findMany({
+      where: { organizationId, scopeType: { not: "RESOURCE" } },
+      select: {
+        id: true,
+        principalType: true,
+        principalId: true,
+        roleKey: true,
+        legacyRole: true,
+        source: true,
+        scopeType: true,
+        scopeId: true,
+        revokedAt: true,
+      },
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      principalType: row.principalType,
+      principalId: row.principalId,
+      roleKey: row.roleKey,
+      legacyRole: row.legacyRole,
+      source: row.source,
+      scopeType: row.scopeType,
+      scopeId: row.scopeId,
+      revoked: row.revokedAt !== null,
+    }));
   }
 
   async findRoleHeads({
@@ -448,7 +485,9 @@ export class PrismaAuthzMigrationRepository
     organizationId: string;
   }): Promise<ResourceGrantRow[]> {
     const rows = await this.prisma.grant.findMany({
-      where: { organizationId, scopeType: "RESOURCE" },
+      // Live rows only: this read serves the ADR-110 proof, and a revoked
+      // link is a deny already applied, not an extra to reconcile.
+      where: { organizationId, scopeType: "RESOURCE", revokedAt: null },
       select: {
         id: true,
         token: true,

--- a/platform/app/src/server/app-layer/share/__tests__/share.ledger.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/share/__tests__/share.ledger.repository.integration.test.ts
@@ -121,7 +121,7 @@ describe("given a cut-over organization's capped share link", () => {
       data: {
         migrationName: AUTHZ_ENGINE_MIGRATION_NAME,
         tenantId: organization.id,
-        status: "migrated",
+        status: "finalized",
         occurredAt: new Date(),
       },
     });

--- a/platform/app/src/server/app-layer/share/__tests__/share.ledger.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/share/__tests__/share.ledger.repository.unit.test.ts
@@ -106,7 +106,7 @@ function buildRepository({
   );
   const cutoverFindUnique = vi
     .fn()
-    .mockResolvedValue(onEngine ? { status: "migrated" } : null);
+    .mockResolvedValue(onEngine ? { status: "finalized" } : null);
   const prisma = {
     systemMigrationTenantState: { findUnique: cutoverFindUnique },
     project: {
@@ -380,7 +380,7 @@ describe("LedgerShareRepository", () => {
           maxViews: null,
         });
         expect(legacy.consumeView).toHaveBeenCalledTimes(1);
-        cutoverFindUnique.mockResolvedValue({ status: "migrated" });
+        cutoverFindUnique.mockResolvedValue({ status: "finalized" });
 
         await repository.deleteById({ id: "share_1", projectId: PROJECT_ID });
 

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -101,35 +101,47 @@ export function registeredMigrations(): SystemMigration[] {
   return [
     new AuthzEngineMigration({
       store: new PrismaAuthzMigrationRepository(prisma),
-      ledger: authzEngineLedger(),
+      ledger: authzEngineLedger,
       now: () => Date.now(),
     }),
   ];
 }
 
+const senders = async () => (await authzGrantsCommands()).commands;
+
 /** The migration's door into the grants ledger — one command, one entity
- *  (ADR-110), over the same lazy senders every live write uses. */
-function authzEngineLedger(): AuthzEngineLedger {
-  const senders = async () => (await authzGrantsCommands()).commands;
-  return {
-    attachGrant: async ({ organizationId, commandId, grant }) => {
-      await (await senders()).attachGrant.send({
-        tenantId: organizationId,
-        organizationId,
-        commandId,
-        grant,
-      });
-    },
-    defineRole: async ({ organizationId, commandId, role, actor }) => {
-      await (await senders()).defineRole.send({
-        tenantId: organizationId,
-        organizationId,
-        commandId,
-        role,
-        actor,
-      });
-    },
-    changeGrantRole: async ({
+ *  (ADR-110), over the same lazy senders every live write uses. Stateless:
+ *  every method resolves the senders at send time, so one module-level
+ *  object serves every pass. */
+const authzEngineLedger: AuthzEngineLedger = {
+  attachGrant: async ({ organizationId, commandId, grant }) => {
+    await (await senders()).attachGrant.send({
+      tenantId: organizationId,
+      organizationId,
+      commandId,
+      grant,
+    });
+  },
+  defineRole: async ({ organizationId, commandId, role, actor }) => {
+    await (await senders()).defineRole.send({
+      tenantId: organizationId,
+      organizationId,
+      commandId,
+      role,
+      actor,
+    });
+  },
+  changeGrantRole: async ({
+    organizationId,
+    commandId,
+    grantId,
+    from,
+    to,
+    actor,
+    occurredAtMs,
+  }) => {
+    await (await senders()).changeGrantRole.send({
+      tenantId: organizationId,
       organizationId,
       commandId,
       grantId,
@@ -137,72 +149,43 @@ function authzEngineLedger(): AuthzEngineLedger {
       to,
       actor,
       occurredAtMs,
-    }) => {
-      await (await senders()).changeGrantRole.send({
-        tenantId: organizationId,
-        organizationId,
-        commandId,
-        grantId,
-        from,
-        to,
-        actor,
-        occurredAtMs,
-      });
-    },
-    changeRolePermissions: async ({
-      organizationId,
-      commandId,
-      roleId,
-      permissions,
-      actor,
-      occurredAtMs,
-    }) => {
-      await (await senders()).changeRolePermissions.send({
-        tenantId: organizationId,
-        organizationId,
-        commandId,
-        roleId,
-        permissions,
-        actor,
-        occurredAtMs,
-      });
-    },
-    revokeGrant: async ({
+    });
+  },
+  revokeGrant: async ({
+    organizationId,
+    commandId,
+    grantId,
+    reason,
+    actor,
+    occurredAtMs,
+  }) => {
+    await (await senders()).revokeGrant.send({
+      tenantId: organizationId,
       organizationId,
       commandId,
       grantId,
       reason,
       actor,
       occurredAtMs,
-    }) => {
-      await (await senders()).revokeGrant.send({
-        tenantId: organizationId,
-        organizationId,
-        commandId,
-        grantId,
-        reason,
-        actor,
-        occurredAtMs,
-      });
-    },
-    deleteRole: async ({
+    });
+  },
+  deleteRole: async ({
+    organizationId,
+    commandId,
+    roleId,
+    actor,
+    occurredAtMs,
+  }) => {
+    await (await senders()).deleteRole.send({
+      tenantId: organizationId,
       organizationId,
       commandId,
       roleId,
       actor,
       occurredAtMs,
-    }) => {
-      await (await senders()).deleteRole.send({
-        tenantId: organizationId,
-        organizationId,
-        commandId,
-        roleId,
-        actor,
-        occurredAtMs,
-      });
-    },
-  };
-}
+    });
+  },
+};
 
 /**
  * The runner's cohort for one pass, per (tenant, migration). On cloud every

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -19,6 +19,12 @@ import { getPrivateClickHouseUrls } from "../../clickhouse/clickhouseClient";
 import { prisma } from "../../db";
 import { tryGetApp } from "../app";
 import {
+  type AuthzEngineLedger,
+  AuthzEngineMigration,
+} from "../authz/authz-engine.migration";
+import { authzGrantsCommands } from "../authz/ledger";
+import { PrismaAuthzMigrationRepository } from "../authz/repositories/authz-migration.prisma.repository";
+import {
   migrationRunsOnThisInstallation,
   organizationMigrates,
 } from "./cohort";
@@ -84,13 +90,118 @@ export const systemMigrationsService = new SystemMigrationsService({
  * ADR-110 replaced the team-user backfill, the genesis import and the
  * cutover with a single migration: it streams an organization's existing
  * grants in as events, proves the projection agrees, and the moment it
- * finishes that organization is on the engine. That migration is not
- * written yet, so nothing is registered and no organization moves — the
- * correct behaviour in the meantime, since every gate ships closed and
- * every organization stays on the legacy path.
+ * finishes that organization is on the engine
+ * (platform/app/src/server/app-layer/authz/authz-engine.migration.ts).
+ * Composed per call so each pass carries a fresh emitter over the shared
+ * lazy senders — a send while the App is still composing waits; an App
+ * without the event-sourcing stack refuses loudly, and the migration then
+ * parks its organization with an honest report.
  */
 export function registeredMigrations(): SystemMigration[] {
-  return [];
+  return [
+    new AuthzEngineMigration({
+      store: new PrismaAuthzMigrationRepository(prisma),
+      ledger: authzEngineLedger(),
+      now: () => Date.now(),
+    }),
+  ];
+}
+
+/** The migration's door into the grants ledger — one command, one entity
+ *  (ADR-110), over the same lazy senders every live write uses. */
+function authzEngineLedger(): AuthzEngineLedger {
+  const senders = async () => (await authzGrantsCommands()).commands;
+  return {
+    attachGrant: async ({ organizationId, commandId, grant }) => {
+      await (await senders()).attachGrant.send({
+        tenantId: organizationId,
+        organizationId,
+        commandId,
+        grant,
+      });
+    },
+    defineRole: async ({ organizationId, commandId, role, actor }) => {
+      await (await senders()).defineRole.send({
+        tenantId: organizationId,
+        organizationId,
+        commandId,
+        role,
+        actor,
+      });
+    },
+    changeGrantRole: async ({
+      organizationId,
+      commandId,
+      grantId,
+      from,
+      to,
+      actor,
+      occurredAtMs,
+    }) => {
+      await (await senders()).changeGrantRole.send({
+        tenantId: organizationId,
+        organizationId,
+        commandId,
+        grantId,
+        from,
+        to,
+        actor,
+        occurredAtMs,
+      });
+    },
+    changeRolePermissions: async ({
+      organizationId,
+      commandId,
+      roleId,
+      permissions,
+      actor,
+      occurredAtMs,
+    }) => {
+      await (await senders()).changeRolePermissions.send({
+        tenantId: organizationId,
+        organizationId,
+        commandId,
+        roleId,
+        permissions,
+        actor,
+        occurredAtMs,
+      });
+    },
+    revokeGrant: async ({
+      organizationId,
+      commandId,
+      grantId,
+      reason,
+      actor,
+      occurredAtMs,
+    }) => {
+      await (await senders()).revokeGrant.send({
+        tenantId: organizationId,
+        organizationId,
+        commandId,
+        grantId,
+        reason,
+        actor,
+        occurredAtMs,
+      });
+    },
+    deleteRole: async ({
+      organizationId,
+      commandId,
+      roleId,
+      actor,
+      occurredAtMs,
+    }) => {
+      await (await senders()).deleteRole.send({
+        tenantId: organizationId,
+        organizationId,
+        commandId,
+        roleId,
+        actor,
+        occurredAtMs,
+      });
+    },
+  };
 }
 
 /**

--- a/platform/app/src/server/rbac/__tests__/role-binding-resolver.fork.unit.test.ts
+++ b/platform/app/src/server/rbac/__tests__/role-binding-resolver.fork.unit.test.ts
@@ -57,7 +57,7 @@ function buildPrisma({
     systemMigrationTenantState: {
       findUnique: vi
         .fn()
-        .mockResolvedValue(onEngine ? { status: "migrated" } : null),
+        .mockResolvedValue(onEngine ? { status: "finalized" } : null),
     },
     project: {
       findUnique: vi.fn().mockResolvedValue({

--- a/specs/migration/authz-grants-rollout.feature
+++ b/specs/migration/authz-grants-rollout.feature
@@ -4,9 +4,10 @@
 # surfaces are the generic runner's and live in
 # specs/migration/system-migrations-runner.feature.
 #
-# Scenarios tagged @unimplemented describe the ADR-110 one-shot migration,
-# which is designed but not yet registered (registeredMigrations() returns
-# nothing for it). They become bindable the moment that migration lands.
+# The ADR-110 one-shot migration is registered
+# (platform/app/src/server/app-layer/authz/authz-engine.migration.ts); the
+# scenarios still tagged @unimplemented are the integration-level ones its
+# unit harness cannot honestly bind.
 
 @migration @authz
 Feature: Moving an organization onto the grants projection
@@ -26,7 +27,7 @@ Feature: Moving an organization onto the grants projection
 
   # ═══ What it reads ════════════════════════════════════════════════════
 
-  @unit @unimplemented
+  @unit
   Scenario Outline: Every legacy table is a source of facts
     Given "org_acme" has <source>
     When the migration runs
@@ -43,14 +44,14 @@ Feature: Moving an organization onto the grants projection
       | a share link                  | a resource grant held by anyone     |
       | a project credential          | a project-scoped grant for that key |
 
-  @unit @unimplemented
+  @unit
   Scenario: Team membership is stated directly, not promoted first
     Given "org_acme" has team memberships with no matching role binding
     When the migration runs
     Then each membership is stated as a grant
     And no legacy role binding row is created for it
 
-  @unit @unimplemented
+  @unit
   Scenario: The organization member floor is stated once
     Given "org_acme" has a member holding no binding anywhere
     When the migration runs
@@ -65,14 +66,14 @@ Feature: Moving an organization onto the grants projection
 
   # ═══ How it runs ══════════════════════════════════════════════════════
 
-  @unit @unimplemented
+  @unit
   Scenario: The migration states its facts and checks once
     When the migration runs for "org_acme"
     Then it states every fact
     And it reads the projection once
     And it does not poll waiting for the projection
 
-  @unit @unimplemented
+  @unit
   Scenario: A projection that has not caught up holds the organization
     Given a pass that has stated every fact
     When the projection does not yet hold them
@@ -80,28 +81,28 @@ Feature: Moving an organization onto the grants projection
     And no error is logged
     And a later pass revisits it
 
-  @unit @unimplemented
+  @unit
   Scenario: A held organization names what is outstanding
     Given a pass whose projection is missing facts
     When the organization is reported
     Then the report names how many facts are outstanding
     And it names a sample of the outstanding ids
 
-  @unit @unimplemented
+  @unit
   Scenario: Re-running the migration states the same facts
     Given a pass that already ran for "org_acme"
     When it runs again against the same legacy rows
     Then every restated fact carries the id it carried before
     And no second copy of any fact is appended
 
-  @unit @unimplemented
+  @unit
   Scenario: A pass that failed partway is safe to repeat
     Given a pass that failed after stating some facts
     When the migration runs again
     Then the facts that landed append nothing
     And the facts that did not land append normally
 
-  @unit @unimplemented
+  @unit
   Scenario: A row deleted on the legacy side is revoked, not left behind
     Given a grant the migration stated whose legacy row has since been deleted
     When the migration runs again
@@ -142,7 +143,7 @@ Feature: Moving an organization onto the grants projection
     When the status lookup's cached answer expires
     Then its authorization writes go to the ledger, not the legacy tables
 
-  @unit @unimplemented
+  @unit
   Scenario: The check that precedes finalizing is proven, not assumed
     Given "org_acme" whose projection disagrees with the legacy path
     When the migration runs


### PR DESCRIPTION
## What

`registeredMigrations()` has returned nothing since the three-stage rollout was deleted (#7358) — the collapsed ADR-110 migration was designed but never written, so nothing migrates and no grants appear. This writes it.

The migration is three modules in `app-layer/authz/`:

- **`authz-engine.facts.ts`** — every legacy table translated into facts, pure. Bindings, custom roles and share links adopt their row ids; team memberships (stated directly, never promoted into binding rows, suppressed exactly where the legacy resolver suppresses its fallback — any binding covering the user at the scopes in play, group-held included; CUSTOM membership rows never stated, matching the resolver's own refusal), the org-member floor, the legacy-admin fallback, lite members and project credentials derive ids from content (`deriveGrantId`).
- **`authz-engine.check.ts`** — the proof over one projection read: missing/extra rows are `outstanding` (the fold has not caught up; a later pass revisits), present-but-disagreeing rows are named diffs. viewCount lag heals as outstanding; a budget that grew back is the named disagreement. Share tokens report as fingerprints, never in the clear.
- **`authz-engine.migration.ts`** — the `SystemMigration`: states facts (content-derived command ids, so a retried pass dedupes and a changed row appends), reconciles the deny direction across BOTH heads (non-resource and the RESOURCE tier — a deleted share link's bearer-token grant is revoked, filtered to migration-owned sources), repairs drift (built-in rekeys and whole-role redefines at today's business time, oscillation-safe ids), checks once, and returns `finalized` / held (`migrated`) with the outstanding count and named diffs in its report.

## Two latent bugs made real by registering a migration, both fixed

1. **The engine gate counted `migrated` as on-engine** (`engine-gate.ts`). `migrated` is the HELD state — the runner's contract and the ops page both promise a held organization behaves exactly as before. Only `finalized` switches now, and `legacy-grant-mint.ts`'s `CUTOVER_STATUSES` narrows to match: a held organization's writes are still imperative legacy rows, so there is no ledger era to date a key against.
2. **Compat writes minted legacy rows for migration facts** (`authz-grants-write.prisma.repository.ts`). Update-only for migration-owned sources now: an adopted row converges onto itself, a derived fact creates no binding row — the migration stays dark before an organization finalizes, by construction.

## Named, not repaired (deliberate, both fail toward less access)

- A derived fact whose head was revoked and whose legacy source came back holds with a `grant_revoked` diff; remediation is the operator's.
- A reassignment onto a `custom:<id>` key is not repaired (`changeGrantRole` clears `legacyRole`, so it could never converge); the proof names the disagreement.

## Spec

`specs/migration/authz-grants-rollout.feature`: ten `@unimplemented` scenarios bound (14/14 bound); the integration-level ones stay tagged until an integration harness can honestly observe them.

## Deployment Impact

None on deploy: the migration drives no organization until an operator enrolls one on the ops Migrations page (cloud), and `runsAutomaticallyOnSelfHosted` is `false` until cloud has soaked. Finalizing an enrolled organization changes who answers its permission checks — that action carries the typed operator confirmation, and rollback applies within the gate's 60-second cache window.

Follows #7358.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added migration of legacy authorization data to the authorization engine.
  * Added verification, reconciliation, retry, drift repair, and finalization checks.
  * Added support for migrating roles, grants, memberships, resource permissions, and share-link usage.
* **Behavior Changes**
  * Only organizations with a `finalized` migration status use the authorization engine; `migrated` remains on the legacy path.
* **Tests**
  * Expanded coverage for migration accuracy, retries, rollback, reconciliation, and cutover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->