### PR TITLE
fix(authz): a pass states only the facts the heads do not carry

### DIFF
--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -1110,4 +1110,267 @@ describe("given an organization with legacy access rows", () => {
       expect(facts.some((fact) => fact.roleKey === "legacy-admin")).toBe(false);
     });
   });
+
+  describe("when the heads already carry what the pass would state", () => {
+    /** @scenario "A pass states only the facts the heads do not carry" */
+    it("stages nothing for a converged organization", async () => {
+      const row = binding();
+      const fact: GrantFact = {
+        grantId: row.id,
+        principal: { type: "user", id: "user_1" },
+        roleKey: "member",
+        scope: { type: "PROJECT", id: "project_1" },
+        source: "migration",
+        occurredAtMs: CREATED,
+      };
+      const { migration, sent } = harness({
+        bindings: [row],
+        organizationCreatedAtMs: null,
+        grantHeads: [foldedHead(fact)],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(sent).toEqual([]);
+    });
+
+    /** @scenario "A pass states only the facts the heads do not carry" */
+    it("stages only the facts missing from the heads", async () => {
+      const folded = binding({ id: "binding_folded" });
+      const missing = binding({
+        id: "binding_missing",
+        userId: "user_2",
+        scopeId: "project_2",
+      });
+      const { migration, sent } = harness({
+        bindings: [folded, missing],
+        organizationCreatedAtMs: null,
+        grantHeads: [
+          foldedHead({
+            grantId: folded.id,
+            principal: { type: "user", id: "user_1" },
+            roleKey: "member",
+            scope: { type: "PROJECT", id: "project_1" },
+            source: "migration",
+            occurredAtMs: CREATED,
+          }),
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent).map((fact) => fact.grantId)).toEqual([
+        "binding_missing",
+      ]);
+    });
+
+    /** @scenario "A pass states only the facts the heads do not carry" */
+    it("restates a fact whose head is revoked while legacy still holds the row", async () => {
+      const row = binding();
+      const fact: GrantFact = {
+        grantId: row.id,
+        principal: { type: "user", id: "user_1" },
+        roleKey: "member",
+        scope: { type: "PROJECT", id: "project_1" },
+        source: "migration",
+        occurredAtMs: CREATED,
+      };
+      const { migration, sent } = harness({
+        bindings: [row],
+        organizationCreatedAtMs: null,
+        grantHeads: [{ ...foldedHead(fact), revoked: true }],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent).map((entry) => entry.grantId)).toEqual([
+        row.id,
+      ]);
+    });
+
+    /** @scenario "A pass states only the facts the heads do not carry" */
+    it("restates a fact whose head disagrees on a field", async () => {
+      const row = binding();
+      const fact: GrantFact = {
+        grantId: row.id,
+        principal: { type: "user", id: "user_1" },
+        roleKey: "member",
+        scope: { type: "PROJECT", id: "project_1" },
+        source: "migration",
+        occurredAtMs: CREATED,
+      };
+      const { migration, sent } = harness({
+        bindings: [row],
+        organizationCreatedAtMs: null,
+        grantHeads: [{ ...foldedHead(fact), roleKey: "viewer" }],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent).map((entry) => entry.grantId)).toEqual([
+        row.id,
+      ]);
+    });
+
+    /** @scenario "A pass states only the facts the heads do not carry" */
+    it("does not restate a role the heads already match", async () => {
+      const role: LegacyRoleRow = {
+        id: "role_1",
+        name: "Support",
+        description: null,
+        permissions: ["traces:read"],
+        kind: "custom",
+        createdAtMs: CREATED,
+      };
+      const { migration, sent } = harness({
+        roles: [role],
+        organizationCreatedAtMs: null,
+        roleHeads: [
+          {
+            id: role.id,
+            name: role.name,
+            description: null,
+            permissions: role.permissions,
+            kind: "custom",
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(sent.filter((entry) => entry.kind === "defineRole")).toEqual([]);
+    });
+
+    /**
+     * The family that made this necessary: one organization carries 428,720
+     * share links, one fact each, and a held organization restaged all of
+     * them on every worker boot.
+     *
+     * @scenario "A pass states only the facts the heads do not carry"
+     */
+    it("does not restate a share link whose resource head matches", async () => {
+      const row = shareLink({ maxViews: 10, viewCount: 3 });
+      const { migration, sent } = harness({
+        shareLinks: [row],
+        organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: row.id,
+            source: "migration",
+            token: row.token,
+            resourceKind: "TRACE",
+            resourceId: row.resourceId,
+            projectId: row.projectId,
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: 10,
+            viewCount: 3,
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent)).toEqual([]);
+    });
+
+    /**
+     * A head whose view count merely lags is `outstanding`, not drift, and
+     * the budget it waits on rides `seedResourceGrantUsage` — which runs on
+     * every pass regardless. Restating the attach would not carry it, so the
+     * link must not be restaged for that alone.
+     *
+     * @scenario "A pass states only the facts the heads do not carry"
+     */
+    it("does not restate a share link whose head only lags on views", async () => {
+      const row = shareLink({ viewCount: 9 });
+      const { migration, sent, seeded } = harness({
+        shareLinks: [row],
+        organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: row.id,
+            source: "migration",
+            token: row.token,
+            resourceKind: "TRACE",
+            resourceId: row.resourceId,
+            projectId: row.projectId,
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: null,
+            viewCount: 4,
+          },
+        ],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(attachedFacts(sent)).toEqual([]);
+      expect(seeded.at(-1)).toEqual([
+        { grantId: row.id, projectId: row.projectId, viewCount: 9 },
+      ]);
+    });
+
+    /**
+     * The filter is the check's own predicate, so what a pass skips can never
+     * change what it reports: the heads it filtered on are the heads it
+     * checks against.
+     *
+     * @scenario "A pass states only the facts the heads do not carry"
+     */
+    it("reports the same held outcome as if it had restated everything", async () => {
+      const folded = binding({ id: "binding_folded" });
+      const missing = binding({
+        id: "binding_missing",
+        userId: "user_2",
+        scopeId: "project_2",
+      });
+      const { migration, sent } = harness({
+        bindings: [folded, missing],
+        organizationCreatedAtMs: null,
+        grantHeads: [
+          foldedHead({
+            grantId: folded.id,
+            principal: { type: "user", id: "user_1" },
+            roleKey: "member",
+            scope: { type: "PROJECT", id: "project_1" },
+            source: "migration",
+            occurredAtMs: CREATED,
+          }),
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      expect(outcome.report).toMatchObject({
+        kind: "authz_engine_held",
+        outstanding: 1,
+        outstandingSample: ["binding_missing"],
+        totalDiffs: 0,
+      });
+      // The counts stay the size of the WORLD, not of what this pass staged.
+      expect(outcome.report).toMatchObject({ bindings: 2 });
+      expect(attachedFacts(sent)).toHaveLength(1);
+    });
+
+    /** @scenario "A pass states only the facts the heads do not carry" */
+    it("still states everything on the first pass, when the heads are empty", async () => {
+      const { migration, sent } = harness({
+        bindings: [binding()],
+        shareLinks: [shareLink()],
+        organizationCreatedAtMs: null,
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(
+        attachedFacts(sent)
+          .map((fact) => fact.grantId)
+          .sort(),
+      ).toEqual(["binding_1", "share_1"]);
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -166,6 +166,43 @@ export function roleDrifted({
   );
 }
 
+/**
+ * Whether a live head already disagrees with the fact the migration would
+ * state. This is the staging filter's question, and deliberately the same
+ * field comparison the check reports on: a fact whose head already matches
+ * is one `attachGrant` would restate identically, so "safe to skip" and
+ * "neither outstanding nor a diff" must be the SAME condition, or a pass
+ * could skip work it then holds the organization for.
+ */
+export function grantDrifted({
+  fact,
+  head,
+}: {
+  fact: GrantFact;
+  head: GrantHeadRow;
+}): boolean {
+  return grantDiffs({ fact, head }).length > 0;
+}
+
+/**
+ * The same question for a share link against its RESOURCE head. Only the
+ * named diffs count: a head whose `viewCount` merely lags the legacy row is
+ * `outstanding`, and the budget it waits on rides `seedResourceGrantUsage`
+ * on every pass rather than the attach, so restating the attach would not
+ * carry it anyway.
+ */
+export function shareLinkDrifted({
+  organizationId,
+  link,
+  head,
+}: {
+  organizationId: string;
+  link: ExpectedShareLink;
+  head: ResourceGrantRow;
+}): boolean {
+  return resourceDiffs({ organizationId, link, head }).diffs.length > 0;
+}
+
 /** Field equality for one stated fact against its head row — against what
  *  the migration SAID, since that is what the head is supposed to hold. */
 function grantDiffs({

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -79,8 +79,10 @@ import {
   checkGrantHeads,
   checkResourceHeads,
   checkRoleHeads,
+  grantDrifted,
   type HeadState,
   roleDrifted,
+  shareLinkDrifted,
 } from "./authz-engine.check";
 import {
   assembleFacts,
@@ -236,7 +238,7 @@ export class AuthzEngineMigration implements SystemMigration {
     // design, not a shortcut.
     const heads = await this.readHeads(organizationId);
 
-    await this.state({ organizationId, expected, signal });
+    await this.state({ organizationId, expected, heads, signal });
     await this.reconcileStale({ organizationId, expected, heads, signal });
     await this.repairDrift({ organizationId, expected, heads, signal });
     // The budget handover rides every pass, monotonically upward: legacy
@@ -326,17 +328,49 @@ export class AuthzEngineMigration implements SystemMigration {
   }
 
   /** Roles before grants: a custom binding's roleKey names its role. */
+  /**
+   * State every fact the heads do not ALREADY carry identically.
+   *
+   * Restating a fact the head already matches is a no-op — the command id is
+   * content-derived, so the event store swallows it — but that dedupe happens
+   * downstream of the queue, which has already paid to enqueue, dispatch and
+   * fold-check it. A grant is its own aggregate since ADR-101, so a held
+   * organization re-drives one group per grant on every pass, and a pass runs
+   * on every worker boot. The organization that made this necessary restaged
+   * ~900k commands per pass, indefinitely, to converge on nothing.
+   *
+   * The filter is the check's own predicate, not a second opinion: a fact
+   * skipped here is exactly a fact `check` counts as neither `outstanding`
+   * nor a diff, so the pass's report is unchanged by the skipping. Anything
+   * the heads lack, hold revoked, or disagree with is still stated, so the
+   * first pass over an organization stages everything as before and drift
+   * repair is untouched. A projection that is behind under-reports the
+   * heads, which restates a fact needlessly — the pre-existing cost, and
+   * still idempotent.
+   */
   private async state({
     organizationId,
     expected,
+    heads,
     signal,
   }: {
     organizationId: string;
     expected: ExpectedFacts;
+    heads: HeadState;
     signal?: AbortSignal;
   }): Promise<void> {
+    const roleHeadById = new Map(
+      heads.roleHeads.map((head) => [head.id, head]),
+    );
+    const grantHeadById = new Map(heads.grantRows.map((row) => [row.id, row]));
+    const resourceHeadById = new Map(
+      heads.resourceRows.map((row) => [row.grantId, row]),
+    );
     await this.each({
-      items: expected.roles,
+      items: expected.roles.filter((role) => {
+        const head = roleHeadById.get(role.roleId);
+        return head === undefined || roleDrifted({ role, head });
+      }),
       signal,
       send: (role) =>
         this.deps.ledger.defineRole({
@@ -350,13 +384,28 @@ export class AuthzEngineMigration implements SystemMigration {
           actor: ACTOR,
         }),
     });
-    const grants = [
+    const nonResourceGrants = [
       ...expected.bindingFacts,
       ...expected.teamFacts,
       ...expected.organizationFacts,
       ...expected.credentialFacts,
-      ...expected.shareLinks.map((link) => link.fact),
-    ];
+    ].filter((fact) => {
+      const head = grantHeadById.get(fact.grantId);
+      if (head === undefined) return true;
+      // A revoked head is not agreement: the fact says the grant is live, so
+      // it must be restated to bring the head back.
+      return head.revoked || grantDrifted({ fact, head });
+    });
+    // Share links are checked against the RESOURCE heads, keyed by the link's
+    // own id, so their filter cannot share the grant-head map above.
+    const shareLinkGrants = expected.shareLinks
+      .filter((link) => {
+        const head = resourceHeadById.get(link.row.id);
+        if (head === undefined) return true;
+        return shareLinkDrifted({ organizationId, link, head });
+      })
+      .map((link) => link.fact);
+    const grants = [...nonResourceGrants, ...shareLinkGrants];
     await this.each({
       items: grants,
       signal,

--- a/platform/app/src/server/app-layer/ops/__tests__/in-flight.unit.test.ts
+++ b/platform/app/src/server/app-layer/ops/__tests__/in-flight.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { type InFlightCounts, totalInFlight } from "../in-flight";
+
+function queue(overrides: Partial<InFlightCounts> = {}): InFlightCounts {
+  return {
+    totalPendingJobs: 0,
+    activeGroupCount: 0,
+    parkedGroupCount: 0,
+    ...overrides,
+  };
+}
+
+describe("given a queue with work in several states", () => {
+  describe("when the dashboard totals what is in flight", () => {
+    /** @scenario "Parked work counts as in flight" */
+    it("counts parked groups alongside pending and active", () => {
+      const total = totalInFlight({
+        queues: [
+          queue({
+            totalPendingJobs: 100,
+            activeGroupCount: 10,
+            parkedGroupCount: 500,
+          }),
+        ],
+      });
+
+      expect(total).toBe(610);
+    });
+
+    /** @scenario "Parked work counts as in flight" */
+    it("sums across every queue", () => {
+      const total = totalInFlight({
+        queues: [
+          queue({ totalPendingJobs: 5, parkedGroupCount: 1 }),
+          queue({ activeGroupCount: 2, parkedGroupCount: 3 }),
+        ],
+      });
+
+      expect(total).toBe(11);
+    });
+
+    it("is zero for an idle fleet", () => {
+      expect(totalInFlight({ queues: [queue(), queue()] })).toBe(0);
+    });
+  });
+
+  /**
+   * The regression this module exists for. `Staged/s` is derived as the
+   * change in in-flight work plus completions, so work moving from pending
+   * into parked must leave the total unchanged. When parking was excluded,
+   * the same movement looked like 500 jobs leaving the system and the
+   * derived ingestion rate lost exactly that much.
+   */
+  describe("when a tenant's groups park", () => {
+    /** @scenario "Parked work counts as in flight" */
+    it("does not change the total when work moves from pending to parked", () => {
+      const before = totalInFlight({
+        queues: [queue({ totalPendingJobs: 900, parkedGroupCount: 0 })],
+      });
+      const after = totalInFlight({
+        queues: [queue({ totalPendingJobs: 400, parkedGroupCount: 500 })],
+      });
+
+      expect(after).toBe(before);
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/ops/in-flight.ts
+++ b/platform/app/src/server/app-layer/ops/in-flight.ts
@@ -1,0 +1,37 @@
+/**
+ * What counts as work IN FLIGHT for the dashboard's throughput arithmetic.
+ *
+ * The ingestion rate is not measured, it is derived: staged ≈ the change in
+ * in-flight work plus what completed and failed over the same window. That
+ * identity only holds if every state staged work can be sitting in is on the
+ * in-flight side of it.
+ *
+ * Parked groups are the case that broke it. A parked group is staged,
+ * unfinished, and returns on its own once its tenant drops back under its
+ * in-flight cap — nothing about it is terminal. Leaving it out made every
+ * group that parked read as work LEAVING the system, so `Staged/s`
+ * under-reported real staging by exactly the parking rate, and the books
+ * balanced only while nothing was parking, which is the one time nobody is
+ * reading the number.
+ *
+ * @see specs/ops/shared-ops-snapshot.feature
+ */
+
+export type InFlightCounts = {
+  totalPendingJobs: number;
+  activeGroupCount: number;
+  parkedGroupCount: number;
+};
+
+export function totalInFlight({
+  queues,
+}: {
+  queues: readonly InFlightCounts[];
+}): number {
+  let total = 0;
+  for (const queue of queues) {
+    total +=
+      queue.totalPendingJobs + queue.activeGroupCount + queue.parkedGroupCount;
+  }
+  return total;
+}

--- a/platform/app/src/server/app-layer/ops/metrics-collector.ts
+++ b/platform/app/src/server/app-layer/ops/metrics-collector.ts
@@ -12,6 +12,7 @@ import {
   mergeHistogramCounts,
   windowPercentiles,
 } from "~/shared/ops/latency";
+import { totalInFlight as computeTotalInFlight } from "./in-flight";
 import { normalizeErrorMessage } from "./normalize-error-message";
 import {
   computeEngineCpuPercent,
@@ -1329,13 +1330,14 @@ export class OpsMetricsCollector {
       const knownPaths = await this.redis.zrange(KNOWN_PIPELINES_KEY, 0, 9999);
       this.knownPipelinePaths = knownPaths;
 
+      // Reported on its own below as `pendingCount`, which stays pending-only.
       let totalPending = 0;
-      let totalActive = 0;
       for (const q of queues) {
         totalPending += q.totalPendingJobs;
-        totalActive += q.activeGroupCount;
       }
-      const totalInFlight = totalPending + totalActive;
+      // Parked groups included: see ./in-flight.ts for why the derived
+      // ingestion rate below is wrong without them.
+      const totalInFlight = computeTotalInFlight({ queues });
 
       const now = Date.now();
       const elapsed = (now - this.lastTimestamp) / 1000;

--- a/specs/migration/authz-grants-rollout.feature
+++ b/specs/migration/authz-grants-rollout.feature
@@ -95,6 +95,22 @@ Feature: Moving an organization onto the grants projection
     Then every restated fact carries the id it carried before
     And no second copy of any fact is appended
 
+  # A restated fact dedupes at the event store, but the queue has already paid
+  # to carry it. A grant is its own aggregate, so a held organization restaged
+  # one group per grant on every worker boot: one organization carries 428,720
+  # share links and converged on nothing while it repeated them.
+  @unit
+  Scenario: A pass states only the facts the heads do not carry
+    Given an organization whose projection already holds some of its facts
+    When a pass runs
+    Then a fact the heads carry unchanged is not stated again
+    And a fact the heads do not carry is stated
+    And a fact whose head is revoked is stated again
+    And a fact whose head disagrees on a field is stated again
+    And a share link whose head only lags on views is not stated again
+    And the first pass over an organization still states everything
+    And the held report is unchanged by what the pass skipped
+
   @unit
   Scenario: A pass that failed partway is safe to repeat
     Given a pass that failed after stating some facts

--- a/specs/ops/shared-ops-snapshot.feature
+++ b/specs/ops/shared-ops-snapshot.feature
@@ -252,3 +252,13 @@ Feature: Shared ops snapshot with a single elected writer
     Given a read found an artifact it could not understand
     When a readable artifact is stored and read
     Then the reader returns it
+
+  # The staging rate is derived from the change in in-flight work, so a state
+  # that holds staged-but-unfinished work has to count as in flight or the
+  # rate reads work as leaving the system when it merely parked.
+  @unit
+  Scenario: Parked work counts as in flight
+    Given a queue holding pending, active, and parked work
+    When the dashboard totals what is in flight
+    Then the total includes the parked groups
+    And work moving from pending into parked leaves the total unchanged


### PR DESCRIPTION
## The problem

A held organization restages its entire fact set on every pass, and a pass runs on **every worker boot** (`startSystemMigrations`; there is no global pass lease, only a per-tenant claim that excludes a *concurrent* pass, not the next one). `migrated` is not terminal, so a held organization is re-driven every time.

The restated facts do dedupe — command ids are content-derived, so the event store swallows them — but that happens **downstream of the queue**, which has already paid to enqueue, dispatch and fold-check every duplicate. Since ADR-101 a grant is its own aggregate, so the cost is one group per grant, per pass.

Measured on the organization it was found on:

| | |
|---|---|
| share links (one fact each) | **428,720** |
| all other families combined | 667 |
| grant rows ever folded | **4,254** |

Every pass restaged all 428,720. The queue sat at ~1M pending and ~800k parked groups, `Failed 0`, and real progress was starved by duplicates of itself.

## The fix

`state()` already had what it needed. The pass reads the heads once at the top — before it states anything — and now filters the staged set against that read, using the check's own predicates (`roleDrifted`, plus new `grantDrifted` / `shareLinkDrifted` wrapping the existing `grantDiffs` / `resourceDiffs`).

That equivalence is the point: **"safe to skip" and "neither `outstanding` nor a diff" are the same condition**, so a pass's report is unchanged by what it skipped. Specifically:

- a fact the heads carry unchanged is not stated again;
- anything the heads **lack**, hold **revoked**, or **disagree with** is still stated;
- a share link whose head only lags on `viewCount` is not restated — that is `outstanding`, and the budget it waits on rides `seedResourceGrantUsage`, which runs every pass regardless;
- the **first** pass over an organization still stages everything;
- a projection that is behind under-reports the heads, which restates a fact needlessly — the pre-existing cost, and still idempotent.

Convergence now shrinks with each pass instead of repeating.

## The number that hid it

`Staged/s` on the ops dashboard is **derived, not counted**: `Δ(pending + active) + completed + failed`. Parked groups were absent from that sum, so every group that parked read as work *leaving* the system, and the rate under-reported real staging by exactly the parking rate. The books balanced only while nothing was parking — the one time nobody reads the number.

The in-flight total moves to `ops/in-flight.ts` with the reasoning and a test that pins the invariant: work moving pending → parked must leave the total unchanged.

## Tests

- `authz-engine.migration.unit.test.ts` — 9 new cases covering skip, each restate condition, share-link lag, first pass, and that the held report is identical to what a restating pass would have produced. 41 pass.
- `in-flight.unit.test.ts` — new, including the pending → parked invariant.
- Full run of both touched trees: 25 files, 264 tests, all passing. Typecheck clean on the touched files (tests included). Biome clean.

Specs: `A pass states only the facts the heads do not carry` and `Parked work counts as in flight`, both `@unit`-tagged, bound, and `check:feature-parity` reports `✓ all bound` for both files.

## Deployment Impact

Behavioural change to a migration that is **live and mid-rollout**. Two things worth knowing:

1. **Rolling this out is itself a pass.** Every booting pod runs one. On a held organization that means one more full restage before the fix takes effect. Consider un-enrolling the large organization first (the cohort read skips unenrolled orgs, so the pass counts them `skipped`), letting the queue drain, then deploying and re-enrolling. Un-enrolment does not touch `migrated` state and does not fire rollback's effects.
2. **No change to what a pass concludes** — only to what it enqueues to get there. Statuses, reports, `finalized` and the gate are untouched.

## Follow-up, not in this PR

`POST /api/trace/:id/share` (`traces-legacy.ts`) mints a **new** share link on every call — `createShare` goes straight to `repo.create` with no dedupe against an existing link for the same trace, and the route passes no `expiresAt` and no `maxViews`. Something has been calling it ~5,000×/day on this organization since at least April, which is where 428,720 permanent, unguessable bearer tokens came from. Worth a decision on idempotency and expiry separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Authorization migrations now avoid restating facts already reflected in projections, while still correcting missing, revoked, or changed access data.
  * Share-link view-count updates are handled without unnecessary restaging.
  * In-flight operations metrics now include parked work for more accurate dashboard totals.

* **Tests**
  * Added coverage for incremental authorization migrations and in-flight work accounting, including pending-to-parked transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->