### PR TITLE
fix(authz): a role event carries the aggregate type of the pipeline it rides

### DIFF
--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/aggregateIdentity.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/aggregateIdentity.unit.test.ts
@@ -145,29 +145,33 @@ describe("authz command aggregate identity", () => {
   describe("when the store validates a command's events on append", () => {
     /** @scenario "A role's aggregate is the role" */
     it.each([
-      ["attach", new AttachGrantCommand(), { ...identity, grant: GRANT }],
-      [
-        "define role",
-        new DefineRoleCommand(),
-        { ...identity, role: ROLE, actor: ACTOR },
-      ],
-      [
-        "change permissions",
-        new ChangeRolePermissionsCommand(),
-        {
+      {
+        label: "attach",
+        handler: new AttachGrantCommand(),
+        data: { ...identity, grant: GRANT },
+      },
+      {
+        label: "define role",
+        handler: new DefineRoleCommand(),
+        data: { ...identity, role: ROLE, actor: ACTOR },
+      },
+      {
+        label: "change permissions",
+        handler: new ChangeRolePermissionsCommand(),
+        data: {
           ...identity,
           roleId: "role_1",
           permissions: ["traces:view"],
           actor: ACTOR,
           occurredAtMs: AT,
         },
-      ],
-      [
-        "delete role",
-        new DeleteRoleCommand(),
-        { ...identity, roleId: "role_1", actor: ACTOR, occurredAtMs: AT },
-      ],
-    ])("accepts every event %s emits", async (_, handler, data) => {
+      },
+      {
+        label: "delete role",
+        handler: new DeleteRoleCommand(),
+        data: { ...identity, roleId: "role_1", actor: ACTOR, occurredAtMs: AT },
+      },
+    ])("accepts every event $label emits", async ({ handler, data }) => {
       const declared = createAuthzGrantsPipeline({
         authzGrantsWriteStore: {} as never,
         authzAuditTrailStore: {} as never,

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/aggregateIdentity.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/aggregateIdentity.unit.test.ts
@@ -11,6 +11,7 @@
  * emitted event's shape would have passed throughout.
  */
 import { describe, expect, it } from "vitest";
+import { validateEventAggregateType } from "../../../stores/eventStoreUtils";
 import {
   AttachGrantCommand,
   ChangeGrantRoleCommand,
@@ -19,10 +20,8 @@ import {
   DeleteRoleCommand,
   RevokeGrantCommand,
 } from "../commands/grantsLedgerCommands";
-import {
-  AUTHZ_GRANT_AGGREGATE_TYPE,
-  AUTHZ_ROLE_AGGREGATE_TYPE,
-} from "../schemas/constants";
+import { createAuthzGrantsPipeline } from "../pipeline";
+import { AUTHZ_GRANT_AGGREGATE_TYPE } from "../schemas/constants";
 
 const ORG = "org_acme";
 const ACTOR = { type: "user", id: "user_admin" } as const;
@@ -125,7 +124,62 @@ describe("authz command aggregate identity", () => {
 
       expect(event?.aggregateId).toBe("role_1");
       expect(event?.aggregateId).not.toBe(ORG);
-      expect(event?.aggregateType).toBe(AUTHZ_ROLE_AGGREGATE_TYPE);
+      // The aggregate TYPE is the pipeline's, not a per-family label: see
+      // the append guard below for why a role event stamping its own type
+      // could never be stored.
+      expect(event?.aggregateType).toBe(AUTHZ_GRANT_AGGREGATE_TYPE);
+    });
+  });
+
+  /**
+   * The regression this file previously could not catch. Both families ride
+   * the `authz_grant` pipeline, and the event store validates every event's
+   * aggregate type against the one its pipeline declares — so a role event
+   * stamping `authz_role` was rejected at index 0 of the very first batch,
+   * which parked the whole ADR-110 migration before a single fact landed.
+   *
+   * Asserting each command's constant against itself is what let that ship.
+   * This asserts against the pipeline's OWN declared type, run through the
+   * store's real validator, so the two cannot drift apart again.
+   */
+  describe("when the store validates a command's events on append", () => {
+    /** @scenario "A role's aggregate is the role" */
+    it.each([
+      ["attach", new AttachGrantCommand(), { ...identity, grant: GRANT }],
+      [
+        "define role",
+        new DefineRoleCommand(),
+        { ...identity, role: ROLE, actor: ACTOR },
+      ],
+      [
+        "change permissions",
+        new ChangeRolePermissionsCommand(),
+        {
+          ...identity,
+          roleId: "role_1",
+          permissions: ["traces:view"],
+          actor: ACTOR,
+          occurredAtMs: AT,
+        },
+      ],
+      [
+        "delete role",
+        new DeleteRoleCommand(),
+        { ...identity, roleId: "role_1", actor: ACTOR, occurredAtMs: AT },
+      ],
+    ])("accepts every event %s emits", async (_, handler, data) => {
+      const declared = createAuthzGrantsPipeline({
+        authzGrantsWriteStore: {} as never,
+        authzAuditTrailStore: {} as never,
+      }).metadata.aggregateType;
+      const events = await emit(handler as never, data);
+
+      expect(events.length).toBeGreaterThan(0);
+      for (const [index, event] of events.entries()) {
+        expect(() =>
+          validateEventAggregateType(event as never, declared, index),
+        ).not.toThrow();
+      }
     });
   });
 

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/commands/grantsLedgerCommands.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/commands/grantsLedgerCommands.ts
@@ -18,7 +18,6 @@ import {
   ATTACH_GRANT_COMMAND_TYPE,
   AUTHZ_GRANT_AGGREGATE_TYPE,
   AUTHZ_GRANTS_EVENT_VERSION_LATEST,
-  AUTHZ_ROLE_AGGREGATE_TYPE,
   CHANGE_GRANT_ROLE_COMMAND_TYPE,
   CHANGE_ROLE_PERMISSIONS_COMMAND_TYPE,
   DEFINE_ROLE_COMMAND_TYPE,
@@ -194,7 +193,7 @@ export class DefineRoleCommand
     const { occurredAtMs, ...data } = role;
     return [
       EventUtils.createEvent<RoleDefinedEvent>({
-        aggregateType: AUTHZ_ROLE_AGGREGATE_TYPE,
+        aggregateType: AUTHZ_GRANT_AGGREGATE_TYPE,
         aggregateId: role.roleId,
         tenantId: createTenantId(command.tenantId),
         type: ROLE_DEFINED_EVENT_TYPE,
@@ -232,7 +231,7 @@ export class ChangeRolePermissionsCommand
       command.data;
     return [
       EventUtils.createEvent<RolePermissionsChangedEvent>({
-        aggregateType: AUTHZ_ROLE_AGGREGATE_TYPE,
+        aggregateType: AUTHZ_GRANT_AGGREGATE_TYPE,
         aggregateId: roleId,
         tenantId: createTenantId(command.tenantId),
         type: ROLE_PERMISSIONS_CHANGED_EVENT_TYPE,
@@ -265,7 +264,7 @@ export class DeleteRoleCommand
     const { commandId, roleId, actor, occurredAtMs } = command.data;
     return [
       EventUtils.createEvent<RoleDeletedEvent>({
-        aggregateType: AUTHZ_ROLE_AGGREGATE_TYPE,
+        aggregateType: AUTHZ_GRANT_AGGREGATE_TYPE,
         aggregateId: roleId,
         tenantId: createTenantId(command.tenantId),
         type: ROLE_DELETED_EVENT_TYPE,

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/pipeline.ts
@@ -37,9 +37,11 @@ export interface AuthzGrantsPipelineDeps {
  * entity and its events apply independently of every other. The organization
  * is the tenant of all of them and the aggregate of none.
  *
- * The declared aggregate type is a label: it names the killswitch keys, and
- * nothing routes on it. Both families ride this one pipeline; what places an
- * event is the aggregate id its command stamped.
+ * Both families ride this one pipeline, so both stamp its aggregate TYPE —
+ * that is not a label. It is the storage partition key, and the event store
+ * refuses at append any event whose type differs from the one declared here.
+ * What separates one entity's fold from another's is the aggregate ID its
+ * command stamped: a grant id, or a role id.
  */
 export function createAuthzGrantsPipeline(deps: AuthzGrantsPipelineDeps) {
   return definePipeline<AuthzGrantsEvent>()

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/schemas/constants.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/schemas/constants.ts
@@ -1,12 +1,17 @@
-// ADR-110. Two aggregates, both keyed by the entity their events are about.
-// The organization is the tenant of every event and the aggregate of nothing.
-// Rollout state is not here: the migration's status is the read fork.
-
+// ADR-110. Two aggregates, both keyed by the entity their events are about:
+// what separates a grant's fold from a role's is the aggregate ID its command
+// stamps, which is the whole point of the split. The organization is the
+// tenant of every event and the aggregate of nothing. Rollout state is not
+// here: the migration's status is the read fork.
+//
+// ONE aggregate TYPE for both families, and it is not cosmetic. The type is
+// the storage partition key (`domain/aggregateType.ts`: "events are
+// partitioned by tenantId + aggregateType") and the event store rejects, at
+// append, any event whose type differs from the one its pipeline declares.
+// Both families ride the `authz_grant` pipeline, so both stamp its type; a
+// separate `authz_role` type would have to come with a pipeline of its own.
 export const AUTHZ_GRANT_PIPELINE_NAME = "authz_grant" as const;
 export const AUTHZ_GRANT_AGGREGATE_TYPE = "authz_grant" as const;
-
-export const AUTHZ_ROLE_PIPELINE_NAME = "authz_role" as const;
-export const AUTHZ_ROLE_AGGREGATE_TYPE = "authz_role" as const;
 
 // Each command names one grant; a command may not straddle aggregates.
 export const ATTACH_GRANT_COMMAND_TYPE = "lw.authz_grant.attach" as const;


### PR DESCRIPTION
## What

The ADR-110 migration cannot state a single fact. Every pass dies on the first event it sends:

```
[VALIDATION] Event at index 0 has aggregate type 'authz_role' that does not
match pipeline aggregate type 'authz_grant' (field: aggregateType)
```

#7358 split one aggregate into two — `authz_grant` and `authz_role` — but left both families riding the one `authz_grant` pipeline. The aggregate type is not a label. It is the storage partition key (`domain/aggregateType.ts`: "events are partitioned by tenantId + aggregateType"), and `abstractEventStore` validates **every** event against the type its pipeline declares before storing anything.

Roles are stated before grants, so the failure lands at index 0 of the first batch and the whole organization parks. Nothing after it runs.

The three role commands now stamp the aggregate type of the pipeline they actually ride. What separates a role's fold from a grant's is the aggregate **id** its command stamps — a role id, not a grant id — which is what ADR-110 was about; the type was never doing that work.

`AUTHZ_ROLE_AGGREGATE_TYPE` and `AUTHZ_ROLE_PIPELINE_NAME` are deleted. Both were unused after this change, and leaving a constant lying around that names a pipeline nobody built is precisely the trap that produced the bug. The comment claiming the declared type "is a label, nothing routes on it" is corrected to say what the store actually does.

## Blast radius

**Migration path only.** `ledger.defineRole` forks to an imperative write when an organization is not yet on the engine, and no organization is finalized, so live role writes never reached the event path. Customer-facing role management was not affected.

Nothing needs backfilling: no event carrying `authz_role` was ever stored, because the store refused all of them.

## Why the tests missed it

`aggregateIdentity.unit.test.ts` asserted each command's own constant back at itself — `expect(event.aggregateType).toBe(AUTHZ_ROLE_AGGREGATE_TYPE)` against the command that stamps `AUTHZ_ROLE_AGGREGATE_TYPE`. That passes no matter what either value is, and it kept passing while the store rejected every one of those events.

It now asserts against the **pipeline's own declared type**, run through the store's real `validateEventAggregateType`, so a command and its pipeline cannot drift apart again.

Verified the guard is not vacuous: re-introducing the old stamp fails both the new append test and the identity test.

## Test plan

- `pnpm test:unit run src/server/event-sourcing/pipelines/authz-grants src/server/app-layer/authz` — 319 passing.
- Sabotage check: restore `aggregateType: "authz_role"` on `DefineRoleCommand` and the suite goes red at exactly the two tests that should catch it.

## Deployment Impact

None on deploy. This unblocks the ADR-110 migration, which still drives no organization until an operator enrolls one, and `runsAutomaticallyOnSelfHosted` remains `false`.

Follows #7404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected role-related authorization events so they use the shared authorization grants event stream.
  * Improved event validation for grant and role operations, preventing aggregate-type mismatches and ensuring consistent event processing.

* **Documentation**
  * Clarified how grants and roles share the authorization event stream while remaining distinguishable through their individual identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->