### PR TITLE
feat(lwql): thread the granularity contract through run-by-chart-id and the REST door

### DIFF
--- a/platform/app/src/app/api/analytics-sql/[[...route]]/app.v1.ts
+++ b/platform/app/src/app/api/analytics-sql/[[...route]]/app.v1.ts
@@ -78,6 +78,13 @@ const lwqlQuerySchema = z.object({
    * which is also why sending either of those under `parameters` is refused.
    */
   timeWindow: lwqlTimeWindowSchema.optional(),
+  /**
+   * The datapoint step for a statement that declares
+   * `{period_granularity_seconds:UInt32}`, in seconds — the REST twin of the
+   * workbench's step control, so a statement's bucketing means the same thing
+   * at both doors. Shape only: the bucket-budget refusal is the service's.
+   */
+  granularitySeconds: z.number().int().positive().optional(),
 });
 
 // Response schemas exist for the published OpenAPI document. The service owns
@@ -100,6 +107,13 @@ const lwqlResultSchema = z.object({
   // What a consumer can say from it is that this result was offered the period
   // beside it, not that the period bounded it.
   followsTimeWindow: z.boolean(),
+  // The granularity facts, mirroring the service's result: whether the
+  // statement declares the reserved parameter at all, the step this run was
+  // bucketed at when one was supplied for it, and — never set on this
+  // caller-owned door today — what a coarsening surface asked for.
+  followsGranularity: z.boolean(),
+  granularitySeconds: z.number().optional(),
+  coarsenedFromSeconds: z.number().optional(),
   diagnostics: z.array(
     z.object({
       // Enumerated rather than a bare string: a consumer branches on the code,
@@ -141,9 +155,7 @@ const lwqlSchemaSchema = z.object({
   ),
 });
 
-export function registerLangWatchQLRoutes(
-  secured: ReturnType<typeof createProjectApp>,
-): void {
+function registerQuery(secured: ReturnType<typeof createProjectApp>): void {
   secured.access(requires("analytics:view")).post(
     "/:projectId/analytics/query/clickhouse",
     describeRoute({
@@ -172,7 +184,8 @@ export function registerLangWatchQLRoutes(
         project: c.get("project"),
         requestedProjectId: c.req.param("projectId"),
       });
-      const { sql, parameters, timeWindow } = c.req.valid("json");
+      const { sql, parameters, timeWindow, granularitySeconds } =
+        c.req.valid("json");
 
       logger.info(
         { projectId: project.id, sqlLength: sql.length },
@@ -187,11 +200,14 @@ export function registerLangWatchQLRoutes(
         sql,
         ...(parameters ? { parameters } : {}),
         ...(timeWindow ? { timeWindow } : {}),
+        ...(granularitySeconds === undefined ? {} : { granularitySeconds }),
       });
       return c.json(result);
     },
   );
+}
 
+function registerSchema(secured: ReturnType<typeof createProjectApp>): void {
   secured.access(requires("analytics:view")).get(
     "/:projectId/analytics/schema",
     describeRoute({
@@ -225,4 +241,17 @@ export function registerLangWatchQLRoutes(
       );
     },
   );
+}
+
+/**
+ * Registers the LangWatchQL analytics SQL routes on the analytics SQL app.
+ *
+ * One function per verb because the house line ceiling is per function; the
+ * split is mechanical and the registration order is the document's.
+ */
+export function registerLangWatchQLRoutes(
+  secured: ReturnType<typeof createProjectApp>,
+): void {
+  registerQuery(secured);
+  registerSchema(secured);
 }

--- a/platform/app/src/app/api/analytics-sql/[[...route]]/app.v1.ts
+++ b/platform/app/src/app/api/analytics-sql/[[...route]]/app.v1.ts
@@ -36,6 +36,7 @@ import {
   LWQL_DIAGNOSTIC_CODES,
   MAX_LWQL_LENGTH,
 } from "~/server/analytics/lwql";
+import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
 import { lwqlTimeWindowSchema } from "~/server/analytics/lwql/timeWindowSchema";
 import { type createProjectApp, requires } from "~/server/api/security";
 import { getProtectionsForProject } from "~/server/api/utils";
@@ -82,9 +83,18 @@ const lwqlQuerySchema = z.object({
    * The datapoint step for a statement that declares
    * `{period_granularity_seconds:UInt32}`, in seconds — the REST twin of the
    * workbench's step control, so a statement's bucketing means the same thing
-   * at both doors. Shape only: the bucket-budget refusal is the service's.
+   * at both doors. Restricted to the steps the surface actually offers
+   * ({@link LWQL_GRANULARITY_STEPS}) rather than any positive integer, so an
+   * off-list value is a clean schema rejection instead of reaching the
+   * service's backstop. The bucket-budget refusal is still the service's.
    */
-  granularitySeconds: z.number().int().positive().optional(),
+  granularitySeconds: z
+    .union([
+      z.literal(LWQL_GRANULARITY_STEPS[0]),
+      z.literal(LWQL_GRANULARITY_STEPS[1]),
+      z.literal(LWQL_GRANULARITY_STEPS[2]),
+    ])
+    .optional(),
 });
 
 // Response schemas exist for the published OpenAPI document. The service owns

--- a/platform/app/src/app/api/analytics-sql/__tests__/lwqlGranularityRestApi.integration.test.ts
+++ b/platform/app/src/app/api/analytics-sql/__tests__/lwqlGranularityRestApi.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The LangWatchQL query endpoint's granularity budget refusal, driven through
+ * the real HTTP app — auth middleware, RBAC, the feature switch, the validator,
+ * the service — against a real Postgres.
+ *
+ * No ClickHouse, for the same reason the saved-charts REST suite needs none:
+ * the refusal under test fires inside the service before any executor is
+ * consulted, so an unprovisioned deployment answers it identically. The
+ * fitting-step control below leans on that on purpose — past the budget gate
+ * this deployment's honest answer is `lwql_unavailable`, which proves the
+ * refusal was about the bucket arithmetic and not about the door.
+ *
+ * The family publishes the canonical error envelope, so the refusal is read at
+ * `body.error.code` with its structured detail at `body.error.meta` — by code,
+ * never by message prose.
+ *
+ * @see specs/analytics/lwql-workbench.feature
+ * @see ~/server/analytics/lwql/resolveTimeWindow.ts — the budget contract
+ */
+
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import type { Organization, Project, Team } from "~/generated/prisma/client";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import {
+  type PlanProvider,
+  PlanProviderService,
+} from "~/server/app-layer/subscription/plan-provider";
+import { prisma } from "~/server/db";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import { app } from "../[[...route]]/app";
+
+type Body = Record<string, any>;
+
+/** Declares the granularity parameter alongside both reserved period bounds. */
+const GRANULARITY_SQL =
+  "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+  "count() AS value FROM analytics.traces " +
+  "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+  "GROUP BY bucket ORDER BY bucket";
+
+/** Seven days, in seconds — the window every request below reports over. */
+const WEEK_SECONDS = 7 * 24 * 3600;
+
+describe("given the LangWatchQL REST query endpoint and the granularity budget", () => {
+  const ns = nanoid(8);
+
+  let organization: Organization;
+  let team: Team;
+  let project: Project;
+
+  const queryPath = (p: Project) =>
+    `/api/v1/projects/${p.id}/analytics/query/clickhouse`;
+
+  const post = async (
+    body: Record<string, unknown>,
+  ): Promise<{
+    status: number;
+    body: Body;
+  }> => {
+    const response = await app.request(queryPath(project), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Auth-Token": project.apiKey,
+      },
+      body: JSON.stringify(body),
+    });
+    return { status: response.status, body: (await response.json()) as Body };
+  };
+
+  beforeAll(async () => {
+    // The surface ships behind the experimental feature switch. The suite runs
+    // with it on via the flag's own env override — the same lever a deployment
+    // uses.
+    process.env.RELEASE_LWQL_WORKBENCH = "1";
+
+    await resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: vi
+          .fn()
+          .mockResolvedValue(FREE_PLAN) as PlanProvider["getActivePlan"],
+      }),
+      usageLimits: {
+        notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+
+    organization = await prisma.organization.create({
+      data: { name: "Granularity org", slug: `granularity-${ns}` },
+    });
+    team = await prisma.team.create({
+      data: {
+        name: "Granularity team",
+        slug: `granularity-${ns}`,
+        organizationId: organization.id,
+      },
+    });
+    project = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: `granularity-${ns}` }),
+        teamId: team.id,
+        personalFeatures: {},
+      },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    delete process.env.RELEASE_LWQL_WORKBENCH;
+    // Guarded on the identifiers actually used, so a setup failure halfway
+    // through never turns an undefined id into a delete that matches every row.
+    if (team && organization) {
+      await prisma.project.deleteMany({ where: { teamId: team.id } });
+      await prisma.team.delete({ where: { id: team.id } });
+      await prisma.organization.delete({ where: { id: organization.id } });
+    }
+  });
+
+  describe("when a statement declaring the parameter is run at one-second steps over a week", () => {
+    /** @scenario "A window that would produce more buckets than the ceiling refuses on the workbench and REST" */
+    it("is refused with the named code and the bucket arithmetic in the envelope's meta", async () => {
+      const { status, body } = await post({
+        sql: GRANULARITY_SQL,
+        timeWindow: {
+          start: "2026-02-20T00:00:00.000Z",
+          end: "2026-02-27T00:00:00.000Z",
+        },
+        granularitySeconds: 1,
+      });
+
+      expect(status).toBe(400);
+      expect(body.error.code).toBe("lwql_granularity_too_fine");
+      expect(body.error.meta).toMatchObject({
+        requestedGranularitySeconds: 1,
+        windowSeconds: WEEK_SECONDS,
+        maxBuckets: 10_000,
+      });
+    });
+  });
+
+  describe("when the same statement is run at an hour, which fits the ceiling", () => {
+    it("gets past the budget gate and reaches the next gate instead", async () => {
+      const { status, body } = await post({
+        sql: GRANULARITY_SQL,
+        timeWindow: {
+          start: "2026-02-20T00:00:00.000Z",
+          end: "2026-02-27T00:00:00.000Z",
+        },
+        granularitySeconds: 3600,
+      });
+
+      // This deployment provisions no LangWatchQL identity, so the honest
+      // answer past the budget gate is unavailability — proving the refusal
+      // above was about the bucket arithmetic and not about the door.
+      expect(status).toBe(503);
+      expect(body.error.code).toBe("lwql_unavailable");
+    });
+  });
+});

--- a/platform/app/src/app/api/analytics-sql/__tests__/lwqlGranularityRestApi.integration.test.ts
+++ b/platform/app/src/app/api/analytics-sql/__tests__/lwqlGranularityRestApi.integration.test.ts
@@ -153,11 +153,14 @@ describe("given the LangWatchQL REST query endpoint and the granularity budget",
         granularitySeconds: 3600,
       });
 
-      // This deployment provisions no LangWatchQL identity, so the honest
-      // answer past the budget gate is unavailability — proving the refusal
-      // above was about the bucket arithmetic and not about the door.
-      expect(status).toBe(503);
-      expect(body.error.code).toBe("lwql_unavailable");
+      // What this proves is that the refusal above was about the bucket
+      // arithmetic and not about the door: at an hour the budget gate lets
+      // the request through to whatever gate comes next. Which gate that is
+      // depends on the deployment (no LWQL identity -> lwql_unavailable;
+      // a provisioned ClickHouse -> the query path itself), so assert only
+      // that the budget refusal is gone, not which honest answer follows.
+      expect(status).not.toBe(400);
+      expect(body.error?.code).not.toBe("lwql_granularity_too_fine");
     });
   });
 });

--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLWorkbench.browser.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLWorkbench.browser.test.tsx
@@ -155,6 +155,7 @@ function evaluationResult(): LangWatchQLQueryResult {
     truncated: false,
     diagnostics: [],
     followsTimeWindow: false,
+    followsGranularity: false,
   };
 }
 

--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLWorkbench.integration.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLWorkbench.integration.test.tsx
@@ -476,6 +476,144 @@ describe("the LangWatchQL workbench", () => {
       });
     });
 
