### PR TITLE
perf(authz): grant commands share a sharded organization lane (ADR-114)

### DIFF
--- a/dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
+++ b/dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
@@ -111,16 +111,35 @@ grant commands are pure appends: validate, stamp identity, emit". Each handler
 derives its event from its own command alone and never reads back a same-batch
 append.
 
-### 2. The statement budget reserves capacity for foreground work
+### 2. The statement budget is shared per producer, not first-come
 
-`withStatementLimit` gains a priority class. Statements are `interactive` by
-default; a caller may declare itself `background`. Background statements may
-occupy at most a configured fraction of the budget (initially 50%), so a bulk
-producer can never take the last slot a customer write needs.
+**Deferred, with its design settled here.** Not implemented in the PR that
+carries this ADR.
 
-This is a separate change on a shared hot path — every ClickHouse caller in
-the app goes through that wrapper — and ships as its own PR, not alongside
-the lane change.
+The first shape considered was a two-class split: statements are
+`interactive` by default, a caller may declare itself `background`, and
+background work may hold at most a fraction of the budget. Writing it down
+killed it. `recordSpan` — the job whose 13.5-second latency is the reason
+this matters — is queue work too. Any rule that classes "queue work" as
+background starves customer ingestion alongside the migration and contains
+nothing that actually happened here.
+
+The axis that separates them is the **producer**, not the caller's
+interactivity. The correct shape is the one the dispatch path already has:
+a max-min fair share of the statement budget across the pipelines with
+demand, so a lone producer may use the whole budget and N producers converge
+on a fair share of it. A migration flooding `authz_grant` would then be
+bounded by its own share while `trace-processing` keeps drawing on its own.
+
+The seam exists. `groupQueue.ts` already runs every job body inside
+`runWithContext`, so a statement can learn which pipeline it is being issued
+for without a parameter on every call site.
+
+This is deferred rather than sketched-and-shipped because it is a piece of
+work on the scale of the dispatch water-fill itself, and it sits on a hot
+path every ClickHouse caller in the app crosses. Decision 1 removes the
+pressure that made it urgent; this removes the class of incident. They are
+not substitutes and the second one should not be rushed behind the first.
 
 ## Rationale / Trade-offs
 
@@ -151,8 +170,9 @@ statements and never was slots.
 
 - The migration's statement pressure falls by roughly the batch factor, so a
   bulk import stops being visible to unrelated pipelines.
-- Foreground ClickHouse work keeps a floor under load, so a background
-  producer degrades itself rather than customer ingestion.
+- Until decision 2 lands, one producer can still exhaust the statement
+  budget. Decision 1 makes that far harder for this pipeline and does
+  nothing for the next one; the containment gap stays open and named.
 - Grant commands for one organization serialize 32-ways rather than
   arbitrarily wide. Anything that assumed unbounded per-grant command
   parallelism would notice; nothing does today.

--- a/dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
+++ b/dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
@@ -40,7 +40,7 @@ Measured in production, 14:29 → 16:03 UTC+2:
 
 Every number follows from the first row:
 
-```
+```text
 200-statement budget, ~1 s per statement
    -> ~195 statements/s drained
       -> 1,090 queued / 195 = 5.6 s wait
@@ -60,7 +60,7 @@ no free slots and a saturated limiter. It would have made this worse.
 **The blast radius was the whole platform, not the migration.** Mean job
 duration during the window, by job type:
 
-```
+```text
 executeEvaluation    ████████████████████ 20.7 s
 metricTimeRollup     ███████████████ 15.5 s
 canonicalLogStorage  ██████████████ 14.9 s
@@ -79,19 +79,31 @@ statement is *for*. A bulk backfill and a customer's trace write are peers.
 ### 1. Grant commands ride a sharded per-organization lane
 
 `attachGrant`, `revokeGrant` and `changeGrantRole` take a `getGroupKey` that
-returns `<organizationId>:<shard>`, where `shard = hash(aggregateId) % 32`,
-and a `coalesceMaxBatch` so that a lane's queued commands fold into one
-multi-row append.
+returns `hash(aggregateId) % 32` — the shard ALONE — plus a
+`coalesceMaxBatch` so that a lane's queued commands fold into one multi-row
+append.
 
+The callback's result is not the queue key. `buildGroupKey`
+(`queueManager.ts`) composes `${tenantId}/${jobPath}/${aggregateType}:${key}`,
+so the organization is already in every key and the callback would only
+repeat it. That is what makes these lanes per-organization without the
+callback ever naming one:
+
+```text
+                    callback returns   final queue key
+BEFORE (aggregate)  "grant_7Hk2mQ"     <org>/command/attachGrant/authz_grant:grant_7Hk2mQ
+AFTER  (shard)      "14"               <org>/command/attachGrant/authz_grant:14
 ```
-BEFORE                              AFTER
-authz_grant:g1  -> 1 insert         org:HXE...:0  -> [g1 g33 g65 ...] 1 insert
-authz_grant:g2  -> 1 insert         org:HXE...:1  -> [g2 g34 g66 ...] 1 insert
-authz_grant:g3  -> 1 insert         ...
-   x 428,720                        org:HXE...:31 -> [...]           1 insert
 
-428,720 statements                  ~8,500 statements at batch 50
-1,270-way parallelism               32-way parallelism per organization
+```text
+BEFORE                          AFTER
+one lane per grant              32 lanes per organization
+  grant_7Hk2mQ -> 1 insert        lane 14 -> [grant_7Hk2mQ, ...] 1 insert
+  grant_9Fs4tR -> 1 insert        lane 12 -> [grant_9Fs4tR, ...] 1 insert
+     x 428,720                    ...
+
+428,720 statements              ~8,500 statements at batch 50
+1,270-way parallelism           32-way parallelism per organization
 ```
 
 The shard count is the trade: lanes buy parallelism, batches buy statement

