### PR TITLE
feat(migrations): a cohort can draw the organizations it normally holds back

### DIFF
--- a/platform/app/src/components/ops/migrations/MigrationsContent.tsx
+++ b/platform/app/src/components/ops/migrations/MigrationsContent.tsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { Play, Undo2, UserPlus, Users } from "lucide-react";
 import { useEffect, useState } from "react";
+import { Checkbox } from "~/components/ui/checkbox";
 import { ListTable } from "~/components/ui/ListTable";
 import { toaster } from "~/components/ui/toaster";
 import { HandledErrorAlert, showErrorToast } from "~/features/errors";
@@ -529,25 +530,128 @@ function EnrollAction({
 /**
  * Enroll a sampled cohort for THIS migration in one action. The first
  * step's sample is drawn from organizations not yet enrolled; a later
- * step's from the step before it. The platform excludes the ones it
- * already knows to leave alone by data: an active enterprise
+ * step's from the step before it. The platform leaves out the ones it
+ * already knows to hold back, by data: an active enterprise
  * subscription, or a dedicated data plane configured in the environment.
  * No organization is ever named in code to exclude it.
+ *
+ * Both are defaults an operator can lift, one at a time, which is how a
+ * proven rollout is finished without enrolling the held-back
+ * organizations one id at a time. The description says which of them this
+ * draw will include, because "left out" and "included" must never be a
+ * guess about a checkbox the reader has already ticked.
  */
 function cohortDialogDescription({
   previousMigrationTitle,
   requiresConfirmation,
+  includeEnterprise,
+  includePrivateDataplane,
 }: {
   previousMigrationTitle?: string;
   requiresConfirmation: boolean;
+  includeEnterprise: boolean;
+  includePrivateDataplane: boolean;
 }): string {
   const pool = previousMigrationTitle
     ? `Enrolls a random sample of organizations enrolled for the ${previousMigrationTitle.toLowerCase()} but not yet for this step. `
     : "Enrolls a random sample of organizations not yet enrolled for this step. ";
   const consequence = requiresConfirmation
-    ? "Once their earlier steps finish, the next pass proves parity and moves every enrolled organization's permission checks onto the new engine. Organizations on an enterprise plan or with a dedicated data plane are always left out."
-    : "It changes nothing about who answers permission checks. Organizations on an enterprise plan or with a dedicated data plane are always left out.";
-  return pool + consequence;
+    ? "Once their earlier steps finish, the next pass proves parity and moves every enrolled organization's permission checks onto the new engine. "
+    : "It changes nothing about who answers permission checks. ";
+  const included = [
+    includeEnterprise ? "on an enterprise plan" : undefined,
+    includePrivateDataplane ? "with a dedicated data plane" : undefined,
+  ].filter((phrase) => phrase !== undefined);
+  const heldBack = [
+    includeEnterprise ? undefined : "on an enterprise plan",
+    includePrivateDataplane ? undefined : "with a dedicated data plane",
+  ].filter((phrase) => phrase !== undefined);
+  const sentence = (phrases: string[], verb: string) =>
+    `Organizations ${phrases.join(" or ")} ${verb}`;
+  const scope =
+    included.length === 0
+      ? `${sentence(heldBack, "are left out.")}`
+      : heldBack.length === 0
+        ? `${sentence(included, "can be drawn.")}`
+        : `${sentence(included, "can be drawn;")} ${sentence(
+            heldBack,
+            "are left out.",
+          ).toLowerCase()}`;
+  return pool + consequence + scope;
+}
+
+/**
+ * What a finished cohort draw says. A short pool is not an error — the
+ * action asked for a sample and got everything that was left — so it reads
+ * as success with the shortfall explained, and an empty pool as information.
+ */
+function cohortResultToast({
+  enrolledCount,
+  sampleSize,
+}: {
+  enrolledCount: number;
+  sampleSize: number;
+}) {
+  if (enrolledCount === 0) {
+    return {
+      title: "No organizations enrolled",
+      description:
+        "No eligible organizations remained to enroll for this step.",
+      type: "info" as const,
+    };
+  }
+  return {
+    title:
+      enrolledCount === 1
+        ? "1 organization enrolled"
+        : `${enrolledCount} organizations enrolled`,
+    description:
+      enrolledCount < sampleSize
+        ? "Fewer eligible organizations remained than the requested cohort size, so every remaining one was enrolled. The next migration pass picks them up automatically."
+        : "The next migration pass picks the cohort up automatically.",
+    type: "success" as const,
+  };
+}
+
+/**
+ * The two classes a cohort leaves out by default, each on its own switch.
+ * Separate because the risks are different in kind — an enterprise
+ * organization is a commercial relationship, a dedicated-data-plane one
+ * keeps its events in a ClickHouse instance of its own — and a single
+ * "include everything" control would hide that from whoever ticks it.
+ */
+function HeldBackClassFields({
+  includeEnterprise,
+  onIncludeEnterpriseChange,
+  includePrivateDataplane,
+  onIncludePrivateDataplaneChange,
+}: {
+  includeEnterprise: boolean;
+  onIncludeEnterpriseChange: (next: boolean) => void;
+  includePrivateDataplane: boolean;
+  onIncludePrivateDataplaneChange: (next: boolean) => void;
+}) {
+  return (
+    <Stack gap={2} paddingTop={3}>
+      <Text fontSize="sm">Organizations normally held back</Text>
+      <Checkbox
+        size="sm"
+        checked={includeEnterprise}
+        onCheckedChange={() => onIncludeEnterpriseChange(!includeEnterprise)}
+      >
+        Include organizations on an enterprise plan
+      </Checkbox>
+      <Checkbox
+        size="sm"
+        checked={includePrivateDataplane}
+        onCheckedChange={() =>
+          onIncludePrivateDataplaneChange(!includePrivateDataplane)
+        }
+      >
+        Include organizations with a dedicated data plane
+      </Checkbox>
+    </Stack>
+  );
 }
 
 function EnrollCohortAction({
@@ -563,36 +667,47 @@ function EnrollCohortAction({
   requiresConfirmation: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const [sampleSizeText, setSampleSizeText] = useState("50");
-  // Number, not parseInt: "1e3" and "50.5" must disable Confirm rather than
-  // be silently reinterpreted as 1 and 50.
-  const sampleSize = Number(sampleSizeText);
-  const sampleSizeValid =
-    Number.isInteger(sampleSize) && sampleSize >= 1 && sampleSize <= 1000;
+
+  return (
+    <>
+      <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+        <Users size={13} /> Enroll cohort…
+      </Button>
+      {/* Mounted only while open, so the draft — the sample size and both
+       *  lifted exclusions — starts fresh on every open. Lifting an
+       *  exclusion is a decision about ONE cohort, and a checkbox that
+       *  remembered its last state would silently widen the next draw. */}
+      {open && (
+        <CohortDialog
+          migrationName={migrationName}
+          migrationTitle={migrationTitle}
+          previousMigrationTitle={previousMigrationTitle}
+          requiresConfirmation={requiresConfirmation}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+/** The mutation behind the cohort dialog, with the surfaces it refreshes. */
+function useEnrollCohort({
+  sampleSize,
+  onEnrolled,
+}: {
+  sampleSize: number;
+  onEnrolled: () => void;
+}) {
   const utils = api.useUtils();
-  const enrollCohort = api.ops.enrollMigrationCohort.useMutation({
+  return api.ops.enrollMigrationCohort.useMutation({
     onSuccess: async (result) => {
       toaster.create(
-        result.enrolled.length === 0
-          ? {
-              title: "No organizations enrolled",
-              description:
-                "No eligible organizations remained to enroll for this step.",
-              type: "info",
-            }
-          : {
-              title:
-                result.enrolled.length === 1
-                  ? "1 organization enrolled"
-                  : `${result.enrolled.length} organizations enrolled`,
-              description:
-                result.enrolled.length < sampleSize
-                  ? "Fewer eligible organizations remained than the requested cohort size, so every remaining one was enrolled. The next migration pass picks them up automatically."
-                  : "The next migration pass picks the cohort up automatically.",
-              type: "success",
-            },
+        cohortResultToast({
+          enrolledCount: result.enrolled.length,
+          sampleSize,
+        }),
       );
-      setOpen(false);
+      onEnrolled();
       await Promise.all([
         utils.ops.listMigrationEnrollments.invalidate(),
         utils.ops.listSystemMigrations.invalidate(),
@@ -601,45 +716,74 @@ function EnrollCohortAction({
     onError: (error) =>
       showErrorToast({ error, fallbackTitle: "Couldn't enroll the cohort" }),
   });
+}
+
+function CohortDialog({
+  migrationName,
+  migrationTitle,
+  previousMigrationTitle,
+  requiresConfirmation,
+  onClose,
+}: {
+  migrationName: string;
+  migrationTitle: string;
+  previousMigrationTitle?: string;
+  requiresConfirmation: boolean;
+  onClose: () => void;
+}) {
+  const [sampleSizeText, setSampleSizeText] = useState("50");
+  const [includeEnterprise, setIncludeEnterprise] = useState(false);
+  const [includePrivateDataplane, setIncludePrivateDataplane] = useState(false);
+  // Number, not parseInt: "1e3" and "50.5" must disable Confirm rather than
+  // be silently reinterpreted as 1 and 50.
+  const sampleSize = Number(sampleSizeText);
+  const sampleSizeValid =
+    Number.isInteger(sampleSize) && sampleSize >= 1 && sampleSize <= 1000;
+  const enrollCohort = useEnrollCohort({ sampleSize, onEnrolled: onClose });
 
   return (
-    <>
-      <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
-        <Users size={13} /> Enroll cohort…
-      </Button>
-      <ConfirmDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        onConfirm={() => {
-          if (!sampleSizeValid) return;
-          enrollCohort.mutate({
-            migrationName,
-            sampleSize,
-            ...(requiresConfirmation ? { confirm: "ENROLL" as const } : {}),
-          });
-        }}
-        title={`Enroll a cohort for the ${migrationTitle.toLowerCase()}`}
-        description={cohortDialogDescription({
-          previousMigrationTitle,
-          requiresConfirmation,
-        })}
-        isLoading={enrollCohort.isPending}
-        confirmDisabled={!sampleSizeValid}
-      >
-        <Stack gap={1}>
-          <Text fontSize="sm">How many organizations to enroll</Text>
-          <Input
-            size="sm"
-            type="number"
-            min={1}
-            max={1000}
-            step={1}
-            value={sampleSizeText}
-            onChange={(event) => setSampleSizeText(event.target.value)}
-          />
-        </Stack>
-      </ConfirmDialog>
-    </>
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      onConfirm={() => {
+        if (!sampleSizeValid) return;
+        enrollCohort.mutate({
+          migrationName,
+          sampleSize,
+          includeEnterprise,
+          includePrivateDataplane,
+          ...(requiresConfirmation ? { confirm: "ENROLL" as const } : {}),
+        });
+      }}
+      title={`Enroll a cohort for the ${migrationTitle.toLowerCase()}`}
+      description={cohortDialogDescription({
+        previousMigrationTitle,
+        requiresConfirmation,
+        includeEnterprise,
+        includePrivateDataplane,
+      })}
+      isLoading={enrollCohort.isPending}
+      confirmDisabled={!sampleSizeValid}
+    >
+      <Stack gap={1}>
+        <Text fontSize="sm">How many organizations to enroll</Text>
+        <Input
+          size="sm"
+          type="number"
+          min={1}
+          max={1000}
+          step={1}
+          value={sampleSizeText}
+          onChange={(event) => setSampleSizeText(event.target.value)}
+        />
+        <HeldBackClassFields
+          includeEnterprise={includeEnterprise}
+          onIncludeEnterpriseChange={setIncludeEnterprise}
+          includePrivateDataplane={includePrivateDataplane}
+          onIncludePrivateDataplaneChange={setIncludePrivateDataplane}
+        />
+      </Stack>
+    </ConfirmDialog>
   );
 }
 

--- a/platform/app/src/server/api/routers/__tests__/ops.migrationEnrollment.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/ops.migrationEnrollment.integration.test.ts
@@ -160,9 +160,37 @@ describe("ops migration enrollment procedures", () => {
         migrationName: "authz-team-user-backfill",
         sampleSize: 25,
         actorUserId: "user_alex",
+        // A caller that names neither gets the SAFE pool: the zod defaults
+        // are what make an older client's request still mean what it did.
+        includeEnterprise: false,
+        includePrivateDataplane: false,
       });
       expect(demandedPermissions.get("enrollMigrationCohort")).toBe(
         "ops:manage",
+      );
+    });
+
+    /** @scenario "An operator can draw enterprise organizations into a cohort" */
+    it("passes a lifted exclusion through to the service", async () => {
+      service.enrollCohort.mockResolvedValue({
+        enrolled: [],
+        eligibleCount: 0,
+      });
+      const caller = buildCaller();
+
+      await caller.enrollMigrationCohort({
+        migrationName: "authz-team-user-backfill",
+        sampleSize: 25,
+        includeEnterprise: true,
+      });
+
+      expect(service.enrollCohort).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includeEnterprise: true,
+          // Lifting one leaves the other alone, at the route as well as in
+          // the service.
+          includePrivateDataplane: false,
+        }),
       );
     });
 
@@ -191,6 +219,8 @@ describe("ops migration enrollment procedures", () => {
         migrationName: "authz-grants-cutover",
         sampleSize: 10,
         actorUserId: "user_alex",
+        includeEnterprise: false,
+        includePrivateDataplane: false,
       });
     });
   });

--- a/platform/app/src/server/api/routers/ops.ts
+++ b/platform/app/src/server/api/routers/ops.ts
@@ -1556,6 +1556,11 @@ export const opsRouter = createTRPCRouter({
    * enrolled, excluding enterprise plans and private-dataplane routes by
    * data rather than by any list in code. The cutover keeps its typed
    * confirmation: a cohort of cutovers is the same flip N times over.
+   *
+   * Either exclusion can be lifted for one draw, separately, so finishing a
+   * proven rollout does not mean enrolling the held-back organizations one
+   * id at a time. Both default to false here as well as in the service: an
+   * older client that sends neither field gets the safe pool.
    */
   enrollMigrationCohort: protectedProcedure
     .use(opsManagePermission)
@@ -1563,6 +1568,8 @@ export const opsRouter = createTRPCRouter({
       z.object({
         migrationName: z.string().min(1).max(200),
         sampleSize: z.number().int().min(1).max(1000),
+        includeEnterprise: z.boolean().default(false),
+        includePrivateDataplane: z.boolean().default(false),
         confirm: z.literal("ENROLL").optional(),
       }),
     )
@@ -1578,6 +1585,8 @@ export const opsRouter = createTRPCRouter({
         migrationName: input.migrationName,
         sampleSize: input.sampleSize,
         actorUserId: ctx.session.user.id,
+        includeEnterprise: input.includeEnterprise,
+        includePrivateDataplane: input.includePrivateDataplane,
       });
     }),
 

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/cohort-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/cohort-enrollment.unit.test.ts
@@ -108,7 +108,7 @@ describe("SystemMigrationsService.enrollCohort", () => {
         );
       });
 
-      /** @scenario "A cohort never includes an enterprise organization" */
+      /** @scenario "A cohort leaves out a private-dataplane organization by default" */
       it("asks the pool to exclude the private-dataplane organizations from the environment", async () => {
         const { service, findCohortEligibleOrganizations } = serviceWith({
           privateDataplaneOrganizationIds: ["org_isolated_inc"],
@@ -124,7 +124,49 @@ describe("SystemMigrationsService.enrollCohort", () => {
           migrationName: MIGRATION,
           enrolledForMigrationName: undefined,
           excludeOrganizationIds: ["org_isolated_inc"],
+          includeEnterprise: false,
         });
+      });
+
+      /** @scenario "An operator can draw private-dataplane organizations into a cohort" */
+      it("stops naming the private-dataplane ids when that class is included", async () => {
+        const { service, findCohortEligibleOrganizations } = serviceWith({
+          privateDataplaneOrganizationIds: ["org_isolated_inc"],
+        });
+
+        await service.enrollCohort({
+          migrationName: MIGRATION,
+          sampleSize: 5,
+          actorUserId: "user_ops",
+          includePrivateDataplane: true,
+        });
+
+        // Not naming the ids IS the lift: the environment's routing table
+        // stays the only place those organizations are listed.
+        expect(findCohortEligibleOrganizations).toHaveBeenCalledWith(
+          expect.objectContaining({ excludeOrganizationIds: [] }),
+        );
+      });
+
+      /** @scenario "Including one held-back class does not include the other" */
+      it("keeps the private-dataplane exclusion when only enterprise is included", async () => {
+        const { service, findCohortEligibleOrganizations } = serviceWith({
+          privateDataplaneOrganizationIds: ["org_isolated_inc"],
+        });
+
+        await service.enrollCohort({
+          migrationName: MIGRATION,
+          sampleSize: 5,
+          actorUserId: "user_ops",
+          includeEnterprise: true,
+        });
+
+        expect(findCohortEligibleOrganizations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            includeEnterprise: true,
+            excludeOrganizationIds: ["org_isolated_inc"],
+          }),
+        );
       });
 
       /** @scenario "A later step's cohort samples only organizations enrolled for the step before it" */
@@ -204,6 +246,30 @@ describe("SystemMigrationsService.enrollCohort", () => {
             }),
           );
         }
+      });
+
+      /** @scenario "A widened cohort says so in the audit trail" */
+      it("records which held-back classes the draw included", async () => {
+        const { service, audit } = serviceWith({ eligible: organizations(2) });
+
+        await service.enrollCohort({
+          migrationName: MIGRATION,
+          sampleSize: 2,
+          actorUserId: "user_ops",
+          includeEnterprise: true,
+        });
+
+        // On the row, not only in the log: "was this organization drawn
+        // because someone lifted an exclusion?" is asked of ONE organization,
+        // and the trail is where that is answered.
+        expect(audit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            args: expect.objectContaining({
+              includeEnterprise: true,
+              includePrivateDataplane: false,
+            }),
+          }),
+        );
       });
     });
   });

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-cohort-wiring.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-cohort-wiring.unit.test.ts
@@ -58,7 +58,7 @@ describe("the cohort's private-dataplane exclusion wiring", () => {
   });
 
   describe("when a cohort's eligible pool is read through the real composition", () => {
-    /** @scenario "A cohort never includes an enterprise organization" */
+    /** @scenario "A cohort leaves out an enterprise organization by default" */
     it.skip("excludes the organizations named by the private ClickHouse routing table", async () => {
       await systemMigrationsService.enrollCohort({
         migrationName: "authz-team-user-backfill",

--- a/platform/app/src/server/app-layer/system-migrations/repositories/__tests__/cohort-eligibility.integration.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/__tests__/cohort-eligibility.integration.test.ts
@@ -97,7 +97,7 @@ describe("given organizations of every eligibility kind", () => {
   });
 
   describe("when the cohort's eligible pool is read", () => {
-    /** @scenario "A cohort never includes an enterprise organization" */
+    /** @scenario "A cohort leaves out an enterprise organization by default" */
     /** @scenario "A cohort samples only organizations not already enrolled" */
     it("holds the plain and cancelled-enterprise organizations and nothing excluded", async () => {
       const pool = await repository.findCohortEligibleOrganizations({
@@ -110,6 +110,23 @@ describe("given organizations of every eligibility kind", () => {
       expect(poolIds.has(cancelledEnterpriseOrgId)).toBe(true);
       expect(poolIds.has(enterpriseOrgId)).toBe(false);
       expect(poolIds.has(pendingEnterpriseOrgId)).toBe(false);
+      expect(poolIds.has(enrolledOrgId)).toBe(false);
+      expect(poolIds.has(excludedOrgId)).toBe(false);
+    });
+
+    /** @scenario "An operator can draw enterprise organizations into a cohort" */
+    it("holds the enterprise organizations when the exclusion is lifted", async () => {
+      const pool = await repository.findCohortEligibleOrganizations({
+        migrationName: MIGRATION,
+        excludeOrganizationIds: [excludedOrgId],
+        includeEnterprise: true,
+      });
+      const poolIds = new Set(pool.map((organization) => organization.id));
+
+      expect(poolIds.has(enterpriseOrgId)).toBe(true);
+      expect(poolIds.has(pendingEnterpriseOrgId)).toBe(true);
+      // Lifting ONE exclusion lifts only that one: an already-enrolled
+      // organization and a caller-excluded id stay out regardless.
       expect(poolIds.has(enrolledOrgId)).toBe(false);
       expect(poolIds.has(excludedOrgId)).toBe(false);
     });

--- a/platform/app/src/server/app-layer/system-migrations/repositories/system-migration-enrollment.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/system-migrations/repositories/system-migration-enrollment.prisma.repository.ts
@@ -155,10 +155,12 @@ export class PrismaSystemMigrationEnrollmentRepository {
     migrationName,
     enrolledForMigrationName,
     excludeOrganizationIds,
+    includeEnterprise = false,
   }: {
     migrationName: string;
     enrolledForMigrationName?: string;
     excludeOrganizationIds: string[];
+    includeEnterprise?: boolean;
   }): Promise<Array<{ id: string; name: string }>> {
     // The enrollment table has no relation to Organization (a plain string
     // column pair), so the enrolled ids are read first and excluded by id -
@@ -188,9 +190,22 @@ export class PrismaSystemMigrationEnrollmentRepository {
         // PENDING rides along with ACTIVE: a just-signed enterprise whose
         // subscription has not settled is exactly the organization the
         // exclusion exists to keep out of an experimental cohort.
-        subscriptions: {
-          none: { status: { in: ["ACTIVE", "PENDING"] }, plan: "ENTERPRISE" },
-        },
+        //
+        // Spread rather than a ternary INSIDE `subscriptions`, because
+        // `subscriptions: undefined` and no `subscriptions` key are the same
+        // query to Prisma but not the same thing to a reader: omitting the
+        // key says "this filter does not apply", which is what lifting the
+        // exclusion means.
+        ...(includeEnterprise
+          ? {}
+          : {
+              subscriptions: {
+                none: {
+                  status: { in: ["ACTIVE", "PENDING"] },
+                  plan: "ENTERPRISE",
+                },
+              },
+            }),
       },
       select: { id: true, name: true },
     });

--- a/platform/app/src/server/app-layer/system-migrations/system-migrations.service.ts
+++ b/platform/app/src/server/app-layer/system-migrations/system-migrations.service.ts
@@ -92,6 +92,10 @@ export interface SystemMigrationEnrollmentStore {
      *  for this migration - a later step samples the step before it. */
     enrolledForMigrationName?: string;
     excludeOrganizationIds: string[];
+    /** Lift the enterprise-subscription exclusion for this draw. Defaults to
+     *  false at the repository, so a caller that says nothing gets the safe
+     *  pool rather than the wide one. */
+    includeEnterprise?: boolean;
   }): Promise<Array<{ id: string; name: string }>>;
   createMany(args: {
     organizationIds: string[];
@@ -422,15 +426,33 @@ export class SystemMigrationsService {
    * some fixed order every time - and the result names every organization
    * it picked, because an action over N organizations is only auditable if
    * it says which N.
+   *
+   * Both exclusions are DEFAULTS, not laws. They exist so an experimental
+   * cohort cannot sweep up the organizations we would least like to
+   * surprise; once a migration has proven itself across the long tail,
+   * finishing the rollout means taking those two classes over too, and an
+   * operator who has decided that should not have to enroll them one id at
+   * a time (the single-organization `enroll` never applied either
+   * exclusion). Each is lifted SEPARATELY and named in the audit trail:
+   * they carry different risks - an enterprise organization is a
+   * commercial one, a private-dataplane organization has its events in a
+   * ClickHouse instance of its own - and one checkbox for both would hide
+   * that.
    */
   async enrollCohort({
     migrationName,
     sampleSize,
     actorUserId,
+    includeEnterprise = false,
+    includePrivateDataplane = false,
   }: {
     migrationName: string;
     sampleSize: number;
     actorUserId: string;
+    /** Draw organizations with an active or pending ENTERPRISE subscription. */
+    includeEnterprise?: boolean;
+    /** Draw organizations whose events live in their own ClickHouse instance. */
+    includePrivateDataplane?: boolean;
   }): Promise<{
     enrolled: Array<{ id: string; name: string }>;
     eligibleCount: number;
@@ -450,7 +472,14 @@ export class SystemMigrationsService {
       await this.deps.enrollments.findCohortEligibleOrganizations({
         migrationName,
         enrolledForMigrationName: previous?.name,
-        excludeOrganizationIds: this.deps.privateDataplaneOrganizationIds(),
+        // Lifting the private-dataplane exclusion is simply not naming the
+        // ids, so the environment stays the only place those organizations
+        // are listed - the same reason the exclusion reads them from the
+        // routing table rather than from a constant.
+        excludeOrganizationIds: includePrivateDataplane
+          ? []
+          : this.deps.privateDataplaneOrganizationIds(),
+        includeEnterprise,
       });
     const picked = sample({ pool: eligible, count: sampleSize });
     const { insertedCount } = await this.deps.enrollments.createMany({
@@ -468,6 +497,10 @@ export class SystemMigrationsService {
         pickedCount: picked.length,
         insertedCount,
         eligibleCount: eligible.length,
+        // Which exclusions this cohort lifted, so a widened pool is legible
+        // in the log rather than inferred from an unusually large sample.
+        includeEnterprise,
+        includePrivateDataplane,
         organizationIds: picked.map((organization) => organization.id),
       },
       "operator enrolled a cohort for the in-place migration rollout",
@@ -481,7 +514,17 @@ export class SystemMigrationsService {
         userId: actorUserId,
         organizationId: organization.id,
         action: "systemMigrations.enrollCohort",
-        args: { migrationName, sampleSize, cohortSize: picked.length },
+        args: {
+          migrationName,
+          sampleSize,
+          cohortSize: picked.length,
+          // On the row itself, not only in the log: "was this organization
+          // drawn because an operator lifted an exclusion?" is a question
+          // asked of one organization, and the audit trail is where it is
+          // answered.
+          includeEnterprise,
+          includePrivateDataplane,
+        },
       });
     }
     return { enrolled: picked, eligibleCount: eligible.length };

--- a/specs/migration/system-migrations-runner.feature
+++ b/specs/migration/system-migrations-runner.feature
@@ -110,10 +110,47 @@ Feature: Running system migrations across organizations
     Then none of the already-enrolled organizations are drawn again
 
   @unit
-  Scenario: A cohort never includes an enterprise organization
+  Scenario: A cohort leaves out an enterprise organization by default
     Given an enterprise organization exists
     When a cohort is sampled
-    Then the enterprise organization is never drawn
+    Then the enterprise organization is not drawn
+
+  @unit
+  Scenario: A cohort leaves out a private-dataplane organization by default
+    Given an organization with a dedicated data plane exists
+    When a cohort is sampled
+    Then that organization is not drawn
+
+  # Finishing a proven rollout means taking the held-back organizations over
+  # too, and the single-organization enroll never applied either exclusion —
+  # so the only thing the default was buying was an operator enrolling them
+  # one id at a time.
+  @unit
+  Scenario: An operator can draw enterprise organizations into a cohort
+    Given an enterprise organization exists
+    When a cohort is sampled with enterprise organizations included
+    Then the enterprise organization can be drawn
+
+  @unit
+  Scenario: An operator can draw private-dataplane organizations into a cohort
+    Given an organization with a dedicated data plane exists
+    When a cohort is sampled with dedicated-data-plane organizations included
+    Then that organization can be drawn
+
+  # Two switches, not one: an enterprise organization is a commercial risk and
+  # a private-dataplane organization keeps its events in a ClickHouse instance
+  # of its own. Lifting one must never lift the other.
+  @unit
+  Scenario: Including one held-back class does not include the other
+    Given an enterprise organization and a dedicated-data-plane organization exist
+    When a cohort is sampled with only enterprise organizations included
+    Then the enterprise organization can be drawn
+    And the dedicated-data-plane organization is not drawn
+
+  @unit
+  Scenario: A widened cohort says so in the audit trail
+    When a cohort is sampled with a held-back class included
+    Then each enrolled organization's audit row records which classes were included
 
   @unit
   Scenario: A later step's cohort samples only organizations enrolled for the step before it


### PR DESCRIPTION
Cohort enrolment leaves out two classes of organization by data rather than by a list in code: an active or pending `ENTERPRISE` subscription, and any organization in the environment's private ClickHouse routing table. That is the right default for an experimental cohort and the wrong one for finishing a proven rollout.

The authz-engine migration is now finalized for **7,193 organizations**, and the ones still not enrolled are exactly those two held-back classes. The only way to take them over was the single-organization enroll — which never applied either exclusion — one id at a time.

## The change

Each exclusion can now be lifted for one draw:

```ts
enrollCohort({ ..., includeEnterprise?, includePrivateDataplane? })
```

Both default to `false` in the service, in the repository **and** in the tRPC input, so a caller that names neither gets exactly the pool it always got.

**Separately, not as one switch.** The risks differ in kind — an enterprise organization is a commercial relationship; a private-dataplane organization keeps its events in a ClickHouse instance of its own — and a single "include everything" control would hide that from whoever ticks it.

## Two details worth reviewing

**Lifting the private-dataplane exclusion is implemented as *not naming the ids*** rather than as a flag the repository interprets:

```ts
excludeOrganizationIds: includePrivateDataplane
  ? []
  : this.deps.privateDataplaneOrganizationIds(),
```

That keeps the environment's routing table the only place those organizations are listed — the same reason the exclusion reads them from the environment instead of a constant in code.

**Lifting the enterprise exclusion omits the `subscriptions` key entirely** rather than setting it to `undefined`. Identical to Prisma; not identical to a reader. Omitting the key says "this filter does not apply", which is what lifting an exclusion means.

## Audit

Both flags are recorded in the log line **and** on each per-organization audit row. "Was this organization drawn because someone lifted an exclusion?" is a question asked of *one* organization, and the per-organization row — with its indexed `organizationId` — is where that gets answered.

## UI

Two checkboxes under a "Organizations normally held back" heading. The dialog's description now names which classes the draw will include instead of always claiming both are left out, so what the reader is told matches the checkbox they just ticked.

The dialog is also split up on the way past. It now mounts only while open, which makes the draft state (sample size and both exclusions) starting fresh on every open **structural** rather than a hand-written reset in the button's `onClick` — and keeps the function inside the repo's 60-line budget, which the added fields had pushed it over.

## Tests

- 59 unit tests in `system-migrations`, all passing.
- New service tests: the private-dataplane lift stops naming the ids; lifting enterprise alone **keeps** the private-dataplane exclusion; a widened draw records both flags on the audit row.
- New repository integration test: the enterprise organizations enter the pool when the exclusion is lifted, while an already-enrolled organization and a caller-excluded id still stay out.
- New route test: a lifted exclusion reaches the service, and the other stays false.
- `check:feature-parity` reports `43/43 ✓ all bound`. One scenario was renamed — "A cohort never includes an enterprise organization" → "…leaves out an enterprise organization by default" — because "never" is no longer true, and its three `@scenario` annotations moved with it. One existing test also had the *enterprise* annotation on a *private-dataplane* assertion; it now carries the right one.
- Scoped typecheck and biome clean on every touched file.

**Not run locally:** the datastore-lane tests (`cohort-eligibility.integration`, `ops.migrationEnrollment`). This machine has no container runtime and no `LANGWATCH_TEST_*` endpoints configured, so that lane cannot start. CI covers them.

## Deployment Impact

None. No migration, no backfill, no config. The new inputs are optional and default to the existing behaviour at all three layers, so an older client and an un-ticked dialog both draw the same pool as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Operators can independently include enterprise organizations and dedicated-dataplane organizations when enrolling migration cohorts.
  - Enrollment dialogs clearly describe which organization types will be included or held back.
  - Selection options reset when reopening a dialog, and successful enrollment closes it automatically.
  - Enrollment records capture the selected organization categories for auditability.

- **Bug Fixes**
  - Enterprise and dedicated-dataplane organizations remain excluded by default unless explicitly selected.
  - Selecting one organization category no longer implicitly includes the other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->