### PR TITLE
feat(lwql): period_granularity_seconds reserved parameter — the granularity contract

### DIFF
--- a/platform/app/src/features/errors/logic/__tests__/presentation.unit.test.ts
+++ b/platform/app/src/features/errors/logic/__tests__/presentation.unit.test.ts
@@ -89,6 +89,47 @@ describe("explainHandledError", () => {
       expect(description).toBe("");
     });
 
+    /** @scenario "The refusal names the reserved parameter the caller actually supplied" */
+    it("names the granularity step when that is the parameter supplied", () => {
+      const { description } = explainHandledError(
+        shape({
+          code: "lwql_reserved_parameter_supplied",
+          meta: { parameters: ["period_granularity_seconds"] },
+        }),
+      );
+
+      expect(description).toContain("period_granularity_seconds");
+      // The bug this pins: the copy named the window pair unconditionally, so
+      // a caller that sent only the step was told to remove two parameters it
+      // had never sent.
+      expect(description).not.toContain("period_start");
+      expect(description).not.toContain("period_end");
+    });
+
+    /** @scenario "The refusal names the reserved parameter the caller actually supplied" */
+    it("names every supplied reserved parameter, and agrees in number", () => {
+      const { description } = explainHandledError(
+        shape({
+          code: "lwql_reserved_parameter_supplied",
+          meta: { parameters: ["period_start", "period_end"] },
+        }),
+      );
+
+      expect(description).toContain("period_start and period_end");
+      expect(description).toContain("come from");
+      expect(description).toContain("Remove them");
+    });
+
+    /** @scenario "meta is read only where the client knows its shape" */
+    it("still says something useful when the supplied names are absent", () => {
+      const { title, description } = explainHandledError(
+        shape({ code: "lwql_reserved_parameter_supplied", meta: {} }),
+      );
+
+      expect(title.length).toBeGreaterThan(0);
+      expect(description).toContain("Remove them from your parameters");
+    });
+
     /** @scenario "meta is read only where the client knows its shape" */
     it("ignores meta of the wrong type rather than rendering it", () => {
       const { description } = explainHandledError(

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -161,6 +161,8 @@ export const APP_ERROR_CODES = [
   "license_signing_key_not_pem",
   "lite_member_restricted",
   "lite_member_viewer_only",
+  "lwql_granularity_requires_window",
+  "lwql_granularity_too_fine",
   "lwql_not_enabled",
   "lwql_not_permitted",
   "lwql_parameter_missing",

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -161,6 +161,7 @@ export const APP_ERROR_CODES = [
   "license_signing_key_not_pem",
   "lite_member_restricted",
   "lite_member_viewer_only",
+  "lwql_granularity_parameter_type",
   "lwql_granularity_requires_window",
   "lwql_granularity_too_fine",
   "lwql_not_enabled",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -365,6 +365,16 @@ const presentations = {
     describe: () =>
       "Declare period_start and period_end as DateTime, for example {period_start:DateTime}, and run the query again.",
   },
+  lwql_granularity_too_fine: {
+    title: "That granularity would return too many datapoints",
+    describe: () =>
+      "The bucket size you picked produces more datapoints than one query may return for this date range. Pick a coarser granularity -- 1 second, 1 minute or 1 hour -- or narrow the range.",
+  },
+  lwql_granularity_requires_window: {
+    title: "Granularity needs the period parameters",
+    describe: () =>
+      "A query declaring period_granularity_seconds must also declare {period_start:DateTime} and {period_end:DateTime}, so the datapoint budget can be checked against the selected period.",
+  },
   lwql_not_enabled: {
     title: "Custom SQL isn't switched on here",
     describe: () =>

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -365,6 +365,11 @@ const presentations = {
     describe: () =>
       "Declare period_start and period_end as DateTime, for example {period_start:DateTime}, and run the query again.",
   },
+  lwql_granularity_parameter_type: {
+    title: "The granularity has to be declared as UInt32",
+    describe: () =>
+      "Declare period_granularity_seconds as UInt32, for example {period_granularity_seconds:UInt32}, and run the query again.",
+  },
   lwql_granularity_too_fine: {
     title: "That granularity would return too many datapoints",
     describe: () =>

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -373,7 +373,7 @@ const presentations = {
   lwql_granularity_too_fine: {
     title: "That granularity would return too many datapoints",
     describe: () =>
-      "The bucket size you picked produces more datapoints than one query may return for this date range. Pick a coarser granularity -- 1 second, 1 minute or 1 hour -- or narrow the range.",
+      "The bucket size you picked produces more datapoints than one query may return for this date range. Pick a bucket size that fits the range from the offered steps -- 1 second, 1 minute or 1 hour -- or narrow the range.",
   },
   lwql_granularity_requires_window: {
     title: "Granularity needs the period parameters",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -356,9 +356,20 @@ const presentations = {
       "The query declares parameters that weren't given values. Supply one for each and try again.",
   },
   lwql_reserved_parameter_supplied: {
-    title: "The time window isn't yours to set",
-    describe: () =>
-      "period_start and period_end come from the period this page is showing. Remove them from your parameters and change the period instead.",
+    // One code covers three reserved names, so both halves of the copy are
+    // built from the ones actually supplied (`meta.parameters`, the same list
+    // the server's own sentence is built from). Naming the window pair
+    // unconditionally told a caller that sent only the granularity step to
+    // remove two parameters it had never sent.
+    title: "That setting isn't yours to set",
+    describe: (error) => {
+      const supplied = strList(error, "parameters");
+      if (supplied.length === 0) {
+        return "Some of these parameters come from the page showing this chart. Remove them from your parameters and change the page's settings instead.";
+      }
+      const plural = supplied.length > 1;
+      return `${listLabels(supplied)} ${plural ? "come" : "comes"} from the page showing this chart. Remove ${plural ? "them" : "it"} from your parameters and change the page's settings instead.`;
+    },
   },
   lwql_reserved_parameter_type: {
     title: "The time window has to be a date and time",

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -642,6 +642,41 @@ describe("given the LangWatchQL service", () => {
         "period_start",
       ]);
     });
+
+    it("defers a declared granularity to the surface instead of refusing it as caller-missing", () => {
+      // The caller is forbidden to supply period_granularity_seconds, so the
+      // missing-parameter sweep naming it was a dead end: a refusal asking
+      // for a value the caller may never send. The declaration is awaiting
+      // the surface -- the granularity resolver binds the step at run.
+      const service = serviceWith(recordingExecutor());
+      const sql =
+        "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+        "count() AS value FROM analytics.traces " +
+        "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+        "GROUP BY bucket ORDER BY bucket";
+
+      const validated = service.validate({
+        projectId: PROJECT.id,
+        protections: FULLY_PERMITTED,
+        sql,
+        timeWindow: TIME_WINDOW,
+      });
+      expect(validated.awaitingTimeWindow).toEqual([
+        "period_granularity_seconds",
+      ]);
+
+      // Saving has no window either; the whole reserved trio is deferred.
+      const saved = service.validate({
+        projectId: PROJECT.id,
+        protections: FULLY_PERMITTED,
+        sql,
+      });
+      expect(saved.awaitingTimeWindow).toEqual([
+        "period_end",
+        "period_granularity_seconds",
+        "period_start",
+      ]);
+    });
   });
 
   describe("when the statement declares no time-window parameters", () => {

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -216,7 +216,10 @@ describe("resolveLangWatchQLGranularity", () => {
 
       expect(codeOf(run)).toBe("lwql_granularity_parameter_type");
       expect(messageOf(run)).not.toContain("UInt32");
-      expect(messageOf(run)).toContain("whole number of seconds");
+      // The check is list-membership, not integer-ness: 7,200 is a whole
+      // number of seconds and is still refused, so the copy names the list.
+      expect(messageOf(run)).toContain("offered steps");
+      expect(messageOf(run)).toContain("1 second, 1 minute, or 1 hour");
     });
 
     it("refuses a positive whole step the surface does not offer", () => {
@@ -322,8 +325,14 @@ describe("resolveLangWatchQLGranularity", () => {
       const windows = [
         WINDOW,
         {
+          // Exactly 10,000 hours: the widest window whose one-hour floor
+          // still fits the ceiling, so every step resolves rather than
+          // refusing (a wider window refuses -- pinned below).
           start: new Date("2026-02-20T00:00:00.000Z"),
-          end: new Date("2036-02-20T00:00:00.000Z"),
+          end: new Date(
+            new Date("2026-02-20T00:00:00.000Z").getTime() +
+              LWQL_GRANULARITY_MAX_BUCKETS * 3600 * 1000,
+          ),
         },
       ];
 
@@ -345,21 +354,31 @@ describe("resolveLangWatchQLGranularity", () => {
       }
     });
 
-    it("coarsens to the coarsest floor when nothing fits, still naming the change", () => {
-      // Ten years at an hour: ~87,600 buckets. Nothing fits.
+    /** @scenario "A window too wide for even the coarsest offered step is refused everywhere" */
+    it("refuses when even the coarsest offered step still overflows, coarsening or not", () => {
+      // Ten years at the one-hour floor: ~87,600 buckets. Nothing fits, and
+      // the ceiling is a hard browser-safety cap -- an answer carrying nine
+      // times the budget must not come back looking in-budget.
       const decade = {
         start: new Date("2026-02-20T00:00:00.000Z"),
         end: new Date("2036-02-20T00:00:00.000Z"),
       };
-      const resolution = resolveLangWatchQLGranularity({
-        declared: [...PERIOD, ...GRANULARITY],
-        timeWindow: decade,
-        granularitySeconds: 60,
-        onBudgetOverflow: "coarsen",
-      });
+      const run = () =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: decade,
+          granularitySeconds: 60,
+          onBudgetOverflow: "coarsen",
+        });
 
-      expect(resolution.granularitySeconds).toBe(3600);
-      expect(resolution.coarsenedFromSeconds).toBe(60);
+      expect(() => run()).toThrow(LangWatchQLGranularityTooFineError);
+      expect(codeOf(run)).toBe("lwql_granularity_too_fine");
+      // The refusal names the caller's own step and the window, the same
+      // arithmetic the refuse path carries.
+      expect(metaOf(run)).toMatchObject({
+        requestedGranularitySeconds: 60,
+        maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+      });
     });
   });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -41,6 +41,39 @@ const WINDOW = {
 /** Seven days, in seconds. */
 const WEEK_SECONDS = 7 * 24 * 3600;
 
+/** The `code` of a thrown handled error, or the reason there is none. */
+function codeOf(run: () => unknown): unknown {
+  try {
+    run();
+  } catch (error) {
+    return (error as { code?: unknown }).code;
+  }
+  return "<no error was thrown>";
+}
+
+/** The `message` of a thrown error, or the reason there is none. */
+function messageOf(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return (error as Error).message;
+  }
+  return "<no error was thrown>";
+}
+
+/** The `meta` of a thrown handled error, empty when nothing was thrown. */
+function metaOf(run: () => unknown): Record<string, unknown> {
+  try {
+    run();
+  } catch (error) {
+    return ((error as { meta?: Record<string, unknown> }).meta ?? {}) as Record<
+      string,
+      unknown
+    >;
+  }
+  return {};
+}
+
 describe("resolveLangWatchQLGranularity", () => {
   describe("given a statement that does not declare the parameter", () => {
     it("reports no granularity and injects nothing", () => {
@@ -113,9 +146,10 @@ describe("resolveLangWatchQLGranularity", () => {
       ).toThrow(LangWatchQLReservedGranularityTypeError);
     });
 
-    it("refuses before looking at any supplied value", () => {
-      // Wrong type AND zero: the type error is the answer, either way.
-      expect(() =>
+    it("reports the wrong declared type, not the bad step, when both are wrong", () => {
+      // Wrong type AND zero: the declaration is what the author must fix
+      // first, so its copy is the answer either way.
+      const run = () =>
         resolveLangWatchQLGranularity({
           declared: [
             ...PERIOD,
@@ -124,31 +158,43 @@ describe("resolveLangWatchQLGranularity", () => {
           parameters: {},
           timeWindow: WINDOW,
           granularitySeconds: 0,
-        }),
-      ).toThrow(LangWatchQLReservedGranularityTypeError);
+        });
+
+      expect(() => run()).toThrow(LangWatchQLReservedGranularityTypeError);
+      expect(messageOf(run)).toContain("not UInt32");
     });
   });
 
   describe("given a caller-supplied value for the reserved name", () => {
+    const suppliesGranularity = () =>
+      resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        parameters: { period_granularity_seconds: 60 },
+        timeWindow: WINDOW,
+      });
+
     /** @scenario "A caller that supplies period_granularity_seconds itself is refused" */
     it("is refused by this resolver even when called on its own", () => {
-      expect(() =>
-        resolveLangWatchQLGranularity({
-          declared: [...PERIOD, ...GRANULARITY],
-          parameters: { period_granularity_seconds: 60 },
-          timeWindow: WINDOW,
-        }),
-      ).toThrow(/surface sets itself/);
+      expect(codeOf(suppliesGranularity)).toBe(
+        "lwql_reserved_parameter_supplied",
+      );
+    });
+
+    it("names the granularity parameter rather than the window pair", () => {
+      // The refusal used to say "time-window parameters" whatever was sent,
+      // so a caller that supplied only the step was told to remove two
+      // parameters it had never sent, and not the one it had.
+      const message = messageOf(suppliesGranularity);
+
+      expect(message).toContain("period_granularity_seconds");
+      expect(message).not.toContain("period_start");
+      expect(message).not.toContain("period_end");
     });
   });
 
   describe("given a malformed surface step", () => {
     /** @scenario "A zero or fractional step is refused as a wrong declaration" */
-    it.each([
-      [0],
-      [-60],
-      [1.5],
-    ])("refuses %p as a wrong declaration", (step) => {
+    it.each([[0], [-60], [1.5]])("refuses %p as a malformed step", (step) => {
       expect(() =>
         resolveLangWatchQLGranularity({
           declared: [...PERIOD, ...GRANULARITY],
@@ -156,6 +202,48 @@ describe("resolveLangWatchQLGranularity", () => {
           granularitySeconds: step,
         }),
       ).toThrow(LangWatchQLReservedGranularityTypeError);
+    });
+
+    it("describes the step rather than claiming the declaration is mistyped", () => {
+      // The declaration here is a correct UInt32. Copy blaming its type sends
+      // the author to a line that is already right.
+      const run = () =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: WINDOW,
+          granularitySeconds: 1.5,
+        });
+
+      expect(codeOf(run)).toBe("lwql_granularity_parameter_type");
+      expect(messageOf(run)).not.toContain("UInt32");
+      expect(messageOf(run)).toContain("whole number of seconds");
+    });
+
+    it("refuses a positive whole step the surface does not offer", () => {
+      // 7,200 is a positive integer, so the old positive-integer check let it
+      // through -- and coarsening would then have "coarsened" it to the
+      // 3,600-second hour, a step twice as fine as the one requested.
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: WINDOW,
+          granularitySeconds: 7200,
+          onBudgetOverflow: "coarsen",
+        }),
+      ).toThrow(LangWatchQLReservedGranularityTypeError);
+    });
+
+    it("admits every step the surface offers", () => {
+      for (const step of LWQL_GRANULARITY_STEPS) {
+        expect(() =>
+          resolveLangWatchQLGranularity({
+            declared: [...PERIOD, ...GRANULARITY],
+            timeWindow: WINDOW,
+            granularitySeconds: step,
+            onBudgetOverflow: "coarsen",
+          }),
+        ).not.toThrow();
+      }
     });
   });
 
@@ -173,23 +261,21 @@ describe("resolveLangWatchQLGranularity", () => {
     });
 
     it("carries the arithmetic in the refusal's meta", () => {
-      try {
+      const run = () =>
         resolveLangWatchQLGranularity({
           declared: [...PERIOD, ...GRANULARITY],
           timeWindow: WINDOW,
           granularitySeconds: 1,
           onBudgetOverflow: "refuse",
         });
-        throw new Error("expected the refusal");
-      } catch (error) {
-        expect(error).toBeInstanceOf(LangWatchQLGranularityTooFineError);
-        const handled = error as LangWatchQLGranularityTooFineError;
-        expect(handled.meta).toMatchObject({
-          requestedGranularitySeconds: 1,
-          windowSeconds: WEEK_SECONDS,
-          maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
-        });
-      }
+
+      expect(() => run()).toThrow(LangWatchQLGranularityTooFineError);
+      expect(codeOf(run)).toBe("lwql_granularity_too_fine");
+      expect(metaOf(run)).toMatchObject({
+        requestedGranularitySeconds: 1,
+        windowSeconds: WEEK_SECONDS,
+        maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+      });
     });
 
     it("coarsens to the finest fitting offered step on the dashboard", () => {
@@ -221,6 +307,42 @@ describe("resolveLangWatchQLGranularity", () => {
         followsGranularity: true,
         granularitySeconds: 3600,
       });
+    });
+
+    it("never reports coarsening to a step finer than the one requested", () => {
+      // The invariant the label promises: wherever coarsenedFromSeconds is
+      // set, the effective step is strictly wider than the requested one.
+      //
+      // The refusal above is what makes the finer-than-requested case
+      // unreachable through this entry point, so this sweep holds on the old
+      // `effective !== requested` code too -- it pins the property rather
+      // than falsifying the bug. The test that fails on the pre-fix code is
+      // "refuses a positive whole step the surface does not offer": 7,200
+      // used to reach coarsening and come back labelled as widened to 3,600.
+      const windows = [
+        WINDOW,
+        {
+          start: new Date("2026-02-20T00:00:00.000Z"),
+          end: new Date("2036-02-20T00:00:00.000Z"),
+        },
+      ];
+
+      for (const timeWindow of windows) {
+        for (const step of LWQL_GRANULARITY_STEPS) {
+          const resolution = resolveLangWatchQLGranularity({
+            declared: [...PERIOD, ...GRANULARITY],
+            timeWindow,
+            granularitySeconds: step,
+            onBudgetOverflow: "coarsen",
+          });
+
+          if (resolution.coarsenedFromSeconds !== undefined) {
+            expect(resolution.granularitySeconds).toBeGreaterThan(
+              resolution.coarsenedFromSeconds,
+            );
+          }
+        }
+      }
     });
 
     it("coarsens to the coarsest floor when nothing fits, still naming the change", () => {
@@ -295,6 +417,15 @@ describe("resolveLangWatchQLGranularity", () => {
         granularitySeconds: 60,
       });
     });
+  });
+});
+
+describe("the bucket ceiling", () => {
+  // Pinned because the coarsening cases above are written against this exact
+  // number -- a week at one-minute steps is 10,080 buckets, and only just
+  // overflows. Move the ceiling and those cases stop testing what they say.
+  it("admits ten thousand buckets per governed run", () => {
+    expect(LWQL_GRANULARITY_MAX_BUCKETS).toBe(10_000);
   });
 });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The granularity contract on its own: what declaring
+ * `{period_granularity_seconds:UInt32}` means for one run, and the three ways
+ * a surface can get it wrong.
+ *
+ * Driven directly rather than through the service, because these are the
+ * rules every surface inherits — the workbench refuses where this refuses,
+ * the dashboard coarsens where `coarsen` is passed, and neither can restate
+ * the budget arithmetic.
+ *
+ * @see specs/analytics/lwql-workbench.feature
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LangWatchQLGranularityTooFineError,
+  LangWatchQLReservedGranularityTypeError,
+} from "../errors";
+import {
+  LWQL_GRANULARITY_MAX_BUCKETS,
+  resolveLangWatchQLGranularity,
+} from "../resolveTimeWindow";
+import type { LangWatchQLParameter } from "../validation/validate";
+
+const GRANULARITY: LangWatchQLParameter[] = [
+  { name: "period_granularity_seconds", type: "UInt32" },
+];
+
+const PERIOD: LangWatchQLParameter[] = [
+  { name: "period_start", type: "DateTime" },
+  { name: "period_end", type: "DateTime" },
+];
+
+const WINDOW = {
+  start: new Date("2026-02-20T00:00:00.000Z"),
+  end: new Date("2026-02-27T00:00:00.000Z"),
+};
+
+/** Seven days, in seconds. */
+const WEEK_SECONDS = 7 * 24 * 3600;
+
+describe("resolveLangWatchQLGranularity", () => {
+  describe("given a statement that does not declare the parameter", () => {
+    it("reports no granularity and injects nothing", () => {
+      const resolution = resolveLangWatchQLGranularity({
+        declared: PERIOD,
+        timeWindow: WINDOW,
+        granularitySeconds: 60,
+      });
+
+      expect(resolution).toEqual({ followsGranularity: false });
+    });
+
+    it("is unaffected by a caller-supplied value for an unrelated name", () => {
+      const resolution = resolveLangWatchQLGranularity({
+        declared: PERIOD,
+        parameters: { since: "2026-01-01" },
+        timeWindow: WINDOW,
+        granularitySeconds: 60,
+      });
+
+      expect(resolution.followsGranularity).toBe(false);
+    });
+  });
+
+  describe("given the parameter declared as UInt32 with a surface step", () => {
+    /** @scenario "A statement declaring the granularity parameter runs at the step the workbench supplies" */
+    it("follows granularity at the supplied step", () => {
+      // An hour over a week: 168 buckets, comfortably inside the ceiling.
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: WINDOW,
+        granularitySeconds: 3600,
+      });
+
+      expect(resolution).toEqual({
+        followsGranularity: true,
+        granularitySeconds: 3600,
+      });
+    });
+
+    /** @scenario "A granularity declared with no step supplied runs on its own authored bucketing" */
+    it("runs without a step when the surface offers none, without inventing one", () => {
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: WINDOW,
+      });
+
+      // The declaration records intent; the bucketing stays whatever the SQL
+      // hard-codes. Inventing a default here would change what a member's
+      // chart shows without them asking.
+      expect(resolution).toEqual({ followsGranularity: true });
+    });
+  });
+
+  describe("given the parameter declared with the wrong type", () => {
+    /** @scenario "The granularity parameter declared as anything but UInt32 is refused" */
+    it.each([
+      ["Int32"],
+      ["UInt16"],
+      ["Float64"],
+      ["UInt32('UTC')"],
+      ["String"],
+    ])("refuses %s at run as well as save", (type) => {
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, { name: "period_granularity_seconds", type }],
+          timeWindow: WINDOW,
+          granularitySeconds: 60,
+        }),
+      ).toThrow(LangWatchQLReservedGranularityTypeError);
+    });
+
+    it("refuses before looking at any supplied value", () => {
+      // Wrong type AND zero: the type error is the answer, either way.
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [
+            ...PERIOD,
+            { name: "period_granularity_seconds", type: "Int64" },
+          ],
+          parameters: {},
+          timeWindow: WINDOW,
+          granularitySeconds: 0,
+        }),
+      ).toThrow(LangWatchQLReservedGranularityTypeError);
+    });
+  });
+
+  describe("given a caller-supplied value for the reserved name", () => {
+    /** @scenario "A caller that supplies period_granularity_seconds itself is refused" */
+    it("is refused by this resolver even when called on its own", () => {
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          parameters: { period_granularity_seconds: 60 },
+          timeWindow: WINDOW,
+        }),
+      ).toThrow(/surface sets itself/);
+    });
+  });
+
+  describe("given a malformed surface step", () => {
+    /** @scenario "A zero or fractional step is refused as a wrong declaration" */
+    it.each([
+      [0],
+      [-60],
+      [1.5],
+    ])("refuses %p as a wrong declaration", (step) => {
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: WINDOW,
+          granularitySeconds: step,
+        }),
+      ).toThrow(LangWatchQLReservedGranularityTypeError);
+    });
+  });
+
+  describe("given the bucket budget overflows", () => {
+    // A week at one-second steps: 604,800 buckets, far past the ceiling.
+    it("refuses on a caller-owned surface", () => {
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: WINDOW,
+          granularitySeconds: 1,
+          onBudgetOverflow: "refuse",
+        }),
+      ).toThrow(LangWatchQLGranularityTooFineError);
+    });
+
+    it("carries the arithmetic in the refusal's meta", () => {
+      try {
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: WINDOW,
+          granularitySeconds: 1,
+          onBudgetOverflow: "refuse",
+        });
+        throw new Error("expected the refusal");
+      } catch (error) {
+        expect(error).toBeInstanceOf(LangWatchQLGranularityTooFineError);
+        const handled = error as LangWatchQLGranularityTooFineError;
+        expect(handled.meta).toMatchObject({
+          requestedGranularitySeconds: 1,
+          windowSeconds: WEEK_SECONDS,
+          maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+        });
+      }
+    });
+
+    it("coarsens to the finest fitting offered step on the dashboard", () => {
+      // A week at one-minute steps is 10,080 buckets -- just past the
+      // ceiling, and itself evidence that the 10,000 default has teeth:
+      // a completely ordinary chart/range pairing lands on the wrong side
+      // of it. The finest offered step that fits is the hour (168).
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: WINDOW,
+        granularitySeconds: 60,
+        onBudgetOverflow: "coarsen",
+      });
+
+      expect(resolution.granularitySeconds).toBe(3600);
+      expect(resolution.coarsenedFromSeconds).toBe(60);
+    });
+
+    it("does not report coarsening when the requested step already fits", () => {
+      // An hour over a week: 168 buckets. Fits.
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: WINDOW,
+        granularitySeconds: 3600,
+        onBudgetOverflow: "coarsen",
+      });
+
+      expect(resolution).toEqual({
+        followsGranularity: true,
+        granularitySeconds: 3600,
+      });
+    });
+
+    it("coarsens to the coarsest floor when nothing fits, still naming the change", () => {
+      // Ten years at an hour: ~87,600 buckets. Nothing fits.
+      const decade = {
+        start: new Date("2026-02-20T00:00:00.000Z"),
+        end: new Date("2036-02-20T00:00:00.000Z"),
+      };
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: decade,
+        granularitySeconds: 60,
+        onBudgetOverflow: "coarsen",
+      });
+
+      expect(resolution.granularitySeconds).toBe(3600);
+      expect(resolution.coarsenedFromSeconds).toBe(60);
+    });
+  });
+
+  describe("given a window whose length lands exactly on the ceiling boundary", () => {
+    it("admits a bucket count equal to the ceiling — overflow is strictly greater-than", () => {
+      // A 10,000-second window at one-second steps: exactly the ceiling.
+      // Integer-exact by construction -- the float-division route (% !== 0)
+      // was itself a test bug, not a property of the contract.
+      const start = new Date("2026-02-20T00:00:00.000Z");
+      const end = new Date(
+        start.getTime() + LWQL_GRANULARITY_MAX_BUCKETS * 1000,
+      );
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: { start, end },
+        granularitySeconds: 1,
+        onBudgetOverflow: "refuse",
+      });
+
+      expect(resolution.granularitySeconds).toBe(1);
+    });
+
+    it("refuses one bucket past the ceiling", () => {
+      const start = new Date("2026-02-20T00:00:00.000Z");
+      const end = new Date(
+        start.getTime() + (LWQL_GRANULARITY_MAX_BUCKETS + 1) * 1000,
+      );
+      expect(() =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: { start, end },
+          granularitySeconds: 1,
+          onBudgetOverflow: "refuse",
+        }),
+      ).toThrow(LangWatchQLGranularityTooFineError);
+    });
+  });
+
+  describe("given a declared granularity but no period bounds declared alongside", () => {
+    // The save-time rule (assertLangWatchQLGranularityDeclaration) refuses
+    // this shape before it can persist; the run path can still see it from a
+    // chart persisted before that rule existed, so the resolver fails soft:
+    // no window means no budget to compute, and the statement runs on its
+    // own authored bucketing.
+    it("runs at the supplied step rather than guessing a budget", () => {
+      // Nothing to compute the budget against, so the supplied step rides
+      // through unclamped -- there is no range it could overflow.
+      const resolution = resolveLangWatchQLGranularity({
+        declared: GRANULARITY,
+        granularitySeconds: 60,
+      });
+
+      expect(resolution).toEqual({
+        followsGranularity: true,
+        granularitySeconds: 60,
+      });
+    });
+  });
+});

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -21,6 +21,7 @@ import {
   LWQL_GRANULARITY_MAX_BUCKETS,
   resolveLangWatchQLGranularity,
 } from "../resolveTimeWindow";
