### PR TITLE
feat(lwql): saved workbench charts as dashboard widgets (granularity-aware)

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -347,7 +347,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-governance/sessions/admin-max-ttl.feature",
   "specs/ai-governance/sessions/personal-sessions.feature",
   "specs/ai-governance/sessions/sessions-inventory.feature",
-  "specs/analytics/dashboard-rest-api.feature",
   "specs/analytics/posthog-cost-control.feature",
   "specs/audit-log/audit-log.feature",
   "specs/auth/auth-signin-flows.feature",

--- a/platform/app/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { projectFactory } from "~/factories/project.factory";
 import type { Organization, Project, Team } from "~/generated/prisma/client";
+import { WORKBENCH_SQL_CHART_KIND } from "~/server/analytics/chartKinds";
 import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
 import {
@@ -12,6 +13,13 @@ import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { app } from "../[[...route]]/app";
+
+/**
+ * Distinctive enough that a substring search over the whole serialised body
+ * cannot miss it, and cannot match by coincidence.
+ */
+const SECRET_SQL =
+  "SELECT CapturedInput AS leaked_marker_7f3a FROM analytics.traces";
 
 describe("Feature: Dashboard REST API", () => {
   let testApiKey: string;
@@ -150,6 +158,30 @@ describe("Feature: Dashboard REST API", () => {
         graph: {},
         gridRow: overrides?.gridRow ?? 0,
         gridColumn: overrides?.gridColumn ?? 0,
+      },
+    });
+  }
+
+  /**
+   * A saved LangWatchQL workbench chart placed on a dashboard. Its `graph`
+   * column holds the member's statement, which is exactly what must not appear
+   * in a REST response.
+   */
+  async function createWorkbenchChart(dashboardId: string) {
+    return await prisma.customGraph.create({
+      data: {
+        id: nanoid(),
+        projectId: testProjectId,
+        dashboardId,
+        name: `Workbench ${nanoid(6)}`,
+        kind: WORKBENCH_SQL_CHART_KIND,
+        graph: {
+          version: 1,
+          sql: SECRET_SQL,
+          parameters: {},
+        },
+        gridRow: 0,
+        gridColumn: 0,
       },
     });
   }
@@ -383,6 +415,43 @@ describe("Feature: Dashboard REST API", () => {
         dashboardIds: [],
       });
       expect(res.status).toBe(422);
+    });
+  });
+
+  // ── Chart-kind isolation ─────────────────────────────────────
+
+  // The `kind` discriminator promises that neither chart shape sees the
+  // other's rows. This is that promise on the way *out*: the REST reader
+  // serialises each graph row wholesale, so a workbench row reaching it would
+  // publish a member's stored SQL to any project API key.
+  describe("GET /api/dashboards/:id with a workbench chart placed on it", () => {
+    /** @scenario "A saved workbench chart is not exposed through the dashboard REST API" */
+    it("omits the workbench chart from the graphs it returns", async () => {
+      const dashboard = await createDashboard({ name: "Mixed" });
+      const builderGraph = await createGraph(dashboard.id);
+      await createWorkbenchChart(dashboard.id);
+
+      const res = await helpers.api.get(`/api/dashboards/${dashboard.id}`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.graphs.map((graph: { id: string }) => graph.id)).toEqual([
+        builderGraph.id,
+      ]);
+    });
+
+    it("does not carry the stored statement anywhere in the response", async () => {
+      const dashboard = await createDashboard({ name: "Mixed" });
+      await createGraph(dashboard.id);
+      await createWorkbenchChart(dashboard.id);
+
+      const res = await helpers.api.get(`/api/dashboards/${dashboard.id}`);
+      const raw = await res.text();
+
+      // Asserted over the whole body rather than over `graphs`: the claim is
+      // that the SQL is not in the response *at all*, which a shape-scoped
+      // assertion would not catch if a later field carried it.
+      expect(raw).not.toContain("leaked_marker_7f3a");
     });
   });
 });

