### PR TITLE
fix(ci): dedupe release notes by commit SHA

### DIFF
--- a/.github/scripts/dedupe-release-notes.test.ts
+++ b/.github/scripts/dedupe-release-notes.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { dedupeNewestReleaseSection, newestReleaseCommitShas } from "./dedupe-release-notes.ts";
+
+const sha = (value: string): string => value.repeat(40 / value.length);
+
+const entry = (title: string, commit: string, pullRequest?: number): string => {
+  const pullRequestLink = pullRequest
+    ? ` ([#${pullRequest}](https://github.com/langwatch/langwatch/issues/${pullRequest}))`
+    : "";
+  return `* ${title}${pullRequestLink} ([${commit.slice(0, 7)}](https://github.com/langwatch/langwatch/commit/${commit}))`;
+};
+
+describe("dedupeNewestReleaseSection", () => {
+  it("keeps the entry linked to the canonical squash subject PR", () => {
+    const duplicate = sha("a");
+    const content = [
+      "# Changelog",
+      "",
+      "## [3.16.0] (2026-08-21)",
+      "",
+      "### Features",
+      entry("body conventional commit", duplicate, 7346),
+      entry("squash subject", duplicate, 7347),
+      "",
+      "## [3.15.0] (2026-08-01)",
+      entry("historical entry", duplicate, 7000),
+      "",
+    ].join("\n");
+
+    const result = dedupeNewestReleaseSection(content, { [duplicate]: 7347 });
+
+    assert.match(result.content, /squash subject/);
+    assert.doesNotMatch(result.content, /body conventional commit/);
+    assert.match(result.content, /historical entry/);
+    assert.deepEqual(result.removedCommitShas, [duplicate]);
+  });
+
+  it("prefers a PR-linked entry when the commit subject has no PR reference", () => {
+    const duplicate = sha("b");
+    const content = [
+      "## [1.0.0] (2026-08-21)",
+      entry("unlinked body", duplicate),
+      entry("linked subject", duplicate, 42),
+    ].join("\n");
+
+    const result = dedupeNewestReleaseSection(content, {});
+
+    assert.match(result.content, /linked subject/);
+    assert.doesNotMatch(result.content, /unlinked body/);
+  });
+
+  it("is a no-op for unique entries and for a second run", () => {
+    const one = sha("c");
+    const two = sha("d");
+    const content = [
+      "# Changelog",
+      "",
+      "## [1.0.0] (2026-08-21)",
+      entry("one", one, 1),
+      entry("two", two, 2),
+      "",
+    ].join("\n");
+
+    const first = dedupeNewestReleaseSection(content, {});
+    const second = dedupeNewestReleaseSection(first.content, {});
+
+    assert.equal(first.content, content);
+    assert.equal(second.content, content);
+    assert.deepEqual(newestReleaseCommitShas(content), [one, two]);
+  });
+});

