### PR TITLE
feat(home): give the first-trace pill the one setup menu

### DIFF
--- a/platform/app/src/components/SetupWithAgentButton.tsx
+++ b/platform/app/src/components/SetupWithAgentButton.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, chakra, HStack, Text } from "@chakra-ui/react";
+import type React from "react";
 import { useState } from "react";
 import {
   LuBookOpen,
@@ -188,8 +189,12 @@ export function AgentActionsMenu({
 }: {
   /** Labels the default outline button. Ignored when `trigger` is given. */
   triggerLabel?: string;
-  /** A trigger of the surface's own, in place of the default button. */
-  trigger?: React.ReactNode;
+  /**
+   * A trigger of the surface's own, in place of the default button.
+   * One element, because `Menu.Trigger asChild` clones it with the
+   * handlers and the ref: a string or a list has nowhere to put them.
+   */
+  trigger?: React.ReactElement;
   /** Match the sibling buttons of the surface this sits in. */
   size?: "sm" | "md";
   /**

--- a/platform/app/src/components/SetupWithAgentButton.tsx
+++ b/platform/app/src/components/SetupWithAgentButton.tsx
@@ -171,23 +171,41 @@ export function SetupWithAgentButton({
 }
 
 /**
- * The one agent-actions menu shell: trigger button, the Langy entry (shown
- * only when the viewer can ask Langy), the copy-a-prompt entry with its
- * confirmation toast, and the docs link. `SetupWithAgentButton` and the /me
- * `ConnectYourAgentButton` are both thin configurations of this, so the two
- * controls can never drift apart in anatomy or behavior.
+ * The one agent-actions menu shell: a trigger, the copy-a-prompt entry with
+ * its confirmation toast, the Langy entry (shown only when the viewer can
+ * ask Langy), and the docs link. `SetupWithAgentButton`, the home
+ * `OnboardAgentPill` and the /me `ConnectYourAgentButton` are all thin
+ * configurations of this, so the controls can never drift apart in anatomy
+ * or behavior.
  */
 export function AgentActionsMenu({
   triggerLabel,
+  trigger,
   size = "sm",
   langy,
   copy,
   docs,
 }: {
-  triggerLabel: string;
+  /** Labels the default outline button. Ignored when `trigger` is given. */
+  triggerLabel?: string;
+  /** A trigger of the surface's own, in place of the default button. */
+  trigger?: React.ReactNode;
   /** Match the sibling buttons of the surface this sits in. */
   size?: "sm" | "md";
-  langy: { prompt: string; label: string; hint: string };
+  /**
+   * Null where the surface already knows Langy is out of reach. Otherwise
+   * the entry still needs `useCanAskLangy` to agree.
+   */
+  langy: {
+    prompt: string;
+    label: string;
+    hint: string;
+    /**
+     * Takes the prompt instead of the Langy store, for a surface that
+     * animates its own composer on the way in.
+     */
+    onAsk?: (prompt: string) => void;
+  } | null;
   copy: {
     /** What the reader gets while the skill is still on its way. */
     prompt: string;
@@ -201,7 +219,13 @@ export function AgentActionsMenu({
     /** The endpoint that token belongs to, on a self-hosted deployment. */
     endpoint?: string;
   };
-  docs: { href: string; label: string; hint: string };
+  docs: {
+    href: string;
+    label: string;
+    hint: string;
+    /** Overrides the book glyph where the surface reads better with another. */
+    icon?: typeof LuBookOpen;
+  };
 }) {
   const canAsk = useCanAskLangy();
   const askLangy = useLangyStore((s) => s.askLangy);
@@ -240,11 +264,13 @@ export function AgentActionsMenu({
         {/* The same outline/size the primary actions on these pages wear
             (PageLayout.HeaderButton), so the control reads as one of the
             page's own buttons rather than a themed import. */}
-        <Button variant="outline" size={size} aria-haspopup="menu">
-          <LuSparkles size={14} />
-          {triggerLabel}
-          <LuChevronDown size={14} />
-        </Button>
+        {trigger ?? (
+          <Button variant="outline" size={size} aria-haspopup="menu">
+            <LuSparkles size={14} />
+            {triggerLabel}
+            <LuChevronDown size={14} />
+          </Button>
+        )}
       </Menu.Trigger>
       <Menu.Content minWidth="300px" padding={1}>
         <Menu.Item value="copy-prompt" paddingY={2} onClick={copyPrompt}>
@@ -254,11 +280,11 @@ export function AgentActionsMenu({
             hint={copy.hint}
           />
         </Menu.Item>
-        {canAsk ? (
+        {langy && canAsk ? (
           <Menu.Item
             value="ask-langy"
             paddingY={2}
-            onClick={() => askLangy(langy.prompt)}
+            onClick={() => (langy.onAsk ?? askLangy)(langy.prompt)}
           >
             <AgentMenuOption
               icon={LuSparkles}
@@ -271,7 +297,7 @@ export function AgentActionsMenu({
         <Menu.Item value="docs" paddingY={2} asChild>
           <chakra.a href={docs.href} target="_blank" rel="noreferrer">
             <AgentMenuOption
-              icon={LuBookOpen}
+              icon={docs.icon ?? LuBookOpen}
               label={docs.label}
               hint={docs.hint}
             />

--- a/platform/app/src/components/home/OnboardAgentPill.tsx
+++ b/platform/app/src/components/home/OnboardAgentPill.tsx
@@ -1,38 +1,30 @@
-import { Box, chakra, HStack, Text } from "@chakra-ui/react";
+import { Box, chakra, HStack } from "@chakra-ui/react";
+import type React from "react";
 import { LuBot, LuChevronDown, LuSparkles, LuTerminal } from "react-icons/lu";
-import { Menu } from "~/components/ui/menu";
-import { toaster } from "~/components/ui/toaster";
+import {
+  AgentActionsMenu,
+  setupAgentPrompt,
+} from "~/components/SetupWithAgentButton";
+import { selfHostedEndpoint } from "~/features/traces-v2/onboarding/logic/selfHostedEndpoint";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { usePublicEnv } from "~/hooks/usePublicEnv";
 
 const INTEGRATION_DOCS = "https://docs.langwatch.ai/integration/overview";
 
-/**
- * The prompt you hand to YOUR coding agent.
- *
- * This is the honest version of "onboard your agent": most people reading this
- * line are about to go and instrument a codebase, and the fastest way through
- * that is not a tab of documentation, it is a brief their own agent can act on.
- * It names the docs rather than reciting an API, because reciting one here is
- * how it silently goes stale the next time the SDK changes.
- */
-const CODING_AGENT_PROMPT = `Instrument this codebase with LangWatch so I can see my agent's traces.
-
-Read the integration guide at ${INTEGRATION_DOCS} and pick the SDK that matches this project. Then:
-1. Add the dependency and initialise it where the app starts.
-2. Read the API key from the environment, never hardcode it.
-3. Instrument the main agent or LLM call path so a request produces one trace.
-4. Tell me what you changed and how to verify a trace arrives.`;
+const LANGY_WALKTHROUGH_PROMPT =
+  "Walk me through sending my first trace to this project. Ask me what my agent is built with, then give me the exact steps.";
 
 /**
- * The route into agent onboarding: friendly copy, tool glyphs in their own
- * small tiles.
+ * The route into agent onboarding on the home page: friendly copy, tool
+ * glyphs in their own small tiles.
  *
- * Its own component because it has two homes and, more importantly, because
- * what it DOES changed. It used to be a link to the docs, which on a page
- * whose whole premise is "ask for what you want in plain language" was the one
- * control that shrugged and sent you to read. Now it offers the two ways
- * people actually onboard an agent: hand the job to Langy, or take a brief
- * away to the coding agent already open in their editor. The docs are still
- * there, third, for the reader who wanted them all along.
+ * It offers the two ways people actually onboard an agent: take the tracing
+ * skill away to the coding agent already open in their editor, or hand the
+ * job to Langy. The docs are third, for the reader who wanted them all along.
+ *
+ * The menu itself is `AgentActionsMenu`, the same one every empty state
+ * carries, so the routes stay in one order and the copied text stays the one
+ * text. Only the trigger and the wording are this surface's own.
  *
  * `onAskLangy` is optional, and its absence is meaningful: on a page where
  * Langy is not available that item must not appear, rather than appear and
@@ -46,177 +38,138 @@ export function OnboardAgentPill({
   onAskLangy?: (prompt: string) => void;
   /**
    * Lead with it rather than tuck it away. For a project with no data, this is
-   * not one option among several — it is the only thing that makes the rest of
+   * not one option among several: it is the only thing that makes the rest of
    * the page mean anything, so it stops being a quiet outline at the end of a
    * row and becomes the filled control the eye lands on.
    */
   prominent?: boolean;
 } = {}) {
-  // A toast, not an inline "Copied" label. The label lived inside a Menu.Item
-  // and zag's menu closes on select, so the confirmation rendered into a menu
-  // that was already gone — it was unreachable, and a copy that says nothing is
-  // indistinguishable from one that failed. The toast also gives the rejection
-  // path somewhere to go; it used to be swallowed.
-  const copyPrompt = () => {
-    void navigator.clipboard?.writeText(CODING_AGENT_PROMPT).then(
-      () =>
-        toaster.create({
-          type: "success",
-          title: "Prompt copied. Paste it to your coding agent",
-        }),
-      () =>
-        toaster.create({
-          type: "error",
-          title: "Couldn't copy the prompt",
-        }),
-    );
-  };
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const publicEnv = usePublicEnv();
 
   return (
-    <Menu.Root positioning={{ placement: "bottom-end", gutter: 6 }}>
-      <Menu.Trigger asChild>
-        <chakra.button
-          type="button"
-          /* It opens a menu — it does not fire a prompt like the asks beside
-             it do. Announce that, and show it (the caret below). */
-          aria-haspopup="menu"
-          display="inline-flex"
-          alignItems="center"
-          gap={2}
-          whiteSpace="nowrap"
-          borderWidth="1px"
-          borderColor={prominent ? "orange.emphasized" : "border.emphasized"}
-          borderRadius="full"
-          /* A DIFFERENT SHADE on purpose. The asks around this are borrowable
-             questions on the panel's translucent chip surface; this is the one
-             control that goes and does something — it hands you a prompt to
-             take away, or a link to follow. Sitting it on the solid raised
-             surface, a step darker than the chips, is what says "not one of
-             those" before the caret confirms it. */
-          background={prominent ? "orange.subtle" : "bg.muted"}
-          paddingLeft={prominent ? 4 : 3}
-          paddingRight="4px"
-          paddingY={prominent ? "5px" : "3px"}
-          boxShadow={prominent ? "xs" : "2xs"}
-          cursor="pointer"
-          transition="border-color 130ms ease, background 130ms ease"
-          _hover={{
-            borderColor: prominent ? "orange.solid" : "border.emphasized",
-            background: prominent ? "orange.muted" : "bg.emphasized",
-          }}
-        >
-          <chakra.span
-            fontSize={prominent ? "13px" : "12px"}
-            fontWeight={prominent ? "medium" : undefined}
-            color={prominent ? "orange.fg" : "fg"}
-          >
-            {prominent ? "Send your first trace" : "Onboard your agent"}
-          </chakra.span>
-          <HStack gap="3px">
-            {[
-              { Glyph: LuBot, color: "fg.muted" },
-              { Glyph: LuTerminal, color: "fg.muted" },
-              { Glyph: LuSparkles, color: "orange.fg" },
-            ].map(({ Glyph, color }, i) => (
-              <Box
-                key={i}
-                boxSize="18px"
-                borderRadius="5px"
-                /* The pill's own ground went a step darker, so the tiles take
-                   the raised surface to stay legible against it. */
-                background="bg.surface"
-                borderWidth="1px"
-                borderColor="border.muted"
-                display="grid"
-                placeItems="center"
-                color={color}
-              >
-                <Glyph size={10} />
-              </Box>
-            ))}
-          </HStack>
-          {/* The caret is the interaction, stated. An ask fires the moment you
-              click it; this one opens and asks you to choose a route, and a
-              control should look like what it does before you touch it. */}
-          <Box
-            aria-hidden
-            display="grid"
-            color="fg.subtle"
-            paddingRight="3px"
-            flexShrink={0}
-          >
-            <LuChevronDown size={13} />
-          </Box>
-        </chakra.button>
-      </Menu.Trigger>
-      <Menu.Content minWidth="280px" padding={1}>
-        {onAskLangy ? (
-          <Menu.Item
-            value="ask-langy"
-            paddingY={2}
-            onClick={() =>
-              onAskLangy(
-                "Walk me through sending my first trace to this project. Ask me what my agent is built with, then give me the exact steps.",
-              )
+    <AgentActionsMenu
+      trigger={<OnboardPillTrigger prominent={prominent} />}
+      langy={
+        onAskLangy
+          ? {
+              prompt: LANGY_WALKTHROUGH_PROMPT,
+              onAsk: onAskLangy,
+              label: "Walk me through it",
+              hint: "Langy asks what you are building, then gives you the steps",
             }
-          >
-            <OnboardOption
-              icon={LuSparkles}
-              accent
-              label="Walk me through it"
-              hint="Langy asks what you are building, then gives you the steps"
-            />
-          </Menu.Item>
-        ) : null}
-        <Menu.Item value="copy-prompt" paddingY={2} onClick={copyPrompt}>
-          <OnboardOption
-            icon={LuTerminal}
-            label="Copy a prompt for your coding agent"
-            hint="Paste it into Claude Code, Cursor, or whatever you use"
-          />
-        </Menu.Item>
-        <Menu.Item value="docs" paddingY={2} asChild>
-          <chakra.a href={INTEGRATION_DOCS} target="_blank" rel="noreferrer">
-            <OnboardOption
-              icon={LuBot}
-              label="Read the integration guide"
-              hint="Every SDK, and what each one instruments"
-            />
-          </chakra.a>
-        </Menu.Item>
-      </Menu.Content>
-    </Menu.Root>
+          : null
+      }
+      copy={{
+        prompt: setupAgentPrompt("traces"),
+        skill: "tracing",
+        // The project's own key, so the agent gets a setup it can run rather
+        // than one that stops to ask for credentials.
+        apiKey: project?.apiKey,
+        endpoint: selfHostedEndpoint(publicEnv.data?.BASE_HOST) ?? undefined,
+        label: "Copy a prompt for your coding agent",
+        hint: "Paste it into Claude Code, Cursor, or whatever you use",
+        copiedTitle: "Prompt copied. Paste it to your coding agent",
+      }}
+      docs={{
+        href: INTEGRATION_DOCS,
+        icon: LuBot,
+        label: "Read the integration guide",
+        hint: "Every SDK, and what each one instruments",
+      }}
+    />
   );
 }
 
-function OnboardOption({
-  icon: Icon,
-  label,
-  hint,
-  accent = false,
-}: {
-  icon: typeof LuBot;
-  label: string;
-  hint: string;
-  accent?: boolean;
-}) {
+/**
+ * The pill itself. A different shade from the asks beside it on purpose, and
+ * the tiles read left to right in the order the menu offers its routes.
+ *
+ * The menu opens it through `asChild`, which clones this element with the
+ * handlers and the ref it needs, so everything but `prominent` goes straight
+ * through to the button. Swallow them and the pill stops opening anything.
+ */
+function OnboardPillTrigger({
+  prominent,
+  ...menuProps
+}: { prominent: boolean } & React.ComponentProps<typeof chakra.button>) {
   return (
-    <HStack gap={2.5} width="full" align="start">
-      <Box
-        color={accent ? "orange.fg" : "fg.subtle"}
-        display="grid"
-        paddingTop="2px"
+    <chakra.button
+      type="button"
+      /* It opens a menu — it does not fire a prompt like the asks beside
+         it do. Announce that, and show it (the caret below). */
+      aria-haspopup="menu"
+      {...menuProps}
+      display="inline-flex"
+      alignItems="center"
+      gap={2}
+      whiteSpace="nowrap"
+      borderWidth="1px"
+      borderColor={prominent ? "orange.emphasized" : "border.emphasized"}
+      borderRadius="full"
+      /* A DIFFERENT SHADE on purpose. The asks around this are borrowable
+         questions on the panel's translucent chip surface; this is the one
+         control that goes and does something — it hands you a prompt to
+         take away, or a link to follow. Sitting it on the solid raised
+         surface, a step darker than the chips, is what says "not one of
+         those" before the caret confirms it. */
+      background={prominent ? "orange.subtle" : "bg.muted"}
+      paddingLeft={prominent ? 4 : 3}
+      paddingRight="4px"
+      paddingY={prominent ? "5px" : "3px"}
+      boxShadow={prominent ? "xs" : "2xs"}
+      cursor="pointer"
+      transition="border-color 130ms ease, background 130ms ease"
+      _hover={{
+        borderColor: prominent ? "orange.solid" : "border.emphasized",
+        background: prominent ? "orange.muted" : "bg.emphasized",
+      }}
+    >
+      <chakra.span
+        fontSize={prominent ? "13px" : "12px"}
+        fontWeight={prominent ? "medium" : undefined}
+        color={prominent ? "orange.fg" : "fg"}
       >
-        <Icon size={13} />
+        {prominent ? "Send your first trace" : "Onboard your agent"}
+      </chakra.span>
+      <HStack gap="3px">
+        {[
+          { Glyph: LuTerminal, color: "fg.muted" },
+          { Glyph: LuSparkles, color: "orange.fg" },
+          { Glyph: LuBot, color: "fg.muted" },
+        ].map(({ Glyph, color }, i) => (
+          <Box
+            key={i}
+            boxSize="18px"
+            borderRadius="5px"
+            /* The pill's own ground went a step darker, so the tiles take
+               the raised surface to stay legible against it. */
+            background="bg.surface"
+            borderWidth="1px"
+            borderColor="border.muted"
+            display="grid"
+            placeItems="center"
+            color={color}
+          >
+            <Glyph size={10} />
+          </Box>
+        ))}
+      </HStack>
+      {/* The caret is the interaction, stated. An ask fires the moment you
+          click it; this one opens and asks you to choose a route, and a
+          control should look like what it does before you touch it. */}
+      <Box
+        aria-hidden
+        display="grid"
+        color="fg.subtle"
+        paddingRight="3px"
+        flexShrink={0}
+      >
+        <LuChevronDown size={13} />
       </Box>
-      <Box minWidth={0} flex={1}>
-        <Text textStyle="xs" fontWeight="medium">
-          {label}
-        </Text>
-        <Text textStyle="2xs" color="fg.subtle" lineClamp={2}>
-          {hint}
-        </Text>
-      </Box>
-    </HStack>
+    </chakra.button>
   );
 }

--- a/platform/app/src/components/home/OnboardAgentPill.tsx
+++ b/platform/app/src/components/home/OnboardAgentPill.tsx
@@ -5,6 +5,7 @@ import {
   AgentActionsMenu,
   setupAgentPrompt,
 } from "~/components/SetupWithAgentButton";
+import { useCanAskLangy } from "~/features/langy/hooks/useCanAskLangy";
 import { selfHostedEndpoint } from "~/features/traces-v2/onboarding/logic/selfHostedEndpoint";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
@@ -49,12 +50,16 @@ export function OnboardAgentPill({
     redirectToProjectOnboarding: false,
   });
   const publicEnv = usePublicEnv();
+  const canAsk = useCanAskLangy();
+  // The same condition the menu itself applies, so the tiles on the pill
+  // count the routes the menu actually opens with.
+  const hasLangy = !!onAskLangy && canAsk;
 
   return (
     <AgentActionsMenu
-      trigger={<OnboardPillTrigger prominent={prominent} />}
+      trigger={<OnboardPillTrigger prominent={prominent} hasLangy={hasLangy} />}
       langy={
-        onAskLangy
+        hasLangy && onAskLangy
           ? {
               prompt: LANGY_WALKTHROUGH_PROMPT,
               onAsk: onAskLangy,
@@ -92,14 +97,58 @@ export function OnboardAgentPill({
  * handlers and the ref it needs, so everything but `prominent` goes straight
  * through to the button. Swallow them and the pill stops opening anything.
  */
+/**
+ * The two presentations, side by side.
+ *
+ * `lead` is the filled control a project with no data needs; `quiet` is the
+ * outline one that sits at the end of a row once there is data. A DIFFERENT
+ * SHADE from the asks around it in both cases: those are borrowable
+ * questions on the panel's translucent chip surface, and this is the one
+ * control that goes and does something. The solid raised surface, a step
+ * darker than the chips, is what says "not one of those" before the caret
+ * confirms it.
+ */
+const PILL_STYLES = {
+  lead: {
+    borderColor: "orange.emphasized",
+    background: "orange.subtle",
+    paddingLeft: 4,
+    paddingY: "5px",
+    boxShadow: "xs",
+    label: "Send your first trace",
+    fontSize: "13px",
+    fontWeight: "medium",
+    color: "orange.fg",
+    _hover: { borderColor: "orange.solid", background: "orange.muted" },
+  },
+  quiet: {
+    borderColor: "border.emphasized",
+    background: "bg.muted",
+    paddingLeft: 3,
+    paddingY: "3px",
+    boxShadow: "2xs",
+    label: "Onboard your agent",
+    fontSize: "12px",
+    fontWeight: undefined,
+    color: "fg",
+    _hover: { borderColor: "border.emphasized", background: "bg.emphasized" },
+  },
+} as const;
+
 function OnboardPillTrigger({
   prominent,
+  hasLangy,
   ...menuProps
-}: { prominent: boolean } & React.ComponentProps<typeof chakra.button>) {
+}: {
+  prominent: boolean;
+  /** Drops the Langy tile where the menu drops the Langy route. */
+  hasLangy: boolean;
+} & React.ComponentProps<typeof chakra.button>) {
+  const style = prominent ? PILL_STYLES.lead : PILL_STYLES.quiet;
   return (
     <chakra.button
       type="button"
-      /* It opens a menu — it does not fire a prompt like the asks beside
+      /* It opens a menu, it does not fire a prompt like the asks beside
          it do. Announce that, and show it (the caret below). */
       aria-haspopup="menu"
       {...menuProps}
@@ -108,37 +157,28 @@ function OnboardPillTrigger({
       gap={2}
       whiteSpace="nowrap"
       borderWidth="1px"
-      borderColor={prominent ? "orange.emphasized" : "border.emphasized"}
+      borderColor={style.borderColor}
       borderRadius="full"
-      /* A DIFFERENT SHADE on purpose. The asks around this are borrowable
-         questions on the panel's translucent chip surface; this is the one
-         control that goes and does something — it hands you a prompt to
-         take away, or a link to follow. Sitting it on the solid raised
-         surface, a step darker than the chips, is what says "not one of
-         those" before the caret confirms it. */
-      background={prominent ? "orange.subtle" : "bg.muted"}
-      paddingLeft={prominent ? 4 : 3}
+      background={style.background}
+      paddingLeft={style.paddingLeft}
       paddingRight="4px"
-      paddingY={prominent ? "5px" : "3px"}
-      boxShadow={prominent ? "xs" : "2xs"}
+      paddingY={style.paddingY}
+      boxShadow={style.boxShadow}
       cursor="pointer"
       transition="border-color 130ms ease, background 130ms ease"
-      _hover={{
-        borderColor: prominent ? "orange.solid" : "border.emphasized",
-        background: prominent ? "orange.muted" : "bg.emphasized",
-      }}
+      _hover={style._hover}
     >
       <chakra.span
-        fontSize={prominent ? "13px" : "12px"}
-        fontWeight={prominent ? "medium" : undefined}
-        color={prominent ? "orange.fg" : "fg"}
+        fontSize={style.fontSize}
+        fontWeight={style.fontWeight}
+        color={style.color}
       >
-        {prominent ? "Send your first trace" : "Onboard your agent"}
+        {style.label}
       </chakra.span>
       <HStack gap="3px">
         {[
           { Glyph: LuTerminal, color: "fg.muted" },
-          { Glyph: LuSparkles, color: "orange.fg" },
+          ...(hasLangy ? [{ Glyph: LuSparkles, color: "orange.fg" }] : []),
           { Glyph: LuBot, color: "fg.muted" },
         ].map(({ Glyph, color }, i) => (
           <Box

--- a/platform/app/src/components/home/__tests__/LangyHomeHero.integration.test.tsx
+++ b/platform/app/src/components/home/__tests__/LangyHomeHero.integration.test.tsx
@@ -12,7 +12,7 @@
  * and store, the ambient dev state, and the project's reach.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -40,6 +40,26 @@ vi.mock("../WelcomeHeader", () => ({
 const reachMock = vi.fn();
 vi.mock("../useProjectReach", () => ({
   useProjectReach: () => reachMock(),
+}));
+
+// The pill's menu is `AgentActionsMenu`, which reads the project for its
+// key and fetches the skill the copy hands over.
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project_1", apiKey: "sk-lw-home" },
+    organization: { id: "org_1" },
+  }),
+}));
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: { BASE_HOST: "https://app.langwatch.ai" } }),
+}));
+const SKILL_BODY = "# Add LangWatch Tracing to Your Code";
+vi.mock("~/utils/api", () => ({
+  api: {
+    setupSkills: {
+      getPrompt: { useQuery: () => ({ data: { body: SKILL_BODY } }) },
+    },
+  },
 }));
 
 import { LangyHomeHero } from "../LangyHomeHero";
@@ -97,17 +117,44 @@ describe("LangyHomeHero onboarding control", () => {
     });
 
     describe("when the pill's menu is opened with ask access", () => {
-      it("offers the walkthrough, the coding-agent prompt, and the docs", async () => {
+      it("offers the coding-agent prompt first, then the walkthrough, then the docs", async () => {
         reachMock.mockReturnValue(NEW_PROJECT_REACH);
         renderHero();
 
         await userEvent.click(onboardingTriggers()[0]!);
 
-        expect(await screen.findByText("Walk me through it")).toBeDefined();
-        expect(
-          screen.getByText("Copy a prompt for your coding agent"),
-        ).toBeDefined();
-        expect(screen.getByText("Read the integration guide")).toBeDefined();
+        const copy = await screen.findByText(
+          "Copy a prompt for your coding agent",
+        );
+        const walkthrough = screen.getByText("Walk me through it");
+        const docs = screen.getByText("Read the integration guide");
+
+        // The same order every empty page's setup menu offers.
+        expect(renders_before(copy, walkthrough)).toBe(true);
+        expect(renders_before(walkthrough, docs)).toBe(true);
+      });
+
+      it("copies the tracing skill led by the project's keys", async () => {
+        reachMock.mockReturnValue(NEW_PROJECT_REACH);
+        const writeText = vi.fn((_text: string) => Promise.resolve());
+        Object.defineProperty(navigator, "clipboard", {
+          value: { writeText },
+          configurable: true,
+        });
+        renderHero();
+
+        await userEvent.click(onboardingTriggers()[0]!);
+        await userEvent.click(
+          await screen.findByText("Copy a prompt for your coding agent"),
+        );
+
+        await waitFor(() => expect(writeText).toHaveBeenCalled());
+        const copied = writeText.mock.calls[0]?.[0] ?? "";
+        expect(copied.indexOf("Use these keys to instrument:")).toBe(0);
+        expect(copied).toContain('LANGWATCH_API_KEY="sk-lw-home"');
+        expect(copied.indexOf(SKILL_BODY)).toBeGreaterThan(0);
+        // Cloud is the SDK default, so no endpoint line to get wrong.
+        expect(copied).not.toContain("LANGWATCH_ENDPOINT");
       });
     });
 

--- a/platform/app/src/components/home/__tests__/LangyHomeHero.integration.test.tsx
+++ b/platform/app/src/components/home/__tests__/LangyHomeHero.integration.test.tsx
@@ -12,7 +12,7 @@
  * and store, the ambient dev state, and the project's reach.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -136,7 +136,11 @@ describe("LangyHomeHero onboarding control", () => {
 
       it("copies the tracing skill led by the project's keys", async () => {
         reachMock.mockReturnValue(NEW_PROJECT_REACH);
-        const writeText = vi.fn((_text: string) => Promise.resolve());
+        let copied = "";
+        const writeText = vi.fn((text: string) => {
+          copied = text;
+          return Promise.resolve();
+        });
         Object.defineProperty(navigator, "clipboard", {
           value: { writeText },
           configurable: true,
@@ -149,7 +153,6 @@ describe("LangyHomeHero onboarding control", () => {
         );
 
         await waitFor(() => expect(writeText).toHaveBeenCalled());
-        const copied = writeText.mock.calls[0]?.[0] ?? "";
         expect(copied.indexOf("Use these keys to instrument:")).toBe(0);
         expect(copied).toContain('LANGWATCH_API_KEY="sk-lw-home"');
         expect(copied.indexOf(SKILL_BODY)).toBeGreaterThan(0);
@@ -171,6 +174,23 @@ describe("LangyHomeHero onboarding control", () => {
         ).toBeDefined();
         expect(screen.queryByText("Walk me through it")).toBeNull();
         expect(screen.getByText("Read the integration guide")).toBeDefined();
+      });
+
+      it("drops the Langy glyph so the tiles still count the routes", () => {
+        canAskMock.mockReturnValue(false);
+        reachMock.mockReturnValue(NEW_PROJECT_REACH);
+        renderHero();
+
+        const withoutLangy =
+          onboardingTriggers()[0]!.querySelectorAll("svg").length;
+        cleanup();
+
+        canAskMock.mockReturnValue(true);
+        renderHero();
+        const withLangy =
+          onboardingTriggers()[0]!.querySelectorAll("svg").length;
+
+        expect(withoutLangy).toBe(withLangy - 1);
       });
     });
   });

--- a/platform/app/src/components/me/ConnectYourAgentButton.tsx
+++ b/platform/app/src/components/me/ConnectYourAgentButton.tsx
@@ -8,8 +8,8 @@ import { docsUrl } from "~/utils/docsUrl";
  *
  * The mirror image of `SetupWithAgentButton`: that one lives on empty states
  * and sets a feature up; this one appears only once usage EXISTS and hands an
- * agent the reader's own usage to explore. Same menu anatomy (Langy first,
- * copy-a-prompt, docs), different job.
+ * agent the reader's own usage to explore. Same menu anatomy (copy-a-prompt,
+ * Langy, docs), different job.
  *
  * The gate is `Project.firstMessage` on the personal project, the same
  * first-traces signal the authorize page's post-login watch polls

--- a/specs/home/langy-home.feature
+++ b/specs/home/langy-home.feature
@@ -109,7 +109,9 @@ Feature: The Langy home
     Given the Langy home renders
     And the project has never received a trace
     Then a prominent send-your-first-trace control sits above the example asks
-    And it offers Langy's walkthrough, a prompt for my coding agent, and the docs
+    And it offers the same routes in the same order as every empty page: the
+      prompt for my coding agent first, Langy's walkthrough second, the docs third
+    And the prompt it copies is the tracing skill, led by the project's keys
     And the walkthrough route is withheld when I cannot start conversations
 
   Scenario: A populated project keeps the quiet onboarding route

--- a/specs/home/langy-home.feature
+++ b/specs/home/langy-home.feature
@@ -111,8 +111,11 @@ Feature: The Langy home
     Then a prominent send-your-first-trace control sits above the example asks
     And it offers the same routes in the same order as every empty page: the
       prompt for my coding agent first, Langy's walkthrough second, the docs third
-    And the prompt it copies is the tracing skill, led by the project's keys
+    And the prompt it copies is the tracing skill, led by the project's keys,
+      falling back to the install line while the skill is still on its way
+      (specs/skills/empty-state-skill-setup.feature)
     And the walkthrough route is withheld when I cannot start conversations
+    And the control's glyphs count the routes it opens with
 
   Scenario: A populated project keeps the quiet onboarding route
     Given the Langy home renders


### PR DESCRIPTION
#7411 put the setup menu in one order on every empty page: the coding-agent prompt first, Langy second, the docs third, and the copied text is the skill itself. The "Send your first trace" pill on the home page missed that change, because it carried its own copy of the menu.

![The home pill's menu](https://github.com/langwatch/pr-screenshots/blob/main/instrument-declutter/home-pill-menu.png?raw=true)

## What changed

The pill is now a configuration of `AgentActionsMenu`, the shell the empty states and the /me "Connect your agent" control already use. All three carry one order and one copied text. Only the trigger and the wording stay the home's own, and the pill's three glyph tiles read in the order the menu offers its routes.

Its copy used to be a short brief telling the agent to go and read the integration guide. It is now the tracing skill, led by the project's keys, the same text the traces page hands over.

`AgentActionsMenu` gained three small slots to absorb it:

- `trigger`, in place of the default outline button.
- `langy`, which can be null where a surface already knows Langy is out of reach. The home passes null when the reader cannot start conversations, which is how that route stays withheld.
- `langy.onAsk`, for the home, which animates its own composer on the way in rather than calling the Langy store.

`ConnectYourAgentButton`'s comment still claimed "Langy first". Corrected.

## Testing

- `LangyHomeHero.integration.test.tsx`: the menu order, and the copied text being the skill led by the project's keys with no endpoint line on cloud. 6/6.
- 236 tests pass across the 41 files that mount either menu.
- `specs/home/langy-home.feature`: the first-trace control names the order and what the prompt carries. 18/18 bound, parity `OK: 8126`.
- Browser QA on the dogfood account: order reads Copy, Walk me through it, Read the integration guide; the copied text is 3098 characters opening with the keys block and the real project key, the tracing skill under it, and no `npx skills add` line. The request stays free of the token, as #7411 set up: `input={"0":{"json":{"projectId":"...","skill":"tracing"}}}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable action-menu triggers and documentation icons.
  * Added optional Langy actions with custom prompt handling.
  * Updated onboarding actions with coding-agent prompts, Langy guidance, and integration documentation.
  * Coding-agent prompts now include project credentials and tracing instructions, with an installation fallback while content loads.

* **Improvements**
  * Reordered onboarding options: copy a prompt, Langy walkthrough, then documentation.
  * Langy options and icons now reflect conversation availability.

* **Tests**
  * Expanded coverage for prompt contents, option order, and conditional Langy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->