### PR TITLE
fix(coding-agent): one cost formula on every surface, agent-reported figure kept as a drift alarm

### DIFF
--- a/platform/app/src/features/traces-v2/components/TraceDrawer/sessionView/SessionView.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/sessionView/SessionView.tsx
@@ -110,6 +110,19 @@ export function SessionView({ session, entries }: SessionViewProps) {
   );
 }
 
+/**
+ * The fold keeps its dedup sets bounded at 50 entries (MAX_SET in
+ * coding-agent-session.derivation.ts), so a set-derived figure that reads
+ * exactly 50 is a floor, not a count — a long session shows "50+" rather
+ * than presenting the cap as the total. Counter-derived figures (model
+ * calls, tools run) are exact and never pass through this.
+ */
+const FOLD_SET_CAP = 50;
+
+function boundedCount(n: number): string {
+  return n >= FOLD_SET_CAP ? `${FOLD_SET_CAP}+` : String(n);
+}
+
 function Headline({ session }: { session: CodingAgentSessionRow }) {
   // No agent / version / model chips here: the drawer header directly above
   // already carries Service and Models, and the agent version opens the
@@ -123,7 +136,7 @@ function Headline({ session }: { session: CodingAgentSessionRow }) {
     <VStack align="stretch" gap={3}>
       {session.traceIds.length > 1 && (
         <HStack gap={2} flexWrap="wrap">
-          <MetaChip>{`spans ${session.traceIds.length} traces`}</MetaChip>
+          <MetaChip>{`spans ${boundedCount(session.traceIds.length)} traces`}</MetaChip>
         </HStack>
       )}
 
@@ -136,11 +149,11 @@ function Headline({ session }: { session: CodingAgentSessionRow }) {
         <Stat label="Model calls" value={String(session.modelCalls)} />
         <Stat label="Tools run" value={String(session.toolCalls)} />
         {session.subAgents > 0 && (
-          <Stat label="Sub-agents" value={String(session.subAgents)} />
+          <Stat label="Sub-agents" value={boundedCount(session.subAgents)} />
         )}
         <Stat
           label="Files touched"
-          value={String(session.filesTouched.length)}
+          value={boundedCount(session.filesTouched.length)}
         />
       </Grid>
     </VStack>

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/SessionView.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/SessionView.integration.test.tsx
@@ -81,6 +81,7 @@ const REAL_SESSION: CodingAgentSessionRow = {
   cacheReadTokens: 14_030_972,
   cacheCreationTokens: 284_220,
   costUsd: 10.6188605,
+  agentReportedCostUsd: 10.9,
   modelCallMs: 713_056,
   toolMs: 687_202,
   ttftMsTotal: 0,
@@ -218,6 +219,21 @@ describe("SessionView", () => {
         traceIds: ["trace-a", "trace-b", "trace-c"],
       });
       expect(screen.getByText("spans 3 traces")).toBeTruthy();
+    });
+  });
+
+  describe("given a session that saturated the fold's bounded sets", () => {
+    /** @scenario "Saturated session sets state their bound" */
+    it("states each saturated figure as a floor, not an exact count", () => {
+      // The fold keeps its dedup sets bounded at 50, so exactly 50 means "at
+      // least 50" — a long session must not present the cap as the total.
+      renderSession({
+        traceIds: Array.from({ length: 50 }, (_, i) => `trace-${i}`),
+        subAgents: 50,
+        filesTouched: Array.from({ length: 50 }, (_, i) => `src/f-${i}.ts`),
+      });
+      expect(screen.getByText("spans 50+ traces")).toBeTruthy();
+      expect(screen.getAllByText("50+")).toHaveLength(2);
     });
   });
 

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/sessionSignals.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/sessionSignals.unit.test.ts
@@ -54,6 +54,7 @@ function session(
     cacheReadTokens: 1_000_000,
     cacheCreationTokens: 0,
     costUsd: 1.5,
+    agentReportedCostUsd: 0,
     modelCallMs: 30_000,
     toolMs: 10_000,
     ttftMsTotal: 2_000,

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/terminalView/TerminalTab.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/terminalView/TerminalTab.tsx
@@ -65,14 +65,14 @@ export function TerminalTab({
     { projectId, traceId, occurredAtMs },
     { refetchOnWindowFocus: false, staleTime: 60_000 },
   );
-  // The version/model/repo Claude Code itself would print above the prompt.
-  // Sourced from the resource attributes rather than the coding-agent-session
-  // fold: that fold is a bounded aggregate (ADR-041) and deliberately doesn't
-  // carry identity strings the drawer already has a dedicated read for.
+  // The version/model/repo Claude Code itself would print above the prompt,
+  // off the resource attributes (the session fold deliberately carries no
+  // identity strings, ADR-041).
   const resourceQuery = api.tracesV2.resourceInfo.useQuery(
     { projectId, traceId, occurredAtMs },
     { refetchOnWindowFocus: false, staleTime: 60_000 },
   );
+  const sessionCostUsd = useSessionCostUsd({ projectId, traceId });
 
   const toolSpans = useMemo(
     () =>
@@ -115,18 +115,7 @@ export function TerminalTab({
   }
 
   if (transcriptQuery.isError) {
-    return (
-      <VStack
-        align="center"
-        justify="center"
-        height="full"
-        bg={TERMINAL_TOKENS.screenBg}
-      >
-        <Text textStyle="xs" color="fg.error" fontFamily="mono">
-          Couldn&apos;t load this session&apos;s transcript
-        </Text>
-      </VStack>
-    );
+    return <TranscriptError />;
   }
 
   return (
@@ -138,8 +127,46 @@ export function TerminalTab({
       scrollback={scrollback}
       earlierTotals={session.earlierTotals}
       sessionStartAtMs={session.sessionStartAtMs}
+      sessionCostUsd={sessionCostUsd}
       banner={banner}
       sessionName={sessionName}
     />
   );
+}
+
+function TranscriptError() {
+  return (
+    <VStack
+      align="center"
+      justify="center"
+      height="full"
+      bg={TERMINAL_TOKENS.screenBg}
+    >
+      <Text textStyle="xs" color="fg.error" fontFamily="mono">
+        Couldn&apos;t load this session&apos;s transcript
+      </Text>
+    </VStack>
+  );
+}
+
+/**
+ * The whole session's cost for the bottom bar, off the same pre-folded row
+ * the Usage tab reads (and the same query, so opening both tabs fetches
+ * once). The replay walks backward only and its turn list is bounded, so the
+ * bar's running figure alone understates any session bigger than what loaded
+ * — stating this total beside it is what keeps a position-scoped number from
+ * passing for the session total.
+ */
+function useSessionCostUsd({
+  projectId,
+  traceId,
+}: {
+  projectId: string;
+  traceId: string;
+}): number | null {
+  const sessionQuery = api.tracesV2.codingAgentSession.useQuery(
+    { projectId, traceId },
+    { refetchOnWindowFocus: false, staleTime: 60_000 },
+  );
+  return sessionQuery.data?.costUsd ?? null;
 }

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/terminalView/TerminalView.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/terminalView/TerminalView.tsx
@@ -358,6 +358,15 @@ interface TerminalViewProps {
   earlierTotals?: EarlierTotals | null;
   /** When the session's first turn started — anchors the bar's elapsed time. */
   sessionStartAtMs?: number | null;
+  /**
+   * The whole session's cost off the session row — the same figure the Usage
+   * tab shows. The bar states it beside the running figure ("$12.34 of
+   * $210.00") so the position-scoped number can never pass for the session
+   * total: the replay walks backward only and its turn list is bounded, so
+   * the running figure alone understates any session bigger than what
+   * loaded.
+   */
+  sessionCostUsd?: number | null;
 }
 
 /**
@@ -387,6 +396,7 @@ export const TerminalView = memo(function TerminalView({
   scrollback,
   earlierTotals,
   sessionStartAtMs,
+  sessionCostUsd,
 }: TerminalViewProps) {
   const timeline = useMemo(
     () => buildEntryTimeline({ entries, startAtMs: sessionStartAtMs }),
@@ -730,6 +740,7 @@ export const TerminalView = memo(function TerminalView({
           earlier: earlierTotals?.costUsd,
           loaded: point?.cumulativeCostUsd ?? 0,
         })}
+        sessionCostUsd={sessionCostUsd ?? null}
         elapsedMs={point?.elapsedMs ?? 0}
         model={modelAtScroll}
         sessionName={sessionName}
@@ -1731,6 +1742,7 @@ function StatusLine({
   currentStep,
   tokens,
   costUsd,
+  sessionCostUsd,
   elapsedMs,
   model,
   sessionName,
@@ -1740,10 +1752,13 @@ function StatusLine({
   /** Null when the session total cannot be stated, which is not zero. */
   tokens: number | null;
   costUsd: number | null;
+  /** The whole session's cost off the session row; null when there is none. */
+  sessionCostUsd: number | null;
   elapsedMs: number;
   model?: string | null;
   sessionName?: string | null;
 }) {
+  const costLabel = statusLineCostLabel({ costUsd, sessionCostUsd });
   return (
     <VStack
       align="stretch"
@@ -1802,13 +1817,37 @@ function StatusLine({
           {tokens !== null && tokens > 0 && (
             <Stat label={`${formatTokens(tokens)} tokens`} />
           )}
-          {costUsd !== null && costUsd > 0 && (
-            <Stat label={formatCost(costUsd)} accent />
-          )}
+          {costLabel !== null && <Stat label={costLabel} accent />}
         </HStack>
       </HStack>
     </VStack>
   );
+}
+
+/**
+ * The bar's cost stat: the running figure at the reader's position, and the
+ * session total beside it when the session holds more than the position
+ * covers. "$12.34 of $210.00" — the first number moves with the scroll, the
+ * second is the same figure the Usage tab shows. They fold from the same
+ * spans, so once everything is loaded and read to the end the two meet, and
+ * the suffix drops rather than stating "$210.00 of $210.00". Tiny fold
+ * rounding is not "more session", hence the cent of slack.
+ */
+export function statusLineCostLabel({
+  costUsd,
+  sessionCostUsd,
+}: {
+  costUsd: number | null;
+  sessionCostUsd: number | null;
+}): string | null {
+  const running = costUsd !== null && costUsd > 0 ? costUsd : null;
+  const session =
+    sessionCostUsd !== null && sessionCostUsd > 0 ? sessionCostUsd : null;
+  if (running === null) return session === null ? null : formatCost(session);
+  if (session === null || session <= running + 0.01) {
+    return formatCost(running);
+  }
+  return `${formatCost(running)} of ${formatCost(session)}`;
 }
 
 function Stat({ label, accent }: { label: string; accent?: boolean }) {

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/terminalView/__tests__/TerminalView.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/terminalView/__tests__/TerminalView.integration.test.tsx
@@ -13,7 +13,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptEntry } from "~/server/app-layer/traces/coding-agent-transcript.derivation";
 import type { TurnDivider } from "../sessionScrollback";
-import { TerminalView } from "../TerminalView";
+import { statusLineCostLabel, TerminalView } from "../TerminalView";
 
 /** How tall a laid-out row is, so a test can say what moved in whole rows. */
 const ROW_HEIGHT = 150;
@@ -1280,3 +1280,47 @@ function prependEarlierTurn(
     });
   });
 }
+
+describe("the bottom bar's cost stat", () => {
+  describe("given a session bigger than what loaded", () => {
+    /** @scenario "The terminal footer states the session total next to the running figure" */
+    it("states the session total beside the running figure", () => {
+      // The running figure moves with the scroll; the session total is the
+      // same figure the Usage tab shows, off the session row. Side by side,
+      // the position-scoped number can never pass for the whole session.
+      expect(statusLineCostLabel({ costUsd: 12.34, sessionCostUsd: 210 })).toBe(
+        "$12.34 of $210.00",
+      );
+    });
+  });
+
+  describe("given the reader has the whole session on screen", () => {
+    it("drops the suffix rather than stating a figure of itself", () => {
+      expect(
+        statusLineCostLabel({ costUsd: 210.001, sessionCostUsd: 210 }),
+      ).toBe("$210.00");
+    });
+  });
+
+  describe("given no session row exists for the trace", () => {
+    it("keeps the running figure alone, as before", () => {
+      expect(
+        statusLineCostLabel({ costUsd: 12.34, sessionCostUsd: null }),
+      ).toBe("$12.34");
+    });
+  });
+
+  describe("given the loaded steps carry no cost", () => {
+    it("still states the session total rather than nothing", () => {
+      expect(statusLineCostLabel({ costUsd: null, sessionCostUsd: 210 })).toBe(
+        "$210.00",
+      );
+    });
+
+    it("shows nothing when neither figure exists", () => {
+      expect(
+        statusLineCostLabel({ costUsd: null, sessionCostUsd: null }),
+      ).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/coding-agent-session.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/coding-agent-session.service.unit.test.ts
@@ -100,6 +100,7 @@ function emptyState() {
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
     costUsd: 0,
+    agentReportedCostUsd: 0,
     modelCallMs: 0,
     toolMs: 0,
     ttftMsTotal: 0,

--- a/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -93,6 +93,7 @@ function sessionRow(
     cacheReadTokens: 9_000_000_000,
     cacheCreationTokens: 10,
     costUsd: 1.25,
+    agentReportedCostUsd: 0,
     modelCallMs: 5000,
     toolMs: 1234,
     ttftMsTotal: 300,

--- a/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -98,6 +98,7 @@ interface ClickHouseWriteRecord {
   CacheReadTokens: string;
   CacheCreationTokens: string;
   CostUsd: number;
+  AgentReportedCostUsd: number;
 
   ModelCallMs: string;
   ToolMs: string;
@@ -261,6 +262,7 @@ function toRecord({
     CacheReadTokens: big(row.cacheReadTokens),
     CacheCreationTokens: big(row.cacheCreationTokens),
     CostUsd: row.costUsd,
+    AgentReportedCostUsd: row.agentReportedCostUsd,
 
     ModelCallMs: big(row.modelCallMs),
     ToolMs: big(row.toolMs),
@@ -1108,6 +1110,7 @@ function fromRecord(record: Record<string, unknown>): CodingAgentSessionRow {
     cacheReadTokens: asNumber(record.CacheReadTokens),
     cacheCreationTokens: asNumber(record.CacheCreationTokens),
     costUsd: asNumber(record.CostUsd),
+    agentReportedCostUsd: asNumber(record.AgentReportedCostUsd),
 
     modelCallMs: asNumber(record.ModelCallMs),
     toolMs: asNumber(record.ToolMs),

--- a/platform/app/src/server/app-layer/github/__tests__/codingAgentSessionRowFixture.ts
+++ b/platform/app/src/server/app-layer/github/__tests__/codingAgentSessionRowFixture.ts
@@ -63,6 +63,7 @@ export function codingAgentSessionRow(
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
     costUsd: 0,
+    agentReportedCostUsd: 0,
 
     modelCallMs: 0,
     toolMs: 0,

--- a/platform/app/src/server/app-layer/traces/__tests__/coding-agent-cost-agreement.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/coding-agent-cost-agreement.unit.test.ts
@@ -11,9 +11,12 @@
  *
  * The fixture is a real turn, taken off a local session's `api_request` log.
  * The span states how many tokens went to the cache but never how long the
- * entry lives, so the writes price short-lived and the figure sits under what
- * Anthropic charged. Both numbers are pinned here: the one every surface must
- * agree on, and the bill it does not yet reach.
+ * entry lives; the lifetime follows the call's request context
+ * (`llm_request.context`), measured against Claude Code's live traffic: a
+ * main-thread call writes hour-long entries, a sub-agent call five-minute
+ * ones. Both prices are pinned here: the charged figure a main-thread call
+ * must reach on every surface, and the short-lived one a sub-agent call — or
+ * a call with no stated context — stays at.
  *
  * The span goes in as claude actually emits it, bare `input_tokens` /
  * `cache_creation_tokens` under the CLI's own names, and every surface runs
@@ -59,16 +62,14 @@ const CALL = {
 
 /**
  * What Anthropic charged for that turn, straight off the call's own
- * `api_request` log event. Not read at runtime, and deliberately not what the
- * surfaces are asserted against: reaching it needs the provider's own 5m/1h
- * breakdown on the span, which arrives on the log stream instead. It is pinned
- * so the size of that gap is visible rather than folklore.
+ * `api_request` log event. A main-thread call's writes are hour-long, and
+ * every surface must reach this figure for one.
  */
 const CHARGED_USD = 0.1930215;
 
 /**
- * What the surfaces do compute: every cache write priced short-lived, which is
- * the only rate a span with no stated lifetime supports.
+ * The same call with five-minute writes: what a sub-agent call prices at, and
+ * the conservative answer for a call that states no context at all.
  */
 const SHORT_LIVED_USD = 0.126069;
 
@@ -78,50 +79,55 @@ const SHORT_LIVED_USD = 0.126069;
  */
 const CENTS_OF_A_CENT = 6;
 
-function claudeCallEvent(): SpanReceivedEvent {
+function claudeCallEvent(
+  extra: Record<string, string | number> = {},
+): SpanReceivedEvent {
   return createSpanReceivedEvent({
     traceId: TRACE_ID,
     spanId: SPAN_ID,
     name: "claude_code.llm_request",
     startTimeUnixNano: String(START_MS * 1_000_000),
     endTimeUnixNano: String(END_MS * 1_000_000),
-    attributes: { ...CALL, "langwatch.span.type": "llm" },
+    attributes: { ...CALL, ...extra, "langwatch.span.type": "llm" },
   });
 }
+
+type CallExtra = Record<string, string | number>;
 
 const noopFoldStore = { store: async () => {}, get: async () => null };
 const noopAppendStore = { append: async () => {}, bulkAppend: async () => {} };
 
 /** The trace header, and the trace list's cost column. */
-function traceSummaryCost(): number | null {
+function traceSummaryCost(extra: CallExtra = {}): number | null {
   return new TraceSummaryFoldProjection({
     store: noopFoldStore,
-  }).handleTraceSpanReceived(claudeCallEvent(), createInitState()).totalCost;
+  }).handleTraceSpanReceived(claudeCallEvent(extra), createInitState())
+    .totalCost;
 }
 
 /** The analytics fold, which answers cost-over-time when the rollup cannot. */
-function traceAnalyticsCost(): number | null {
+function traceAnalyticsCost(extra: CallExtra = {}): number | null {
   const projection = new TraceAnalyticsFoldProjection({
     store: noopFoldStore,
   });
   return projection.handleTraceSpanReceived(
-    claudeCallEvent(),
+    claudeCallEvent(extra),
     projection.init(),
   ).totalCost;
 }
 
 /** The per-minute rollup the analytics graphs read by default. */
-function analyticsRollupCost(): number {
+function analyticsRollupCost(extra: CallExtra = {}): number {
   return new TraceAnalyticsRollupMapProjection({
     store: noopAppendStore as never,
-  }).mapTraceSpanReceived(claudeCallEvent()).costSum;
+  }).mapTraceSpanReceived(claudeCallEvent(extra)).costSum;
 }
 
 /** `stored_spans.Cost`: the waterfall's per-span figure, and the CSV export's. */
-function storedSpanCost(): number | null {
+function storedSpanCost(extra: CallExtra = {}): number | null {
   return new SpanStorageMapProjection({
     store: noopAppendStore as never,
-  }).mapTraceSpanReceived(claudeCallEvent()).cost;
+  }).mapTraceSpanReceived(claudeCallEvent(extra)).cost;
 }
 
 /**
@@ -129,10 +135,10 @@ function storedSpanCost(): number | null {
  * repository selects the same canonical attributes ingest wrote, so the row is
  * built from the normalized span rather than from the raw wire values.
  */
-function recomputedSummaryRowCost(): number | null {
+function recomputedSummaryRowCost(extra: CallExtra = {}): number | null {
   const attrs = new SpanStorageMapProjection({
     store: noopAppendStore as never,
-  }).mapTraceSpanReceived(claudeCallEvent()).spanAttributes;
+  }).mapTraceSpanReceived(claudeCallEvent(extra)).spanAttributes;
   const attr = (key: string): string => String(attrs[key] ?? "");
 
   return mapSpanSummaryRow({
@@ -174,10 +180,10 @@ function recomputedSummaryRowCost(): number | null {
  * uses: the stored span becomes a span detail, the detail becomes a transcript
  * entry, and the entries accumulate.
  */
-function terminalFooterCost(): number {
+function terminalFooterCost(extra: CallExtra = {}): number {
   const stored = new SpanStorageMapProjection({
     store: noopAppendStore as never,
-  }).mapTraceSpanReceived(claudeCallEvent());
+  }).mapTraceSpanReceived(claudeCallEvent(extra));
   const span = mapNormalizedSpanToSpan(stored);
 
   const detail = {
@@ -201,33 +207,71 @@ function terminalFooterCost(): number {
   );
 }
 
-describe("the cost of one claude code model call", () => {
-  describe("given a call whose cache writes carry no stated lifetime", () => {
-    /** @scenario "Every surface prices one call at one number" */
-    it("prices it the same on every surface a customer can read", () => {
-      const surfaces = {
-        traceSummary: traceSummaryCost(),
-        traceAnalytics: traceAnalyticsCost(),
-        analyticsRollup: analyticsRollupCost(),
-        storedSpan: storedSpanCost(),
-        recomputedSummaryRow: recomputedSummaryRowCost(),
-        terminalFooter: terminalFooterCost(),
-      };
+function allSurfaces(extra: CallExtra = {}): Record<string, number | null> {
+  return {
+    traceSummary: traceSummaryCost(extra),
+    traceAnalytics: traceAnalyticsCost(extra),
+    analyticsRollup: analyticsRollupCost(extra),
+    storedSpan: storedSpanCost(extra),
+    recomputedSummaryRow: recomputedSummaryRowCost(extra),
+    terminalFooter: terminalFooterCost(extra),
+  };
+}
 
-      for (const [surface, cost] of Object.entries(surfaces)) {
+describe("the cost of one claude code model call", () => {
+  describe("given a main-thread call (llm_request.context: interaction)", () => {
+    /** @scenario "A main-thread call's cache writes price as hour-long entries" */
+    it("prices the call at the amount the provider charged, on every surface", () => {
+      for (const [surface, cost] of Object.entries(
+        allSurfaces({ "llm_request.context": "interaction" }),
+      )) {
+        expect(cost, `${surface} priced the call differently`).toBeCloseTo(
+          CHARGED_USD,
+          CENTS_OF_A_CENT,
+        );
+      }
+    });
+  });
+
+  describe("given a sub-agent call (llm_request.context: tool)", () => {
+    /** @scenario "A sub-agent call's cache writes price as five-minute entries" */
+    it("prices the writes short-lived, on every surface", () => {
+      for (const [surface, cost] of Object.entries(
+        allSurfaces({ "llm_request.context": "tool" }),
+      )) {
         expect(cost, `${surface} priced the call differently`).toBeCloseTo(
           SHORT_LIVED_USD,
           CENTS_OF_A_CENT,
         );
       }
     });
+  });
 
-    /** @scenario "A call that does not say how long its cache lives is priced as before" */
-    it("prices the writes short-lived, below what the provider charged", () => {
-      // The distance between these two is what carrying the provider's own
-      // 5m/1h breakdown onto the span would close.
-      expect(traceSummaryCost()).toBeCloseTo(SHORT_LIVED_USD, CENTS_OF_A_CENT);
+  describe("given a call whose cache writes carry no stated lifetime", () => {
+    /** @scenario "A call with no stated context prices its writes conservatively" */
+    it("prices it short-lived, the same on every surface a customer can read", () => {
+      for (const [surface, cost] of Object.entries(allSurfaces())) {
+        expect(cost, `${surface} priced the call differently`).toBeCloseTo(
+          SHORT_LIVED_USD,
+          CENTS_OF_A_CENT,
+        );
+      }
+      // Never overstates: the conservative rate sits under the charged one.
       expect(SHORT_LIVED_USD).toBeLessThan(CHARGED_USD);
+    });
+  });
+
+  describe("given a call whose span already states an hour-long count", () => {
+    /** @scenario "A provider-stated split is never overwritten" */
+    it("keeps the provider's own count over the context rule", () => {
+      // A sub-agent call (5m by the rule) whose span nonetheless states the
+      // full write as hour-long: the stated split must win.
+      const cost = traceSummaryCost({
+        "llm_request.context": "tool",
+        "gen_ai.usage.cache_creation_1h.input_tokens":
+          CALL.cache_creation_tokens,
+      });
+      expect(cost).toBeCloseTo(CHARGED_USD, CENTS_OF_A_CENT);
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/__tests__/coding-agent-cost-agreement.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/coding-agent-cost-agreement.unit.test.ts
@@ -247,8 +247,27 @@ describe("the cost of one claude code model call", () => {
     });
   });
 
+  describe("given a main-thread call known only by its query source", () => {
+    /** @scenario "A main-thread call known only by its query source prices the same way" */
+    it("prices the call at the charged amount, on every surface", () => {
+      // Claude names the main thread twice: `llm_request.context` on the span
+      // and `query_source` on the log side. The session fold reads both, so
+      // the trace surfaces must too, or one span reads hour-long in the Usage
+      // tab and five-minute in the trace header.
+      for (const [surface, cost] of Object.entries(
+        allSurfaces({ query_source: "repl_main_thread" }),
+      )) {
+        expect(cost, `${surface} priced the call differently`).toBeCloseTo(
+          CHARGED_USD,
+          CENTS_OF_A_CENT,
+        );
+      }
+    });
+  });
+
   describe("given a call whose cache writes carry no stated lifetime", () => {
     /** @scenario "A call with no stated context prices its writes conservatively" */
+    /** @scenario "Every surface prices one call at one number" */
     it("prices it short-lived, the same on every surface a customer can read", () => {
       for (const [surface, cost] of Object.entries(allSurfaces())) {
         expect(cost, `${surface} priced the call differently`).toBeCloseTo(

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
@@ -176,6 +176,7 @@ export class ClaudeCodeExtractor implements CanonicalAttributesExtractor {
       cacheWriteTokens > 0 &&
       claudeCacheWritesLongLived({
         llmRequestContext: asString(attrs.get("llm_request.context")),
+        querySource: asString(attrs.get("query_source")),
       })
     ) {
       ctx.setAttrIfAbsent(

--- a/platform/app/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
+++ b/platform/app/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
@@ -108,6 +108,32 @@ export const isConversationalQuerySource = (
 const asString = (raw: unknown): string | null =>
   typeof raw === "string" && raw.length > 0 ? raw : null;
 
+/**
+ * Whether a Claude Code call's cache writes buy hour-long entries.
+ *
+ * Anthropic bills an hour-long cache entry at 2x the input rate and a
+ * five-minute one at 1.25x, and the llm_request span states how many tokens
+ * were written but not how long they live. The lifetime follows the call's
+ * request context, measured against Claude Code's live traffic: a main-thread
+ * request (`llm_request.context: "interaction"`, `query_source:
+ * "repl_main_thread"` on the log side) writes hour-long entries, a sub-agent
+ * request (`"tool"` / `agent:*`) writes five-minute ones, and utility calls
+ * write nothing. An unknown context prices short-lived, which never
+ * overstates.
+ *
+ * The provider can change this policy without notice. The session fold keeps
+ * the cost the agent reports about itself next to the computed one, and the
+ * two drifting apart is the alarm that this rule went stale.
+ */
+export const claudeCacheWritesLongLived = ({
+  llmRequestContext,
+  querySource,
+}: {
+  llmRequestContext?: string | null;
+  querySource?: string | null;
+}): boolean =>
+  llmRequestContext === "interaction" || querySource === "repl_main_thread";
+
 export class ClaudeCodeExtractor implements CanonicalAttributesExtractor {
   readonly id = "claude-code";
 
@@ -137,14 +163,27 @@ export class ClaudeCodeExtractor implements CanonicalAttributesExtractor {
       "cache_creation_tokens",
       ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
     );
-    // No hour-long count is lifted here. The span says how many tokens were
-    // written to the cache but never how long they live, and Anthropic bills an
-    // hour-long entry at twice the input rate against a five-minute entry's
-    // 1.25x. The real split is stated only in the response body, which reaches
-    // us on the log stream: liftApiResponseBodyUsage reads it there, and a
-    // response can report both buckets at once. Deriving an hour-long count
-    // from the write total would assert a lifetime nothing measured, so a span
-    // whose writes are unqualified prices them short-lived.
+    // The span states how many tokens were written to the cache but not how
+    // long they live; the lifetime follows the call's request context (see
+    // claudeCacheWritesLongLived). A main-thread call's writes are stamped
+    // hour-long so computeSpanCost prices them at 2x input rather than the
+    // five-minute 1.25x, which undercounted every cache-heavy turn by about a
+    // third. setAttrIfAbsent keeps a provider-stated split, should the span
+    // ever start carrying one, ahead of this rule.
+    const cacheWriteTokens = asNumber(attrs.get("cache_creation_tokens"));
+    if (
+      cacheWriteTokens !== null &&
+      cacheWriteTokens > 0 &&
+      claudeCacheWritesLongLived({
+        llmRequestContext: asString(attrs.get("llm_request.context")),
+      })
+    ) {
+      ctx.setAttrIfAbsent(
+        ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_1H_INPUT_TOKENS,
+        cacheWriteTokens,
+      );
+      fired = true;
+    }
 
     const model = attrs.get("model");
     if (typeof model === "string" && model.length > 0) {

--- a/platform/app/src/server/clickhouse/migrations/00085_coding_agent_sessions_agent_reported_cost.sql
+++ b/platform/app/src/server/clickhouse/migrations/00085_coding_agent_sessions_agent_reported_cost.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- coding_agent_sessions: the cost the agent reports about itself, beside the
+-- computed one.
+--
+--   AgentReportedCostUsd: sum of the `cost_usd` the agent states on its
+--                         api_request events — 0 on rows from before this
+--                         column, and for agents that report no cost.
+--
+-- `CostUsd` becomes the computed figure: the session's own tokens priced
+-- against the model registry, the same formula and the same cache-write
+-- lifetime the trace pipeline applies to the identical spans, so a session
+-- and its traces state one number. What the agent says it was billed moves
+-- here. The two are kept side by side because their disagreement is a
+-- signal: it caught the registry pricing hour-long cache writes short-lived,
+-- and the agent billing a model at a withdrawn price, on the same day.
+-- ============================================================================
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS AgentReportedCostUsd Float64 DEFAULT 0 CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose Down
+-- IRREVERSIBLE: the rollback is a DROP COLUMN, which forgets what every
+-- already-folded session reported about its own bill. `up` is idempotent
+-- (`ADD COLUMN IF NOT EXISTS`), so `down` is deliberately a no-op.
+--
+-- To roll back, uncomment and run manually.
+--
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS AgentReportedCostUsd;

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/metrics.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/metrics.ts
@@ -1,0 +1,38 @@
+import { Counter, register } from "prom-client";
+
+/**
+ * The cost-drift canary (see specs/trace-processing/coding-agent-cost.feature).
+ *
+ * Two dollar counters, one per pricing authority: what the model registry
+ * computes for a call's tokens, and what the agent reports it was billed for
+ * the same call. Per model, because that is the grain a stale price lives at:
+ * their ratio drifting from ~1 for one model is the alarm that either our
+ * registry or the agent's own pricing went stale — it caught the registry
+ * pricing hour-long cache writes short-lived, and Claude Code billing Sonnet 5
+ * at a withdrawn price, on the same day.
+ *
+ * Incremented in the session fold's handlers, so a refold wave replays them;
+ * both counters replay proportionally, and the alert reads the ratio of
+ * rates, so the alarm's meaning survives a refold.
+ */
+const metricNames = [
+  "coding_agent_cost_computed_usd_total",
+  "coding_agent_cost_reported_usd_total",
+] as const;
+
+// Remove existing metrics if they exist (for hot reload)
+for (const name of metricNames) {
+  register.removeSingleMetric(name);
+}
+
+export const codingAgentCostComputedUsd = new Counter({
+  name: "coding_agent_cost_computed_usd_total",
+  help: "Coding-agent cost computed from tokens against the model registry, in USD",
+  labelNames: ["agent", "model"] as const,
+});
+
+export const codingAgentCostReportedUsd = new Counter({
+  name: "coding_agent_cost_reported_usd_total",
+  help: "Coding-agent cost as reported by the agent about its own bill, in USD",
+  labelNames: ["agent", "model"] as const,
+});

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -262,6 +262,25 @@ describe("CodingAgentSessionFoldProjection", () => {
     it("prices a call with no stated context conservatively", () => {
       expect(pricedCall(undefined).costUsd).toBeCloseTo(17_854 * 0.00000375, 6);
     });
+
+    /** @scenario "A main-thread call known only by its query source prices the same way" */
+    it("prices a call named main-thread by its query source at the hour-long rate", () => {
+      const projection = makeProjection();
+      const state = projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "claude_code.llm_request",
+          spanId: "llm-ttl-query-source",
+          facts: {
+            model: "claude-sonnet-4-5",
+            cache_creation_tokens: 17_854,
+            query_source: "repl_main_thread",
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.costUsd).toBeCloseTo(17_854 * 0.000006, 6);
+    });
   });
 
   describe("when a tool span FAILED", () => {
@@ -361,6 +380,7 @@ describe("CodingAgentSessionFoldProjection", () => {
 
   describe("when the agent reports its own bill on a log", () => {
     /** @scenario "The agent-reported figure is kept as a drift signal" */
+    /** @scenario "an agent that states its own price keeps it beside the computed one" */
     it("sums it beside the computed cost, never into it", () => {
       const projection = makeProjection();
       let state = initStateOf(projection);

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -188,8 +188,8 @@ describe("CodingAgentSessionFoldProjection", () => {
       expect(state.agent).toBe("claude_code");
     });
 
-    /** @scenario "an agent that states its own price keeps it" */
-    it("keeps the reported cost and adds no estimate for the same turn", () => {
+    /** @scenario "The session's cost is computed from tokens, same formula as the trace" */
+    it("computes the span's cost and keeps the reported figure beside it", () => {
       const projection = makeProjection();
       let state = initStateOf(projection);
 
@@ -215,12 +215,52 @@ describe("CodingAgentSessionFoldProjection", () => {
         state,
       );
 
-      // The reported cost survives and the span adds nothing on top.
-      // Estimating this span too would charge the turn twice, at two
-      // different rates. Folding the span alone and expecting 0 would pass
-      // just as well if the reported amount were dropped, so both halves
-      // are folded here.
-      expect(state.costUsd).toBe(0.25);
+      // Two figures, two homes: the session's cost is the span's tokens
+      // priced against the registry — the same formula the trace pipeline
+      // applies to the same span — and what the agent reported rides beside
+      // it. Folding either into the other would charge the turn twice, at
+      // two different rates.
+      expect(state.agentReportedCostUsd).toBe(0.25);
+      // 100 in x $3/M + 50 out x $15/M + 900 cache-read x $0.30/M.
+      expect(state.costUsd).toBeCloseTo(0.00132, 6);
+    });
+  });
+
+  describe("when claude llm_request spans price their cache writes", () => {
+    const pricedCall = (context: string | undefined) => {
+      const projection = makeProjection();
+      return projection.handleCodingAgentSessionSpanFactsContributed(
+        spanFactsEvent({
+          name: "claude_code.llm_request",
+          spanId: `llm-ttl-${context ?? "none"}`,
+          facts: {
+            model: "claude-sonnet-4-5",
+            cache_creation_tokens: 17_854,
+            ...(context !== undefined
+              ? { "llm_request.context": context }
+              : {}),
+          },
+        }),
+        initStateOf(projection),
+      );
+    };
+
+    it("prices a main-thread call's writes at the hour-long rate", () => {
+      // 17,854 writes at sonnet-4.5's $6/M hour-long rate vs $3.75/M
+      // five-minute rate — the same lifetime rule the trace pipeline's
+      // extractor stamps on the identical span.
+      expect(pricedCall("interaction").costUsd).toBeCloseTo(
+        17_854 * 0.000006,
+        6,
+      );
+    });
+
+    it("prices a sub-agent call's writes at the five-minute rate", () => {
+      expect(pricedCall("tool").costUsd).toBeCloseTo(17_854 * 0.00000375, 6);
+    });
+
+    it("prices a call with no stated context conservatively", () => {
+      expect(pricedCall(undefined).costUsd).toBeCloseTo(17_854 * 0.00000375, 6);
     });
   });
 
@@ -319,8 +359,9 @@ describe("CodingAgentSessionFoldProjection", () => {
     });
   });
 
-  describe("when the authoritative cost arrives on a log", () => {
-    it("sums it into the session", () => {
+  describe("when the agent reports its own bill on a log", () => {
+    /** @scenario "The agent-reported figure is kept as a drift signal" */
+    it("sums it beside the computed cost, never into it", () => {
       const projection = makeProjection();
       let state = initStateOf(projection);
 
@@ -338,7 +379,10 @@ describe("CodingAgentSessionFoldProjection", () => {
         state,
       );
 
-      expect(state.costUsd).toBe(0.75);
+      expect(state.agentReportedCostUsd).toBe(0.75);
+      // The session's cost is computed from its spans' tokens; a span-bearing
+      // agent's api_request event contributes only the reported figure.
+      expect(state.costUsd).toBe(0);
     });
   });
 
@@ -1415,8 +1459,28 @@ describe("coding-agent session fold, per-agent gating", () => {
       expect(state.outputTokens).toBe(50);
       expect(state.cacheReadTokens).toBe(1_000);
       expect(state.cacheCreationTokens).toBe(200);
-      expect(state.costUsd).toBeCloseTo(0.42);
       expect(state.models).toEqual(["claude-fable-5"]);
+      expect(state.costUsd).toBeCloseTo(0.42);
+    });
+
+    /** @scenario "A logs-only agent keeps its reported cost as the session cost" */
+    it("keeps the reported cost as the session's cost, with no span to compute from", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          agent: "claude_cowork",
+          facts: {
+            "event.name": "claude_code.api_request",
+            cost_usd: 0.42,
+            model: "claude-fable-5",
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.costUsd).toBeCloseTo(0.42);
+      expect(state.agentReportedCostUsd).toBeCloseTo(0.42);
     });
 
     it("folds the tool run — name, count, step — from the tool_result event", () => {
@@ -1531,7 +1595,7 @@ describe("coding-agent session fold, per-agent gating", () => {
 
   describe("when a span-bearing agent's api_request event contributes", () => {
     /** @scenario re-delivered telemetry does not inflate a session */
-    it("folds cost only — its tokens arrive on the llm_request span", () => {
+    it("folds the reported cost only — its tokens arrive on the llm_request span", () => {
       const projection = makeProjection();
 
       const state = projection.handleCodingAgentSessionLogFactsContributed(
@@ -1547,8 +1611,10 @@ describe("coding-agent session fold, per-agent gating", () => {
         initStateOf(projection),
       );
 
-      expect(state.costUsd).toBeCloseTo(0.42);
-      // The double-count gate: these fold from the span for claude_code.
+      expect(state.agentReportedCostUsd).toBeCloseTo(0.42);
+      // The double-count gate: these fold from the span for claude_code,
+      // including the computed cost.
+      expect(state.costUsd).toBe(0);
       expect(state.modelCalls).toBe(0);
       expect(state.inputTokens).toBe(0);
       expect(state.outputTokens).toBe(0);

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
@@ -7,6 +7,10 @@ import type {
   FoldProjectionStore,
 } from "~/server/event-sourcing/projections/foldProjection.types";
 import {
+  codingAgentCostComputedUsd,
+  codingAgentCostReportedUsd,
+} from "../metrics";
+import {
   type LogFactsContributedEvent,
   logFactsContributedEventSchema,
   type MetricFactsContributedEvent,
@@ -59,6 +63,16 @@ const codingAgentSessionEvents = [
 
 /** Schema-snapshot version (calendar date). Bump when the derivation changes.
  *
+ *  2026-08-23: the session's `CostUsd` became the computed figure — the
+ *  call's own tokens priced against the model registry, the same formula and
+ *  the same cache-write lifetime the trace pipeline applies to the identical
+ *  span — and what the agent reports about its own bill moved to the new
+ *  `AgentReportedCostUsd` (migration 00085). Rows stamped earlier carry the
+ *  agent-reported number AS CostUsd and decode the new column as zero, so the
+ *  bump refolds each session once: the replayed span contributions rebuild
+ *  the computed cost, and the replayed api_request contributions land on the
+ *  reported column where they belong.
+ *
  *  2026-08-10: `GitBranches` (migration 00077) joined the projected row shape,
  *  the bounded first-seen set of every branch a session reported. A row stamped
  *  2026-08-02 decodes it as an empty array, which is exactly what a session
@@ -106,7 +120,25 @@ const codingAgentSessionEvents = [
  *  `PreviousCallContextTokens`, `StepStartedAt`, `MetricSeries`,
  *  `LastEventOccurredAt`) and 00054 (`AppliedEventIds`) joined the projected row
  *  shape. That shape change is exactly what this stamp records (ADR-021/022). */
-export const CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST = "2026-08-10";
+export const CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST = "2026-08-23";
+
+/** The cost-drift counters' label set, off one contribution's facts. */
+function costDriftLabels({
+  agent,
+  facts,
+}: {
+  agent?: string;
+  facts: Record<string, unknown>;
+}): { agent: string; model: string } {
+  const model =
+    facts.model ??
+    facts["gen_ai.request.model"] ??
+    facts["gen_ai.response.model"];
+  return {
+    agent: agent ?? "unknown",
+    model: typeof model === "string" && model.length > 0 ? model : "unknown",
+  };
+}
 
 /**
  * The stamp rows carried while migrations 00053 and 00054 shipped.
@@ -321,6 +353,16 @@ export class CodingAgentSessionFoldProjection
       agent: data.agent,
     });
 
+    // The computed half of the cost-drift canary: what this span's tokens
+    // priced at. Its reported counterpart rides the log handler below.
+    const computedDelta = next.costUsd - state.costUsd;
+    if (computedDelta > 0) {
+      codingAgentCostComputedUsd.inc(
+        costDriftLabels({ agent: data.agent, facts: data.facts }),
+        computedDelta,
+      );
+    }
+
     const withIdentity = this.withContributionIdentity(
       { ...state, ...next },
       { ...data, occurredAt: data.startTimeUnixMs },
@@ -341,6 +383,19 @@ export class CodingAgentSessionFoldProjection
       agent: data.agent,
       occurredAtMs: data.timeUnixMs,
     });
+
+    // The reported half of the cost-drift canary: what the agent says this
+    // call billed. Computed-vs-reported per model is the alarm for a stale
+    // price, ours or theirs.
+    const reportedDelta =
+      next.agentReportedCostUsd - state.agentReportedCostUsd;
+    if (reportedDelta > 0) {
+      codingAgentCostReportedUsd.inc(
+        costDriftLabels({ agent: data.agent, facts: data.facts }),
+        reportedDelta,
+      );
+    }
+
     return this.withContributionIdentity(
       { ...state, ...next },
       { ...data, occurredAt: data.timeUnixMs },
@@ -446,6 +501,7 @@ export interface CodingAgentSessionRow {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   costUsd: number;
+  agentReportedCostUsd: number;
 
   modelCallMs: number;
   toolMs: number;
@@ -573,6 +629,7 @@ export function projectCodingAgentSessionToRow({
     cacheReadTokens: state.cacheReadTokens,
     cacheCreationTokens: state.cacheCreationTokens,
     costUsd: state.costUsd,
+    agentReportedCostUsd: state.agentReportedCostUsd,
 
     modelCallMs: state.modelCallMs,
     toolMs: state.toolMs,
@@ -771,6 +828,7 @@ export function codingAgentSessionStateFromRow(
     cacheReadTokens: row.cacheReadTokens,
     cacheCreationTokens: row.cacheCreationTokens,
     costUsd: row.costUsd,
+    agentReportedCostUsd: row.agentReportedCostUsd,
 
     modelCallMs: row.modelCallMs,
     toolMs: row.toolMs,

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
@@ -320,6 +320,10 @@ export const CODING_AGENT_CONTRIBUTION_KEYS: readonly string[] = [
   "prompt.id",
   "event.sequence",
   "speed",
+  // The llm_request span's request context ("interaction" for the main
+  // thread, "tool" for a sub-agent call), which decides the cache-write
+  // lifetime the fold prices the call's writes at.
+  "llm_request.context",
   "decision_type",
   "decision_source",
   // Sub-agent lineage, for agents that stamp it (the claude_code

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -1,3 +1,4 @@
+import { claudeCacheWritesLongLived } from "~/server/app-layer/traces/canonicalisation/extractors/claudeCode";
 import { computeSpanCost } from "~/server/app-layer/traces/model-cost-matching";
 import {
   CODING_AGENT_REGISTRY,
@@ -321,6 +322,7 @@ export function createInitCodingAgentSession(): CodingAgentSessionData {
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
     costUsd: 0,
+    agentReportedCostUsd: 0,
 
     modelCallMs: 0,
     toolMs: 0,
@@ -623,18 +625,18 @@ function foldModelCall(
 }
 
 /**
- * What one turn cost, for an agent whose telemetry states no price of its own.
+ * What one turn cost: the model registry's price for the call's own tokens.
  *
- * Claude reports what it was billed on its API_REQUEST event, and that number
- * is the session's cost. Codex reports a model and token counts and nothing
- * else, so its sessions read as free while the SAME turn's trace states a
- * figure — the trace pipeline prices the identical span against the model
- * registry. This is that same call, so the two agree.
+ * Every span-bearing agent's session is priced this way — the trace pipeline
+ * prices the identical span against the same registry, so a session and its
+ * traces state one figure by construction. What an agent reports about its
+ * own bill (claude's `cost_usd`) rides agentReportedCostUsd beside this,
+ * never instead of it.
  *
  * The facts are the respelled ones, whose `input_tokens` is the disjoint
- * non-cached bucket, and whose cache buckets keep codex's own spellings —
- * which are the gen_ai keys {@link computeSpanCost} reads. An unpriced model
- * comes back zero rather than an invented rate.
+ * non-cached bucket, and whose cache buckets are the gen_ai keys
+ * {@link computeSpanCost} reads. An unpriced model comes back zero rather
+ * than an invented rate.
  */
 function pricedFromTokens(facts: Record<string, unknown>): number {
   return computeSpanCost({
@@ -643,6 +645,33 @@ function pricedFromTokens(facts: Record<string, unknown>): number {
     promptTokens: num(facts.input_tokens),
     completionTokens: num(facts.output_tokens),
   });
+}
+
+/**
+ * A Claude Code call's tokens, respelled into the gen_ai keys
+ * {@link computeSpanCost} reads. The llm_request span carries the CLI's bare
+ * spellings, whose `input_tokens` is already the disjoint non-cached bucket,
+ * so this is a respelling plus one judgment: the cache-write lifetime the
+ * call's request context implies ({@link claudeCacheWritesLongLived}) — the
+ * same stamp the trace pipeline's extractor puts on the identical span, so
+ * the session and the trace price one call to one figure.
+ */
+function claudeCallTokenFacts(
+  attrs: Record<string, unknown>,
+): Record<string, unknown> {
+  const cacheWriteTokens = num(attrs.cache_creation_tokens);
+  return {
+    ...attrs,
+    "gen_ai.usage.cache_read.input_tokens": num(attrs.cache_read_tokens),
+    "gen_ai.usage.cache_creation.input_tokens": cacheWriteTokens,
+    ...(cacheWriteTokens > 0 &&
+    claudeCacheWritesLongLived({
+      llmRequestContext: str(attrs["llm_request.context"]),
+      querySource: str(attrs.query_source),
+    })
+      ? { "gen_ai.usage.cache_creation_1h.input_tokens": cacheWriteTokens }
+      : {}),
+  };
 }
 
 /**
@@ -707,9 +736,16 @@ export function applySpanToCodingAgentSession({
 
   if (span.name === CLAUDE.SPAN.LLM_REQUEST) {
     // Identity still rides the span; only the counted facts are the log's.
-    return isLogsOnly
-      ? withIdentity(state, attrs)
-      : foldModelCall(withIdentity(state, attrs), attrs, durationMs);
+    if (isLogsOnly) return withIdentity(state, attrs);
+    const folded = foldModelCall(withIdentity(state, attrs), attrs, durationMs);
+    // Priced from the span's tokens with the same formula and the same
+    // cache-write lifetime the trace pipeline applies to the identical span,
+    // so the session and its traces state one figure. The cost the agent
+    // reports about itself lands on agentReportedCostUsd instead.
+    return {
+      ...folded,
+      costUsd: folded.costUsd + pricedFromTokens(claudeCallTokenFacts(attrs)),
+    };
   }
 
   if (span.name === CODEX.SPAN.TURN) {
@@ -929,12 +965,27 @@ export function applyLogToCodingAgentSession({
       };
 
     case CLAUDE.EVENT.API_REQUEST: {
-      // The authoritative cost: the agent reports what it was actually billed,
-      // which no span carries.
-      const withCost = { ...base, costUsd: base.costUsd + num(attrs.cost_usd) };
+      // What the agent says it was billed, kept NEXT TO the computed cost
+      // rather than as it. The two disagreeing is a signal, not noise: the
+      // reported figure caught the registry pricing hour-long cache writes
+      // short-lived, and the computed one caught the agent still billing a
+      // model at a withdrawn price. Neither is trusted alone.
+      const reported = num(attrs.cost_usd);
+      const withReported = {
+        ...base,
+        agentReportedCostUsd: base.agentReportedCostUsd + reported,
+      };
       // For a logs-only agent this event IS the model call — the same facts
-      // the llm_request span carries for Claude Code fold from here instead.
-      return isLogsOnly ? foldModelCall(withCost, attrs, 0) : withCost;
+      // the llm_request span carries for Claude Code fold from here instead —
+      // and with no token-bearing span to compute from, the reported figure
+      // is also the session's cost.
+      return isLogsOnly
+        ? foldModelCall(
+            { ...withReported, costUsd: withReported.costUsd + reported },
+            attrs,
+            0,
+          )
+        : withReported;
     }
 
     case CLAUDE.EVENT.API_RESPONSE:

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.types.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.types.ts
@@ -178,7 +178,19 @@ export interface CodingAgentSessionData {
    * cache is burning money in a way raw token counts do not show.
    */
   cacheCreationTokens: number;
+  /**
+   * Priced from the session's own tokens against the model registry — the
+   * same formula the trace pipeline applies to the same calls, so a session
+   * and its traces state one figure. A logs-only agent, with no token-bearing
+   * span to compute from, carries its reported cost here instead.
+   */
   costUsd: number;
+  /**
+   * What the agent says it was billed, summed off its api_request events.
+   * Kept beside the computed cost, never shown as it: the two drifting apart
+   * per model is the alarm that a price went stale — ours or theirs.
+   */
+  agentReportedCostUsd: number;
 
   // ── Time ──────────────────────────────────────────────────────────────
   /** Wall-clock inside model calls, and inside tools. */

--- a/specs/coding-agent/session-aggregate.feature
+++ b/specs/coding-agent/session-aggregate.feature
@@ -165,10 +165,15 @@ Feature: Coding-agent sessions
     When the turn is folded
     Then the session's tokens are counted and its cost stays at zero
 
-  Scenario: an agent that states its own price keeps it
+  Scenario: an agent that states its own price keeps it beside the computed one
     Given a session whose telemetry reports what it was billed
     When its model calls are folded
-    Then the session's cost is the reported one, never a second estimate
+    Then the session's cost is worked out from the call tokens
+    And the reported figure is kept apart from it, as a drift signal
+    # One session, two figures with two homes. The computed one is the same
+    # formula the trace pipeline applies to the same spans, so a session and
+    # its traces cannot disagree; the reported one tells us when either our
+    # price registry or the agent's own pricing went stale.
 
   Scenario: a codex shell command counts once despite its sandbox outcome event
     When a codex session runs one shell command that reports a tool result and a sandbox outcome

--- a/specs/trace-processing/coding-agent-cost.feature
+++ b/specs/trace-processing/coding-agent-cost.feature
@@ -31,6 +31,14 @@ Feature: Coding-agent cost, one formula on every surface
     And the call prices its writes at the five-minute rate
 
   @unit
+  Scenario: A main-thread call known only by its query source prices the same way
+    Given a claude_code.llm_request span with no llm_request.context attribute
+    And the span states a main-thread query source
+    When the span is canonicalised
+    Then its cache writes carry the hour-long count
+    And the trace surfaces and the session fold state one figure for the call
+
+  @unit
   Scenario: A call with no stated context prices its writes conservatively
     Given a claude_code.llm_request span with no llm_request.context attribute
     When the span is canonicalised

--- a/specs/trace-processing/coding-agent-cost.feature
+++ b/specs/trace-processing/coding-agent-cost.feature
@@ -1,0 +1,78 @@
+Feature: Coding-agent cost, one formula on every surface
+  As a customer tracking what my coding agents spend
+  I want the terminal footer, the trace header and the Usage tab to state one cost
+  So that two screens never disagree about the same session
+
+  Background:
+    Given a Claude Code session ingested through OTLP
+    And the model price registry carries the provider's published rates
+
+  # Anthropic bills an hour-long cache entry at 2x the input rate and a
+  # five-minute entry at 1.25x. The llm_request span states how many tokens
+  # were written but not how long they live. The span's own request context
+  # states which policy applies: measured against Claude Code, a main-thread
+  # request ("interaction") writes hour-long entries and a sub-agent request
+  # ("tool") writes five-minute ones. The agent-reported cost drift signal
+  # below is what catches the day the provider changes this policy.
+
+  @unit
+  Scenario: A main-thread call's cache writes price as hour-long entries
+    Given a claude_code.llm_request span whose llm_request.context is "interaction"
+    And the span reports cache-write tokens with no lifetime split of its own
+    When the span is canonicalised
+    Then its cache writes carry the hour-long count
+    And every surface prices the call at the amount the provider charged
+
+  @unit
+  Scenario: A sub-agent call's cache writes price as five-minute entries
+    Given a claude_code.llm_request span whose llm_request.context is "tool"
+    When the span is canonicalised
+    Then no hour-long count is asserted
+    And the call prices its writes at the five-minute rate
+
+  @unit
+  Scenario: A call with no stated context prices its writes conservatively
+    Given a claude_code.llm_request span with no llm_request.context attribute
+    When the span is canonicalised
+    Then no hour-long count is asserted
+
+  @unit
+  Scenario: A provider-stated split is never overwritten
+    Given a claude_code.llm_request span that already carries an hour-long cache count
+    When the span is canonicalised
+    Then the provider's own count is kept
+
+  @unit
+  Scenario: The session's cost is computed from tokens, same formula as the trace
+    Given a Claude Code session with model calls on its llm_request spans
+    When the session fold prices the session
+    Then the session's cost equals the sum of the same calls priced by the trace pipeline
+    And the cost the agent reported about itself is folded into a separate figure
+
+  @unit
+  Scenario: The agent-reported figure is kept as a drift signal
+    Given the agent reports a cost for a call on its api_request event
+    When the session fold applies the event
+    Then the reported amount accumulates on the session without touching the computed cost
+    # The two figures disagreeing is the alarm: it means either our price
+    # registry or the agent's own pricing went stale.
+
+  @unit
+  Scenario: A logs-only agent keeps its reported cost as the session cost
+    Given an agent whose telemetry has no spans and reports cost on its api_request events
+    When the session fold prices the session
+    Then the reported cost is the session's cost
+    # With no token-bearing span there is nothing to compute from.
+
+  @unit
+  Scenario: Saturated session sets state their bound
+    Given a session that touched more traces, sub-agents or files than the fold retains
+    When the Usage tab renders the session
+    Then each saturated card states the value as a lower bound, not an exact count
+
+  @unit
+  Scenario: The terminal footer states the session total next to the running figure
+    Given a session replay opened on one of many turns
+    When the footer renders cost
+    Then the running figure covers the loaded steps up to the reader's position
+    And the session total comes from the session row, the same source the Usage tab reads


### PR DESCRIPTION
## What

One cost figure for a coding-agent session, on every surface. Before this PR the Terminal footer, the trace header and the Usage tab could state three different amounts for the same session. On a real production session the footer said $32.03 while the Usage tab said $2,142.10.

Spec: `specs/trace-processing/coding-agent-cost.feature` (10/10 scenarios bound).

## Why the numbers disagreed

Measured against a controlled Sonnet session instrumented to a local LangWatch, with the on-disk transcript as ground truth, plus Anthropic's published prices:

1. **The span lane priced every cache write at the five-minute rate.** Claude Code sessions write hour-long cache entries on the main thread, which bill 2x input instead of 1.25x. The span states how many tokens were written but not how long they live, so the extractor refused to assert a lifetime and priced short-lived. On the test turn: computed $0.139 vs charged $0.2205.
2. **The Usage tab used the cost the agent reports about itself**, and Claude Code currently bills Sonnet 5 at $3/$15, the September 1 price increase Anthropic cancelled. The published price is $2/$10. Every Sonnet 5 call was overstated by exactly 1.5x (measured 1.5000 on a cache-read turn).
3. **The footer showed one trace as the session total.** The replay pages backward only, its turn list is capped at 200 turns, and a session past the cap fell back to the opened trace with no indicator.
4. **"spans 50 traces", "50 sub-agents", "50 files touched" were a bound, shown as a count.** The fold's dedup sets cap at 50.

## Changes

**The lifetime rule (extractor + fold).** The `llm_request` span's own request context states which cache policy applies, measured against live traffic: `llm_request.context: "interaction"` (main thread) writes hour-long entries, `"tool"` (sub-agent) writes five-minute ones. Claude names the main thread twice, `llm_request.context: "interaction"` on the span and `query_source: "repl_main_thread"` on the log side, and both the extractor and the fold read both, so one call cannot classify two ways. The extractor stamps the hour-long count on the span, `computeSpanCost` already prices the split, and a provider-stated split always wins over the rule. A call with no stated context stays short-lived, which never overstates.

**One formula for the session (fold).** The session's `CostUsd` is now computed from its spans' tokens against the model registry, the same formula and the same lifetime rule the trace pipeline applies to the identical spans, so the session and its traces agree by construction. Codex already worked this way. A logs-only agent (no token-bearing span) keeps its reported cost.

**The agent-reported figure becomes a drift alarm.** What the agent says it was billed moves to the new `AgentReportedCostUsd` column (migration 00085), beside the computed figure, and two Prometheus counters (`coding_agent_cost_computed_usd_total`, `coding_agent_cost_reported_usd_total`, per agent and model) track the two. Their ratio drifting from ~1 for one model means a price went stale, ours or theirs. This disagreement is what caught both bugs above. The Grafana alert rule on these counters lands in the infrastructure repo separately.

**Projection version bump to 2026-08-23.** Existing rows carry the agent-reported number as `CostUsd`; the bump refolds each session once from its stored contributions, which rebuilds the computed cost and files the reported amounts where they now belong.

**The footer states its scope.** The bar keeps the running figure that moves with the scroll, and states the session total beside it: `$12.34 of $210.00`. The total comes off the same pre-folded session row the Usage tab reads (same query, fetched once). When the reader has the whole session on screen, the suffix drops.

**Saturated sets state their bound.** The three set-derived cards render `50+` at the cap instead of presenting it as an exact count.

## What this deliberately does not do

- No new queries, reads or stages in the event-sourcing pipeline: the stamp rides the existing canonicalisation, the cost rides the existing fold, the counters increment in the existing handlers.
- No forward pagination in the replay. With the session total stated in the bar, the backward-only window is a display bound, not a wrong number.
- Claude Code's own Sonnet 5 pricing is not ours to fix; the drift alarm is the guard.

## Tests

- `coding-agent-cost-agreement.unit.test.ts` now pins the charged figure across all six surfaces for a main-thread call, the short-lived figure for sub-agent and context-less calls, and that a provider-stated split is never overwritten.
- Fold tests: computed cost beside reported, the logs-only rule, and the lifetime rule at the fold level.
- `SessionView` and `TerminalView` tests for the `50+` bound and the `$X of $Y` bar.
- `pnpm typecheck`, `pnpm typecheck:all`, targeted biome: clean.

## Live verification

Verified end to end against a local stack with a real Claude Sonnet session in tmux: the stamped hour-long count on new spans, the trace cost at the charged figure, and the session row carrying both columns. The clean-session numbers reconcile exactly: span lane $0.221882 equals the token math against the published prices, session `CostUsd` equals the sum of its spans' costs, and `AgentReportedCostUsd` sits at 1.4977x computed, which is the Sonnet 5 pricing drift the alarm exists to catch.

The Terminal footer opened on an earlier turn of the session, with the running figure and the session total side by side:

![Terminal footer with session total](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7427/terminal-footer-of-total.png)

The Usage tab for the same session shows the same computed total the footer states ($0.27), instead of the agent-reported $0.41:

![Usage tab computed cost](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7427/session-usage-tab.png)

The `50+` bound state needs a session with more than 50 traces, which the local QA session does not have; the `SessionView` integration test pins it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal views now show running cost, session totals, or both in the status bar.
  - Session costs distinguish calculated usage from amounts reported by the coding agent.
  - Cache usage pricing is more accurately reflected based on request context.

- **Improvements**
  - Large trace, sub-agent, and file counts now display a clear lower bound such as `50+`.
  - Cost calculations are more consistent across traces, sessions, usage views, and terminal displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->