### PR TITLE
fix(analytics): reject aggregations a metric does not allow before they reach ClickHouse

### DIFF
--- a/platform/app/src/server/analytics/__tests__/registry.unit.test.ts
+++ b/platform/app/src/server/analytics/__tests__/registry.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { analyticsMetrics } from "../registry";
+import {
+  analyticsMetrics,
+  flattenAnalyticsMetricsEnum,
+  getMetric,
+  seriesInput,
+} from "../registry";
+import { allAggregationTypes } from "../types";
 
 describe("analyticsMetrics", () => {
   describe("evaluation_pass_rate", () => {
@@ -9,5 +15,68 @@ describe("analyticsMetrics", () => {
         "0%",
       );
     });
+  });
+});
+
+describe("seriesInput allowedAggregations enforcement", () => {
+  /** @scenario "A metric paired with an aggregation outside its allowed set is rejected" */
+  it("rejects every pairing the registry does not allow", () => {
+    // The production instance was a ["cardinality"]-only metric paired with
+    // "sum"; make sure the registry still contains that class so the sweep
+    // below cannot go vacuous if metrics are later loosened.
+    const cardinalityOnly = flattenAnalyticsMetricsEnum.filter((metric) => {
+      const allowed = getMetric(metric).allowedAggregations;
+      return allowed.length === 1 && allowed[0] === "cardinality";
+    });
+    expect(cardinalityOnly.length).toBeGreaterThan(0);
+
+    let rejectedPairings = 0;
+    for (const metric of flattenAnalyticsMetricsEnum) {
+      const allowed = getMetric(metric).allowedAggregations;
+      for (const aggregation of allAggregationTypes) {
+        if (allowed.includes(aggregation)) continue;
+        // The query layer executes `terms` as `cardinality`, so the schema
+        // accepts the alias wherever cardinality is allowed.
+        if (aggregation === "terms" && allowed.includes("cardinality")) {
+          continue;
+        }
+        const result = seriesInput.safeParse({ metric, aggregation });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const issue = result.error.issues[0]!;
+          expect(issue.path).toEqual(["aggregation"]);
+          expect(issue.message).toContain(metric);
+          expect(issue.message).toContain(aggregation);
+          for (const allowedAggregation of allowed) {
+            expect(issue.message).toContain(allowedAggregation);
+          }
+        }
+        rejectedPairings++;
+      }
+    }
+    expect(rejectedPairings).toBeGreaterThan(0);
+  });
+
+  /** @scenario "Every aggregation a metric allows still validates" */
+  it("accepts every pairing the registry allows", () => {
+    for (const metric of flattenAnalyticsMetricsEnum) {
+      for (const aggregation of getMetric(metric).allowedAggregations) {
+        const result = seriesInput.safeParse({ metric, aggregation });
+        expect(result.success).toBe(true);
+      }
+    }
+  });
+
+  /** @scenario "The legacy terms alias keeps validating wherever cardinality is allowed" */
+  it("accepts terms on a cardinality-only metric (pre-rename stored graphs)", () => {
+    const cardinalityOnly = flattenAnalyticsMetricsEnum.filter((metric) => {
+      const allowed = getMetric(metric).allowedAggregations;
+      return allowed.length === 1 && allowed[0] === "cardinality";
+    });
+    expect(cardinalityOnly.length).toBeGreaterThan(0);
+    for (const metric of cardinalityOnly) {
+      const result = seriesInput.safeParse({ metric, aggregation: "terms" });
+      expect(result.success).toBe(true);
+    }
   });
 });

--- a/platform/app/src/server/analytics/__tests__/registry.unit.test.ts
+++ b/platform/app/src/server/analytics/__tests__/registry.unit.test.ts
@@ -18,65 +18,76 @@ describe("analyticsMetrics", () => {
   });
 });
 
