### PR TITLE
fix(ai-gateway): emit missing-usage notice as SSE comment, not data frame

### DIFF
--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -1498,11 +1498,11 @@ func setMetaHeaders(w http.ResponseWriter, meta app.DispatchMeta) {
 // Pre-allocated SSE framing bytes — three w.Write calls instead of one
 // fmt.Fprintf avoids allocating a format buffer per chunk.
 var (
-	sseDataPrefix  = []byte("data: ")
-	sseDoubleNL    = []byte("\n\n")
-	sseErrorPrefix = []byte("event: error\ndata: ")
-	sseWarnPrefix  = []byte("event: warning\ndata: ")
-	sseDone        = []byte("data: [DONE]\n\n")
+	sseDataPrefix    = []byte("data: ")
+	sseDoubleNL      = []byte("\n\n")
+	sseErrorPrefix   = []byte("event: error\ndata: ")
+	sseCommentPrefix = []byte(": ")
+	sseDone          = []byte("data: [DONE]\n\n")
 )
 
 // streamErrorFrame builds the data payload for a terminal `event: error`.
@@ -1598,8 +1598,14 @@ func writeSSE(ctx context.Context, w http.ResponseWriter, iter domain.StreamIter
 	}
 
 	if !raw && iter.Usage().TotalTokens == 0 {
+		// Emit the missing-usage notice as an SSE comment line, never as a
+		// data: frame. SDK clients (OpenAI Responses, Vercel AI SDK) schema-
+		// validate every data payload against {choices}|{error}; a bare
+		// warning object there crashes strict clients mid-stream (see
+		// issue #7421). Comment lines are ignored by spec-compliant
+		// parsers but stay visible to curl-style debugging.
 		warnJSON, _ := sonic.Marshal(map[string]string{"warning": "provider_did_not_report_usage_on_stream"})
-		_, _ = w.Write(sseWarnPrefix)
+		_, _ = w.Write(sseCommentPrefix)
 		_, _ = w.Write(warnJSON)
 		_, _ = w.Write(sseDoubleNL)
 	}

--- a/services/aigateway/adapters/httpapi/router_test.go
+++ b/services/aigateway/adapters/httpapi/router_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -924,4 +925,61 @@ func TestRouter_ModelsEndpoint_KeepsTheFamilyInOwnedBy(t *testing.T) {
 	require.Len(t, parsed.Data, 1)
 	assert.Equal(t, "eu/claude-sonnet-5", parsed.Data[0].ID)
 	assert.Equal(t, "anthropic", parsed.Data[0].OwnedBy)
+}
+
+// Regression for issue #7421: the missing-usage notice used to be emitted
+// as its own data: frame carrying a bare {"warning": ...} object. Strict
+// OpenAI-compatible SDK clients (Vercel AI SDK / @ai-sdk/opencompatible)
+// schema-validate every data payload against a {choices}|{error} union and
+// hard-crash mid-stream on anything else. The notice must ride as an SSE
+// comment line, which spec-compliant parsers ignore.
+type zeroUsageIter struct {
+	chunks [][]byte
+	i      int
+}
+
+func (it *zeroUsageIter) Next(_ context.Context) bool {
+	if it.i >= len(it.chunks) {
+		return false
+	}
+	it.i++
+	return true
+}
+
+func (it *zeroUsageIter) Chunk() []byte       { return it.chunks[it.i-1] }
+func (it *zeroUsageIter) Usage() domain.Usage { return domain.Usage{} }
+func (it *zeroUsageIter) Err() error          { return nil }
+func (it *zeroUsageIter) Close() error        { return nil }
+
+func TestWriteSSE_MissingUsageNotice_IsCommentNotDataFrame(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeSSE(context.Background(), rec, &zeroUsageIter{
+		chunks: [][]byte{
+			[]byte(`{"id":"1","choices":[{"delta":{"content":"hi"}}]}`),
+			[]byte(`{"id":"1","choices":[],"usage":{"prompt_tokens":89,"completion_tokens":45,"total_tokens":134}}`),
+		},
+	})
+	body := rec.Body.String()
+
+	require.Contains(t, body, "provider_did_not_report_usage_on_stream",
+		"notice should still be emitted for curl-style debugging")
+	require.NotContains(t, body, "data: {\"warning\"",
+		"the notice must never be its own data: frame")
+
+	// Every data payload the client sees must satisfy the strict
+	// {choices}|{error} union (or be the [DONE] sentinel).
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		var probe map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(payload), &probe),
+			"data payload is not a JSON object: %q", line)
+		require.True(t, probe["choices"] != nil || probe["error"] != nil,
+			"data payload without choices/error crashes strict spec-validating clients: %q", line)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #7421.

When an upstream provider does not report usage on a streamed chat completion, the gateway appended a terminal warning frame on OpenAI-compatible endpoints:

```
event: warning
data: {"warning":"provider_did_not_report_usage_on_stream"}

```

The `data:` payload is a bare object with neither `choices` nor `error`. Strict OpenAI-compatible SDK clients schema-validate every data payload against that union — `@ai-sdk/openai-compatible` (Vercel AI SDK) throws `AI_TypeValidationError` and the client process dies mid-stream. The issue reporter observed 3 such crashes on long agent sessions against a custom vLLM provider row.

The codebase already handles this correctly for terminal errors: `streamErrorFrame` deliberately shapes its payload as `{"type":"error","error":{...}}` precisely because "SDK clients schema-validate every data payload". The warning frame was the one remaining violation of that convention.

**Fix:** emit the notice as an SSE comment line instead:

```
: {"warning":"provider_did_not_report_usage_on_stream"}

```

Per the SSE spec, parsers must ignore lines starting with `:`, so no client can crash on it — while the JSON payload stays fully visible to curl-style debugging and grep. The `X-LangWatch-Usage-Warning` response header and `success_no_usage` span status are unchanged.

## Verification

- New regression test `TestWriteSSE_MissingUsageNotice_IsCommentNotDataFrame` in `services/aigateway/adapters/httpapi/router_test.go`: streams two chunks through `writeSSE` with a zero-usage iterator, then asserts (a) the notice is still present, (b) it never appears as a `data:` frame, and (c) **every** remaining `data:` payload parses to an object with `choices` or `error`.
- Red→green confirmed: with the old framing restored, the test fails with the exact crash-inducing frame from the issue (`data: {"warning":...}`) in the output.
- `go test ./services/aigateway/...`: 19 packages, all ok.
- `gofmt` clean; `make go-lint-changed` (golangci-lint v2.11.4, pinned by Makefile): 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses when usage metadata is unavailable.
  * Warning messages are now delivered in a format that strict SSE clients won’t mistake for response data.
  * Existing response payloads remain compatible with standard validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->