### PR TITLE
fix(ui): a markdown link is an inline box again, so long URLs wrap instead of escaping the message

### DIFF
--- a/platform/app/src/components/__tests__/markdown-long-token-wrap.browser.test.tsx
+++ b/platform/app/src/components/__tests__/markdown-long-token-wrap.browser.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Long unbreakable strings — signed URLs, base64 payloads, tool-result JSON —
+ * used to paint outside their container.
+ *
+ * Chakra's preflight already puts `word-wrap: break-word` on `*`, so ordinary
+ * paragraph text has always wrapped. Two shapes escape it, and both are here:
+ *
+ *  - an autolinked URL renders through Chakra's link recipe, whose base is
+ *    `display: inline-flex`. That is an atomic inline box — it cannot be split
+ *    across line boxes at all, so an inherited wrap rule never reaches it.
+ *  - a markdown table uses `table-layout: auto`, which sizes columns from
+ *    min-content. `overflow-wrap: break-word` deliberately does not shrink
+ *    min-content, so one unbreakable cell widens the whole table.
+ *
+ * jsdom cannot catch either — it has no layout, so `scrollWidth` is always 0.
+ * These assertions need real Chromium.
+ *
+ * https://github.com/langwatch/langwatch/issues/7433
+ */
+
+import { Box, ChakraProvider } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
+import { RenderedMarkdown } from "~/features/traces-v2/components/TraceDrawer/markdownView/RenderedMarkdown";
+import { system } from "~/pages/_app";
+import { Markdown } from "../Markdown";
+
+/**
+ * The shape from the report: an external URL whose query string is one long
+ * run of `%3A` / `&` / `=` / `_`, which offers no UAX#14 break opportunity.
+ */
+const SIGNED_URL =
+  "https://host.example/download?token=" +
+  "A".repeat(200) +
+  "&filter=a%3Ab%3Ac%3Ad%3Ae%3Af&scope=read_write_admin";
+
+/**
+ * 480 characters, no whitespace, no `/` or `-`: zero break opportunities.
+ *
+ * One repeated character rather than a mixed alphanumeric run. Line breaking
+ * does not care which characters these are — only that none of them offers a
+ * break — but a secret scanner does: a `*_TOKEN` constant holding a long
+ * high-entropy literal reads as an API key and fails the build.
+ */
+const UNBREAKABLE_RUN = "a".repeat(480);
+
+const CONTAINER_WIDTH = 320;
+
+/** Mirrors the real shape: a width-constrained scroll region (drawer body). */
+function ConstrainedViewport({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter>
+      <ChakraProvider value={system}>
+        <Box
+          data-testid="viewport"
+          width={`${CONTAINER_WIDTH}px`}
+          overflow="hidden"
+        >
+          {children}
+        </Box>
+      </ChakraProvider>
+    </MemoryRouter>
+  );
+}
+
+/**
+ * The container's own `scrollWidth` misses ink that overflows a line box, so
+ * measure where the widest descendant actually paints. That is the reported
+ * symptom: text landing to the right of the container's edge.
+ */
+function widestPaintedEdge() {
+  const viewport = document.querySelector<HTMLElement>(
+    '[data-testid="viewport"]',
+  );
+  if (!viewport) throw new Error("viewport not rendered");
+  const containerRight = viewport.getBoundingClientRect().right;
+
+  /**
+   * A scroll container legitimately holds wider content — that is what its
+   * scrollbar is for — and so does everything nested inside it. Only overflow
+   * that nothing clips reaches the screen as the reported symptom.
+   */
+  const isClipped = (el: HTMLElement) => {
+    // Stop *before* the viewport: it is the reference frame we are measuring
+    // against, not a clipper whose overflow excuses the content inside it.
+    for (
+      let node: HTMLElement | null = el;
+      node && node !== viewport;
+      node = node.parentElement
+    ) {
+      if (getComputedStyle(node).overflowX !== "visible") return true;
+    }
+    return false;
+  };
+
+  let widest = containerRight;
+  for (const el of Array.from(viewport.querySelectorAll<HTMLElement>("*"))) {
+    if (isClipped(el)) continue;
+    widest = Math.max(widest, el.getBoundingClientRect().right);
+  }
+  return { containerRight, widest, overhang: widest - containerRight };
+}
+
+afterEach(() => cleanup());
+
+describe("given a markdown message body with an unbreakable string", () => {
+  describe("when the text contains a long autolinked URL", () => {
+    it("keeps the link inside the container", () => {
+      render(
+        <ConstrainedViewport>
+          <Markdown>{SIGNED_URL}</Markdown>
+        </ConstrainedViewport>,
+      );
+
+      expect(widestPaintedEdge().overhang).toBeLessThanOrEqual(0);
+    });
+
+    it("renders the anchor as a breakable inline box, not an atomic one", () => {
+      render(
+        <ConstrainedViewport>
+          <Markdown>{SIGNED_URL}</Markdown>
+        </ConstrainedViewport>,
+      );
+
+      const anchor = document.querySelector("a");
+      if (!anchor) throw new Error("no anchor rendered");
+      expect(getComputedStyle(anchor).display).toBe("inline");
+    });
+  });
+
+  describe("when a tool result embeds a URL in its JSON", () => {
+    it("keeps the message inside the container", () => {
+      render(
+        <ConstrainedViewport>
+          <Markdown>{`[tool_complete] {"url": "${SIGNED_URL}"}`}</Markdown>
+        </ConstrainedViewport>,
+      );
+
+      expect(widestPaintedEdge().overhang).toBeLessThanOrEqual(0);
+    });
+  });
+
+  describe("when an unbreakable run sits in a table cell", () => {
+    it("keeps the table inside the container", () => {
+      render(
+        <ConstrainedViewport>
+          <Markdown>{`| url |\n| --- |\n| ${UNBREAKABLE_RUN} |`}</Markdown>
+        </ConstrainedViewport>,
+      );
+
+      expect(widestPaintedEdge().overhang).toBeLessThanOrEqual(0);
+    });
+  });
+
+  /**
+   * The guard against over-fixing. Breaking a fenced code block mid-token is
+   * worse than scrolling it, so `& pre` keeps `overflow-x: auto` and the code
+   * inside must stay on one line.
+   */
+  describe("when the run is in a fenced code block", () => {
+    it("scrolls the code block horizontally rather than breaking the line", () => {
+      render(
+        <ConstrainedViewport>
+          <Markdown>{`\`\`\`\n${UNBREAKABLE_RUN}\n\`\`\``}</Markdown>
+        </ConstrainedViewport>,
+      );
+
+      const pre = document.querySelector<HTMLElement>("pre");
+      if (!pre) throw new Error("no code block rendered");
+
+      expect(pre.scrollWidth).toBeGreaterThan(pre.clientWidth);
+      expect(widestPaintedEdge().overhang).toBeLessThanOrEqual(0);
+    });
+  });
+});
+
+describe("given a trace drawer markdown view with an unbreakable string", () => {
+  describe("when the text contains a long autolinked URL", () => {
+    it("keeps the link inside the container", () => {
+      render(
+        <ConstrainedViewport>
+          <RenderedMarkdown markdown={SIGNED_URL} />
+        </ConstrainedViewport>,
+      );
+
+      expect(widestPaintedEdge().overhang).toBeLessThanOrEqual(0);
+    });
+
+    it("renders the anchor as a breakable inline box, not an atomic one", () => {
+      render(
+        <ConstrainedViewport>
+          <RenderedMarkdown markdown={SIGNED_URL} />
+        </ConstrainedViewport>,
+      );
+
+      const anchor = document.querySelector("a");
+      if (!anchor) throw new Error("no anchor rendered");
+      expect(getComputedStyle(anchor).display).toBe("inline");
+    });
+  });
+});