-describe("seriesInput allowedAggregations enforcement", () => {
-  /** @scenario "A metric paired with an aggregation outside its allowed set is rejected" */
-  it("rejects every pairing the registry does not allow", () => {
-    // The production instance was a ["cardinality"]-only metric paired with
-    // "sum"; make sure the registry still contains that class so the sweep
-    // below cannot go vacuous if metrics are later loosened.
-    const cardinalityOnly = flattenAnalyticsMetricsEnum.filter((metric) => {
-      const allowed = getMetric(metric).allowedAggregations;
-      return allowed.length === 1 && allowed[0] === "cardinality";
-    });
-    expect(cardinalityOnly.length).toBeGreaterThan(0);
+describe("seriesInput", () => {
+  describe("given each metric's allowedAggregations in the registry", () => {
+    describe("when a series pairs a metric with a disallowed aggregation", () => {
+      /** @scenario "A metric paired with an aggregation outside its allowed set is rejected" */
+      it("rejects every pairing the registry does not allow", () => {
+        // The production instance was a ["cardinality"]-only metric paired
+        // with "sum"; make sure the registry still contains that class so the
+        // sweep below cannot go vacuous if metrics are later loosened.
+        const cardinalityOnly = flattenAnalyticsMetricsEnum.filter((metric) => {
+          const allowed = getMetric(metric).allowedAggregations;
+          return allowed.length === 1 && allowed[0] === "cardinality";
+        });
+        expect(cardinalityOnly.length).toBeGreaterThan(0);
 
-    let rejectedPairings = 0;
-    for (const metric of flattenAnalyticsMetricsEnum) {
-      const allowed = getMetric(metric).allowedAggregations;
-      for (const aggregation of allAggregationTypes) {
-        if (allowed.includes(aggregation)) continue;
-        // The query layer executes `terms` as `cardinality`, so the schema
-        // accepts the alias wherever cardinality is allowed.
-        if (aggregation === "terms" && allowed.includes("cardinality")) {
-          continue;
-        }
-        const result = seriesInput.safeParse({ metric, aggregation });
-        expect(result.success).toBe(false);
-        if (!result.success) {
-          const issue = result.error.issues[0]!;
-          expect(issue.path).toEqual(["aggregation"]);
-          expect(issue.message).toContain(metric);
-          expect(issue.message).toContain(aggregation);
-          for (const allowedAggregation of allowed) {
-            expect(issue.message).toContain(allowedAggregation);
+        let rejectedPairings = 0;
+        for (const metric of flattenAnalyticsMetricsEnum) {
+          const allowed = getMetric(metric).allowedAggregations;
+          for (const aggregation of allAggregationTypes) {
+            if (allowed.includes(aggregation)) continue;
+            // The query layer executes `terms` as `cardinality`, so the
+            // schema accepts the alias wherever cardinality is allowed.
+            if (aggregation === "terms" && allowed.includes("cardinality")) {
+              continue;
+            }
+            const result = seriesInput.safeParse({ metric, aggregation });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+              const issue = result.error.issues[0]!;
+              expect(issue.path).toEqual(["aggregation"]);
+              expect(issue.message).toContain(metric);
+              expect(issue.message).toContain(aggregation);
+              for (const allowedAggregation of allowed) {
+                expect(issue.message).toContain(allowedAggregation);
+              }
+            }
+            rejectedPairings++;
           }
         }
-        rejectedPairings++;
-      }
-    }
-    expect(rejectedPairings).toBeGreaterThan(0);
-  });
-
-  /** @scenario "Every aggregation a metric allows still validates" */
-  it("accepts every pairing the registry allows", () => {
-    for (const metric of flattenAnalyticsMetricsEnum) {
-      for (const aggregation of getMetric(metric).allowedAggregations) {
-        const result = seriesInput.safeParse({ metric, aggregation });
-        expect(result.success).toBe(true);
-      }
-    }
-  });
-
-  /** @scenario "The legacy terms alias keeps validating wherever cardinality is allowed" */
-  it("accepts terms on a cardinality-only metric (pre-rename stored graphs)", () => {
-    const cardinalityOnly = flattenAnalyticsMetricsEnum.filter((metric) => {
-      const allowed = getMetric(metric).allowedAggregations;
-      return allowed.length === 1 && allowed[0] === "cardinality";
+        expect(rejectedPairings).toBeGreaterThan(0);
+      });
     });
-    expect(cardinalityOnly.length).toBeGreaterThan(0);
-    for (const metric of cardinalityOnly) {
-      const result = seriesInput.safeParse({ metric, aggregation: "terms" });
-      expect(result.success).toBe(true);
-    }
+
+    describe("when a series pairs a metric with an aggregation it allows", () => {
+      /** @scenario "Every aggregation a metric allows still validates" */
+      it("accepts every pairing the registry allows", () => {
+        for (const metric of flattenAnalyticsMetricsEnum) {
+          for (const aggregation of getMetric(metric).allowedAggregations) {
+            const result = seriesInput.safeParse({ metric, aggregation });
+            expect(result.success).toBe(true);
+          }
+        }
+      });
+    });
+
+    describe("when a stored series uses the legacy terms alias", () => {
+      /** @scenario "The legacy terms alias keeps validating wherever cardinality is allowed" */
+      it("accepts terms on a cardinality-only metric (pre-rename stored graphs)", () => {
+        const cardinalityOnly = flattenAnalyticsMetricsEnum.filter((metric) => {
+          const allowed = getMetric(metric).allowedAggregations;
+          return allowed.length === 1 && allowed[0] === "cardinality";
+        });
+        expect(cardinalityOnly.length).toBeGreaterThan(0);
+        for (const metric of cardinalityOnly) {
+          const result = seriesInput.safeParse({
+            metric,
+            aggregation: "terms",
+          });
+          expect(result.success).toBe(true);
+        }
+      });
+    });
   });
 });

--- a/platform/app/src/server/analytics/registry.ts
+++ b/platform/app/src/server/analytics/registry.ts
@@ -386,29 +386,55 @@ export const getGroup = (
   return (analyticsGroups[group] as any)[field];
 };
 
-export const seriesInput = z.object({
-  metric: z.enum(flattenAnalyticsMetricsEnum),
-  key: z.optional(z.string()),
-  subkey: z.optional(z.string()),
-  aggregation: aggregationTypesEnum,
-  pipeline: z.optional(
-    z.object({
-      field: pipelineFieldsEnum,
-      aggregation: pipelineAggregationTypesEnum,
-    }),
-  ),
-  filters: z.optional(
-    z.record(
-      filterFieldsEnum,
-      z.union([
-        z.array(z.string()),
-        z.record(z.string(), z.array(z.string())),
-        z.record(z.string(), z.record(z.string(), z.array(z.string()))),
-      ]),
+export const seriesInput = z
+  .object({
+    metric: z.enum(flattenAnalyticsMetricsEnum),
+    key: z.optional(z.string()),
+    subkey: z.optional(z.string()),
+    aggregation: aggregationTypesEnum,
+    pipeline: z.optional(
+      z.object({
+        field: pipelineFieldsEnum,
+        aggregation: pipelineAggregationTypesEnum,
+      }),
     ),
-  ),
-  asPercent: z.optional(z.boolean()),
-});
+    filters: z.optional(
+      z.record(
+        filterFieldsEnum,
+        z.union([
+          z.array(z.string()),
+          z.record(z.string(), z.array(z.string())),
+          z.record(z.string(), z.record(z.string(), z.array(z.string()))),
+        ]),
+      ),
+    ),
+    asPercent: z.optional(z.boolean()),
+  })
+  // Each metric's `allowedAggregations` is the single source of truth for
+  // which pairings are valid — the aggregation dropdown reads it, and this
+  // refinement derives from the same declaration so the two cannot drift. An
+  // aggregation the metric does not allow would otherwise only fail inside
+  // ClickHouse (e.g. `sum` over a String column: ILLEGAL_TYPE_OF_ARGUMENT),
+  // after SQL was already built. `terms` is the legacy ES alias for
+  // `cardinality` — the whole query layer executes it as `uniq` and
+  // `buildSeriesName` rewrites it — so stored graphs that predate the rename
+  // must keep validating wherever `cardinality` is allowed.
+  .superRefine((series, ctx) => {
+    const allowed = getMetric(series.metric).allowedAggregations;
+    const aggregation =
+      series.aggregation === "terms" && allowed.includes("cardinality")
+        ? "cardinality"
+        : series.aggregation;
+    if (!allowed.includes(aggregation)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["aggregation"],
+        message: `metric ${series.metric} does not allow aggregation "${
+          series.aggregation
+        }"; allowed: ${allowed.join(", ")}`,
+      });
+    }
+  });
 
 export type SeriesInputType = z.infer<typeof seriesInput>;
 

--- a/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-evaluation.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/graph-trigger-evaluation.service.unit.test.ts
@@ -1166,4 +1166,40 @@ describe("evaluateGraphTrigger", () => {
       expect(result.detail).toContain("threshold");
     });
   });
+
+  describe("given a stored series whose aggregation the metric does not allow", () => {
+    /** @scenario "A graph trigger whose stored series pairs a disallowed aggregation skips instead of querying" */
+    it("skips with a detail naming the pairing, without querying", async () => {
+      harness = makeHarness({
+        graph: makeGraph({
+          graph: {
+            series: [
+              {
+                name: "Trace count",
+                metric: "metadata.trace_id",
+                aggregation: "sum",
+                colorSet: "blueTones",
+              },
+            ],
+            groupBy: undefined,
+            groupByKey: undefined,
+            timeScale: 60,
+          },
+        } as Partial<CustomGraph>),
+        series: timeseries(15),
+      });
+
+      const result = await evaluateGraphTrigger({
+        deps: harness.deps,
+        triggerId: TRIGGER_ID,
+        projectId: PROJECT_ID,
+        reason: "real-time",
+      });
+
+      expect(result.status).toBe("skipped");
+      expect(result.detail).toContain("metadata.trace_id");
+      expect(harness.getTimeseries).not.toHaveBeenCalled();
+      expect(harness.dispatch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/automations/graph-trigger-evaluation.service.ts
+++ b/platform/app/src/server/app-layer/automations/graph-trigger-evaluation.service.ts
@@ -31,9 +31,10 @@ import { buildGraphAlertTemplateContext } from "@langwatch/automations/templatin
 import { createLogger } from "@langwatch/observability";
 import type { CustomGraphInput } from "~/components/analytics/CustomGraph";
 import type { CustomGraph, Project, Trigger } from "~/generated/prisma/client";
-import type {
-  SeriesInputType,
-  TimeseriesInputType,
+import {
+  type SeriesInputType,
+  seriesInput as seriesInputSchema,
+  type TimeseriesInputType,
 } from "~/server/analytics/registry";
 import type { TimeseriesResult } from "~/server/analytics/types";
 import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
@@ -294,15 +295,31 @@ export async function evaluateGraphTrigger({
   const endDate = now;
   const startDate = new Date(endDate.getTime() - timePeriod * 60 * 1000);
 
-  const seriesInput: SeriesInputType = {
-    metric: series.metric as SeriesInputType["metric"],
-    aggregation: series.aggregation as SeriesInputType["aggregation"],
+  // Stored graph JSON never went through the request schema; parse instead of
+  // asserting, so a pairing the metric's `allowedAggregations` forbids skips
+  // this trigger with a named reason rather than failing in ClickHouse — a
+  // configuration fault must not reach the caller's failure count (see the
+  // oversized-result skip below for why a throw would quarantine the lane).
+  const parsedSeries = seriesInputSchema.safeParse({
+    metric: series.metric,
+    aggregation: series.aggregation,
     key: series.key,
     subkey: series.subkey,
-    pipeline: series.pipeline as SeriesInputType["pipeline"],
-    filters: series.filters as SeriesInputType["filters"],
+    pipeline: series.pipeline,
+    filters: series.filters,
     asPercent: series.asPercent,
-  };
+  });
+  if (!parsedSeries.success) {
+    return skipped({
+      triggerId,
+      projectId,
+      reason,
+      detail: `invalid series configuration: ${
+        parsedSeries.error.issues[0]?.message ?? "schema mismatch"
+      }`,
+    });
+  }
+  const seriesInput: SeriesInputType = parsedSeries.data;
   const timeseriesInput: TimeseriesInputType = {
     projectId,
     startDate: startDate.getTime(),

--- a/platform/app/src/server/app-layer/reports/__tests__/report-chart.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/reports/__tests__/report-chart.service.unit.test.ts
@@ -279,36 +279,38 @@ describe("loadReportCharts", () => {
   });
 
   describe("given a stored series whose aggregation the metric does not allow", () => {
-    /** @scenario "A report chart whose stored series pairs a disallowed aggregation fails validation before querying" */
-    it("fails with a validation error before any query is dispatched", async () => {
-      const deps = makeDeps({
-        graphs: [
-          makeGraph({
-            graph: {
-              graphId: "graph-1",
-              graphType: "line",
-              series: [
-                {
-                  metric: "metadata.trace_id",
-                  aggregation: "sum",
-                  name: "Broken",
-                },
-              ],
-              includePrevious: false,
-              timeScale: 60,
-            },
-          } as unknown as Partial<CustomGraph>),
-        ],
-        timeseries: { previousPeriod: [], currentPeriod: [] },
-      });
+    describe("when the report's charts are built", () => {
+      /** @scenario "A report chart whose stored series pairs a disallowed aggregation fails validation before querying" */
+      it("fails with a validation error before any query is dispatched", async () => {
+        const deps = makeDeps({
+          graphs: [
+            makeGraph({
+              graph: {
+                graphId: "graph-1",
+                graphType: "line",
+                series: [
+                  {
+                    metric: "metadata.trace_id",
+                    aggregation: "sum",
+                    name: "Broken",
+                  },
+                ],
+                includePrevious: false,
+                timeScale: 60,
+              },
+            } as unknown as Partial<CustomGraph>),
+          ],
+          timeseries: { previousPeriod: [], currentPeriod: [] },
+        });
 
-      await expect(
-        run({
-          deps,
-          source: { kind: "customGraph", customGraphId: "graph-1" },
-        }),
-      ).rejects.toThrow(/metadata\.trace_id/);
-      expect(deps.getTimeseries).not.toHaveBeenCalled();
+        await expect(
+          run({
+            deps,
+            source: { kind: "customGraph", customGraphId: "graph-1" },
+          }),
+        ).rejects.toThrow(/metadata\.trace_id/);
+        expect(deps.getTimeseries).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/platform/app/src/server/app-layer/reports/__tests__/report-chart.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/reports/__tests__/report-chart.service.unit.test.ts
@@ -277,4 +277,38 @@ describe("loadReportCharts", () => {
       expect(deps.getTimeseries).not.toHaveBeenCalled();
     });
   });
+
+  describe("given a stored series whose aggregation the metric does not allow", () => {
+    /** @scenario "A report chart whose stored series pairs a disallowed aggregation fails validation before querying" */
+    it("fails with a validation error before any query is dispatched", async () => {
+      const deps = makeDeps({
+        graphs: [
+          makeGraph({
+            graph: {
+              graphId: "graph-1",
+              graphType: "line",
+              series: [
+                {
+                  metric: "metadata.trace_id",
+                  aggregation: "sum",
+                  name: "Broken",
+                },
+              ],
+              includePrevious: false,
+              timeScale: 60,
+            },
+          } as unknown as Partial<CustomGraph>),
+        ],
+        timeseries: { previousPeriod: [], currentPeriod: [] },
+      });
+
+      await expect(
+        run({
+          deps,
+          source: { kind: "customGraph", customGraphId: "graph-1" },
+        }),
+      ).rejects.toThrow(/metadata\.trace_id/);
+      expect(deps.getTimeseries).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/reports/report-chart.service.ts
+++ b/platform/app/src/server/app-layer/reports/report-chart.service.ts
@@ -1,9 +1,10 @@
 import type { ReportChart } from "@langwatch/automations/templating/templateContext";
 import type { CustomGraphInput } from "~/components/analytics/CustomGraph";
 import type { CustomGraph } from "~/generated/prisma/client";
-import type {
-  SeriesInputType,
-  TimeseriesInputType,
+import {
+  type SeriesInputType,
+  seriesInput as seriesInputSchema,
+  type TimeseriesInputType,
 } from "~/server/analytics/registry";
 import type { TimeseriesResult } from "~/server/analytics/types";
 import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
@@ -191,17 +192,23 @@ async function buildChart({
 }): Promise<ReportChart> {
   const graphData = graph.graph as unknown as CustomGraphInput;
   const type = chartTypeOf(graphData.graphType);
+  // Stored graph JSON never went through the request schema, so parse it here:
+  // a pairing the metric's `allowedAggregations` forbids (e.g. after a metric's
+  // meaning changed under a saved dashboard) must surface as a validation error
+  // naming the series, not as a ClickHouse type error mid-query.
   const seriesInputs: SeriesInputType[] = (graphData.series ?? [])
     .slice(0, MAX_SERIES)
-    .map((series) => ({
-      metric: series.metric,
-      aggregation: series.aggregation,
-      key: series.key,
-      subkey: series.subkey,
-      pipeline: series.pipeline,
-      filters: series.filters,
-      asPercent: series.asPercent,
-    }));
+    .map((series) =>
+      seriesInputSchema.parse({
+        metric: series.metric,
+        aggregation: series.aggregation,
+        key: series.key,
+        subkey: series.subkey,
+        pipeline: series.pipeline,
+        filters: series.filters,
+        asPercent: series.asPercent,
+      }),
+    );
 
   const empty: ReportChart = {
     id: graph.id,

--- a/specs/analytics/allowed-aggregations-enforcement.feature
+++ b/specs/analytics/allowed-aggregations-enforcement.feature
@@ -1,0 +1,53 @@
+Feature: Allowed aggregations are enforced per metric
+
+  Every analytics metric declares which aggregations are valid for it in the
+  metric registry (`allowedAggregations`), but historically nothing on the
+  server enforced that declaration: an invalid pairing passed straight through
+  to the query builder and failed inside ClickHouse with
+  ILLEGAL_TYPE_OF_ARGUMENT. The request schema now derives its validation from
+  the registry, so an invalid pairing is rejected with a validation error
+  before any SQL is built. Stored-graph paths (report charts, graph trigger
+  evaluation) construct series from stored JSON rather than a parsed request,
+  so they parse through the same schema before dispatching.
+
+  # ---------------------------------------------------------------------------
+  # Schema boundary (tRPC + REST both parse through seriesInput)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A metric paired with an aggregation outside its allowed set is rejected
+    Given the analytics metric registry
+    When a series pairs a metric with an aggregation its allowedAggregations does not contain
+    Then the schema rejects it with a validation error on the aggregation field
+    And the error names the metric and its allowed aggregations
+    And no SQL is built for the request
+
+  @unit
+  Scenario: Every aggregation a metric allows still validates
+    Given the analytics metric registry
+    When a series pairs a metric with any aggregation from its allowedAggregations
+    Then the schema accepts it
+
+  @unit
+  Scenario: The legacy terms alias keeps validating wherever cardinality is allowed
+    Given the query layer executes the terms aggregation as cardinality
+    When a stored series pairs a cardinality-only metric with the terms aggregation
+    Then the schema accepts it, so pre-rename stored graphs keep working
+
+  # ---------------------------------------------------------------------------
+  # Stored-graph paths (saved dashboards bypass the request schema)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A report chart whose stored series pairs a disallowed aggregation fails validation before querying
+    Given a report whose stored graph pairs a metric with a disallowed aggregation
+    When the report's charts are built
+    Then building fails with a validation error
+    And no timeseries query is dispatched
+
+  @unit
+  Scenario: A graph trigger whose stored series pairs a disallowed aggregation skips instead of querying
+    Given a graph trigger whose stored graph pairs a metric with a disallowed aggregation
+    When the trigger is evaluated
+    Then the evaluation is skipped with a detail naming the invalid pairing
+    And no timeseries query is dispatched


### PR DESCRIPTION
## Why

Every analytics metric declares `allowedAggregations` in the metric registry, but nothing enforced it: the request schema accepted any aggregation for any metric, and an invalid pairing flowed straight into the query builder and failed inside ClickHouse (`sum` over a String column → `ILLEGAL_TYPE_OF_ARGUMENT`). Seen twice in production on the timeseries path.

Closes #6779

## What changed

Both halves discussed on the issue:

- **Schema boundary**: `seriesInput` gets a `superRefine` that checks `aggregation` against `getMetric(metric).allowedAggregations`. The check derives from the registry rather than restating it, so adding a metric cannot silently skip validation. tRPC and both REST routes all parse through `z.array(seriesInput)`, so one refinement covers every request entry point.
- **Stored-graph paths**: `report-chart.service.ts` and `graph-trigger-evaluation.service.ts` used to build series from stored graph JSON with type assertions and dispatch unchecked. They now parse through `seriesInput` before dispatching — one validation rule in one place, as agreed on the issue.

## How it works

The two stored-graph call sites fail differently on purpose, matching each file's existing error contract:

- **Report charts** use throwing `parse`: a report either renders every panel or fails as a whole (the documented all-or-nothing contract). A bad stored pairing previously threw from ClickHouse at the same point; now it throws a validation error naming the metric and its allowed set, before any SQL is built.
- **Graph triggers** use `safeParse` → `skipped` with a detail naming the pairing. A configuration fault must not reach the caller's failure count — same reasoning as the existing oversized-result skip in that file, which would otherwise let one bad graph quarantine the tenant's trigger lane.

One deliberate carve-out: `terms` is accepted wherever `cardinality` is allowed. The whole query layer executes `terms` as `uniq` (metric-translator, slim query builders) and `buildSeriesName` rewrites it to `cardinality`, so stored graphs that predate the rename keep validating. An existing trigger test locks in exactly that stored shape (`metadata.user_id` + `terms`); rejecting it would have broken live triggers.

## Test plan

Spec `specs/analytics/allowed-aggregations-enforcement.feature`, 5 scenarios, all `@unit`-bound (`check-feature-parity` passes 5/5):

- Registry-driven sweep: every metric × every aggregation outside its allowed set is rejected, with the error on the `aggregation` path naming the metric, the aggregation, and the allowed set. Guarded against going vacuous (asserts the registry still contains a `["cardinality"]`-only metric, and that at least one pairing was rejected).
- Every allowed pairing still validates, and `terms` on cardinality-only metrics still validates.
- Report chart with a stored `metadata.trace_id` + `sum` series: build rejects before `getTimeseries` is ever called.
- Graph trigger with the same stored pairing: evaluation skips with a detail naming the metric; no query, no dispatch.

All three failure tests were verified to fail without the fix (the report/trigger ones proceed to the mocked query layer on revert). 44/44 in the touched suites; the wider analytics/reports/automations sweep shows no new failures vs `main` (the pre-existing reds are environment-dependent suites); biome and typecheck deltas vs `main` are both zero.

## Anything surprising?

- The stored-graph call sites now enforce the *whole* `seriesInput` schema, not just aggregations — a stored series with a removed metric or invalid filter key also fails validation there now. The dashboard view path already parses stored series through the same schema on read, so anything newly rejected in reports/triggers was already broken on the dashboard, and previously died in ClickHouse at the same point anyway.
- Registry quirk the sweep surfaced but this PR leaves alone: `events.event_score` excludes `cardinality` but still lists `terms` (which executes as `uniq`). The refinement honors the registry as declared; whether that entry should drop `terms` is a registry-data question, not a validation one.
- The MCP schema copy drift stays out of scope per the issue discussion — happy to file that separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced valid aggregation choices for each analytics metric.
  * Prevented invalid report charts and graph triggers from sending unsupported queries.
  * Added clear validation errors and safely skipped invalid graph triggers.
  * Preserved support for the legacy `terms` alias where applicable.

* **Tests**
  * Added coverage for valid and invalid metric/aggregation combinations across analytics, reports, and graph triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->