### PR TITLE
feat(lwql): chart placement service + REST endpoints (Langy authoring slice 1)

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -4297,6 +4297,15 @@
                     "followsTimeWindow": {
                       "type": "boolean"
                     },
+                    "followsGranularity": {
+                      "type": "boolean"
+                    },
+                    "granularitySeconds": {
+                      "type": "number"
+                    },
+                    "coarsenedFromSeconds": {
+                      "type": "number"
+                    },
                     "diagnostics": {
                       "type": "array",
                       "items": {
@@ -4333,6 +4342,7 @@
                     "statistics",
                     "truncated",
                     "followsTimeWindow",
+                    "followsGranularity",
                     "diagnostics"
                   ]
                 }
@@ -4625,6 +4635,10 @@
                       "start",
                       "end"
                     ]
+                  },
+                  "granularitySeconds": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
                   }
                 },
                 "required": [
@@ -5026,6 +5040,24 @@
                           },
                           "platformUrl": {
                             "type": "string"
+                          },
+                          "dashboardId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "gridColumn": {
+                            "type": "number"
+                          },
+                          "gridRow": {
+                            "type": "number"
+                          },
+                          "colSpan": {
+                            "type": "number"
+                          },
+                          "rowSpan": {
+                            "type": "number"
                           }
                         },
                         "required": [
@@ -5034,7 +5066,12 @@
                           "definition",
                           "createdAt",
                           "updatedAt",
-                          "platformUrl"
+                          "platformUrl",
+                          "dashboardId",
+                          "gridColumn",
+                          "gridRow",
+                          "colSpan",
+                          "rowSpan"
                         ]
                       }
                     }
@@ -5292,6 +5329,24 @@
                     },
                     "platformUrl": {
                       "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5300,7 +5355,12 @@
                     "definition",
                     "createdAt",
                     "updatedAt",
-                    "platformUrl"
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
                   ]
                 }
               }
@@ -5575,6 +5635,24 @@
                     },
                     "platformUrl": {
                       "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5583,7 +5661,12 @@
                     "definition",
                     "createdAt",
                     "updatedAt",
-                    "platformUrl"
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
                   ]
                 }
               }
@@ -5887,6 +5970,24 @@
                     },
                     "platformUrl": {
                       "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5895,7 +5996,12 @@
                     "definition",
                     "createdAt",
                     "updatedAt",
-                    "platformUrl"
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
                   ]
                 }
               }
