### PR TITLE
feat(cli-auth): langwatch login mints a user-scoped key that inherits the user's permissions

### DIFF
--- a/docs/integration/cli.mdx
+++ b/docs/integration/cli.mdx
@@ -79,6 +79,17 @@ You'll see two questions:
 
 The browser shows an "Approve" or "Send API key" button (depending on the chosen mode); after you click, the credential is delivered back to the CLI over the same RFC 8628 device-code poll. **You never copy-paste a key.**
 
+### What the login key can access
+
+The AI-tools login mints a login key that inherits your own access. The authorize screen shows the scopes and permissions before you approve:
+
+- **Scopes**: an organization admin gets the whole organization by default; other members get their teams plus their personal workspace. You can narrow the selection to specific teams or projects.
+- **Permissions**: everything you can do day to day (traces, datasets, prompts, evaluations, the AI Gateway, model providers). Organization management stays off by default: the key cannot create or delete projects, manage members and roles, or manage the organization unless you turn those on under **Customize**.
+
+Every request the key makes is checked against your live permissions, so the key can never do more than you can, and it shrinks with you if your role changes. A new login from the same machine replaces the previous login key, and `langwatch logout` revokes it.
+
+Data commands keep targeting your personal workspace by default. Pass `--project <id|slug>` to read another project the key covers, and run `langwatch projects list` to see which projects those are. `langwatch whoami` shows the key's reach.
+
 ### Storage discipline (where credentials land)
 
 | Scope | Path | What lives there |
@@ -288,6 +299,13 @@ langwatch trace search --limit 10              # most recent traces
 langwatch trace search --query "error"         # full-text search
 langwatch trace get <trace-id>                 # one trace in detail
 langwatch trace export --output traces.jsonl   # stream traces for offline analysis
+```
+
+With a device login, these commands read your personal workspace by default. Add `--project <id|slug>` to read any other project your login key covers:
+
+```bash
+langwatch projects list                              # projects the key can read
+langwatch trace search --project checkout-agent      # search another project by slug
 ```
 
 Agents use this to debug their own instrumentation: after running your code once, ask the assistant to run `langwatch trace search --limit 5` and verify traces are flowing. If nothing appears, the instrumentation is wrong, no need to read logs.

--- a/docs/integration/cli.mdx
+++ b/docs/integration/cli.mdx
@@ -84,7 +84,9 @@ The browser shows an "Approve" or "Send API key" button (depending on the chosen
 The AI-tools login mints a login key that inherits your own access. The authorize screen shows the scopes and permissions before you approve:
 
 - **Scopes**: an organization admin gets the whole organization by default; other members get their teams plus their personal workspace. You can narrow the selection to specific teams or projects.
-- **Permissions**: everything you can do day to day (traces, datasets, prompts, evaluations, the AI Gateway, model providers). Organization management stays off by default: the key cannot create or delete projects, manage members and roles, or manage the organization unless you turn those on under **Customize**.
+- **Permissions**: everything you can do day to day (traces, datasets, prompts, evaluations, the AI Gateway, model providers). Organization management stays off by default: the key cannot manage members and roles, or manage the organization, unless you turn those on under **Customize**.
+
+Project administration is the one thing that rides along. Model providers and project settings are gated by the project management permission, and that same permission answers a project create or delete request, so a key that can configure model providers can also create and delete projects in the scopes it covers. To withhold it, set **Project** to **Read** under **Customize**, which turns model provider writes off with it.
 
 Every request the key makes is checked against your live permissions, so the key can never do more than you can, and it shrinks with you if your role changes. A new login from the same machine replaces the previous login key, and `langwatch logout` revokes it.
 

--- a/platform/app/src/app/api/projects/[[...route]]/app.ts
+++ b/platform/app/src/app/api/projects/[[...route]]/app.ts
@@ -10,6 +10,7 @@ import {
 import { validator as zValidator } from "~/server/api/validation";
 import type { ApiKeyService } from "~/server/api-key/api-key.service";
 import { resolveVisibleProjects } from "~/server/api-key/project-visibility";
+import type { OrgResolvedToken } from "~/server/api-key/token-resolver";
 import {
   DestinationTeamNotFoundError,
   PersonalProjectProtectedError,
@@ -141,10 +142,17 @@ secured
       const { page, limit } = c.req.valid("query");
       const service = c.get("projectService") as ProjectService;
 
+      // Read the resolved credential itself rather than the loose context
+      // key: this family authenticates organization API keys only, so
+      // `apiKeyId` is always a real key here, and taking it from the typed
+      // token is what keeps that true if the family ever grows another
+      // credential class.
+      const resolved = c.get("orgResolvedToken") as OrgResolvedToken;
+
       const visible = await resolveVisibleProjects({
         prisma,
-        apiKeyId: c.get("apiKeyId") as string,
-        userId: (c.get("apiKeyUserId") as string | null) ?? null,
+        apiKeyId: resolved.apiKeyId,
+        userId: resolved.userId,
         organizationId: organization.id,
       });
 

--- a/platform/app/src/app/api/projects/[[...route]]/app.ts
+++ b/platform/app/src/app/api/projects/[[...route]]/app.ts
@@ -2,12 +2,14 @@ import { describeRoute } from "hono-openapi";
 import { z } from "zod";
 import type { Organization } from "~/generated/prisma/client";
 import {
+  anyAuthenticated,
   createOrgApp,
   requires,
   requiresOnProject,
 } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
 import type { ApiKeyService } from "~/server/api-key/api-key.service";
+import { resolveVisibleProjects } from "~/server/api-key/project-visibility";
 import {
   DestinationTeamNotFoundError,
   PersonalProjectProtectedError,
@@ -120,8 +122,15 @@ const secured = createOrgApp<ExtraVariables>({
 
 secured.hono.onError(handleProjectError);
 
+// The listing is not gated on organization-wide `project:view`: a credential
+// whose view does not reach org scope gets a 200 with exactly the projects it
+// holds `project:view` on (key bindings ∩ owner ceiling, resolved by
+// `resolveVisibleProjects`) instead of a 403. Content, not access, is what the
+// permission decides here, so the policy is anyAuthenticated and the handler
+// does the scoping — the same shape the model-defaults family uses.
+// Spec: specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
 secured
-  .access(requires("project:view"))
+  .access(anyAuthenticated())
   .get(
     "/",
     projectServiceMiddleware,
@@ -132,10 +141,18 @@ secured
       const { page, limit } = c.req.valid("query");
       const service = c.get("projectService") as ProjectService;
 
+      const visible = await resolveVisibleProjects({
+        prisma,
+        apiKeyId: c.get("apiKeyId") as string,
+        userId: (c.get("apiKeyUserId") as string | null) ?? null,
+        organizationId: organization.id,
+      });
+
       const result = await service.listByOrganization({
         organizationId: organization.id,
         page,
         limit,
+        ...(visible.kind === "some" ? { projectIds: visible.ids } : {}),
       });
 
       return c.json({

--- a/platform/app/src/app/api/projects/__tests__/projects-filtered-listing.integration.test.ts
+++ b/platform/app/src/app/api/projects/__tests__/projects-filtered-listing.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @vitest-environment node
+ *
+ * GET /api/projects returns exactly the projects the credential can view:
+ * an org-reaching key keeps the full listing, a narrower key gets a 200
+ * with the filtered list (key bindings ∩ owner ceiling), never a 403.
+ * Real Postgres, no mocks.
+ *
+ * Spec: specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+ */
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { app } from "../[[...route]]/app";
+
+describe("Feature: GET /api/projects honours the credential's reach", () => {
+  const ns = `projects-reach-${nanoid(8)}`;
+
+  let organizationId: string;
+  let teamAId: string;
+  let teamBId: string;
+  let adminId: string;
+  let memberId: string;
+  const projectIds: string[] = [];
+  const teamAProjectIds: string[] = [];
+  const teamBProjectIds: string[] = [];
+
+  const listAs = async (token: string) => {
+    const res = await app.request("/api/projects?limit=100", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return {
+      status: res.status,
+      json: (await res.json()) as {
+        data?: Array<{ id: string }>;
+        pagination?: { total: number };
+      },
+    };
+  };
+
+  const mintKey = async (args: {
+    userId: string;
+    bindings: Array<{
+      scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+      scopeId: string;
+    }>;
+    permissions?: string[];
+  }) =>
+    (
+      await ApiKeyService.create(prisma).create({
+        name: `reach-${nanoid(6)}`,
+        userId: args.userId,
+        createdByUserId: args.userId,
+        organizationId,
+        permissionMode: "restricted",
+        permissions: args.permissions ?? ["project:view", "traces:view"],
+        bindings: args.bindings.map((binding) => ({
+          role: TeamUserRole.CUSTOM,
+          scopeType: RoleBindingScopeType[binding.scopeType],
+          scopeId: binding.scopeId,
+        })),
+      })
+    ).token;
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Projects Reach Org", slug: `--test-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const teamA = await prisma.team.create({
+      data: {
+        name: "Reach Team A",
+        slug: `--test-team-a-${ns}`,
+        organizationId,
+      },
+    });
+    teamAId = teamA.id;
+    const teamB = await prisma.team.create({
+      data: {
+        name: "Reach Team B",
+        slug: `--test-team-b-${ns}`,
+        organizationId,
+      },
+    });
+    teamBId = teamB.id;
+
+    const admin = await prisma.user.create({
+      data: { name: "Reach Admin", email: `reach-admin-${ns}@example.com` },
+    });
+    adminId = admin.id;
+    const member = await prisma.user.create({
+      data: { name: "Reach Member", email: `reach-member-${ns}@example.com` },
+    });
+    memberId = member.id;
+
+    await prisma.organizationUser.createMany({
+      data: [
+        { userId: adminId, organizationId, role: OrganizationUserRole.ADMIN },
+        { userId: memberId, organizationId, role: OrganizationUserRole.MEMBER },
+      ],
+    });
+    await prisma.roleBinding.createMany({
+      data: [
+        {
+          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+          organizationId,
+          userId: adminId,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organizationId,
+        },
+        {
+          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+          organizationId,
+          userId: memberId,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: teamAId,
+        },
+      ],
+    });
+
+    // Five projects: three in team A, two in team B.
+    for (const [index, teamId] of [
+      teamAId,
+      teamAId,
+      teamAId,
+      teamBId,
+      teamBId,
+    ].entries()) {
+      const project = await prisma.project.create({
+        data: {
+          name: `Reach Project ${index}`,
+          slug: `--test-reach-${index}-${ns}`,
+          apiKey: `test-reach-${index}-${ns}`,
+          teamId,
+          language: "typescript",
+          framework: "openai",
+        },
+      });
+      projectIds.push(project.id);
+      (teamId === teamAId ? teamAProjectIds : teamBProjectIds).push(project.id);
+    }
+  });
+
+  afterAll(async () => {
+    // Setup died before the fixture existed. Every filter below would carry
+    // `undefined`, which Prisma drops from the where clause, turning these
+    // into unscoped deletes against the shared integration database.
+    if (!organizationId) return;
+
+    await cleanupTestRows(prisma, [
+      ["roleBinding", { organizationId }],
+      ["apiKey", { organizationId }],
+      ["customRole", { organizationId }],
+      ["project", { team: { organizationId } }],
+      ["teamUser", { team: { organizationId } }],
+      ["organizationUser", { organizationId }],
+      ["team", { organizationId }],
+    ]);
+    const userIds = [adminId, memberId].filter(Boolean);
+    if (userIds.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    }
+    await prisma.organization.delete({ where: { id: organizationId } });
+  });
+
+  describe("given a CLI key with an ORGANIZATION-scoped binding granting project:view", () => {
+    /** @scenario "org-scoped key lists every project in the organization" */
+    it("lists every non-archived project in the organization", async () => {
+      const token = await mintKey({
+        userId: adminId,
+        bindings: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+      });
+
+      const { status, json } = await listAs(token);
+
+      expect(status).toBe(200);
+      expect(json.data!.map((project) => project.id).sort()).toEqual(
+        [...projectIds].sort(),
+      );
+    });
+  });
+
+  describe("given a CLI key bound to two of the organization's five projects", () => {
+    /** @scenario "project-scoped key gets a filtered list, not a refusal" */
+    it("answers 200 with exactly those two projects", async () => {
+      const bound = [teamAProjectIds[0]!, teamBProjectIds[0]!];
+      const token = await mintKey({
+        userId: adminId,
+        bindings: bound.map((scopeId) => ({
+          scopeType: "PROJECT" as const,
+          scopeId,
+        })),
+      });
+
+      const { status, json } = await listAs(token);
+
+      expect(status).toBe(200);
+      expect(json.data!.map((project) => project.id).sort()).toEqual(
+        [...bound].sort(),
+      );
+      expect(json.pagination!.total).toBe(2);
+    });
+  });
+
+  describe("given an org-wide key whose owner has lost access to one team", () => {
+    /** @scenario "the filtered list respects the owner's ceiling" */
+    it("omits the projects of the team the owner can no longer view", async () => {
+      // The member holds team A only, but an admin-created key can be bound
+      // org-wide only within the OWNER's ceiling — so mint it while the
+      // member briefly holds an org-wide binding, then take that binding
+      // away, exactly like a demotion after login.
+      const temporary = await prisma.roleBinding.create({
+        data: {
+          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+          organizationId,
+          userId: memberId,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organizationId,
+        },
+      });
+      const token = await mintKey({
+        userId: memberId,
+        bindings: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+      });
+      await prisma.roleBinding.delete({ where: { id: temporary.id } });
+
+      const { status, json } = await listAs(token);
+
+      expect(status).toBe(200);
+      const listed = json.data!.map((project) => project.id).sort();
+      expect(listed).toEqual([...teamAProjectIds].sort());
+      for (const absent of teamBProjectIds) {
+        expect(listed).not.toContain(absent);
+      }
+    });
+  });
+
+  describe("given a key whose bindings grant no project:view at all", () => {
+    /** @scenario "a key without project:view gets an empty list, not a refusal" */
+    it("answers 200 with an empty list rather than a refusal", async () => {
+      const token = await mintKey({
+        userId: memberId,
+        bindings: [{ scopeType: "TEAM", scopeId: teamAId }],
+        permissions: ["traces:view"],
+      });
+
+      const { status, json } = await listAs(token);
+
+      expect(status).toBe(200);
+      expect(json.data).toEqual([]);
+      expect(json.pagination!.total).toBe(0);
+    });
+  });
+});

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -56,6 +56,7 @@ export const APP_ERROR_CODES = [
   "cannot_remove_last_admin",
   "cannot_remove_self",
   "cannot_remove_self_as_last_admin",
+  "cli_key_selection_invalid",
   "clickhouse_overloaded",
   "clickhouse_unavailable",
   "codex_auth_failed",

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -223,6 +223,7 @@ export const APP_ERROR_CODES = [
   "personal_workspace_not_managed_here",
   "project_not_found",
   "project_permission_denied",
+  "project_visibility_too_wide",
   "prompt_not_found",
   "provider_endpoint_redirected",
   "provider_key_invalid",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -568,6 +568,12 @@ const presentations = {
     describe: () => "It doesn't include the required scope.",
   },
 
+  project_visibility_too_wide: {
+    title: "Too many projects to list for this key",
+    describe: () =>
+      "This key reaches more projects than we can list in one request. Bind it to the teams or projects it works with, then try again.",
+  },
+
   // ==========================================================================
   // Avatar upload. One set of codes for both halves of the same check: the
   // browser rejects the file before it is ever encoded (`processAvatarImage`)

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -377,6 +377,21 @@ const presentations = {
     describe: () =>
       "This feature isn't switched on for this workspace yet. Ask your workspace administrator to enable it, or contact support.",
   },
+  cli_key_selection_invalid: {
+    title: "Check the access selection",
+    describe: (error) => {
+      const fieldErrors = error.meta.fieldErrors;
+      if (fieldErrors && typeof fieldErrors === "object") {
+        if (Object.hasOwn(fieldErrors, "bindings")) {
+          return "Select at least one workspace, team, or project for the key.";
+        }
+        if (Object.hasOwn(fieldErrors, "permissions")) {
+          return "Select at least one valid permission for the key.";
+        }
+      }
+      return "The selected scopes and permissions aren't valid.";
+    },
+  },
   clickhouse_unavailable: {
     title: "Search is temporarily unavailable",
     describe: () => "We're on it. Try again in a moment.",

--- a/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -127,6 +127,20 @@ vi.mock("~/utils/api", async () => {
           useQuery: () => ({ data: undefined, isLoading: false }),
         },
       },
+      // Org admin ceiling so the device-session flow defaults to a full
+      // organization scope selection and the Approve button stays enabled;
+      // the key-selection UI itself is covered by
+      // cliAuthKeySelection.integration.test.tsx.
+      apiKey: {
+        myBindings: {
+          useQuery: () => ({
+            data: [
+              { scopeType: "ORGANIZATION", scopeId: "org-1", role: "ADMIN" },
+            ],
+            isLoading: false,
+          }),
+        },
+      },
       project: {
         getHasFirstMessage: {
           useQuery: (

--- a/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
@@ -263,8 +263,6 @@ describe("/cli/auth key selection, given an organization admin", () => {
     for (const excluded of [
       "organization:manage",
       "organization:delete",
-      "project:create",
-      "project:delete",
       "team:manage",
       "ops:view",
       "ops:manage",
@@ -364,6 +362,7 @@ describe("/cli/auth key selection, given teams the user holds different roles on
     ];
   });
 
+  /** @scenario "the offered permissions are the intersection of every selected scope" */
   it("sends only the permissions every selected team grants", async () => {
     const user = userEvent.setup();
     renderPage();
@@ -389,6 +388,7 @@ describe("/cli/auth key selection, given teams the user holds different roles on
     }
   });
 
+  /** @scenario "the offered permissions are the intersection of every selected scope" */
   it("locks the write level on rows only one team grants", async () => {
     const user = userEvent.setup();
     renderPage();

--- a/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
@@ -1,0 +1,351 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers the authorize-screen scenarios of
+ * specs/ai-governance/cli-onboarding/login-user-scoped-key.feature.
+ *
+ * The real /cli/auth page runs in device_session mode. The screen now shows
+ * what the minted CLI key will be able to access: a scope selection
+ * preselected to the widest access the user holds (organization for org
+ * admins, shared teams plus personal workspace for members) and a permission
+ * default that keeps organization management off. Only the network boundary
+ * is replaced: `fetch` answers like the CLI auth REST endpoints and the tRPC
+ * hooks resolve fixtures. Under test is what the approve request carries in
+ * `key_selection` and when the approve action is available.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultCliKeyPermissions } from "../../../server/api-key/cli-key-defaults";
+
+const { fetchMock, sessionRef, orgsRef, bindingsRef } = vi.hoisted(() => {
+  const fetchMock = vi.fn();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return {
+    fetchMock,
+    sessionRef: {
+      current: {
+        data: { user: { id: "user-1", email: "dev@example.com" } },
+        status: "authenticated" as const,
+      },
+    },
+    orgsRef: { current: [] as unknown[] },
+    bindingsRef: {
+      current: [] as Array<{
+        scopeType: string;
+        scopeId: string;
+        role: string;
+      }>,
+    },
+  };
+});
+
+vi.mock("~/utils/auth-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/auth-client")>();
+  return { ...actual, useSession: () => sessionRef.current };
+});
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    publicEnv: {
+      useQuery: () => ({ data: {}, isLoading: false }),
+    },
+    sharedTrace: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+    },
+    organization: {
+      getAll: {
+        useQuery: () => ({
+          data: orgsRef.current,
+          isLoading: false,
+          isFetched: true,
+        }),
+      },
+    },
+    modelProvider: {
+      getAllForProject: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+    apiKey: {
+      myBindings: {
+        useQuery: () => ({ data: bindingsRef.current, isLoading: false }),
+      },
+    },
+    project: {
+      getHasFirstMessage: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+  },
+}));
+
+import { useRouter } from "~/utils/compat/next-router";
+import CliAuthPage from "../auth";
+
+const mockRouter = useRouter();
+
+const personalTeam = {
+  id: "team-personal",
+  slug: "personal-team",
+  name: "Jane's Workspace",
+  isPersonal: true,
+  ownerUserId: "user-1",
+  projects: [
+    {
+      id: "proj-personal",
+      slug: "personal-proj",
+      name: "Personal Workspace",
+      isPersonal: true,
+      ownerUserId: "user-1",
+      kind: "application",
+    },
+  ],
+};
+
+const sharedTeam = ({
+  id,
+  name,
+  projects,
+}: {
+  id: string;
+  name: string;
+  projects: Array<Record<string, unknown>>;
+}) => ({
+  id,
+  slug: id,
+  name,
+  isPersonal: false,
+  ownerUserId: null,
+  projects,
+});
+
+const sharedProject = ({ id, name }: { id: string; name: string }) => ({
+  id,
+  slug: id,
+  name,
+  isPersonal: false,
+  kind: "application",
+});
+
+const acmeOrg = {
+  id: "org-1",
+  name: "Acme Org",
+  teams: [
+    personalTeam,
+    sharedTeam({
+      id: "team-eng",
+      name: "Engineering",
+      projects: [sharedProject({ id: "proj-a", name: "Alpha" })],
+    }),
+    sharedTeam({
+      id: "team-res",
+      name: "Research",
+      projects: [sharedProject({ id: "proj-b", name: "Beta" })],
+    }),
+  ],
+};
+
+const approveBodies: Array<{
+  organization_id?: string;
+  key_selection?: {
+    bindings: Array<{ scope_type: string; scope_id: string }>;
+    permissions: string[];
+  };
+}> = [];
+
+const serveCliAuthEndpoints = () => {
+  fetchMock.mockImplementation(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/auth/cli/lookup")) {
+        return new Response(
+          JSON.stringify({
+            user_code: "WDJB-MJHT",
+            status: "pending",
+            expires_at: Date.now() + 10 * 60_000,
+            credential_type: "device_session",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/api/auth/cli/approve")) {
+        approveBodies.push(
+          JSON.parse(String(init?.body ?? "{}")) as (typeof approveBodies)[0],
+        );
+        return new Response(
+          JSON.stringify({ ok: true, kind: "device_session" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  );
+};
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <CliAuthPage />
+    </ChakraProvider>,
+  );
+
+const approveButton = () =>
+  screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  (mockRouter.push as unknown as Mock).mockClear();
+  (mockRouter.replace as unknown as Mock).mockClear();
+  mockRouter.query = { user_code: "WDJB-MJHT" };
+  approveBodies.length = 0;
+  orgsRef.current = [acmeOrg];
+  window.localStorage.clear();
+  serveCliAuthEndpoints();
+});
+
+afterEach(() => {
+  cleanup();
+  mockRouter.query = {};
+});
+
+describe("/cli/auth key selection, given an organization admin", () => {
+  beforeEach(() => {
+    bindingsRef.current = [
+      { scopeType: "ORGANIZATION", scopeId: "org-1", role: "ADMIN" },
+    ];
+  });
+
+  /** @scenario "org admin defaults to organization scope" */
+  it("preselects the whole organization and approves with an organization binding", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Acme Org").length).toBeGreaterThan(0),
+    );
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+    await user.click(approveButton());
+
+    await waitFor(() => expect(approveBodies.length).toBe(1));
+    expect(approveBodies[0]?.organization_id).toBe("org-1");
+    expect(approveBodies[0]?.key_selection?.bindings).toEqual([
+      { scope_type: "ORGANIZATION", scope_id: "org-1" },
+    ]);
+    expect(approveBodies[0]?.key_selection?.permissions).toEqual(
+      defaultCliKeyPermissions(),
+    );
+  });
+
+  /** @scenario "the organization-management permissions are off by default" */
+  it("sends a default permission list without the organization-management set", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+    await user.click(approveButton());
+
+    await waitFor(() => expect(approveBodies.length).toBe(1));
+    const permissions = approveBodies[0]?.key_selection?.permissions ?? [];
+    // The literal set the scenario names, so removing one from the constant
+    // fails here instead of passing vacuously.
+    for (const excluded of [
+      "organization:manage",
+      "organization:delete",
+      "project:create",
+      "project:delete",
+      "team:manage",
+      "ops:view",
+      "ops:manage",
+    ]) {
+      expect(permissions).not.toContain(excluded);
+    }
+    // Gateway permissions and project settings stay in for everyday work.
+    expect(permissions).toContain("gatewayBudgets:view");
+    expect(permissions).toContain("project:manage");
+    expect(permissions).toContain("traces:view");
+  });
+
+  /** @scenario "approval with zero scopes selected is refused" */
+  it("disables the approve action when every scope is deselected", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+
+    // Toggle the sole organization scope off in the multi-select.
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: /Acme Org/ }));
+
+    await waitFor(() => expect(approveButton().disabled).toBe(true));
+    await user.click(approveButton());
+    expect(approveBodies.length).toBe(0);
+  });
+
+  /** @scenario "narrowing the selection narrows the minted key" */
+  it("sends the customized permission list after narrowing traces to read", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+    await user.click(screen.getByRole("button", { name: "Customize" }));
+
+    const tracesRow = screen.getByText("Traces").parentElement as HTMLElement;
+    await user.click(within(tracesRow).getByText("Write"));
+    await user.click(await screen.findByRole("menuitem", { name: "Read" }));
+
+    await user.click(approveButton());
+    await waitFor(() => expect(approveBodies.length).toBe(1));
+    const permissions = approveBodies[0]?.key_selection?.permissions ?? [];
+    expect(permissions).toContain("traces:view");
+    expect(permissions).not.toContain("traces:update");
+  });
+});
+
+describe("/cli/auth key selection, given a regular member of two shared teams", () => {
+  beforeEach(() => {
+    bindingsRef.current = [
+      { scopeType: "TEAM", scopeId: "team-eng", role: "MEMBER" },
+      { scopeType: "TEAM", scopeId: "team-res", role: "MEMBER" },
+      { scopeType: "TEAM", scopeId: "team-personal", role: "ADMIN" },
+    ];
+  });
+
+  /** @scenario "regular member defaults to their own teams plus personal workspace" */
+  it("preselects the shared teams plus the personal workspace, not the organization", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0),
+    );
+    expect(screen.getAllByText("Research").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Personal Workspace").length).toBeGreaterThan(0);
+
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+    await user.click(approveButton());
+
+    await waitFor(() => expect(approveBodies.length).toBe(1));
+    expect(approveBodies[0]?.key_selection?.bindings).toEqual([
+      { scope_type: "TEAM", scope_id: "team-eng" },
+      { scope_type: "TEAM", scope_id: "team-res" },
+      { scope_type: "PROJECT", scope_id: "proj-personal" },
+    ]);
+    expect(
+      approveBodies[0]?.key_selection?.bindings.some(
+        (b) => b.scope_type === "ORGANIZATION",
+      ),
+    ).toBe(false);
+  });
+});

--- a/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
@@ -349,3 +349,60 @@ describe("/cli/auth key selection, given a regular member of two shared teams", 
     ).toBe(false);
   });
 });
+
+describe("/cli/auth key selection, given teams the user holds different roles on", () => {
+  beforeEach(() => {
+    // ADMIN on one shared team, VIEWER on the other. One permission list
+    // serves every binding on the minted key, so the ceiling the screen shows
+    // has to be the intersection — offering an ADMIN-only permission would
+    // make approve fail with api_key_scope_violation at the VIEWER team.
+    bindingsRef.current = [
+      { scopeType: "TEAM", scopeId: "team-eng", role: "ADMIN" },
+      { scopeType: "TEAM", scopeId: "team-res", role: "VIEWER" },
+      // Their own workspace, which the defaults always add as a scope.
+      { scopeType: "TEAM", scopeId: "team-personal", role: "ADMIN" },
+    ];
+  });
+
+  it("sends only the permissions every selected team grants", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+    await user.click(approveButton());
+
+    await waitFor(() => expect(approveBodies.length).toBe(1));
+    const permissions = approveBodies[0]?.key_selection?.permissions ?? [];
+    const held = new Set(permissions);
+
+    // A VIEWER holds the read side everywhere, so it survives the
+    // intersection.
+    expect(held.has("traces:view")).toBe(true);
+    // The write side is ADMIN-only on one team and absent on the other, so
+    // no permission the VIEWER team refuses may go out.
+    for (const adminOnly of [
+      "traces:update",
+      "datasets:manage",
+      "project:manage",
+    ]) {
+      expect(held.has(adminOnly)).toBe(false);
+    }
+  });
+
+  it("locks the write level on rows only one team grants", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(approveButton().disabled).toBe(false));
+    await user.click(screen.getByRole("button", { name: "Customize" }));
+
+    const tracesRow = screen.getByText("Traces").parentElement as HTMLElement;
+    await user.click(within(tracesRow).getByText("Read"));
+
+    // Only Read and None are offered: Write is above the intersected ceiling.
+    expect(
+      await screen.findByRole("menuitem", { name: "Read" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Write" })).toBeNull();
+  });
+});

--- a/platform/app/src/pages/cli/__tests__/cliAuthProjectPicker.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthProjectPicker.integration.test.tsx
@@ -61,6 +61,13 @@ vi.mock("~/utils/api", () => ({
         useQuery: () => ({ data: undefined, isLoading: false }),
       },
     },
+    // Never enabled in project_api_key mode; present because the page always
+    // calls the hook.
+    apiKey: {
+      myBindings: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
     project: {
       getHasFirstMessage: {
         useQuery: () => ({ data: undefined, isLoading: false }),

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -197,7 +197,8 @@ export default function CliAuthPage() {
   const [scopeDefaultsOrgId, setScopeDefaultsOrgId] = useState<string | null>(
     null,
   );
-  const [permissionsCustomized, setPermissionsCustomized] = useState(false);
+  const [arePermissionsCustomized, setArePermissionsCustomized] =
+    useState(false);
   const [permissionSelections, setPermissionSelections] = useState<
     Record<string, PermissionSelection>
   >({});
@@ -267,7 +268,7 @@ export default function CliAuthPage() {
     setSelectedProjectId(null);
     setSelectedScopes([]);
     setScopeDefaultsOrgId(null);
-    setPermissionsCustomized(false);
+    setArePermissionsCustomized(false);
     setPermissionSelections({});
   }, [selectedOrgId]);
   useEffect(() => {
@@ -423,17 +424,6 @@ export default function CliAuthPage() {
     personalProject,
   ]);
 
-  // The permission list the approve request carries. Untouched, the default
-  // list goes out verbatim; customized, it is exactly what the category
-  // selections compute.
-  const cliKeyPermissions = useMemo<string[]>(
-    () =>
-      permissionsCustomized
-        ? computePermissionsFromSelections(permissionSelections)
-        : defaultCliKeyPermissions(),
-    [permissionsCustomized, permissionSelections],
-  );
-
   // The user's own permissions across EVERY selected scope, mirroring the
   // Create API key drawer: rows above this ceiling render locked. One
   // permission list serves every binding on the minted key, so the ceiling
@@ -467,26 +457,63 @@ export default function CliAuthPage() {
     );
   }, [selectedScopes, selectedOrgId, myBindings.data, offeredProjects]);
 
+  // Whether the picker has anything at all to offer, which separates "you
+  // deselected everything" from "there is nothing here for you".
+  const hasAnyScopeToOffer =
+    sharedTeams.length > 0 || offeredProjects.length > 0;
+
+  // The default list, narrowed to what the user actually holds everywhere the
+  // key will be bound. The rule the key lives by is "never more than your own
+  // access", and the mint asserts it: sending `project:manage` for a member
+  // who does not hold it would refuse the whole approval rather than drop the
+  // one permission.
+  const defaultCliKeyPermissionsHeld = useMemo<string[]>(() => {
+    const held = new Set(cliKeyUserPermissions);
+    return defaultCliKeyPermissions().filter((permission) =>
+      held.has(permission),
+    );
+  }, [cliKeyUserPermissions]);
+
+  // The permission list the approve request carries. Untouched, the narrowed
+  // default goes out; customized, it is exactly what the category selections
+  // compute, itself bounded by the locked rows.
+  const cliKeyPermissions = useMemo<string[]>(
+    () =>
+      arePermissionsCustomized
+        ? computePermissionsFromSelections(permissionSelections)
+        : defaultCliKeyPermissionsHeld,
+    [
+      arePermissionsCustomized,
+      permissionSelections,
+      defaultCliKeyPermissionsHeld,
+    ],
+  );
+
   const handleToggleCustomizePermissions = () => {
-    if (permissionsCustomized) {
-      setPermissionsCustomized(false);
+    if (arePermissionsCustomized) {
+      setArePermissionsCustomized(false);
       setPermissionSelections({});
     } else {
       setPermissionSelections(
-        selectionsFromPermissions(defaultCliKeyPermissions()),
+        selectionsFromPermissions(defaultCliKeyPermissionsHeld),
       );
-      setPermissionsCustomized(true);
+      setArePermissionsCustomized(true);
     }
   };
 
-  const deviceSessionSelectionIncomplete =
+  // Approve stays unavailable while the bindings are still arriving: the
+  // ceiling is empty until they land, so an approval sent now would carry an
+  // empty permission list.
+  const isDeviceSessionSelectionIncomplete =
     !requiresProject &&
-    (selectedScopes.length === 0 || cliKeyPermissions.length === 0);
+    (myBindings.isLoading ||
+      selectedScopes.length === 0 ||
+      cliKeyPermissions.length === 0);
 
   const handleApprove = async () => {
     if (!selectedOrgId || !userCode) return;
     if (requiresProject && !selectedProjectId) return;
-    if (deviceSessionSelectionIncomplete) return;
+    if (isDeviceSessionSelectionIncomplete) return;
     setAction({ kind: "submitting" });
     try {
       const r = await fetch("/api/auth/cli/approve", {
@@ -802,6 +829,16 @@ export default function CliAuthPage() {
                           showSummary={false}
                         />
                       )}
+                      {!myBindings.isLoading &&
+                        selectedScopes.length === 0 &&
+                        !hasAnyScopeToOffer && (
+                          <Text textStyle="xs" color="orange.fg" mt={2}>
+                            Your account holds no access in this organization,
+                            so there is nothing to give the CLI. Ask an
+                            administrator to add you to a team, then run{" "}
+                            <code>langwatch login</code> again.
+                          </Text>
+                        )}
                     </Box>
 
                     <Box>
@@ -815,10 +852,12 @@ export default function CliAuthPage() {
                           color="fg.muted"
                           onClick={handleToggleCustomizePermissions}
                         >
-                          {permissionsCustomized ? "Use default" : "Customize"}
+                          {arePermissionsCustomized
+                            ? "Use default"
+                            : "Customize"}
                         </Button>
                       </HStack>
-                      {permissionsCustomized ? (
+                      {arePermissionsCustomized ? (
                         <VStack align="stretch" gap={2}>
                           <PermissionCounter count={cliKeyPermissions.length} />
                           <PermissionCategoryList
@@ -863,7 +902,7 @@ export default function CliAuthPage() {
                     disabled={
                       !selectedOrgId ||
                       (requiresProject && !selectedProjectId) ||
-                      deviceSessionSelectionIncomplete
+                      isDeviceSessionSelectionIncomplete
                     }
                   >
                     {requiresProject ? "Send API key" : "Approve"}

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -6,10 +6,15 @@
  *   2. CLI prints: "Open https://app.langwatch.com/cli/auth?user_code=WDJB-MJHT"
  *   3. User clicks → lands here. If unauthenticated, gets bounced through SSO.
  *   4. Page calls GET /api/auth/cli/lookup to verify the code is still pending.
- *   5. User picks an organization (if they're in multiple) and clicks "Approve".
+ *   5. User picks an organization (if they're in multiple), reviews what the
+ *      CLI key will be able to access (scopes + permissions, preselected to
+ *      the widest access they hold minus organization management), and clicks
+ *      "Approve".
  *   6. Page calls POST /api/auth/cli/approve which:
  *        a. Mints (or returns existing) personal VK
- *        b. Flips the device-code record to `approved` with the VK secret
+ *        b. Flips the device-code record to `approved` with the VK secret and
+ *           the reviewed `key_selection` (scopes + permissions); the exchange
+ *           endpoint mints the user-scoped CLI key from it
  *   7. CLI's polling /exchange returns 200 with the secret on its next poll.
  *   8. Done, user closes the browser tab.
  *
@@ -35,14 +40,32 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { CreateProjectDrawer } from "~/components/projects/CreateProjectDrawer";
-import { ScopeChipPicker } from "~/components/settings/ScopeChipPicker";
+import {
+  ScopeChipPicker,
+  type ScopeTriadEntry,
+} from "~/components/settings/ScopeChipPicker";
 import { OnboardingContainer } from "~/features/onboarding/components/containers/OnboardingContainer";
+import type { TeamUserRole } from "~/generated/prisma/client";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { getTeamRolePermissions } from "~/server/api/rbac";
+import { defaultCliKeyPermissions } from "~/server/api-key/cli-key-defaults";
+import {
+  computePermissionsFromSelections,
+  selectionsFromPermissions,
+} from "~/server/api-key/permission-categories";
+import { api } from "~/utils/api";
 import { setAttributionIfAbsent } from "~/utils/attribution";
 import { useSession } from "~/utils/auth-client";
 import Head from "~/utils/compat/next-head";
 import { useRouter } from "~/utils/compat/next-router";
+import {
+  PermissionCategoryList,
+  PermissionCounter,
+  type PermissionSelection,
+} from "../settings/api-keys/PermissionCategoryList";
+import { getUserPermissionsAtScope } from "../settings/api-keys/utils";
 import { resolveCliAuthProjects } from "./cliAuthProjects";
+import { defaultCliKeyScopes } from "./cliKeyScopeDefaults";
 import { FirstTraceRedirect } from "./FirstTraceRedirect";
 
 /**
@@ -164,6 +187,21 @@ export default function CliAuthPage() {
     null,
   );
 
+  // device_session mode: what the minted CLI key will be able to access.
+  // Scopes preselect to the widest access the user holds (see
+  // defaultCliKeyScopes); permissions start from the everyday-work default
+  // and only switch to the category list when the user customizes.
+  const [selectedScopes, setSelectedScopes] = useState<ScopeTriadEntry[]>([]);
+  // The org the current scope defaults were computed for, so arriving data
+  // never clobbers a user's edited selection within the same org.
+  const [scopeDefaultsOrgId, setScopeDefaultsOrgId] = useState<string | null>(
+    null,
+  );
+  const [permissionsCustomized, setPermissionsCustomized] = useState(false);
+  const [permissionSelections, setPermissionSelections] = useState<
+    Record<string, PermissionSelection>
+  >({});
+
   // Auto-pick the first org if there's only one. The chooser is only
   // necessary when the user is in 2+.
   useEffect(() => {
@@ -223,10 +261,14 @@ export default function CliAuthPage() {
     [projectsForOrg, personalProject],
   );
 
-  // Reset when org changes so the picker is fresh per-org, then apply the
-  // computed default selection.
+  // Reset when org changes so the pickers are fresh per-org, then apply the
+  // computed default selections.
   useEffect(() => {
     setSelectedProjectId(null);
+    setSelectedScopes([]);
+    setScopeDefaultsOrgId(null);
+    setPermissionsCustomized(false);
+    setPermissionSelections({});
   }, [selectedOrgId]);
   useEffect(() => {
     if (defaultProjectId && !selectedProjectId) {
@@ -331,9 +373,120 @@ export default function CliAuthPage() {
     lookup.kind === "ready" ? lookup.credentialType : "device_session";
   const requiresProject = credentialType === "project_api_key";
 
+  // The user's own role bindings in the picked org: the ceiling the CLI key
+  // can never exceed. Drives the scope defaults and which permission rows
+  // are available in the customize list.
+  const myBindings = api.apiKey.myBindings.useQuery(
+    { organizationId: selectedOrgId ?? "" },
+    {
+      enabled: !!selectedOrgId && lookup.kind === "ready" && !requiresProject,
+    },
+  );
+
+  // Non-personal teams of the picked org, in display order. Personal teams
+  // are never offered as scopes; the user's own personal workspace is
+  // offered as its project instead.
+  const sharedTeams = useMemo(() => {
+    const org = organizations?.find((o) => o.id === selectedOrgId);
+    return (org?.teams ?? [])
+      .filter((team) => !team.isPersonal)
+      .map((team) => ({ id: team.id, name: team.name }));
+  }, [organizations, selectedOrgId]);
+
+  const selectedOrgName = useMemo(
+    () => organizations?.find((o) => o.id === selectedOrgId)?.name,
+    [organizations, selectedOrgId],
+  );
+
+  // Preselect the widest access the user holds, once the bindings for the
+  // picked org are in. Guarded by scopeDefaultsOrgId so a refetch never
+  // clobbers scopes the user already edited.
+  useEffect(() => {
+    if (requiresProject) return;
+    if (!selectedOrgId || !myBindings.data) return;
+    if (scopeDefaultsOrgId === selectedOrgId) return;
+    setSelectedScopes(
+      defaultCliKeyScopes({
+        organizationId: selectedOrgId,
+        bindings: myBindings.data,
+        sharedTeamIds: sharedTeams.map((team) => team.id),
+        personalProjectId: personalProject?.id ?? null,
+      }),
+    );
+    setScopeDefaultsOrgId(selectedOrgId);
+  }, [
+    requiresProject,
+    selectedOrgId,
+    myBindings.data,
+    scopeDefaultsOrgId,
+    sharedTeams,
+    personalProject,
+  ]);
+
+  // The permission list the approve request carries. Untouched, the default
+  // list goes out verbatim; customized, it is exactly what the category
+  // selections compute.
+  const cliKeyPermissions = useMemo<string[]>(
+    () =>
+      permissionsCustomized
+        ? computePermissionsFromSelections(permissionSelections)
+        : defaultCliKeyPermissions(),
+    [permissionsCustomized, permissionSelections],
+  );
+
+  // The user's own permissions across EVERY selected scope, mirroring the
+  // Create API key drawer: rows above this ceiling render locked. One
+  // permission list serves every binding on the minted key, so the ceiling
+  // is the intersection — a permission the user holds on one team but not
+  // on another would make approve fail with api_key_scope_violation.
+  const cliKeyUserPermissions = useMemo(() => {
+    if (selectedScopes.length === 0 || !selectedOrgId) return [];
+    const orgProjects = offeredProjects.map((p) => ({
+      id: p.id,
+      teamId: p.teamId,
+    }));
+    const perScope = selectedScopes.map(
+      (scope) =>
+        new Set(
+          getUserPermissionsAtScope({
+            myBindings: myBindings.data,
+            scopeType: scope.scopeType,
+            scopeId: scope.scopeId,
+            organizationId: selectedOrgId,
+            orgProjects,
+            isServiceKey: false,
+            getTeamRolePermissions: (role) =>
+              getTeamRolePermissions(role as TeamUserRole),
+          }),
+        ),
+    );
+    const [first, ...rest] = perScope;
+    if (!first) return [];
+    return [...first].filter((permission) =>
+      rest.every((held) => held.has(permission)),
+    );
+  }, [selectedScopes, selectedOrgId, myBindings.data, offeredProjects]);
+
+  const handleToggleCustomizePermissions = () => {
+    if (permissionsCustomized) {
+      setPermissionsCustomized(false);
+      setPermissionSelections({});
+    } else {
+      setPermissionSelections(
+        selectionsFromPermissions(defaultCliKeyPermissions()),
+      );
+      setPermissionsCustomized(true);
+    }
+  };
+
+  const deviceSessionSelectionIncomplete =
+    !requiresProject &&
+    (selectedScopes.length === 0 || cliKeyPermissions.length === 0);
+
   const handleApprove = async () => {
     if (!selectedOrgId || !userCode) return;
     if (requiresProject && !selectedProjectId) return;
+    if (deviceSessionSelectionIncomplete) return;
     setAction({ kind: "submitting" });
     try {
       const r = await fetch("/api/auth/cli/approve", {
@@ -345,6 +498,17 @@ export default function CliAuthPage() {
           ...(requiresProject && selectedProjectId
             ? { project_id: selectedProjectId }
             : {}),
+          ...(requiresProject
+            ? {}
+            : {
+                key_selection: {
+                  bindings: selectedScopes.map((scope) => ({
+                    scope_type: scope.scopeType,
+                    scope_id: scope.scopeId,
+                  })),
+                  permissions: cliKeyPermissions,
+                },
+              }),
         }),
       });
       const data = (await r.json().catch(() => ({}))) as {
@@ -604,6 +768,82 @@ export default function CliAuthPage() {
                   </Box>
                 )}
 
+                {!requiresProject && (
+                  <>
+                    <Box>
+                      <Text
+                        textStyle="sm"
+                        fontWeight="semibold"
+                        color="fg"
+                        mb={1}
+                      >
+                        What the CLI can access
+                      </Text>
+                      <Text textStyle="xs" color="fg.muted" mb={2}>
+                        The key works inside these scopes, always limited to
+                        your own access.
+                      </Text>
+                      {myBindings.isLoading ? (
+                        <HStack>
+                          <Spinner size="sm" />
+                          <Text textStyle="sm" color="fg.muted">
+                            Loading your access…
+                          </Text>
+                        </HStack>
+                      ) : (
+                        <ScopeChipPicker
+                          value={selectedScopes}
+                          onChange={setSelectedScopes}
+                          organizationId={selectedOrgId ?? undefined}
+                          organizationName={selectedOrgName}
+                          availableTeams={sharedTeams}
+                          availableProjects={offeredProjects}
+                          label=""
+                          showSummary={false}
+                        />
+                      )}
+                    </Box>
+
+                    <Box>
+                      <HStack justify="space-between" align="center" mb={1}>
+                        <Text textStyle="sm" fontWeight="semibold" color="fg">
+                          Permissions
+                        </Text>
+                        <Button
+                          size="xs"
+                          variant="ghost"
+                          color="fg.muted"
+                          onClick={handleToggleCustomizePermissions}
+                        >
+                          {permissionsCustomized ? "Use default" : "Customize"}
+                        </Button>
+                      </HStack>
+                      {permissionsCustomized ? (
+                        <VStack align="stretch" gap={2}>
+                          <PermissionCounter count={cliKeyPermissions.length} />
+                          <PermissionCategoryList
+                            selections={permissionSelections}
+                            userPermissions={cliKeyUserPermissions}
+                            onChange={setPermissionSelections}
+                          />
+                          {cliKeyPermissions.length === 0 && (
+                            <Text textStyle="xs" color="fg.muted">
+                              Select at least one permission to approve.
+                            </Text>
+                          )}
+                        </VStack>
+                      ) : (
+                        <Text textStyle="xs" color="fg.muted" lineHeight="tall">
+                          The key gets your access for everyday work: traces,
+                          datasets, prompts, evaluations, and the AI Gateway. It
+                          cannot create projects, manage members and roles, or
+                          manage the organization.
+                        </Text>
+                      )}
+                    </Box>
+                  </>
+                )}
+
                 {action.kind === "error" && (
                   <StatusCard
                     palette="red"
@@ -621,7 +861,9 @@ export default function CliAuthPage() {
                     onClick={handleApprove}
                     loading={action.kind === "submitting"}
                     disabled={
-                      !selectedOrgId || (requiresProject && !selectedProjectId)
+                      !selectedOrgId ||
+                      (requiresProject && !selectedProjectId) ||
+                      deviceSessionSelectionIncomplete
                     }
                   >
                     {requiresProject ? "Send API key" : "Approve"}

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -870,9 +870,9 @@ export default function CliAuthPage() {
                       ) : (
                         <Text textStyle="xs" color="fg.muted" lineHeight="tall">
                           The key gets your access for everyday work: traces,
-                          datasets, prompts, evaluations, and the AI Gateway. It
-                          cannot create projects, manage members and roles, or
-                          manage the organization.
+                          datasets, prompts, evaluations, the AI Gateway, and
+                          project settings. It cannot manage members and roles,
+                          or manage the organization.
                         </Text>
                       )}
                     </Box>

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -63,7 +63,7 @@ import {
   PermissionCounter,
   type PermissionSelection,
 } from "../settings/api-keys/PermissionCategoryList";
-import { getUserPermissionsAtScope } from "../settings/api-keys/utils";
+import { getUserPermissionsAcrossScopes } from "../settings/api-keys/utils";
 import { resolveCliAuthProjects } from "./cliAuthProjects";
 import { defaultCliKeyScopes } from "./cliKeyScopeDefaults";
 import { FirstTraceRedirect } from "./FirstTraceRedirect";
@@ -431,36 +431,32 @@ export default function CliAuthPage() {
   // on another would make approve fail with api_key_scope_violation.
   const cliKeyUserPermissions = useMemo(() => {
     if (selectedScopes.length === 0 || !selectedOrgId) return [];
-    const orgProjects = offeredProjects.map((p) => ({
-      id: p.id,
-      teamId: p.teamId,
-    }));
-    const perScope = selectedScopes.map(
-      (scope) =>
-        new Set(
-          getUserPermissionsAtScope({
-            myBindings: myBindings.data,
-            scopeType: scope.scopeType,
-            scopeId: scope.scopeId,
-            organizationId: selectedOrgId,
-            orgProjects,
-            isServiceKey: false,
-            getTeamRolePermissions: (role) =>
-              getTeamRolePermissions(role as TeamUserRole),
-          }),
-        ),
-    );
-    const [first, ...rest] = perScope;
-    if (!first) return [];
-    return [...first].filter((permission) =>
-      rest.every((held) => held.has(permission)),
-    );
+    return getUserPermissionsAcrossScopes({
+      myBindings: myBindings.data,
+      scopes: selectedScopes,
+      organizationId: selectedOrgId,
+      orgProjects: offeredProjects.map((p) => ({ id: p.id, teamId: p.teamId })),
+      isServiceKey: false,
+      getTeamRolePermissions: (role) =>
+        getTeamRolePermissions(role as TeamUserRole),
+    });
   }, [selectedScopes, selectedOrgId, myBindings.data, offeredProjects]);
 
-  // Whether the picker has anything at all to offer, which separates "you
-  // deselected everything" from "there is nothing here for you".
-  const hasAnyScopeToOffer =
-    sharedTeams.length > 0 || offeredProjects.length > 0;
+  // Whether the picker has anything to offer THIS user, which separates "you
+  // deselected everything" from "there is nothing here for you". Read from
+  // the same defaults the screen preselects, because a team listed in the
+  // organization the user holds no binding on is not a scope they can bind.
+  const hasAnyScopeToOffer = useMemo(() => {
+    if (!selectedOrgId || !myBindings.data) return false;
+    return (
+      defaultCliKeyScopes({
+        organizationId: selectedOrgId,
+        bindings: myBindings.data,
+        sharedTeamIds: sharedTeams.map((team) => team.id),
+        personalProjectId: personalProject?.id ?? null,
+      }).length > 0
+    );
+  }, [selectedOrgId, myBindings.data, sharedTeams, personalProject]);
 
   // The default list, narrowed to what the user actually holds everywhere the
   // key will be bound. The rule the key lives by is "never more than your own

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -63,7 +63,10 @@ import {
   PermissionCounter,
   type PermissionSelection,
 } from "../settings/api-keys/PermissionCategoryList";
-import { getUserPermissionsAcrossScopes } from "../settings/api-keys/utils";
+import {
+  clampSelectionsToAvailability,
+  getUserPermissionsAcrossScopes,
+} from "../settings/api-keys/utils";
 import { resolveCliAuthProjects } from "./cliAuthProjects";
 import { defaultCliKeyScopes } from "./cliKeyScopeDefaults";
 import { FirstTraceRedirect } from "./FirstTraceRedirect";
@@ -470,17 +473,30 @@ export default function CliAuthPage() {
     );
   }, [cliKeyUserPermissions]);
 
+  // The customized rows, re-narrowed to the ceiling of whatever is selected
+  // NOW. Changing the scopes after customizing shrinks the ceiling, and a
+  // level chosen under the old one would otherwise stay checked and fail the
+  // approval with a scope violation.
+  const effectivePermissionSelections = useMemo(
+    () =>
+      clampSelectionsToAvailability({
+        selections: permissionSelections,
+        userPermissions: cliKeyUserPermissions,
+      }),
+    [permissionSelections, cliKeyUserPermissions],
+  );
+
   // The permission list the approve request carries. Untouched, the narrowed
   // default goes out; customized, it is exactly what the category selections
   // compute, itself bounded by the locked rows.
   const cliKeyPermissions = useMemo<string[]>(
     () =>
       arePermissionsCustomized
-        ? computePermissionsFromSelections(permissionSelections)
+        ? computePermissionsFromSelections(effectivePermissionSelections)
         : defaultCliKeyPermissionsHeld,
     [
       arePermissionsCustomized,
-      permissionSelections,
+      effectivePermissionSelections,
       defaultCliKeyPermissionsHeld,
     ],
   );
@@ -857,7 +873,7 @@ export default function CliAuthPage() {
                         <VStack align="stretch" gap={2}>
                           <PermissionCounter count={cliKeyPermissions.length} />
                           <PermissionCategoryList
-                            selections={permissionSelections}
+                            selections={effectivePermissionSelections}
                             userPermissions={cliKeyUserPermissions}
                             onChange={setPermissionSelections}
                           />

--- a/platform/app/src/pages/cli/cliKeyScopeDefaults.ts
+++ b/platform/app/src/pages/cli/cliKeyScopeDefaults.ts
@@ -1,0 +1,54 @@
+/**
+ * Default scope selection for the CLI login key on the device-session
+ * authorize screen (`/cli/auth`, credential_type device_session).
+ *
+ * The key a `langwatch login` mints should reach everything the user works
+ * with, so the preselected scopes mirror the widest access they hold:
+ *
+ *   - An ORGANIZATION-scoped binding of any role collapses to a single
+ *     organization chip: one binding already covers every project, at
+ *     whatever level the role allows. A MEMBER or VIEWER org binding is
+ *     org-wide access too, so narrowing it to the personal project would
+ *     hand the key less than the user holds.
+ *   - Everyone else starts from the shared teams they hold a TEAM-scoped
+ *     binding on, plus their own personal workspace project. The team list
+ *     keeps the organization's team order so the chips render stably.
+ *
+ * Bindings come from `api.apiKey.myBindings` (the same source the API key
+ * drawers mirror the user's ceiling from), so the defaults can never offer
+ * a scope the approve endpoint would refuse.
+ */
+import type { ScopeTriadEntry } from "~/components/settings/ScopeChipPicker";
+
+export function defaultCliKeyScopes(args: {
+  organizationId: string;
+  /** The caller's own role bindings in this organization. */
+  bindings:
+    | Array<{ scopeType: string; scopeId: string; role: string }>
+    | undefined;
+  /** Non-personal team ids of the organization, in display order. */
+  sharedTeamIds: string[];
+  /** The caller's own personal workspace project, when one exists. */
+  personalProjectId: string | null;
+}): ScopeTriadEntry[] {
+  const bindings = args.bindings ?? [];
+
+  const hasOrgBinding = bindings.some(
+    (b) => b.scopeType === "ORGANIZATION" && b.scopeId === args.organizationId,
+  );
+  if (hasOrgBinding) {
+    return [{ scopeType: "ORGANIZATION", scopeId: args.organizationId }];
+  }
+
+  const boundTeamIds = new Set(
+    bindings.filter((b) => b.scopeType === "TEAM").map((b) => b.scopeId),
+  );
+  const scopes: ScopeTriadEntry[] = args.sharedTeamIds
+    .filter((teamId) => boundTeamIds.has(teamId))
+    .map((teamId) => ({ scopeType: "TEAM", scopeId: teamId }));
+
+  if (args.personalProjectId) {
+    scopes.push({ scopeType: "PROJECT", scopeId: args.personalProjectId });
+  }
+  return scopes;
+}

--- a/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
+++ b/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
@@ -15,10 +15,7 @@ import {
   type ScopeChipPickerEntry,
 } from "../../../components/settings/ScopeChipPicker";
 import { Drawer } from "../../../components/ui/drawer";
-import {
-  getTeamRolePermissions,
-  hasPermissionWithHierarchy,
-} from "../../../server/api/rbac";
+import { getTeamRolePermissions } from "../../../server/api/rbac";
 import {
   computePermissionsFromSelections,
   PERMISSION_CATEGORIES,
@@ -34,6 +31,7 @@ import {
   bindingsToPermissionMode,
   bindingsToScopes,
   bindingsToSelections,
+  categoryAccessAvailability,
   deriveBindingRole,
   findBindingAtScope,
   type PermissionMode,
@@ -161,14 +159,10 @@ export function EditApiKeyDrawer({
     ) {
       const allSelected: Record<string, PermissionSelection> = {};
       for (const cat of PERMISSION_CATEGORIES) {
-        const canRead = cat.readPermissions.every((p) =>
-          hasPermissionWithHierarchy(userPermissions, p),
-        );
-        const canWrite =
-          cat.accessLevels.includes("write") &&
-          cat.writePermissions.every((p) =>
-            hasPermissionWithHierarchy(userPermissions, p),
-          );
+        const { canRead, canWrite } = categoryAccessAvailability({
+          category: cat,
+          userPermissions,
+        });
         allSelected[cat.key] = canWrite ? "write" : canRead ? "read" : "none";
       }
       setCategorySelections(allSelected);

--- a/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
+++ b/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
@@ -32,6 +32,7 @@ import {
   bindingsToScopes,
   bindingsToSelections,
   categoryAccessAvailability,
+  clampSelectionsToAvailability,
   deriveBindingRole,
   getUserPermissionsAcrossScopes,
   type PermissionMode,
@@ -161,11 +162,26 @@ export function EditApiKeyDrawer({
     }
   }, [apiKey, organizationId, currentTeamId, currentProjectId]);
 
+  // Re-narrowed to the ceiling of whatever is selected NOW: the key's stored
+  // level, or one picked before another scope was added, can sit above what
+  // the caller holds everywhere the key will be bound, and the save would
+  // come back `api_key_scope_violation` for a row that still looked granted.
+  const effectiveCategorySelections = useMemo(
+    () =>
+      clampSelectionsToAvailability({
+        selections: categorySelections,
+        userPermissions,
+      }) as Record<string, PermissionSelection>,
+    [categorySelections, userPermissions],
+  );
+
   const handlePermissionModeChange = (mode: "all" | "restricted") => {
     setPermissionMode(mode);
     if (
       mode === "restricted" &&
-      Object.values(categorySelections).every((v) => !v || v === "none")
+      Object.values(effectiveCategorySelections).every(
+        (v) => !v || v === "none",
+      )
     ) {
       const allSelected: Record<string, PermissionSelection> = {};
       for (const cat of PERMISSION_CATEGORIES) {
@@ -184,7 +200,7 @@ export function EditApiKeyDrawer({
 
     const permissions =
       permissionMode === "restricted"
-        ? computePermissionsFromSelections(categorySelections)
+        ? computePermissionsFromSelections(effectiveCategorySelections)
         : undefined;
 
     const bindings = selectedScopes.map((s) => ({
@@ -312,7 +328,7 @@ export function EditApiKeyDrawer({
                 {permissionMode === "restricted" && (
                   <PermissionCounter
                     count={
-                      Object.values(categorySelections).filter(
+                      Object.values(effectiveCategorySelections).filter(
                         (v) => v && v !== "none",
                       ).length
                     }
@@ -322,7 +338,7 @@ export function EditApiKeyDrawer({
 
               {permissionMode === "restricted" && (
                 <PermissionCategoryList
-                  selections={categorySelections}
+                  selections={effectiveCategorySelections}
                   userPermissions={userPermissions}
                   onChange={setCategorySelections}
                 />

--- a/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
+++ b/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
@@ -33,7 +33,7 @@ import {
   bindingsToSelections,
   categoryAccessAvailability,
   deriveBindingRole,
-  getUserPermissionsAtScope,
+  getUserPermissionsAcrossScopes,
   type PermissionMode,
 } from "./utils";
 
@@ -98,20 +98,30 @@ export function EditApiKeyDrawer({
 
   const isServiceKey = apiKey ? !apiKey.userId : false;
 
-  const primaryScope = selectedScopes[0] ?? {
-    scopeType: "PROJECT" as const,
-    scopeId: currentProjectId ?? "",
-  };
+  const ceilingScopes = useMemo(
+    () =>
+      selectedScopes.length > 0
+        ? selectedScopes
+        : [
+            {
+              scopeType: "PROJECT" as const,
+              scopeId: currentProjectId ?? "",
+            },
+          ],
+    [selectedScopes, currentProjectId],
+  );
+  const primaryScope = ceilingScopes[0]!;
 
   // Same ceiling the create drawer shows: the team-role bags carry no
   // organization, gateway, governance or playground permissions, so reading
   // them directly would lock rows a service key or an organization admin can
-  // in fact grant.
+  // in fact grant. Across every selected scope, not only the first: one
+  // permission list serves every binding, so a row the second scope refuses
+  // would fail the save with a scope violation.
   const userPermissions = useMemo(() => {
-    return getUserPermissionsAtScope({
+    return getUserPermissionsAcrossScopes({
       myBindings: myBindings.data,
-      scopeType: primaryScope.scopeType,
-      scopeId: primaryScope.scopeId,
+      scopes: ceilingScopes,
       organizationId,
       orgProjects,
       isServiceKey,
@@ -120,8 +130,7 @@ export function EditApiKeyDrawer({
     });
   }, [
     myBindings.data,
-    primaryScope.scopeType,
-    primaryScope.scopeId,
+    ceilingScopes,
     organizationId,
     orgProjects,
     isServiceKey,

--- a/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
+++ b/platform/app/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
@@ -9,7 +9,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useEffect, useMemo, useState } from "react";
-import { TeamUserRole } from "~/generated/prisma/client";
+import type { TeamUserRole } from "~/generated/prisma/client";
 import {
   ScopeChipPicker,
   type ScopeChipPickerEntry,
@@ -33,7 +33,7 @@ import {
   bindingsToSelections,
   categoryAccessAvailability,
   deriveBindingRole,
-  findBindingAtScope,
+  getUserPermissionsAtScope,
   type PermissionMode,
 } from "./utils";
 
@@ -103,20 +103,21 @@ export function EditApiKeyDrawer({
     scopeId: currentProjectId ?? "",
   };
 
+  // Same ceiling the create drawer shows: the team-role bags carry no
+  // organization, gateway, governance or playground permissions, so reading
+  // them directly would lock rows a service key or an organization admin can
+  // in fact grant.
   const userPermissions = useMemo(() => {
-    if (isServiceKey) return getTeamRolePermissions(TeamUserRole.ADMIN);
-    if (!myBindings.data) return [];
-
-    const binding = findBindingAtScope({
-      bindings: myBindings.data,
+    return getUserPermissionsAtScope({
+      myBindings: myBindings.data,
       scopeType: primaryScope.scopeType,
       scopeId: primaryScope.scopeId,
       organizationId,
       orgProjects,
+      isServiceKey,
+      getTeamRolePermissions: (role) =>
+        getTeamRolePermissions(role as TeamUserRole),
     });
-
-    if (!binding) return [];
-    return getTeamRolePermissions(binding.role as TeamUserRole);
   }, [
     myBindings.data,
     primaryScope.scopeType,

--- a/platform/app/src/pages/settings/api-keys/PermissionCategoryList.tsx
+++ b/platform/app/src/pages/settings/api-keys/PermissionCategoryList.tsx
@@ -2,12 +2,12 @@ import { Box, HStack, Text } from "@chakra-ui/react";
 import { ChevronsUpDown, Lock } from "lucide-react";
 import { Menu } from "../../../components/ui/menu";
 import { Tooltip } from "../../../components/ui/tooltip";
-import { hasPermissionWithHierarchy } from "../../../server/api/rbac";
 import {
   type AccessLevel,
   PERMISSION_CATEGORIES,
   type PermissionCategory,
 } from "../../../server/api-key/permission-categories";
+import { categoryAccessAvailability } from "./utils";
 
 export type PermissionSelection = "none" | AccessLevel;
 
@@ -39,21 +39,16 @@ function PermissionRow({
   userPermissions: string[];
   onChange: (next: PermissionSelection) => void;
 }) {
-  const canRead = category.readPermissions.every((p) =>
-    hasPermissionWithHierarchy(userPermissions, p),
-  );
-  const canWrite =
-    category.writePermissions.length > 0 &&
-    category.writePermissions.every((p) =>
-      hasPermissionWithHierarchy(userPermissions, p),
-    );
-  const isDisabled = !canRead;
+  const { canRead, canWrite } = categoryAccessAvailability({
+    category,
+    userPermissions,
+  });
+  const isDisabled = !canRead && !canWrite;
   const isActive = value !== "none";
 
   const options: Array<{ value: PermissionSelection; label: string }> = [];
   if (canRead) options.push({ value: "read", label: "Read" });
-  if (canWrite && category.accessLevels.includes("write"))
-    options.push({ value: "write", label: "Write" });
+  if (canWrite) options.push({ value: "write", label: "Write" });
   options.push({ value: "none", label: "None" });
 
   const trigger = (

--- a/platform/app/src/pages/settings/api-keys/utils.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.ts
@@ -412,3 +412,51 @@ export function getUserPermissionsAtScope({
   }
   return getRolePerms(binding.role);
 }
+
+/**
+ * The ceiling for a key bound to several scopes at once: the intersection of
+ * what the caller holds at each of them.
+ *
+ * One permission list serves every binding on a key, so a permission held on
+ * one team but not on another cannot go out — `assertSelectionWithinCeiling`
+ * walks every binding at save time and refuses the whole selection. Offering
+ * such a permission would turn a valid-looking form into a scope violation.
+ */
+export function getUserPermissionsAcrossScopes({
+  myBindings,
+  scopes,
+  organizationId,
+  orgProjects,
+  isServiceKey,
+  getTeamRolePermissions: getRolePerms,
+}: {
+  myBindings:
+    | Array<{ scopeType: string; scopeId: string; role: string }>
+    | undefined;
+  scopes: Array<{ scopeType: string; scopeId: string }>;
+  organizationId: string;
+  orgProjects: Array<{ id: string; teamId: string }>;
+  isServiceKey: boolean;
+  getTeamRolePermissions: (role: string) => string[];
+}): string[] {
+  const perScope = scopes.map(
+    (scope) =>
+      new Set(
+        getUserPermissionsAtScope({
+          myBindings,
+          scopeType: scope.scopeType,
+          scopeId: scope.scopeId,
+          organizationId,
+          orgProjects,
+          isServiceKey,
+          getTeamRolePermissions: getRolePerms,
+        }),
+      ),
+  );
+
+  const [first, ...rest] = perScope;
+  if (!first) return [];
+  return [...first].filter((permission) =>
+    rest.every((held) => held.has(permission)),
+  );
+}

--- a/platform/app/src/pages/settings/api-keys/utils.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.ts
@@ -1,7 +1,9 @@
 import { createListCollection } from "@chakra-ui/react";
 import { hasPermissionWithHierarchy } from "../../../server/api/rbac";
 import {
+  type AccessLevel,
   categorizablePermissions,
+  PERMISSION_CATEGORIES,
   type PermissionCategory,
 } from "../../../server/api-key/permission-categories";
 
@@ -459,4 +461,53 @@ export function getUserPermissionsAcrossScopes({
   return [...first].filter((permission) =>
     rest.every((held) => held.has(permission)),
   );
+}
+
+/**
+ * Narrows category selections to what the ceiling still allows.
+ *
+ * The ceiling moves while the form is open: selecting one more scope drops
+ * the intersection to what the caller holds everywhere, and a level picked
+ * under the wider ceiling would otherwise stay selected and leave the form
+ * looking valid until the save comes back `api_key_scope_violation`. Write
+ * falls back to read where read survives, and to none where neither does,
+ * so the rows the user reads are the permissions that actually go out.
+ *
+ * A category the ceiling no longer covers renders locked, which is the same
+ * `categoryAccessAvailability` answer the rows themselves use.
+ */
+export function clampSelectionsToAvailability({
+  selections,
+  userPermissions,
+}: {
+  selections: Record<string, AccessLevel | "none">;
+  userPermissions: string[];
+}): Record<string, AccessLevel | "none"> {
+  const clamped: Record<string, AccessLevel | "none"> = {};
+  for (const [key, level] of Object.entries(selections)) {
+    const category = PERMISSION_CATEGORIES.find((c) => c.key === key);
+    clamped[key] =
+      level === "none" || !category
+        ? "none"
+        : highestLevelStillGranted({
+            level,
+            ...categoryAccessAvailability({ category, userPermissions }),
+          });
+  }
+  return clamped;
+}
+
+/** Write where write survives, otherwise read, otherwise nothing. */
+function highestLevelStillGranted({
+  level,
+  canRead,
+  canWrite,
+}: {
+  level: AccessLevel;
+  canRead: boolean;
+  canWrite: boolean;
+}): AccessLevel | "none" {
+  if (level === "write" && canWrite) return "write";
+  if (canRead) return "read";
+  return "none";
 }

--- a/platform/app/src/pages/settings/api-keys/utils.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.ts
@@ -1,4 +1,42 @@
 import { createListCollection } from "@chakra-ui/react";
+import { hasPermissionWithHierarchy } from "../../../server/api/rbac";
+import {
+  categorizablePermissions,
+  type PermissionCategory,
+} from "../../../server/api-key/permission-categories";
+
+/**
+ * Whether the user may hand a category's read or write level to an API key.
+ *
+ * A level is available when the category declares it, the matching permission
+ * array is non-empty, and the user holds every permission in it. The
+ * non-empty guard is what keeps a write-only category (project
+ * administration) from reading as available: `[].every(...)` is `true`.
+ *
+ * One copy for both consumers, the category rows and the drawer's
+ * select-all — a security-relevant predicate kept in two places drifts.
+ */
+export function categoryAccessAvailability({
+  category,
+  userPermissions,
+}: {
+  category: PermissionCategory;
+  userPermissions: string[];
+}): { canRead: boolean; canWrite: boolean } {
+  const holdsAll = (permissions: readonly string[]) =>
+    permissions.length > 0 &&
+    permissions.every((permission) =>
+      hasPermissionWithHierarchy(userPermissions, permission),
+    );
+  return {
+    canRead:
+      category.accessLevels.includes("read") &&
+      holdsAll(category.readPermissions),
+    canWrite:
+      category.accessLevels.includes("write") &&
+      holdsAll(category.writePermissions),
+  };
+}
 
 export const EXPIRATION_OPTIONS = [
   { label: "No expiration", value: "" },
@@ -298,7 +336,9 @@ export function bindingsToSelections(
   if (mode === "readonly") {
     const selections: Record<string, string> = {};
     for (const cat of deps.permissionCategories) {
-      selections[cat.key] = "read";
+      // Write-only categories (no read level) have nothing to show on a
+      // readonly key.
+      if (cat.accessLevels.includes("read")) selections[cat.key] = "read";
     }
     return selections;
   }
@@ -316,7 +356,7 @@ export function bindingsToSelections(
   if (binding.role === "VIEWER") {
     const selections: Record<string, string> = {};
     for (const cat of deps.permissionCategories) {
-      selections[cat.key] = "read";
+      if (cat.accessLevels.includes("read")) selections[cat.key] = "read";
     }
     return selections;
   }
@@ -353,7 +393,11 @@ export function getUserPermissionsAtScope({
   isServiceKey: boolean;
   getTeamRolePermissions: (role: string) => string[];
 }): string[] {
-  if (isServiceKey) return getRolePerms("ADMIN");
+  // Service keys and organization admins can grant anything grantable: the
+  // permission resolver short-circuits an ORGANIZATION-scoped ADMIN binding to
+  // full access, so the team-role bags (which carry no organization, gateway,
+  // governance or playground permissions) understate their ceiling.
+  if (isServiceKey) return categorizablePermissions();
 
   const binding = findBindingAtScope({
     bindings: myBindings,
@@ -363,5 +407,8 @@ export function getUserPermissionsAtScope({
     orgProjects,
   });
   if (!binding) return [];
+  if (binding.scopeType === "ORGANIZATION" && binding.role === "ADMIN") {
+    return categorizablePermissions();
+  }
   return getRolePerms(binding.role);
 }

--- a/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   categorizablePermissions,
+  categoryPermissions,
   PERMISSION_CATEGORIES,
 } from "../../../server/api-key/permission-categories";
 import {
   bindingsToPermissionMode,
   bindingsToScopes,
   bindingsToSelections,
+  clampSelectionsToAvailability,
   computeBindings,
   getUserPermissionsAcrossScopes,
   getUserPermissionsAtScope,
@@ -753,6 +755,78 @@ describe("getUserPermissionsAcrossScopes()", () => {
           scopeId: "team-1",
         }),
       );
+    });
+  });
+});
+
+describe("clampSelectionsToAvailability()", () => {
+  const tracesRead = categoryPermissions({ key: "traces", level: "read" });
+  const tracesWrite = categoryPermissions({ key: "traces", level: "write" });
+
+  describe("when the ceiling still covers the chosen level", () => {
+    it("keeps the selection untouched", () => {
+      const result = clampSelectionsToAvailability({
+        selections: { traces: "write" },
+        userPermissions: tracesWrite,
+      });
+      expect(result).toEqual({ traces: "write" });
+    });
+  });
+
+  describe("when the ceiling shrank to read only", () => {
+    /** @scenario Customized permissions follow the scopes that are selected */
+    it("falls back to read instead of sending a refused write", () => {
+      const result = clampSelectionsToAvailability({
+        selections: { traces: "write" },
+        userPermissions: tracesRead,
+      });
+      expect(result).toEqual({ traces: "read" });
+    });
+  });
+
+  describe("when the ceiling no longer covers the category at all", () => {
+    it("drops the selection to none", () => {
+      expect(
+        clampSelectionsToAvailability({
+          selections: { traces: "write" },
+          userPermissions: [],
+        }),
+      ).toEqual({ traces: "none" });
+      expect(
+        clampSelectionsToAvailability({
+          selections: { traces: "read" },
+          userPermissions: [],
+        }),
+      ).toEqual({ traces: "none" });
+    });
+  });
+
+  describe("when a selection names a category that does not exist", () => {
+    it("drops it rather than passing it through", () => {
+      const result = clampSelectionsToAvailability({
+        selections: { "not-a-category": "write" },
+        userPermissions: categorizablePermissions(),
+      });
+      expect(result).toEqual({ "not-a-category": "none" });
+    });
+  });
+
+  describe("when the caller holds everything", () => {
+    it("leaves every category at the level it was set to", () => {
+      const selections = Object.fromEntries(
+        PERMISSION_CATEGORIES.map((category) => [
+          category.key,
+          category.accessLevels.includes("write")
+            ? ("write" as const)
+            : ("read" as const),
+        ]),
+      );
+      expect(
+        clampSelectionsToAvailability({
+          selections,
+          userPermissions: categorizablePermissions(),
+        }),
+      ).toEqual(selections);
     });
   });
 });

--- a/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
@@ -8,6 +8,7 @@ import {
   bindingsToScopes,
   bindingsToSelections,
   computeBindings,
+  getUserPermissionsAcrossScopes,
   getUserPermissionsAtScope,
   permissionLabelToRole,
   permissionsSummary,
@@ -676,6 +677,82 @@ describe("getUserPermissionsAtScope()", () => {
         getTeamRolePermissions: mockGetPerms,
       });
       expect(result).toEqual(["project:view", "project:update"]);
+    });
+  });
+});
+
+describe("getUserPermissionsAcrossScopes()", () => {
+  const mockGetPerms = (role: string) => {
+    if (role === "ADMIN") return ["project:manage", "project:view"];
+    if (role === "MEMBER") return ["project:view", "project:update"];
+    return ["project:view"];
+  };
+
+  const orgProjects = [
+    { id: "proj-1", teamId: "team-1" },
+    { id: "proj-2", teamId: "team-2" },
+  ];
+
+  describe("when the caller holds different roles on the selected scopes", () => {
+    it("offers only what every scope grants", () => {
+      const result = getUserPermissionsAcrossScopes({
+        myBindings: [
+          { scopeType: "TEAM", scopeId: "team-1", role: "ADMIN" },
+          { scopeType: "TEAM", scopeId: "team-2", role: "VIEWER" },
+        ],
+        scopes: [
+          { scopeType: "TEAM", scopeId: "team-1" },
+          { scopeType: "TEAM", scopeId: "team-2" },
+        ],
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      // One permission list serves every binding, and the VIEWER team would
+      // refuse project:manage at save time.
+      expect(result).toEqual(["project:view"]);
+    });
+  });
+
+  describe("when a selected scope carries nothing", () => {
+    it("offers nothing at all", () => {
+      const result = getUserPermissionsAcrossScopes({
+        myBindings: [{ scopeType: "TEAM", scopeId: "team-1", role: "ADMIN" }],
+        scopes: [
+          { scopeType: "TEAM", scopeId: "team-1" },
+          { scopeType: "TEAM", scopeId: "team-unbound" },
+        ],
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("when a single scope is selected", () => {
+    it("matches the single-scope ceiling", () => {
+      const args = {
+        myBindings: [{ scopeType: "TEAM", scopeId: "team-1", role: "ADMIN" }],
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      };
+      expect(
+        getUserPermissionsAcrossScopes({
+          ...args,
+          scopes: [{ scopeType: "TEAM", scopeId: "team-1" }],
+        }),
+      ).toEqual(
+        getUserPermissionsAtScope({
+          ...args,
+          scopeType: "TEAM",
+          scopeId: "team-1",
+        }),
+      );
     });
   });
 });

--- a/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { categorizablePermissions } from "../../../server/api-key/permission-categories";
+import {
+  categorizablePermissions,
+  PERMISSION_CATEGORIES,
+} from "../../../server/api-key/permission-categories";
 import {
   bindingsToPermissionMode,
   bindingsToScopes,
@@ -302,7 +305,7 @@ describe("permissionsSummary()", () => {
         permissionsSummary({
           permissionMode: "all",
           grantedCount: 0,
-          totalCount: 14,
+          totalCount: PERMISSION_CATEGORIES.length,
         }),
       ).toBe("All");
     });
@@ -315,9 +318,11 @@ describe("permissionsSummary()", () => {
         permissionsSummary({
           permissionMode: "restricted",
           grantedCount: 3,
-          totalCount: 14,
+          totalCount: PERMISSION_CATEGORIES.length,
         }),
-      ).toBe("3 of 14 permissions");
+        // The denominator is the number of categories a key can be given,
+        // read from the registry so it cannot drift as categories are added.
+      ).toBe(`3 of ${PERMISSION_CATEGORIES.length} permissions`);
     });
   });
 });
@@ -655,8 +660,10 @@ describe("getUserPermissionsAtScope()", () => {
       // full access, so the ceiling shown here has to match it.
       expect(result).toEqual(categorizablePermissions());
     });
+  });
 
-    it("returns the team-role bag for a non-ADMIN org binding", () => {
+  describe("when an org-level non-ADMIN binding covers a project scope", () => {
+    it("returns the team-role bag", () => {
       const result = getUserPermissionsAtScope({
         myBindings: [
           { scopeType: "ORGANIZATION", scopeId: "org-1", role: "MEMBER" },

--- a/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { categorizablePermissions } from "../../../server/api-key/permission-categories";
 import {
   bindingsToPermissionMode,
   bindingsToScopes,
@@ -572,7 +573,7 @@ describe("getUserPermissionsAtScope()", () => {
   const orgProjects = [{ id: "proj-1", teamId: "team-1" }];
 
   describe("when isServiceKey is true", () => {
-    it("returns ADMIN permissions regardless of bindings", () => {
+    it("returns everything grantable regardless of bindings", () => {
       const result = getUserPermissionsAtScope({
         myBindings: undefined,
         scopeType: "PROJECT",
@@ -582,7 +583,9 @@ describe("getUserPermissionsAtScope()", () => {
         isServiceKey: true,
         getTeamRolePermissions: mockGetPerms,
       });
-      expect(result).toEqual(["project:manage", "project:view"]);
+      // The team-role bags carry no organization, gateway, governance or
+      // playground permissions, so they understate a service key's ceiling.
+      expect(result).toEqual(categorizablePermissions());
     });
   });
 
@@ -635,8 +638,8 @@ describe("getUserPermissionsAtScope()", () => {
     });
   });
 
-  describe("when org-level binding covers a project scope", () => {
-    it("falls back to the org binding", () => {
+  describe("when an org-level ADMIN binding covers a project scope", () => {
+    it("returns everything grantable, not the team-role bag", () => {
       const result = getUserPermissionsAtScope({
         myBindings: [
           { scopeType: "ORGANIZATION", scopeId: "org-1", role: "ADMIN" },
@@ -648,7 +651,24 @@ describe("getUserPermissionsAtScope()", () => {
         isServiceKey: false,
         getTeamRolePermissions: mockGetPerms,
       });
-      expect(result).toEqual(["project:manage", "project:view"]);
+      // The resolver short-circuits an ORGANIZATION-scoped ADMIN binding to
+      // full access, so the ceiling shown here has to match it.
+      expect(result).toEqual(categorizablePermissions());
+    });
+
+    it("returns the team-role bag for a non-ADMIN org binding", () => {
+      const result = getUserPermissionsAtScope({
+        myBindings: [
+          { scopeType: "ORGANIZATION", scopeId: "org-1", role: "MEMBER" },
+        ],
+        scopeType: "PROJECT",
+        scopeId: "proj-1",
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      expect(result).toEqual(["project:view", "project:update"]);
     });
   });
 });

--- a/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
@@ -1,56 +1,52 @@
+import { ALL_PERMISSIONS } from "@langwatch/authz";
 import { describe, expect, it } from "vitest";
-import { Resources } from "~/utils/rbacVocabulary";
 import { CustomRolePermissionsSchema } from "../../rbac/custom-role-permissions";
+import { defaultCliKeyPermissions } from "../cli-key-defaults";
 import {
+  categorizablePermissions,
   categoryPermissions,
   computePermissionsFromSelections,
   PERMISSION_CATEGORIES,
   selectionsFromPermissions,
 } from "../permission-categories";
 
-const RESOURCES_EXCLUDED_FROM_API_KEY_CATEGORIES = new Set<string>([
-  Resources.ORGANIZATION,
-  Resources.PLAYGROUND,
-  Resources.OPS,
-  Resources.VIRTUAL_KEYS,
-  Resources.GATEWAY_BUDGETS,
-  Resources.GATEWAY_PROVIDERS,
-  Resources.GATEWAY_GUARDRAILS,
-  Resources.GATEWAY_LOGS,
-  Resources.GATEWAY_USAGE,
-  Resources.GATEWAY_CACHE_RULES,
-  // Org-anchored like the gateway surfaces above: managed through org API
-  // keys and RoleBindings, never through user-issued project API keys.
-  Resources.WEBHOOK_ENDPOINTS,
-  Resources.GATEWAY_SPEND,
-  // Iter 110 governance resources — admin-config surfaces governed by
-  // RoleBinding alone, never reachable through user-issued API keys.
-  Resources.ROUTING_POLICIES,
-  Resources.GOVERNANCE,
-  Resources.INGESTION_SOURCES,
-  Resources.ANOMALY_RULES,
-  Resources.COMPLIANCE_EXPORT,
-  Resources.ACTIVITY_MONITOR,
-  Resources.AI_TOOLS,
-]);
-
 describe("PERMISSION_CATEGORIES", () => {
-  it("covers every non-excluded Resource from the RBAC source of truth", () => {
-    const categoryResources = new Set(PERMISSION_CATEGORIES.map((c) => c.key));
-    const allResources = Object.values(Resources);
-    const uncovered = allResources.filter(
-      (r) =>
-        !categoryResources.has(r) &&
-        !RESOURCES_EXCLUDED_FROM_API_KEY_CATEGORIES.has(r),
+  /** @scenario Every registry permission belongs to a category */
+  it("covers every registry permission except the platform tier", () => {
+    const covered = new Set<string>(
+      PERMISSION_CATEGORIES.flatMap((c) => [
+        ...c.readPermissions,
+        ...c.writePermissions,
+      ]),
+    );
+    const uncovered = categorizablePermissions().filter(
+      (permission) => !covered.has(permission),
     );
     expect(
       uncovered,
-      "Resources missing from PERMISSION_CATEGORIES — add a category or mark as excluded",
+      "Registry permissions missing from PERMISSION_CATEGORIES — add them to a category",
     ).toEqual([]);
+
+    // The only permissions outside the categories are the platform tier,
+    // which can never ride on an API key.
+    const categorizable = new Set<string>(categorizablePermissions());
+    const platformOnly = ALL_PERMISSIONS.filter(
+      (permission) => !categorizable.has(permission),
+    );
+    expect(platformOnly).toEqual(["ops:view", "ops:manage"]);
+  });
+
+  it("only names permissions that exist in the registry", () => {
+    const registry = new Set<string>(ALL_PERMISSIONS);
+    const unknown = PERMISSION_CATEGORIES.flatMap((c) => [
+      ...c.readPermissions,
+      ...c.writePermissions,
+    ]).filter((permission) => !registry.has(permission));
+    expect(unknown).toEqual([]);
   });
 
   /** @scenario Permission categories include all platform resources */
-  it("includes all 15 platform resource categories with correct access levels", () => {
+  it("lists the categories with their access levels", () => {
     const result = PERMISSION_CATEGORIES.map((c) => ({
       category: c.label,
       accessLevels: c.accessLevels.join(", "),
@@ -69,11 +65,62 @@ describe("PERMISSION_CATEGORIES", () => {
       { category: "Workflows", accessLevels: "read, write" },
       { category: "Experiments", accessLevels: "read, write" },
       { category: "Prompts", accessLevels: "read, write" },
+      { category: "Playground", accessLevels: "read, write" },
       { category: "Secrets", accessLevels: "read, write" },
       { category: "Audit Log", accessLevels: "read" },
       { category: "Team", accessLevels: "read, write" },
-      { category: "Project", accessLevels: "read, write" },
+      { category: "Project settings", accessLevels: "read, write" },
+      { category: "Project administration", accessLevels: "write" },
+      { category: "Organization", accessLevels: "read, write" },
+      { category: "Gateway", accessLevels: "read, write" },
+      { category: "Governance", accessLevels: "read, write" },
     ]);
+  });
+
+  it("splits project creation and deletion away from project settings", () => {
+    expect(
+      categoryPermissions({ key: "projectSettings", level: "write" }),
+    ).toEqual(["project:view", "project:update", "project:manage"]);
+    expect(
+      categoryPermissions({ key: "projectAdministration", level: "write" }),
+    ).toEqual(["project:create", "project:delete"]);
+    expect(
+      categoryPermissions({ key: "projectAdministration", level: "read" }),
+    ).toEqual([]);
+  });
+
+  /** @scenario "write" access includes all mutating permissions for that resource */
+  it("grants a resource's full registry action set at the write level", () => {
+    expect(categoryPermissions({ key: "scenarios", level: "write" })).toEqual([
+      "scenarios:view",
+      "scenarios:create",
+      "scenarios:update",
+      "scenarios:delete",
+      "scenarios:manage",
+    ]);
+    expect(categoryPermissions({ key: "traces", level: "write" })).toEqual([
+      "traces:view",
+      "traces:create",
+      "traces:update",
+      "traces:share",
+    ]);
+
+    const gatewayWrite = categoryPermissions({
+      key: "gateway",
+      level: "write",
+    });
+    expect(gatewayWrite).toContain("virtualKeys:viewOtherPersonal");
+    expect(gatewayWrite).toContain("gatewaySpend:manage");
+    expect(gatewayWrite).toContain("webhookEndpoints:manage");
+    expect(gatewayWrite).toContain("routingPolicies:manage");
+
+    const governanceWrite = categoryPermissions({
+      key: "governance",
+      level: "write",
+    });
+    expect(governanceWrite).toContain("governance:manage");
+    expect(governanceWrite).toContain("aiTools:manage");
+    expect(governanceWrite).toContain("complianceExport:view");
   });
 });
 
@@ -85,70 +132,19 @@ describe("categoryPermissions()", () => {
         "traces:view",
       ]);
     });
-  });
 
-  describe("when level is write", () => {
-    /** @scenario "write" access includes all mutating permissions for that resource */
-    it("returns all mutating permissions per category", () => {
-      const results = PERMISSION_CATEGORIES.filter((c) =>
-        c.accessLevels.includes("write"),
-      ).map((c) => ({
-        category: c.label,
-        permissions: categoryPermissions({ key: c.key, level: "write" }).join(
-          ", ",
-        ),
-      }));
-
-      expect(results).toEqual([
-        {
-          category: "Traces",
-          permissions:
-            "traces:view, traces:create, traces:update, traces:share",
-        },
-        {
-          category: "Scenarios",
-          permissions: "scenarios:view, scenarios:manage",
-        },
-        {
-          category: "Annotations",
-          permissions: "annotations:view, annotations:manage",
-        },
-        {
-          category: "Analytics",
-          permissions: "analytics:view, analytics:manage",
-        },
-        {
-          category: "Evaluations",
-          permissions: "evaluations:view, evaluations:manage",
-        },
-        {
-          category: "Langy",
-          permissions: "langy:view, langy:create, langy:update, langy:delete",
-        },
-        {
-          category: "Datasets",
-          permissions: "datasets:view, datasets:manage",
-        },
-        {
-          category: "Triggers",
-          permissions: "triggers:view, triggers:manage",
-        },
-        {
-          category: "Workflows",
-          permissions: "workflows:view, workflows:manage",
-        },
-        {
-          category: "Experiments",
-          permissions: "experiments:view, experiments:manage",
-        },
-        { category: "Prompts", permissions: "prompts:view, prompts:manage" },
-        { category: "Secrets", permissions: "secrets:view, secrets:manage" },
-        { category: "Team", permissions: "team:view, team:manage" },
-        {
-          category: "Project",
-          permissions:
-            "project:view, project:create, project:update, project:delete, project:manage",
-        },
+    it("returns every view permission for multi-resource categories", () => {
+      expect(categoryPermissions({ key: "gateway", level: "read" })).toEqual([
+        "virtualKeys:view",
+        "gatewayBudgets:view",
+        "gatewayProviders:view",
+        "routingPolicies:view",
+        "gatewayGuardrails:view",
+        "gatewayLogs:view",
+        "gatewayUsage:view",
+        "gatewayCacheRules:view",
+        "gatewaySpend:view",
+        "webhookEndpoints:view",
       ]);
     });
   });
@@ -187,7 +183,10 @@ describe("computePermissionsFromSelections()", () => {
       });
 
       expect(result).toEqual([
+        "annotations:create",
+        "annotations:delete",
         "annotations:manage",
+        "annotations:update",
         "annotations:view",
         "traces:view",
       ]);
@@ -205,8 +204,9 @@ describe("selectionsFromPermissions()", () => {
     });
   });
 
-  describe("when permissions contain manage entries", () => {
-    it("maps to write for those categories", () => {
+  describe("when permissions come from a key stored before the expanded write lists", () => {
+    /** @scenario Older stored keys keep reading as write via the manage hierarchy */
+    it("maps [view, manage] to write through the hierarchy", () => {
       const result = selectionsFromPermissions([
         "datasets:view",
         "datasets:manage",
@@ -219,6 +219,15 @@ describe("selectionsFromPermissions()", () => {
   describe("when permissions are empty", () => {
     it("returns empty object", () => {
       expect(selectionsFromPermissions([])).toEqual({});
+    });
+
+    it("never invents a read selection for a write-only category", () => {
+      expect(selectionsFromPermissions([]).projectAdministration).toBe(
+        undefined,
+      );
+      expect(
+        selectionsFromPermissions(["project:view"]).projectAdministration,
+      ).toBe(undefined);
     });
   });
 
@@ -237,6 +246,45 @@ describe("selectionsFromPermissions()", () => {
 
       expect(reversed).toEqual(original);
     });
+  });
+});
+
+describe("the CLI login key default", () => {
+  /** @scenario the organization-management permissions are off by default */
+  it("seeds the expected levels from the default permission list", () => {
+    const seed = selectionsFromPermissions(defaultCliKeyPermissions());
+
+    expect(seed.projectSettings).toBe("write");
+    expect(seed.projectAdministration).toBe(undefined);
+    expect(seed.team).toBe("read");
+    expect(seed.organization).toBe("read");
+    expect(seed.gateway).toBe("write");
+    expect(seed.governance).toBe("write");
+    expect(seed.traces).toBe("write");
+    expect(seed.playground).toBe("write");
+    expect(seed.cost).toBe("read");
+    expect(seed.auditLog).toBe("read");
+  });
+
+  it("leaves out every platform-tier permission", () => {
+    const categorizable = new Set<string>(categorizablePermissions());
+    const platformOnly = ALL_PERMISSIONS.filter(
+      (permission) => !categorizable.has(permission),
+    );
+    const defaults = new Set<string>(defaultCliKeyPermissions());
+
+    expect(platformOnly.length).toBeGreaterThan(0);
+    expect(
+      platformOnly.filter((permission) => defaults.has(permission)),
+      "A platform-tier permission reached the CLI login key defaults",
+    ).toEqual([]);
+  });
+
+  it("round-trips the default permission list exactly", () => {
+    const seed = selectionsFromPermissions(defaultCliKeyPermissions());
+    const computed = computePermissionsFromSelections(seed);
+
+    expect(new Set(computed)).toEqual(new Set(defaultCliKeyPermissions()));
   });
 });
 

--- a/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
@@ -17,27 +17,60 @@ import {
 describe("PERMISSION_CATEGORIES", () => {
   /** @scenario Every registry permission belongs to a category */
   it("covers every registry permission except the platform tier", () => {
-    const covered = new Set<string>(
-      PERMISSION_CATEGORIES.flatMap((c) => [
-        ...c.readPermissions,
-        ...c.writePermissions,
-      ]),
-    );
+    // Which categories claim each permission, rather than whether any does:
+    // the categories partition the registry, so a permission owned by two of
+    // them is as wrong as one owned by none. A flat Set hides that, and the
+    // second owner is what silently widens a key — granting one category
+    // would hand over another category's resources. Read and write of the
+    // SAME category both naming a permission is the intended shape, since a
+    // write level always carries its own reads.
+    const owners = new Map<string, string[]>();
+    for (const category of PERMISSION_CATEGORIES) {
+      for (const permission of new Set([
+        ...category.readPermissions,
+        ...category.writePermissions,
+      ])) {
+        owners.set(permission, [
+          ...(owners.get(permission) ?? []),
+          category.key,
+        ]);
+      }
+    }
+
     const uncovered = categorizablePermissions().filter(
-      (permission) => !covered.has(permission),
+      (permission) => !owners.has(permission),
     );
     expect(
       uncovered,
       "Registry permissions missing from PERMISSION_CATEGORIES — add them to a category",
     ).toEqual([]);
 
+    const claimedTwice = [...owners.entries()]
+      .filter(([, categoryKeys]) => categoryKeys.length > 1)
+      .map(
+        ([permission, categoryKeys]) =>
+          `${permission}: ${categoryKeys.join(", ")}`,
+      );
+    expect(
+      claimedTwice,
+      "Permissions claimed by more than one category — granting one category would hand over the other's resources",
+    ).toEqual([]);
+
     // The only permissions outside the categories are the platform tier,
-    // which can never ride on an API key.
+    // which can never ride on an API key — so no category may name one.
     const categorizable = new Set<string>(categorizablePermissions());
     const platformOnly = ALL_PERMISSIONS.filter(
       (permission) => !categorizable.has(permission),
     );
     expect(platformOnly).toEqual(["ops:view", "ops:manage"]);
+
+    const platformInCategory = platformOnly.filter((permission) =>
+      owners.has(permission),
+    );
+    expect(
+      platformInCategory,
+      "Platform-tier permissions cannot ride on an API key — remove them from the categories",
+    ).toEqual([]);
   });
 
   it("only names permissions that exist in the registry", () => {

--- a/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
@@ -2,7 +2,10 @@ import { ALL_PERMISSIONS } from "@langwatch/authz";
 import { describe, expect, it } from "vitest";
 import { hasPermissionWithHierarchy } from "../../api/rbac";
 import { CustomRolePermissionsSchema } from "../../rbac/custom-role-permissions";
-import { defaultCliKeyPermissions } from "../cli-key-defaults";
+import {
+  CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS,
+  defaultCliKeyPermissions,
+} from "../cli-key-defaults";
 import {
   categorizablePermissions,
   categoryPermissions,
@@ -70,24 +73,31 @@ describe("PERMISSION_CATEGORIES", () => {
       { category: "Secrets", accessLevels: "read, write" },
       { category: "Audit Log", accessLevels: "read" },
       { category: "Team", accessLevels: "read, write" },
-      { category: "Project settings", accessLevels: "read, write" },
-      { category: "Project administration", accessLevels: "write" },
+      { category: "Project", accessLevels: "read, write" },
       { category: "Organization", accessLevels: "read, write" },
       { category: "Gateway", accessLevels: "read, write" },
       { category: "Governance", accessLevels: "read, write" },
     ]);
   });
 
-  it("splits project creation and deletion away from project settings", () => {
+  /** @scenario Project write carries creation and deletion, because manage implies them */
+  it("keeps the whole project resource in one category", () => {
+    expect(categoryPermissions({ key: "project", level: "write" })).toEqual([
+      "project:view",
+      "project:create",
+      "project:update",
+      "project:delete",
+      "project:manage",
+    ]);
+    // Why they cannot be offered separately: the request path answers a
+    // create or delete check with the category's own manage grant, so a
+    // narrower category would describe a separation that does not exist.
     expect(
-      categoryPermissions({ key: "projectSettings", level: "write" }),
-    ).toEqual(["project:view", "project:update", "project:manage"]);
+      hasPermissionWithHierarchy(["project:manage"], "project:create"),
+    ).toBe(true);
     expect(
-      categoryPermissions({ key: "projectAdministration", level: "write" }),
-    ).toEqual(["project:create", "project:delete"]);
-    expect(
-      categoryPermissions({ key: "projectAdministration", level: "read" }),
-    ).toEqual([]);
+      hasPermissionWithHierarchy(["project:manage"], "project:delete"),
+    ).toBe(true);
   });
 
   /** @scenario "write" access includes all mutating permissions for that resource */
@@ -223,14 +233,12 @@ describe("selectionsFromPermissions()", () => {
     });
   });
 
-  describe("when a category is write-only", () => {
-    it("never invents a read selection for it", () => {
-      expect(selectionsFromPermissions([]).projectAdministration).toBe(
-        undefined,
+  describe("when a category is read-only", () => {
+    it("never invents a write selection for it", () => {
+      expect(selectionsFromPermissions(["cost:view"]).cost).toBe("read");
+      expect(selectionsFromPermissions(["auditLog:view"]).auditLog).toBe(
+        "read",
       );
-      expect(
-        selectionsFromPermissions(["project:view"]).projectAdministration,
-      ).toBe(undefined);
     });
   });
 
@@ -257,8 +265,7 @@ describe("the CLI login key default", () => {
   it("seeds the expected levels from the default permission list", () => {
     const seed = selectionsFromPermissions(defaultCliKeyPermissions());
 
-    expect(seed.projectSettings).toBe("write");
-    expect(seed.projectAdministration).toBe(undefined);
+    expect(seed.project).toBe("write");
     expect(seed.team).toBe("read");
     expect(seed.organization).toBe("read");
     expect(seed.gateway).toBe("write");
@@ -270,19 +277,30 @@ describe("the CLI login key default", () => {
   });
 
   /** @scenario the organization-management permissions are off by default */
-  it("cannot reach project creation or deletion through project:manage", () => {
+  it("holds the organization exclusions in effect, not only in the list", () => {
     const defaults = defaultCliKeyPermissions();
 
-    // The exclusion has to hold in effect, not only in the list: the RBAC
-    // hierarchy promotes a `:create` or `:delete` check to `:manage` for
-    // every other resource, and `project:manage` IS in the defaults because
-    // model providers and project settings ride on it.
+    // An exclusion is only real when the request path agrees: the hierarchy
+    // promotes a `:create`, `:update` or `:delete` check to the resource's
+    // own `:manage`, so an excluded permission must not be reachable that way.
+    for (const excluded of CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS) {
+      expect(hasPermissionWithHierarchy(defaults, excluded)).toBe(false);
+    }
+  });
+
+  /** @scenario project administration rides along with project settings */
+  it("grants project administration with project:manage, and says so", () => {
+    const defaults = defaultCliKeyPermissions();
+
+    // `project:manage` is in the defaults because model providers, project
+    // settings and topic clustering check it, and it answers a create or
+    // delete check too. The list names both rather than implying an
+    // exclusion the request path would not honour.
     expect(defaults).toContain("project:manage");
-    expect(hasPermissionWithHierarchy(defaults, "project:create")).toBe(false);
-    expect(hasPermissionWithHierarchy(defaults, "project:delete")).toBe(false);
-    // The promotion still works everywhere else.
+    expect(defaults).toContain("project:create");
+    expect(defaults).toContain("project:delete");
     expect(
-      hasPermissionWithHierarchy(["datasets:manage"], "datasets:create"),
+      hasPermissionWithHierarchy(["project:manage"], "project:create"),
     ).toBe(true);
   });
 

--- a/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/permission-categories.unit.test.ts
@@ -1,5 +1,6 @@
 import { ALL_PERMISSIONS } from "@langwatch/authz";
 import { describe, expect, it } from "vitest";
+import { hasPermissionWithHierarchy } from "../../api/rbac";
 import { CustomRolePermissionsSchema } from "../../rbac/custom-role-permissions";
 import { defaultCliKeyPermissions } from "../cli-key-defaults";
 import {
@@ -220,8 +221,10 @@ describe("selectionsFromPermissions()", () => {
     it("returns empty object", () => {
       expect(selectionsFromPermissions([])).toEqual({});
     });
+  });
 
-    it("never invents a read selection for a write-only category", () => {
+  describe("when a category is write-only", () => {
+    it("never invents a read selection for it", () => {
       expect(selectionsFromPermissions([]).projectAdministration).toBe(
         undefined,
       );
@@ -264,6 +267,23 @@ describe("the CLI login key default", () => {
     expect(seed.playground).toBe("write");
     expect(seed.cost).toBe("read");
     expect(seed.auditLog).toBe("read");
+  });
+
+  /** @scenario the organization-management permissions are off by default */
+  it("cannot reach project creation or deletion through project:manage", () => {
+    const defaults = defaultCliKeyPermissions();
+
+    // The exclusion has to hold in effect, not only in the list: the RBAC
+    // hierarchy promotes a `:create` or `:delete` check to `:manage` for
+    // every other resource, and `project:manage` IS in the defaults because
+    // model providers and project settings ride on it.
+    expect(defaults).toContain("project:manage");
+    expect(hasPermissionWithHierarchy(defaults, "project:create")).toBe(false);
+    expect(hasPermissionWithHierarchy(defaults, "project:delete")).toBe(false);
+    // The promotion still works everywhere else.
+    expect(
+      hasPermissionWithHierarchy(["datasets:manage"], "datasets:create"),
+    ).toBe(true);
   });
 
   it("leaves out every platform-tier permission", () => {

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -85,7 +85,7 @@ type RoleBindingBase = {
   scopeId: string;
 };
 
-type RoleBindingInput =
+export type RoleBindingInput =
   | (RoleBindingBase & { role: "ADMIN" | "MEMBER" | "VIEWER" })
   | (RoleBindingBase & { role: "CUSTOM"; customRoleId?: string });
 
@@ -567,6 +567,52 @@ export class ApiKeyService {
         meta: { userId, organizationId },
       });
     }
+  }
+
+  /**
+   * The mint-time validation of {@link create}, exposed as a dry run for
+   * callers that decide a selection long before they mint (the CLI device-flow
+   * approval stamps a selection that `create` only consumes at exchange time).
+   * Same checks, same errors, nothing persisted: the permission format, the
+   * empty-input refusals, org membership, every binding within the user's own
+   * ceiling for every permission, and personal-team scopes owned by the user.
+   * An input this method accepts is an input `create` mints.
+   */
+  async assertSelectionWithinCeiling({
+    userId,
+    organizationId,
+    bindings,
+    permissions,
+  }: {
+    userId: string;
+    organizationId: string;
+    bindings: RoleBindingInput[];
+    permissions: string[];
+  }): Promise<void> {
+    if (permissions.length === 0) {
+      throw new ApiKeyScopeViolationError(
+        "CUSTOM bindings require at least one permission",
+      );
+    }
+    if (bindings.length === 0) {
+      throw new ApiKeyScopeViolationError(
+        "A personal API key needs at least one role binding",
+      );
+    }
+    ApiKeyService.assertPermissionFormat(permissions);
+    await this.ensureCallerIsOrgMember({ userId, organizationId });
+    await this.assertBindingsWithinCeiling({
+      prisma: this.prisma,
+      ceilingUserId: userId,
+      organizationId,
+      bindings,
+      rawPermissions: [...permissions].sort(),
+    });
+    await assertPersonalTeamScopesOwnedBy({
+      client: this.prisma,
+      scopes: bindings,
+      ownerUserId: userId,
+    });
   }
 
   /**

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -87,7 +87,17 @@ type RoleBindingBase = {
 
 export type RoleBindingInput =
   | (RoleBindingBase & { role: "ADMIN" | "MEMBER" | "VIEWER" })
-  | (RoleBindingBase & { role: "CUSTOM"; customRoleId?: string });
+  | CustomRoleBindingInput;
+
+/**
+ * A binding carrying an explicit permission list rather than a built-in role.
+ * Only these are mintable under `permissionMode: "restricted"`, so the
+ * selection dry run takes exactly this shape.
+ */
+export type CustomRoleBindingInput = RoleBindingBase & {
+  role: "CUSTOM";
+  customRoleId?: string;
+};
 
 type CreatorScope =
   | { type: "org"; id: string }
@@ -577,6 +587,12 @@ export class ApiKeyService {
    * empty-input refusals, org membership, every binding within the user's own
    * ceiling for every permission, and personal-team scopes owned by the user.
    * An input this method accepts is an input `create` mints.
+   *
+   * The bindings are CUSTOM by type, not by runtime guard: `create` refuses a
+   * restricted key whose bindings carry a built-in role, and the ceiling walk
+   * routes a built-in role to a one-permission probe that never reads the
+   * supplied list. Accepting one here would be both permissive and weaker
+   * than the mint, so the compiler rules it out instead.
    */
   async assertSelectionWithinCeiling({
     userId,
@@ -586,7 +602,7 @@ export class ApiKeyService {
   }: {
     userId: string;
     organizationId: string;
-    bindings: RoleBindingInput[];
+    bindings: CustomRoleBindingInput[];
     permissions: string[];
   }): Promise<void> {
     if (permissions.length === 0) {

--- a/platform/app/src/server/api-key/cli-key-defaults.ts
+++ b/platform/app/src/server/api-key/cli-key-defaults.ts
@@ -1,0 +1,37 @@
+import type { AuthzPermission } from "@langwatch/authz";
+import { categorizablePermissions } from "./permission-categories";
+
+/**
+ * Permissions a CLI login key does NOT get by default. The key a
+ * `langwatch login` mints inherits the user's access for day-to-day work
+ * (traces, datasets, prompts, gateway, model providers, ...), but a leaked
+ * key must not be able to escalate: create projects, change RBAC, manage
+ * API keys or the organization itself.
+ *
+ * The platform tier (`ops:*`) is not on this list because it is excluded
+ * structurally: the defaults start from `categorizablePermissions()`, which
+ * drops every permission on a platform-scoped resource, so a platform
+ * resource added later can never reach the defaults through a name list.
+ *
+ * The user can still opt in to any of these on the authorize screen; this
+ * list only shapes the default selection and is enforced nowhere else —
+ * request-time enforcement is the key's bindings intersected with the
+ * owner's live permissions.
+ */
+export const CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS: readonly AuthzPermission[] =
+  [
+    "organization:manage",
+    "organization:delete",
+    "project:create",
+    "project:delete",
+    "team:manage",
+  ];
+
+const excluded = new Set<string>(CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS);
+
+/** The default permission list for a CLI login key. */
+export function defaultCliKeyPermissions(): AuthzPermission[] {
+  return categorizablePermissions().filter(
+    (permission) => !excluded.has(permission),
+  ) as AuthzPermission[];
+}

--- a/platform/app/src/server/api-key/cli-key-defaults.ts
+++ b/platform/app/src/server/api-key/cli-key-defaults.ts
@@ -5,8 +5,15 @@ import { categorizablePermissions } from "./permission-categories";
  * Permissions a CLI login key does NOT get by default. The key a
  * `langwatch login` mints inherits the user's access for day-to-day work
  * (traces, datasets, prompts, gateway, model providers, ...), but a leaked
- * key must not be able to escalate: create projects, change RBAC, manage
- * API keys or the organization itself.
+ * key must not be able to change RBAC or the organization itself.
+ *
+ * `project:create` and `project:delete` are NOT on this list, and cannot be:
+ * model providers, project settings and topic clustering all check
+ * `project:manage`, and `hasPermissionWithHierarchy` answers a create or
+ * delete check with that same manage grant. Naming them here would withhold
+ * them from the stored list while the request path still allowed the call.
+ * A user who wants project administration off the key sets Project to Read
+ * on the authorize screen, which drops `project:manage` with it.
  *
  * The platform tier (`ops:*`) is not on this list because it is excluded
  * structurally: the defaults start from `categorizablePermissions()`, which
@@ -19,13 +26,7 @@ import { categorizablePermissions } from "./permission-categories";
  * owner's live permissions.
  */
 export const CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS: readonly AuthzPermission[] =
-  [
-    "organization:manage",
-    "organization:delete",
-    "project:create",
-    "project:delete",
-    "team:manage",
-  ];
+  ["organization:manage", "organization:delete", "team:manage"];
 
 const excluded = new Set<string>(CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS);
 

--- a/platform/app/src/server/api-key/cli-login-key.service.ts
+++ b/platform/app/src/server/api-key/cli-login-key.service.ts
@@ -1,0 +1,480 @@
+import { isRegistryPermission } from "@langwatch/authz";
+import { HandledError } from "@langwatch/handled-error";
+import { createLogger } from "@langwatch/observability";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { RoleBindingScopeType } from "~/generated/prisma/client";
+import {
+  batchTeamsPermissions,
+  isOrgExclusivePermission,
+  type Permission,
+} from "~/server/api/rbac";
+import { ApiKeyService, type RoleBindingInput } from "./api-key.service";
+import { defaultCliKeyPermissions } from "./cli-key-defaults";
+import { ApiKeyAlreadyRevokedError, ApiKeyNotFoundError } from "./errors";
+
+const logger = createLogger("langwatch:api-key:cli-login-key");
+
+/**
+ * The marker that, together with `createdByDeviceLabel`, identifies a key the
+ * device-flow login minted. Re-login from the same device revokes the previous
+ * key by this pair before minting the next one, so logins never accumulate
+ * credentials.
+ */
+export const CLI_LOGIN_KEY_NAME_PREFIX = "CLI login - ";
+
+/** The device label stamped when an older CLI sends no client_info. */
+export const CLI_LOGIN_UNKNOWN_DEVICE_LABEL = "unknown-device";
+
+export type CliKeyScopeType = "ORGANIZATION" | "TEAM" | "PROJECT";
+
+export interface CliKeyBindingSelection {
+  scopeType: CliKeyScopeType;
+  scopeId: string;
+}
+
+/**
+ * The scope + permission selection the authorize screen approves. Stamped on
+ * the Redis device-code record at /approve time; consumed by the /exchange
+ * mint. Carries no role — the minted bindings are always CUSTOM with the
+ * selected permission list.
+ */
+export interface CliKeySelection {
+  bindings: CliKeyBindingSelection[];
+  permissions: string[];
+}
+
+/** The reach of a minted CLI login key, shipped to the CLI at exchange. */
+export interface CliKeyScopeSummary {
+  kind: "organization" | "projects";
+  projectIds: string[];
+}
+
+/**
+ * An approve request carried a selection the server cannot stamp: empty
+ * bindings, empty permissions, or a permission the registry does not know.
+ * `meta.fieldErrors` names the offending field so the authorize screen can
+ * mark it in place.
+ */
+export class CliKeySelectionInvalidError extends HandledError {
+  declare readonly code: "cli_key_selection_invalid";
+
+  constructor(fieldErrors: Record<string, string[]>) {
+    super("cli_key_selection_invalid", "The key selection is not valid", {
+      httpStatus: 422,
+      meta: { fieldErrors },
+    });
+    this.name = "CliKeySelectionInvalidError";
+  }
+}
+
+/**
+ * Mints, replaces and revokes the user-scoped API key a `langwatch login`
+ * device session carries, and resolves the selection that shapes it.
+ *
+ * Spec: specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+ */
+export class CliLoginKeyService {
+  private readonly prisma: PrismaClient;
+  private readonly apiKeyService: ApiKeyService;
+
+  constructor({
+    prisma,
+    apiKeyService,
+  }: {
+    prisma: PrismaClient;
+    apiKeyService: ApiKeyService;
+  }) {
+    this.prisma = prisma;
+    this.apiKeyService = apiKeyService;
+  }
+
+  static create(prisma: PrismaClient): CliLoginKeyService {
+    return new CliLoginKeyService({
+      prisma,
+      apiKeyService: ApiKeyService.create(prisma),
+    });
+  }
+
+  /**
+   * Validates an explicit selection from the authorize screen and returns the
+   * normalized form to stamp.
+   *
+   * Refusals, all before anything is stamped:
+   *   - zero bindings / zero permissions / unknown permissions →
+   *     {@link CliKeySelectionInvalidError} with `meta.fieldErrors`
+   *   - scopes outside the organization, bindings above the approving user's
+   *     own ceiling, personal teams the approver does not own →
+   *     `ApiKeyScopeViolationError` / `PersonalWorkspaceNotManagedHereError`
+   *     from the same checks `ApiKeyService.create` runs at mint time.
+   *
+   * Org-exclusive permissions are FILTERED, not refused, when the selection
+   * carries no ORGANIZATION binding: a team- or project-scoped binding can
+   * never grant them (ADR-021), so keeping them on the key would only store a
+   * list the resolver ignores. The same filter shapes the default selection,
+   * so the two paths agree.
+   */
+  async validateSelection({
+    userId,
+    organizationId,
+    selection,
+  }: {
+    userId: string;
+    organizationId: string;
+    selection: CliKeySelection;
+  }): Promise<CliKeySelection> {
+    const bindings = dedupeBindings(selection.bindings);
+    if (bindings.length === 0) {
+      throw new CliKeySelectionInvalidError({
+        bindings: ["Select at least one scope"],
+      });
+    }
+
+    const unknown = selection.permissions.filter(
+      (permission) => !isRegistryPermission(permission),
+    );
+    if (unknown.length > 0) {
+      throw new CliKeySelectionInvalidError({
+        permissions: unknown.map(
+          (permission) => `Unknown permission "${permission}"`,
+        ),
+      });
+    }
+
+    const permissions = filterToGrantable({
+      permissions: [...new Set(selection.permissions)],
+      bindings,
+    });
+    if (permissions.length === 0) {
+      throw new CliKeySelectionInvalidError({
+        permissions: ["Select at least one permission"],
+      });
+    }
+
+    await this.apiKeyService.assertSelectionWithinCeiling({
+      userId,
+      organizationId,
+      bindings: asCustomBindings(bindings),
+      permissions,
+    });
+
+    return { bindings, permissions: permissions.sort() };
+  }
+
+  /**
+   * The selection stamped when a client approves without an explicit one:
+   * the widest scope the user holds, with the default permission list
+   * narrowed to what they really hold there.
+   *
+   *   - org-scope ADMIN role binding → one ORGANIZATION binding, full
+   *     `defaultCliKeyPermissions()` (an org admin holds all of them).
+   *   - otherwise → TEAM bindings for the user's teams (their personal
+   *     workspace included), permissions = the default list minus
+   *     org-exclusive ones, intersected across those teams. A team where the
+   *     user holds none of them is dropped rather than zeroing the whole key.
+   *
+   * Returns null when nothing mintable remains — the login then completes
+   * without a scoped key, exactly like a pre-selection client.
+   */
+  async resolveDefaultSelection({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }): Promise<CliKeySelection | null> {
+    const defaults = defaultCliKeyPermissions();
+
+    if (await this.apiKeyService.isOrgAdmin({ userId, organizationId })) {
+      return {
+        bindings: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        permissions: [...defaults].sort(),
+      };
+    }
+
+    // Team-scoped role bindings carry only a scopeId (no relation to Team by
+    // design), so membership is the union of TeamUser rows and TEAM-scoped
+    // bindings, resolved against the team table in one pass.
+    const boundTeamIds = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId,
+        userId,
+        scopeType: RoleBindingScopeType.TEAM,
+      },
+      select: { scopeId: true },
+    });
+    const teams = await this.prisma.team.findMany({
+      where: {
+        organizationId,
+        archivedAt: null,
+        OR: [
+          { members: { some: { userId } } },
+          ...(boundTeamIds.length > 0
+            ? [{ id: { in: boundTeamIds.map((binding) => binding.scopeId) } }]
+            : []),
+        ],
+        // Another member's personal workspace is never a scope for this
+        // user's key, whatever membership rows exist.
+        NOT: { isPersonal: true, ownerUserId: { not: userId } },
+      },
+      select: { id: true },
+    });
+    if (teams.length === 0) return null;
+
+    const candidate = defaults.filter(
+      (permission) => !isOrgExclusivePermission(permission),
+    );
+    const heldByTeam = await batchTeamsPermissions(
+      { prisma: this.prisma, session: sessionFor(userId) },
+      {
+        organizationId,
+        teamIds: teams.map((team) => team.id),
+        permissions: candidate,
+      },
+    );
+
+    // One permission list serves every binding, and the mint asserts it at
+    // every stamped scope — so the list is the intersection across the teams
+    // that grant anything at all, and a team granting nothing (for example a
+    // personal team whose owner grant has not projected yet) is dropped
+    // instead of zeroing the key.
+    let permissions: Set<string> | null = null;
+    const teamIds: string[] = [];
+    for (const [teamId, held] of heldByTeam) {
+      if (held.length === 0) continue;
+      teamIds.push(teamId);
+      if (permissions === null) {
+        permissions = new Set(held);
+      } else {
+        const kept: ReadonlySet<string> = permissions;
+        permissions = new Set(
+          held.filter((permission) => kept.has(permission)),
+        );
+      }
+    }
+    if (!permissions || permissions.size === 0 || teamIds.length === 0) {
+      return null;
+    }
+
+    return {
+      bindings: teamIds.map((teamId) => ({
+        scopeType: "TEAM" as const,
+        scopeId: teamId,
+      })),
+      permissions: [...permissions].sort(),
+    };
+  }
+
+  /**
+   * Mints the login key at exchange time, replacing any previous CLI login
+   * key of the same user + organization + device label first. Returns the
+   * plaintext token (shown once, shipped to the CLI) and the scope summary
+   * the CLI persists beside it.
+   */
+  async mintForDeviceSession({
+    userId,
+    organizationId,
+    deviceLabel,
+    selection,
+  }: {
+    userId: string;
+    organizationId: string;
+    deviceLabel: string;
+    selection: CliKeySelection;
+  }): Promise<{ token: string; apiKeyId: string; scope: CliKeyScopeSummary }> {
+    await this.revokeLoginKeysForDevice({
+      userId,
+      organizationId,
+      deviceLabel,
+    });
+
+    const created = await this.apiKeyService.create({
+      name: `${CLI_LOGIN_KEY_NAME_PREFIX}${deviceLabel}`,
+      userId,
+      createdByUserId: userId,
+      organizationId,
+      permissionMode: "restricted",
+      permissions: selection.permissions,
+      bindings: asCustomBindings(selection.bindings),
+      createdByDeviceLabel: deviceLabel,
+    });
+
+    return {
+      token: created.token,
+      apiKeyId: created.apiKey.id,
+      scope: await this.resolveScopeSummary({
+        organizationId,
+        bindings: selection.bindings,
+      }),
+    };
+  }
+
+  /**
+   * Revokes every non-revoked CLI login key this user holds for this device
+   * label in this organization. Used before a re-login mint and by logout.
+   */
+  async revokeLoginKeysForDevice({
+    userId,
+    organizationId,
+    deviceLabel,
+  }: {
+    userId: string;
+    organizationId: string;
+    deviceLabel: string;
+  }): Promise<void> {
+    const priorKeys = await this.prisma.apiKey.findMany({
+      where: {
+        organizationId,
+        userId,
+        createdByDeviceLabel: deviceLabel,
+        name: { startsWith: CLI_LOGIN_KEY_NAME_PREFIX },
+        revokedAt: null,
+      },
+      select: { id: true },
+    });
+    for (const key of priorKeys) {
+      await this.revokeQuietly({ apiKeyId: key.id, userId, organizationId });
+    }
+  }
+
+  /**
+   * Revokes one login key by id — the logout path, which stored the minted
+   * key's id on the session's Redis token records. Idempotent: a key already
+   * revoked (or gone) leaves logout a success, like the token deletes beside
+   * it.
+   */
+  async revokeForLogout({
+    apiKeyId,
+    userId,
+    organizationId,
+  }: {
+    apiKeyId: string;
+    userId: string;
+    organizationId: string;
+  }): Promise<void> {
+    await this.revokeQuietly({ apiKeyId, userId, organizationId });
+  }
+
+  private async revokeQuietly({
+    apiKeyId,
+    userId,
+    organizationId,
+  }: {
+    apiKeyId: string;
+    userId: string;
+    organizationId: string;
+  }): Promise<void> {
+    try {
+      await this.apiKeyService.revoke({
+        id: apiKeyId,
+        callerUserId: userId,
+        callerIsAdmin: false,
+        organizationId,
+      });
+    } catch (err) {
+      if (ApiKeyAlreadyRevokedError.is(err) || ApiKeyNotFoundError.is(err)) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * The reach summary the CLI shows in `whoami` and uses for `--project`
+   * resolution. An ORGANIZATION binding means the whole organization;
+   * otherwise the project ids the bindings expand to at mint time.
+   */
+  private async resolveScopeSummary({
+    organizationId,
+    bindings,
+  }: {
+    organizationId: string;
+    bindings: CliKeyBindingSelection[];
+  }): Promise<CliKeyScopeSummary> {
+    if (bindings.some((binding) => binding.scopeType === "ORGANIZATION")) {
+      return { kind: "organization", projectIds: [] };
+    }
+    const teamIds = bindings
+      .filter((binding) => binding.scopeType === "TEAM")
+      .map((binding) => binding.scopeId);
+    const projectIds = bindings
+      .filter((binding) => binding.scopeType === "PROJECT")
+      .map((binding) => binding.scopeId);
+
+    const projects = await this.prisma.project.findMany({
+      where: {
+        archivedAt: null,
+        team: { organizationId },
+        OR: [
+          ...(projectIds.length > 0 ? [{ id: { in: projectIds } }] : []),
+          ...(teamIds.length > 0 ? [{ teamId: { in: teamIds } }] : []),
+        ],
+      },
+      select: { id: true },
+    });
+    return {
+      kind: "projects",
+      projectIds: projects.map((project) => project.id).sort(),
+    };
+  }
+}
+
+function dedupeBindings(
+  bindings: CliKeyBindingSelection[],
+): CliKeyBindingSelection[] {
+  const seen = new Set<string>();
+  const result: CliKeyBindingSelection[] = [];
+  for (const binding of bindings) {
+    const key = `${binding.scopeType}::${binding.scopeId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ scopeType: binding.scopeType, scopeId: binding.scopeId });
+  }
+  return result;
+}
+
+/**
+ * Drops permissions no selected binding could ever grant: org-exclusive ones
+ * survive only alongside an ORGANIZATION binding (ADR-021).
+ */
+function filterToGrantable({
+  permissions,
+  bindings,
+}: {
+  permissions: string[];
+  bindings: CliKeyBindingSelection[];
+}): string[] {
+  const hasOrgBinding = bindings.some(
+    (binding) => binding.scopeType === "ORGANIZATION",
+  );
+  if (hasOrgBinding) return permissions;
+  const filtered = permissions.filter(
+    (permission) => !isOrgExclusivePermission(permission as Permission),
+  );
+  if (filtered.length !== permissions.length) {
+    logger.debug(
+      { dropped: permissions.length - filtered.length },
+      "dropped org-exclusive permissions from a selection with no organization binding",
+    );
+  }
+  return filtered;
+}
+
+function asCustomBindings(
+  bindings: CliKeyBindingSelection[],
+): RoleBindingInput[] {
+  return bindings.map((binding) => ({
+    role: "CUSTOM" as const,
+    scopeType: binding.scopeType,
+    scopeId: binding.scopeId,
+  }));
+}
+
+/**
+ * The minimal session shape the batch resolver reads — the same trick
+ * `PermissionService` uses; only `user.id` is ever accessed.
+ */
+function sessionFor(userId: string) {
+  return { user: { id: userId } } as Parameters<
+    typeof batchTeamsPermissions
+  >[0]["session"];
+}

--- a/platform/app/src/server/api-key/cli-login-key.service.ts
+++ b/platform/app/src/server/api-key/cli-login-key.service.ts
@@ -8,7 +8,7 @@ import {
   isOrgExclusivePermission,
   type Permission,
 } from "~/server/api/rbac";
-import { ApiKeyService, type RoleBindingInput } from "./api-key.service";
+import { ApiKeyService, type CustomRoleBindingInput } from "./api-key.service";
 import { defaultCliKeyPermissions } from "./cli-key-defaults";
 import { ApiKeyAlreadyRevokedError, ApiKeyNotFoundError } from "./errors";
 
@@ -278,6 +278,14 @@ export class CliLoginKeyService {
     deviceLabel: string;
     selection: CliKeySelection;
   }): Promise<{ token: string; apiKeyId: string; scope: CliKeyScopeSummary }> {
+    // Resolved BEFORE the mint, though it only describes it: these are two
+    // more reads, and a read that fails after the key row is live would fail
+    // the exchange while leaving that key behind, active and unreachable.
+    const scope = await this.resolveScopeSummary({
+      organizationId,
+      bindings: selection.bindings,
+    });
+
     await this.revokeLoginKeysForDevice({
       userId,
       organizationId,
@@ -295,14 +303,7 @@ export class CliLoginKeyService {
       createdByDeviceLabel: deviceLabel,
     });
 
-    return {
-      token: created.token,
-      apiKeyId: created.apiKey.id,
-      scope: await this.resolveScopeSummary({
-        organizationId,
-        bindings: selection.bindings,
-      }),
-    };
+    return { token: created.token, apiKeyId: created.apiKey.id, scope };
   }
 
   /**
@@ -486,7 +487,7 @@ function filterToGrantable({
 
 function asCustomBindings(
   bindings: CliKeyBindingSelection[],
-): RoleBindingInput[] {
+): CustomRoleBindingInput[] {
   return bindings.map((binding) => ({
     role: "CUSTOM" as const,
     scopeType: binding.scopeType,

--- a/platform/app/src/server/api-key/cli-login-key.service.ts
+++ b/platform/app/src/server/api-key/cli-login-key.service.ts
@@ -191,9 +191,49 @@ export class CliLoginKeyService {
       };
     }
 
-    // Team-scoped role bindings carry only a scopeId (no relation to Team by
-    // design), so membership is the union of TeamUser rows and TEAM-scoped
-    // bindings, resolved against the team table in one pass.
+    const teamIdsOfUser = await this.teamsTheUserCanScopeTo({
+      userId,
+      organizationId,
+    });
+    if (teamIdsOfUser.length === 0) return null;
+
+    const heldByTeam = await batchTeamsPermissions(
+      { prisma: this.prisma, session: sessionFor(userId) },
+      {
+        organizationId,
+        teamIds: teamIdsOfUser,
+        permissions: defaults.filter(
+          (permission) => !isOrgExclusivePermission(permission),
+        ),
+      },
+    );
+
+    const narrowed = intersectAcrossTeams(heldByTeam);
+    if (!narrowed) return null;
+
+    return {
+      bindings: narrowed.teamIds.map((teamId) => ({
+        scopeType: "TEAM" as const,
+        scopeId: teamId,
+      })),
+      permissions: narrowed.permissions,
+    };
+  }
+
+  /**
+   * The teams whose scope this user's key may carry.
+   *
+   * Team-scoped role bindings carry only a scopeId (no relation to Team by
+   * design), so membership is the union of TeamUser rows and TEAM-scoped
+   * bindings, resolved against the team table in one pass.
+   */
+  private async teamsTheUserCanScopeTo({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }): Promise<string[]> {
     const boundTeamIds = await this.prisma.roleBinding.findMany({
       where: {
         organizationId,
@@ -218,50 +258,7 @@ export class CliLoginKeyService {
       },
       select: { id: true },
     });
-    if (teams.length === 0) return null;
-
-    const candidate = defaults.filter(
-      (permission) => !isOrgExclusivePermission(permission),
-    );
-    const heldByTeam = await batchTeamsPermissions(
-      { prisma: this.prisma, session: sessionFor(userId) },
-      {
-        organizationId,
-        teamIds: teams.map((team) => team.id),
-        permissions: candidate,
-      },
-    );
-
-    // One permission list serves every binding, and the mint asserts it at
-    // every stamped scope — so the list is the intersection across the teams
-    // that grant anything at all, and a team granting nothing (for example a
-    // personal team whose owner grant has not projected yet) is dropped
-    // instead of zeroing the key.
-    let permissions: Set<string> | null = null;
-    const teamIds: string[] = [];
-    for (const [teamId, held] of heldByTeam) {
-      if (held.length === 0) continue;
-      teamIds.push(teamId);
-      if (permissions === null) {
-        permissions = new Set(held);
-      } else {
-        const kept: ReadonlySet<string> = permissions;
-        permissions = new Set(
-          held.filter((permission) => kept.has(permission)),
-        );
-      }
-    }
-    if (!permissions || permissions.size === 0 || teamIds.length === 0) {
-      return null;
-    }
-
-    return {
-      bindings: teamIds.map((teamId) => ({
-        scopeType: "TEAM" as const,
-        scopeId: teamId,
-      })),
-      permissions: [...permissions].sort(),
-    };
+    return teams.map((team) => team.id);
   }
 
   /**
@@ -416,6 +413,34 @@ export class CliLoginKeyService {
       projectIds: projects.map((project) => project.id).sort(),
     };
   }
+}
+
+/**
+ * Narrow the per-team held permissions to the one list a key can carry.
+ *
+ * One permission list serves every binding, and the mint asserts it at every
+ * stamped scope — so the list is the intersection across the teams that grant
+ * anything at all, and a team granting nothing (for example a personal team
+ * whose owner grant has not projected yet) is dropped instead of zeroing the
+ * key. Returns null when nothing mintable remains.
+ */
+function intersectAcrossTeams(
+  heldByTeam: Map<string, string[]>,
+): { teamIds: string[]; permissions: string[] } | null {
+  const teamIds: string[] = [];
+  let kept: string[] | null = null;
+  for (const [teamId, held] of heldByTeam) {
+    if (held.length === 0) continue;
+    teamIds.push(teamId);
+    if (kept === null) {
+      kept = [...held];
+      continue;
+    }
+    const heldHere = new Set(held);
+    kept = kept.filter((permission) => heldHere.has(permission));
+  }
+  if (!kept || kept.length === 0) return null;
+  return { teamIds, permissions: [...kept].sort() };
 }
 
 function dedupeBindings(

--- a/platform/app/src/server/api-key/cli-login-key.service.ts
+++ b/platform/app/src/server/api-key/cli-login-key.service.ts
@@ -286,12 +286,6 @@ export class CliLoginKeyService {
       bindings: selection.bindings,
     });
 
-    await this.revokeLoginKeysForDevice({
-      userId,
-      organizationId,
-      deviceLabel,
-    });
-
     const created = await this.apiKeyService.create({
       name: `${CLI_LOGIN_KEY_NAME_PREFIX}${deviceLabel}`,
       userId,
@@ -303,21 +297,46 @@ export class CliLoginKeyService {
       createdByDeviceLabel: deviceLabel,
     });
 
+    // The predecessor stays usable until its replacement exists. A mint has
+    // several fallible steps, and the key this call replaces is the one in
+    // the user's CLI config right now: revoking it first would leave a
+    // failed re-login with no working key at all.
+    try {
+      await this.revokeLoginKeysForDevice({
+        userId,
+        organizationId,
+        deviceLabel,
+        exceptApiKeyId: created.apiKey.id,
+      });
+    } catch (err) {
+      // The exchange is about to fail, so the replacement must not survive
+      // it: the CLI never receives this token and nothing else can revoke it.
+      await this.revokeQuietly({
+        apiKeyId: created.apiKey.id,
+        userId,
+        organizationId,
+      });
+      throw err;
+    }
+
     return { token: created.token, apiKeyId: created.apiKey.id, scope };
   }
 
   /**
    * Revokes every non-revoked CLI login key this user holds for this device
-   * label in this organization. Used before a re-login mint and by logout.
+   * label in this organization. Used after a re-login mint (which passes its
+   * fresh key as `exceptApiKeyId`) and by logout.
    */
   async revokeLoginKeysForDevice({
     userId,
     organizationId,
     deviceLabel,
+    exceptApiKeyId,
   }: {
     userId: string;
     organizationId: string;
     deviceLabel: string;
+    exceptApiKeyId?: string;
   }): Promise<void> {
     const priorKeys = await this.prisma.apiKey.findMany({
       where: {
@@ -326,6 +345,7 @@ export class CliLoginKeyService {
         createdByDeviceLabel: deviceLabel,
         name: { startsWith: CLI_LOGIN_KEY_NAME_PREFIX },
         revokedAt: null,
+        ...(exceptApiKeyId ? { id: { not: exceptApiKeyId } } : {}),
       },
       select: { id: true },
     });

--- a/platform/app/src/server/api-key/cli-login-key.service.ts
+++ b/platform/app/src/server/api-key/cli-login-key.service.ts
@@ -307,6 +307,7 @@ export class CliLoginKeyService {
         organizationId,
         deviceLabel,
         exceptApiKeyId: created.apiKey.id,
+        createdBefore: created.apiKey.createdAt,
       });
     } catch (err) {
       // The exchange is about to fail, so the replacement must not survive
@@ -325,18 +326,28 @@ export class CliLoginKeyService {
   /**
    * Revokes every non-revoked CLI login key this user holds for this device
    * label in this organization. Used after a re-login mint (which passes its
-   * fresh key as `exceptApiKeyId`) and by logout.
+   * fresh key as `exceptApiKeyId`) and by logout, which passes neither filter
+   * and so clears the device outright.
+   *
+   * `createdBefore` is what keeps two logins racing on the same device from
+   * revoking each other: each mint clears only keys OLDER than the one it
+   * just created, so the newer key always survives and the CLI is never
+   * handed a token that the other exchange revoked a moment later. Two keys
+   * created in the same millisecond both survive, which costs a stale key
+   * the next login clears rather than a dead credential.
    */
   async revokeLoginKeysForDevice({
     userId,
     organizationId,
     deviceLabel,
     exceptApiKeyId,
+    createdBefore,
   }: {
     userId: string;
     organizationId: string;
     deviceLabel: string;
     exceptApiKeyId?: string;
+    createdBefore?: Date;
   }): Promise<void> {
     const priorKeys = await this.prisma.apiKey.findMany({
       where: {
@@ -346,6 +357,7 @@ export class CliLoginKeyService {
         name: { startsWith: CLI_LOGIN_KEY_NAME_PREFIX },
         revokedAt: null,
         ...(exceptApiKeyId ? { id: { not: exceptApiKeyId } } : {}),
+        ...(createdBefore ? { createdAt: { lt: createdBefore } } : {}),
       },
       select: { id: true },
     });

--- a/platform/app/src/server/api-key/errors.ts
+++ b/platform/app/src/server/api-key/errors.ts
@@ -160,6 +160,34 @@ export class ApiKeyReservedNameError extends HandledError {
   }
 }
 
+/**
+ * Thrown when answering "which projects can this credential see" would have
+ * to walk more projects than the resolution is allowed to. The caller can act
+ * on it: narrow the key's bindings to the projects or teams it works with.
+ *
+ * `platform` fault: the credential is legitimate and the request is
+ * well-formed, so this is our limit showing, not the caller's mistake.
+ */
+export class ProjectVisibilityTooWideError extends HandledError {
+  declare readonly code: "project_visibility_too_wide";
+
+  constructor(
+    message: string,
+    options: {
+      meta?: Record<string, unknown>;
+      reasons?: readonly Error[];
+    } = {},
+  ) {
+    super("project_visibility_too_wide", message, {
+      httpStatus: 507,
+      fault: "platform",
+      ...remediation("project_visibility_too_wide"),
+      ...options,
+    });
+    this.name = "ProjectVisibilityTooWideError";
+  }
+}
+
 export class ApiKeyScopeViolationError extends HandledError {
   declare readonly code: "api_key_scope_violation";
 

--- a/platform/app/src/server/api-key/permission-categories.ts
+++ b/platform/app/src/server/api-key/permission-categories.ts
@@ -1,3 +1,10 @@
+import {
+  ALL_PERMISSIONS,
+  AUTHZ_RESOURCES,
+  type AuthzResource,
+  permissionResource,
+  permissionSatisfiedBy,
+} from "@langwatch/authz";
 import type { Permission } from "../api/rbac";
 
 export type AccessLevel = "read" | "write";
@@ -10,53 +17,99 @@ export interface PermissionCategory {
   writePermissions: Permission[];
 }
 
+/**
+ * Every registry permission of the given resources. The write level of a
+ * category grants its resources wholesale, derived from the registry so a
+ * new action can never be stranded outside the UI: the coverage test in
+ * permission-categories.unit.test.ts pins categories to ALL_PERMISSIONS.
+ */
+function allActionsOf(...resources: AuthzResource[]): Permission[] {
+  return resources.flatMap((resource) =>
+    AUTHZ_RESOURCES[resource].actions.map(
+      (action) => `${resource}:${action}` as Permission,
+    ),
+  );
+}
+
+function viewsOf(...resources: AuthzResource[]): Permission[] {
+  return resources.map((resource) => `${resource}:view` as Permission);
+}
+
+/**
+ * The resources the Gateway category grants as one unit: virtual keys,
+ * budgets, providers, routing, guardrails, caching, usage/log/spend
+ * reporting, and webhook endpoints.
+ */
+const GATEWAY_RESOURCES: AuthzResource[] = [
+  "virtualKeys",
+  "gatewayBudgets",
+  "gatewayProviders",
+  "routingPolicies",
+  "gatewayGuardrails",
+  "gatewayLogs",
+  "gatewayUsage",
+  "gatewayCacheRules",
+  "gatewaySpend",
+  "webhookEndpoints",
+];
+
+/**
+ * The resources the Governance category grants as one unit. All of them are
+ * org-exclusive at enforcement time (registry scopes: ["organization"]);
+ * the category needs no special casing for that — a grant a binding cannot
+ * carry simply never takes effect.
+ */
+const GOVERNANCE_RESOURCES: AuthzResource[] = [
+  "governance",
+  "ingestionSources",
+  "anomalyRules",
+  "complianceExport",
+  "activityMonitor",
+  "aiTools",
+];
+
 export const PERMISSION_CATEGORIES: readonly PermissionCategory[] = [
   {
     key: "traces",
     label: "Traces",
     accessLevels: ["read", "write"],
-    readPermissions: ["traces:view"],
-    writePermissions: [
-      "traces:view",
-      "traces:create",
-      "traces:update",
-      "traces:share",
-    ],
+    readPermissions: viewsOf("traces"),
+    writePermissions: allActionsOf("traces"),
   },
   {
     key: "cost",
     label: "Cost",
     accessLevels: ["read"],
-    readPermissions: ["cost:view"],
+    readPermissions: viewsOf("cost"),
     writePermissions: [],
   },
   {
     key: "scenarios",
     label: "Scenarios",
     accessLevels: ["read", "write"],
-    readPermissions: ["scenarios:view"],
-    writePermissions: ["scenarios:view", "scenarios:manage"],
+    readPermissions: viewsOf("scenarios"),
+    writePermissions: allActionsOf("scenarios"),
   },
   {
     key: "annotations",
     label: "Annotations",
     accessLevels: ["read", "write"],
-    readPermissions: ["annotations:view"],
-    writePermissions: ["annotations:view", "annotations:manage"],
+    readPermissions: viewsOf("annotations"),
+    writePermissions: allActionsOf("annotations"),
   },
   {
     key: "analytics",
     label: "Analytics",
     accessLevels: ["read", "write"],
-    readPermissions: ["analytics:view"],
-    writePermissions: ["analytics:view", "analytics:manage"],
+    readPermissions: viewsOf("analytics"),
+    writePermissions: allActionsOf("analytics"),
   },
   {
     key: "evaluations",
     label: "Evaluations",
     accessLevels: ["read", "write"],
-    readPermissions: ["evaluations:view"],
-    writePermissions: ["evaluations:view", "evaluations:manage"],
+    readPermissions: viewsOf("evaluations"),
+    writePermissions: allActionsOf("evaluations"),
   },
   {
     key: "langy",
@@ -65,84 +118,128 @@ export const PERMISSION_CATEGORIES: readonly PermissionCategory[] = [
     // Write here means "may run the assistant" — starting a turn provisions
     // credentials and spends model budget, so it is deliberately not part of
     // the read level.
-    readPermissions: ["langy:view"],
-    writePermissions: [
-      "langy:view",
-      "langy:create",
-      "langy:update",
-      "langy:delete",
-    ],
+    readPermissions: viewsOf("langy"),
+    writePermissions: allActionsOf("langy"),
   },
   {
     key: "datasets",
     label: "Datasets",
     accessLevels: ["read", "write"],
-    readPermissions: ["datasets:view"],
-    writePermissions: ["datasets:view", "datasets:manage"],
+    readPermissions: viewsOf("datasets"),
+    writePermissions: allActionsOf("datasets"),
   },
   {
     key: "triggers",
     label: "Triggers",
     accessLevels: ["read", "write"],
-    readPermissions: ["triggers:view"],
-    writePermissions: ["triggers:view", "triggers:manage"],
+    readPermissions: viewsOf("triggers"),
+    writePermissions: allActionsOf("triggers"),
   },
   {
     key: "workflows",
     label: "Workflows",
     accessLevels: ["read", "write"],
-    readPermissions: ["workflows:view"],
-    writePermissions: ["workflows:view", "workflows:manage"],
+    readPermissions: viewsOf("workflows"),
+    writePermissions: allActionsOf("workflows"),
   },
   {
     key: "experiments",
     label: "Experiments",
     accessLevels: ["read", "write"],
-    readPermissions: ["experiments:view"],
-    writePermissions: ["experiments:view", "experiments:manage"],
+    readPermissions: viewsOf("experiments"),
+    writePermissions: allActionsOf("experiments"),
   },
   {
     key: "prompts",
     label: "Prompts",
     accessLevels: ["read", "write"],
-    readPermissions: ["prompts:view"],
-    writePermissions: ["prompts:view", "prompts:manage"],
+    readPermissions: viewsOf("prompts"),
+    writePermissions: allActionsOf("prompts"),
+  },
+  {
+    key: "playground",
+    label: "Playground",
+    accessLevels: ["read", "write"],
+    readPermissions: viewsOf("playground"),
+    writePermissions: allActionsOf("playground"),
   },
   {
     key: "secrets",
     label: "Secrets",
     accessLevels: ["read", "write"],
-    readPermissions: ["secrets:view"],
-    writePermissions: ["secrets:view", "secrets:manage"],
+    readPermissions: viewsOf("secrets"),
+    writePermissions: allActionsOf("secrets"),
   },
   {
     key: "auditLog",
     label: "Audit Log",
     accessLevels: ["read"],
-    readPermissions: ["auditLog:view"],
+    readPermissions: viewsOf("auditLog"),
     writePermissions: [],
   },
   {
     key: "team",
     label: "Team",
     accessLevels: ["read", "write"],
-    readPermissions: ["team:view"],
-    writePermissions: ["team:view", "team:manage"],
+    readPermissions: viewsOf("team"),
+    writePermissions: allActionsOf("team"),
   },
   {
-    key: "project",
-    label: "Project",
+    key: "projectSettings",
+    label: "Project settings",
     accessLevels: ["read", "write"],
-    readPermissions: ["project:view"],
-    writePermissions: [
-      "project:view",
-      "project:create",
-      "project:update",
-      "project:delete",
-      "project:manage",
-    ],
+    readPermissions: viewsOf("project"),
+    writePermissions: ["project:view", "project:update", "project:manage"],
+  },
+  {
+    // Write-only on purpose: creating and deleting projects is an
+    // administrative act with no read counterpart, split from Project
+    // settings so a key can manage a project without being able to add or
+    // remove projects.
+    key: "projectAdministration",
+    label: "Project administration",
+    accessLevels: ["write"],
+    readPermissions: [],
+    writePermissions: ["project:create", "project:delete"],
+  },
+  {
+    key: "organization",
+    label: "Organization",
+    accessLevels: ["read", "write"],
+    readPermissions: viewsOf("organization"),
+    writePermissions: allActionsOf("organization"),
+  },
+  {
+    key: "gateway",
+    label: "Gateway",
+    accessLevels: ["read", "write"],
+    readPermissions: viewsOf(...GATEWAY_RESOURCES),
+    writePermissions: allActionsOf(...GATEWAY_RESOURCES),
+  },
+  {
+    key: "governance",
+    label: "Governance",
+    accessLevels: ["read", "write"],
+    readPermissions: viewsOf(...GOVERNANCE_RESOURCES),
+    writePermissions: allActionsOf(...GOVERNANCE_RESOURCES),
   },
 ] as const;
+
+/**
+ * The registry permissions the categories deliberately do NOT cover: the
+ * platform tier (`scopes: ["platform"]`), which is grantable only to
+ * platform staff and can never ride on an API key. Everything else in
+ * ALL_PERMISSIONS belongs to at least one category — enforced by
+ * permission-categories.unit.test.ts so the registry cannot drift out of
+ * the UI again.
+ */
+export function categorizablePermissions(): Permission[] {
+  return [...ALL_PERMISSIONS].filter((permission) => {
+    const def =
+      AUTHZ_RESOURCES[permissionResource(permission) as AuthzResource];
+    return !(def.scopes as readonly string[]).includes("platform");
+  }) as Permission[];
+}
 
 export function categoryPermissions({
   key,
@@ -174,18 +271,43 @@ export function computePermissionsFromSelections(
 export function selectionsFromPermissions(
   permissions: string[],
 ): Record<string, AccessLevel> {
+  const granted = new Set(permissions);
+
+  // Hierarchy-aware so a stored list carrying `datasets:manage` still
+  // satisfies `datasets:create` (keys stored before the write lists were
+  // expanded keep reading as "write") — but the implication only rides on a
+  // manage grant the category ITSELF carries. `project:manage` belongs to
+  // Project settings, so it must never make Project administration
+  // (`project:create`/`project:delete`) read as granted.
+  const heldWithinCategory = (
+    category: PermissionCategory,
+    permission: Permission,
+  ) =>
+    granted.has(permission) ||
+    category.writePermissions.some(
+      (writePermission) =>
+        writePermission.endsWith(":manage") &&
+        granted.has(writePermission) &&
+        permissionSatisfiedBy({
+          granted: new Set([writePermission]),
+          requested: permission,
+        }),
+    );
+
   const selections: Record<string, AccessLevel> = {};
   for (const category of PERMISSION_CATEGORIES) {
     const hasWrite =
       category.writePermissions.length > 0 &&
-      category.writePermissions.every((p) => permissions.includes(p));
-    const hasRead = category.readPermissions.every((p) =>
-      permissions.includes(p),
-    );
+      category.writePermissions.every((p) => heldWithinCategory(category, p));
+    // A write-only category (no read permissions) must never fall back to
+    // "read": there is nothing a read level would grant.
+    const hasRead =
+      category.readPermissions.length > 0 &&
+      category.readPermissions.every((p) => heldWithinCategory(category, p));
 
     if (hasWrite) {
       selections[category.key] = "write";
-    } else if (hasRead) {
+    } else if (hasRead && category.accessLevels.includes("read")) {
       selections[category.key] = "read";
     }
   }

--- a/platform/app/src/server/api-key/permission-categories.ts
+++ b/platform/app/src/server/api-key/permission-categories.ts
@@ -185,22 +185,17 @@ export const PERMISSION_CATEGORIES: readonly PermissionCategory[] = [
     writePermissions: allActionsOf("team"),
   },
   {
-    key: "projectSettings",
-    label: "Project settings",
+    // One category, because the role model gives no way to split it:
+    // `project:manage` is the umbrella grant for the project resource, and
+    // `hasPermissionWithHierarchy` answers a `project:create` or
+    // `project:delete` check with it. A category that offered project
+    // settings without project creation would describe a separation the
+    // request path does not make.
+    key: "project",
+    label: "Project",
     accessLevels: ["read", "write"],
     readPermissions: viewsOf("project"),
-    writePermissions: ["project:view", "project:update", "project:manage"],
-  },
-  {
-    // Write-only on purpose: creating and deleting projects is an
-    // administrative act with no read counterpart, split from Project
-    // settings so a key can manage a project without being able to add or
-    // remove projects.
-    key: "projectAdministration",
-    label: "Project administration",
-    accessLevels: ["write"],
-    readPermissions: [],
-    writePermissions: ["project:create", "project:delete"],
+    writePermissions: allActionsOf("project"),
   },
   {
     key: "organization",
@@ -275,10 +270,9 @@ export function selectionsFromPermissions(
 
   // Hierarchy-aware so a stored list carrying `datasets:manage` still
   // satisfies `datasets:create` (keys stored before the write lists were
-  // expanded keep reading as "write") — but the implication only rides on a
-  // manage grant the category ITSELF carries. `project:manage` belongs to
-  // Project settings, so it must never make Project administration
-  // (`project:create`/`project:delete`) read as granted.
+  // expanded keep reading as "write"). The implication rides only on a manage
+  // grant the category itself carries, so one category's manage can never
+  // mark another category granted.
   const heldWithinCategory = (
     category: PermissionCategory,
     permission: Permission,

--- a/platform/app/src/server/api-key/project-visibility.ts
+++ b/platform/app/src/server/api-key/project-visibility.ts
@@ -5,6 +5,7 @@ import {
   checkRoleBindingPermission,
   resolveApiKeyPermission,
 } from "~/server/rbac/role-binding-resolver";
+import { ProjectVisibilityTooWideError } from "./errors";
 
 /**
  * The projects a credential may list: everything in the organization, or an
@@ -112,6 +113,10 @@ async function boundScopes({
   apiKeyId: string;
   organizationId: string;
 }): Promise<BoundScopes | null> {
+  // No key, no bindings to read: Prisma drops an `undefined` from the filter,
+  // which would widen this to every binding in the organization.
+  if (!apiKeyId) return null;
+
   const bindings = await prisma.roleBinding.findMany({
     where: { organizationId, apiKeyId },
     select: { scopeType: true, scopeId: true },
@@ -134,8 +139,39 @@ async function boundScopes({
   };
 }
 
+/**
+ * The most projects one visibility resolution will carry.
+ *
+ * An org-bound key whose owner has lost org-wide `project:view` cannot be
+ * answered from the fast path: the reach is "every project in the
+ * organization, minus what the owner can no longer see", so the candidates
+ * have to be enumerated. The cap bounds that work. It is not a silent
+ * truncation — going over it refuses the request, because a short list would
+ * be a wrong answer rather than a slow one.
+ */
+const MAX_CANDIDATE_PROJECTS = 5_000;
+
 /** Phase 2b: the non-archived projects those bound scopes can reach. */
 async function candidateProjects({
+  prisma,
+  organizationId,
+  bound,
+}: {
+  prisma: PrismaClient;
+  organizationId: string;
+  bound: BoundScopes;
+}): Promise<CandidateProject[]> {
+  const candidates = await findCandidates({ prisma, organizationId, bound });
+  if (candidates.length > MAX_CANDIDATE_PROJECTS) {
+    throw new ProjectVisibilityTooWideError(
+      `Resolving this credential's project visibility would scan more than ${MAX_CANDIDATE_PROJECTS} projects`,
+      { meta: { organizationId, limit: MAX_CANDIDATE_PROJECTS } },
+    );
+  }
+  return candidates;
+}
+
+async function findCandidates({
   prisma,
   organizationId,
   bound,
@@ -162,6 +198,9 @@ async function candidateProjects({
           }),
     },
     select: { id: true, teamId: true },
+    // One over the cap: enough to know it was exceeded, without reading an
+    // unbounded row set to find out.
+    take: MAX_CANDIDATE_PROJECTS + 1,
   });
 }
 

--- a/platform/app/src/server/api-key/project-visibility.ts
+++ b/platform/app/src/server/api-key/project-visibility.ts
@@ -1,0 +1,275 @@
+import type { PrismaClient } from "~/generated/prisma/client";
+import { RoleBindingScopeType } from "~/generated/prisma/client";
+import { batchScopePermissions } from "~/server/api/rbac";
+import {
+  checkRoleBindingPermission,
+  resolveApiKeyPermission,
+} from "~/server/rbac/role-binding-resolver";
+
+/**
+ * The projects a credential may list: everything in the organization, or an
+ * explicit id set (possibly empty).
+ */
+export type VisibleProjects = { kind: "all" } | { kind: "some"; ids: string[] };
+
+/**
+ * Which projects an organization-scoped API key credential holds
+ * `project:view` on.
+ *
+ * The answer `GET /api/projects` filters by: a credential whose reach covers
+ * the whole organization keeps the full listing, anything narrower gets
+ * exactly the projects where key bindings ∩ owner ceiling grant the view —
+ * through the resolvers on both heads, never raw grant walks.
+ *
+ * Shaped to avoid the per-project resolver loop:
+ *   1. one org-scope `resolveApiKeyPermission` answers the unchanged fast
+ *      path (both heads, ceiling included);
+ *   2. the key's bindings enumerate the CANDIDATE projects (org binding →
+ *      all, team binding → that team's projects, project binding → itself);
+ *   3. the key head is asked once per binding scope via
+ *      `checkRoleBindingPermission`, all scopes concurrently;
+ *   4. the owner ceiling is applied over all candidates in one
+ *      `batchScopePermissions` round.
+ *
+ * Spec: specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+ */
+export async function resolveVisibleProjects({
+  prisma,
+  apiKeyId,
+  userId,
+  organizationId,
+}: {
+  prisma: PrismaClient;
+  apiKeyId: string;
+  /** The key's owner; null for service keys, which have no owner ceiling. */
+  userId: string | null;
+  organizationId: string;
+}): Promise<VisibleProjects> {
+  const orgWide = await resolveApiKeyPermission({
+    prisma,
+    apiKeyId,
+    userId,
+    organizationId,
+    scope: { type: "org", id: organizationId },
+    permission: "project:view",
+  });
+  if (orgWide) return { kind: "all" };
+
+  const bound = await boundScopes({ prisma, apiKeyId, organizationId });
+  if (!bound) return { kind: "some", ids: [] };
+
+  const candidates = await candidateProjects({
+    prisma,
+    organizationId,
+    bound,
+  });
+  if (candidates.length === 0) return { kind: "some", ids: [] };
+
+  const keyVisible = await projectsTheKeyGrants({
+    prisma,
+    apiKeyId,
+    organizationId,
+    bound,
+    candidates,
+  });
+  if (keyVisible.length === 0) return { kind: "some", ids: [] };
+
+  // A service key has no owner ceiling; the key head is the whole answer.
+  if (!userId) {
+    return { kind: "some", ids: keyVisible.map((project) => project.id) };
+  }
+
+  return {
+    kind: "some",
+    ids: await narrowToOwnerCeiling({
+      prisma,
+      userId,
+      organizationId,
+      projects: keyVisible,
+    }),
+  };
+}
+
+type CandidateProject = { id: string; teamId: string };
+
+type BoundScopes = {
+  hasOrgBinding: boolean;
+  teamIds: string[];
+  projectIds: string[];
+};
+
+/**
+ * Phase 2: the scopes the key's own bindings name, as candidate enumeration
+ * only — every grant DECISION is taken by a resolver later. `null` means the
+ * key has no bindings at all, so it can see nothing.
+ */
+async function boundScopes({
+  prisma,
+  apiKeyId,
+  organizationId,
+}: {
+  prisma: PrismaClient;
+  apiKeyId: string;
+  organizationId: string;
+}): Promise<BoundScopes | null> {
+  const bindings = await prisma.roleBinding.findMany({
+    where: { organizationId, apiKeyId },
+    select: { scopeType: true, scopeId: true },
+  });
+  if (bindings.length === 0) return null;
+
+  const idsOfType = (scopeType: RoleBindingScopeType) => [
+    ...new Set(
+      bindings
+        .filter((binding) => binding.scopeType === scopeType)
+        .map((binding) => binding.scopeId),
+    ),
+  ];
+  return {
+    hasOrgBinding: bindings.some(
+      (binding) => binding.scopeType === RoleBindingScopeType.ORGANIZATION,
+    ),
+    teamIds: idsOfType(RoleBindingScopeType.TEAM),
+    projectIds: idsOfType(RoleBindingScopeType.PROJECT),
+  };
+}
+
+/** Phase 2b: the non-archived projects those bound scopes can reach. */
+async function candidateProjects({
+  prisma,
+  organizationId,
+  bound,
+}: {
+  prisma: PrismaClient;
+  organizationId: string;
+  bound: BoundScopes;
+}): Promise<CandidateProject[]> {
+  return prisma.project.findMany({
+    where: {
+      archivedAt: null,
+      team: { organizationId },
+      ...(bound.hasOrgBinding
+        ? {}
+        : {
+            OR: [
+              ...(bound.projectIds.length > 0
+                ? [{ id: { in: bound.projectIds } }]
+                : []),
+              ...(bound.teamIds.length > 0
+                ? [{ teamId: { in: bound.teamIds } }]
+                : []),
+            ],
+          }),
+    },
+    select: { id: true, teamId: true },
+  });
+}
+
+/**
+ * Phase 3: the key head, asked once per binding scope rather than once per
+ * project. The scope checks are independent reads, so they run concurrently.
+ */
+async function projectsTheKeyGrants({
+  prisma,
+  apiKeyId,
+  organizationId,
+  bound,
+  candidates,
+}: {
+  prisma: PrismaClient;
+  apiKeyId: string;
+  organizationId: string;
+  bound: BoundScopes;
+  candidates: CandidateProject[];
+}): Promise<CandidateProject[]> {
+  const principal = { type: "apiKey" as const, id: apiKeyId };
+  const grants = (
+    scope: Parameters<typeof checkRoleBindingPermission>[0]["scope"],
+  ) =>
+    checkRoleBindingPermission({
+      prisma,
+      principal,
+      organizationId,
+      scope,
+      permission: "project:view",
+    });
+
+  const candidateById = new Map(
+    candidates.map((project) => [project.id, project]),
+  );
+  const boundProjects = bound.projectIds
+    .map((projectId) => candidateById.get(projectId))
+    .filter((project): project is CandidateProject => !!project);
+
+  const [orgWide, teamResults, projectResults] = await Promise.all([
+    bound.hasOrgBinding
+      ? grants({ type: "org", id: organizationId })
+      : Promise.resolve(false),
+    Promise.all(
+      bound.teamIds.map(async (teamId) => ({
+        teamId,
+        granted: await grants({ type: "team", id: teamId }),
+      })),
+    ),
+    Promise.all(
+      boundProjects.map(async (project) => ({
+        projectId: project.id,
+        granted: await grants({
+          type: "project",
+          id: project.id,
+          teamId: project.teamId,
+        }),
+      })),
+    ),
+  ]);
+
+  if (orgWide) return candidates;
+  const keyTeams = new Set(
+    teamResults.filter((r) => r.granted).map((r) => r.teamId),
+  );
+  const keyProjects = new Set(
+    projectResults.filter((r) => r.granted).map((r) => r.projectId),
+  );
+  return candidates.filter(
+    (project) => keyTeams.has(project.teamId) || keyProjects.has(project.id),
+  );
+}
+
+/** Phase 4: the owner ceiling, over all candidates in one batch round. */
+async function narrowToOwnerCeiling({
+  prisma,
+  userId,
+  organizationId,
+  projects,
+}: {
+  prisma: PrismaClient;
+  userId: string;
+  organizationId: string;
+  projects: CandidateProject[];
+}): Promise<string[]> {
+  const owner = await batchScopePermissions(
+    { prisma, session: ownerSession(userId) },
+    {
+      organizationId,
+      teamIds: [],
+      projectIds: projects.map((project) => project.id),
+      projectTeamId: Object.fromEntries(
+        projects.map((project) => [project.id, project.teamId]),
+      ),
+      permission: "project:view",
+    },
+  );
+  return projects
+    .filter((project) => owner.projects.get(project.id) === true)
+    .map((project) => project.id);
+}
+
+/**
+ * The minimal session shape the batch resolver reads; only `user.id` is ever
+ * accessed (same shape `PermissionService` passes).
+ */
+function ownerSession(userId: string) {
+  return { user: { id: userId } } as Parameters<
+    typeof batchScopePermissions
+  >[0]["session"];
+}

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -424,6 +424,8 @@ export function hasPermissionWithHierarchy(
     return true;
   }
 
+  if (NOT_IMPLIED_BY_MANAGE.has(requestedPermission)) return false;
+
   // Hierarchy rule: manage permissions include view, create, update, delete,
   // and gateway-specific sub-actions (rotate, attach, detach).
   const actionSuffixes = [
@@ -446,6 +448,25 @@ export function hasPermissionWithHierarchy(
 
   return false;
 }
+
+/**
+ * Permissions the `:manage` hierarchy does NOT imply.
+ *
+ * Creating and deleting a project is not "managing" one. `project:manage` is
+ * what everyday project administration rides on — settings, model providers,
+ * topic clustering — and every API key that does that work would otherwise
+ * also be able to create and destroy projects, which is what the separate
+ * "Project administration" permission category exists to withhold.
+ *
+ * No built-in role loses anything: team ADMIN lists `project:create` and
+ * `project:delete` outright, and team MEMBER lists `project:create`. Only a
+ * custom role (an API key) holding `project:manage` alone is narrowed, which
+ * is the intended separation.
+ */
+const NOT_IMPLIED_BY_MANAGE = new Set<string>([
+  "project:create",
+  "project:delete",
+]);
 
 /**
  * Check if a team role has a specific permission

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -424,8 +424,6 @@ export function hasPermissionWithHierarchy(
     return true;
   }
 
-  if (NOT_IMPLIED_BY_MANAGE.has(requestedPermission)) return false;
-
   // Hierarchy rule: manage permissions include view, create, update, delete,
   // and gateway-specific sub-actions (rotate, attach, detach).
   const actionSuffixes = [
@@ -448,25 +446,6 @@ export function hasPermissionWithHierarchy(
 
   return false;
 }
-
-/**
- * Permissions the `:manage` hierarchy does NOT imply.
- *
- * Creating and deleting a project is not "managing" one. `project:manage` is
- * what everyday project administration rides on — settings, model providers,
- * topic clustering — and every API key that does that work would otherwise
- * also be able to create and destroy projects, which is what the separate
- * "Project administration" permission category exists to withhold.
- *
- * No built-in role loses anything: team ADMIN lists `project:create` and
- * `project:delete` outright, and team MEMBER lists `project:create`. Only a
- * custom role (an API key) holding `project:manage` alone is narrowed, which
- * is the intended separation.
- */
-const NOT_IMPLIED_BY_MANAGE = new Set<string>([
-  "project:create",
-  "project:delete",
-]);
 
 /**
  * Check if a team role has a specific permission

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -1675,6 +1675,55 @@ export async function batchProjectPermissions(
 }
 
 /**
+ * MANY permissions, MANY team scopes — the team-scope counterpart of
+ * `batchProjectPermissions`, resolved with one `loadScopeResolution` round
+ * for the whole team set.
+ *
+ * Exists for the CLI login-key default selection: the minted key carries one
+ * permission list asserted at every stamped team scope, so the default list
+ * has to be narrowed to what the user really holds per team BEFORE the mint
+ * asserts it — and asking per permission per team is the pool-starving
+ * fan-out `batchProjectPermissions` documents. Like that function, this is
+ * the legacy resolution on purpose: it feeds a mint whose ceiling is
+ * re-asserted (and forked on cut-over organizations) by
+ * `ApiKeyService.create`, so a divergence can only narrow the result, never
+ * widen it.
+ *
+ * Returns the held subset per team, in the order given.
+ */
+export async function batchTeamsPermissions(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  args: {
+    organizationId: string;
+    teamIds: string[];
+    permissions: Permission[];
+  },
+): Promise<Map<string, Permission[]>> {
+  const result = new Map<string, Permission[]>();
+  const resolution = await loadScopeResolution(ctx, {
+    organizationId: args.organizationId,
+    scopeIds: args.teamIds,
+  });
+  for (const teamId of args.teamIds) {
+    if (!resolution) {
+      result.set(teamId, []);
+      continue;
+    }
+    result.set(
+      teamId,
+      args.permissions.filter((permission) =>
+        teamGrants(
+          resolution,
+          { organizationId: args.organizationId, teamId },
+          permission,
+        ),
+      ),
+    );
+  }
+  return result;
+}
+
+/**
  * The legacy batch resolution — the answering path in `batchScopePermissions`
  * when the organization is still on legacy. (It was also the fork's
  * reverse-shadow thunk before the shadow comparison was removed; the engine

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -206,6 +206,12 @@ const registry = {
     ],
     docsPath: "/api-reference/api-keys/create-api-key",
   },
+  project_visibility_too_wide: {
+    tips: [
+      "Bind the key to the teams or projects it works with instead of the whole organization",
+    ],
+    docsPath: "/api-reference/api-keys/create-api-key",
+  },
   api_key_reserved_name: {
     tips: [
       "This name is reserved for keys LangWatch manages on your behalf — pick a different name",

--- a/platform/app/src/server/app-layer/projects/project.service.ts
+++ b/platform/app/src/server/app-layer/projects/project.service.ts
@@ -425,6 +425,8 @@ export class ProjectService {
     organizationId: string;
     page: number;
     limit: number;
+    /** See {@link ProjectRepository.findAllByOrganization}. */
+    projectIds?: string[];
   }): Promise<PaginatedResult<Project>> {
     return this.repo.findAllByOrganization(params);
   }

--- a/platform/app/src/server/app-layer/projects/repositories/project.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/projects/repositories/project.prisma.repository.ts
@@ -228,12 +228,18 @@ export class PrismaProjectRepository implements ProjectRepository {
     organizationId,
     page,
     limit,
+    projectIds,
   }: {
     organizationId: string;
     page: number;
     limit: number;
+    projectIds?: string[];
   }): Promise<PaginatedResult<Project>> {
-    const where = { archivedAt: null, team: { organizationId } };
+    const where = {
+      archivedAt: null,
+      team: { organizationId },
+      ...(projectIds ? { id: { in: projectIds } } : {}),
+    };
     const [data, total] = await Promise.all([
       this.prisma.project.findMany({
         where,

--- a/platform/app/src/server/app-layer/projects/repositories/project.repository.ts
+++ b/platform/app/src/server/app-layer/projects/repositories/project.repository.ts
@@ -138,6 +138,12 @@ export interface ProjectRepository {
     organizationId: string;
     page: number;
     limit: number;
+    /**
+     * When set, restricts the listing (and its total) to these project ids —
+     * the filtered listing a credential without organization-wide
+     * `project:view` receives. An empty array lists nothing.
+     */
+    projectIds?: string[];
   }): Promise<PaginatedResult<Project>>;
   findBySlugInTeam(params: {
     slug: string;
@@ -226,6 +232,7 @@ export class NullProjectRepository implements ProjectRepository {
     organizationId: string;
     page: number;
     limit: number;
+    projectIds?: string[];
   }): Promise<PaginatedResult<Project>> {
     return { data: [], pagination: { page: 1, limit: 50, total: 0 } };
   }

--- a/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
@@ -727,6 +727,79 @@ describe("CLI login user-scoped key, given a device-session flow", () => {
     });
   });
 
+  describe("when a re-login from the same device fails at the mint", () => {
+    /** @scenario "a failed re-login leaves the previous key working" */
+    it("leaves the key already in the user's CLI config active", async () => {
+      const HOSTNAME = `failed-relogin-${suffix}`;
+      await runFlow({ as: memberUser, hostname: HOSTNAME });
+      const firstKey = await mintedKeyFor({
+        userId: MEMBER_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(firstKey).not.toBeNull();
+
+      identity.current = memberUser;
+      const dc = await mintDeviceCode();
+      const approved = await approve({
+        userCode: dc.user_code,
+        keySelection: {
+          bindings: [{ scope_type: "TEAM", scope_id: TEAM_SHARED_ID }],
+          permissions: ["traces:view"],
+        },
+      });
+      expect(approved.status).toBe(200);
+
+      // Same window the access_denied case uses: the approval is valid and
+      // the mint is not, which is the only way to fail a mint from outside.
+      const removedBindings = await prisma.roleBinding.findMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+      const removedMemberships = await prisma.organizationUser.findMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+      await prisma.roleBinding.deleteMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+      await prisma.organizationUser.deleteMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+
+      try {
+        const exchanged = await exchange({
+          deviceCode: dc.device_code,
+          hostname: HOSTNAME,
+        });
+        expect(exchanged.status).toBe(410);
+
+        const firstAfter = await prisma.apiKey.findFirst({
+          where: { id: firstKey!.id, organizationId: ORG_ID },
+          select: { revokedAt: true },
+        });
+        expect(firstAfter!.revokedAt).toBeNull();
+
+        // And no half-minted replacement outlives the failed exchange.
+        const active = await prisma.apiKey.count({
+          where: {
+            organizationId: ORG_ID,
+            userId: MEMBER_ID,
+            createdByDeviceLabel: HOSTNAME,
+            revokedAt: null,
+          },
+        });
+        expect(active).toBe(1);
+      } finally {
+        await prisma.organizationUser.createMany({
+          data: removedMemberships,
+          skipDuplicates: true,
+        });
+        await prisma.roleBinding.createMany({
+          data: removedBindings,
+          skipDuplicates: true,
+        });
+      }
+    });
+  });
+
   describe("when the owner is demoted after the key was minted", () => {
     /** @scenario "the key can never exceed the owner's live permissions" */
     it("refuses a trace search on a project the owner can no longer view", async () => {

--- a/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
@@ -1,0 +1,693 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration coverage for the user-scoped CLI login key: the device-session
+ * approval stamps a scope + permission selection (explicit or server-side
+ * default), /exchange mints a `restricted` ApiKey owned by the approving
+ * user, re-login replaces it, and /logout revokes it. Real Redis + real
+ * Postgres; only the NextAuth session identity is stubbed.
+ *
+ * Spec: specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+ */
+import type { Redis } from "ioredis";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const identity = vi.hoisted(() => ({
+  current: { id: "unset", email: "unset@example.com", name: "Unset" },
+}));
+
+// Only the auth identity is stubbed; everything else runs real.
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn(async () => ({ user: identity.current })),
+}));
+
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import {
+  CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS,
+  defaultCliKeyPermissions,
+} from "~/server/api-key/cli-key-defaults";
+import { prisma } from "~/server/db";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import {
+  clearClickHouseTestApp,
+  installClickHouseTestApp,
+} from "~/test-utils/clickhouseTestApp";
+import { app as projectsApp } from "../../../app/api/projects/[[...route]]/app";
+import { app as tracesApp } from "../../../app/api/traces/[[...route]]/app";
+import { app } from "../auth-cli";
+
+// Device labels are normalized server-side to [a-z0-9-]; keeping the suffix
+// in that charset means the fixture hostname IS the stored label.
+const suffix = nanoid(8)
+  .toLowerCase()
+  .replace(/[^a-z0-9]/g, "0");
+
+const ORG_ID = `org-clikey-${suffix}`;
+const ADMIN_ID = `usr-clikey-admin-${suffix}`;
+const MEMBER_ID = `usr-clikey-member-${suffix}`;
+const CEILING_ID = `usr-clikey-ceiling-${suffix}`;
+const TEAM_SHARED_ID = `team-clikey-shared-${suffix}`;
+const TEAM_OTHER_ID = `team-clikey-other-${suffix}`;
+const MEMBER_PTEAM_ID = `pteam-clikey-member-${suffix}`;
+const PROJECT_A_ID = `proj-clikey-a-${suffix}`;
+const PROJECT_B_ID = `proj-clikey-b-${suffix}`;
+const MEMBER_PPROJECT_ID = `proj-clikey-personal-${suffix}`;
+
+let redisConnection: Redis | null = null;
+
+type IdentityUser = { id: string; email: string; name: string };
+
+const adminUser: IdentityUser = {
+  id: ADMIN_ID,
+  email: `clikey-admin-${suffix}@example.com`,
+  name: `CliKey Admin ${suffix}`,
+};
+const memberUser: IdentityUser = {
+  id: MEMBER_ID,
+  email: `clikey-member-${suffix}@example.com`,
+  name: `CliKey Member ${suffix}`,
+};
+const ceilingUser: IdentityUser = {
+  id: CEILING_ID,
+  email: `clikey-ceiling-${suffix}@example.com`,
+  name: `CliKey Ceiling ${suffix}`,
+};
+
+interface KeySelectionBody {
+  bindings: Array<{ scope_type: string; scope_id: string }>;
+  permissions: string[];
+}
+
+interface ExchangeSuccess {
+  kind: string;
+  access_token: string;
+  refresh_token: string;
+  personal_project?: { id: string; api_key: string };
+  cli_api_key?: string;
+  cli_api_key_scope?: { kind: string; project_ids: string[] };
+}
+
+async function mintDeviceCode(): Promise<{
+  device_code: string;
+  user_code: string;
+}> {
+  const res = await app.request("/api/auth/cli/device-code", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ credential_type: "device_session" }),
+  });
+  return (await res.json()) as { device_code: string; user_code: string };
+}
+
+async function approve({
+  userCode,
+  keySelection,
+}: {
+  userCode: string;
+  keySelection?: KeySelectionBody;
+}): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request("/api/auth/cli/approve", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      user_code: userCode,
+      organization_id: ORG_ID,
+      ...(keySelection ? { key_selection: keySelection } : {}),
+    }),
+  });
+  return {
+    status: res.status,
+    json: (await res.json()) as Record<string, unknown>,
+  };
+}
+
+async function exchange({
+  deviceCode,
+  hostname,
+}: {
+  deviceCode: string;
+  hostname: string;
+}): Promise<{ status: number; json: ExchangeSuccess }> {
+  const res = await app.request("/api/auth/cli/exchange", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      device_code: deviceCode,
+      client_info: { hostname, platform: "darwin" },
+    }),
+  });
+  return { status: res.status, json: (await res.json()) as ExchangeSuccess };
+}
+
+/** Full device flow as the current identity: mint, approve, exchange. */
+async function runFlow(args: {
+  as: IdentityUser;
+  hostname: string;
+  keySelection?: KeySelectionBody;
+}): Promise<ExchangeSuccess> {
+  identity.current = args.as;
+  const dc = await mintDeviceCode();
+  const approved = await approve({
+    userCode: dc.user_code,
+    keySelection: args.keySelection,
+  });
+  expect(approved.status).toBe(200);
+  const exchanged = await exchange({
+    deviceCode: dc.device_code,
+    hostname: args.hostname,
+  });
+  expect(exchanged.status).toBe(200);
+  return exchanged.json;
+}
+
+async function mintedKeyFor({
+  userId,
+  deviceLabel,
+}: {
+  userId: string;
+  deviceLabel: string;
+}) {
+  return prisma.apiKey.findFirst({
+    where: {
+      organizationId: ORG_ID,
+      userId,
+      createdByDeviceLabel: deviceLabel,
+      revokedAt: null,
+    },
+    include: { roleBindings: true },
+  });
+}
+
+/** The explicit permission list behind a restricted key's custom role. */
+async function keyPermissions(apiKeyId: string): Promise<string[]> {
+  const key = await prisma.apiKey.findFirst({
+    where: { id: apiKeyId, organizationId: ORG_ID },
+    include: { roleBindings: true },
+  });
+  const customRoleIds = [
+    ...new Set(
+      (key?.roleBindings ?? [])
+        .map((binding) => binding.customRoleId)
+        .filter((id): id is string => !!id),
+    ),
+  ];
+  const roles = await prisma.customRole.findMany({
+    where: { id: { in: customRoleIds }, organizationId: ORG_ID },
+    select: { permissions: true },
+  });
+  return [
+    ...new Set(
+      roles.flatMap((role) =>
+        Array.isArray(role.permissions) ? (role.permissions as string[]) : [],
+      ),
+    ),
+  ].sort();
+}
+
+beforeAll(async () => {
+  await startTestContainers();
+  redisConnection = getTestRedisConnection();
+  installClickHouseTestApp({
+    resolveClient: async () => getTestClickHouseClient(),
+    redis: redisConnection,
+  });
+
+  await prisma.organization.create({
+    data: {
+      id: ORG_ID,
+      name: `CliKey Org ${suffix}`,
+      slug: `clikey-${suffix}`,
+    },
+  });
+  for (const user of [adminUser, memberUser, ceilingUser]) {
+    await prisma.user.create({
+      data: { id: user.id, email: user.email, name: user.name },
+    });
+  }
+  await prisma.organizationUser.createMany({
+    data: [
+      { userId: ADMIN_ID, organizationId: ORG_ID, role: "ADMIN" },
+      { userId: MEMBER_ID, organizationId: ORG_ID, role: "MEMBER" },
+      { userId: CEILING_ID, organizationId: ORG_ID, role: "ADMIN" },
+    ],
+  });
+  await prisma.team.createMany({
+    data: [
+      {
+        id: TEAM_SHARED_ID,
+        name: `CliKey Shared ${suffix}`,
+        slug: `clikey-shared-${suffix}`,
+        organizationId: ORG_ID,
+      },
+      {
+        id: TEAM_OTHER_ID,
+        name: `CliKey Other ${suffix}`,
+        slug: `clikey-other-${suffix}`,
+        organizationId: ORG_ID,
+      },
+      {
+        id: MEMBER_PTEAM_ID,
+        name: `CliKey Personal ${suffix}`,
+        slug: `clikey-pteam-${suffix}`,
+        organizationId: ORG_ID,
+        isPersonal: true,
+        ownerUserId: MEMBER_ID,
+      },
+    ],
+  });
+  await prisma.project.createMany({
+    data: [
+      {
+        id: PROJECT_A_ID,
+        name: `CliKey Project A ${suffix}`,
+        slug: `clikey-a-${suffix}`,
+        apiKey: `test-clikey-a-${suffix}`,
+        teamId: TEAM_SHARED_ID,
+        language: "typescript",
+        framework: "openai",
+      },
+      {
+        id: PROJECT_B_ID,
+        name: `CliKey Project B ${suffix}`,
+        slug: `clikey-b-${suffix}`,
+        apiKey: `test-clikey-b-${suffix}`,
+        teamId: TEAM_OTHER_ID,
+        language: "typescript",
+        framework: "openai",
+      },
+      {
+        id: MEMBER_PPROJECT_ID,
+        name: `CliKey Personal Project ${suffix}`,
+        slug: `clikey-personal-${suffix}`,
+        apiKey: `test-clikey-personal-${suffix}`,
+        teamId: MEMBER_PTEAM_ID,
+        language: "typescript",
+        framework: "openai",
+        isPersonal: true,
+        ownerUserId: MEMBER_ID,
+      },
+    ],
+  });
+  await prisma.teamUser.createMany({
+    data: [
+      { userId: MEMBER_ID, teamId: TEAM_SHARED_ID, role: TeamUserRole.ADMIN },
+      { userId: MEMBER_ID, teamId: MEMBER_PTEAM_ID, role: TeamUserRole.ADMIN },
+    ],
+  });
+  // Role bindings decide the ceiling: org-scope ADMIN for the two admins,
+  // team-scope ADMIN for the member (shared team + their personal team, the
+  // latter seeded directly so the default-selection path is deterministic
+  // rather than racing the personal-workspace grant projection).
+  await prisma.roleBinding.createMany({
+    data: [
+      {
+        id: `rb-clikey-admin-${suffix}`,
+        organizationId: ORG_ID,
+        userId: ADMIN_ID,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: ORG_ID,
+      },
+      {
+        id: `rb-clikey-ceiling-${suffix}`,
+        organizationId: ORG_ID,
+        userId: CEILING_ID,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: ORG_ID,
+      },
+      {
+        id: `rb-clikey-member-shared-${suffix}`,
+        organizationId: ORG_ID,
+        userId: MEMBER_ID,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: TEAM_SHARED_ID,
+      },
+      {
+        id: `rb-clikey-member-personal-${suffix}`,
+        organizationId: ORG_ID,
+        userId: MEMBER_ID,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: MEMBER_PTEAM_ID,
+      },
+    ],
+  });
+}, 120_000);
+
+afterAll(async () => {
+  await clearClickHouseTestApp();
+  await prisma.roleBinding.deleteMany({ where: { organizationId: ORG_ID } });
+  await prisma.apiKey.deleteMany({ where: { organizationId: ORG_ID } });
+  await prisma.customRole.deleteMany({ where: { organizationId: ORG_ID } });
+  const teams = await prisma.team.findMany({
+    where: { organizationId: ORG_ID },
+    select: { id: true },
+  });
+  const teamIds = teams.map((team) => team.id);
+  await prisma.project.deleteMany({ where: { teamId: { in: teamIds } } });
+  await prisma.teamUser.deleteMany({ where: { teamId: { in: teamIds } } });
+  await prisma.team.deleteMany({ where: { id: { in: teamIds } } });
+  await prisma.organizationUser.deleteMany({
+    where: { organizationId: ORG_ID },
+  });
+  await prisma.user.deleteMany({
+    where: { id: { in: [ADMIN_ID, MEMBER_ID, CEILING_ID] } },
+  });
+  await prisma.organization.deleteMany({ where: { id: ORG_ID } });
+  await stopTestContainers().catch(() => {});
+});
+
+describe("CLI login user-scoped key, given a device-session flow", () => {
+  describe("when an org admin approves with no explicit selection and the CLI exchanges", () => {
+    const HOSTNAME = `admin-default-${suffix}`;
+    let result: ExchangeSuccess;
+
+    beforeAll(async () => {
+      result = await runFlow({ as: adminUser, hostname: HOSTNAME });
+    }, 60_000);
+
+    /** @scenario "exchange returns a user-owned scoped key" */
+    it("returns a user-owned restricted key beside the unchanged personal project", async () => {
+      expect(result.kind).toBe("device_session");
+      expect(result.cli_api_key).toMatch(/^sk-lw-.+_.+$/);
+      // Older CLI versions keep working unchanged.
+      expect(result.personal_project).toBeDefined();
+      expect(result.access_token).toMatch(/^lw_at_/);
+
+      const key = await mintedKeyFor({
+        userId: ADMIN_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(key).not.toBeNull();
+      expect(key!.userId).toBe(ADMIN_ID);
+      expect(key!.permissionMode).toBe("restricted");
+      const permissions = await keyPermissions(key!.id);
+      expect(permissions).toEqual([...defaultCliKeyPermissions()].sort());
+    });
+
+    /** @scenario "org admin defaults to organization scope" */
+    it("binds the default key to the whole organization", async () => {
+      const key = await mintedKeyFor({
+        userId: ADMIN_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(key!.roleBindings).toHaveLength(1);
+      expect(key!.roleBindings[0]!.scopeType).toBe("ORGANIZATION");
+      expect(key!.roleBindings[0]!.scopeId).toBe(ORG_ID);
+      expect(result.cli_api_key_scope).toEqual({
+        kind: "organization",
+        project_ids: [],
+      });
+    });
+
+    /** @scenario "the organization-management permissions are off by default" */
+    it("excludes the organization-management set and keeps gateway + project:manage", async () => {
+      const key = await mintedKeyFor({
+        userId: ADMIN_ID,
+        deviceLabel: HOSTNAME,
+      });
+      const permissions = await keyPermissions(key!.id);
+      for (const excluded of CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS) {
+        expect(permissions).not.toContain(excluded);
+      }
+      expect(permissions).toContain("project:manage");
+      expect(permissions).toContain("virtualKeys:view");
+      expect(permissions).toContain("gatewayBudgets:view");
+      expect(permissions).toContain("gatewayProviders:view");
+      expect(permissions).toContain("routingPolicies:view");
+    });
+  });
+
+  describe("when a regular member approves with no explicit selection", () => {
+    const HOSTNAME = `member-default-${suffix}`;
+    let result: ExchangeSuccess;
+
+    beforeAll(async () => {
+      result = await runFlow({ as: memberUser, hostname: HOSTNAME });
+    }, 60_000);
+
+    /** @scenario "regular member defaults to their own teams plus personal workspace" */
+    it("binds the default key to the member's teams and personal workspace, never the org", async () => {
+      const key = await mintedKeyFor({
+        userId: MEMBER_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(key).not.toBeNull();
+      const scopes = key!.roleBindings
+        .map((binding) => `${binding.scopeType}:${binding.scopeId}`)
+        .sort();
+      expect(scopes).toEqual(
+        [`TEAM:${TEAM_SHARED_ID}`, `TEAM:${MEMBER_PTEAM_ID}`].sort(),
+      );
+      expect(result.cli_api_key_scope!.kind).toBe("projects");
+      expect([...result.cli_api_key_scope!.project_ids].sort()).toEqual(
+        [PROJECT_A_ID, MEMBER_PPROJECT_ID].sort(),
+      );
+    });
+  });
+
+  describe("when the user narrows the selection to one project, read only", () => {
+    const HOSTNAME = `member-narrow-${suffix}`;
+    let result: ExchangeSuccess;
+
+    beforeAll(async () => {
+      result = await runFlow({
+        as: memberUser,
+        hostname: HOSTNAME,
+        keySelection: {
+          bindings: [{ scope_type: "PROJECT", scope_id: PROJECT_A_ID }],
+          permissions: ["traces:view"],
+        },
+      });
+    }, 60_000);
+
+    /** @scenario "narrowing the selection narrows the minted key" */
+    it("mints exactly one PROJECT binding carrying traces:view and nothing wider", async () => {
+      const key = await mintedKeyFor({
+        userId: MEMBER_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(key).not.toBeNull();
+      expect(key!.roleBindings).toHaveLength(1);
+      expect(key!.roleBindings[0]!.scopeType).toBe("PROJECT");
+      expect(key!.roleBindings[0]!.scopeId).toBe(PROJECT_A_ID);
+      const permissions = await keyPermissions(key!.id);
+      expect(permissions).toContain("traces:view");
+      expect(permissions).not.toContain("traces:update");
+      expect(result.cli_api_key_scope).toEqual({
+        kind: "projects",
+        project_ids: [PROJECT_A_ID],
+      });
+    });
+  });
+
+  describe("when an approve request carries zero bindings", () => {
+    /** @scenario "approval with zero scopes selected is refused" */
+    it("refuses with a handled error naming the bindings field and stamps nothing", async () => {
+      identity.current = memberUser;
+      const dc = await mintDeviceCode();
+      const before = await prisma.apiKey.count({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+
+      const refused = await approve({
+        userCode: dc.user_code,
+        keySelection: {
+          bindings: [],
+          permissions: ["traces:view"],
+        },
+      });
+
+      expect(refused.status).toBe(422);
+      expect(refused.json.error).toBe("cli_key_selection_invalid");
+      expect(
+        (refused.json.fieldErrors as Record<string, unknown>).bindings,
+      ).toBeDefined();
+
+      const raw = await redisConnection!.get(`lwcli:device:${dc.device_code}`);
+      const record = JSON.parse(raw!) as {
+        status: string;
+        key_selection?: unknown;
+      };
+      expect(record.status).toBe("pending");
+      expect(record.key_selection).toBeUndefined();
+      expect(
+        await prisma.apiKey.count({
+          where: { organizationId: ORG_ID, userId: MEMBER_ID },
+        }),
+      ).toBe(before);
+    });
+  });
+
+  describe("when a member claims an organization-wide binding", () => {
+    /** @scenario "approve refuses bindings above the approving user's ceiling" */
+    it("refuses the approval and leaves the device code pending, selection unstamped", async () => {
+      identity.current = memberUser;
+      const dc = await mintDeviceCode();
+
+      const refused = await approve({
+        userCode: dc.user_code,
+        keySelection: {
+          bindings: [{ scope_type: "ORGANIZATION", scope_id: ORG_ID }],
+          permissions: ["traces:view"],
+        },
+      });
+
+      expect(refused.status).toBe(403);
+      expect(refused.json.error).toBe("api_key_scope_violation");
+
+      const raw = await redisConnection!.get(`lwcli:device:${dc.device_code}`);
+      const record = JSON.parse(raw!) as {
+        status: string;
+        key_selection?: unknown;
+      };
+      expect(record.status).toBe("pending");
+      expect(record.key_selection).toBeUndefined();
+    });
+  });
+
+  describe("when an approval is never exchanged", () => {
+    /** @scenario "an approval that is never exchanged mints nothing" */
+    it("creates no ApiKey row for the login", async () => {
+      identity.current = adminUser;
+      const before = await prisma.apiKey.count({
+        where: { organizationId: ORG_ID, userId: ADMIN_ID },
+      });
+
+      const dc = await mintDeviceCode();
+      const approved = await approve({ userCode: dc.user_code });
+      expect(approved.status).toBe(200);
+
+      // The selection is stamped on the Redis record and nowhere else.
+      const raw = await redisConnection!.get(`lwcli:device:${dc.device_code}`);
+      const record = JSON.parse(raw!) as {
+        status: string;
+        key_selection?: unknown;
+      };
+      expect(record.status).toBe("approved");
+      expect(record.key_selection).toBeDefined();
+
+      expect(
+        await prisma.apiKey.count({
+          where: { organizationId: ORG_ID, userId: ADMIN_ID },
+        }),
+      ).toBe(before);
+    });
+  });
+
+  describe("when the user logs in again from the same device", () => {
+    /** @scenario "re-login from the same device replaces the previous CLI key" */
+    it("revokes the previous key and leaves exactly one active for the device label", async () => {
+      const HOSTNAME = `relogin-${suffix}`;
+      const first = await runFlow({ as: memberUser, hostname: HOSTNAME });
+      const firstKey = await mintedKeyFor({
+        userId: MEMBER_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(firstKey).not.toBeNull();
+
+      const second = await runFlow({ as: memberUser, hostname: HOSTNAME });
+      expect(second.cli_api_key).toBeDefined();
+      expect(second.cli_api_key).not.toBe(first.cli_api_key);
+
+      const firstAfter = await prisma.apiKey.findFirst({
+        where: { id: firstKey!.id, organizationId: ORG_ID },
+        select: { revokedAt: true },
+      });
+      expect(firstAfter!.revokedAt).not.toBeNull();
+
+      const active = await prisma.apiKey.count({
+        where: {
+          organizationId: ORG_ID,
+          userId: MEMBER_ID,
+          createdByDeviceLabel: HOSTNAME,
+          revokedAt: null,
+        },
+      });
+      expect(active).toBe(1);
+    });
+  });
+
+  describe("when the CLI calls the logout endpoint", () => {
+    /** @scenario "logout revokes the CLI key" */
+    it("revokes the login key along with the session tokens", async () => {
+      const HOSTNAME = `logout-${suffix}`;
+      const result = await runFlow({ as: memberUser, hostname: HOSTNAME });
+      const key = await mintedKeyFor({
+        userId: MEMBER_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(key).not.toBeNull();
+
+      const res = await app.request("/api/auth/cli/logout", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          refresh_token: result.refresh_token,
+          access_token: result.access_token,
+        }),
+      });
+      expect(res.status).toBe(200);
+
+      const after = await prisma.apiKey.findFirst({
+        where: { id: key!.id, organizationId: ORG_ID },
+        select: { revokedAt: true },
+      });
+      expect(after!.revokedAt).not.toBeNull();
+      expect(
+        await redisConnection!.get(`lwcli:access:${result.access_token}`),
+      ).toBeNull();
+      expect(
+        await redisConnection!.get(`lwcli:refresh:${result.refresh_token}`),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the owner is demoted after the key was minted", () => {
+    /** @scenario "the key can never exceed the owner's live permissions" */
+    it("refuses a trace search on a project the owner can no longer view", async () => {
+      const HOSTNAME = `ceiling-${suffix}`;
+      const result = await runFlow({ as: ceilingUser, hostname: HOSTNAME });
+      const cliKey = result.cli_api_key!;
+
+      // Positive control before the demotion: the key reaches the project.
+      const before = await projectsApp.request(
+        `/api/projects/${PROJECT_B_ID}`,
+        { headers: { Authorization: `Bearer ${cliKey}` } },
+      );
+      expect(before.status).toBe(200);
+
+      // Demote: the owner keeps org membership but loses the org-wide role.
+      await prisma.roleBinding.deleteMany({
+        where: { organizationId: ORG_ID, userId: CEILING_ID },
+      });
+      await prisma.organizationUser.updateMany({
+        where: { userId: CEILING_ID, organizationId: ORG_ID },
+        data: { role: OrganizationUserRole.MEMBER },
+      });
+
+      const basic = Buffer.from(`${PROJECT_B_ID}:${cliKey}`).toString("base64");
+      const res = await tracesApp.request("/api/traces/search", {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${basic}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
@@ -31,6 +31,7 @@ import {
   CLI_KEY_DEFAULT_EXCLUDED_PERMISSIONS,
   defaultCliKeyPermissions,
 } from "~/server/api-key/cli-key-defaults";
+import { CliLoginKeyService } from "~/server/api-key/cli-login-key.service";
 import { prisma } from "~/server/db";
 import {
   getTestClickHouseClient,
@@ -631,6 +632,50 @@ describe("CLI login user-scoped key, given a device-session flow", () => {
         },
       });
       expect(active).toBe(1);
+    });
+  });
+
+  describe("when two logins for one device label are exchanged at the same time", () => {
+    /** @scenario "two logins racing on one device leave the newer key alive" */
+    it("revokes only the keys older than each mint, so the newest survives", async () => {
+      const HOSTNAME = `race-${suffix}`;
+      const first = await runFlow({ as: memberUser, hostname: HOSTNAME });
+      const firstKey = await prisma.apiKey.findFirst({
+        where: {
+          organizationId: ORG_ID,
+          userId: MEMBER_ID,
+          createdByDeviceLabel: HOSTNAME,
+        },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, createdAt: true },
+      });
+      expect(firstKey).not.toBeNull();
+
+      const second = await runFlow({ as: memberUser, hostname: HOSTNAME });
+      expect(second.cli_api_key).not.toBe(first.cli_api_key);
+      const secondKey = await mintedKeyFor({
+        userId: MEMBER_ID,
+        deviceLabel: HOSTNAME,
+      });
+      expect(secondKey).not.toBeNull();
+
+      // The first exchange's revoke, arriving after the second mint already
+      // landed — the interleaving the race produces. Excluding only its own
+      // key is not enough; without the createdBefore bound it would revoke
+      // the key the second exchange just handed to the CLI.
+      await CliLoginKeyService.create(prisma).revokeLoginKeysForDevice({
+        userId: MEMBER_ID,
+        organizationId: ORG_ID,
+        deviceLabel: HOSTNAME,
+        exceptApiKeyId: firstKey!.id,
+        createdBefore: firstKey!.createdAt,
+      });
+
+      const secondAfter = await prisma.apiKey.findFirst({
+        where: { id: secondKey!.id, organizationId: ORG_ID },
+        select: { revokedAt: true },
+      });
+      expect(secondAfter!.revokedAt).toBeNull();
     });
   });
 

--- a/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
@@ -149,7 +149,13 @@ async function exchange({
   return { status: res.status, json: (await res.json()) as ExchangeSuccess };
 }
 
-/** Full device flow as the current identity: mint, approve, exchange. */
+/**
+ * Full device flow as the current identity: mint, approve, exchange.
+ *
+ * A failed step throws with the body the server answered, rather than
+ * asserting: the assertion belongs to the test, and a helper that swallows a
+ * 403 into a bare "expected 403 to be 200" hides why it was refused.
+ */
 async function runFlow(args: {
   as: IdentityUser;
   hostname: string;
@@ -161,12 +167,20 @@ async function runFlow(args: {
     userCode: dc.user_code,
     keySelection: args.keySelection,
   });
-  expect(approved.status).toBe(200);
+  if (approved.status !== 200) {
+    throw new Error(
+      `approve answered ${approved.status}: ${JSON.stringify(approved.json)}`,
+    );
+  }
   const exchanged = await exchange({
     deviceCode: dc.device_code,
     hostname: args.hostname,
   });
-  expect(exchanged.status).toBe(200);
+  if (exchanged.status !== 200) {
+    throw new Error(
+      `exchange answered ${exchanged.status}: ${JSON.stringify(exchanged.json)}`,
+    );
+  }
   return exchanged.json;
 }
 

--- a/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-login-key.integration.test.ts
@@ -669,6 +669,64 @@ describe("CLI login user-scoped key, given a device-session flow", () => {
     });
   });
 
+  describe("when the approver loses access between approve and exchange", () => {
+    /** @scenario "access lost between approve and exchange ends the login" */
+    it("answers a fatal access_denied and burns the device code", async () => {
+      identity.current = memberUser;
+      const dc = await mintDeviceCode();
+      const approved = await approve({
+        userCode: dc.user_code,
+        keySelection: {
+          bindings: [{ scope_type: "TEAM", scope_id: TEAM_SHARED_ID }],
+          permissions: ["traces:view"],
+        },
+      });
+      expect(approved.status).toBe(200);
+
+      // The window between approve and exchange is minutes wide in practice.
+      // Take the access the selection was approved against away inside it:
+      // removed from the organization, the approver holds nothing anywhere,
+      // so the mint refuses however the selection was scoped.
+      const removedBindings = await prisma.roleBinding.findMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+      const removedMemberships = await prisma.organizationUser.findMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+      await prisma.roleBinding.deleteMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+      await prisma.organizationUser.deleteMany({
+        where: { organizationId: ORG_ID, userId: MEMBER_ID },
+      });
+
+      try {
+        const exchanged = await exchange({
+          deviceCode: dc.device_code,
+          hostname: `lost-access-${suffix}`,
+        });
+
+        expect(exchanged.status).toBe(410);
+        expect((exchanged.json as unknown as { error: string }).error).toBe(
+          "access_denied",
+        );
+        // Burned, so the CLI's next poll cannot re-run the ceiling walk.
+        expect(
+          await redisConnection!.get(`lwcli:device:${dc.device_code}`),
+        ).toBeNull();
+      } finally {
+        await prisma.organizationUser.createMany({
+          data: removedMemberships,
+          skipDuplicates: true,
+        });
+        await prisma.roleBinding.createMany({
+          data: removedBindings,
+          skipDuplicates: true,
+        });
+      }
+    });
+  });
+
   describe("when the owner is demoted after the key was minted", () => {
     /** @scenario "the key can never exceed the owner's live permissions" */
     it("refuses a trace search on a project the owner can no longer view", async () => {

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -310,6 +310,11 @@ describe("CLI login personal-project guards", () => {
     await prisma.roleBinding.deleteMany({
       where: { organizationId: ORG_ID },
     });
+    // The device-session exchange now mints a user-scoped CLI ApiKey (plus
+    // its private custom role); ApiKey→Organization is a Restrict relation,
+    // so these go before the organization delete.
+    await prisma.apiKey.deleteMany({ where: { organizationId: ORG_ID } });
+    await prisma.customRole.deleteMany({ where: { organizationId: ORG_ID } });
     await prisma.project.deleteMany({
       where: { team: { organizationId: ORG_ID } },
     });

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
@@ -316,32 +316,22 @@ afterAll(async () => {
     select: { id: true },
   });
   const teamIds = personalTeams.map((t) => t.id);
-  await prisma.roleBinding
-    .deleteMany({ where: { organizationId: ORG_ID } })
-    .catch(() => {});
+  await prisma.roleBinding.deleteMany({ where: { organizationId: ORG_ID } });
   // The device-session exchange mints a user-scoped CLI ApiKey (plus its
   // private custom role); ApiKey→Organization is a Restrict relation, so
   // these must go before the organization delete or it silently no-ops.
   await prisma.apiKey.deleteMany({ where: { organizationId: ORG_ID } });
   await prisma.customRole.deleteMany({ where: { organizationId: ORG_ID } });
-  await prisma.project
-    .deleteMany({ where: { teamId: { in: teamIds } } })
-    .catch(() => {});
-  await prisma.teamUser
-    .deleteMany({ where: { teamId: { in: teamIds } } })
-    .catch(() => {});
-  await prisma.team
-    .deleteMany({ where: { id: { in: teamIds } } })
-    .catch(() => {});
-  await prisma.organizationUser
-    .deleteMany({ where: { organizationId: ORG_ID } })
-    .catch(() => {});
-  await prisma.user
-    .deleteMany({ where: { id: { in: [USER_ID, OTHER_USER_ID] } } })
-    .catch(() => {});
-  await prisma.organization
-    .deleteMany({ where: { id: ORG_ID } })
-    .catch(() => {});
+  await prisma.project.deleteMany({ where: { teamId: { in: teamIds } } });
+  await prisma.teamUser.deleteMany({ where: { teamId: { in: teamIds } } });
+  await prisma.team.deleteMany({ where: { id: { in: teamIds } } });
+  await prisma.organizationUser.deleteMany({
+    where: { organizationId: ORG_ID },
+  });
+  await prisma.user.deleteMany({
+    where: { id: { in: [USER_ID, OTHER_USER_ID] } },
+  });
+  await prisma.organization.deleteMany({ where: { id: ORG_ID } });
   await stopTestContainers().catch(() => {});
 });
 

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
@@ -319,6 +319,11 @@ afterAll(async () => {
   await prisma.roleBinding
     .deleteMany({ where: { organizationId: ORG_ID } })
     .catch(() => {});
+  // The device-session exchange mints a user-scoped CLI ApiKey (plus its
+  // private custom role); ApiKey→Organization is a Restrict relation, so
+  // these must go before the organization delete or it silently no-ops.
+  await prisma.apiKey.deleteMany({ where: { organizationId: ORG_ID } });
+  await prisma.customRole.deleteMany({ where: { organizationId: ORG_ID } });
   await prisma.project
     .deleteMany({ where: { teamId: { in: teamIds } } })
     .catch(() => {});

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -60,6 +60,7 @@ import {
   type CliKeySelection,
   CliLoginKeyService,
 } from "~/server/api-key/cli-login-key.service";
+import { ApiKeyScopeViolationError } from "~/server/api-key/errors";
 import { getApp, tryGetApp } from "~/server/app-layer/app";
 import {
   probeOrganizationPermission,
@@ -872,14 +873,42 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
           parsed.data.client_info?.device_label ??
             parsed.data.client_info?.hostname,
         ) ?? CLI_LOGIN_UNKNOWN_DEVICE_LABEL;
-      const minted = await CliLoginKeyService.create(
-        prisma,
-      ).mintForDeviceSession({
-        userId: user.id,
-        organizationId: organization.id,
-        deviceLabel,
-        selection: record.key_selection,
-      });
+      let minted: Awaited<
+        ReturnType<CliLoginKeyService["mintForDeviceSession"]>
+      >;
+      try {
+        minted = await CliLoginKeyService.create(prisma).mintForDeviceSession({
+          userId: user.id,
+          organizationId: organization.id,
+          deviceLabel,
+          selection: record.key_selection,
+        });
+      } catch (err) {
+        // A ceiling refusal is permanent: the selection was approved minutes
+        // ago and the approver has lost access since, so every later poll
+        // would refuse again. The CLI treats a non-200 as "keep polling", so
+        // leaving the record approved for its remaining TTL means one full
+        // ceiling walk every 4 seconds with no terminal error on screen.
+        // Burn the device code and answer with the one code the CLI already
+        // treats as fatal.
+        if (ApiKeyScopeViolationError.is(err)) {
+          logger.warn(
+            { err, userId: user.id, organizationId: organization.id },
+            "[auth-cli] CLI login key refused at exchange; terminating the device code",
+          );
+          await redis.del(deviceCodeKey(device_code));
+          await redis.del(userCodeKey(record.user_code));
+          return c.json(
+            {
+              error: "access_denied",
+              error_description:
+                "Your access changed after you approved this login. Run `langwatch login` again.",
+            },
+            410,
+          );
+        }
+        throw err;
+      }
       cliApiKey = minted.token;
       cliApiKeyId = minted.apiKeyId;
       cliApiKeyScope = {

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -55,6 +55,11 @@ import {
 } from "~/server/api/enterprise";
 import type { Permission } from "~/server/api/rbac";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import {
+  CLI_LOGIN_UNKNOWN_DEVICE_LABEL,
+  type CliKeySelection,
+  CliLoginKeyService,
+} from "~/server/api-key/cli-login-key.service";
 import { getApp, tryGetApp } from "~/server/app-layer/app";
 import {
   probeOrganizationPermission,
@@ -206,6 +211,13 @@ interface DeviceCodeRecord {
     project_name: string;
     api_key: string;
   };
+  /**
+   * For `credential_type: "device_session"` after approval — the scope +
+   * permission selection the authorize screen approved (or the server-side
+   * default when the client sent none). Consumed by /exchange, which mints
+   * the user-scoped CLI ApiKey from it. Approval itself mints nothing.
+   */
+  key_selection?: CliKeySelection;
 }
 
 /**
@@ -237,6 +249,12 @@ interface RefreshTokenRecord {
   expires_at: number;
   /** Phase 8 — present when the CLI sent client_info on /exchange. */
   client_info?: ClientInfo;
+  /**
+   * The user-scoped CLI ApiKey /exchange minted for this session, carried
+   * across /refresh rotations so /logout can revoke the key alongside the
+   * tokens. Absent for sessions that minted no key.
+   */
+  cli_api_key_id?: string;
 }
 
 interface AccessTokenRecord {
@@ -247,6 +265,8 @@ interface AccessTokenRecord {
   /** Phase 8 — mirror of refresh-token client_info; useful for the
    * devices inventory, which reads access tokens directly. */
   client_info?: ClientInfo;
+  /** Mirror of the refresh-token field; see there. */
+  cli_api_key_id?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -829,6 +849,45 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
       );
     }
 
+    // User-scoped CLI ApiKey — minted HERE, from the selection approval
+    // stamped, so an approval that is never exchanged mints nothing. Minted
+    // before the session tokens: a mint failure fails the whole exchange
+    // (handled error via onError) rather than leaving a half-logged-in CLI
+    // holding tokens but no key. Re-login from the same device label revokes
+    // the previous login key inside the service, so logins never accumulate
+    // credentials.
+    let cliApiKey: string | undefined;
+    let cliApiKeyId: string | undefined;
+    let cliApiKeyScope:
+      | { kind: "organization" | "projects"; project_ids: string[] }
+      | undefined;
+    if (record.key_selection) {
+      // Same normalization the other label paths use, and the user-chosen
+      // label wins over the machine hostname. The value names the key AND
+      // matches the previous login key for replacement, so an unnormalized
+      // value would leave the old key alive on a hostname or formatting
+      // change and let credentials accumulate.
+      const deviceLabel =
+        sanitizeDeviceLabel(
+          parsed.data.client_info?.device_label ??
+            parsed.data.client_info?.hostname,
+        ) ?? CLI_LOGIN_UNKNOWN_DEVICE_LABEL;
+      const minted = await CliLoginKeyService.create(
+        prisma,
+      ).mintForDeviceSession({
+        userId: user.id,
+        organizationId: organization.id,
+        deviceLabel,
+        selection: record.key_selection,
+      });
+      cliApiKey = minted.token;
+      cliApiKeyId = minted.apiKeyId;
+      cliApiKeyScope = {
+        kind: minted.scope.kind,
+        project_ids: minted.scope.projectIds,
+      };
+    }
+
     // Mint access + refresh tokens, persist both in Redis with TTL so
     // protected CLI endpoints (/budget/status etc.) can validate Bearer
     // tokens against an authoritative store.
@@ -848,6 +907,7 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
       issued_at: now,
       expires_at: now + ACCESS_TOKEN_TTL_SECONDS * 1000,
       client_info: clientInfoStamped,
+      cli_api_key_id: cliApiKeyId,
     };
     const refreshRecord: RefreshTokenRecord = {
       user_id: user.id,
@@ -855,6 +915,7 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
       issued_at: now,
       expires_at: now + REFRESH_TOKEN_TTL_SECONDS * 1000,
       client_info: clientInfoStamped,
+      cli_api_key_id: cliApiKeyId,
     };
     // Per-key sets — Redis cluster CROSSSLOT-rejects multi-key ops
     // when keys differ in hash slot. The two records can briefly diverge
@@ -913,6 +974,11 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
         },
         default_personal_vk: record.personal_vk,
         personal_project: personalProject,
+        // The user-scoped key + its reach summary. Additive: an older CLI
+        // ignores both and keeps using personal_project exactly as before.
+        ...(cliApiKey && cliApiKeyScope
+          ? { cli_api_key: cliApiKey, cli_api_key_scope: cliApiKeyScope }
+          : {}),
         endpoint: responseEndpoint,
       },
       200,
@@ -1032,6 +1098,9 @@ secured.access(CLI_POLICY).post("/refresh", async (c: Context) => {
     issued_at: now,
     expires_at: now + ACCESS_TOKEN_TTL_SECONDS * 1000,
     client_info: carriedClientInfo,
+    // Carried across rotations so /logout can still revoke the CLI key
+    // this session minted at /exchange.
+    cli_api_key_id: record.cli_api_key_id,
   };
   const newRefreshRecord: RefreshTokenRecord = {
     user_id: record.user_id,
@@ -1039,6 +1108,7 @@ secured.access(CLI_POLICY).post("/refresh", async (c: Context) => {
     issued_at: now,
     expires_at: now + REFRESH_TOKEN_TTL_SECONDS * 1000,
     client_info: carriedClientInfo,
+    cli_api_key_id: record.cli_api_key_id,
   };
 
   await redis
@@ -2402,6 +2472,30 @@ const approveRequestSchema = z.object({
    * verbatim copy of `Project.apiKey` for the SDK to consume).
    */
   project_id: z.string().optional(),
+  /**
+   * For `device_session` approvals — the scope + permission selection the
+   * authorize screen collected for the user-scoped CLI key /exchange mints.
+   * Optional: a client that sends none gets the server-side default (the
+   * widest scope the approving user holds, with the default CLI permission
+   * list narrowed to what they hold there).
+   */
+  key_selection: z
+    .object({
+      // Bounded at the edge: the ceiling assertion runs one database round
+      // per binding per permission, so an unbounded body is a request-thread
+      // fan-out that starves the connection pool, and every unrecognised
+      // permission is echoed back in the field errors.
+      bindings: z
+        .array(
+          z.object({
+            scope_type: z.enum(["ORGANIZATION", "TEAM", "PROJECT"]),
+            scope_id: z.string().min(1).max(64),
+          }),
+        )
+        .max(200),
+      permissions: z.array(z.string().min(1).max(128)).max(500),
+    })
+    .optional(),
 });
 
 secured.access(cliApproveAuth).post("/approve", async (c: Context) => {
@@ -2580,15 +2674,67 @@ secured.access(cliApproveAuth).post("/approve", async (c: Context) => {
     );
   }
 
-  // Approval proves identity and nothing else. The personal virtual key is
-  // minted later, by POST /virtual-key, the first time a tool resolves to
-  // gateway mode: a key issued here would be handed to users who only send
-  // traces, and every re-login on an already-keyed machine would leave one
-  // more VirtualKey row behind.
+  // Approval proves identity and stamps the key SELECTION — it still mints
+  // no credential. The personal virtual key is minted later, by POST
+  // /virtual-key, and the user-scoped CLI ApiKey is minted by /exchange from
+  // the selection stamped here, so an approval that is never exchanged
+  // leaves no ApiKey row behind.
+  const cliLoginKeys = CliLoginKeyService.create(prisma);
+  let keySelection: CliKeySelection | undefined;
+  if (parsed.data.key_selection) {
+    // Explicit selection from the authorize screen: validated against the
+    // registry and the approving user's own ceiling. A violation throws a
+    // HandledError (cli_key_selection_invalid / api_key_scope_violation /
+    // personal_workspace_not_managed_here) and nothing is stamped.
+    keySelection = await cliLoginKeys.validateSelection({
+      userId: session.user.id,
+      organizationId: organization_id,
+      selection: {
+        bindings: parsed.data.key_selection.bindings.map((binding) => ({
+          scopeType: binding.scope_type,
+          scopeId: binding.scope_id,
+        })),
+        permissions: parsed.data.key_selection.permissions,
+      },
+    });
+  } else {
+    // Legacy client (no selection): stamp the server-side default. The
+    // personal workspace is ensured first so its team can be part of the
+    // default reach — idempotent, and not a credential. Both steps are
+    // best-effort: a default that cannot be resolved must not fail the
+    // login, it just completes without a scoped key.
+    try {
+      await new PersonalWorkspaceService(prisma).ensure({
+        userId: session.user.id,
+        organizationId: organization_id,
+        displayName: session.user.name,
+        displayEmail: session.user.email,
+      });
+    } catch (err) {
+      logger.warn(
+        { err, userId: session.user.id, organizationId: organization_id },
+        "[auth-cli] could not ensure personal workspace at approve; default key selection proceeds without it",
+      );
+    }
+    try {
+      keySelection =
+        (await cliLoginKeys.resolveDefaultSelection({
+          userId: session.user.id,
+          organizationId: organization_id,
+        })) ?? undefined;
+    } catch (err) {
+      logger.warn(
+        { err, userId: session.user.id, organizationId: organization_id },
+        "[auth-cli] could not resolve the default key selection; device session proceeds without a scoped key",
+      );
+    }
+  }
+
   await approveDeviceCode({
     deviceCode: record.device_code,
     userId: session.user.id,
     organizationId: organization_id,
+    keySelection,
   });
 
   return c.json({ ok: true, organization_id }, 200);
@@ -2632,6 +2778,9 @@ secured.access(CLI_POLICY).post("/deny", async (c: Context) => {
 // only the refresh is revoked and the access token expires naturally
 // in up to 1h — which is a real security gap if the access token was
 // stolen, hence the new `access_token` field added alongside refresh.
+// Also revokes the user-scoped CLI ApiKey the session's /exchange minted
+// (its id rides on the token records), so a logout leaves no live
+// credential behind.
 // ---------------------------------------------------------------------------
 const logoutRequestSchema = z.object({
   refresh_token: z.string().optional(),
@@ -2647,6 +2796,19 @@ secured.access(CLI_POLICY).post("/logout", async (c: Context) => {
     // to fail if they pass garbage; just nothing to revoke.
     return c.json({ ok: true });
   }
+
+  // Read the records BEFORE the delete: they carry the id of the CLI ApiKey
+  // /exchange minted for this session, which logout revokes alongside the
+  // tokens so the wiped config leaves no live credential behind.
+  const [refreshRaw, accessRaw] = await Promise.all([
+    parsed.data.refresh_token
+      ? redis.get(refreshTokenKey(parsed.data.refresh_token))
+      : null,
+    parsed.data.access_token
+      ? redis.get(accessTokenKey(parsed.data.access_token))
+      : null,
+  ]);
+
   const ops = redis.multi();
   if (parsed.data.refresh_token) {
     ops.del(refreshTokenKey(parsed.data.refresh_token));
@@ -2655,8 +2817,47 @@ secured.access(CLI_POLICY).post("/logout", async (c: Context) => {
     ops.del(accessTokenKey(parsed.data.access_token));
   }
   await ops.exec();
+
+  await revokeCliKeysFromTokenRecords([refreshRaw, accessRaw]);
+
   return c.json({ ok: true });
 });
+
+/**
+ * Revokes the CLI ApiKeys named by a logout's token records. Best-effort and
+ * idempotent, like the token deletes beside it: logout stays a 200 whatever
+ * state the key is in, and a failed revoke is logged rather than surfaced —
+ * the key still dies with the owner's next re-login from the same device.
+ */
+async function revokeCliKeysFromTokenRecords(
+  raws: Array<string | null>,
+): Promise<void> {
+  const seen = new Set<string>();
+  for (const raw of raws) {
+    if (!raw) continue;
+    let record: RefreshTokenRecord | AccessTokenRecord;
+    try {
+      record = JSON.parse(raw) as RefreshTokenRecord;
+    } catch {
+      continue;
+    }
+    const apiKeyId = record.cli_api_key_id;
+    if (!apiKeyId || seen.has(apiKeyId)) continue;
+    seen.add(apiKeyId);
+    try {
+      await CliLoginKeyService.create(prisma).revokeForLogout({
+        apiKeyId,
+        userId: record.user_id,
+        organizationId: record.organization_id,
+      });
+    } catch (err) {
+      logger.warn(
+        { err, apiKeyId, userId: record.user_id },
+        "[auth-cli] failed to revoke the CLI key on logout",
+      );
+    }
+  }
+}
 
 export const app = secured.hono;
 
@@ -2693,6 +2894,7 @@ export async function approveDeviceCode({
   userId,
   organizationId,
   projectApiKey,
+  keySelection,
 }: {
   deviceCode: string;
   userId: string;
@@ -2703,6 +2905,12 @@ export async function approveDeviceCode({
     project_name: string;
     api_key: string;
   };
+  /**
+   * For a `device_session` code — the validated scope + permission selection
+   * /exchange mints the user-scoped CLI key from. Stamping it here mints
+   * nothing.
+   */
+  keySelection?: CliKeySelection;
 }): Promise<{ approved: boolean }> {
   const redis = getRedis();
   const raw = await redis.get(deviceCodeKey(deviceCode));
@@ -2717,6 +2925,7 @@ export async function approveDeviceCode({
     user_id: userId,
     organization_id: organizationId,
     project_api_key: projectApiKey,
+    key_selection: keySelection,
   };
 
   // Preserve original TTL by computing remaining seconds.

--- a/sdks/typescript/src/cli/commands/__tests__/cli-cross-project-credentials.integration.test.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/cli-cross-project-credentials.integration.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Which credential a data command authenticates with after `langwatch login`,
+ * and which project that credential names when no flag says otherwise.
+ *
+ * Feature: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+import { describe, expect, it } from "vitest";
+import {
+  installCrossProjectHarness,
+  LOGIN_KEY,
+  ORG_WIDE_SCOPE,
+  PERSONAL_KEY,
+  PERSONAL_PROJECT,
+} from "./crossProjectAccessHarness";
+
+const { writeSession, run, basicFor, recorded } = installCrossProjectHarness();
+
+describe("given a login that minted a user-scoped CLI key", () => {
+  describe("when a data command runs with no other credential", () => {
+    /** @scenario "data commands authenticate with the user-scoped key" */
+    it("authenticates with the stored login key against the personal project", async () => {
+      writeSession({
+        cli_api_key: LOGIN_KEY,
+        cli_api_key_scope: ORG_WIDE_SCOPE,
+      });
+
+      const result = await run({ args: ["trace", "search", "-o", "json"] });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.searchAuth).toBe(
+        basicFor({ projectId: PERSONAL_PROJECT.id, apiKey: LOGIN_KEY }),
+      );
+      // The default target did not move: no listing was needed to find it.
+      expect(recorded.projectsListCalls).toBe(0);
+    });
+  });
+
+  describe("when LANGWATCH_API_KEY is set in the environment", () => {
+    /** @scenario "explicit credentials still win over the session key" */
+    it("authenticates with the environment key and leaves the login key unused", async () => {
+      writeSession({
+        cli_api_key: LOGIN_KEY,
+        cli_api_key_scope: ORG_WIDE_SCOPE,
+      });
+
+      const result = await run({
+        args: ["trace", "search", "-o", "json"],
+        env: { LANGWATCH_API_KEY: "sk-lw-envprojectkey" },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.searchAuth).toBe("Bearer sk-lw-envprojectkey");
+      expect(recorded.searchAuth).not.toContain(LOGIN_KEY);
+    });
+  });
+});
+
+describe("given a server that mints no user-scoped CLI key", () => {
+  describe("when a data command runs", () => {
+    /** @scenario "a server without user-scoped keys falls back to the old behavior" */
+    it("authenticates with the personal project's own key, exactly as before", async () => {
+      writeSession(); // no cli_api_key: a pre-feature login
+
+      const result = await run({ args: ["trace", "search", "-o", "json"] });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.searchAuth).toBe(`Bearer ${PERSONAL_KEY}`);
+    });
+  });
+});

--- a/sdks/typescript/src/cli/commands/__tests__/cli-cross-project-reporting.integration.test.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/cli-cross-project-reporting.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * How the CLI answers a `--project` it cannot resolve, and how it reports the
+ * reach of the login key: `projects list` and `whoami`.
+ *
+ * Feature: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+import { readCliErrorDocument } from "@langwatch/langy/cards/handled-error";
+import { describe, expect, it } from "vitest";
+import {
+  installCrossProjectHarness,
+  LOGIN_KEY,
+  ORG_WIDE_SCOPE,
+  OTHER_PROJECT,
+  PERSONAL_PROJECT,
+  PERSONAL_PROJECT_ROW,
+} from "./crossProjectAccessHarness";
+
+const { writeSession, run, recorded } = installCrossProjectHarness();
+
+const loginWithOrgWideKey = () =>
+  writeSession({
+    cli_api_key: LOGIN_KEY,
+    cli_api_key_scope: ORG_WIDE_SCOPE,
+  });
+
+describe("given a login that minted a user-scoped CLI key", () => {
+  describe("when --project names a project the key cannot reach", () => {
+    /** @scenario "--project outside the key's reach fails with a clear message" */
+    it("exits non-zero and says the login key has no access to it", async () => {
+      writeSession({
+        cli_api_key: LOGIN_KEY,
+        cli_api_key_scope: {
+          kind: "projects",
+          project_ids: [OTHER_PROJECT.id],
+        },
+      });
+
+      const result = await run({
+        args: ["trace", "get", "abc123", "--project", "someone-elses", "-o", "json"],
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      const document = readCliErrorDocument(result.stdout);
+      expect(document?.code).toBe("project_not_accessible");
+      expect(document?.meta?.project).toBe("someone-elses");
+      expect(result.stderr).toContain("someone-elses");
+      expect(result.stderr).toContain("no access");
+      // The request was never made: nothing was read from a project the key
+      // cannot reach.
+      expect(recorded.traceGetAuth).toBeNull();
+    });
+  });
+
+  describe("when --project names nothing that exists", () => {
+    /** @scenario "--project with an unknown slug fails with a clear message" */
+    it("exits non-zero and says no accessible project matches the value", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({
+        args: ["trace", "search", "--project", "does-not-exist"],
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain(
+        'no accessible project matches "does-not-exist"',
+      );
+      expect(recorded.searchAuth).toBeNull();
+    });
+  });
+
+  describe("when the user lists the projects the login reaches", () => {
+    /** @scenario "projects list shows every project the key can view" */
+    it("lists every project of the organization with its id and slug", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({ args: ["projects", "list"] });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.projectsAuth).toBe(`Bearer ${LOGIN_KEY}`);
+      for (const project of [PERSONAL_PROJECT_ROW, OTHER_PROJECT]) {
+        expect(result.stdout).toContain(project.id);
+        expect(result.stdout).toContain(project.slug);
+      }
+    });
+  });
+
+  describe("when the user asks who they are", () => {
+    /** @scenario "whoami summarises the login key's scope" */
+    it("names the organization and states the login key's reach", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({ args: ["whoami"] });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Organization: Acme");
+      expect(result.stdout).toContain("Login key:    whole organization");
+    });
+
+    it("counts the projects when the key covers a subset", async () => {
+      writeSession({
+        cli_api_key: LOGIN_KEY,
+        cli_api_key_scope: {
+          kind: "projects",
+          project_ids: [PERSONAL_PROJECT.id, OTHER_PROJECT.id],
+        },
+      });
+
+      const result = await run({ args: ["whoami"] });
+
+      expect(result.stdout).toContain("Login key:    2 projects");
+    });
+
+    it("says nothing about a login key when the server minted none", async () => {
+      writeSession();
+
+      const result = await run({ args: ["whoami"] });
+
+      expect(result.stdout).not.toContain("Login key:");
+    });
+  });
+});

--- a/sdks/typescript/src/cli/commands/__tests__/cli-cross-project-selection.integration.test.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/cli-cross-project-selection.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Where `--project` moves a data command, by id and by slug, and how the
+ * selected project reaches the commands that assemble their own request.
+ *
+ * Feature: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+import { describe, expect, it } from "vitest";
+import {
+  installCrossProjectHarness,
+  LOGIN_KEY,
+  ORG_WIDE_SCOPE,
+  OTHER_PROJECT,
+} from "./crossProjectAccessHarness";
+
+const { writeSession, run, basicFor, recorded } = installCrossProjectHarness();
+
+const loginWithOrgWideKey = () =>
+  writeSession({
+    cli_api_key: LOGIN_KEY,
+    cli_api_key_scope: ORG_WIDE_SCOPE,
+  });
+
+describe("given a login key that reaches the whole organization", () => {
+  describe("when --project names another project by id", () => {
+    /** @scenario "trace search against another project by id" */
+    it("scopes the search to that project", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({
+        args: ["trace", "search", "--project", "proj-b", "-o", "json"],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.searchAuth).toBe(
+        basicFor({ projectId: "proj-b", apiKey: LOGIN_KEY }),
+      );
+    });
+  });
+
+  describe("when --project names another project by slug", () => {
+    /** @scenario "trace search against another project by slug" */
+    it("resolves the slug through the project list and scopes the search to its id", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({
+        args: ["trace", "search", "--project", "checkout-agent", "-o", "json"],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.projectsListCalls).toBe(1);
+      expect(recorded.projectsAuth).toBe(`Bearer ${LOGIN_KEY}`);
+      expect(recorded.searchAuth).toBe(
+        basicFor({ projectId: OTHER_PROJECT.id, apiKey: LOGIN_KEY }),
+      );
+    });
+  });
+
+  describe("when a command calls the platform without the generated client", () => {
+    // `trace export` and `session events` assemble their own request, so the
+    // project id has to reach them by a second route. A wiring guard rather
+    // than a scenario: nothing about the user's story changes per command.
+    it("scopes trace export to the selected project", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({
+        args: [
+          "trace",
+          "export",
+          "--project",
+          "checkout-agent",
+          "--format",
+          "jsonl",
+        ],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.searchAuth).toBe(
+        basicFor({ projectId: OTHER_PROJECT.id, apiKey: LOGIN_KEY }),
+      );
+    });
+
+    it("scopes session events to the selected project", async () => {
+      loginWithOrgWideKey();
+
+      const result = await run({
+        args: [
+          "session",
+          "events",
+          "sess_1",
+          "--project",
+          "proj-b",
+          "-o",
+          "json",
+        ],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(recorded.sessionEventsAuth).toBe(
+        basicFor({ projectId: OTHER_PROJECT.id, apiKey: LOGIN_KEY }),
+      );
+    });
+  });
+});

--- a/sdks/typescript/src/cli/commands/__tests__/crossProjectAccessHarness.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/crossProjectAccessHarness.ts
@@ -1,0 +1,296 @@
+/**
+ * The fixture the cross-project-access suites share: a real HTTP server
+ * standing in for the platform, a temporary CLI config, and a runner that
+ * spawns the REAL built CLI against both.
+ *
+ * The server records the exact `Authorization` header of every data request,
+ * because that header IS the feature: a user-scoped key carries no project
+ * identity, so `Basic base64(projectId:key)` is the only thing that tells the
+ * platform which project the command means.
+ *
+ * Requires `pnpm build` (like the other CLI integration tests in this
+ * package). One `installCrossProjectHarness()` call per suite file installs
+ * the hooks and returns everything the cases read.
+ *
+ * Feature: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+
+const CLI_PATH = path.resolve(__dirname, "../../../../dist/cli/index.js");
+
+/** The user-scoped login key: `sk-lw-{lookupId}_{secret}`, per the contract. */
+export const LOGIN_KEY = "sk-lw-cliLookup01_clisecret01";
+/** The personal project's own key: the legacy shape, no underscore. */
+export const PERSONAL_KEY = "sk-lw-personalprojectkey";
+
+export const PERSONAL_PROJECT = {
+  id: "proj_personal",
+  slug: "personal-dev",
+  name: "Personal Workspace",
+  api_key: PERSONAL_KEY,
+};
+
+/** A second project the login key reaches, addressable by id and by slug. */
+export const OTHER_PROJECT = {
+  id: "proj-b",
+  name: "Checkout Agent",
+  slug: "checkout-agent",
+  language: "python",
+  framework: "langchain",
+  teamId: "team_1",
+  piiRedactionLevel: "ESSENTIAL",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+export const PERSONAL_PROJECT_ROW = {
+  id: PERSONAL_PROJECT.id,
+  name: PERSONAL_PROJECT.name,
+  slug: PERSONAL_PROJECT.slug,
+  language: "python",
+  framework: "langchain",
+  teamId: "team_personal",
+  piiRedactionLevel: "ESSENTIAL",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+/** What the platform recorded while the last command ran. */
+export interface RecordedRequests {
+  searchAuth: string | null;
+  traceGetAuth: string | null;
+  projectsAuth: string | null;
+  sessionEventsAuth: string | null;
+  projectsListCalls: number;
+}
+
+export interface CrossProjectHarness {
+  /** Write a logged-in CLI config, with any extra keys merged in. */
+  writeSession: (extra?: Record<string, unknown>) => void;
+  /** Run the built CLI with the harness environment. */
+  run: (args: {
+    args: string[];
+    env?: Record<string, string>;
+  }) => Promise<RunResult>;
+  /** The header a user-scoped key produces for a named project. */
+  basicFor: (args: { projectId: string; apiKey: string }) => string;
+  /** What the platform saw during the current case. */
+  recorded: RecordedRequests;
+}
+
+/**
+ * Install the server, the temporary directories and the per-case reset.
+ * Call once at the top level of a suite file.
+ */
+export function installCrossProjectHarness(): CrossProjectHarness {
+  let server: http.Server;
+  let endpoint = "";
+  let stateDir = "";
+  let workDir = "";
+  const recorded: RecordedRequests = {
+    searchAuth: null,
+    traceGetAuth: null,
+    projectsAuth: null,
+    sessionEventsAuth: null,
+    projectsListCalls: 0,
+  };
+
+  const configPath = () => path.join(stateDir, "config.json");
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      const url = req.url ?? "";
+      let body = "";
+      req.on("data", (c: Buffer) => (body += c.toString()));
+      req.on("end", () => {
+        const auth = req.headers.authorization ?? "";
+        const json = (status: number, payload: unknown) => {
+          res.writeHead(status, { "content-type": "application/json" });
+          res.end(JSON.stringify(payload));
+        };
+
+        if (url.startsWith("/api/auth/cli/personal-project")) {
+          if (auth !== "Bearer lw_at_valid") {
+            json(401, { error: "unauthorized" });
+            return;
+          }
+          json(200, { project: PERSONAL_PROJECT });
+          return;
+        }
+
+        if (url.startsWith("/api/projects")) {
+          recorded.projectsListCalls++;
+          recorded.projectsAuth = auth;
+          // The platform filters the listing by what the credential can view,
+          // so only the login key sees both projects.
+          const visible =
+            auth === `Bearer ${LOGIN_KEY}`
+              ? [PERSONAL_PROJECT_ROW, OTHER_PROJECT]
+              : [PERSONAL_PROJECT_ROW];
+          json(200, {
+            data: visible,
+            pagination: {
+              page: 1,
+              limit: 100,
+              total: visible.length,
+              totalPages: 1,
+            },
+          });
+          return;
+        }
+
+        if (url.startsWith("/api/traces/search")) {
+          recorded.searchAuth = auth;
+          json(200, { traces: [], pagination: { totalHits: 0 } });
+          return;
+        }
+
+        if (url.startsWith("/api/coding-agent/sessions/")) {
+          recorded.sessionEventsAuth = auth;
+          json(200, { events: [], nextCursor: null });
+          return;
+        }
+
+        if (url.startsWith("/api/traces/")) {
+          recorded.traceGetAuth = auth;
+          json(200, { trace_id: "abc123" });
+          return;
+        }
+
+        if (url.startsWith("/api/me/project")) {
+          json(200, {
+            id: PERSONAL_PROJECT.id,
+            name: PERSONAL_PROJECT.name,
+            slug: PERSONAL_PROJECT.slug,
+            isPersonal: true,
+          });
+          return;
+        }
+
+        json(404, { error: "not_found" });
+      });
+    });
+    await new Promise<void>((resolveListen) =>
+      server.listen(0, "127.0.0.1", resolveListen),
+    );
+    endpoint = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await new Promise<void>((resolveClose) =>
+      server.close(() => resolveClose()),
+    );
+  });
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "lw-xproj-state-"));
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "lw-xproj-work-"));
+    recorded.searchAuth = null;
+    recorded.traceGetAuth = null;
+    recorded.projectsAuth = null;
+    recorded.sessionEventsAuth = null;
+    recorded.projectsListCalls = 0;
+  });
+
+  afterEach(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const writeSession = (extra: Record<string, unknown> = {}) => {
+    fs.writeFileSync(
+      configPath(),
+      JSON.stringify({
+        control_plane_url: endpoint,
+        gateway_url: "http://localhost:5563",
+        access_token: "lw_at_valid",
+        refresh_token: "lw_rt_valid",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        user: { id: "user_1", email: "dev@example.com", name: "Dev" },
+        organization: { id: "org_1", name: "Acme", slug: "acme" },
+        personal_project: {
+          ...PERSONAL_PROJECT,
+          validated_at: Math.floor(Date.now() / 1000),
+        },
+        ...extra,
+      }),
+    );
+  };
+
+  const run = ({
+    args,
+    env = {},
+  }: {
+    args: string[];
+    env?: Record<string, string>;
+  }): Promise<RunResult> =>
+    new Promise((resolve) => {
+      // The runner's own shell (and the repo .env vitest loads) may carry a
+      // real LANGWATCH_API_KEY; every case here is about a CLI with NO key in
+      // its environment except where the case sets one. The agent-mode
+      // markers are scrubbed too, or an agent running this suite would flip
+      // the CLI into agents format and change which rendering the assertions
+      // see.
+      const baseEnv: Record<string, string | undefined> = { ...process.env };
+      delete baseEnv.LANGWATCH_API_KEY;
+      delete baseEnv.LANGWATCH_PROJECT_ID;
+      for (const marker of [
+        "CLAUDECODE",
+        "CLAUDE_CODE",
+        "CURSOR_AGENT",
+        "GITHUB_COPILOT",
+        "AMAZON_Q",
+        "LW_AGENT_MODE",
+        "LANGWATCH_AGENT_MODE",
+      ]) {
+        delete baseEnv[marker];
+      }
+      const child = spawn(process.execPath, [CLI_PATH, ...args], {
+        cwd: workDir,
+        // stdio: "pipe" makes this a non-TTY invocation, the agent shape.
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...baseEnv,
+          LANGWATCH_ENDPOINT: endpoint,
+          LANGWATCH_CLI_CONFIG: configPath(),
+          LANGWATCH_NO_DAEMON: "1",
+          LANGWATCH_DAEMON_NO_SPAWN: "1",
+          ...env,
+        },
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
+      child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+      child.on("close", (exitCode) => resolve({ stdout, stderr, exitCode }));
+    });
+
+  const basicFor = ({
+    projectId,
+    apiKey,
+  }: {
+    projectId: string;
+    apiKey: string;
+  }): string =>
+    `Basic ${Buffer.from(`${projectId}:${apiKey}`, "utf-8").toString("base64")}`;
+
+  return { writeSession, run, basicFor, recorded };
+}
+
+/** The scope value for a login key that reaches the whole organization. */
+export const ORG_WIDE_SCOPE = {
+  kind: "organization" as const,
+  project_ids: [] as string[],
+};

--- a/sdks/typescript/src/cli/commands/sessions/events.ts
+++ b/sdks/typescript/src/cli/commands/sessions/events.ts
@@ -10,7 +10,7 @@ import {
   type RawOutputFlags,
 } from "../../utils/output";
 import { createCommandEvents } from "../../telemetry/events";
-import { buildAuthHeaders } from "@/internal/api/auth";
+import { cliAuthHeaders } from "../../utils/authHeaders";
 
 /** Bound each page request so a quiet socket cannot hold the CLI open forever. */
 const REQUEST_TIMEOUT_MS = 60_000;
@@ -127,7 +127,7 @@ const fetchAllSessionEvents = async ({
     const response = await fetch(
       `${endpoint}/api/coding-agent/sessions/${encodeURIComponent(sessionId)}/events?${params}`,
       {
-        headers: buildAuthHeaders({ apiKey }),
+        headers: cliAuthHeaders({ apiKey }),
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       },
     );
@@ -163,9 +163,12 @@ export const sessionEventsCommand = async (
     limit?: string;
     from?: string;
     to?: string;
+    project?: string;
   } & RawOutputFlags,
 ): Promise<void> => {
-  const { apiKey, endpoint } = await resolveCredentials();
+  const { apiKey, endpoint } = await resolveCredentials({
+    project: options.project,
+  });
 
   const limit = parseLimitOption(options.limit);
   const fromMs = parseTimeOption(options.from, "--from");

--- a/sdks/typescript/src/cli/commands/traces/export.ts
+++ b/sdks/typescript/src/cli/commands/traces/export.ts
@@ -6,7 +6,7 @@ import { resolveCredentials } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { createCommandEvents, type CommandEvents } from "../../telemetry/events";
-import { buildAuthHeaders } from "@/internal/api/auth";
+import { cliAuthHeaders } from "../../utils/authHeaders";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import { parseOriginOption } from "./origin-filter";
@@ -66,8 +66,9 @@ export const exportTracesCommand = async (options: {
   origin?: string;
   errorsOnly?: boolean;
   includeSpans?: boolean;
+  project?: string;
 }): Promise<void> => {
-  await resolveCredentials();
+  await resolveCredentials({ project: options.project });
 
   const apiKey = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
   const endpoint = resolveControlPlaneUrl();
@@ -126,7 +127,7 @@ export const exportTracesCommand = async (options: {
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         headers: {
           "Content-Type": "application/json",
-          ...buildAuthHeaders({ apiKey }),
+          ...cliAuthHeaders({ apiKey }),
         },
         body: JSON.stringify({
           query: options.query,

--- a/sdks/typescript/src/cli/commands/traces/get.ts
+++ b/sdks/typescript/src/cli/commands/traces/get.ts
@@ -11,9 +11,9 @@ import {
 
 export const getTraceCommand = async (
   traceId: string,
-  options: RawOutputFlags,
+  options: RawOutputFlags & { project?: string },
 ): Promise<void> => {
-  await resolveCredentials();
+  await resolveCredentials({ project: options.project });
 
   const service = new TracesApiService();
   const spinner = createSpinner(`Fetching trace "${traceId}"...`).start();

--- a/sdks/typescript/src/cli/commands/traces/search.ts
+++ b/sdks/typescript/src/cli/commands/traces/search.ts
@@ -31,8 +31,9 @@ export const searchTracesCommand = async (options: {
   limit?: string;
   origin?: string;
   errorsOnly?: boolean;
+  project?: string;
 } & RawOutputFlags): Promise<void> => {
-  await resolveCredentials();
+  await resolveCredentials({ project: options.project });
 
   const service = new TracesApiService();
   const spinner = createSpinner("Searching traces...").start();

--- a/sdks/typescript/src/cli/commands/traces/transcript.ts
+++ b/sdks/typescript/src/cli/commands/traces/transcript.ts
@@ -11,7 +11,7 @@ import {
   type RawOutputFlags,
 } from "../../utils/output";
 import { createCommandEvents } from "../../telemetry/events";
-import { buildAuthHeaders } from "@/internal/api/auth";
+import { cliAuthHeaders } from "../../utils/authHeaders";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 
@@ -49,9 +49,9 @@ type TranscriptDocument = z.infer<typeof transcriptDocumentSchema>;
 
 export const transcriptTraceCommand = async (
   traceId: string,
-  options: RawOutputFlags,
+  options: RawOutputFlags & { project?: string },
 ): Promise<void> => {
-  await resolveCredentials();
+  await resolveCredentials({ project: options.project });
 
   const apiKey = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
   const endpoint = resolveControlPlaneUrl();
@@ -65,7 +65,7 @@ export const transcriptTraceCommand = async (
     const response = await fetch(
       `${endpoint}/api/traces/${encodeURIComponent(traceId)}/transcript`,
       {
-        headers: buildAuthHeaders({ apiKey }),
+        headers: cliAuthHeaders({ apiKey }),
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       },
     );

--- a/sdks/typescript/src/cli/commands/whoami.ts
+++ b/sdks/typescript/src/cli/commands/whoami.ts
@@ -1,5 +1,25 @@
 import chalk from "chalk";
-import { loadConfig, isLoggedIn } from "@/cli/utils/governance/config";
+import {
+  loadConfig,
+  isLoggedIn,
+  type GovernanceConfig,
+} from "@/cli/utils/governance/config";
+
+/**
+ * One line for what the login key reaches. The key is minted from the scope
+ * the user picked while approving, and that choice is invisible afterwards —
+ * a `--project` that fails is otherwise the first sign of it. Nothing is
+ * printed when the field is absent: the login predates the feature, or the
+ * server does not mint login keys, and either way there is no reach to state.
+ */
+export const loginKeyScopeLine = (
+  scope: GovernanceConfig["cli_api_key_scope"],
+): string | undefined => {
+  if (!scope) return undefined;
+  if (scope.kind === "organization") return "Login key:    whole organization";
+  const count = scope.project_ids.length;
+  return `Login key:    ${count} project${count === 1 ? "" : "s"}`;
+};
 
 /**
  * `langwatch whoami` — prints the device-flow identity persisted at
@@ -17,6 +37,8 @@ export const whoamiCommand = async (): Promise<void> => {
   if (cfg.user?.email) console.log(`User:         ${cfg.user.email}`);
   if (cfg.user?.name) console.log(`Name:         ${cfg.user.name}`);
   if (cfg.organization?.name) console.log(`Organization: ${cfg.organization.name}`);
+  const scopeLine = loginKeyScopeLine(cfg.cli_api_key_scope);
+  if (scopeLine) console.log(scopeLine);
   console.log(`Gateway:      ${cfg.gateway_url}`);
   console.log(`Dashboard:    ${cfg.control_plane_url}`);
   if (cfg.default_personal_vk?.prefix) {

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -2465,6 +2465,14 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     .command("trace")
     .description("Search and inspect traces");
 
+  /**
+   * Help for `--project`, shared by every command that reads across projects.
+   * The default is the personal project, which is where these commands pointed
+   * before the flag existed, so an existing script keeps its meaning.
+   */
+  const PROJECT_FLAG_HELP =
+    "Project to read from, by id or slug (default: your personal project). Needs a login that reaches it; `langwatch projects list` shows which ones do";
+
   rendersOwnResult(
     traceCmd
       .command("search")
@@ -2484,6 +2492,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
         "--errors-only",
         "Only traces that contain an error. The error is on the span, not in the searchable text, so this is the way to find failures",
       )
+      .option("--project <idOrSlug>", PROJECT_FLAG_HELP)
       .option("-f, --format <format>", "Output format: table (default) or json", "table"),
   ).action(async (_options: unknown, command: Command) => {
     const { searchTracesCommand: impl } = await import("./commands/traces/search.js");
@@ -2514,7 +2523,8 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     .option("-o, --output <file>", "Write output to file instead of stdout")
     .option("--limit <n>", "Max traces to export (default: 1000); limits above one server page are fetched by cursor paging")
     .option("--include-spans", "Include full span data for each trace (slower, larger output)")
-    .action(async (options: { startDate?: string; endDate?: string; query?: string; origin?: string; format?: string; output?: string; limit?: string; includeSpans?: boolean }) => {
+    .option("--project <idOrSlug>", PROJECT_FLAG_HELP)
+    .action(async (options: { startDate?: string; endDate?: string; query?: string; origin?: string; format?: string; output?: string; limit?: string; includeSpans?: boolean; project?: string }) => {
       const { exportTracesCommand: impl } = await import("./commands/traces/export.js");
       await impl(options);
     });
@@ -2523,6 +2533,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     traceCmd
       .command("get <traceId>")
       .description("Get full trace details by ID")
+      .option("--project <idOrSlug>", PROJECT_FLAG_HELP)
       .option("-f, --format <format>", "Output format: digest (default, human-readable) or json", "digest"),
   ).action(async (traceId: string, _options: unknown, command: Command) => {
     const { getTraceCommand: impl } = await import("./commands/traces/get.js");
@@ -2533,6 +2544,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     traceCmd
       .command("transcript <traceId>")
       .description("Print the coding-agent transcript of a trace (what the agent did, in order)")
+      .option("--project <idOrSlug>", PROJECT_FLAG_HELP)
       .option("-f, --format <format>", "Output format: table (default, human-readable) or json", "table"),
   ).action(async (traceId: string, _options: unknown, command: Command) => {
     const { transcriptTraceCommand: impl } = await import("./commands/traces/transcript.js");
@@ -2552,6 +2564,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
       .option("--limit <n>", "Max events to return (default: 500); larger limits are fetched by cursor paging")
       .option("--from <date>", "Start date (ISO string or epoch ms); with --to, prunes storage partitions for faster reads")
       .option("--to <date>", "End date (ISO string or epoch ms)")
+      .option("--project <idOrSlug>", PROJECT_FLAG_HELP)
       .option("-f, --format <format>", "Output format: table (default) or json", "table"),
   ).action(async (sessionId: string, _options: unknown, command: Command) => {
     const { sessionEventsCommand: impl } = await import("./commands/sessions/events.js");

--- a/sdks/typescript/src/cli/utils/__tests__/apiKey.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/apiKey.unit.test.ts
@@ -38,8 +38,28 @@ vi.mock("../governance/session-api", async () => {
   return { SessionApiError: actual.SessionApiError, fetchPersonalProject: vi.fn() };
 });
 
+// The selector itself has its own unit suite (projectScope.unit.test.ts).
+// Here only the wiring is under test: that `--project` reaches the resolver,
+// that the resolved id becomes the request's project, and that an
+// unresolvable value ends the command instead of silently falling back to
+// the personal project. `ProjectScopeError` stays real.
+vi.mock("../projectScope", async () => {
+  const actual =
+    await vi.importActual<typeof import("../projectScope")>("../projectScope");
+  return {
+    ProjectScopeError: actual.ProjectScopeError,
+    projectScopeErrorLines: actual.projectScopeErrorLines,
+    resolveProjectSelector: vi.fn(),
+  };
+});
+
 import { config } from "dotenv";
 import { loadConfig, saveConfig } from "../governance/config";
+import {
+  ProjectScopeError,
+  resolveProjectSelector,
+} from "../projectScope";
+import { scopedProjectId } from "../../../internal/credentialContext";
 import {
   fetchPersonalProject,
   SessionApiError,
@@ -53,6 +73,7 @@ const mockedLoadConfig = vi.mocked(loadConfig);
 const mockedSaveConfig = vi.mocked(saveConfig);
 const mockedFetchPersonalProject = vi.mocked(fetchPersonalProject);
 const mockedNotice = vi.mocked(maybePrintIdentityNotice);
+const mockedResolveProjectSelector = vi.mocked(resolveProjectSelector);
 
 const loggedOutConfig = () => ({
   control_plane_url: "https://app.langwatch.ai",
@@ -109,6 +130,7 @@ describe("resolveCredentials()", () => {
     mockedFetchPersonalProject.mockReset();
     mockedFetchPersonalProject.mockResolvedValue(null as never);
     mockedNotice.mockClear();
+    mockedResolveProjectSelector.mockReset();
     logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     exitSpy = vi
@@ -193,6 +215,103 @@ describe("resolveCredentials()", () => {
           }),
         }),
       );
+    });
+  });
+
+  describe("when the login minted a user-scoped CLI key", () => {
+    it("prefers the login key over the personal project's own key", async () => {
+      mockedLoadConfig.mockReturnValue(
+        loggedInConfig({
+          ...freshPersonal(),
+          cli_api_key: "sk-lw-lookup01_secret01",
+        }) as never,
+      );
+
+      const resolved = await resolveCredentials();
+
+      expect(resolved.apiKey).toBe("sk-lw-lookup01_secret01");
+      // The key reaches further, but the request still names the project the
+      // command pointed at before this feature.
+      expect(resolved.projectId).toBe("proj_1");
+    });
+
+    it("keeps LANGWATCH_API_KEY ahead of the login key", async () => {
+      process.env.LANGWATCH_API_KEY = "sk-from-env";
+      mockedLoadConfig.mockReturnValue(
+        loggedInConfig({
+          ...freshPersonal(),
+          cli_api_key: "sk-lw-lookup01_secret01",
+        }) as never,
+      );
+
+      const resolved = await resolveCredentials();
+
+      expect(resolved.source).toBe("env");
+      expect(resolved.apiKey).toBe("sk-from-env");
+    });
+
+    it("wipes the login key too when the session turns out to be revoked", async () => {
+      const cfg = loggedInConfig({
+        ...stalePersonal(),
+        cli_api_key: "sk-lw-lookup01_secret01",
+        cli_api_key_scope: { kind: "organization", project_ids: [] },
+      });
+      mockedLoadConfig.mockReturnValue(cfg as never);
+      mockedFetchPersonalProject.mockRejectedValue(
+        new SessionApiError(401, "unauthorized", "Session expired or revoked"),
+      );
+
+      await expect(resolveCredentials()).rejects.toThrow("process.exit called");
+
+      // A login key left behind would keep authenticating after the device was
+      // revoked — the exact bypass the personal key's wipe exists to close.
+      const stored = cfg as {
+        cli_api_key?: unknown;
+        cli_api_key_scope?: unknown;
+      };
+      expect(stored.cli_api_key).toBeUndefined();
+      expect(stored.cli_api_key_scope).toBeUndefined();
+      expect(mockedSaveConfig).toHaveBeenCalled();
+    });
+
+    it("targets the project --project names, not the personal project", async () => {
+      mockedLoadConfig.mockReturnValue(
+        loggedInConfig({
+          ...freshPersonal(),
+          cli_api_key: "sk-lw-lookup01_secret01",
+        }) as never,
+      );
+      mockedResolveProjectSelector.mockResolvedValue("proj_checkout");
+
+      const resolved = await resolveCredentials({ project: "checkout-agent" });
+
+      expect(mockedResolveProjectSelector).toHaveBeenCalledWith(
+        expect.objectContaining({ selector: "checkout-agent" }),
+      );
+      expect(resolved.projectId).toBe("proj_checkout");
+      expect(scopedProjectId()).toBe("proj_checkout");
+    });
+
+    it("ends the command when --project names nothing the key can see", async () => {
+      mockedLoadConfig.mockReturnValue(
+        loggedInConfig({
+          ...freshPersonal(),
+          cli_api_key: "sk-lw-lookup01_secret01",
+        }) as never,
+      );
+      mockedResolveProjectSelector.mockRejectedValue(
+        new ProjectScopeError(
+          "project_not_accessible",
+          'no accessible project matches "ghost".',
+          "ghost",
+        ),
+      );
+
+      await expect(
+        resolveCredentials({ project: "ghost" }),
+      ).rejects.toThrow("process.exit called");
+      // No silent fallback: the personal project must not become the target.
+      expect(scopedProjectId()).not.toBe("proj_1");
     });
   });
 

--- a/sdks/typescript/src/cli/utils/__tests__/apiKey.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/apiKey.unit.test.ts
@@ -8,6 +8,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readCliErrorDocument } from "@langwatch/langy/cards/handled-error";
+import type * as ProjectScopeNs from "../projectScope";
+import type * as SessionApiNs from "../governance/session-api";
 
 // A developer's local .env must not decide whether these tests see a key; the
 // scoped loader's `parse` results are stubbed per test below.
@@ -31,10 +33,9 @@ vi.mock("../governance/config", () => ({
 // Keep SessionApiError real (the resolver branches on `err.status`), mock only
 // the network call.
 vi.mock("../governance/session-api", async () => {
-  const actual =
-    await vi.importActual<typeof import("../governance/session-api")>(
-      "../governance/session-api",
-    );
+  const actual = await vi.importActual<typeof SessionApiNs>(
+    "../governance/session-api",
+  );
   return { SessionApiError: actual.SessionApiError, fetchPersonalProject: vi.fn() };
 });
 
@@ -44,8 +45,7 @@ vi.mock("../governance/session-api", async () => {
 // unresolvable value ends the command instead of silently falling back to
 // the personal project. `ProjectScopeError` stays real.
 vi.mock("../projectScope", async () => {
-  const actual =
-    await vi.importActual<typeof import("../projectScope")>("../projectScope");
+  const actual = await vi.importActual<typeof ProjectScopeNs>("../projectScope");
   return {
     ProjectScopeError: actual.ProjectScopeError,
     projectScopeErrorLines: actual.projectScopeErrorLines,

--- a/sdks/typescript/src/cli/utils/__tests__/projectScope.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/projectScope.unit.test.ts
@@ -1,0 +1,179 @@
+/**
+ * How a `--project <idOrSlug>` value becomes a project id: what answers
+ * without a round trip, which match wins when an id and a slug could both
+ * apply, and which failure the user is told about.
+ *
+ * Feature: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  PaginatedProjects,
+  Project,
+  ProjectsApiService,
+} from "@/client-sdk/services/projects/projects-api.service";
+import { ProjectsApiError } from "@/client-sdk/services/projects/projects-api.service";
+import { ProjectScopeError, resolveProjectSelector } from "../projectScope";
+
+const project = (over: Partial<Project> & Pick<Project, "id" | "slug">): Project => ({
+  name: over.slug,
+  language: "python",
+  framework: "langchain",
+  teamId: "team_1",
+  piiRedactionLevel: "ESSENTIAL",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...over,
+});
+
+/** A listing service whose pages are whatever the test hands it. */
+const listing = (
+  pages: Project[][],
+): { service: ProjectsApiService; list: ReturnType<typeof vi.fn> } => {
+  const list = vi.fn(async ({ page }: { page?: number } = {}) => {
+    const index = (page ?? 1) - 1;
+    return {
+      data: pages[index] ?? [],
+      pagination: {
+        page: page ?? 1,
+        limit: 100,
+        total: pages.flat().length,
+        totalPages: pages.length,
+      },
+    } satisfies PaginatedProjects;
+  });
+  return { service: { list } as unknown as ProjectsApiService, list };
+};
+
+/** A listing service that fails with the given status. */
+const failingListing = (status: number): ProjectsApiService =>
+  ({
+    list: vi.fn(async () => {
+      throw new ProjectsApiError(
+        "Failed to list projects",
+        "list projects",
+        undefined,
+        status,
+      );
+    }),
+  }) as unknown as ProjectsApiService;
+
+const personalConfig = {
+  gateway_url: "https://gateway.langwatch.ai",
+  control_plane_url: "https://app.langwatch.ai",
+  personal_project: { id: "proj_personal", slug: "personal-dev" },
+};
+
+describe("resolveProjectSelector()", () => {
+  describe("when the value names the stored personal project", () => {
+    it("answers from the stored config without listing anything", async () => {
+      const { service, list } = listing([[]]);
+
+      const resolved = await resolveProjectSelector({
+        selector: "personal-dev",
+        cfg: personalConfig,
+        service,
+      });
+
+      expect(resolved).toBe("proj_personal");
+      expect(list).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the value names another project", () => {
+    it("matches an id", async () => {
+      const resolved = await resolveProjectSelector({
+        selector: "proj-b",
+        cfg: personalConfig,
+        service: listing([[project({ id: "proj-b", slug: "checkout-agent" })]])
+          .service,
+      });
+
+      expect(resolved).toBe("proj-b");
+    });
+
+    it("matches a slug", async () => {
+      const resolved = await resolveProjectSelector({
+        selector: "checkout-agent",
+        cfg: personalConfig,
+        service: listing([[project({ id: "proj-b", slug: "checkout-agent" })]])
+          .service,
+      });
+
+      expect(resolved).toBe("proj-b");
+    });
+
+    it("prefers the id when one project's slug reads like another project's id", async () => {
+      const resolved = await resolveProjectSelector({
+        selector: "proj-b",
+        cfg: personalConfig,
+        service: listing([
+          [
+            project({ id: "proj-c", slug: "proj-b" }),
+            project({ id: "proj-b", slug: "checkout-agent" }),
+          ],
+        ]).service,
+      });
+
+      expect(resolved).toBe("proj-b");
+    });
+
+    it("walks every page of the listing", async () => {
+      const resolved = await resolveProjectSelector({
+        selector: "checkout-agent",
+        cfg: personalConfig,
+        service: listing([
+          [project({ id: "proj-a", slug: "alpha" })],
+          [project({ id: "proj-b", slug: "checkout-agent" })],
+        ]).service,
+      });
+
+      expect(resolved).toBe("proj-b");
+    });
+  });
+
+  describe("when the value matches nothing the credential can see", () => {
+    it("reports it as not accessible and echoes the value back", async () => {
+      const failure = await resolveProjectSelector({
+        selector: "someone-elses",
+        cfg: personalConfig,
+        service: listing([[project({ id: "proj-b", slug: "checkout-agent" })]])
+          .service,
+      }).catch((err: unknown) => err);
+
+      expect(failure).toBeInstanceOf(ProjectScopeError);
+      expect((failure as ProjectScopeError).code).toBe(
+        "project_not_accessible",
+      );
+      expect((failure as ProjectScopeError).project).toBe("someone-elses");
+      expect((failure as ProjectScopeError).message).toContain(
+        'no accessible project matches "someone-elses"',
+      );
+    });
+  });
+
+  describe("when the listing itself is refused", () => {
+    it("reports a 403 as no access to that project", async () => {
+      const failure = await resolveProjectSelector({
+        selector: "proj-b",
+        cfg: personalConfig,
+        service: failingListing(403),
+      }).catch((err: unknown) => err);
+
+      expect((failure as ProjectScopeError).code).toBe(
+        "project_not_accessible",
+      );
+      expect((failure as ProjectScopeError).message).toContain("proj-b");
+    });
+
+    it("keeps a server failure separate from a missing project", async () => {
+      const failure = await resolveProjectSelector({
+        selector: "proj-b",
+        cfg: personalConfig,
+        service: failingListing(500),
+      }).catch((err: unknown) => err);
+
+      // The credential may well reach this project; we simply could not ask.
+      expect((failure as ProjectScopeError).code).toBe("project_lookup_failed");
+    });
+  });
+});

--- a/sdks/typescript/src/cli/utils/__tests__/projectScope.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/projectScope.unit.test.ts
@@ -176,4 +176,25 @@ describe("resolveProjectSelector()", () => {
       expect((failure as ProjectScopeError).code).toBe("project_lookup_failed");
     });
   });
+
+  describe("when the organization has more projects than the page walk covers", () => {
+    it("says the lookup failed rather than reporting the project as inaccessible", async () => {
+      // One more page than the walk will read, so the cap is reached with
+      // pages still to go. Answering "no accessible project matches" here
+      // would be a wrong answer, not a slow one.
+      const pages = Array.from({ length: 51 }, (_, index) => [
+        project({ id: `proj-${index}`, slug: `project-${index}` }),
+      ]);
+      const { service } = listing(pages);
+
+      const failure = await resolveProjectSelector({
+        selector: "project-50",
+        cfg: personalConfig,
+        service,
+      }).catch((err: unknown) => err);
+
+      expect((failure as ProjectScopeError).code).toBe("project_lookup_failed");
+      expect((failure as ProjectScopeError).message).toContain("5000");
+    });
+  });
 });

--- a/sdks/typescript/src/cli/utils/apiKey.ts
+++ b/sdks/typescript/src/cli/utils/apiKey.ts
@@ -1,6 +1,9 @@
 import chalk from "chalk";
 import { config } from "dotenv";
-import { setResolvedApiKey } from "@/internal/credentialContext";
+import {
+  setResolvedApiKey,
+  setResolvedProjectId,
+} from "@/internal/credentialContext";
 import { getEndpoint } from "./endpoint";
 import { getOutputFormat, renderErrorAsJson } from "./errorOutput";
 import { maybePrintIdentityNotice } from "./identityNotice";
@@ -14,6 +17,11 @@ import {
   fetchPersonalProject,
   SessionApiError,
 } from "./governance/session-api";
+import {
+  projectScopeErrorLines,
+  ProjectScopeError,
+  resolveProjectSelector,
+} from "./projectScope";
 
 /**
  * Re-read the caller's .env, applying only the LANGWATCH_* keys.
@@ -51,6 +59,12 @@ export interface ResolvedCredentials {
   source: "flag" | "env" | "session";
   /** Control-plane endpoint the command targets (4-source resolver). */
   endpoint: string;
+  /**
+   * The project the request names, published into the credential context. A
+   * user-scoped key needs it (the server resolves the role binding from it);
+   * a legacy project key ignores it. Undefined when nothing named a project.
+   */
+  projectId?: string;
 }
 
 /**
@@ -75,8 +89,16 @@ export const SESSION_REVALIDATE_WINDOW_MS = 5 * 60 * 1000;
  *   2. `LANGWATCH_API_KEY` from the environment or the caller's .env
  *      (scoped load above, so CI and scripts are never surprised),
  *   3. the device session in ~/.langwatch/config.json, which resolves the
- *      PERSONAL PROJECT's API key: shipped by the login exchange, then
- *      periodically re-validated against session liveness (see below).
+ *      user-scoped LOGIN KEY (`cli_api_key`) when the login minted one, and
+ *      the PERSONAL PROJECT's API key otherwise: both are shipped by the login
+ *      exchange, then periodically re-validated against session liveness (see
+ *      below).
+ *
+ * The session path also decides WHICH PROJECT the request names. The login key
+ * carries no project identity, so the server reads it off the request: the
+ * personal project by default, or the one `--project <id|slug>` selects. Both
+ * the key and the project id go into the request-scoped credential store, and
+ * `buildAuthHeaders` turns the pair into `Basic base64(projectId:key)`.
  *
  * The winning key is published into the request-scoped credential store
  * (internal/credentialContext.ts), NOT the shared `process.env`. Every
@@ -98,7 +120,7 @@ export const SESSION_REVALIDATE_WINDOW_MS = 5 * 60 * 1000;
  * Spec: specs/ai-governance/cli-onboarding/me-credentials.feature
  */
 export const resolveCredentials = async (
-  opts: { apiKey?: string } = {},
+  opts: { apiKey?: string; project?: string } = {},
 ): Promise<ResolvedCredentials> => {
   // Load environment variables from .env file (scoped, see above)
   loadEnvFileScoped();
@@ -112,12 +134,14 @@ export const resolveCredentials = async (
   const flagKey = opts.apiKey?.trim();
   if (flagKey) {
     setResolvedApiKey(flagKey);
+    const projectId = await applyProjectScope({ project: opts.project });
+    setResolvedProjectId(projectId);
     await maybePrintIdentityNotice({
       mode: "api-key",
       apiKey: flagKey,
       endpoint,
     });
-    return { apiKey: flagKey, source: "flag", endpoint };
+    return { apiKey: flagKey, source: "flag", endpoint, projectId };
   }
 
   // Trimmed for use, not just for the emptiness check: a `.env` written as
@@ -126,12 +150,14 @@ export const resolveCredentials = async (
   const envKey = process.env.LANGWATCH_API_KEY?.trim();
   if (envKey) {
     setResolvedApiKey(envKey);
+    const projectId = await applyProjectScope({ project: opts.project });
+    setResolvedProjectId(projectId);
     await maybePrintIdentityNotice({
       mode: "api-key",
       apiKey: envKey,
       endpoint,
     });
-    return { apiKey: envKey, source: "env", endpoint };
+    return { apiKey: envKey, source: "env", endpoint, projectId };
   }
 
   // Stored state. Re-read from disk on every call, never cached in-process
@@ -143,15 +169,26 @@ export const resolveCredentials = async (
     cfg = undefined;
   }
   if (cfg && isLoggedIn(cfg)) {
-    const sessionKey = await resolveSessionProjectKey(cfg);
-    if (sessionKey) {
-      setResolvedApiKey(sessionKey);
-      await maybePrintIdentityNotice({
-        mode: "device",
-        apiKey: sessionKey,
-        endpoint,
-      });
-      return { apiKey: sessionKey, source: "session", endpoint };
+    const session = await resolveSessionCredential(cfg);
+    if (session) {
+      setResolvedApiKey(session.apiKey);
+      // `--project` decides the target BEFORE anything is published: the
+      // personal project is the default only when no flag says otherwise,
+      // and a flag that does not resolve must leave no target behind at all.
+      const projectId =
+        (await applyProjectScope({ project: opts.project, cfg })) ??
+        session.projectId;
+      setResolvedProjectId(projectId);
+      // An explicit --project names the identity on the command line, so
+      // there is nothing implicit left to warn about.
+      if (opts.project === undefined) {
+        await maybePrintIdentityNotice({
+          mode: session.usedLoginKey ? "device-login-key" : "device",
+          apiKey: session.apiKey,
+          endpoint,
+        });
+      }
+      return { apiKey: session.apiKey, source: "session", endpoint, projectId };
     }
   }
 
@@ -159,21 +196,102 @@ export const resolveCredentials = async (
 };
 
 /**
- * The personal-project key for a device session, gated on session liveness.
+ * Resolve `--project` into the request's target project and publish it.
  *
- * The cached key (delivered by the login exchange, or a prior lazy exchange)
- * is a long-lived `Project.apiKey`. Using it unconditionally is the
- * revocation bypass: a config carrying `personal_project.api_key` would
- * authenticate forever even after the device was revoked. So the cache is
- * trusted only within `SESSION_REVALIDATE_WINDOW_MS`; past it, every call
- * re-confirms the session through the session-authenticated
- * `GET /api/auth/cli/personal-project` (which fails once Redis has dropped
- * the revoked/expired tokens), and:
+ * Returns undefined when no flag was given, which leaves whatever the session
+ * path already published in place. A value that does not resolve ends the
+ * command: there is no safe fallback, since silently running against the
+ * personal project would answer a question the user did not ask.
+ */
+async function applyProjectScope({
+  project,
+  cfg,
+}: {
+  project?: string;
+  cfg?: GovernanceConfig;
+}): Promise<string | undefined> {
+  if (project === undefined) return undefined;
+  try {
+    const projectId = await resolveProjectSelector({
+      selector: project,
+      cfg,
+    });
+    return projectId;
+  } catch (err) {
+    if (err instanceof ProjectScopeError) reportProjectScopeError(err);
+    throw err;
+  }
+}
+
+function reportProjectScopeError(error: ProjectScopeError): never {
+  if (getOutputFormat() !== "text") {
+    console.log(
+      renderErrorAsJson({
+        code: error.code,
+        kind: error.code,
+        message: error.message,
+        httpStatus: 0,
+        meta: { project: error.project },
+        isHandled: true,
+      }),
+    );
+    console.error(chalk.red(`Error: ${error.message}`));
+    process.exit(1);
+  }
+
+  const [headline, ...rest] = projectScopeErrorLines(error);
+  console.error(chalk.red(headline));
+  for (const line of rest) {
+    console.error(line.startsWith("  ") ? chalk.cyan(line) : chalk.gray(line));
+  }
+  process.exit(1);
+}
+
+/**
+ * A stored key, trimmed, or undefined when there is nothing usable there.
+ * Trimmed for USE, not just for the emptiness check: a hand-edited config
+ * would otherwise ship the stray whitespace into the Authorization header.
+ */
+const trimmedOrUndefined = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+/** The key a device session authenticates with, and the project it names. */
+interface SessionCredential {
+  apiKey: string;
+  /** The personal project. Undefined only on a session that never cached one. */
+  projectId?: string;
+  /** True when the credential is the user-scoped login key rather than the
+   * personal project's key; the identity notice words the two differently. */
+  usedLoginKey: boolean;
+}
+
+/**
+ * The key for a device session, gated on session liveness.
  *
- *   - success       : refresh the key + validation clock, use it.
- *   - 401 (revoked) : DELETE the cached key from config and return undefined,
- *                     so the command reports not-logged-in and the stolen
- *                     config is now inert.
+ * TWO KEYS CAN BE CACHED, and the login key wins when it is there. The
+ * user-scoped `cli_api_key` reaches every project the user selected while
+ * approving the login, so `--project` can move a command across projects with
+ * it; `personal_project.api_key` reaches exactly one project and is what a
+ * server predating the feature ships. Either way the request names the
+ * personal project by default, so a login with a login key behaves exactly
+ * like one without until a `--project` says otherwise.
+ *
+ * Both are long-lived credentials rather than session-bound tokens, so using
+ * either unconditionally is the revocation bypass: a stolen
+ * `~/.langwatch/config.json` would authenticate forever after the device was
+ * revoked. The cache is therefore trusted only within
+ * `SESSION_REVALIDATE_WINDOW_MS`; past it, every call re-confirms the session
+ * through the session-authenticated `GET /api/auth/cli/personal-project`
+ * (which fails once Redis has dropped the revoked/expired tokens), and:
+ *
+ *   - success       : refresh the personal project + validation clock, use it.
+ *   - 401 (revoked) : DELETE both cached keys from config and return
+ *                     undefined, so the command reports not-logged-in and the
+ *                     stolen config is now inert.
+ *   - 403 (session refused) : same as 401 — a session the server refuses is
+ *                     one the CLI must stop presenting.
  *   - 404 (a server predating the endpoint) : can't revalidate; keep the
  *                     legacy key and reset the clock so old servers still
  *                     "just work" (they have no device-revocation semantics
@@ -181,16 +299,24 @@ export const resolveCredentials = async (
  *   - network/other : offline; keep the last-known key WITHOUT resetting the
  *                     clock, so the very next online command revalidates.
  */
-async function resolveSessionProjectKey(
+async function resolveSessionCredential(
   cfg: GovernanceConfig,
-): Promise<string | undefined> {
-  const trimmedKey = cfg.personal_project?.api_key?.trim() ?? "";
-  const cached: string | undefined =
-    trimmedKey.length > 0 ? trimmedKey : undefined;
+): Promise<SessionCredential | undefined> {
+  const loginKey = trimmedOrUndefined(cfg.cli_api_key);
+  const personalKey = trimmedOrUndefined(cfg.personal_project?.api_key);
+  // One clock for both: the probe below confirms the SESSION, and the session
+  // is what either key's continued validity rests on.
+  const cached = loginKey ?? personalKey;
   const validatedAtMs = (cfg.personal_project?.validated_at ?? 0) * 1000;
-  const fresh =
+  const isFresh =
     !!cached && Date.now() - validatedAtMs < SESSION_REVALIDATE_WINDOW_MS;
-  if (fresh) return cached;
+  if (isFresh) {
+    return {
+      apiKey: cached,
+      projectId: cfg.personal_project?.id,
+      usedLoginKey: cached === loginKey,
+    };
+  }
 
   try {
     const project = await fetchPersonalProject(cfg);
@@ -200,7 +326,11 @@ async function resolveSessionProjectKey(
       // command.
       if (cached) {
         markPersonalProjectValidated(cfg);
-        return cached;
+        return {
+          apiKey: cached,
+          projectId: cfg.personal_project?.id,
+          usedLoginKey: cached === loginKey,
+        };
       }
       return undefined;
     }
@@ -212,19 +342,37 @@ async function resolveSessionProjectKey(
       validated_at: Math.floor(Date.now() / 1000),
     };
     saveConfig(cfg);
-    return project.api_key;
+    return {
+      apiKey: loginKey ?? project.api_key,
+      projectId: project.id,
+      usedLoginKey: loginKey !== undefined,
+    };
   } catch (err) {
-    if (err instanceof SessionApiError && err.status === 401) {
-      // Session revoked or expired: sever access. Drop the cached key so the
-      // retained config can no longer authenticate. (fetchPersonalProject's
-      // refresh path may already have cleared it; this is idempotent.)
+    if (
+      err instanceof SessionApiError &&
+      (err.status === 401 || err.status === 403)
+    ) {
+      // Session revoked, expired or refused: sever access. Drop both cached
+      // keys so the retained config can no longer authenticate. 403 counts
+      // the same as 401 — a session the server refuses is one the CLI must
+      // stop presenting, whichever status says so. (fetchPersonalProject's
+      // refresh path may already have cleared the personal project; this is
+      // idempotent.)
       delete cfg.personal_project;
+      delete cfg.cli_api_key;
+      delete cfg.cli_api_key_scope;
       saveConfig(cfg);
       return undefined;
     }
     // Offline / transient: fall back to the last-known key, but do NOT touch
     // the validation clock, so the next reachable command revalidates.
-    return cached;
+    return cached
+      ? {
+          apiKey: cached,
+          projectId: cfg.personal_project?.id,
+          usedLoginKey: cached === loginKey,
+        }
+      : undefined;
   }
 }
 

--- a/sdks/typescript/src/cli/utils/apiKey.ts
+++ b/sdks/typescript/src/cli/utils/apiKey.ts
@@ -183,7 +183,7 @@ export const resolveCredentials = async (
       // there is nothing implicit left to warn about.
       if (opts.project === undefined) {
         await maybePrintIdentityNotice({
-          mode: session.usedLoginKey ? "device-login-key" : "device",
+          mode: session.isLoginKey ? "device-login-key" : "device",
           apiKey: session.apiKey,
           endpoint,
         });
@@ -264,7 +264,7 @@ interface SessionCredential {
   projectId?: string;
   /** True when the credential is the user-scoped login key rather than the
    * personal project's key; the identity notice words the two differently. */
-  usedLoginKey: boolean;
+  isLoginKey: boolean;
 }
 
 /**
@@ -314,7 +314,7 @@ async function resolveSessionCredential(
     return {
       apiKey: cached,
       projectId: cfg.personal_project?.id,
-      usedLoginKey: cached === loginKey,
+      isLoginKey: cached === loginKey,
     };
   }
 
@@ -329,7 +329,7 @@ async function resolveSessionCredential(
         return {
           apiKey: cached,
           projectId: cfg.personal_project?.id,
-          usedLoginKey: cached === loginKey,
+          isLoginKey: cached === loginKey,
         };
       }
       return undefined;
@@ -345,7 +345,7 @@ async function resolveSessionCredential(
     return {
       apiKey: loginKey ?? project.api_key,
       projectId: project.id,
-      usedLoginKey: loginKey !== undefined,
+      isLoginKey: loginKey !== undefined,
     };
   } catch (err) {
     if (
@@ -370,7 +370,7 @@ async function resolveSessionCredential(
       ? {
           apiKey: cached,
           projectId: cfg.personal_project?.id,
-          usedLoginKey: cached === loginKey,
+          isLoginKey: cached === loginKey,
         }
       : undefined;
   }

--- a/sdks/typescript/src/cli/utils/authHeaders.ts
+++ b/sdks/typescript/src/cli/utils/authHeaders.ts
@@ -1,0 +1,23 @@
+/**
+ * Auth headers for the CLI commands that call the platform with a bare
+ * `fetch` instead of the generated API client.
+ *
+ * The client factory reads the request-scoped project id for them
+ * (internal/api/client.ts); a hand-written `fetch` has to ask. Without it a
+ * user-scoped login key goes out as a bare Bearer with no project named, the
+ * server cannot resolve the role binding, and the command 401s while the same
+ * command through the API client works.
+ */
+
+import {
+  buildAuthHeaders,
+  type LangWatchAuthHeaders,
+} from "@/internal/api/auth";
+import { scopedProjectId } from "@/internal/credentialContext";
+
+export const cliAuthHeaders = ({
+  apiKey,
+}: {
+  apiKey: string;
+}): LangWatchAuthHeaders =>
+  buildAuthHeaders({ apiKey, projectId: scopedProjectId() });

--- a/sdks/typescript/src/cli/utils/governance/__tests__/config.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/config.unit.test.ts
@@ -199,6 +199,75 @@ describe("governance config persistence", () => {
     });
   });
 
+  describe("when loading a user-scoped login key", () => {
+    const write = (extra: Record<string, unknown>): void => {
+      fs.writeFileSync(
+        p,
+        JSON.stringify({
+          gateway_url: "https://gateway.langwatch.ai",
+          control_plane_url: "https://app.langwatch.ai",
+          ...extra,
+        }),
+      );
+    };
+
+    it("survives a save and load round trip", () => {
+      saveConfig({
+        gateway_url: "g",
+        control_plane_url: "c",
+        cli_api_key: "sk-lw-lookup01_secret01",
+        cli_api_key_scope: { kind: "projects", project_ids: ["proj_a"] },
+      });
+
+      const cfg = loadConfig();
+
+      expect(cfg.cli_api_key).toBe("sk-lw-lookup01_secret01");
+      expect(cfg.cli_api_key_scope).toEqual({
+        kind: "projects",
+        project_ids: ["proj_a"],
+      });
+    });
+
+    it("drops a blank key, and the scope that described it", () => {
+      write({
+        cli_api_key: "   ",
+        cli_api_key_scope: { kind: "organization", project_ids: [] },
+      });
+
+      const cfg = loadConfig();
+
+      expect(cfg.cli_api_key).toBeUndefined();
+      expect(cfg.cli_api_key_scope).toBeUndefined();
+    });
+
+    it("drops a scope in a shape whoami cannot read, keeping the key", () => {
+      write({
+        cli_api_key: "sk-lw-lookup01_secret01",
+        cli_api_key_scope: { kind: "everything" },
+      });
+
+      const cfg = loadConfig();
+
+      expect(cfg.cli_api_key).toBe("sk-lw-lookup01_secret01");
+      expect(cfg.cli_api_key_scope).toBeUndefined();
+    });
+
+    it("drops an organization scope that also carries project ids", () => {
+      write({
+        cli_api_key: "sk-lw-lookup01_secret01",
+        cli_api_key_scope: {
+          kind: "organization",
+          project_ids: ["proj_a", "proj_b"],
+        },
+      });
+
+      const cfg = loadConfig();
+
+      expect(cfg.cli_api_key).toBe("sk-lw-lookup01_secret01");
+      expect(cfg.cli_api_key_scope).toBeUndefined();
+    });
+  });
+
   it("env var override changes the path", () => {
     expect(configPath()).toBe(p);
   });

--- a/sdks/typescript/src/cli/utils/governance/__tests__/login-flow-personal-project.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/login-flow-personal-project.unit.test.ts
@@ -153,3 +153,69 @@ describe("runUnifiedLoginFlow (device session) personal-project persistence", ()
     );
   });
 });
+
+/**
+ * Feature: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+describe("runUnifiedLoginFlow (device session) login-key persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.LANGWATCH_BROWSER = "none";
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.LANGWATCH_BROWSER;
+    vi.restoreAllMocks();
+  });
+
+  describe("when the exchange carries a user-scoped key", () => {
+    it("stores the key and the scope it reaches", async () => {
+      pollUntilDone.mockResolvedValue(
+        exchangeResult({
+          cli_api_key: "sk-lw-lookup01_secret01",
+          cli_api_key_scope: { kind: "organization", project_ids: [] },
+        }),
+      );
+
+      const cfg = await runUnifiedLoginFlow({ kind: "device_session" });
+
+      expect(cfg.cli_api_key).toBe("sk-lw-lookup01_secret01");
+      expect(cfg.cli_api_key_scope).toEqual({
+        kind: "organization",
+        project_ids: [],
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ cli_api_key: "sk-lw-lookup01_secret01" }),
+      );
+    });
+  });
+
+  describe("when the server predates the feature", () => {
+    it("leaves both fields unset", async () => {
+      pollUntilDone.mockResolvedValue(exchangeResult());
+
+      const cfg = await runUnifiedLoginFlow({ kind: "device_session" });
+
+      expect(cfg.cli_api_key).toBeUndefined();
+      expect(cfg.cli_api_key_scope).toBeUndefined();
+    });
+
+    it("clears the previous login's key rather than carrying it over", async () => {
+      // The stored key belongs to whoever logged in last. Kept, every command
+      // in the new session would authenticate as them.
+      vi.mocked(loadConfig).mockReturnValue({
+        control_plane_url: "https://app.langwatch.ai",
+        gateway_url: "https://gateway.langwatch.ai",
+        cli_api_key: "sk-lw-priorlookup01_secret01",
+        cli_api_key_scope: { kind: "organization", project_ids: [] },
+      } as never);
+      pollUntilDone.mockResolvedValue(exchangeResult());
+
+      const cfg = await runUnifiedLoginFlow({ kind: "device_session" });
+
+      expect(cfg.cli_api_key).toBeUndefined();
+      expect(cfg.cli_api_key_scope).toBeUndefined();
+    });
+  });
+});

--- a/sdks/typescript/src/cli/utils/governance/config.ts
+++ b/sdks/typescript/src/cli/utils/governance/config.ts
@@ -55,6 +55,28 @@ export interface GovernanceConfig {
   };
 
   /**
+   * The user-scoped API key minted for this login by
+   * `POST /api/auth/cli/exchange`, in the `sk-lw-{lookupId}_{secret}` shape.
+   * It reaches every project the user picked on the authorize screen, so data
+   * and management commands use it instead of the personal project's own key
+   * and `--project <id|slug>` can point them at another project. Absent when
+   * the server predates the feature; the resolver then falls back to
+   * `personal_project.api_key`, exactly as before.
+   * Spec: specs/typescript-sdk/cli-cross-project-access.feature
+   */
+  cli_api_key?: string;
+
+  /**
+   * What `cli_api_key` reaches, as the exchange reported it. `organization`
+   * means every project of the organization, now and later; `projects` means
+   * the listed ids only. Read by `langwatch whoami` to summarise the login.
+   */
+  cli_api_key_scope?: {
+    kind: "organization" | "projects";
+    project_ids: string[];
+  };
+
+  /**
    * Personal ingest keys (write-only ingest ApiKeys in the
    * `ik-lw-{lookupId}_{secret}` shape minted by
    * `/api/auth/cli/governance/ingestion-key`), keyed by the tool's
@@ -227,6 +249,27 @@ export function isCanonicalVkSecret(secret: string | undefined): boolean {
   return !!secret && secret.startsWith(VK_SECRET_PREFIX);
 }
 
+/** Whether a stored `cli_api_key_scope` is in the shape `whoami` can read. */
+function isWellFormedCliKeyScope(
+  scope: GovernanceConfig["cli_api_key_scope"],
+): boolean {
+  if (!scope) return false;
+  if (scope.kind !== "organization" && scope.kind !== "projects") return false;
+  if (
+    !Array.isArray(scope.project_ids) ||
+    !scope.project_ids.every((id) => typeof id === "string")
+  ) {
+    return false;
+  }
+  // An organization scope carries no project ids by definition. A scope
+  // holding both would have `whoami` report "whole organization" while the
+  // list says otherwise, so refuse it as malformed.
+  if (scope.kind === "organization" && scope.project_ids.length > 0) {
+    return false;
+  }
+  return true;
+}
+
 /**
  * Returns the absolute path to the config file. Override with
  * LANGWATCH_CLI_CONFIG for tests / non-default homes.
@@ -275,6 +318,19 @@ export function loadConfig(): GovernanceConfig {
           ([, pin]) => typeof pin?.secret === "string" && pin.secret !== "",
         ),
       );
+    }
+    // A blank or non-string `cli_api_key` is a hand-edit, not a credential.
+    // Kept, it would win over the personal-project key in the resolver and
+    // send `Basic base64(projectId:undefined)` at every command; dropped, the
+    // resolver degrades to the pre-feature path and the next login writes a
+    // working key again. The scope goes with it: it describes a key that is
+    // no longer there, and `whoami` would otherwise report a reach the CLI
+    // cannot use.
+    if (typeof cfg.cli_api_key !== "string" || cfg.cli_api_key.trim() === "") {
+      delete cfg.cli_api_key;
+      delete cfg.cli_api_key_scope;
+    } else if (!isWellFormedCliKeyScope(cfg.cli_api_key_scope)) {
+      delete cfg.cli_api_key_scope;
     }
     return cfg;
   } catch (err) {

--- a/sdks/typescript/src/cli/utils/governance/device-flow.ts
+++ b/sdks/typescript/src/cli/utils/governance/device-flow.ts
@@ -59,6 +59,16 @@ export interface ExchangePersonalProject {
 }
 
 /**
+ * What the minted `cli_api_key` reaches. `organization` covers every project
+ * of the organization and carries an empty `project_ids`; `projects` names the
+ * exact ids the user picked on the authorize screen.
+ */
+export interface ExchangeCliApiKeyScope {
+  kind: "organization" | "projects";
+  project_ids: string[];
+}
+
+/**
  * The CLI device-code flow can mint two distinct credential types:
  *   - "device_session" — the user-scoped OAuth-style access+refresh
  *     token pair used by `langwatch claude/codex/...` wrappers.
@@ -82,6 +92,13 @@ export interface ExchangeDeviceSessionResult {
   organization: ExchangeOrganization;
   default_personal_vk?: ExchangePersonalVK;
   personal_project?: ExchangePersonalProject;
+  /**
+   * The user-scoped API key minted for this login, reaching every project the
+   * user selected while approving. Absent on servers that predate the feature,
+   * and the CLI then authenticates with the personal project's own key.
+   */
+  cli_api_key?: string;
+  cli_api_key_scope?: ExchangeCliApiKeyScope;
   endpoint?: string;
 }
 

--- a/sdks/typescript/src/cli/utils/governance/login-flow.ts
+++ b/sdks/typescript/src/cli/utils/governance/login-flow.ts
@@ -356,6 +356,22 @@ function persistDeviceSession(
 			validated_at: Math.floor(Date.now() / 1000),
 		};
 	}
+	// The user-scoped login key, and what it reaches. The previous login's key
+	// goes first for the same reason its personal project does: it belongs to
+	// the user who logged in before, and keeping it would authenticate the new
+	// session as them. A server that ships no key leaves both fields absent,
+	// which is what puts the resolver back on the personal-project path.
+	delete cfg.cli_api_key;
+	delete cfg.cli_api_key_scope;
+	if (result.cli_api_key) {
+		cfg.cli_api_key = result.cli_api_key;
+		if (result.cli_api_key_scope) {
+			cfg.cli_api_key_scope = {
+				kind: result.cli_api_key_scope.kind,
+				project_ids: result.cli_api_key_scope.project_ids ?? [],
+			};
+		}
+	}
 	if (result.endpoint) {
 		cfg.control_plane_url = normalizeEndpoint(result.endpoint);
 	}

--- a/sdks/typescript/src/cli/utils/identityNotice.ts
+++ b/sdks/typescript/src/cli/utils/identityNotice.ts
@@ -8,8 +8,13 @@
  * assumed a shared one). The notice names the identity, and the two commands
  * that change it, in one line:
  *
- *   device mode   Using your personal project (device login). Read another project: langwatch login --project
- *   api-key mode  Using API key for project "<name>". Switch: langwatch login --project | --device
+ *   device mode           Using your personal project (device login). Read another project: langwatch login --project
+ *   device-login-key mode Using your login key on your personal project. Read another project: add --project <id|slug>
+ *   api-key mode          Using API key for project "<name>". Switch: langwatch login --project | --device
+ *
+ * A command carrying an explicit `--project` prints no notice at all: the
+ * identity is named on the command line, so there is nothing implicit to
+ * warn about.
  *
  * Contract, in order of importance:
  *   - ALWAYS stderr. Stdout belongs to the command's output; `-o json` and
@@ -48,7 +53,7 @@ const STATE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
  * make every CLI command feel slow. */
 const NAME_FETCH_TIMEOUT_MS = 1_500;
 
-export type NoticeMode = "device" | "api-key";
+export type NoticeMode = "device" | "device-login-key" | "api-key";
 
 interface NoticeState {
   /** sha256(mode:credential) -> epoch ms the notice was last shown. */
@@ -144,6 +149,9 @@ async function fetchProjectName(
 function renderLine(mode: NoticeMode, projectName: string | undefined): string {
   if (mode === "device") {
     return "Using your personal project (device login). Read another project: langwatch login --project";
+  }
+  if (mode === "device-login-key") {
+    return "Using your login key on your personal project. Read another project: add --project <id|slug>";
   }
   if (projectName) {
     return `Using API key for project "${projectName}". Switch: langwatch login --project | --device`;

--- a/sdks/typescript/src/cli/utils/projectScope.ts
+++ b/sdks/typescript/src/cli/utils/projectScope.ts
@@ -1,0 +1,162 @@
+/**
+ * Turns a `--project <idOrSlug>` value into the project id a command targets.
+ *
+ * The user-scoped login key (`cli_api_key`) reaches every project the user
+ * selected while approving the login, but it carries no project identity of
+ * its own: the server resolves the role binding from the project the REQUEST
+ * names. So a command that runs against another project needs an id, and the
+ * user is entitled to type the slug they see in the URL bar instead.
+ *
+ * One resolver for every command group. `--project` starts on the `trace`
+ * commands and `session events`; anything that adopts the flag later passes
+ * the value to `resolveCredentials({ project })` and gets the same lookup, the
+ * same errors and the same wiring for free.
+ *
+ * Spec: specs/typescript-sdk/cli-cross-project-access.feature
+ */
+
+import {
+  ProjectsApiService,
+  type Project,
+} from "@/client-sdk/services/projects/projects-api.service";
+import type { GovernanceConfig } from "./governance/config";
+
+/**
+ * A `--project` value the CLI could not turn into a project it may use.
+ *
+ * `code` is the contract; the message is copy. `project_not_accessible` covers
+ * both shapes of that answer — a name nothing matches, and a name the login
+ * key is not allowed to see — because the platform answers them identically:
+ * a credential that cannot view a project does not get it in the listing.
+ * `project_lookup_failed` is the different case, where the listing itself did
+ * not come back and we know nothing about the project either way.
+ */
+export class ProjectScopeError extends Error {
+  constructor(
+    public readonly code: "project_not_accessible" | "project_lookup_failed",
+    message: string,
+    /** The `--project` value the user typed, echoed back for the message. */
+    public readonly project: string,
+  ) {
+    super(message);
+    this.name = "ProjectScopeError";
+  }
+}
+
+/** Projects fetched per request. High enough that one page covers most orgs. */
+const PAGE_SIZE = 100;
+
+/** Hard stop on the page walk, so a miscounting server cannot loop forever. */
+const MAX_PAGES = 50;
+
+/** The status the platform answered with, whichever error class carried it. */
+const statusOf = (error: unknown): number | undefined => {
+  const candidate = error as { httpStatus?: unknown; status?: unknown };
+  if (typeof candidate?.httpStatus === "number") return candidate.httpStatus;
+  if (typeof candidate?.status === "number") return candidate.status;
+  return undefined;
+};
+
+/**
+ * Every project the current credential can view, walked page by page. The
+ * listing is filtered server-side by what the credential holds `project:view`
+ * on, so "not in here" and "not yours" are the same fact.
+ */
+const listAccessibleProjects = async (
+  service: ProjectsApiService,
+): Promise<Project[]> => {
+  const collected: Project[] = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const result = await service.list({ page, limit: PAGE_SIZE });
+    collected.push(...result.data);
+    if (page >= (result.pagination.totalPages || 1)) break;
+    if (result.data.length === 0) break;
+    // The cap is reached with pages still to walk: the listing is
+    // incomplete, so "not in here" would be a wrong answer rather than a
+    // slow one. Say the lookup failed instead of reporting a project the
+    // credential CAN see as inaccessible.
+    if (page === MAX_PAGES) {
+      throw new ProjectScopeError(
+        "project_lookup_failed",
+        `More than ${MAX_PAGES * PAGE_SIZE} projects to search. Pass --project with the project id instead of the slug.`,
+        "",
+      );
+    }
+  }
+  return collected;
+};
+
+/**
+ * Resolve a `--project` value to a project id.
+ *
+ * The stored personal project answers without a round trip, since it is the
+ * one project the CLI already knows by both id and slug. Everything else goes
+ * through the listing, matching on id FIRST: ids and slugs live in one
+ * namespace here, and an id is the exact reference, so a slug that happens to
+ * read like another project's id can never steal the request.
+ *
+ * Throws `ProjectScopeError` rather than exiting, so the caller decides how to
+ * render it (prose or the structured document) and the resolution stays
+ * testable on its own.
+ */
+export const resolveProjectSelector = async ({
+  selector,
+  cfg,
+  service,
+}: {
+  selector: string;
+  cfg?: GovernanceConfig;
+  service?: ProjectsApiService;
+}): Promise<string> => {
+  const wanted = selector.trim();
+  if (wanted === "") {
+    throw new ProjectScopeError(
+      "project_not_accessible",
+      "--project needs a project id or slug.",
+      wanted,
+    );
+  }
+
+  const personal = cfg?.personal_project;
+  if (personal?.id && (personal.id === wanted || personal.slug === wanted)) {
+    return personal.id;
+  }
+
+  let projects: Project[];
+  try {
+    projects = await listAccessibleProjects(service ?? new ProjectsApiService());
+  } catch (error) {
+    const status = statusOf(error);
+    if (status === 401 || status === 403) {
+      throw new ProjectScopeError(
+        "project_not_accessible",
+        `your login key has no access to project "${wanted}".`,
+        wanted,
+      );
+    }
+    throw new ProjectScopeError(
+      "project_lookup_failed",
+      `could not look up project "${wanted}": ${(error as Error).message}`,
+      wanted,
+    );
+  }
+
+  const matched =
+    projects.find((project) => project.id === wanted) ??
+    projects.find((project) => project.slug === wanted);
+  if (matched) return matched.id;
+
+  throw new ProjectScopeError(
+    "project_not_accessible",
+    `no accessible project matches "${wanted}". Your login key has no access to a project with that id or slug.`,
+    wanted,
+  );
+};
+
+/** The human error block for a `--project` that did not resolve. */
+export const projectScopeErrorLines = (error: ProjectScopeError): string[] => [
+  `Error: ${error.message}`,
+  "",
+  "List the projects your login reaches:",
+  "  langwatch projects list",
+];

--- a/sdks/typescript/src/client-sdk/services/projects/projects-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/projects/projects-api.service.ts
@@ -56,6 +56,13 @@ export class ProjectsApiError extends Error {
     message: string,
     public readonly operation: string,
     public readonly originalError?: unknown,
+    /**
+     * The status the platform answered with. Callers that resolve a
+     * `--project` selector through the listing branch on it: a 401/403 means
+     * the credential cannot see the listing at all, which is a different
+     * answer to the user than "no project of yours matches this name".
+     */
+    public readonly status?: number,
   ) {
     super(message);
     this.name = "ProjectsApiError";
@@ -71,6 +78,13 @@ export class ProjectsApiService {
     this.apiKey = config?.apiKey ?? scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
   }
 
+  /**
+   * Bearer, never the project-pinned Basic shape the data routes use. The
+   * listing is the question "which projects can this credential see?", so
+   * naming one project in the header would scope the answer to that project
+   * and defeat the call — including the `--project <slug>` lookup, which reads
+   * the listing precisely because it does not know the id yet.
+   */
   private headers(): Record<string, string> {
     return {
       Authorization: `Bearer ${this.apiKey}`,
@@ -101,7 +115,12 @@ export class ProjectsApiService {
         status: response.status,
         message,
       });
-      throw new ProjectsApiError(message, operation, parsedBody);
+      throw new ProjectsApiError(
+        message,
+        operation,
+        parsedBody,
+        response.status,
+      );
     }
     return (await response.json()) as T;
   }

--- a/sdks/typescript/src/internal/api/client.ts
+++ b/sdks/typescript/src/internal/api/client.ts
@@ -8,7 +8,7 @@ import {
   LANGWATCH_SDK_VERSION,
 } from "../constants";
 import { resolveEndpoint } from "@/internal/endpoint";
-import { scopedApiKey } from "@/internal/credentialContext";
+import { scopedApiKey, scopedProjectId } from "@/internal/credentialContext";
 import { buildAuthHeaders } from "./auth";
 import { handledErrorFrom } from "./errors";
 
@@ -80,7 +80,12 @@ export const createLangWatchApiClient = (
   // scope and falls back to the environment unchanged.
   apiKey: string = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "",
   endpoint?: string,
-  projectId: string | undefined = process.env.LANGWATCH_PROJECT_ID,
+  // Same precedence as the key: the request-scoped target project (the CLI
+  // resolver's output, personal by default and `--project` when given) wins
+  // over the global env, and a plain SDK embed that scopes nothing falls back
+  // to the environment unchanged.
+  projectId: string | undefined = scopedProjectId() ??
+    process.env.LANGWATCH_PROJECT_ID,
 ) => {
   const client = openApiCreateClient<paths>({
     baseUrl: resolveEndpoint(endpoint),

--- a/sdks/typescript/src/internal/credentialContext.ts
+++ b/sdks/typescript/src/internal/credentialContext.ts
@@ -30,6 +30,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 interface CredentialHolder {
   apiKey?: string;
+  projectId?: string;
 }
 
 const storage = new AsyncLocalStorage<CredentialHolder>();
@@ -73,9 +74,32 @@ export function scopedApiKey(): string | undefined {
 }
 
 /**
+ * Publish the project the current request targets. A user-scoped API key
+ * (`sk-lw-{lookupId}_{secret}`) carries no project identity of its own, so the
+ * server resolves the role binding from the project the request names: the
+ * resolver decides which project that is (the personal one by default,
+ * `--project <id|slug>` otherwise) and every client built afterwards reads it
+ * from here. Same request scoping as the key, for the same reason — two
+ * concurrent daemon requests can target different projects.
+ */
+export function setResolvedProjectId(projectId: string | undefined): void {
+  currentHolder().projectId = projectId;
+}
+
+/**
+ * The project id resolved for the current request, or undefined when nothing
+ * has resolved in this context. Client factories fall back to
+ * `LANGWATCH_PROJECT_ID` then, exactly as a plain SDK embed does.
+ */
+export function scopedProjectId(): string | undefined {
+  return currentHolder().projectId;
+}
+
+/**
  * Clear the process-local fallback holder. Test-only: a unit test that sets a
  * key outside any scope would otherwise leak it into the next test.
  */
 export function resetFallbackCredentialHolder(): void {
   fallbackHolder.apiKey = undefined;
+  fallbackHolder.projectId = undefined;
 }

--- a/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+++ b/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
@@ -1,0 +1,159 @@
+Feature: CLI login mints a user-scoped API key that inherits the user's permissions
+
+  A user who signs in with `langwatch login` (device-session flow) today only
+  receives their personal project's legacy API key. An org admin can therefore
+  not read traces from any other project through the CLI, even though the web
+  app grants them that access.
+
+  The device-session approval now mints a scoped `ApiKey` owned by the
+  approving user. Its role bindings and permission list are selected on the
+  authorize screen, default to the widest access the user holds minus
+  organization-management permissions, and are always intersected with the
+  owner's live permissions at request time. This lets `langwatch projects list`
+  and `langwatch trace search --project <id|slug>` reach every project the user
+  can see, while a leaked key can never create projects, manage RBAC, or mint
+  other keys unless the user opted in.
+
+  Pairs with:
+    - specs/ai-governance/cli-onboarding/login-unified.feature      (CLI login UX)
+    - specs/ai-governance/cli-onboarding/authorize-project-picker.feature
+    - specs/api-keys/unified-api-keys.feature                       (ApiKey + ceiling model)
+    - specs/typescript-sdk/cli-cross-project-access.feature         (CLI side)
+
+  Background:
+    Given a user who is a member of an organization
+    And the organization has governance enabled (`release_ui_ai_governance_enabled`)
+    And a pending device code with credential_type "device_session"
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Authorize screen defaults
+  # ─────────────────────────────────────────────────────────────────────
+
+  Rule: the authorize screen preselects the widest scope the user holds
+
+    @integration
+    Scenario: org admin defaults to organization scope
+      Given the user holds an ORGANIZATION-scoped ADMIN role binding
+      When the user opens the authorize screen for the device code
+      Then the scope selection defaults to the whole organization
+      And the permission selection defaults to every permission except the
+        organization-management set
+
+    @integration
+    Scenario: regular member defaults to their own teams plus personal workspace
+      Given the user is an org MEMBER who belongs to two shared teams
+      When the user opens the authorize screen for the device code
+      Then the scope selection defaults to those two teams and the user's
+        personal workspace
+      And the whole-organization scope is not selected
+
+    @integration
+    Scenario: the organization-management permissions are off by default
+      When the user opens the authorize screen for the device code
+      Then "organization:manage", "organization:delete", "project:create",
+        "project:delete" and "team:manage" are not part of the default
+        permission list
+      And gateway permissions (virtual keys, budgets, providers, routing
+        policies) and "project:manage" (model providers, project settings)
+        are part of the default permission list
+
+  Rule: the user can customize scopes and permissions before approving
+
+    @integration
+    Scenario: narrowing the selection narrows the minted key
+      Given the user deselects everything except one shared project
+      And sets the permission level for traces to read only
+      When the user approves and the CLI exchanges the device code
+      Then the minted key has exactly one PROJECT-scoped binding for that project
+      And its permission list contains "traces:view" but not "traces:update"
+
+    @integration
+    Scenario: approval with zero scopes selected is refused
+      Given the user deselects every scope on the authorize screen
+      Then the approve action is unavailable
+      And an approve request carrying zero bindings is refused with a handled
+        error naming the bindings field
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Minting mechanics
+  # ─────────────────────────────────────────────────────────────────────
+
+  Rule: the key is minted at exchange time, owned by the user, ceiling-capped
+
+    @integration
+    Scenario: exchange returns a user-owned scoped key
+      Given the user approved the device code with the default selection
+      When the CLI polls the exchange endpoint
+      Then the response carries a `cli_api_key` in the `sk-lw-{lookupId}_{secret}` format
+      And the ApiKey row records the approving user as owner
+      And its permissionMode is "restricted" with the selected permission list
+      And the response still carries the personal project and its API key,
+        so older CLI versions keep working unchanged
+
+    @integration
+    Scenario: an approval that is never exchanged mints nothing
+      Given the user approved the device code
+      But the CLI never polls the exchange endpoint before the code expires
+      Then no ApiKey row is created for this login
+
+    @integration
+    Scenario: the key can never exceed the owner's live permissions
+      Given a minted CLI key whose bindings cover the whole organization
+      And the owner is later demoted from org ADMIN to MEMBER
+      When the key is used to search traces on a project the owner can no
+        longer view
+      Then the request is refused with a 403
+
+    @integration
+    Scenario: approve refuses bindings above the approving user's ceiling
+      Given the user is an org MEMBER of one team
+      When an approve request claims an ORGANIZATION-scoped binding
+      Then the approval is refused with a handled error
+      And no selection is stamped on the device code
+
+  Rule: re-login and logout do not accumulate keys
+
+    @integration
+    Scenario: re-login from the same device replaces the previous CLI key
+      Given the user already holds a CLI key minted for device label "my-laptop"
+      When the user logs in again from "my-laptop" and completes the exchange
+      Then the previous CLI key for that device label is revoked
+      And exactly one active CLI key remains for that user and device label
+
+    @integration
+    Scenario: logout revokes the CLI key
+      Given the user holds an active CLI key from this login
+      When the CLI calls the logout endpoint
+      Then that CLI key is revoked along with the device session tokens
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Project listing honours the key's reach
+  # ─────────────────────────────────────────────────────────────────────
+
+  Rule: GET /api/projects returns exactly the projects the credential can view
+
+    @integration
+    Scenario: org-scoped key lists every project in the organization
+      Given a CLI key with an ORGANIZATION-scoped binding granting "project:view"
+      When the key calls GET /api/projects
+      Then the response lists every non-archived project in the organization
+
+    @integration
+    Scenario: project-scoped key gets a filtered list, not a refusal
+      Given a CLI key bound to two of the organization's five projects
+      When the key calls GET /api/projects
+      Then the response lists exactly those two projects
+      And the response is a 200, not a 403
+
+    @integration
+    Scenario: a key without project:view gets an empty list, not a refusal
+      Given a CLI key bound to one team but carrying only "traces:view"
+      When the key calls GET /api/projects
+      Then the response is a 200 with an empty list and a total of zero
+
+    @integration
+    Scenario: the filtered list respects the owner's ceiling
+      Given a CLI key bound to the whole organization
+      And the owner has meanwhile lost access to one team's projects
+      When the key calls GET /api/projects
+      Then that team's projects are absent from the response

--- a/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+++ b/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
@@ -86,6 +86,14 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
       Then only the permissions both teams grant are sent on approval
       And the write level is unavailable on a row only one of the teams grants
 
+    @unit
+    Scenario: Customized permissions follow the scopes that are selected
+      Given the user customized the permission rows under one set of scopes
+      When a scope is added that grants less than the rows already chosen
+      Then each row drops to the highest level the new selection still grants
+      And the approval carries what the rows show, so it is never refused for
+        a level the screen still displayed as chosen
+
     @integration
     Scenario: approval with zero scopes selected is refused
       Given the user deselects every scope on the authorize screen
@@ -156,6 +164,14 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
       When the user logs in again from "my-laptop" and completes the exchange
       Then the previous CLI key for that device label is revoked
       And exactly one active CLI key remains for that user and device label
+
+    @integration
+    Scenario: two logins racing on one device leave the newer key alive
+      Given two logins from the same device label are exchanged at the same
+        time
+      When both mints complete
+      Then each mint revokes only the keys created before its own
+      And the key the last exchange handed to the CLI is still active
 
     @integration
     Scenario: logout revokes the CLI key

--- a/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+++ b/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
@@ -50,14 +50,23 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
     @integration
     Scenario: the organization-management permissions are off by default
       When the user opens the authorize screen for the device code
-      Then "organization:manage", "organization:delete", "project:create",
-        "project:delete" and "team:manage" are not part of the default
-        permission list
-      And a key holding "project:manage" still cannot create or delete a
-        project, so the exclusion holds in effect and not only in the list
+      Then "organization:manage", "organization:delete" and "team:manage" are
+        not part of the default permission list
+      And none of them is reachable through the manage hierarchy either, so
+        the exclusion holds in effect and not only in the list
       And gateway permissions (virtual keys, budgets, providers, routing
         policies) and "project:manage" (model providers, project settings)
         are part of the default permission list
+
+    @unit
+    Scenario: project administration rides along with project settings
+      Given "project:manage" is in the default permission list, because model
+        providers and project settings check it
+      When a request checks "project:create" or "project:delete"
+      Then the manage grant answers it, so the default list names both rather
+        than withholding what the request path would still allow
+      And a user who wants project administration off the key sets Project to
+        Read on the authorize screen
 
   Rule: the user can customize scopes and permissions before approving
 
@@ -68,6 +77,14 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
       When the user approves and the CLI exchanges the device code
       Then the minted key has exactly one PROJECT-scoped binding for that project
       And its permission list contains "traces:view" but not "traces:update"
+
+    @integration
+    Scenario: the offered permissions are the intersection of every selected scope
+      Given the user is ADMIN on one shared team and VIEWER on another
+      And both teams are in the scope selection
+      When the user opens the authorize screen for the device code
+      Then only the permissions both teams grant are sent on approval
+      And the write level is unavailable on a row only one of the teams grants
 
     @integration
     Scenario: approval with zero scopes selected is refused
@@ -105,6 +122,14 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
       When the key is used to search traces on a project the owner can no
         longer view
       Then the request is refused with a 403
+
+    @integration
+    Scenario: a failed re-login leaves the previous key working
+      Given the user already has a login key for this device
+      When a second login from the same device fails at the mint
+      Then the previous key is still active, because the replacement is
+        created before the key it replaces is revoked
+      And no half-minted replacement outlives the failed exchange
 
     @integration
     Scenario: access lost between approve and exchange ends the login

--- a/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+++ b/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
@@ -53,6 +53,8 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
       Then "organization:manage", "organization:delete", "project:create",
         "project:delete" and "team:manage" are not part of the default
         permission list
+      And a key holding "project:manage" still cannot create or delete a
+        project, so the exclusion holds in effect and not only in the list
       And gateway permissions (virtual keys, budgets, providers, routing
         policies) and "project:manage" (model providers, project settings)
         are part of the default permission list
@@ -103,6 +105,16 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
       When the key is used to search traces on a project the owner can no
         longer view
       Then the request is refused with a 403
+
+    @integration
+    Scenario: access lost between approve and exchange ends the login
+      Given the user approved the device code
+      But the user loses the access the selection was approved against before
+        the CLI polls the exchange endpoint
+      When the CLI polls the exchange endpoint
+      Then the response is a fatal "access_denied" telling the user to log in
+        again
+      And the device code is gone, so the next poll cannot re-run the mint
 
     @integration
     Scenario: approve refuses bindings above the approving user's ceiling

--- a/specs/api-keys/scope-based-permissions.feature
+++ b/specs/api-keys/scope-based-permissions.feature
@@ -270,9 +270,10 @@ Feature: API Key Scope and Fine-Grained Permissions
 
   @unit
   Scenario: permissionsSummary counts granted categories for restricted keys
-    Given a key with 3 permission categories granted
+    Given a key with 3 of the registry's permission categories granted
     When I compute the permissions summary
-    Then the result is "3 of 14 permissions"
+    Then the result reads "3 of N permissions", where N is the number of
+      categories the registry offers
 
   @unit
   Scenario: scopeLabel formats project scope correctly

--- a/specs/api-keys/scope-based-permissions.feature
+++ b/specs/api-keys/scope-based-permissions.feature
@@ -98,15 +98,19 @@ Feature: API Key Scope and Fine-Grained Permissions
       | Secrets                | read, write   |
       | Audit Log              | read          |
       | Team                   | read, write   |
-      | Project settings       | read, write   |
-      | Project administration | write         |
+      | Project                | read, write   |
       | Organization           | read, write   |
       | Gateway                | read, write   |
       | Governance             | read, write   |
 
-  # Project creation and deletion sit in their own write-only category, so a key
-  # can carry project settings without carrying the power to create or destroy
-  # a project.
+  @unit
+  Scenario: Project write carries creation and deletion, because manage implies them
+    Given a category "Project" with "write" selected
+    When I compute the backend permissions
+    Then the result includes "project:create" and "project:delete"
+    And a check for "project:create" is answered by "project:manage", so a
+      category that offered project settings alone would describe a
+      separation the request path does not make
 
   @unit
   Scenario: Every registry permission belongs to a category
@@ -133,8 +137,7 @@ Feature: API Key Scope and Fine-Grained Permissions
       | Scenarios              | scenarios:view, scenarios:create, scenarios:update, scenarios:delete, scenarios:manage |
       | Audit Log              | auditLog:view                                                            |
       | Team                   | team:view, team:manage                                                   |
-      | Project settings       | project:view, project:update, project:manage                             |
-      | Project administration | project:create, project:delete                                           |
+      | Project                | project:view, project:create, project:update, project:delete, project:manage |
 
   @unit
   Scenario: Older stored keys keep reading as write via the manage hierarchy

--- a/specs/api-keys/scope-based-permissions.feature
+++ b/specs/api-keys/scope-based-permissions.feature
@@ -81,26 +81,40 @@ Feature: API Key Scope and Fine-Grained Permissions
     Given the permission registry
     When I list the available categories
     Then the categories include:
-      | category    | access levels |
-      | Traces      | read, write   |
-      | Cost        | read          |
-      | Scenarios   | read, write   |
-      | Annotations | read, write   |
-      | Analytics   | read, write   |
-      | Evaluations | read, write   |
-      | Datasets    | read, write   |
-      | Triggers    | read, write   |
-      | Workflows   | read, write   |
-      | Prompts     | read, write   |
-      | Secrets     | read, write   |
-      | Audit Log   | read          |
-      | Team        | read, write   |
-      | Project     | read, write   |
+      | category               | access levels |
+      | Traces                 | read, write   |
+      | Cost                   | read          |
+      | Scenarios              | read, write   |
+      | Annotations            | read, write   |
+      | Analytics              | read, write   |
+      | Evaluations            | read, write   |
+      | Langy                  | read, write   |
+      | Datasets               | read, write   |
+      | Triggers               | read, write   |
+      | Workflows              | read, write   |
+      | Experiments            | read, write   |
+      | Prompts                | read, write   |
+      | Playground             | read, write   |
+      | Secrets                | read, write   |
+      | Audit Log              | read          |
+      | Team                   | read, write   |
+      | Project settings       | read, write   |
+      | Project administration | write         |
+      | Organization           | read, write   |
+      | Gateway                | read, write   |
+      | Governance             | read, write   |
 
-  # Deferred: Gateway permissions (virtualKeys, gatewayBudgets, gatewayProviders,
-  # gatewayGuardrails, gatewayCacheRules, gatewayUsage) inherit from the scope's
-  # built-in role. Fine-grained gateway control will be added when the gateway UI
-  # supports per-key configuration.
+  # Project creation and deletion sit in their own write-only category, so a key
+  # can carry project settings without carrying the power to create or destroy
+  # a project.
+
+  @unit
+  Scenario: Every registry permission belongs to a category
+    Given the permission registry
+    When I list the permissions every category names
+    Then every registry permission appears in exactly one category
+    And the only permissions left out are the platform tier ("ops:view",
+      "ops:manage"), which can never ride on an API key
 
   @unit
   Scenario: "read" access maps to view permission
@@ -113,21 +127,21 @@ Feature: API Key Scope and Fine-Grained Permissions
     Given the permission registry
     When I compute "write" permissions for each category
     Then the exact backend permissions are:
-      | category    | permissions                                                    |
-      | Traces      | traces:view, traces:create, traces:update, traces:share        |
-      | Cost        | cost:view                                                      |
-      | Scenarios   | scenarios:view, scenarios:manage                               |
-      | Annotations | annotations:view, annotations:manage                           |
-      | Analytics   | analytics:view, analytics:manage                               |
-      | Evaluations | evaluations:view, evaluations:manage                           |
-      | Datasets    | datasets:view, datasets:manage                                 |
-      | Triggers    | triggers:view, triggers:manage                                 |
-      | Workflows   | workflows:view, workflows:manage                               |
-      | Prompts     | prompts:view, prompts:manage                                   |
-      | Secrets     | secrets:view, secrets:manage                                   |
-      | Audit Log   | auditLog:view                                                  |
-      | Team        | team:view, team:manage                                         |
-      | Project     | project:view, project:create, project:update, project:delete, project:manage |
+      | category               | permissions                                                              |
+      | Traces                 | traces:view, traces:create, traces:update, traces:share                  |
+      | Cost                   | cost:view                                                                |
+      | Scenarios              | scenarios:view, scenarios:create, scenarios:update, scenarios:delete, scenarios:manage |
+      | Audit Log              | auditLog:view                                                            |
+      | Team                   | team:view, team:manage                                                   |
+      | Project settings       | project:view, project:update, project:manage                             |
+      | Project administration | project:create, project:delete                                           |
+
+  @unit
+  Scenario: Older stored keys keep reading as write via the manage hierarchy
+    Given a stored key whose permissions are "datasets:view" and
+      "datasets:manage", written before the expanded write lists
+    When the drawer maps those permissions back to category selections
+    Then the Datasets category reads as "write"
 
   @unit
   Scenario: Selecting no categories produces an empty permission set

--- a/specs/typescript-sdk/cli-cross-project-access.feature
+++ b/specs/typescript-sdk/cli-cross-project-access.feature
@@ -1,0 +1,81 @@
+Feature: CLI cross-project access with the user-scoped login key
+
+  After `langwatch login`, the CLI holds a user-scoped API key whose reach the
+  user selected on the authorize screen. Data commands keep defaulting to the
+  personal project, and a `--project <id|slug>` flag points any trace command
+  at another project the key can reach. `langwatch projects list` shows which
+  projects those are.
+
+  Pairs with:
+    - specs/ai-governance/cli-onboarding/login-user-scoped-key.feature  (minting)
+    - specs/typescript-sdk/cli-projects-api-keys.feature                (projects commands)
+
+  Background:
+    Given the user completed `langwatch login` against a server that mints
+      user-scoped CLI keys
+    And `~/.langwatch/config.json` holds the minted `cli_api_key`
+    And no `LANGWATCH_API_KEY` is set in the environment or `.env`
+
+  Rule: credential resolution prefers the user-scoped key for session logins
+
+    @integration
+    Scenario: data commands authenticate with the user-scoped key
+      When the user runs `langwatch trace search`
+      Then the request authenticates with the stored `cli_api_key`
+      And targets the personal project, matching the pre-existing default
+
+    @integration
+    Scenario: explicit credentials still win over the session key
+      Given `LANGWATCH_API_KEY` is set in the environment
+      When the user runs `langwatch trace search`
+      Then the request authenticates with `LANGWATCH_API_KEY`
+      And the stored `cli_api_key` is not used
+
+    @integration
+    Scenario: a server without user-scoped keys falls back to the old behavior
+      Given the exchange response carried no `cli_api_key`
+      When the user runs `langwatch trace search`
+      Then the request authenticates with the personal project's API key,
+        exactly as before this feature
+
+  Rule: --project selects the target project by id or slug
+
+    @integration
+    Scenario: trace search against another project by id
+      Given the key reaches a project with id "proj-b"
+      When the user runs `langwatch trace search --project proj-b`
+      Then the search request is scoped to "proj-b"
+
+    @integration
+    Scenario: trace search against another project by slug
+      Given the key reaches a project with slug "checkout-agent"
+      When the user runs `langwatch trace search --project checkout-agent`
+      Then the CLI resolves the slug through the project list
+      And the search request is scoped to that project's id
+
+    @integration
+    Scenario: --project outside the key's reach fails with a clear message
+      Given the key does not reach project "someone-elses"
+      When the user runs `langwatch trace get abc123 --project someone-elses`
+      Then the command exits non-zero
+      And the error names the project and says the login key has no access to it
+
+    @integration
+    Scenario: --project with an unknown slug fails with a clear message
+      When the user runs `langwatch trace search --project does-not-exist`
+      Then the command exits non-zero
+      And the error says no accessible project matches "does-not-exist"
+
+  Rule: projects list shows the key's reach
+
+    @integration
+    Scenario: projects list shows every project the key can view
+      Given the key is bound to the whole organization
+      When the user runs `langwatch projects list`
+      Then every project of the organization is listed with id and slug
+
+    @integration
+    Scenario: whoami summarises the login key's scope
+      When the user runs `langwatch whoami`
+      Then the output names the organization and states whether the login key
+        covers the whole organization or a subset of projects


### PR DESCRIPTION
## What

`langwatch login` (device-session flow) now mints a user-scoped API key that inherits the user's permissions, instead of only handing the CLI the personal project's key. An org admin can read traces from every project through the CLI; a member gets exactly their teams plus their personal workspace.

- The `/cli/auth` authorize screen shows what the CLI will be able to access before approval: a multi-scope picker (organization chip for org admins, team chips plus personal workspace for members) and a permission summary with a Customize section.
- The default permission set is everything the user holds except organization management: `organization:manage`, `organization:delete`, `team:manage` and `ops:*` stay off unless the user opts in. Gateway, model providers, and all day-to-day resources stay on.
- One deliberate trade-off inside that default: `project:manage` stays on because model providers, project settings and topic clustering all check it, and the role model treats `:manage` as the umbrella grant for its resource, so `hasPermissionWithHierarchy` answers a `project:create` or `project:delete` check with it. The default therefore covers project administration, and names `project:create` and `project:delete` rather than listing an exclusion the request path would not honour. A key minted this way is still capped by the owner's live permissions, so it cannot escalate. Set Project to Read under Customize to drop it, which turns model provider writes off with it.
- The key is a normal `ApiKey` row: `permissionMode: "restricted"`, owned by the user, so every request is enforced as key bindings intersected with the owner's live permissions. Demote the user and the key shrinks with them.
- Minted at exchange time only (an approval that is never exchanged mints nothing). Re-login from the same device revokes the previous key for that device label; logout revokes it too.
- `GET /api/projects` now returns a filtered 200 for credentials that do not reach org scope, instead of a 403.
- CLI: stores the key in `~/.langwatch/config.json`, prefers it for data commands (the personal project stays the default target), adds `--project <id|slug>` to `trace search|get|transcript|export` and `session events`, and `whoami` reports the key's reach. Older servers (no `cli_api_key` in the exchange) keep today's behavior.
- The API key permission categories now cover the whole permission registry (new Gateway, Governance, Organization, Playground categories), so the Customize view can express the default exactly. This also improves the settings API keys drawers: organization admins are no longer locked out of the category rows the team-role bags do not carry, and a multi-scope key shows the ceiling every selected scope grants rather than the first one's.

## Specs

- `specs/ai-governance/cli-onboarding/login-user-scoped-key.feature` (19/19 scenarios bound)
- `specs/typescript-sdk/cli-cross-project-access.feature` (9/9 scenarios bound)
- `specs/api-keys/scope-based-permissions.feature` (21/21 scenarios bound)

## Error paths

- `cli_key_selection_invalid` (422, field errors) for empty or unknown selections, with presentation copy.
- Selections above the approving user's ceiling refuse with the existing `api_key_scope_violation`.
- A mint failure at exchange fails the login with a handled error; no partial login. The replacement is created before the key it replaces is revoked, so a failed re-login leaves the key already in the user's CLI config working. A refusal that cannot succeed on a retry burns the device code and answers `access_denied`, which the CLI treats as fatal.
- CLI: `--project` with an unreachable or unknown project exits non-zero naming the input; a default target the key does not cover reports the missing permission and the key id.

## QA (dogfooded end to end on a local stack)

Full flow exercised as a real user three times over: login, approve with the org-admin default, `whoami` ("Login key: whole organization"), `projects list` (16 projects), `trace search --project scenario-ci-dogfood` by slug across projects; then a second login narrowed to one project (key replaced per device label, listing filtered to exactly that project, out-of-reach project refused with a named error, default personal target refused with the missing permission); then logout (key revoked server-side, config cleared).

Re-driven in a browser after the Project category merge: the Customize view lists 20 categories with one Project row seeded to Write, approve mints an organization-scoped key, and `GET /api/projects` with that key returns all 16 projects. The stored permission list is 121 entries carrying `project:manage`, `project:create` and `project:delete`, without `organization:manage`, `team:manage` or the platform tier, which is what the screen said it would grant.

Authorize screen, org admin default:

![authorize defaults](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7410/authorize/authorize-org-admin-default.png)

Scope and permission summary before approving:

![scope and permissions](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7410/authorize/authorize-scope-permissions.png)

Customize, seeded with the default (one Project category at Write, Team and Organization at Read, Gateway and Governance on):

![customize categories](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7410/authorize/authorize-customize-final.png)

Narrowed to a single project before approving:

![narrowed scope](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7410/authorize/authorize-narrowed-scope.png)

Signed in:

![success](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7410/authorize/authorize-success.png)

```
$ langwatch whoami
User:         dogfood@langwatch.local
Organization: Rogerio Org
Login key:    whole organization

$ langwatch trace search --project scenario-ci-dogfood --start-date 2026-08-01 --limit 1 -f json
{ "traces": [ { "trace_id": "2e4ce3ace33abd99...", "project_id": "project_0002rD4UzUZVSegrE3orvIVSQHcTB", ... } ] }

$ langwatch trace search --project does-not-exist
Error: no accessible project matches "does-not-exist". Your login key has no access to a project with that id or slug.
```

Coverage note: the member (non-admin) default selection (team chips plus personal workspace) is covered by component and backend integration tests; the live browser pass used an org admin account.

One note from QA: the key's bindings land through the grants ledger with the standard read-your-writes convergence window, so on a backlogged fold the first command right after login can briefly see an empty project list. On a healthy system the window absorbs this (the local repro required a broken projection table).

## Deployment Impact

Additive API surface: the exchange response gains optional `cli_api_key` and `cli_api_key_scope` fields; old CLIs ignore them and keep receiving the personal project key. Device-session logins now create one `ApiKey` row per device (replaced on re-login, revoked on logout). `GET /api/projects` changes from refusing non-org-scoped credentials (403) to returning the filtered project list (200). No migrations, no new environment variables, no feature flags beyond the existing `release_ui_ai_governance_enabled` gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI device login lets you review and customize project scopes and permissions before approval.
  - CLI commands support selecting projects by ID or slug with `--project`.
  - `whoami` reports the active login key’s organization or project scope.
  - Login keys are replaced on re-login and revoked on logout.
  - Project listings respect API-key visibility and current access permissions.
- **Bug Fixes**
  - Improved permission availability and validation, with clearer errors for invalid or overly broad selections.
- **Documentation**
  - Added guidance for scoped CLI login keys and cross-project access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