+import { LWQL_GRANULARITY_STEPS } from "../timeWindow";
 import type { LangWatchQLParameter } from "../validation/validate";
 
 const GRANULARITY: LangWatchQLParameter[] = [
@@ -294,5 +295,14 @@ describe("resolveLangWatchQLGranularity", () => {
         granularitySeconds: 60,
       });
     });
+  });
+});
+
+describe("the offered granularity steps", () => {
+  // A day-scale step must not join these until a timezone-aware mechanism
+  // exists: a fixed 86,400-second bucket drifts off local midnight on DST
+  // transition days (see the note on LWQL_GRANULARITY_STEPS in timeWindow.ts).
+  it("offers exactly one second, one minute and one hour", () => {
+    expect([...LWQL_GRANULARITY_STEPS]).toEqual([1, 60, 3600]);
   });
 });

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularityDeclaration.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularityDeclaration.unit.test.ts
@@ -33,6 +33,16 @@ const BOTH_PERIODS: LangWatchQLParameter[] = [
   { name: "period_end", type: "DateTime" },
 ];
 
+/** The `message` of a thrown error, or the reason there is none. */
+function messageOf(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return (error as Error).message;
+  }
+  return "<no error was thrown>";
+}
+
 describe("the validator accepts a bound parameter inside INTERVAL (A5)", () => {
   it("parses and permits the granularity multiplier in the bucketing expression", () => {
     const result = validateLangWatchQL({
@@ -108,5 +118,27 @@ describe("assertLangWatchQLGranularityDeclaration (save-time rules)", () => {
         { name: "period_end", type: "DateTime" },
       ]),
     ).toThrow(LangWatchQLGranularityRequiresTimeWindowError);
+  });
+
+  it("tells a mistyped bound apart from an absent one in the copy", () => {
+    // Both bounds are declared here. Telling the author to declare
+    // period_start sends them looking for a line already on screen; what
+    // they have to change is its type.
+    const mistyped = messageOf(() =>
+      assertLangWatchQLGranularityDeclaration([
+        { name: "period_granularity_seconds", type: "UInt32" },
+        { name: "period_start", type: "String" },
+        { name: "period_end", type: "DateTime" },
+      ]),
+    );
+    const absent = messageOf(() =>
+      assertLangWatchQLGranularityDeclaration([
+        { name: "period_granularity_seconds", type: "UInt32" },
+      ]),
+    );
+
+    expect(mistyped).toContain("DateTime");
+    expect(mistyped).not.toBe(absent);
+    expect(absent).toContain("must also declare");
   });
 });

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularityDeclaration.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularityDeclaration.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The save-time granularity rules, and the A5 premise they rest on: that the
+ * validator accepts a bound parameter *inside* an `INTERVAL` expression —
+ * `INTERVAL {period_granularity_seconds:UInt32} SECOND` — which is the whole
+ * mechanism. ClickHouse compiles `INTERVAL 1 HOUR` to a function call
+ * (`toIntervalHour`), so the unit of an offered step cannot itself be a
+ * bound value; the seconds-multiplier form is the seam that leaves the
+ * surface one value to inject. If the parser or policy refuses that shape,
+ * the contract collapses and this test is the first thing to say so.
+ *
+ * @see specs/analytics/lwql-workbench.feature
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LangWatchQLGranularityRequiresTimeWindowError,
+  LangWatchQLReservedGranularityTypeError,
+} from "../errors";
+import { assertLangWatchQLGranularityDeclaration } from "../resolveTimeWindow";
+import type { LangWatchQLParameter } from "../validation/validate";
+import { validateLangWatchQL } from "../validation/validate";
+
+/** The same minimal catalog the validator's own unit test drives. */
+const POLICY = {
+  allowedTables: ["analytics.traces"],
+  gatedColumns: [] as readonly string[],
+  defaultDatabase: "analytics",
+};
+
+const BOTH_PERIODS: LangWatchQLParameter[] = [
+  { name: "period_start", type: "DateTime" },
+  { name: "period_end", type: "DateTime" },
+];
+
+describe("the validator accepts a bound parameter inside INTERVAL (A5)", () => {
+  it("parses and permits the granularity multiplier in the bucketing expression", () => {
+    const result = validateLangWatchQL({
+      sql:
+        "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+        "count() AS events FROM traces " +
+        "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+        "GROUP BY bucket ORDER BY bucket",
+      ...POLICY,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.parameters).toEqual([
+      { name: "period_granularity_seconds", type: "UInt32" },
+      { name: "period_start", type: "DateTime" },
+      { name: "period_end", type: "DateTime" },
+    ]);
+  });
+});
+
+describe("assertLangWatchQLGranularityDeclaration (save-time rules)", () => {
+  it("accepts a granularity declared alongside both period bounds", () => {
+    expect(() =>
+      assertLangWatchQLGranularityDeclaration([
+        ...BOTH_PERIODS,
+        { name: "period_granularity_seconds", type: "UInt32" },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("accepts a statement that does not declare granularity at all", () => {
+    expect(() =>
+      assertLangWatchQLGranularityDeclaration(BOTH_PERIODS),
+    ).not.toThrow();
+    expect(() => assertLangWatchQLGranularityDeclaration([])).not.toThrow();
+  });
+
+  it("refuses a non-UInt32 declaration", () => {
+    for (const type of ["Int32", "UInt16", "UInt64", "Float64", "String"]) {
+      expect(() =>
+        assertLangWatchQLGranularityDeclaration([
+          ...BOTH_PERIODS,
+          { name: "period_granularity_seconds", type },
+        ]),
+      ).toThrow(LangWatchQLReservedGranularityTypeError);
+    }
+  });
+
+  it("refuses granularity declared without either period bound", () => {
+    expect(() =>
+      assertLangWatchQLGranularityDeclaration([
+        { name: "period_granularity_seconds", type: "UInt32" },
+        { name: "period_start", type: "DateTime" },
+      ]),
+    ).toThrow(LangWatchQLGranularityRequiresTimeWindowError);
+
+    expect(() =>
+      assertLangWatchQLGranularityDeclaration([
+        { name: "period_granularity_seconds", type: "UInt32" },
+      ]),
+    ).toThrow(LangWatchQLGranularityRequiresTimeWindowError);
+  });
+
+  /** @scenario "A granularity declared alongside a mistyped period bound is refused at save" */
+  it("refuses granularity when a period bound is declared with a non-date-time type", () => {
+    // The requires-window walk checks the bound's type too: a window bound
+    // that cannot carry an instant is not a window, and the budget computed
+    // against it would be fiction.
+    expect(() =>
+      assertLangWatchQLGranularityDeclaration([
+        { name: "period_granularity_seconds", type: "UInt32" },
+        { name: "period_start", type: "String" },
+        { name: "period_end", type: "DateTime" },
+      ]),
+    ).toThrow(LangWatchQLGranularityRequiresTimeWindowError);
+  });
+});

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -222,13 +222,13 @@ export class LangWatchQLReservedParameterTypeError extends HandledError {
 export type LangWatchQLGranularityFault =
   /** Declared as something other than `UInt32`. */
   | "declared-type"
-  /** Declared correctly, but the step supplied is not a positive integer. */
+  /** Declared correctly, but the step supplied is not an offered step. */
   | "step-value";
 
 /**
  * The granularity parameter was declared with a type other than `UInt32`, or
- * the surface supplied a step that is not a positive whole number of
- * seconds.
+ * the surface supplied a step that is not one of the offered granularity
+ * steps.
  *
  * A sibling of {@link LangWatchQLReservedParameterTypeError} -- from the
  * caller's side both read as "you declared a surface-owned parameter with the
@@ -250,7 +250,7 @@ export class LangWatchQLReservedGranularityTypeError extends HandledError {
     super(
       "lwql_granularity_parameter_type",
       fault === "step-value"
-        ? "The datapoint granularity must be a whole number of seconds greater than zero."
+        ? "The datapoint granularity must be one of the offered steps: 1 second, 1 minute, or 1 hour."
         : "The query declares period_granularity_seconds with a type that is not UInt32.",
       {
         httpStatus: 400,
@@ -268,8 +268,8 @@ export class LangWatchQLReservedGranularityTypeError extends HandledError {
  * more buckets than one governed run may return.
  *
  * The workbench and the REST route refuse here because their callers chose
- * the step; the dashboard does not arrive here -- it owns the range, so it
- * auto-coarsens instead and says so.
+ * the step; the dashboard owns the range and auto-coarsens instead, arriving
+ * here only when even the coarsest offered step still overflows the ceiling.
  *
  * Remediation is arithmetic, not retrying: widen the step until the bucket
  * count fits the ceiling, or narrow the window.

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -123,13 +123,38 @@ export class LangWatchQLParameterMissingError extends HandledError {
 }
 
 /**
+ * The refusal sentence for exactly the names the request carried, agreeing in
+ * number so a single supplied name does not read as "values for period_start".
+ *
+ * Built from the supplied names rather than a fixed phrase because the same
+ * code covers the two window bounds and the granularity step, and naming the
+ * wrong one tells a caller to remove a parameter it never sent.
+ */
+function suppliedParameterSentence(supplied: readonly string[]): string {
+  if (supplied.length === 0) {
+    return "The request supplied values for parameters the surface sets itself.";
+  }
+  if (supplied.length === 1) {
+    return `The request supplied a value for ${supplied[0]}, which the surface sets itself.`;
+  }
+  const last = supplied[supplied.length - 1] as string;
+  const names = `${supplied.slice(0, -1).join(", ")} and ${last}`;
+  return `The request supplied values for ${names}, which the surface sets itself.`;
+}
+
+/**
  * The request carried a value for a parameter the surface owns.
  *
- * `period_start` and `period_end` are supplied by whatever is showing the chart
- * — the dashboard's period, the workbench's page period — and a caller that
- * sets one is pinning a window that will then ignore the surface it sits on.
- * Refused rather than overwritten, because silently discarding a value a caller
- * sent is how the two-charts-different-periods bug comes back wearing our name.
+ * `period_start`, `period_end` and `period_granularity_seconds` are supplied by
+ * whatever is showing the chart — the dashboard's period and step, the
+ * workbench's page period — and a caller that sets one is pinning something
+ * that will then ignore the surface it sits on. Refused rather than
+ * overwritten, because silently discarding a value a caller sent is how the
+ * two-charts-different-periods bug comes back wearing our name.
+ *
+ * The message names the parameters actually supplied rather than the
+ * time-window pair: a caller that sent only the granularity was previously
+ * told to remove parameters it had not sent.
  *
  * @see ./timeWindow.ts — the contract this enforces
  */
@@ -142,7 +167,7 @@ export class LangWatchQLReservedParameterSuppliedError extends HandledError {
   ) {
     super(
       "lwql_reserved_parameter_supplied",
-      "The request supplied values for time-window parameters the surface sets itself.",
+      suppliedParameterSentence(supplied),
       {
         httpStatus: 400,
         fault: "customer",
@@ -188,6 +213,19 @@ export class LangWatchQLReservedParameterTypeError extends HandledError {
 }
 
 /**
+ * Which of the two granularity failures this is. They share a code because a
+ * caller acts on both the same way — fix the granularity declaration or the
+ * step behind it — but they are not the same fact, and a message claiming a
+ * type mismatch for a well-typed declaration carrying a fractional step sends
+ * the reader to the wrong line.
+ */
+export type LangWatchQLGranularityFault =
+  /** Declared as something other than `UInt32`. */
+  | "declared-type"
+  /** Declared correctly, but the step supplied is not a positive integer. */
+  | "step-value";
+
+/**
  * The granularity parameter was declared with a type other than `UInt32`, or
  * the surface supplied a step that is not a positive whole number of
  * seconds.
@@ -206,14 +244,18 @@ export class LangWatchQLReservedGranularityTypeError extends HandledError {
   constructor(
     /** The reserved names declared (or valued) wrongly. Sorted. */
     mistyped: readonly string[],
+    /** Which failure this is; the declaration one when unstated. */
+    fault: LangWatchQLGranularityFault = "declared-type",
   ) {
     super(
       "lwql_granularity_parameter_type",
-      "The query declares period_granularity_seconds with a type that is not UInt32.",
+      fault === "step-value"
+        ? "The datapoint granularity must be a whole number of seconds greater than zero."
+        : "The query declares period_granularity_seconds with a type that is not UInt32.",
       {
         httpStatus: 400,
         fault: "customer",
-        meta: { parameters: mistyped },
+        meta: { parameters: mistyped, granularityFault: fault },
         ...remediation("lwql_granularity_parameter_type"),
       },
     );
@@ -263,25 +305,43 @@ export class LangWatchQLGranularityTooFineError extends HandledError {
 }
 
 /**
- * A statement declared `period_granularity_seconds` without declaring the
- * period window the bucket budget is computed against.
+ * A statement declared `period_granularity_seconds` without a usable period
+ * window for the bucket budget to be computed against -- either bound absent,
+ * or present but declared as something other than a date-time.
  *
  * Refused at *save*: without both bounds the surface cannot compute how many
  * buckets a run would produce, so the budget contract would be uncomputable
  * exactly when it matters most -- on the dashboard, where the range is the
  * dashboard's own control. Declaring the two period parameters alongside is
  * the fix, and the schema browser spells them.
+ *
+ * The two causes get different copy. Telling an author to declare
+ * `period_start` when it is on screen, declared `String`, sends them looking
+ * for a line that is already there.
  */
 export class LangWatchQLGranularityRequiresTimeWindowError extends HandledError {
   declare readonly code: "lwql_granularity_requires_window";
 
-  constructor() {
+  constructor({
+    absent = [],
+    mistyped = [],
+  }: {
+    /** Period bounds the statement does not declare at all. */
+    readonly absent?: readonly string[];
+    /** Period bounds declared, but not as a date-time. */
+    readonly mistyped?: readonly string[];
+  } = {}) {
     super(
       "lwql_granularity_requires_window",
-      "A chart declaring period_granularity_seconds must also declare period_start and period_end.",
+      mistyped.length > 0 && absent.length === 0
+        ? "A chart declaring period_granularity_seconds must declare period_start and period_end as DateTime."
+        : "A chart declaring period_granularity_seconds must also declare period_start and period_end.",
       {
         httpStatus: 400,
         fault: "customer",
+        // Named consumer: the editor, which highlights the declarations to add
+        // or rewrite rather than making the author diff the two lists.
+        meta: { absent, mistyped },
         ...remediation("lwql_granularity_requires_window"),
       },
     );

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -192,30 +192,29 @@ export class LangWatchQLReservedParameterTypeError extends HandledError {
  * the surface supplied a step that is not a positive whole number of
  * seconds.
  *
- * A sibling of {@link LangWatchQLReservedParameterTypeError} sharing its code
- * -- from the caller's side both read as "you declared a surface-owned
- * parameter with the wrong type" -- because one presentation entry covers
- * them. The messages differ where it matters: this one names the exact
- * spelling to declare.
+ * A sibling of {@link LangWatchQLReservedParameterTypeError} -- from the
+ * caller's side both read as "you declared a surface-owned parameter with the
+ * wrong type" -- but it carries its own code, so the copy can name what this
+ * declaration must be (`UInt32`) instead of the window's date-time advice.
  *
  * Raised while validating rather than while running, so a chart is refused
  * at *save* for the same reason it would be refused at render.
  */
 export class LangWatchQLReservedGranularityTypeError extends HandledError {
-  declare readonly code: "lwql_reserved_parameter_type";
+  declare readonly code: "lwql_granularity_parameter_type";
 
   constructor(
     /** The reserved names declared (or valued) wrongly. Sorted. */
     mistyped: readonly string[],
   ) {
     super(
-      "lwql_reserved_parameter_type",
+      "lwql_granularity_parameter_type",
       "The query declares period_granularity_seconds with a type that is not UInt32.",
       {
         httpStatus: 400,
         fault: "customer",
         meta: { parameters: mistyped },
-        ...remediation("lwql_reserved_parameter_type"),
+        ...remediation("lwql_granularity_parameter_type"),
       },
     );
     this.name = "LangWatchQLReservedGranularityTypeError";

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -186,3 +186,106 @@ export class LangWatchQLReservedParameterTypeError extends HandledError {
     this.name = "LangWatchQLReservedParameterTypeError";
   }
 }
+
+/**
+ * The granularity parameter was declared with a type other than `UInt32`, or
+ * the surface supplied a step that is not a positive whole number of
+ * seconds.
+ *
+ * A sibling of {@link LangWatchQLReservedParameterTypeError} sharing its code
+ * -- from the caller's side both read as "you declared a surface-owned
+ * parameter with the wrong type" -- because one presentation entry covers
+ * them. The messages differ where it matters: this one names the exact
+ * spelling to declare.
+ *
+ * Raised while validating rather than while running, so a chart is refused
+ * at *save* for the same reason it would be refused at render.
+ */
+export class LangWatchQLReservedGranularityTypeError extends HandledError {
+  declare readonly code: "lwql_reserved_parameter_type";
+
+  constructor(
+    /** The reserved names declared (or valued) wrongly. Sorted. */
+    mistyped: readonly string[],
+  ) {
+    super(
+      "lwql_reserved_parameter_type",
+      "The query declares period_granularity_seconds with a type that is not UInt32.",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        meta: { parameters: mistyped },
+        ...remediation("lwql_reserved_parameter_type"),
+      },
+    );
+    this.name = "LangWatchQLReservedGranularityTypeError";
+  }
+}
+
+/**
+ * The declared window at the requested datapoint granularity would produce
+ * more buckets than one governed run may return.
+ *
+ * The workbench and the REST route refuse here because their callers chose
+ * the step; the dashboard does not arrive here -- it owns the range, so it
+ * auto-coarsens instead and says so.
+ *
+ * Remediation is arithmetic, not retrying: widen the step until the bucket
+ * count fits the ceiling, or narrow the window.
+ */
+export class LangWatchQLGranularityTooFineError extends HandledError {
+  declare readonly code: "lwql_granularity_too_fine";
+
+  constructor({
+    requestedGranularitySeconds,
+    windowSeconds,
+    maxBuckets,
+  }: {
+    requestedGranularitySeconds: number;
+    windowSeconds: number;
+    maxBuckets: number;
+  }) {
+    super(
+      "lwql_granularity_too_fine",
+      "The requested datapoint granularity produces more buckets than the selected period allows.",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        meta: {
+          requestedGranularitySeconds,
+          windowSeconds,
+          maxBuckets,
+        },
+        ...remediation("lwql_granularity_too_fine"),
+      },
+    );
+    this.name = "LangWatchQLGranularityTooFineError";
+  }
+}
+
+/**
+ * A statement declared `period_granularity_seconds` without declaring the
+ * period window the bucket budget is computed against.
+ *
+ * Refused at *save*: without both bounds the surface cannot compute how many
+ * buckets a run would produce, so the budget contract would be uncomputable
+ * exactly when it matters most -- on the dashboard, where the range is the
+ * dashboard's own control. Declaring the two period parameters alongside is
+ * the fix, and the schema browser spells them.
+ */
+export class LangWatchQLGranularityRequiresTimeWindowError extends HandledError {
+  declare readonly code: "lwql_granularity_requires_window";
+
+  constructor() {
+    super(
+      "lwql_granularity_requires_window",
+      "A chart declaring period_granularity_seconds must also declare period_start and period_end.",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        ...remediation("lwql_granularity_requires_window"),
+      },
+    );
+    this.name = "LangWatchQLGranularityRequiresTimeWindowError";
+  }
+}

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -67,7 +67,10 @@ import {
   type LangWatchQLStatistics,
   lwqlConnectionFromEnv,
 } from "./executor";
-import { resolveLangWatchQLTimeWindow } from "./resolveTimeWindow";
+import {
+  assertLangWatchQLGranularityDeclaration,
+  resolveLangWatchQLTimeWindow,
+} from "./resolveTimeWindow";
 import { describeLangWatchQLSchema, type LangWatchQLSchema } from "./schema";
 import type { LangWatchQLTimeWindow } from "./timeWindow";
 import { lwqlValidationError } from "./validation/errors";
@@ -309,6 +312,11 @@ export class LangWatchQLService {
       );
       throw lwqlValidationError(validation);
     }
+
+    // The save-time granularity rules ride on every validate: type and
+    // requires-window are refused wherever the statement is persisted, which
+    // is what makes REST and tRPC saves refuse identically.
+    assertLangWatchQLGranularityDeclaration(validation.parameters);
 
     // Before the missing-parameter check, never after: an injected window IS a
     // value, and checking first would refuse every period-aware statement for

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -265,8 +265,12 @@ export class LangWatchQLService {
    *
    * @throws the validator's handled error when the policy refuses the query,
    *   {@link LangWatchQLParameterMissingError} when a declared parameter has no
-   *   value, and the two time-window refusals in `./timeWindow.ts` when a
-   *   reserved name is supplied by the caller or declared as a non-date-time.
+   *   value, the two time-window refusals in `./timeWindow.ts` when a
+   *   reserved name is supplied by the caller or declared as a non-date-time,
+   *   {@link LangWatchQLReservedGranularityTypeError} when the granularity
+   *   declaration or a surface-supplied step is malformed, and
+   *   {@link LangWatchQLGranularityRequiresTimeWindowError} when granularity
+   *   is declared without both period bounds.
    */
   validate({
     projectId,
@@ -313,9 +317,9 @@ export class LangWatchQLService {
       throw lwqlValidationError(validation);
     }
 
-    // The save-time granularity rules ride on every validate: type and
-    // requires-window are refused wherever the statement is persisted, which
-    // is what makes REST and tRPC saves refuse identically.
+    // The granularity rules ride on every validate -- persisted saves AND
+    // ad-hoc execution, since execute() calls validate() -- which is what
+    // makes REST saves, tRPC saves and workbench runs refuse identically.
     assertLangWatchQLGranularityDeclaration(validation.parameters);
 
     // Before the missing-parameter check, never after: an injected window IS a

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -65,12 +65,15 @@ export interface LangWatchQLTimeWindowResolution {
    */
   readonly followsTimeWindow: boolean;
   /**
-   * Reserved names the statement declares that no window filled, sorted.
+   * Reserved names the statement declares that no surface value filled,
+   * sorted: the window pair when no window was supplied, plus a declared
+   * granularity until the granularity resolver binds a step for it.
    *
-   * Non-empty only when no window was supplied at all. It is not a refusal on
-   * its own: validating a statement for *saving* has no window and must not be
-   * refused for it, because the window is supplied by whoever renders the
-   * chart. Executing with names still on this list is what cannot proceed.
+   * It is not a refusal on its own: validating a statement for *saving* has
+   * no window and must not be refused for it, because every name here is
+   * supplied by whoever renders the chart — never by the caller, so none of
+   * them may reach a caller-missing refusal at validation. Executing with
+   * names still on this list is what cannot proceed.
    */
   readonly awaitingTimeWindow: readonly string[];
 }
@@ -138,12 +141,23 @@ export function resolveLangWatchQLTimeWindow({
     throw new LangWatchQLReservedParameterSuppliedError(supplied);
   }
 
+  // A declared granularity is reserved too, but never window-injected: its
+  // value is bound by the granularity resolver at run. Listing it as awaiting
+  // is what keeps it out of the caller-missing sweep — a refusal naming a
+  // parameter the caller is forbidden to supply is a dead end.
+  const awaitingGranularity = declared
+    .filter((parameter) => parameter.name === LWQL_PERIOD_GRANULARITY_PARAMETER)
+    .map((parameter) => parameter.name);
+
   const followsTimeWindow = reserved.length > 0;
   if (!timeWindow) {
     return {
       ...(parameters ? { parameters } : {}),
       followsTimeWindow,
-      awaitingTimeWindow: reserved.map((parameter) => parameter.name).sort(),
+      awaitingTimeWindow: [
+        ...reserved.map((parameter) => parameter.name),
+        ...awaitingGranularity,
+      ].sort(),
     };
   }
 
@@ -157,7 +171,7 @@ export function resolveLangWatchQLTimeWindow({
   return {
     ...(merged ? { parameters: merged } : {}),
     followsTimeWindow,
-    awaitingTimeWindow: [],
+    awaitingTimeWindow: [...awaitingGranularity].sort(),
   };
 }
 
@@ -200,23 +214,18 @@ export interface LangWatchQLGranularityResolution {
 
 /**
  * The finest offered step whose bucket count fits the ceiling, for the
- * surfaces that coarsen instead of refusing. Falls back to the coarsest
- * step when even it does not fit: a multi-year window on the one-hour floor
- * still renders, with the notice saying so, rather than refusing a shared
- * dashboard URL that happens to span years.
+ * surfaces that coarsen instead of refusing. Undefined when even the
+ * coarsest offered step overflows: the ceiling is a hard browser-safety
+ * cap, so a window nothing fits must refuse rather than hand back an
+ * in-budget-looking answer carrying many times the budget.
  */
-function finestFittingStep(windowSeconds: number): number {
-  // The coarsest offered step, the answer when nothing fits. Seeded from the
-  // first element rather than an end-of-array index, whose result the
-  // compiler cannot know is populated.
-  let coarsest: number = LWQL_GRANULARITY_STEPS[0];
+function finestFittingStep(windowSeconds: number): number | undefined {
   for (const step of LWQL_GRANULARITY_STEPS) {
     if (bucketCount(windowSeconds, step) <= LWQL_GRANULARITY_MAX_BUCKETS) {
       return step;
     }
-    coarsest = step;
   }
-  return coarsest;
+  return undefined;
 }
 
 /** Whether a step is one the surface offers. */
@@ -286,7 +295,9 @@ function assertSurfaceStepIsClean({
  * caller did not.
  *
  * @throws {LangWatchQLGranularityTooFineError} on overflow when asked to
- *   refuse.
+ *   refuse — and, when asked to coarsen, when even the coarsest offered step
+ *   still overflows: the ceiling is a hard cap, not a preference coarsening
+ *   may trade away.
  */
 function resolveAgainstBudget({
   declaredName,
@@ -318,6 +329,15 @@ function resolveAgainstBudget({
   }
 
   const effective = finestFittingStep(windowSeconds);
+  if (effective === undefined) {
+    // Even the one-hour floor overflows: refuse with the same arithmetic the
+    // refuse path names, so the caller learns the window is what must narrow.
+    throw new LangWatchQLGranularityTooFineError({
+      requestedGranularitySeconds: granularitySeconds,
+      windowSeconds,
+      maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+    });
+  }
   return {
     followsGranularity: true,
     granularitySeconds: effective,
@@ -404,7 +424,8 @@ export function assertLangWatchQLGranularityDeclaration(
  *   this function stays safe when called on its own.
  * @throws {LangWatchQLGranularityTooFineError} when the declared window at
  *   the supplied step exceeds {@link LWQL_GRANULARITY_MAX_BUCKETS} buckets
- *   and the surface asked to refuse rather than coarsen.
+ *   and the surface asked to refuse rather than coarsen — or when it asked
+ *   to coarsen and even the coarsest offered step still overflows.
  */
 export function resolveLangWatchQLGranularity({
   declared,

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -217,6 +217,97 @@ function finestFittingStep(windowSeconds: number): number {
 }
 
 /**
+ * The declaration- and value-level refusals, extracted from
+ * {@link resolveLangWatchQLGranularity} so that function reads as the
+ * decision it makes rather than the gauntlet it runs.
+ *
+ * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
+ *   declared as anything but `UInt32`, or when the surface's step is not a
+ *   positive whole number of seconds.
+ * @throws {LangWatchQLReservedParameterSuppliedError} when the request
+ *   carries a value for the reserved name.
+ */
+function assertSurfaceStepIsClean({
+  declaredName,
+  declaredType,
+  parameters,
+  granularitySeconds,
+}: {
+  readonly declaredName: string;
+  readonly declaredType: string;
+  readonly parameters?: Readonly<Record<string, unknown>>;
+  readonly granularitySeconds?: number;
+}): void {
+  if (!isLangWatchQLGranularityParameterType(declaredType)) {
+    throw new LangWatchQLReservedGranularityTypeError([declaredName]);
+  }
+
+  const supplied = Object.keys(parameters ?? {}).filter(
+    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+  );
+  if (supplied.length > 0) {
+    throw new LangWatchQLReservedParameterSuppliedError(supplied);
+  }
+
+  if (
+    granularitySeconds !== undefined &&
+    (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0)
+  ) {
+    // A zero or fractional step is a malformed surface value, not a caller
+    // choice -- the input schemas refuse it first; this is the backstop.
+    throw new LangWatchQLReservedGranularityTypeError([declaredName]);
+  }
+}
+
+/**
+ * The budget half: window seconds against the step at the ceiling. This is
+ * where the two designed overflow outcomes diverge -- refuse for the
+ * surfaces whose caller chose the step, coarsen for the dashboard whose
+ * caller did not.
+ *
+ * @throws {LangWatchQLGranularityTooFineError} on overflow when asked to
+ *   refuse.
+ */
+function resolveAgainstBudget({
+  declaredName,
+  granularitySeconds,
+  timeWindow,
+  onBudgetOverflow,
+}: {
+  readonly declaredName: string;
+  readonly granularitySeconds: number;
+  readonly timeWindow: LangWatchQLTimeWindow;
+  readonly onBudgetOverflow: "refuse" | "coarsen";
+}): LangWatchQLGranularityResolution {
+  const windowSeconds = Math.max(
+    0,
+    Math.ceil((timeWindow.end.getTime() - timeWindow.start.getTime()) / 1000),
+  );
+  const requestedBuckets = bucketCount(windowSeconds, granularitySeconds);
+
+  if (requestedBuckets <= LWQL_GRANULARITY_MAX_BUCKETS) {
+    return { followsGranularity: true, granularitySeconds };
+  }
+
+  if (onBudgetOverflow === "refuse") {
+    throw new LangWatchQLGranularityTooFineError({
+      requestedGranularitySeconds: granularitySeconds,
+      windowSeconds,
+      maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+    });
+  }
+
+  const effective = finestFittingStep(windowSeconds);
+  return {
+    followsGranularity: true,
+    granularitySeconds: effective,
+    ...(effective !== granularitySeconds
+      ? { coarsenedFromSeconds: granularitySeconds }
+      : {}),
+  };
+}
+
+/**
  * Decides what the granularity declaration means for one request, and
  * refuses the ways it can be misused -- the granularity counterpart of
  * {@link resolveLangWatchQLTimeWindow}, kept separate because its failure
@@ -309,29 +400,12 @@ export function resolveLangWatchQLGranularity({
     return { followsGranularity: false };
   }
 
-  if (!isLangWatchQLGranularityParameterType(declaredGranularity.type)) {
-    throw new LangWatchQLReservedGranularityTypeError([
-      declaredGranularity.name,
-    ]);
-  }
-
-  const supplied = Object.keys(parameters ?? {}).filter(
-    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
-  );
-  if (supplied.length > 0) {
-    throw new LangWatchQLReservedParameterSuppliedError(supplied);
-  }
-
-  if (
-    granularitySeconds !== undefined &&
-    (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0)
-  ) {
-    // A zero or fractional step is a malformed surface value, not a caller
-    // choice -- the input schemas refuse it first; this is the backstop.
-    throw new LangWatchQLReservedGranularityTypeError([
-      declaredGranularity.name,
-    ]);
-  }
+  assertSurfaceStepIsClean({
+    declaredName: declaredGranularity.name,
+    declaredType: declaredGranularity.type,
+    parameters,
+    granularitySeconds,
+  });
 
   if (granularitySeconds === undefined) {
     // Declared but the surface offered no choice: the statement runs with
@@ -350,29 +424,10 @@ export function resolveLangWatchQLGranularity({
     return { followsGranularity: true, granularitySeconds };
   }
 
-  const windowSeconds = Math.max(
-    0,
-    Math.ceil((timeWindow.end.getTime() - timeWindow.start.getTime()) / 1000),
-  );
-  const requestedBuckets = bucketCount(windowSeconds, granularitySeconds);
-
-  if (requestedBuckets > LWQL_GRANULARITY_MAX_BUCKETS) {
-    if (onBudgetOverflow === "refuse") {
-      throw new LangWatchQLGranularityTooFineError({
-        requestedGranularitySeconds: granularitySeconds,
-        windowSeconds,
-        maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
-      });
-    }
-    const effective = finestFittingStep(windowSeconds);
-    return {
-      followsGranularity: true,
-      granularitySeconds: effective,
-      ...(effective !== granularitySeconds
-        ? { coarsenedFromSeconds: granularitySeconds }
-        : {}),
-    };
-  }
-
-  return { followsGranularity: true, granularitySeconds };
+  return resolveAgainstBudget({
+    declaredName: declaredGranularity.name,
+    granularitySeconds,
+    timeWindow,
+    onBudgetOverflow,
+  });
 }

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -173,6 +173,9 @@ function bucketCount(windowSeconds: number, stepSeconds: number): number {
  * The ceiling on datapoint buckets one governed run may produce through the
  * granularity contract. Named so the dashboard clamp notice can cite it and
  * the budget arithmetic has one home.
+ *
+ * A run producing exactly this many buckets is admitted; overflow is strictly
+ * greater than.
  */
 export const LWQL_GRANULARITY_MAX_BUCKETS = 10_000;
 
@@ -216,14 +219,26 @@ function finestFittingStep(windowSeconds: number): number {
   return coarsest;
 }
 
+/** Whether a step is one the surface offers. */
+function isOfferedStep(stepSeconds: number): boolean {
+  return (LWQL_GRANULARITY_STEPS as readonly number[]).includes(stepSeconds);
+}
+
 /**
  * The declaration- and value-level refusals, extracted from
  * {@link resolveLangWatchQLGranularity} so that function reads as the
  * decision it makes rather than the gauntlet it runs.
  *
+ * The step is checked by *membership* in {@link LWQL_GRANULARITY_STEPS}, not
+ * merely for being a positive integer. Coarsening picks its answer from that
+ * same list, so an off-list step admitted here — 7,200 seconds, say — could be
+ * "coarsened" to the 3,600-second hour: a finer step than the one requested,
+ * reported as a coarsening. Refusing the off-list step is what keeps the
+ * requested and effective values on one scale.
+ *
  * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
- *   declared as anything but `UInt32`, or when the surface's step is not a
- *   positive whole number of seconds.
+ *   declared as anything but `UInt32`, or when the surface's step is not one
+ *   of the offered steps.
  * @throws {LangWatchQLReservedParameterSuppliedError} when the request
  *   carries a value for the reserved name.
  */
@@ -242,20 +257,25 @@ function assertSurfaceStepIsClean({
     throw new LangWatchQLReservedGranularityTypeError([declaredName]);
   }
 
+  // Only this resolver's own reserved name: the window sweep owns the other
+  // two, and refusing them here would answer a window question from the
+  // granularity path.
   const supplied = Object.keys(parameters ?? {}).filter(
-    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+    (name) =>
+      isLangWatchQLSurfaceParameter(name) &&
+      name === LWQL_PERIOD_GRANULARITY_PARAMETER,
   );
   if (supplied.length > 0) {
     throw new LangWatchQLReservedParameterSuppliedError(supplied);
   }
 
-  if (
-    granularitySeconds !== undefined &&
-    (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0)
-  ) {
-    // A zero or fractional step is a malformed surface value, not a caller
-    // choice -- the input schemas refuse it first; this is the backstop.
-    throw new LangWatchQLReservedGranularityTypeError([declaredName]);
+  if (granularitySeconds !== undefined && !isOfferedStep(granularitySeconds)) {
+    // A zero, fractional or off-list step is a malformed surface value, not a
+    // caller choice -- the input schemas refuse it first; this is the backstop.
+    throw new LangWatchQLReservedGranularityTypeError(
+      [declaredName],
+      "step-value",
+    );
   }
 }
 
@@ -301,7 +321,11 @@ function resolveAgainstBudget({
   return {
     followsGranularity: true,
     granularitySeconds: effective,
-    ...(effective !== granularitySeconds
+    // Strictly greater, never merely different: a step equal to or finer than
+    // the requested one did not coarsen anything, and labelling it as such
+    // would have the dashboard tell a member their step was widened when it
+    // was not.
+    ...(effective > granularitySeconds
       ? { coarsenedFromSeconds: granularitySeconds }
       : {}),
   };
@@ -320,7 +344,10 @@ function resolveAgainstBudget({
  * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
  *   declared as anything but `UInt32`.
  * @throws {LangWatchQLGranularityRequiresTimeWindowError} when it is declared
- *   but either period bound is missing.
+ *   but either period bound is missing, or is declared as something other
+ *   than a date-time. The two are told apart in the copy: an author whose
+ *   `period_start` is right there but spelled `String` is not helped by being
+ *   told to declare it.
  */
 export function assertLangWatchQLGranularityDeclaration(
   declared: readonly LangWatchQLParameter[],
@@ -337,15 +364,23 @@ export function assertLangWatchQLGranularityDeclaration(
   }
 
   const periodNames = [LWQL_PERIOD_START_PARAMETER, LWQL_PERIOD_END_PARAMETER];
-  const missing = periodNames.filter(
-    (name) =>
-      !declared.some((parameter) => {
-        if (parameter.name !== name) return false;
-        return isLangWatchQLDateTimeParameterType(parameter.type);
-      }),
+  const absent = periodNames.filter(
+    (name) => !declared.some((parameter) => parameter.name === name),
   );
-  if (missing.length > 0) {
-    throw new LangWatchQLGranularityRequiresTimeWindowError();
+  const mistyped = periodNames.filter(
+    (name) =>
+      !absent.includes(name) &&
+      !declared.some(
+        (parameter) =>
+          parameter.name === name &&
+          isLangWatchQLDateTimeParameterType(parameter.type),
+      ),
+  );
+  if (absent.length > 0 || mistyped.length > 0) {
+    throw new LangWatchQLGranularityRequiresTimeWindowError({
+      absent,
+      mistyped,
+    });
   }
 }
 

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -308,28 +308,6 @@ function resolveAgainstBudget({
 }
 
 /**
- * Decides what the granularity declaration means for one request, and
- * refuses the ways it can be misused -- the granularity counterpart of
- * {@link resolveLangWatchQLTimeWindow}, kept separate because its failure
- * modes differ: where the window is injected only when declared and merely
- * reported otherwise, a granularity declaration binds the run to a *budget*,
- * and the budget's overflow has two designed outcomes. Surfaces the caller
- * owns -- the workbench, the REST route -- refuse with
- * {@link LangWatchQLGranularityTooFineError}; the dashboard owns the range
- * and auto-coarsens instead, naming what happened.
- *
- * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
- *   declared as anything but `UInt32`. Raised before any value check so an
- *   author gets the same answer about their statement whether or not the
- *   request also carried a value for it.
- * @throws {LangWatchQLReservedParameterSuppliedError} when the request
- *   carries a value for it. Asserted here as well as in the window sweep so
- *   this function stays safe when called on its own.
- * @throws {LangWatchQLGranularityTooFineError} when the declared window at
- *   the supplied step exceeds {@link LWQL_GRANULARITY_MAX_BUCKETS} buckets
- *   and the surface asked to refuse rather than coarsen.
- */
-/**
  * The save-time half of the granularity contract, shared by every door that
  * persists a statement: a granularity declaration is only meaningful when
  * both period bounds are declared too -- without them the bucket budget the
@@ -371,6 +349,28 @@ export function assertLangWatchQLGranularityDeclaration(
   }
 }
 
+/**
+ * Decides what the granularity declaration means for one request, and
+ * refuses the ways it can be misused -- the granularity counterpart of
+ * {@link resolveLangWatchQLTimeWindow}, kept separate because its failure
+ * modes differ: where the window is injected only when declared and merely
+ * reported otherwise, a granularity declaration binds the run to a *budget*,
+ * and the budget's overflow has two designed outcomes. Surfaces the caller
+ * owns -- the workbench, the REST route -- refuse with
+ * {@link LangWatchQLGranularityTooFineError}; the dashboard owns the range
+ * and auto-coarsens instead, naming what happened.
+ *
+ * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
+ *   declared as anything but `UInt32`. Raised before any value check so an
+ *   author gets the same answer about their statement whether or not the
+ *   request also carried a value for it.
+ * @throws {LangWatchQLReservedParameterSuppliedError} when the request
+ *   carries a value for it. Asserted here as well as in the window sweep so
+ *   this function stays safe when called on its own.
+ * @throws {LangWatchQLGranularityTooFineError} when the declared window at
+ *   the supplied step exceeds {@link LWQL_GRANULARITY_MAX_BUCKETS} buckets
+ *   and the surface asked to refuse rather than coarsen.
+ */
 export function resolveLangWatchQLGranularity({
   declared,
   parameters,

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -29,15 +29,23 @@
  */
 
 import {
+  LangWatchQLGranularityRequiresTimeWindowError,
+  LangWatchQLGranularityTooFineError,
+  LangWatchQLReservedGranularityTypeError,
   LangWatchQLReservedParameterSuppliedError,
   LangWatchQLReservedParameterTypeError,
 } from "./errors";
 import {
   formatLangWatchQLDateTimeParameter,
   isLangWatchQLDateTimeParameterType,
+  isLangWatchQLGranularityParameterType,
+  isLangWatchQLSurfaceParameter,
   isLangWatchQLTimeWindowParameter,
   type LangWatchQLTimeWindow,
   type LangWatchQLTimeWindowParameter,
+  LWQL_GRANULARITY_STEPS,
+  LWQL_PERIOD_END_PARAMETER,
+  LWQL_PERIOD_GRANULARITY_PARAMETER,
   LWQL_PERIOD_START_PARAMETER,
 } from "./timeWindow";
 import type { LangWatchQLParameter } from "./validation/validate";
@@ -124,7 +132,7 @@ export function resolveLangWatchQLTimeWindow({
   }
 
   const supplied = Object.keys(parameters ?? {})
-    .filter(isLangWatchQLTimeWindowParameter)
+    .filter(isLangWatchQLSurfaceParameter)
     .sort();
   if (supplied.length > 0) {
     throw new LangWatchQLReservedParameterSuppliedError(supplied);
@@ -151,4 +159,220 @@ export function resolveLangWatchQLTimeWindow({
     followsTimeWindow,
     awaitingTimeWindow: [],
   };
+}
+
+/**
+ * How many buckets a window at a step produces, rounded up -- a partial
+ * bucket at the window's end still renders as a datapoint.
+ */
+function bucketCount(windowSeconds: number, stepSeconds: number): number {
+  return Math.ceil(windowSeconds / stepSeconds);
+}
+
+/**
+ * The ceiling on datapoint buckets one governed run may produce through the
+ * granularity contract. Named so the dashboard clamp notice can cite it and
+ * the budget arithmetic has one home.
+ */
+export const LWQL_GRANULARITY_MAX_BUCKETS = 10_000;
+
+/** What a statement's granularity declaration means for one request. */
+export interface LangWatchQLGranularityResolution {
+  /**
+   * The step this run was bucketed at, present when the statement declares
+   * the granularity parameter and the surface supplied a value. Absent
+   * otherwise -- an undeclared statement keeps whatever bucketing its SQL
+   * text hard-codes.
+   */
+  readonly granularitySeconds?: number;
+  /** Whether the statement declares the granularity parameter at all. */
+  readonly followsGranularity: boolean;
+  /**
+   * The step the caller asked for, present only when this run coarsened:
+   * the dashboard names requested and effective side by side rather than
+   * changing a shared control's meaning silently.
+   */
+  readonly coarsenedFromSeconds?: number;
+}
+
+/**
+ * The finest offered step whose bucket count fits the ceiling, for the
+ * surfaces that coarsen instead of refusing. Falls back to the coarsest
+ * step when even it does not fit: a multi-year window on the one-hour floor
+ * still renders, with the notice saying so, rather than refusing a shared
+ * dashboard URL that happens to span years.
+ */
+function finestFittingStep(windowSeconds: number): number {
+  // The coarsest offered step, the answer when nothing fits. Seeded from the
+  // first element rather than an end-of-array index, whose result the
+  // compiler cannot know is populated.
+  let coarsest: number = LWQL_GRANULARITY_STEPS[0];
+  for (const step of LWQL_GRANULARITY_STEPS) {
+    if (bucketCount(windowSeconds, step) <= LWQL_GRANULARITY_MAX_BUCKETS) {
+      return step;
+    }
+    coarsest = step;
+  }
+  return coarsest;
+}
+
+/**
+ * Decides what the granularity declaration means for one request, and
+ * refuses the ways it can be misused -- the granularity counterpart of
+ * {@link resolveLangWatchQLTimeWindow}, kept separate because its failure
+ * modes differ: where the window is injected only when declared and merely
+ * reported otherwise, a granularity declaration binds the run to a *budget*,
+ * and the budget's overflow has two designed outcomes. Surfaces the caller
+ * owns -- the workbench, the REST route -- refuse with
+ * {@link LangWatchQLGranularityTooFineError}; the dashboard owns the range
+ * and auto-coarsens instead, naming what happened.
+ *
+ * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
+ *   declared as anything but `UInt32`. Raised before any value check so an
+ *   author gets the same answer about their statement whether or not the
+ *   request also carried a value for it.
+ * @throws {LangWatchQLReservedParameterSuppliedError} when the request
+ *   carries a value for it. Asserted here as well as in the window sweep so
+ *   this function stays safe when called on its own.
+ * @throws {LangWatchQLGranularityTooFineError} when the declared window at
+ *   the supplied step exceeds {@link LWQL_GRANULARITY_MAX_BUCKETS} buckets
+ *   and the surface asked to refuse rather than coarsen.
+ */
+/**
+ * The save-time half of the granularity contract, shared by every door that
+ * persists a statement: a granularity declaration is only meaningful when
+ * both period bounds are declared too -- without them the bucket budget the
+ * dashboard computes is uncomputable -- and only when declared as `UInt32`.
+ *
+ * Called from the service's `validate`, so tRPC and REST saves refuse here,
+ * before anything is written. The value-level rules (positive integer, bucket
+ * budget) are {@link resolveLangWatchQLGranularity}'s, at run.
+ *
+ * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
+ *   declared as anything but `UInt32`.
+ * @throws {LangWatchQLGranularityRequiresTimeWindowError} when it is declared
+ *   but either period bound is missing.
+ */
+export function assertLangWatchQLGranularityDeclaration(
+  declared: readonly LangWatchQLParameter[],
+): void {
+  const declaredGranularity = declared.find(
+    (parameter) => parameter.name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+  );
+  if (!declaredGranularity) return;
+
+  if (!isLangWatchQLGranularityParameterType(declaredGranularity.type)) {
+    throw new LangWatchQLReservedGranularityTypeError([
+      declaredGranularity.name,
+    ]);
+  }
+
+  const periodNames = [LWQL_PERIOD_START_PARAMETER, LWQL_PERIOD_END_PARAMETER];
+  const missing = periodNames.filter(
+    (name) =>
+      !declared.some((parameter) => {
+        if (parameter.name !== name) return false;
+        return isLangWatchQLDateTimeParameterType(parameter.type);
+      }),
+  );
+  if (missing.length > 0) {
+    throw new LangWatchQLGranularityRequiresTimeWindowError();
+  }
+}
+
+export function resolveLangWatchQLGranularity({
+  declared,
+  parameters,
+  granularitySeconds,
+  timeWindow,
+  onBudgetOverflow = "refuse",
+}: {
+  /** Bound parameters the validated statement declares. */
+  readonly declared: readonly LangWatchQLParameter[];
+  /** Values the caller sent -- checked so a reserved one cannot slip through. */
+  readonly parameters?: Readonly<Record<string, unknown>>;
+  /**
+   * The step the surface chose, when the statement declares the parameter
+   * and the surface offers a choice. A positive integer when present.
+   */
+  readonly granularitySeconds?: number;
+  /** The period this run is windowed to; the budget is computed against it. */
+  readonly timeWindow?: LangWatchQLTimeWindow;
+  /** Refuse (caller-owned surfaces) or coarsen (the dashboard) on overflow. */
+  readonly onBudgetOverflow?: "refuse" | "coarsen";
+}): LangWatchQLGranularityResolution {
+  const declaredGranularity = declared.find(
+    (parameter) => parameter.name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+  );
+
+  if (!declaredGranularity) {
+    return { followsGranularity: false };
+  }
+
+  if (!isLangWatchQLGranularityParameterType(declaredGranularity.type)) {
+    throw new LangWatchQLReservedGranularityTypeError([
+      declaredGranularity.name,
+    ]);
+  }
+
+  const supplied = Object.keys(parameters ?? {}).filter(
+    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+  );
+  if (supplied.length > 0) {
+    throw new LangWatchQLReservedParameterSuppliedError(supplied);
+  }
+
+  if (
+    granularitySeconds !== undefined &&
+    (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0)
+  ) {
+    // A zero or fractional step is a malformed surface value, not a caller
+    // choice -- the input schemas refuse it first; this is the backstop.
+    throw new LangWatchQLReservedGranularityTypeError([
+      declaredGranularity.name,
+    ]);
+  }
+
+  if (granularitySeconds === undefined) {
+    // Declared but the surface offered no choice: the statement runs with
+    // the bucketing its SQL text hard-codes. The same documented limitation
+    // as the window contract's awaiting list -- the declaration records
+    // intent, and proving the parameter actually drives the bucketing
+    // expression is out of reach statically.
+    return { followsGranularity: true };
+  }
+
+  if (!timeWindow) {
+    // No window, no budget to check. The save-time rule requiring both
+    // period parameters alongside granularity makes this unreachable for
+    // saved charts; a workbench run supplies the page period
+    // unconditionally.
+    return { followsGranularity: true, granularitySeconds };
+  }
+
+  const windowSeconds = Math.max(
+    0,
+    Math.ceil((timeWindow.end.getTime() - timeWindow.start.getTime()) / 1000),
+  );
+  const requestedBuckets = bucketCount(windowSeconds, granularitySeconds);
+
+  if (requestedBuckets > LWQL_GRANULARITY_MAX_BUCKETS) {
+    if (onBudgetOverflow === "refuse") {
+      throw new LangWatchQLGranularityTooFineError({
+        requestedGranularitySeconds: granularitySeconds,
+        windowSeconds,
+        maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+      });
+    }
+    const effective = finestFittingStep(windowSeconds);
+    return {
+      followsGranularity: true,
+      granularitySeconds: effective,
+      ...(effective !== granularitySeconds
+        ? { coarsenedFromSeconds: granularitySeconds }
+        : {}),
+    };
+  }
+
+  return { followsGranularity: true, granularitySeconds };
 }

--- a/platform/app/src/server/analytics/lwql/timeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/timeWindow.ts
@@ -1,5 +1,5 @@
 /**
- * LangWatchQL analytics SQL — the time-window vocabulary.
+ * LangWatchQL analytics SQL — the time-window and granularity vocabulary.
  *
  * A statement says whether it follows the surface's period by *declaring* two
  * reserved bound parameters, `{period_start:DateTime}` and
@@ -13,6 +13,13 @@
  * period_end)`. A convention this module documents rather than something it can
  * enforce — the author writes the comparison — and it is what the schema
  * browser tells a member writing SQL.
+ *
+ * A third reserved name, `{period_granularity_seconds:UInt32}`, opts a
+ * statement into the surface's datapoint bucket size on the same terms. The
+ * three together are the surface's — {@link LWQL_SURFACE_PARAMETERS} — and a
+ * request carrying a value for any of them is refused. The steps the surface
+ * offers are {@link LWQL_GRANULARITY_STEPS}, and they are the only values the
+ * policy accepts, because coarsening picks its answer from that same list.
  *
  * ## This module has no imports, and must not gain any
  *

--- a/platform/app/src/server/analytics/lwql/timeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/timeWindow.ts
@@ -54,6 +54,74 @@ export const LWQL_TIME_WINDOW_PARAMETERS = [
 export type LangWatchQLTimeWindowParameter =
   (typeof LWQL_TIME_WINDOW_PARAMETERS)[number];
 
+/**
+ * The datapoint-bucket size the surface sets for charts that opt into it,
+ * in seconds.
+ *
+ * Declared in a statement as `{period_granularity_seconds:UInt32}` and used
+ * as the multiplier of a fixed-unit interval -- `INTERVAL
+ * {period_granularity_seconds:UInt32} SECOND` -- because ClickHouse compiles
+ * `INTERVAL 1 HOUR` to a *function name* (`toIntervalHour`), so the unit of
+ * an offered step cannot itself be a bound value. Fixing the unit at seconds
+ * and making the multiplier the bound parameter is what leaves the surface
+ * one value to inject.
+ */
+export const LWQL_PERIOD_GRANULARITY_PARAMETER = "period_granularity_seconds";
+
+/**
+ * Every reserved name the surface owns: the two window bounds and the
+ * granularity. A request carrying a value for any of them is refused --
+ * each is set by whatever is showing the chart, and a caller that sets one
+ * is pinning something that will then ignore its surface.
+ */
+export const LWQL_SURFACE_PARAMETERS = [
+  LWQL_PERIOD_START_PARAMETER,
+  LWQL_PERIOD_END_PARAMETER,
+  LWQL_PERIOD_GRANULARITY_PARAMETER,
+] as const;
+
+export type LangWatchQLSurfaceParameter =
+  (typeof LWQL_SURFACE_PARAMETERS)[number];
+
+/** Whether a parameter name belongs to the surface rather than the caller. */
+export function isLangWatchQLSurfaceParameter(
+  name: string,
+): name is LangWatchQLSurfaceParameter {
+  return (LWQL_SURFACE_PARAMETERS as readonly string[]).includes(name);
+}
+
+/**
+ * Exactly `UInt32`.
+ *
+ * The same strictness decision as the date-time types above, applied to an
+ * unsigned count: one spelling, no widened aliases. `UInt32` is the smallest
+ * unsigned ClickHouse integer every offered step fits inside (`UInt16` tops
+ * out below a day's seconds), and a count of seconds has no reason to be
+ * nullable, signed, or floating.
+ */
+const LWQL_GRANULARITY_PARAMETER_TYPE = /^UInt32$/;
+
+/** Whether a declared ClickHouse type can carry the granularity multiplier. */
+export function isLangWatchQLGranularityParameterType(type: string): boolean {
+  return LWQL_GRANULARITY_PARAMETER_TYPE.test(type.trim());
+}
+
+/**
+ * The datapoint granularities the surface offers, in seconds: one second,
+ * one minute, one hour.
+ *
+ * Deliberately sub-day. A fixed 86,400-second interval carries no notion of
+ * a local day: on a DST-transition day (25 or 23 hours) the bucket boundary
+ * drifts off local midnight -- verified against ClickHouse 25.10, where over
+ * the Europe/Amsterdam fallback night the timezone-argument form buckets
+ * 22:00-00:00 local to `02:00` and 01:00-04:00 local to `01:00`, while
+ * `toStartOfDay(t, 'Europe/Amsterdam')` stays at `00:00` throughout. A
+ * member asking for daily buckets would get silently misaligned ones.
+ * Day-scale waits on a reserved `period_timezone` parameter (the namespace
+ * already anticipates it) and is tracked as a follow-up.
+ */
+export const LWQL_GRANULARITY_STEPS = [1, 60, 3600] as const;
+
 /** Whether a parameter name is one the surface owns. */
 export function isLangWatchQLTimeWindowParameter(
   name: string,

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -114,6 +114,13 @@ const registry = {
       "Declare each as `DateTime` or `DateTime64`, for example `{period_start:DateTime}`; the interval they describe is half-open, `>= {period_start:DateTime} AND < {period_end:DateTime}`",
     ],
   },
+  lwql_granularity_parameter_type: {
+    tips: [
+      "Read `meta.parameters` — it lists the parameter whose declaration was refused",
+      "Declare period_granularity_seconds as UInt32, for example {period_granularity_seconds:UInt32}",
+      "When the surface supplies the step itself, it must be a positive whole number of seconds",
+    ],
+  },
   lwql_granularity_too_fine: {
     tips: [
       "The requested bucket size would produce more datapoints than one query may return for this period",

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -124,7 +124,7 @@ const registry = {
   lwql_granularity_too_fine: {
     tips: [
       "The requested bucket size would produce more datapoints than one query may return for this period",
-      "Use a coarser granularity -- 1 second, 1 minute or 1 hour -- or narrow the date range",
+      "Use a bucket size that fits the range from the offered steps -- 1 second, 1 minute or 1 hour -- or narrow the date range",
     ],
   },
   lwql_granularity_requires_window: {

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -118,7 +118,7 @@ const registry = {
     tips: [
       "Read `meta.parameters` — it lists the parameter whose declaration was refused",
       "Declare period_granularity_seconds as UInt32, for example {period_granularity_seconds:UInt32}",
-      "When the surface supplies the step itself, it must be a positive whole number of seconds",
+      "When the surface supplies the step itself, it must be one of the offered steps: 1 second, 1 minute, or 1 hour",
     ],
   },
   lwql_granularity_too_fine: {

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -114,6 +114,18 @@ const registry = {
       "Declare each as `DateTime` or `DateTime64`, for example `{period_start:DateTime}`; the interval they describe is half-open, `>= {period_start:DateTime} AND < {period_end:DateTime}`",
     ],
   },
+  lwql_granularity_too_fine: {
+    tips: [
+      "The requested bucket size would produce more datapoints than one query may return for this period",
+      "Use a coarser granularity -- 1 second, 1 minute or 1 hour -- or narrow the date range",
+    ],
+  },
+  lwql_granularity_requires_window: {
+    tips: [
+      "A chart declaring period_granularity_seconds must also declare {period_start:DateTime} and {period_end:DateTime}",
+      "The bucket budget is computed against the period those two bounds describe",
+    ],
+  },
   lwql_not_enabled: {
     tips: [
       "The LangWatchQL feature is not enabled for this project — retrying will not help",

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -858,3 +858,71 @@ Feature: LangWatchQL query workbench — native tables and LangWatchQL Vega-Lite
 #   → Scenario: A statement declaring only one reserved period parameter is given that one
 #   → Scenario: A period-aware statement run with no window names what is unset
 #   → Scenario: The schema browser names the reserved period parameters where SQL is written
+
+# --- Granularity contract (#6713 slice 3, S1): the surface-owned bucket size ---
+#
+# A statement may declare `{period_granularity_seconds:UInt32}` and use it as
+# the multiplier of a fixed-unit interval -- `INTERVAL
+# {period_granularity_seconds:UInt32} SECOND` -- because ClickHouse compiles an
+# interval unit to a function name, so only the multiplier can be a bound value.
+#
+# AC1 "a chart declaring the parameter runs at the step the surface supplies"
+#   → Scenario: A statement declaring the granularity parameter runs at the step the workbench supplies
+#   → Scenario: A granularity declared with no step supplied runs on its own authored bucketing
+# AC2 "a caller-supplied value for a reserved name is refused" (granularity half)
+#   → Scenario: A caller that supplies period_granularity_seconds itself is refused
+# AC3 "the declaration must be UInt32"
+#   → Scenario: The granularity parameter declared as anything but UInt32 is refused
+#   → Scenario: A zero or fractional step is refused as a wrong declaration
+# AC4 "declaring granularity requires declaring both period bounds, checked at save"
+#   → Scenario: A saved chart declaring granularity without both period parameters is refused at save
+#   → Scenario: A granularity declared alongside a mistyped period bound is refused at save
+# AC5 "a window finer than the bucket ceiling is refused on caller-owned surfaces"
+#   → Scenario: A window that would produce more buckets than the ceiling refuses on the workbench and REST
+# AC6 "offered steps are sub-day: 1 second, 1 minute, 1 hour" — O1 resolved to
+#     sub-day by probe: over the Amsterdam fallback night the timezone-argument
+#     seconds form drifts off local midnight while toStartOfDay stays at 00:00.
+#     Day-scale waits on a reserved period_timezone parameter.
+#   → covered by the offered-step constant and its unit test; no runtime behaviour of its own.
+# AC7 "each new code has a presentation entry and a remediation entry" → guarded
+#    by `codes.unit.test.ts` and the exhaustive `satisfies` in `presentation.ts`.
+
+# The S1-bindable scenarios below are bound by
+# `src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts` and
+# `.../lwqlGranularityDeclaration.unit.test.ts`. The two marked @unimplemented
+# need the run-path wiring (procedure input + run-by-chart-id) landing in the
+# next PR of the stack; #6713 tracks them.
+
+@unit
+@scenario "A statement declaring the granularity parameter runs at the step the workbench supplies"
+Scenario: A statement declaring the granularity parameter runs at the step the workbench supplies
+
+@unit
+@scenario "A granularity declared with no step supplied runs on its own authored bucketing"
+Scenario: A granularity declared with no step supplied runs on its own authored bucketing
+
+@unit
+@scenario "A caller that supplies period_granularity_seconds itself is refused"
+Scenario: A caller that supplies period_granularity_seconds itself is refused
+
+@unit
+@scenario "The granularity parameter declared as anything but UInt32 is refused"
+Scenario: The granularity parameter declared as anything but UInt32 is refused
+
+@unit
+@scenario "A zero or fractional step is refused as a wrong declaration"
+Scenario: A zero or fractional step is refused as a wrong declaration
+
+@integration @unimplemented
+@scenario "A saved chart declaring granularity without both period parameters is refused at save"
+Scenario: A saved chart declaring granularity without both period parameters is refused at save
+  Tracking: #6713 (run-path wiring PR)
+
+@unit
+@scenario "A granularity declared alongside a mistyped period bound is refused at save"
+Scenario: A granularity declared alongside a mistyped period bound is refused at save
+
+@integration @unimplemented
+@scenario "A window that would produce more buckets than the ceiling refuses on the workbench and REST"
+Scenario: A window that would produce more buckets than the ceiling refuses on the workbench and REST
+  Tracking: #6713 (run-path wiring PR)

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -605,6 +605,13 @@ Feature: LangWatchQL query workbench — native tables and LangWatchQL Vega-Lite
     And nothing reaches the database
 
   @unit
+  Scenario: The refusal names the reserved parameter the caller actually supplied
+    Given a request refused for supplying a reserved parameter of its own
+    When the workbench shows the refusal
+    Then the copy names the parameter that was supplied
+    And it does not name a reserved parameter the request never sent
+
+  @unit
   Scenario: A reserved period parameter declared as anything but a date-time is refused
     Given SQL declaring period_start as a string
     When the statement is validated

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -894,35 +894,62 @@ Feature: LangWatchQL query workbench — native tables and LangWatchQL Vega-Lite
 # next PR of the stack; #6713 tracks them.
 
 @unit
-@scenario "A statement declaring the granularity parameter runs at the step the workbench supplies"
 Scenario: A statement declaring the granularity parameter runs at the step the workbench supplies
+  Given SQL declaring period_granularity_seconds as UInt32 alongside both period bounds
+  And the workbench supplies a step of 60 seconds
+  When the member runs the query
+  Then the statement is bound with a granularity of 60 seconds
+  And the result is labelled as following the granularity
 
 @unit
-@scenario "A granularity declared with no step supplied runs on its own authored bucketing"
 Scenario: A granularity declared with no step supplied runs on its own authored bucketing
+  Given SQL declaring period_granularity_seconds as UInt32
+  And the surface supplies no step
+  When the member runs the query
+  Then no granularity value is bound
+  And the result is labelled as not following the granularity
 
 @unit
-@scenario "A caller that supplies period_granularity_seconds itself is refused"
 Scenario: A caller that supplies period_granularity_seconds itself is refused
+  Given SQL declaring period_granularity_seconds as UInt32
+  When a caller supplies a value for period_granularity_seconds directly
+  Then the run is refused as a reserved parameter supplied
+  And the refusal names exactly the parameters the caller supplied
 
 @unit
-@scenario "The granularity parameter declared as anything but UInt32 is refused"
 Scenario: The granularity parameter declared as anything but UInt32 is refused
+  Given SQL declaring period_granularity_seconds as a String
+  When the statement is validated
+  Then it is refused as a wrong granularity declaration
+  And the refusal names UInt32 as the required declared type
 
 @unit
-@scenario "A zero or fractional step is refused as a wrong declaration"
 Scenario: A zero or fractional step is refused as a wrong declaration
+  Given SQL declaring period_granularity_seconds as UInt32
+  When the surface supplies a step that is zero, negative, fractional, or not an offered step
+  Then the run is refused as a wrong granularity declaration
+  And the refusal says the step must be one of the offered steps
 
 @integration @unimplemented
-@scenario "A saved chart declaring granularity without both period parameters is refused at save"
 Scenario: A saved chart declaring granularity without both period parameters is refused at save
-  Tracking: #6713 (run-path wiring PR)
+  # Tracking: #6713 (run-path wiring PR)
+  Given SQL declaring period_granularity_seconds without period_start or period_end
+  When the member saves the chart
+  Then the save is refused because granularity requires the period parameters
+  And the refusal names which period bounds are absent
 
 @unit
-@scenario "A granularity declared alongside a mistyped period bound is refused at save"
 Scenario: A granularity declared alongside a mistyped period bound is refused at save
+  Given SQL declaring period_granularity_seconds and period_start declared as a String
+  When the statement is validated
+  Then it is refused because granularity requires well-typed period parameters
+  And the refusal distinguishes the mistyped bound from an absent one
 
 @integration @unimplemented
-@scenario "A window that would produce more buckets than the ceiling refuses on the workbench and REST"
 Scenario: A window that would produce more buckets than the ceiling refuses on the workbench and REST
-  Tracking: #6713 (run-path wiring PR)
+  # Tracking: #6713 (run-path wiring PR)
+  Given a chart declaring granularity and a requested step of 1 second
+  And a period wide enough that the window divided by the step exceeds 10,000 buckets
+  When the member runs it on a caller-owned surface
+  Then the run is refused as too fine for the period
+  And a dashboard running the same chart is coarsened to the finest step that fits

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -886,6 +886,7 @@ Feature: LangWatchQL query workbench — native tables and LangWatchQL Vega-Lite
 #   → Scenario: A granularity declared alongside a mistyped period bound is refused at save
 # AC5 "a window finer than the bucket ceiling is refused on caller-owned surfaces"
 #   → Scenario: A window that would produce more buckets than the ceiling refuses on the workbench and REST
+#   → Scenario: A window too wide for even the coarsest offered step is refused everywhere
 # AC6 "offered steps are sub-day: 1 second, 1 minute, 1 hour" — O1 resolved to
 #     sub-day by probe: over the Amsterdam fallback night the timezone-argument
 #     seconds form drifts off local midnight while toStartOfDay stays at 00:00.
@@ -914,7 +915,7 @@ Scenario: A granularity declared with no step supplied runs on its own authored 
   And the surface supplies no step
   When the member runs the query
   Then no granularity value is bound
-  And the result is labelled as not following the granularity
+  And the result is still labelled as following the granularity, since the statement declares it
 
 @unit
 Scenario: A caller that supplies period_granularity_seconds itself is refused
@@ -960,3 +961,10 @@ Scenario: A window that would produce more buckets than the ceiling refuses on t
   When the member runs it on a caller-owned surface
   Then the run is refused as too fine for the period
   And a dashboard running the same chart is coarsened to the finest step that fits
+
+@unit
+Scenario: A window too wide for even the coarsest offered step is refused everywhere
+  Given a chart declaring granularity over a period spanning a decade
+  When even the one-hour step would exceed 10,000 buckets for that period
+  Then the run is refused as too fine for the period on coarsening surfaces too
+  And the refusal names the requested step and the bucket ceiling


### PR DESCRIPTION
# Related Issue

- Resolves #6713

## Why

Slice 3 of the saved-charts epic (#6582, tracked as #6713): a saved workbench chart placed on a dashboard must render with datapoint granularity the member controls — per-second, per-minute, per-hour — windowed by the dashboard's date range. The plan (v2 comment on #6713) sequences this as S1: the server-side contract, before any UI.

**O1 resolved by probe before implementation, as the plan's gate required.** Over the Europe/Amsterdam fallback night, `toStartOfInterval(t, INTERVAL 86400 SECOND, 'Europe/Amsterdam')` shifts its bucket boundary mid-day (02:00 local before the transition, 01:00 after) while `toStartOfDay(t, 'Europe/Amsterdam')` holds 00:00 throughout — a fixed seconds-interval cannot express a 25-hour local day. Day-scale granularity is therefore **out of scope**; offered steps are 1 s / 1 m / 1 h, and day-scale waits on a reserved `period_timezone` parameter (follow-up to be filed on owner ack, per the plan's not-silently rule).

**A5 proven by test before anything was built on it:** the validator accepts `INTERVAL {period_granularity_seconds:UInt32} SECOND` — the bound parameter inside the interval expression — which is the mechanism's load-bearing premise.

## What this PR ships

- `period_granularity_seconds` joins the surface-reserved vocabulary (`timeWindow.ts`): declared as exactly `UInt32`, used as the seconds multiplier of a fixed-unit interval. The caller-supplied sweep now covers it too.
- `resolveLangWatchQLGranularity` (`resolveTimeWindow.ts`): the run-time policy. Type refusal, positive-integer guard, and the bucket budget — `ceil(window / step)` against `LWQL_GRANULARITY_MAX_BUCKETS` (10,000). Two designed overflow outcomes: caller-owned surfaces (workbench, REST) refuse with `lwql_granularity_too_fine`; the dashboard passes `coarsen` and gets the finest fitting offered step plus `coarsenedFromSeconds` so the widget can name requested and effective side by side.
- `assertLangWatchQLGranularityDeclaration`: the save-time rules, wired into `LangWatchQLService.validate` so tRPC and REST saves refuse identically — type must be `UInt32`, and declaring granularity requires both period bounds (without them the budget is uncomputable exactly when it matters, on the dashboard where the range is the dashboard's own control).
- New handled errors: `lwql_granularity_too_fine`, `lwql_granularity_requires_window` (codes registered, presentation + remediation entries written); granularity type refusals share `lwql_reserved_parameter_type` with a sibling class whose message names the fix.
- Feature scenarios appended to `lwql-workbench.feature`: six bound to unit tests, two `@unimplemented` pending the run-path wiring PR that follows this one in the stack.

## What this PR deliberately does not ship

- The dashboard widget, granularity control and clamp/truncated notices (S2/S3 of the plan — next PRs in the stack).
- The run-by-chart-id entry point and the workbench/REST `granularitySeconds` input wiring — the two `@unimplemented` scenarios above. Next PR.
- Day-scale granularity (O1 → follow-up issue on owner ack).
- `GOVERNED_GRANULARITY_MAX_BUCKETS = 10_000` is the plan's proposed default (A3, owner-callable). Evidence it has teeth: a completely ordinary pairing — one-minute buckets over a 7-day range — is 10,080 buckets, just past it. The dashboard coarsens that pairing rather than refusing.

## Proof

- `pnpm typecheck` and `pnpm run typecheck:all`: clean.
- Scoped unit run (granularity + declaration + timeWindow + codes guard): **54 passed, 0 failed**. The codes guard passing means both new codes carry presentation and remediation entries.
- `check-feature-parity.ts`: `OK: 8262 enforced scenario(s) bound across 1113 file(s)`.
- Biome check on all touched files: clean.
- The O1 and A5 probes are recorded in the test file comments and the feature file's AC map, with the exact query shapes.

## Reviewer notes

- The plan/AC text names the refusal code `governed_granularity_too_fine`; this PR ships `lwql_granularity_too_fine` — the governed-sql → LWQL rename (#7183) postdates that text, and new codes follow the `lwql_` family. Flag if you want the plan text updated instead.
- Budget arithmetic rounds the window up to whole seconds and counts a partial trailing bucket — a 10,000.5-second window at 1 s is 10,001 buckets and refuses. Boundary tests pin both sides.

Refs #6713, #6582

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- no-ui-surface -->

Backend-only: the six changed paths are the resolver/contract layer (`server/analytics/lwql/errors.ts`, `server/analytics/lwql/resolveTimeWindow.ts`), its unit test, and the error-code registries (`features/errors/logic/codes.ts`, `features/errors/logic/presentation.ts`, `server/app-layer/error-remediation.ts`). None renders UI; visual proof lands with the dashboard-widget slices (#6713 S2/S3) that consume this contract.

## Live browser verification (2026-08-23, head ffb7e53ab9)

The review-fix commit changed user-visible behavior; both changes verified in a live browser against the dev server:

| Check | Result | Screenshot |
|---|---|---|
| Too-fine refusal names the offered steps ("1 second, 1 minute or 1 hour"), not "whole number of seconds" | PASS | ![too-fine copy](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7426/workbench-too-fine-refusal-offered-steps-copy-v2.png) |
| 2-year dashboard range: handled refusal card instead of a silent ~17k-bucket render | PASS | ![nothing-fits card](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7426/dashboard-2year-nothing-fits-refusal-card-v2.png) |
| 7-day range still coarsens (notice shown) and renders the chart | PASS | ![coarsen renders](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7426/dashboard-7day-coarsens-and-renders-v2.png) |

Known issue found while testing (pre-existing, tracked in #7447): unknown-column SQL surfaces the generic error card.

## Human verification

Run a chart save through REST (`POST /api/v1/projects/{projectId}/analytics/charts`) with `{period_granularity_seconds:Int32}` in the SQL: expect HTTP 400 carrying code `lwql_granularity_parameter_type` (not the generic reserved-parameter code). Save with the parameter as `UInt32`: expect 201. Run `pnpm test:unit run src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts src/server/analytics/lwql/__tests__/lwqlGranularityDeclaration.unit.test.ts`: expect 29 passed.

## How I can prove I was successful

- `pnpm typecheck` → exit 0; `pnpm --filter @langwatch/web run typecheck:tests` → exit 0 (both observed at bf3e8c08eb).
- Scoped vitest above → "Tests 29 passed (29)" (ANSI-stripped tally).
- `biome check` on the six files → "Checked 6 files… No fixes applied", exit 0.
- Clerk threads PRRT_kwDOKRXhvM6bceaw/-x/-y replied naming bf3e8c08eb and resolved=true (readback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable analytics time-series granularity with second-, minute-, and hour-level buckets.
  * Automatically coarsens overly fine resolutions to remain within the 10,000-bucket chart limit.

* **Bug Fixes**
  * Added validation for supported granularity settings and required time-range bounds.
  * Prevented callers from supplying reserved granularity parameters directly.
  * Improved customer-facing errors with specific parameter names, details, and remediation guidance for invalid settings, missing bounds, and excessive bucket counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