+    describe("when a statement declares the granularity step", () => {
+      /** The refusal a first run of a granularity statement earns. */
+      const awaitingStep = () =>
+        handledErrorEnvelope({
+          code: "lwql_parameter_missing",
+          meta: { parameters: ["period_granularity_seconds"] },
+        });
+
+      /** Runs once so the workbench learns the statement declares the step. */
+      const revealPicker = async () => {
+        harness.mutation.mockRejectedValue(awaitingStep());
+        const editor = await renderWorkbench();
+        typeSql(editor, SQL);
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+        await screen.findByTestId("lwql-granularity");
+        return editor;
+      };
+
+      /** @scenario "The step a statement declares is offered as a control, not as a parameter to fill in" */
+      it("does not ask the member to fill the step in as a parameter", async () => {
+        harness.mutation.mockRejectedValue(awaitingStep());
+
+        const editor = await renderWorkbench();
+        typeSql(editor, SQL);
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+        await screen.findByTestId("lwql-granularity");
+        // The catch-22 this pins: the step was listed as a value to type in,
+        // and typing it is itself refused as a reserved name.
+        const parameters = screen.getByTestId("lwql-parameters");
+        expect(
+          within(parameters).queryByText("Give these parameters a value"),
+        ).toBeNull();
+        expect(parameters).not.toHaveTextContent("period_granularity_seconds");
+      });
+
+      /** @scenario "The step a statement declares is offered as a control, not as a parameter to fill in" */
+      it("still prompts for the member's own missing names, without the step", async () => {
+        harness.mutation.mockRejectedValue(
+          handledErrorEnvelope({
+            code: "lwql_parameter_missing",
+            meta: { parameters: ["period_granularity_seconds", "since"] },
+          }),
+        );
+
+        const editor = await renderWorkbench();
+        typeSql(editor, SQL);
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+        const parameters = await screen.findByTestId("lwql-parameters");
+        const alert = await within(parameters).findByRole("alert");
+        // The member's own omission still has to be reported: filtering the
+        // reserved name must not take the rest of the refusal with it.
+        expect(alert).toHaveTextContent("Give these parameters a value");
+        expect(alert).toHaveTextContent("since");
+        expect(alert).not.toHaveTextContent("period_granularity_seconds");
+      });
+
+      /** @scenario "The step a statement declares is offered as a control, not as a parameter to fill in" */
+      it("offers exactly the steps the contract admits", async () => {
+        await revealPicker();
+
+        const picker = screen.getByTestId("lwql-granularity");
+        for (const label of ["1 second", "1 minute", "1 hour"]) {
+          expect(
+            within(picker).getByRole("button", { name: label }),
+          ).toBeTruthy();
+        }
+      });
+
+      /** @scenario "Choosing a step sends it beside the query rather than among its parameters" */
+      it("sends the chosen step in its own field, never as a parameter", async () => {
+        await revealPicker();
+        harness.mutation.mockResolvedValue(
+          lwqlResult({ followsGranularity: true, granularitySeconds: 60 }),
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "1 minute" }));
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+        await waitFor(() => {
+          const [, input] = harness.mutation.mock.calls.at(-1) ?? [];
+          expect(input).toMatchObject({ granularitySeconds: 60 });
+        });
+        const [, input] = harness.mutation.mock.calls.at(-1) ?? [];
+        const sent = input as { parameters?: Record<string, unknown> };
+        // Sending it as a parameter is what the backend refuses outright.
+        expect(sent.parameters ?? {}).not.toHaveProperty(
+          "period_granularity_seconds",
+        );
+      });
+
+      /** @scenario "A step too fine for the window is refused where the member chose it" */
+      it("shows the too-fine refusal when the chosen step overflows the budget", async () => {
+        await revealPicker();
+        harness.mutation.mockRejectedValue(
+          handledErrorEnvelope({
+            code: "lwql_granularity_too_fine",
+            meta: {
+              granularitySeconds: 1,
+              maxBuckets: 10_000,
+            },
+          }),
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "1 second" }));
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+        // Reachable at all is the point: before the picker there was no way to
+        // ask for a step, so this refusal could not be produced from the UI.
+        await waitFor(() => {
+          const [, input] = harness.mutation.mock.calls.at(-1) ?? [];
+          expect(input).toMatchObject({ granularitySeconds: 1 });
+        });
+        expect(
+          await screen.findByText(
+            "That granularity would return too many datapoints",
+          ),
+        ).toBeTruthy();
+      });
+
+      /** @scenario "Choosing a step sends it beside the query rather than among its parameters" */
+      it("sends no step for a statement that never declared one", async () => {
+        harness.mutation.mockResolvedValue(lwqlResult());
+
+        const editor = await renderWorkbench();
+        typeSql(editor, SQL);
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+        await waitFor(() => expect(harness.mutation).toHaveBeenCalled());
+        expect(screen.queryByTestId("lwql-granularity")).toBeNull();
+        const [, input] = harness.mutation.mock.calls.at(-1) ?? [];
+        // A step sent for an undeclared statement is a reserved value the
+        // backend refuses.
+        expect(input).not.toHaveProperty("granularitySeconds");
+      });
+    });
+
     describe("when the workbench opens on a page whose period selector names a window", () => {
       /** @scenario "The workbench fills the period parameters from the page's period selector" */
       it("shows that window in the spelling the database is bound with", async () => {

--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLWorkbench.integration.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLWorkbench.integration.test.tsx
@@ -568,6 +568,35 @@ describe("the LangWatchQL workbench", () => {
         );
       });
 
+      /** @scenario "Choosing a step sends it beside the query rather than among its parameters" */
+      it("sends the step shown as pressed when the member runs without picking", async () => {
+        await revealPicker();
+
+        // The default renders as pressed the moment the picker appears...
+        expect(screen.getByRole("button", { name: "1 hour" })).toHaveAttribute(
+          "aria-pressed",
+          "true",
+        );
+
+        // ...so running without a click must send that very step. A picker
+        // that shows a pressed default but sends nothing earns the
+        // missing-parameter refusal again — for the reserved name, which the
+        // prompt filter cannot show — leaving a prompt with nothing to name.
+        harness.mutation.mockResolvedValue(
+          lwqlResult({ followsGranularity: true, granularitySeconds: 3600 }),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+        await waitFor(() => {
+          const [, input] = harness.mutation.mock.calls.at(-1) ?? [];
+          expect(input).toMatchObject({ granularitySeconds: 3600 });
+        });
+        // And nothing prompts for a value: the alert that would have named
+        // the reserved step names nothing at all, so it must not render.
+        const parameters = screen.getByTestId("lwql-parameters");
+        expect(within(parameters).queryByRole("alert")).toBeNull();
+      });
+
       /** @scenario "A step too fine for the window is refused where the member chose it" */
       it("shows the too-fine refusal when the chosen step overflows the budget", async () => {
         await revealPicker();
@@ -611,6 +640,151 @@ describe("the LangWatchQL workbench", () => {
         // A step sent for an undeclared statement is a reserved value the
         // backend refuses.
         expect(input).not.toHaveProperty("granularitySeconds");
+      });
+
+      // The two cases below pin `useWorkbenchGranularity`'s own state, held
+      // across renders and keyed on `openedRevision` rather than derived from
+      // the live result. Deriving "does this statement declare the step" from
+      // the result it feeds `setGranularity` fed back into staleness and
+      // looped the render; writing the shown default into the draft on
+      // appearance marked the refusal snapshot stale and withdrew every other
+      // annotation the refusal carried, including the member's own missing
+      // parameters. Neither failure is visible from a single chart — both
+      // need the multi-run, multi-chart sequence these reproduce.
+      describe("when a saved chart is opened after the picker was showing", () => {
+        /** @scenario "The step a statement declares is offered as a control, not as a parameter to fill in" */
+        it("hides the picker for a statement that does not declare the step, and never sends the previous chart's chosen step", async () => {
+          harness.charts = [
+            { id: "chart-a", name: "Chart A" },
+            { id: "chart-b", name: "Chart B" },
+          ];
+          harness.openableChart = {
+            id: "chart-a",
+            name: "Chart A",
+            definition: { sql: SQL, parameters: {} },
+          };
+
+          const editor = await renderWorkbench();
+          await userEvent.click(screen.getByTestId("open-saved-chart"));
+          await userEvent.click(await screen.findByText("Chart A"));
+
+          // Chart A's first run is refused for the unfilled step: the picker
+          // appears and the member picks something other than the default.
+          harness.mutation.mockRejectedValue(awaitingStep());
+          fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+          await screen.findByTestId("lwql-granularity");
+          fireEvent.click(screen.getByRole("button", { name: "1 second" }));
+          expect(
+            screen.getByRole("button", { name: "1 second" }),
+          ).toHaveAttribute("aria-pressed", "true");
+
+          // Opening Chart B replaces the statement with one that never
+          // declares the parameter — nothing has run for it yet, so there is
+          // no refusal to derive "declared" from either way.
+          harness.openableChart = {
+            id: "chart-b",
+            name: "Chart B",
+            definition: { sql: "SELECT 1", parameters: {} },
+          };
+          await userEvent.click(screen.getByTestId("open-saved-chart"));
+          await userEvent.click(await screen.findByText("Chart B"));
+
+          // No leftover picker, and no leftover pick: the workbench must not
+          // go on sending Chart A's `1 second` for a statement that never
+          // asked for a step, which the backend refuses as a reserved value.
+          expect(screen.queryByTestId("lwql-granularity")).toBeNull();
+          harness.mutation.mockResolvedValue(lwqlResult());
+          typeSql(editor, "SELECT 1");
+          fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+          await waitFor(() => expect(harness.mutation).toHaveBeenCalled());
+          const [, input] = harness.mutation.mock.calls.at(-1) ?? [];
+          expect(input).not.toHaveProperty("granularitySeconds");
+        });
+
+        /** @scenario "The step a statement declares is offered as a control, not as a parameter to fill in" */
+        it("shows the picker at its default step for a chart that declares it fresh, not the previous chart's pick", async () => {
+          harness.charts = [
+            { id: "chart-a", name: "Chart A" },
+            { id: "chart-b", name: "Chart B" },
+          ];
+          harness.openableChart = {
+            id: "chart-a",
+            name: "Chart A",
+            definition: { sql: SQL, parameters: {} },
+          };
+
+          await renderWorkbench();
+          await userEvent.click(screen.getByTestId("open-saved-chart"));
+          await userEvent.click(await screen.findByText("Chart A"));
+
+          harness.mutation.mockRejectedValue(awaitingStep());
+          fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+          await screen.findByTestId("lwql-granularity");
+          fireEvent.click(screen.getByRole("button", { name: "1 second" }));
+
+          // Chart B declares the step too, but has never been run — its own
+          // first refusal is what reveals its picker.
+          harness.openableChart = {
+            id: "chart-b",
+            name: "Chart B",
+            definition: { sql: SQL, parameters: {} },
+          };
+          await userEvent.click(screen.getByTestId("open-saved-chart"));
+          await userEvent.click(await screen.findByText("Chart B"));
+          expect(screen.queryByTestId("lwql-granularity")).toBeNull();
+
+          fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+          await screen.findByTestId("lwql-granularity");
+
+          // The coarsest offered step is the default shown before anyone has
+          // picked for THIS chart — never Chart A's leftover `1 second`.
+          expect(
+            screen.getByRole("button", { name: "1 hour" }),
+          ).toHaveAttribute("aria-pressed", "true");
+          expect(
+            screen.getByRole("button", { name: "1 second" }),
+          ).toHaveAttribute("aria-pressed", "false");
+        });
+      });
+
+      describe("when a saved chart declaring the step is opened and the member has not picked", () => {
+        /** @scenario "The step a statement declares is offered as a control, not as a parameter to fill in" */
+        it("still shows the window prompt for a statement missing both the window and the step", async () => {
+          harness.charts = [{ id: "chart-1", name: "Traces per day" }];
+          harness.openableChart = {
+            id: "chart-1",
+            name: "Traces per day",
+            definition: { sql: SQL, parameters: {} },
+          };
+
+          await renderWorkbench();
+          await userEvent.click(screen.getByTestId("open-saved-chart"));
+          await userEvent.click(await screen.findByText("Traces per day"));
+
+          // The refusal names the reserved step alongside a name the member
+          // owns — the exact shape a statement missing both a window
+          // parameter and the step earns on its first run.
+          harness.mutation.mockRejectedValue(
+            handledErrorEnvelope({
+              code: "lwql_parameter_missing",
+              meta: { parameters: ["period_granularity_seconds", "since"] },
+            }),
+          );
+          fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+          // The picker appears, and appearing must not by itself dirty the
+          // draft: if showing the default step marked the refusal snapshot
+          // stale, `failureView` would withdraw every annotation the refusal
+          // carried, including the prompt below for the member's own missing
+          // name — silently, with nothing on screen to explain why.
+          await screen.findByTestId("lwql-granularity");
+          const parameters = await screen.findByTestId("lwql-parameters");
+          const alert = await within(parameters).findByRole("alert");
+          expect(alert).toHaveTextContent("Give these parameters a value");
+          expect(alert).toHaveTextContent("since");
+          expect(alert).not.toHaveTextContent("period_granularity_seconds");
+        });
       });
     });
 

--- a/platform/app/src/features/analytics-query/__tests__/lwqlFixtures.ts
+++ b/platform/app/src/features/analytics-query/__tests__/lwqlFixtures.ts
@@ -119,6 +119,7 @@ export function lwqlResult(
     truncated: false,
     diagnostics: [],
     followsTimeWindow: true,
+    followsGranularity: false,
     ...overrides,
   };
 }

--- a/platform/app/src/features/analytics-query/__tests__/lwqlRequestState.unit.test.ts
+++ b/platform/app/src/features/analytics-query/__tests__/lwqlRequestState.unit.test.ts
@@ -153,6 +153,52 @@ describe("the LangWatchQL request machine", () => {
       });
     });
 
+    describe("when the member changes the granularity step", () => {
+      /** @scenario "Choosing a step sends it beside the query rather than among its parameters" */
+      it("carries the step in its own field, not among the parameters", () => {
+        const { calls, controller } = controllerWith({ sql: "SELECT 1" });
+
+        controller.setGranularity(60);
+        controller.runQuery();
+
+        expect(calls[0]!.request.granularitySeconds).toBe(60);
+        expect(calls[0]!.request.parameters ?? {}).not.toHaveProperty(
+          "period_granularity_seconds",
+        );
+      });
+
+      /** @scenario "Editing SQL or parameters marks the result stale and restores Run query" */
+      it("marks the visible result stale, since it answers a different question", async () => {
+        const { calls, controller } = controllerWith({ sql: "SELECT 1" });
+
+        controller.setGranularity(3600);
+        controller.runQuery();
+        calls[0]!.deferred.resolve(lwqlResult());
+        await settle();
+
+        controller.setGranularity(60);
+
+        // An hourly answer is not the minute-by-minute one just asked for, and
+        // nothing else in the request changed to say so.
+        const state = controller.getState();
+        expect(isLangWatchQLResultStale(state)).toBe(true);
+        expect(lwqlActionLabel(state)).toBe("Run query");
+      });
+
+      /** @scenario "A granularity declared with no step supplied runs on its own authored bucketing" */
+      it("sends no step at all once it is cleared", () => {
+        const { calls, controller } = controllerWith({ sql: "SELECT 1" });
+
+        controller.setGranularity(60);
+        controller.setGranularity(undefined);
+        controller.runQuery();
+
+        // Absent, not present-and-undefined: the door reads an absent field as
+        // "the surface offers no step", which is a different request.
+        expect(calls[0]!.request).not.toHaveProperty("granularitySeconds");
+      });
+    });
+
     describe("when the workbench is disposed before the second submission answers", () => {
       /** @scenario "A stale result stays labelled as belonging to the previous submission" */
       it("leaves the earlier result stale rather than crediting it to the abandoned request", async () => {

--- a/platform/app/src/features/analytics-query/__tests__/useSavedChartWiring.unit.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/useSavedChartWiring.unit.test.tsx
@@ -102,6 +102,7 @@ function fakeQuery(): UseLangWatchQLQuery {
       draft = { ...draft, parameters };
     },
     setTimeWindow: vi.fn(),
+    setGranularity: vi.fn(),
     runQuery: vi.fn(),
     reload: vi.fn(),
     cancelQuery: vi.fn(),

--- a/platform/app/src/features/analytics-query/components/LangWatchQLGranularityPicker.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLGranularityPicker.tsx
@@ -22,6 +22,7 @@ import { Button, HStack, Stack, Text } from "@chakra-ui/react";
 // it: `timeWindow.ts` is import-free so the browser can share the contract's
 // names and steps without dragging the executor in behind them.
 import {
+  type LangWatchQLGranularityStep,
   LWQL_GRANULARITY_STEPS,
   LWQL_PERIOD_GRANULARITY_PARAMETER,
 } from "~/server/analytics/lwql/timeWindow";
@@ -43,7 +44,7 @@ const STEP_SHORT_LABELS: Readonly<Record<number, string>> = {
 export interface LangWatchQLGranularityPickerProps {
   /** The step the next submission carries. */
   value: number;
-  onChange: (granularitySeconds: number) => void;
+  onChange: (granularitySeconds: LangWatchQLGranularityStep) => void;
   /**
    * The step the visible answer was actually bucketed at, when it reports one.
    * `undefined` before anything has run, or when the statement does not declare

--- a/platform/app/src/features/analytics-query/components/LangWatchQLGranularityPicker.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLGranularityPicker.tsx
@@ -1,0 +1,104 @@
+/**
+ * The step a submission buckets at.
+ *
+ * A third value that looks like a parameter and deliberately is not:
+ * `period_granularity_seconds` is supplied by whatever surface is showing the
+ * chart, exactly as the period is, and the backend refuses a request that sends
+ * it among its own named parameters. Offering it as a filled-in parameter would
+ * be offering the member a way to be refused.
+ *
+ * Only the steps the contract admits are offered. An arbitrary number is not a
+ * finer control but a broken one: an off-list step is refused outright, and one
+ * that fits the bucket budget only by accident produces a chart whose buckets
+ * silently stop lining up with everyone else's.
+ *
+ * @see ~/server/analytics/lwql/timeWindow — the contract this fills
+ * @see specs/analytics/lwql-workbench.feature
+ */
+
+import { Button, HStack, Stack, Text } from "@chakra-ui/react";
+
+// The leaf module, never the barrel — same reason the time-window editor reads
+// it: `timeWindow.ts` is import-free so the browser can share the contract's
+// names and steps without dragging the executor in behind them.
+import {
+  LWQL_GRANULARITY_STEPS,
+  LWQL_PERIOD_GRANULARITY_PARAMETER,
+} from "~/server/analytics/lwql/timeWindow";
+
+/** What each admitted step is called where a person reads it. */
+const STEP_LABELS: Readonly<Record<number, string>> = {
+  1: "1 second",
+  60: "1 minute",
+  3600: "1 hour",
+};
+
+/** The short form for the buttons, which sit in a row. */
+const STEP_SHORT_LABELS: Readonly<Record<number, string>> = {
+  1: "1s",
+  60: "1m",
+  3600: "1h",
+};
+
+export interface LangWatchQLGranularityPickerProps {
+  /** The step the next submission carries. */
+  value: number;
+  onChange: (granularitySeconds: number) => void;
+  /**
+   * The step the visible answer was actually bucketed at, when it reports one.
+   * `undefined` before anything has run, or when the statement does not declare
+   * the parameter.
+   */
+  ranAtSeconds?: number | undefined;
+  /**
+   * The step the caller asked for, present only when the run coarsened. No
+   * current workbench door coarsens — it refuses — but a result that says it
+   * coarsened must not be read as one that honoured the request.
+   */
+  coarsenedFromSeconds?: number | undefined;
+}
+
+export function LangWatchQLGranularityPicker({
+  value,
+  onChange,
+  ranAtSeconds,
+  coarsenedFromSeconds,
+}: LangWatchQLGranularityPickerProps) {
+  return (
+    <Stack gap={2} width="full" data-testid="lwql-granularity">
+      <HStack gap={2}>
+        <Text fontSize="13px" fontWeight="600">
+          Granularity
+        </Text>
+        <Text fontSize="12px" color="fg.muted" fontFamily="mono">
+          {`{${LWQL_PERIOD_GRANULARITY_PARAMETER}:UInt32}`}
+        </Text>
+      </HStack>
+
+      <HStack gap={2} flexWrap="wrap">
+        {LWQL_GRANULARITY_STEPS.map((step) => (
+          <Button
+            key={step}
+            size="xs"
+            variant={step === value ? "solid" : "outline"}
+            aria-pressed={step === value}
+            aria-label={STEP_LABELS[step]}
+            onClick={() => onChange(step)}
+          >
+            {STEP_SHORT_LABELS[step]}
+          </Button>
+        ))}
+      </HStack>
+
+      {coarsenedFromSeconds !== undefined && ranAtSeconds !== undefined && (
+        <Text
+          fontSize="12px"
+          color="fg.muted"
+          data-testid="granularity-coarsened"
+        >
+          {`Too many buckets at ${STEP_LABELS[coarsenedFromSeconds] ?? `${coarsenedFromSeconds} seconds`}, so this ran at ${STEP_LABELS[ranAtSeconds] ?? `${ranAtSeconds} seconds`}.`}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/platform/app/src/features/analytics-query/components/LangWatchQLWorkbench.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLWorkbench.tsx
@@ -26,6 +26,12 @@ import {
 } from "react";
 
 import { usePeriodSelector } from "~/components/PeriodSelector";
+// The leaf module, never the barrel — see LangWatchQLTimeWindowEditor.
+import {
+  isLangWatchQLSurfaceParameter,
+  LWQL_GRANULARITY_STEPS,
+  LWQL_PERIOD_GRANULARITY_PARAMETER,
+} from "~/server/analytics/lwql/timeWindow";
 
 import { useLangWatchQLQuery } from "../hooks/useLangWatchQLQuery";
 import { useLangWatchQLSchema } from "../hooks/useLangWatchQLSchema";
@@ -43,6 +49,7 @@ import {
   type LangWatchQLTimeWindowValues,
 } from "../logic/lwqlRequestState";
 import { LangWatchQLEditor } from "./LangWatchQLEditor";
+import { LangWatchQLGranularityPicker } from "./LangWatchQLGranularityPicker";
 import {
   type LangWatchQLParametersChange,
   LangWatchQLParametersEditor,
@@ -61,6 +68,12 @@ interface FailureView {
   readonly markers: readonly LangWatchQLEditorMarker[];
   readonly missingParameters: readonly string[];
   readonly reservedParameters: readonly string[];
+  /**
+   * Whether the last refusal said the statement declares the granularity step
+   * and no value filled it. Shows the picker for a statement that has never
+   * run, which is every granularity statement's first submission.
+   */
+  readonly awaitsGranularity: boolean;
 }
 
 /** Stable identity, so an unchanged "nothing to report" never re-renders a form. */
@@ -68,6 +81,7 @@ const NO_FAILURE_VIEW: FailureView = {
   markers: [],
   missingParameters: [],
   reservedParameters: [],
+  awaitsGranularity: false,
 };
 
 /**
@@ -82,6 +96,26 @@ function chartResultLabel(sql: string): string {
   return collapsed.length > 120 ? `${collapsed.slice(0, 117)}…` : collapsed;
 }
 
+/**
+ * Splits the names a missing-parameter refusal listed into the ones a member
+ * can actually fill in and the reserved ones they cannot.
+ *
+ * A reserved name reaching that list is not a member's omission: it is the
+ * surface's own to supply, and the granularity step's arrives on the very first
+ * run of a statement that declares it. Prompting for it sent the member to a
+ * form where typing the name is itself refused — the catch-22 this split
+ * removes. The step gets its own control instead.
+ */
+function splitMissing(names: readonly string[]): {
+  fillable: readonly string[];
+  reserved: readonly string[];
+} {
+  return {
+    fillable: names.filter((name) => !isLangWatchQLSurfaceParameter(name)),
+    reserved: names.filter((name) => isLangWatchQLSurfaceParameter(name)),
+  };
+}
+
 function failureView(state: LangWatchQLRequestState): FailureView {
   const { outcome } = state;
   if (outcome?.kind !== "error") return NO_FAILURE_VIEW;
@@ -94,17 +128,25 @@ function failureView(state: LangWatchQLRequestState): FailureView {
   if (isLangWatchQLResultStale(state)) return NO_FAILURE_VIEW;
 
   const failure = readLangWatchQLFailure(outcome.error);
+  const missing =
+    failure.code === LWQL_PARAMETER_MISSING_CODE
+      ? splitMissing(failure.parameters)
+      : { fillable: [], reserved: [] };
   return {
     markers: lwqlEditorMarkers(failure),
     // The payload carries one list of names; only the code says what they
     // mean, so only the code decides which form answers them. Every other
     // refusal is about the statement.
-    missingParameters:
-      failure.code === LWQL_PARAMETER_MISSING_CODE ? failure.parameters : [],
+    missingParameters: missing.fillable,
     reservedParameters:
       failure.code === LWQL_RESERVED_PARAMETER_SUPPLIED_CODE
         ? failure.parameters
         : [],
+    // A refusal naming the step is the only way the workbench learns a
+    // statement declares it before anything has successfully run.
+    awaitsGranularity: missing.reserved.includes(
+      LWQL_PERIOD_GRANULARITY_PARAMETER,
+    ),
   };
 }
 
@@ -122,6 +164,118 @@ function followsTimeWindowOf(
   if (state.outcome?.kind !== "result") return undefined;
   if (isLangWatchQLResultStale(state)) return undefined;
   return state.outcome.result.followsTimeWindow;
+}
+
+/**
+ * The step the visible answer was bucketed at, when it reports one.
+ *
+ * Read off the result for the same reason `followsTimeWindow` is: only the
+ * backend parses the statement. Staleness is not consulted, because choosing a
+ * step is itself what makes the visible result stale — and the note this feeds
+ * describes the answer on screen, which is exactly the stale one.
+ */
+function ranAtGranularityOf(state: LangWatchQLRequestState): {
+  ranAt?: number;
+  coarsenedFrom?: number;
+} {
+  if (state.outcome?.kind !== "result") return {};
+  const { result } = state.outcome;
+  return {
+    ...(result.granularitySeconds !== undefined
+      ? { ranAt: result.granularitySeconds }
+      : {}),
+    ...(result.coarsenedFromSeconds !== undefined
+      ? { coarsenedFrom: result.coarsenedFromSeconds }
+      : {}),
+  };
+}
+
+/**
+ * What the last answer said about the statement declaring the step.
+ *
+ * `undefined` when the answer says nothing either way, which is every failure
+ * other than the unfilled-step refusal — a timeout tells you nothing about what
+ * the statement declares, so it must not be read as a denial.
+ *
+ * Deliberately NOT filtered by staleness, unlike `followsTimeWindow`. The step
+ * is part of the draft, so choosing one makes the visible result stale by
+ * definition; hiding the picker on that basis would retract the very control
+ * that was just used. Staleness governs what a result *claims*, not whether the
+ * control that produced it exists.
+ */
+function granularityDeclaredBy(
+  state: LangWatchQLRequestState,
+  awaitsGranularity: boolean,
+): boolean | undefined {
+  if (awaitsGranularity) return true;
+  if (state.outcome?.kind === "result") {
+    return state.outcome.result.followsGranularity;
+  }
+  return undefined;
+}
+
+/**
+ * The step the workbench sends, held for the member.
+ *
+ * Shows the coarsest offered step rather than the finest: the coarsest is the
+ * one that fits the bucket budget over any period a page can show, so the first
+ * run of a granularity statement answers instead of being refused for asking a
+ * finer question than the member ever asked for.
+ *
+ * That shown step is NOT written into the draft until the member picks one, and
+ * the distinction is load-bearing. The picker appears in response to a refusal;
+ * writing to the draft as it appeared would move the draft away from the
+ * snapshot that refusal belongs to, marking it stale — and a stale refusal has
+ * its annotations withdrawn, so the very act of offering the step would erase
+ * the rest of the refusal that prompted it, including the member's own missing
+ * parameters.
+ */
+function useWorkbenchGranularity({
+  query,
+  declared,
+  openedRevision,
+}: {
+  query: ReturnType<typeof useLangWatchQLQuery>;
+  /** What the last answer said, or `undefined` when it said nothing. */
+  declared: boolean | undefined;
+  /** Bumped whenever a saved chart is opened. */
+  openedRevision: number;
+}) {
+  const coarsest =
+    LWQL_GRANULARITY_STEPS[LWQL_GRANULARITY_STEPS.length - 1] ?? 3600;
+  // `null` until the member picks: the shown step is what the control reads,
+  // the chosen step is what the request carries, and only the second is a
+  // change to the draft.
+  const [chosen, setChosen] = useState<number | null>(null);
+  // Held rather than derived per render, and this is load-bearing. Sending the
+  // step puts it in the draft, which makes the visible result stale; deriving
+  // "does it declare one" from that same result would flip the answer back,
+  // clear the step, un-stale the result, and set it again — an update loop
+  // through the store. What the statement declares is a fact about a past
+  // answer, so it is remembered as one.
+  const [shown, setShown] = useState<{ revision: number; on: boolean }>({
+    revision: openedRevision,
+    on: false,
+  });
+
+  // Opening a saved chart replaces the statement, so what the previous one
+  // declared says nothing about this one.
+  const on = shown.revision === openedRevision && shown.on;
+  if (declared !== undefined && declared !== on) {
+    setShown({ revision: openedRevision, on: declared });
+  } else if (shown.revision !== openedRevision) {
+    setShown({ revision: openedRevision, on: false });
+  }
+
+  const { setGranularity } = query;
+  // Cleared while the statement does not declare the parameter: sending a step
+  // for a statement that never asked for one makes it a reserved value the
+  // backend refuses.
+  useEffect(() => {
+    setGranularity(on && chosen !== null ? chosen : undefined);
+  }, [setGranularity, on, chosen]);
+
+  return { value: chosen ?? coarsest, onChange: setChosen, shown: on };
 }
 
 /**
@@ -416,6 +570,11 @@ export function LangWatchQLWorkbench({ projectId }: LangWatchQLWorkbenchProps) {
     query,
     openedRevision: wiring.openedRevision,
   });
+  const granularity = useWorkbenchGranularity({
+    query,
+    declared: granularityDeclaredBy(query.state, failure.awaitsGranularity),
+    openedRevision: wiring.openedRevision,
+  });
   const { shownSpecText, setEditedSpecText } = useSpecDraft(wiring);
 
   return (
@@ -452,6 +611,7 @@ export function LangWatchQLWorkbench({ projectId }: LangWatchQLWorkbenchProps) {
           onToggleSchema={() => setSchemaVisible((visible) => !visible)}
           wiring={wiring}
           timeWindow={timeWindow}
+          granularity={granularity}
           onParametersChange={parameters}
           parametersSendable={parametersSendable}
         />
@@ -540,6 +700,7 @@ function QueryCard({
   onToggleSchema,
   wiring,
   timeWindow,
+  granularity,
   onParametersChange,
   parametersSendable,
 }: {
@@ -551,6 +712,7 @@ function QueryCard({
   onToggleSchema: () => void;
   wiring: ReturnType<typeof useSavedChartWiring>;
   timeWindow: ReturnType<typeof useWorkbenchTimeWindow>;
+  granularity: ReturnType<typeof useWorkbenchGranularity>;
   onParametersChange: (change: LangWatchQLParametersChange) => void;
   parametersSendable: boolean;
 }) {
@@ -620,6 +782,8 @@ function QueryCard({
           onSendableChange={timeWindow.onSendableChange}
         />
 
+        <GranularityRow query={query} granularity={granularity} />
+
         <LangWatchQLParametersEditor
           key={`parameters-${wiring.openedRevision}`}
           onChange={onParametersChange}
@@ -631,6 +795,32 @@ function QueryCard({
         />
       </Box>
     </Box>
+  );
+}
+
+/**
+ * The step picker, shown only once something has said the statement declares
+ * the parameter. Its own component so the read of the result happens once.
+ */
+function GranularityRow({
+  query,
+  granularity,
+}: {
+  query: ReturnType<typeof useLangWatchQLQuery>;
+  granularity: ReturnType<typeof useWorkbenchGranularity>;
+}) {
+  if (!granularity.shown) return null;
+
+  const { ranAt, coarsenedFrom } = ranAtGranularityOf(query.state);
+  return (
+    <LangWatchQLGranularityPicker
+      value={granularity.value}
+      onChange={granularity.onChange}
+      {...(ranAt !== undefined ? { ranAtSeconds: ranAt } : {})}
+      {...(coarsenedFrom !== undefined
+        ? { coarsenedFromSeconds: coarsenedFrom }
+        : {})}
+    />
   );
 }
 

--- a/platform/app/src/features/analytics-query/components/LangWatchQLWorkbench.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLWorkbench.tsx
@@ -29,6 +29,7 @@ import { usePeriodSelector } from "~/components/PeriodSelector";
 // The leaf module, never the barrel — see LangWatchQLTimeWindowEditor.
 import {
   isLangWatchQLSurfaceParameter,
+  type LangWatchQLGranularityStep,
   LWQL_GRANULARITY_STEPS,
   LWQL_PERIOD_GRANULARITY_PARAMETER,
 } from "~/server/analytics/lwql/timeWindow";
@@ -222,13 +223,16 @@ function granularityDeclaredBy(
  * run of a granularity statement answers instead of being refused for asking a
  * finer question than the member ever asked for.
  *
- * That shown step is NOT written into the draft until the member picks one, and
- * the distinction is load-bearing. The picker appears in response to a refusal;
- * writing to the draft as it appeared would move the draft away from the
- * snapshot that refusal belongs to, marking it stale — and a stale refusal has
- * its annotations withdrawn, so the very act of offering the step would erase
- * the rest of the refusal that prompted it, including the member's own missing
- * parameters.
+ * That shown step is NOT written into the draft until the member picks one or
+ * runs, and the distinction is load-bearing. The picker appears in response to
+ * a refusal; writing to the draft as it appeared would move the draft away from
+ * the snapshot that refusal belongs to, marking it stale — and a stale refusal
+ * has its annotations withdrawn, so the very act of offering the step would
+ * erase the rest of the refusal that prompted it, including the member's own
+ * missing parameters. What the picker renders as pressed and what a submission
+ * carries must still be the same number, so `armForRun` writes the shown step
+ * — chosen or default — into the draft at the moment Run is pressed, when
+ * staling the refusal is exactly what running does anyway.
  */
 function useWorkbenchGranularity({
   query,
@@ -245,8 +249,13 @@ function useWorkbenchGranularity({
     LWQL_GRANULARITY_STEPS[LWQL_GRANULARITY_STEPS.length - 1] ?? 3600;
   // `null` until the member picks: the shown step is what the control reads,
   // the chosen step is what the request carries, and only the second is a
-  // change to the draft.
-  const [chosen, setChosen] = useState<number | null>(null);
+  // change to the draft. Keyed to the opened revision the way the window
+  // override is: a step picked while chart A was open must not become the step
+  // chart B renders — or sends — the moment it is opened.
+  const [chosen, setChosen] = useState<{
+    revision: number;
+    step: LangWatchQLGranularityStep;
+  } | null>(null);
   // Held rather than derived per render, and this is load-bearing. Sending the
   // step puts it in the draft, which makes the visible result stale; deriving
   // "does it declare one" from that same result would flip the answer back,
@@ -257,25 +266,59 @@ function useWorkbenchGranularity({
     revision: openedRevision,
     on: false,
   });
+  // The revision the last submission ran under. `declared` is read off the
+  // live outcome, and the outcome does not know which chart earned it: open a
+  // chart whose statement is byte-identical to a refused one and the old
+  // refusal stops being stale — its answer would resurrect the picker for a
+  // chart that has never run. Only an answer produced by this revision's own
+  // run may flip the picker.
+  const [ranRevision, setRanRevision] = useState<number | null>(null);
 
   // Opening a saved chart replaces the statement, so what the previous one
   // declared says nothing about this one.
   const on = shown.revision === openedRevision && shown.on;
-  if (declared !== undefined && declared !== on) {
+  if (
+    declared !== undefined &&
+    ranRevision === openedRevision &&
+    declared !== on
+  ) {
     setShown({ revision: openedRevision, on: declared });
   } else if (shown.revision !== openedRevision) {
     setShown({ revision: openedRevision, on: false });
   }
+
+  const chosenStep =
+    chosen !== null && chosen.revision === openedRevision ? chosen.step : null;
+  const value = chosenStep ?? coarsest;
 
   const { setGranularity } = query;
   // Cleared while the statement does not declare the parameter: sending a step
   // for a statement that never asked for one makes it a reserved value the
   // backend refuses.
   useEffect(() => {
-    setGranularity(on && chosen !== null ? chosen : undefined);
-  }, [setGranularity, on, chosen]);
+    setGranularity(on && chosenStep !== null ? chosenStep : undefined);
+  }, [setGranularity, on, chosenStep]);
 
-  return { value: chosen ?? coarsest, onChange: setChosen, shown: on };
+  const onChange = useCallback(
+    (step: LangWatchQLGranularityStep) =>
+      setChosen({ revision: openedRevision, step }),
+    [openedRevision],
+  );
+
+  // Every submission goes through this rather than `query.runQuery`: while
+  // the picker is on screen, the request must carry the very step it shows as
+  // pressed — a picker that renders a pressed default but sends nothing earns
+  // the missing-parameter refusal for a value the member is looking at. The
+  // controller is synchronous, so arming writes the draft before the same
+  // tick snapshots it.
+  const { runQuery } = query;
+  const run = useCallback(() => {
+    setRanRevision(openedRevision);
+    setGranularity(on ? value : undefined);
+    runQuery();
+  }, [setGranularity, on, value, openedRevision, runQuery]);
+
+  return { value, onChange, shown: on, run };
 }
 
 /**
@@ -511,12 +554,15 @@ function useSpecDraft(wiring: ReturnType<typeof useSavedChartWiring>) {
 /** The result card: every pixel the query card leaves, behind one border. */
 function ResultCard({
   query,
+  onRun,
   insertExample,
   wiring,
   shownSpecText,
   setEditedSpecText,
 }: {
   query: ReturnType<typeof useLangWatchQLQuery>;
+  /** Submits the draft with the shown granularity step armed. */
+  onRun: () => void;
   insertExample: (() => void) | undefined;
   wiring: ReturnType<typeof useSavedChartWiring>;
   shownSpecText: string | null;
@@ -537,7 +583,7 @@ function ResultCard({
     >
       <LangWatchQLResultPane
         state={query.state}
-        onRun={query.runQuery}
+        onRun={onRun}
         {...(insertExample ? { onInsertExample: insertExample } : {})}
         renderChartArea={chartArea({
           state: query.state,
@@ -604,6 +650,7 @@ export function LangWatchQLWorkbench({ projectId }: LangWatchQLWorkbenchProps) {
             it is what buries a result under an empty editor. */}
         <QueryCard
           query={query}
+          onRun={granularity.run}
           schemaModel={schema.model}
           failure={failure}
           registerInsert={registerInsert}
@@ -618,6 +665,7 @@ export function LangWatchQLWorkbench({ projectId }: LangWatchQLWorkbenchProps) {
 
         <ResultCard
           query={query}
+          onRun={granularity.run}
           insertExample={insertExample}
           wiring={wiring}
           shownSpecText={shownSpecText}
@@ -693,6 +741,7 @@ function useParameterState({
 
 function QueryCard({
   query,
+  onRun,
   schemaModel,
   failure,
   registerInsert,
@@ -705,6 +754,8 @@ function QueryCard({
   parametersSendable,
 }: {
   query: ReturnType<typeof useLangWatchQLQuery>;
+  /** Submits the draft with the shown granularity step armed. */
+  onRun: () => void;
   schemaModel: ReturnType<typeof useLangWatchQLSchema>["model"];
   failure: FailureView;
   registerInsert: (insert: ((text: string) => void) | null) => void;
@@ -744,7 +795,7 @@ function QueryCard({
         // result, so this IS a reload — and unlike `reload()` it can never
         // re-send a superseded submission the member is no longer looking
         // at.
-        onRun={query.runQuery}
+        onRun={onRun}
         onCancel={query.cancelQuery}
         savedCharts={
           <BoundSavedCharts
@@ -760,7 +811,7 @@ function QueryCard({
         schema={schemaModel}
         markers={failure.markers}
         registerInsert={registerInsert}
-        onRun={query.runQuery}
+        onRun={onRun}
       />
 
       <Box

--- a/platform/app/src/features/analytics-query/hooks/useLangWatchQLQuery.ts
+++ b/platform/app/src/features/analytics-query/hooks/useLangWatchQLQuery.ts
@@ -44,6 +44,8 @@ export interface UseLangWatchQLQuery {
   ) => void;
   /** Sets the period the next submission reports over, or clears it. */
   setTimeWindow: (timeWindow: LangWatchQLTimeWindowValues | undefined) => void;
+  /** Sets the step the next submission buckets at, or clears it. */
+  setGranularity: (granularitySeconds: number | undefined) => void;
   /** Submits the current draft. Ignored while a request is in flight. */
   runQuery: () => void;
   /** Re-sends the submitted snapshot, never the draft. */
@@ -98,6 +100,11 @@ export function useLangWatchQLQuery({
       controller.setTimeWindow(timeWindow),
     [controller],
   );
+  const setGranularity = useCallback(
+    (granularitySeconds: number | undefined) =>
+      controller.setGranularity(granularitySeconds),
+    [controller],
+  );
   const runQuery = useCallback(() => controller.runQuery(), [controller]);
   const reload = useCallback(() => controller.reload(), [controller]);
   const cancelQuery = useCallback(() => controller.cancel(), [controller]);
@@ -109,6 +116,7 @@ export function useLangWatchQLQuery({
     setSql,
     setParameters,
     setTimeWindow,
+    setGranularity,
     runQuery,
     reload,
     cancelQuery,

--- a/platform/app/src/features/analytics-query/hooks/useLangWatchQLQuery.ts
+++ b/platform/app/src/features/analytics-query/hooks/useLangWatchQLQuery.ts
@@ -16,6 +16,7 @@ import {
   useSyncExternalStore,
 } from "react";
 
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 import { api } from "~/utils/api";
 
 import { createLangWatchQLExecute } from "../logic/lwqlExecute";
@@ -45,7 +46,9 @@ export interface UseLangWatchQLQuery {
   /** Sets the period the next submission reports over, or clears it. */
   setTimeWindow: (timeWindow: LangWatchQLTimeWindowValues | undefined) => void;
   /** Sets the step the next submission buckets at, or clears it. */
-  setGranularity: (granularitySeconds: number | undefined) => void;
+  setGranularity: (
+    granularitySeconds: LangWatchQLGranularityStep | undefined,
+  ) => void;
   /** Submits the current draft. Ignored while a request is in flight. */
   runQuery: () => void;
   /** Re-sends the submitted snapshot, never the draft. */
@@ -101,7 +104,7 @@ export function useLangWatchQLQuery({
     [controller],
   );
   const setGranularity = useCallback(
-    (granularitySeconds: number | undefined) =>
+    (granularitySeconds: LangWatchQLGranularityStep | undefined) =>
       controller.setGranularity(granularitySeconds),
     [controller],
   );

--- a/platform/app/src/features/analytics-query/logic/lwqlExecute.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlExecute.ts
@@ -35,6 +35,7 @@ type LangWatchQLQueryInput = {
   sql: string;
   parameters?: Readonly<Record<string, LangWatchQLParameterValue>>;
   timeWindow?: { start: Date; end: Date };
+  granularitySeconds?: number;
 };
 
 /**

--- a/platform/app/src/features/analytics-query/logic/lwqlExecute.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlExecute.ts
@@ -13,6 +13,7 @@
 import { getUntypedClient } from "@trpc/client";
 
 import type { LangWatchQLQueryResult } from "~/server/analytics/lwql";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 import type { api, RouterInputs } from "~/utils/api";
 
 import type { LangWatchQLExecute } from "./lwqlRequestController";
@@ -35,7 +36,7 @@ type LangWatchQLQueryInput = {
   sql: string;
   parameters?: Readonly<Record<string, LangWatchQLParameterValue>>;
   timeWindow?: { start: Date; end: Date };
-  granularitySeconds?: number;
+  granularitySeconds?: LangWatchQLGranularityStep;
 };
 
 /**

--- a/platform/app/src/features/analytics-query/logic/lwqlRequestController.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlRequestController.ts
@@ -39,6 +39,13 @@ export interface LangWatchQLExecuteRequest {
    * was supposed to own.
    */
   readonly timeWindow?: LangWatchQLTimeWindowValues;
+  /**
+   * The bucketing step this submission asks for. Travels in its own field for
+   * the same reason the window does — the backend refuses it as a named
+   * parameter, because a chart pinning its own step would ignore the one the
+   * surface showing it chose.
+   */
+  readonly granularitySeconds?: number;
 }
 
 /** How a submission reaches the server. */
@@ -63,6 +70,14 @@ export interface LangWatchQLRequestController {
    * caller that tries to send it as one.
    */
   setTimeWindow(timeWindow: LangWatchQLTimeWindowValues | undefined): void;
+  /**
+   * Sets the step the next submission buckets at, or clears it.
+   *
+   * Separate from {@link LangWatchQLRequestController.setParameters} for the
+   * same reason the window is: the surface supplies it, and the backend refuses
+   * a caller that sends it as a parameter of its own.
+   */
+  setGranularity(granularitySeconds: number | undefined): void;
   /** Submits the current draft. No-op while a request is in flight. */
   runQuery(): void;
   /**
@@ -100,6 +115,9 @@ function requestFor(snapshot: LangWatchQLSnapshot): LangWatchQLExecuteRequest {
     sql: snapshot.sql,
     ...(Object.keys(parameters).length > 0 ? { parameters } : {}),
     ...(snapshot.timeWindow ? { timeWindow: snapshot.timeWindow } : {}),
+    ...(snapshot.granularitySeconds !== undefined
+      ? { granularitySeconds: snapshot.granularitySeconds }
+      : {}),
   };
 }
 
@@ -166,6 +184,10 @@ export function createLangWatchQLRequestController({
 
     setTimeWindow(timeWindow) {
       apply({ type: "timeWindowChanged", timeWindow });
+    },
+
+    setGranularity(granularitySeconds) {
+      apply({ type: "granularityChanged", granularitySeconds });
     },
 
     runQuery() {

--- a/platform/app/src/features/analytics-query/logic/lwqlRequestController.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlRequestController.ts
@@ -16,6 +16,7 @@
  */
 
 import type { LangWatchQLQueryResult } from "~/server/analytics/lwql";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 
 import {
   initialLangWatchQLRequestState,
@@ -45,7 +46,7 @@ export interface LangWatchQLExecuteRequest {
    * parameter, because a chart pinning its own step would ignore the one the
    * surface showing it chose.
    */
-  readonly granularitySeconds?: number;
+  readonly granularitySeconds?: LangWatchQLGranularityStep;
 }
 
 /** How a submission reaches the server. */
@@ -77,7 +78,9 @@ export interface LangWatchQLRequestController {
    * same reason the window is: the surface supplies it, and the backend refuses
    * a caller that sends it as a parameter of its own.
    */
-  setGranularity(granularitySeconds: number | undefined): void;
+  setGranularity(
+    granularitySeconds: LangWatchQLGranularityStep | undefined,
+  ): void;
   /** Submits the current draft. No-op while a request is in flight. */
   runQuery(): void;
   /**

--- a/platform/app/src/features/analytics-query/logic/lwqlRequestState.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlRequestState.ts
@@ -51,6 +51,16 @@ export interface LangWatchQLSnapshot {
    * that only ever writes unbounded statements.
    */
   readonly timeWindow?: LangWatchQLTimeWindowValues;
+  /**
+   * The step the surface supplies for the reserved `period_granularity_seconds`
+   * parameter, when it offers one.
+   *
+   * Part of the snapshot for the same reason the window is: it is part of the
+   * request. A result bucketed by the hour is not the answer to the same
+   * question asked by the second, and only a snapshot that carries the step can
+   * say the one on screen has gone stale.
+   */
+  readonly granularitySeconds?: number;
 }
 
 /**
@@ -119,6 +129,10 @@ export type LangWatchQLRequestAction =
       readonly type: "timeWindowChanged";
       readonly timeWindow: LangWatchQLTimeWindowValues | undefined;
     }
+  | {
+      readonly type: "granularityChanged";
+      readonly granularitySeconds: number | undefined;
+    }
   | { readonly type: "submitted"; readonly snapshot: LangWatchQLSnapshot }
   | {
       readonly type: "settled";
@@ -172,7 +186,8 @@ export function lwqlSnapshotsMatch(
   return (
     a.sql === b.sql &&
     parametersMatch(a.parameters, b.parameters) &&
-    timeWindowsMatch(a.timeWindow, b.timeWindow)
+    timeWindowsMatch(a.timeWindow, b.timeWindow) &&
+    a.granularitySeconds === b.granularitySeconds
   );
 }
 
@@ -198,6 +213,8 @@ export function lwqlRequestReducer(
       return withParameters(state, action.parameters);
     case "timeWindowChanged":
       return withTimeWindow(state, action.timeWindow);
+    case "granularityChanged":
+      return withGranularity(state, action.granularitySeconds);
     case "submitted":
       return withSubmission(state, action.snapshot);
     case "settled":
@@ -232,6 +249,24 @@ function withTimeWindow(
   return {
     ...state,
     draft: { ...rest, ...(timeWindow ? { timeWindow } : {}) },
+  };
+}
+
+function withGranularity(
+  state: LangWatchQLRequestState,
+  granularitySeconds: number | undefined,
+): LangWatchQLRequestState {
+  if (granularitySeconds === state.draft.granularitySeconds) return state;
+  // Dropped rather than set to `undefined`, matching the window above: the
+  // request builder spreads the draft, and a present-but-undefined key is a
+  // different request shape from an absent one.
+  const { granularitySeconds: _dropped, ...rest } = state.draft;
+  return {
+    ...state,
+    draft: {
+      ...rest,
+      ...(granularitySeconds !== undefined ? { granularitySeconds } : {}),
+    },
   };
 }
 

--- a/platform/app/src/features/analytics-query/logic/lwqlRequestState.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlRequestState.ts
@@ -16,6 +16,7 @@
  */
 
 import type { LangWatchQLQueryResult } from "~/server/analytics/lwql";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 
 /**
  * A bound parameter's value. Scalars only, matching what the API accepts — a
@@ -60,7 +61,7 @@ export interface LangWatchQLSnapshot {
    * question asked by the second, and only a snapshot that carries the step can
    * say the one on screen has gone stale.
    */
-  readonly granularitySeconds?: number;
+  readonly granularitySeconds?: LangWatchQLGranularityStep;
 }
 
 /**
@@ -131,7 +132,7 @@ export type LangWatchQLRequestAction =
     }
   | {
       readonly type: "granularityChanged";
-      readonly granularitySeconds: number | undefined;
+      readonly granularitySeconds: LangWatchQLGranularityStep | undefined;
     }
   | { readonly type: "submitted"; readonly snapshot: LangWatchQLSnapshot }
   | {
@@ -254,7 +255,7 @@ function withTimeWindow(
 
 function withGranularity(
   state: LangWatchQLRequestState,
-  granularitySeconds: number | undefined,
+  granularitySeconds: LangWatchQLGranularityStep | undefined,
 ): LangWatchQLRequestState {
   if (granularitySeconds === state.draft.granularitySeconds) return state;
   // Dropped rather than set to `undefined`, matching the window above: the

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -376,6 +376,14 @@ const presentations = {
     describe: () =>
       "Declare period_start and period_end as DateTime, for example {period_start:DateTime}, and run the query again.",
   },
+  // `LangWatchQLReservedGranularityTypeError` carries a `granularityFault` of
+  // either `"declared-type"` or `"step-value"`, but the three doors that can
+  // reach this code (REST, the ad-hoc tRPC query, run-by-chart-id) now reject
+  // an off-list `granularitySeconds` at their own zod schema before a request
+  // ever reaches the service's `"step-value"` backstop, so this code is only
+  // ever live for the declaration-type fault today. One message, not a
+  // `meta`-branched pair, for a discriminator whose other branch is
+  // unreachable from every current caller.
   lwql_granularity_parameter_type: {
     title: "The granularity has to be declared as UInt32",
     describe: () =>

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -771,6 +771,7 @@ describe("given the LangWatchQL service", () => {
       });
       expect(validated.awaitingTimeWindow).toEqual([
         "period_end",
+        "period_granularity_seconds",
         "period_start",
       ]);
     });

--- a/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwql.service.unit.test.ts
@@ -703,6 +703,138 @@ describe("given the LangWatchQL service", () => {
     });
   });
 
+  describe("when the statement declares the granularity parameter", () => {
+    const GRANULARITY_SQL =
+      "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+      "count() AS value FROM analytics.traces " +
+      "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+      "GROUP BY bucket ORDER BY bucket";
+    const TIME_WINDOW = {
+      start: new Date("2026-02-20T00:00:00.000Z"),
+      end: new Date("2026-02-27T00:00:00.000Z"),
+    };
+    /** Seven days, in seconds — the window's own arithmetic. */
+    const WEEK_SECONDS = 7 * 24 * 3600;
+
+    /** @scenario "A chart declaring the granularity parameter runs at the step the surface supplies" */
+    it("binds the supplied step alongside the surface's window and reports both facts", async () => {
+      const executor = recordingExecutor();
+
+      const result = await serviceWith(executor).execute({
+        project: PROJECT,
+        protections: FULLY_PERMITTED,
+        sql: GRANULARITY_SQL,
+        timeWindow: TIME_WINDOW,
+        granularitySeconds: 3600,
+      });
+
+      expect(executor.calls[0]!.parameters).toEqual({
+        period_start: "2026-02-20 00:00:00",
+        period_end: "2026-02-27 00:00:00",
+        period_granularity_seconds: 3600,
+      });
+      expect(result.followsGranularity).toBe(true);
+      expect(result.granularitySeconds).toBe(3600);
+      expect(result.followsTimeWindow).toBe(true);
+      // Nothing coarsened: an hour over a week fits the ceiling comfortably.
+      expect(result.coarsenedFromSeconds).toBeUndefined();
+    });
+
+    /** @scenario "A declared granularity with no step supplied refuses to run naming the parameter" */
+    it("refuses to run when no step was supplied, naming the parameter", async () => {
+      const executor = recordingExecutor();
+      const service = serviceWith(executor);
+      const run = () =>
+        service.execute({
+          project: PROJECT,
+          protections: FULLY_PERMITTED,
+          sql: GRANULARITY_SQL,
+          timeWindow: TIME_WINDOW,
+        });
+
+      expect(await codeOf(run)).toBe("lwql_parameter_missing");
+      expect(await metaOf(run)).toEqual({
+        parameters: ["period_granularity_seconds"],
+      });
+      expect(
+        executor.calls,
+        "a declared step with no value reached the database",
+      ).toHaveLength(0);
+
+      // Saving is not running: the same statement validates for a save with
+      // nothing refused, because the step belongs to whoever later renders
+      // the chart.
+      const validated = service.validate({
+        projectId: PROJECT.id,
+        protections: FULLY_PERMITTED,
+        sql: GRANULARITY_SQL,
+      });
+      expect(validated.awaitingTimeWindow).toEqual([
+        "period_end",
+        "period_start",
+      ]);
+    });
+
+    it("refuses a window finer than the bucket ceiling before execution, carrying the arithmetic", async () => {
+      const executor = recordingExecutor();
+      const service = serviceWith(executor);
+      const run = () =>
+        service.execute({
+          project: PROJECT,
+          protections: FULLY_PERMITTED,
+          sql: GRANULARITY_SQL,
+          timeWindow: TIME_WINDOW,
+          granularitySeconds: 1,
+        });
+
+      expect(await codeOf(run)).toBe("lwql_granularity_too_fine");
+      expect(await metaOf(run)).toMatchObject({
+        requestedGranularitySeconds: 1,
+        windowSeconds: WEEK_SECONDS,
+        maxBuckets: 10_000,
+      });
+      expect(
+        executor.calls,
+        "an overflowing budget reached the database",
+      ).toHaveLength(0);
+    });
+
+    it("runs a statement that does not declare the parameter untouched, reporting that it does not follow granularity", async () => {
+      const executor = recordingExecutor();
+
+      const result = await serviceWith(executor).execute({
+        project: PROJECT,
+        protections: FULLY_PERMITTED,
+        sql: BOUNDED_COUNT,
+        granularitySeconds: 60,
+      });
+
+      expect(result.followsGranularity).toBe(false);
+      expect(result.granularitySeconds).toBeUndefined();
+      expect(
+        executor.calls[0]!.parameters,
+        "a step was injected into a statement that never asked for one",
+      ).toBeUndefined();
+    });
+
+    it("refuses a malformed step as a wrong declaration rather than running it", async () => {
+      for (const step of [0, -60, 1.5]) {
+        expect(
+          await codeOf(() =>
+            serviceWith(recordingExecutor()).execute({
+              project: PROJECT,
+              protections: FULLY_PERMITTED,
+              sql: GRANULARITY_SQL,
+              timeWindow: TIME_WINDOW,
+              granularitySeconds: step,
+            }),
+          ),
+          `step ${step}`,
+        ).toBe("lwql_granularity_parameter_type");
+      }
+    });
+  });
+
   describe("when no restricted identity is provisioned", () => {
     /**
      * Fail-closed. The alternative — running a customer's SQL as the

--- a/platform/app/src/server/analytics/lwql/index.ts
+++ b/platform/app/src/server/analytics/lwql/index.ts
@@ -51,8 +51,14 @@ export {
   LangWatchQLService,
   setLangWatchQLService,
 } from "./lwql.service";
-export type { LangWatchQLTimeWindowResolution } from "./resolveTimeWindow";
-export { resolveLangWatchQLTimeWindow } from "./resolveTimeWindow";
+export type {
+  LangWatchQLGranularityResolution,
+  LangWatchQLTimeWindowResolution,
+} from "./resolveTimeWindow";
+export {
+  resolveLangWatchQLGranularity,
+  resolveLangWatchQLTimeWindow,
+} from "./resolveTimeWindow";
 export type {
   LangWatchQLSchema,
   LangWatchQLSchemaColumn,

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -14,6 +14,9 @@
  *  3. Validate, then resolve the surface's time window into the reserved
  *     parameters the statement declares (`./resolveTimeWindow.ts`) — in that order,
  *     because an injected window is what satisfies the missing-parameter check.
+ *     The granularity declaration is resolved the same way at run, refusing on
+ *     bucket-budget overflow: every door through here is caller-owned, so a
+ *     step finer than the period allows is refused rather than coarsened.
  *     A refusal is thrown as the validator's own handled error and the query
  *     never reaches the database.
  *  4. Execute as the restricted identity, carrying the caller's tenant
@@ -69,10 +72,13 @@ import {
 } from "./executor";
 import {
   assertLangWatchQLGranularityDeclaration,
+  type LangWatchQLGranularityResolution,
+  resolveLangWatchQLGranularity,
   resolveLangWatchQLTimeWindow,
 } from "./resolveTimeWindow";
 import { describeLangWatchQLSchema, type LangWatchQLSchema } from "./schema";
 import type { LangWatchQLTimeWindow } from "./timeWindow";
+import { LWQL_PERIOD_GRANULARITY_PARAMETER } from "./timeWindow";
 import { lwqlValidationError } from "./validation/errors";
 import {
   type AcceptedLangWatchQL,
@@ -80,6 +86,73 @@ import {
 } from "./validation/validate";
 
 const logger = createLogger("langwatch:analytics:lwql");
+
+/**
+ * The run-path half of the reserved-parameter contract, as one step: resolve
+ * what the caller's window and step mean for this request on a caller-owned
+ * door, then refuse when any declared reserved name would still reach the
+ * database without a value — one refusal naming everything the surface forgot
+ * rather than only its first omission.
+ *
+ * An unvalued declared name cannot simply ride along: ClickHouse answers a
+ * missing substitution with `UNKNOWN_QUERY_PARAMETER`, which reaches the caller
+ * as an unknown 500 for something a surface can fix by sending its window or
+ * step. Refusing here, before execution, is what turns that into a named code.
+ *
+ * @throws {LangWatchQLReservedGranularityTypeError} for a mistyped declaration
+ *   or malformed step, {@link LangWatchQLReservedParameterSuppliedError} when
+ *   the request carries a surface-owned value,
+ *   {@link LangWatchQLGranularityTooFineError} on bucket-budget overflow, and
+ *   {@link LangWatchQLParameterMissingError} when a declared reserved name has
+ *   no value.
+ */
+function resolveRunGranularityOrRefuseUnfilled({
+  declared,
+  parameters,
+  timeWindow,
+  granularitySeconds,
+  awaitingTimeWindow,
+}: {
+  /** Bound parameters the validated statement declares. */
+  readonly declared: Parameters<
+    typeof resolveLangWatchQLGranularity
+  >[0]["declared"];
+  /** Values the caller sent. */
+  readonly parameters?: Readonly<Record<string, unknown>>;
+  /** The period the surface is showing, when it has one. */
+  readonly timeWindow?: LangWatchQLTimeWindow;
+  /** The step the caller-owned surface chose, when it offers one. */
+  readonly granularitySeconds?: number;
+  /**
+   * Reserved window names no window filled — already computed by validate,
+   * joined here so one refusal can name every omission together.
+   */
+  readonly awaitingTimeWindow: readonly string[];
+}): LangWatchQLGranularityResolution {
+  // Caller-owned doors resolve the granularity contract with refuse on
+  // overflow: whoever is asking picked the step, so coarsening it for them
+  // would change the answer they asked for.
+  const granularity = resolveLangWatchQLGranularity({
+    declared,
+    ...(parameters ? { parameters } : {}),
+    ...(granularitySeconds !== undefined ? { granularitySeconds } : {}),
+    ...(timeWindow ? { timeWindow } : {}),
+    onBudgetOverflow: "refuse",
+  });
+
+  const unfilledReserved = [
+    ...awaitingTimeWindow,
+    ...(granularity.followsGranularity &&
+    granularity.granularitySeconds === undefined
+      ? [LWQL_PERIOD_GRANULARITY_PARAMETER]
+      : []),
+  ].sort();
+  if (unfilledReserved.length > 0) {
+    throw new LangWatchQLParameterMissingError(unfilledReserved);
+  }
+
+  return granularity;
+}
 
 /** What a caller gets back from the query endpoint. */
 export interface LangWatchQLQueryResult {
@@ -111,6 +184,28 @@ export interface LangWatchQLQueryResult {
    * @see ./timeWindow.ts
    */
   readonly followsTimeWindow: boolean;
+  /**
+   * Whether the statement declares the reserved granularity parameter at all.
+   *
+   * Like `followsTimeWindow`, declaring is all this reports: the author writes
+   * the bucketing expression, so a declaration the SQL never multiplies an
+   * interval with still answers `true`.
+   */
+  readonly followsGranularity: boolean;
+  /**
+   * The step this run was bucketed at, present when the statement declares the
+   * granularity parameter and the caller supplied a step for it. Absent
+   * otherwise — an undeclared statement keeps whatever bucketing its SQL
+   * hard-codes.
+   */
+  readonly granularitySeconds?: number;
+  /**
+   * The step the caller asked for, present only when this run coarsened.
+   * Every current caller refuses on overflow rather than coarsening, so this
+   * is never set through {@link execute} today; it is carried so the result
+   * shape is already the one the dashboard's coarsening door reports into.
+   */
+  readonly coarsenedFromSeconds?: number;
 }
 
 /** The tenant a query runs for. Only these two fields are ever needed. */
@@ -140,6 +235,16 @@ export interface LangWatchQLExecuteInput {
    * @see ./timeWindow.ts
    */
   readonly timeWindow?: LangWatchQLTimeWindow;
+  /**
+   * The datapoint step the caller-owned surface chose, in seconds, for a
+   * statement that declares `{period_granularity_seconds:UInt32}`. Injected
+   * like the window and refused when the period at this step would overflow
+   * the bucket ceiling — every door through {@link execute} belongs to a
+   * caller who picked the step, so there is no coarsening to hide behind.
+   *
+   * Ignored by a statement that does not declare the parameter.
+   */
+  readonly granularitySeconds?: number;
 }
 
 /**
@@ -337,6 +442,12 @@ export class LangWatchQLService {
       // A reserved name with no window yet is not missing — it is deferred to
       // the surface, and `execute` is where that becomes a refusal.
       .filter((name) => !window.awaitingTimeWindow.includes(name))
+      // The granularity is surface-owned exactly like the window bounds, so a
+      // declaration with no step yet is deferred rather than missing: a save
+      // request can never legitimately carry one (the reserved-supplied sweep
+      // above refuses it), and demanding it here would leave every chart that
+      // declares the parameter unsavable.
+      .filter((name) => name !== LWQL_PERIOD_GRANULARITY_PARAMETER)
       .sort();
     if (missing.length > 0) throw new LangWatchQLParameterMissingError(missing);
 
@@ -354,7 +465,10 @@ export class LangWatchQLService {
    *
    * @throws the validator's handled error when the policy refuses the query,
    *   {@link LangWatchQLParameterMissingError} when a declared parameter has no
-   *   value, and {@link LangWatchQLUnavailableError} when no LangWatchQL identity
+   *   value — including a declared granularity with no step supplied —
+   *   {@link LangWatchQLGranularityTooFineError} when the period at the
+   *   supplied step overflows the bucket ceiling, and
+   *   {@link LangWatchQLUnavailableError} when no LangWatchQL identity
    *   is provisioned.
    */
   async execute({
@@ -363,6 +477,7 @@ export class LangWatchQLService {
     sql,
     parameters,
     timeWindow,
+    granularitySeconds,
   }: LangWatchQLExecuteInput): Promise<LangWatchQLQueryResult> {
     const validation = this.validate({
       projectId: project.id,
@@ -371,13 +486,13 @@ export class LangWatchQLService {
       ...(parameters ? { parameters } : {}),
       ...(timeWindow ? { timeWindow } : {}),
     });
-
-    // A statement that asks for the period but was handed none cannot run: the
-    // database would answer `UNKNOWN_QUERY_PARAMETER`, which reaches the caller
-    // as an unknown 500 for something a surface can fix by sending its window.
-    if (validation.awaitingTimeWindow.length > 0) {
-      throw new LangWatchQLParameterMissingError(validation.awaitingTimeWindow);
-    }
+    const granularity = resolveRunGranularityOrRefuseUnfilled({
+      declared: validation.parameters,
+      ...(parameters ? { parameters } : {}),
+      ...(granularitySeconds !== undefined ? { granularitySeconds } : {}),
+      ...(timeWindow ? { timeWindow } : {}),
+      awaitingTimeWindow: validation.awaitingTimeWindow,
+    });
 
     // Fail closed. The check is here rather than in the constructor so that a
     // deployment with no LangWatchQL identity still answers the schema endpoint,
@@ -392,12 +507,52 @@ export class LangWatchQLService {
       throw new LangWatchQLUnavailableError();
     }
 
+    return await this.executeValidated({
+      executor,
+      project,
+      sql,
+      validation,
+      granularity,
+    });
+  }
+
+  /**
+   * Runs a statement that passed every gate as the restricted identity, and
+   * shapes what came back with the facts those gates recorded.
+   *
+   * Split from {@link execute} because it is the half of the order that has no
+   * more decisions to make — only the database call, the advisory diagnostics
+   * over its answer, and the result both of them describe.
+   */
+  private async executeValidated({
+    executor,
+    project,
+    sql,
+    validation,
+    granularity,
+  }: {
+    readonly executor: LangWatchQLExecutor;
+    readonly project: LangWatchQLCaller;
+    readonly sql: string;
+    readonly validation: ValidatedLangWatchQL;
+    readonly granularity: LangWatchQLGranularityResolution;
+  }): Promise<LangWatchQLQueryResult> {
+    // The resolved record plus the step this run was bucketed at, when the
+    // statement declares the parameter. Built unconditionally and omitted when
+    // empty, so an unparameterised query keeps the request shape it had.
+    const executionParameters = {
+      ...validation.boundParameters,
+      ...(granularity.granularitySeconds === undefined
+        ? {}
+        : {
+            [LWQL_PERIOD_GRANULARITY_PARAMETER]: granularity.granularitySeconds,
+          }),
+    };
+
     const execution = await executor.execute({
       sql,
-      // The resolved record, not the caller's: it is the one carrying the
-      // window this surface injected.
-      ...(validation.boundParameters
-        ? { parameters: validation.boundParameters }
+      ...(Object.keys(executionParameters).length > 0
+        ? { parameters: executionParameters }
         : {}),
       tenantCapability: lwqlTenantCapability({
         secret: project.lwqlKey,
@@ -430,6 +585,7 @@ export class LangWatchQLService {
         truncated: execution.truncated,
         diagnostics: diagnostics.map((diagnostic) => diagnostic.code),
         followsTimeWindow: validation.followsTimeWindow,
+        followsGranularity: granularity.followsGranularity,
       },
       "LangWatchQL executed",
     );
@@ -441,6 +597,13 @@ export class LangWatchQLService {
       truncated: execution.truncated,
       diagnostics,
       followsTimeWindow: validation.followsTimeWindow,
+      followsGranularity: granularity.followsGranularity,
+      ...(granularity.granularitySeconds === undefined
+        ? {}
+        : { granularitySeconds: granularity.granularitySeconds }),
+      ...(granularity.coarsenedFromSeconds === undefined
+        ? {}
+        : { coarsenedFromSeconds: granularity.coarsenedFromSeconds }),
     };
   }
 }

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -140,8 +140,13 @@ function resolveRunGranularityOrRefuseUnfilled({
     onBudgetOverflow: "refuse",
   });
 
+  // Validate lists a declared granularity as awaiting alongside the window
+  // pair; whether it is actually unfilled is this resolver's answer, so the
+  // name is re-derived from the resolution rather than carried over.
   const unfilledReserved = [
-    ...awaitingTimeWindow,
+    ...awaitingTimeWindow.filter(
+      (name) => name !== LWQL_PERIOD_GRANULARITY_PARAMETER,
+    ),
     ...(granularity.followsGranularity &&
     granularity.granularitySeconds === undefined
       ? [LWQL_PERIOD_GRANULARITY_PARAMETER]

--- a/platform/app/src/server/analytics/lwql/timeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/timeWindow.ts
@@ -129,6 +129,10 @@ export function isLangWatchQLGranularityParameterType(type: string): boolean {
  */
 export const LWQL_GRANULARITY_STEPS = [1, 60, 3600] as const;
 
+/** One of the offered steps — the only values any door accepts. */
+export type LangWatchQLGranularityStep =
+  (typeof LWQL_GRANULARITY_STEPS)[number];
+
 /** Whether a parameter name is one the surface owns. */
 export function isLangWatchQLTimeWindowParameter(
   name: string,

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts
@@ -17,6 +17,10 @@ import type { CustomGraph } from "~/generated/prisma/client";
 
 import type { Protections } from "../../../traces/protections";
 import { WORKBENCH_SQL_CHART_KIND } from "../../chartKinds";
+import type {
+  LangWatchQLExecutionRequest,
+  LangWatchQLExecutor,
+} from "../../lwql/executor";
 import { LangWatchQLService } from "../../lwql/lwql.service";
 import type {
   CreateSavedWorkbenchChartInput,
@@ -173,13 +177,43 @@ class FakeStore implements SavedWorkbenchChartStore {
   }
 }
 
-function build() {
+/**
+ * An executor that records what it was asked to run and answers a fixed small
+ * result — the same fake the LangWatchQL service suite drives, because the
+ * claims worth making about a run are "what reached the database", which is an
+ * artifact to inspect rather than a call sequence to verify.
+ */
+function recordingExecutor(): LangWatchQLExecutor & {
+  readonly calls: LangWatchQLExecutionRequest[];
+} {
+  const calls: LangWatchQLExecutionRequest[] = [];
+  return {
+    calls,
+    async execute(request) {
+      calls.push(request);
+      return {
+        columns: [{ name: "value", type: "UInt64" }],
+        rows: [{ value: 7 }],
+        truncated: false,
+        statistics: {
+          elapsedMs: 2,
+          rowsRead: 4,
+          bytesRead: 40,
+          rowsReturned: 1,
+        },
+      };
+    },
+  };
+}
+
+function build(executor: LangWatchQLExecutor | null = null) {
   const store = new FakeStore();
   const service = new SavedWorkbenchChartService({
     repository: store,
-    // No executor: the gate is a policy decision, not a database round trip.
+    // No executor by default: the save gate is a policy decision, not a
+    // database round trip. The run suites pass a recording one.
     lwql: new LangWatchQLService({
-      executor: null,
+      executor,
       database: "analytics",
     }),
   });
@@ -529,6 +563,199 @@ describe("editing a saved workbench chart", () => {
 
         expect(renamed.name).toBe("Traces per week");
         expect(renamed.definition).toEqual(saved.definition);
+      });
+    });
+  });
+});
+
+/**
+ * The run path: what a saved chart becomes when someone opens it and presses
+ * run. Same harness as saving — the real LangWatchQL gate over an in-memory
+ * store — with a recording executor behind the gate, because the claims worth
+ * making are about *what reached the database*: the stored statement, the
+ * stored values, the surface's window and step, or nothing at all.
+ */
+describe("running a saved workbench chart", () => {
+  /** The tenant the run executes for. Only these two fields are ever needed. */
+  const RUNNER = { id: PROJECT_ID, lwqlKey: "sk-lw-run-chart-unit-test-key" };
+
+  /** Seven days — wide enough that only the hour step fits the bucket ceiling. */
+  const WEEK = {
+    start: new Date("2026-02-20T00:00:00.000Z"),
+    end: new Date("2026-02-27T00:00:00.000Z"),
+  };
+
+  /** Declares both reserved window bounds and the granularity parameter. */
+  const BUCKETED_SQL =
+    "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+    "count() AS value FROM analytics.traces " +
+    "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+    "AND TraceName = {name:String} GROUP BY bucket ORDER BY bucket";
+
+  async function saveBucketedChart(
+    service: ReturnType<typeof build>["service"],
+  ) {
+    return await service.createChart({
+      projectId: PROJECT_ID,
+      protections: FULLY_PERMITTED,
+      input: {
+        name: "Traces per step",
+        definition: definition({
+          sql: BUCKETED_SQL,
+          parameters: { name: "checkout" },
+        }),
+      },
+    });
+  }
+
+  describe("given a chart saved with both reserved declarations and its own parameter values", () => {
+    describe("when it is run with the surface's period and step", () => {
+      /** @scenario "Running a saved chart executes its stored statement with its saved values and the surface's window and step" */
+      it("executes the stored statement with all three bound, and reports the facts", async () => {
+        const executor = recordingExecutor();
+        const { service } = build(executor);
+        const saved = await saveBucketedChart(service);
+
+        const result = await service.runChart({
+          id: saved.id,
+          projectId: PROJECT_ID,
+          project: RUNNER,
+          protections: FULLY_PERMITTED,
+          input: {
+            timeWindow: WEEK,
+            // An hour over a week: 168 buckets, inside the ceiling.
+            granularitySeconds: 3600,
+          },
+        });
+
+        expect(executor.calls).toHaveLength(1);
+        expect(executor.calls[0]!.sql).toBe(BUCKETED_SQL);
+        expect(executor.calls[0]!.parameters).toEqual({
+          // Saved alongside the query at save time.
+          name: "checkout",
+          // Injected from the surface at run time.
+          period_start: "2026-02-20 00:00:00",
+          period_end: "2026-02-27 00:00:00",
+          period_granularity_seconds: 3600,
+        });
+        expect(result.rows).toEqual([{ value: 7 }]);
+        expect(result.followsTimeWindow).toBe(true);
+        expect(result.followsGranularity).toBe(true);
+        expect(result.granularitySeconds).toBe(3600);
+      });
+    });
+  });
+
+  describe("given a chart in another project, or an id nothing saved", () => {
+    describe("when the runner names either on their own project", () => {
+      /** @scenario "Another project's saved chart is not runnable" */
+      it("answers not found, identically, and runs nothing", async () => {
+        const executor = recordingExecutor();
+        const { service } = build(executor);
+        const saved = await saveBucketedChart(service);
+
+        expect(
+          (
+            await refusalOf(() =>
+              service.runChart({
+                id: saved.id,
+                projectId: "project-elsewhere",
+                project: { ...RUNNER, id: "project-elsewhere" },
+                protections: FULLY_PERMITTED,
+                input: { timeWindow: WEEK },
+              }),
+            )
+          ).code,
+        ).toBe("saved_workbench_chart_not_found");
+        expect(
+          (
+            await refusalOf(() =>
+              service.runChart({
+                id: "never-saved",
+                projectId: PROJECT_ID,
+                project: RUNNER,
+                protections: FULLY_PERMITTED,
+                input: {},
+              }),
+            )
+          ).code,
+        ).toBe("saved_workbench_chart_not_found");
+        expect(executor.calls).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("given a step finer than the period's bucket budget allows", () => {
+    describe("when the chart declaring the granularity parameter is run with it", () => {
+      /** @scenario "Running a saved chart refuses a step finer than the period's bucket budget" */
+      it("refuses the run with the ceiling arithmetic and executes nothing", async () => {
+        const executor = recordingExecutor();
+        const { service } = build(executor);
+        const saved = await saveBucketedChart(service);
+
+        const refusal = await refusalOf(() =>
+          service.runChart({
+            id: saved.id,
+            projectId: PROJECT_ID,
+            project: RUNNER,
+            protections: FULLY_PERMITTED,
+            input: {
+              timeWindow: WEEK,
+              // A week of one-second buckets: 604,800, far past 10,000.
+              granularitySeconds: 1,
+            },
+          }),
+        );
+
+        expect(refusal.code).toBe("lwql_granularity_too_fine");
+        expect(refusal.meta).toMatchObject({
+          requestedGranularitySeconds: 1,
+          windowSeconds: 7 * 24 * 3600,
+          maxBuckets: 10_000,
+        });
+        expect(executor.calls).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("given a chart whose SQL reads a column the runner may no longer see", () => {
+    describe("when someone with narrowed permissions runs it", () => {
+      it("refuses the run on their own current protections, not the author's", async () => {
+        const executor = recordingExecutor();
+        const { service } = build(executor);
+        const saved = await service.createChart({
+          projectId: PROJECT_ID,
+          protections: FULLY_PERMITTED,
+          input: {
+            name: "Captured input",
+            definition: definition({ sql: CONTENT_SQL }),
+          },
+        });
+
+        expect(
+          (
+            await refusalOf(() =>
+              service.runChart({
+                id: saved.id,
+                projectId: PROJECT_ID,
+                project: RUNNER,
+                protections: WITHOUT_CONTENT,
+                input: {},
+              }),
+            )
+          ).code,
+        ).toBe("lwql_not_permitted");
+        expect(executor.calls).toHaveLength(0);
+
+        // A caller who does hold the permission runs the very same chart.
+        await service.runChart({
+          id: saved.id,
+          projectId: PROJECT_ID,
+          project: RUNNER,
+          protections: FULLY_PERMITTED,
+          input: {},
+        });
+        expect(executor.calls).toHaveLength(1);
       });
     });
   });

--- a/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
@@ -44,8 +44,11 @@ import type { Protections } from "../../traces/protections";
 import { isUniqueConstraintError } from "../../utils/prismaErrors";
 import {
   getLangWatchQLService,
+  type LangWatchQLCaller,
+  type LangWatchQLQueryResult,
   type LangWatchQLService,
 } from "../lwql/lwql.service";
+import type { LangWatchQLTimeWindow } from "../lwql/timeWindow";
 import {
   SavedWorkbenchChartAlreadyExistsError,
   SavedWorkbenchChartDefinitionInvalidError,
@@ -259,6 +262,67 @@ export class SavedWorkbenchChartService {
     if (!row) throw new SavedWorkbenchChartNotFoundError();
 
     return this.present(row);
+  }
+
+  /**
+   * Runs a saved chart: loads it through the one read path charts have and
+   * executes its stored statement through the LangWatchQL gate, with the
+   * surface's period and datapoint step supplied fresh by whoever is asking.
+   *
+   * It lives here rather than beside the ad-hoc query endpoint because the
+   * chart — its stored values, its versioned definition — is this service's
+   * fact, and the execution gate is a dependency it already holds; a second
+   * runner would be a second place that knows what a chart becomes a run.
+   *
+   * The stored definition is re-parsed on the way in (via {@link getById}), so
+   * a row this build can no longer read is refused by name rather than
+   * executed. Validation is not repeated as a separate step because execution
+   * validates first itself, against the caller's own current protections — a
+   * member whose permissions narrowed after saving cannot run the chart into
+   * columns they may no longer read.
+   *
+   * @throws {SavedWorkbenchChartNotFoundError} when no chart of this kind has
+   *   that id in this project — another project's id included.
+   * @throws the LangWatchQL gate's own handled errors: the validator's refusal,
+   *   {@link LangWatchQLParameterMissingError} when the statement declares a
+   *   reserved name the request supplies no value for (a declared granularity
+   *   with no step among them), and
+   *   {@link LangWatchQLGranularityTooFineError} when the period at the
+   *   supplied step overflows the bucket ceiling — a direct chart run is
+   *   caller-owned, so it refuses where the dashboard will coarsen.
+   */
+  async runChart({
+    id,
+    projectId,
+    project,
+    protections,
+    input,
+  }: {
+    id: string;
+    projectId: string;
+    /** The tenant the query runs for; its key never appears in the result. */
+    project: LangWatchQLCaller;
+    /** The runner's content permissions, resolved server-side for this request. */
+    protections: Protections;
+    input: {
+      /** The period the surface is showing, when it has one. */
+      timeWindow?: LangWatchQLTimeWindow;
+      /** The step the surface chose, for a statement that declares the parameter. */
+      granularitySeconds?: number;
+    };
+  }): Promise<LangWatchQLQueryResult> {
+    const chart = await this.getById({ id, projectId });
+
+    return this.deps.lwql.execute({
+      project,
+      protections,
+      sql: chart.definition.sql,
+      parameters: chart.definition.parameters,
+      ...(input.timeWindow ? { timeWindow: input.timeWindow } : {}),
+      ...(input.granularitySeconds !== undefined
+        ? { granularitySeconds: input.granularitySeconds }
+        : {}),
+    });
   }
 
   /**

--- a/platform/app/src/server/api/routers/__tests__/lwqlGranularityBudget.router.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/lwqlGranularityBudget.router.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment node
+ *
+ * The workbench door of the granularity bucket budget: the `analytics.lwql.query`
+ * procedure carries the caller's step into the real service, and a window-step
+ * pair past the ceiling is refused with the coded arithmetic before anything
+ * reaches a database.
+ *
+ * Unlike the feature-switch suite beside it, the LangWatchQL service is NOT
+ * mocked here — the refusal under test IS the service's decision, and a stub
+ * would agree with whatever it was told. What is faked is everything around it:
+ * the flag, RBAC, the protections resolver and the Prisma client. No ClickHouse
+ * is needed: the refusal fires before the availability check, so the
+ * unprovisioned singleton answers the control case below rather than a
+ * database.
+ *
+ * Spec: specs/analytics/lwql-workbench.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFeatureFlagIsEnabled } = vi.hoisted(() => ({
+  mockFeatureFlagIsEnabled: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: { isEnabled: mockFeatureFlagIsEnabled },
+}));
+
+vi.mock("@ee/audit-log/auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
+  };
+});
+
+vi.mock("../../utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils")>();
+  return {
+    ...actual,
+    getUserProtectionsForProject: vi.fn().mockResolvedValue({
+      canSeeCapturedInput: true,
+      canSeeCapturedOutput: true,
+      canSeeCosts: true,
+    }),
+  };
+});
+
+import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
+import { lwqlRouter } from "../analytics/lwql";
+
+wireDefaultTestApp();
+
+const PROJECT_ID = "proj_granularity_budget_test";
+
+const mockPrismaClient = {
+  project: {
+    findUnique: vi.fn().mockResolvedValue({
+      id: PROJECT_ID,
+      lwqlKey: "sk-lw-lwql-granularity-budget-test-key",
+      team: { organizationId: "org_granularity_budget_test" },
+    }),
+  },
+} as any;
+
+function createCaller() {
+  return lwqlRouter.createCaller({
+    session: { user: { id: "user_test_123" }, expires: "2099-01-01" },
+    req: undefined,
+    res: undefined,
+    prisma: mockPrismaClient,
+    permissionChecked: false,
+    publiclyShared: false,
+    organizationRole: undefined,
+  } as any);
+}
+
+/** Declares the granularity parameter alongside both reserved period bounds. */
+const GRANULARITY_SQL =
+  "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+  "count() AS value FROM analytics.traces " +
+  "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+  "GROUP BY bucket ORDER BY bucket";
+
+/** Seven days, in seconds — the window the request reports over. */
+const WEEK_SECONDS = 7 * 24 * 3600;
+const WEEK = {
+  start: new Date("2026-02-20T00:00:00.000Z"),
+  end: new Date("2026-02-27T00:00:00.000Z"),
+};
+
+/** The tRPC-wrapped handled error's cause: the original HandledError itself. */
+async function causeOf(run: () => Promise<unknown>): Promise<{
+  code?: unknown;
+  meta?: Record<string, unknown>;
+}> {
+  try {
+    await run();
+  } catch (error) {
+    const cause = (error as { cause?: unknown }).cause ?? error;
+    return {
+      code: (cause as { code?: unknown }).code,
+      meta: (cause as { meta?: Record<string, unknown> }).meta,
+    };
+  }
+  throw new Error("expected the query to be refused, but it succeeded");
+}
+
+describe("given the workbench query procedure and the granularity budget", () => {
+  let caller: ReturnType<typeof createCaller>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrismaClient.project.findUnique.mockResolvedValue({
+      id: PROJECT_ID,
+      lwqlKey: "sk-lw-lwql-granularity-budget-test-key",
+      team: { organizationId: "org_granularity_budget_test" },
+    });
+    caller = createCaller();
+  });
+
+  describe("when a statement declaring the parameter is run at one-second steps over a week", () => {
+    /** @scenario "A window that would produce more buckets than the ceiling refuses on the workbench and REST" */
+    it("is refused with the named code and the bucket arithmetic in its meta", async () => {
+      const refusal = await causeOf(() =>
+        caller.query({
+          projectId: PROJECT_ID,
+          sql: GRANULARITY_SQL,
+          timeWindow: WEEK,
+          granularitySeconds: 1,
+        }),
+      );
+
+      // By code, never by prose: the code is the contract every client keys on.
+      expect(refusal.code).toBe("lwql_granularity_too_fine");
+      expect(refusal.meta).toMatchObject({
+        requestedGranularitySeconds: 1,
+        windowSeconds: WEEK_SECONDS,
+        maxBuckets: 10_000,
+      });
+    });
+  });
+
+  describe("when the same statement is run at an hour, which fits the ceiling", () => {
+    it("gets past the budget gate and reaches the next gate instead", async () => {
+      // This deployment provisions no LangWatchQL identity, so the honest
+      // answer past the budget gate is unavailability — proving the refusal
+      // above was about the budget and not about the door.
+      const refusal = await causeOf(() =>
+        caller.query({
+          projectId: PROJECT_ID,
+          sql: GRANULARITY_SQL,
+          timeWindow: WEEK,
+          granularitySeconds: 3600,
+        }),
+      );
+
+      expect(refusal.code).toBe("lwql_unavailable");
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/__tests__/savedWorkbenchCharts.router.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/savedWorkbenchCharts.router.integration.test.ts
@@ -17,6 +17,7 @@
 import { nanoid } from "nanoid";
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -59,7 +60,9 @@ vi.mock("../../utils", async (importOriginal) => {
   };
 });
 
+import { lwqlResult } from "~/features/analytics-query/__tests__/lwqlFixtures";
 import { VEGA_LITE_SCHEMA_URL } from "~/features/analytics-query/visualization/vegaLiteSchema";
+import { getLangWatchQLService } from "~/server/analytics/lwql/lwql.service";
 import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
 import { prisma } from "../../../db";
 import type { Permission } from "../../rbac";
@@ -102,6 +105,20 @@ const NETWORK_SPEC = {
   data: { url: "https://example.invalid/rows.json" },
   mark: "bar",
 };
+
+/**
+ * A statement declaring the granularity parameter alongside both period bounds
+ * — the shape a saved chart has to have for the surface to supply it a step.
+ *
+ * Module-scoped because two describe blocks assert about the same declaration:
+ * one that it saves, one that running it reaches the database with the step
+ * bound. Two copies could drift into agreeing with a bug in either.
+ */
+const GRANULARITY_WITH_BOUNDS_SQL =
+  "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+  "count() AS value FROM analytics.traces " +
+  "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+  "GROUP BY bucket ORDER BY bucket";
 
 const ALL_ANALYTICS: Permission[] = [
   "analytics:view",
@@ -261,6 +278,7 @@ describe("the saved workbench chart router", () => {
   describe("given the workbench switch is off for the project", () => {
     describe("when the member reaches any of the procedures", () => {
       /** @scenario "Saved charts stay unreachable while the workbench switch is off" */
+      /** @scenario "Running a saved chart carries the same permission and switch as every other chart procedure" */
       it("refuses every one of them the same way", async () => {
         const saved = await saveChart();
         isEnabled.mockResolvedValue(false);
@@ -288,6 +306,11 @@ describe("the saved workbench chart router", () => {
         expect(
           await refusalOf(() =>
             author.delete({ projectId: PROJECT, id: saved.id }),
+          ),
+        ).toBe("lwql_not_enabled");
+        expect(
+          await refusalOf(() =>
+            author.run({ projectId: PROJECT, id: saved.id }),
           ),
         ).toBe("lwql_not_enabled");
       });
@@ -386,6 +409,11 @@ describe("the saved workbench chart router", () => {
             author.delete({ projectId: PROJECT, id: theirs.id }),
           ),
         ).toBe("saved_workbench_chart_not_found");
+        expect(
+          await refusalOf(() =>
+            author.run({ projectId: PROJECT, id: theirs.id }),
+          ),
+        ).toBe("saved_workbench_chart_not_found");
 
         // Still theirs, still named what they named it.
         expect(
@@ -449,12 +477,6 @@ describe("the saved workbench chart router", () => {
       "WHERE OccurredAt >= {period_start:DateTime} " +
       "GROUP BY bucket ORDER BY bucket";
 
-    const GRANULARITY_WITH_BOUNDS_SQL =
-      "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
-      "count() AS value FROM analytics.traces " +
-      "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
-      "GROUP BY bucket ORDER BY bucket";
-
     describe("when the member saves it without both period parameters", () => {
       /** @scenario "A saved chart declaring granularity without both period parameters is refused at save" */
       it("is refused at save with the requires-window code and nothing is written", async () => {
@@ -514,6 +536,164 @@ describe("the saved workbench chart router", () => {
 
         const remaining = await author.getAll({ projectId: PROJECT });
         expect(remaining.map(({ id }) => id)).toEqual([first.id]);
+      });
+    });
+  });
+
+  /**
+   * Running a saved chart, at the router rather than at the service.
+   *
+   * What the service suite already proves — that the stored statement executes
+   * with its saved values, that another project's id is not runnable, that a
+   * step past the bucket budget refuses — is not restated here. The claims this
+   * layer owns are the four the service never sees: that `run` carries the same
+   * permission and the same switch as its five siblings, that the tenant key it
+   * runs under is read from the database for the project *named in the request*
+   * rather than accepted from the caller, and that the result reaches the
+   * workbench with the reserved-parameter facts intact.
+   *
+   * Only the database call is stubbed, and it is stubbed on the real service
+   * instance. Replacing the whole service would also replace `validate`, which
+   * the save-gate tests above depend on being the genuine one.
+   */
+  describe("running a saved chart through the router", () => {
+    const WEEK = {
+      start: new Date("2026-02-20T00:00:00Z"),
+      end: new Date("2026-02-27T00:00:00Z"),
+    };
+
+    /** The stubbed database call, re-armed per test so the counts are per-test. */
+    const stubExecute = () =>
+      vi.spyOn(getLangWatchQLService(), "execute").mockResolvedValue(
+        lwqlResult({
+          columns: [
+            { name: "bucket", type: "DateTime" },
+            { name: "value", type: "UInt64" },
+          ],
+          rows: [{ bucket: "2026-02-20 00:00:00", value: 7 }],
+          followsTimeWindow: true,
+          followsGranularity: true,
+          granularitySeconds: 3600,
+        }),
+      );
+
+    let execute: ReturnType<typeof stubExecute>;
+
+    beforeEach(() => {
+      execute = stubExecute();
+    });
+
+    afterEach(() => {
+      execute.mockRestore();
+    });
+
+    const saveBucketed = () =>
+      author.create({
+        projectId: PROJECT,
+        name: "Traces per hour",
+        definition: {
+          ...DEFINITION,
+          sql: GRANULARITY_WITH_BOUNDS_SQL,
+          parameters: {},
+        },
+      });
+
+    describe("given a chart saved in the member's own project", () => {
+      describe("when they run it with the surface's period and step", () => {
+        /** @scenario "A run names the tenant the database holds for the project in the request" */
+        it("returns the result with its reserved-parameter facts, run as the project's own tenant", async () => {
+          const saved = await saveBucketed();
+
+          const result = await author.run({
+            projectId: PROJECT,
+            id: saved.id,
+            timeWindow: WEEK,
+            granularitySeconds: 3600,
+          });
+
+          // The shape the workbench card reads to decide what it may claim.
+          expect(result.followsTimeWindow).toBe(true);
+          expect(result.followsGranularity).toBe(true);
+          expect(result.granularitySeconds).toBe(3600);
+          expect(result.rows).toEqual([
+            { bucket: "2026-02-20 00:00:00", value: 7 },
+          ]);
+
+          expect(execute).toHaveBeenCalledTimes(1);
+          const call = execute.mock.calls[0]![0];
+
+          // The stored statement, not one rebuilt from the request.
+          expect(call.sql).toBe(GRANULARITY_WITH_BOUNDS_SQL);
+
+          // The period and the step come from this request, which is the whole
+          // reserved-parameter contract: the surface owns them, the row does not.
+          expect(call.timeWindow).toEqual(WEEK);
+          expect(call.granularitySeconds).toBe(3600);
+
+          // The tenant identity is the one the database holds for the project
+          // named in the request — never anything the caller could supply.
+          const project = await prisma.project.findUniqueOrThrow({
+            where: { id: PROJECT },
+            select: { lwqlKey: true },
+          });
+          expect(call.project.id).toBe(PROJECT);
+          expect(call.project.lwqlKey).toBe(project.lwqlKey);
+        });
+      });
+    });
+
+    describe("given a member of another organization naming this project", () => {
+      describe("when they run one of its charts", () => {
+        it("is refused before the query reaches the database", async () => {
+          const saved = await saveBucketed();
+
+          await expect(
+            stranger.run({ projectId: PROJECT, id: saved.id }),
+          ).rejects.toThrow();
+
+          expect(execute).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("given a member with no analytics permission at all", () => {
+      describe("when they run a chart in their own project", () => {
+        /** @scenario "A run is refused for a member without the analytics view permission, and nothing is executed" */
+        it("is refused for want of the view permission, and nothing is executed", async () => {
+          const saved = await saveBucketed();
+          // A custom role with an EMPTY permission list falls back to the
+          // VIEWER defaults (which include analytics:view) — see rbac.ts. So a
+          // caller "without analytics" needs a non-empty grant that simply
+          // lacks it, or the fallback would hand the permission right back.
+          const outsider = await seedCaller(ORG, ["annotations:view"]);
+
+          expect(
+            await refusalOf(() =>
+              outsider.run({ projectId: PROJECT, id: saved.id }),
+            ),
+          ).toBe("permission_denied");
+
+          expect(execute).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("given a member who may view analytics but not change them", () => {
+      describe("when they run a chart someone else saved", () => {
+        /** @scenario "Being allowed to read a chart is being allowed to run one" */
+        it("lets the run through, because running is reading with execution attached", async () => {
+          const saved = await saveBucketed();
+
+          const result = await reader.run({
+            projectId: PROJECT,
+            id: saved.id,
+            timeWindow: WEEK,
+            granularitySeconds: 3600,
+          });
+
+          expect(result.followsGranularity).toBe(true);
+          expect(execute).toHaveBeenCalledTimes(1);
+        });
       });
     });
   });

--- a/platform/app/src/server/api/routers/__tests__/savedWorkbenchCharts.router.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/savedWorkbenchCharts.router.integration.test.ts
@@ -439,6 +439,61 @@ describe("the saved workbench chart router", () => {
     });
   });
 
+  describe("given a chart declaring the granularity parameter", () => {
+    // The granularity declaration is only meaningful when both period bounds
+    // are declared alongside — without them, the bucket budget no surface can
+    // compute is exactly the one the dashboard needs.
+    const GRANULARITY_WITHOUT_BOUNDS_SQL =
+      "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+      "count() AS value FROM analytics.traces " +
+      "WHERE OccurredAt >= {period_start:DateTime} " +
+      "GROUP BY bucket ORDER BY bucket";
+
+    const GRANULARITY_WITH_BOUNDS_SQL =
+      "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+      "count() AS value FROM analytics.traces " +
+      "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+      "GROUP BY bucket ORDER BY bucket";
+
+    describe("when the member saves it without both period parameters", () => {
+      /** @scenario "A saved chart declaring granularity without both period parameters is refused at save" */
+      it("is refused at save with the requires-window code and nothing is written", async () => {
+        expect(
+          await refusalOf(() =>
+            author.create({
+              projectId: PROJECT,
+              name: "Bucketed, half a window",
+              definition: {
+                ...DEFINITION,
+                sql: GRANULARITY_WITHOUT_BOUNDS_SQL,
+                parameters: {},
+              },
+            }),
+          ),
+        ).toBe("lwql_granularity_requires_window");
+
+        expect((await author.getAll({ projectId: PROJECT })).length).toBe(0);
+      });
+
+      it("saves the same declaration once both period bounds stand beside it", async () => {
+        // The control behind the refusal: the declaration itself is fine — it
+        // is the missing bounds that refuse. This also proves a granularity
+        // chart is savable at all now that its surface-owned step is deferred
+        // to run instead of demanded of a save request that may never carry one.
+        const saved = await author.create({
+          projectId: PROJECT,
+          name: "Bucketed, whole window",
+          definition: {
+            ...DEFINITION,
+            sql: GRANULARITY_WITH_BOUNDS_SQL,
+            parameters: {},
+          },
+        });
+        expect(saved.definition.sql).toBe(GRANULARITY_WITH_BOUNDS_SQL);
+      });
+    });
+  });
+
   describe("given a member saving and then editing a chart", () => {
     describe("when they save, read, rename and delete it", () => {
       /** @scenario "A saved chart can be renamed or deleted from the list" */

--- a/platform/app/src/server/api/routers/analytics/__tests__/workbenchAccessMiddleware.unit.test.ts
+++ b/platform/app/src/server/api/routers/analytics/__tests__/workbenchAccessMiddleware.unit.test.ts
@@ -57,6 +57,7 @@ describe("the workbench feature gate", () => {
         "delete",
         "getAll",
         "getById",
+        "run",
         "update",
       ]);
       // And the closure: a sixth procedure added without the gate fails here.

--- a/platform/app/src/server/api/routers/analytics/lwql.ts
+++ b/platform/app/src/server/api/routers/analytics/lwql.ts
@@ -128,6 +128,12 @@ const query = protectedProcedure
       sql: z.string().min(1).max(MAX_LWQL_LENGTH),
       parameters: z.record(z.string(), parameterValueSchema).optional(),
       timeWindow: lwqlTimeWindowSchema.optional(),
+      /**
+       * The datapoint step for a statement that declares
+       * `{period_granularity_seconds:UInt32}`, in seconds. Shape only — the
+       * bucket-budget arithmetic and its refusal are the service's.
+       */
+      granularitySeconds: z.number().int().positive().optional(),
     }),
   )
   .permission("analytics:view")
@@ -152,6 +158,9 @@ const query = protectedProcedure
       sql: input.sql,
       ...(input.parameters ? { parameters: input.parameters } : {}),
       ...(input.timeWindow ? { timeWindow: input.timeWindow } : {}),
+      ...(input.granularitySeconds === undefined
+        ? {}
+        : { granularitySeconds: input.granularitySeconds }),
     });
   });
 

--- a/platform/app/src/server/api/routers/analytics/lwql.ts
+++ b/platform/app/src/server/api/routers/analytics/lwql.ts
@@ -20,7 +20,6 @@
  * @see specs/analytics/lwql-workbench.feature
  */
 
-import { NotFoundError } from "@langwatch/handled-error";
 import { z } from "zod";
 
 import {
@@ -28,11 +27,13 @@ import {
   MAX_LWQL_LENGTH,
 } from "~/server/analytics/lwql";
 import { lwqlEnabled } from "~/server/analytics/lwql/access";
+import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
 import { lwqlTimeWindowSchema } from "~/server/analytics/lwql/timeWindowSchema";
 
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 import { getUserProtectionsForProject } from "../../utils";
 
+import { resolveLangWatchQLCaller } from "./lwqlCaller";
 import { enforceWorkbenchEnabled } from "./workbenchAccessMiddleware";
 
 /**
@@ -130,31 +131,31 @@ const query = protectedProcedure
       timeWindow: lwqlTimeWindowSchema.optional(),
       /**
        * The datapoint step for a statement that declares
-       * `{period_granularity_seconds:UInt32}`, in seconds. Shape only — the
-       * bucket-budget arithmetic and its refusal are the service's.
+       * `{period_granularity_seconds:UInt32}`, in seconds — restricted to the
+       * offered steps ({@link LWQL_GRANULARITY_STEPS}) so an off-list value is
+       * a schema rejection here rather than reaching the service's backstop.
+       * The bucket-budget arithmetic and its refusal are still the service's.
        */
-      granularitySeconds: z.number().int().positive().optional(),
+      granularitySeconds: z
+        .union([
+          z.literal(LWQL_GRANULARITY_STEPS[0]),
+          z.literal(LWQL_GRANULARITY_STEPS[1]),
+          z.literal(LWQL_GRANULARITY_STEPS[2]),
+        ])
+        .optional(),
     }),
   )
   .permission("analytics:view")
   .use(enforceWorkbenchEnabled)
   .mutation(async ({ ctx, input }) => {
-    // The project's LangWatchQL secret is hashed into the tenant capability
-    // the query runs under. It is read server-side and never leaves this
-    // function — no field of it appears in the response.
-    const project = await ctx.prisma.project.findUnique({
-      where: { id: input.projectId },
-      select: { id: true, lwqlKey: true },
-    });
-    if (!project) {
-      throw new NotFoundError("project_not_found", "Project", input.projectId);
-    }
+    const { project, protections } = await resolveLangWatchQLCaller(
+      ctx,
+      input.projectId,
+    );
 
     return getLangWatchQLService().execute({
       project,
-      protections: await getUserProtectionsForProject(ctx, {
-        projectId: project.id,
-      }),
+      protections,
       sql: input.sql,
       ...(input.parameters ? { parameters: input.parameters } : {}),
       ...(input.timeWindow ? { timeWindow: input.timeWindow } : {}),

--- a/platform/app/src/server/api/routers/analytics/lwqlCaller.ts
+++ b/platform/app/src/server/api/routers/analytics/lwqlCaller.ts
@@ -1,0 +1,41 @@
+/**
+ * Who a session-authenticated LangWatchQL execution runs as.
+ *
+ * Every tRPC procedure that hands a statement to the LangWatchQL service —
+ * the workbench's ad-hoc `query` and the saved chart's `run` — needs the same
+ * two answers resolved the same way: the project row carrying the `lwqlKey`
+ * the tenant capability is hashed from, and the member's own content
+ * protections. One resolver keeps those two doors from drifting apart.
+ */
+
+import { NotFoundError } from "@langwatch/handled-error";
+import type { PrismaClient } from "~/generated/prisma/client";
+import type { Session } from "~/server/auth";
+
+import { getUserProtectionsForProject } from "../../utils";
+
+/**
+ * Resolves the project identity and the member's protections a LangWatchQL
+ * execution runs under.
+ *
+ * The project's LangWatchQL secret is hashed into the tenant capability the
+ * query runs under. It is read server-side and must never leave the calling
+ * procedure — no field of it may appear in a response.
+ */
+export async function resolveLangWatchQLCaller(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  projectId: string,
+) {
+  const project = await ctx.prisma.project.findUnique({
+    where: { id: projectId },
+    select: { id: true, lwqlKey: true },
+  });
+  if (!project) {
+    throw new NotFoundError("project_not_found", "Project", projectId);
+  }
+
+  return {
+    project,
+    protections: await getUserProtectionsForProject(ctx, { projectId }),
+  };
+}

--- a/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
+++ b/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
@@ -23,8 +23,10 @@
  * @see specs/analytics/lwql-saved-charts.feature
  */
 
+import { NotFoundError } from "@langwatch/handled-error";
 import { z } from "zod";
 
+import { lwqlTimeWindowSchema } from "~/server/analytics/lwql/timeWindowSchema";
 import { SavedWorkbenchChartService } from "~/server/analytics/saved-workbench-charts/savedWorkbenchChart.service";
 
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
@@ -133,10 +135,59 @@ const deleteChart = protectedProcedure
     return { success: true };
   });
 
+/**
+ * Runs one saved chart and returns its result.
+ *
+ * A sibling of `getById` rather than a new surface — running is reading with
+ * execution attached — chained through the same permission and switch gates as
+ * every other procedure here. The period and the datapoint step are supplied by
+ * this request, never read out of the stored definition: they are the surface's
+ * to set, which is the whole reserved-parameter contract. Handled errors
+ * propagate untouched, like on `create`: the boundary serialises their code plus
+ * `meta`, and the workbench renders registry copy keyed by that code — including
+ * `lwql_granularity_too_fine`'s bucket arithmetic.
+ */
+const run = protectedProcedure
+  .input(
+    chartScopeSchema.extend({
+      timeWindow: lwqlTimeWindowSchema.optional(),
+      granularitySeconds: z.number().int().positive().optional(),
+    }),
+  )
+  .permission("analytics:view")
+  .use(enforceWorkbenchEnabled)
+  .mutation(async ({ ctx, input }) => {
+    // The project's LangWatchQL secret is hashed into the tenant capability the
+    // query runs under; it is read server-side and never leaves this function.
+    const project = await ctx.prisma.project.findUnique({
+      where: { id: input.projectId },
+      select: { id: true, lwqlKey: true },
+    });
+    if (!project) {
+      throw new NotFoundError("project_not_found", "Project", input.projectId);
+    }
+
+    return SavedWorkbenchChartService.create(ctx.prisma).runChart({
+      id: input.id,
+      projectId: input.projectId,
+      project,
+      protections: await getUserProtectionsForProject(ctx, {
+        projectId: input.projectId,
+      }),
+      input: {
+        ...(input.timeWindow ? { timeWindow: input.timeWindow } : {}),
+        ...(input.granularitySeconds === undefined
+          ? {}
+          : { granularitySeconds: input.granularitySeconds }),
+      },
+    });
+  });
+
 export const savedWorkbenchChartsRouter = createTRPCRouter({
   getAll,
   getById,
   create,
   update,
+  run,
   delete: deleteChart,
 });

--- a/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
+++ b/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
@@ -23,15 +23,16 @@
  * @see specs/analytics/lwql-saved-charts.feature
  */
 
-import { NotFoundError } from "@langwatch/handled-error";
 import { z } from "zod";
 
+import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
 import { lwqlTimeWindowSchema } from "~/server/analytics/lwql/timeWindowSchema";
 import { SavedWorkbenchChartService } from "~/server/analytics/saved-workbench-charts/savedWorkbenchChart.service";
 
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 import { getUserProtectionsForProject } from "../../utils";
 
+import { resolveLangWatchQLCaller } from "./lwqlCaller";
 import { enforceWorkbenchEnabled } from "./workbenchAccessMiddleware";
 
 const projectScopeSchema = z.object({ projectId: z.string() });
@@ -151,29 +152,33 @@ const run = protectedProcedure
   .input(
     chartScopeSchema.extend({
       timeWindow: lwqlTimeWindowSchema.optional(),
-      granularitySeconds: z.number().int().positive().optional(),
+      /**
+       * The datapoint step, in seconds — restricted to the offered steps
+       * ({@link LWQL_GRANULARITY_STEPS}) so an off-list value is a schema
+       * rejection here rather than reaching the service's backstop.
+       */
+      granularitySeconds: z
+        .union([
+          z.literal(LWQL_GRANULARITY_STEPS[0]),
+          z.literal(LWQL_GRANULARITY_STEPS[1]),
+          z.literal(LWQL_GRANULARITY_STEPS[2]),
+        ])
+        .optional(),
     }),
   )
   .permission("analytics:view")
   .use(enforceWorkbenchEnabled)
   .mutation(async ({ ctx, input }) => {
-    // The project's LangWatchQL secret is hashed into the tenant capability the
-    // query runs under; it is read server-side and never leaves this function.
-    const project = await ctx.prisma.project.findUnique({
-      where: { id: input.projectId },
-      select: { id: true, lwqlKey: true },
-    });
-    if (!project) {
-      throw new NotFoundError("project_not_found", "Project", input.projectId);
-    }
+    const { project, protections } = await resolveLangWatchQLCaller(
+      ctx,
+      input.projectId,
+    );
 
     return SavedWorkbenchChartService.create(ctx.prisma).runChart({
       id: input.id,
       projectId: input.projectId,
       project,
-      protections: await getUserProtectionsForProject(ctx, {
-        projectId: input.projectId,
-      }),
+      protections,
       input: {
         ...(input.timeWindow ? { timeWindow: input.timeWindow } : {}),
         ...(input.granularitySeconds === undefined

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -973,3 +973,72 @@ Scenario: A window too wide for even the coarsest offered step is refused everyw
   When even the one-hour step would exceed 10,000 buckets for that period
   Then the run is refused as too fine for the period on coarsening surfaces too
   And the refusal names the requested step and the bucket ceiling
+
+@unit
+Scenario: A chart declaring the granularity parameter runs at the step the surface supplies
+  Given a saved chart whose SQL declares period_granularity_seconds as UInt32
+  And the surface supplies an offered step
+  When the chart is run by id
+  Then the stored statement is executed at the supplied step
+  And the result is labelled as following the granularity
+
+@unit
+Scenario: A declared granularity with no step supplied refuses to run naming the parameter
+  Given a saved chart whose SQL declares period_granularity_seconds as UInt32
+  And the surface supplies no step
+  When the chart is run by id
+  Then the run is refused for the missing parameter
+  And the refusal names period_granularity_seconds
+
+@unit
+Scenario: Running a saved chart executes its stored statement with its saved values and the surface's window and step
+  Given a saved chart with stored SQL and saved parameter values
+  When the surface runs it with its own time window and step
+  Then the stored statement is executed with the saved values
+  And the surface's window and step are the ones bound
+
+@unit
+Scenario: Another project's saved chart is not runnable
+  Given a chart saved in one project
+  When a run names it from another project
+  Then the run is refused as chart not found
+
+@unit
+Scenario: Running a saved chart refuses a step finer than the period's bucket budget
+  Given a saved chart declaring granularity
+  And a step and period whose quotient exceeds the bucket ceiling
+  When the chart is run by id
+  Then the run is refused as too fine for the period
+
+# The run-by-chart-id procedure's own wiring, as distinct from what the service
+# decides. Bound by
+# `src/server/api/routers/__tests__/savedWorkbenchCharts.router.integration.test.ts`,
+# which runs against a real Postgres and the real RBAC tables so the permission
+# claims cannot be answered by a fake that was told what to return.
+
+@integration
+Scenario: Running a saved chart carries the same permission and switch as every other chart procedure
+  Given a project with the LangWatchQL workbench switched off
+  When a member runs a saved chart by id
+  Then the run is refused with the not-enabled code
+  And with the switch on, the run requires the analytics view permission
+
+@integration
+Scenario: A run is refused for a member without the analytics view permission, and nothing is executed
+  Given a member whose role carries no analytics view permission
+  When they run a saved chart by id
+  Then the run is refused as permission denied
+  And the query engine is never consulted
+
+@integration
+Scenario: A run names the tenant the database holds for the project in the request
+  Given a project whose LangWatchQL key is stored in the database
+  When a member runs a saved chart by id
+  Then the execution request carries that stored key
+  And not any key supplied by the caller
+
+@integration
+Scenario: Being allowed to read a chart is being allowed to run one
+  Given a member whose role grants analytics view but not chart management
+  When they run a saved chart by id
+  Then the run succeeds

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -916,6 +916,26 @@ Scenario: A statement declaring the granularity parameter runs at the step the w
   And the result is labelled as following the granularity
 
 @unit
+Scenario: The step a statement declares is offered as a control, not as a parameter to fill in
+  Given a statement whose first run is refused for an unfilled period_granularity_seconds
+  When the workbench shows the refusal
+  Then the step is not listed among the parameters to give a value
+  And a granularity control offers the steps the contract admits
+
+@unit
+Scenario: Choosing a step sends it beside the query rather than among its parameters
+  Given the workbench is showing the granularity control
+  When the member chooses a step and runs the query
+  Then the request carries that step in its own field
+  And no reserved name appears among the parameters sent
+
+@unit
+Scenario: A step too fine for the window is refused where the member chose it
+  Given the workbench is showing the granularity control
+  When the member chooses a step that would exceed the bucket ceiling
+  Then the refusal is shown against the query
+
+@unit
 Scenario: A granularity declared with no step supplied runs on its own authored bucketing
   Given SQL declaring period_granularity_seconds as UInt32
   And the surface supplies no step

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -897,9 +897,15 @@ Feature: LangWatchQL query workbench — native tables and LangWatchQL Vega-Lite
 
 # The S1-bindable scenarios below are bound by
 # `src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts` and
-# `.../lwqlGranularityDeclaration.unit.test.ts`. The two marked @unimplemented
-# need the run-path wiring (procedure input + run-by-chart-id) landing in the
-# next PR of the stack; #6713 tracks them.
+# `.../lwqlGranularityDeclaration.unit.test.ts`. The run-path ones are bound by
+# the wiring suites: save-time refusal by
+# `src/server/api/routers/__tests__/savedWorkbenchCharts.router.integration.test.ts`,
+# the budget refusal on caller-owned doors by
+# `src/server/api/routers/__tests__/lwqlGranularityBudget.router.integration.test.ts`
+# (workbench) and
+# `src/app/api/analytics-sql/__tests__/lwqlGranularityRestApi.integration.test.ts`
+# (REST), and run-by-chart-id by
+# `src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts`.
 
 @unit
 Scenario: A statement declaring the granularity parameter runs at the step the workbench supplies
@@ -938,9 +944,8 @@ Scenario: A zero or fractional step is refused as a wrong declaration
   Then the run is refused as a wrong granularity declaration
   And the refusal says the step must be one of the offered steps
 
-@integration @unimplemented
+@integration
 Scenario: A saved chart declaring granularity without both period parameters is refused at save
-  # Tracking: #6713 (run-path wiring PR)
   Given SQL declaring period_granularity_seconds without period_start or period_end
   When the member saves the chart
   Then the save is refused because granularity requires the period parameters
@@ -953,14 +958,14 @@ Scenario: A granularity declared alongside a mistyped period bound is refused at
   Then it is refused because granularity requires well-typed period parameters
   And the refusal distinguishes the mistyped bound from an absent one
 
-@integration @unimplemented
+@integration
 Scenario: A window that would produce more buckets than the ceiling refuses on the workbench and REST
-  # Tracking: #6713 (run-path wiring PR)
   Given a chart declaring granularity and a requested step of 1 second
   And a period wide enough that the window divided by the step exceeds 10,000 buckets
   When the member runs it on a caller-owned surface
   Then the run is refused as too fine for the period
   And a dashboard running the same chart is coarsened to the finest step that fits
+  And the refusal carries the bucket arithmetic in its structured detail
 
 @unit
 Scenario: A window too wide for even the coarsest offered step is refused everywhere


### PR DESCRIPTION
# Related Issue

- Part of #6713 / epic #6582. Stacked on #7426 (base `issue6713/lwql-granularity-contract`).

## What

- Caller-owned doors (tRPC `analytics.lwql.run`, tRPC `savedWorkbenchCharts.run`, REST `POST /api/v1/.../analytics-sql`) resolve the reserved `{period_granularity_seconds:UInt32}` parameter through the shared contract with `onBudgetOverflow: "refuse"`; all three door schemas constrain `granularitySeconds` to the offered steps (`z.union` of the `LWQL_GRANULARITY_STEPS` literals), and the `LangWatchQLGranularityStep` union is threaded end-to-end through the client pipeline.
- Run-by-chart-id: `savedWorkbenchCharts.run` executes a saved chart under the caller's own permissions, sharing `resolveLangWatchQLCaller` with `lwql.query` (one project/key/protections resolution, not two).
- **Workbench granularity picker (UI)**: a refused too-fine run surfaces a 1s/1m/1h step picker. The pick is revision-scoped (`chosen` is `{revision, step}` — chart B never inherits chart A's pick), the displayed step is always the step actually sent (every Run entry point arms `chosen ?? coarsest` before submit), and a byte-identical SQL snapshot cannot resurrect a stale refusal (`ranRevision` latch).
- Reserved-parameter prompt filtering: `period_start`/`period_end`/`period_granularity_seconds` never appear in the "give these parameters a value" prompt, and the prompt never renders with an empty name list.

## How I can prove I was successful

- **[proven] CI fully green at head `f84135fe4b`**: 55/55 checks.
- **[proven] Review clerk READY** at `f84135fe4b` (verdict comment on this PR): all five fan-out findings verified fixed — step-union doors, shared caller resolution, revision-scoped pick, middleware pin covering `run` (teeth-verified), picker sends-what-it-shows.
- **[proven] Live browser QA** (dev server + dedicated ClickHouse harness, screenshots in [langwatch/pr-screenshots `pr-7431/`](https://github.com/langwatch/pr-screenshots/tree/main/pr-7431)):

  Picker appears on a refused too-fine run; an explicit pick sends `granularitySeconds` and renders:

  ![picker and successful run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7431/01-picker-appears-after-first-refusal.png)

  Bucket counts change with the step — same 3-hour window, 20 rows at 1m vs 3 rows at 1h:

  ![buckets at 1h](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7431/04-switch-1h-3-buckets.png)

  Too-fine over 30 days refuses live (`lwql_granularity_too_fine`):

  ![too-fine refusal](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7431/02-too-fine-refusal-live.png)

  Mixed case — custom param unset + granularity declared — prompts only for the custom name, reserved names filtered:

  ![reserved filtered](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7431/05-mixed-case-since-prompt-reserved-filtered.png)

  QA found one bug (picker rendered a pressed step it never sent → Run-without-click refused with a prompt naming nothing) — **fixed on this branch** (`c2fa3ea174`) with a test pinning that the request carries the displayed step.
- **[proven] Sabotage-verified tests**: reverting the sends-what-it-shows fix fails its test alone; unkeying the revision scope fails the cross-chart reset test; ungating `run` fails the middleware pin.

## Human verification

- Open a saved chart that declares granularity, hit Run: expect a refusal with the 1s/1m/1h picker, then a successful run after (or without) an explicit pick — never a "missing a value" prompt naming nothing.
- Open a second chart after picking on the first: the picker must show its own default, not the first chart's pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
