### PR TITLE
fix(sdks): stop excludeHttpRequests preset from dropping user spans

### DIFF
--- a/sdks/go/exporter_test.go
+++ b/sdks/go/exporter_test.go
@@ -84,6 +84,7 @@ func TestExcludeHTTPRequests_KeepsUserSpansWithVerbPrefixedNames(t *testing.T) {
 	exporter := NewFilteringExporter(mock, ExcludeHTTPRequests())
 
 	userSpans := []string{
+		"POST-process",
 		"post-process",
 		"post-publish-smoke",
 		"get-user-profile",

--- a/sdks/go/exporter_test.go
+++ b/sdks/go/exporter_test.go
@@ -76,6 +76,55 @@ func TestFilteringExporter_AllFiltered(t *testing.T) {
 	assert.Len(t, mock.GetSpans(), 0)
 }
 
+// Regression test for #7413: the filter used to match case-insensitively with
+// a word boundary, so user spans named "post-process", "get-user-profile", ...
+// were silently dropped alongside real HTTP request spans.
+func TestExcludeHTTPRequests_KeepsUserSpansWithVerbPrefixedNames(t *testing.T) {
+	mock := testutil.NewMockExporter()
+	exporter := NewFilteringExporter(mock, ExcludeHTTPRequests())
+
+	userSpans := []string{
+		"post-process",
+		"post-publish-smoke",
+		"get-user-profile",
+		"delete-account",
+		"put-record",
+		"patch-config",
+		"head-request-handler",
+		"options-resolver",
+		"get /lowercase-verb-route",
+	}
+
+	spans := make([]sdktrace.ReadOnlySpan, 0, len(userSpans))
+	for _, name := range userSpans {
+		spans = append(spans, testutil.CreateMockSpan(name, "custom"))
+	}
+
+	err := exporter.ExportSpans(context.Background(), spans)
+	require.NoError(t, err)
+
+	result := mock.GetSpans()
+	assert.Len(t, result, len(userSpans))
+	for i, name := range userSpans {
+		assert.Equal(t, name, result[i].Name())
+	}
+}
+
+func TestExcludeHTTPRequests_DropsRealHTTPShapes(t *testing.T) {
+	mock := testutil.NewMockExporter()
+	exporter := NewFilteringExporter(mock, ExcludeHTTPRequests())
+
+	spans := []sdktrace.ReadOnlySpan{
+		testutil.CreateMockSpan("GET", "net/http"),
+		testutil.CreateMockSpan("POST /v1/traces", "net/http"),
+	}
+
+	err := exporter.ExportSpans(context.Background(), spans)
+	require.NoError(t, err)
+
+	assert.Len(t, mock.GetSpans(), 0)
+}
+
 func TestFilteringExporter_Shutdown(t *testing.T) {
 	mock := testutil.NewMockExporter()
 	exporter := NewFilteringExporter(mock)

--- a/sdks/go/filter.go
+++ b/sdks/go/filter.go
@@ -164,11 +164,19 @@ func Exclude(criteria Criteria) Filter {
 	})
 }
 
-// httpVerbRegex matches HTTP request span names (e.g., "GET /api/users", "POST /data")
-var httpVerbRegex = regexp.MustCompile(`(?i)^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)\b`)
+// httpVerbRegex matches HTTP request span names in the shapes OpenTelemetry
+// HTTP instrumentation emits: an uppercase verb on its own, or an uppercase
+// verb followed by a space and the route (e.g., "GET /api/users", "POST /data").
+//
+// Matching is case-sensitive and requires a space or end-of-string after the
+// verb: a case-insensitive or word-boundary match also swallows ordinary user
+// span names such as "post-process" or "get-user-profile"
+// ((?i)^post\b matches them), silently dropping them from exports.
+var httpVerbRegex = regexp.MustCompile(`^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)(?: |$)`)
 
 // ExcludeHTTPRequests creates a filter that removes HTTP request spans.
-// This matches spans whose names start with HTTP verbs (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD).
+// This matches spans whose names are an uppercase HTTP verb, optionally
+// followed by a route ("GET", "POST /api/users").
 func ExcludeHTTPRequests() Filter {
 	return FilterFunc(func(spans []sdktrace.ReadOnlySpan) []sdktrace.ReadOnlySpan {
 		result := make([]sdktrace.ReadOnlySpan, 0, len(spans))

--- a/sdks/go/filter.go
+++ b/sdks/go/filter.go
@@ -172,16 +172,48 @@ func Exclude(criteria Criteria) Filter {
 // verb: a case-insensitive or word-boundary match also swallows ordinary user
 // span names such as "post-process" or "get-user-profile"
 // ((?i)^post\b matches them), silently dropping them from exports.
-var httpVerbRegex = regexp.MustCompile(`^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)(?: |$)`)
+var httpVerbRegex = regexp.MustCompile(`^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|CONNECT|TRACE)(?: |$)`)
+
+// httpInstrumentationScopes contains the scope names of the OpenTelemetry Go
+// HTTP instrumentations. Only fully qualified package scopes count: an
+// application is free to name its own instrumentation "http", and such spans
+// are user data.
+var httpInstrumentationScopes = map[string]struct{}{
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp": {},
+}
+
+// isHTTPRequestSpan reports whether the span is an HTTP instrumentation span.
+//
+// The exact signals come first: the emitting instrumentation scope, or the
+// semantic-convention method attribute ("http.request.method", or the legacy
+// "http.method"). Only when neither is present does the name heuristic apply,
+// and it matches only the shape OpenTelemetry's HTTP instrumentations
+// actually emit — an uppercase verb alone or followed by a space. User spans
+// like "post-publish-smoke" or "get-user-profile" never match it.
+func isHTTPRequestSpan(span sdktrace.ReadOnlySpan) bool {
+	if _, ok := httpInstrumentationScopes[span.InstrumentationScope().Name]; ok {
+		return true
+	}
+
+	for _, attr := range span.Attributes() {
+		if attr.Key == "http.request.method" || attr.Key == "http.method" {
+			return true
+		}
+	}
+
+	return httpVerbRegex.MatchString(span.Name())
+}
 
 // ExcludeHTTPRequests creates a filter that removes HTTP request spans.
-// This matches spans whose names are an uppercase HTTP verb, optionally
-// followed by a route ("GET", "POST /api/users").
+// Spans are identified as HTTP requests by the HTTP instrumentation scope
+// that emitted them, or by the "http.request.method" / "http.method"
+// attribute, falling back to an uppercase-verb span name — mirroring the
+// TypeScript SDK's preset so both SDKs behave the same way.
 func ExcludeHTTPRequests() Filter {
 	return FilterFunc(func(spans []sdktrace.ReadOnlySpan) []sdktrace.ReadOnlySpan {
 		result := make([]sdktrace.ReadOnlySpan, 0, len(spans))
 		for _, span := range spans {
-			if !httpVerbRegex.MatchString(span.Name()) {
+			if !isHTTPRequestSpan(span) {
 				result = append(result, span)
 			}
 		}

--- a/sdks/go/filter_test.go
+++ b/sdks/go/filter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/langwatch/langwatch/sdks/go/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -205,6 +206,69 @@ func TestExcludeHTTPRequests_KeepsLowercaseVerbNames(t *testing.T) {
 	result := filter.Apply(spans)
 
 	assert.Len(t, result, 2)
+}
+
+func TestExcludeHTTPRequests_ExcludesByInstrumentationScope(t *testing.T) {
+	filter := ExcludeHTTPRequests()
+
+	spans := []sdktrace.ReadOnlySpan{
+		// Fully qualified otelhttp scope: excluded whatever its name says.
+		testutil.CreateMockSpan("totally-not-http", "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
+		// An application naming its own scope "http" is user data.
+		testutil.CreateMockSpan("fetch-user-profile", "http"),
+	}
+
+	result := filter.Apply(spans)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "fetch-user-profile", result[0].Name())
+}
+
+func TestExcludeHTTPRequests_ExcludesByMethodAttribute(t *testing.T) {
+	filter := ExcludeHTTPRequests()
+
+	spans := []sdktrace.ReadOnlySpan{
+		testutil.CreateMockSpanWithAttributes("custom-name", "my-scope",
+			attribute.String("http.request.method", "POST")),
+		testutil.CreateMockSpanWithAttributes("custom-name", "my-scope",
+			attribute.String("http.method", "GET")),
+		testutil.CreateMockSpanWithAttributes("custom-name", "my-scope",
+			attribute.String("db.system", "postgresql")),
+	}
+
+	result := filter.Apply(spans)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "custom-name", result[0].Name())
+}
+
+func TestExcludeHTTPRequests_NameFallbackMatchesOnlyUppercaseVerbShape(t *testing.T) {
+	filter := ExcludeHTTPRequests()
+
+	spans := []sdktrace.ReadOnlySpan{
+		// Emitted shapes: uppercase verb alone or followed by a space.
+		testutil.CreateMockSpan("POST", "my-scope"),
+		testutil.CreateMockSpan("POST /v1/traces", "my-scope"),
+		testutil.CreateMockSpan("TRACE /health", "my-scope"),
+		testutil.CreateMockSpan("CONNECT proxy.example:443", "my-scope"),
+		// Lookalikes the application chose: kept.
+		testutil.CreateMockSpan("post /v1/traces", "my-scope"),
+		testutil.CreateMockSpan("GETAWAY", "custom"),
+		testutil.CreateMockSpan("postgres-query", "db"),
+		testutil.CreateMockSpan("GETTING", "http"),
+	}
+
+	result := filter.Apply(spans)
+
+	assert.Len(t, result, 4)
+	names := make([]string, len(result))
+	for i, s := range result {
+		names[i] = s.Name()
+	}
+	assert.Contains(t, names, "post /v1/traces")
+	assert.Contains(t, names, "GETAWAY")
+	assert.Contains(t, names, "postgres-query")
+	assert.Contains(t, names, "GETTING")
 }
 
 func TestLangWatchOnly(t *testing.T) {

--- a/sdks/go/filter_test.go
+++ b/sdks/go/filter_test.go
@@ -191,18 +191,20 @@ func TestExcludeHTTPRequests(t *testing.T) {
 	assert.Contains(t, names, "fetch-user")
 }
 
-func TestExcludeHTTPRequests_CaseInsensitive(t *testing.T) {
+// Regression test for #7413: OpenTelemetry HTTP instrumentation emits
+// uppercase verbs, so lowercase names are user spans and must survive the
+// filter (they used to be dropped case-insensitively).
+func TestExcludeHTTPRequests_KeepsLowercaseVerbNames(t *testing.T) {
 	filter := ExcludeHTTPRequests()
 
 	spans := []sdktrace.ReadOnlySpan{
 		testutil.CreateMockSpan("get /api", "any"),
 		testutil.CreateMockSpan("Get /api", "any"),
-		testutil.CreateMockSpan("GET /api", "any"),
 	}
 
 	result := filter.Apply(spans)
 
-	assert.Len(t, result, 0)
+	assert.Len(t, result, 2)
 }
 
 func TestLangWatchOnly(t *testing.T) {

--- a/sdks/go/internal/testutil/mock_span.go
+++ b/sdks/go/internal/testutil/mock_span.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -11,6 +12,16 @@ func CreateMockSpan(name, scopeName string) sdktrace.ReadOnlySpan {
 	stub := tracetest.SpanStub{
 		Name:                 name,
 		InstrumentationScope: instrumentation.Scope{Name: scopeName},
+	}
+	return stub.Snapshot()
+}
+
+// CreateMockSpanWithAttributes creates a mock ReadOnlySpan carrying span attributes.
+func CreateMockSpanWithAttributes(name, scopeName string, attrs ...attribute.KeyValue) sdktrace.ReadOnlySpan {
+	stub := tracetest.SpanStub{
+		Name:                 name,
+		InstrumentationScope: instrumentation.Scope{Name: scopeName},
+		Attributes:           attrs,
 	}
 	return stub.Snapshot()
 }

--- a/specs/go-sdk/observability-http-span-filter.feature
+++ b/specs/go-sdk/observability-http-span-filter.feature
@@ -1,0 +1,41 @@
+Feature: The excludeHttpRequests preset drops HTTP instrumentation spans only
+  As a service owner shipping the LangWatch observability Go SDK
+  I want the default span filter to recognise real HTTP instrumentation spans
+  So that my own spans named after everyday verbs are never silently dropped
+
+  # The preset exists to stop the SDK's own exporter traffic from feeding back
+  # on itself. It used to match any span whose name began with an HTTP verb
+  # word followed by a word boundary, case-insensitively, so ordinary user
+  # spans like "post-publish-smoke" vanished before export with no error and
+  # no signal. A span an SDK user creates is data; only spans the HTTP
+  # instrumentations emit are filter noise.
+  #
+  # This mirrors the TypeScript SDK preset (see
+  # specs/typescript-sdk/observability-http-span-filter.feature) so both SDKs
+  # identify HTTP spans the same way: by scope first, then by the
+  # semantic-convention method attribute, and only then by the
+  # uppercase-verb name shape.
+  #
+  # Implementation:
+  #   sdks/go/filter.go
+
+  Background:
+    Given the observability Go SDK is set up with its default filters
+
+  @unit
+  Scenario: A user span named after a hyphenated verb word reaches the exporter
+    When the application records a span named "post-process"
+    Then the excludeHttpRequests preset keeps it
+    And the same holds for "get-user-profile", "delete-account", "put-record" and "patch-config"
+
+  @unit
+  Scenario: An HTTP instrumentation span is still excluded
+    When a span carries the "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp" instrumentation scope
+    Or it carries the "http.request.method" attribute
+    Then the excludeHttpRequests preset drops it
+
+  @unit
+  Scenario: The name fallback matches only the uppercase verb shape OpenTelemetry emits
+    When a span from an unknown scope is named "POST" or "POST /v1/traces"
+    Then the excludeHttpRequests preset drops it by name
+    But a span named "post /v1/traces" or "GETAWAY" or "postgres-query" stays


### PR DESCRIPTION
Fixes #7413

## Problem

The `excludeHttpRequests` preset (the **default** filter set for the TypeScript trace exporter) over-matched. Its predicate matched case-insensitively with a word boundary, so any user span whose name begins with a verb word followed by a non-word character was silently discarded before export:

- dropped: `post-process`, `post-publish-smoke`, `get-user-profile`, `delete-account`, `put-record`, `patch-config`, `head-request-handler`, `options-resolver`
- kept: `post_process` (underscore is a word character)

No error, no warning, no rejected-span count — traces just went missing, and the inconsistency between `post-process` and `post_process` was the worst part. The same predicate existed in the Go SDK (`sdks/go/filter.go`).

## Solution

The preset only exists to drop the SDK exporter's own feedback-loop spans, and OpenTelemetry HTTP instrumentation names those with an **uppercase verb plus an optional route** (`GET`, `POST /v1/traces`). Both predicates now require exactly that shape — case-sensitive verb followed by a space or end of string:

| before | after |
|---|---|
| `/^(GET\|POST\|PUT\|DELETE\|PATCH\|OPTIONS\|HEAD)\b/i` | `/^(GET\|POST\|PUT\|DELETE\|PATCH\|OPTIONS\|HEAD)(?: \|$)/` |
| `(?i)^(...)\b` (Go) | `^(...)(?: \|$)` (Go) |

All real HTTP shapes still match; every lowercase / punctuation-followed user span survives.

## Testing

**TypeScript** — `trace-filters.test.ts`: rewrote the pinned "is case-insensitive" assertions into regressions asserting lowercase verbs are kept (they were the bug), added verb+punctuation user-name cases and bare uppercase verb coverage; existing uppercase route-shape cases pass unchanged. `50/50 passed`, plus `langwatch-trace-exporter.unit.test.ts` `39/39 passed`.

**Go** — rewrote pinned `TestExcludeHTTPRequests_CaseInsensitive` into `TestExcludeHTTPRequests_KeepsLowercaseVerbNames`, added `TestExcludeHTTPRequests_KeepsUserSpansWithVerbPrefixedNames` and `TestExcludeHTTPRequests_DropsRealHTTPShapes`. `go test ./...` all packages ok, `gofmt`/`go vet` clean.

Note: `pnpm --filter langwatch typecheck` fails on pristine main in this environment with TS5103 (`--ignoreDeprecations`) — local tsc resolves to 5.9.3 while the tsconfig targets the repo's newer compiler; unrelated to this change.

> [!NOTE]
> LLM-assisted contribution, reviewed by a human contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request span filtering to avoid excluding user-defined spans with lowercase or route-like names.
  * Reliably excludes HTTP spans identified by instrumentation metadata, semantic attributes, or valid uppercase HTTP naming patterns.
  * Added support for additional HTTP methods, including `CONNECT` and `TRACE`.

* **Tests**
  * Added regression coverage for retained user spans and correctly excluded HTTP spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->