--- a/.github/scripts/dedupe-release-notes.test.ts
+++ b/.github/scripts/dedupe-release-notes.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { describe, it } from "node:test";
 
 import {
@@ -156,15 +157,17 @@ describe("subjectPullRequestsFor", () => {
   /** @scenario "An unavailable commit subject does not stop generated release notes" */
   it("skips an unavailable commit subject", () => {
     const missingCommit = sha("0");
+    const existingCommit = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
     const warnings: string[] = [];
 
     const result = subjectPullRequestsFor({
-      commitShas: [missingCommit],
+      commitShas: [missingCommit, existingCommit],
       cwd: process.cwd(),
       warn: (message) => warnings.push(message),
     });
 
-    assert.deepEqual(result, { [missingCommit]: undefined });
+    assert.equal(result[missingCommit], undefined);
+    assert.ok(Object.hasOwn(result, existingCommit));
     assert.match(warnings[0]!, new RegExp(missingCommit));
   });
 });

--- a/.github/scripts/dedupe-release-notes.test.ts
+++ b/.github/scripts/dedupe-release-notes.test.ts
@@ -1,11 +1,23 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { dedupeNewestReleaseSection, newestReleaseCommitShas } from "./dedupe-release-notes.ts";
+import {
+  dedupeNewestReleaseSection,
+  newestReleaseCommitShas,
+  subjectPullRequestsFor,
+} from "./dedupe-release-notes.ts";
 
 const sha = (value: string): string => value.repeat(40 / value.length);
 
-const entry = (title: string, commit: string, pullRequest?: number): string => {
+const entry = ({
+  title,
+  commit,
+  pullRequest,
+}: {
+  title: string;
+  commit: string;
+  pullRequest?: number;
+}): string => {
   const pullRequestLink = pullRequest
     ? ` ([#${pullRequest}](https://github.com/langwatch/langwatch/issues/${pullRequest}))`
     : "";
@@ -13,6 +25,7 @@ const entry = (title: string, commit: string, pullRequest?: number): string => {
 };
 
 describe("dedupeNewestReleaseSection", () => {
+  /** @scenario "Duplicate commit entries leave one generated release note" */
   it("keeps the entry linked to the canonical squash subject PR", () => {
     const duplicate = sha("a");
     const content = [
@@ -21,15 +34,18 @@ describe("dedupeNewestReleaseSection", () => {
       "## [3.16.0] (2026-08-21)",
       "",
       "### Features",
-      entry("body conventional commit", duplicate, 7346),
-      entry("squash subject", duplicate, 7347),
+      entry({ title: "body conventional commit", commit: duplicate, pullRequest: 7346 }),
+      entry({ title: "squash subject", commit: duplicate, pullRequest: 7347 }),
       "",
       "## [3.15.0] (2026-08-01)",
-      entry("historical entry", duplicate, 7000),
+      entry({ title: "historical entry", commit: duplicate, pullRequest: 7000 }),
       "",
     ].join("\n");
 
-    const result = dedupeNewestReleaseSection(content, { [duplicate]: 7347 });
+    const result = dedupeNewestReleaseSection({
+      content,
+      subjectPullRequests: { [duplicate]: 7347 },
+    });
 
     assert.match(result.content, /squash subject/);
     assert.doesNotMatch(result.content, /body conventional commit/);
@@ -41,33 +57,114 @@ describe("dedupeNewestReleaseSection", () => {
     const duplicate = sha("b");
     const content = [
       "## [1.0.0] (2026-08-21)",
-      entry("unlinked body", duplicate),
-      entry("linked subject", duplicate, 42),
+      entry({ title: "unlinked body", commit: duplicate }),
+      entry({ title: "linked subject", commit: duplicate, pullRequest: 42 }),
     ].join("\n");
 
-    const result = dedupeNewestReleaseSection(content, {});
+    const result = dedupeNewestReleaseSection({ content, subjectPullRequests: {} });
 
     assert.match(result.content, /linked subject/);
     assert.doesNotMatch(result.content, /unlinked body/);
   });
 
-  it("is a no-op for unique entries and for a second run", () => {
+  it("leaves unique entries unchanged", () => {
     const one = sha("c");
     const two = sha("d");
     const content = [
       "# Changelog",
       "",
       "## [1.0.0] (2026-08-21)",
-      entry("one", one, 1),
-      entry("two", two, 2),
+      entry({ title: "one", commit: one, pullRequest: 1 }),
+      entry({ title: "two", commit: two, pullRequest: 2 }),
       "",
     ].join("\n");
 
-    const first = dedupeNewestReleaseSection(content, {});
-    const second = dedupeNewestReleaseSection(first.content, {});
+    const result = dedupeNewestReleaseSection({ content, subjectPullRequests: {} });
 
-    assert.equal(first.content, content);
-    assert.equal(second.content, content);
+    assert.equal(result.content, content);
+    assert.deepEqual(result.removedCommitShas, []);
     assert.deepEqual(newestReleaseCommitShas(content), [one, two]);
+  });
+
+  it("is idempotent after removing duplicate entries", () => {
+    const duplicate = sha("e");
+    const content = [
+      "## [1.0.0] (2026-08-21)",
+      entry({ title: "first generated entry", commit: duplicate }),
+      entry({ title: "duplicate generated entry", commit: duplicate }),
+    ].join("\n");
+
+    const first = dedupeNewestReleaseSection({ content, subjectPullRequests: {} });
+    const second = dedupeNewestReleaseSection({
+      content: first.content,
+      subjectPullRequests: {},
+    });
+
+    assert.doesNotMatch(first.content, /duplicate generated entry/);
+    assert.deepEqual(first.removedCommitShas, [duplicate]);
+    assert.equal(second.content, first.content);
+    assert.deepEqual(second.removedCommitShas, []);
+  });
+
+  /** @scenario "Duplicate removal preserves following changelog sections" */
+  it("preserves subsection headings after a removed entry", () => {
+    const duplicate = sha("f");
+    const other = sha("1");
+    const content = [
+      "## [1.0.0] (2026-08-21)",
+      "### Features",
+      entry({ title: "first generated entry", commit: duplicate }),
+      entry({ title: "duplicate generated entry", commit: duplicate }),
+      "### Fixes",
+      entry({ title: "unrelated fix", commit: other }),
+    ].join("\n");
+
+    const result = dedupeNewestReleaseSection({ content, subjectPullRequests: {} });
+
+    assert.match(result.content, /^### Fixes$/m);
+    assert.match(result.content, /unrelated fix/);
+    assert.doesNotMatch(result.content, /duplicate generated entry/);
+  });
+
+  /** @scenario "Incomplete changelogs remain unchanged" */
+  it("keeps changelogs without a generated release section unchanged", () => {
+    const content = "# Changelog\n\nNo releases have been generated yet.\n";
+
+    const result = dedupeNewestReleaseSection({ content, subjectPullRequests: {} });
+
+    assert.deepEqual(result, { content, removedCommitShas: [] });
+  });
+
+  /** @scenario "Incomplete changelogs remain unchanged" */
+  it("skips entries without a commit SHA", () => {
+    const commit = sha("2");
+    const content = [
+      "## [1.0.0] (2026-08-21)",
+      "* Entry with a missing commit link",
+      entry({ title: "valid entry", commit }),
+    ].join("\n");
+
+    const result = dedupeNewestReleaseSection({ content, subjectPullRequests: {} });
+
+    assert.equal(result.content, content);
+    assert.deepEqual(result.removedCommitShas, []);
+    assert.deepEqual(newestReleaseCommitShas(content), [commit]);
+  });
+});
+
+describe("subjectPullRequestsFor", () => {
+  /** @scenario "An unavailable commit subject does not stop generated release notes" */
+  it("skips an unavailable commit subject", () => {
+    const missingCommit = sha("0");
+    const warnings: string[] = [];
+
+    const result = subjectPullRequestsFor({
+      commitShas: [missingCommit],
+      cwd: process.cwd(),
+      warn: (message) => warnings.push(message),
+    });
+
+    assert.deepEqual(result, { [missingCommit]: undefined });
+    assert.match(warnings[0]!, new RegExp(missingCommit));
   });
 });

--- a/.github/scripts/dedupe-release-notes.ts
+++ b/.github/scripts/dedupe-release-notes.ts
@@ -1,0 +1,266 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+interface ReleasePullRequest {
+  number: number;
+  headBranchName: string;
+}
+
+interface ReleaseNoteEntry {
+  sha: string;
+  pullRequestNumbers: number[];
+  start: number;
+  end: number;
+}
+
+export interface DeduplicationResult {
+  content: string;
+  removedCommitShas: string[];
+}
+
+const RELEASE_PLEASE_BRANCH_PREFIX = "release-please--branches--main--components--";
+const RELEASE_HEADER = /^## \[[^\]]+\]/;
+const BULLET = /^\* /;
+const COMMIT_SHA = /\/commit\/([0-9a-f]{7,64})(?=[)\s])/i;
+const PULL_REQUEST_LINK = /\/(?:issues|pull)\/(\d+)(?=[)#\s])/g;
+const SUBJECT_PULL_REQUEST = /\(#(\d+)\)\s*$/;
+
+const newestReleaseSection = (lines: string[]): { start: number; end: number } | null => {
+  const start = lines.findIndex((line) => RELEASE_HEADER.test(line));
+  if (start === -1) return null;
+
+  const nextRelease = lines.findIndex((line, index) => index > start && RELEASE_HEADER.test(line));
+  return { start, end: nextRelease === -1 ? lines.length : nextRelease };
+};
+
+const entryPullRequestNumbers = (text: string): number[] =>
+  [...text.matchAll(PULL_REQUEST_LINK)].map((match) => Number(match[1]));
+
+const entriesIn = (lines: string[], start: number, end: number): ReleaseNoteEntry[] => {
+  const entries: ReleaseNoteEntry[] = [];
+
+  for (let index = start + 1; index < end; index++) {
+    if (!BULLET.test(lines[index]!)) continue;
+
+    let entryEnd = index + 1;
+    while (entryEnd < end && !BULLET.test(lines[entryEnd]!)) entryEnd++;
+
+    const text = lines.slice(index, entryEnd).join("\n");
+    const sha = text.match(COMMIT_SHA)?.[1];
+    if (sha) {
+      entries.push({
+        sha: sha.toLowerCase(),
+        pullRequestNumbers: entryPullRequestNumbers(text),
+        start: index,
+        end: entryEnd,
+      });
+    }
+
+    index = entryEnd - 1;
+  }
+
+  return entries;
+};
+
+/** Commit SHAs represented by release-note bullets in the newest release. */
+export const newestReleaseCommitShas = (content: string): string[] => {
+  const lines = content.split("\n");
+  const section = newestReleaseSection(lines);
+  if (!section) return [];
+  return [...new Set(entriesIn(lines, section.start, section.end).map((entry) => entry.sha))];
+};
+
+/**
+ * Keep one release-note bullet per commit in the newest generated release.
+ *
+ * release-please can parse both a squash commit subject and a conventional
+ * commit line at the beginning of its body. They point at the same SHA, but
+ * can carry different wording or even different PR references. Prefer the
+ * entry linked to the PR named by the canonical squash subject, then any
+ * entry with a PR link, then the first generated entry.
+ */
+export const dedupeNewestReleaseSection = (
+  content: string,
+  subjectPullRequests: Readonly<Record<string, number | undefined>>,
+): DeduplicationResult => {
+  const lines = content.split("\n");
+  const section = newestReleaseSection(lines);
+  if (!section) return { content, removedCommitShas: [] };
+
+  const bySha = new Map<string, ReleaseNoteEntry[]>();
+  for (const entry of entriesIn(lines, section.start, section.end)) {
+    const group = bySha.get(entry.sha) ?? [];
+    group.push(entry);
+    bySha.set(entry.sha, group);
+  }
+
+  const removedLines = new Set<number>();
+  const removedCommitShas: string[] = [];
+  for (const [sha, group] of bySha) {
+    if (group.length < 2) continue;
+
+    const expectedPullRequest = subjectPullRequests[sha];
+    const keep =
+      group.find(
+        (entry) =>
+          expectedPullRequest !== undefined && entry.pullRequestNumbers.includes(expectedPullRequest),
+      ) ?? group.find((entry) => entry.pullRequestNumbers.length > 0) ?? group[0]!;
+
+    for (const entry of group) {
+      if (entry === keep) continue;
+      for (let index = entry.start; index < entry.end; index++) removedLines.add(index);
+    }
+    removedCommitShas.push(sha);
+  }
+
+  if (removedLines.size === 0) return { content, removedCommitShas };
+  return {
+    content: lines.filter((_line, index) => !removedLines.has(index)).join("\n"),
+    removedCommitShas,
+  };
+};
+
+const run = (command: string, args: string[], cwd: string): string =>
+  execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+const requireRepository = (): string => {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository || !/^[^/]+\/[^/]+$/.test(repository)) {
+    throw new Error("GITHUB_REPOSITORY must be an owner/repository value");
+  }
+  return repository;
+};
+
+const releasePullRequests = (): ReleasePullRequest[] => {
+  const raw = process.env.RELEASE_PLEASE_PRS;
+  if (!raw) return [];
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("RELEASE_PLEASE_PRS must be a JSON array");
+
+  return parsed.map((value) => {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !Number.isInteger((value as ReleasePullRequest).number) ||
+      typeof (value as ReleasePullRequest).headBranchName !== "string"
+    ) {
+      throw new Error("RELEASE_PLEASE_PRS contains an invalid pull request");
+    }
+    return value as ReleasePullRequest;
+  });
+};
+
+const stagedChanges = (cwd: string): boolean => {
+  const result = spawnSync("git", ["diff", "--cached", "--quiet"], {
+    cwd,
+    env: process.env,
+    stdio: "ignore",
+  });
+  if (result.status === 0) return false;
+  if (result.status === 1) return true;
+  throw new Error("Unable to inspect staged changes");
+};
+
+const safeRepositoryPath = (path: string, cwd: string): string => {
+  const absolutePath = resolve(cwd, path);
+  if (!absolutePath.startsWith(`${resolve(cwd)}/`)) {
+    throw new Error(`Refusing to write outside the repository: ${path}`);
+  }
+  return absolutePath;
+};
+
+const subjectPullRequestsFor = (
+  commitShas: string[],
+  cwd: string,
+): Record<string, number | undefined> =>
+  Object.fromEntries(
+    commitShas.map((sha) => {
+      const subject = run("git", ["show", "-s", "--format=%s", sha], cwd);
+      const pullRequest = subject.match(SUBJECT_PULL_REQUEST)?.[1];
+      return [sha, pullRequest === undefined ? undefined : Number(pullRequest)];
+    }),
+  );
+
+const dedupePullRequest = (pullRequest: ReleasePullRequest, repository: string, cwd: string): void => {
+  if (!pullRequest.headBranchName.startsWith(RELEASE_PLEASE_BRANCH_PREFIX)) {
+    throw new Error(`Unexpected release-please branch: ${pullRequest.headBranchName}`);
+  }
+
+  const details = JSON.parse(
+    run("gh", ["api", `repos/${repository}/pulls/${pullRequest.number}`], cwd),
+  ) as { head?: { ref?: string; repo?: { full_name?: string } | null } };
+  if (
+    details.head?.repo?.full_name !== repository ||
+    details.head.ref !== pullRequest.headBranchName
+  ) {
+    throw new Error(`Release PR #${pullRequest.number} no longer points at its expected branch`);
+  }
+
+  run(
+    "git",
+    [
+      "fetch",
+      "--no-tags",
+      "origin",
+      `+refs/heads/${pullRequest.headBranchName}:refs/remotes/origin/${pullRequest.headBranchName}`,
+    ],
+    cwd,
+  );
+  run("git", ["switch", "--detach", `origin/${pullRequest.headBranchName}`], cwd);
+
+  const files = JSON.parse(
+    run(
+      "gh",
+      ["pr", "view", String(pullRequest.number), "--repo", repository, "--json", "files"],
+      cwd,
+    ),
+  ) as { files?: Array<{ path?: string }> };
+  const changelogs = (files.files ?? [])
+    .map((file) => file.path)
+    .filter((path): path is string => typeof path === "string" && path.endsWith("CHANGELOG.md"));
+
+  const changedPaths: string[] = [];
+  for (const path of changelogs) {
+    const absolutePath = safeRepositoryPath(path, cwd);
+    const content = readFileSync(absolutePath, "utf8");
+    const subjects = subjectPullRequestsFor(newestReleaseCommitShas(content), cwd);
+    const result = dedupeNewestReleaseSection(content, subjects);
+    if (result.content === content) continue;
+
+    writeFileSync(absolutePath, result.content);
+    changedPaths.push(path);
+    console.info(
+      `Release PR #${pullRequest.number}: removed duplicate entries for ${result.removedCommitShas.join(", ")}`,
+    );
+  }
+
+  if (changedPaths.length === 0) return;
+
+  run("git", ["add", "--", ...changedPaths], cwd);
+  if (!stagedChanges(cwd)) return;
+
+  run("git", ["config", "user.name", "github-actions[bot]"], cwd);
+  run("git", ["config", "user.email", "github-actions[bot]@users.noreply.github.com"], cwd);
+  run("git", ["commit", "-m", "chore(release): dedupe generated changelog"], cwd);
+  run("git", ["push", "origin", `HEAD:refs/heads/${pullRequest.headBranchName}`], cwd);
+};
+
+export const main = (): void => {
+  const cwd = process.cwd();
+  const repository = requireRepository();
+  for (const pullRequest of releasePullRequests()) {
+    dedupePullRequest(pullRequest, repository, cwd);
+  }
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/.github/scripts/dedupe-release-notes.ts
+++ b/.github/scripts/dedupe-release-notes.ts
@@ -23,6 +23,7 @@ export interface DeduplicationResult {
 const RELEASE_PLEASE_BRANCH_PREFIX = "release-please--branches--main--components--";
 const RELEASE_HEADER = /^## \[[^\]]+\]/;
 const BULLET = /^\* /;
+const CHANGELOG_HEADING = /^#{1,6}\s/;
 const COMMIT_SHA = /\/commit\/([0-9a-f]{7,64})(?=[)\s])/i;
 const PULL_REQUEST_LINK = /\/(?:issues|pull)\/(\d+)(?=[)#\s])/g;
 const SUBJECT_PULL_REQUEST = /\(#(\d+)\)\s*$/;
@@ -38,14 +39,28 @@ const newestReleaseSection = (lines: string[]): { start: number; end: number } |
 const entryPullRequestNumbers = (text: string): number[] =>
   [...text.matchAll(PULL_REQUEST_LINK)].map((match) => Number(match[1]));
 
-const entriesIn = (lines: string[], start: number, end: number): ReleaseNoteEntry[] => {
+const entriesIn = ({
+  lines,
+  start,
+  end,
+}: {
+  lines: string[];
+  start: number;
+  end: number;
+}): ReleaseNoteEntry[] => {
   const entries: ReleaseNoteEntry[] = [];
 
   for (let index = start + 1; index < end; index++) {
     if (!BULLET.test(lines[index]!)) continue;
 
     let entryEnd = index + 1;
-    while (entryEnd < end && !BULLET.test(lines[entryEnd]!)) entryEnd++;
+    while (
+      entryEnd < end &&
+      !BULLET.test(lines[entryEnd]!) &&
+      !CHANGELOG_HEADING.test(lines[entryEnd]!)
+    ) {
+      entryEnd++;
+    }
 
     const text = lines.slice(index, entryEnd).join("\n");
     const sha = text.match(COMMIT_SHA)?.[1];
@@ -69,7 +84,11 @@ export const newestReleaseCommitShas = (content: string): string[] => {
   const lines = content.split("\n");
   const section = newestReleaseSection(lines);
   if (!section) return [];
-  return [...new Set(entriesIn(lines, section.start, section.end).map((entry) => entry.sha))];
+  return [
+    ...new Set(
+      entriesIn({ lines, start: section.start, end: section.end }).map((entry) => entry.sha),
+    ),
+  ];
 };
 
 /**
@@ -81,16 +100,19 @@ export const newestReleaseCommitShas = (content: string): string[] => {
  * entry linked to the PR named by the canonical squash subject, then any
  * entry with a PR link, then the first generated entry.
  */
-export const dedupeNewestReleaseSection = (
-  content: string,
-  subjectPullRequests: Readonly<Record<string, number | undefined>>,
-): DeduplicationResult => {
+export const dedupeNewestReleaseSection = ({
+  content,
+  subjectPullRequests,
+}: {
+  content: string;
+  subjectPullRequests: Readonly<Record<string, number | undefined>>;
+}): DeduplicationResult => {
   const lines = content.split("\n");
   const section = newestReleaseSection(lines);
   if (!section) return { content, removedCommitShas: [] };
 
   const bySha = new Map<string, ReleaseNoteEntry[]>();
-  for (const entry of entriesIn(lines, section.start, section.end)) {
+  for (const entry of entriesIn({ lines, start: section.start, end: section.end })) {
     const group = bySha.get(entry.sha) ?? [];
     group.push(entry);
     bySha.set(entry.sha, group);
@@ -122,7 +144,7 @@ export const dedupeNewestReleaseSection = (
   };
 };
 
-const run = (command: string, args: string[], cwd: string): string =>
+const run = ({ command, args, cwd }: { command: string; args: string[]; cwd: string }): string =>
   execFileSync(command, args, {
     cwd,
     encoding: "utf8",
@@ -169,7 +191,7 @@ const stagedChanges = (cwd: string): boolean => {
   throw new Error("Unable to inspect staged changes");
 };
 
-const safeRepositoryPath = (path: string, cwd: string): string => {
+const safeRepositoryPath = ({ path, cwd }: { path: string; cwd: string }): string => {
   const absolutePath = resolve(cwd, path);
   if (!absolutePath.startsWith(`${resolve(cwd)}/`)) {
     throw new Error(`Refusing to write outside the repository: ${path}`);
@@ -177,25 +199,43 @@ const safeRepositoryPath = (path: string, cwd: string): string => {
   return absolutePath;
 };
 
-const subjectPullRequestsFor = (
-  commitShas: string[],
-  cwd: string,
-): Record<string, number | undefined> =>
+export const subjectPullRequestsFor = ({
+  commitShas,
+  cwd,
+  warn = console.warn,
+}: {
+  commitShas: string[];
+  cwd: string;
+  warn?: (message: string) => void;
+}): Record<string, number | undefined> =>
   Object.fromEntries(
     commitShas.map((sha) => {
-      const subject = run("git", ["show", "-s", "--format=%s", sha], cwd);
-      const pullRequest = subject.match(SUBJECT_PULL_REQUEST)?.[1];
-      return [sha, pullRequest === undefined ? undefined : Number(pullRequest)];
+      try {
+        const subject = run({ command: "git", args: ["show", "-s", "--format=%s", sha], cwd });
+        const pullRequest = subject.match(SUBJECT_PULL_REQUEST)?.[1];
+        return [sha, pullRequest === undefined ? undefined : Number(pullRequest)];
+      } catch {
+        warn(`Unable to resolve commit subject for ${sha}; skipping canonical PR lookup.`);
+        return [sha, undefined];
+      }
     }),
   );
 
-const dedupePullRequest = (pullRequest: ReleasePullRequest, repository: string, cwd: string): void => {
+const dedupePullRequest = ({
+  pullRequest,
+  repository,
+  cwd,
+}: {
+  pullRequest: ReleasePullRequest;
+  repository: string;
+  cwd: string;
+}): void => {
   if (!pullRequest.headBranchName.startsWith(RELEASE_PLEASE_BRANCH_PREFIX)) {
     throw new Error(`Unexpected release-please branch: ${pullRequest.headBranchName}`);
   }
 
   const details = JSON.parse(
-    run("gh", ["api", `repos/${repository}/pulls/${pullRequest.number}`], cwd),
+    run({ command: "gh", args: ["api", `repos/${repository}/pulls/${pullRequest.number}`], cwd }),
   ) as { head?: { ref?: string; repo?: { full_name?: string } | null } };
   if (
     details.head?.repo?.full_name !== repository ||
@@ -204,24 +244,24 @@ const dedupePullRequest = (pullRequest: ReleasePullRequest, repository: string, 
     throw new Error(`Release PR #${pullRequest.number} no longer points at its expected branch`);
   }
 
-  run(
-    "git",
-    [
+  run({
+    command: "git",
+    args: [
       "fetch",
       "--no-tags",
       "origin",
       `+refs/heads/${pullRequest.headBranchName}:refs/remotes/origin/${pullRequest.headBranchName}`,
     ],
     cwd,
-  );
-  run("git", ["switch", "--detach", `origin/${pullRequest.headBranchName}`], cwd);
+  });
+  run({ command: "git", args: ["switch", "--detach", `origin/${pullRequest.headBranchName}`], cwd });
 
   const files = JSON.parse(
-    run(
-      "gh",
-      ["pr", "view", String(pullRequest.number), "--repo", repository, "--json", "files"],
+    run({
+      command: "gh",
+      args: ["pr", "view", String(pullRequest.number), "--repo", repository, "--json", "files"],
       cwd,
-    ),
+    }),
   ) as { files?: Array<{ path?: string }> };
   const changelogs = (files.files ?? [])
     .map((file) => file.path)
@@ -229,10 +269,13 @@ const dedupePullRequest = (pullRequest: ReleasePullRequest, repository: string, 
 
   const changedPaths: string[] = [];
   for (const path of changelogs) {
-    const absolutePath = safeRepositoryPath(path, cwd);
+    const absolutePath = safeRepositoryPath({ path, cwd });
     const content = readFileSync(absolutePath, "utf8");
-    const subjects = subjectPullRequestsFor(newestReleaseCommitShas(content), cwd);
-    const result = dedupeNewestReleaseSection(content, subjects);
+    const subjects = subjectPullRequestsFor({
+      commitShas: newestReleaseCommitShas(content),
+      cwd,
+    });
+    const result = dedupeNewestReleaseSection({ content, subjectPullRequests: subjects });
     if (result.content === content) continue;
 
     writeFileSync(absolutePath, result.content);
@@ -244,20 +287,24 @@ const dedupePullRequest = (pullRequest: ReleasePullRequest, repository: string, 
 
   if (changedPaths.length === 0) return;
 
-  run("git", ["add", "--", ...changedPaths], cwd);
+  run({ command: "git", args: ["add", "--", ...changedPaths], cwd });
   if (!stagedChanges(cwd)) return;
 
-  run("git", ["config", "user.name", "github-actions[bot]"], cwd);
-  run("git", ["config", "user.email", "github-actions[bot]@users.noreply.github.com"], cwd);
-  run("git", ["commit", "-m", "chore(release): dedupe generated changelog"], cwd);
-  run("git", ["push", "origin", `HEAD:refs/heads/${pullRequest.headBranchName}`], cwd);
+  run({ command: "git", args: ["config", "user.name", "github-actions[bot]"], cwd });
+  run({
+    command: "git",
+    args: ["config", "user.email", "github-actions[bot]@users.noreply.github.com"],
+    cwd,
+  });
+  run({ command: "git", args: ["commit", "-m", "chore(release): dedupe generated changelog"], cwd });
+  run({ command: "git", args: ["push", "origin", `HEAD:refs/heads/${pullRequest.headBranchName}`], cwd });
 };
 
 export const main = (): void => {
   const cwd = process.cwd();
   const repository = requireRepository();
   for (const pullRequest of releasePullRequests()) {
-    dedupePullRequest(pullRequest, repository, cwd);
+    dedupePullRequest({ pullRequest, repository, cwd });
   }
 };
 

--- a/.github/workflows/release-please-sdks.yml
+++ b/.github/workflows/release-please-sdks.yml
@@ -54,6 +54,22 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # release-please and the post-processor both write branches. The PAT
+          # also lets the resulting push trigger normal release-PR validation.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 24
+
+      - name: Test release-note deduplication
+        run: node --test --experimental-strip-types .github/scripts/dedupe-release-notes.test.ts
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -61,3 +77,14 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      # A squash merge can expose both its conventional-commit subject and a
+      # conventional-commit line at the start of its body. release-please then
+      # writes two bullets for one commit SHA. Post-process only the release
+      # PRs returned by this trusted action; never hand-edit a release PR.
+      - name: Deduplicate generated release notes
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}
+        run: node --experimental-strip-types .github/scripts/dedupe-release-notes.ts

--- a/specs/ci/release-note-deduplication.feature
+++ b/specs/ci/release-note-deduplication.feature
@@ -1,0 +1,28 @@
+Feature: Generated release notes keep one entry per change
+  As a maintainer preparing a release
+  I want generated release notes to remain complete and readable
+  So that release pull requests can be safely published
+
+  @unit
+  Scenario: Duplicate commit entries leave one generated release note
+    Given generated release notes contain two entries for the same commit
+    When release-note deduplication runs
+    Then one entry for that commit remains
+
+  @unit
+  Scenario: Duplicate removal preserves following changelog sections
+    Given a duplicate entry appears before another changelog section
+    When release-note deduplication removes the duplicate
+    Then the following changelog section remains
+
+  @unit
+  Scenario: Incomplete changelogs remain unchanged
+    Given generated release notes have no release section or commit link
+    When release-note deduplication runs
+    Then the incomplete content remains unchanged
+
+  @unit
+  Scenario: An unavailable commit subject does not stop generated release notes
+    Given a generated release note references an unavailable commit subject
+    When release-note deduplication runs
+    Then the remaining generated release notes continue to be processed


### PR DESCRIPTION
Fixes #7392.

Deduplicates generated release-note entries by commit SHA and keeps the matching PR entry when there is one.

Tested with `node --test --experimental-strip-types .github/scripts/dedupe-release-notes.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed duplicate entries from newly generated release notes while preserving historical entries.
  - Retained the most relevant entry for each change and reported removed commit references.
  - Preserved subsequent changelog sections and left incomplete changelogs unchanged.

- **Chores**
  - Added automated deduplication during the release process.
  - Added validation for unavailable commit subjects and repeat-safe processing.
  - Expanded coverage for duplicate detection, entry preference, and changelog preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->