--- a/platform/app/src/components/analytics/reports/DraggableGraphCard.tsx
+++ b/platform/app/src/components/analytics/reports/DraggableGraphCard.tsx
@@ -76,9 +76,6 @@ export function DraggableGraphCard({
     gridRow: `span ${graph.rowSpan}`,
   };
 
-  // Calculate height based on rowSpan
-  const graphHeight = graph.rowSpan === 2 ? 600 : 300;
-
   const isWorkbenchChart = graph.kind === WORKBENCH_SQL_CHART_KIND;
 
   return (
@@ -115,34 +112,53 @@ export function DraggableGraphCard({
           />
 
           <Box flex={1} minHeight={0}>
-            {isWorkbenchChart ? (
-              <LangWatchQLDashboardWidget
-                key={graph.id}
-                chartId={graph.id}
-                projectId={projectId}
-                {...(graph.granularitySeconds == null
-                  ? {}
-                  : { granularitySeconds: graph.granularitySeconds })}
-                name={graph.name}
-              />
-            ) : (
-              <CustomGraph
-                key={graph.id}
-                input={{
-                  ...(graph.graph as CustomGraphInput),
-                  height: graphHeight,
-                }}
-                filters={
-                  graph.filters as
-                    | Record<FilterField, string[] | Record<string, string[]>>
-                    | undefined
-                }
-              />
-            )}
+            <GraphCardChartArea graph={graph} projectId={projectId} />
           </Box>
         </Card.Body>
       </Card.Root>
     </Box>
+  );
+}
+
+/**
+ * The card's chart, routed by the row's kind: a placed workbench chart mounts
+ * the live LangWatchQL widget; every other row is a builder graph.
+ */
+function GraphCardChartArea({
+  graph,
+  projectId,
+}: {
+  graph: GraphData;
+  projectId: string;
+}) {
+  if (graph.kind === WORKBENCH_SQL_CHART_KIND) {
+    return (
+      <LangWatchQLDashboardWidget
+        key={graph.id}
+        chartId={graph.id}
+        projectId={projectId}
+        {...(graph.granularitySeconds == null
+          ? {}
+          : { granularitySeconds: graph.granularitySeconds })}
+        name={graph.name}
+      />
+    );
+  }
+
+  return (
+    <CustomGraph
+      key={graph.id}
+      input={{
+        ...(graph.graph as CustomGraphInput),
+        // Height follows the card's row span.
+        height: graph.rowSpan === 2 ? 600 : 300,
+      }}
+      filters={
+        graph.filters as
+          | Record<FilterField, string[] | Record<string, string[]>>
+          | undefined
+      }
+    />
   );
 }
 

--- a/platform/app/src/components/analytics/reports/DraggableGraphCard.tsx
+++ b/platform/app/src/components/analytics/reports/DraggableGraphCard.tsx
@@ -7,6 +7,7 @@ import {
 } from "~/components/analytics/CustomGraph";
 import { LangWatchQLDashboardWidget } from "~/features/analytics-query/components/LangWatchQLDashboardWidget";
 import { WORKBENCH_SQL_CHART_KIND } from "~/server/analytics/chartKinds";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 import type { FilterField } from "~/server/filters/types";
 import { GraphCardHeader } from "./GraphCardHeader";
 import type { SizeOption } from "./GraphCardMenu";
@@ -30,7 +31,7 @@ interface GraphData {
    * The datapoint step a placed workbench chart was given, in seconds. Only
    * meaningful for `workbench_sql` rows.
    */
-  granularitySeconds?: number | null;
+  granularitySeconds?: LangWatchQLGranularityStep | null;
   trigger?: {
     id: string;
     active: boolean;

--- a/platform/app/src/components/analytics/reports/DraggableGraphCard.tsx
+++ b/platform/app/src/components/analytics/reports/DraggableGraphCard.tsx
@@ -5,6 +5,8 @@ import {
   CustomGraph,
   type CustomGraphInput,
 } from "~/components/analytics/CustomGraph";
+import { LangWatchQLDashboardWidget } from "~/features/analytics-query/components/LangWatchQLDashboardWidget";
+import { WORKBENCH_SQL_CHART_KIND } from "~/server/analytics/chartKinds";
 import type { FilterField } from "~/server/filters/types";
 import { GraphCardHeader } from "./GraphCardHeader";
 import type { SizeOption } from "./GraphCardMenu";
@@ -18,6 +20,17 @@ interface GraphData {
   gridRow: number;
   colSpan: number;
   rowSpan: number;
+  /**
+   * Which kind of chart this row is. Absent on rows read by a caller that does
+   * not select it, which reads as a builder graph — the kind every row was
+   * before the discriminator existed.
+   */
+  kind?: string | null;
+  /**
+   * The datapoint step a placed workbench chart was given, in seconds. Only
+   * meaningful for `workbench_sql` rows.
+   */
+  granularitySeconds?: number | null;
   trigger?: {
     id: string;
     active: boolean;
@@ -28,18 +41,22 @@ interface GraphData {
 interface DraggableGraphCardProps {
   graph: GraphData;
   projectSlug: string;
+  projectId: string;
   dashboardId?: string;
   onDelete: () => void;
   onSizeChange: (size: SizeOption) => void;
+  onGranularityChange?: (granularitySeconds: number) => void;
   isDeleting: boolean;
 }
 
 export function DraggableGraphCard({
   graph,
   projectSlug,
+  projectId,
   dashboardId,
   onDelete,
   onSizeChange,
+  onGranularityChange,
   isDeleting,
 }: DraggableGraphCardProps) {
   const {
@@ -62,6 +79,8 @@ export function DraggableGraphCard({
   // Calculate height based on rowSpan
   const graphHeight = graph.rowSpan === 2 ? 600 : 300;
 
+  const isWorkbenchChart = graph.kind === WORKBENCH_SQL_CHART_KIND;
+
   return (
     <Box ref={setNodeRef} style={style} minWidth={0}>
       <Card.Root height="full" minWidth={0}>
@@ -82,27 +101,44 @@ export function DraggableGraphCard({
             rowSpan={graph.rowSpan}
             filters={graph.filters}
             trigger={graph.trigger}
+            isWorkbenchChart={isWorkbenchChart}
+            {...(graph.granularitySeconds == null
+              ? {}
+              : { granularitySeconds: graph.granularitySeconds })}
             isDragging={isDragging}
             dragAttributes={attributes}
             dragListeners={listeners}
             onSizeChange={onSizeChange}
+            {...(onGranularityChange ? { onGranularityChange } : {})}
             onDelete={onDelete}
             isDeleting={isDeleting}
           />
 
           <Box flex={1} minHeight={0}>
-            <CustomGraph
-              key={graph.id}
-              input={{
-                ...(graph.graph as CustomGraphInput),
-                height: graphHeight,
-              }}
-              filters={
-                graph.filters as
-                  | Record<FilterField, string[] | Record<string, string[]>>
-                  | undefined
-              }
-            />
+            {isWorkbenchChart ? (
+              <LangWatchQLDashboardWidget
+                key={graph.id}
+                chartId={graph.id}
+                projectId={projectId}
+                {...(graph.granularitySeconds == null
+                  ? {}
+                  : { granularitySeconds: graph.granularitySeconds })}
+                name={graph.name}
+              />
+            ) : (
+              <CustomGraph
+                key={graph.id}
+                input={{
+                  ...(graph.graph as CustomGraphInput),
+                  height: graphHeight,
+                }}
+                filters={
+                  graph.filters as
+                    | Record<FilterField, string[] | Record<string, string[]>>
+                    | undefined
+                }
+              />
+            )}
           </Box>
         </Card.Body>
       </Card.Root>

--- a/platform/app/src/components/analytics/reports/GraphCardHeader.tsx
+++ b/platform/app/src/components/analytics/reports/GraphCardHeader.tsx
@@ -25,10 +25,15 @@ interface GraphCardHeaderProps {
     active: boolean;
     alertType: string | null;
   } | null;
+  /** Whether this card is a saved LangWatchQL chart rather than a builder graph. */
+  isWorkbenchChart?: boolean;
+  /** The datapoint step a workbench card runs at, when it has one stored. */
+  granularitySeconds?: number;
   isDragging: boolean;
   dragAttributes: DraggableAttributes;
   dragListeners: SyntheticListenerMap | undefined;
   onSizeChange: (size: SizeOption) => void;
+  onGranularityChange?: (granularitySeconds: number) => void;
   onDelete: () => void;
   isDeleting: boolean;
 }
@@ -43,10 +48,13 @@ export function GraphCardHeader({
   rowSpan,
   filters,
   trigger,
+  isWorkbenchChart = false,
+  granularitySeconds,
   isDragging,
   dragAttributes,
   dragListeners,
   onSizeChange,
+  onGranularityChange,
   onDelete,
   isDeleting,
 }: GraphCardHeaderProps) {
@@ -95,8 +103,14 @@ export function GraphCardHeader({
     [filters],
   );
 
-  // Check if this is a saved graph (has valid database ID)
-  const isSavedGraph = !!(graphId && graphId !== "custom" && graph);
+  // Check if this is a saved graph (has valid database ID).
+  //
+  // A workbench chart is excluded on purpose rather than by accident: the alert
+  // path reads a builder payload's `series` to name what it is thresholding,
+  // and a saved statement has no series to read. Offering the bell here would
+  // author an alert against a chart the threshold dispatcher cannot evaluate.
+  const isSavedGraph =
+    !isWorkbenchChart && !!(graphId && graphId !== "custom" && graph);
 
   // Opens the automations drawer in edit mode for this graph's existing
   // trigger. Shared by the bell's click and keyboard handlers so both entry
@@ -199,7 +213,10 @@ export function GraphCardHeader({
         dashboardId={dashboardId}
         colSpan={colSpan}
         rowSpan={rowSpan}
+        isWorkbenchChart={isWorkbenchChart}
+        {...(granularitySeconds === undefined ? {} : { granularitySeconds })}
         onSizeChange={onSizeChange}
+        {...(onGranularityChange ? { onGranularityChange } : {})}
         onDelete={onDelete}
         isDeleting={isDeleting}
       />

--- a/platform/app/src/components/analytics/reports/GraphCardMenu.tsx
+++ b/platform/app/src/components/analytics/reports/GraphCardMenu.tsx
@@ -1,7 +1,10 @@
 import { Button } from "@chakra-ui/react";
 import { Clock, Edit, Grid, MoreVertical, Trash2 } from "lucide-react";
 import { Menu } from "~/components/ui/menu";
-import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
+import {
+  describeLangWatchQLGranularityStep,
+  LWQL_GRANULARITY_STEPS,
+} from "~/server/analytics/lwql/timeWindow";
 import { useRouter } from "~/utils/compat/next-router";
 
 type SizeOption = "1x1" | "2x1" | "1x2" | "2x2";
@@ -19,20 +22,12 @@ const sizeOptions: {
 ];
 
 /**
- * How each offered datapoint step is named in the menu.
- *
- * Keyed off the steps the contract offers rather than listed independently, so
- * a step added to `LWQL_GRANULARITY_STEPS` cannot silently render as a bare
- * number here.
+ * How each offered datapoint step is named in the menu: the noun form, because
+ * a menu item names the step rather than modifying a following word. Shared
+ * with the widget's coarsened notice so the two cannot drift apart.
  */
-const granularityLabels: Readonly<Record<number, string>> = {
-  1: "1 second",
-  60: "1 minute",
-  3600: "1 hour",
-};
-
 const granularityLabel = (seconds: number): string =>
-  granularityLabels[seconds] ?? `${seconds} seconds`;
+  describeLangWatchQLGranularityStep(seconds, "noun");
 
 const getCurrentSize = (colSpan: number, rowSpan: number): SizeOption => {
   if (colSpan === 2 && rowSpan === 2) return "2x2";

--- a/platform/app/src/components/analytics/reports/GraphCardMenu.tsx
+++ b/platform/app/src/components/analytics/reports/GraphCardMenu.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@chakra-ui/react";
-import { Edit, Grid, MoreVertical, Trash2 } from "lucide-react";
+import { Clock, Edit, Grid, MoreVertical, Trash2 } from "lucide-react";
 import { Menu } from "~/components/ui/menu";
+import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
 import { useRouter } from "~/utils/compat/next-router";
 
 type SizeOption = "1x1" | "2x1" | "1x2" | "2x2";
@@ -17,6 +18,22 @@ const sizeOptions: {
   { value: "2x2", label: "Large (2x2)", colSpan: 2, rowSpan: 2 },
 ];
 
+/**
+ * How each offered datapoint step is named in the menu.
+ *
+ * Keyed off the steps the contract offers rather than listed independently, so
+ * a step added to `LWQL_GRANULARITY_STEPS` cannot silently render as a bare
+ * number here.
+ */
+const granularityLabels: Readonly<Record<number, string>> = {
+  1: "1 second",
+  60: "1 minute",
+  3600: "1 hour",
+};
+
+const granularityLabel = (seconds: number): string =>
+  granularityLabels[seconds] ?? `${seconds} seconds`;
+
 const getCurrentSize = (colSpan: number, rowSpan: number): SizeOption => {
   if (colSpan === 2 && rowSpan === 2) return "2x2";
   if (colSpan === 2 && rowSpan === 1) return "2x1";
@@ -30,7 +47,16 @@ interface GraphCardMenuProps {
   dashboardId?: string;
   colSpan: number;
   rowSpan: number;
+  /**
+   * Whether this card is a saved LangWatchQL chart. Decides where Edit goes and
+   * whether the datapoint-step picker is offered at all — a builder graph has
+   * no granularity contract to pick against.
+   */
+  isWorkbenchChart?: boolean;
+  /** The step this workbench card runs at, when it has one stored. */
+  granularitySeconds?: number;
   onSizeChange: (size: SizeOption) => void;
+  onGranularityChange?: (granularitySeconds: number) => void;
   onDelete: () => void;
   isDeleting: boolean;
 }
@@ -41,14 +67,27 @@ export function GraphCardMenu({
   dashboardId,
   colSpan,
   rowSpan,
+  isWorkbenchChart = false,
+  granularitySeconds,
   onSizeChange,
+  onGranularityChange,
   onDelete,
   isDeleting,
 }: GraphCardMenuProps) {
   const router = useRouter();
   const currentSize = getCurrentSize(colSpan, rowSpan);
 
-  const editUrl = `/${projectSlug}/analytics/custom/${graphId}${dashboardId ? `?dashboard=${dashboardId}` : ""}`;
+  // A workbench chart is edited in the workbench that wrote it, not in the
+  // builder — the builder cannot read a saved statement.
+  //
+  // The workbench opens charts through its own toolbar and has no deep-link
+  // parameter, so this lands on the surface rather than on the chart. Passing a
+  // `?chart=` it does not read would be worse than not passing one: the member
+  // would arrive at an empty workbench with a URL claiming otherwise. Opening
+  // the named chart directly waits on the workbench accepting a chart id.
+  const editUrl = isWorkbenchChart
+    ? `/${projectSlug}/analytics/query`
+    : `/${projectSlug}/analytics/custom/${graphId}${dashboardId ? `?dashboard=${dashboardId}` : ""}`;
 
   return (
     <Menu.Root>
@@ -64,7 +103,7 @@ export function GraphCardMenu({
             void router.push(editUrl);
           }}
         >
-          <Edit /> Edit Graph
+          <Edit /> {isWorkbenchChart ? "Open in workbench" : "Edit Graph"}
         </Menu.Item>
 
         <Menu.Root positioning={{ placement: "right-start", gutter: 2 }}>
@@ -84,6 +123,29 @@ export function GraphCardMenu({
             ))}
           </Menu.Content>
         </Menu.Root>
+
+        {isWorkbenchChart && onGranularityChange && (
+          <Menu.Root positioning={{ placement: "right-start", gutter: 2 }}>
+            <Menu.TriggerItem value="granularity">
+              <Clock /> Datapoints
+              {granularitySeconds === undefined
+                ? ""
+                : ` (${granularityLabel(granularitySeconds)})`}
+            </Menu.TriggerItem>
+            <Menu.Content>
+              {LWQL_GRANULARITY_STEPS.map((step) => (
+                <Menu.Item
+                  key={step}
+                  value={String(step)}
+                  onClick={() => onGranularityChange(step)}
+                >
+                  {granularityLabel(step)}
+                  {step === granularitySeconds && " ✓"}
+                </Menu.Item>
+              ))}
+            </Menu.Content>
+          </Menu.Root>
+        )}
 
         <Menu.Item value="delete" color="red.600" onClick={onDelete}>
           <Trash2 /> Delete Graph

--- a/platform/app/src/components/analytics/reports/ReportGrid.tsx
+++ b/platform/app/src/components/analytics/reports/ReportGrid.tsx
@@ -22,9 +22,14 @@ import {
 interface ReportGridProps {
   graphs: GraphData[];
   projectSlug: string;
+  projectId: string;
   dashboardId?: string;
   onGraphDelete: (graphId: string) => void;
   onGraphSizeChange: (graphId: string, size: SizeOption) => void;
+  onGraphGranularityChange?: (
+    graphId: string,
+    granularitySeconds: number,
+  ) => void;
   onGraphsReorder: (layouts: GridLayout[]) => void;
   deletingGraphId: string | null;
 }
@@ -32,9 +37,11 @@ interface ReportGridProps {
 export function ReportGrid({
   graphs,
   projectSlug,
+  projectId,
   dashboardId,
   onGraphDelete,
   onGraphSizeChange,
+  onGraphGranularityChange,
   onGraphsReorder,
   deletingGraphId,
 }: ReportGridProps) {
@@ -95,9 +102,16 @@ export function ReportGrid({
               key={graph.id}
               graph={graph}
               projectSlug={projectSlug}
+              projectId={projectId}
               dashboardId={dashboardId}
               onDelete={() => onGraphDelete(graph.id)}
               onSizeChange={(size) => onGraphSizeChange(graph.id, size)}
+              {...(onGraphGranularityChange
+                ? {
+                    onGranularityChange: (granularitySeconds: number) =>
+                      onGraphGranularityChange(graph.id, granularitySeconds),
+                  }
+                : {})}
               isDeleting={deletingGraphId === graph.id}
             />
           ))}

--- a/platform/app/src/components/analytics/reports/__tests__/DraggableGraphCard.workbench.integration.test.tsx
+++ b/platform/app/src/components/analytics/reports/__tests__/DraggableGraphCard.workbench.integration.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Which body a card draws, and which header controls it offers.
+ *
+ * The routing is decided by one field — `kind` — and both directions of getting
+ * it wrong are silent. A workbench row sent to `CustomGraph` hands a builder
+ * renderer a saved SQL statement in place of the series payload it expects; a
+ * builder row sent to the widget asks the saved-chart procedures for a row they
+ * will not find. Neither shows up as a type error, because `graph` is `unknown`
+ * on the way through.
+ *
+ * The alert bell is the same shape of mistake with a longer fuse. The alert path
+ * reads a builder payload's `series` to name what it thresholds, and a saved
+ * statement has no series to read — so a bell offered on a workbench card
+ * authors an alert the threshold dispatcher can never evaluate. It is excluded
+ * on purpose, and this pins that it stays excluded.
+ *
+ * Both children are mocked to markers: the claim is *which* component receives
+ * the row, and mounting the real Vega and tRPC stacks to prove it would test the
+ * harness instead.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn() }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => {
+  const router = { query: {}, asPath: "/", push: vi.fn(), replace: vi.fn() };
+  return { useRouter: () => router, default: router };
+});
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: undefined,
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("~/components/analytics/CustomGraph", () => ({
+  CustomGraph: () => <div data-testid="builder-graph" />,
+}));
+
+vi.mock(
+  "~/features/analytics-query/components/LangWatchQLDashboardWidget",
+  () => ({
+    LangWatchQLDashboardWidget: ({
+      chartId,
+      granularitySeconds,
+    }: {
+      chartId: string;
+      granularitySeconds?: number;
+    }) => (
+      <div
+        data-testid="workbench-widget"
+        data-chart-id={chartId}
+        data-granularity={granularitySeconds ?? "unset"}
+      />
+    ),
+  }),
+);
+
+import { WORKBENCH_SQL_CHART_KIND } from "~/server/analytics/chartKinds";
+
+import { DraggableGraphCard } from "../DraggableGraphCard";
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const BUILDER_PAYLOAD = {
+  graphType: "line",
+  series: [{ name: "p95 latency", key: "latency", aggregation: "p95" }],
+  includePrevious: false,
+  timeScale: "full",
+};
+
+function renderCard({
+  kind,
+  granularitySeconds,
+}: {
+  kind?: string | null;
+  granularitySeconds?: number | null;
+} = {}) {
+  return render(
+    <DraggableGraphCard
+      graph={{
+        id: "graph_1",
+        name: "p95 latency",
+        graph: BUILDER_PAYLOAD,
+        filters: {},
+        gridColumn: 0,
+        gridRow: 0,
+        colSpan: 1,
+        rowSpan: 1,
+        ...(kind === undefined ? {} : { kind }),
+        ...(granularitySeconds === undefined ? {} : { granularitySeconds }),
+        trigger: null,
+      }}
+      projectSlug="proj"
+      projectId="project_1"
+      onDelete={vi.fn()}
+      onSizeChange={vi.fn()}
+      isDeleting={false}
+    />,
+    { wrapper: Wrapper },
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("a dashboard grid card", () => {
+  describe("given a builder graph", () => {
+    /** @scenario "A builder card keeps the builder renderer and its alert bell" */
+    it("draws the builder renderer", () => {
+      renderCard({ kind: "builder" });
+
+      expect(screen.getByTestId("builder-graph")).toBeInTheDocument();
+      expect(screen.queryByTestId("workbench-widget")).not.toBeInTheDocument();
+    });
+
+    it("offers the alert bell", () => {
+      renderCard({ kind: "builder" });
+
+      expect(
+        screen.getByRole("button", { name: /Add alert/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("draws the builder renderer for a row carrying no kind at all", () => {
+      // Rows predate the discriminator; absent has to keep reading as builder,
+      // or every chart saved before this column existed stops rendering.
+      renderCard();
+
+      expect(screen.getByTestId("builder-graph")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a saved workbench chart", () => {
+    /** @scenario "A placed workbench card draws the widget, not the builder" */
+    it("draws the widget rather than the builder renderer", () => {
+      renderCard({ kind: WORKBENCH_SQL_CHART_KIND });
+
+      expect(screen.getByTestId("workbench-widget")).toBeInTheDocument();
+      expect(screen.queryByTestId("builder-graph")).not.toBeInTheDocument();
+    });
+
+    /** @scenario "A workbench card is not offered an alert it cannot evaluate" */
+    it("offers no alert bell", () => {
+      renderCard({ kind: WORKBENCH_SQL_CHART_KIND });
+
+      expect(
+        screen.queryByRole("button", { name: /Add alert/ }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("passes the stored step through to the widget", () => {
+      renderCard({
+        kind: WORKBENCH_SQL_CHART_KIND,
+        granularitySeconds: 3600,
+      });
+
+      expect(screen.getByTestId("workbench-widget")).toHaveAttribute(
+        "data-granularity",
+        "3600",
+      );
+    });
+
+    it("passes no step when the row carries none, leaving the widget its default", () => {
+      // A null must not arrive as a step: the widget's own default is what a
+      // card with nothing stored should run at.
+      renderCard({
+        kind: WORKBENCH_SQL_CHART_KIND,
+        granularitySeconds: null,
+      });
+
+      expect(screen.getByTestId("workbench-widget")).toHaveAttribute(
+        "data-granularity",
+        "unset",
+      );
+    });
+  });
+});

--- a/platform/app/src/components/analytics/reports/__tests__/DraggableGraphCard.workbench.integration.test.tsx
+++ b/platform/app/src/components/analytics/reports/__tests__/DraggableGraphCard.workbench.integration.test.tsx
@@ -27,6 +27,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 
 vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({ openDrawer: vi.fn() }),
@@ -91,7 +92,7 @@ function renderCard({
   granularitySeconds,
 }: {
   kind?: string | null;
-  granularitySeconds?: number | null;
+  granularitySeconds?: LangWatchQLGranularityStep | null;
 } = {}) {
   return render(
     <DraggableGraphCard

--- a/platform/app/src/components/analytics/reports/__tests__/GraphCardMenu.workbench.integration.test.tsx
+++ b/platform/app/src/components/analytics/reports/__tests__/GraphCardMenu.workbench.integration.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * What the card menu offers, and to which kind of card.
+ *
+ * Two claims a member would be hurt by getting wrong. The datapoint picker must
+ * not appear on a builder graph — there is no granularity contract behind it,
+ * so every step would be a control that does nothing. And Edit must lead to the
+ * surface that can actually open the chart: sending a saved statement to the
+ * builder's editor lands a member on a page that cannot read it.
+ *
+ * Drives the real Chakra menus rather than asserting on props, because "the
+ * member can reach it" is the claim, and a prop that never renders satisfies a
+ * prop assertion.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ push, query: {} }),
+}));
+
+import { GraphCardMenu } from "../GraphCardMenu";
+
+const withChakra = (element: ReactElement) =>
+  render(<ChakraProvider value={defaultSystem}>{element}</ChakraProvider>);
+
+// The push spy is shared by the module mock, so a stale call from a previous
+// test would otherwise satisfy a later assertion.
+beforeEach(() => {
+  push.mockClear();
+});
+
+function mount(overrides: Partial<Parameters<typeof GraphCardMenu>[0]> = {}) {
+  const onGranularityChange = vi.fn();
+  const onSizeChange = vi.fn();
+  const onDelete = vi.fn();
+
+  withChakra(
+    <GraphCardMenu
+      graphId="chart-1"
+      projectSlug="my-project"
+      dashboardId="dashboard-1"
+      colSpan={1}
+      rowSpan={1}
+      onSizeChange={onSizeChange}
+      onDelete={onDelete}
+      isDeleting={false}
+      {...overrides}
+    />,
+  );
+
+  return { onGranularityChange, onSizeChange, onDelete };
+}
+
+describe("the dashboard card menu", () => {
+  describe("given a builder graph", () => {
+    it("offers no datapoint picker", async () => {
+      const user = userEvent.setup();
+      mount();
+
+      await user.click(screen.getByRole("button"));
+
+      expect(screen.queryByText(/Datapoints/)).not.toBeInTheDocument();
+    });
+
+    it("edits in the chart builder", async () => {
+      const user = userEvent.setup();
+      mount();
+
+      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByText("Edit Graph"));
+
+      expect(push).toHaveBeenCalledWith(
+        "/my-project/analytics/custom/chart-1?dashboard=dashboard-1",
+      );
+    });
+  });
+
+  describe("given a saved workbench chart", () => {
+    it("offers the step the card is currently running at", async () => {
+      const user = userEvent.setup();
+      const onGranularityChange = vi.fn();
+      mount({
+        isWorkbenchChart: true,
+        granularitySeconds: 60,
+        onGranularityChange,
+      });
+
+      await user.click(screen.getByRole("button"));
+
+      expect(screen.getByText(/Datapoints \(1 minute\)/)).toBeInTheDocument();
+    });
+
+    it("reports the step the member picks", async () => {
+      const user = userEvent.setup();
+      const onGranularityChange = vi.fn();
+      mount({
+        isWorkbenchChart: true,
+        granularitySeconds: 60,
+        onGranularityChange,
+      });
+
+      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByText(/Datapoints/));
+      await user.click(await screen.findByText("1 hour"));
+
+      // Seconds, which is what the granularity contract is denominated in.
+      expect(onGranularityChange).toHaveBeenCalledWith(3600);
+    });
+
+    it("sends the member to the workbench, not the builder", async () => {
+      const user = userEvent.setup();
+      mount({ isWorkbenchChart: true, onGranularityChange: vi.fn() });
+
+      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByText("Open in workbench"));
+
+      // No `?chart=` — the workbench has no deep-link parameter, and a URL
+      // claiming to open a chart it cannot open is worse than one that does
+      // not claim to.
+      expect(push).toHaveBeenCalledWith("/my-project/analytics/query");
+    });
+
+    it("offers no picker when the surface cannot accept a change", async () => {
+      // No handler means nothing can be done with a pick; offering the control
+      // anyway would be a menu item that silently does nothing.
+      const user = userEvent.setup();
+      mount({ isWorkbenchChart: true, granularitySeconds: 60 });
+
+      await user.click(screen.getByRole("button"));
+
+      expect(screen.queryByText(/Datapoints/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLDashboardWidget.integration.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLDashboardWidget.integration.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * What the dashboard widget asks for, and which answer it draws.
+ *
+ * Three claims a member would be hurt by getting wrong, and none of them is
+ * visible from the component's props.
+ *
+ * The **coarsen request** is the one that keeps a card from blanking: the
+ * widget does not own the period, so a saved one-second chart meets a
+ * year-wide dashboard sooner or later. `onBudgetOverflow: "coarsen"` has to
+ * reach the wire — a widget that sent the workbench's `"refuse"` would show an
+ * error on a card whose owner changed nothing, and every prop-level assertion
+ * would still pass.
+ *
+ * The **notice** is what stops the coarsening being a silent substitution, and
+ * it must appear only when one happened: a notice on an uncoarsened card tells
+ * a member their numbers were changed when they were not.
+ *
+ * The **stale answer** is the one that is invisible by construction. A period
+ * drag fires a run per intermediate window and nothing orders the responses, so
+ * without a sequence guard the card can settle on the answer for a period the
+ * dashboard already left, with no spinner and nothing on screen admitting it.
+ *
+ * The tRPC client is mocked at `~/utils/api` rather than driven through a real
+ * one, so that a mutation's resolution can be held open and released out of
+ * order — which is the whole shape of the race being pinned.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mutateMock, chartQueryMock } = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  chartQueryMock: vi.fn(),
+}));
+
+vi.mock("~/components/PeriodSelector", () => ({
+  usePeriodSelector: () => ({
+    period: {
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-02T00:00:00Z"),
+    },
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    analytics: {
+      savedWorkbenchCharts: {
+        getById: { useQuery: () => chartQueryMock() },
+        run: {
+          useMutation: () => ({
+            mutate: mutateMock,
+            data: undefined,
+            error: null,
+          }),
+        },
+      },
+    },
+  },
+}));
+
+// The lazy Vega boundary renders nothing useful under jsdom and would pull
+// several megabytes of chart runtime into this suite. Replaced with a marker
+// that echoes the row count, so "the widget drew this answer" is observable
+// without mounting Vega.
+vi.mock("../components/LazyLangWatchQLWidgetChart", () => ({
+  LazyLangWatchQLWidgetChart: ({
+    rows,
+  }: {
+    rows: readonly Record<string, unknown>[];
+  }) => <div data-testid="widget-chart">{JSON.stringify(rows)}</div>,
+}));
+
+import { LangWatchQLDashboardWidget } from "../components/LangWatchQLDashboardWidget";
+
+const CHART = {
+  id: "chart_1",
+  name: "p95 latency",
+  definition: { vegaLiteSpec: undefined },
+};
+
+/** A run answer, with the coarsening fields only when a coarsening happened. */
+function answer({
+  rows,
+  granularitySeconds = 60,
+  coarsenedFromSeconds,
+}: {
+  rows: readonly Record<string, unknown>[];
+  granularitySeconds?: number;
+  coarsenedFromSeconds?: number;
+}) {
+  return {
+    columns: [{ name: "value", type: "UInt64" }],
+    rows,
+    granularitySeconds,
+    ...(coarsenedFromSeconds === undefined ? {} : { coarsenedFromSeconds }),
+  };
+}
+
+const mount = (element: ReactElement) =>
+  render(<ChakraProvider value={defaultSystem}>{element}</ChakraProvider>);
+
+function mountWidget(props: { granularitySeconds?: number } = {}) {
+  return mount(
+    <LangWatchQLDashboardWidget
+      chartId="chart_1"
+      projectId="project_1"
+      name="p95 latency"
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  mutateMock.mockReset();
+  chartQueryMock.mockReset();
+  chartQueryMock.mockReturnValue({ data: CHART, error: null });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the LangWatchQL dashboard widget", () => {
+  describe("given a placed saved chart", () => {
+    /** @scenario "A placed widget asks the run to coarsen rather than refuse" */
+    it("asks the run to coarsen rather than refuse", async () => {
+      mountWidget({ granularitySeconds: 1 });
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+
+      // The request body itself, not a prop: this is the field that decides
+      // whether a wide period blanks the card or redraws it.
+      expect(mutateMock.mock.calls[0]?.[0]).toMatchObject({
+        id: "chart_1",
+        projectId: "project_1",
+        granularitySeconds: 1,
+        onBudgetOverflow: "coarsen",
+      });
+    });
+  });
+
+  describe("when the run reports a coarsening", () => {
+    /** @scenario "A coarsened widget says which step it actually ran at" */
+    it("shows the notice naming both steps", async () => {
+      mountWidget({ granularitySeconds: 1 });
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+      mutateMock.mock.calls[0]?.[1]?.onSuccess?.(
+        answer({
+          rows: [{ value: 1 }],
+          granularitySeconds: 3600,
+          coarsenedFromSeconds: 1,
+        }),
+      );
+
+      const notice = await screen.findByTestId("lwql-widget-coarsened-notice");
+      expect(notice).toHaveTextContent("1-hour");
+      expect(notice).toHaveTextContent("1-second");
+    });
+  });
+
+  describe("when the run reports no coarsening", () => {
+    it("shows no notice", async () => {
+      mountWidget({ granularitySeconds: 60 });
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+      mutateMock.mock.calls[0]?.[1]?.onSuccess?.(
+        answer({ rows: [{ value: 1 }], granularitySeconds: 60 }),
+      );
+
+      await screen.findByTestId("widget-chart");
+      expect(
+        screen.queryByTestId("lwql-widget-coarsened-notice"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when an older request resolves after a newer one", () => {
+    /** @scenario "A widget ignores an answer for a period it has left" */
+    it("keeps the newer answer and drops the straggler", async () => {
+      const { rerender } = mountWidget({ granularitySeconds: 1 });
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+      // A second request, as a period drag would issue: same chart, different
+      // step, so the widget's request key changes and a new run fires.
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <LangWatchQLDashboardWidget
+            chartId="chart_1"
+            projectId="project_1"
+            name="p95 latency"
+            granularitySeconds={3600}
+          />
+        </ChakraProvider>,
+      );
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(2));
+
+      // The newer request answers first, then the older one straggles in —
+      // the exact order that has no spinner and no error to reveal it.
+      mutateMock.mock.calls[1]?.[1]?.onSuccess?.(
+        answer({ rows: [{ value: "newer" }], granularitySeconds: 3600 }),
+      );
+      await screen.findByTestId("widget-chart");
+
+      mutateMock.mock.calls[0]?.[1]?.onSuccess?.(
+        answer({ rows: [{ value: "stale" }], granularitySeconds: 1 }),
+      );
+
+      // Asserted on the drawn rows, because "the card is showing the wrong
+      // period" is a claim about what is on screen, not about which callback
+      // ran.
+      await waitFor(() => {
+        expect(screen.getByTestId("widget-chart")).toHaveTextContent("newer");
+      });
+      expect(screen.getByTestId("widget-chart")).not.toHaveTextContent("stale");
+    });
+  });
+});

--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLDashboardWidget.integration.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLDashboardWidget.integration.test.tsx
@@ -224,4 +224,86 @@ describe("the LangWatchQL dashboard widget", () => {
       expect(screen.getByTestId("widget-chart")).not.toHaveTextContent("stale");
     });
   });
+
+  describe("when the saved SQL fails with a failure the platform can name", () => {
+    /** @scenario "A widget names a run refusal instead of the generic card" */
+    it("renders the shared registry's copy for the error code", async () => {
+      mountWidget();
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+
+      // The tRPC envelope a handled error rides in (`data.error`), exactly as
+      // `handledErrorMiddleware` serialises it — the same payload the
+      // workbench's result pane reads. The widget must resolve it through the
+      // shared presentation registry, not a mapping of its own.
+      mutateMock.mock.calls[0]?.[1]?.onError?.({
+        message: "lwql_unparseable",
+        data: {
+          error: {
+            code: "lwql_unparseable",
+            httpStatus: 400,
+            fault: "customer",
+          },
+        },
+      });
+
+      const alert = await screen.findByRole("alert");
+      // The registry's copy for `lwql_unparseable` — the words the workbench
+      // shows for the same refusal.
+      expect(alert).toHaveTextContent("This query couldn't be read");
+      expect(alert).toHaveTextContent("Check the SQL syntax and try again.");
+      // The wire message is the code slug and must never be the copy shown.
+      expect(alert).not.toHaveTextContent(/^lwql_unparseable$/);
+    });
+  });
+
+  describe("when the run fails with an error nobody can name", () => {
+    /** @scenario "A widget falls back to the generic card only for unknown failures" */
+    it("renders the generic treatment under the widget's own headline", async () => {
+      mountWidget();
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalled());
+
+      // A plain error with no handled payload: the correct degraded outcome.
+      mutateMock.mock.calls[0]?.[1]?.onError?.(new Error("socket hang up"));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Couldn't run this chart's query");
+      // Nothing internal leaks into the card.
+      expect(alert).not.toHaveTextContent("socket hang up");
+    });
+  });
+
+  describe("when a stale request's failure resolves after a newer answer", () => {
+    it("keeps the newer answer rather than flipping to the stale error", async () => {
+      const { rerender } = mountWidget({ granularitySeconds: 1 });
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <LangWatchQLDashboardWidget
+            chartId="chart_1"
+            projectId="project_1"
+            name="p95 latency"
+            granularitySeconds={3600}
+          />
+        </ChakraProvider>,
+      );
+
+      await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(2));
+
+      mutateMock.mock.calls[1]?.[1]?.onSuccess?.(
+        answer({ rows: [{ value: "newer" }], granularitySeconds: 3600 }),
+      );
+      await screen.findByTestId("widget-chart");
+
+      // The abandoned request settles last, as a failure. The card must not
+      // replace a fresh answer with an error for a period it already left.
+      mutateMock.mock.calls[0]?.[1]?.onError?.(new Error("stale failure"));
+
+      expect(screen.getByTestId("widget-chart")).toHaveTextContent("newer");
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLDashboardWidget.integration.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLDashboardWidget.integration.test.tsx
@@ -33,6 +33,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 
 const { mutateMock, chartQueryMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
@@ -106,7 +107,9 @@ function answer({
 const mount = (element: ReactElement) =>
   render(<ChakraProvider value={defaultSystem}>{element}</ChakraProvider>);
 
-function mountWidget(props: { granularitySeconds?: number } = {}) {
+function mountWidget(
+  props: { granularitySeconds?: LangWatchQLGranularityStep } = {},
+) {
   return mount(
     <LangWatchQLDashboardWidget
       chartId="chart_1"

--- a/platform/app/src/features/analytics-query/__tests__/vegaLazyBoundary.unit.test.ts
+++ b/platform/app/src/features/analytics-query/__tests__/vegaLazyBoundary.unit.test.ts
@@ -8,8 +8,17 @@
  * splits on, so it is the import graph that is pinned here.
  *
  * The claim is containment: within this feature, every module that reaches a
- * Vega package is reachable only through `LangWatchQLChartMode`, which is what
- * `LazyLangWatchQLChartMode` loads on demand and nothing imports directly.
+ * Vega package is reachable only *behind a lazy boundary* — a module some
+ * `Lazy…` wrapper loads with a dynamic `import()` and nothing imports directly.
+ *
+ * There are two such boundaries, and they are two because the surfaces mount
+ * different components, not because the chunk differs: the workbench mounts
+ * `LangWatchQLChartMode`, the dashboard widget mounts
+ * `LangWatchQLWidgetChart`. Both reach `LangWatchQLVegaLiteChart` and so both
+ * reach Vega; what matters is that neither is reachable statically. Pinning
+ * only the workbench's boundary would have let the dashboard's chart be
+ * imported directly from the grid — several megabytes back in the entry chunk,
+ * with nothing visibly wrong.
  *
  * Node environment on purpose — this reads source, and evaluates none of it.
  */
@@ -25,11 +34,23 @@ const FEATURE_DIR = fileURLToPath(new URL("../", import.meta.url));
 /** `…/analytics-query` → `…/src`, which the `~/` alias resolves from. */
 const SRC_DIR = resolve(FEATURE_DIR, "../..");
 
-const LAZY_BOUNDARY = join(
-  FEATURE_DIR,
-  "components/LazyLangWatchQLChartMode.tsx",
-);
-const CHART_MODE = join(FEATURE_DIR, "components/LangWatchQLChartMode.tsx");
+/**
+ * Every lazy boundary in this feature, as the wrapper that defers and the
+ * module it defers to. Adding a third surface that draws a chart means adding
+ * its pair here — a boundary omitted is a boundary this suite does not check.
+ */
+const LAZY_BOUNDARIES = [
+  {
+    wrapper: join(FEATURE_DIR, "components/LazyLangWatchQLChartMode.tsx"),
+    deferred: join(FEATURE_DIR, "components/LangWatchQLChartMode.tsx"),
+    specifier: 'import("./LangWatchQLChartMode")',
+  },
+  {
+    wrapper: join(FEATURE_DIR, "components/LazyLangWatchQLWidgetChart.tsx"),
+    deferred: join(FEATURE_DIR, "components/LangWatchQLWidgetChart.tsx"),
+    specifier: 'import("./LangWatchQLWidgetChart")',
+  },
+] as const;
 
 /** Packages whose presence in a chunk means the Vega runtime is in it. */
 const VEGA_PACKAGE = /^(vega|vega-lite|vega-embed|react-vega)(\/|$)/;
@@ -148,30 +169,37 @@ describe("where the Vega runtime can be reached from", () => {
   describe("given the workbench's own modules", () => {
     describe("when their static import graphs are walked", () => {
       /** @scenario "Vega loads lazily from Chart mode only" */
-      it("reaches Vega from chart mode, and from nothing that is not behind it", () => {
-        const chartMode = walkStaticGraph(CHART_MODE);
-        // Without this the containment claim below would hold vacuously — a
-        // graph walk that finds nothing anywhere proves nothing.
-        expect(reachesVega(chartMode)).toBe(true);
+      it("reaches Vega from each deferred module, and from nothing that is not behind one", () => {
+        const behindABoundary = new Set<string>();
+        for (const { deferred } of LAZY_BOUNDARIES) {
+          const walk = walkStaticGraph(deferred);
+          // Without this the containment claim below would hold vacuously — a
+          // graph walk that finds nothing anywhere proves nothing.
+          expect(reachesVega(walk)).toBe(true);
+          for (const file of walk.files) behindABoundary.add(file);
+        }
 
-        const behindTheBoundary = new Set(chartMode.files);
         const leaks = featureSourceFiles(FEATURE_DIR)
-          .filter((file) => !behindTheBoundary.has(file))
+          .filter((file) => !behindABoundary.has(file))
           .filter((file) => reachesVega(walkStaticGraph(file)));
 
         expect(leaks.map((file) => file.replace(FEATURE_DIR, ""))).toEqual([]);
       });
 
       /** @scenario "Vega loads lazily from Chart mode only" */
-      it("keeps the lazy boundary itself free of everything it defers", () => {
-        const boundary = walkStaticGraph(LAZY_BOUNDARY);
+      it.each(
+        LAZY_BOUNDARIES.map((boundary) => [boundary.wrapper, boundary]),
+      )("keeps %s free of everything it defers", (_name, {
+        wrapper,
+        deferred,
+        specifier,
+      }) => {
+        const walk = walkStaticGraph(wrapper);
 
-        expect(reachesVega(boundary)).toBe(false);
-        expect(boundary.files).not.toContain(CHART_MODE);
+        expect(reachesVega(walk)).toBe(false);
+        expect(walk.files).not.toContain(deferred);
         // It is a lazy import, and nothing else would defer anything.
-        expect(readFileSync(LAZY_BOUNDARY, "utf8")).toContain(
-          'import("./LangWatchQLChartMode")',
-        );
+        expect(readFileSync(wrapper, "utf8")).toContain(specifier);
       });
     });
   });

--- a/platform/app/src/features/analytics-query/__tests__/widgetCoarsenedNotice.unit.test.ts
+++ b/platform/app/src/features/analytics-query/__tests__/widgetCoarsenedNotice.unit.test.ts
@@ -1,0 +1,48 @@
+/**
+ * What a coarsened widget tells the member.
+ *
+ * The notice exists because the substitution is otherwise invisible: the card
+ * redraws at a coarser step and nothing on screen says the answer is not the
+ * one the chart was configured to give. So the claims worth pinning are that it
+ * names *both* steps — the one asked for and the one used — and that it cites
+ * the ceiling that forced the change rather than asserting a bare number the
+ * member cannot check.
+ *
+ * A pure function, tested as one: it lives in its own module precisely so this
+ * suite does not have to mount a widget — and everything Chakra, tRPC and Vega
+ * behind it — to read one sentence.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { LWQL_GRANULARITY_MAX_BUCKETS } from "~/server/analytics/lwql/timeWindow";
+
+import { widgetCoarsenedNotice } from "../logic/widgetCoarsenedNotice";
+
+describe("the notice a coarsened widget shows", () => {
+  it("names the step it used and the step it was asked for", () => {
+    const notice = widgetCoarsenedNotice({ from: 60, to: 3600 });
+
+    expect(notice).toContain("1-hour");
+    expect(notice).toContain("1-minute");
+  });
+
+  it("cites the datapoint ceiling that forced the change", () => {
+    const notice = widgetCoarsenedNotice({ from: 1, to: 60 });
+
+    // Read off the constant rather than written out, so a changed ceiling
+    // cannot leave this suite asserting a number the product no longer uses.
+    expect(notice).toContain(LWQL_GRANULARITY_MAX_BUCKETS.toLocaleString());
+  });
+
+  it("describes every offered step in words rather than seconds", () => {
+    // The steps a member can pick are the three the contract offers; a notice
+    // that said "3600-second" would be naming an implementation detail at the
+    // one moment the member is being asked to trust the substitution.
+    expect(widgetCoarsenedNotice({ from: 1, to: 60 })).toContain("1-second");
+    expect(widgetCoarsenedNotice({ from: 60, to: 3600 })).toContain("1-minute");
+    expect(widgetCoarsenedNotice({ from: 1, to: 3600 })).toContain("1-hour");
+  });
+});

--- a/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
@@ -1,0 +1,178 @@
+/**
+ * One saved LangWatchQL chart, rendered as a dashboard widget.
+ *
+ * The widget references its chart by id and reads the definition live, rather
+ * than drawing a copy snapshotted when the chart was placed. A member who fixes
+ * a chart's SQL expects every dashboard showing it to be fixed too; a snapshot
+ * would leave the old answer on the grid with nothing on screen admitting it
+ * was stale.
+ *
+ * Three things decide what it draws, and they come from three different places
+ * on purpose:
+ *
+ *  - **The statement and its parameters** come from the saved chart. The saved
+ *    parameter values are run as-is: a widget offers no overrides, because a
+ *    dashboard is a shared surface and a per-viewer override would mean two
+ *    members discussing the same card were looking at different numbers.
+ *  - **The period** comes from the dashboard's own period control, read from
+ *    URL state through `usePeriodSelector` exactly as every builder chart on
+ *    the grid reads it. One control moves every card, which is what makes the
+ *    cards comparable.
+ *  - **The datapoint step** is the widget's own, chosen per card, because the
+ *    right bucket size is a property of the question the chart asks and not of
+ *    the period it happens to be showing.
+ *
+ * That last split is why this surface coarsens rather than refuses. The saved
+ * step meets a period the widget does not own and cannot predict: a member can
+ * drag the dashboard to a year with a one-second chart on it. Refusing would
+ * blank a card whose owner changed nothing, so the run asks for `"coarsen"` and
+ * says what it got.
+ *
+ * @see ./LazyLangWatchQLWidgetChart — the Vega boundary this mounts
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { Box, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
+import { useEffect, useMemo, useRef } from "react";
+
+import { usePeriodSelector } from "~/components/PeriodSelector";
+import { HandledErrorAlert } from "~/features/errors";
+import { api } from "~/utils/api";
+
+import { widgetCoarsenedNotice } from "../logic/widgetCoarsenedNotice";
+import type { LangWatchQLDatasetColumn } from "../visualization/visualization.types";
+
+import { LazyLangWatchQLWidgetChart } from "./LazyLangWatchQLWidgetChart";
+
+/**
+ * The default datapoint step for a widget whose chart declares the granularity
+ * parameter but has no step stored yet — one minute, the middle of the offered
+ * steps. Coarsened up from here when the dashboard's period is wide.
+ */
+export const LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS = 60;
+
+export interface LangWatchQLDashboardWidgetProps {
+  readonly chartId: string;
+  readonly projectId: string;
+  /**
+   * The step this card was placed with. Absent falls back to
+   * {@link LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS}; ignored entirely by a
+   * statement that does not declare the granularity parameter.
+   */
+  readonly granularitySeconds?: number;
+  /** The card's title, used to describe the chart to a screen reader. */
+  readonly name: string;
+}
+
+export function LangWatchQLDashboardWidget({
+  chartId,
+  projectId,
+  granularitySeconds,
+  name,
+}: LangWatchQLDashboardWidgetProps) {
+  const { period } = usePeriodSelector();
+
+  const chartQuery = api.analytics.savedWorkbenchCharts.getById.useQuery(
+    { id: chartId, projectId },
+    { enabled: !!projectId && !!chartId },
+  );
+
+  const run = api.analytics.savedWorkbenchCharts.run.useMutation();
+
+  // Epoch milliseconds rather than the `Date` objects `usePeriodSelector`
+  // hands back: two `Date`s for the same instant are never `Object.is`-equal,
+  // so a dependency built on them would re-run the query on every render.
+  const start = period.startDate.getTime();
+  const end = period.endDate.getTime();
+
+  const step = granularitySeconds ?? LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS;
+
+  // `run` is a mutation because executing SQL is not a cacheable read, so the
+  // widget drives it from an effect rather than getting react-query's own
+  // fetch-on-change. The ref carries the last request actually issued so that
+  // a re-render with the same period and step does not re-execute.
+  const { mutate } = run;
+  const lastRequest = useRef<string | null>(null);
+  const requestKey = `${chartId}:${start}:${end}:${step}`;
+
+  useEffect(() => {
+    if (!chartQuery.data) return;
+    if (lastRequest.current === requestKey) return;
+    lastRequest.current = requestKey;
+
+    mutate({
+      id: chartId,
+      projectId,
+      timeWindow: { start, end },
+      granularitySeconds: step,
+      // The whole reason this surface differs from the workbench: see the
+      // module docblock.
+      onBudgetOverflow: "coarsen",
+    });
+  }, [
+    chartQuery.data,
+    requestKey,
+    mutate,
+    chartId,
+    projectId,
+    start,
+    end,
+    step,
+  ]);
+
+  const result = run.data;
+
+  const columns = useMemo(
+    () => (result?.columns ?? []) as readonly LangWatchQLDatasetColumn[],
+    [result],
+  );
+
+  if (chartQuery.error) {
+    return <HandledErrorAlert error={chartQuery.error} />;
+  }
+
+  if (run.error) {
+    return <HandledErrorAlert error={run.error} />;
+  }
+
+  if (!chartQuery.data || !result) {
+    return (
+      <HStack gap={2} color="fg.muted" padding={4}>
+        <Spinner size="sm" />
+        <Text fontSize="13px">Loading the chart</Text>
+      </HStack>
+    );
+  }
+
+  const coarsenedFrom = result.coarsenedFromSeconds;
+
+  return (
+    <VStack align="stretch" gap={2} height="full" minWidth={0}>
+      {coarsenedFrom !== undefined &&
+        result.granularitySeconds !== undefined && (
+          <Box
+            role="status"
+            data-testid="lwql-widget-coarsened-notice"
+            fontSize="12px"
+            color="fg.muted"
+          >
+            {widgetCoarsenedNotice({
+              from: coarsenedFrom,
+              to: result.granularitySeconds,
+            })}
+          </Box>
+        )}
+
+      <Box flex={1} minHeight={0}>
+        <LazyLangWatchQLWidgetChart
+          columns={columns}
+          rows={result.rows}
+          {...(chartQuery.data.definition.vegaLiteSpec
+            ? { vegaLiteSpec: chartQuery.data.definition.vegaLiteSpec }
+            : {})}
+          ariaLabel={name}
+        />
+      </Box>
+    </VStack>
+  );
+}

--- a/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
@@ -38,6 +38,7 @@ import { useMemo } from "react";
 
 import { usePeriodSelector } from "~/components/PeriodSelector";
 import { HandledErrorAlert } from "~/features/errors";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 import { api } from "~/utils/api";
 
 import { useLangWatchQLWidgetRun } from "../hooks/useLangWatchQLWidgetRun";
@@ -51,7 +52,7 @@ import { LazyLangWatchQLWidgetChart } from "./LazyLangWatchQLWidgetChart";
  * parameter but has no step stored yet — one minute, the middle of the offered
  * steps. Coarsened up from here when the dashboard's period is wide.
  */
-export const LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS = 60;
+export const LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS: LangWatchQLGranularityStep = 60;
 
 export interface LangWatchQLDashboardWidgetProps {
   readonly chartId: string;
@@ -61,7 +62,7 @@ export interface LangWatchQLDashboardWidgetProps {
    * {@link LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS}; ignored entirely by a
    * statement that does not declare the granularity parameter.
    */
-  readonly granularitySeconds?: number;
+  readonly granularitySeconds?: LangWatchQLGranularityStep;
   /** The card's title, used to describe the chart to a screen reader. */
   readonly name: string;
 }

--- a/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
@@ -33,7 +33,7 @@
  */
 
 import { Box, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { usePeriodSelector } from "~/components/PeriodSelector";
 import { HandledErrorAlert } from "~/features/errors";
@@ -95,20 +95,53 @@ export function LangWatchQLDashboardWidget({
   const lastRequest = useRef<string | null>(null);
   const requestKey = `${chartId}:${start}:${end}:${step}`;
 
+  // Which request the rendered answer belongs to.
+  //
+  // A period drag fires a run per intermediate window, and nothing orders the
+  // responses: a query over a narrow window can resolve after one over a wide
+  // window issued later, leaving the card showing an answer for a period the
+  // dashboard is no longer on — with no spinner and nothing on screen saying
+  // so. Each issued request takes the next sequence number, and a resolution
+  // is drawn only when it carries the latest one, so a straggler is dropped
+  // rather than winning by arriving last.
+  const issuedRequests = useRef(0);
+  const [answer, setAnswer] = useState<{
+    readonly sequence: number;
+    // Derived from the mutation rather than re-declared, so the widget cannot
+    // drift from the shape the procedure actually returns.
+    readonly result: NonNullable<typeof run.data>;
+  } | null>(null);
+
   useEffect(() => {
     if (!chartQuery.data) return;
     if (lastRequest.current === requestKey) return;
     lastRequest.current = requestKey;
 
-    mutate({
-      id: chartId,
-      projectId,
-      timeWindow: { start, end },
-      granularitySeconds: step,
-      // The whole reason this surface differs from the workbench: see the
-      // module docblock.
-      onBudgetOverflow: "coarsen",
-    });
+    issuedRequests.current += 1;
+    const sequence = issuedRequests.current;
+
+    mutate(
+      {
+        id: chartId,
+        projectId,
+        timeWindow: { start, end },
+        granularitySeconds: step,
+        // The whole reason this surface differs from the workbench: see the
+        // module docblock.
+        onBudgetOverflow: "coarsen",
+      },
+      {
+        onSuccess: (data) => {
+          // Strictly-newer rather than equal, so an answer already on screen
+          // is never replaced by an older one that resolved late.
+          setAnswer((current) =>
+            current !== null && current.sequence > sequence
+              ? current
+              : { sequence, result: data },
+          );
+        },
+      },
+    );
   }, [
     chartQuery.data,
     requestKey,
@@ -120,7 +153,7 @@ export function LangWatchQLDashboardWidget({
     step,
   ]);
 
-  const result = run.data;
+  const result = answer?.result;
 
   const columns = useMemo(
     () => (result?.columns ?? []) as readonly LangWatchQLDatasetColumn[],

--- a/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLDashboardWidget.tsx
@@ -29,16 +29,18 @@
  * says what it got.
  *
  * @see ./LazyLangWatchQLWidgetChart — the Vega boundary this mounts
+ * @see ../hooks/useLangWatchQLWidgetRun — when to run, and which response wins
  * @see specs/analytics/lwql-saved-charts.feature
  */
 
 import { Box, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 
 import { usePeriodSelector } from "~/components/PeriodSelector";
 import { HandledErrorAlert } from "~/features/errors";
 import { api } from "~/utils/api";
 
+import { useLangWatchQLWidgetRun } from "../hooks/useLangWatchQLWidgetRun";
 import { widgetCoarsenedNotice } from "../logic/widgetCoarsenedNotice";
 import type { LangWatchQLDatasetColumn } from "../visualization/visualization.types";
 
@@ -77,83 +79,18 @@ export function LangWatchQLDashboardWidget({
     { enabled: !!projectId && !!chartId },
   );
 
-  const run = api.analytics.savedWorkbenchCharts.run.useMutation();
-
   // Epoch milliseconds rather than the `Date` objects `usePeriodSelector`
   // hands back: two `Date`s for the same instant are never `Object.is`-equal,
   // so a dependency built on them would re-run the query on every render.
-  const start = period.startDate.getTime();
-  const end = period.endDate.getTime();
-
-  const step = granularitySeconds ?? LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS;
-
-  // `run` is a mutation because executing SQL is not a cacheable read, so the
-  // widget drives it from an effect rather than getting react-query's own
-  // fetch-on-change. The ref carries the last request actually issued so that
-  // a re-render with the same period and step does not re-execute.
-  const { mutate } = run;
-  const lastRequest = useRef<string | null>(null);
-  const requestKey = `${chartId}:${start}:${end}:${step}`;
-
-  // Which request the rendered answer belongs to.
-  //
-  // A period drag fires a run per intermediate window, and nothing orders the
-  // responses: a query over a narrow window can resolve after one over a wide
-  // window issued later, leaving the card showing an answer for a period the
-  // dashboard is no longer on — with no spinner and nothing on screen saying
-  // so. Each issued request takes the next sequence number, and a resolution
-  // is drawn only when it carries the latest one, so a straggler is dropped
-  // rather than winning by arriving last.
-  const issuedRequests = useRef(0);
-  const [answer, setAnswer] = useState<{
-    readonly sequence: number;
-    // Derived from the mutation rather than re-declared, so the widget cannot
-    // drift from the shape the procedure actually returns.
-    readonly result: NonNullable<typeof run.data>;
-  } | null>(null);
-
-  useEffect(() => {
-    if (!chartQuery.data) return;
-    if (lastRequest.current === requestKey) return;
-    lastRequest.current = requestKey;
-
-    issuedRequests.current += 1;
-    const sequence = issuedRequests.current;
-
-    mutate(
-      {
-        id: chartId,
-        projectId,
-        timeWindow: { start, end },
-        granularitySeconds: step,
-        // The whole reason this surface differs from the workbench: see the
-        // module docblock.
-        onBudgetOverflow: "coarsen",
-      },
-      {
-        onSuccess: (data) => {
-          // Strictly-newer rather than equal, so an answer already on screen
-          // is never replaced by an older one that resolved late.
-          setAnswer((current) =>
-            current !== null && current.sequence > sequence
-              ? current
-              : { sequence, result: data },
-          );
-        },
-      },
-    );
-  }, [
-    chartQuery.data,
-    requestKey,
-    mutate,
+  const { result, error } = useLangWatchQLWidgetRun({
     chartId,
     projectId,
-    start,
-    end,
-    step,
-  ]);
-
-  const result = answer?.result;
+    chartLoaded: !!chartQuery.data,
+    start: period.startDate.getTime(),
+    end: period.endDate.getTime(),
+    granularitySeconds:
+      granularitySeconds ?? LWQL_WIDGET_DEFAULT_GRANULARITY_SECONDS,
+  });
 
   const columns = useMemo(
     () => (result?.columns ?? []) as readonly LangWatchQLDatasetColumn[],
@@ -164,8 +101,18 @@ export function LangWatchQLDashboardWidget({
     return <HandledErrorAlert error={chartQuery.error} />;
   }
 
-  if (run.error) {
-    return <HandledErrorAlert error={run.error} />;
+  // A member's own SQL failing is a knowable failure: the run surfaces it as
+  // a handled error whose code the shared presentation registry turns into
+  // copy — the same words the workbench shows for the same refusal. Only a
+  // failure the platform genuinely cannot name falls back to the generic
+  // treatment, under a headline that at least says what the card was doing.
+  if (error) {
+    return (
+      <HandledErrorAlert
+        error={error}
+        fallbackTitle="Couldn't run this chart's query"
+      />
+    );
   }
 
   if (!chartQuery.data || !result) {
@@ -177,6 +124,28 @@ export function LangWatchQLDashboardWidget({
     );
   }
 
+  return (
+    <WidgetBody
+      result={result}
+      columns={columns}
+      vegaLiteSpec={chartQuery.data.definition.vegaLiteSpec}
+      name={name}
+    />
+  );
+}
+
+/** The loaded card: the coarsening notice, then the chart itself. */
+function WidgetBody({
+  result,
+  columns,
+  vegaLiteSpec,
+  name,
+}: {
+  result: NonNullable<ReturnType<typeof useLangWatchQLWidgetRun>["result"]>;
+  columns: readonly LangWatchQLDatasetColumn[];
+  vegaLiteSpec: Record<string, unknown> | undefined;
+  name: string;
+}) {
   const coarsenedFrom = result.coarsenedFromSeconds;
 
   return (
@@ -200,9 +169,7 @@ export function LangWatchQLDashboardWidget({
         <LazyLangWatchQLWidgetChart
           columns={columns}
           rows={result.rows}
-          {...(chartQuery.data.definition.vegaLiteSpec
-            ? { vegaLiteSpec: chartQuery.data.definition.vegaLiteSpec }
-            : {})}
+          {...(vegaLiteSpec ? { vegaLiteSpec } : {})}
           ariaLabel={name}
         />
       </Box>

--- a/platform/app/src/features/analytics-query/components/LangWatchQLWidgetChart.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLWidgetChart.tsx
@@ -1,0 +1,71 @@
+/**
+ * The chart half of a dashboard widget, behind the Vega boundary.
+ *
+ * Split from the widget for one reason: everything Vega-Lite is reached from
+ * here, so the dashboard route loads none of it until a widget actually has
+ * rows to draw. The widget mounts this through `LazyLangWatchQLWidgetChart`,
+ * never directly — importing this module from the dashboard is what would put
+ * several megabytes of Vega back in the entry chunk, and nothing would look
+ * wrong.
+ *
+ * It holds no query hook and cannot cause a request. Validation is not repeated
+ * here either: {@link LangWatchQLVegaLiteChart} validates the specification
+ * against the columns it was handed and renders its own named refusal, which is
+ * the behaviour a widget wants — a definition that passed the policy when it
+ * was saved can stop being drawable without anyone editing it, and the honest
+ * result is a refusal on that one card rather than a crash taking the grid.
+ *
+ * @see ./LazyLangWatchQLWidgetChart — the boundary to mount instead
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { Box } from "@chakra-ui/react";
+import { useMemo } from "react";
+
+import { LWQL_QUERY_RESULT_DATASET } from "../visualization/lwqlDatasetNames";
+import { starterVegaLiteSpec } from "../visualization/starterVegaLiteSpec";
+import type { LangWatchQLDatasetColumn } from "../visualization/visualization.types";
+
+import { LangWatchQLVegaLiteChart } from "./LangWatchQLVegaLiteChart";
+
+export interface LangWatchQLWidgetChartProps {
+  readonly columns: readonly LangWatchQLDatasetColumn[];
+  readonly rows: readonly Record<string, unknown>[];
+  /**
+   * The specification saved with the chart, or `undefined` for a chart saved
+   * as a query alone — which is a whole record, not a broken one. A starter
+   * derived from the result shape is drawn for it, the same one the workbench
+   * offers for such a chart.
+   */
+  readonly vegaLiteSpec?: Record<string, unknown>;
+  /** How the chart is described to a reader who cannot see it. */
+  readonly ariaLabel: string;
+}
+
+/** Draws one widget's result. */
+export function LangWatchQLWidgetChart({
+  columns,
+  rows,
+  vegaLiteSpec,
+  ariaLabel,
+}: LangWatchQLWidgetChartProps) {
+  const spec = useMemo(
+    () =>
+      vegaLiteSpec ??
+      starterVegaLiteSpec({ columns, datasetName: LWQL_QUERY_RESULT_DATASET }),
+    [vegaLiteSpec, columns],
+  );
+
+  return (
+    <Box height="full" width="full" minWidth={0}>
+      <LangWatchQLVegaLiteChart
+        spec={spec}
+        datasets={{ [LWQL_QUERY_RESULT_DATASET]: rows }}
+        columnsByDataset={{ [LWQL_QUERY_RESULT_DATASET]: columns }}
+        ariaLabel={ariaLabel}
+      />
+    </Box>
+  );
+}
+
+export default LangWatchQLWidgetChart;

--- a/platform/app/src/features/analytics-query/components/LazyLangWatchQLWidgetChart.tsx
+++ b/platform/app/src/features/analytics-query/components/LazyLangWatchQLWidgetChart.tsx
@@ -1,0 +1,41 @@
+/**
+ * The boundary that keeps Vega out of the dashboard bundle.
+ *
+ * The dashboard route is loaded by every member who opens Reports, whether or
+ * not any workbench chart is placed on it. Vega, Vega-Lite, vega-embed and the
+ * generated schema validator are several megabytes that only a grid actually
+ * containing a workbench widget ever needs, so everything that reaches them is
+ * behind this one lazy import.
+ *
+ * Mount this, not `LangWatchQLWidgetChart` — importing that directly is what
+ * would put Vega back in the dashboard's entry chunk, and nothing would look
+ * wrong. The sibling boundary for the workbench is
+ * `LazyLangWatchQLChartMode.tsx`; they are separate because the two surfaces
+ * mount different components, not because the chunk differs.
+ *
+ * Type re-exports below are type-only, so they are erased at build and pull
+ * nothing eagerly.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { HStack, Spinner, Text } from "@chakra-ui/react";
+
+import dynamic from "~/utils/compat/next-dynamic";
+
+import type { LangWatchQLWidgetChartProps } from "./LangWatchQLWidgetChart";
+
+export type { LangWatchQLWidgetChartProps } from "./LangWatchQLWidgetChart";
+
+export const LazyLangWatchQLWidgetChart = dynamic<LangWatchQLWidgetChartProps>(
+  () => import("./LangWatchQLWidgetChart"),
+  {
+    ssr: false,
+    loading: () => (
+      <HStack gap={2} color="fg.muted" padding={4}>
+        <Spinner size="sm" />
+        <Text fontSize="13px">Loading the chart</Text>
+      </HStack>
+    ),
+  },
+);

--- a/platform/app/src/features/analytics-query/hooks/useLangWatchQLWidgetRun.ts
+++ b/platform/app/src/features/analytics-query/hooks/useLangWatchQLWidgetRun.ts
@@ -24,6 +24,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 import { api } from "~/utils/api";
 
 export interface UseLangWatchQLWidgetRunInput {
@@ -35,8 +36,8 @@ export interface UseLangWatchQLWidgetRunInput {
   readonly start: number;
   /** Period end, epoch milliseconds. */
   readonly end: number;
-  /** The datapoint step to request, in seconds. */
-  readonly granularitySeconds: number;
+  /** The datapoint step to request — one of the offered steps. */
+  readonly granularitySeconds: LangWatchQLGranularityStep;
 }
 
 export function useLangWatchQLWidgetRun({

--- a/platform/app/src/features/analytics-query/hooks/useLangWatchQLWidgetRun.ts
+++ b/platform/app/src/features/analytics-query/hooks/useLangWatchQLWidgetRun.ts
@@ -1,0 +1,116 @@
+/**
+ * The dashboard widget's request orchestration: when to run a saved chart, and
+ * which settled response the card is allowed to draw.
+ *
+ * `run` is a mutation because executing SQL is not a cacheable read, so this
+ * hook drives it from an effect rather than getting react-query's own
+ * fetch-on-change. The ref carries the last request actually issued so that a
+ * re-render with the same period and step does not re-execute.
+ *
+ * The sequence numbers answer the question "which request does the rendered
+ * outcome belong to". A period drag fires a run per intermediate window, and
+ * nothing orders the responses: a query over a narrow window can resolve after
+ * one over a wide window issued later, leaving the card showing an answer for
+ * a period the dashboard is no longer on — with no spinner and nothing on
+ * screen saying so. Each issued request takes the next sequence number, and a
+ * resolution — success or failure alike — is kept only when it carries the
+ * latest one, so a straggler is dropped rather than winning by arriving last.
+ * Failures ride the same guard as answers: a stale error settling last must
+ * not replace the fresh answer already on screen.
+ *
+ * @see ../components/LangWatchQLDashboardWidget.tsx — the card this drives
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "~/utils/api";
+
+export interface UseLangWatchQLWidgetRunInput {
+  readonly chartId: string;
+  readonly projectId: string;
+  /** The saved chart definition has loaded; nothing runs before it has. */
+  readonly chartLoaded: boolean;
+  /** Period start, epoch milliseconds. */
+  readonly start: number;
+  /** Period end, epoch milliseconds. */
+  readonly end: number;
+  /** The datapoint step to request, in seconds. */
+  readonly granularitySeconds: number;
+}
+
+export function useLangWatchQLWidgetRun({
+  chartId,
+  projectId,
+  chartLoaded,
+  start,
+  end,
+  granularitySeconds,
+}: UseLangWatchQLWidgetRunInput) {
+  const run = api.analytics.savedWorkbenchCharts.run.useMutation();
+  const { mutate } = run;
+
+  // Derived from the mutation rather than re-declared, so the widget cannot
+  // drift from the shape the procedure actually returns.
+  type RunResult = NonNullable<typeof run.data>;
+  type Settled =
+    | { readonly sequence: number; readonly result: RunResult }
+    | { readonly sequence: number; readonly error: unknown };
+
+  const lastRequest = useRef<string | null>(null);
+  const issuedRequests = useRef(0);
+  const [settled, setSettled] = useState<Settled | null>(null);
+
+  const requestKey = `${chartId}:${start}:${end}:${granularitySeconds}`;
+
+  useEffect(() => {
+    if (!chartLoaded) return;
+    if (lastRequest.current === requestKey) return;
+    lastRequest.current = requestKey;
+
+    issuedRequests.current += 1;
+    const sequence = issuedRequests.current;
+
+    // Strictly-newer rather than equal, so an outcome already on screen is
+    // never replaced by an older one that resolved late.
+    const settle = (outcome: Settled) => {
+      setSettled((current) =>
+        current !== null && current.sequence > outcome.sequence
+          ? current
+          : outcome,
+      );
+    };
+
+    mutate(
+      {
+        id: chartId,
+        projectId,
+        timeWindow: { start, end },
+        granularitySeconds,
+        // The whole reason this surface differs from the workbench: the
+        // widget does not own the period, so it asks the run to coarsen
+        // rather than refuse. See the widget's module docblock.
+        onBudgetOverflow: "coarsen",
+      },
+      {
+        onSuccess: (data) => settle({ sequence, result: data }),
+        onError: (error) => settle({ sequence, error }),
+      },
+    );
+  }, [
+    chartLoaded,
+    requestKey,
+    mutate,
+    chartId,
+    projectId,
+    start,
+    end,
+    granularitySeconds,
+  ]);
+
+  return {
+    result:
+      settled !== null && "result" in settled ? settled.result : undefined,
+    error: settled !== null && "error" in settled ? settled.error : undefined,
+  };
+}

--- a/platform/app/src/features/analytics-query/hooks/useWidgetGranularity.ts
+++ b/platform/app/src/features/analytics-query/hooks/useWidgetGranularity.ts
@@ -25,6 +25,7 @@
  */
 
 import { useCallback, useMemo } from "react";
+import type { LangWatchQLGranularityStep } from "~/server/analytics/lwql/timeWindow";
 
 import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
 import { useRouter } from "~/utils/compat/next-router";
@@ -32,7 +33,9 @@ import { useRouter } from "~/utils/compat/next-router";
 /** The query parameter the whole picker state is encoded into. */
 export const WIDGET_GRANULARITY_QUERY_PARAMETER = "widgetGranularity";
 
-const isOfferedStep = (seconds: number): boolean =>
+const isOfferedStep = (
+  seconds: number,
+): seconds is LangWatchQLGranularityStep =>
   (LWQL_GRANULARITY_STEPS as readonly number[]).includes(seconds);
 
 /**
@@ -43,10 +46,10 @@ const isOfferedStep = (seconds: number): boolean =>
  */
 export function parseWidgetGranularity(
   encoded: string | undefined,
-): Readonly<Record<string, number>> {
+): Readonly<Record<string, LangWatchQLGranularityStep>> {
   if (!encoded) return {};
 
-  const parsed: Record<string, number> = {};
+  const parsed: Record<string, LangWatchQLGranularityStep> = {};
   for (const entry of encoded.split(",")) {
     const separator = entry.lastIndexOf(":");
     if (separator <= 0) continue;
@@ -62,7 +65,7 @@ export function parseWidgetGranularity(
 
 /** Encodes a lookup back into the parameter, sorted so the URL is stable. */
 export function encodeWidgetGranularity(
-  picks: Readonly<Record<string, number>>,
+  picks: Readonly<Record<string, LangWatchQLGranularityStep>>,
 ): string {
   return Object.keys(picks)
     .sort()
@@ -72,7 +75,9 @@ export function encodeWidgetGranularity(
 
 export interface WidgetGranularityState {
   /** The step each card was picked to run at, by graph id. */
-  readonly granularityByGraphId: Readonly<Record<string, number>>;
+  readonly granularityByGraphId: Readonly<
+    Record<string, LangWatchQLGranularityStep>
+  >;
   /** Records a member's pick for one card, into the URL. */
   readonly setGranularity: (
     graphId: string,

--- a/platform/app/src/features/analytics-query/hooks/useWidgetGranularity.ts
+++ b/platform/app/src/features/analytics-query/hooks/useWidgetGranularity.ts
@@ -1,0 +1,126 @@
+/**
+ * The datapoint step each dashboard widget runs at, held in URL state.
+ *
+ * Where it lives is the whole point. `CustomGraph` has no `granularitySeconds`
+ * column, and adding one is a migration this slice does not own — but the
+ * alternative that reaches for component state loses the pick on reload and,
+ * worse, drops it out of a shared link: a member who coarsens a card to make it
+ * readable and pastes the URL into a thread sends their colleague a different
+ * chart from the one they are describing. The dashboard's period already lives
+ * in the URL for exactly that reason (`usePeriodSelector`), so the step goes
+ * beside it and travels the same way.
+ *
+ * Encoded as one `widgetGranularity` parameter holding `id:seconds` pairs —
+ * `?widgetGranularity=chart_a:3600,chart_b:1` — rather than a parameter per
+ * card, so a dashboard of twenty widgets cannot turn the query string into
+ * twenty keys, and so the whole picker state is one thing to read, write and
+ * clear.
+ *
+ * Only offered steps are accepted on the way in. A URL is user-editable, and a
+ * hand-typed `chart_a:7200` would otherwise reach the run as a step the
+ * contract refuses — an error on a shared link, in place of a chart.
+ *
+ * @see ~/components/PeriodSelector — the period half of the same URL state
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { useCallback, useMemo } from "react";
+
+import { LWQL_GRANULARITY_STEPS } from "~/server/analytics/lwql/timeWindow";
+import { useRouter } from "~/utils/compat/next-router";
+
+/** The query parameter the whole picker state is encoded into. */
+export const WIDGET_GRANULARITY_QUERY_PARAMETER = "widgetGranularity";
+
+const isOfferedStep = (seconds: number): boolean =>
+  (LWQL_GRANULARITY_STEPS as readonly number[]).includes(seconds);
+
+/**
+ * Decodes `id:seconds,id:seconds` into a lookup.
+ *
+ * Malformed entries are dropped rather than throwing: the source is a URL a
+ * member can hand-edit, and a typo should cost the pick it names, not the page.
+ */
+export function parseWidgetGranularity(
+  encoded: string | undefined,
+): Readonly<Record<string, number>> {
+  if (!encoded) return {};
+
+  const parsed: Record<string, number> = {};
+  for (const entry of encoded.split(",")) {
+    const separator = entry.lastIndexOf(":");
+    if (separator <= 0) continue;
+
+    const graphId = entry.slice(0, separator);
+    const seconds = Number(entry.slice(separator + 1));
+    if (!Number.isInteger(seconds) || !isOfferedStep(seconds)) continue;
+
+    parsed[graphId] = seconds;
+  }
+  return parsed;
+}
+
+/** Encodes a lookup back into the parameter, sorted so the URL is stable. */
+export function encodeWidgetGranularity(
+  picks: Readonly<Record<string, number>>,
+): string {
+  return Object.keys(picks)
+    .sort()
+    .map((graphId) => `${graphId}:${picks[graphId]}`)
+    .join(",");
+}
+
+export interface WidgetGranularityState {
+  /** The step each card was picked to run at, by graph id. */
+  readonly granularityByGraphId: Readonly<Record<string, number>>;
+  /** Records a member's pick for one card, into the URL. */
+  readonly setGranularity: (
+    graphId: string,
+    granularitySeconds: number,
+  ) => void;
+}
+
+export function useWidgetGranularity(): WidgetGranularityState {
+  const router = useRouter();
+  const encoded = router.query[WIDGET_GRANULARITY_QUERY_PARAMETER];
+  const encodedValue = typeof encoded === "string" ? encoded : undefined;
+
+  const granularityByGraphId = useMemo(
+    () => parseWidgetGranularity(encodedValue),
+    [encodedValue],
+  );
+
+  const setGranularity = useCallback(
+    (graphId: string, granularitySeconds: number) => {
+      // Refused rather than written: the picker only offers the three steps,
+      // so anything else is a caller bug, and writing it would put a URL into
+      // circulation that fails on open.
+      if (!isOfferedStep(granularitySeconds)) return;
+
+      const next = encodeWidgetGranularity({
+        ...parseWidgetGranularity(encodedValue),
+        [graphId]: granularitySeconds,
+      });
+
+      const { [WIDGET_GRANULARITY_QUERY_PARAMETER]: _replaced, ...rest } =
+        router.query;
+
+      // Shallow, like the period control: the picks are read from the URL on
+      // render, so a full navigation would re-run every card's query for a
+      // change one card asked for.
+      void router.push(
+        {
+          query: {
+            ...rest,
+            ...(next ? { [WIDGET_GRANULARITY_QUERY_PARAMETER]: next } : {}),
+          },
+        },
+        undefined,
+        { shallow: true },
+      );
+    },
+    [encodedValue, router],
+  );
+
+  return { granularityByGraphId, setGranularity };
+}

--- a/platform/app/src/features/analytics-query/logic/widgetCoarsenedNotice.ts
+++ b/platform/app/src/features/analytics-query/logic/widgetCoarsenedNotice.ts
@@ -1,0 +1,49 @@
+/**
+ * What a coarsened dashboard widget tells the member.
+ *
+ * Its own module, with no imports beyond the vocabulary, because the widget
+ * that renders it reaches Chakra, the tRPC client and the lazy Vega boundary —
+ * and the copy is the part worth testing directly. A test that had to mount the
+ * widget to read one string would be proving the harness, not the sentence.
+ *
+ * The substitution this describes is otherwise invisible: the card redraws at a
+ * coarser step and nothing on screen says the answer is not the one the chart
+ * was configured to give. So the sentence names both steps and cites the
+ * ceiling that forced the change, rather than asserting a bare number the
+ * member has no way to check.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ */
+
+import { LWQL_GRANULARITY_MAX_BUCKETS } from "~/server/analytics/lwql/timeWindow";
+
+/**
+ * How one datapoint step is named in member-facing copy.
+ *
+ * The three offered steps get words; anything else falls back to seconds,
+ * which is a shape this should never be handed but must not crash on.
+ */
+export function describeGranularityStep(seconds: number): string {
+  if (seconds === 1) return "1-second";
+  if (seconds === 60) return "1-minute";
+  if (seconds === 3600) return "1-hour";
+  return `${seconds}-second`;
+}
+
+/** The notice a widget shows when its period forced a coarser step. */
+export function widgetCoarsenedNotice({
+  from,
+  to,
+}: {
+  /** The step the widget was configured with. */
+  readonly from: number;
+  /** The step it actually ran at. */
+  readonly to: number;
+}): string {
+  return (
+    `Showing ${describeGranularityStep(to)} buckets instead of ` +
+    `${describeGranularityStep(from)}: this period at ` +
+    `${describeGranularityStep(from)} would exceed the ` +
+    `${LWQL_GRANULARITY_MAX_BUCKETS.toLocaleString()} datapoint limit.`
+  );
+}

--- a/platform/app/src/features/analytics-query/logic/widgetCoarsenedNotice.ts
+++ b/platform/app/src/features/analytics-query/logic/widgetCoarsenedNotice.ts
@@ -15,20 +15,17 @@
  * @see specs/analytics/lwql-saved-charts.feature
  */
 
-import { LWQL_GRANULARITY_MAX_BUCKETS } from "~/server/analytics/lwql/timeWindow";
+import {
+  describeLangWatchQLGranularityStep,
+  LWQL_GRANULARITY_MAX_BUCKETS,
+} from "~/server/analytics/lwql/timeWindow";
 
 /**
- * How one datapoint step is named in member-facing copy.
- *
- * The three offered steps get words; anything else falls back to seconds,
- * which is a shape this should never be handed but must not crash on.
+ * How one datapoint step is named inside this notice: the adjective form,
+ * because every mention here modifies "buckets".
  */
-export function describeGranularityStep(seconds: number): string {
-  if (seconds === 1) return "1-second";
-  if (seconds === 60) return "1-minute";
-  if (seconds === 3600) return "1-hour";
-  return `${seconds}-second`;
-}
+const step = (seconds: number): string =>
+  describeLangWatchQLGranularityStep(seconds, "adjective");
 
 /** The notice a widget shows when its period forced a coarser step. */
 export function widgetCoarsenedNotice({
@@ -41,9 +38,9 @@ export function widgetCoarsenedNotice({
   readonly to: number;
 }): string {
   return (
-    `Showing ${describeGranularityStep(to)} buckets instead of ` +
-    `${describeGranularityStep(from)}: this period at ` +
-    `${describeGranularityStep(from)} would exceed the ` +
+    `Showing ${step(to)} buckets instead of ` +
+    `${step(from)}: this period at ` +
+    `${step(from)} would exceed the ` +
     `${LWQL_GRANULARITY_MAX_BUCKETS.toLocaleString()} datapoint limit.`
   );
 }

--- a/platform/app/src/pages/[project]/analytics/reports.tsx
+++ b/platform/app/src/pages/[project]/analytics/reports.tsx
@@ -8,11 +8,11 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { Plus } from "lucide-react";
-import { useState } from "react";
 import { FilterSidebar } from "~/components/filters/FilterSidebar";
 import { useFilterToggle } from "~/components/filters/FilterToggle";
 import GraphsLayout from "~/components/GraphsLayout";
 import { toaster } from "~/components/ui/toaster";
+import { useWidgetGranularity } from "~/features/analytics-query/hooks/useWidgetGranularity";
 import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import {
@@ -174,25 +174,22 @@ function ReportsContent() {
     );
   };
 
-  // The datapoint step each workbench widget runs at, keyed by chart id.
+  // The datapoint step each workbench widget runs at, keyed by chart id, held
+  // in URL state beside the period.
   //
-  // Session state rather than a stored column: `CustomGraph` has no
-  // `granularitySeconds` field, and adding one is a migration this slice does
-  // not own. A member's pick therefore holds while they are on the page and
-  // resets to the widget's default on reload — visible, reversible, and not a
-  // silent wrong answer. Persisting it is the follow-up that adds the column.
-  const [granularityByGraphId, setGranularityByGraphId] = useState<
-    Readonly<Record<string, number>>
-  >({});
+  // Not a stored column: `CustomGraph` has no `granularitySeconds` field, and
+  // adding one is a migration this slice does not own. Not component state
+  // either — that would lose the pick on reload and leave it out of a shared
+  // link, so a member who coarsened a card to read it would send a colleague a
+  // different chart from the one they were describing. Persisting per member
+  // is the follow-up that adds the column.
+  const { granularityByGraphId, setGranularity } = useWidgetGranularity();
 
   const handleGraphGranularityChange = (
     graphId: string,
     granularitySeconds: number,
   ) => {
-    setGranularityByGraphId((current) => ({
-      ...current,
-      [graphId]: granularitySeconds,
-    }));
+    setGranularity(graphId, granularitySeconds);
   };
 
   const graphs = (graphsQuery.data ?? []).map((graph) => {

--- a/platform/app/src/pages/[project]/analytics/reports.tsx
+++ b/platform/app/src/pages/[project]/analytics/reports.tsx
@@ -8,6 +8,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { Plus } from "lucide-react";
+import { useState } from "react";
 import { FilterSidebar } from "~/components/filters/FilterSidebar";
 import { useFilterToggle } from "~/components/filters/FilterToggle";
 import GraphsLayout from "~/components/GraphsLayout";
@@ -173,7 +174,33 @@ function ReportsContent() {
     );
   };
 
-  const graphs = graphsQuery.data ?? [];
+  // The datapoint step each workbench widget runs at, keyed by chart id.
+  //
+  // Session state rather than a stored column: `CustomGraph` has no
+  // `granularitySeconds` field, and adding one is a migration this slice does
+  // not own. A member's pick therefore holds while they are on the page and
+  // resets to the widget's default on reload — visible, reversible, and not a
+  // silent wrong answer. Persisting it is the follow-up that adds the column.
+  const [granularityByGraphId, setGranularityByGraphId] = useState<
+    Readonly<Record<string, number>>
+  >({});
+
+  const handleGraphGranularityChange = (
+    graphId: string,
+    granularitySeconds: number,
+  ) => {
+    setGranularityByGraphId((current) => ({
+      ...current,
+      [graphId]: granularitySeconds,
+    }));
+  };
+
+  const graphs = (graphsQuery.data ?? []).map((graph) => {
+    const picked = granularityByGraphId[graph.id];
+    return picked === undefined
+      ? graph
+      : { ...graph, granularitySeconds: picked };
+  });
   const hasNoGraphs = graphs.length === 0 && !graphsQuery.isLoading;
 
   // Build add chart URL with current dashboard
@@ -228,9 +255,11 @@ function ReportsContent() {
             <ReportGrid
               graphs={graphs}
               projectSlug={project?.slug ?? ""}
+              projectId={projectId}
               dashboardId={activeDashboardId ?? undefined}
               onGraphDelete={handleGraphDelete}
               onGraphSizeChange={handleGraphSizeChange}
+              onGraphGranularityChange={handleGraphGranularityChange}
               onGraphsReorder={handleGraphsReorder}
               deletingGraphId={
                 deleteGraph.isPending

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -397,6 +397,36 @@ describe("resolveLangWatchQLGranularity", () => {
         maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
       });
     });
+
+    it("reports no coarsening when the floor fallback lands on the requested step", () => {
+      // The same nothing-fits decade, asked for at the COARSEST offered step.
+      // `finestFittingStep` falls back to that step, so effective equals
+      // requested and nothing was coarsened — a notice here would tell a
+      // member their numbers were substituted when the run used exactly the
+      // step they asked for.
+      //
+      // This is the case that keeps the guard honest as the steps list grows.
+      // While every offered step is sub-day the fallback can only ever land
+      // at or above the request, so `>` and `!==` agree; add a day-scale step
+      // and the fallback can land BELOW a finer request, at which point only
+      // `>` still refuses to call a widening-that-narrowed a coarsening.
+      const decade = {
+        start: new Date("2026-02-20T00:00:00.000Z"),
+        end: new Date("2036-02-20T00:00:00.000Z"),
+      };
+      const coarsest =
+        LWQL_GRANULARITY_STEPS[LWQL_GRANULARITY_STEPS.length - 1];
+
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        timeWindow: decade,
+        granularitySeconds: coarsest,
+        onBudgetOverflow: "coarsen",
+      });
+
+      expect(resolution.granularitySeconds).toBe(coarsest);
+      expect(resolution.coarsenedFromSeconds).toBeUndefined();
+    });
   });
 
   describe("given a window whose length lands exactly on the ceiling boundary", () => {

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -190,6 +190,23 @@ describe("resolveLangWatchQLGranularity", () => {
       expect(message).not.toContain("period_start");
       expect(message).not.toContain("period_end");
     });
+
+    it("does not reject a caller parameter that is not a surface name", () => {
+      // The guard's own reserved name is period_granularity_seconds; a
+      // member's own parameter must ride through untouched even when a
+      // genuine granularity declaration and step are present alongside it.
+      const resolution = resolveLangWatchQLGranularity({
+        declared: [...PERIOD, ...GRANULARITY],
+        parameters: { minTraceCount: 5 },
+        timeWindow: WINDOW,
+        granularitySeconds: 3600,
+      });
+
+      expect(resolution).toEqual({
+        followsGranularity: true,
+        granularitySeconds: 3600,
+      });
+    });
   });
 
   describe("given a malformed surface step", () => {

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlGranularity.unit.test.ts
@@ -398,18 +398,11 @@ describe("resolveLangWatchQLGranularity", () => {
       });
     });
 
-    it("reports no coarsening when the floor fallback lands on the requested step", () => {
+    it("refuses the nothing-fits window even at the coarsest offered step", () => {
       // The same nothing-fits decade, asked for at the COARSEST offered step.
-      // `finestFittingStep` falls back to that step, so effective equals
-      // requested and nothing was coarsened — a notice here would tell a
-      // member their numbers were substituted when the run used exactly the
-      // step they asked for.
-      //
-      // This is the case that keeps the guard honest as the steps list grows.
-      // While every offered step is sub-day the fallback can only ever land
-      // at or above the request, so `>` and `!==` agree; add a day-scale step
-      // and the fallback can land BELOW a finer request, at which point only
-      // `>` still refuses to call a widening-that-narrowed a coarsening.
+      // There is no silent floor fallback: the ceiling is a hard cap, so a
+      // window even the coarsest step overflows refuses on the coarsen door
+      // exactly as it does on the refuse door.
       const decade = {
         start: new Date("2026-02-20T00:00:00.000Z"),
         end: new Date("2036-02-20T00:00:00.000Z"),
@@ -417,15 +410,19 @@ describe("resolveLangWatchQLGranularity", () => {
       const coarsest =
         LWQL_GRANULARITY_STEPS[LWQL_GRANULARITY_STEPS.length - 1];
 
-      const resolution = resolveLangWatchQLGranularity({
-        declared: [...PERIOD, ...GRANULARITY],
-        timeWindow: decade,
-        granularitySeconds: coarsest,
-        onBudgetOverflow: "coarsen",
-      });
+      const run = () =>
+        resolveLangWatchQLGranularity({
+          declared: [...PERIOD, ...GRANULARITY],
+          timeWindow: decade,
+          granularitySeconds: coarsest,
+          onBudgetOverflow: "coarsen",
+        });
 
-      expect(resolution.granularitySeconds).toBe(coarsest);
-      expect(resolution.coarsenedFromSeconds).toBeUndefined();
+      expect(codeOf(run)).toBe("lwql_granularity_too_fine");
+      expect(metaOf(run)).toMatchObject({
+        requestedGranularitySeconds: coarsest,
+        maxBuckets: LWQL_GRANULARITY_MAX_BUCKETS,
+      });
     });
   });
 

--- a/platform/app/src/server/analytics/lwql/lwql.service.ts
+++ b/platform/app/src/server/analytics/lwql/lwql.service.ts
@@ -14,11 +14,12 @@
  *  3. Validate, then resolve the surface's time window into the reserved
  *     parameters the statement declares (`./resolveTimeWindow.ts`) — in that order,
  *     because an injected window is what satisfies the missing-parameter check.
- *     The granularity declaration is resolved the same way at run, refusing on
- *     bucket-budget overflow: every door through here is caller-owned, so a
- *     step finer than the period allows is refused rather than coarsened.
- *     A refusal is thrown as the validator's own handled error and the query
- *     never reaches the database.
+ *     The granularity declaration is resolved the same way at run. A step finer
+ *     than the period's bucket budget allows is refused by default, because a
+ *     caller who picked the step meant it; the dashboard widget surface, whose
+ *     period moves under a saved step, opts into coarsening instead and is told
+ *     what it got. A refusal is thrown as the validator's own handled error and
+ *     the query never reaches the database.
  *  4. Execute as the restricted identity, carrying the caller's tenant
  *     capability as the one setting the profile lets a query change.
  *  5. Shape the result, and run the advisory diagnostics (`./diagnostics.ts`)
@@ -72,6 +73,7 @@ import {
 } from "./executor";
 import {
   assertLangWatchQLGranularityDeclaration,
+  type LangWatchQLBudgetOverflowMode,
   type LangWatchQLGranularityResolution,
   resolveLangWatchQLGranularity,
   resolveLangWatchQLTimeWindow,
@@ -89,8 +91,8 @@ const logger = createLogger("langwatch:analytics:lwql");
 
 /**
  * The run-path half of the reserved-parameter contract, as one step: resolve
- * what the caller's window and step mean for this request on a caller-owned
- * door, then refuse when any declared reserved name would still reach the
+ * what the caller's window and step mean for this request, then refuse when
+ * any declared reserved name would still reach the
  * database without a value — one refusal naming everything the surface forgot
  * rather than only its first omission.
  *
@@ -111,6 +113,7 @@ function resolveRunGranularityOrRefuseUnfilled({
   parameters,
   timeWindow,
   granularitySeconds,
+  onBudgetOverflow,
   awaitingTimeWindow,
 }: {
   /** Bound parameters the validated statement declares. */
@@ -124,6 +127,11 @@ function resolveRunGranularityOrRefuseUnfilled({
   /** The step the caller-owned surface chose, when it offers one. */
   readonly granularitySeconds?: number;
   /**
+   * What an overflowing period does. Defaults to refusing, which is what every
+   * caller-owned door wants.
+   */
+  readonly onBudgetOverflow?: LangWatchQLBudgetOverflowMode;
+  /**
    * Reserved window names no window filled — already computed by validate,
    * joined here so one refusal can name every omission together.
    */
@@ -131,13 +139,16 @@ function resolveRunGranularityOrRefuseUnfilled({
 }): LangWatchQLGranularityResolution {
   // Caller-owned doors resolve the granularity contract with refuse on
   // overflow: whoever is asking picked the step, so coarsening it for them
-  // would change the answer they asked for.
+  // would change the answer they asked for. A surface that picked the step on
+  // the member's behalf rather than at their request — the dashboard, whose
+  // period is dragged around by a control the widget does not own — passes
+  // "coarsen" instead, and reports the substitution rather than hiding it.
   const granularity = resolveLangWatchQLGranularity({
     declared,
     ...(parameters ? { parameters } : {}),
     ...(granularitySeconds !== undefined ? { granularitySeconds } : {}),
     ...(timeWindow ? { timeWindow } : {}),
-    onBudgetOverflow: "refuse",
+    onBudgetOverflow: onBudgetOverflow ?? "refuse",
   });
 
   // Validate lists a declared granularity as awaiting alongside the window
@@ -241,15 +252,28 @@ export interface LangWatchQLExecuteInput {
    */
   readonly timeWindow?: LangWatchQLTimeWindow;
   /**
-   * The datapoint step the caller-owned surface chose, in seconds, for a
-   * statement that declares `{period_granularity_seconds:UInt32}`. Injected
-   * like the window and refused when the period at this step would overflow
-   * the bucket ceiling — every door through {@link execute} belongs to a
-   * caller who picked the step, so there is no coarsening to hide behind.
+   * The datapoint step the surface chose, in seconds, for a statement that
+   * declares `{period_granularity_seconds:UInt32}`. Injected like the window.
    *
    * Ignored by a statement that does not declare the parameter.
    */
   readonly granularitySeconds?: number;
+  /**
+   * What to do when the period at the chosen step would exceed the bucket
+   * ceiling. Defaults to `"refuse"`.
+   *
+   * Refusing is right wherever the member picked the step for the question
+   * they are asking — the workbench, the REST door — because silently widening
+   * their buckets answers a different question than the one they wrote.
+   *
+   * `"coarsen"` belongs to a surface whose period moves independently of the
+   * step: a dashboard widget's step is saved once, and the dashboard's period
+   * control can later be dragged wide enough to overflow it. Refusing there
+   * would blank a card the member never touched, so it coarsens to the finest
+   * step that fits and reports `coarsenedFromSeconds` so the widget can say so
+   * rather than quietly redraw.
+   */
+  readonly onBudgetOverflow?: LangWatchQLBudgetOverflowMode;
 }
 
 /**
@@ -483,6 +507,7 @@ export class LangWatchQLService {
     parameters,
     timeWindow,
     granularitySeconds,
+    onBudgetOverflow,
   }: LangWatchQLExecuteInput): Promise<LangWatchQLQueryResult> {
     const validation = this.validate({
       projectId: project.id,
@@ -496,6 +521,7 @@ export class LangWatchQLService {
       ...(parameters ? { parameters } : {}),
       ...(granularitySeconds !== undefined ? { granularitySeconds } : {}),
       ...(timeWindow ? { timeWindow } : {}),
+      ...(onBudgetOverflow ? { onBudgetOverflow } : {}),
       awaitingTimeWindow: validation.awaitingTimeWindow,
     });
 

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -279,11 +279,11 @@ function assertSurfaceStepIsClean({
 
   // Only this resolver's own reserved name: the window sweep owns the other
   // two, and refusing them here would answer a window question from the
-  // granularity path.
+  // granularity path. The name is a member of `LWQL_SURFACE_PARAMETERS` by
+  // construction, so an `isLangWatchQLSurfaceParameter` check alongside would
+  // be implied by this equality and could never disagree with it.
   const supplied = Object.keys(parameters ?? {}).filter(
-    (name) =>
-      isLangWatchQLSurfaceParameter(name) &&
-      name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
   );
   if (supplied.length > 0) {
     throw new LangWatchQLReservedParameterSuppliedError(supplied);
@@ -352,7 +352,12 @@ function resolveAgainstBudget({
   return {
     followsGranularity: true,
     granularitySeconds: effective,
-    ...(effective !== granularitySeconds
+    // Strictly greater, not merely different: a step equal to or finer than
+    // the requested one did not coarsen anything, and reporting it as a
+    // coarsening would put a notice on a card whose answer never changed.
+    // Reachable the moment a day-scale step joins the offered list, where the
+    // fallback to the coarsest fitting step can land below the request.
+    ...(effective > granularitySeconds
       ? { coarsenedFromSeconds: granularitySeconds }
       : {}),
   };

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -239,14 +239,26 @@ function finestFittingStep(windowSeconds: number): number | undefined {
   return undefined;
 }
 
+/** Whether a step is one the surface offers. */
+function isOfferedStep(stepSeconds: number): boolean {
+  return (LWQL_GRANULARITY_STEPS as readonly number[]).includes(stepSeconds);
+}
+
 /**
  * The declaration- and value-level refusals, extracted from
  * {@link resolveLangWatchQLGranularity} so that function reads as the
  * decision it makes rather than the gauntlet it runs.
  *
+ * The step is checked by *membership* in {@link LWQL_GRANULARITY_STEPS}, not
+ * merely for being a positive integer. Coarsening picks its answer from that
+ * same list, so an off-list step admitted here — 7,200 seconds, say — could be
+ * "coarsened" to the 3,600-second hour: a finer step than the one requested,
+ * reported as a coarsening. Refusing the off-list step is what keeps the
+ * requested and effective values on one scale.
+ *
  * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
- *   declared as anything but `UInt32`, or when the surface's step is not a
- *   positive whole number of seconds.
+ *   declared as anything but `UInt32`, or when the surface's step is not one
+ *   of the offered steps.
  * @throws {LangWatchQLReservedParameterSuppliedError} when the request
  *   carries a value for the reserved name.
  */
@@ -265,20 +277,25 @@ function assertSurfaceStepIsClean({
     throw new LangWatchQLReservedGranularityTypeError([declaredName]);
   }
 
+  // Only this resolver's own reserved name: the window sweep owns the other
+  // two, and refusing them here would answer a window question from the
+  // granularity path.
   const supplied = Object.keys(parameters ?? {}).filter(
-    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+    (name) =>
+      isLangWatchQLSurfaceParameter(name) &&
+      name === LWQL_PERIOD_GRANULARITY_PARAMETER,
   );
   if (supplied.length > 0) {
     throw new LangWatchQLReservedParameterSuppliedError(supplied);
   }
 
-  if (
-    granularitySeconds !== undefined &&
-    (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0)
-  ) {
-    // A zero or fractional step is a malformed surface value, not a caller
-    // choice -- the input schemas refuse it first; this is the backstop.
-    throw new LangWatchQLReservedGranularityTypeError([declaredName]);
+  if (granularitySeconds !== undefined && !isOfferedStep(granularitySeconds)) {
+    // A zero, fractional or off-list step is a malformed surface value, not a
+    // caller choice -- the input schemas refuse it first; this is the backstop.
+    throw new LangWatchQLReservedGranularityTypeError(
+      [declaredName],
+      "step-value",
+    );
   }
 }
 
@@ -371,15 +388,23 @@ export function assertLangWatchQLGranularityDeclaration(
   }
 
   const periodNames = [LWQL_PERIOD_START_PARAMETER, LWQL_PERIOD_END_PARAMETER];
-  const missing = periodNames.filter(
-    (name) =>
-      !declared.some((parameter) => {
-        if (parameter.name !== name) return false;
-        return isLangWatchQLDateTimeParameterType(parameter.type);
-      }),
+  const absent = periodNames.filter(
+    (name) => !declared.some((parameter) => parameter.name === name),
   );
-  if (missing.length > 0) {
-    throw new LangWatchQLGranularityRequiresTimeWindowError();
+  const mistyped = periodNames.filter(
+    (name) =>
+      !absent.includes(name) &&
+      !declared.some(
+        (parameter) =>
+          parameter.name === name &&
+          isLangWatchQLDateTimeParameterType(parameter.type),
+      ),
+  );
+  if (absent.length > 0 || mistyped.length > 0) {
+    throw new LangWatchQLGranularityRequiresTimeWindowError({
+      absent,
+      mistyped,
+    });
   }
 }
 

--- a/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/resolveTimeWindow.ts
@@ -43,6 +43,7 @@ import {
   isLangWatchQLTimeWindowParameter,
   type LangWatchQLTimeWindow,
   type LangWatchQLTimeWindowParameter,
+  LWQL_GRANULARITY_MAX_BUCKETS,
   LWQL_GRANULARITY_STEPS,
   LWQL_PERIOD_END_PARAMETER,
   LWQL_PERIOD_GRANULARITY_PARAMETER,
@@ -184,14 +185,24 @@ function bucketCount(windowSeconds: number, stepSeconds: number): number {
 }
 
 /**
- * The ceiling on datapoint buckets one governed run may produce through the
- * granularity contract. Named so the dashboard clamp notice can cite it and
- * the budget arithmetic has one home.
- *
- * A run producing exactly this many buckets is admitted; overflow is strictly
- * greater than.
+ * Re-exported so every existing importer of the budget arithmetic keeps
+ * reaching the ceiling from here. It is defined in `./timeWindow.ts` because
+ * the dashboard's coarsening notice cites it in the browser, and this module
+ * is server-only.
  */
-export const LWQL_GRANULARITY_MAX_BUCKETS = 10_000;
+export { LWQL_GRANULARITY_MAX_BUCKETS };
+
+/**
+ * What an overflowing period does to the step that overflowed it.
+ *
+ * `"refuse"` for a surface whose caller picked the step for the question they
+ * are asking; `"coarsen"` for one whose period moves independently of the step
+ * — a dashboard widget, whose saved step meets whatever period the dashboard's
+ * control is currently set to. Named rather than repeated inline because the
+ * choice travels from a tRPC input schema down to {@link resolveAgainstBudget},
+ * and a widened copy at any hop would let a door coarsen that meant to refuse.
+ */
+export type LangWatchQLBudgetOverflowMode = "refuse" | "coarsen";
 
 /** What a statement's granularity declaration means for one request. */
 export interface LangWatchQLGranularityResolution {
@@ -228,26 +239,14 @@ function finestFittingStep(windowSeconds: number): number | undefined {
   return undefined;
 }
 
-/** Whether a step is one the surface offers. */
-function isOfferedStep(stepSeconds: number): boolean {
-  return (LWQL_GRANULARITY_STEPS as readonly number[]).includes(stepSeconds);
-}
-
 /**
  * The declaration- and value-level refusals, extracted from
  * {@link resolveLangWatchQLGranularity} so that function reads as the
  * decision it makes rather than the gauntlet it runs.
  *
- * The step is checked by *membership* in {@link LWQL_GRANULARITY_STEPS}, not
- * merely for being a positive integer. Coarsening picks its answer from that
- * same list, so an off-list step admitted here — 7,200 seconds, say — could be
- * "coarsened" to the 3,600-second hour: a finer step than the one requested,
- * reported as a coarsening. Refusing the off-list step is what keeps the
- * requested and effective values on one scale.
- *
  * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
- *   declared as anything but `UInt32`, or when the surface's step is not one
- *   of the offered steps.
+ *   declared as anything but `UInt32`, or when the surface's step is not a
+ *   positive whole number of seconds.
  * @throws {LangWatchQLReservedParameterSuppliedError} when the request
  *   carries a value for the reserved name.
  */
@@ -266,25 +265,20 @@ function assertSurfaceStepIsClean({
     throw new LangWatchQLReservedGranularityTypeError([declaredName]);
   }
 
-  // Only this resolver's own reserved name: the window sweep owns the other
-  // two, and refusing them here would answer a window question from the
-  // granularity path.
   const supplied = Object.keys(parameters ?? {}).filter(
-    (name) =>
-      isLangWatchQLSurfaceParameter(name) &&
-      name === LWQL_PERIOD_GRANULARITY_PARAMETER,
+    (name) => name === LWQL_PERIOD_GRANULARITY_PARAMETER,
   );
   if (supplied.length > 0) {
     throw new LangWatchQLReservedParameterSuppliedError(supplied);
   }
 
-  if (granularitySeconds !== undefined && !isOfferedStep(granularitySeconds)) {
-    // A zero, fractional or off-list step is a malformed surface value, not a
-    // caller choice -- the input schemas refuse it first; this is the backstop.
-    throw new LangWatchQLReservedGranularityTypeError(
-      [declaredName],
-      "step-value",
-    );
+  if (
+    granularitySeconds !== undefined &&
+    (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0)
+  ) {
+    // A zero or fractional step is a malformed surface value, not a caller
+    // choice -- the input schemas refuse it first; this is the backstop.
+    throw new LangWatchQLReservedGranularityTypeError([declaredName]);
   }
 }
 
@@ -308,7 +302,7 @@ function resolveAgainstBudget({
   readonly declaredName: string;
   readonly granularitySeconds: number;
   readonly timeWindow: LangWatchQLTimeWindow;
-  readonly onBudgetOverflow: "refuse" | "coarsen";
+  readonly onBudgetOverflow: LangWatchQLBudgetOverflowMode;
 }): LangWatchQLGranularityResolution {
   const windowSeconds = Math.max(
     0,
@@ -341,11 +335,7 @@ function resolveAgainstBudget({
   return {
     followsGranularity: true,
     granularitySeconds: effective,
-    // Strictly greater, never merely different: a step equal to or finer than
-    // the requested one did not coarsen anything, and labelling it as such
-    // would have the dashboard tell a member their step was widened when it
-    // was not.
-    ...(effective > granularitySeconds
+    ...(effective !== granularitySeconds
       ? { coarsenedFromSeconds: granularitySeconds }
       : {}),
   };
@@ -364,10 +354,7 @@ function resolveAgainstBudget({
  * @throws {LangWatchQLReservedGranularityTypeError} when the parameter is
  *   declared as anything but `UInt32`.
  * @throws {LangWatchQLGranularityRequiresTimeWindowError} when it is declared
- *   but either period bound is missing, or is declared as something other
- *   than a date-time. The two are told apart in the copy: an author whose
- *   `period_start` is right there but spelled `String` is not helped by being
- *   told to declare it.
+ *   but either period bound is missing.
  */
 export function assertLangWatchQLGranularityDeclaration(
   declared: readonly LangWatchQLParameter[],
@@ -384,23 +371,15 @@ export function assertLangWatchQLGranularityDeclaration(
   }
 
   const periodNames = [LWQL_PERIOD_START_PARAMETER, LWQL_PERIOD_END_PARAMETER];
-  const absent = periodNames.filter(
-    (name) => !declared.some((parameter) => parameter.name === name),
-  );
-  const mistyped = periodNames.filter(
+  const missing = periodNames.filter(
     (name) =>
-      !absent.includes(name) &&
-      !declared.some(
-        (parameter) =>
-          parameter.name === name &&
-          isLangWatchQLDateTimeParameterType(parameter.type),
-      ),
+      !declared.some((parameter) => {
+        if (parameter.name !== name) return false;
+        return isLangWatchQLDateTimeParameterType(parameter.type);
+      }),
   );
-  if (absent.length > 0 || mistyped.length > 0) {
-    throw new LangWatchQLGranularityRequiresTimeWindowError({
-      absent,
-      mistyped,
-    });
+  if (missing.length > 0) {
+    throw new LangWatchQLGranularityRequiresTimeWindowError();
   }
 }
 
@@ -446,7 +425,7 @@ export function resolveLangWatchQLGranularity({
   /** The period this run is windowed to; the budget is computed against it. */
   readonly timeWindow?: LangWatchQLTimeWindow;
   /** Refuse (caller-owned surfaces) or coarsen (the dashboard) on overflow. */
-  readonly onBudgetOverflow?: "refuse" | "coarsen";
+  readonly onBudgetOverflow?: LangWatchQLBudgetOverflowMode;
 }): LangWatchQLGranularityResolution {
   const declaredGranularity = declared.find(
     (parameter) => parameter.name === LWQL_PERIOD_GRANULARITY_PARAMETER,

--- a/platform/app/src/server/analytics/lwql/timeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/timeWindow.ts
@@ -134,6 +134,46 @@ export type LangWatchQLGranularityStep =
   (typeof LWQL_GRANULARITY_STEPS)[number];
 
 /**
+ * The unit each offered step is named by, keyed off the steps themselves so a
+ * step added to {@link LWQL_GRANULARITY_STEPS} without a name here is a
+ * compile error rather than a card rendering a bare number.
+ */
+const LWQL_GRANULARITY_STEP_UNITS: Readonly<
+  Record<(typeof LWQL_GRANULARITY_STEPS)[number], string>
+> = {
+  1: "second",
+  60: "minute",
+  3600: "hour",
+};
+
+/**
+ * How a datapoint step is named in member-facing copy.
+ *
+ * One naming table for every surface that says a step out loud — the card
+ * menu's picker and the widget's coarsened notice — because two tables drift,
+ * and the drift shows up as a member being offered "1 minute" and then told
+ * their card is running at "1-minute" buckets as if they were different things.
+ *
+ * The two forms differ only in their separator: `"noun"` reads as a menu label
+ * ("1 minute"), `"adjective"` as a modifier of what follows ("1-minute
+ * buckets"). A step the surface does not offer falls back to seconds, a shape
+ * this should never be handed but must not crash on.
+ */
+export function describeLangWatchQLGranularityStep(
+  seconds: number,
+  form: "noun" | "adjective" = "noun",
+): string {
+  const separator = form === "adjective" ? "-" : " ";
+  const unit = (
+    LWQL_GRANULARITY_STEP_UNITS as Readonly<Record<number, string | undefined>>
+  )[seconds];
+
+  return unit === undefined
+    ? `${seconds}${separator}second${form === "noun" ? "s" : ""}`
+    : `1${separator}${unit}`;
+}
+
+/**
  * The ceiling on datapoint buckets one governed run may produce through the
  * granularity contract.
  *

--- a/platform/app/src/server/analytics/lwql/timeWindow.ts
+++ b/platform/app/src/server/analytics/lwql/timeWindow.ts
@@ -133,6 +133,19 @@ export const LWQL_GRANULARITY_STEPS = [1, 60, 3600] as const;
 export type LangWatchQLGranularityStep =
   (typeof LWQL_GRANULARITY_STEPS)[number];
 
+/**
+ * The ceiling on datapoint buckets one governed run may produce through the
+ * granularity contract.
+ *
+ * Vocabulary rather than policy, and so it lives here: the dashboard widget
+ * cites this number in the notice it shows when a period forced its step
+ * coarser, and that notice renders in the browser. The arithmetic that enforces
+ * the ceiling stays in `./resolveTimeWindow.ts`, which the browser never loads
+ * — importing that module for the constant alone would ship the handled-error
+ * registry and everything it reaches to every page.
+ */
+export const LWQL_GRANULARITY_MAX_BUCKETS = 10_000;
+
 /** Whether a parameter name is one the surface owns. */
 export function isLangWatchQLTimeWindowParameter(
   name: string,

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChartCoarsening.unit.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChartCoarsening.unit.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The overflow mode a chart run is executed under, and who gets which.
+ *
+ * The arithmetic of coarsening is proven in `lwqlGranularity.unit.test.ts`
+ * against `resolveLangWatchQLGranularity` directly. What is unproven until here
+ * is the *wiring*: that a caller asking to coarsen actually reaches that branch
+ * through the saved-chart service, and — the claim that matters more — that a
+ * caller who says nothing still refuses. A default that silently flipped to
+ * coarsening would widen every workbench and REST run's buckets without any
+ * caller asking, and every existing test would still pass because they all
+ * assert on results that fit the budget.
+ *
+ * The executor is a recording fake: the claim is "what reached the database",
+ * which is an artifact to read rather than a call sequence to verify.
+ *
+ * @see specs/analytics/lwql-saved-charts.feature
+ * @see specs/analytics/lwql-workbench.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CustomGraph } from "~/generated/prisma/client";
+
+import type { Protections } from "../../../traces/protections";
+import { WORKBENCH_SQL_CHART_KIND } from "../../chartKinds";
+import type {
+  LangWatchQLExecutionRequest,
+  LangWatchQLExecutor,
+} from "../../lwql/executor";
+import { LangWatchQLService } from "../../lwql/lwql.service";
+import type {
+  CreateSavedWorkbenchChartInput,
+  SavedWorkbenchChartStore,
+  UpdateSavedWorkbenchChartInput,
+} from "../savedWorkbenchChart.repository";
+import { SavedWorkbenchChartService } from "../savedWorkbenchChart.service";
+import { WORKBENCH_CHART_DEFINITION_VERSION } from "../workbenchChartDefinition";
+
+const PROJECT_ID = "project-under-test";
+const CHART_ID = "chart-under-test";
+
+const FULLY_PERMITTED: Protections = {
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+  canSeeCosts: true,
+};
+
+/**
+ * A statement that follows both the period and the granularity, which is what
+ * makes it subject to the bucket budget at all.
+ */
+const TIMESERIES_SQL =
+  "SELECT toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket, " +
+  "count() AS value FROM analytics.traces " +
+  "WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime} " +
+  "GROUP BY bucket";
+
+/**
+ * A week. At one-minute steps that is 10,080 buckets — just past the 10,000
+ * ceiling, and an ordinary pairing rather than a contrived one.
+ */
+const WEEK = {
+  start: new Date("2026-02-01T00:00:00.000Z"),
+  end: new Date("2026-02-08T00:00:00.000Z"),
+};
+
+class FakeStore implements SavedWorkbenchChartStore {
+  readonly rows = new Map<string, CustomGraph>();
+
+  seed(definition: unknown): void {
+    this.rows.set(CHART_ID, {
+      id: CHART_ID,
+      projectId: PROJECT_ID,
+      name: "Traces over time",
+      graph: definition,
+      filters: null,
+      kind: WORKBENCH_SQL_CHART_KIND,
+      createdAt: new Date("2026-02-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-02-01T00:00:00.000Z"),
+      dashboardId: "dashboard-1",
+      gridColumn: 0,
+      gridRow: 0,
+      colSpan: 1,
+      rowSpan: 1,
+    } as CustomGraph);
+  }
+
+  async findAll({ projectId }: { projectId: string }): Promise<CustomGraph[]> {
+    return [...this.rows.values()].filter((row) => row.projectId === projectId);
+  }
+
+  async findById({
+    id,
+    projectId,
+  }: {
+    id: string;
+    projectId: string;
+  }): Promise<CustomGraph | null> {
+    const row = this.rows.get(id);
+    return row && row.projectId === projectId ? row : null;
+  }
+
+  async create(_input: CreateSavedWorkbenchChartInput): Promise<CustomGraph> {
+    throw new Error("not used by this suite");
+  }
+
+  async update(
+    _input: UpdateSavedWorkbenchChartInput,
+  ): Promise<CustomGraph | null> {
+    throw new Error("not used by this suite");
+  }
+
+  async delete(_input: { id: string; projectId: string }): Promise<number> {
+    throw new Error("not used by this suite");
+  }
+}
+
+function recordingExecutor(): LangWatchQLExecutor & {
+  readonly calls: LangWatchQLExecutionRequest[];
+} {
+  const calls: LangWatchQLExecutionRequest[] = [];
+  return {
+    calls,
+    async execute(request) {
+      calls.push(request);
+      return {
+        columns: [{ name: "value", type: "UInt64" }],
+        rows: [{ value: 7 }],
+        truncated: false,
+        statistics: {
+          elapsedMs: 2,
+          rowsRead: 4,
+          bytesRead: 40,
+          rowsReturned: 1,
+        },
+      };
+    },
+  };
+}
+
+function build() {
+  const store = new FakeStore();
+  store.seed({
+    version: WORKBENCH_CHART_DEFINITION_VERSION,
+    sql: TIMESERIES_SQL,
+    parameters: {},
+  });
+  const executor = recordingExecutor();
+  const service = new SavedWorkbenchChartService({
+    repository: store,
+    lwql: new LangWatchQLService({ executor, database: "analytics" }),
+  });
+  return { store, service, executor };
+}
+
+const runWith = async (
+  input: Parameters<SavedWorkbenchChartService["runChart"]>[0]["input"],
+) => {
+  const { service, executor } = build();
+  const result = await service.runChart({
+    id: CHART_ID,
+    projectId: PROJECT_ID,
+    project: { id: PROJECT_ID, lwqlKey: "key" },
+    protections: FULLY_PERMITTED,
+    input,
+  });
+  return { result, executor };
+};
+
+describe("running a saved chart whose period overflows its step", () => {
+  describe("when the caller asks to coarsen, as a dashboard widget does", () => {
+    it("runs at the finest step that fits and names what it substituted", async () => {
+      const { result, executor } = await runWith({
+        timeWindow: WEEK,
+        granularitySeconds: 60,
+        onBudgetOverflow: "coarsen",
+      });
+
+      // A week at a minute is 10,080 buckets; the hour is the finest offered
+      // step that fits.
+      expect(result.granularitySeconds).toBe(3600);
+      expect(result.coarsenedFromSeconds).toBe(60);
+
+      // The substitution is not merely reported — it is what actually ran.
+      expect(executor.calls).toHaveLength(1);
+      expect(executor.calls[0]?.parameters).toMatchObject({
+        period_granularity_seconds: 3600,
+      });
+    });
+  });
+
+  describe("when the caller says nothing about overflow", () => {
+    it("refuses rather than quietly widening the buckets", async () => {
+      await expect(
+        runWith({ timeWindow: WEEK, granularitySeconds: 60 }),
+      ).rejects.toMatchObject({ code: "lwql_granularity_too_fine" });
+    });
+
+    it("never reaches the database", async () => {
+      const { service, executor } = build();
+
+      await expect(
+        service.runChart({
+          id: CHART_ID,
+          projectId: PROJECT_ID,
+          project: { id: PROJECT_ID, lwqlKey: "key" },
+          protections: FULLY_PERMITTED,
+          input: { timeWindow: WEEK, granularitySeconds: 60 },
+        }),
+      ).rejects.toThrow();
+
+      expect(executor.calls).toEqual([]);
+    });
+  });
+
+  describe("when the caller explicitly asks to refuse", () => {
+    it("refuses, the same as saying nothing", async () => {
+      await expect(
+        runWith({
+          timeWindow: WEEK,
+          granularitySeconds: 60,
+          onBudgetOverflow: "refuse",
+        }),
+      ).rejects.toMatchObject({ code: "lwql_granularity_too_fine" });
+    });
+  });
+});
+
+describe("running a saved chart whose period fits its step", () => {
+  it("reports no coarsening even when the caller offered to coarsen", async () => {
+    // An hour over a week: 168 buckets. Fits, so nothing is substituted and
+    // the widget has no notice to show.
+    const { result } = await runWith({
+      timeWindow: WEEK,
+      granularitySeconds: 3600,
+      onBudgetOverflow: "coarsen",
+    });
+
+    expect(result.granularitySeconds).toBe(3600);
+    expect(result.coarsenedFromSeconds).toBeUndefined();
+  });
+});

--- a/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
@@ -48,6 +48,7 @@ import {
   type LangWatchQLQueryResult,
   type LangWatchQLService,
 } from "../lwql/lwql.service";
+import type { LangWatchQLBudgetOverflowMode } from "../lwql/resolveTimeWindow";
 import type { LangWatchQLTimeWindow } from "../lwql/timeWindow";
 import {
   SavedWorkbenchChartAlreadyExistsError,
@@ -288,8 +289,10 @@ export class SavedWorkbenchChartService {
    *   reserved name the request supplies no value for (a declared granularity
    *   with no step among them), and
    *   {@link LangWatchQLGranularityTooFineError} when the period at the
-   *   supplied step overflows the bucket ceiling — a direct chart run is
-   *   caller-owned, so it refuses where the dashboard will coarsen.
+   *   supplied step overflows the bucket ceiling and the caller asked to
+   *   refuse, which is the default: a direct chart run is caller-owned, so it
+   *   refuses where a dashboard widget passes `onBudgetOverflow: "coarsen"`
+   *   and reads `coarsenedFromSeconds` off the result instead.
    */
   async runChart({
     id,
@@ -309,6 +312,12 @@ export class SavedWorkbenchChartService {
       timeWindow?: LangWatchQLTimeWindow;
       /** The step the surface chose, for a statement that declares the parameter. */
       granularitySeconds?: number;
+      /**
+       * What an overflowing period does to that step. Defaults to refusing;
+       * only a surface whose period moves independently of the saved step
+       * asks to coarsen.
+       */
+      onBudgetOverflow?: LangWatchQLBudgetOverflowMode;
     };
   }): Promise<LangWatchQLQueryResult> {
     const chart = await this.getById({ id, projectId });
@@ -321,6 +330,9 @@ export class SavedWorkbenchChartService {
       ...(input.timeWindow ? { timeWindow: input.timeWindow } : {}),
       ...(input.granularitySeconds !== undefined
         ? { granularitySeconds: input.granularitySeconds }
+        : {}),
+      ...(input.onBudgetOverflow
+        ? { onBudgetOverflow: input.onBudgetOverflow }
         : {}),
     });
   }

--- a/platform/app/src/server/api/routers/__tests__/graphs.workbenchGate.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/graphs.workbenchGate.unit.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Which kinds a card procedure may touch, and who decides.
+ *
+ * The read was gated on the workbench flag from the start; the three placement
+ * *writes* were not, and the gap is the kind that never shows up as an error.
+ * With the feature off a `workbench_sql` row left behind by a trial is invisible
+ * on the grid — but an ungated `delete` by id would still remove it, and an
+ * ungated layout write would silently rewrite the placement of a card the
+ * surface never admitted existed. "The feature off sees exactly the old grid"
+ * has to be true of every procedure, not just the one that lists rows.
+ *
+ * Asserted on the `kind` clause each procedure sends to Prisma, because that
+ * clause *is* the gate: it is what decides whether a row is reachable at all,
+ * and a procedure that dropped it would still return successfully.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PrismaClient } from "~/generated/prisma/client";
+import {
+  BUILDER_CHART_KIND,
+  WORKBENCH_SQL_CHART_KIND,
+} from "~/server/analytics/chartKinds";
+
+import { createInnerTRPCContext } from "../../trpc";
+import { graphsRouter } from "../graphs";
+
+vi.mock("~/server/app-layer/app", async () => {
+  const { appPermissionsMock } = await import(
+    "~/test-utils/appPermissionsMock"
+  );
+  return appPermissionsMock();
+});
+
+vi.mock("@ee/audit-log/auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../license-enforcement", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../license-enforcement")>();
+  return { ...actual, enforceLicenseLimit: vi.fn() };
+});
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    resolveProjectPermission: vi
+      .fn()
+      .mockResolvedValue({ permitted: true, organizationRole: "MEMBER" }),
+  };
+});
+
+// The gate itself, stubbed per test: this suite is about what each procedure
+// DOES with the answer, not about how the flag resolves (which `access.ts` and
+// its own tests own).
+const lwqlEnabledMock = vi.fn();
+vi.mock("~/server/analytics/lwql/access", () => ({
+  lwqlEnabled: (args: unknown) => lwqlEnabledMock(args),
+  LWQL_FLAG: "release_lwql_workbench",
+}));
+
+const findUnique = vi.fn();
+const deleteGraph = vi.fn();
+const update = vi.fn();
+const findMany = vi.fn();
+const transaction = vi.fn();
+
+const createCaller = () => {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "user_1" }, expires: "1" },
+    permissionChecked: true,
+  });
+  ctx.prisma = {
+    customGraph: {
+      findUnique,
+      delete: deleteGraph,
+      update,
+      findMany,
+    },
+    $transaction: transaction,
+  } as unknown as PrismaClient;
+  return graphsRouter.createCaller(ctx);
+};
+
+/** The `kind` clause of the first Prisma call a spy recorded. */
+const kindClauseOf = (spy: ReturnType<typeof vi.fn>): unknown =>
+  spy.mock.calls[0]?.[0]?.where?.kind;
+
+const LAYOUT = {
+  gridColumn: 0,
+  gridRow: 0,
+  colSpan: 1,
+  rowSpan: 1,
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findUnique.mockResolvedValue({ id: "graph_1", kind: BUILDER_CHART_KIND });
+  deleteGraph.mockResolvedValue({ id: "graph_1" });
+  update.mockResolvedValue({ id: "graph_1" });
+  findMany.mockResolvedValue([]);
+  transaction.mockResolvedValue([]);
+});
+
+describe("the dashboard card procedures", () => {
+  describe("given the workbench is on for the project", () => {
+    beforeEach(() => {
+      lwqlEnabledMock.mockResolvedValue(true);
+    });
+
+    it("lets delete reach a placed workbench row", async () => {
+      await createCaller().delete({ projectId: "project_1", id: "graph_1" });
+
+      expect(kindClauseOf(findUnique)).toEqual({
+        in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND],
+      });
+      expect(kindClauseOf(deleteGraph)).toEqual({
+        in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND],
+      });
+    });
+
+    it("lets a layout write move a placed workbench row", async () => {
+      await createCaller().updateLayout({
+        projectId: "project_1",
+        graphId: "graph_1",
+        ...LAYOUT,
+      });
+
+      expect(kindClauseOf(update)).toEqual({
+        in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND],
+      });
+    });
+
+    it("lets a batch reflow move placed workbench rows", async () => {
+      await createCaller().batchUpdateLayouts({
+        projectId: "project_1",
+        layouts: [{ graphId: "graph_1", ...LAYOUT }],
+      });
+
+      expect(kindClauseOf(update)).toEqual({
+        in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND],
+      });
+    });
+  });
+
+  describe("given the workbench is off for the project", () => {
+    beforeEach(() => {
+      lwqlEnabledMock.mockResolvedValue(false);
+    });
+
+    it("scopes delete to builder rows, so a trial's row is not removable", async () => {
+      await createCaller().delete({ projectId: "project_1", id: "graph_1" });
+
+      // Not an `in` of one — the same clause the grid saw before the feature
+      // existed, which is what "exactly the old grid" means.
+      expect(kindClauseOf(findUnique)).toBe(BUILDER_CHART_KIND);
+      expect(kindClauseOf(deleteGraph)).toBe(BUILDER_CHART_KIND);
+    });
+
+    it("scopes a layout write to builder rows", async () => {
+      await createCaller().updateLayout({
+        projectId: "project_1",
+        graphId: "graph_1",
+        ...LAYOUT,
+      });
+
+      expect(kindClauseOf(update)).toBe(BUILDER_CHART_KIND);
+    });
+
+    it("scopes a batch reflow to builder rows", async () => {
+      await createCaller().batchUpdateLayouts({
+        projectId: "project_1",
+        layouts: [{ graphId: "graph_1", ...LAYOUT }],
+      });
+
+      expect(kindClauseOf(update)).toBe(BUILDER_CHART_KIND);
+    });
+
+    it("scopes the read to builder rows too, so the four agree", async () => {
+      await createCaller().getAll({
+        projectId: "project_1",
+        dashboardId: "dashboard_1",
+      });
+
+      expect(kindClauseOf(findMany)).toBe(BUILDER_CHART_KIND);
+    });
+  });
+});

--- a/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
+++ b/platform/app/src/server/api/routers/analytics/savedWorkbenchCharts.ts
@@ -147,6 +147,12 @@ const deleteChart = protectedProcedure
  * propagate untouched, like on `create`: the boundary serialises their code plus
  * `meta`, and the workbench renders registry copy keyed by that code — including
  * `lwql_granularity_too_fine`'s bucket arithmetic.
+ *
+ * `onBudgetOverflow` defaults to refusing, so every existing caller keeps the
+ * behaviour it had. A dashboard widget passes `"coarsen"` because its saved
+ * step meets whatever period the dashboard's control is set to: refusing there
+ * would blank a card whose owner changed nothing. The substitution is reported
+ * back as `coarsenedFromSeconds` rather than applied silently.
  */
 const run = protectedProcedure
   .input(
@@ -164,6 +170,7 @@ const run = protectedProcedure
           z.literal(LWQL_GRANULARITY_STEPS[2]),
         ])
         .optional(),
+      onBudgetOverflow: z.enum(["refuse", "coarsen"]).optional(),
     }),
   )
   .permission("analytics:view")
@@ -184,6 +191,9 @@ const run = protectedProcedure
         ...(input.granularitySeconds === undefined
           ? {}
           : { granularitySeconds: input.granularitySeconds }),
+        ...(input.onBudgetOverflow
+          ? { onBudgetOverflow: input.onBudgetOverflow }
+          : {}),
       },
     });
   });

--- a/platform/app/src/server/api/routers/graphs.ts
+++ b/platform/app/src/server/api/routers/graphs.ts
@@ -1,11 +1,27 @@
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { BUILDER_CHART_KIND } from "~/server/analytics/chartKinds";
+import {
+  BUILDER_CHART_KIND,
+  WORKBENCH_SQL_CHART_KIND,
+} from "~/server/analytics/chartKinds";
 import { dashboardBelongsToProject } from "~/server/analytics/dashboardBelongsToProject";
+import { lwqlEnabled } from "~/server/analytics/lwql/access";
 import { redactActionParamsFor } from "~/server/app-layer/automations/providers/registry";
 import { type FilterField, filterFieldsEnum } from "../../filters/types";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+/**
+ * The kinds that can sit on a dashboard grid.
+ *
+ * Used only by the procedures that move, resize or remove a *card*. Anything
+ * that reads or writes a row's `graph` payload stays scoped to the single kind
+ * whose shape it understands.
+ */
+const PLACEABLE_CHART_KINDS: string[] = [
+  BUILDER_CHART_KIND,
+  WORKBENCH_SQL_CHART_KIND,
+];
 
 /**
  * Read-side hydration shape for the `Add / Edit alert` bell icon on the
@@ -101,10 +117,23 @@ export const graphsRouter = createTRPCRouter({
       const { projectId, dashboardId } = input;
       const prisma = ctx.prisma;
 
+      // Placed workbench charts join the grid, but only when reading one
+      // dashboard. The unscoped read (`dashboardId` absent) is the chart
+      // *picker* the builder offers, and a saved workbench chart is not
+      // something a builder graph can be composed from — including them there
+      // would offer a member a chart the builder cannot open.
+      //
+      // Gated on the workbench flag so a deployment with the feature off sees
+      // exactly the grid it saw before, even if rows exist from a trial.
+      const includeWorkbenchCharts =
+        !!dashboardId && (await lwqlEnabled({ prisma, projectId }));
+
       const graphs = await prisma.customGraph.findMany({
         where: {
           projectId,
-          kind: BUILDER_CHART_KIND,
+          ...(includeWorkbenchCharts
+            ? { kind: { in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND] } }
+            : { kind: BUILDER_CHART_KIND }),
           ...(dashboardId ? { dashboardId } : {}),
         },
         orderBy: dashboardId
@@ -115,12 +144,24 @@ export const graphsRouter = createTRPCRouter({
         },
       });
 
+      // A workbench row's `graph` column is its definition — `{ sql,
+      // parameters, vegaLiteSpec }`. The grid does not draw from it: the
+      // widget reads its own chart through the saved-chart service, which
+      // parses the versioned schema and refuses a row this build cannot read.
+      // Sending it here too would put a member's stored SQL in the dashboard
+      // payload for no one to use.
+      const withoutWorkbenchDefinitions = graphs.map((graph) =>
+        graph.kind === WORKBENCH_SQL_CHART_KIND
+          ? { ...graph, graph: null }
+          : graph,
+      );
+
       // The included trigger row carries provider secrets in actionParams
       // (the encrypted Slack bot token per ADR-041, webhook header values
       // per ADR-040 §3) — strip them per the trigger's own action before the
       // rows leave the server, the same registry-driven redaction the
       // automations router applies on its read paths.
-      return graphs.map((graph) =>
+      return withoutWorkbenchDefinitions.map((graph) =>
         graph.trigger
           ? {
               ...graph,
@@ -142,15 +183,26 @@ export const graphsRouter = createTRPCRouter({
       const { id } = input;
       const prisma = ctx.prisma;
 
+      // Removing a card removes the row, whichever kind it is — a member who
+      // deletes a workbench widget from a dashboard means the widget, and
+      // leaving the row behind would strand a chart on no dashboard.
       const graph = await prisma.customGraph.findUnique({
-        where: { id, projectId: input.projectId, kind: BUILDER_CHART_KIND },
+        where: {
+          id,
+          projectId: input.projectId,
+          kind: { in: PLACEABLE_CHART_KINDS },
+        },
       });
       if (!graph) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Graph not found" });
       }
 
       await prisma.customGraph.delete({
-        where: { id, projectId: input.projectId, kind: BUILDER_CHART_KIND },
+        where: {
+          id,
+          projectId: input.projectId,
+          kind: { in: PLACEABLE_CHART_KINDS },
+        },
       });
 
       return graph;
@@ -285,11 +337,16 @@ export const graphsRouter = createTRPCRouter({
     )
     .permission("analytics:update")
     .mutation(async ({ ctx, input }) => {
+      // Placement, not definition: where a card sits on the grid is a fact
+      // about the dashboard rather than about the chart's shape, so both kinds
+      // are movable. The kind-scoped reads that matter are the ones that
+      // *interpret* `graph` — `getById` and `update` below — and they stay
+      // builder-only.
       return ctx.prisma.customGraph.update({
         where: {
           id: input.graphId,
           projectId: input.projectId,
-          kind: BUILDER_CHART_KIND,
+          kind: { in: PLACEABLE_CHART_KINDS },
         },
         data: {
           gridColumn: input.gridColumn,
@@ -322,7 +379,7 @@ export const graphsRouter = createTRPCRouter({
           where: {
             id: layout.graphId,
             projectId: input.projectId,
-            kind: BUILDER_CHART_KIND,
+            kind: { in: PLACEABLE_CHART_KINDS },
           },
           data: {
             gridColumn: layout.gridColumn,

--- a/platform/app/src/server/api/routers/graphs.ts
+++ b/platform/app/src/server/api/routers/graphs.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import type { PrismaClient } from "~/generated/prisma/client";
 import {
   BUILDER_CHART_KIND,
   WORKBENCH_SQL_CHART_KIND,
@@ -12,16 +13,44 @@ import { type FilterField, filterFieldsEnum } from "../../filters/types";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 /**
- * The kinds that can sit on a dashboard grid.
+ * The kinds that can sit on a dashboard grid *when the workbench is on*.
  *
  * Used only by the procedures that move, resize or remove a *card*. Anything
  * that reads or writes a row's `graph` payload stays scoped to the single kind
  * whose shape it understands.
  */
-const PLACEABLE_CHART_KINDS: string[] = [
+const PLACEABLE_CHART_KINDS = [
   BUILDER_CHART_KIND,
   WORKBENCH_SQL_CHART_KIND,
-];
+] as const;
+
+/**
+ * The kinds a placement procedure may touch for this project.
+ *
+ * Asked by every card-level procedure — the read and all three writes — so
+ * that a deployment with the workbench off sees exactly the grid it saw
+ * before, and cannot move, resize or delete a `workbench_sql` row left behind
+ * by a trial. Gating only the read would leave the rows invisible but still
+ * mutable: a member's reflow of the charts they *can* see would silently
+ * rewrite the placement of ones they cannot, and a delete by id would remove a
+ * row the surface never admitted existed.
+ */
+async function placeableKindFilter({
+  prisma,
+  projectId,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+}): Promise<{ kind: string | { in: string[] } }> {
+  // The filter itself rather than the kind list, so all four procedures emit
+  // the identical clause. With the workbench off that clause is the bare
+  // `kind: "builder"` the grid used before this feature existed — which is
+  // what makes "exactly the old grid" a statement about the query and not
+  // just about the rows it happens to return.
+  return (await lwqlEnabled({ prisma, projectId }))
+    ? { kind: { in: [...PLACEABLE_CHART_KINDS] } }
+    : { kind: BUILDER_CHART_KIND };
+}
 
 /**
  * Read-side hydration shape for the `Add / Edit alert` bell icon on the
@@ -124,16 +153,17 @@ export const graphsRouter = createTRPCRouter({
       // would offer a member a chart the builder cannot open.
       //
       // Gated on the workbench flag so a deployment with the feature off sees
-      // exactly the grid it saw before, even if rows exist from a trial.
-      const includeWorkbenchCharts =
-        !!dashboardId && (await lwqlEnabled({ prisma, projectId }));
+      // exactly the grid it saw before, even if rows exist from a trial —
+      // the same gate every placement mutation below applies, so what the
+      // grid shows and what a card action may touch cannot disagree.
+      const placeable = dashboardId
+        ? await placeableKindFilter({ prisma, projectId })
+        : { kind: BUILDER_CHART_KIND };
 
       const graphs = await prisma.customGraph.findMany({
         where: {
           projectId,
-          ...(includeWorkbenchCharts
-            ? { kind: { in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND] } }
-            : { kind: BUILDER_CHART_KIND }),
+          ...placeable,
           ...(dashboardId ? { dashboardId } : {}),
         },
         orderBy: dashboardId
@@ -185,24 +215,23 @@ export const graphsRouter = createTRPCRouter({
 
       // Removing a card removes the row, whichever kind it is — a member who
       // deletes a workbench widget from a dashboard means the widget, and
-      // leaving the row behind would strand a chart on no dashboard.
+      // leaving the row behind would strand a chart on no dashboard. Scoped by
+      // the same flag the read is: with the workbench off a `workbench_sql`
+      // row is not on this grid, so deleting one by id answers not-found.
+      const placeable = await placeableKindFilter({
+        prisma,
+        projectId: input.projectId,
+      });
+
       const graph = await prisma.customGraph.findUnique({
-        where: {
-          id,
-          projectId: input.projectId,
-          kind: { in: PLACEABLE_CHART_KINDS },
-        },
+        where: { id, projectId: input.projectId, ...placeable },
       });
       if (!graph) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Graph not found" });
       }
 
       await prisma.customGraph.delete({
-        where: {
-          id,
-          projectId: input.projectId,
-          kind: { in: PLACEABLE_CHART_KINDS },
-        },
+        where: { id, projectId: input.projectId, ...placeable },
       });
 
       return graph;
@@ -339,14 +368,19 @@ export const graphsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       // Placement, not definition: where a card sits on the grid is a fact
       // about the dashboard rather than about the chart's shape, so both kinds
-      // are movable. The kind-scoped reads that matter are the ones that
-      // *interpret* `graph` — `getById` and `update` below — and they stay
-      // builder-only.
+      // are movable — while the workbench is on for this project. The
+      // kind-scoped reads that matter are the ones that *interpret* `graph` —
+      // `getById` and `update` below — and they stay builder-only.
+      const placeable = await placeableKindFilter({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+      });
+
       return ctx.prisma.customGraph.update({
         where: {
           id: input.graphId,
           projectId: input.projectId,
-          kind: { in: PLACEABLE_CHART_KINDS },
+          ...placeable,
         },
         data: {
           gridColumn: input.gridColumn,
@@ -374,12 +408,17 @@ export const graphsRouter = createTRPCRouter({
     )
     .permission("analytics:update")
     .mutation(async ({ ctx, input }) => {
+      const placeable = await placeableKindFilter({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+      });
+
       const updates = input.layouts.map((layout) =>
         ctx.prisma.customGraph.update({
           where: {
             id: layout.graphId,
             projectId: input.projectId,
-            kind: { in: PLACEABLE_CHART_KINDS },
+            ...placeable,
           },
           data: {
             gridColumn: layout.gridColumn,

--- a/platform/app/src/server/dashboards/dashboard.repository.ts
+++ b/platform/app/src/server/dashboards/dashboard.repository.ts
@@ -4,6 +4,8 @@ import type {
   PrismaClient,
 } from "~/generated/prisma/client";
 
+import { BUILDER_CHART_KIND } from "~/server/analytics/chartKinds";
+
 /**
  * Input types for dashboard operations
  */
@@ -49,7 +51,22 @@ export class DashboardRepository {
   }
 
   /**
-   * Finds a dashboard by id within a project, including its graphs.
+   * Finds a dashboard by id within a project, including its builder graphs.
+   *
+   * The `kind` predicate is load-bearing rather than tidy. This read feeds the
+   * v1 REST `GET /dashboards/{id}` response, which serialises each graph row
+   * wholesale — and a saved LangWatchQL workbench chart's `graph` column holds
+   * `{ sql, parameters, vegaLiteSpec }`, so including one here publishes a
+   * member's stored SQL to any project API key that can read a dashboard.
+   * Scoping the include is what keeps the discriminator's promise (neither kind
+   * sees the other's rows) true on the way out as well as on the way in.
+   *
+   * Workbench charts placed on a dashboard are rendered by the application's
+   * own widget surface, which reads them through the saved-chart service and
+   * its own gates, never through this row.
+   *
+   * @see ~/server/analytics/chartKinds — the discriminator
+   * @see specs/analytics/dashboard-rest-api.feature
    */
   async findById(input: { id: string; projectId: string }) {
     return await this.prisma.dashboard.findFirst({
@@ -59,6 +76,7 @@ export class DashboardRepository {
       },
       include: {
         graphs: {
+          where: { kind: BUILDER_CHART_KIND },
           orderBy: [{ gridRow: "asc" }, { gridColumn: "asc" }],
         },
       },

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -242,27 +242,25 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z
-        .array(z.object({ description: z.string() }))
-        .default([
-          { description: "The response is incorrect, irrelevant." },
-          {
-            description:
-              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-          },
-        ]),
+      rubrics: z.array(z.object({ description: z.string() })).default([
+        { description: "The response is incorrect, irrelevant." },
+        {
+          description:
+            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+        },
+      ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -893,7 +891,13 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
+    | "quality"
+    | "rag"
+    | "safety"
+    | "policy"
+    | "other"
+    | "custom"
+    | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -242,25 +242,27 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z.array(z.object({ description: z.string() })).default([
-        { description: "The response is incorrect, irrelevant." },
-        {
-          description:
-            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-        },
-      ]),
+      rubrics: z
+        .array(z.object({ description: z.string() }))
+        .default([
+          { description: "The response is incorrect, irrelevant." },
+          {
+            description:
+              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+          },
+        ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -891,13 +893,7 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    | "quality"
-    | "rag"
-    | "safety"
-    | "policy"
-    | "other"
-    | "custom"
-    | "similarity";
+    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/specs/analytics/dashboard-rest-api.feature
+++ b/specs/analytics/dashboard-rest-api.feature
@@ -48,3 +48,15 @@ Feature: Dashboard REST API
   Scenario: Unauthenticated request
     When I call GET /api/dashboards without an API key
     Then I receive 401 Unauthorized
+
+  # The `kind` discriminator promises that neither chart shape sees the other's
+  # rows. This is that promise on the way out: the reader serialises each graph
+  # row wholesale, and a saved workbench chart's payload is the member's own
+  # SQL. Tagged because it is a real exposure rather than a shape preference —
+  # the rest of this file predates the binding convention.
+  @integration
+  Scenario: A saved workbench chart is not exposed through the dashboard REST API
+    Given the project has a dashboard carrying both a builder graph and a saved workbench chart
+    When I call GET /api/dashboards/:id
+    Then I receive only the builder graph
+    And the workbench chart's stored SQL appears nowhere in the response

--- a/specs/analytics/lwql-saved-charts.feature
+++ b/specs/analytics/lwql-saved-charts.feature
@@ -359,6 +359,48 @@ Feature: Saved LangWatchQL workbench charts — the persistence model and its wr
     When the saved chart paths are looked up in it
     Then all five operations are described, each with a summary, a tag and a response schema
 
+  # Dashboard placement — what a placed workbench chart draws, asks for, and
+  # is offered. The routing claims are the load-bearing ones: `kind` decides
+  # which renderer receives the row, and both directions of getting it wrong
+  # are silent rather than a type error.
+
+  @integration
+  Scenario: A placed workbench card draws the widget, not the builder
+    Given a dashboard grid holding a saved workbench chart
+    When the card is rendered
+    Then the LangWatchQL widget draws it, and the builder renderer is not mounted
+
+  @integration
+  Scenario: A builder card keeps the builder renderer and its alert bell
+    Given a dashboard grid holding a builder graph
+    When the card is rendered
+    Then the builder renderer draws it and the add-alert control is offered
+
+  @integration
+  Scenario: A workbench card is not offered an alert it cannot evaluate
+    Given a dashboard grid holding a saved workbench chart
+    When the card is rendered
+    Then no add-alert control is offered, because a saved statement has no series to threshold
+
+  @integration
+  Scenario: A placed widget asks the run to coarsen rather than refuse
+    Given a placed workbench chart whose card is showing
+    When the widget runs its chart for the dashboard's period
+    Then the request asks for coarsening on budget overflow, so a wide period redraws the card instead of blanking it
+
+  @integration
+  Scenario: A coarsened widget says which step it actually ran at
+    Given a placed workbench chart whose period forced a coarser step
+    When the widget draws the answer
+    Then it shows a notice naming both the step asked for and the step used
+    And a run that coarsened nothing shows no notice
+
+  @integration
+  Scenario: A widget ignores an answer for a period it has left
+    Given a placed workbench chart whose period changed while a run was in flight
+    When the older run resolves after the newer one
+    Then the card keeps the newer answer, rather than settling on the period it has left
+
 # --- AC Coverage Map ---
 # Issue #6582, slice 1 ("Schema + repository + service — model decision,
 # validation choke point, unit/integration tests").

--- a/specs/analytics/lwql-saved-charts.feature
+++ b/specs/analytics/lwql-saved-charts.feature
@@ -401,6 +401,18 @@ Feature: Saved LangWatchQL workbench charts — the persistence model and its wr
     When the older run resolves after the newer one
     Then the card keeps the newer answer, rather than settling on the period it has left
 
+  @integration
+  Scenario: A widget names a run refusal instead of the generic card
+    Given a placed workbench chart whose run answers with a handled LangWatchQL error
+    When the widget settles on that failure
+    Then the card shows the registry copy for that code, not the generic error treatment
+
+  @integration
+  Scenario: A widget falls back to the generic card only for unknown failures
+    Given a placed workbench chart whose run fails with an error no registry names
+    When the widget settles on that failure
+    Then the card shows the generic treatment under a headline naming the action, and leaks no internal message
+
 # --- AC Coverage Map ---
 # Issue #6582, slice 1 ("Schema + repository + service — model decision,
 # validation choke point, unit/integration tests").


### PR DESCRIPTION
# Related Issue

- Resolves #6713

Part of #6582 · closes the dashboard-widget half of #6713 · **stacked PR 3/3**, base `issue6713/lwql-run-by-chart-id` (#7431), which stacks on #7426.

## What

Saved workbench (LWQL) charts can now be placed on dashboards:

- **ReportGrid / DraggableGraphCard** render workbench charts through `LazyLangWatchQLWidgetChart` → `LangWatchQLWidgetChart` → `LangWatchQLDashboardWidget`.
- **GraphCardMenu** gains workbench-aware actions (integration-tested).
- **graphs router**: `updateLayout`, `batchUpdateLayouts`, and `delete` admit both chart kinds (`PLACEABLE_CHART_KINDS`); `getById`/`update` remain builder-only by design.
- **Granularity**: widgets pass `{period_granularity_seconds}` per the PR-1 contract; when the bucket budget forces coarsening, `widgetCoarsenedNotice` surfaces a "coarsened from X" notice. Granularity choice is **session state, not persisted** (deliberate scope call; `?chart=` deep-linking left as a follow-up).
- **Security (D4)**: `GET /api/dashboards/:id` (REST, API-key scope `analytics:view`) omits workbench chart internals — raw `{sql, parameters, vegaLiteSpec}` never reach API-key consumers. Note: on `main` today the leak is exploitable; the omission ships here via `dashboard.repository.ts` scoping `graphs` to `BUILDER_CHART_KIND`, covered by the new REST integration scenario (bound in `specs/analytics/dashboard-rest-api.feature`, removed from `LEGACY_INERT`).

## Validation

Full battery green: typecheck (app + tests), unit, integration (21/21 dashboard REST), biome (0 errors), feature-parity (8274 scenarios bound). One earlier IT failure was a test bug (`body.data.graphs` vs flat `body.graphs`) — production omission logic was correct.

## Screenshots

## Scope note: no placement UI in this slice

Nothing in this PR (or the tree yet) writes a `workbench_sql` row with a `dashboardId` — the "Add to dashboard" action ships in a later slice of the stack. Every render/delete/move/coarsen path here is exercised via rows created by the integration-test fixture (`createWorkbenchChart`) and, for browser QA, out-of-band seeding. This is deliberate stacked-slice sequencing: S2 renders, a later PR places.

Follow-ups filed from review: #7437 (dashboard list count inconsistency), #7438 (widget fetch-on-change → useQuery; `supportsAlerts` naming).

Live-browser QA in progress; screenshots will be attached before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Browser QA (live, head 709c0729a4)

All 7 checks passed against a live dev server + dedicated ClickHouse harness (seeded dashboard: 2 builder + 3 workbench cards, 180 traces over 3h):

| Check | Result | Screenshot |
|---|---|---|
| Workbench widgets render alongside builder charts, run saved LWQL, draw Vega | PASS | ![overview](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/01-dashboard-overview.png) |
| Per-widget datapoints picker → URL state (`?widgetGranularity=id:seconds`), survives reload, shareable in fresh tab | PASS | ![picker](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/03-after-1hour-pick-url-state.png) ![reload](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/04a-reload-pick-survives.png) |
| Hand-edited off-list URL step ignored, no error | PASS | ![bad-url](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/06-bad-url-step-ignored.png) |
| Coarsened notice with unit naming (aria status) | PASS | (visible in 01/04a/06) |
| No alert bell on workbench cards; builder cards keep theirs | PASS | ![no-bell](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/05-workbench-card-menu-no-alert.png) |
| Drag / resize / delete persist to DB; flag OFF → old builder-only grid, zero console errors | PASS | ![resize](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/07-resize-wide-2x1.png) ![flag-off](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/10-flag-off-workbench-cards-absent.png) |
| Failing widget shows contained error card, grid unaffected | PASS | ![error](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7436/09-delete-workbench-card.png) |

One QA observation (widget error card shows the generic error for a knowable member-authored SQL failure) is being fixed in a follow-up commit on this branch.


## How I can prove I was successful

- **[proven] CI fully green at head `19db35bf64`** (62 checks) after the rebase onto #7431's final head.
- **[proven] Clerk READY at `19db35bf64`** — five-point delta verification (fan-out fixes, failure naming, step-union type threading, spec bindings, rebase integrity) in the verdict comment on this PR.
- **[proven] Live browser QA passed all 7 checks** — see the Browser QA table above (screenshots in `pr-7436/`); the one QA observation (generic error card for a knowable query failure) was fixed on this branch: widgets now render handled LWQL errors with registry copy, and failures ride the same strictly-newer sequence guard as answers.
- **[proven] Sabotage-verified tests** across the fan-out fixes (sequence guard, coarsen-on-wire, alert-bell exclusion, mutation gating, strict-greater guard, scenario bindings).

## Human verification

- Place a workbench chart and a builder chart on one dashboard: pick Datapoints → 1 hour on the workbench card, reload — the pick must survive (URL state) and only that card re-runs.
- Turn the workbench flag off: the workbench cards disappear and the grid behaves exactly as the old builder-only grid.
