### PR TITLE
fix(langy): show what a tool returned, and stop reading a rejected command as an empty result

### DIFF
--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -123,9 +123,9 @@ function opensJsonContent({
  *
  * A scalar counts only when what follows it is what a document would put
  * there. The first character is not enough, and neither is the whole word: a
- * log line reads `[notice] using the cache`, `[failed to reach the api` or
- * `[true story, we retried]`, and all three open with the spelling of a JSON
- * value. In a document a scalar is followed by a comma or the closing bracket.
+ * log line reads `[null pointer while reading the cache` or `[2026-08-22
+ * fetching traces`, and both open with the spelling of a JSON value. In a
+ * document a scalar is followed by a comma or the closing bracket.
  */
 function opensJsonValue({ text, at }: { text: string; at: number }): boolean {
   const char = text[at]!;

--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -15,6 +15,16 @@
 /** Give up scanning a huge stdout after this many `{`/`[` candidates. */
 const MAX_CANDIDATES = 32;
 
+/**
+ * A JSON scalar and the separator a document puts after it. Anchored, so it
+ * reads the token AT the position rather than searching the rest of stdout.
+ */
+const SCALAR_THEN_SEPARATOR =
+  /^(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(?:[,\]]|$)/;
+
+/** Room for the longest scalar worth reading, plus the separator after it. */
+const SCALAR_WINDOW = 40;
+
 function tryParse(candidate: string): { value: unknown } | null {
   try {
     return { value: JSON.parse(candidate) as unknown };
@@ -27,7 +37,13 @@ function tryParse(candidate: string): { value: unknown } | null {
  * Index of the bracket that closes the one at `start`, or -1. String-aware, so
  * a `}` inside a JSON string value does not close the document early.
  */
-function findBalancedEnd(text: string, start: number): number {
+function findBalancedEnd({
+  text,
+  start,
+}: {
+  text: string;
+  start: number;
+}): number {
   let depth = 0;
   let inString = false;
 
@@ -58,9 +74,16 @@ function findBalancedEnd(text: string, start: number): number {
  * before it. A spinner ends its frame with `\r` rather than `\n`, so both count
  * as the start of a line.
  */
-function startsAtDocumentBoundary(text: string, start: number): boolean {
-  const lineStart =
-    Math.max(text.lastIndexOf("\n", start - 1), text.lastIndexOf("\r", start - 1)) + 1;
+function startsAtDocumentBoundary({
+  text,
+  start,
+}: {
+  text: string;
+  start: number;
+}): boolean {
+  const newline = text.lastIndexOf("\n", start - 1);
+  const carriageReturn = text.lastIndexOf("\r", start - 1);
+  const lineStart = Math.max(newline, carriageReturn) + 1;
   return text.slice(lineStart, start).trim().length === 0;
 }
 
@@ -72,27 +95,42 @@ function startsAtDocumentBoundary(text: string, start: number): boolean {
  * bracket the rest of the output never closes is otherwise read as a truncated
  * document, which stops the scan. Reading its first token tells the two apart.
  */
-function opensJsonContent(text: string, start: number): boolean {
+function opensJsonContent({
+  text,
+  start,
+}: {
+  text: string;
+  start: number;
+}): boolean {
   const opensObject = text[start] === "{";
   const close = opensObject ? "}" : "]";
 
   for (let i = start + 1; i < text.length; i++) {
     const char = text[i]!;
-    if (char === " " || char === "\t" || char === "\n" || char === "\r") continue;
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      continue;
+    }
     if (char === close) return true;
+    // An object opens with a key, and with nothing else.
     if (opensObject) return char === '"';
-    return (
-      char === '"' ||
-      char === "{" ||
-      char === "[" ||
-      char === "-" ||
-      (char >= "0" && char <= "9") ||
-      char === "t" ||
-      char === "f" ||
-      char === "n"
-    );
+    return opensJsonValue({ text, at: i });
   }
   return false;
+}
+
+/**
+ * Whether a JSON value begins at `at`.
+ *
+ * A scalar counts only when what follows it is what a document would put
+ * there. The first character is not enough, and neither is the whole word: a
+ * log line reads `[notice] using the cache`, `[failed to reach the api` or
+ * `[true story, we retried]`, and all three open with the spelling of a JSON
+ * value. In a document a scalar is followed by a comma or the closing bracket.
+ */
+function opensJsonValue({ text, at }: { text: string; at: number }): boolean {
+  const char = text[at]!;
+  if (char === '"' || char === "{" || char === "[") return true;
+  return SCALAR_THEN_SEPARATOR.test(text.slice(at, at + SCALAR_WINDOW));
 }
 
 /**
@@ -123,10 +161,10 @@ export function parseCliJson(output: string): unknown | null {
     // reported it as a count. Every `--help` did the same. When nothing here is
     // a document, the command's own output is what stays (see the null
     // contract above).
-    if (!startsAtDocumentBoundary(output, i)) continue;
+    if (!startsAtDocumentBoundary({ text: output, start: i })) continue;
     if (++candidates > MAX_CANDIDATES) break;
 
-    const end = findBalancedEnd(output, i);
+    const end = findBalancedEnd({ text: output, start: i });
     if (end === -1) {
       // A JSON-looking document that opens a line but never closes is a
       // truncated OUTER result. Do not walk into it and promote a complete
@@ -136,7 +174,7 @@ export function parseCliJson(output: string): unknown | null {
       //
       // A log line that opens with a bracket and never closes it is not that
       // result, so it must not stop the scan before the document under it.
-      if (opensJsonContent(output, i)) return null;
+      if (opensJsonContent({ text: output, start: i })) return null;
       continue;
     }
     const parsed = tryParse(output.slice(i, end + 1));

--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -160,9 +160,17 @@ function numberEnd({ text, at }: { text: string; at: number }): number {
   let i = at;
   if (text[i] === "-") i++;
 
-  const integerFrom = i;
-  while (isDigit(text[i])) i++;
-  if (i === integerFrom) return -1;
+  // JSON writes no leading zero: a number is `0` on its own, or a non-zero
+  // digit and the digits after it. `01` is not one, so `[01,` is a line of
+  // prose and the document under it still gets read.
+  if (text[i] === "0") {
+    i++;
+  } else {
+    const integerFrom = i;
+    while (isDigit(text[i])) i++;
+    if (i === integerFrom) return -1;
+  }
+  if (isDigit(text[i])) return -1;
 
   if (text[i] === ".") {
     i++;

--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -65,6 +65,37 @@ function startsAtDocumentBoundary(text: string, start: number): boolean {
 }
 
 /**
+ * Whether what follows the bracket at `start` can begin a JSON document: a key
+ * inside `{`, any value inside `[`, or the matching close for an empty one.
+ *
+ * A log line can open a line with a bracket too (`[retrying request`), and a
+ * bracket the rest of the output never closes is otherwise read as a truncated
+ * document, which stops the scan. Reading its first token tells the two apart.
+ */
+function opensJsonContent(text: string, start: number): boolean {
+  const opensObject = text[start] === "{";
+  const close = opensObject ? "}" : "]";
+
+  for (let i = start + 1; i < text.length; i++) {
+    const char = text[i]!;
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") continue;
+    if (char === close) return true;
+    if (opensObject) return char === '"';
+    return (
+      char === '"' ||
+      char === "{" ||
+      char === "[" ||
+      char === "-" ||
+      (char >= "0" && char <= "9") ||
+      char === "t" ||
+      char === "f" ||
+      char === "n"
+    );
+  }
+  return false;
+}
+
+/**
  * The JSON document a CLI command printed, or null when its output holds none —
  * a human table, an error message, an empty string. Null reads as "leave the raw
  * output alone".
@@ -102,7 +133,11 @@ export function parseCliJson(output: string): unknown | null {
       // nested object (for example one trace's {"output":{"value":"…"}}) into
       // the result for the whole command. That was how an oversized trace
       // search rendered an unrelated sentence as its card.
-      return null;
+      //
+      // A log line that opens with a bracket and never closes it is not that
+      // result, so it must not stop the scan before the document under it.
+      if (opensJsonContent(output, i)) return null;
+      continue;
     }
     const parsed = tryParse(output.slice(i, end + 1));
     if (parsed) return parsed.value;

--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -53,8 +53,14 @@ function findBalancedEnd(text: string, start: number): number {
   return -1;
 }
 
+/**
+ * Whether the bracket at `start` opens its own line, with nothing but whitespace
+ * before it. A spinner ends its frame with `\r` rather than `\n`, so both count
+ * as the start of a line.
+ */
 function startsAtDocumentBoundary(text: string, start: number): boolean {
-  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  const lineStart =
+    Math.max(text.lastIndexOf("\n", start - 1), text.lastIndexOf("\r", start - 1)) + 1;
   return text.slice(lineStart, start).trim().length === 0;
 }
 
@@ -75,18 +81,28 @@ export function parseCliJson(output: string): unknown | null {
   for (let i = 0; i < output.length; i++) {
     const char = output[i]!;
     if (char !== "{" && char !== "[") continue;
+    // A DOCUMENT OPENS ITS OWN LINE. A BRACKET INSIDE PROSE IS PROSE.
+    //
+    // Without this the scan reached into sentences. `langwatch trace search
+    // --start now-1d` names a flag the command does not have, so the CLI
+    // printed `error: unknown option '--start'` followed by its usage, and that
+    // usage documents `--jq` with the example `.traces[].traceId`. The `[]` in
+    // it parses as an empty array, so a REJECTED command became the JSON
+    // document `[]`. The agent read that as "no traces in the last day" and
+    // reported it as a count. Every `--help` did the same. When nothing here is
+    // a document, the command's own output is what stays (see the null
+    // contract above).
+    if (!startsAtDocumentBoundary(output, i)) continue;
     if (++candidates > MAX_CANDIDATES) break;
 
     const end = findBalancedEnd(output, i);
     if (end === -1) {
-      // A JSON-looking document that starts at the beginning of a line but
-      // never closes is a truncated OUTER result. Do not continue walking into
-      // it and accidentally promote a complete nested object (for example one
-      // trace's {"output":{"value":"…"}}) into the result for the whole
-      // command. That was how an oversized trace search rendered an unrelated
-      // sentence as its card.
-      if (startsAtDocumentBoundary(output, i)) return null;
-      continue;
+      // A JSON-looking document that opens a line but never closes is a
+      // truncated OUTER result. Do not walk into it and promote a complete
+      // nested object (for example one trace's {"output":{"value":"…"}}) into
+      // the result for the whole command. That was how an oversized trace
+      // search rendered an unrelated sentence as its card.
+      return null;
     }
     const parsed = tryParse(output.slice(i, end + 1));
     if (parsed) return parsed.value;

--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -16,14 +16,16 @@
 const MAX_CANDIDATES = 32;
 
 /**
- * A JSON scalar and the separator a document puts after it. Anchored, so it
- * reads the token AT the position rather than searching the rest of stdout.
+ * A JSON scalar and the separator a document puts after it.
+ *
+ * Sticky rather than `^`-anchored: it reads the token AT `lastIndex` without
+ * copying the rest of stdout to get there, and `$` keeps meaning the end of
+ * the output. Reading a fixed window instead made `$` match the end of the
+ * WINDOW, so a scalar padded that far from its prose read as a truncated
+ * result. `^` cannot be used with `y`, since it would pin the match to index 0.
  */
 const SCALAR_THEN_SEPARATOR =
-  /^(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(?:[,\]]|$)/;
-
-/** Room for the longest scalar worth reading, plus the separator after it. */
-const SCALAR_WINDOW = 40;
+  /(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(?:[,\]]|$)/y;
 
 function tryParse(candidate: string): { value: unknown } | null {
   try {
@@ -130,7 +132,8 @@ function opensJsonContent({
 function opensJsonValue({ text, at }: { text: string; at: number }): boolean {
   const char = text[at]!;
   if (char === '"' || char === "{" || char === "[") return true;
-  return SCALAR_THEN_SEPARATOR.test(text.slice(at, at + SCALAR_WINDOW));
+  SCALAR_THEN_SEPARATOR.lastIndex = at;
+  return SCALAR_THEN_SEPARATOR.test(text);
 }
 
 /**

--- a/packages/langy/src/cards/cliJson.ts
+++ b/packages/langy/src/cards/cliJson.ts
@@ -15,17 +15,17 @@
 /** Give up scanning a huge stdout after this many `{`/`[` candidates. */
 const MAX_CANDIDATES = 32;
 
-/**
- * A JSON scalar and the separator a document puts after it.
- *
- * Sticky rather than `^`-anchored: it reads the token AT `lastIndex` without
- * copying the rest of stdout to get there, and `$` keeps meaning the end of
- * the output. Reading a fixed window instead made `$` match the end of the
- * WINDOW, so a scalar padded that far from its prose read as a truncated
- * result. `^` cannot be used with `y`, since it would pin the match to index 0.
- */
-const SCALAR_THEN_SEPARATOR =
-  /(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(?:[,\]]|$)/y;
+/** The scalars a document can spell out, as opposed to a number. */
+const JSON_LITERALS = ["true", "false", "null"];
+
+/** The four characters JSON counts as whitespace. */
+function isWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r";
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= "0" && char <= "9";
+}
 
 function tryParse(candidate: string): { value: unknown } | null {
   try {
@@ -109,9 +109,7 @@ function opensJsonContent({
 
   for (let i = start + 1; i < text.length; i++) {
     const char = text[i]!;
-    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
-      continue;
-    }
+    if (isWhitespace(char)) continue;
     if (char === close) return true;
     // An object opens with a key, and with nothing else.
     if (opensObject) return char === '"';
@@ -132,8 +130,56 @@ function opensJsonContent({
 function opensJsonValue({ text, at }: { text: string; at: number }): boolean {
   const char = text[at]!;
   if (char === '"' || char === "{" || char === "[") return true;
-  SCALAR_THEN_SEPARATOR.lastIndex = at;
-  return SCALAR_THEN_SEPARATOR.test(text);
+
+  const scalar = scalarEnd({ text, at });
+  if (scalar === -1) return false;
+
+  let i = scalar;
+  while (isWhitespace(text[i])) i++;
+  // Nothing after the scalar means the output ended on it, which is a result
+  // cut short rather than a sentence.
+  return i === text.length || text[i] === "," || text[i] === "]";
+}
+
+/** Index just past the scalar that starts at `at`, or -1 when none does. */
+function scalarEnd({ text, at }: { text: string; at: number }): number {
+  for (const literal of JSON_LITERALS) {
+    if (text.startsWith(literal, at)) return at + literal.length;
+  }
+  return numberEnd({ text, at });
+}
+
+/**
+ * Index just past the number that starts at `at`, or -1 when none does.
+ *
+ * One forward pass that never reconsiders a character. A regular expression
+ * reads better but backtracks over a long run of digits, and this runs on
+ * whatever a tool wrote to its stdout.
+ */
+function numberEnd({ text, at }: { text: string; at: number }): number {
+  let i = at;
+  if (text[i] === "-") i++;
+
+  const integerFrom = i;
+  while (isDigit(text[i])) i++;
+  if (i === integerFrom) return -1;
+
+  if (text[i] === ".") {
+    i++;
+    const fractionFrom = i;
+    while (isDigit(text[i])) i++;
+    if (i === fractionFrom) return -1;
+  }
+
+  if (text[i] === "e" || text[i] === "E") {
+    i++;
+    if (text[i] === "+" || text[i] === "-") i++;
+    const exponentFrom = i;
+    while (isDigit(text[i])) i++;
+    if (i === exponentFrom) return -1;
+  }
+
+  return i;
 }
 
 /**

--- a/packages/langy/src/cards/cliJson.unit.test.ts
+++ b/packages/langy/src/cards/cliJson.unit.test.ts
@@ -60,6 +60,39 @@ describe("parseCliJson", () => {
       expect(parseCliJson(output)).toEqual({ total: 2 });
     });
 
+    it("lifts the document under a log line that starts like a JSON literal", () => {
+      const lines = [
+        "[notice] using the cache",
+        "[failed to reach the api",
+        "[trying again",
+      ];
+
+      for (const line of lines) {
+        expect(parseCliJson(`${line}\n{"total": 2}\n`)).toEqual({ total: 2 });
+      }
+    });
+
+    it("lifts the document under a log line whose first word IS a JSON value", () => {
+      const lines = [
+        "[true retrying the request",
+        "[null pointer while reading the cache",
+        "[false start, reconnecting",
+        "[2026-08-22 fetching traces",
+      ];
+
+      for (const line of lines) {
+        expect(parseCliJson(`${line}\n{"total": 2}\n`)).toEqual({ total: 2 });
+      }
+    });
+
+    it("still reads an array of literals as the document", () => {
+      expect(parseCliJson("✔ Done\n[true, false, null]\n")).toEqual([
+        true,
+        false,
+        null,
+      ]);
+    });
+
     it("lifts a document a spinner frame left on the same line", () => {
       expect(parseCliJson('⠋ Searching traces...\r{"traces":[]}')).toEqual({
         traces: [],
@@ -112,6 +145,12 @@ describe("parseCliJson", () => {
         '{"traces":[{"trace_id":"trace_1","output":{"value":"unrelated nested answer"}},{"trace_id":"trace_2"';
 
       expect(parseCliJson(truncated)).toBeNull();
+    });
+
+    it("still stops on a truncated array of scalars", () => {
+      // `true` here is followed by a comma, which is what a document puts
+      // after it, so the array is cut short rather than a sentence.
+      expect(parseCliJson("reading…\n[true, false")).toBeNull();
     });
 
     it("still stops on a truncated array of results, log line or not", () => {

--- a/packages/langy/src/cards/cliJson.unit.test.ts
+++ b/packages/langy/src/cards/cliJson.unit.test.ts
@@ -85,6 +85,17 @@ describe("parseCliJson", () => {
       }
     });
 
+    it("lifts the document under a log line that pads its first word", () => {
+      // The check used to read a fixed window, so the end anchor matched the
+      // end of the WINDOW. A scalar padded that far from the prose after it
+      // then read as a result cut short, and the document below it was lost.
+      for (const padding of [1, 35, 36, 37, 200]) {
+        const line = `[true${" ".repeat(padding)}retrying`;
+
+        expect(parseCliJson(`${line}\n{"total": 2}\n`)).toEqual({ total: 2 });
+      }
+    });
+
     it("still reads an array of literals as the document", () => {
       expect(parseCliJson("✔ Done\n[true, false, null]\n")).toEqual([
         true,
@@ -151,6 +162,13 @@ describe("parseCliJson", () => {
       // `true` here is followed by a comma, which is what a document puts
       // after it, so the array is cut short rather than a sentence.
       expect(parseCliJson("reading…\n[true, false")).toBeNull();
+    });
+
+    it("still stops on a result cut off at its first scalar", () => {
+      // Nothing follows the scalar because the output ends there. This is what
+      // the end anchor is for, so it has to keep working from the real end.
+      expect(parseCliJson("reading…\n[true")).toBeNull();
+      expect(parseCliJson("reading…\n[true\n")).toBeNull();
     });
 
     it("still stops on a truncated array of results, log line or not", () => {

--- a/packages/langy/src/cards/cliJson.unit.test.ts
+++ b/packages/langy/src/cards/cliJson.unit.test.ts
@@ -54,6 +54,12 @@ describe("parseCliJson", () => {
       ]);
     });
 
+    it("lifts the document under a log line that opens a bracket it never closes", () => {
+      const output = '[retrying request\n{"total": 2}\n';
+
+      expect(parseCliJson(output)).toEqual({ total: 2 });
+    });
+
     it("lifts a document a spinner frame left on the same line", () => {
       expect(parseCliJson('⠋ Searching traces...\r{"traces":[]}')).toEqual({
         traces: [],
@@ -104,6 +110,13 @@ describe("parseCliJson", () => {
     it("does not mistake a nested object inside a truncated result for the document", () => {
       const truncated =
         '{"traces":[{"trace_id":"trace_1","output":{"value":"unrelated nested answer"}},{"trace_id":"trace_2"';
+
+      expect(parseCliJson(truncated)).toBeNull();
+    });
+
+    it("still stops on a truncated array of results, log line or not", () => {
+      const truncated =
+        'reading…\n[{"trace_id":"trace_1","output":{"value":"unrelated nested answer"}},{"trace_id":"trace_2"';
 
       expect(parseCliJson(truncated)).toBeNull();
     });

--- a/packages/langy/src/cards/cliJson.unit.test.ts
+++ b/packages/langy/src/cards/cliJson.unit.test.ts
@@ -96,6 +96,12 @@ describe("parseCliJson", () => {
       }
     });
 
+    it("lifts the document under a log line numbered with a leading zero", () => {
+      for (const line of ["[01,", "[-01,", "[007 retrying"]) {
+        expect(parseCliJson(`${line}\n{"total": 2}\n`)).toEqual({ total: 2 });
+      }
+    });
+
     it("still reads an array of literals as the document", () => {
       expect(parseCliJson("✔ Done\n[true, false, null]\n")).toEqual([
         true,
@@ -164,6 +170,14 @@ describe("parseCliJson", () => {
       expect(parseCliJson("reading…\n[true, false")).toBeNull();
     });
 
+    it("still stops on a truncated array of numbers", () => {
+      // These ARE numbers the way JSON writes them, so each array is a result
+      // cut short rather than a sentence.
+      expect(parseCliJson("reading…\n[0, 1")).toBeNull();
+      expect(parseCliJson("reading…\n[0.5, 1")).toBeNull();
+      expect(parseCliJson("reading…\n[-2e10, 1")).toBeNull();
+    });
+
     it("still stops on a result cut off at its first scalar", () => {
       // Nothing follows the scalar because the output ends there. This is what
       // the end anchor is for, so it has to keep working from the real end.
@@ -180,6 +194,35 @@ describe("parseCliJson", () => {
 
     it("returns null for an empty output", () => {
       expect(parseCliJson("")).toBeNull();
+    });
+
+    // The scan decides "result cut short" from the first scalar after the
+    // bracket, so its idea of a scalar has to be JSON's. Rather than restate
+    // the grammar here, ask the parser that owns it.
+    it("agrees with JSON.parse about what counts as a scalar", () => {
+      const scalars = [
+        "0", "-0", "1", "42", "-42", "0.5", "-0.5", "1e3", "1E3", "1e+3",
+        "1e-3", "-2e10", "0.0", "123456789012345678901234567890",
+        "01", "-01", "007", "00", "1.", ".5", "-", "+1", "1e", "1e+", "0x1f",
+        "1_000", "Infinity", "NaN", "true", "false", "null", "tru", "nul",
+      ];
+
+      for (const scalar of scalars) {
+        let isRealJson: boolean;
+        try {
+          JSON.parse(`[${scalar},1]`);
+          isRealJson = true;
+        } catch {
+          isRealJson = false;
+        }
+
+        // A real scalar makes the bracket a result cut short, which stops the
+        // scan. Anything else is prose, and the document below it is read.
+        expect({
+          scalar,
+          cutShort: parseCliJson(`[${scalar},\n{"total": 2}\n`) === null,
+        }).toEqual({ scalar, cutShort: isRealJson });
+      }
     });
   });
 });

--- a/packages/langy/src/cards/cliJson.unit.test.ts
+++ b/packages/langy/src/cards/cliJson.unit.test.ts
@@ -53,6 +53,41 @@ describe("parseCliJson", () => {
         { id: "ds_1" },
       ]);
     });
+
+    it("lifts a document a spinner frame left on the same line", () => {
+      expect(parseCliJson('⠋ Searching traces...\r{"traces":[]}')).toEqual({
+        traces: [],
+      });
+    });
+  });
+
+  describe("given stdout that is the command's own usage text", () => {
+    /** @scenario A rejected command is never read as an empty result */
+    it("returns null for help that documents a jq path", () => {
+      const help = [
+        "Usage: langwatch trace search [options]",
+        "",
+        "Options:",
+        "  --limit <n>            Max results to return (default: 25)",
+        "  --jq <expr>            Filter output with a path expression (e.g.",
+        "                         .traces[].traceId)",
+      ].join("\n");
+
+      expect(parseCliJson(help)).toBeNull();
+    });
+
+    /** @scenario A rejected command is never read as an empty result */
+    it("returns null for a rejected flag and the usage under it", () => {
+      const rejected = [
+        "error: unknown option '--start'",
+        "",
+        "Usage: langwatch trace search [options]",
+        "  --jq <expr>  Filter output with a path expression (e.g.",
+        "               .traces[].traceId)",
+      ].join("\n");
+
+      expect(parseCliJson(rejected)).toBeNull();
+    });
   });
 
   describe("given stdout that holds no JSON", () => {

--- a/platform/app/src/features/langy/__tests__/LangyReceiptToolResults.integration.test.tsx
+++ b/platform/app/src/features/langy/__tests__/LangyReceiptToolResults.integration.test.tsx
@@ -104,6 +104,111 @@ describe("the completed receipt's tool results", () => {
     });
   });
 
+  describe("when the call came through the CLI envelope", () => {
+    /** @scenario An opened row shows the data a tool returned, not its envelope */
+    it("shows the payload, indented, without the transport around it", () => {
+      renderMessage(
+        assistantMessage([
+          {
+            type: "tool-langwatch.trace.search",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { command: 'langwatch trace search --start "now-1d"' },
+            output: JSON.stringify({
+              kind: "json",
+              payload: { count: 6, window: "1d" },
+            }),
+          },
+          { type: "text", text: "Six traces.", role: "assistant" },
+        ]),
+      );
+
+      const row = screen.getAllByRole("listitem")[0]!;
+      fireEvent.click(within(row).getAllByRole("button")[0]!);
+
+      const shown = row.textContent ?? "";
+      expect(shown).toContain('"count": 6');
+      expect(shown).not.toContain("kind");
+      expect(shown).not.toContain("payload");
+    });
+
+    /** @scenario An opened row names the command behind each result */
+    it("names the command of every call the row grouped", () => {
+      renderMessage(
+        assistantMessage([
+          {
+            type: "tool-langwatch.trace.search",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { command: 'langwatch trace search --start "now-1d"' },
+            output: JSON.stringify({ kind: "json", payload: [] }),
+          },
+          {
+            type: "tool-langwatch.trace.search",
+            toolCallId: "call-2",
+            state: "output-available",
+            input: { command: "langwatch trace search" },
+            output: JSON.stringify({ kind: "json", payload: [{ id: "t_1" }] }),
+          },
+          { type: "text", text: "Six traces.", role: "assistant" },
+        ]),
+      );
+
+      const row = screen.getAllByRole("listitem")[0]!;
+      fireEvent.click(within(row).getAllByRole("button")[0]!);
+
+      expect(
+        screen.getByText('$ langwatch trace search --start "now-1d"'),
+      ).toBeDefined();
+      expect(screen.getByText("$ langwatch trace search")).toBeDefined();
+    });
+  });
+
+  describe("when the call is a plain shell command", () => {
+    /** @scenario An opened row shows the data a tool returned, not its envelope */
+    it("keeps stdout exactly as the model read it", () => {
+      const stdout = "zsh:1: command not found: langwatch\n";
+      renderMessage(
+        assistantMessage([
+          {
+            type: "tool-bash",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { command: "langwatch --help" },
+            output: stdout,
+          },
+          { type: "text", text: "Not installed.", role: "assistant" },
+        ]),
+      );
+
+      const row = screen.getAllByRole("listitem")[0]!;
+      fireEvent.click(within(row).getAllByRole("button")[0]!);
+      expect(screen.getByText(stdout.trim())).toBeDefined();
+    });
+
+    /** @scenario An opened row shows the data a tool returned, not its envelope */
+    it("keeps a log line that came before the JSON", () => {
+      const stdout = 'connecting…\n{"total":2}\n';
+      renderMessage(
+        assistantMessage([
+          {
+            type: "tool-bash",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { command: "./report.sh" },
+            output: stdout,
+          },
+          { type: "text", text: "Two.", role: "assistant" },
+        ]),
+      );
+
+      const row = screen.getAllByRole("listitem")[0]!;
+      fireEvent.click(within(row).getAllByRole("button")[0]!);
+      expect(row.textContent).toContain("connecting…");
+      expect(row.textContent).toContain('{"total":2}');
+    });
+  });
+
   describe("when a row's calls recorded no result", () => {
     it("offers nothing to open", () => {
       renderMessage(

--- a/platform/app/src/features/langy/__tests__/LangyReceiptToolResults.integration.test.tsx
+++ b/platform/app/src/features/langy/__tests__/LangyReceiptToolResults.integration.test.tsx
@@ -105,7 +105,7 @@ describe("the completed receipt's tool results", () => {
   });
 
   describe("when the call came through the CLI envelope", () => {
-    /** @scenario An opened row shows the data a tool returned, not its envelope */
+    /** @scenario An opened row shows the data a tool returned, formatted to read */
     it("shows the payload, indented, without the transport around it", () => {
       renderMessage(
         assistantMessage([
@@ -132,7 +132,7 @@ describe("the completed receipt's tool results", () => {
       expect(shown).not.toContain("payload");
     });
 
-    /** @scenario An opened row names the command behind each result */
+    /** @scenario An opened result names the command that produced it */
     it("names the command of every call the row grouped", () => {
       renderMessage(
         assistantMessage([
@@ -165,7 +165,7 @@ describe("the completed receipt's tool results", () => {
   });
 
   describe("when the call is a plain shell command", () => {
-    /** @scenario An opened row shows the data a tool returned, not its envelope */
+    /** @scenario An opened row shows the data a tool returned, formatted to read */
     it("keeps stdout exactly as the model read it", () => {
       const stdout = "zsh:1: command not found: langwatch\n";
       renderMessage(
@@ -186,7 +186,7 @@ describe("the completed receipt's tool results", () => {
       expect(screen.getByText(stdout.trim())).toBeDefined();
     });
 
-    /** @scenario An opened row shows the data a tool returned, not its envelope */
+    /** @scenario An opened row shows the data a tool returned, formatted to read */
     it("keeps a log line that came before the JSON", () => {
       const stdout = 'connecting…\n{"total":2}\n';
       renderMessage(

--- a/platform/app/src/features/langy/__tests__/LangyRunningActivityCard.integration.test.tsx
+++ b/platform/app/src/features/langy/__tests__/LangyRunningActivityCard.integration.test.tsx
@@ -142,6 +142,28 @@ describe("a turn's activity cards", () => {
         ).toBeTruthy();
       });
 
+      /** @scenario An opened result names the command that produced it */
+      it("names the command under which each result came back", () => {
+        useLangyStore.setState({ turnPhase: "active" });
+        renderTurn(
+          turnFromParts([
+            {
+              type: "tool-langwatch.trace.search",
+              toolCallId: "call-1",
+              state: "output-available",
+              input: { command: 'langwatch trace search --limit "5"' },
+              output: JSON.stringify({ kind: "json", payload: { count: 5 } }),
+            },
+          ]),
+        );
+
+        fireEvent.click(screen.getByRole("button", { expanded: false }));
+
+        expect(
+          screen.getByText('$ langwatch trace search --limit "5"'),
+        ).toBeTruthy();
+      });
+
       it("offers no disclosure when the call recorded no result", () => {
         useLangyStore.setState({ turnPhase: "active" });
         const { container } = renderTurn(

--- a/platform/app/src/features/langy/components/LangyToolActivity.tsx
+++ b/platform/app/src/features/langy/components/LangyToolActivity.tsx
@@ -34,7 +34,12 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
-import { parseCliJson, readCliErrorDocument } from "@langwatch/langy";
+import {
+  cliToolResultPayload,
+  cliToolResultSchema,
+  parseCliJson,
+  readCliErrorDocument,
+} from "@langwatch/langy";
 import type { UIMessage } from "ai";
 import { Braces, Check, ChevronRight, Layers3 } from "lucide-react";
 import { Fragment, type ReactNode, useEffect, useRef, useState } from "react";
@@ -54,7 +59,11 @@ import {
   type LangyToolErrorPresentation,
   presentLangyToolError,
 } from "../logic/langyToolFailure";
-import { describeToolCall, effectiveToolName } from "../logic/langyToolLabel";
+import {
+  commandOf,
+  describeToolCall,
+  effectiveToolName,
+} from "../logic/langyToolLabel";
 import { useLangyStore } from "../stores/langyStore";
 import {
   type CapabilityProgress,
@@ -1006,7 +1015,8 @@ function CompletedActivityRow({
             onToggle={() => setResultOpen((value) => !value)}
           >
             {label}
-            {detail}
+            {/* The truncated command gives way to the full one below it. */}
+            {resultOpen ? null : detail}
           </ResultDisclosureButton>
         ) : (
           <>
@@ -1022,9 +1032,9 @@ function CompletedActivityRow({
         ) : null}
       </HStack>
       {resultOpen ? (
-        <VStack align="stretch" gap={1} paddingBottom={1.5}>
+        <VStack align="stretch" gap={1.5} paddingBottom={1.5}>
           {callsWithResult.map((call, index) => (
-            <ToolResultBlock key={call.toolCallId ?? index} call={call} />
+            <OpenedToolCall key={call.toolCallId ?? index} call={call} />
           ))}
         </VStack>
       ) : null}
@@ -1116,18 +1126,84 @@ function RawDataToggle({
  * What one finished call returned, as the model read it. A failed call's
  * result IS its error text. Null when the record kept no result at all —
  * the caller uses that to withhold the disclosure, not to render "nothing".
+ *
+ * The DATA, not the transport. A CLI result travels as a JSON string holding
+ * the `{ kind, payload }` envelope (see `cliToolResultSchema`), so printing
+ * `call.output` verbatim showed the reader `{"kind":"json","payload":[]}` on
+ * one unindented line: the envelope quoted at them, with the answer they came
+ * for as a fragment inside it. Unwrap to the payload and indent it.
+ *
+ * Only an output that is JSON *whole* is reformatted, which is why this parses
+ * strictly instead of reaching for `parseCliJson`. That reader lifts the first
+ * balanced document out of surrounding console noise, which is right for a card
+ * (it wants the document) and wrong here (the noise is part of what the model
+ * read). A shell call that logs a line and then prints JSON keeps both.
  */
 function toolResultText(call: ToolCall): string | null {
   if (call.errorText) return call.errorText;
-  if (call.output === undefined || call.output === null) return null;
-  if (typeof call.output === "string") {
-    return call.output.trim().length > 0 ? call.output : null;
-  }
+  const raw = call.output;
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") return renderResultValue(unwrapCliEnvelope(raw));
+  if (raw.trim().length === 0) return null;
+
+  const parsed = parseWholeJson(raw);
+  return parsed === undefined
+    ? raw
+    : renderResultValue(unwrapCliEnvelope(parsed.value));
+}
+
+/** The payload a CLI envelope carries, or the document when it is not one. */
+function unwrapCliEnvelope(document: unknown): unknown {
+  const envelope = cliToolResultSchema.safeParse(document);
+  return envelope.success ? cliToolResultPayload(envelope.data) : document;
+}
+
+/** A result value as text: a string as it stands, anything else indented. */
+function renderResultValue(value: unknown): string | null {
+  if (typeof value === "string") return value.trim().length > 0 ? value : null;
   try {
-    return JSON.stringify(call.output, null, 2);
+    return JSON.stringify(value, null, 2);
   } catch {
-    return String(call.output);
+    return String(value);
   }
+}
+
+/** The value a string holds when the WHOLE string is JSON, else undefined. */
+function parseWholeJson(text: string): { value: unknown } | undefined {
+  try {
+    return { value: JSON.parse(text) as unknown };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * One finished call, opened: what ran, and then what came back.
+ *
+ * The command is shown again here rather than left to the row's label, because
+ * a row groups calls by what they DID: two `langwatch trace search` calls that
+ * differ only in their flags share the single label "Searched traces", and the
+ * command is then the only thing that says which result belongs to which. That
+ * is not a corner case. Asking for one day and then for everything is how the
+ * agent answers a question about a time range.
+ */
+function OpenedToolCall({ call }: { call: ToolCall }) {
+  const command = commandOf(call.input);
+  return (
+    <VStack align="stretch" gap={1}>
+      {command ? (
+        <Text
+          textStyle="2xs"
+          fontFamily="mono"
+          color="fg.subtle"
+          wordBreak="break-all"
+        >
+          $ {command}
+        </Text>
+      ) : null}
+      <ToolResultBlock call={call} />
+    </VStack>
+  );
 }
 
 function ToolResultBlock({ call }: { call: ToolCall }) {

--- a/platform/app/src/features/langy/components/LangyToolActivity.tsx
+++ b/platform/app/src/features/langy/components/LangyToolActivity.tsx
@@ -1627,16 +1627,20 @@ function LatestSettledActivityCard({
           isExpanded={resultOpen}
           onToggle={() => setResultOpen((value) => !value)}
         >
-          <SettledActivityLabel label={group.label} detail={detail} />
+          {/* The truncated command gives way to the full one below it. */}
+          <SettledActivityLabel
+            label={group.label}
+            detail={resultOpen ? undefined : detail}
+          />
         </ResultDisclosureButton>
       ) : (
         <SettledActivityLabel label={group.label} detail={detail} />
       )}
 
       {resultOpen ? (
-        <VStack align="stretch" gap={1}>
+        <VStack align="stretch" gap={1.5}>
           {callsWithResult.map((call, index) => (
-            <ToolResultBlock key={call.toolCallId ?? index} call={call} />
+            <OpenedToolCall key={call.toolCallId ?? index} call={call} />
           ))}
         </VStack>
       ) : null}

--- a/platform/app/src/features/langy/logic/langyToolLabel.ts
+++ b/platform/app/src/features/langy/logic/langyToolLabel.ts
@@ -61,6 +61,21 @@ export function shellCommandOf(
 }
 
 /**
+ * The command an input carries, whatever the call is NAMED.
+ *
+ * A LangWatch call reaches the panel under two names: live it is still
+ * `bash("langwatch trace search …")`, and durably the server envelope has
+ * renamed it `langwatch.trace.search`. Only the name changes, and both keep the
+ * command in their input. Reading the input rather than the name is what keeps
+ * a replayed turn as specific as the live one: without it, a reopened
+ * conversation showed two `langwatch trace search` calls as two identical
+ * "Searched traces" rows, and which one returned nothing was unanswerable.
+ */
+export function commandOf(input: unknown): string | undefined {
+  return readString(input, COMMAND_KEYS);
+}
+
+/**
  * The name a tool frame should be TREATED as.
  *
  * A shell call running a LangWatch CLI command is not a shell call — it is that
@@ -233,7 +248,7 @@ export function describeToolCall({
   //    the running line and the settled card cannot disagree.
   const progress = resolveCapabilityProgress(effectiveToolName(name, input));
   if (progress) {
-    const command = shellCommandOf(name, input);
+    const command = commandOf(input);
     return {
       title: progress.headline,
       detail: command ? truncate(command) : undefined,

--- a/specs/langy/langy-cli-tool-envelope.feature
+++ b/specs/langy/langy-cli-tool-envelope.feature
@@ -74,6 +74,16 @@ Feature: Langy recognises its own CLI behind a shell tool call
       When the LangWatch CLI exits with an error
       Then the recorded tool result keeps the error text the CLI printed
 
+    # The CLI documents its --jq flag with the example ".traces[].traceId". The
+    # "[]" in that sentence parses as an empty array, so every usage text and
+    # every --help was recorded as the JSON document []. The agent read a
+    # rejected command as "no results" and reported that as a count.
+    @unit
+    Scenario: A rejected command is never read as an empty result
+      When the LangWatch CLI rejects a flag and prints its usage text
+      Then the recorded tool result is that text, not a fragment of JSON from inside it
+      And the same holds for a command that only printed its help
+
   # A failure the CLI described precisely — what went wrong, why, and what to do
   # about it — used to reach the panel as a bare sentence, because the envelope
   # kept only the message and threw the structure away. The card then had nothing

--- a/specs/langy/langy-frontend-realtime.feature
+++ b/specs/langy/langy-frontend-realtime.feature
@@ -105,6 +105,26 @@ Feature: Langy consumes the event-sourced backend with optimized fetches and lig
     Then the row expands to show the result the model saw
     And a row whose calls recorded no result does not pretend to open
 
+  # A LangWatch result travels as a JSON string holding a {kind, payload}
+  # envelope, so the first version of the disclosure quoted the transport at
+  # the reader on one unindented line and left the answer as a fragment inside
+  # it. The reader wants the data.
+  @integration
+  Scenario: An opened row shows the data a tool returned, not its envelope
+    Given a finished call whose result came through the CLI envelope
+    When the user opens that row
+    Then the row shows the payload indented, without the envelope around it
+    And a plain shell command's output stays exactly the text the model read
+
+  # A row groups calls by what they DID, so two searches that differ only in
+  # their flags share one label. Which result belongs to which is then only
+  # answerable from the command.
+  @integration
+  Scenario: An opened row names the command behind each result
+    Given a row that grouped two calls of the same capability
+    When the user opens that row
+    Then each result is shown under the command that produced it
+
   # The live view of a turn is driven by two independent cursors toward the
   # same durable event log: the freshness signal (push, low latency) and the
   # polled history snapshot (pull, always running while a turn is in flight).

--- a/specs/langy/langy-frontend-realtime.feature
+++ b/specs/langy/langy-frontend-realtime.feature
@@ -106,24 +106,25 @@ Feature: Langy consumes the event-sourced backend with optimized fetches and lig
     And a row whose calls recorded no result does not pretend to open
 
   # A LangWatch result travels as a JSON string holding a {kind, payload}
-  # envelope, so the first version of the disclosure quoted the transport at
+  # envelope, so the first version of the disclosure quoted that transport at
   # the reader on one unindented line and left the answer as a fragment inside
   # it. The reader wants the data.
   @integration
-  Scenario: An opened row shows the data a tool returned, not its envelope
-    Given a finished call whose result came through the CLI envelope
+  Scenario: An opened row shows the data a tool returned, formatted to read
+    Given a finished call that returned structured data
     When the user opens that row
-    Then the row shows the payload indented, without the envelope around it
+    Then the row shows that data indented, with nothing wrapped around it
     And a plain shell command's output stays exactly the text the model read
 
   # A row groups calls by what they DID, so two searches that differ only in
   # their flags share one label. Which result belongs to which is then only
   # answerable from the command.
   @integration
-  Scenario: An opened row names the command behind each result
+  Scenario: An opened result names the command that produced it
     Given a row that grouped two calls of the same capability
     When the user opens that row
     Then each result is shown under the command that produced it
+    And the card the turn holds open names its command the same way
 
   # The live view of a turn is driven by two independent cursors toward the
   # same durable event log: the freshness signal (push, low latency) and the


### PR DESCRIPTION
# fix(langy): show what a tool returned, and stop reading a rejected command as an empty result

Follow-up to #7403, from the same dogfooding session. Opening a receipt row showed the transport envelope instead of the data, and chasing that down found the reason the agent had reported a wrong number in the first place.

## 1. An opened row shows the data, not the envelope

A LangWatch CLI result travels as a JSON string holding a `{ kind, payload }` envelope. The disclosure printed `call.output` verbatim, so the reader got:

```
{"kind":"json","payload":[]}
```

The envelope quoted at them, on one unindented line, with the answer they came for as a fragment inside it. The row now shows the payload, indented.

The conversation from the report, reopened. The row that read `{"kind":"json","payload":[]}` now names its command and shows the result alone:

![Opened row with its command and payload](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7408/langy-tool-results/opened-row-command-and-payload.png)

Only an output that is JSON **whole** is reformatted. The panel parses strictly here rather than reusing `parseCliJson`, which lifts the first balanced document out of surrounding console noise: right for a card, wrong for this view, where the noise is part of what the model read. A shell call that logs a line and then prints JSON keeps both lines.

## 2. An opened result names the command that produced it

A receipt row groups calls by what they DID, so two `langwatch trace search` calls that differ only in their flags share the single label "Searched traces". Nothing said which result belonged to which, and the two results were `[]` and six traces.

Each result is now shown under its own `$ <command>` line. The truncated command in the row header gives way to the full one while the row is open, so nothing is printed twice. The card the turn holds open while the model thinks does the same, since it groups its calls the same way.

The header can show a command at all now: `describeToolCall` read it with `shellCommandOf`, which returns nothing unless the tool is NAMED `bash`. A replayed turn carries the envelope's typed name (`langwatch.trace.search`) and still carries the command in its input, so a reopened conversation was less specific than the live one. It reads the input instead.

## 3. A rejected command is no longer recorded as an empty result

This is the bug behind the report, and it is not a display problem.

`langwatch trace search --start "now-1d"` names a flag the command does not have. The CLI printed `error: unknown option '--start'` and its usage text. That usage documents `--jq` with the example `.traces[].traceId`, and the `[]` in that sentence parses as an empty JSON array, so `parseCliJson` scavenged it and the envelope recorded the whole rejection as the document `[]`.

The agent read `[]` as "no traces in the last day". It then ran a second search with no time filter, got six, and answered "6 traces from the last day". Every `--help` did the same thing: `langwatch trace search --help` was recorded as `[]`.

A JSON document now has to open its own line. A bracket inside prose is prose. When nothing in the output is a document, the command's own text is what gets recorded, which is the existing contract for a human table, and the agent sees the error it actually caused.

A line can also open with a bracket and never close it (`[retrying request`). That is a log line, not a truncated result, so the scan reads the first token after the bracket to tell the two apart and walks past the prose to the document under it.

Reading the token means reading all of it. A log line can spell a JSON value and then carry on in prose, as `[null pointer while reading the cache` and `[2026-08-22 fetching traces` do, so a scalar counts as a document only when a comma or the closing bracket follows it. `[true, false` is a result cut short and still stops the scan; `[true retrying the request` is a sentence. Stopping the scan is what keeps a nested object out of the result for the whole command.

Verified against the real CLI:

| Output | Recorded before | Recorded now |
|---|---|---|
| `langwatch trace search --help` | `[]` | the help text |
| `langwatch trace search --start now-1d` | `[]` | `error: unknown option '--start'` and its usage |
| `--format json` result with spinner lines around it | the document | the document |

Dogfooded on the running stack after the fix. The agent asked for the help text, got it, and could answer the question from it:

![An opened row showing the help text the CLI printed](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7408/langy-tool-results/opened-row-help-text.png)

## Tests

- `packages/langy`: parser cases for usage text, a rejected flag, a document a spinner frame left on the same line, log lines that open a bracket they never close (including ones that spell a JSON value first, pad it, or number it with a leading zero), and results cut short at a scalar, at an array of scalars or numbers, and mid-object. One test pins the scan's idea of a scalar to `JSON.parse` over 33 spellings, so a future edit that drifts from the JSON grammar fails rather than waiting for review. 321 pass.
- `LangyReceiptToolResults.integration.test.tsx`: the payload is shown without the envelope, every grouped call is named by its command, plain stdout is untouched, and a log line before the JSON survives. 6 pass.
- `LangyRunningActivityCard.integration.test.tsx`: the held card names the command under which each result came back. It fails against the old rendering.
- Specs: two scenarios in `langy-frontend-realtime.feature`, one in `langy-cli-tool-envelope.feature`, all tagged and bound.
- `pnpm typecheck:all` exit 0. Langy lanes: 298 component, 1313 unit. No new Biome findings (the file's five complexity warnings are all present on main).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved display of tool results with readable, indented JSON payloads.
  - Tool activity now shows the command that produced each result.
  - Grouped results identify their originating commands.
  - Plain shell output and preceding log lines are preserved.

- **Bug Fixes**
  - Improved recognition of embedded JSON in CLI output.
  - Prevented help text, rejected commands, truncated data, and unmatched brackets from being misinterpreted as JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->