### PR TITLE
fix(coding-agent): a codex session states what it cost and finds its own traces

### DIFF
--- a/platform/app/src/components/me/SessionsTable.tsx
+++ b/platform/app/src/components/me/SessionsTable.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { NoDataInfoBlock } from "~/components/NoDataInfoBlock";
 import { ListTable } from "~/components/ui/ListTable";
 import { Pagination } from "~/components/ui/Pagination";
+import { useDrawer } from "~/hooks/useDrawer";
 import { api } from "~/utils/api";
 import { SessionRow } from "./sessions/SessionRow";
 import { SessionsTableHeader } from "./sessions/SessionsTableHeader";
@@ -206,6 +207,7 @@ const OnePageOfSessions: React.FC<{
   onPageSizeChange,
 }) => {
   const replay = useTerminalReplay({ projectId, projectSlug });
+  const { openDrawer } = useDrawer();
   const largestTotal = rows.reduce(
     (max, row) => Math.max(max, row.totalTokens),
     0,
@@ -230,6 +232,14 @@ const OnePageOfSessions: React.FC<{
               onOpenReplay={() => void replay.openReplay(row)}
               onOpenInExplorer={
                 projectSlug ? () => void replay.openInExplorer(row) : undefined
+              }
+              onOpenPullRequest={(pullRequest) =>
+                openDrawer("pullRequestDetail", {
+                  projectId,
+                  repositoryHost: row.repositoryHost,
+                  repositoryFullName: row.repositoryFullName,
+                  prNumber: pullRequest.number,
+                })
               }
               onPrefetch={() => replay.prefetch(row)}
             />

--- a/platform/app/src/components/me/__tests__/SessionsTable.integration.test.tsx
+++ b/platform/app/src/components/me/__tests__/SessionsTable.integration.test.tsx
@@ -277,10 +277,9 @@ describe("the personal Sessions table", () => {
       expect(screen.getByText("38m waiting")).toBeInTheDocument();
 
       expect(screen.getByText("$12.50")).toBeInTheDocument();
-      expect(screen.getByText("#4218").closest("a")).toHaveAttribute(
-        "href",
-        "https://github.com/acme/widgets/pull/4218",
-      );
+      expect(
+        screen.getByRole("button", { name: "Open pull request #4218" }),
+      ).toBeInTheDocument();
     });
 
     it("explains what the two context figures each count", async () => {
@@ -364,6 +363,38 @@ describe("the personal Sessions table", () => {
       // Every other cell on this row has something to say, so the one
       // placeholder on screen is the pull request cell's.
       expect(screen.getAllByText("—")).toHaveLength(1);
+    });
+  });
+
+  describe("given a session row that lists a pull request", () => {
+    /** @scenario "A pull request number opens what the change cost, not GitHub" */
+    it("opens the pull request's detail and not the session replay", async () => {
+      pinSessions([sessionRow()]);
+      const user = userEvent.setup();
+      renderTable();
+
+      await user.click(screen.getByText("#4218"));
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("pullRequestDetail", {
+        projectId: "proj-personal",
+        repositoryHost: "github.com",
+        repositoryFullName: "acme/widgets",
+        prNumber: 4218,
+      });
+      expect(mockOpenDrawer).not.toHaveBeenCalledWith(
+        "traceV2Details",
+        expect.anything(),
+      );
+    });
+
+    /** @scenario "A pull request number is drawn as something to choose" */
+    it("underlines the number", () => {
+      pinSessions([sessionRow()]);
+      renderTable();
+
+      expect(screen.getByText("#4218")).toHaveStyle({
+        textDecoration: "underline",
+      });
     });
   });
 
@@ -729,14 +760,19 @@ describe("the personal Sessions table", () => {
       );
     });
 
-    it("leaves a pull request chip to GitHub rather than to the replay", async () => {
+    /** @scenario "A pull request number opens what the change cost, not GitHub" */
+    it("leaves a pull request number to its own detail rather than to the replay", async () => {
       const user = userEvent.setup();
       renderTable();
 
       await user.click(screen.getByText("#4218"));
 
       expect(mockOpenTrace).not.toHaveBeenCalled();
-      expect(mockOpenDrawer).not.toHaveBeenCalled();
+      expect(mockOpenDrawer).toHaveBeenCalledTimes(1);
+      expect(mockOpenDrawer).toHaveBeenCalledWith(
+        "pullRequestDetail",
+        expect.objectContaining({ prNumber: 4218 }),
+      );
     });
   });
 

--- a/platform/app/src/components/me/sessions/SessionRow.tsx
+++ b/platform/app/src/components/me/sessions/SessionRow.tsx
@@ -11,7 +11,7 @@ import { PullRequestsCell } from "./cells/PullRequestsCell";
 import { SessionNameCell } from "./cells/SessionNameCell";
 import { TokenCostCell } from "./cells/TokenCostCell";
 import { SessionRowActions } from "./SessionRowActions";
-import type { SessionListRow } from "./sessionListRow";
+import type { SessionListRow, SessionPullRequest } from "./sessionListRow";
 
 /**
  * One session, read left to right. The whole row is the target that opens the
@@ -25,6 +25,7 @@ export const SessionRow: React.FC<{
   isOpening: boolean;
   onOpenReplay: () => void;
   onOpenInExplorer: (() => void) | undefined;
+  onOpenPullRequest: (pullRequest: SessionPullRequest) => void;
   onPrefetch: () => void;
 }> = ({
   row,
@@ -33,6 +34,7 @@ export const SessionRow: React.FC<{
   isOpening,
   onOpenReplay,
   onOpenInExplorer,
+  onOpenPullRequest,
   onPrefetch,
 }) => (
   <Table.Row
@@ -68,7 +70,10 @@ export const SessionRow: React.FC<{
       <TokenCostCell row={row} largestCost={largestCost} />
     </Table.Cell>
     <Table.Cell>
-      <PullRequestsCell pullRequests={row.pullRequests} />
+      <PullRequestsCell
+        pullRequests={row.pullRequests}
+        onOpenDetail={onOpenPullRequest}
+      />
     </Table.Cell>
     <Table.Cell>
       <SessionRowActions

--- a/platform/app/src/components/me/sessions/cells/PullRequestsCell.tsx
+++ b/platform/app/src/components/me/sessions/cells/PullRequestsCell.tsx
@@ -1,7 +1,6 @@
-import { HStack, Text, VStack } from "@chakra-ui/react";
+import { chakra, HStack, Text, VStack } from "@chakra-ui/react";
 import type React from "react";
 
-import { Link } from "~/components/ui/link";
 import { Tooltip } from "~/components/ui/tooltip";
 
 import type { SessionPullRequest } from "../sessionListRow";
@@ -13,12 +12,18 @@ const MAX_LISTED_PULL_REQUESTS = 3;
 /**
  * What the session shipped. A session that lands a change, moves to the next
  * branch and opens a second pull request is one session with two, so the row
- * names each of them and links out; past a handful the rest go behind a hover
- * rather than pushing every other column off the page.
+ * names each of them; past a handful the rest go behind a hover rather than
+ * pushing every other column off the page.
+ *
+ * A number opens the pull request's own detail, the same drawer the pull
+ * requests screen opens, because what a reader wants from this column is what
+ * the change cost across every session that worked on it. GitHub is one more
+ * click from there, in the drawer's own header.
  */
 export const PullRequestsCell: React.FC<{
   pullRequests: readonly SessionPullRequest[];
-}> = ({ pullRequests }) => {
+  onOpenDetail: (pullRequest: SessionPullRequest) => void;
+}> = ({ pullRequests, onOpenDetail }) => {
   if (pullRequests.length === 0) {
     return <MissingValue />;
   }
@@ -29,19 +34,31 @@ export const PullRequestsCell: React.FC<{
   return (
     <HStack gap={2} whiteSpace="nowrap">
       {listed.map((pullRequest) => (
-        // The row opens the replay; this link leaves for GitHub, so it stops
-        // the click from reaching the row underneath it.
-        <Link
+        // The row opens the replay; this opens the pull request instead, so
+        // it stops the click from reaching the row underneath it.
+        <chakra.button
           key={pullRequest.number}
-          href={pullRequest.url}
-          isExternal
+          type="button"
+          aria-label={`Open pull request #${pullRequest.number}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenDetail(pullRequest);
+          }}
+          bg="transparent"
+          border="none"
+          padding={0}
+          cursor="pointer"
           color="fg.muted"
           fontFamily="mono"
           fontSize="sm"
-          onClick={(event) => event.stopPropagation()}
+          // Underlined because it is the one part of the row that goes
+          // somewhere other than where the row goes.
+          textDecoration="underline"
+          textUnderlineOffset="3px"
+          _hover={{ color: "fg" }}
         >
           #{pullRequest.number}
-        </Link>
+        </chakra.button>
       ))}
       {rest.length > 0 ? (
         <Tooltip

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
@@ -244,6 +244,31 @@ describe("CodexExtractor.applyLog", () => {
       );
     });
 
+    /** @scenario "A codex turn is filed under its session, not under itself" */
+    it("keeps the turn id when the thread is hyphenated but not a session id", () => {
+      const ctx = createExtractorContext(
+        {
+          model: "gpt-5.5",
+          "codex.turn.token_usage.input_tokens": "14365",
+          // Hyphenated but not a UUID. A bare "10" fails even a loose check,
+          // so only this shape catches a guard that tests for a hyphen rather
+          // than for the session id shape.
+          "thread.id": "worker-10",
+          "turn.id": "019e9bfe-92ad-7591-a7fd-d6250ce88904",
+        },
+        {
+          name: "session_task.turn",
+          instrumentationScope: { name: "codex_cli_rs", version: null },
+        },
+      );
+
+      new CodexExtractor().apply(ctx);
+
+      expect(ctx.out["gen_ai.conversation.id"]).toBe(
+        "019e9bfe-92ad-7591-a7fd-d6250ce88904",
+      );
+    });
+
     /** @scenario "Codex reasoning effort is canonicalised from the turn span" */
     it("canonicalises codex.turn.reasoning_effort to gen_ai.request.reasoning_effort", () => {
       const ctx = createExtractorContext(

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
@@ -157,6 +157,50 @@ describe("CodexExtractor.applyLog", () => {
       expect(ctx.recordRule).toHaveBeenCalledWith("codex/session_task.turn");
     });
 
+    /** @scenario "A codex turn is filed under its session, not under itself" */
+    it("files the turn under the session id when the span carries one", () => {
+      const ctx = createExtractorContext(
+        {
+          model: "gpt-5.5",
+          "codex.turn.token_usage.input_tokens": "14365",
+          "thread.id": "019e9bfe-7749-7440-8506-39152afbc9ff",
+          "turn.id": "019e9bfe-92ad-7591-a7fd-d6250ce88904",
+        },
+        {
+          name: "session_task.turn",
+          instrumentationScope: { name: "codex_cli_rs", version: null },
+        },
+      );
+
+      new CodexExtractor().apply(ctx);
+
+      expect(ctx.out["gen_ai.conversation.id"]).toBe(
+        "019e9bfe-7749-7440-8506-39152afbc9ff",
+      );
+    });
+
+    /** @scenario "A codex turn is filed under its session, not under itself" */
+    it("keeps the turn id when the span's thread is a worker rather than a session", () => {
+      const ctx = createExtractorContext(
+        {
+          model: "gpt-5.5",
+          "codex.turn.token_usage.input_tokens": "14365",
+          "thread.id": "10",
+          "turn.id": "019e9bfe-92ad-7591-a7fd-d6250ce88904",
+        },
+        {
+          name: "session_task.turn",
+          instrumentationScope: { name: "codex_cli_rs", version: null },
+        },
+      );
+
+      new CodexExtractor().apply(ctx);
+
+      expect(ctx.out["gen_ai.conversation.id"]).toBe(
+        "019e9bfe-92ad-7591-a7fd-d6250ce88904",
+      );
+    });
+
     /** @scenario "Codex reasoning effort is canonicalised from the turn span" */
     it("canonicalises codex.turn.reasoning_effort to gen_ai.request.reasoning_effort", () => {
       const ctx = createExtractorContext(

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/__tests__/codex.unit.test.ts
@@ -148,13 +148,56 @@ describe("CodexExtractor.applyLog", () => {
         "langwatch.span.type": "agent",
         "gen_ai.request.model": "gpt-5.5",
         "gen_ai.response.model": "gpt-5.5",
-        "gen_ai.usage.input_tokens": 14365,
+        // Codex reports the WHOLE input; the canonical key is the disjoint
+        // non-cached bucket, so the cache read comes off it.
+        "gen_ai.usage.input_tokens": 14365 - 10112,
         "gen_ai.usage.output_tokens": 6,
         "gen_ai.usage.cache_read.input_tokens": 10112,
         "gen_ai.request.reasoning_effort": "high",
         "gen_ai.conversation.id": "019e939c-48a1-7021-a71d-714f74d6ad64",
       });
       expect(ctx.recordRule).toHaveBeenCalledWith("codex/session_task.turn");
+    });
+
+    /** @scenario "A codex turn's cached input is priced once, not twice" */
+    it("prefers codex's own non-cached count over the subtraction", () => {
+      const ctx = createExtractorContext(
+        {
+          model: "gpt-5.6-sol",
+          "codex.turn.token_usage.input_tokens": "43001",
+          "codex.turn.token_usage.cached_input_tokens": "36096",
+          "codex.turn.token_usage.non_cached_input_tokens": "6905",
+        },
+        {
+          name: "session_task.turn",
+          instrumentationScope: { name: "codex_cli_rs", version: null },
+        },
+      );
+
+      new CodexExtractor().apply(ctx);
+
+      expect(ctx.out["gen_ai.usage.input_tokens"]).toBe(6905);
+      expect(ctx.out["gen_ai.usage.cache_read.input_tokens"]).toBe(36096);
+    });
+
+    /** @scenario "A codex turn's cached input is priced once, not twice" */
+    it("takes the cache write off the input as well", () => {
+      const ctx = createExtractorContext(
+        {
+          model: "gpt-5.6-sol",
+          "codex.turn.token_usage.input_tokens": "1000",
+          "codex.turn.token_usage.cached_input_tokens": "600",
+          "codex.turn.token_usage.cache_write_input_tokens": "300",
+        },
+        {
+          name: "session_task.turn",
+          instrumentationScope: { name: "codex_cli_rs", version: null },
+        },
+      );
+
+      new CodexExtractor().apply(ctx);
+
+      expect(ctx.out["gen_ai.usage.input_tokens"]).toBe(100);
     });
 
     /** @scenario "A codex turn is filed under its session, not under itself" */

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
@@ -120,10 +120,16 @@ type CanonicalLift = readonly [string, string | number | null];
  * keyed by the session id, resolved none of its own traces and read as having
  * stored nothing. The session id is what groups them.
  *
- * Guarded to UUID-shaped values because codex's other spans stamp the tokio
- * worker id ("10") under the same key; the turn id stays the answer when
- * `thread.id` is one of those.
+ * Guarded to the full UUID shape because codex's other spans stamp the tokio
+ * worker id under the same key, and those are not session ids. A bare "10"
+ * fails any check, but "worker-10" would pass a looser one and then become a
+ * conversation id no session could ever resolve, which is the same defect
+ * this function exists to fix. Anything that is not UUID-shaped, or absent,
+ * leaves the turn id as the answer.
  */
+const UUID_SHAPE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function conversationIdOf(attrs: {
   get: (key: string) => unknown;
   take: (key: string) => unknown;
@@ -132,7 +138,7 @@ function conversationIdOf(attrs: {
   // same attribute.
   const sessionId = asString(attrs.get("thread.id"));
   const turnId = asString(attrs.take("turn.id"));
-  return sessionId?.includes("-") ? sessionId : turnId;
+  return sessionId !== null && UUID_SHAPE.test(sessionId) ? sessionId : turnId;
 }
 
 /**

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
@@ -125,11 +125,49 @@ type CanonicalLift = readonly [string, string | number | null];
  * `thread.id` is one of those.
  */
 function conversationIdOf(attrs: {
+  get: (key: string) => unknown;
   take: (key: string) => unknown;
 }): string | null {
-  const sessionId = asString(attrs.take("thread.id"));
+  // Read, not taken: the coding-agent pipeline keys a codex session off this
+  // same attribute.
+  const sessionId = asString(attrs.get("thread.id"));
   const turnId = asString(attrs.take("turn.id"));
   return sessionId?.includes("-") ? sessionId : turnId;
+}
+
+/**
+ * The input tokens the turn actually paid full price for.
+ *
+ * The canonical key is the DISJOINT non-cached bucket: the cache buckets are
+ * reported beside it and priced at their own rates, so they add on top rather
+ * than overlap. Codex's `input_tokens` is the WHOLE input, cache included
+ * (43001 = 36096 cache-read + 6905 non-cached on a live turn), so lifting it
+ * straight across charged the cached tokens twice, once at the full input
+ * rate and again at the cache rate, and priced such a turn about four times
+ * over.
+ *
+ * Codex's own non-cached count is preferred; when a build omits it, the
+ * subtraction recovers it. The same re-derivation the session fold does, so a
+ * codex turn's trace and its session state one figure.
+ */
+function nonCachedInput({
+  attrs,
+  cacheRead,
+  cacheCreation,
+}: {
+  attrs: { get: (key: string) => unknown; take: (key: string) => unknown };
+  cacheRead: number | null;
+  cacheCreation: number | null;
+}): number | null {
+  // Read, not taken: the coding-agent session fold reads codex's own count
+  // off the same span.
+  const own = asNumber(
+    attrs.get("codex.turn.token_usage.non_cached_input_tokens"),
+  );
+  const whole = asNumber(attrs.take("codex.turn.token_usage.input_tokens"));
+  if (own !== null) return own;
+  if (whole === null) return null;
+  return Math.max(0, whole - (cacheRead ?? 0) - (cacheCreation ?? 0));
 }
 
 /**
@@ -205,6 +243,12 @@ export class CodexExtractor implements CanonicalAttributesExtractor {
 
     const { attrs } = ctx.bag;
     const model = asString(attrs.take("model"));
+    const cacheRead = asNumber(
+      attrs.take("codex.turn.token_usage.cached_input_tokens"),
+    );
+    const cacheCreation = asNumber(
+      attrs.take("codex.turn.token_usage.cache_write_input_tokens"),
+    );
     // codex spells cache creation "cache_write"; the canonical keys follow the
     // Anthropic-derived semconv names.
     const lifts: CanonicalLift[] = [
@@ -212,20 +256,14 @@ export class CodexExtractor implements CanonicalAttributesExtractor {
       [ATTR_KEYS.GEN_AI_RESPONSE_MODEL, model],
       [
         ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS,
-        asNumber(attrs.take("codex.turn.token_usage.input_tokens")),
+        nonCachedInput({ attrs, cacheRead, cacheCreation }),
       ],
       [
         ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS,
         asNumber(attrs.take("codex.turn.token_usage.output_tokens")),
       ],
-      [
-        ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-        asNumber(attrs.take("codex.turn.token_usage.cached_input_tokens")),
-      ],
-      [
-        ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
-        asNumber(attrs.take("codex.turn.token_usage.cache_write_input_tokens")),
-      ],
+      [ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, cacheRead],
+      [ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, cacheCreation],
       [
         ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS,
         asNumber(attrs.take("codex.turn.token_usage.reasoning_output_tokens")),

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/codex.ts
@@ -35,7 +35,7 @@
  *   - codex.turn.token_usage.reasoning_output_tokens (a.k.a. reasoning)
  *   - codex.turn.token_usage.total_tokens
  *   - codex.turn.reasoning_effort (the request setting, e.g. "high")
- *   - turn.id (a.k.a. thread / turn identifier)
+ *   - thread.id (the session) and turn.id (this one turn)
  * This extractor lifts those to gen_ai.* canonical so the trace
  * summary fold mirrors them to the top-level columns and the
  * receiver-side pricing lookup computes cost (codex never emits cost
@@ -49,7 +49,7 @@
  * - langwatch.input_tokens
  * - langwatch.output_tokens
  * - langwatch.cache_read_tokens
- * - langwatch.thread.id (from conversation.id OR turn.id)
+ * - langwatch.thread.id (the session: thread.id, or turn.id when absent)
  * - langwatch.principal.email (from user.email)
  * - langwatch.input (from codex.user_prompt prompt)
  */
@@ -107,6 +107,30 @@ const positiveOrNull = (n: number | null): number | null =>
 
 /** A canonical key and the codex-spelled value to lift onto it, if reported. */
 type CanonicalLift = readonly [string, string | number | null];
+
+/**
+ * Which conversation a turn belongs to. The turn span carries two ids, and
+ * they are one character apart to read: `thread.id` is the SESSION, the same
+ * id codex's log records spell `conversation.id` and the id its transcript
+ * on disk is filed under, while `turn.id` names this one turn. Both are
+ * time-ordered UUIDs minted seconds apart, so they share a prefix.
+ *
+ * Filing the trace under the turn gave every turn a conversation of its own:
+ * a codex session's turns never grouped, and a coding-agent session, which is
+ * keyed by the session id, resolved none of its own traces and read as having
+ * stored nothing. The session id is what groups them.
+ *
+ * Guarded to UUID-shaped values because codex's other spans stamp the tokio
+ * worker id ("10") under the same key; the turn id stays the answer when
+ * `thread.id` is one of those.
+ */
+function conversationIdOf(attrs: {
+  take: (key: string) => unknown;
+}): string | null {
+  const sessionId = asString(attrs.take("thread.id"));
+  const turnId = asString(attrs.take("turn.id"));
+  return sessionId?.includes("-") ? sessionId : turnId;
+}
 
 /**
  * Write every reported lift onto its canonical key, leaving an already-present
@@ -210,7 +234,7 @@ export class CodexExtractor implements CanonicalAttributesExtractor {
         ATTR_KEYS.GEN_AI_REQUEST_REASONING_EFFORT,
         asString(attrs.take("codex.turn.reasoning_effort")),
       ],
-      [ATTR_KEYS.GEN_AI_CONVERSATION_ID, asString(attrs.take("turn.id"))],
+      [ATTR_KEYS.GEN_AI_CONVERSATION_ID, conversationIdOf(attrs)],
     ];
 
     if (applyCanonicalLifts(ctx, lifts)) {

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -1574,11 +1574,16 @@ describe("coding-agent session fold, per-agent gating", () => {
 });
 
 describe("coding-agent session fold, codex", () => {
-  /** A live turn span's facts, verbatim spellings from codex-rs 0.147. */
+  /**
+   * A live turn span from codex-rs 0.147, as the fold receives it: after
+   * canonicalisation, where the input has already been made the disjoint
+   * non-cached bucket (2936 of the 13944 codex reported, the other 11008
+   * being the cache read).
+   */
   const codexTurnFacts = {
     "gen_ai.request.model": "gpt-5.6-sol",
     "gen_ai.response.model": "gpt-5.6-sol",
-    "gen_ai.usage.input_tokens": "13944",
+    "gen_ai.usage.input_tokens": "2936",
     "gen_ai.usage.output_tokens": "7",
     "gen_ai.usage.cache_read.input_tokens": "11008",
     "gen_ai.usage.cache_creation.input_tokens": "0",
@@ -1687,7 +1692,7 @@ describe("coding-agent session fold, codex", () => {
       expect(state.costUsd).toBe(0);
     });
 
-    it("derives the non-cached input when codex's own count is absent", () => {
+    it("reads the input the canonicalisation settled on, without deriving it again", () => {
       const projection = makeProjection();
       const {
         "codex.turn.token_usage.non_cached_input_tokens": _omit,
@@ -1704,7 +1709,9 @@ describe("coding-agent session fold, codex", () => {
         initStateOf(projection),
       );
 
-      expect(state.inputTokens).toBe(13_944 - 11_008);
+      // Taking the cache off a second time would leave nothing here, which
+      // is what a session whose turns all read zero input looked like.
+      expect(state.inputTokens).toBe(2_936);
       expect(state.cacheReadTokens).toBe(11_008);
     });
 

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -189,10 +189,19 @@ describe("CodingAgentSessionFoldProjection", () => {
     });
 
     /** @scenario "an agent that states its own price keeps it" */
-    it("charges nothing for a call by an agent that reports its own cost", () => {
+    it("keeps the reported cost and adds no estimate for the same turn", () => {
       const projection = makeProjection();
+      let state = initStateOf(projection);
 
-      const state = projection.handleCodingAgentSessionSpanFactsContributed(
+      // What the agent states it was billed for the turn.
+      state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          facts: { "event.name": "claude_code.api_request", cost_usd: 0.25 },
+        }),
+        state,
+      );
+
+      state = projection.handleCodingAgentSessionSpanFactsContributed(
         spanFactsEvent({
           name: "claude_code.llm_request",
           spanId: "llm-priced",
@@ -203,13 +212,15 @@ describe("CodingAgentSessionFoldProjection", () => {
             cache_read_tokens: 900,
           },
         }),
-        initStateOf(projection),
+        state,
       );
 
-      // The cost comes from the api_request event, which states what the
-      // agent was billed. Estimating this span too would charge the turn
-      // twice, at two different rates.
-      expect(state.costUsd).toBe(0);
+      // The reported cost survives and the span adds nothing on top.
+      // Estimating this span too would charge the turn twice, at two
+      // different rates. Folding the span alone and expecting 0 would pass
+      // just as well if the reported amount were dropped, so both halves
+      // are folded here.
+      expect(state.costUsd).toBe(0.25);
     });
   });
 

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -187,6 +187,30 @@ describe("CodingAgentSessionFoldProjection", () => {
       expect(state.sessionId).toBe(SESSION_ID);
       expect(state.agent).toBe("claude_code");
     });
+
+    /** @scenario "an agent that states its own price keeps it" */
+    it("charges nothing for a call by an agent that reports its own cost", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "claude_code.llm_request",
+          spanId: "llm-priced",
+          facts: {
+            model: "claude-sonnet-4-5",
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 900,
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      // The cost comes from the api_request event, which states what the
+      // agent was billed. Estimating this span too would charge the turn
+      // twice, at two different rates.
+      expect(state.costUsd).toBe(0);
+    });
   });
 
   describe("when a tool span FAILED", () => {
@@ -1591,6 +1615,76 @@ describe("coding-agent session fold, codex", () => {
       // does not pretend to be model latency.
       expect(state.modelCallMs).toBe(0);
       expect(state.attempts).toBe(1);
+    });
+
+    /** @scenario "a codex session is priced from the tokens it reported" */
+    it("prices the turn from its tokens, since codex states no cost", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "session_task.turn",
+          spanId: "turn-priced",
+          agent: "codex",
+          facts: codexTurnFacts,
+        }),
+        initStateOf(projection),
+      );
+
+      // 2,936 non-cached input + 11,008 cache-read + 7 output at gpt-5.6-sol's
+      // registry rates. The figure is the registry's, not one written here, so
+      // the assertion is that a price was worked out at all.
+      expect(state.costUsd).toBeGreaterThan(0);
+      expect(state.costUsd).toBeLessThan(1);
+    });
+
+    /** @scenario "a codex session is priced from the tokens it reported" */
+    it("adds a second turn's price to the session's total", () => {
+      const projection = makeProjection();
+
+      const first = projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "session_task.turn",
+          spanId: "turn-priced-1",
+          agent: "codex",
+          facts: codexTurnFacts,
+        }),
+        initStateOf(projection),
+      );
+      const second = projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "session_task.turn",
+          spanId: "turn-priced-2",
+          agent: "codex",
+          facts: codexTurnFacts,
+        }),
+        first,
+      );
+
+      expect(first.costUsd).toBeGreaterThan(0);
+      expect(second.costUsd).toBeCloseTo(first.costUsd * 2, 10);
+    });
+
+    /** @scenario "a turn priced at an unknown model costs nothing rather than guessing" */
+    it("counts the tokens but charges nothing for a model in no price list", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "session_task.turn",
+          spanId: "turn-unpriced",
+          agent: "codex",
+          facts: {
+            ...codexTurnFacts,
+            "gen_ai.request.model": "a-model-no-registry-lists",
+            "gen_ai.response.model": "a-model-no-registry-lists",
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.inputTokens).toBe(2_936);
+      expect(state.costUsd).toBe(0);
     });
 
     it("derives the non-cached input when codex's own count is absent", () => {

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -117,9 +117,10 @@ const CLAUDE = {
  *     `modelCallMs` (zero reads as "not measured"); TTFT arrives on the
  *     `codex.turn_ttft` EVENT instead, and tool runs on `tool_result` events
  *     (`foldsToolRunsFromEvents` on the definition — codex has no tool span).
- *   - `gen_ai.usage.input_tokens` INCLUDES the cache buckets, unlike the
- *     disjoint claude spellings — {@link codexTurnTokenFacts} re-derives the
- *     disjoint input before the shared fold runs.
+ *   - codex reports an input that INCLUDES the cache buckets, unlike the
+ *     disjoint claude spellings. The canonicalisation takes the cache off it,
+ *     so `gen_ai.usage.input_tokens` is already disjoint here and
+ *     {@link codexTurnTokenFacts} only respells the keys.
  */
 const CODEX = {
   SPAN: {
@@ -133,7 +134,6 @@ const CODEX = {
     OUTPUT_TOKENS: "gen_ai.usage.output_tokens",
     CACHE_READ_TOKENS: "gen_ai.usage.cache_read.input_tokens",
     CACHE_CREATION_TOKENS: "gen_ai.usage.cache_creation.input_tokens",
-    NON_CACHED_INPUT_TOKENS: "codex.turn.token_usage.non_cached_input_tokens",
     RESPONSE_MODEL: "gen_ai.response.model",
   },
 } as const;
@@ -646,32 +646,24 @@ function pricedFromTokens(facts: Record<string, unknown>): number {
 }
 
 /**
- * Codex's turn tokens, respelled into the disjoint claude vocabulary
+ * Codex's turn tokens, respelled into the claude vocabulary
  * {@link foldModelCall} reads — one fold, one convention.
  *
- * The re-derivation is the point: codex's `gen_ai.usage.input_tokens` is the
- * WHOLE input, cache included (13944 = 11008 cache-read + 2936 non-cached on
- * a live turn), while the shared fold's `input_tokens` is the disjoint
- * non-cached bucket. Codex's own non-cached count is preferred; when a build
- * omits it, the subtraction recovers it from the gen_ai buckets.
+ * Only a respelling: codex reports the WHOLE input, cache included, and the
+ * canonicalisation already took the cache off it, so `gen_ai.usage.input_tokens`
+ * is the disjoint non-cached bucket by the time a span reaches this fold. That
+ * is the same value the trace is priced from, which is what makes a codex
+ * session and its trace state one figure.
  */
 function codexTurnTokenFacts(
   attrs: Record<string, unknown>,
 ): Record<string, unknown> {
-  const cacheRead = num(attrs[CODEX.ATTR.CACHE_READ_TOKENS]);
-  const cacheCreation = num(attrs[CODEX.ATTR.CACHE_CREATION_TOKENS]);
-  const wholeInput = num(attrs[CODEX.ATTR.INPUT_TOKENS]);
-  const nonCachedInput =
-    attrs[CODEX.ATTR.NON_CACHED_INPUT_TOKENS] !== undefined
-      ? num(attrs[CODEX.ATTR.NON_CACHED_INPUT_TOKENS])
-      : Math.max(0, wholeInput - cacheRead - cacheCreation);
-
   return {
     ...attrs,
-    input_tokens: nonCachedInput,
+    input_tokens: num(attrs[CODEX.ATTR.INPUT_TOKENS]),
     output_tokens: num(attrs[CODEX.ATTR.OUTPUT_TOKENS]),
-    cache_read_tokens: cacheRead,
-    cache_creation_tokens: cacheCreation,
+    cache_read_tokens: num(attrs[CODEX.ATTR.CACHE_READ_TOKENS]),
+    cache_creation_tokens: num(attrs[CODEX.ATTR.CACHE_CREATION_TOKENS]),
     model:
       str(attrs["gen_ai.request.model"]) ??
       str(attrs[CODEX.ATTR.RESPONSE_MODEL]),

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -1,3 +1,4 @@
+import { computeSpanCost } from "~/server/app-layer/traces/model-cost-matching";
 import {
   CODING_AGENT_REGISTRY,
   EVENTS_FOLD_TOOL_RUNS_AGENT_IDS,
@@ -622,6 +623,29 @@ function foldModelCall(
 }
 
 /**
+ * What one turn cost, for an agent whose telemetry states no price of its own.
+ *
+ * Claude reports what it was billed on its API_REQUEST event, and that number
+ * is the session's cost. Codex reports a model and token counts and nothing
+ * else, so its sessions read as free while the SAME turn's trace states a
+ * figure — the trace pipeline prices the identical span against the model
+ * registry. This is that same call, so the two agree.
+ *
+ * The facts are the respelled ones, whose `input_tokens` is the disjoint
+ * non-cached bucket, and whose cache buckets keep codex's own spellings —
+ * which are the gen_ai keys {@link computeSpanCost} reads. An unpriced model
+ * comes back zero rather than an invented rate.
+ */
+function pricedFromTokens(facts: Record<string, unknown>): number {
+  return computeSpanCost({
+    attrs: facts,
+    model: str(facts.model) ?? undefined,
+    promptTokens: num(facts.input_tokens),
+    completionTokens: num(facts.output_tokens),
+  });
+}
+
+/**
  * Codex's turn tokens, respelled into the disjoint claude vocabulary
  * {@link foldModelCall} reads — one fold, one convention.
  *
@@ -701,13 +725,11 @@ export function applySpanToCodingAgentSession({
     // declined foreign spans reusing this bare name, and one that still
     // arrives labeled as another agent contributes identity only.
     if (agent !== "codex" || isLogsOnly) return withIdentity(state, attrs);
+    const facts = codexTurnTokenFacts(attrs);
     // Fallback duration 0, not the span's: the turn's wall time includes the
     // tools that ran inside it, and zero reads honestly as "not measured".
-    return foldModelCall(
-      withIdentity(state, attrs),
-      codexTurnTokenFacts(attrs),
-      0,
-    );
+    const folded = foldModelCall(withIdentity(state, attrs), facts, 0);
+    return { ...folded, costUsd: folded.costUsd + pricedFromTokens(facts) };
   }
 
   if (span.name === CLAUDE.SPAN.SUBAGENT_SPAWN) {

--- a/specs/coding-agent/session-aggregate.feature
+++ b/specs/coding-agent/session-aggregate.feature
@@ -152,6 +152,24 @@ Feature: Coding-agent sessions
     Then the session counts one model call for the turn
     And the token buckets stay disjoint, with the cached input counted once
 
+  Scenario: a codex session is priced from the tokens it reported
+    Given a codex session, whose telemetry states no price of its own
+    When its turn span reports the model and the token totals
+    Then the session's cost is worked out from those tokens at that model's price
+    And a second turn adds its own price to the session's total
+    # Without this a codex session reads as free, while the same turn's trace
+    # states a figure: the trace pipeline prices the identical span.
+
+  Scenario: a turn priced at an unknown model costs nothing rather than guessing
+    Given a codex turn whose model is in no price list
+    When the turn is folded
+    Then the session's tokens are counted and its cost stays at zero
+
+  Scenario: an agent that states its own price keeps it
+    Given a session whose telemetry reports what it was billed
+    When its model calls are folded
+    Then the session's cost is the reported one, never a second estimate
+
   Scenario: a codex shell command counts once despite its sandbox outcome event
     When a codex session runs one shell command that reports a tool result and a sandbox outcome
     Then the session counts one tool run

--- a/specs/coding-agent/sessions-screen.feature
+++ b/specs/coding-agent/sessions-screen.feature
@@ -229,6 +229,23 @@ Rule: A session lists every pull request it drove
     When the user reads its row
     Then the pull request cell reads as absent
 
+  @integration
+  Scenario: A pull request number opens what the change cost, not GitHub
+    Given a session row that lists a pull request
+    When the user chooses the pull request number
+    Then the pull request's detail opens over the table
+    And the replay of the session does not open
+    # The reader is on this screen to read spend, so the number leads to the
+    # same detail the pull requests screen opens, which is where every
+    # session that worked on that change is added up. GitHub is one click
+    # further, in that detail's own header.
+
+  @integration
+  Scenario: A pull request number is drawn as something to choose
+    Given a session row that lists a pull request
+    When the user reads the row
+    Then the number is underlined
+
 Rule: The table narrows, sorts and pages
 
   @integration

--- a/specs/coding-agent/trace-fidelity.feature
+++ b/specs/coding-agent/trace-fidelity.feature
@@ -30,6 +30,22 @@ Feature: Coding Agent Trace Fidelity (Path B direct OTLP)
     Then the span carries the reasoning tokens under the canonical usage key
     And the trace summary reasoning token total includes them
 
+  # --- Which conversation a codex turn belongs to ---------------------------
+
+  # A codex turn span names two ids: the session it belongs to, and the turn
+  # itself. Filing the trace under the turn gave every turn a conversation of
+  # its own, so a session's turns never grouped and the session, which is keyed
+  # by the session id, resolved none of its own traces. A reader opening such a
+  # session was told nothing had been stored, while the traces were there under
+  # ids nothing looked up.
+
+  @unit
+  Scenario: A codex turn is filed under its session, not under itself
+    Given a codex turn span that names both its session and the turn
+    When the span is canonicalised
+    Then the trace belongs to the session's conversation
+    And a turn span that names no session keeps the turn's own id
+
   # --- Reasoning effort (the request setting, not the token count) -----------
 
   @unit

--- a/specs/coding-agent/trace-fidelity.feature
+++ b/specs/coding-agent/trace-fidelity.feature
@@ -30,6 +30,16 @@ Feature: Coding Agent Trace Fidelity (Path B direct OTLP)
     Then the span carries the reasoning tokens under the canonical usage key
     And the trace summary reasoning token total includes them
 
+  @unit
+  Scenario: A codex turn's cached input is priced once, not twice
+    Given a codex turn span whose reported input includes its cached tokens
+    When the span is canonicalised
+    Then the span's input tokens are the part that was not cached
+    And the cached tokens stay on their own keys, at their own rates
+    # Codex reports the whole input, cache included. Lifting that straight
+    # across charged the cached tokens at the full input rate and again at
+    # the cache rate, which priced such a turn about four times over.
+
   # --- Which conversation a codex turn belongs to ---------------------------
 
   # A codex turn span names two ids: the session it belongs to, and the turn


### PR DESCRIPTION
## What

A codex session's row in the sessions screen said almost nothing, and what it did say about money was wrong. Found by running real codex sessions and following the data through, not by reading the code.

- **Cost read as nothing.** Every codex session, at any size.
- **The trace's cost was about four times what the turn cost.**
- **Choosing a session said nothing had been stored**, while its traces were in ClickHouse the whole time.

![The sessions screen](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7420/sessions-row.png)

## Cost on the session

Codex reports a model and token counts and states no price of its own. Claude states what it was billed, on its `api_request` event, and that number is the session's cost. So a codex session had no cost at all.

The session fold now prices the turn against the model registry, the same one the trace pipeline uses. Only the codex turn span is priced: estimating claude's span as well would charge one turn twice, at two different rates. A model in no price list comes back zero rather than an invented rate.

## The cached input, priced twice

Codex's reported input INCLUDES its cache buckets:

```
gen_ai.usage.input_tokens           43001    codex: the whole input
gen_ai.usage.cache_read.input_tokens 36096   of which this was cached
                                     6905    what the turn actually paid for
```

The canonical input key is the disjoint non-cached bucket, because the cache buckets ride beside it and price at their own, much lower, rates. Lifting codex's whole input straight across charged the cached tokens twice: once at the full input rate, and again at the cache rate. That turn priced at **$0.2395 where it cost $0.0590**, on every codex trace we have ever stored.

The canonicalisation now takes the cache off the input, preferring codex's own non-cached count and subtracting when a build omits it. The session fold used to do that same re-derivation, and doing it a second time on an already-disjoint value left every codex turn reading zero input, so it now reads the settled value. One adaptation, at the boundary.

Verified end to end on a live codex session: turn span `$0.064466`, session `$0.064466`, on 8,108 input, 213 output and 35,072 cache-read.

## Traces

A codex turn span names two ids, and they read almost alike because both are time-ordered UUIDs minted seconds apart:

```
thread.id  019e9bfe-7749-7440-8506-39152afbc9ff   the session
turn.id    019e9bfe-92ad-7591-a7fd-d6250ce88904   this one turn
```

`thread.id` is the session: the same id codex's log records spell `conversation.id`, the id its transcript on disk is filed under, and the id the coding-agent session is keyed by. The trace took `turn.id`.

So every turn became a conversation of its own, and a session resolved none of its traces. Choosing one said "No stored traces for this session yet" while the traces sat under ids nothing looked up. The session id is what groups them. The turn id stays the answer when the span carries no session, which is what the tokio worker id (`"10"`) under the same key would otherwise be read as.

![The terminal replay](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7420/terminal-replay.png)

Closes #7418
Closes #7402

## Pull request numbers

A reader is on this screen to read spend, and the numbers left for GitHub, which states none. They now open the same detail the pull requests screen opens, where every session that worked on that change is added up. GitHub stays one click away, in that detail's own header. They are underlined, because they are the one part of a row that goes somewhere other than where the row goes.

![The pull request detail](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7420/pull-request-drawer.png)

## Data already stored

Traces and sessions written before this keep the ids and the figures they were written with. Nothing is rewritten.

## Tests

Seven scenarios, all bound, mutation-checked where they guard a branch:

- `specs/coding-agent/session-aggregate.feature`: a codex session is priced from the tokens it reported; a turn priced at an unknown model costs nothing rather than guessing; an agent that states its own price keeps it
- `specs/coding-agent/trace-fidelity.feature`: a codex turn's cached input is priced once, not twice; a codex turn is filed under its session, not under itself
- `specs/coding-agent/sessions-screen.feature`: a pull request number opens what the change cost, not GitHub; a pull request number is drawn as something to choose

Removing the pricing line fails the pricing test and nothing else. Restoring the turn id fails the conversation test and nothing else.

Gate: 2,095 unit tests across the coding-agent and traces trees, 23 in the sessions table, `pnpm typecheck:all` clean, biome clean on the touched files, feature parity OK.

## How it was checked

A local LangWatch, a real `codex` TUI session driven in tmux with its telemetry pointed at it, and the sessions screen read in a browser. The screenshots above are that run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-request numbers in the Sessions table now open an in-app detail drawer instead of an external page.
  * Selecting a pull request no longer opens the session replay.
  * Pull-request numbers are visibly interactive for easier discovery.

* **Bug Fixes**
  * Improved Codex conversation attribution and token accounting.
  * Added more accurate Codex cost calculation, including cached-token pricing and multi-turn totals.
  * Unknown Codex models now correctly report zero calculated cost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->