--- a/dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
+++ b/dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
@@ -1,0 +1,170 @@
+# ADR-114: Grant commands share a sharded lane, and the statement budget is not first-come
+
+**Date:** 2026-08-23
+
+**Status:** Proposed
+
+**Builds on:** ADR-110 (a grant is its own aggregate), ADR-100 (the
+aggregate-scoped lane), ADR-066 pillar 2 (append coalescing).
+
+**Related:** ADR-092 (the authorization engine), ADR-101's lineage in
+ADR-110's supersession note.
+
+## Context
+
+ADR-110 gave every grant its own aggregate, which fixed the whole-org fold:
+one aggregate's state is now one grant, not every grant the organization has
+ever held. That was correct and it stands.
+
+It also, as a side effect, gave every grant its own **queue lane**. A
+command's group key is `${aggregateType}:${getAggregateId(payload)}`
+(`queueManager.ts`), so `attachGrant` for grant `g` lands in the lane
+`authz_grant:g` — a lane of one. Nothing else ever joins it.
+
+That is fine for interactive access changes, which arrive one at a time. It
+is the wrong shape for a bulk producer. On 2026-08-23 the ADR-110 migration
+restaged 428,720 share-link facts for organization `HXECRq2mRfSQpxTiSCcsS`
+and each fact appended its own single-row insert into `event_log`.
+
+Measured in production, 14:29 → 16:03 UTC+2:
+
+| | during | after staging stopped |
+|---|---|---|
+| ClickHouse statements in flight | **200** (the limiter's whole budget) | 39 → 11 |
+| ClickHouse statements queued | ~1,090 | 0 |
+| mean wait for a statement slot | **5.7 s** | 0.000018 s |
+| mean job duration | 6,300 ms | 571 ms |
+| jobs completed | ~200/s | ~2,092/s |
+| worker CPU (10 pods) | 1.5–2.2 cores total | unchanged |
+| active groups | 1,259–1,280 | 1,265 |
+
+Every number follows from the first row:
+
+```
+200-statement budget, ~1 s per statement
+   -> ~195 statements/s drained
+      -> 1,090 queued / 195 = 5.6 s wait
+         -> job = 5.7 s waiting + 0.6 s working = 6.3 s
+            -> 1,270 fleet slots / 6.3 s = 200 jobs/s
+```
+
+Two things are worth stating plainly about that table.
+
+**Concurrency was never the constraint.** Active groups sat at ~1,270 the
+entire time and worker CPU never moved off ~0.2 of a core per pod, on a
+single-threaded runtime. The fleet was full of jobs that were all asleep
+waiting for the same semaphore. Raising the dispatch budget — the intuitive
+fix, and one we considered — would have admitted more jobs into a fleet with
+no free slots and a saturated limiter. It would have made this worse.
+
+**The blast radius was the whole platform, not the migration.** Mean job
+duration during the window, by job type:
+
+```
+executeEvaluation    ████████████████████ 20.7 s
+metricTimeRollup     ███████████████ 15.5 s
+canonicalLogStorage  ██████████████ 14.9 s
+recordSpan           █████████████ 13.5 s   <- customer trace ingestion
+authzGrantsWrite     ███████████ 11.6 s
+```
+
+Customer span ingestion took 13.5 seconds a job because a background
+migration was allowed to hold all 200 statement slots. The statement limiter
+(`server/clickhouse/statementLimit.ts`) is first-come, first-served: it bounds
+total concurrency and bounds the wait queue, but it has no notion of what the
+statement is *for*. A bulk backfill and a customer's trace write are peers.
+
+## Decision
+
+### 1. Grant commands ride a sharded per-organization lane
+
+`attachGrant`, `revokeGrant` and `changeGrantRole` take a `getGroupKey` that
+returns `<organizationId>:<shard>`, where `shard = hash(aggregateId) % 32`,
+and a `coalesceMaxBatch` so that a lane's queued commands fold into one
+multi-row append.
+
+```
+BEFORE                              AFTER
+authz_grant:g1  -> 1 insert         org:HXE...:0  -> [g1 g33 g65 ...] 1 insert
+authz_grant:g2  -> 1 insert         org:HXE...:1  -> [g2 g34 g66 ...] 1 insert
+authz_grant:g3  -> 1 insert         ...
+   x 428,720                        org:HXE...:31 -> [...]           1 insert
+
+428,720 statements                  ~8,500 statements at batch 50
+1,270-way parallelism               32-way parallelism per organization
+```
+
+The shard count is the trade: lanes buy parallelism, batches buy statement
+economy, and 32 is where an organization keeps enough of both. It is a
+constant with a name, not a tuned magic number, and the reasoning for
+changing it is recorded here.
+
+**The fold is untouched.** ADR-110's aggregate stays the grant: fold state is
+still one grant, still `authz_grant:<grantId>`. What changes is only which
+queue lane a command *waits in* before it is handled. Aggregate identity and
+lane identity were the same string by default; this separates them, which is
+what the `getGroupKey` override on `CommandHandlerOptions` already exists for.
+
+The commands qualify for coalescing on the ADR-066 contract without
+modification: `grantsLedgerCommands.ts` says it in its own docblock — "the
+grant commands are pure appends: validate, stamp identity, emit". Each handler
+derives its event from its own command alone and never reads back a same-batch
+append.
+
+### 2. The statement budget reserves capacity for foreground work
+
+`withStatementLimit` gains a priority class. Statements are `interactive` by
+default; a caller may declare itself `background`. Background statements may
+occupy at most a configured fraction of the budget (initially 50%), so a bulk
+producer can never take the last slot a customer write needs.
+
+This is a separate change on a shared hot path — every ClickHouse caller in
+the app goes through that wrapper — and ships as its own PR, not alongside
+the lane change.
+
+## Rationale / Trade-offs
+
+**Why not raise the statement budget?** It is per-server on purpose and sized
+to what ClickHouse itself will accept; raising it moves the queue from our
+process into the database, where it is less visible and less recoverable. The
+budget is not the bug. Consuming all of it for restated facts is.
+
+**Why not just stop the restaging?** We are (PR #7429, the heads filter). But
+that fixes one producer. The lane shape is what made *any* bulk producer on
+this pipeline a platform-wide event, and the next migration would find it
+again. ADR-110's measurement and this one are the same pipeline's
+partitioning biting twice.
+
+**Why 32 shards and batch 50?** 428,720 facts ÷ (32 × 50) ≈ 268 rounds; at
+~1 s a statement that is a few minutes of appends rather than an afternoon,
+while leaving 32 concurrent lanes per organization. Both are constants that
+review may move; the ADR records the reasoning, not a claim of optimality.
+
+**What we give up.** An organization's grant commands no longer run
+1,270-wide. For interactive access changes this is invisible — they arrive
+one at a time and coalesce to batches of one, which is the pre-existing path
+unchanged. For bulk producers, 32 lanes of batched appends beats 1,270 lanes
+of single appends by roughly the batch factor, because the constraint is
+statements and never was slots.
+
+## Consequences
+
+- The migration's statement pressure falls by roughly the batch factor, so a
+  bulk import stops being visible to unrelated pipelines.
+- Foreground ClickHouse work keeps a floor under load, so a background
+  producer degrades itself rather than customer ingestion.
+- Grant commands for one organization serialize 32-ways rather than
+  arbitrarily wide. Anything that assumed unbounded per-grant command
+  parallelism would notice; nothing does today.
+- `gq_parked_groups` and the dispatch budget are unchanged. Parking was not
+  the constraint, and this ADR deliberately does not touch it.
+
+## References
+
+- `platform/app/src/server/event-sourcing/pipelines/authz-grants/pipeline.ts`
+- `platform/app/src/server/event-sourcing/services/queues/queueManager.ts`
+  (the group key: `${aggregateType}:${getAggregateId(payload)}`)
+- `platform/app/src/server/clickhouse/statementLimit.ts`
+- `specs/event-sourcing/authz-grant-command-lanes.feature`
+- PR #7429 — the heads filter that stops the restaging at source
+- ADR-110 — a grant is its own aggregate

--- a/platform/app/src/server/event-sourcing/pipeline/commandShardKey.ts
+++ b/platform/app/src/server/event-sourcing/pipeline/commandShardKey.ts
@@ -1,13 +1,15 @@
 /**
- * Shared shard-bucketing helper for the trace-processing command group key.
+ * Shard-bucketing shared by every pipeline that fans one owner's commands
+ * across parallel GroupQueue lanes.
  *
  * `spanCommandGroupKey` (recordSpan) fans a hot trace's spans across
- * `traceId:<shard>` lanes on the GroupQueue, bucketing on the record's span id
- * with the rolling hash and clamp shape defined here. Holding the shard math in
- * one module keeps a record's bucket byte-stable — deterministic across
- * processes and restarts, the property a record's retries and its dedup squash
- * window depend on. `spanCommandGroupKey` keeps its own public API and its own
- * `MAX_SPAN_SHARD_COUNT` constant.
+ * `traceId:<shard>` lanes; `grantCommandGroupKey` (ADR-114) fans an
+ * organization's grant commands across `<organizationId>:<shard>` lanes.
+ * Holding the shard math in one module keeps a record's bucket byte-stable —
+ * deterministic across processes and restarts, the property a record's
+ * retries and its dedup squash window depend on. Each caller keeps its own
+ * public API and its own `MAX_*_SHARD_COUNT` constant, because the right
+ * ceiling is a property of the workload, not of the hash.
  */
 
 // FNV-1a (32-bit) constants. A record's bucket must be deterministic across

--- a/platform/app/src/server/event-sourcing/pipeline/commandShardKey.ts
+++ b/platform/app/src/server/event-sourcing/pipeline/commandShardKey.ts
@@ -3,8 +3,10 @@
  * across parallel GroupQueue lanes.
  *
  * `spanCommandGroupKey` (recordSpan) fans a hot trace's spans across
- * `traceId:<shard>` lanes; `grantCommandGroupKey` (ADR-114) fans an
- * organization's grant commands across `<organizationId>:<shard>` lanes.
+ * `traceId:<shard>` lanes; `grantCommandLane` (ADR-114) buckets an
+ * organization's grant commands, returning the shard ALONE — the tenant that
+ * makes those lanes per-organization is prepended by `buildGroupKey`, not by
+ * the `getGroupKey` callback.
  * Holding the shard math in one module keeps a record's bucket byte-stable —
  * deterministic across processes and restarts, the property a record's
  * retries and its dedup squash window depend on. Each caller keeps its own

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/grantCommandLane.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/grantCommandLane.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * ADR-114 — the lane a grant command waits in.
+ *
+ * @see specs/event-sourcing/authz-grant-command-lanes.feature
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GRANT_COALESCE_MAX_BATCH,
+  GRANT_SHARD_COUNT,
+  grantCommandLane,
+  MAX_GRANT_SHARD_COUNT,
+} from "../commands/grantCommandLane";
+
+describe("given grant commands to place on a queue lane", () => {
+  describe("when two commands name the same grant", () => {
+    /** @scenario "Commands about the same grant share a lane" */
+    it("puts both in the same lane", () => {
+      const first = grantCommandLane({ aggregateId: "grant_abc" });
+      const second = grantCommandLane({ aggregateId: "grant_abc" });
+
+      expect(first).toBe(second);
+    });
+  });
+
+  describe("when the commands name different grants", () => {
+    /** @scenario "Commands about different grants spread across lanes" */
+    it("spreads them across the organization's lanes", () => {
+      const lanes = new Set(
+        Array.from({ length: 500 }, (_, i) =>
+          grantCommandLane({ aggregateId: `grant_${i}` }),
+        ),
+      );
+
+      // Every lane in use, and none of them holding the whole population.
+      expect(lanes.size).toBe(GRANT_SHARD_COUNT);
+    });
+
+    /** @scenario "Commands about different grants spread across lanes" */
+    it("gives no single lane all of them", () => {
+      const counts = new Map<string, number>();
+      for (let i = 0; i < 500; i++) {
+        const lane = grantCommandLane({ aggregateId: `grant_${i}` });
+        counts.set(lane, (counts.get(lane) ?? 0) + 1);
+      }
+
+      expect(Math.max(...counts.values())).toBeLessThan(500);
+    });
+  });
+
+  describe("when the same id is placed twice", () => {
+    /** @scenario "A lane is stable across processes and restarts" */
+    it("derives the same lane both times", () => {
+      // A literal, not a round-trip: this pins the bucket against an accidental
+      // change to the hash, which would silently re-lane every in-flight retry.
+      expect(
+        grantCommandLane({ aggregateId: "grant_abc", shardCount: 4 }),
+      ).toBe(grantCommandLane({ aggregateId: "grant_abc", shardCount: 4 }));
+      expect(
+        grantCommandLane({ aggregateId: "grant_abc", shardCount: 4 }),
+      ).toMatch(/^[0-3]$/);
+    });
+  });
+
+  describe("when the lane is read", () => {
+    /** @scenario "The organization is not repeated in the lane" */
+    it("does not restate the organization", () => {
+      const lane = grantCommandLane({ aggregateId: "grant_abc" });
+
+      // `buildGroupKey` already prepends the tenant; repeating it here would
+      // only lengthen every key.
+      expect(lane).toMatch(/^\d+$/);
+    });
+  });
+
+  describe("when sharding is turned off", () => {
+    /** @scenario "Sharding can be turned off" */
+    it("collapses every command into one lane", () => {
+      const lanes = new Set(
+        Array.from({ length: 50 }, (_, i) =>
+          grantCommandLane({ aggregateId: `grant_${i}`, shardCount: 1 }),
+        ),
+      );
+
+      expect(lanes.size).toBe(1);
+    });
+  });
+
+  describe("when the shard count makes no sense", () => {
+    /** @scenario "A nonsensical shard count falls back to one lane" */
+    it.each([0, -1, 1.5])("falls back to one lane for %s", (count) => {
+      const lanes = new Set(
+        Array.from({ length: 20 }, (_, i) =>
+          grantCommandLane({ aggregateId: `grant_${i}`, shardCount: count }),
+        ),
+      );
+
+      expect(lanes.size).toBe(1);
+    });
+  });
+
+  describe("when the shard count is above the maximum", () => {
+    /** @scenario "The shard count is bounded" */
+    it("uses the maximum instead", () => {
+      const lanes = new Set(
+        Array.from({ length: 4000 }, (_, i) =>
+          grantCommandLane({
+            aggregateId: `grant_${i}`,
+            shardCount: MAX_GRANT_SHARD_COUNT * 10,
+          }),
+        ),
+      );
+
+      expect(lanes.size).toBeLessThanOrEqual(MAX_GRANT_SHARD_COUNT);
+    });
+  });
+
+  describe("when the batch bound is read", () => {
+    /** @scenario "The batch bound is a flat number, not a resolver" */
+    it("is a flat number the byte budget can weigh", () => {
+      expect(typeof GRANT_COALESCE_MAX_BATCH).toBe("number");
+      expect(GRANT_COALESCE_MAX_BATCH).toBeGreaterThan(1);
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/grantCommandLane.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/grantCommandLane.unit.test.ts
@@ -49,15 +49,15 @@ describe("given grant commands to place on a queue lane", () => {
 
   describe("when the same id is placed twice", () => {
     /** @scenario "A lane is stable across processes and restarts" */
-    it("derives the same lane both times", () => {
-      // A literal, not a round-trip: this pins the bucket against an accidental
-      // change to the hash, which would silently re-lane every in-flight retry.
+    it("derives the bucket this input has always had", () => {
+      // A LITERAL, deliberately. Comparing two calls to each other would pass
+      // through any rewrite of the hash — and a changed hash silently re-lanes
+      // every in-flight retry, which is the one thing this must catch. If this
+      // assertion fails, the bucket moved: that is a migration, not a nit.
       expect(
         grantCommandLane({ aggregateId: "grant_abc", shardCount: 4 }),
-      ).toBe(grantCommandLane({ aggregateId: "grant_abc", shardCount: 4 }));
-      expect(
-        grantCommandLane({ aggregateId: "grant_abc", shardCount: 4 }),
-      ).toMatch(/^[0-3]$/);
+      ).toBe("2");
+      expect(grantCommandLane({ aggregateId: "grant_abc" })).toBe("2");
     });
   });
 

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/grantsPipelineLanes.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/grantsPipelineLanes.unit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * ADR-114 — the pipeline actually DECLARES the lane and the batch bound.
+ *
+ * The lane module can be perfect and the change still be inert: a
+ * `getGroupKey` or `coalesceMaxBatch` that never reaches the registry looks
+ * exactly like one that does, and the queue quietly keeps its old shape. This
+ * file asserts the registration, not the helper.
+ *
+ * @see specs/event-sourcing/authz-grant-command-lanes.feature
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GRANT_COALESCE_MAX_BATCH,
+  GRANT_SHARD_COUNT,
+} from "../commands/grantCommandLane";
+import { createAuthzGrantsPipeline } from "../pipeline";
+
+function buildPipeline() {
+  return createAuthzGrantsPipeline({
+    authzGrantsWriteStore: {} as never,
+    authzAuditTrailStore: {} as never,
+  });
+}
+
+function commandNamed(name: string) {
+  const entry = buildPipeline().commands.find(
+    (command) => command.name === name,
+  );
+  if (!entry) throw new Error(`no command registered as "${name}"`);
+  return entry;
+}
+
+/** The three a bulk producer emits in volume. */
+const BATCHED = ["attachGrant", "changeGrantRole", "revokeGrant"] as const;
+
+/** Rare, human-sized entities: an organization has a handful of roles. */
+const UNBATCHED = [
+  "defineRole",
+  "changeRolePermissions",
+  "deleteRole",
+] as const;
+
+describe("given the grants pipeline", () => {
+  describe("when the commands a bulk producer emits are registered", () => {
+    /** @scenario "The grant commands a bulk producer emits are registered to coalesce" */
+    it.each(BATCHED)("%s declares a batch bound", (name) => {
+      expect(commandNamed(name).options?.coalesceMaxBatch).toBe(
+        GRANT_COALESCE_MAX_BATCH,
+      );
+    });
+
+    /** @scenario "The grant commands a bulk producer emits are registered to coalesce" */
+    it.each(BATCHED)("%s declares the sharded lane", (name) => {
+      expect(typeof commandNamed(name).options?.getGroupKey).toBe("function");
+    });
+
+    /** @scenario "Commands about different grants spread across lanes" */
+    it.each(
+      BATCHED,
+    )("%s routes different grants to different lanes", (name) => {
+      const getGroupKey = commandNamed(name).options?.getGroupKey;
+      if (!getGroupKey) throw new Error(`${name} declares no lane`);
+
+      // Through the REGISTERED function, so a pipeline wired to the wrong
+      // aggregate id — the mistake that would silently give every command one
+      // lane — fails here rather than passing on the helper's own test.
+      const lanes = new Set(
+        Array.from({ length: 300 }, (_, i) =>
+          getGroupKey(payloadFor({ name, grantId: `grant_${i}` })),
+        ),
+      );
+
+      expect(lanes.size).toBe(GRANT_SHARD_COUNT);
+    });
+
+    /** @scenario "Commands about the same grant share a lane" */
+    it.each(BATCHED)("%s keeps one grant in one lane", (name) => {
+      const getGroupKey = commandNamed(name).options?.getGroupKey;
+      if (!getGroupKey) throw new Error(`${name} declares no lane`);
+
+      expect(getGroupKey(payloadFor({ name, grantId: "grant_same" }))).toBe(
+        getGroupKey(payloadFor({ name, grantId: "grant_same" })),
+      );
+    });
+
+    /** @scenario "The batch bound is a flat number, not a resolver" */
+    it.each(BATCHED)("%s bounds the batch with a number", (name) => {
+      expect(typeof commandNamed(name).options?.coalesceMaxBatch).toBe(
+        "number",
+      );
+    });
+  });
+
+  describe("when the role commands are registered", () => {
+    /** @scenario "Role commands keep the default lane" */
+    it.each(UNBATCHED)("%s declares no lane override", (name) => {
+      expect(commandNamed(name).options?.getGroupKey).toBeUndefined();
+    });
+
+    /** @scenario "Role commands keep the default lane" */
+    it.each(UNBATCHED)("%s declares no batch bound", (name) => {
+      expect(commandNamed(name).options?.coalesceMaxBatch).toBeUndefined();
+    });
+  });
+});
+
+/** The shape each command's `getAggregateId` reads a grant id out of. */
+function payloadFor({
+  name,
+  grantId,
+}: {
+  name: string;
+  grantId: string;
+}): Record<string, unknown> {
+  if (name === "attachGrant") {
+    return { grant: { grantId } };
+  }
+  return { grantId };
+}

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/commands/grantCommandLane.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/commands/grantCommandLane.ts
@@ -1,0 +1,103 @@
+/**
+ * The queue lane a grant command waits in (ADR-114).
+ *
+ * ADR-110 made a grant its own AGGREGATE, which is what stopped one fold
+ * state from being every grant an organization holds. Because a command's
+ * group key defaults to `${aggregateType}:${getAggregateId(payload)}`
+ * (queueManager.ts), that also gave every grant its own LANE — a lane of
+ * one, which nothing else can ever join and so nothing can ever batch with.
+ *
+ * For interactive access changes that is the right shape and this module
+ * changes nothing about them: they arrive one at a time, so a lane holds one
+ * command and coalescing folds a batch of one, which is the pre-existing
+ * path exactly. For a bulk producer it is the wrong shape. On 2026-08-23 a
+ * migration restated 428,720 facts for one organization and each fact
+ * appended its own single-row insert into `event_log`, saturating the
+ * ClickHouse statement limiter (200 slots, ~1s a statement) for ninety
+ * minutes. Every job on the fleet — customer span ingestion included — then
+ * spent 5.7 of its 6.3 seconds waiting for a slot.
+ *
+ * So the lane becomes the organization — which the framework already puts in
+ * every key — divided into shards:
+ *
+ *   before   one lane per grant   g1 -> 1 insert          (x 428,720)
+ *   after    32 lanes per org     0  -> [g1 g33 ...] 1 insert  (x 32)
+ *
+ * Aggregate identity and lane identity were the same string only by
+ * default. This separates them, which is what `getGroupKey` on
+ * `CommandHandlerOptions` exists for. The FOLD is untouched: state is still
+ * one grant, keyed by its own id, exactly as ADR-110 decided.
+ *
+ * Sharding rather than one lane per organization is the whole point of the
+ * shape. A single organization-wide lane would serialize every grant command
+ * an organization makes and could be slower than the per-grant lanes it
+ * replaces, batching or not.
+ *
+ * Sharding is safe HERE in a way it is not everywhere. The coding-agent
+ * pipeline coalesces without sharding because its derivation depends on
+ * per-session order, and a shard would break it. A grant command carries no
+ * such dependency: two commands about the SAME grant share an aggregate id,
+ * so they hash to the same shard and stay ordered, while two commands about
+ * DIFFERENT grants are different aggregates whose order was never meaningful.
+ * Commands of different TYPES already sat in different lanes before this
+ * change — the job path carries the command name — so nothing that was
+ * ordered stops being ordered.
+ *
+ * @see dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
+ * @see specs/event-sourcing/authz-grant-command-lanes.feature
+ */
+import {
+  clampShardCount,
+  shardIndexFor,
+} from "../../../pipeline/commandShardKey";
+
+/**
+ * Upper bound on the lane count for one organization. Lanes buy parallelism
+ * and batches buy statement economy; past this the batches get too small to
+ * pay for themselves and the statement pressure this exists to remove comes
+ * back.
+ */
+export const MAX_GRANT_SHARD_COUNT = 64;
+
+/**
+ * Lanes per organization. 32 keeps a bulk import wide enough to use the
+ * fleet while cutting its statement count by the batch factor; an
+ * organization's ordinary traffic never fills one lane, let alone 32.
+ */
+export const GRANT_SHARD_COUNT = 32;
+
+/**
+ * How many of a lane's queued commands fold into one multi-row append.
+ *
+ * The commands qualify for coalescing on the ADR-066 contract without any
+ * change: `grantsLedgerCommands.ts` states it in its own words — "the grant
+ * commands are pure appends: validate, stamp identity, emit". Each handler
+ * derives its event from its own command alone and never reads back a
+ * same-batch append.
+ *
+ * A flat number is honest here, unlike the span case that needed a resolver:
+ * a grant command's payload is a handful of ids and never expands after
+ * dequeue, so the drain's byte budget weighs it correctly.
+ */
+export const GRANT_COALESCE_MAX_BATCH = 50;
+
+/**
+ * The lane for one grant command, as a bucket of its aggregate id.
+ *
+ * The organization does not appear here on purpose: `buildGroupKey` already
+ * prepends the command's tenant, so every lane this returns is per-organization
+ * whether or not the string says so, and repeating it would only make the key
+ * longer. `shardCount <= 1` collapses to a single lane per organization, which
+ * is the "sharding off" spelling.
+ */
+export function grantCommandLane({
+  aggregateId,
+  shardCount = GRANT_SHARD_COUNT,
+}: {
+  aggregateId: string;
+  shardCount?: number;
+}): string {
+  const lanes = clampShardCount(shardCount, MAX_GRANT_SHARD_COUNT);
+  if (lanes <= 1) return "0";
+  return String(shardIndexFor(aggregateId, lanes));
+}

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/pipeline.ts
@@ -1,5 +1,9 @@
 import { definePipeline } from "../..";
 import {
+  GRANT_COALESCE_MAX_BATCH,
+  grantCommandLane,
+} from "./commands/grantCommandLane";
+import {
   AttachGrantCommand,
   ChangeGrantRoleCommand,
   ChangeRolePermissionsCommand,
@@ -44,22 +48,48 @@ export interface AuthzGrantsPipelineDeps {
  * command stamped: a grant id, or a role id.
  */
 export function createAuthzGrantsPipeline(deps: AuthzGrantsPipelineDeps) {
-  return definePipeline<AuthzGrantsEvent>()
-    .withName(AUTHZ_GRANT_PIPELINE_NAME)
-    .withAggregateType(AUTHZ_GRANT_AGGREGATE_TYPE)
-    .withMapProjection(
-      AUTHZ_GRANTS_WRITE_PROJECTION_NAME,
-      new AuthzGrantsWriteProjection({ store: deps.authzGrantsWriteStore }),
-    )
-    .withSubscriber(
-      "auditTrail",
-      createAuthzAuditTrailSubscriber({ store: deps.authzAuditTrailStore }),
-    )
-    .withCommand("attachGrant", AttachGrantCommand)
-    .withCommand("changeGrantRole", ChangeGrantRoleCommand)
-    .withCommand("revokeGrant", RevokeGrantCommand)
-    .withCommand("defineRole", DefineRoleCommand)
-    .withCommand("changeRolePermissions", ChangeRolePermissionsCommand)
-    .withCommand("deleteRole", DeleteRoleCommand)
-    .build();
+  return (
+    definePipeline<AuthzGrantsEvent>()
+      .withName(AUTHZ_GRANT_PIPELINE_NAME)
+      .withAggregateType(AUTHZ_GRANT_AGGREGATE_TYPE)
+      .withMapProjection(
+        AUTHZ_GRANTS_WRITE_PROJECTION_NAME,
+        new AuthzGrantsWriteProjection({ store: deps.authzGrantsWriteStore }),
+      )
+      .withSubscriber(
+        "auditTrail",
+        createAuthzAuditTrailSubscriber({ store: deps.authzAuditTrailStore }),
+      )
+      // ADR-114: the three grant commands a bulk producer emits in volume share
+      // a sharded per-organization lane, so their appends coalesce instead of
+      // spending one ClickHouse statement each. The fold is untouched — state is
+      // still one grant, keyed by its own id (ADR-110). The role commands keep
+      // the default per-aggregate lane: a role is a rare, human-sized entity and
+      // an organization has a handful, so there is nothing to batch.
+      .withCommand("attachGrant", AttachGrantCommand, {
+        getGroupKey: (payload) =>
+          grantCommandLane({
+            aggregateId: AttachGrantCommand.getAggregateId(payload),
+          }),
+        coalesceMaxBatch: GRANT_COALESCE_MAX_BATCH,
+      })
+      .withCommand("changeGrantRole", ChangeGrantRoleCommand, {
+        getGroupKey: (payload) =>
+          grantCommandLane({
+            aggregateId: ChangeGrantRoleCommand.getAggregateId(payload),
+          }),
+        coalesceMaxBatch: GRANT_COALESCE_MAX_BATCH,
+      })
+      .withCommand("revokeGrant", RevokeGrantCommand, {
+        getGroupKey: (payload) =>
+          grantCommandLane({
+            aggregateId: RevokeGrantCommand.getAggregateId(payload),
+          }),
+        coalesceMaxBatch: GRANT_COALESCE_MAX_BATCH,
+      })
+      .withCommand("defineRole", DefineRoleCommand)
+      .withCommand("changeRolePermissions", ChangeRolePermissionsCommand)
+      .withCommand("deleteRole", DeleteRoleCommand)
+      .build()
+  );
 }

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/spanCommandGroupKey.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/commands/spanCommandGroupKey.ts
@@ -23,7 +23,10 @@
  * hot trace cannot starve its neighbours (see specs/event-sourcing/tenant-soft-cap.feature).
  */
 
-import { clampShardCount, shardIndexFor } from "./commandShardKey";
+import {
+  clampShardCount,
+  shardIndexFor,
+} from "../../../pipeline/commandShardKey";
 
 /**
  * Upper bound on the shard count. A hot trace never needs more parallelism than

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorageGroupKey.ts
@@ -29,7 +29,7 @@
  */
 
 import type { Event } from "../../../domain/types";
-import { shardIndexFor } from "../commands/commandShardKey";
+import { shardIndexFor } from "../../../pipeline/commandShardKey";
 
 /**
  * Lanes per tenant. Matches `MAX_SPAN_SHARD_COUNT` on the recordSpan command

--- a/specs/event-sourcing/authz-grant-command-lanes.feature
+++ b/specs/event-sourcing/authz-grant-command-lanes.feature
@@ -1,0 +1,106 @@
+# See dev/docs/adr/114-grant-command-lanes-and-the-statement-budget.md
+#
+# ADR-110 made a grant its own AGGREGATE, which fixed the whole-organization
+# fold. Because a command's group key defaults to the aggregate id, it also
+# gave every grant its own LANE — a lane of one, which nothing can batch with.
+# That is right for interactive access changes and wrong for a bulk producer:
+# on 2026-08-23 one migration's 428,720 single-row appends held all 200
+# ClickHouse statement slots for ninety minutes, and every pipeline on the
+# fleet — customer span ingestion included — queued behind it.
+#
+# The fold is not in scope here and does not change: state is still one grant.
+# This file is only about which queue lane a command WAITS in.
+
+@event-sourcing @authz
+Feature: Grant commands share a sharded organization lane
+  As the LangWatch platform
+  I want a bulk grant producer's appends to coalesce instead of spending one
+  ClickHouse statement each
+  So that a background import cannot exhaust the statement budget that
+  customer-facing work depends on
+
+  # ═══ The lane ═════════════════════════════════════════════════════════
+
+  @unit
+  Scenario: Commands about the same grant share a lane
+    Given two commands naming the same grant
+    When their lanes are derived
+    Then both land in the same lane
+    And their order relative to each other is preserved
+
+  @unit
+  Scenario: Commands about different grants spread across lanes
+    Given grant commands for many different grants in one organization
+    When their lanes are derived
+    Then they are spread across the organization's lanes
+    And no lane holds all of them
+
+  @unit
+  Scenario: A lane is stable across processes and restarts
+    Given a grant id
+    When its lane is derived twice
+    Then both derivations give the same lane
+
+  @unit
+  Scenario: The organization is not repeated in the lane
+    Given a grant command for an organization
+    When its lane is derived
+    Then the lane does not restate the organization
+    And the queue key still separates one organization from another
+
+  @unit
+  Scenario: Sharding can be turned off
+    Given a shard count of one
+    When lanes are derived for many grants
+    Then every command lands in a single lane per organization
+
+  @unit
+  Scenario Outline: A nonsensical shard count falls back to one lane
+    Given a shard count of <count>
+    When a lane is derived
+    Then it does not throw
+    And the command lands in the single lane
+
+    Examples:
+      | count |
+      | 0     |
+      | -1    |
+      | 1.5   |
+
+  @unit
+  Scenario: The shard count is bounded
+    Given a shard count above the maximum
+    When a lane is derived
+    Then the maximum is used instead
+
+  # ═══ The batching ═════════════════════════════════════════════════════
+
+  @unit
+  Scenario: The grant commands a bulk producer emits are registered to coalesce
+    When the grants pipeline is built
+    Then attaching, revoking and role-changing each declare a batch bound
+    And each declares the sharded lane
+
+  @unit
+  Scenario: Role commands keep the default lane
+    When the grants pipeline is built
+    Then defining, changing and deleting a role declare no lane override
+    And they declare no batch bound
+
+  # A grant command's payload is a handful of ids and never expands after it is
+  # dequeued, so the drain's byte budget weighs it honestly and a flat bound is
+  # safe — unlike the span case, whose spooled payloads needed a resolver.
+  @unit
+  Scenario: The batch bound is a flat number, not a resolver
+    When the grants pipeline is built
+    Then the batch bound is a number
+
+  # ═══ What must not change ═════════════════════════════════════════════
+  #
+  # That the fold still keys on the GRANT — the event carries the grant as its
+  # aggregate and the organization only as its tenant — is ADR-110's guarantee,
+  # not this change's, and it is already covered by "A grant's aggregate is the
+  # grant" in specs/rbac/authz-grants.feature. A lane cannot move an aggregate
+  # id: the id comes from the command handler and the lane only decides which
+  # queue the command waits in. Restating it here would be a second copy of
+  # someone else's scenario.


### PR DESCRIPTION
Implements ADR-114 (included). Companion to #7429, independent of it — #7429 stops one producer restaging; this changes the shape that made *any* bulk producer on this pipeline a platform-wide event.

## What we measured

A migration restated 428,720 share-link facts for one organization, each appending its own single-row insert into `event_log`. Production, 14:29 → 16:03 UTC+2:

| | during | after staging stopped |
|---|---|---|
| ClickHouse statements **in flight** | **200** — the limiter's entire budget | 39 → 11 |
| ClickHouse statements queued | ~1,090 | 0 |
| mean wait for a statement slot | **5.7 s** | 0.000018 s |
| mean job duration | 6,300 ms | 571 ms |
| jobs completed | ~200/s | ~2,092/s |
| worker CPU (10 pods) | 1.5–2.2 cores total | unchanged |
| active groups | 1,259–1,280 | 1,265 |

Every number follows from the first row:

```
200-statement budget, ~1 s per statement
   -> ~195 statements/s drained
      -> 1,090 queued / 195 = 5.6 s wait
         -> job = 5.7 s waiting + 0.6 s working = 6.3 s
            -> 1,270 fleet slots / 6.3 s = 200 jobs/s
```

**Concurrency was never the constraint.** Active groups sat at ~1,270 and worker CPU never moved off ~0.2 of a core per pod, on a single-threaded runtime. The fleet was full of jobs all asleep on the same semaphore. Raising the dispatch budget — the intuitive fix — would have admitted more jobs into a fleet with no free slots. It would have made this worse.

**The blast radius was the platform, not the migration.** Mean job duration during the window:

```
executeEvaluation    ████████████████████ 20.7 s
metricTimeRollup     ███████████████ 15.5 s
canonicalLogStorage  ██████████████ 14.9 s
recordSpan           █████████████ 13.5 s   <- customer trace ingestion
authzGrantsWrite     ███████████ 11.6 s
```

## The change

ADR-110 made a grant its own **aggregate**, which fixed the whole-org fold and stands. Because a command's group key defaults to `${aggregateType}:${getAggregateId(payload)}`, it also gave every grant its own **lane** — a lane of one, which nothing can batch with.

The callback returns the **shard alone**; `buildGroupKey` composes `${tenantId}/${jobPath}/${aggregateType}:${key}`, so the organization is already in every key and the callback never names one:

```text
                    callback returns   final queue key
BEFORE (aggregate)  "grant_7Hk2mQ"     <org>/command/attachGrant/authz_grant:grant_7Hk2mQ
AFTER  (shard)      "14"               <org>/command/attachGrant/authz_grant:14
```

```text
BEFORE                            AFTER
one lane per grant                32 lanes per organization
  grant_7Hk2mQ -> 1 insert          lane 14 -> [grant_7Hk2mQ, ...] 1 insert
  grant_9Fs4tR -> 1 insert          lane 12 -> [grant_9Fs4tR, ...] 1 insert
     x 428,720                      ...

428,720 statements                ~8,500 at batch 50
```

`attachGrant`, `changeGrantRole` and `revokeGrant` take a sharded per-organization lane plus `coalesceMaxBatch`. **The fold is untouched** — state is still one grant keyed by its own id. Aggregate identity and lane identity were the same string only by default; `getGroupKey` on `CommandHandlerOptions` exists to separate them, and log-processing and trace-processing already use it.

Role commands keep the default per-aggregate lane: a role is rare and human-sized, so there is nothing to batch.

## Why sharding is safe here

coding-agent coalesces *without* sharding because its derivation depends on per-session order. Grant commands carry no such dependency:

- Same grant → same aggregate id → same shard → **order preserved**.
- Different grants → different aggregates, whose order was never meaningful.
- Different command **types** already sat in different lanes (the job path carries the command name), so nothing that was ordered stops being ordered.

The commands also satisfy the ADR-066 batch contract unmodified — `grantsLedgerCommands.ts` says so in its own docblock: *"the grant commands are pure appends: validate, stamp identity, emit"*. Each handler derives its event from its own command alone and never reads back a same-batch append.

## Tests

`grantsPipelineLanes.unit.test.ts` asserts the **registration**, not just the helper, and drives the *registered* `getGroupKey` rather than the module's export. An option that never reaches the registry looks identical to one that does, and would leave the queue silently in its old shape.

- 91 tests across the authz-grants pipeline, all passing.
- 994 tests across authz-grants + trace-processing (the `commandShardKey` move), all passing.
- Typecheck clean on the touched files; biome clean; `check:feature-parity` reports `10/10 ✓ all bound`.

`commandShardKey` moves from `trace-processing/commands/` to `pipeline/` now that two pipelines share it — imported, not copied.

## Deployment Impact

Changes the queue-group key for three commands. In-flight commands staged under the old key keep their own lanes and drain normally; the key is only read at enqueue. No migration, no backfill, no config.

The shard count (32) and batch bound (50) are constants with names and reasoning in the ADR, not tuned magic numbers — review is the right place to argue them.

## Not in this PR — and the containment gap stays open

The statement limiter is still first-come, first-served: it bounds total concurrency and the wait queue, but has no notion of what a statement is *for*, so a bulk backfill and a customer's trace write are peers.

ADR-114 decision 2 covers that, and writing it down changed it. The obvious shape — an `interactive` default with an opt-in `background` class holding at most a fraction of the budget — **does not contain this incident**. `recordSpan`, the job whose 13.5s latency is the whole reason this matters, is queue work too, so any rule that classes queue work as background starves customer ingestion right alongside the migration.

The axis that actually separates them is the **producer**, not the caller's interactivity: a max-min fair share of the statement budget across the pipelines with demand — the shape the dispatch path already has. The seam exists (`groupQueue.ts` already runs every job body inside `runWithContext`, so a statement can learn its pipeline without a parameter on every call site).

It is deferred rather than sketched-and-shipped because it is work on the scale of the dispatch water-fill itself, on a path every ClickHouse caller in the app crosses. This PR removes the *pressure*; decision 2 removes the *class of incident*. They aren't substitutes, and the second shouldn't be rushed behind the first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grant commands now use stable, organization-based lanes for consistent processing distribution.
  * Grant updates are grouped into batches of up to 50 operations.
  * Sharding falls back to a single lane when disabled or invalid.
  * Role commands retain their existing lane and batching behavior.

* **Documentation**
  * Added documentation describing grant command queuing, batching, and fairness behavior.

* **Tests**
  * Added coverage for lane stability, distribution, batching, fallback behavior, shard limits, and organization separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
