### PR TITLE
fix(cli): the codex harvest reads the checkout, so a session reports the branch it is on

### DIFF
--- a/sdks/typescript/src/cli/utils/governance/__tests__/codex-turn-harvest.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/codex-turn-harvest.unit.test.ts
@@ -110,6 +110,28 @@ const spansOf = (bodies: any[]) =>
 const attrOf = (span: any, key: string) =>
 	span.attributes.find((a: any) => a.key === key)?.value?.stringValue;
 
+/** One attribute of the session-context record, from the logs POST. */
+const contextAttr = (bodies: any[], urls: string[], key: string) =>
+	attrOf(
+		bodies[urls.indexOf("https://e/v1/logs")].resourceLogs[0].scopeLogs[0]
+			.logRecords[0],
+		key,
+	);
+
+/**
+ * A working directory git answers for: the checkout the session is sitting in,
+ * on the branch it is on right now, which is what the harvest reads instead of
+ * trusting the transcript's record of the session's first minute.
+ */
+const checkoutOn =
+	(branch: string) =>
+	({ args }: { args: string[]; cwd: string }): string | null => {
+		if (args[0] === "remote") return "https://github.com/acme/acme-app.git";
+		if (args[0] === "branch") return branch;
+		// Not a linked worktree, so readWorktreeName finds nothing to name.
+		return null;
+	};
+
 describe("harvestCodexThread", () => {
 	describe("given a session that ran without the langwatch wrapper", () => {
 		describe("when its completed turn is harvested", () => {
@@ -351,6 +373,94 @@ describe("harvestCodexThread", () => {
 				expect(attr("vcs.repository.name")).toBe("acme-app");
 				expect(attr("vcs.ref.head.name")).toBe("feat/pricing");
 				expect(urls).toContain("https://e/v1/traces");
+			});
+
+			/** @scenario "The reported branch follows the checkout, not the session's first minute" */
+			it("reports the branch the checkout is on now", async () => {
+				writeRollout(THREAD, [
+					sessionMeta(GIT),
+					taskStarted(TRACE),
+					userMessage("hi"),
+					agentFinal("hello"),
+				]);
+				const { bodies, urls, impl } = recordingFetch();
+
+				await harvestCodexThread({
+					threadId: THREAD,
+					nowMs: 1785654950000,
+					endpoint: "https://e/v1/traces",
+					logsEndpoint: "https://e/v1/logs",
+					token: "sk-lw-test",
+					sessionsRoot: root,
+					stateDir,
+					fetchImpl: impl,
+					runGit: checkoutOn("review/pr-7412"),
+				});
+
+				expect(contextAttr(bodies, urls, "vcs.ref.head.name")).toBe(
+					"review/pr-7412",
+				);
+				expect(contextAttr(bodies, urls, "vcs.repository.name")).toBe(
+					"acme-app",
+				);
+			});
+
+			/** @scenario "A session whose transcript records no repository still reports one" */
+			it("reports the working directory's repository when the transcript has none", async () => {
+				writeRollout(THREAD, [
+					sessionMeta(),
+					taskStarted(TRACE),
+					userMessage("hi"),
+					agentFinal("hello"),
+				]);
+				const { bodies, urls, impl } = recordingFetch();
+
+				await harvestCodexThread({
+					threadId: THREAD,
+					nowMs: 1785654950000,
+					endpoint: "https://e/v1/traces",
+					logsEndpoint: "https://e/v1/logs",
+					token: "sk-lw-test",
+					sessionsRoot: root,
+					stateDir,
+					fetchImpl: impl,
+					runGit: checkoutOn("review/pr-7412"),
+				});
+
+				expect(contextAttr(bodies, urls, "vcs.repository.owner")).toBe("acme");
+				expect(contextAttr(bodies, urls, "vcs.ref.head.name")).toBe(
+					"review/pr-7412",
+				);
+			});
+
+			/** @scenario "A transcript harvested away from its checkout keeps what codex recorded" */
+			it("falls back to the transcript when git cannot read the directory", async () => {
+				writeRollout(THREAD, [
+					sessionMeta(GIT),
+					taskStarted(TRACE),
+					userMessage("hi"),
+					agentFinal("hello"),
+				]);
+				const { bodies, urls, impl } = recordingFetch();
+
+				await harvestCodexThread({
+					threadId: THREAD,
+					nowMs: 1785654950000,
+					endpoint: "https://e/v1/traces",
+					logsEndpoint: "https://e/v1/logs",
+					token: "sk-lw-test",
+					sessionsRoot: root,
+					stateDir,
+					fetchImpl: impl,
+					runGit: () => null,
+				});
+
+				expect(contextAttr(bodies, urls, "vcs.ref.head.name")).toBe(
+					"feat/pricing",
+				);
+				expect(contextAttr(bodies, urls, "vcs.repository.name")).toBe(
+					"acme-app",
+				);
 			});
 
 			/** @scenario "A notify that fires after every turn posts the repository once" */

--- a/sdks/typescript/src/cli/utils/governance/__tests__/codex-turn-harvest.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/codex-turn-harvest.unit.test.ts
@@ -111,12 +111,21 @@ const attrOf = (span: any, key: string) =>
 	span.attributes.find((a: any) => a.key === key)?.value?.stringValue;
 
 /** One attribute of the session-context record, from the logs POST. */
-const contextAttr = (bodies: any[], urls: string[], key: string) =>
-	attrOf(
-		bodies[urls.indexOf("https://e/v1/logs")].resourceLogs[0].scopeLogs[0]
-			.logRecords[0],
-		key,
-	);
+const contextAttr = ({
+	bodies,
+	urls,
+	key,
+}: {
+	bodies: any[];
+	urls: string[];
+	key: string;
+}) => {
+	const at = urls.indexOf("https://e/v1/logs");
+	// Without this the missing POST reads as `bodies[-1]` and the chain
+	// throws a TypeError, which hides which expectation actually failed.
+	expect(at, "no session-context record was posted").toBeGreaterThan(-1);
+	return attrOf(bodies[at].resourceLogs[0].scopeLogs[0].logRecords[0], key);
+};
 
 /**
  * A working directory git answers for: the checkout the session is sitting in,
@@ -397,10 +406,10 @@ describe("harvestCodexThread", () => {
 					runGit: checkoutOn("review/pr-7412"),
 				});
 
-				expect(contextAttr(bodies, urls, "vcs.ref.head.name")).toBe(
+				expect(contextAttr({ bodies, urls, key: "vcs.ref.head.name" })).toBe(
 					"review/pr-7412",
 				);
-				expect(contextAttr(bodies, urls, "vcs.repository.name")).toBe(
+				expect(contextAttr({ bodies, urls, key: "vcs.repository.name" })).toBe(
 					"acme-app",
 				);
 			});
@@ -427,8 +436,8 @@ describe("harvestCodexThread", () => {
 					runGit: checkoutOn("review/pr-7412"),
 				});
 
-				expect(contextAttr(bodies, urls, "vcs.repository.owner")).toBe("acme");
-				expect(contextAttr(bodies, urls, "vcs.ref.head.name")).toBe(
+				expect(contextAttr({ bodies, urls, key: "vcs.repository.owner" })).toBe("acme");
+				expect(contextAttr({ bodies, urls, key: "vcs.ref.head.name" })).toBe(
 					"review/pr-7412",
 				);
 			});
@@ -455,10 +464,10 @@ describe("harvestCodexThread", () => {
 					runGit: () => null,
 				});
 
-				expect(contextAttr(bodies, urls, "vcs.ref.head.name")).toBe(
+				expect(contextAttr({ bodies, urls, key: "vcs.ref.head.name" })).toBe(
 					"feat/pricing",
 				);
-				expect(contextAttr(bodies, urls, "vcs.repository.name")).toBe(
+				expect(contextAttr({ bodies, urls, key: "vcs.repository.name" })).toBe(
 					"acme-app",
 				);
 			});
@@ -553,24 +562,6 @@ describe("harvestCodexThread", () => {
 				stateDir,
 				fetchImpl: impl,
 			});
-
-		const contextAttr = ({
-			bodies,
-			urls,
-			key,
-		}: {
-			bodies: any[];
-			urls: string[];
-			key: string;
-		}) => {
-			const at = urls.indexOf("https://e/v1/logs");
-			// Without this the missing POST reads as `bodies[-1]` and the chain
-			// throws a TypeError, which hides which expectation actually failed.
-			expect(at, "no session-context record was posted").toBeGreaterThan(-1);
-			return bodies[at].resourceLogs[0].scopeLogs[0].logRecords[0].attributes.find(
-				(a: any) => a.key === key,
-			)?.value?.stringValue;
-		};
 
 		describe("when the session is harvested", () => {
 			/** @scenario "The harvest names the session by the first thing the user asked" */

--- a/sdks/typescript/src/cli/utils/governance/codex-rollout-otlp.ts
+++ b/sdks/typescript/src/cli/utils/governance/codex-rollout-otlp.ts
@@ -9,6 +9,11 @@ import { createHash } from "node:crypto";
 import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  type GitRunner,
+  readSessionContext,
+  runGitCommand,
+} from "@/cli/commands/ingestion/git-context";
 import { LANGWATCH_SDK_VERSION } from "@/internal/constants";
 import { GovernanceCliError } from "./cli-api";
 import {
@@ -216,6 +221,7 @@ export async function harvestCodexThread(args: {
   sessionsRoot?: string;
   stateDir?: string;
   fetchImpl?: typeof fetch;
+  runGit?: GitRunner;
 }): Promise<number> {
   const root = args.sessionsRoot ?? defaultCodexSessionsRoot();
   const file = await findRolloutForThread(args.threadId, root);
@@ -236,6 +242,7 @@ export async function harvestCodexThread(args: {
     threadName: meta?.sessionId ? threadNames.get(meta.sessionId) : null,
     stateDir: args.stateDir,
     fetchImpl: args.fetchImpl,
+    runGit: args.runGit,
   });
   const recent = turns.slice(-RECENT_TURN_WINDOW);
   if (recent.length === 0) return 0;
@@ -371,6 +378,44 @@ async function postCodexTurns(args: {
  * the grammar cannot read, or a refused POST emits nothing and reports false,
  * because the content spans riding beside this are worth posting either way.
  */
+/**
+ * Which repository and branch a codex session is working in.
+ *
+ * The rollout's own `session_meta` is the weaker of the two sources and is
+ * consulted second. Codex fills it only when the session STARTED inside a
+ * repository, and never revises it: a reviewer that checks out one pull
+ * request's branch after another still reports the branch it opened with, and a
+ * session started a directory above the checkout reports nothing for its whole
+ * life, however much repository work it does. Codex has no equivalent of a
+ * native worktree switch, so that first directory is the session for good.
+ *
+ * The harvest runs on the machine that ran the turn, moments after it, so the
+ * working directory can be read directly and answers for the turn being
+ * harvested rather than for the session's first minute. The rollout's values
+ * stay as the fallback, which is what a transcript harvested on another machine
+ * (or after the checkout is gone) still has.
+ */
+function codexSessionContext({
+  meta,
+  runGit,
+}: {
+  meta: CodexRolloutMeta;
+  runGit: GitRunner;
+}): SessionContext | null {
+  const live = meta.cwd
+    ? readSessionContext({ directory: meta.cwd, runGit })
+    : null;
+  if (live) return live;
+  const repository = meta.gitRepositoryUrl
+    ? parseGitRemoteUrl(meta.gitRepositoryUrl)
+    : null;
+  if (!repository) return null;
+  return {
+    repository,
+    ...(meta.gitBranch ? { branch: meta.gitBranch } : {}),
+  };
+}
+
 export async function postCodexSessionContext(args: {
   meta: CodexRolloutMeta | null;
   nowMs: number;
@@ -380,28 +425,34 @@ export async function postCodexSessionContext(args: {
   threadName?: string | null;
   stateDir?: string;
   fetchImpl?: typeof fetch;
+  runGit?: GitRunner;
 }): Promise<boolean> {
-  const { meta, nowMs, logsEndpoint, token, threadName, stateDir, fetchImpl } =
-    args;
+  const {
+    meta,
+    nowMs,
+    logsEndpoint,
+    token,
+    threadName,
+    stateDir,
+    fetchImpl,
+    runGit,
+  } = args;
   if (!logsEndpoint) return false;
   if (!meta?.sessionId) return false;
-  const repository = meta.gitRepositoryUrl
-    ? parseGitRemoteUrl(meta.gitRepositoryUrl)
-    : null;
   const title = meta.firstUserMessage
     ? sessionTitleFromPrompt(meta.firstUserMessage)
     : null;
   const name = normalizeSessionName(threadName);
+  const context = codexSessionContext({
+    meta,
+    runGit: runGit ?? runGitCommand,
+  });
   // A codex session appears in the sessions screen only through this
   // record, so a session outside any repository still posts one as long
   // as there is a name to carry. With no identity and no name there is
   // nothing to say.
-  if (!repository && !title && !name) return false;
-  const context: SessionContext = {
-    ...(repository ? { repository } : {}),
-    ...(meta.gitBranch ? { branch: meta.gitBranch } : {}),
-  };
-  const fingerprint = sessionContextFingerprint(context, { title, name });
+  if (!context && !title && !name) return false;
+  const fingerprint = sessionContextFingerprint(context ?? {}, { title, name });
   const stateFile = stateFilePath({
     stateDir: stateDir ?? defaultStateDir(),
     agent: "codex",
@@ -411,7 +462,7 @@ export async function postCodexSessionContext(args: {
   const payload = buildSessionContextLogPayload({
     sessionId: meta.sessionId,
     agent: "codex",
-    context,
+    context: context ?? {},
     timeUnixNano: `${nowMs}000000`,
     scopeVersion: LANGWATCH_SDK_VERSION,
     // Codex withholds prompt text from its own events, so the transcript's
@@ -484,6 +535,7 @@ async function postCodexSessionContexts(args: {
   threadNames?: Map<string, string>;
   stateDir?: string;
   fetchImpl?: typeof fetch;
+  runGit?: GitRunner;
 }): Promise<void> {
   const { metas, threadNames, ...post } = args;
   if (metas.length === 0) return;
@@ -537,6 +589,7 @@ export async function harvestAndEmitCodexIO(args: {
   sessionsRoot?: string;
   stateDir?: string;
   fetchImpl?: typeof fetch;
+  runGit?: GitRunner;
 }): Promise<number> {
   const {
     sinceMs,
@@ -547,6 +600,7 @@ export async function harvestAndEmitCodexIO(args: {
     sessionsRoot,
     stateDir,
     fetchImpl,
+    runGit,
   } = args;
   const root = sessionsRoot ?? defaultCodexSessionsRoot();
   const { turns, metas } = await readRollouts({
@@ -561,6 +615,7 @@ export async function harvestAndEmitCodexIO(args: {
     threadNames: await readCodexThreadNames(codexSessionIndexPath(root)),
     stateDir,
     fetchImpl,
+    runGit,
   });
   if (turns.length === 0) return 0;
   await postCodexTurns({ turns, nowMs, endpoint, token, fetchImpl });
@@ -585,6 +640,7 @@ export function createCodexIOStreamer(args: {
   sessionsRoot?: string;
   stateDir?: string;
   fetchImpl?: typeof fetch;
+  runGit?: GitRunner;
 }): { harvest: (nowMs: number) => Promise<number> } {
   const root = args.sessionsRoot ?? defaultCodexSessionsRoot();
   const emitted = new Set<string>();
@@ -606,6 +662,7 @@ export function createCodexIOStreamer(args: {
         threadNames: await readCodexThreadNames(codexSessionIndexPath(root)),
         stateDir: args.stateDir,
         fetchImpl: args.fetchImpl,
+        runGit: args.runGit,
       });
       const fresh = turns.filter((t) => t.traceId && !emitted.has(t.traceId));
       if (fresh.length === 0) return 0;

--- a/specs/ai-governance/cli-wrappers/codex-rollout-io.feature
+++ b/specs/ai-governance/cli-wrappers/codex-rollout-io.feature
@@ -138,12 +138,38 @@ Feature: Codex Path B recovers the full request body from the rollout transcript
     branch (which is what links it to its pull request) with no hooks.json
     entry and no per-hook trust grant.
 
+    What codex recorded is the weaker source and is read second. It is written
+    only when the session started inside a repository, and it is never revised,
+    so a reviewer that checks out one pull request's branch after another would
+    report the branch it opened with for the rest of its life. The harvest runs
+    on the machine that ran the turn, moments after it, so it reads the working
+    directory itself and answers for the turn it is harvesting.
+
     @unit
     Scenario: The harvest reports the repository the session worked on
       Given a rollout whose session_meta names a remote and a branch
       When the completed turn is harvested
       Then one session-context record posts beside the conversation
       And the codex session gains its repository and branch
+
+    @unit
+    Scenario: The reported branch follows the checkout, not the session's first minute
+      Given a session that has moved its checkout to another branch since it started
+      When the completed turn is harvested
+      Then the record names the branch the checkout is on now
+
+    @unit
+    Scenario: A session whose transcript records no repository still reports one
+      Given a rollout whose session_meta records no git identity
+      And a working directory that is a checkout
+      When the completed turn is harvested
+      Then the record names the repository of that working directory
+
+    @unit
+    Scenario: A transcript harvested away from its checkout keeps what codex recorded
+      Given a rollout whose working directory cannot be read as a repository
+      When the completed turn is harvested
+      Then the record falls back to the remote and branch in the session_meta
 
     @unit
     Scenario: A notify that fires after every turn posts the repository once


### PR DESCRIPTION
## What

A codex session could not attribute to a pull request, ever. The sessions screen showed our box's codex reviewer with tens of millions of tokens and no repository, so none of its spend reached the pull requests it reviewed.

The harvest built its session-context record from the rollout's `session_meta` alone. Codex writes git identity there only when the session STARTED inside a repository, and never revises it.

Both halves of that hurt:

- Every agent on the box starts codex one directory above its checkouts, so `session_meta` carries `git: null`. The session reported no repository for its whole life, however many pull requests it reviewed. Verified on the box: a three-week-old reviewer session with 53.7M tokens of context reporting an empty repository.
- A session that does start inside a checkout is no better off over time. It reports the branch it opened with, so a reviewer moving from one pull request to the next keeps naming the first one.

## Change

The harvest runs on the machine that ran the turn, moments after it, so the working directory can be read directly. `postCodexSessionContext` now derives the context with `readSessionContext`, the same helper the claude hook uses, and keeps the transcript's values as the fallback for a rollout harvested away from its checkout.

That also means a codex session gains a worktree name for free, like claude's.

`runGit` is threaded through the harvest entry points so tests inject a stub instead of spawning git.

## Proven on the agents box

A codex turn in a checkout on PR #7412's branch, with this build installed:

```
codex-01a029f9-3e4a-78c1-bc5b-13137666d4a8.json
{"fingerprint":"github.com/langwatch/langwatch@feat/home-pill-setup-menu#langwatch-review!~"}
```

and the usage API for that pull request:

```
codex   project=background-agents   sessions=1   tokens=38473
```

Before this change, the same session posted `@#`, meaning no repository and no branch.

## Tests

Three scenarios in `specs/ai-governance/cli-wrappers/codex-rollout-io.feature`, bound in `codex-turn-harvest.unit.test.ts`:

- the reported branch follows the checkout, not the session's first minute
- a session whose transcript records no repository still reports the one in its working directory
- a transcript harvested away from its checkout keeps what codex recorded

The first two were mutation-checked: making the code ignore the live checkout fails both.

Green locally, from `sdks/typescript` unless noted:

- `pnpm test:unit src/cli/utils/governance/__tests__/codex-turn-harvest.unit.test.ts`, 24/24, the touched suite
- `pnpm test:unit src/cli/utils/governance/__tests__/`, 726/726 across 47 files, the whole governance surface
- `pnpm test:unit src/cli/commands/ingestion/__tests__/`, 74/74, the hook that shares `readSessionContext`
- `npx tsc --noEmit -p sdks/typescript/tsconfig.json` clean, and `npx eslint` clean on both touched files. The SDK uses eslint, not biome, so a biome run here fails for a missing binary rather than for a lint error.
- `pnpm check:feature-parity` from `platform/app`, OK with 8202 scenarios bound

## One behavior change to know about

A rollout with a branch but no parseable repository URL used to post a branch-only context. It now posts none, because the context is dropped once the repository fails to parse. Nothing is lost, since a branch with no repository cannot attribute to a pull request, and the record still posts when a title or name exists. It also makes codex agree with claude, whose hook has always refused to report anything it cannot tie to an origin remote.

## Not fixed here

A codex session still reports one repository, the one it started in, because codex has no equivalent of a native worktree switch and its working directory is fixed for the session's life. An agent that reviews pull requests across several repositories needs to be started in the checkout it is reviewing, which is a launcher change, not a CLI one.

https://claude.ai/code/session_01BUKKUiZbSBHmrLK9JJj4Ba


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session context now reflects the current checkout’s repository and branch when available.
  * Context harvesting supports sessions continued from a different checkout or branch.
  * Recorded session metadata is used automatically when current checkout details cannot be read.

* **Bug Fixes**
  * Improved handling of sessions with incomplete transcript metadata.
  * Session context can now be posted when only basic title or name information is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