--- a/platform/app/src/components/ui/prose.tsx
+++ b/platform/app/src/components/ui/prose.tsx
@@ -36,6 +36,18 @@ export const Prose = chakra("div", {
       textDecorationThickness: "2px",
       textDecorationColor: "border.muted",
       fontWeight: "500",
+      // Chakra's link recipe is `display: inline-flex`, which makes an anchor
+      // an atomic inline box: it cannot be split across line boxes, so the
+      // global `word-wrap: break-word` from the preflight never applies to it.
+      // An autolinked signed URL then grows the box to its full text width and
+      // paints outside the message. Prose links flow with the text, so put
+      // them back in the normal inline formatting context.
+      display: "inline",
+      // `break-word` alone only breaks a token that doesn't fit on its own
+      // line; it leaves min-content sizing at the full token width, so a link
+      // inside a table cell still forces the cell wide. `anywhere` shrinks
+      // min-content too.
+      overflowWrap: "anywhere",
     },
     [inWhere("& strong")]: {
       fontWeight: "600",
@@ -153,6 +165,14 @@ export const Prose = chakra("div", {
       lineHeight: "1.5em",
       marginTop: "2em",
       marginBottom: "2em",
+    },
+    // `table-layout: auto` sizes columns from their min-content width, and the
+    // preflight's `word-wrap: break-word` deliberately does not shrink
+    // min-content. A cell holding one unbreakable token therefore widens the
+    // whole table past its container. `anywhere` is the one value that lets a
+    // break opportunity count towards intrinsic sizing.
+    [inWhere("& th, td")]: {
+      overflowWrap: "anywhere",
     },
     [inWhere("& thead")]: {
       borderBottomWidth: "1px",

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/components.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/components.tsx
@@ -67,7 +67,19 @@ export function buildMarkdownComponents(colorMode: string) {
       </Box>
     ),
     a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
-      <Link href={href} color="blue.fg" textDecoration="underline">
+      // `display="inline"` for the same reason `strong`/`em`/`del` below set
+      // it: Chakra's link recipe is `inline-flex`, which makes the anchor an
+      // atomic inline box that cannot break across lines. A long autolinked
+      // URL would then paint outside the message. `overflowWrap="anywhere"`
+      // additionally shrinks min-content so a link in a table cell doesn't
+      // force the column wide.
+      <Link
+        href={href}
+        color="blue.fg"
+        textDecoration="underline"
+        display="inline"
+        overflowWrap="anywhere"
+      >
         {children}
       </Link>
     ),


### PR DESCRIPTION
Fixes #7433.

## Cause

Two shapes, neither of them the missing wrap rule the issue originally claimed. Chakra's preflight already puts `word-wrap: break-word` on `*`, so ordinary paragraph text has always wrapped — [the correction is on the issue](https://github.com/langwatch/langwatch/issues/7433#issuecomment-5386630162).

1. **`platform/app/src/components/ui/prose.tsx:32`** — Chakra's link recipe base is `display: inline-flex`. An inline-flex box is *atomic*: it cannot be split across line boxes at all, so no inherited wrap rule reaches it. `MarkdownLink` routes external `https?://` links through Chakra's `Link` (internal ones get a plain `chakra.a`), which is exactly the signed-URL case in the report.
2. **`platform/app/src/components/ui/prose.tsx:151`** — `table-layout: auto` sizes columns from min-content, and `overflow-wrap: break-word` deliberately does *not* shrink min-content. One unbreakable cell widens the whole table. `anywhere` is the only value that lets a break opportunity count towards intrinsic sizing.

The same anchor defect exists in the second markdown root, `markdownView/components.tsx:69` — its `a` was the only inline element not setting `display="inline"`, unlike its own `strong`/`em`/`del` right below it.

## Failing test, before the fix

`src/components/__tests__/markdown-long-token-wrap.browser.test.tsx`, real Chromium via `vitest.browser.config.ts` (jsdom cannot catch this — no layout, so `scrollWidth` is always 0).

```
× keeps the link inside the container
× renders the anchor as a breakable inline box, not an atomic one
× keeps the message inside the container
× keeps the table inside the container
× keeps the link inside the container            (markdownView)
× renders the anchor as a breakable inline box   (markdownView)

AssertionError: expected 1990.015625 to be less than or equal to 0
AssertionError: expected 'inline-flex' to be 'inline'
AssertionError: expected 2003.65625 to be less than or equal to 0
AssertionError: expected 3445.34375 to be less than or equal to 0
AssertionError: expected 1668.015625 to be less than or equal to 0
AssertionError: expected 'inline-flex' to be 'inline'

Tests  6 failed | 1 passed (7)
```

The one passing test is the guard against over-fixing: a fenced code block must keep scrolling horizontally rather than breaking mid-token, so it is green in both directions by design.

## Passing, after the fix

```
Test Files  1 passed (1)
     Tests  7 passed (7)
```

Overhang for all three overflow cases goes to 0. Constructs that never overflowed and still don't: paragraphs, bullet and numbered lists, blockquotes, headings, inline code.

## Sweep

For the shape, not the defect.

- **Markdown renderers:** exactly two in the app (`components/Markdown.tsx`, `markdownView/RenderedMarkdown.tsx`). Both fixed. The third `components={` hit (`pages/[project]/analytics/custom/index.tsx:1542`) is react-select, not markdown.
- **`table-layout: auto`:** only `prose.tsx:151`. Every other table in the app is `fixed` (`TraceTableShell.tsx:147`, `EvaluationsV3Table.tsx:2001`, `LLMModelCost.tsx:95`, `DatasetPreviewTable.tsx:290`, `DatasetEditorTable.tsx:734`), which is inherently safe. `markdownView` already wraps its table in `<Box overflowX="auto">`.
- **`Prose` consumers:** one (`Markdown.tsx:66`), so the blast radius of the CSS change is exactly "all markdown rendering", which is the intent.

## Noticed, not fixed

- `components/suites/ScenarioTargetRow.tsx:236` — `truncate` with no `minWidth={0}`. A flex item with `white-space: nowrap` takes its full text width as its automatic minimum size and refuses to shrink, so the row overflows instead of ellipsing. **This is a flexbox defect, not a wrapping one — nothing in this PR touches it.** `GroupRow.tsx:95` does it correctly. Left open on #7433.
- `components/settings/TeamForm.tsx:59` — a Chakra `Link` wrapping a project name in a table cell: the same atomic-inline shape, different surface, bounded input. Not in the reported path.
- Linked images (`[![alt](img)](href)`) now have an anchor box spanning the full line rather than hugging the image, because a block-level `img` inside an `inline` anchor forces a block-in-inline split. Verified the image itself renders identically (120×40 under both `inline` and `inline-flex`); the only visible difference is the background band on a mismatched-URL link.

## Review notes

- `/ruthless-review` was run **without subagents** (this session forbids spawning them), so the refutation pass had no independent context attacking claims it had not formed. That is a real loss of independence, not just of effort. The decisive checks were executed rather than reasoned — the linked-image geometry above came from a temporary probe, run and deleted.
- No P0/P1. The findings above are the P3s.
- **Pre-existing, not caused by this change:** the browser suite fails 8 tests on a clean checkout of the base commit as well (`SearchBar`, `BatchTargetCell`, `evaluator-form-zod-source`, `ActiveSearchEditor` — all missing Router context); baseline and post-fix counts are identical. `typecheck:tests` reports 101 errors, all cascading from an unbuilt `langwatch` workspace SDK in this fresh worktree; none are in the changed files.
- Not verified: the running app was never driven. Evidence is real-Chromium layout measurement of the actual components with the app's own theme (`system` from `pages/_app`), not a synthetic page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Long URLs and other unbreakable content now wrap within constrained layouts, preventing horizontal overflow.
  - Markdown tables better accommodate lengthy links and tokens without expanding beyond the viewport.
  - Fenced code blocks retain horizontal scrolling for readability.

- **Tests**
  - Added browser-based coverage for markdown wrapping, table overflow, long URLs, and code-block scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
