### PR TITLE
feat(aigateway): serve ElevenLabs' own speech and text routes

### DIFF
--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -103,7 +103,7 @@ These routes need an ElevenLabs key on the virtual key. They carry that vendor's
 
 Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads are capped at 25 MB of audio, the same limit as `/v1/audio/transcriptions`; larger uploads get a `413` before any provider is contacted. Send a `cloud_storage_url` for a bigger file: ElevenLabs fetches it directly and the gateway never holds it.
 
-The gateway refuses asynchronous transcription. A truthy `webhook` part gets a `400` from the gateway itself, before ElevenLabs is contacted at all. That mode makes the vendor answer before it has transcribed anything, so the reply carries no duration and the call would be billed as free.
+The gateway refuses asynchronous transcription. A truthy `webhook` part gets a `400` from the gateway itself, before ElevenLabs is contacted at all, so no call is made and nothing is billed. The reason for the refusal is that the mode makes the vendor answer before it has transcribed anything: were the request forwarded, the reply would carry no duration and the transcription would meter as free.
 
 Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the Unicode characters of `text`, counted as characters rather than bytes so an accented or non-Latin script costs what it reads; transcription is billed by the audio duration ElevenLabs reports on its own answer. A call costs the same whichever of the two wires it arrives on.
 

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -101,11 +101,11 @@ audio = client.text_to_speech.convert(
 
 These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
 
-Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped at 26 MB, the same limit as `/v1/audio/transcriptions`; use `cloud_storage_url` for anything larger.
+Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads are capped at 25 MB of audio, the same limit as `/v1/audio/transcriptions`; larger uploads get a `413` before any provider is contacted. Send a `cloud_storage_url` for a bigger file: ElevenLabs fetches it directly and the gateway never holds it.
 
-Asynchronous transcription (`webhook=true`) returns `400`. The vendor answers that request before it has transcribed anything, so the call carries no duration and would bill nothing.
+The gateway refuses asynchronous transcription. A truthy `webhook` part gets a `400` from the gateway itself, before ElevenLabs is contacted at all. That mode makes the vendor answer before it has transcribed anything, so the reply carries no duration and the call would be billed as free.
 
-Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the characters of `text`, transcription by the duration the vendor reports. A call costs the same whichever of the two wires it arrives on.
+Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the Unicode characters of `text`, counted as characters rather than bytes so an accented or non-Latin script costs what it reads; transcription is billed by the audio duration ElevenLabs reports on its own answer. A call costs the same whichever of the two wires it arrives on.
 
 Streaming (`/v1/text-to-speech/{voice_id}/stream`) is not served yet.
 

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -1,6 +1,6 @@
 ---
 title: POST /v1/audio/*
-description: Text to speech and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
+description: Speech synthesis and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
 sidebarTitle: Audio (TTS + STT)
 ---
 
@@ -82,7 +82,7 @@ POST /v1/speech-to-text
 xi-api-key: vk-lw-<ULID>
 ```
 
-The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The model comes from `model_id`, and the virtual key's aliases and allowlist apply to it exactly as they do on every other route. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
+The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The one field the gateway changes is `model_id`: it is replaced with whatever the virtual key's aliases and allowlist resolve the name to, so `elevenlabs/eleven_flash_v2_5` and a key alias both reach the vendor as the bare model it knows. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
 
 ```python
 from elevenlabs import ElevenLabs
@@ -101,7 +101,9 @@ audio = client.text_to_speech.convert(
 
 These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
 
-Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped by the deployment's request size limit (32 MB by default); use `cloud_storage_url` for anything larger.
+Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped at 26 MB, the same limit as `/v1/audio/transcriptions`; use `cloud_storage_url` for anything larger.
+
+Asynchronous transcription (`webhook=true`) returns `400`. The vendor answers that request before it has transcribed anything, so the call carries no duration and would bill nothing.
 
 Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the characters of `text`, transcription by the duration the vendor reports. A call costs the same whichever of the two wires it arrives on.
 

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -99,7 +99,7 @@ audio = client.text_to_speech.convert(
 )
 ```
 
-These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
+These routes need the virtual key to reach an ElevenLabs provider. The vendor key itself lives on the organization's ElevenLabs provider row, never on the virtual key, so what matters is that the key's provider access still includes ElevenLabs. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them: a key that cannot reach ElevenLabs is refused rather than served by whichever provider it does hold.
 
 Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads are capped at 25 MB of audio, the same limit as `/v1/audio/transcriptions`; larger uploads get a `413` before any provider is contacted. Send a `cloud_storage_url` for a bigger file: ElevenLabs fetches it directly and the gateway never holds it.
 

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -1,6 +1,6 @@
 ---
 title: POST /v1/audio/*
-description: OpenAI-compatible text to speech and transcription through the LangWatch AI Gateway, for OpenAI and ElevenLabs voice models.
+description: Text to speech and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
 sidebarTitle: Audio (TTS + STT)
 ---
 
@@ -71,6 +71,41 @@ print(transcript.text)
 ```
 
 The response is the standard JSON transcript with `text`, plus whatever the provider reports (duration, segments, token usage).
+
+## ElevenLabs' own audio paths
+
+The two routes above take OpenAI's request shape. If your code already uses the ElevenLabs SDK, you do not have to rewrite it: the gateway also serves that vendor's own paths, so changing the base URL is the whole change.
+
+```
+POST /v1/text-to-speech/{voice_id}
+POST /v1/speech-to-text
+xi-api-key: vk-lw-<ULID>
+```
+
+The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The model comes from `model_id`, and the virtual key's aliases and allowlist apply to it exactly as they do on every other route. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
+
+```python
+from elevenlabs import ElevenLabs
+
+client = ElevenLabs(
+    base_url="https://gateway.langwatch.ai",
+    api_key="vk-lw-...",
+)
+audio = client.text_to_speech.convert(
+    voice_id="EXAVITQu4vr4xnSDxMaL",
+    text="Hello from the gateway.",
+    model_id="eleven_flash_v2_5",
+    output_format="mp3_44100_128",
+)
+```
+
+These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
+
+Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped by the deployment's request size limit (32 MB by default); use `cloud_storage_url` for anything larger.
+
+Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the characters of `text`, transcription by the duration the vendor reports. A call costs the same whichever of the two wires it arrives on.
+
+Streaming (`/v1/text-to-speech/{voice_id}/stream`) is not served yet.
 
 ## Observability and cost measures
 

--- a/docs/ai-gateway/api/audio.mdx
+++ b/docs/ai-gateway/api/audio.mdx
@@ -74,7 +74,7 @@ The response is the standard JSON transcript with `text`, plus whatever the prov
 
 ## ElevenLabs' own audio paths
 
-The two routes above take OpenAI's request shape. If your code already uses the ElevenLabs SDK, you do not have to rewrite it: the gateway also serves that vendor's own paths, so changing the base URL is the whole change.
+The two routes above take OpenAI's request shape. If your code already uses the ElevenLabs SDK, you do not have to rewrite it: the gateway also serves that vendor's own paths, so two settings are the whole change. Point the SDK's base URL at the gateway, and give it a LangWatch virtual key in place of your ElevenLabs key. Your ElevenLabs key stays where it belongs, configured once in **Settings → Model Providers**; an SDK still holding it will be rejected, because the gateway reads that header as a virtual key.
 
 ```
 POST /v1/text-to-speech/{voice_id}
@@ -82,7 +82,7 @@ POST /v1/speech-to-text
 xi-api-key: vk-lw-<ULID>
 ```
 
-The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The one field the gateway changes is `model_id`: it is replaced with whatever the virtual key's aliases and allowlist resolve the name to, so `elevenlabs/eleven_flash_v2_5` and a key alias both reach the vendor as the bare model it knows. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
+The virtual key goes in the `xi-api-key` header the SDK already sends, so no code changes. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The one field the gateway changes is `model_id`: it is replaced with whatever the virtual key's aliases and allowlist resolve the name to, so `elevenlabs/eleven_flash_v2_5` and a key alias both reach the vendor as the bare model it knows. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
 
 ```python
 from elevenlabs import ElevenLabs

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1532,7 +1532,7 @@ For additional help, contact us at [support@langwatch.ai](mailto:support@langwat
 
 ---
 title: POST /v1/audio/*
-description: OpenAI-compatible text to speech and transcription through the LangWatch AI Gateway, for OpenAI and ElevenLabs voice models.
+description: Text to speech and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
 sidebarTitle: Audio (TTS + STT)
 ---
 
@@ -1603,6 +1603,41 @@ print(transcript.text)
 ```
 
 The response is the standard JSON transcript with `text`, plus whatever the provider reports (duration, segments, token usage).
+
+## ElevenLabs' own audio paths
+
+The two routes above take OpenAI's request shape. If your code already uses the ElevenLabs SDK, you do not have to rewrite it: the gateway also serves that vendor's own paths, so changing the base URL is the whole change.
+
+```
+POST /v1/text-to-speech/{voice_id}
+POST /v1/speech-to-text
+xi-api-key: vk-lw-<ULID>
+```
+
+The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The model comes from `model_id`, and the virtual key's aliases and allowlist apply to it exactly as they do on every other route. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
+
+```python
+from elevenlabs import ElevenLabs
+
+client = ElevenLabs(
+    base_url="https://gateway.langwatch.ai",
+    api_key="vk-lw-...",
+)
+audio = client.text_to_speech.convert(
+    voice_id="EXAVITQu4vr4xnSDxMaL",
+    text="Hello from the gateway.",
+    model_id="eleven_flash_v2_5",
+    output_format="mp3_44100_128",
+)
+```
+
+These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
+
+Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped by the deployment's request size limit (32 MB by default); use `cloud_storage_url` for anything larger.
+
+Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the characters of `text`, transcription by the duration the vendor reports. A call costs the same whichever of the two wires it arrives on.
+
+Streaming (`/v1/text-to-speech/{voice_id}/stream`) is not served yet.
 
 ## Observability and cost measures
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1532,7 +1532,7 @@ For additional help, contact us at [support@langwatch.ai](mailto:support@langwat
 
 ---
 title: POST /v1/audio/*
-description: Text to speech and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
+description: Speech synthesis and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
 sidebarTitle: Audio (TTS + STT)
 ---
 
@@ -1614,7 +1614,7 @@ POST /v1/speech-to-text
 xi-api-key: vk-lw-<ULID>
 ```
 
-The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The model comes from `model_id`, and the virtual key's aliases and allowlist apply to it exactly as they do on every other route. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
+The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The one field the gateway changes is `model_id`: it is replaced with whatever the virtual key's aliases and allowlist resolve the name to, so `elevenlabs/eleven_flash_v2_5` and a key alias both reach the vendor as the bare model it knows. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
 
 ```python
 from elevenlabs import ElevenLabs
@@ -1633,7 +1633,9 @@ audio = client.text_to_speech.convert(
 
 These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
 
-Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped by the deployment's request size limit (32 MB by default); use `cloud_storage_url` for anything larger.
+Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped at 26 MB, the same limit as `/v1/audio/transcriptions`; use `cloud_storage_url` for anything larger.
+
+Asynchronous transcription (`webhook=true`) returns `400`. The vendor answers that request before it has transcribed anything, so the call carries no duration and would bill nothing.
 
 Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the characters of `text`, transcription by the duration the vendor reports. A call costs the same whichever of the two wires it arrives on.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1635,7 +1635,7 @@ These routes need an ElevenLabs key on the virtual key. They carry that vendor's
 
 Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads are capped at 25 MB of audio, the same limit as `/v1/audio/transcriptions`; larger uploads get a `413` before any provider is contacted. Send a `cloud_storage_url` for a bigger file: ElevenLabs fetches it directly and the gateway never holds it.
 
-The gateway refuses asynchronous transcription. A truthy `webhook` part gets a `400` from the gateway itself, before ElevenLabs is contacted at all. That mode makes the vendor answer before it has transcribed anything, so the reply carries no duration and the call would be billed as free.
+The gateway refuses asynchronous transcription. A truthy `webhook` part gets a `400` from the gateway itself, before ElevenLabs is contacted at all, so no call is made and nothing is billed. The reason for the refusal is that the mode makes the vendor answer before it has transcribed anything: were the request forwarded, the reply would carry no duration and the transcription would meter as free.
 
 Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the Unicode characters of `text`, counted as characters rather than bytes so an accented or non-Latin script costs what it reads; transcription is billed by the audio duration ElevenLabs reports on its own answer. A call costs the same whichever of the two wires it arrives on.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1631,7 +1631,7 @@ audio = client.text_to_speech.convert(
 )
 ```
 
-These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
+These routes need the virtual key to reach an ElevenLabs provider. The vendor key itself lives on the organization's ElevenLabs provider row, never on the virtual key, so what matters is that the key's provider access still includes ElevenLabs. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them: a key that cannot reach ElevenLabs is refused rather than served by whichever provider it does hold.
 
 Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads are capped at 25 MB of audio, the same limit as `/v1/audio/transcriptions`; larger uploads get a `413` before any provider is contacted. Send a `cloud_storage_url` for a bigger file: ElevenLabs fetches it directly and the gateway never holds it.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1606,7 +1606,7 @@ The response is the standard JSON transcript with `text`, plus whatever the prov
 
 ## ElevenLabs' own audio paths
 
-The two routes above take OpenAI's request shape. If your code already uses the ElevenLabs SDK, you do not have to rewrite it: the gateway also serves that vendor's own paths, so changing the base URL is the whole change.
+The two routes above take OpenAI's request shape. If your code already uses the ElevenLabs SDK, you do not have to rewrite it: the gateway also serves that vendor's own paths, so two settings are the whole change. Point the SDK's base URL at the gateway, and give it a LangWatch virtual key in place of your ElevenLabs key. Your ElevenLabs key stays where it belongs, configured once in **Settings → Model Providers**; an SDK still holding it will be rejected, because the gateway reads that header as a virtual key.
 
 ```
 POST /v1/text-to-speech/{voice_id}
@@ -1614,7 +1614,7 @@ POST /v1/speech-to-text
 xi-api-key: vk-lw-<ULID>
 ```
 
-The virtual key goes in the `xi-api-key` header the SDK already sends. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The one field the gateway changes is `model_id`: it is replaced with whatever the virtual key's aliases and allowlist resolve the name to, so `elevenlabs/eleven_flash_v2_5` and a key alias both reach the vendor as the bare model it knows. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
+The virtual key goes in the `xi-api-key` header the SDK already sends, so no code changes. Bodies, form parts and query parameters reach ElevenLabs as you wrote them, so voice settings, `output_format`, diarization, timestamp granularity and the rest keep working. The one field the gateway changes is `model_id`: it is replaced with whatever the virtual key's aliases and allowlist resolve the name to, so `elevenlabs/eleven_flash_v2_5` and a key alias both reach the vendor as the bare model it knows. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor would have used.
 
 ```python
 from elevenlabs import ElevenLabs

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1633,11 +1633,11 @@ audio = client.text_to_speech.convert(
 
 These routes need an ElevenLabs key on the virtual key. They carry that vendor's own request shape, so the gateway will not fall back to another provider for them.
 
-Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads through the gateway are capped at 26 MB, the same limit as `/v1/audio/transcriptions`; use `cloud_storage_url` for anything larger.
+Transcription accepts a `file` part, or a `cloud_storage_url` part for ElevenLabs to fetch the audio itself. Uploads are capped at 25 MB of audio, the same limit as `/v1/audio/transcriptions`; larger uploads get a `413` before any provider is contacted. Send a `cloud_storage_url` for a bigger file: ElevenLabs fetches it directly and the gateway never holds it.
 
-Asynchronous transcription (`webhook=true`) returns `400`. The vendor answers that request before it has transcribed anything, so the call carries no duration and would bill nothing.
+The gateway refuses asynchronous transcription. A truthy `webhook` part gets a `400` from the gateway itself, before ElevenLabs is contacted at all. That mode makes the vendor answer before it has transcribed anything, so the reply carries no duration and the call would be billed as free.
 
-Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the characters of `text`, transcription by the duration the vendor reports. A call costs the same whichever of the two wires it arrives on.
+Metering is the same as on the OpenAI-shaped routes: synthesis is billed by the Unicode characters of `text`, counted as characters rather than bytes so an accented or non-Latin script costs what it reads; transcription is billed by the audio duration ElevenLabs reports on its own answer. A call costs the same whichever of the two wires it arrives on.
 
 Streaming (`/v1/text-to-speech/{voice_id}/stream`) is not served yet.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -463,7 +463,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [POST /v1/chat/completions](https://langwatch.ai/docs/ai-gateway/api/chat-completions.md): OpenAI-compatible chat completions through the LangWatch AI Gateway.
 - [POST /v1/messages](https://langwatch.ai/docs/ai-gateway/api/messages.md): Anthropic-compatible Messages endpoint through the LangWatch AI Gateway.
 - [POST /v1/embeddings](https://langwatch.ai/docs/ai-gateway/api/embeddings.md): OpenAI-compatible embeddings endpoint through the LangWatch AI Gateway.
-- [POST /v1/audio/*](https://langwatch.ai/docs/ai-gateway/api/audio.md): OpenAI-compatible text to speech and transcription through the LangWatch AI Gateway, for OpenAI and ElevenLabs voice models.
+- [POST /v1/audio/*](https://langwatch.ai/docs/ai-gateway/api/audio.md): Text to speech and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
 - [Realtime voice](https://langwatch.ai/docs/ai-gateway/api/realtime.md): Mint a vendor session credential on a virtual key, so voice spend lands under a budget while the media socket runs client to vendor.
 - [GET /v1/models](https://langwatch.ai/docs/ai-gateway/api/models.md): List the models a virtual key can access through the LangWatch AI Gateway.
 - [Error Envelope](https://langwatch.ai/docs/ai-gateway/api/errors.md): OpenAI-compatible error shapes and a complete type enum.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -463,7 +463,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [POST /v1/chat/completions](https://langwatch.ai/docs/ai-gateway/api/chat-completions.md): OpenAI-compatible chat completions through the LangWatch AI Gateway.
 - [POST /v1/messages](https://langwatch.ai/docs/ai-gateway/api/messages.md): Anthropic-compatible Messages endpoint through the LangWatch AI Gateway.
 - [POST /v1/embeddings](https://langwatch.ai/docs/ai-gateway/api/embeddings.md): OpenAI-compatible embeddings endpoint through the LangWatch AI Gateway.
-- [POST /v1/audio/*](https://langwatch.ai/docs/ai-gateway/api/audio.md): Text to speech and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
+- [POST /v1/audio/*](https://langwatch.ai/docs/ai-gateway/api/audio.md): Speech synthesis and transcription through the LangWatch AI Gateway, on OpenAI's wire and on ElevenLabs' own.
 - [Realtime voice](https://langwatch.ai/docs/ai-gateway/api/realtime.md): Mint a vendor session credential on a virtual key, so voice spend lands under a budget while the media socket runs client to vendor.
 - [GET /v1/models](https://langwatch.ai/docs/ai-gateway/api/models.md): List the models a virtual key can access through the LangWatch AI Gateway.
 - [Error Envelope](https://langwatch.ai/docs/ai-gateway/api/errors.md): OpenAI-compatible error shapes and a complete type enum.

--- a/pkg/customertracebridge/emitter.go
+++ b/pkg/customertracebridge/emitter.go
@@ -590,8 +590,12 @@ func extractInputMessages(body []byte, reqType domain.RequestType) string {
 	case domain.RequestTypeSpeech:
 		// TTS: the synthesized text is the meaningful input. Rendered as a
 		// single user message so the trace viewer shows it like any chat.
-		if in := gjson.GetBytes(body, "input"); in.Exists() && in.String() != "" {
-			return fmt.Sprintf(`[{"role":"user","content":%s}]`, jsonString(in.String()))
+		// Two field names because two wires reach this shape: the OpenAI one
+		// calls it input, and ElevenLabs' own route calls it text.
+		for _, field := range []string{"input", "text"} {
+			if in := gjson.GetBytes(body, field); in.Exists() && in.String() != "" {
+				return fmt.Sprintf(`[{"role":"user","content":%s}]`, jsonString(in.String()))
+			}
 		}
 		return ""
 	default:

--- a/services/aigateway/adapters/httpapi/elevenlabs_audio_test.go
+++ b/services/aigateway/adapters/httpapi/elevenlabs_audio_test.go
@@ -199,6 +199,88 @@ func TestElevenLabsNativeTranscription_MissingModelNamesTheFormFieldThisRouteRea
 	assert.Contains(t, body, "/v1/speech-to-text")
 }
 
+// The branch that decides 400 against 200 at the HTTP boundary: this vendor
+// fetches a cloud_storage_url itself, so an upload with no file part is a
+// complete request rather than a missing one.
+func TestElevenLabsNativeTranscription_AcceptsACloudStorageURLWithNoFile(t *testing.T) {
+	var captured domain.Request
+	router := nativeAudioRouter(&captured, elevenLabsCred())
+
+	form, contentType := multipartBody(t, map[string]string{
+		"model_id":          "scribe_v1",
+		"cloud_storage_url": "https://example.test/clip.mp3",
+	}, "", "", nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.Transcription)
+	assert.Empty(t, captured.Transcription.File)
+	assert.Equal(t, "https://example.test/clip.mp3",
+		captured.Transcription.Params["cloud_storage_url"])
+}
+
+// @scenario "Asynchronous transcription is refused rather than billed at zero"
+func TestElevenLabsNativeTranscription_AsyncWebhookIsRefused(t *testing.T) {
+	// Every spelling a form part uses for true, because the one that slips
+	// through is the one that bills nothing.
+	for _, value := range []string{"true", "TRUE", "1", "yes", " on "} {
+		t.Run(value, func(t *testing.T) {
+			dispatched := false
+			router := buildRouter(
+				app.WithAuth(audioAuth(elevenLabsCred())),
+				app.WithProviders(&mockProvider{
+					dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+						dispatched = true
+						return successResponse(), nil
+					},
+				}),
+				app.WithModels(modelresolver.New()),
+				app.WithLogger(zap.NewNop()),
+			)
+
+			form, contentType := multipartBody(t, map[string]string{
+				"model_id": "scribe_v1",
+				"webhook":  value,
+			}, "file", "clip.wav", []byte("RIFF-fake-wav"))
+			req := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+			req.Header.Set("xi-api-key", "vk-lw-test")
+			req.Header.Set("Content-Type", contentType)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "webhook")
+			assert.False(t, dispatched,
+				"an async request carries no duration to bill, so it must not reach the vendor")
+		})
+	}
+}
+
+// A webhook part that is not asking for the async mode is just another form
+// field, and refusing it would break a caller that never opted in.
+func TestElevenLabsNativeTranscription_AFalseWebhookPartIsNotRefused(t *testing.T) {
+	var captured domain.Request
+	router := nativeAudioRouter(&captured, elevenLabsCred())
+
+	form, contentType := multipartBody(t, map[string]string{
+		"model_id": "scribe_v1",
+		"webhook":  "false",
+	}, "file", "clip.wav", []byte("RIFF-fake-wav"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.Transcription)
+	assert.Equal(t, "false", captured.Transcription.Params["webhook"])
+}
+
 func TestElevenLabsNativeTranscription_NoAudioAtAllIsRefused(t *testing.T) {
 	router := nativeAudioRouter(nil, elevenLabsCred())
 

--- a/services/aigateway/adapters/httpapi/elevenlabs_audio_test.go
+++ b/services/aigateway/adapters/httpapi/elevenlabs_audio_test.go
@@ -1,0 +1,300 @@
+package httpapi
+
+// The HTTP boundary of ElevenLabs' own audio routes: what an ElevenLabs SDK
+// sends, what the pipeline is handed, and what comes back.
+//
+// Binds specs/ai-gateway/audio-endpoints.feature.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/services/aigateway/adapters/modelresolver"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func elevenLabsCred() domain.Credential {
+	return domain.Credential{
+		ID: "cred-11labs", ProviderID: domain.ProviderElevenLabs, APIKey: "sk-11labs-test",
+	}
+}
+
+// nativeAudioRouter answers both native routes with vendor-shaped bodies.
+func nativeAudioRouter(capture *domain.Request, creds ...domain.Credential) http.Handler {
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, req *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			if capture != nil {
+				*capture = *req
+			}
+			if req.Type == domain.RequestTypeSpeech {
+				return &domain.Response{
+					Body:       []byte("ID3-fake-mp3-bytes"),
+					StatusCode: http.StatusOK,
+					Headers:    map[string]string{"Content-Type": "audio/mpeg"},
+					Usage:      domain.Usage{InputChars: 33},
+				}, nil
+			}
+			return &domain.Response{
+				Body:       []byte(`{"text":"hello","audio_duration_secs":1.99}`),
+				StatusCode: http.StatusOK,
+				Usage:      domain.Usage{AudioSeconds: 1.99},
+			}, nil
+		},
+	}
+	return buildRouter(
+		app.WithAuth(audioAuth(creds...)),
+		app.WithProviders(provider),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+}
+
+// @scenario "An ElevenLabs SDK reaches the native audio routes unchanged"
+func TestElevenLabsNativeSpeech_ForwardsVoiceQueryAndAudioBytes(t *testing.T) {
+	var captured domain.Request
+	router := nativeAudioRouter(&captured, elevenLabsCred())
+
+	body := `{"text":"Hello from the LangWatch gateway.","model_id":"eleven_flash_v2_5"}`
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL?output_format=mp3_44100_128",
+		strings.NewReader(body))
+	// The vendor's own auth header, so an ElevenLabs SDK needs only its base
+	// URL changed.
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ID3-fake-mp3-bytes", rec.Body.String(),
+		"the audio must reach the caller with no JSON envelope around it")
+	assert.Equal(t, "audio/mpeg", rec.Header().Get("Content-Type"))
+
+	assert.Equal(t, domain.RequestTypeSpeech, captured.Type)
+	require.NotNil(t, captured.ElevenLabs)
+	assert.Equal(t, "EXAVITQu4vr4xnSDxMaL", captured.ElevenLabs.VoiceID)
+	assert.Equal(t, "output_format=mp3_44100_128", captured.ElevenLabs.RawQuery)
+	assert.Equal(t, domain.ElevenLabsSpeechSurface(), captured.Surface)
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, "eleven_flash_v2_5", captured.Resolved.ModelID)
+}
+
+// A provider-prefixed spelling is rewritten into the vendor's own field, not
+// into the "model" field no ElevenLabs endpoint reads.
+func TestElevenLabsNativeSpeech_ResolvedModelLandsInModelId(t *testing.T) {
+	var captured domain.Request
+	router := nativeAudioRouter(&captured, elevenLabsCred())
+
+	body := `{"text":"Hi.","model_id":"elevenlabs/eleven_flash_v2_5"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/text-to-speech/voice_1", strings.NewReader(body))
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(captured.Body, &sent))
+	assert.Equal(t, "eleven_flash_v2_5", sent["model_id"])
+	assert.NotContains(t, sent, "model",
+		`a stray "model" field is not part of this vendor's wire and must not be invented`)
+}
+
+// A request that names no model still bills and gates against a model, so the
+// virtual key's allowlist applies to it exactly as it does to a stated one.
+func TestElevenLabsNativeSpeech_NoModelUsesTheVendorsOwnDefault(t *testing.T) {
+	var captured domain.Request
+	router := nativeAudioRouter(&captured, elevenLabsCred())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/text-to-speech/voice_1",
+		strings.NewReader(`{"text":"Hi."}`))
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, domain.ElevenLabsDefaultSpeechModel, captured.Resolved.ModelID)
+}
+
+func TestElevenLabsNativeSpeech_MissingTextIsRefusedBeforeAnyProvider(t *testing.T) {
+	dispatched := false
+	router := buildRouter(
+		app.WithAuth(audioAuth(elevenLabsCred())),
+		app.WithProviders(&mockProvider{
+			dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+				dispatched = true
+				return successResponse(), nil
+			},
+		}),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/text-to-speech/voice_1",
+		strings.NewReader(`{"model_id":"eleven_flash_v2_5"}`))
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "text")
+	assert.False(t, dispatched, "no provider may be contacted for a request that speaks nothing")
+}
+
+// @scenario "ElevenLabs' own transcription path reaches the vendor unchanged"
+func TestElevenLabsNativeTranscription_CarriesEveryVendorFormField(t *testing.T) {
+	var captured domain.Request
+	router := nativeAudioRouter(&captured, elevenLabsCred())
+
+	form, contentType := multipartBody(t, map[string]string{
+		"model_id":               "scribe_v1",
+		"diarize":                "true",
+		"timestamps_granularity": "word",
+	}, "file", "clip.wav", []byte("RIFF-fake-wav"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"text":"hello","audio_duration_secs":1.99}`, rec.Body.String())
+
+	assert.Equal(t, domain.RequestTypeTranscription, captured.Type)
+	assert.Equal(t, domain.ElevenLabsTranscriptionSurface(), captured.Surface)
+	require.NotNil(t, captured.Transcription)
+	assert.Equal(t, "RIFF-fake-wav", string(captured.Transcription.File))
+	assert.Equal(t, "clip.wav", captured.Transcription.Filename)
+	// Filtering to a known list would drop this vendor's settings the moment
+	// it adds one, on a route whose whole point is carrying them.
+	assert.Equal(t, "true", captured.Transcription.Params["diarize"])
+	assert.Equal(t, "word", captured.Transcription.Params["timestamps_granularity"])
+	require.NotNil(t, captured.Resolved)
+	assert.Equal(t, "scribe_v1", captured.Resolved.ModelID)
+}
+
+func TestElevenLabsNativeTranscription_MissingModelNamesTheFormFieldThisRouteReads(t *testing.T) {
+	router := nativeAudioRouter(nil, elevenLabsCred())
+
+	form, contentType := multipartBody(t, nil, "file", "clip.wav", []byte("RIFF-fake-wav"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "model_id",
+		"naming the OpenAI route's own field would send the caller to fix one this endpoint never reads")
+	assert.Contains(t, body, "/v1/speech-to-text")
+}
+
+func TestElevenLabsNativeTranscription_NoAudioAtAllIsRefused(t *testing.T) {
+	router := nativeAudioRouter(nil, elevenLabsCred())
+
+	form, contentType := multipartBody(t, map[string]string{"model_id": "scribe_v1"}, "", "", nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "cloud_storage_url")
+}
+
+// @scenario "A native ElevenLabs route refuses a key with no ElevenLabs credential"
+func TestElevenLabsNativeRoutes_RefuseAKeyWithNoElevenLabsCredential(t *testing.T) {
+	dispatched := false
+	// No ElevenLabs credential: the default bundle carries OpenAI only. The
+	// body is this vendor's own wire, so forwarding it to whichever provider
+	// the key does hold would spend a credential the caller never named on an
+	// API that cannot read the request.
+	router := buildRouter(
+		app.WithAuth(audioAuth()),
+		app.WithProviders(&mockProvider{
+			dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+				dispatched = true
+				return successResponse(), nil
+			},
+		}),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	speech := httptest.NewRequest(http.MethodPost, "/v1/text-to-speech/voice_1",
+		strings.NewReader(`{"text":"Hi.","model_id":"eleven_flash_v2_5"}`))
+	speech.Header.Set("xi-api-key", "vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, speech)
+	assert.GreaterOrEqual(t, rec.Code, 400)
+	assert.Contains(t, strings.ToLower(rec.Body.String()), "elevenlabs")
+
+	form, contentType := multipartBody(t, map[string]string{"model_id": "scribe_v1"},
+		"file", "clip.wav", []byte("RIFF-fake-wav"))
+	stt := httptest.NewRequest(http.MethodPost, "/v1/speech-to-text", form)
+	stt.Header.Set("xi-api-key", "vk-lw-test")
+	stt.Header.Set("Content-Type", contentType)
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, stt)
+	assert.GreaterOrEqual(t, rec.Code, 400)
+
+	assert.False(t, dispatched, "neither request may reach a provider the route does not name")
+}
+
+// @scenario "The virtual key's model allowlist applies"
+func TestElevenLabsNativeRoutes_ModelAllowlistApplies(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			b := testBundle()
+			b.Credentials = append(b.Credentials, elevenLabsCred())
+			b.Config.AllowedModels = []string{"eleven_flash_v2_5"}
+			return b, nil
+		},
+	}
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(&mockProvider{
+			dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+				return successResponse(), nil
+			},
+		}),
+		app.WithModels(modelresolver.New()),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/text-to-speech/voice_1",
+		strings.NewReader(`{"text":"Hi.","model_id":"eleven_multilingual_v2"}`))
+	req.Header.Set("xi-api-key", "vk-lw-test")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// The same status and code the chat endpoint returns for a disallowed model.
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "model_not_allowed")
+	assert.Contains(t, rec.Body.String(), "eleven_multilingual_v2")
+}
+
+// The router's own routing, so a missing route is told apart from a vendor
+// 404: chi answers an unmounted path in plain text with no gateway headers.
+func TestElevenLabsNativeRoutes_AreMounted(t *testing.T) {
+	router := nativeAudioRouter(nil, elevenLabsCred())
+
+	for _, path := range []string{"/v1/text-to-speech/voice_1", "/v1/speech-to-text"} {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(nil))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		assert.NotEqual(t, "404 page not found\n", rec.Body.String(),
+			"%s must be a mounted route, not chi's unrouted answer", path)
+	}
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -188,6 +188,13 @@ func NewRouter(deps RouterDeps) http.Handler {
 			// credential opens goes client to vendor and never comes here.
 			v1.Post("/realtime/client_secrets", openAIRealtimeSessionHandler(deps))
 			v1.Get("/convai/conversation/get-signed-url", elevenLabsSignedURLHandler(deps))
+			// ElevenLabs' own audio paths, mirrored for the same reason the
+			// mint above is: an ElevenLabs SDK reaches them by base URL alone,
+			// so a customer already using that SDK gets metering, budgets and
+			// traces without rewriting their calls into the OpenAI shape the
+			// /v1/audio routes take.
+			v1.Post("/text-to-speech/{voice_id}", elevenLabsSpeechHandler(deps))
+			v1.Post("/speech-to-text", elevenLabsTranscriptionHandler(deps))
 			// The OpenAI socket reports its usage to the client, not to us, so
 			// the client posts it back to close the session's spend record.
 			v1.Post("/realtime/sessions/{session_id}/usage", realtimeUsageHandler(deps))
@@ -609,6 +616,180 @@ func elevenLabsSignedURLHandler(deps RouterDeps) http.HandlerFunc {
 		setMetaHeaders(w, result.Meta)
 		writeJSONResponse(w, result.Response)
 	}
+}
+
+// maxElevenLabsSpeechBodyBytes caps a native synthesis body. The vendor's own
+// text limit is tens of thousands of characters, and the rest of the body is
+// voice settings, so a megabyte is far past any real request and well short of
+// a payload worth forwarding by mistake.
+const maxElevenLabsSpeechBodyBytes = 1 << 20
+
+// elevenLabsSpeechHandler terminates POST /v1/text-to-speech/{voice_id},
+// ElevenLabs' own synthesis path.
+//
+// The body reaches the vendor as the caller wrote it. Only the model is read
+// here, so the virtual key's aliases, allowlist, budgets and spend record all
+// apply to it, and the response is the vendor's audio bytes unchanged.
+func elevenLabsSpeechHandler(deps RouterDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bundle, ok := requireBundle(w, r, deps.Logger)
+		if !ok {
+			return
+		}
+		body, ok := readFullBody(deps.Logger, w, r, maxElevenLabsSpeechBodyBytes)
+		if !ok {
+			return
+		}
+		if gjson.GetBytes(body, "text").String() == "" {
+			writeError(deps.Logger, w, r.Context(), herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+				"message": `text is required: ElevenLabs synthesis takes the text to speak in a top-level "text" field`,
+				"fault":   "customer",
+			}))
+			return
+		}
+		// Absent means the vendor's own default, so the gateway names that
+		// model rather than leaving the request unmetered and ungated.
+		model := gjson.GetBytes(body, domain.ElevenLabsModelField).String()
+		if model == "" {
+			model = domain.ElevenLabsDefaultSpeechModel
+		}
+
+		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			return deps.App.HandleElevenLabsSpeech(r.Context(), bundle, app.ElevenLabsAudioDispatch{
+				Model: model,
+				Body:  body,
+				Route: domain.ElevenLabsAudioRequest{
+					VoiceID:  chi.URLParam(r, "voice_id"),
+					RawQuery: r.URL.RawQuery,
+				},
+			})
+		})
+		if err != nil {
+			writeError(deps.Logger, hw, r.Context(), err)
+			return
+		}
+		setMetaHeaders(hw, result.Meta)
+		writeJSONResponse(hw, result.Response)
+	}
+}
+
+// elevenLabsTranscriptionHandler terminates POST /v1/speech-to-text,
+// ElevenLabs' own transcription path.
+//
+// Multipart like the OpenAI-wire transcription route, and parsed here for the
+// same reason: this is the only layer holding the *http.Request. Every text
+// part is carried through to the vendor rather than filtered to a known list,
+// because on a route that mirrors a vendor's own path the caller's settings
+// are the request.
+func elevenLabsTranscriptionHandler(deps RouterDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bundle, ok := requireBundle(w, r, deps.Logger)
+		if !ok {
+			return
+		}
+		upload, ok := parseElevenLabsUpload(deps, w, r)
+		if !ok {
+			return
+		}
+		// Not defaulted: ElevenLabs has no default transcription model, so a
+		// request without one is incomplete and guessing would bill a model
+		// the caller never chose. An empty value is refused by the resolver,
+		// which is the one place that says where each surface names its model.
+		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			return deps.App.HandleElevenLabsTranscription(r.Context(), bundle, app.ElevenLabsAudioDispatch{
+				Model:  upload.Params[domain.ElevenLabsModelField],
+				Upload: upload,
+				Route:  domain.ElevenLabsAudioRequest{RawQuery: r.URL.RawQuery},
+			})
+		})
+		if err != nil {
+			writeError(deps.Logger, hw, r.Context(), err)
+			return
+		}
+		setMetaHeaders(hw, result.Meta)
+		writeJSONResponse(hw, result.Response)
+	}
+}
+
+// parseElevenLabsUpload reads the native transcription form into the shared
+// upload shape.
+//
+// The audio part is optional, because this vendor also accepts a
+// cloud_storage_url it fetches itself; a request with neither is refused here
+// rather than at the vendor. The size cap is the gateway's own request
+// ceiling: the vendor accepts far larger files through that URL, and a
+// multi-gigabyte upload through this process is not something to hold in
+// memory.
+func parseElevenLabsUpload(deps RouterDeps, w http.ResponseWriter, r *http.Request) (*domain.TranscriptionUpload, bool) {
+	if err := readElevenLabsForm(deps, w, r); err != nil {
+		writeError(deps.Logger, w, r.Context(), err)
+		return nil, false
+	}
+	upload, err := elevenLabsUploadFromForm(r)
+	if err != nil {
+		writeError(deps.Logger, w, r.Context(), err)
+		return nil, false
+	}
+	return upload, true
+}
+
+// readElevenLabsForm caps the body and parses the multipart envelope.
+func readElevenLabsForm(deps RouterDeps, w http.ResponseWriter, r *http.Request) error {
+	maxBytes := deps.MaxRequestBodyBytes
+	if maxBytes <= 0 {
+		maxBytes = config.DefaultMaxRequestBodyBytes
+	}
+	if err := prepareRequestBody(w, r, maxBytes); err != nil {
+		return err
+	}
+	// Memory threshold: parts up to 10 MB stay in memory, larger ones spill to
+	// a temp file ParseMultipartForm cleans up on r.Body close.
+	//nolint:gosec // G120: prepareRequestBody already wrapped r.Body in a MaxBytesReader at maxBytes
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		if bodyReadErrorCode(err) == domain.ErrPayloadTooLarge {
+			return herr.New(r.Context(), domain.ErrPayloadTooLarge, herr.M{
+				"message": fmt.Sprintf(
+					"the audio upload exceeds this gateway's %d byte request limit; "+
+						"send a cloud_storage_url part instead for a file this large", maxBytes),
+			})
+		}
+		return herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			"message": "malformed multipart/form-data body: " + err.Error(),
+		})
+	}
+	return nil
+}
+
+// elevenLabsUploadFromForm lifts the parsed form into the shared upload shape.
+func elevenLabsUploadFromForm(r *http.Request) (*domain.TranscriptionUpload, error) {
+	upload := &domain.TranscriptionUpload{Params: map[string]string{}}
+	if r.MultipartForm != nil {
+		for name, values := range r.MultipartForm.Value {
+			if len(values) > 0 {
+				upload.Params[name] = values[0]
+			}
+		}
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		if upload.Params["cloud_storage_url"] != "" {
+			return upload, nil
+		}
+		return nil, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			"message": `missing audio: send a "file" part, or a "cloud_storage_url" part for the provider to fetch`,
+			"fault":   "customer",
+		})
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			"message": "failed reading uploaded file: " + err.Error(),
+		})
+	}
+	upload.File = data
+	upload.Filename = header.Filename
+	return upload, nil
 }
 
 // maxRealtimeUsageBodyBytes caps a usage report. It is one usage object.

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -624,6 +624,17 @@ func elevenLabsSignedURLHandler(deps RouterDeps) http.HandlerFunc {
 // a payload worth forwarding by mistake.
 const maxElevenLabsSpeechBodyBytes = 1 << 20
 
+// maxElevenLabsUploadBytes caps a native transcription upload, at the same
+// 26 MB the OpenAI-wire transcription route uses so the two audio routes agree.
+//
+// It is its own constant rather than the gateway-wide request ceiling because
+// this upload is held in memory twice: once as the parsed file, and again in
+// the multipart body rebuilt for the vendor, for as long as the vendor call
+// runs. The vendor accepts far larger files, and a caller who has one sends a
+// cloud_storage_url part instead, which ElevenLabs fetches itself and which
+// costs this process nothing.
+const maxElevenLabsUploadBytes = maxTranscriptionBodyBytes
+
 // elevenLabsSpeechHandler terminates POST /v1/text-to-speech/{voice_id},
 // ElevenLabs' own synthesis path.
 //
@@ -721,7 +732,7 @@ func elevenLabsTranscriptionHandler(deps RouterDeps) http.HandlerFunc {
 // multi-gigabyte upload through this process is not something to hold in
 // memory.
 func parseElevenLabsUpload(deps RouterDeps, w http.ResponseWriter, r *http.Request) (*domain.TranscriptionUpload, bool) {
-	if err := readElevenLabsForm(deps, w, r); err != nil {
+	if err := readElevenLabsForm(w, r); err != nil {
 		writeError(deps.Logger, w, r.Context(), err)
 		return nil, false
 	}
@@ -734,11 +745,8 @@ func parseElevenLabsUpload(deps RouterDeps, w http.ResponseWriter, r *http.Reque
 }
 
 // readElevenLabsForm caps the body and parses the multipart envelope.
-func readElevenLabsForm(deps RouterDeps, w http.ResponseWriter, r *http.Request) error {
-	maxBytes := deps.MaxRequestBodyBytes
-	if maxBytes <= 0 {
-		maxBytes = config.DefaultMaxRequestBodyBytes
-	}
+func readElevenLabsForm(w http.ResponseWriter, r *http.Request) error {
+	maxBytes := int64(maxElevenLabsUploadBytes)
 	if err := prepareRequestBody(w, r, maxBytes); err != nil {
 		return err
 	}
@@ -749,7 +757,7 @@ func readElevenLabsForm(deps RouterDeps, w http.ResponseWriter, r *http.Request)
 		if bodyReadErrorCode(err) == domain.ErrPayloadTooLarge {
 			return herr.New(r.Context(), domain.ErrPayloadTooLarge, herr.M{
 				"message": fmt.Sprintf(
-					"the audio upload exceeds this gateway's %d byte request limit; "+
+					"the audio upload exceeds this gateway's %d byte limit; "+
 						"send a cloud_storage_url part instead for a file this large", maxBytes),
 			})
 		}
@@ -762,16 +770,14 @@ func readElevenLabsForm(deps RouterDeps, w http.ResponseWriter, r *http.Request)
 
 // elevenLabsUploadFromForm lifts the parsed form into the shared upload shape.
 func elevenLabsUploadFromForm(r *http.Request) (*domain.TranscriptionUpload, error) {
-	upload := &domain.TranscriptionUpload{Params: map[string]string{}}
-	if r.MultipartForm != nil {
-		for name, values := range r.MultipartForm.Value {
-			if len(values) > 0 {
-				upload.Params[name] = values[0]
-			}
-		}
+	upload := &domain.TranscriptionUpload{Params: elevenLabsFormValues(r)}
+	if err := refuseElevenLabsAsyncTranscription(r, upload.Params); err != nil {
+		return nil, err
 	}
 	file, header, err := r.FormFile("file")
 	if err != nil {
+		// No audio uploaded is a complete request when the caller named a
+		// cloud_storage_url, which this vendor fetches itself.
 		if upload.Params["cloud_storage_url"] != "" {
 			return upload, nil
 		}
@@ -790,6 +796,62 @@ func elevenLabsUploadFromForm(r *http.Request) (*domain.TranscriptionUpload, err
 	upload.File = data
 	upload.Filename = header.Filename
 	return upload, nil
+}
+
+// elevenLabsFormValues collects every text part the caller sent. They are all
+// carried through rather than filtered to a known list, because on a route
+// that mirrors a vendor's own path the caller's settings are the request, and
+// an allowlist goes stale the moment the vendor adds a parameter.
+func elevenLabsFormValues(r *http.Request) map[string]string {
+	values := map[string]string{}
+	if r.MultipartForm == nil {
+		return values
+	}
+	for name, part := range r.MultipartForm.Value {
+		if len(part) > 0 {
+			values[name] = part[0]
+		}
+	}
+	return values
+}
+
+// refuseElevenLabsAsyncTranscription rejects the vendor's own asynchronous
+// mode on this route.
+//
+// With a webhook part, ElevenLabs answers before it has transcribed anything
+// and delivers the result to a workspace webhook later. That first answer
+// carries no duration and no word timings, so the call would confirm its spend
+// record at zero seconds and bill nothing for audio the customer was charged
+// for. The gateway has no settlement path for those deliveries either: the
+// existing /v1/convai/webhook relay is for Conversational AI post-call
+// reports, which are a different payload keyed on a different id.
+//
+// Refusing says so, rather than billing zero and looking like it worked. The
+// synchronous request the caller can send instead is the one line of the fix.
+func refuseElevenLabsAsyncTranscription(r *http.Request, params map[string]string) error {
+	// The vendor names this parameter "webhook" and reports it back as
+	// `"param": "webhook"` on its own validation errors (measured against the
+	// live API, 2026-08-21). Any truthy spelling is refused, because the
+	// spelling that gets through is the one that bills nothing.
+	if value, ok := params["webhook"]; !ok || !isTruthyFormValue(value) {
+		return nil
+	}
+	return herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+		"message": "webhook=true is not supported on this gateway route: the vendor answers " +
+			"before it has transcribed anything, so the call carries no duration to bill. " +
+			"Send the request without the webhook part and read the transcript from the response",
+		"fault": "customer",
+	})
+}
+
+// isTruthyFormValue reads a boolean the way a form part spells one.
+func isTruthyFormValue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // maxRealtimeUsageBodyBytes caps a usage report. It is one usage object.

--- a/services/aigateway/adapters/modelresolver/resolver.go
+++ b/services/aigateway/adapters/modelresolver/resolver.go
@@ -53,10 +53,29 @@ const fallbackMissingModelMessage = `this request names no model. Supply one the
 	`expects: a top-level "model" field in the JSON body on the completion endpoints, a "model" form ` +
 	`part on /v1/audio/transcriptions, or the model in the URL path on the Gemini surface`
 
+// missingModelSurfaceMessages says where a route that mirrors a vendor's own
+// path names the model, for the routes whose request type is shared with a
+// translated route and so cannot be told apart by type alone. ElevenLabs'
+// transcription path takes the same multipart shape as /v1/audio/transcriptions
+// but reads a different form part, and naming the wrong one sends the caller
+// to fix a field the endpoint does not read.
+var missingModelSurfaceMessages = map[string]string{
+	domain.ElevenLabsTranscriptionSurface().Name: `POST /v1/speech-to-text sends a multipart/form-data body ` +
+		`and takes the model from a "` + domain.ElevenLabsModelField + `" form field, not from JSON. Add one ` +
+		`naming the model or the virtual key's alias for it, for example "scribe_v1", alongside the audio`,
+}
+
 // missingModelMessage returns the rejection wording for the surface the
-// request arrived on.
-func missingModelMessage(requestType domain.RequestType) string {
-	if message, ok := missingModelMessages[requestType]; ok {
+// request arrived on. A route carrying a vendor's own wire answers first,
+// because its request type is shared with the translated route it mirrors.
+func missingModelMessage(req *domain.Request) string {
+	if req == nil {
+		return fallbackMissingModelMessage
+	}
+	if message, ok := missingModelSurfaceMessages[req.InboundSurface().Name]; ok {
+		return message
+	}
+	if message, ok := missingModelMessages[req.Type]; ok {
 		return message
 	}
 	return fallbackMissingModelMessage
@@ -83,7 +102,7 @@ func (r *Resolver) Resolve(ctx context.Context, req *domain.Request, config doma
 		// errProviderNotAllowed states it: a malformed body is the caller's
 		// to fix, and an unannotated rejection reads as a platform problem.
 		return nil, herr.New(ctx, domain.ErrMissingModel, herr.M{
-			"message":      missingModelMessage(requestType),
+			"message":      missingModelMessage(req),
 			"fault":        "customer",
 			"request_type": string(requestType),
 		})

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -75,6 +75,11 @@ type BifrostRouter struct {
 	// the customer's provider key in a header Go does not strip across
 	// hosts.
 	realtimeClient *http.Client
+	// elevenLabsClient serves the two ElevenLabs-native audio routes, which
+	// Bifrost cannot forward. Its own client for the same reasons as the mint
+	// above, with the gateway-wide provider timeout because synthesis and
+	// transcription are real work rather than a mint.
+	elevenLabsClient *http.Client
 }
 
 // BifrostOptions configures the bifrost router.
@@ -150,6 +155,8 @@ func NewBifrostRouter(ctx context.Context, opts BifrostOptions) (*BifrostRouter,
 		codexRefresher:  opts.CodexRefresher,
 		codexBackendURL: codexURL,
 		realtimeClient:  newRealtimeClient(endpointPolicy),
+
+		elevenLabsClient: newElevenLabsAudioClient(endpointPolicy),
 	}, nil
 }
 
@@ -207,6 +214,17 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 	// provider mapping because the route already named the vendor.
 	if req.Type == domain.RequestTypeRealtimeSession {
 		return r.dispatchRealtimeSession(ctx, req, cred)
+	}
+
+	// ElevenLabs' own audio paths carry that vendor's wire, which Bifrost's
+	// ElevenLabs provider answers with an unsupported-operation error, so the
+	// gateway calls the vendor itself. The route pinned the provider, so the
+	// credential here is already an ElevenLabs one.
+	if elevenLabsNativeRoute(req) {
+		if req.Type == domain.RequestTypeTranscription {
+			return r.dispatchElevenLabsTranscription(ctx, req, cred)
+		}
+		return r.dispatchElevenLabsSpeech(ctx, req, cred)
 	}
 
 	model := req.Model

--- a/services/aigateway/adapters/providers/elevenlabs.go
+++ b/services/aigateway/adapters/providers/elevenlabs.go
@@ -1,0 +1,382 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// ElevenLabs' own audio wire. Bifrost's ElevenLabs provider answers
+// Passthrough with an unsupported-operation error, so these two routes call
+// the vendor over plain HTTP the way the session mint does: one bounded
+// request, the caller's body forwarded as written, the vendor's own answer
+// forwarded back.
+
+const (
+	// elevenLabsTextToSpeechPath takes the voice id as its last segment.
+	elevenLabsTextToSpeechPath = "/v1/text-to-speech/"
+	elevenLabsSpeechToTextPath = "/v1/speech-to-text"
+
+	// elevenLabsAudioMaxResponseBytes caps a synthesis answer. Ten minutes of
+	// mp3 is under 10 MiB, so this leaves room for the longest text the vendor
+	// accepts and still refuses a body that is a wrong endpoint rather than
+	// audio.
+	elevenLabsAudioMaxResponseBytes = 32 << 20
+
+	// elevenLabsSTTFileField is the multipart part the vendor reads the audio
+	// from. It is rebuilt rather than forwarded because the router already
+	// consumed the inbound form.
+	elevenLabsSTTFileField = "file"
+)
+
+// newElevenLabsAudioClient builds the client for the native audio routes.
+// Redirects are never followed and every resolved address is re-checked
+// against the endpoint policy at dial time, for the reason the mint client
+// gives: the request carries the customer's provider key in a header Go does
+// not strip across hosts. The timeout is the gateway-wide provider ceiling,
+// because synthesis and transcription are real work rather than a mint.
+func newElevenLabsAudioClient(policy customerEndpointPolicy) *http.Client {
+	timeout := ProviderRequestTimeoutSeconds * time.Second
+	dialer := policyDialer(policy, timeout)
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{DialContext: dialer.DialContext},
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// fallbackElevenLabsAudioClient serves a zero-value router, which only tests
+// build: NewBifrostRouter always sets elevenLabsClient.
+var fallbackElevenLabsAudioClient = func() func(customerEndpointPolicy) *http.Client {
+	var (
+		once   sync.Once
+		client *http.Client
+	)
+	return func(policy customerEndpointPolicy) *http.Client {
+		once.Do(func() { client = newElevenLabsAudioClient(policy) })
+		return client
+	}
+}()
+
+// dispatchElevenLabsSpeech posts the caller's own synthesis body to
+// ElevenLabs and returns the audio bytes verbatim.
+//
+// The body is the caller's, forwarded as they wrote it apart from the model
+// id, which the resolver already rewrote to what the virtual key's aliases
+// and allowlist settled on. Voice settings, language, seed, the
+// previous/next text fields and everything else are theirs and reach the
+// vendor untouched.
+func (r *BifrostRouter) dispatchElevenLabsSpeech(
+	ctx context.Context,
+	req *domain.Request,
+	cred domain.Credential,
+) (*domain.Response, error) {
+	route := req.ElevenLabs
+	if route == nil || route.VoiceID == "" {
+		return nil, herr.New(ctx, domain.ErrBadRequest, herr.M{
+			"message": "voice_id is required: ElevenLabs synthesis names the voice in the URL path",
+			"fault":   "customer",
+		})
+	}
+	endpoint := elevenLabsAudioEndpoint(
+		cred, elevenLabsTextToSpeechPath+url.PathEscape(route.VoiceID), route.RawQuery)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(req.Body))
+	if err != nil {
+		return nil, herr.New(ctx, domain.ErrProviderError, herr.M{"reason": err.Error()})
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("xi-api-key", cred.APIKey)
+
+	resp, err := r.doElevenLabsAudio(ctx, httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return resp, nil
+	}
+	resp.Usage = domain.Usage{InputChars: elevenLabsSynthesizedChars(req.Body)}
+	return resp, nil
+}
+
+// dispatchElevenLabsTranscription posts the caller's audio to ElevenLabs and
+// returns the transcript JSON verbatim.
+//
+// The form is rebuilt rather than relayed because the router already parsed
+// the inbound one to reach the model. Every text part the caller sent is
+// carried over as written, so this vendor's own settings (diarization,
+// timestamp granularity, language, additional formats) keep working; only
+// the model part is replaced, with what the virtual key resolved.
+func (r *BifrostRouter) dispatchElevenLabsTranscription(
+	ctx context.Context,
+	req *domain.Request,
+	cred domain.Credential,
+) (*domain.Response, error) {
+	model := elevenLabsDispatchModel(req)
+	upload := req.Transcription
+	if upload == nil {
+		return nil, herr.New(ctx, domain.ErrInternal, herr.M{
+			"message": "the ElevenLabs transcription dispatch reached the provider router with no upload",
+			"fault":   "gateway",
+		})
+	}
+	form, contentType, err := elevenLabsTranscriptionForm(upload, model)
+	if err != nil {
+		return nil, herr.New(ctx, domain.ErrInternal, herr.M{
+			"message": "the transcription upload could not be re-encoded for the provider",
+			"fault":   "gateway",
+		}, err)
+	}
+
+	rawQuery := ""
+	if req.ElevenLabs != nil {
+		rawQuery = req.ElevenLabs.RawQuery
+	}
+	endpoint := elevenLabsAudioEndpoint(cred, elevenLabsSpeechToTextPath, rawQuery)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(form))
+	if err != nil {
+		return nil, herr.New(ctx, domain.ErrProviderError, herr.M{"reason": err.Error()})
+	}
+	httpReq.Header.Set("Content-Type", contentType)
+	httpReq.Header.Set("xi-api-key", cred.APIKey)
+
+	resp, err := r.doElevenLabsAudio(ctx, httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return resp, nil
+	}
+	resp.Usage = domain.Usage{AudioSeconds: elevenLabsTranscribedSeconds(resp.Body)}
+	return resp, nil
+}
+
+// elevenLabsTranscriptionForm rebuilds the multipart body the vendor reads.
+// The model part carries the resolved id, so an alias or a provider-prefixed
+// spelling reaches the vendor as the bare model it names. The audio part is
+// written only when the caller uploaded bytes: this vendor also accepts a
+// cloud_storage_url it fetches itself, which arrives as one more text part.
+func elevenLabsTranscriptionForm(upload *domain.TranscriptionUpload, model string) ([]byte, string, error) {
+	buf := &bytes.Buffer{}
+	w := multipart.NewWriter(buf)
+	if err := writeElevenLabsTextParts(w, upload.Params, model); err != nil {
+		return nil, "", err
+	}
+	if err := writeElevenLabsAudioPart(w, upload); err != nil {
+		return nil, "", err
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), w.FormDataContentType(), nil
+}
+
+// writeElevenLabsTextParts carries the caller's own settings over and states
+// the resolved model in place of whatever spelling they wrote.
+func writeElevenLabsTextParts(w *multipart.Writer, params map[string]string, model string) error {
+	for name, value := range params {
+		if name == domain.ElevenLabsModelField {
+			continue
+		}
+		if err := w.WriteField(name, value); err != nil {
+			return err
+		}
+	}
+	if model == "" {
+		return nil
+	}
+	return w.WriteField(domain.ElevenLabsModelField, model)
+}
+
+// writeElevenLabsAudioPart adds the uploaded audio, and nothing at all when
+// the caller named a cloud_storage_url for the vendor to fetch instead.
+func writeElevenLabsAudioPart(w *multipart.Writer, upload *domain.TranscriptionUpload) error {
+	if len(upload.File) == 0 {
+		return nil
+	}
+	filename := upload.Filename
+	if filename == "" {
+		filename = "audio"
+	}
+	part, err := w.CreateFormFile(elevenLabsSTTFileField, filename)
+	if err != nil {
+		return err
+	}
+	_, err = part.Write(upload.File)
+	return err
+}
+
+// elevenLabsSynthesizedChars measures what a synthesis call is priced by.
+// ElevenLabs bills speech per character of the text it spoke, and the catalog
+// carries a per-character rate, so the count is of the request's own text.
+//
+// Counted in runes, the same measure the OpenAI-wire speech route reports, so
+// the identical call bills the same on either wire.
+//
+// The vendor also states a character-cost response header, and that is
+// deliberately not used: it is credits under the account's own plan, not
+// characters, and it already carries the model's price factor (the same text
+// reported 18 on eleven_multilingual_v2 and 9 on eleven_flash_v2_5, measured
+// 2026-08-21). Rating credits at a per-character rate would apply that factor
+// twice.
+func elevenLabsSynthesizedChars(body []byte) int {
+	return utf8.RuneCountInString(gjson.GetBytes(body, "text").String())
+}
+
+// elevenLabsTranscribedSeconds measures what a transcription call is priced
+// by: the duration of the audio, which the vendor states on its answer as
+// audio_duration_secs.
+//
+// The word timings are the fallback for a response that carries no duration,
+// including the multi-channel shape that nests its transcripts. They end at
+// the last spoken word rather than at the end of the file, so they under-
+// measure any audio with trailing silence; the stated duration is preferred
+// wherever it exists for exactly that reason.
+func elevenLabsTranscribedSeconds(body []byte) float64 {
+	if stated := gjson.GetBytes(body, "audio_duration_secs"); stated.Exists() {
+		if seconds := stated.Float(); seconds > 0 {
+			return seconds
+		}
+	}
+	longest := 0.0
+	for _, path := range []string{"words.#.end", "transcripts.#.words.#.end"} {
+		gjson.GetBytes(body, path).ForEach(func(_, value gjson.Result) bool {
+			if value.IsArray() {
+				value.ForEach(func(_, inner gjson.Result) bool {
+					longest = max(longest, inner.Float())
+					return true
+				})
+				return true
+			}
+			longest = max(longest, value.Float())
+			return true
+		})
+	}
+	return longest
+}
+
+// elevenLabsAudioEndpoint resolves the vendor host for this credential and
+// re-attaches the caller's query. A customer on a residency endpoint stores
+// it as the provider's base URL, and calling the default host would send
+// their audio to the wrong region.
+func elevenLabsAudioEndpoint(cred domain.Credential, path, rawQuery string) string {
+	endpoint := realtimeEndpoint(cred, elevenLabsRealtimeDefaultBaseURL, path)
+	if rawQuery != "" {
+		endpoint += "?" + rawQuery
+	}
+	return endpoint
+}
+
+// doElevenLabsAudio performs the vendor call and shapes the answer. A vendor
+// error is returned as a success-shaped Response carrying the upstream status
+// and native body, the same contract the other raw-forward lanes use, so the
+// caller sees the vendor's own words and the retry walk classifies the status
+// itself.
+func (r *BifrostRouter) doElevenLabsAudio(
+	ctx context.Context,
+	httpReq *http.Request,
+) (*domain.Response, error) {
+	client := r.elevenLabsClient
+	if client == nil {
+		client = fallbackElevenLabsAudioClient(r.endpointPolicy)
+	}
+	httpResp, err := client.Do(httpReq) //nolint:gosec // vetted by the endpoint policy at dispatch and again at dial time
+	if err != nil {
+		return nil, herr.New(ctx, domain.ErrProviderError, herr.M{
+			"reason": "the ElevenLabs audio request failed: " + err.Error(),
+			"fault":  "provider",
+		})
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	// One byte past the cap, so a truncated answer is distinguishable from
+	// one that exactly fills it. Forwarding truncated audio under the
+	// vendor's 200 would hand the caller a file that will not play.
+	raw, err := io.ReadAll(io.LimitReader(httpResp.Body, elevenLabsAudioMaxResponseBytes+1))
+	if err != nil {
+		return nil, herr.New(ctx, domain.ErrProviderError, herr.M{
+			"reason": "the ElevenLabs audio response could not be read: " + err.Error(),
+			"fault":  "provider",
+		})
+	}
+	if len(raw) > elevenLabsAudioMaxResponseBytes {
+		return nil, herr.New(ctx, domain.ErrProviderError, herr.M{
+			"reason": fmt.Sprintf(
+				"the ElevenLabs audio response exceeded %d bytes", elevenLabsAudioMaxResponseBytes),
+			"fault": "provider",
+		})
+	}
+	return &domain.Response{
+		Body:       raw,
+		StatusCode: httpResp.StatusCode,
+		Headers:    elevenLabsResponseHeaders(httpResp.Header),
+	}, nil
+}
+
+// elevenLabsResponseHeaders keeps the headers a caller needs and drops the
+// ones that describe a body this hop re-frames.
+//
+// Content-Type is what tells an SDK whether it holds mp3, PCM or the
+// transcript JSON, so it must survive; the audio format is the caller's own
+// query parameter and the answer has to say which one it got. The vendor's
+// request-id and its concurrency counters ride along because a customer
+// debugging with ElevenLabs support needs the id the vendor logged, and a
+// client backing off needs to see its own limit. Content-Length is dropped
+// for the reason the passthrough lane drops it.
+func elevenLabsResponseHeaders(h http.Header) map[string]string {
+	forward := []string{
+		"Content-Type",
+		"Request-Id",
+		"History-Item-Id",
+		"Current-Concurrent-Requests",
+		"Maximum-Concurrent-Requests",
+		"Retry-After",
+	}
+	out := make(map[string]string, len(forward))
+	for _, name := range forward {
+		if v := h.Get(name); v != "" {
+			out[name] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// elevenLabsNativeRoute reports whether this request arrived on one of
+// ElevenLabs' own audio paths, which is what sends it to the vendor directly
+// instead of through Bifrost.
+func elevenLabsNativeRoute(req *domain.Request) bool {
+	return req != nil && req.ElevenLabs != nil
+}
+
+// elevenLabsDispatchModel is the bare model id to send the vendor. Resolution
+// already returns the bare form, so the prefix strip only guards the path
+// where nothing resolved and the caller's own spelling is all there is.
+func elevenLabsDispatchModel(req *domain.Request) string {
+	model := req.Model
+	if req.Resolved != nil {
+		model = req.Resolved.ModelID
+	}
+	if _, bare, found := strings.Cut(model, "/"); found {
+		return bare
+	}
+	return model
+}

--- a/services/aigateway/adapters/providers/elevenlabs_test.go
+++ b/services/aigateway/adapters/providers/elevenlabs_test.go
@@ -1,0 +1,252 @@
+package providers
+
+// The ElevenLabs-native audio dispatch: what reaches the vendor, what comes
+// back, and the quantity each route is metered by.
+//
+// Binds specs/ai-gateway/audio-endpoints.feature.
+
+import (
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func elevenLabsAudioRouter(server *httptest.Server) *BifrostRouter {
+	return &BifrostRouter{elevenLabsClient: server.Client()}
+}
+
+// @scenario "ElevenLabs' own synthesis path reaches the vendor unchanged"
+func TestElevenLabsSpeechForwardsTheCallersBodyAndMetersCharacters(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotQuery, gotKey, gotContentType string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		gotKey, gotContentType = r.Header.Get("xi-api-key"), r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("Request-Id", "vendor_req_1")
+		// The vendor states credits under the account's plan here, which is
+		// not a character count. Present so the assertion below proves it is
+		// ignored.
+		w.Header().Set("character-cost", "9")
+		_, _ = w.Write([]byte("ID3-fake-mp3-bytes"))
+	}))
+	defer server.Close()
+
+	body := []byte(`{"text":"Olá, mundo","model_id":"eleven_flash_v2_5","voice_settings":{"speed":1.1}}`)
+	req := &domain.Request{
+		Type:       domain.RequestTypeSpeech,
+		Model:      "eleven_flash_v2_5",
+		Body:       body,
+		ElevenLabs: &domain.ElevenLabsAudioRequest{VoiceID: "voice 9", RawQuery: "output_format=mp3_44100_128"},
+		Surface:    domain.ElevenLabsSpeechSurface(),
+	}
+	resp, err := elevenLabsAudioRouter(server).dispatchElevenLabsSpeech(
+		context.Background(), req, elevenLabsCredential(server))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1/text-to-speech/voice 9", gotPath,
+		"the voice is a path segment, so a space in it must be escaped rather than dropped")
+	assert.Equal(t, "output_format=mp3_44100_128", gotQuery,
+		"this vendor takes the audio format in the query, so dropping it returns a format nobody asked for")
+	assert.Equal(t, "xi-secret", gotKey)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.JSONEq(t, string(body), string(gotBody),
+		"the caller's own voice settings must reach the vendor untouched")
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ID3-fake-mp3-bytes", string(resp.Body))
+	assert.Equal(t, "audio/mpeg", resp.Headers["Content-Type"])
+	assert.Equal(t, "vendor_req_1", resp.Headers["Request-Id"])
+	// Ten runes, not eleven bytes: "Olá, mundo" carries a two-byte á, and the
+	// OpenAI-wire route counts runes too, so the same call bills the same on
+	// either wire.
+	assert.Equal(t, 10, resp.Usage.InputChars)
+	assert.Zero(t, resp.Usage.AudioSeconds)
+}
+
+// @scenario "ElevenLabs' own transcription path reaches the vendor unchanged"
+func TestElevenLabsTranscriptionRebuildsTheFormAndMetersDuration(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotKey string
+	gotFields := map[string]string{}
+	var gotFile []byte
+	var gotFilename string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotKey = r.URL.Path, r.Header.Get("xi-api-key")
+		_, params, parseErr := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if !assert.NoError(t, parseErr) {
+			return
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, partErr := reader.NextPart()
+			if partErr != nil {
+				break
+			}
+			data, _ := io.ReadAll(part)
+			if part.FileName() != "" {
+				gotFile, gotFilename = data, part.FileName()
+				continue
+			}
+			gotFields[part.FormName()] = string(data)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// audio_duration_secs is the vendor's own measure and runs past the
+		// last word, which is why it is preferred over the word timings.
+		_, _ = w.Write([]byte(
+			`{"text":"hello","audio_duration_secs":1.9969375,"words":[{"text":"hello","start":0.079,"end":0.459}]}`))
+	}))
+	defer server.Close()
+
+	req := &domain.Request{
+		Type:  domain.RequestTypeTranscription,
+		Model: "scribe_v1",
+		Transcription: &domain.TranscriptionUpload{
+			File:     []byte("RIFF-fake-wav"),
+			Filename: "clip.wav",
+			Params: map[string]string{
+				"model_id":     "elevenlabs/scribe_v1",
+				"diarize":      "true",
+				"num_speakers": "2",
+			},
+		},
+		ElevenLabs: &domain.ElevenLabsAudioRequest{},
+		Surface:    domain.ElevenLabsTranscriptionSurface(),
+	}
+	resp, err := elevenLabsAudioRouter(server).dispatchElevenLabsTranscription(
+		context.Background(), req, elevenLabsCredential(server))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1/speech-to-text", gotPath)
+	assert.Equal(t, "xi-secret", gotKey)
+	assert.Equal(t, "RIFF-fake-wav", string(gotFile))
+	assert.Equal(t, "clip.wav", gotFilename)
+	assert.Equal(t, "scribe_v1", gotFields["model_id"],
+		"the resolved model replaces whatever spelling the caller sent")
+	assert.Equal(t, "true", gotFields["diarize"],
+		"this vendor's own settings are the request on a route that mirrors its path")
+	assert.Equal(t, "2", gotFields["num_speakers"])
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.InDelta(t, 1.9969375, resp.Usage.AudioSeconds, 1e-9)
+	assert.Zero(t, resp.Usage.InputChars)
+}
+
+// A vendor rejection is forwarded as the vendor wrote it, which is what lets
+// the retry walk classify the status rather than see a gateway 500.
+func TestElevenLabsAudioForwardsAVendorRejectionVerbatim(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":{"status":"voice_not_found"}}`))
+	}))
+	defer server.Close()
+
+	req := &domain.Request{
+		Type:       domain.RequestTypeSpeech,
+		Model:      "eleven_flash_v2_5",
+		Body:       []byte(`{"text":"hi"}`),
+		ElevenLabs: &domain.ElevenLabsAudioRequest{VoiceID: "nope"},
+	}
+	resp, err := elevenLabsAudioRouter(server).dispatchElevenLabsSpeech(
+		context.Background(), req, elevenLabsCredential(server))
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	assert.JSONEq(t, `{"detail":{"status":"voice_not_found"}}`, string(resp.Body))
+	assert.Zero(t, resp.Usage.InputChars,
+		"a call the vendor refused synthesized nothing, so it must not be billed for characters")
+}
+
+// A cloud_storage_url request carries no file part, and refusing it here
+// would break a path the vendor supports.
+func TestElevenLabsTranscriptionAcceptsACloudStorageURLWithNoFile(t *testing.T) {
+	t.Parallel()
+
+	sawFile := false
+	gotFields := map[string]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, parseErr := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if !assert.NoError(t, parseErr) {
+			return
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, partErr := reader.NextPart()
+			if partErr != nil {
+				break
+			}
+			data, _ := io.ReadAll(part)
+			if part.FileName() != "" {
+				sawFile = true
+				continue
+			}
+			gotFields[part.FormName()] = string(data)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"hello","audio_duration_secs":12.5}`))
+	}))
+	defer server.Close()
+
+	req := &domain.Request{
+		Type:  domain.RequestTypeTranscription,
+		Model: "scribe_v1",
+		Transcription: &domain.TranscriptionUpload{
+			Params: map[string]string{"cloud_storage_url": "https://example.test/clip.mp3"},
+		},
+		ElevenLabs: &domain.ElevenLabsAudioRequest{},
+	}
+	resp, err := elevenLabsAudioRouter(server).dispatchElevenLabsTranscription(
+		context.Background(), req, elevenLabsCredential(server))
+	require.NoError(t, err)
+
+	assert.False(t, sawFile, "no audio was uploaded, so no file part may be invented")
+	assert.Equal(t, "https://example.test/clip.mp3", gotFields["cloud_storage_url"])
+	assert.InDelta(t, 12.5, resp.Usage.AudioSeconds, 1e-9)
+}
+
+func TestElevenLabsTranscribedSecondsFallsBackToWordTimings(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		body string
+		want float64
+	}{
+		"the stated duration wins over the last word": {
+			body: `{"audio_duration_secs":2.5,"words":[{"end":1.7}]}`,
+			want: 2.5,
+		},
+		"word timings answer when no duration is stated": {
+			body: `{"words":[{"end":0.4},{"end":1.75}]}`,
+			want: 1.75,
+		},
+		"the multi-channel shape nests its transcripts": {
+			body: `{"transcripts":[{"words":[{"end":0.9}]},{"words":[{"end":3.25}]}]}`,
+			want: 3.25,
+		},
+		"a body with neither measures nothing": {
+			body: `{"text":"hello"}`,
+			want: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.InDelta(t, tc.want, elevenLabsTranscribedSeconds([]byte(tc.body)), 1e-9)
+		})
+	}
+}

--- a/services/aigateway/adapters/providers/elevenlabs_test.go
+++ b/services/aigateway/adapters/providers/elevenlabs_test.go
@@ -220,6 +220,45 @@ func TestElevenLabsTranscriptionAcceptsACloudStorageURLWithNoFile(t *testing.T) 
 	assert.InDelta(t, 12.5, resp.Usage.AudioSeconds, 1e-9)
 }
 
+// The redirect refusal is why this client exists rather than a shared one:
+// Go strips Authorization across hosts but not xi-api-key, so a followed
+// redirect from a customer-configured base URL would hand the customer's
+// ElevenLabs key to whatever host answered. Built through the real
+// constructor, because the injected test client in every case above bypasses
+// exactly the configuration under test here.
+func TestElevenLabsAudioClientDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	leaked := make(chan string, 1)
+	elsewhere := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked <- r.Header.Get("xi-api-key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer elsewhere.Close()
+
+	vendor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, elsewhere.URL+"/v1/text-to-speech/voice_1", http.StatusFound)
+	}))
+	defer vendor.Close()
+
+	client := newElevenLabsAudioClient(newCustomerEndpointPolicy(false, false, nil))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, vendor.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("xi-api-key", "xi-secret")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode,
+		"the redirect must be returned to the caller, never followed")
+	select {
+	case key := <-leaked:
+		t.Fatalf("the redirect target received the provider key %q", key)
+	default:
+	}
+}
+
 func TestElevenLabsTranscribedSecondsFallsBackToWordTimings(t *testing.T) {
 	t.Parallel()
 

--- a/services/aigateway/app/handlers.go
+++ b/services/aigateway/app/handlers.go
@@ -82,6 +82,49 @@ func (a *App) HandleTranscription(ctx context.Context, bundle *domain.Bundle, up
 	})
 }
 
+// HandleElevenLabsSpeech dispatches POST /v1/text-to-speech/{voice_id},
+// ElevenLabs' own synthesis path. Same request type, pipeline and metering as
+// the OpenAI-wire TTS route: only the wire differs, and the vendor reads that
+// wire directly. The response body is binary audio.
+func (a *App) HandleElevenLabsSpeech(ctx context.Context, bundle *domain.Bundle, in ElevenLabsAudioDispatch) (*CompletionResult, error) {
+	route := in.Route
+	return a.pipeline.Sync(ctx, bundle, &domain.Request{
+		Type:       domain.RequestTypeSpeech,
+		Model:      in.Model,
+		Body:       in.Body,
+		ElevenLabs: &route,
+		Surface:    domain.ElevenLabsSpeechSurface(),
+	})
+}
+
+// HandleElevenLabsTranscription dispatches POST /v1/speech-to-text,
+// ElevenLabs' own transcription path. The router parsed the multipart form,
+// so the upload rides on req.Transcription and Body carries the synthesized
+// JSON summary the body-reading pipeline stages need, exactly as the
+// OpenAI-wire transcription route does.
+func (a *App) HandleElevenLabsTranscription(ctx context.Context, bundle *domain.Bundle, in ElevenLabsAudioDispatch) (*CompletionResult, error) {
+	route := in.Route
+	body := []byte(`{"` + domain.ElevenLabsModelField + `":` + strconv.Quote(in.Model) + `}`)
+	return a.pipeline.Sync(ctx, bundle, &domain.Request{
+		Type:          domain.RequestTypeTranscription,
+		Model:         in.Model,
+		Body:          body,
+		Transcription: in.Upload,
+		ElevenLabs:    &route,
+		Surface:       domain.ElevenLabsTranscriptionSurface(),
+	})
+}
+
+// ElevenLabsAudioDispatch is one ElevenLabs-native audio call: the model it
+// bills under, the vendor-shaped body or upload, and the URL-level parameters
+// the vendor's own path carries.
+type ElevenLabsAudioDispatch struct {
+	Model  string
+	Body   []byte
+	Upload *domain.TranscriptionUpload
+	Route  domain.ElevenLabsAudioRequest
+}
+
 // HandlePassthrough dispatches a provider-native request whose wire shape
 // the gateway doesn't translate (e.g. Gemini /v1beta/models/{m}:generateContent).
 // Body, path, method, query, and forwarded headers ride on req.Passthrough;

--- a/services/aigateway/app/handlers.go
+++ b/services/aigateway/app/handlers.go
@@ -3,8 +3,8 @@ package app
 import (
 	"context"
 	"io"
-	"strconv"
 
+	"github.com/bytedance/sonic"
 	"github.com/tidwall/gjson"
 
 	"github.com/langwatch/langwatch/services/aigateway/app/pipeline"
@@ -73,11 +73,10 @@ func (a *App) HandleSpeech(ctx context.Context, bundle *domain.Bundle, body io.R
 // body-reading pipeline stages see well-formed bytes instead of multipart
 // framing.
 func (a *App) HandleTranscription(ctx context.Context, bundle *domain.Bundle, upload *domain.TranscriptionUpload, model string) (*CompletionResult, error) {
-	body := []byte(`{"model":` + strconv.Quote(model) + `}`)
 	return a.pipeline.Sync(ctx, bundle, &domain.Request{
 		Type:          domain.RequestTypeTranscription,
 		Model:         model,
-		Body:          body,
+		Body:          modelOnlyBody("model", model),
 		Transcription: upload,
 	})
 }
@@ -104,15 +103,34 @@ func (a *App) HandleElevenLabsSpeech(ctx context.Context, bundle *domain.Bundle,
 // OpenAI-wire transcription route does.
 func (a *App) HandleElevenLabsTranscription(ctx context.Context, bundle *domain.Bundle, in ElevenLabsAudioDispatch) (*CompletionResult, error) {
 	route := in.Route
-	body := []byte(`{"` + domain.ElevenLabsModelField + `":` + strconv.Quote(in.Model) + `}`)
 	return a.pipeline.Sync(ctx, bundle, &domain.Request{
 		Type:          domain.RequestTypeTranscription,
 		Model:         in.Model,
-		Body:          body,
+		Body:          modelOnlyBody(domain.ElevenLabsModelField, in.Model),
 		Transcription: in.Upload,
 		ElevenLabs:    &route,
 		Surface:       domain.ElevenLabsTranscriptionSurface(),
 	})
+}
+
+// modelOnlyBody is the synthesized JSON a multipart route hands the pipeline,
+// so the body-reading stages see a well-formed object instead of multipart
+// framing.
+//
+// Marshaled rather than concatenated, the same rule the realtime mint states:
+// the model is a caller-supplied form part, and strconv.Quote emits Go escapes
+// such as \x01 for a control byte, which is not JSON. Every stage downstream
+// parses this body, including the sjson rewrite that puts the resolved model
+// back into it, so one control byte would break resolution rather than the
+// request that carried it. A marshal failure cannot happen for a map of two
+// strings; an empty object is still valid JSON and the resolver refuses the
+// missing model with its own message.
+func modelOnlyBody(field, model string) []byte {
+	body, err := sonic.Marshal(map[string]string{field: model})
+	if err != nil {
+		return []byte(`{}`)
+	}
+	return body
 }
 
 // ElevenLabsAudioDispatch is one ElevenLabs-native audio call: the model it

--- a/services/aigateway/domain/elevenlabs.go
+++ b/services/aigateway/domain/elevenlabs.go
@@ -1,0 +1,61 @@
+package domain
+
+// ElevenLabs' own audio wire, brokered rather than translated.
+//
+// The gateway already serves ElevenLabs speech and transcription through the
+// OpenAI-shaped /v1/audio routes, which any provider can answer. That covers a
+// caller willing to write OpenAI-shaped requests. It does not cover a caller
+// who already uses the ElevenLabs SDK: that SDK posts to this vendor's own
+// paths with this vendor's own body, so its traffic went straight to the
+// vendor and none of it was metered. These two routes mirror the vendor's
+// paths so an ElevenLabs SDK reaches the gateway by base URL alone.
+
+// ElevenLabsModelField is where ElevenLabs names the model on both of its
+// audio routes: a JSON field on synthesis, a form part on transcription.
+// Neither is the "model" every translated route uses, so the resolver writes
+// the resolved id here instead.
+const ElevenLabsModelField = "model_id"
+
+// ElevenLabsDefaultSpeechModel is the model ElevenLabs synthesizes with when
+// a request names none, so the gateway meters and gates the same model the
+// vendor would have used. Naming it here rather than leaving the field empty
+// is what lets the virtual key's allowlist and aliases apply to a request
+// that omitted the model, exactly as they apply to one that stated it.
+const ElevenLabsDefaultSpeechModel = "eleven_multilingual_v2"
+
+// ElevenLabsAudioRequest is what an ElevenLabs-native audio route needs
+// beyond the body.
+type ElevenLabsAudioRequest struct {
+	// VoiceID is the voice the synthesis path names. Empty on transcription,
+	// which takes no voice.
+	VoiceID string
+	// RawQuery is the caller's query string without the leading "?".
+	// output_format, enable_logging and the optimize-latency setting ride
+	// there on this vendor's wire rather than in the body, so dropping it
+	// would silently return audio in a format the caller did not ask for.
+	RawQuery string
+}
+
+// ElevenLabsSpeechSurface is POST /v1/text-to-speech/{voice_id}: ElevenLabs'
+// own synthesis path, served only by an ElevenLabs credential.
+//
+// The pin is what keeps the body on the vendor the caller named. The request
+// reaches the vendor as written, so a fallback to another provider would post
+// an ElevenLabs body to an API that cannot parse it, and would spend a
+// credential the caller never chose.
+func ElevenLabsSpeechSurface() Surface {
+	return Surface{
+		Name:      "/v1/text-to-speech/{voice_id}",
+		Providers: []ProviderID{ProviderElevenLabs},
+	}
+}
+
+// ElevenLabsTranscriptionSurface is POST /v1/speech-to-text: ElevenLabs' own
+// transcription path, served only by an ElevenLabs credential, for the same
+// reason the synthesis surface pins.
+func ElevenLabsTranscriptionSurface() Surface {
+	return Surface{
+		Name:      "/v1/speech-to-text",
+		Providers: []ProviderID{ProviderElevenLabs},
+	}
+}

--- a/services/aigateway/domain/request.go
+++ b/services/aigateway/domain/request.go
@@ -39,6 +39,14 @@ type Request struct {
 	// RequestTypeRealtimeSession. Nil otherwise.
 	RealtimeSession *RealtimeSessionRequest
 
+	// ElevenLabs carries the URL-level parameters of an ElevenLabs-native
+	// audio route and, by being set at all, says the request arrived on one.
+	// Those routes carry that vendor's own wire, so they dispatch straight to
+	// it rather than through a translation layer. Nil on every other route,
+	// including the OpenAI-wire audio routes that reach ElevenLabs by model
+	// name.
+	ElevenLabs *ElevenLabsAudioRequest
+
 	// Surface is the route this request arrived on, stated by the handler
 	// registered there, when that route can only be served by named
 	// providers. Zero on the routes the gateway translates, which any
@@ -58,10 +66,17 @@ func (r *Request) InboundSurface() Surface {
 }
 
 // ModelBodyPath is where the model id sits in this request's JSON body, in
-// sjson path syntax. The realtime mint nests it under the session object the
-// vendor reads; every other shape uses the top-level field.
+// sjson path syntax. A route that carries a vendor's own wire uses the field
+// that vendor reads; the realtime mint nests it under the session object;
+// every other shape uses the top-level field.
 func (r *Request) ModelBodyPath() string {
-	if r != nil && r.Type == RequestTypeRealtimeSession {
+	if r == nil {
+		return "model"
+	}
+	if r.ElevenLabs != nil {
+		return ElevenLabsModelField
+	}
+	if r.Type == RequestTypeRealtimeSession {
 		return "session.model"
 	}
 	return "model"

--- a/services/aigateway/tests/matrix/audio_test.go
+++ b/services/aigateway/tests/matrix/audio_test.go
@@ -21,16 +21,20 @@ package matrix
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 const spokenLine = "The quick brown fox jumps over the lazy dog"
@@ -241,8 +245,9 @@ func TestAudio_ElevenLabs_Transcription(t *testing.T) {
 //	ELEVENLABS_VOICE_ID=EXAVITQu4vr4xnSDxMaL \
 //	  go test -tags=live_audio -run TestAudio_ElevenLabsNative ./services/aigateway/tests/matrix/... -v
 
-// speakNative fires the vendor's own synthesis path and returns the audio.
-func speakNative(t *testing.T, vk, voice, model string) []byte {
+// speakNative fires the vendor's own synthesis path and returns the audio
+// together with the trace id the call was billed under.
+func speakNative(t *testing.T, vk, voice, model string) ([]byte, string) {
 	t.Helper()
 	body := fmt.Sprintf(`{"text":%q,"model_id":%q}`, spokenLine, model)
 	url := fmt.Sprintf("%s/v1/text-to-speech/%s?output_format=mp3_44100_128", gatewayURL(), voice)
@@ -254,6 +259,7 @@ func speakNative(t *testing.T, vk, voice, model string) []byte {
 	// path: an ElevenLabs SDK changes its base URL and nothing else.
 	req.Header.Set("xi-api-key", vk)
 	req.Header.Set("Content-Type", "application/json")
+	traceID := newTraceParent(t, req)
 
 	resp, err := audioHTTPClient().Do(req)
 	if err != nil {
@@ -277,12 +283,12 @@ func speakNative(t *testing.T, vk, voice, model string) []byte {
 	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "audio/") {
 		t.Fatalf("native speech Content-Type = %q, want audio/*", ct)
 	}
-	return audio
+	return audio, traceID
 }
 
 // transcribeNative fires the vendor's own transcription path and returns the
 // whole answer, which carries the duration the call is billed by.
-func transcribeNative(t *testing.T, vk, model, filename string, file []byte) (string, float64) {
+func transcribeNative(t *testing.T, vk, model, filename string, file []byte) (string, float64, string) {
 	t.Helper()
 	buf := &bytes.Buffer{}
 	w := multipart.NewWriter(buf)
@@ -306,6 +312,7 @@ func transcribeNative(t *testing.T, vk, model, filename string, file []byte) (st
 	}
 	req.Header.Set("xi-api-key", vk)
 	req.Header.Set("Content-Type", w.FormDataContentType())
+	traceID := newTraceParent(t, req)
 
 	resp, err := audioHTTPClient().Do(req)
 	if err != nil {
@@ -330,7 +337,101 @@ func transcribeNative(t *testing.T, vk, model, filename string, file []byte) (st
 	if parsed.Text == "" {
 		t.Fatalf("native transcription returned empty text: %s", truncate(body, 300))
 	}
-	return parsed.Text, parsed.Duration
+	return parsed.Text, parsed.Duration, traceID
+}
+
+// elevenLabsPublishedRates are the vendor's own API prices, which are what a
+// call through the gateway must be rated at. ElevenLabs publishes $0.05 per
+// 1,000 characters for Flash and Turbo, $0.10 for Multilingual v2, and $0.22
+// per hour for Scribe (https://elevenlabs.io/pricing/api, checked 2026-08-21).
+var elevenLabsPublishedRates = map[string]float64{
+	"eleven_flash_v2":        0.05 / 1000,
+	"eleven_flash_v2_5":      0.05 / 1000,
+	"eleven_turbo_v2_5":      0.05 / 1000,
+	"eleven_multilingual_v2": 0.10 / 1000,
+}
+
+const elevenLabsScribePerSecondUSD = 0.22 / 3600
+
+// ratedCostTolerance is 1%, and it is not slack for a wrong rate. The catalog
+// stores the published per-second price rounded to three significant figures,
+// the spend record rounds the duration to whole milliseconds, and the rated
+// cost is quantized to nano-USD. A rate that is actually wrong is wrong by a
+// factor, not by a fraction of a percent.
+const ratedCostTolerance = 0.01
+
+// newTraceParent stamps a fresh W3C traceparent on the request and returns its
+// trace id, so the call can be read back from the trace API afterwards. The
+// gateway carries the caller's own trace rather than inventing one, which is
+// what makes a billing assertion possible from outside the process.
+func newTraceParent(t *testing.T, req *http.Request) string {
+	t.Helper()
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatalf("generate trace id: %v", err)
+	}
+	traceID := hex.EncodeToString(raw)
+	span := make([]byte, 8)
+	if _, err := rand.Read(span); err != nil {
+		t.Fatalf("generate span id: %v", err)
+	}
+	req.Header.Set("traceparent", "00-"+traceID+"-"+hex.EncodeToString(span)+"-01")
+	return traceID
+}
+
+// awaitAudioTraceCost polls the trace API until the call lands with a cost.
+//
+// It cannot reuse assertTraceCaptured: that helper also waits for a non-zero
+// token count, and an audio call priced by characters or seconds reports no
+// tokens at all, so it would time out on a perfectly billed request.
+func awaitAudioTraceCost(t *testing.T, traceID string) float64 {
+	t.Helper()
+	apiKey := requireEnv(t, "LW_PROJECT_API_KEY")
+
+	deadline := time.Now().Add(45 * time.Second)
+	backoff := 500 * time.Millisecond
+	url := lwBaseURL() + "/api/trace/" + traceID
+	for {
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("X-Auth-Token", apiKey)
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err == nil {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var parsed struct {
+					Metrics struct {
+						TotalCost float64 `json:"total_cost"`
+					} `json:"metrics"`
+				}
+				if json.Unmarshal(body, &parsed) == nil && parsed.Metrics.TotalCost > 0 {
+					return parsed.Metrics.TotalCost
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("trace %s did not land with a cost within 45s; an audio call that "+
+				"measures nothing is billed as free", traceID)
+		}
+		time.Sleep(backoff)
+		if backoff < 4*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// assertRatedCost requires the cost the platform charged to match the vendor's
+// published price for the quantity the call actually used.
+func assertRatedCost(t *testing.T, label string, got, want float64) {
+	t.Helper()
+	if want == 0 {
+		t.Fatalf("%s: no published rate to compare against", label)
+	}
+	if diff := math.Abs(got-want) / want; diff > ratedCostTolerance {
+		t.Fatalf("%s: rated $%.9f, vendor price says $%.9f (%.2f%% off)",
+			label, got, want, diff*100)
+	}
+	t.Logf("%s: rated $%.9f against the vendor's published $%.9f", label, got, want)
 }
 
 // @scenario "A native ElevenLabs synthesis call bills the characters it spoke"
@@ -346,13 +447,22 @@ func TestAudio_ElevenLabsNative_SpeechToTranscriptionRoundTrip(t *testing.T) {
 		ttsModel = "eleven_flash_v2_5"
 	}
 
-	audio := speakNative(t, vk, voice, ttsModel)
+	audio, speechTrace := speakNative(t, vk, voice, ttsModel)
 	t.Logf("native TTS produced %d bytes of mp3 for %d characters", len(audio), len(spokenLine))
 
-	transcript, duration := transcribeNative(t, vk, "scribe_v1", "native.mp3", audio)
+	transcript, duration, transcribeTrace := transcribeNative(t, vk, "scribe_v1", "native.mp3", audio)
 	t.Logf("native STT transcript: %q over %.4f seconds", transcript, duration)
 	assertHeardTheFox(t, transcript)
 	if duration <= 0 {
 		t.Fatalf("the vendor stated no audio duration, so the call would bill nothing")
 	}
+
+	// The two billing scenarios this test binds. Without these the cells prove
+	// only that audio crossed both routes, and metering could be silently zero.
+	assertRatedCost(t, "synthesis",
+		awaitAudioTraceCost(t, speechTrace),
+		float64(utf8.RuneCountInString(spokenLine))*elevenLabsPublishedRates[ttsModel])
+	assertRatedCost(t, "transcription",
+		awaitAudioTraceCost(t, transcribeTrace),
+		duration*elevenLabsScribePerSecondUSD)
 }

--- a/services/aigateway/tests/matrix/audio_test.go
+++ b/services/aigateway/tests/matrix/audio_test.go
@@ -229,3 +229,130 @@ func TestAudio_ElevenLabs_Transcription(t *testing.T) {
 	t.Logf("openai->elevenlabs transcript: %q", transcript)
 	assertHeardTheFox(t, transcript)
 }
+
+// --- ElevenLabs native cells ---
+//
+// The vendor's own paths, mirrored by the gateway. These prove the two things
+// a unit test cannot: that a real ElevenLabs account answers the request the
+// gateway builds, and that the audio survives a round trip through both new
+// routes.
+//
+//	TEST_VK_ELEVENLABS=vk-lw-... \
+//	ELEVENLABS_VOICE_ID=EXAVITQu4vr4xnSDxMaL \
+//	  go test -tags=live_audio -run TestAudio_ElevenLabsNative ./services/aigateway/tests/matrix/... -v
+
+// speakNative fires the vendor's own synthesis path and returns the audio.
+func speakNative(t *testing.T, vk, voice, model string) []byte {
+	t.Helper()
+	body := fmt.Sprintf(`{"text":%q,"model_id":%q}`, spokenLine, model)
+	url := fmt.Sprintf("%s/v1/text-to-speech/%s?output_format=mp3_44100_128", gatewayURL(), voice)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build native speech request: %v", err)
+	}
+	// The vendor's own auth header, which is the whole point of mirroring the
+	// path: an ElevenLabs SDK changes its base URL and nothing else.
+	req.Header.Set("xi-api-key", vk)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := audioHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("native speech request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	audio, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read native speech response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("native speech returned %d: %s", resp.StatusCode, truncate(audio, 500))
+	}
+	if len(audio) < 1024 {
+		t.Fatalf("native speech returned implausibly small audio (%d bytes): %s",
+			len(audio), truncate(audio, 200))
+	}
+	if json.Valid(audio) {
+		t.Fatalf("native speech response is JSON, expected raw audio: %s", truncate(audio, 300))
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "audio/") {
+		t.Fatalf("native speech Content-Type = %q, want audio/*", ct)
+	}
+	return audio
+}
+
+// transcribeNative fires the vendor's own transcription path and returns the
+// whole answer, which carries the duration the call is billed by.
+func transcribeNative(t *testing.T, vk, model, filename string, file []byte) (string, float64) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	w := multipart.NewWriter(buf)
+	fw, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := fw.Write(file); err != nil {
+		t.Fatalf("write form file: %v", err)
+	}
+	if err := w.WriteField("model_id", model); err != nil {
+		t.Fatalf("write model_id field: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, gatewayURL()+"/v1/speech-to-text", buf)
+	if err != nil {
+		t.Fatalf("build native transcription request: %v", err)
+	}
+	req.Header.Set("xi-api-key", vk)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := audioHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("native transcription request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read native transcription response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("native transcription returned %d: %s", resp.StatusCode, truncate(body, 500))
+	}
+	var parsed struct {
+		Text     string  `json:"text"`
+		Duration float64 `json:"audio_duration_secs"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("native transcription answer is not the vendor's JSON shape: %v; body: %s",
+			err, truncate(body, 300))
+	}
+	if parsed.Text == "" {
+		t.Fatalf("native transcription returned empty text: %s", truncate(body, 300))
+	}
+	return parsed.Text, parsed.Duration
+}
+
+// @scenario "A native ElevenLabs synthesis call bills the characters it spoke"
+// @scenario "A native ElevenLabs transcription call bills the seconds it heard"
+func TestAudio_ElevenLabsNative_SpeechToTranscriptionRoundTrip(t *testing.T) {
+	vk := requireEnv(t, "TEST_VK_ELEVENLABS")
+	voice := os.Getenv("ELEVENLABS_VOICE_ID")
+	if voice == "" {
+		t.Skip("ELEVENLABS_VOICE_ID not set")
+	}
+	ttsModel := os.Getenv("ELEVENLABS_TTS_MODEL")
+	if ttsModel == "" {
+		ttsModel = "eleven_flash_v2_5"
+	}
+
+	audio := speakNative(t, vk, voice, ttsModel)
+	t.Logf("native TTS produced %d bytes of mp3 for %d characters", len(audio), len(spokenLine))
+
+	transcript, duration := transcribeNative(t, vk, "scribe_v1", "native.mp3", audio)
+	t.Logf("native STT transcript: %q over %.4f seconds", transcript, duration)
+	assertHeardTheFox(t, transcript)
+	if duration <= 0 {
+		t.Fatalf("the vendor stated no audio duration, so the call would bill nothing")
+	}
+}

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -112,8 +112,9 @@ Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and E
   @unit
   Scenario: ElevenLabs' own synthesis path reaches the vendor unchanged
     When the gateway dispatches a native synthesis request
-    Then the caller's body, including voice settings, is forwarded byte for byte
-    And the resolved model is written into "model_id", the field this vendor reads
+    Then every field of the caller's body, including voice settings, is forwarded as written
+    And the one exception is "model_id", which carries the model resolution settled on
+    And no "model" field is invented, because no ElevenLabs endpoint reads one
     And the character count of the spoken text is the usage measure reported
     # The vendor's character-cost response header is credits under the
     # account's own plan, not characters, and it already carries the model's
@@ -123,9 +124,18 @@ Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and E
   Scenario: ElevenLabs' own transcription path reaches the vendor unchanged
     When the gateway dispatches a native transcription request
     Then every text form part the caller sent is carried through to the vendor
-    And the resolved model replaces whatever spelling the caller wrote
+    And the one exception is "model_id", which carries the model resolution settled on
     And the audio duration the vendor states is the usage measure reported
     And a request naming a cloud_storage_url instead of a file is accepted
+
+  @unit
+  Scenario: Asynchronous transcription is refused rather than billed at zero
+    When the client sends a "webhook" part asking the vendor to answer later
+    Then the gateway responds 400 naming the webhook part, and contacts no provider
+    # The vendor's early answer carries no duration and no word timings, so the
+    # spend record would confirm at zero seconds for audio the customer was
+    # charged for, and the gateway has no settlement path for the delivery that
+    # follows.
 
   @unit
   Scenario: A native ElevenLabs route refuses a key with no ElevenLabs credential

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -89,6 +89,67 @@ Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and E
     And no provider is contacted
 
   # ============================================================
+  # Group: ElevenLabs' own audio paths, mirrored
+  # ============================================================
+
+  # The OpenAI-shaped routes above cover a caller willing to write
+  # OpenAI-shaped requests. An ElevenLabs SDK is not: it posts to that
+  # vendor's own paths with that vendor's own body, so its traffic went
+  # straight to the vendor and none of it was metered. These two routes
+  # mirror the vendor's paths so an ElevenLabs SDK reaches the gateway by
+  # base URL alone. Bifrost cannot forward them (its ElevenLabs provider
+  # answers Passthrough with unsupported-operation), so the gateway calls
+  # the vendor itself the way the session mint does.
+
+  @unit
+  Scenario: An ElevenLabs SDK reaches the native audio routes unchanged
+    When the client POSTs /v1/text-to-speech/{voice_id} with the ElevenLabs wire shape
+    And it authenticates with the xi-api-key header the SDK already sends
+    Then the response is 200 with the vendor's audio bytes and its own Content-Type
+    And the voice from the URL path and the caller's query string both reach the vendor
+    And the model resolves through the virtual key's aliases and allowlist like every other route
+
+  @unit
+  Scenario: ElevenLabs' own synthesis path reaches the vendor unchanged
+    When the gateway dispatches a native synthesis request
+    Then the caller's body, including voice settings, is forwarded byte for byte
+    And the resolved model is written into "model_id", the field this vendor reads
+    And the character count of the spoken text is the usage measure reported
+    # The vendor's character-cost response header is credits under the
+    # account's own plan, not characters, and it already carries the model's
+    # price factor, so rating it per character would apply that factor twice.
+
+  @unit
+  Scenario: ElevenLabs' own transcription path reaches the vendor unchanged
+    When the gateway dispatches a native transcription request
+    Then every text form part the caller sent is carried through to the vendor
+    And the resolved model replaces whatever spelling the caller wrote
+    And the audio duration the vendor states is the usage measure reported
+    And a request naming a cloud_storage_url instead of a file is accepted
+
+  @unit
+  Scenario: A native ElevenLabs route refuses a key with no ElevenLabs credential
+    Given a virtual key holding no ElevenLabs credential
+    When the client calls either native route
+    Then the request is refused and no provider is contacted
+    # The body is this vendor's own wire, so falling back would spend a
+    # credential the caller never named on an API that cannot read it.
+
+  @integration
+  Scenario: A native ElevenLabs synthesis call bills the characters it spoke
+    When the client synthesizes speech through /v1/text-to-speech/{voice_id}
+    Then the response carries real audio the vendor produced
+    And the spend record carries the character count in input_chars
+    And the rated cost equals the characters times the model's per-character rate
+
+  @integration
+  Scenario: A native ElevenLabs transcription call bills the seconds it heard
+    When the client transcribes audio through /v1/speech-to-text
+    Then the response carries the transcript the vendor produced
+    And the spend record carries the audio duration in audio_ms
+    And the rated cost equals the duration times the model's per-second rate
+
+  # ============================================================
   # Group: Governance (the same pipeline as chat)
   # ============================================================
 


### PR DESCRIPTION
## What this adds

Two new gateway routes that mirror ElevenLabs' own audio paths:

| Route | Wire | Metered by |
|---|---|---|
| `POST /v1/text-to-speech/{voice_id}` | ElevenLabs synthesis JSON | `input_chars` on `gateway_spend` |
| `POST /v1/speech-to-text` | ElevenLabs multipart | `audio_ms` on `gateway_spend` |

The gateway already reaches ElevenLabs through the OpenAI-shaped `/v1/audio/speech` and `/v1/audio/transcriptions` routes. That covers a caller willing to write OpenAI-shaped requests. It does not cover a caller who already uses the ElevenLabs SDK: that SDK posts to the vendor's own paths with the vendor's own body, so the request hit `404 page not found` at our router and the customer sent it straight to the vendor instead. None of that spend was visible to LangWatch.

Both routes take the `xi-api-key` header the SDK already sends, so the customer changes two settings and no code: the SDK's base URL, and a LangWatch virtual key in place of their ElevenLabs key, which stays configured on the provider row. Bodies, form parts and query strings reach the vendor as written, so voice settings, `output_format`, diarization and timestamp granularity keep working.

Two `langwatch/scenario` CI lanes were blocked on this. [scenario#937](https://github.com/langwatch/scenario/pull/937) had to give its ElevenLabs speech and transcription leaves an explicit `baseUrl` and a real vendor key, because one base URL variable could not serve a gateway-fronted lane and un-fronted leaves at the same time. [scenario#938](https://github.com/langwatch/scenario/pull/938) could not enable ElevenLabs brokering in Python CI at all, because the same credential had to be both a LangWatch virtual key and a real ElevenLabs key.

## How it works

Bifrost cannot forward this wire. Its ElevenLabs provider answers `Passthrough` with an unsupported-operation error. So the gateway calls the vendor itself, over the same SSRF-checked client pattern the realtime session mint uses: the endpoint policy vets the customer base URL at dispatch and the dialer re-checks every resolved address before connecting, and redirects are never followed because Go does not strip `xi-api-key` across hosts. A credential with a stored `base_url` (EU residency) is respected.

Both routes pin the ElevenLabs provider through the existing `Surface` mechanism. The body is that vendor's own shape, so a fallback to another provider would post a request the other API cannot read and spend a credential the caller never named.

The model comes from `model_id`, and the model resolver writes the resolved id back into that field rather than the `model` field no ElevenLabs endpoint reads. Aliases, the model allowlist, budgets, rate limits, policy and the spend record all behave exactly as on every other route. A synthesis request that names no `model_id` bills and gates under `eleven_multilingual_v2`, which is what the vendor itself would have used, so an unnamed model is still governed.

Transcription accepts a `cloud_storage_url` form part with no file, which is a path the vendor supports. Uploads through the gateway are capped at 26 MB, the same limit `/v1/audio/transcriptions` uses, because the file is held in memory twice for the length of the vendor call: once parsed, and again in the multipart body rebuilt for the vendor. `cloud_storage_url` is the route for anything larger, and it costs this process nothing.

Asynchronous transcription (`webhook=true`) is refused with a 400. ElevenLabs answers that request before it has transcribed anything, so the response carries no duration and the spend record would confirm at zero seconds for audio the customer was charged for. There is no settlement path for the delivery that follows either: the existing `/v1/convai/webhook/{model_provider_id}` relay carries Conversational AI post-call reports, which are a different payload keyed on a different id. Any truthy spelling is refused, because the spelling that slips through is the one that bills nothing; `webhook=false` is forwarded untouched.

## Metering

Money stays int64 nano-USD and reuses the two audio quantities `gateway_spend` already carries. No new fields, no new catalog entries.

- **Synthesis** reports `utf8.RuneCountInString(text)` into `input_chars`. This is the same measure the OpenAI-wire route reports, so one call costs the same on either wire.
- **Transcription** reports the `audio_duration_secs` the vendor states on its own answer into `audio_ms`. Word timings are the fallback when a response carries no duration, including the multi-channel shape that nests its transcripts.

The vendor also returns a `character-cost` response header on synthesis. It is deliberately not used: it is credits under the account's own plan, not characters, and it already carries the model's price factor. The same 33-character text reported `character-cost: 18` on `eleven_multilingual_v2` and `9` on `eleven_flash_v2_5` (measured against the live API, 2026-08-21). Rating credits at a per-character rate would apply that factor twice.

## Real vendor evidence

Run against a live ElevenLabs account through a local gateway and control plane, not mocks. Text: "The quick brown fox jumps over the lazy dog", 43 characters.

**Synthesis**, `/v1/text-to-speech/{voice_id}` on `eleven_flash_v2_5`: 200 with 38,914 bytes of real mp3, `Content-Type: audio/mpeg`, the vendor's `Request-Id` forwarded.

```
RequestType: speech   Model: eleven_flash_v2_5   Status: confirmed
CharsInput: 43   AudioMS: 0   CostNanoUSD: 2150000
```

43 chars times the catalog's `inputCostPerCharacter` of 5e-5 is $0.00215, which is 2,150,000 nano-USD exactly. The vendor's published API price for Flash and Turbo is **$0.05 per 1,000 characters** (https://elevenlabs.io/pricing/api, checked 2026-08-21), so the catalog rate matches the vendor.

**Transcription**, `/v1/speech-to-text` on `scribe_v1`, fed that same audio back with `diarize=true`: 200 with the exact transcript, and the words carry `speaker_id`, proving the vendor-native form part survived.

```
RequestType: transcription   Model: scribe_v1   Status: confirmed
CharsInput: 0   AudioMS: 2368   CostNanoUSD: 144685
```

The vendor stated `audio_duration_secs: 2.3684375`. 2.368 seconds times the catalog's `inputCostPerSecond` of 6.11e-05 is $0.0001446848, which rounds to 144,685 nano-USD exactly. The vendor's published Scribe price is **$0.22 per hour**, which is 6.111e-05 per second, so the catalog rate matches the vendor.

**Cross-wire agreement**, the same model on both routes:

```
OpenAI wire   /v1/audio/speech            19 chars    950,000 nano
Native wire   /v1/text-to-speech/{voice}  21 chars  1,050,000 nano
```

Both rate at exactly 50,000 nano-USD per character. A customer is charged the same whichever wire they use.

**Traces.** The synthesis span is `gen_ai.speech` with `gen_ai.usage.input_chars = 21`, the input message rendered from the vendor's `text` field, and no output messages, because the response is binary audio and has no renderable message form. The transcription span is `gen_ai.transcription` with `gen_ai.usage.audio_seconds = 2.3684375` and the transcript as its output message. Trace cost equals spend cost on both.

A repeatable live cell for all of this is added to the audio matrix:

```
GATEWAY_URL=http://localhost:5563 TEST_VK_ELEVENLABS=vk-lw-... \
LW_PROJECT_API_KEY=sk-lw-... ELEVENLABS_VOICE_ID=EXAVITQu4vr4xnSDxMaL \
  go test -tags=live_audio -run TestAudio_ElevenLabsNative ./services/aigateway/tests/matrix/... -v
```

That cell does not stop at "audio came back". It stamps its own `traceparent`, reads the call back from `/api/trace/:id`, and requires the rated cost to match the vendor's published price for the quantity the call used:

```
synthesis: rated $0.002150000 against the vendor's published $0.002150000
transcription: rated $0.000148000 against the vendor's published $0.000147576
```

The 1% tolerance is not slack for a wrong rate: the catalog stores $0.22 per hour rounded to 6.11e-05 per second, the spend record rounds duration to whole milliseconds, and the cost is quantized to nano-USD. Changing the expected Flash rate to $0.10 per 1,000 characters fails the cell with "50.00% off", so the assertion is not decorative.

## Left out on purpose

- **Streaming synthesis** (`/v1/text-to-speech/{voice_id}/stream`). The gateway's SSE writer sets `Content-Type: text/event-stream` and writes an `event: error` frame on failure, both wrong for a raw audio stream. Mapping the stream path onto the buffered handler would return correct bytes while silently destroying time to first byte, which is the only reason to use it. It needs a binary stream writer of its own.
- **Asynchronous transcription** (`webhook=true`). Refused rather than served, for the billing reason above. Supporting it needs a Speech-to-Text settlement path of its own, which is a separate piece of work.
- **Bifrost's duration measure on the OpenAI-wire ElevenLabs transcription lane.** Bifrost derives duration from the last word timing, so the same clip measured 1.779 seconds there against the vendor's stated 1.997, about 11 percent under. The fix lives in the vendored dependency or in a re-parse of the raw provider body, neither of which belongs in this change. The new native route uses the vendor's own figure.

## Deployment Impact

- **Environment variables:** none added or changed. The routes use the existing per-organization ElevenLabs `ModelProvider` credential, and honour the optional `base_url` already stored on it for EU residency.
- **Helm values:** none. The chart's ingress already allowlists `/v1` as a prefix, so both new paths are reachable with no chart change.
- **Vanilla install:** no action. The routes appear on the gateway once the image is updated; an organization with no ElevenLabs key configured gets the standard `no_provider_configured` refusal, exactly as before.
- **BYOC dataplane:** no action. No new outbound host: the gateway already calls `api.elevenlabs.io` for the Conversational AI session mint, and the same SSRF endpoint policy applies to these calls.
- **Database:** no migration. Metering reuses the `input_chars` and `audio_ms` columns `gateway_spend` already carries.
- **Rollback:** revert the two commits and redeploy. The two routes disappear and callers get the router's 404 again. No state is written that a rollback would leave behind, and no existing route changes behaviour.

**This merge does not deploy the change.** The production gateway is not built by `langwatch/langwatch` CI. It is built in the private `langwatch-saas` repo by `.github/workflows/build-and-push-artifacts.yaml`, job `langwatch-gateway`, from the `langwatch` git submodule, and tagged `git-<short-sha-of-langwatch-saas>`. A `langwatch-saas` submodule bump is what ships it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native ElevenLabs text-to-speech and speech-to-text endpoints.
  - Supports API-key authentication, voice and query parameters, model selection, file uploads, and cloud-storage transcription.
  - Added usage reporting and billing based on synthesized characters and transcription duration.
  - Added validation for required fields, size limits, supported models, and synchronous transcription requirements.

- **Bug Fixes**
  - Speech requests now recognize both `input` and `text` fields.

- **Documentation**
  - Expanded audio API documentation with endpoint behavior, authentication, limits, billing, and unsupported streaming details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->