@@ -6175,6 +6281,630 @@
         "responses": {
           "204": {
             "description": "The chart was deleted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No chart with this id in this project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "chartId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "project_api_key": []
+          }
+        ]
+      }
+    },
+    "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement": {
+      "put": {
+        "operationId": "putApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement",
+        "summary": "Place a saved workbench chart on a dashboard",
+        "description": "Places one saved LangWatchQL chart on a dashboard in the same project, at the grid position supplied — or, when no grid row is given, at the next row free on that dashboard, counting charts of every kind. A dashboard that is not in this project is reported as not found, exactly like a chart that is not, and nothing is written.",
+        "tags": [
+          "Analytics / LangWatchQL"
+        ],
+        "responses": {
+          "200": {
+            "description": "The chart, now placed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "number"
+                        },
+                        "sql": {
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "vegaLiteSpec": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "sql",
+                        "parameters"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "definition",
+                    "createdAt",
+                    "updatedAt",
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No chart with this id in this project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dashboardId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "gridColumn": {
+                    "type": "integer"
+                  },
+                  "gridRow": {
+                    "type": "integer"
+                  },
+                  "colSpan": {
+                    "type": "integer"
+                  },
+                  "rowSpan": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "dashboardId"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "chartId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "project_api_key": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement",
+        "summary": "Remove a saved workbench chart from its dashboard",
+        "description": "Removes one saved LangWatchQL chart from whatever dashboard it is on, clearing its grid position along with the dashboard id. Idempotent: unplacing a chart that is not placed answers 204 all the same. The chart itself — its statement, parameter values and specification — is untouched.",
+        "tags": [
+          "Analytics / LangWatchQL"
+        ],
+        "responses": {
+          "204": {
+            "description": "The chart is no longer on any dashboard"
           },
           "400": {
             "description": "Bad Request",

--- a/docs/scripts/generate-api-reference-pages.ts
+++ b/docs/scripts/generate-api-reference-pages.ts
@@ -92,6 +92,8 @@ const SKIP_PATHS: Record<string, string> = {
     UNDOCUMENTED_LWQL_ANALYTICS_SQL,
   "/api/v1/projects/{projectId}/analytics/charts/{chartId}":
     UNDOCUMENTED_LWQL_ANALYTICS_SQL,
+  "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement":
+    UNDOCUMENTED_LWQL_ANALYTICS_SQL,
 };
 
 const ENDPOINT_GROUPS: EndpointGroup[] = [

--- a/platform/app/src/app/api/analytics-sql/[[...route]]/app.charts.v1.ts
+++ b/platform/app/src/app/api/analytics-sql/[[...route]]/app.charts.v1.ts
@@ -1,19 +1,22 @@
 /**
  * Saved workbench charts — the REST routes.
  *
- * Five endpoints under the LangWatchQL analytics SQL family:
+ * Seven endpoints under the LangWatchQL analytics SQL family:
  *
  *  - `GET    /api/v1/projects/{projectId}/analytics/charts`
  *  - `POST   /api/v1/projects/{projectId}/analytics/charts`
  *  - `GET    /api/v1/projects/{projectId}/analytics/charts/{chartId}`
  *  - `PATCH  /api/v1/projects/{projectId}/analytics/charts/{chartId}`
  *  - `DELETE /api/v1/projects/{projectId}/analytics/charts/{chartId}`
+ *  - `PUT    /api/v1/projects/{projectId}/analytics/charts/{chartId}/placement`
+ *  - `DELETE /api/v1/projects/{projectId}/analytics/charts/{chartId}/placement`
  *
  * They sit here rather than under `/api/dashboards` because a saved chart is a
  * LangWatchQL artifact before it is a dashboard one: it is behind the same
  * experimental switch, resolved for the project's organization by the same
  * guard, and its refusals are `HandledError`s the family already serialises
- * with their `meta` intact. Dashboard placement stays a dashboard concern.
+ * with their `meta` intact. Placement, too, is an operation on the chart — the
+ * dashboard is the value it is given, not the resource being edited.
  *
  * ## Nothing is validated here
  *
@@ -95,6 +98,22 @@ const definitionSchema = z.unknown().superRefine((definition, ctx) => {
   });
 });
 
+/**
+ * A placement request's envelope: a dashboard id, and an optional grid
+ * position. What a valid position *is* — the column and span ceilings, and
+ * which dashboard this project may name — is the service's placement schema
+ * and its tenancy check, not this route's. Re-declaring the bounds here would
+ * fork them, and a placement this route admitted that the service refuses is
+ * answered with the service's own refusal.
+ */
+const placeChartSchema = z.object({
+  dashboardId: z.string().min(1),
+  gridColumn: z.number().int().optional(),
+  gridRow: z.number().int().optional(),
+  colSpan: z.number().int().optional(),
+  rowSpan: z.number().int().optional(),
+});
+
 const createChartSchema = z.object({
   name: nameSchema,
   definition: definitionSchema,
@@ -135,6 +154,12 @@ const chartSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   platformUrl: z.string(),
+  /** `null` when the chart has never been placed, or has been unplaced. */
+  dashboardId: z.string().nullable(),
+  gridColumn: z.number(),
+  gridRow: z.number(),
+  colSpan: z.number(),
+  rowSpan: z.number(),
 });
 
 const chartListSchema = z.object({ data: z.array(chartSchema) });
@@ -188,6 +213,11 @@ function chartResource({
       projectSlug: project.slug,
       path: "/analytics/query",
     }),
+    dashboardId: chart.dashboardId,
+    gridColumn: chart.gridColumn,
+    gridRow: chart.gridRow,
+    colSpan: chart.colSpan,
+    rowSpan: chart.rowSpan,
   };
 }
 
@@ -375,6 +405,67 @@ function registerDelete(secured: ReturnType<typeof createProjectApp>): void {
   );
 }
 
+function registerPlace(secured: ReturnType<typeof createProjectApp>): void {
+  secured.access(requires("analytics:update")).put(
+    "/:projectId/analytics/charts/:chartId/placement",
+    describeRoute({
+      summary: "Place a saved workbench chart on a dashboard",
+      description:
+        "Places one saved LangWatchQL chart on a dashboard in the same project, at the grid position supplied — or, when no grid row is given, at the next row free on that dashboard, counting charts of every kind. A dashboard that is not in this project is reported as not found, exactly like a chart that is not, and nothing is written.",
+      tags: CHART_TAGS,
+      responses: {
+        ...canonicalBaseResponses,
+        ...chartNotFoundResponse,
+        200: {
+          description: "The chart, now placed",
+          content: { "application/json": { schema: resolver(chartSchema) } },
+        },
+      },
+    }),
+    zValidator("json", placeChartSchema),
+    async (c) => {
+      const project = await lwqlProject({
+        project: c.get("project"),
+        requestedProjectId: c.req.param("projectId"),
+      });
+      const chart = await chartService().placeChart({
+        id: chartIdOf(c.req.param("chartId")),
+        projectId: project.id,
+        input: c.req.valid("json"),
+      });
+      return c.json(chartResource({ chart, project }));
+    },
+  );
+}
+
+function registerUnplace(secured: ReturnType<typeof createProjectApp>): void {
+  secured.access(requires("analytics:update")).delete(
+    "/:projectId/analytics/charts/:chartId/placement",
+    describeRoute({
+      summary: "Remove a saved workbench chart from its dashboard",
+      description:
+        "Removes one saved LangWatchQL chart from whatever dashboard it is on, clearing its grid position along with the dashboard id. Idempotent: unplacing a chart that is not placed answers 204 all the same. The chart itself — its statement, parameter values and specification — is untouched.",
+      tags: CHART_TAGS,
+      responses: {
+        ...canonicalBaseResponses,
+        ...chartNotFoundResponse,
+        204: { description: "The chart is no longer on any dashboard" },
+      },
+    }),
+    async (c) => {
+      const project = await lwqlProject({
+        project: c.get("project"),
+        requestedProjectId: c.req.param("projectId"),
+      });
+      await chartService().unplaceChart({
+        id: chartIdOf(c.req.param("chartId")),
+        projectId: project.id,
+      });
+      return c.body(null, 204);
+    },
+  );
+}
+
 /**
  * Registers the saved workbench chart routes on the LangWatchQL analytics SQL app.
  *
@@ -390,4 +481,6 @@ export function registerSavedWorkbenchChartRoutes(
   registerRead(secured);
   registerUpdate(secured);
   registerDelete(secured);
+  registerPlace(secured);
+  registerUnplace(secured);
 }

--- a/platform/app/src/app/api/analytics-sql/__tests__/savedWorkbenchChartsOpenApi.unit.test.ts
+++ b/platform/app/src/app/api/analytics-sql/__tests__/savedWorkbenchChartsOpenApi.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * The five chart operations, in the document an integrator actually reads.
+ * The chart operations, in the document an integrator actually reads.
  *
  * `check:openapi-route-coverage` asks whether a registered route reached the
  * document; this asks whether the *checked-in* document still describes it. The
@@ -8,6 +8,7 @@
  * shipped, and never regenerated is published to nobody.
  *
  * @see specs/analytics/lwql-saved-charts.feature
+ * @see specs/analytics/lwql-langy-authoring.feature — the placement operations
  */
 
 import { describe, expect, it } from "vitest";
@@ -16,6 +17,7 @@ import specification from "../../openapiLangWatch.json";
 
 const COLLECTION = "/api/v1/projects/{projectId}/analytics/charts";
 const RESOURCE = `${COLLECTION}/{chartId}`;
+const PLACEMENT = `${RESOURCE}/placement`;
 
 /** Every chart operation, and the status its success answer carries. */
 const OPERATIONS = [
@@ -24,6 +26,8 @@ const OPERATIONS = [
   { path: RESOURCE, method: "get", success: "200" },
   { path: RESOURCE, method: "patch", success: "200" },
   { path: RESOURCE, method: "delete", success: "204" },
+  { path: PLACEMENT, method: "put", success: "200" },
+  { path: PLACEMENT, method: "delete", success: "204" },
 ] as const;
 
 const paths = (specification as { paths: Record<string, any> }).paths;
@@ -31,7 +35,7 @@ const paths = (specification as { paths: Record<string, any> }).paths;
 describe("given the generated OpenAPI document", () => {
   describe("when the saved workbench chart paths are looked up", () => {
     /** @scenario "Every chart endpoint is published in the API document" */
-    it("describes all five operations, each with a summary, a tag and a success response", () => {
+    it("describes every operation, each with a summary, a tag and a success response", () => {
       for (const { path, method, success } of OPERATIONS) {
         const where = `${method.toUpperCase()} ${path}`;
         const operation = paths[path]?.[method];
@@ -63,10 +67,31 @@ describe("given the generated OpenAPI document", () => {
       }
     });
 
-    it("declares a request body for the two writes that take one", () => {
+    /** @scenario "The placement endpoints are published in the API document" */
+    it("publishes both placement operations, each described and answered with a schema or a 204", () => {
+      const put = paths[PLACEMENT]?.put;
+      const del = paths[PLACEMENT]?.delete;
+
+      expect(put, `PUT ${PLACEMENT} is not in the document`).toBeDefined();
+      expect(del, `DELETE ${PLACEMENT} is not in the document`).toBeDefined();
+      for (const operation of [put, del]) {
+        expect(operation.summary).toBeTruthy();
+        expect(operation.tags).toContain("Analytics / LangWatchQL");
+        // A missing dashboard and a missing chart share the one refusal.
+        expect(operation.responses?.["404"]).toBeDefined();
+      }
+      expect(
+        put.responses?.["200"]?.content?.["application/json"]?.schema,
+        `PUT ${PLACEMENT} publishes no response schema`,
+      ).toBeDefined();
+      expect(del.responses?.["204"]).toBeDefined();
+    });
+
+    it("declares a request body for the three writes that take one", () => {
       for (const { path, method } of [
         { path: COLLECTION, method: "post" },
         { path: RESOURCE, method: "patch" },
+        { path: PLACEMENT, method: "put" },
       ]) {
         expect(
           paths[path]?.[method]?.requestBody,

--- a/platform/app/src/app/api/analytics-sql/__tests__/savedWorkbenchChartsRestApi.integration.test.ts
+++ b/platform/app/src/app/api/analytics-sql/__tests__/savedWorkbenchChartsRestApi.integration.test.ts
@@ -29,6 +29,7 @@
  *   through, including the 5xx redaction one case below turns on
  *
  * @see specs/analytics/lwql-saved-charts.feature
+ * @see specs/analytics/lwql-langy-authoring.feature — the placement routes
  * @see ~/server/analytics/saved-workbench-charts — the service under test
  */
 
@@ -45,6 +46,7 @@ import {
 import { projectFactory } from "~/factories/project.factory";
 import { VEGA_LITE_SCHEMA_URL } from "~/features/analytics-query/visualization/vegaLiteSchema";
 import {
+  type Dashboard,
   type Organization,
   type Project,
   RoleBindingScopeType,
@@ -114,6 +116,37 @@ describe("given the saved workbench chart REST endpoints", () => {
     `/api/v1/projects/${project.id}/analytics/charts`;
   const chartPath = (project: Project, chartId: string) =>
     `${chartsPath(project)}/${chartId}`;
+  const placementPath = (project: Project, chartId: string) =>
+    `${chartPath(project, chartId)}/placement`;
+
+  /** A dashboard owned by the given project, straight into the store. */
+  const createDashboard = async (owner: Project): Promise<Dashboard> =>
+    await prisma.dashboard.create({
+      data: {
+        id: nanoid(),
+        name: `Placement dashboard ${nanoid(6)}`,
+        projectId: owner.id,
+        order: 0,
+      },
+    });
+
+  /** The chart's placement as its own key reads it back. */
+  const placementOf = async (
+    project: Project,
+    chartId: string,
+  ): Promise<Body> => {
+    const read = await succeeds({
+      path: chartPath(project, chartId),
+      auth: asProject(project),
+    });
+    return {
+      dashboardId: read.dashboardId,
+      gridColumn: read.gridColumn,
+      gridRow: read.gridRow,
+      colSpan: read.colSpan,
+      rowSpan: read.rowSpan,
+    };
+  };
 
   /** The credential a request presents: a project's own key, unless told otherwise. */
   const asProject = (project: Project) => ({ "X-Auth-Token": project.apiKey });
@@ -287,6 +320,7 @@ describe("given the saved workbench chart REST endpoints", () => {
       Boolean,
     )) {
       await prisma.customGraph.deleteMany({ where: { projectId: project.id } });
+      await prisma.dashboard.deleteMany({ where: { projectId: project.id } });
     }
   });
 
@@ -302,6 +336,9 @@ describe("given the saved workbench chart REST endpoints", () => {
       .map((project) => project.id);
     if (projectIds.length > 0) {
       await prisma.customGraph.deleteMany({
+        where: { projectId: { in: projectIds } },
+      });
+      await prisma.dashboard.deleteMany({
         where: { projectId: { in: projectIds } },
       });
     }
@@ -836,6 +873,183 @@ describe("given the saved workbench chart REST endpoints", () => {
         auth: asProject(openProject),
       });
       expect(again.error.code).toBe("saved_workbench_chart_not_found");
+    });
+  });
+
+  describe("when an integration places a chart on a dashboard in its project", () => {
+    /** @scenario "An integration places a saved chart on a dashboard over the API" */
+    it("answers with the placed chart, and the placement reads back by id", async () => {
+      const chart = await createChart(openProject, { name: "Placed" });
+      const dashboard = await createDashboard(openProject);
+
+      const placed = await succeeds({
+        path: placementPath(openProject, chart.id),
+        method: "PUT",
+        auth: asProject(openProject),
+        body: {
+          dashboardId: dashboard.id,
+          gridColumn: 1,
+          gridRow: 3,
+          colSpan: 2,
+          rowSpan: 2,
+        },
+      });
+      expect(placed.id).toBe(chart.id);
+      expect(placed.dashboardId).toBe(dashboard.id);
+      expect(placed.gridColumn).toBe(1);
+      expect(placed.gridRow).toBe(3);
+      expect(placed.colSpan).toBe(2);
+      expect(placed.rowSpan).toBe(2);
+
+      expect(await placementOf(openProject, chart.id)).toEqual({
+        dashboardId: dashboard.id,
+        gridColumn: 1,
+        gridRow: 3,
+        colSpan: 2,
+        rowSpan: 2,
+      });
+    });
+
+    /** @scenario "An integration unplaces a saved chart over the API" */
+    it("unplaces with a 204, after which the chart reads back with no placement", async () => {
+      const chart = await createChart(openProject, { name: "Unplaced" });
+      const dashboard = await createDashboard(openProject);
+      await succeeds({
+        path: placementPath(openProject, chart.id),
+        method: "PUT",
+        auth: asProject(openProject),
+        body: { dashboardId: dashboard.id, gridRow: 2 },
+      });
+
+      const response = await call({
+        path: placementPath(openProject, chart.id),
+        method: "DELETE",
+        auth: asProject(openProject),
+      });
+      expect(response.status).toBe(204);
+      expect(await response.text()).toBe("");
+
+      expect(await placementOf(openProject, chart.id)).toEqual({
+        dashboardId: null,
+        gridColumn: 0,
+        gridRow: 0,
+        colSpan: 1,
+        rowSpan: 1,
+      });
+    });
+  });
+
+  describe("when the placement names a dashboard of another project", () => {
+    /** @scenario "Placement onto a foreign dashboard is refused over the API the same way it is inside the application" */
+    it("refuses with the dashboard-not-found code and writes no placement", async () => {
+      const chart = await createChart(openProject, { name: "Stays put" });
+      const foreignDashboard = await createDashboard(otherProject);
+      const before = await placementOf(openProject, chart.id);
+
+      const refusal = await refused({
+        path: placementPath(openProject, chart.id),
+        method: "PUT",
+        auth: asProject(openProject),
+        body: { dashboardId: foreignDashboard.id },
+      });
+      expect(refusal.error.code).toBe(
+        "saved_workbench_chart_dashboard_not_found",
+      );
+
+      expect(await placementOf(openProject, chart.id)).toEqual(before);
+    });
+  });
+
+  describe("when the placement names a chart id absent from this project", () => {
+    /** @scenario "Placing an unknown chart id is refused as not found, indistinguishable from a foreign one" */
+    it("answers the one not-found for a foreign id and a nonexistent one alike", async () => {
+      const theirs = await createChart(otherProject, { name: "Theirs" });
+      const dashboard = await createDashboard(openProject);
+
+      const refusals = [
+        // Another project's real chart, and an id no project has ever held.
+        await refused({
+          path: placementPath(openProject, theirs.id),
+          method: "PUT",
+          auth: asProject(openProject),
+          body: { dashboardId: dashboard.id },
+        }),
+        await refused({
+          path: placementPath(openProject, `never-${nanoid()}`),
+          method: "PUT",
+          auth: asProject(openProject),
+          body: { dashboardId: dashboard.id },
+        }),
+      ];
+      expect(refusals.map((body) => body.error.code)).toEqual(
+        Array(2).fill("saved_workbench_chart_not_found"),
+      );
+
+      // The foreign chart gained nothing from the attempt.
+      expect(await placementOf(otherProject, theirs.id)).toMatchObject({
+        dashboardId: null,
+      });
+    });
+  });
+
+  describe("when the switch is off for the project placing a chart", () => {
+    const withFlagOff = async <T>(request: () => Promise<T>): Promise<T> => {
+      process.env.RELEASE_LWQL_WORKBENCH = "0";
+      try {
+        return await request();
+      } finally {
+        process.env.RELEASE_LWQL_WORKBENCH = "1";
+      }
+    };
+
+    /** @scenario "Placement routes stay dark while the workbench switch is off" */
+    it("refuses both placement verbs with the named refusal, mutating nothing", async () => {
+      const chart = await createChart(openProject, { name: "Dark" });
+      const dashboard = await createDashboard(openProject);
+      const before = await placementOf(openProject, chart.id);
+
+      const refusals = await withFlagOff(async () => [
+        await refused({
+          path: placementPath(openProject, chart.id),
+          method: "PUT",
+          auth: asProject(openProject),
+          body: { dashboardId: dashboard.id },
+        }),
+        await refused({
+          path: placementPath(openProject, chart.id),
+          method: "DELETE",
+          auth: asProject(openProject),
+        }),
+      ]);
+      expect(refusals.map((body) => body.error.code)).toEqual(
+        Array(2).fill("lwql_not_enabled"),
+      );
+
+      expect(await placementOf(openProject, chart.id)).toEqual(before);
+    });
+  });
+
+  describe("when the key may view analytics and tries to place a chart", () => {
+    /** @scenario "A key that may read charts may not place or unplace them" */
+    it("is refused on both placement verbs before the service is reached", async () => {
+      const chart = await createChart(openProject, { name: "Read-only" });
+      const dashboard = await createDashboard(openProject);
+      const before = await placementOf(openProject, chart.id);
+
+      for (const [method, body] of [
+        ["PUT", { dashboardId: dashboard.id }],
+        ["DELETE", undefined],
+      ] as const) {
+        const refusal = await refused({
+          path: placementPath(openProject, chart.id),
+          method,
+          auth: asViewOnly(openProject),
+          ...(body === undefined ? {} : { body }),
+        });
+        expect(refusal.error.code, method).toBe("api_key_permission_denied");
+      }
+
+      expect(await placementOf(openProject, chart.id)).toEqual(before);
     });
   });
 

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -4297,6 +4297,15 @@
                     "followsTimeWindow": {
                       "type": "boolean"
                     },
+                    "followsGranularity": {
+                      "type": "boolean"
+                    },
+                    "granularitySeconds": {
+                      "type": "number"
+                    },
+                    "coarsenedFromSeconds": {
+                      "type": "number"
+                    },
                     "diagnostics": {
                       "type": "array",
                       "items": {
@@ -4333,6 +4342,7 @@
                     "statistics",
                     "truncated",
                     "followsTimeWindow",
+                    "followsGranularity",
                     "diagnostics"
                   ]
                 }
@@ -4625,6 +4635,10 @@
                       "start",
                       "end"
                     ]
+                  },
+                  "granularitySeconds": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
                   }
                 },
                 "required": [
@@ -5026,6 +5040,24 @@
                           },
                           "platformUrl": {
                             "type": "string"
+                          },
+                          "dashboardId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "gridColumn": {
+                            "type": "number"
+                          },
+                          "gridRow": {
+                            "type": "number"
+                          },
+                          "colSpan": {
+                            "type": "number"
+                          },
+                          "rowSpan": {
+                            "type": "number"
                           }
                         },
                         "required": [
@@ -5034,7 +5066,12 @@
                           "definition",
                           "createdAt",
                           "updatedAt",
-                          "platformUrl"
+                          "platformUrl",
+                          "dashboardId",
+                          "gridColumn",
+                          "gridRow",
+                          "colSpan",
+                          "rowSpan"
                         ]
                       }
                     }
@@ -5292,6 +5329,24 @@
                     },
                     "platformUrl": {
                       "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5300,7 +5355,12 @@
                     "definition",
                     "createdAt",
                     "updatedAt",
-                    "platformUrl"
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
                   ]
                 }
               }
@@ -5575,6 +5635,24 @@
                     },
                     "platformUrl": {
                       "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5583,7 +5661,12 @@
                     "definition",
                     "createdAt",
                     "updatedAt",
-                    "platformUrl"
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
                   ]
                 }
               }
@@ -5887,6 +5970,24 @@
                     },
                     "platformUrl": {
                       "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5895,7 +5996,12 @@
                     "definition",
                     "createdAt",
                     "updatedAt",
-                    "platformUrl"
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
                   ]
                 }
               }
@@ -6175,6 +6281,630 @@
         "responses": {
           "204": {
             "description": "The chart was deleted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No chart with this id in this project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "chartId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "project_api_key": []
+          }
+        ]
+      }
+    },
+    "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement": {
+      "put": {
+        "operationId": "putApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement",
+        "summary": "Place a saved workbench chart on a dashboard",
+        "description": "Places one saved LangWatchQL chart on a dashboard in the same project, at the grid position supplied — or, when no grid row is given, at the next row free on that dashboard, counting charts of every kind. A dashboard that is not in this project is reported as not found, exactly like a chart that is not, and nothing is written.",
+        "tags": [
+          "Analytics / LangWatchQL"
+        ],
+        "responses": {
+          "200": {
+            "description": "The chart, now placed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "number"
+                        },
+                        "sql": {
+                          "type": "string"
+                        },
+                        "parameters": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "vegaLiteSpec": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "sql",
+                        "parameters"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string"
+                    },
+                    "dashboardId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gridColumn": {
+                      "type": "number"
+                    },
+                    "gridRow": {
+                      "type": "number"
+                    },
+                    "colSpan": {
+                      "type": "number"
+                    },
+                    "rowSpan": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "definition",
+                    "createdAt",
+                    "updatedAt",
+                    "platformUrl",
+                    "dashboardId",
+                    "gridColumn",
+                    "gridRow",
+                    "colSpan",
+                    "rowSpan"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No chart with this id in this project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dashboardId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "gridColumn": {
+                    "type": "integer"
+                  },
+                  "gridRow": {
+                    "type": "integer"
+                  },
+                  "colSpan": {
+                    "type": "integer"
+                  },
+                  "rowSpan": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "dashboardId"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "chartId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "project_api_key": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement",
+        "summary": "Remove a saved workbench chart from its dashboard",
+        "description": "Removes one saved LangWatchQL chart from whatever dashboard it is on, clearing its grid position along with the dashboard id. Idempotent: unplacing a chart that is not placed answers 204 all the same. The chart itself — its statement, parameter values and specification — is untouched.",
+        "tags": [
+          "Analytics / LangWatchQL"
+        ],
+        "responses": {
+          "204": {
+            "description": "The chart is no longer on any dashboard"
           },
           "400": {
             "description": "Bad Request",

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -251,6 +251,7 @@ export const APP_ERROR_CODES = [
   "rum_rate_limited",
   "run_not_found",
   "saved_workbench_chart_already_exists",
+  "saved_workbench_chart_dashboard_not_found",
   "saved_workbench_chart_definition_invalid",
   "saved_workbench_chart_not_found",
   "saved_workbench_chart_specification_refused",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -409,6 +409,11 @@ const presentations = {
     describe: () =>
       "A saved chart with this id already exists in this project. Save again with a different id, or leave the id out to have one chosen for you.",
   },
+  saved_workbench_chart_dashboard_not_found: {
+    title: "That dashboard isn't here",
+    describe: () =>
+      "It may have been deleted, or it belongs to another project. Check the list of dashboards and try placing the chart again.",
+  },
   saved_workbench_chart_not_found: {
     title: "That saved chart isn't here",
     describe: () =>

--- a/platform/app/src/server/analytics/allocateNextGridRow.ts
+++ b/platform/app/src/server/analytics/allocateNextGridRow.ts
@@ -1,0 +1,26 @@
+import type { PrismaClient } from "~/generated/prisma/client";
+
+/**
+ * The next free grid row on a dashboard, counting every chart already on it.
+ *
+ * One shared decision rather than two writers guessing: a builder graph
+ * created with no explicit row and a saved workbench chart placed with no
+ * explicit row both call this, so neither can land on a row the other already
+ * occupies. Deliberately not filtered by `kind` — the grid is one shared
+ * space, and scoping this to one kind would place a new chart on top of
+ * whichever kind it ignored.
+ *
+ * @see platform/app/src/server/api/routers/graphs.ts — the builder's writer
+ * @see ./saved-workbench-charts/savedWorkbenchChart.service.ts — the
+ *   workbench's writer
+ */
+export async function allocateNextGridRow(
+  prisma: PrismaClient,
+  { dashboardId, projectId }: { dashboardId: string; projectId: string },
+): Promise<number> {
+  const lastGraph = await prisma.customGraph.findFirst({
+    where: { dashboardId, projectId },
+    orderBy: { gridRow: "desc" },
+  });
+  return (lastGraph?.gridRow ?? -1) + 1;
+}

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.integration.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.integration.test.ts
@@ -494,7 +494,10 @@ describe("saved workbench charts (integration)", () => {
         expect(placed.gridRow).toBe(2);
 
         const stillAtTheirRows = await prisma.customGraph.findMany({
-          where: { id: { in: [builderRow0.id, builderRow1.id] } },
+          where: {
+            id: { in: [builderRow0.id, builderRow1.id] },
+            projectId: project.id,
+          },
         });
         expect(
           stillAtTheirRows.find(({ id }) => id === builderRow0.id)?.gridRow,

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.integration.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.integration.test.ts
@@ -14,12 +14,19 @@ import { nanoid } from "nanoid";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { projectFactory } from "~/factories/project.factory";
 import { VEGA_LITE_SCHEMA_URL } from "~/features/analytics-query/visualization/vegaLiteSchema";
-import type { Organization, Project, Team } from "~/generated/prisma/client";
+import type {
+  Dashboard,
+  Organization,
+  Project,
+  Team,
+} from "~/generated/prisma/client";
 import { PrismaAutomationCustomGraphRepository } from "~/server/app-layer/automations/repositories/custom-graph.prisma.repository";
 import { prisma } from "~/server/db";
 
 import type { Protections } from "../../../traces/protections";
+import { allocateNextGridRow } from "../../allocateNextGridRow";
 import { BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND } from "../../chartKinds";
+import { dashboardBelongsToProject } from "../../dashboardBelongsToProject";
 import { LangWatchQLService } from "../../lwql/lwql.service";
 import { SavedWorkbenchChartRepository } from "../savedWorkbenchChart.repository";
 import {
@@ -68,6 +75,37 @@ describe("saved workbench charts (integration)", () => {
       },
     });
 
+  const createDashboard = async (
+    ownerProject: Project,
+    overrides: { name?: string } = {},
+  ): Promise<Dashboard> =>
+    await prisma.dashboard.create({
+      data: {
+        id: nanoid(),
+        name: overrides.name ?? "Test dashboard",
+        projectId: ownerProject.id,
+        order: 0,
+      },
+    });
+
+  /** A builder-kind chart, placed exactly the way `graphs.create` places one. */
+  const createBuilderChart = async (
+    ownerProject: Project,
+    dashboard: Dashboard,
+    overrides: { gridRow?: number; gridColumn?: number } = {},
+  ) =>
+    await prisma.customGraph.create({
+      data: {
+        id: nanoid(),
+        projectId: ownerProject.id,
+        dashboardId: dashboard.id,
+        name: `Builder chart ${nanoid(6)}`,
+        graph: { series: [{ metric: "metadata.trace_id" }] },
+        gridRow: overrides.gridRow ?? 0,
+        gridColumn: overrides.gridColumn ?? 0,
+      },
+    });
+
   const save = async (
     overrides: { name?: string; definition?: unknown } = {},
   ): Promise<SavedWorkbenchChart> =>
@@ -90,6 +128,9 @@ describe("saved workbench charts (integration)", () => {
         executor: null,
         database: "analytics",
       }),
+      dashboardBelongsToProject: (dashboardId, projectId) =>
+        dashboardBelongsToProject(prisma, dashboardId, projectId),
+      allocateNextGridRow: (input) => allocateNextGridRow(prisma, input),
     });
 
     organization = await prisma.organization.create({
@@ -107,7 +148,13 @@ describe("saved workbench charts (integration)", () => {
   });
 
   afterEach(async () => {
+    // `CustomGraph.dashboardId` cascades on delete, so clearing dashboards
+    // would take any chart placed on one with it — cleared explicitly first
+    // so an unplaced chart a test left behind is removed too.
     await prisma.customGraph.deleteMany({
+      where: { projectId: { in: [project.id, otherProject.id] } },
+    });
+    await prisma.dashboard.deleteMany({
       where: { projectId: { in: [project.id, otherProject.id] } },
     });
   });
@@ -348,6 +395,218 @@ describe("saved workbench charts (integration)", () => {
         });
         expect(after.name).toBe("Traces per day");
         expect(after.definition).toEqual(saved.definition);
+      });
+    });
+  });
+
+  describe("given a saved chart and a dashboard in the same project", () => {
+    describe("when the member places the chart with an explicit grid position", () => {
+      /** @scenario "A placed chart round-trips with the dashboard id and grid position it was given" */
+      it("reads back with the same dashboard id and grid position, and appears among that dashboard's charts", async () => {
+        const saved = await save();
+        const dashboard = await createDashboard(project);
+
+        const placed = await service.placeChart({
+          id: saved.id,
+          projectId: project.id,
+          input: {
+            dashboardId: dashboard.id,
+            gridColumn: 1,
+            gridRow: 2,
+            colSpan: 2,
+            rowSpan: 1,
+          },
+        });
+
+        expect(placed.dashboardId).toBe(dashboard.id);
+        expect(placed.gridColumn).toBe(1);
+        expect(placed.gridRow).toBe(2);
+        expect(placed.colSpan).toBe(2);
+        expect(placed.rowSpan).toBe(1);
+
+        const reread = await service.getById({
+          id: saved.id,
+          projectId: project.id,
+        });
+        expect(reread.dashboardId).toBe(dashboard.id);
+        expect(reread.gridColumn).toBe(1);
+        expect(reread.gridRow).toBe(2);
+        expect(reread.colSpan).toBe(2);
+        expect(reread.rowSpan).toBe(1);
+
+        const onDashboard = await prisma.customGraph.findMany({
+          where: { dashboardId: dashboard.id, projectId: project.id },
+        });
+        expect(onDashboard.map(({ id }) => id)).toEqual([saved.id]);
+      });
+    });
+  });
+
+  describe("given a saved chart in one project and a dashboard that belongs to a different project", () => {
+    describe("when the member tries to place the chart on that dashboard", () => {
+      /** @scenario "Placing a chart onto another project's dashboard is refused, and nothing is written" */
+      it("refuses with saved_workbench_chart_dashboard_not_found, and leaves the chart exactly as unplaced as it was", async () => {
+        const saved = await save();
+        const foreignDashboard = await createDashboard(otherProject);
+
+        await expect(
+          service.placeChart({
+            id: saved.id,
+            projectId: project.id,
+            input: { dashboardId: foreignDashboard.id },
+          }),
+        ).rejects.toMatchObject({
+          code: "saved_workbench_chart_dashboard_not_found",
+        });
+
+        const after = await service.getById({
+          id: saved.id,
+          projectId: project.id,
+        });
+        expect(after.dashboardId).toBeNull();
+        expect(after.gridColumn).toBe(0);
+        expect(after.gridRow).toBe(0);
+        expect(after.colSpan).toBe(1);
+        expect(after.rowSpan).toBe(1);
+      });
+    });
+  });
+
+  describe("given a dashboard already holding builder charts across several grid rows", () => {
+    describe("when the member places a saved workbench chart on it with no grid row supplied", () => {
+      /** @scenario "Placing a chart onto a dashboard already holding builder charts does not overlap them" */
+      it("allocates a row none of the existing builder charts occupy, and leaves their rows untouched", async () => {
+        const dashboard = await createDashboard(project);
+        const builderRow0 = await createBuilderChart(project, dashboard, {
+          gridRow: 0,
+        });
+        const builderRow1 = await createBuilderChart(project, dashboard, {
+          gridRow: 1,
+        });
+        const saved = await save();
+
+        const placed = await service.placeChart({
+          id: saved.id,
+          projectId: project.id,
+          input: { dashboardId: dashboard.id },
+        });
+
+        expect(placed.gridRow).toBe(2);
+
+        const stillAtTheirRows = await prisma.customGraph.findMany({
+          where: { id: { in: [builderRow0.id, builderRow1.id] } },
+        });
+        expect(
+          stillAtTheirRows.find(({ id }) => id === builderRow0.id)?.gridRow,
+        ).toBe(0);
+        expect(
+          stillAtTheirRows.find(({ id }) => id === builderRow1.id)?.gridRow,
+        ).toBe(1);
+      });
+    });
+  });
+
+  describe("given a dashboard already holding a placed saved workbench chart", () => {
+    describe("when the member creates a new builder chart on the same dashboard with no grid row supplied", () => {
+      /** @scenario "Placing a saved workbench chart does not let a builder chart land on top of it" */
+      it("allocates the new builder chart a row the saved workbench chart does not occupy", async () => {
+        const dashboard = await createDashboard(project);
+        const saved = await save();
+        const placed = await service.placeChart({
+          id: saved.id,
+          projectId: project.id,
+          input: { dashboardId: dashboard.id, gridRow: 0 },
+        });
+        expect(placed.gridRow).toBe(0);
+
+        // The same allocation `graphs.create` runs when no row is supplied —
+        // proven directly against the shared helper rather than the tRPC
+        // router, which needs a caller context this suite does not build.
+        const allocatedRow = await allocateNextGridRow(prisma, {
+          dashboardId: dashboard.id,
+          projectId: project.id,
+        });
+        const builder = await prisma.customGraph.create({
+          data: {
+            id: nanoid(),
+            projectId: project.id,
+            dashboardId: dashboard.id,
+            name: "A new builder chart",
+            graph: { series: [{ metric: "metadata.trace_id" }] },
+            gridRow: allocatedRow,
+            gridColumn: 0,
+          },
+        });
+
+        expect(builder.gridRow).not.toBe(0);
+        expect(builder.gridRow).toBe(1);
+      });
+    });
+  });
+
+  describe("given a saved chart placed on a dashboard that also holds builder charts", () => {
+    describe("when the member deletes the placed chart", () => {
+      /** @scenario "Deleting a placed chart leaves no dangling reference on its dashboard" */
+      it("removes it from the dashboard's chart list and leaves the remaining charts unaffected", async () => {
+        const dashboard = await createDashboard(project);
+        const builder = await createBuilderChart(project, dashboard, {
+          gridRow: 0,
+        });
+        const saved = await save();
+        const placed = await service.placeChart({
+          id: saved.id,
+          projectId: project.id,
+          input: { dashboardId: dashboard.id, gridRow: 1 },
+        });
+
+        await service.deleteChart({ id: placed.id, projectId: project.id });
+
+        const onDashboard = await prisma.customGraph.findMany({
+          where: { dashboardId: dashboard.id, projectId: project.id },
+        });
+        expect(onDashboard.map(({ id }) => id)).toEqual([builder.id]);
+        expect(onDashboard.find(({ id }) => id === builder.id)?.gridRow).toBe(
+          0,
+        );
+      });
+    });
+  });
+
+  describe("given a saved chart already placed on a dashboard with a grid position", () => {
+    describe("when the chart is unplaced", () => {
+      it("clears every placement field and does not disturb another chart on the same dashboard", async () => {
+        const dashboard = await createDashboard(project);
+        const builder = await createBuilderChart(project, dashboard, {
+          gridRow: 0,
+        });
+        const saved = await save();
+        await service.placeChart({
+          id: saved.id,
+          projectId: project.id,
+          input: {
+            dashboardId: dashboard.id,
+            gridColumn: 1,
+            gridRow: 1,
+            colSpan: 2,
+            rowSpan: 2,
+          },
+        });
+
+        const unplaced = await service.unplaceChart({
+          id: saved.id,
+          projectId: project.id,
+        });
+
+        expect(unplaced.dashboardId).toBeNull();
+        expect(unplaced.gridColumn).toBe(0);
+        expect(unplaced.gridRow).toBe(0);
+        expect(unplaced.colSpan).toBe(1);
+        expect(unplaced.rowSpan).toBe(1);
+
+        const onDashboard = await prisma.customGraph.findMany({
+          where: { dashboardId: dashboard.id, projectId: project.id },
+        });
+        expect(onDashboard.map(({ id }) => id)).toEqual([builder.id]);
       });
     });
   });

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts
@@ -24,6 +24,7 @@ import type {
 import { LangWatchQLService } from "../../lwql/lwql.service";
 import type {
   CreateSavedWorkbenchChartInput,
+  PlaceSavedWorkbenchChartInput,
   SavedWorkbenchChartStore,
   UpdateSavedWorkbenchChartInput,
 } from "../savedWorkbenchChart.repository";
@@ -100,7 +101,22 @@ class FakeStore implements SavedWorkbenchChartStore {
     projectId: string;
     name: string;
     graph: unknown;
+    /** Carried across an update/place/unplace so an untouched field survives. */
+    placement?: {
+      dashboardId: string | null;
+      gridColumn: number;
+      gridRow: number;
+      colSpan: number;
+      rowSpan: number;
+    };
   }): CustomGraph {
+    const placement = input.placement ?? {
+      dashboardId: null,
+      gridColumn: 0,
+      gridRow: 0,
+      colSpan: 1,
+      rowSpan: 1,
+    };
     return {
       id: input.id,
       projectId: input.projectId,
@@ -110,11 +126,7 @@ class FakeStore implements SavedWorkbenchChartStore {
       kind: WORKBENCH_SQL_CHART_KIND,
       createdAt: new Date("2026-02-01T00:00:00.000Z"),
       updatedAt: new Date("2026-02-01T00:00:00.000Z"),
-      dashboardId: null,
-      gridColumn: 0,
-      gridRow: 0,
-      colSpan: 1,
-      rowSpan: 1,
+      ...placement,
     } as CustomGraph;
   }
 
@@ -158,6 +170,61 @@ class FakeStore implements SavedWorkbenchChartStore {
       projectId: existing.projectId,
       name: input.name ?? existing.name,
       graph: input.definition ?? existing.graph,
+      placement: {
+        dashboardId: existing.dashboardId,
+        gridColumn: existing.gridColumn,
+        gridRow: existing.gridRow,
+        colSpan: existing.colSpan,
+        rowSpan: existing.rowSpan,
+      },
+    });
+    this.rows.set(row.id, row);
+    return row;
+  }
+
+  async place(
+    input: PlaceSavedWorkbenchChartInput,
+  ): Promise<CustomGraph | null> {
+    const existing = await this.findById({
+      id: input.id,
+      projectId: input.projectId,
+    });
+    if (!existing) return null;
+
+    const row = this.row({
+      id: existing.id,
+      projectId: existing.projectId,
+      name: existing.name,
+      graph: existing.graph,
+      placement: {
+        dashboardId: input.dashboardId,
+        gridColumn: input.gridColumn,
+        gridRow: input.gridRow,
+        colSpan: input.colSpan,
+        rowSpan: input.rowSpan,
+      },
+    });
+    this.rows.set(row.id, row);
+    return row;
+  }
+
+  async unplace({
+    id,
+    projectId,
+  }: {
+    id: string;
+    projectId: string;
+  }): Promise<CustomGraph | null> {
+    const existing = await this.findById({ id, projectId });
+    if (!existing) return null;
+
+    const row = this.row({
+      id: existing.id,
+      projectId: existing.projectId,
+      name: existing.name,
+      graph: existing.graph,
+      // Defaults — the same shape `row()` already falls back to when no
+      // placement is given, which is exactly "unplaced".
     });
     this.rows.set(row.id, row);
     return row;
@@ -206,7 +273,24 @@ function recordingExecutor(): LangWatchQLExecutor & {
   };
 }
 
-function build(executor: LangWatchQLExecutor | null = null) {
+function build(
+  executor: LangWatchQLExecutor | null = null,
+  overrides: {
+    /** Every dashboard belongs, by default: most suites are not testing tenancy. */
+    dashboardBelongsToProject?: (
+      dashboardId: string,
+      projectId: string,
+    ) => Promise<boolean>;
+    /**
+     * Row 0, by default: most suites place a single chart and never look at
+     * the row it landed on.
+     */
+    allocateNextGridRow?: (input: {
+      dashboardId: string;
+      projectId: string;
+    }) => Promise<number>;
+  } = {},
+) {
   const store = new FakeStore();
   const service = new SavedWorkbenchChartService({
     repository: store,
@@ -216,6 +300,9 @@ function build(executor: LangWatchQLExecutor | null = null) {
       executor,
       database: "analytics",
     }),
+    dashboardBelongsToProject:
+      overrides.dashboardBelongsToProject ?? (async () => true),
+    allocateNextGridRow: overrides.allocateNextGridRow ?? (async () => 0),
   });
   return { store, service };
 }
@@ -563,6 +650,129 @@ describe("editing a saved workbench chart", () => {
 
         expect(renamed.name).toBe("Traces per week");
         expect(renamed.definition).toEqual(saved.definition);
+      });
+    });
+  });
+});
+
+/**
+ * The placement path: what makes an already-saved chart show up on a
+ * dashboard. `dashboardBelongsToProject` and `allocateNextGridRow` are the
+ * only two collaborators `placeChart` reaches for beyond the store, so this
+ * suite drives them as plain fakes rather than a real Prisma client — the
+ * same reason the store itself is a fake.
+ */
+describe("placing a saved workbench chart on a dashboard", () => {
+  describe("given a saved chart and the id of a dashboard in the same project", () => {
+    describe("when the chart is placed with no grid position supplied", () => {
+      /** @scenario "Placing a chart requires a dashboard id and accepts an optional grid position" */
+      it("accepts the placement and allocates a grid position for it", async () => {
+        const { service } = build(null, {
+          allocateNextGridRow: async () => 2,
+        });
+        const saved = await service.createChart({
+          projectId: PROJECT_ID,
+          protections: FULLY_PERMITTED,
+          input: { name: "Traces per day", definition: definition() },
+        });
+
+        const placed = await service.placeChart({
+          id: saved.id,
+          projectId: PROJECT_ID,
+          input: { dashboardId: "dashboard-1" },
+        });
+
+        expect(placed.dashboardId).toBe("dashboard-1");
+        // Allocated, not defaulted to 0: the fake above stands in for "row 0
+        // and row 1 are already taken".
+        expect(placed.gridRow).toBe(2);
+        expect(placed.gridColumn).toBe(0);
+        expect(placed.colSpan).toBe(1);
+        expect(placed.rowSpan).toBe(1);
+      });
+    });
+  });
+
+  describe("given a saved chart already placed on a dashboard with a grid position", () => {
+    describe("when the chart is unplaced", () => {
+      /** @scenario "Unplacing a chart clears every placement field, not just the dashboard id" */
+      it("clears the dashboard id, grid column, grid row, column span and row span, and leaves the definition untouched", async () => {
+        const { service } = build();
+        const saved = await service.createChart({
+          projectId: PROJECT_ID,
+          protections: FULLY_PERMITTED,
+          input: { name: "Traces per day", definition: definition() },
+        });
+        await service.placeChart({
+          id: saved.id,
+          projectId: PROJECT_ID,
+          input: {
+            dashboardId: "dashboard-1",
+            gridColumn: 1,
+            gridRow: 3,
+            colSpan: 2,
+            rowSpan: 2,
+          },
+        });
+
+        const unplaced = await service.unplaceChart({
+          id: saved.id,
+          projectId: PROJECT_ID,
+        });
+
+        expect(unplaced.dashboardId).toBeNull();
+        expect(unplaced.gridColumn).toBe(0);
+        expect(unplaced.gridRow).toBe(0);
+        expect(unplaced.colSpan).toBe(1);
+        expect(unplaced.rowSpan).toBe(1);
+        expect(unplaced.definition).toEqual(saved.definition);
+      });
+    });
+  });
+
+  describe("given a chart id that does not name a saved chart in this project", () => {
+    describe("when the member tries to place it on a dashboard", () => {
+      /** @scenario "Placing a chart that does not exist in this project is refused" */
+      it("refuses the placement as not found", async () => {
+        const { service } = build();
+
+        const refusal = await refusalOf(() =>
+          service.placeChart({
+            id: "never-saved",
+            projectId: PROJECT_ID,
+            input: { dashboardId: "dashboard-1" },
+          }),
+        );
+
+        expect(refusal.code).toBe("saved_workbench_chart_not_found");
+      });
+    });
+  });
+
+  describe("given a dashboard id belonging to another project", () => {
+    describe("when the member tries to place a chart on it", () => {
+      it("refuses the placement and writes nothing", async () => {
+        const { store, service } = build(null, {
+          dashboardBelongsToProject: async () => false,
+        });
+        const saved = await service.createChart({
+          projectId: PROJECT_ID,
+          protections: FULLY_PERMITTED,
+          input: { name: "Traces per day", definition: definition() },
+        });
+
+        const refusal = await refusalOf(() =>
+          service.placeChart({
+            id: saved.id,
+            projectId: PROJECT_ID,
+            input: { dashboardId: "dashboard-elsewhere" },
+          }),
+        );
+
+        expect(refusal.code).toBe(
+          "saved_workbench_chart_dashboard_not_found",
+        );
+        expect(store.rows.get(saved.id)?.dashboardId).toBeNull();
       });
     });
   });

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChart.service.unit.test.ts
@@ -769,9 +769,56 @@ describe("placing a saved workbench chart on a dashboard", () => {
           }),
         );
 
-        expect(refusal.code).toBe(
-          "saved_workbench_chart_dashboard_not_found",
+        expect(refusal.code).toBe("saved_workbench_chart_dashboard_not_found");
+        expect(store.rows.get(saved.id)?.dashboardId).toBeNull();
+      });
+    });
+  });
+
+  describe("given a grid position outside what the store can hold", () => {
+    // The REST envelope enforces integrality too, but the rule lives HERE:
+    // the service is the single write path, and a future non-REST caller
+    // must meet the same refusal, not the Int column's overflow error.
+    describe("when the member places a chart with a fractional grid row", () => {
+      it("refuses it as invalid input and writes nothing", async () => {
+        const { store, service } = build();
+        const saved = await service.createChart({
+          projectId: PROJECT_ID,
+          protections: FULLY_PERMITTED,
+          input: { name: "Traces per day", definition: definition() },
+        });
+
+        const refusal = await refusalOf(() =>
+          service.placeChart({
+            id: saved.id,
+            projectId: PROJECT_ID,
+            input: { dashboardId: "dashboard-1", gridRow: 1.5 },
+          }),
         );
+
+        expect(refusal.code).toBe("validation_error");
+        expect(store.rows.get(saved.id)?.dashboardId).toBeNull();
+      });
+    });
+
+    describe("when the member places a chart with a grid row past the column's range", () => {
+      it("refuses it as invalid input rather than overflowing the store", async () => {
+        const { store, service } = build();
+        const saved = await service.createChart({
+          projectId: PROJECT_ID,
+          protections: FULLY_PERMITTED,
+          input: { name: "Traces per day", definition: definition() },
+        });
+
+        const refusal = await refusalOf(() =>
+          service.placeChart({
+            id: saved.id,
+            projectId: PROJECT_ID,
+            input: { dashboardId: "dashboard-1", gridRow: 9e15 },
+          }),
+        );
+
+        expect(refusal.code).toBe("validation_error");
         expect(store.rows.get(saved.id)?.dashboardId).toBeNull();
       });
     });

--- a/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChartCoarsening.unit.test.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/__tests__/savedWorkbenchChartCoarsening.unit.test.ts
@@ -112,6 +112,25 @@ class FakeStore implements SavedWorkbenchChartStore {
   async delete(_input: { id: string; projectId: string }): Promise<number> {
     throw new Error("not used by this suite");
   }
+
+  async place(_input: {
+    id: string;
+    projectId: string;
+    dashboardId: string;
+    gridColumn: number;
+    gridRow: number;
+    colSpan: number;
+    rowSpan: number;
+  }): Promise<CustomGraph | null> {
+    throw new Error("not used by this suite");
+  }
+
+  async unplace(_input: {
+    id: string;
+    projectId: string;
+  }): Promise<CustomGraph | null> {
+    throw new Error("not used by this suite");
+  }
 }
 
 function recordingExecutor(): LangWatchQLExecutor & {
@@ -148,6 +167,9 @@ function build() {
   const service = new SavedWorkbenchChartService({
     repository: store,
     lwql: new LangWatchQLService({ executor, database: "analytics" }),
+    // Placement is not exercised by this suite; the answers are inert.
+    dashboardBelongsToProject: async () => false,
+    allocateNextGridRow: async () => 0,
   });
   return { store, service, executor };
 }

--- a/platform/app/src/server/analytics/saved-workbench-charts/errors.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/errors.ts
@@ -63,6 +63,31 @@ export class SavedWorkbenchChartAlreadyExistsError extends HandledError {
 }
 
 /**
+ * The dashboard a chart was asked to be placed on does not exist in this
+ * project.
+ *
+ * Covers both a foreign dashboard's id and one that never existed, and
+ * deliberately does not distinguish them — the same reasoning as
+ * {@link SavedWorkbenchChartNotFoundError}, applied to the id on the other
+ * side of a placement. Derived from
+ * {@link import("~/server/analytics/dashboardBelongsToProject").dashboardBelongsToProject},
+ * the identical tenancy check `graphs.create` already runs before it places a
+ * newly created chart.
+ */
+export class SavedWorkbenchChartDashboardNotFoundError extends HandledError {
+  declare readonly code: "saved_workbench_chart_dashboard_not_found";
+
+  constructor() {
+    super("saved_workbench_chart_dashboard_not_found", "Dashboard not found.", {
+      httpStatus: 404,
+      fault: "customer",
+      ...remediation("saved_workbench_chart_dashboard_not_found"),
+    });
+    this.name = "SavedWorkbenchChartDashboardNotFoundError";
+  }
+}
+
+/**
  * The chart policy refused the specification on the way in.
  *
  * Refusing at write is what stops the database becoming a way around the

--- a/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.repository.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.repository.ts
@@ -39,6 +39,17 @@ export type UpdateSavedWorkbenchChartInput = {
   definition?: Prisma.InputJsonValue;
 };
 
+export type PlaceSavedWorkbenchChartInput = {
+  id: string;
+  projectId: string;
+  /** Already checked against this project by the service. */
+  dashboardId: string;
+  gridColumn: number;
+  gridRow: number;
+  colSpan: number;
+  rowSpan: number;
+};
+
 /**
  * What the service needs from storage, and the whole of it.
  *
@@ -55,6 +66,11 @@ export interface SavedWorkbenchChartStore {
   }): Promise<CustomGraph | null>;
   create(input: CreateSavedWorkbenchChartInput): Promise<CustomGraph>;
   update(input: UpdateSavedWorkbenchChartInput): Promise<CustomGraph | null>;
+  place(input: PlaceSavedWorkbenchChartInput): Promise<CustomGraph | null>;
+  unplace(input: {
+    id: string;
+    projectId: string;
+  }): Promise<CustomGraph | null>;
   delete(input: { id: string; projectId: string }): Promise<number>;
 }
 
@@ -124,6 +140,62 @@ export class SavedWorkbenchChartRepository implements SavedWorkbenchChartStore {
       },
     });
     return updated[0] ?? null;
+  }
+
+  /**
+   * Places one saved workbench chart on a dashboard.
+   *
+   * The dashboard's tenancy is the service's to check before calling this —
+   * this method only writes what it is given. Returns `null` when nothing
+   * matched, the same not-found-by-predicate idiom {@link update} uses.
+   */
+  async place(
+    input: PlaceSavedWorkbenchChartInput,
+  ): Promise<CustomGraph | null> {
+    const placed = await this.prisma.customGraph.updateManyAndReturn({
+      where: {
+        id: input.id,
+        projectId: input.projectId,
+        kind: WORKBENCH_SQL_CHART_KIND,
+      },
+      data: {
+        dashboardId: input.dashboardId,
+        gridColumn: input.gridColumn,
+        gridRow: input.gridRow,
+        colSpan: input.colSpan,
+        rowSpan: input.rowSpan,
+      },
+    });
+    return placed[0] ?? null;
+  }
+
+  /**
+   * Removes one saved workbench chart from whatever dashboard it is on.
+   *
+   * Clears every placement field, not just `dashboardId` — a chart with a
+   * dashboard id of `null` but a stale grid position is not meaningfully
+   * unplaced, and would place wrong the moment it was placed again with no
+   * explicit grid row.
+   */
+  async unplace(input: {
+    id: string;
+    projectId: string;
+  }): Promise<CustomGraph | null> {
+    const unplaced = await this.prisma.customGraph.updateManyAndReturn({
+      where: {
+        id: input.id,
+        projectId: input.projectId,
+        kind: WORKBENCH_SQL_CHART_KIND,
+      },
+      data: {
+        dashboardId: null,
+        gridColumn: 0,
+        gridRow: 0,
+        colSpan: 1,
+        rowSpan: 1,
+      },
+    });
+    return unplaced[0] ?? null;
   }
 
   /** Deletes one saved workbench chart. Answers how many rows went. */

--- a/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
@@ -39,11 +39,10 @@ import type {
   Prisma,
   PrismaClient,
 } from "~/generated/prisma/client";
-
-import { allocateNextGridRow } from "../allocateNextGridRow";
-import { dashboardBelongsToProject } from "../dashboardBelongsToProject";
 import type { Protections } from "../../traces/protections";
 import { isUniqueConstraintError } from "../../utils/prismaErrors";
+import { allocateNextGridRow } from "../allocateNextGridRow";
+import { dashboardBelongsToProject } from "../dashboardBelongsToProject";
 import {
   getLangWatchQLService,
   type LangWatchQLCaller,
@@ -142,13 +141,20 @@ export interface SavedWorkbenchChartServiceDependencies {
   }) => Promise<number>;
 }
 
+/**
+ * The ceiling a grid coordinate may carry. Far beyond any real dashboard, but
+ * within Postgres's Int range — a larger value would overflow the column into
+ * a generic 500 instead of this schema's named validation refusal.
+ */
+const MAX_GRID_COORDINATE = 2_000_000_000;
+
 /** Grid bounds a chart may be placed with — the same 2-column grid the chart builder places onto. */
 const placementSchema = z.object({
   dashboardId: z.string().min(1),
-  gridColumn: z.number().min(0).max(1).optional(),
-  gridRow: z.number().min(0).optional(),
-  colSpan: z.number().min(1).max(2).optional(),
-  rowSpan: z.number().min(1).max(2).optional(),
+  gridColumn: z.number().int().min(0).max(1).optional(),
+  gridRow: z.number().int().min(0).max(MAX_GRID_COORDINATE).optional(),
+  colSpan: z.number().int().min(1).max(2).optional(),
+  rowSpan: z.number().int().min(1).max(2).optional(),
 });
 
 export class SavedWorkbenchChartService {

--- a/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
+++ b/platform/app/src/server/analytics/saved-workbench-charts/savedWorkbenchChart.service.ts
@@ -40,6 +40,8 @@ import type {
   PrismaClient,
 } from "~/generated/prisma/client";
 
+import { allocateNextGridRow } from "../allocateNextGridRow";
+import { dashboardBelongsToProject } from "../dashboardBelongsToProject";
 import type { Protections } from "../../traces/protections";
 import { isUniqueConstraintError } from "../../utils/prismaErrors";
 import {
@@ -52,6 +54,7 @@ import type { LangWatchQLBudgetOverflowMode } from "../lwql/resolveTimeWindow";
 import type { LangWatchQLTimeWindow } from "../lwql/timeWindow";
 import {
   SavedWorkbenchChartAlreadyExistsError,
+  SavedWorkbenchChartDashboardNotFoundError,
   SavedWorkbenchChartDefinitionInvalidError,
   SavedWorkbenchChartNotFoundError,
   SavedWorkbenchChartSpecificationRefusedError,
@@ -90,6 +93,17 @@ export interface SavedWorkbenchChart {
   readonly definition: WorkbenchChartDefinition;
   readonly createdAt: Date;
   readonly updatedAt: Date;
+  /**
+   * `null` when the chart has never been placed, or has been unplaced.
+   * `gridColumn`/`gridRow`/`colSpan`/`rowSpan` are meaningful only alongside a
+   * non-null `dashboardId` — an unplaced chart's grid fields are the column's
+   * defaults and are not a position on any dashboard.
+   */
+  readonly dashboardId: string | null;
+  readonly gridColumn: number;
+  readonly gridRow: number;
+  readonly colSpan: number;
+  readonly rowSpan: number;
 }
 
 export interface SavedWorkbenchChartServiceDependencies {
@@ -99,7 +113,43 @@ export interface SavedWorkbenchChartServiceDependencies {
    * identity, so charts can be saved on a deployment that could not run them.
    */
   readonly lwql: LangWatchQLService;
+  /**
+   * Answers whether a dashboard id belongs to a project. Injected rather than
+   * called directly so a unit suite can drive `placeChart`'s tenancy refusal
+   * against an in-memory answer instead of a real Prisma client — the same
+   * reason `repository` is an interface rather than the Prisma repository
+   * itself.
+   *
+   * @default the real {@link dashboardBelongsToProject}, bound to a Prisma
+   *   client by {@link SavedWorkbenchChartService.create}.
+   */
+  readonly dashboardBelongsToProject: (
+    dashboardId: string,
+    projectId: string,
+  ) => Promise<boolean>;
+  /**
+   * The next free grid row on a dashboard, counting every chart on it
+   * regardless of kind. Shared with `graphs.create` via
+   * {@link allocateNextGridRow} so the two writers that can place a chart on
+   * this grid never disagree about which row is free.
+   *
+   * @default the real {@link allocateNextGridRow}, bound to a Prisma client
+   *   by {@link SavedWorkbenchChartService.create}.
+   */
+  readonly allocateNextGridRow: (input: {
+    dashboardId: string;
+    projectId: string;
+  }) => Promise<number>;
 }
+
+/** Grid bounds a chart may be placed with — the same 2-column grid the chart builder places onto. */
+const placementSchema = z.object({
+  dashboardId: z.string().min(1),
+  gridColumn: z.number().min(0).max(1).optional(),
+  gridRow: z.number().min(0).optional(),
+  colSpan: z.number().min(1).max(2).optional(),
+  rowSpan: z.number().min(1).max(2).optional(),
+});
 
 export class SavedWorkbenchChartService {
   constructor(private readonly deps: SavedWorkbenchChartServiceDependencies) {}
@@ -109,6 +159,9 @@ export class SavedWorkbenchChartService {
     return new SavedWorkbenchChartService({
       repository: new SavedWorkbenchChartRepository(prisma),
       lwql: getLangWatchQLService(),
+      dashboardBelongsToProject: (dashboardId, projectId) =>
+        dashboardBelongsToProject(prisma, dashboardId, projectId),
+      allocateNextGridRow: (input) => allocateNextGridRow(prisma, input),
     });
   }
 
@@ -338,6 +391,97 @@ export class SavedWorkbenchChartService {
   }
 
   /**
+   * Places a saved chart on a dashboard.
+   *
+   * `createChart` never places what it writes — this is the only way an
+   * already-saved chart gains a `dashboardId` and a grid position, whether it
+   * is being placed for the first time or moved from where it was.
+   *
+   * When no grid row is supplied, one is allocated the same way a builder
+   * chart created with no explicit row is: the next row free on that
+   * dashboard, counting charts of both kinds, through the shared
+   * {@link SavedWorkbenchChartServiceDependencies.allocateNextGridRow}.
+   *
+   * @throws {SavedWorkbenchChartNotFoundError} when no chart of this kind has
+   *   that id in this project.
+   * @throws {SavedWorkbenchChartDashboardNotFoundError} when the dashboard id
+   *   does not belong to this project — another project's dashboard included.
+   *   Checked before anything is written, through the same
+   *   {@link dashboardBelongsToProject} check dashboard-scoped chart creation
+   *   already runs, so a foreign dashboard id is refused identically whether
+   *   the chart being placed is new or already saved.
+   */
+  async placeChart({
+    id,
+    projectId,
+    input,
+  }: {
+    id: string;
+    projectId: string;
+    input: {
+      dashboardId: string;
+      gridColumn?: number;
+      gridRow?: number;
+      colSpan?: number;
+      rowSpan?: number;
+    };
+  }): Promise<SavedWorkbenchChart> {
+    const parsed = placementSchema.safeParse(input);
+    if (!parsed.success) throw ValidationError.fromZodError(parsed.error);
+
+    // Refused before anything else is resolved, so a member placing onto
+    // another project's dashboard learns only that it is not here — the same
+    // shape of refusal `getById` already gives for a foreign chart id.
+    const belongs = await this.deps.dashboardBelongsToProject(
+      parsed.data.dashboardId,
+      projectId,
+    );
+    if (!belongs) throw new SavedWorkbenchChartDashboardNotFoundError();
+
+    const gridRow =
+      parsed.data.gridRow ??
+      (await this.deps.allocateNextGridRow({
+        dashboardId: parsed.data.dashboardId,
+        projectId,
+      }));
+
+    const row = await this.deps.repository.place({
+      id,
+      projectId,
+      dashboardId: parsed.data.dashboardId,
+      gridColumn: parsed.data.gridColumn ?? 0,
+      gridRow,
+      colSpan: parsed.data.colSpan ?? 1,
+      rowSpan: parsed.data.rowSpan ?? 1,
+    });
+    if (!row) throw new SavedWorkbenchChartNotFoundError();
+
+    return this.present(row);
+  }
+
+  /**
+   * Removes a saved chart from whatever dashboard it is on.
+   *
+   * Idempotent: unplacing a chart that is already unplaced succeeds and
+   * changes nothing, because the caller's intent — "this chart should not be
+   * on a dashboard" — is already true.
+   *
+   * @throws {SavedWorkbenchChartNotFoundError} when no chart of this kind has
+   *   that id in this project.
+   */
+  async unplaceChart({
+    id,
+    projectId,
+  }: {
+    id: string;
+    projectId: string;
+  }): Promise<SavedWorkbenchChart> {
+    const row = await this.deps.repository.unplace({ id, projectId });
+    if (!row) throw new SavedWorkbenchChartNotFoundError();
+    return this.present(row);
+  }
+
+  /**
    * Deletes a saved chart.
    *
    * @throws {SavedWorkbenchChartNotFoundError} when no chart of this kind has
@@ -436,6 +580,11 @@ export class SavedWorkbenchChartService {
       definition: parsed.data,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
+      dashboardId: row.dashboardId,
+      gridColumn: row.gridColumn,
+      gridRow: row.gridRow,
+      colSpan: row.colSpan,
+      rowSpan: row.rowSpan,
     };
   }
 }

--- a/platform/app/src/server/api/routers/graphs.ts
+++ b/platform/app/src/server/api/routers/graphs.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import type { PrismaClient } from "~/generated/prisma/client";
+import { allocateNextGridRow } from "~/server/analytics/allocateNextGridRow";
 import {
   BUILDER_CHART_KIND,
   WORKBENCH_SQL_CHART_KIND,
@@ -97,19 +98,15 @@ export const graphsRouter = createTRPCRouter({
         });
       }
 
-      // If no gridRow provided, find the next available row.
-      //
-      // Deliberately not filtered by `kind`: the grid is one shared space, so
-      // the next free row has to account for every chart occupying it. Scoping
-      // this to builder rows would place a new chart on top of a saved
-      // workbench chart the moment those gain dashboard placement.
+      // If no gridRow provided, find the next available row. Shared with
+      // `placeChart` so the two writers that can put a chart on this grid
+      // never disagree about which row is free.
       let gridRow = input.gridRow;
       if (gridRow === undefined && input.dashboardId) {
-        const lastGraph = await ctx.prisma.customGraph.findFirst({
-          where: { dashboardId: input.dashboardId, projectId: input.projectId },
-          orderBy: { gridRow: "desc" },
+        gridRow = await allocateNextGridRow(ctx.prisma, {
+          dashboardId: input.dashboardId,
+          projectId: input.projectId,
         });
-        gridRow = (lastGraph?.gridRow ?? -1) + 1;
       }
 
       const customGraph = await ctx.prisma.customGraph.create({

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -151,6 +151,12 @@ const registry = {
       "List the project's saved charts to see which ids exist",
     ],
   },
+  saved_workbench_chart_dashboard_not_found: {
+    tips: [
+      "Check the dashboard id — a dashboard from another project cannot be placed on from this one",
+      "List the project's dashboards to see which ids exist",
+    ],
+  },
   saved_workbench_chart_specification_refused: {
     tips: [
       "Read `meta.errors` — each entry names the rule (`rule`) and the JSON path (`path`) that was refused",

--- a/specs/analytics/lwql-langy-authoring.feature
+++ b/specs/analytics/lwql-langy-authoring.feature
@@ -190,8 +190,10 @@ Feature: Langy authors saved workbench charts and places them on dashboards
   # ---------------------------------------------------------------------------
   # Langy's CLI — author, then place (bound in later commits of this slice)
   # ---------------------------------------------------------------------------
+  # The CLI-lane scenarios below are delivered by the next slice of #6712
+  # (SDK client, CLI chart family, skill routing); @unimplemented until it lands.
 
-  @integration
+  @integration @unimplemented
   Scenario: Langy creates a chart with the CLI and reads it back with the same query, parameters and specification
     Given Langy holding CLI credentials for a project
     When it creates a chart from a SQL file, named parameters and a
@@ -199,7 +201,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then the SQL, the parameter values and the specification it reads back are
       the ones it submitted
 
-  @integration
+  @integration @unimplemented
   Scenario: A chart Langy creates is indistinguishable from one a member saves by hand
     Given a chart created through the CLI and a chart saved through the
       application by a member
@@ -208,21 +210,21 @@ Feature: Langy authors saved workbench charts and places them on dashboards
       project scoping
     And they differ only in id, name and timestamps
 
-  @integration
+  @integration @unimplemented
   Scenario: SQL naming a column Langy's credentials cannot read is refused identically everywhere
     Given SQL naming a column that Langy's protections withhold
     When the chart is saved through the CLI, through REST directly and through
       the application's own save path
     Then every path refuses with the same LangWatchQL validator error code
 
-  @integration
+  @integration @unimplemented
   Scenario: A specification the chart policy refuses cannot be written through the CLI
     Given a specification the workbench's Vega-Lite policy refuses
     When Langy tries to create a chart carrying it
     Then the CLI reports error code saved_workbench_chart_specification_refused
     And no chart is created
 
-  @integration
+  @integration @unimplemented
   Scenario: Langy places a saved chart on a dashboard with the CLI
     Given Langy holding CLI credentials and the id of a dashboard in the
       project
@@ -230,7 +232,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then the chart's dashboard id and grid position are set
     And the chart is listed among that dashboard's charts
 
-  @unit
+  @unit @unimplemented
   Scenario: Every new CLI verb is machine-readable, not just human-formatted
     Given a chart created, placed, listed, updated, unplaced or deleted through
       the CLI
@@ -238,7 +240,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then the data returned carries no human-only formatting
     And it can be parsed by an agent without inspecting the human table output
 
-  @unit
+  @unit @unimplemented
   Scenario: Every CLI verb this slice adds refuses while the workbench switch is off, and writes nothing
     Given the LangWatchQL feature switch is off for the project
     When Langy invokes create, update, delete, run, place or unplace through
@@ -246,7 +248,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then every one of them refuses with error code lwql_not_enabled
     And no row is created or mutated by any of them
 
-  @unit
+  @unit @unimplemented
   Scenario: The chart family is discoverable by name, and its skill teaches Langy to check the schema first
     Given the CLI's own command listing and the compiled skill tree
     When the chart command group and the LWQL charts skill are looked up

--- a/specs/analytics/lwql-langy-authoring.feature
+++ b/specs/analytics/lwql-langy-authoring.feature
@@ -1,0 +1,365 @@
+Feature: Langy authors saved workbench charts and places them on dashboards
+
+  As Langy, an agent driving the LangWatch CLI on a member's behalf
+  I want to save a LangWatchQL chart and put it on a dashboard
+  So that a metric I was asked to build keeps updating where the team already
+  looks, without a human ever opening the workbench
+
+  Issue: #6712, epic #6582 slice 5. Builds on the saved-chart persistence and
+  REST surface (#6582 slices 1 and 4, specs/analytics/lwql-saved-charts.feature)
+  and on running a saved chart by id (#6631, specs/analytics/lwql-workbench.feature).
+
+  Scope of this slice. A saved workbench chart has always been a record with no
+  address: `create` wrote a row, and nothing after it could ever set that row's
+  `dashboardId` or grid position. This slice closes exactly that gap — placing
+  and unplacing an already-saved chart — and gives Langy a CLI it can drive to
+  reach the capability. Three surfaces carry the work, and this file states
+  scenarios for each:
+  - the service and repository, which gain `placeChart`/`unplaceChart` alongside
+    the existing `createChart`/`updateChart`/`deleteChart`/`runChart`;
+  - two REST routes beside the five that already exist, under the same
+    LangWatchQL analytics SQL family and the same feature switch and
+    permissions;
+  - the CLI verbs, the skill and the Langy routing row that let an agent reach
+    both without a human touching the workbench. Those scenarios are stated
+    here because they are implied by the same acceptance criteria, but they are
+    bound by commits later than this slice's service and REST work — a `chart`
+    CLI family, a `lwql-charts` recipe and an `AGENTS.md` row do not exist yet
+    at the point this file is written, and the parity check reports them
+    unbound until those commits land.
+
+  The design under proof:
+  - Placing a chart is a service operation, not a side effect of creating one.
+    `createChart` still writes an unplaced row; `placeChart` is the only way a
+    saved chart gains a `dashboardId` and a grid position, and `unplaceChart` is
+    the only way it loses one.
+  - Placement reuses the tenancy check dashboard creation already has —
+    `dashboardBelongsToProject` — rather than re-deriving it. A dashboard id
+    from another project is refused the identical way whether the chart being
+    placed is a builder graph created pre-placed or a saved workbench chart
+    placed after the fact.
+  - Grid-row allocation is one shared decision, not two writers guessing. The
+    same helper that already counts both chart kinds when a builder graph is
+    created without an explicit row now backs `placeChart` too, so a placed
+    workbench chart cannot land on a row a builder chart already occupies, and
+    neither can the reverse.
+  - The REST placement routes validate nothing about what a chart or a
+    dashboard id means — only the request's envelope. What "placed" is allowed
+    to mean stays the service's decision, exactly as it already is for a
+    chart's definition.
+  - A Langy-authored chart is a saved chart like any other. Nothing on the CLI
+    or REST path writes a row a human saving through the workbench could not
+    have produced, and nothing it writes is exempt from a governor a
+    human-authored chart would have to pass.
+
+  Background:
+    Given a project whose member is authorized for LangWatchQL analytics SQL
+    And the project has a saved workbench chart that has never been placed
+
+  # ---------------------------------------------------------------------------
+  # Placing and unplacing a saved chart — the service layer
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Placing a chart requires a dashboard id and accepts an optional grid position
+    Given a saved chart and the id of a dashboard in the same project
+    When the chart is placed on the dashboard with no grid position supplied
+    Then the placement is accepted
+    And a grid position is allocated for it
+
+  @unit
+  Scenario: Unplacing a chart clears every placement field, not just the dashboard id
+    Given a saved chart already placed on a dashboard with a grid position
+    When the chart is unplaced
+    Then its dashboard id, grid column, grid row, column span and row span are
+      all cleared
+    And nothing about its saved definition changes
+
+  @integration
+  Scenario: A placed chart round-trips with the dashboard id and grid position it was given
+    Given a saved chart and a dashboard in the same project
+    When the member places the chart with an explicit grid column, grid row,
+      column span and row span
+    Then reading the chart back shows the same dashboard id and the same grid
+      position
+    And the chart appears among that dashboard's charts
+
+  @integration
+  Scenario: Placing a chart onto another project's dashboard is refused, and nothing is written
+    Given a saved chart in one project and a dashboard that belongs to a
+      different project
+    When the member tries to place the chart on that dashboard
+    Then the placement is refused with error code
+      saved_workbench_chart_dashboard_not_found
+    And the chart is left exactly as unplaced as it was
+
+  @integration
+  Scenario: Placing a chart onto a dashboard already holding builder charts does not overlap them
+    Given a dashboard already holding builder charts across several grid rows
+    When the member places a saved workbench chart on it with no grid row
+      supplied
+    Then the chart is allocated a row none of the existing builder charts
+      occupy
+    And the dashboard's existing builder charts keep the rows they already had
+
+  @integration
+  Scenario: Placing a saved workbench chart does not let a builder chart land on top of it
+    Given a dashboard already holding a placed saved workbench chart
+    When the member creates a new builder chart on the same dashboard with no
+      grid row supplied
+    Then the new builder chart is allocated a row the saved workbench chart
+      does not occupy
+
+  @unit
+  Scenario: Placing a chart that does not exist in this project is refused
+    Given a chart id that does not name a saved chart in this project
+    When the member tries to place it on a dashboard
+    Then the placement is refused as not found
+    And no dashboard's chart list gains an entry for it
+
+  # ---------------------------------------------------------------------------
+  # Placement and REST — the same rules, reached with a project API key
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: An integration places a saved chart on a dashboard over the API
+    Given an integration holding a project API key and a dashboard in its
+      project
+    When it puts a placement on a saved chart naming that dashboard
+    Then the response carries the chart with its new dashboard id and grid
+      position
+    And reading the chart back by its id shows the same placement
+
+  @integration
+  Scenario: An integration unplaces a saved chart over the API
+    Given an integration holding a project API key and a chart already placed
+      on a dashboard
+    When it deletes the chart's placement
+    Then the response has no content
+    And reading the chart back shows no dashboard id and no grid position
+
+  @integration
+  Scenario: Placement onto a foreign dashboard is refused over the API the same way it is inside the application
+    Given an integration holding a project API key and the id of a dashboard
+      that belongs to a different project
+    When it puts a placement on a saved chart naming that dashboard
+    Then the request is refused with error code
+      saved_workbench_chart_dashboard_not_found
+    And the chart's placement is unchanged
+
+  @integration
+  Scenario: Placement routes stay dark while the workbench switch is off
+    Given the LangWatchQL feature switch is off for the project
+    When the integration puts or deletes a chart's placement
+    Then each is refused with error code lwql_not_enabled
+    And the chart's placement is unchanged
+
+  @integration
+  Scenario: A key that may read charts may not place or unplace them
+    Given a key whose permissions allow viewing analytics and nothing more
+    When it tries to put or delete a chart's placement
+    Then each attempt is refused before the service is reached
+    And the chart's placement is unchanged
+
+  @integration
+  Scenario: Placing an unknown chart id is refused as not found, indistinguishable from a foreign one
+    Given an integration holding a project API key
+    When it puts a placement naming a chart id absent from this project
+    Then the request is refused as not found
+    And the answer does not reveal whether the id belongs to another project or
+      to no project at all
+
+  @unit
+  Scenario: The placement endpoints are published in the API document
+    Given the generated OpenAPI document
+    When the placement routes are looked up in it
+    Then both operations are described, each with a summary, a tag and a
+      response schema
+
+  # ---------------------------------------------------------------------------
+  # Deleting a placed chart
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Deleting a placed chart leaves no dangling reference on its dashboard
+    Given a saved chart placed on a dashboard that also holds builder charts
+    When the member deletes the placed chart
+    Then the dashboard's chart list no longer includes it
+    And the dashboard's remaining charts are unaffected
+
+  # ---------------------------------------------------------------------------
+  # Langy's CLI — author, then place (bound in later commits of this slice)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Langy creates a chart with the CLI and reads it back with the same query, parameters and specification
+    Given Langy holding CLI credentials for a project
+    When it creates a chart from a SQL file, named parameters and a
+      specification file, then gets that chart by the id it was given
+    Then the SQL, the parameter values and the specification it reads back are
+      the ones it submitted
+
+  @integration
+  Scenario: A chart Langy creates is indistinguishable from one a member saves by hand
+    Given a chart created through the CLI and a chart saved through the
+      application by a member
+    When the two are compared
+    Then they agree on kind, on the shape of their stored definition and on
+      project scoping
+    And they differ only in id, name and timestamps
+
+  @integration
+  Scenario: SQL naming a column Langy's credentials cannot read is refused identically everywhere
+    Given SQL naming a column that Langy's protections withhold
+    When the chart is saved through the CLI, through REST directly and through
+      the application's own save path
+    Then every path refuses with the same LangWatchQL validator error code
+
+  @integration
+  Scenario: A specification the chart policy refuses cannot be written through the CLI
+    Given a specification the workbench's Vega-Lite policy refuses
+    When Langy tries to create a chart carrying it
+    Then the CLI reports error code saved_workbench_chart_specification_refused
+    And no chart is created
+
+  @integration
+  Scenario: Langy places a saved chart on a dashboard with the CLI
+    Given Langy holding CLI credentials and the id of a dashboard in the
+      project
+    When it places a saved chart on that dashboard
+    Then the chart's dashboard id and grid position are set
+    And the chart is listed among that dashboard's charts
+
+  @unit
+  Scenario: Every new CLI verb is machine-readable, not just human-formatted
+    Given a chart created, placed, listed, updated, unplaced or deleted through
+      the CLI
+    When the result is requested as JSON
+    Then the data returned carries no human-only formatting
+    And it can be parsed by an agent without inspecting the human table output
+
+  @unit
+  Scenario: Every CLI verb this slice adds refuses while the workbench switch is off, and writes nothing
+    Given the LangWatchQL feature switch is off for the project
+    When Langy invokes create, update, delete, run, place or unplace through
+      the CLI
+    Then every one of them refuses with error code lwql_not_enabled
+    And no row is created or mutated by any of them
+
+  @unit
+  Scenario: The chart family is discoverable by name, and its skill teaches Langy to check the schema first
+    Given the CLI's own command listing and the compiled skill tree
+    When the chart command group and the LWQL charts skill are looked up
+    Then the chart group appears in the command listing
+    And the skill instructs discovering the analytics schema before writing SQL
+    And the compiled skill committed in the repository matches a fresh render
+      from its source
+
+# --- AC Coverage Map ---
+# Issue #6712, epic #6582 slice 5 ("Langy authors saved workbench charts and
+# places them on dashboards").
+#
+# AC1 "Langy can author a chart end to end via the CLI"
+#   → Scenario: Langy creates a chart with the CLI and reads it back with the
+#     same query, parameters and specification
+#
+# AC2 "a Langy-authored chart is indistinguishable from a human-saved one"
+#   → Scenario: A chart Langy creates is indistinguishable from one a member
+#     saves by hand
+#
+# AC3 "no privileged bypass — invalid SQL is refused identically on every path"
+#   → Scenario: SQL naming a column Langy's credentials cannot read is refused
+#     identically everywhere
+#
+# AC4 "no privileged bypass — a refused Vega-Lite spec cannot be written"
+#   → Scenario: A specification the chart policy refuses cannot be written
+#     through the CLI
+#   (the "no row is written" half is carried, for the surfaces this slice's
+#   first three commits actually deliver, by: Scenario: Placing a chart onto
+#   another project's dashboard is refused, and nothing is written; Scenario:
+#   A specification the chart policy refuses is refused over the API, and
+#   nothing is written — the latter already lives in
+#   specs/analytics/lwql-saved-charts.feature and is not re-stated here)
+#
+# AC5 "tenant scoping holds on every new verb — get/update/delete/run/place/
+#    unplace against another project's chart id all answer not-found"
+#   → the `get`/`update`/`delete` half is already bound in
+#     specs/analytics/lwql-saved-charts.feature and not re-stated here; `run`
+#     is already bound in specs/analytics/lwql-workbench.feature. The two verbs
+#     genuinely new to this slice are placement:
+#   → Scenario: Placing a chart onto another project's dashboard is refused,
+#     and nothing is written
+#   → Scenario: Placing an unknown chart id is refused as not found,
+#     indistinguishable from a foreign one
+#   → Scenario: Placement onto a foreign dashboard is refused over the API the
+#     same way it is inside the application
+#
+# AC6 "a chart can be placed on a dashboard"
+#   → Scenario: Placing a chart requires a dashboard id and accepts an
+#     optional grid position
+#   → Scenario: A placed chart round-trips with the dashboard id and grid
+#     position it was given
+#   → Scenario: An integration places a saved chart on a dashboard over the API
+#   → Scenario: Langy places a saved chart on a dashboard with the CLI
+#
+# AC7 "placement onto a foreign dashboard is refused"
+#   → Scenario: Placing a chart onto another project's dashboard is refused,
+#     and nothing is written
+#   → Scenario: Placement onto a foreign dashboard is refused over the API the
+#     same way it is inside the application
+#
+# AC8 "placement does not collide with builder charts"
+#   → Scenario: Placing a chart onto a dashboard already holding builder
+#     charts does not overlap them
+#   → Scenario: Placing a saved workbench chart does not let a builder chart
+#     land on top of it
+#
+# AC9 "flag-off refusal — every new CLI verb refuses with lwql_not_enabled; no
+#    row is written or mutated"
+#   → the CLI-verb half is stated in Scenario: Every CLI verb this slice adds
+#     refuses while the workbench switch is off, and writes nothing, and is
+#     bound once commit 5 (the CLI family) lands
+#   → the REST-route half, which this slice's commits 1-3 do bind, is
+#     Scenario: Placement routes stay dark while the workbench switch is off
+#
+# AC10 "the chart family is discoverable by Langy"
+#   → Scenario: The chart family is discoverable by name, and its skill
+#     teaches Langy to check the schema first
+#   → Scenario: Every new CLI verb is machine-readable, not just
+#     human-formatted (discoverability without a usable output shape is not
+#     yet discoverability for an agent)
+#
+# AC11 "deleting a placed chart leaves no dangling dashboard reference"
+#   → Scenario: Deleting a placed chart leaves no dangling reference on its
+#     dashboard
+#
+# AC12 "every new error code has customer-facing copy"
+#   → the process guarantee itself is `pnpm typecheck` against the exhaustive
+#   `codes.ts`/`presentation.ts` registries, verified in the PR diff for
+#   `saved_workbench_chart_dashboard_not_found`; the scenarios that exercise
+#   the code and would surface a missing presentation entry as a broken
+#   refusal message are:
+#   → Scenario: Placing a chart onto another project's dashboard is refused,
+#     and nothing is written
+#   → Scenario: Placement onto a foreign dashboard is refused over the API the
+#     same way it is inside the application
+#
+# AC13 "--json / agent output is machine-readable on every new verb"
+#   → Scenario: Every new CLI verb is machine-readable, not just
+#     human-formatted
+#
+# Additionally bound here, beyond the numbered ACs, because the REST placement
+# routes are a published surface like the five they sit beside:
+#   → Scenario: The placement endpoints are published in the API document
+#   → Scenario: Placing a chart that does not exist in this project is refused
+#   → Scenario: An integration unplaces a saved chart over the API
+#   → Scenario: Unplacing a chart clears every placement field, not just the
+#     dashboard id
+#   → Scenario: A key that may read charts may not place or unplace them
+#
+# Deliberately NOT in this feature file: dashboard *rendering* of a placed
+# workbench chart (widget selection, granularity-aware execution, the
+# coarsened-from notice) — that shipped under #6631/S2 and is bound in
+# specs/analytics/lwql-workbench.feature and the widget-level unit suites
+# alongside it. Running a saved chart by id, and its tenancy and governance
+# scenarios, are likewise already bound there and are not re-stated here.


### PR DESCRIPTION
# Related Issue

- Resolves #6712

Part of #6582 (saved workbench charts epic), implements the first half of #6712.

**Stacked on #7436** (`issue6713/lwql-dashboard-widgets`) — review only the top 3 commits.

## What this slice ships

1. **Spec first** — `specs/analytics/lwql-langy-authoring.feature`: 23 scenarios covering placement, CLI chart family, and skill routing. 15/23 bound now; the 8 unbound are CLI/skill scenarios belonging to the next slice (commits 4–6), so feature-parity is expected mid-stack red on this file until those land.
2. **Service-layer placement** — repository `place()`/`unplace()` (updateManyAndReturn + kind predicate), service `placeChart()`/`unplaceChart()` reusing `dashboardBelongsToProject`, and a shared `allocateNextGridRow` helper used by both `graphs.create` and `placeChart` so the two writers can't drift and overlap charts. New error `saved_workbench_chart_dashboard_not_found` registered in errors/codes/presentation.
3. **REST placement endpoints** — `PUT`/`DELETE /api/v1/projects/{projectId}/analytics/charts/{chartId}/placement` via `lwqlProject()`, envelope-only validation at the route, `chartResource()` now projects the placement fields, OpenAPI regenerated.

## Test evidence

- `pnpm typecheck` + `typecheck:tests` clean (post-rebase onto #7436's head)
- REST integration: 24 passed, incl. cross-project dashboard → 404 indistinguishable from unknown id, and flag-off refusal asserting **no mutation** (row unchanged, not just status)
- Service integration: cross-project refusal falsification-tested (removing `dashboardBelongsToProject` goes red)
- OpenAPI unit: placement operations published with correct tags/permissions/responses

## Coming next (same issue, next slice)

Commits 4–6: typed SDK client regeneration, the `langwatch charts` CLI family, and Langy skill routing.


## How I can prove I was successful

- **[proven] CI fully green at head `dd12f410ab`** (58 checks).
- **[proven] Review fan-out** (security / design / tests) verified clean on the committed refs; the three findings it raised (parity honesty via `@unimplemented`, `.int()` on grid fields, `gridRow` upper bound) are fixed in the review-findings commit with sabotage-verified tests — clerk verdict on this PR.
- **[proven] Live end-to-end**: the placement endpoints this PR ships were driven against a real dev server + ClickHouse harness by the CLI slice's QA (PR #7443): `PUT .../placement` placed a chart (Postgres row verified: dashboardId + all grid fields), the dashboard rendered it live, and `DELETE .../placement` cleared it. Screenshots:

  ![chart placed via the REST endpoint rendering live](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7443/11-dashboard-placed.png)

  ![dashboard after unplace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7443/13-dashboard-unplaced.png)
- **[proven] Load-bearing tests are falsification-tested**: removing `dashboardBelongsToProject` turns the cross-project refusal test red; flag-off asserts the row is unchanged, not just the status code; foreign and nonexistent ids are indistinguishable 404s at both service and REST layers.

## Human verification

- With a project key holding `analytics:update`, `PUT /api/v1/projects/{projectId}/analytics/charts/{chartId}/placement` with another project's dashboardId: expect `saved_workbench_chart_dashboard_not_found` and no row change.
- With the workbench flag off: both placement verbs refuse and write nothing.

## Deployment Impact

No env vars, helm values, or service topology changes — two new REST routes inside the existing app, gated behind the existing `release_lwql_workbench` feature flag. Vanilla `helm install` behavior unchanged (flag off → routes refuse). No BYOC dataplane impact.
