### PR TITLE
feat(lwql): chart CLI family + lwql-charts skill (Langy authoring slice 2)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -55079,10 +55079,10 @@ LangWatchQL analytics is switched per project. If any chart command answers with
 Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
 
 ```bash
-langwatch chart schema --format json
+langwatch chart schema -o json
 ```
 
-Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+Read the datasets, their grain, their time column, and which columns are `available` to you. Saving validates the SQL against the analytics policy and the specification against the chart policy — it does not check that every column exists, so SQL naming a wrong column saves fine and only fails when the chart runs. Writing SQL against the schema you just read, then test-running the chart right after saving it (Step 3), is what catches a bad column before anyone sees it on a dashboard.
 
 ## Step 2: Write the SQL, using the reserved period parameters
 
@@ -55110,26 +55110,26 @@ langwatch chart create \
   --name "Traces per day" \
   --sql-file query.sql \
   --spec-file spec.json \
-  --format json
+  -o json
 ```
 
-`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates the SQL against the analytics policy and the specification against the chart policy before writing anything — a refusal means fix the input, not retry. It does not check column names against the schema, which is why the very next command is always a run: a chart that saves but names a wrong column fails only at run time.
 
 See the numbers before placing it:
 
 ```bash
 langwatch chart run <chart-id> \
   --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
-  --granularity 86400 --format json
+  --granularity 3600 -o json
 ```
 
-`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+`--start`/`--end` fill the reserved period parameters and `--granularity` the datapoint step, which only accepts the offered steps: `1` (second), `60` (minute), `3600` (hour). A chart whose SQL declares the reserved period parameters **requires** `--start` and `--end` on every run — there is no default window, and running without them is refused. Only a chart that declares none of them runs without the flags.
 
 ## Step 4: Place it on a dashboard
 
 ```bash
-langwatch dashboard list --format json          # find or create the target
-langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+langwatch dashboard list -o json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> -o json
 ```
 
 With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
@@ -55137,8 +55137,8 @@ With no `--grid-row`, the platform allocates the next free row, so it never land
 ## Managing saved charts
 
 ```bash
-langwatch chart list --format json
-langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart list -o json
+langwatch chart get <chart-id> -o json    # SQL, parameters, spec, placement
 langwatch chart update <chart-id> --sql-file query.sql
 langwatch chart delete <chart-id>
 ```
@@ -55146,7 +55146,7 @@ langwatch chart delete <chart-id>
 ## Failure modes worth knowing
 
 - `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
-- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- A save that succeeds but a run that fails with an unknown error — the SQL almost certainly names a column that does not exist; re-read the schema (Step 1) and fix the column, then update the chart.
 - `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
 - `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.
 ````

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -55008,6 +55008,162 @@ Write scenarios where the agent makes a mistake and must recover:
   </div>
 </div>
 
+<div className="lw-accordion">
+  <div className="lw-accordion-header" role="button" tabIndex={0} aria-expanded="false">
+    <span className="lw-accordion-title">Build a chart from a question and put it on my dashboard</span>
+    <svg className="lw-accordion-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9L12 15L18 9" /></svg>
+  </div>
+  <div className="lw-accordion-body">
+    <div className="lw-accordion-commands">
+      <div className="lw-accordion-cmd-col">
+        <div className="lw-accordion-cmd-label">Install via CLI</div>
+        <div className="lw-accordion-cmd-box" role="button" tabIndex={0} data-copy={"npx skills add langwatch/skills/recipes/lwql-charts"} data-track="docs_copy_skill_install" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-skill={"langwatch/skills/recipes/lwql-charts"}>
+          <code>npx skills add langwatch/skills/recipes/lwql-charts</code>
+          <span className="lw-inline-copy-btn lw-copy-line-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg></span>
+          <span className="lw-inline-copy-btn lw-copy-line-check" style={{ display: "none" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#059669" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17L4 12" /></svg></span>
+        </div>
+      </div>
+      <div className="lw-accordion-cmd-col">
+        <div className="lw-accordion-cmd-label">Skill Usage</div>
+        <div className="lw-accordion-cmd-box" role="button" tabIndex={0} data-copy={"/lwql-charts"} data-track="docs_copy_slash_command" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-command={"/lwql-charts"}>
+          <code><span className="lw-slash-command">/lwql-charts</span></code>
+          <span className="lw-inline-copy-btn lw-copy-line-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg></span>
+          <span className="lw-inline-copy-btn lw-copy-line-check" style={{ display: "none" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#059669" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17L4 12" /></svg></span>
+        </div>
+      </div>
+    </div>
+    <div className="lw-accordion-actions">
+      <div className="lw-accordion-action" role="button" tabIndex={0} data-copy-source="prompt" data-track="docs_copy_prompt" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-skill={"langwatch/skills/recipes/lwql-charts"}>
+        <span className="lw-accordion-action-icon lw-copy-line-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg></span>
+        <span className="lw-accordion-action-icon lw-copy-line-check" style={{ display: "none" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#059669" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17L4 12" /></svg></span>
+        <span className="lw-accordion-action-text">
+          <span className="lw-accordion-action-title">Copy Full Prompt</span>
+          <span className="lw-accordion-action-subtitle">Run skill without installing</span>
+        </span>
+        <div className="lw-prompt-source">
+
+````text
+Build a chart from a question and put it on my dashboard
+
+You are using LangWatch for your AI agent project. Follow these instructions.
+
+IMPORTANT: You will need a LangWatch API key. Check if LANGWATCH_API_KEY is already in the project's .env file. Use that key instead of asking for a new one. If they have a LANGWATCH_ENDPOINT in .env, they are on a self-hosted instance, so use that endpoint instead of app.langwatch.ai.
+Use the `langwatch` CLI for everything: documentation (`langwatch docs ...`, `langwatch scenario-docs ...`) and platform operations (prompts, scenarios, evaluators, datasets, monitors, traces, analytics). Install it with `npm install -g langwatch` (or run any command via `npx langwatch`).
+
+# Author a Chart and Place It on a Dashboard
+
+Turn a question ("how many traces per day?", "cost by model this week") into a saved chart that keeps updating on a dashboard. The loop is: **discover the schema → write and test-run the SQL → save the chart → place it**.
+
+## Prerequisites
+
+Use `langwatch docs <path>` to read documentation as Markdown. Some useful entry points:
+
+```bash
+langwatch docs                                    # Docs index
+langwatch docs integration/python/guide           # Python integration
+langwatch docs integration/typescript/guide       # TypeScript integration
+langwatch docs prompt-management/cli              # Prompts CLI
+langwatch scenario-docs                           # Scenario docs index
+```
+
+Discover commands with `langwatch --help` and `langwatch <subcommand> --help`. List and get commands accept `--format json` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
+
+If no shell is available, fetch the same Markdown over plain HTTP. Append `.md` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+If anything fails or confuses you while following this skill (broken commands, docs that do not match reality, errors you had to work around), ask the user for permission and run `npx --yes langwatch report --user-approved` with a `--title` and `--summary` (or `--session <transcript.jsonl>`) to send it to the LangWatch team, and it directly shapes what gets fixed. No login or API key needed. Nothing is sent without `--user-approved`, and `--dry-run` prints the exact payload without sending anything. The title, summary and transcript are scrubbed locally first, by pattern: secrets and API keys, plus email addresses, phone numbers, card numbers and public IPv4 addresses. Anything no pattern matches is sent as written, including a contact address passed with `--email`. With `--session`, always run `--dry-run` first and let the user read the payload, because a transcript carries content they never reviewed. `npx --yes langwatch report --help` explains the options.
+
+LangWatchQL analytics is switched per project. If any chart command answers with error code `lwql_not_enabled`, the feature is off for this project — tell the user, do not retry.
+
+## Step 1: Discover the schema before writing any SQL
+
+Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
+
+```bash
+langwatch chart schema --format json
+```
+
+Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+
+## Step 2: Write the SQL, using the reserved period parameters
+
+A chart that should follow the dashboard's period selector declares the reserved bound parameters instead of hardcoding dates:
+
+- `{period_start:DateTime}` / `{period_end:DateTime}` — the surface's period, half-open `[start, end)`
+- `{period_granularity_seconds:UInt32}` — the surface's datapoint step, in seconds
+
+```sql
+SELECT
+  toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket,
+  count() AS traces
+FROM analytics.traces
+WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}
+GROUP BY bucket
+ORDER BY bucket
+```
+
+Your own parameters (`{since:DateTime}`, `{model:String}`, …) get their values from `--param`; never pass a value for the reserved `period_*` names.
+
+## Step 3: Save the chart, then prove it runs
+
+```bash
+langwatch chart create \
+  --name "Traces per day" \
+  --sql-file query.sql \
+  --spec-file spec.json \
+  --format json
+```
+
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+
+See the numbers before placing it:
+
+```bash
+langwatch chart run <chart-id> \
+  --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
+  --granularity 86400 --format json
+```
+
+`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+
+## Step 4: Place it on a dashboard
+
+```bash
+langwatch dashboard list --format json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+```
+
+With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
+
+## Managing saved charts
+
+```bash
+langwatch chart list --format json
+langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart update <chart-id> --sql-file query.sql
+langwatch chart delete <chart-id>
+```
+
+## Failure modes worth knowing
+
+- `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
+- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
+- `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.
+````
+
+        </div>
+      </div>
+      <div className="lw-accordion-action" role="button" tabIndex={0} data-download-url="https://raw.githubusercontent.com/langwatch/skills/main/recipes/lwql-charts/SKILL.md" data-download-name="SKILL.md" data-track="docs_download_skill" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-skill={"langwatch/skills/recipes/lwql-charts"}>
+        <span className="lw-accordion-action-icon"><svg width="16" height="16" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.25 3.75H2.75C1.64543 3.75 0.75 4.64543 0.75 5.75V12.25C0.75 13.3546 1.64543 14.25 2.75 14.25H15.25C16.3546 14.25 17.25 13.3546 17.25 12.25V5.75C17.25 4.64543 16.3546 3.75 15.25 3.75Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /><path d="M8.75 11.25V6.75H8.356L6.25 9.5L4.144 6.75H3.75V11.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /><path d="M11.5 9.5L13.25 11.25L15 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /><path d="M13.25 11.25V6.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg></span>
+        <span className="lw-accordion-action-text">
+          <span className="lw-accordion-action-title">Download SKILL.md</span>
+          <span className="lw-accordion-action-subtitle">Manual installation</span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+
 {/* lw-generated:recipes:end */}
 
 <div className="lw-info-box">

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -6189,10 +6189,10 @@ LangWatchQL analytics is switched per project. If any chart command answers with
 Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
 
 ```bash
-langwatch chart schema --format json
+langwatch chart schema -o json
 ```
 
-Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+Read the datasets, their grain, their time column, and which columns are `available` to you. Saving validates the SQL against the analytics policy and the specification against the chart policy — it does not check that every column exists, so SQL naming a wrong column saves fine and only fails when the chart runs. Writing SQL against the schema you just read, then test-running the chart right after saving it (Step 3), is what catches a bad column before anyone sees it on a dashboard.
 
 ## Step 2: Write the SQL, using the reserved period parameters
 
@@ -6220,26 +6220,26 @@ langwatch chart create \
   --name "Traces per day" \
   --sql-file query.sql \
   --spec-file spec.json \
-  --format json
+  -o json
 ```
 
-`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates the SQL against the analytics policy and the specification against the chart policy before writing anything — a refusal means fix the input, not retry. It does not check column names against the schema, which is why the very next command is always a run: a chart that saves but names a wrong column fails only at run time.
 
 See the numbers before placing it:
 
 ```bash
 langwatch chart run <chart-id> \
   --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
-  --granularity 86400 --format json
+  --granularity 3600 -o json
 ```
 
-`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+`--start`/`--end` fill the reserved period parameters and `--granularity` the datapoint step, which only accepts the offered steps: `1` (second), `60` (minute), `3600` (hour). A chart whose SQL declares the reserved period parameters **requires** `--start` and `--end` on every run — there is no default window, and running without them is refused. Only a chart that declares none of them runs without the flags.
 
 ## Step 4: Place it on a dashboard
 
 ```bash
-langwatch dashboard list --format json          # find or create the target
-langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+langwatch dashboard list -o json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> -o json
 ```
 
 With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
@@ -6247,8 +6247,8 @@ With no `--grid-row`, the platform allocates the next free row, so it never land
 ## Managing saved charts
 
 ```bash
-langwatch chart list --format json
-langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart list -o json
+langwatch chart get <chart-id> -o json    # SQL, parameters, spec, placement
 langwatch chart update <chart-id> --sql-file query.sql
 langwatch chart delete <chart-id>
 ```
@@ -6256,7 +6256,7 @@ langwatch chart delete <chart-id>
 ## Failure modes worth knowing
 
 - `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
-- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- A save that succeeds but a run that fails with an unknown error — the SQL almost certainly names a column that does not exist; re-read the schema (Step 1) and fix the column, then update the chart.
 - `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
 - `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.
 ````

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -6118,6 +6118,162 @@ Write scenarios where the agent makes a mistake and must recover:
   </div>
 </div>
 
+<div className="lw-accordion">
+  <div className="lw-accordion-header" role="button" tabIndex={0} aria-expanded="false">
+    <span className="lw-accordion-title">Build a chart from a question and put it on my dashboard</span>
+    <svg className="lw-accordion-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9L12 15L18 9" /></svg>
+  </div>
+  <div className="lw-accordion-body">
+    <div className="lw-accordion-commands">
+      <div className="lw-accordion-cmd-col">
+        <div className="lw-accordion-cmd-label">Install via CLI</div>
+        <div className="lw-accordion-cmd-box" role="button" tabIndex={0} data-copy={"npx skills add langwatch/skills/recipes/lwql-charts"} data-track="docs_copy_skill_install" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-skill={"langwatch/skills/recipes/lwql-charts"}>
+          <code>npx skills add langwatch/skills/recipes/lwql-charts</code>
+          <span className="lw-inline-copy-btn lw-copy-line-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg></span>
+          <span className="lw-inline-copy-btn lw-copy-line-check" style={{ display: "none" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#059669" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17L4 12" /></svg></span>
+        </div>
+      </div>
+      <div className="lw-accordion-cmd-col">
+        <div className="lw-accordion-cmd-label">Skill Usage</div>
+        <div className="lw-accordion-cmd-box" role="button" tabIndex={0} data-copy={"/lwql-charts"} data-track="docs_copy_slash_command" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-command={"/lwql-charts"}>
+          <code><span className="lw-slash-command">/lwql-charts</span></code>
+          <span className="lw-inline-copy-btn lw-copy-line-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg></span>
+          <span className="lw-inline-copy-btn lw-copy-line-check" style={{ display: "none" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#059669" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17L4 12" /></svg></span>
+        </div>
+      </div>
+    </div>
+    <div className="lw-accordion-actions">
+      <div className="lw-accordion-action" role="button" tabIndex={0} data-copy-source="prompt" data-track="docs_copy_prompt" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-skill={"langwatch/skills/recipes/lwql-charts"}>
+        <span className="lw-accordion-action-icon lw-copy-line-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg></span>
+        <span className="lw-accordion-action-icon lw-copy-line-check" style={{ display: "none" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#059669" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17L4 12" /></svg></span>
+        <span className="lw-accordion-action-text">
+          <span className="lw-accordion-action-title">Copy Full Prompt</span>
+          <span className="lw-accordion-action-subtitle">Run skill without installing</span>
+        </span>
+        <div className="lw-prompt-source">
+
+````text
+Build a chart from a question and put it on my dashboard
+
+You are using LangWatch for your AI agent project. Follow these instructions.
+
+IMPORTANT: You will need a LangWatch API key. Check if LANGWATCH_API_KEY is already in the project's .env file. Use that key instead of asking for a new one. If they have a LANGWATCH_ENDPOINT in .env, they are on a self-hosted instance, so use that endpoint instead of app.langwatch.ai.
+Use the `langwatch` CLI for everything: documentation (`langwatch docs ...`, `langwatch scenario-docs ...`) and platform operations (prompts, scenarios, evaluators, datasets, monitors, traces, analytics). Install it with `npm install -g langwatch` (or run any command via `npx langwatch`).
+
+# Author a Chart and Place It on a Dashboard
+
+Turn a question ("how many traces per day?", "cost by model this week") into a saved chart that keeps updating on a dashboard. The loop is: **discover the schema → write and test-run the SQL → save the chart → place it**.
+
+## Prerequisites
+
+Use `langwatch docs <path>` to read documentation as Markdown. Some useful entry points:
+
+```bash
+langwatch docs                                    # Docs index
+langwatch docs integration/python/guide           # Python integration
+langwatch docs integration/typescript/guide       # TypeScript integration
+langwatch docs prompt-management/cli              # Prompts CLI
+langwatch scenario-docs                           # Scenario docs index
+```
+
+Discover commands with `langwatch --help` and `langwatch <subcommand> --help`. List and get commands accept `--format json` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
+
+If no shell is available, fetch the same Markdown over plain HTTP. Append `.md` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+If anything fails or confuses you while following this skill (broken commands, docs that do not match reality, errors you had to work around), ask the user for permission and run `npx --yes langwatch report --user-approved` with a `--title` and `--summary` (or `--session <transcript.jsonl>`) to send it to the LangWatch team, and it directly shapes what gets fixed. No login or API key needed. Nothing is sent without `--user-approved`, and `--dry-run` prints the exact payload without sending anything. The title, summary and transcript are scrubbed locally first, by pattern: secrets and API keys, plus email addresses, phone numbers, card numbers and public IPv4 addresses. Anything no pattern matches is sent as written, including a contact address passed with `--email`. With `--session`, always run `--dry-run` first and let the user read the payload, because a transcript carries content they never reviewed. `npx --yes langwatch report --help` explains the options.
+
+LangWatchQL analytics is switched per project. If any chart command answers with error code `lwql_not_enabled`, the feature is off for this project — tell the user, do not retry.
+
+## Step 1: Discover the schema before writing any SQL
+
+Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
+
+```bash
+langwatch chart schema --format json
+```
+
+Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+
+## Step 2: Write the SQL, using the reserved period parameters
+
+A chart that should follow the dashboard's period selector declares the reserved bound parameters instead of hardcoding dates:
+
+- `{period_start:DateTime}` / `{period_end:DateTime}` — the surface's period, half-open `[start, end)`
+- `{period_granularity_seconds:UInt32}` — the surface's datapoint step, in seconds
+
+```sql
+SELECT
+  toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket,
+  count() AS traces
+FROM analytics.traces
+WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}
+GROUP BY bucket
+ORDER BY bucket
+```
+
+Your own parameters (`{since:DateTime}`, `{model:String}`, …) get their values from `--param`; never pass a value for the reserved `period_*` names.
+
+## Step 3: Save the chart, then prove it runs
+
+```bash
+langwatch chart create \
+  --name "Traces per day" \
+  --sql-file query.sql \
+  --spec-file spec.json \
+  --format json
+```
+
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+
+See the numbers before placing it:
+
+```bash
+langwatch chart run <chart-id> \
+  --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
+  --granularity 86400 --format json
+```
+
+`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+
+## Step 4: Place it on a dashboard
+
+```bash
+langwatch dashboard list --format json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+```
+
+With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
+
+## Managing saved charts
+
+```bash
+langwatch chart list --format json
+langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart update <chart-id> --sql-file query.sql
+langwatch chart delete <chart-id>
+```
+
+## Failure modes worth knowing
+
+- `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
+- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
+- `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.
+````
+
+        </div>
+      </div>
+      <div className="lw-accordion-action" role="button" tabIndex={0} data-download-url="https://raw.githubusercontent.com/langwatch/skills/main/recipes/lwql-charts/SKILL.md" data-download-name="SKILL.md" data-track="docs_download_skill" data-track-title={"Build a chart from a question and put it on my dashboard"} data-track-skill={"langwatch/skills/recipes/lwql-charts"}>
+        <span className="lw-accordion-action-icon"><svg width="16" height="16" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.25 3.75H2.75C1.64543 3.75 0.75 4.64543 0.75 5.75V12.25C0.75 13.3546 1.64543 14.25 2.75 14.25H15.25C16.3546 14.25 17.25 13.3546 17.25 12.25V5.75C17.25 4.64543 16.3546 3.75 15.25 3.75Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /><path d="M8.75 11.25V6.75H8.356L6.25 9.5L4.144 6.75H3.75V11.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /><path d="M11.5 9.5L13.25 11.25L15 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /><path d="M13.25 11.25V6.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg></span>
+        <span className="lw-accordion-action-text">
+          <span className="lw-accordion-action-title">Download SKILL.md</span>
+          <span className="lw-accordion-action-subtitle">Manual installation</span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+
 {/* lw-generated:recipes:end */}
 
 <div className="lw-info-box">

--- a/docs/skills/skills-pages-manifest.json
+++ b/docs/skills/skills-pages-manifest.json
@@ -50,7 +50,7 @@
         "promptFile": "datasets.docs.txt"
       },
       {
-        "boldPrefix": "\u2b50 All of the above:",
+        "boldPrefix": "⭐ All of the above:",
         "title": "Take my agent to the next level",
         "skill": "langwatch/skills/level-up",
         "slashCommand": "/level-up",
@@ -59,7 +59,7 @@
     ],
     "recipes": [
       {
-        "boldPrefix": "\u2b50",
+        "boldPrefix": "⭐",
         "title": "What should I do next to improve my agent?",
         "skill": "langwatch/skills/agent-improve",
         "slashCommand": "/agent-improve",
@@ -124,6 +124,12 @@
         "skill": "langwatch/skills/recipes/test-cli-usability",
         "slashCommand": "/test-cli-usability",
         "promptFile": "recipes-test-cli-usability.docs.txt"
+      },
+      {
+        "title": "Build a chart from a question and put it on my dashboard",
+        "skill": "langwatch/skills/recipes/lwql-charts",
+        "slashCommand": "/lwql-charts",
+        "promptFile": "recipes-lwql-charts.docs.txt"
       }
     ]
   },

--- a/feature-map.json
+++ b/feature-map.json
@@ -770,9 +770,23 @@
             "graph get",
             "graph create",
             "graph update",
-            "graph delete"
+            "graph delete",
+            "chart schema",
+            "chart list",
+            "chart get",
+            "chart create",
+            "chart update",
+            "chart delete",
+            "chart run",
+            "chart place",
+            "chart unplace"
           ],
-          "skill": null,
+          "hints": {
+            "chart create": "langwatch chart create --name \"Traces per day\" --sql-file query.sql --param since=2026-01-01 --spec-file spec.json",
+            "chart run": "langwatch chart run <chart-id> --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z --granularity 3600",
+            "chart place": "langwatch chart place <chart-id> --dashboard-id <dashboard-id>"
+          },
+          "skill": "lwql-charts",
           "docs": null
         },
         "platform": {

--- a/packages/langy/src/cards/handled-error.ts
+++ b/packages/langy/src/cards/handled-error.ts
@@ -280,6 +280,43 @@ const asErrorBody = (value: unknown): ErrorBody | null => {
     };
   }
 
+  // Dialect 4: THE CANONICAL ONE, from the shared REST envelope
+  // (`app/api/shared/schemas.ts`) that the analytics-sql families and every
+  // new canonical-envelope route answer with:
+  // `{ error: { type, code, message, meta?, trace_id?, span_id? } }` — the
+  // whole failure NESTED under `error` as an object, so none of the flat
+  // readings below can see it. `code` is the discriminant, `type` the
+  // status-class alias the Go plane also emits; reasons ride inside
+  // `meta.reasons` and are lifted out. The Go plane's 402 additionally
+  // carries `tips` / `docs_url` at the same level.
+  const canonical = asRecord(record.error);
+  if (
+    canonical &&
+    !isSystemError(canonical) &&
+    (typeof canonical.code === "string" || typeof canonical.type === "string")
+  ) {
+    const code =
+      typeof canonical.code === "string"
+        ? canonical.code
+        : (canonical.type as string);
+    const { reasons: metaReasons, ...meta } = asRecord(canonical.meta) ?? {};
+    return {
+      code,
+      message:
+        typeof canonical.message === "string" && canonical.message !== code
+          ? canonical.message
+          : undefined,
+      meta,
+      traceId:
+        typeof canonical.trace_id === "string" ? canonical.trace_id : undefined,
+      reasons: asReasons(metaReasons),
+      suggestions:
+        asSuggestions(canonical.tips) ?? asSuggestions(canonical.suggestions),
+      docUrl:
+        typeof canonical.docs_url === "string" ? canonical.docs_url : undefined,
+    };
+  }
+
   // Dialects 1 and 3 (and the deprecated `kind`-only variant). One of them must
   // name the failure; without any, this is not the platform's shape at all.
   //

--- a/packages/langy/src/cards/handled-error.unit.test.ts
+++ b/packages/langy/src/cards/handled-error.unit.test.ts
@@ -249,6 +249,64 @@ describe("parseHandledError, given dialect 3 (the new framework envelope)", () =
  * `specs/features/domain-error-contract.feature` names the CLI as a consumer
  * that must be able to self-diagnose from these.
  */
+describe("parseHandledError, given dialect 4 (the canonical nested envelope)", () => {
+  it("reads code, sentence, trace and meta from under the `error` object", () => {
+    const parsed = parseHandledError({
+      status: 404,
+      body: {
+        error: {
+          type: "not_found",
+          code: "saved_workbench_chart_not_found",
+          message: "Saved chart not found.",
+          meta: { chart_id: "chart-1" },
+          trace_id: TRACE_ID,
+        },
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      code: "saved_workbench_chart_not_found",
+      message: "Saved chart not found.",
+      httpStatus: 404,
+      meta: { chart_id: "chart-1" },
+      traceId: TRACE_ID,
+      isHandled: true,
+    });
+  });
+
+  it("lifts the reason chain out of `meta.reasons`", () => {
+    const parsed = parseHandledError({
+      status: 400,
+      body: {
+        error: {
+          type: "bad_request",
+          code: "validation_error",
+          message: "The request didn't match the expected shape.",
+          meta: {
+            fields: ["granularitySeconds"],
+            reasons: [{ code: "schema_failure" }],
+          },
+        },
+      },
+    });
+
+    expect(parsed.meta).toEqual({ fields: ["granularitySeconds"] });
+    expect(parsed.reasons).toEqual([{ kind: "schema_failure" }]);
+  });
+
+  it("does not read a nested transport failure as the platform speaking", () => {
+    const parsed = parseHandledError({
+      status: 0,
+      body: {
+        error: { code: "ECONNREFUSED", errno: -61, syscall: "connect" },
+      },
+    });
+
+    expect(parsed.isHandled).toBe(false);
+    expect(parsed.code).toBe("network_error");
+  });
+});
+
 describe("parseHandledError, given the platform's remediation channel", () => {
   it("reads `tips` and `docsUrl`, the names the platform actually emits", () => {
     const parsed = parseHandledError({

--- a/platform/app/src/app/api/analytics-sql/__tests__/savedWorkbenchChartsRestApi.integration.test.ts
+++ b/platform/app/src/app/api/analytics-sql/__tests__/savedWorkbenchChartsRestApi.integration.test.ts
@@ -54,6 +54,8 @@ import {
   TeamUserRole,
 } from "~/generated/prisma/client";
 import { WORKBENCH_SQL_CHART_KIND } from "~/server/analytics/chartKinds";
+import { SavedWorkbenchChartService } from "~/server/analytics/saved-workbench-charts/savedWorkbenchChart.service";
+import { getProtectionsForProject } from "~/server/api/utils";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
@@ -1057,6 +1059,185 @@ describe("given the saved workbench chart REST endpoints", () => {
     it("refuses before any chart is considered", async () => {
       const response = await app.request(chartsPath(openProject));
       expect(response.status).toBe(401);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Langy's CLI, at the wire. The `langwatch chart` family is a thin typed
+  // client over exactly these endpoints — its flag-to-request mapping is
+  // pinned by the SDK's own unit suite (chart-commands.unit.test.ts), so what
+  // these cases prove is the half the CLI cannot: that the requests the CLI
+  // emits, sent through the shipped HTTP app, land in the same rows, refusals
+  // and governors as every other path.
+  // ---------------------------------------------------------------------------
+
+  describe("given Langy drives the chart CLI against the API", () => {
+    /** The exact body `langwatch chart create --name … --sql-file … --param … --spec-file …` sends. */
+    const cliCreateBody = (name: string) => ({
+      name,
+      definition: {
+        version: 1,
+        sql: SQL,
+        parameters: { since: "2026-02-01 00:00:00" },
+        vegaLiteSpec: SPEC,
+      },
+    });
+
+    describe("when it creates a chart and reads it back by id", () => {
+      /** @scenario "Langy creates a chart with the CLI and reads it back with the same query, parameters and specification" */
+      it("returns the submitted SQL, parameter values and specification unchanged", async () => {
+        const created = await succeeds({
+          path: chartsPath(openProject),
+          method: "POST",
+          auth: asProject(openProject),
+          status: 201,
+          body: cliCreateBody("Langy's chart"),
+        });
+
+        const read = await succeeds({
+          path: chartPath(openProject, created.id),
+          auth: asProject(openProject),
+        });
+        expect(read.definition.sql).toBe(SQL);
+        expect(read.definition.parameters).toEqual({
+          since: "2026-02-01 00:00:00",
+        });
+        expect(read.definition.vegaLiteSpec).toEqual(SPEC);
+      });
+    });
+
+    describe("when its chart is compared against one saved through the application", () => {
+      /** @scenario "A chart Langy creates is indistinguishable from one a member saves by hand" */
+      it("stores a row equal on kind, definition shape and project scoping", async () => {
+        const viaCli = await succeeds({
+          path: chartsPath(openProject),
+          method: "POST",
+          auth: asProject(openProject),
+          status: 201,
+          body: cliCreateBody("Langy's twin"),
+        });
+
+        // The application's own save path: the service the tRPC router calls,
+        // with the member's protections resolved the same way.
+        const viaApplication = await SavedWorkbenchChartService.create(
+          prisma,
+        ).createChart({
+          projectId: openProject.id,
+          protections: await getProtectionsForProject(prisma, {
+            projectId: openProject.id,
+          }),
+          input: {
+            name: "Member's twin",
+            definition: cliCreateBody("unused").definition,
+          },
+        });
+
+        const rows = await prisma.customGraph.findMany({
+          where: {
+            projectId: openProject.id,
+            id: { in: [viaCli.id, viaApplication.id] },
+          },
+        });
+        expect(rows).toHaveLength(2);
+        const [first, second] = rows as unknown as [Body, Body];
+        expect(first.kind).toBe(WORKBENCH_SQL_CHART_KIND);
+        expect(second.kind).toBe(WORKBENCH_SQL_CHART_KIND);
+        expect(first.graph).toEqual(second.graph);
+        expect(first.projectId).toBe(second.projectId);
+      });
+    });
+
+    describe("when its credentials cannot read a column the SQL names", () => {
+      /** @scenario "SQL naming a column Langy's credentials cannot read is refused identically everywhere" */
+      it("is refused with the same validator code via the CLI's wire, REST directly, and the application's save path", async () => {
+        // The CLI's wire: the chart-create request `langwatch chart create` emits.
+        const viaCli = await refused({
+          path: chartsPath(gatedProject),
+          method: "POST",
+          auth: asProject(gatedProject),
+          body: {
+            name: "Withheld, via CLI",
+            definition: { ...DEFINITION, sql: GATED_SQL },
+          },
+        });
+
+        // REST directly: the governed query door with the same statement.
+        const viaRest = await refused({
+          path: `/api/v1/projects/${gatedProject.id}/analytics/query/clickhouse`,
+          method: "POST",
+          auth: asProject(gatedProject),
+          body: { sql: GATED_SQL },
+        });
+
+        // The application's own save path.
+        let viaApplication: string | undefined;
+        try {
+          await SavedWorkbenchChartService.create(prisma).createChart({
+            projectId: gatedProject.id,
+            protections: await getProtectionsForProject(prisma, {
+              projectId: gatedProject.id,
+            }),
+            input: {
+              name: "Withheld, via application",
+              definition: { ...DEFINITION, sql: GATED_SQL },
+            },
+          });
+        } catch (error) {
+          viaApplication = (error as { code?: string }).code;
+        }
+
+        expect(viaCli.error.code).toBe("lwql_not_permitted");
+        expect(viaRest.error.code).toBe(viaCli.error.code);
+        expect(viaApplication).toBe(viaCli.error.code);
+      });
+    });
+
+    describe("when it submits a specification the chart policy refuses", () => {
+      /** @scenario "A specification the chart policy refuses cannot be written through the CLI" */
+      it("answers the specification-refused code, and no chart is created", async () => {
+        const before = await listedIds(openProject);
+
+        const refusal = await refused({
+          path: chartsPath(openProject),
+          method: "POST",
+          auth: asProject(openProject),
+          body: {
+            name: "Network-loading spec via CLI",
+            definition: { ...DEFINITION, vegaLiteSpec: NETWORK_SPEC },
+          },
+        });
+        expect(refusal.error.code).toBe(
+          "saved_workbench_chart_specification_refused",
+        );
+
+        expect(await listedIds(openProject)).toEqual(before);
+      });
+    });
+
+    describe("when it places a saved chart on a dashboard", () => {
+      /** @scenario "Langy places a saved chart on a dashboard with the CLI" */
+      it("sets the dashboard id and grid position, and the chart lists among the dashboard's charts", async () => {
+        const chart = await createChart(openProject, {
+          name: "Langy placed this",
+        });
+        const dashboard = await createDashboard(openProject);
+
+        // The exact request `langwatch chart place <id> --dashboard-id <d>` emits.
+        const placed = await succeeds({
+          path: placementPath(openProject, chart.id),
+          method: "PUT",
+          auth: asProject(openProject),
+          body: { dashboardId: dashboard.id },
+        });
+        expect(placed.dashboardId).toBe(dashboard.id);
+        expect(typeof placed.gridRow).toBe("number");
+
+        const dashboardCharts = await prisma.customGraph.findMany({
+          where: { projectId: openProject.id, dashboardId: dashboard.id },
+          select: { id: true },
+        });
+        expect(dashboardCharts.map((row) => row.id)).toContain(chart.id);
+      });
     });
   });
 });

--- a/platform/app/src/features/langy/components/capabilities/capabilityCatalog.ts
+++ b/platform/app/src/features/langy/components/capabilities/capabilityCatalog.ts
@@ -230,6 +230,11 @@ export const CAPABILITY_CATALOG = {
     digestStrategy: "id-ref",
     noun: { singular: "graph", plural: "graphs" },
   },
+  chart: {
+    surface: "dashboards",
+    digestStrategy: "id-ref",
+    noun: { singular: "chart", plural: "charts" },
+  },
   trigger: {
     surface: "automations",
     digestStrategy: "id-ref",

--- a/sdks/typescript/src/cli/commands/charts/__tests__/chart-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/charts/__tests__/chart-commands.unit.test.ts
@@ -1,0 +1,350 @@
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChartsApiError } from "@/client-sdk/services/charts/charts-api.service";
+
+vi.mock("@/client-sdk/services/charts/charts-api.service", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    ChartsApiService: vi.fn(),
+  };
+});
+
+vi.mock("../../../utils/apiKey", () => ({
+  resolveCredentials: vi.fn(async () => ({
+    apiKey: "test-key",
+    source: "env",
+    endpoint: "https://app.langwatch.ai",
+    projectId: "project-1",
+  })),
+}));
+
+vi.mock("ora", () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+  }),
+}));
+
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { createChartCommand } from "../create";
+import { deleteChartCommand } from "../delete";
+import { getChartCommand } from "../get";
+import { listChartsCommand } from "../list";
+import { placeChartCommand } from "../place";
+import { runChartCommand } from "../run";
+import { unplaceChartCommand } from "../unplace";
+import { updateChartCommand } from "../update";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const noop = () => {
+  // intentionally empty — suppresses output during tests
+};
+
+const CHART = {
+  id: "chart-1",
+  name: "Traces per day",
+  definition: {
+    version: 1,
+    sql: "SELECT count() AS value FROM analytics.traces WHERE OccurredAt >= {since:DateTime}",
+    parameters: { since: "2026-02-01 00:00:00" },
+    vegaLiteSpec: { mark: "bar" },
+  },
+  createdAt: "2026-01-01",
+  updatedAt: "2026-01-02",
+  platformUrl: "https://app.langwatch.ai/project/analytics",
+  dashboardId: null,
+  gridColumn: 0,
+  gridRow: 0,
+  colSpan: 1,
+  rowSpan: 1,
+};
+
+interface ServiceMocks {
+  schema: ReturnType<typeof vi.fn>;
+  list: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  place: ReturnType<typeof vi.fn>;
+  unplace: ReturnType<typeof vi.fn>;
+  runQuery: ReturnType<typeof vi.fn>;
+}
+
+const installServiceMocks = (): ServiceMocks => {
+  const mocks: ServiceMocks = {
+    schema: vi.fn(),
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    place: vi.fn(),
+    unplace: vi.fn(),
+    runQuery: vi.fn(),
+  };
+  vi.mocked(ChartsApiService).mockImplementation(function () {
+    return mocks as unknown as ChartsApiService;
+  });
+  return mocks;
+};
+
+let mocks: ServiceMocks;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks = installServiceMocks();
+  vi.spyOn(console, "log").mockImplementation(noop);
+  vi.spyOn(console, "error").mockImplementation(noop);
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new ProcessExitError(code as number);
+  });
+});
+
+describe("createChartCommand()", () => {
+  describe("when given a statement, parameters and a specification file", () => {
+    it("maps the flags into one create call with a v1 definition", async () => {
+      mocks.create.mockResolvedValue(CHART);
+      const dir = mkdtempSync(join(tmpdir(), "chart-cli-"));
+      const specPath = join(dir, "spec.json");
+      writeFileSync(specPath, JSON.stringify({ mark: "bar" }));
+
+      await createChartCommand({
+        name: "Traces per day",
+        sql: CHART.definition.sql,
+        param: ["since=2026-02-01 00:00:00", "limit=7", "active=true"],
+        specFile: specPath,
+      });
+
+      expect(mocks.create).toHaveBeenCalledWith({
+        name: "Traces per day",
+        definition: {
+          version: 1,
+          sql: CHART.definition.sql,
+          parameters: {
+            since: "2026-02-01 00:00:00",
+            limit: 7,
+            active: true,
+          },
+          vegaLiteSpec: { mark: "bar" },
+        },
+      });
+    });
+
+    it("reads the statement from --sql-file when given one", async () => {
+      mocks.create.mockResolvedValue(CHART);
+      const dir = mkdtempSync(join(tmpdir(), "chart-cli-"));
+      const sqlPath = join(dir, "query.sql");
+      writeFileSync(sqlPath, "SELECT 1 AS value");
+
+      await createChartCommand({ name: "From file", sqlFile: sqlPath });
+
+      expect(mocks.create).toHaveBeenCalledWith({
+        name: "From file",
+        definition: { version: 1, sql: "SELECT 1 AS value", parameters: {} },
+      });
+    });
+  });
+
+  describe("when no statement is supplied", () => {
+    it("refuses locally without calling the API", async () => {
+      await expect(
+        createChartCommand({ name: "No SQL" }),
+      ).rejects.toThrow(ProcessExitError);
+      expect(mocks.create).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("updateChartCommand()", () => {
+  describe("when nothing is supplied to change", () => {
+    it("refuses locally, matching the API's own refusal of an empty update", async () => {
+      await expect(updateChartCommand("chart-1", {})).rejects.toThrow(
+        ProcessExitError,
+      );
+      expect(mocks.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when only a name is supplied", () => {
+    it("sends the name and no definition", async () => {
+      mocks.update.mockResolvedValue({ ...CHART, name: "Renamed" });
+
+      await updateChartCommand("chart-1", { name: "Renamed" });
+
+      expect(mocks.update).toHaveBeenCalledWith("chart-1", {
+        name: "Renamed",
+      });
+    });
+  });
+});
+
+describe("runChartCommand()", () => {
+  describe("when run with a period and a granularity", () => {
+    it("reads the chart, then executes its own SQL and stored parameters with the window", async () => {
+      mocks.get.mockResolvedValue(CHART);
+      mocks.runQuery.mockResolvedValue({
+        columns: [{ name: "value", type: "UInt64" }],
+        rows: [{ value: 42 }],
+        statistics: { elapsedMs: 5, rowsRead: 1, bytesRead: 8, rowsReturned: 1 },
+        truncated: false,
+        followsTimeWindow: true,
+        followsGranularity: true,
+        diagnostics: [],
+      });
+
+      await runChartCommand("chart-1", {
+        start: "2026-08-01T00:00:00Z",
+        end: "2026-08-08T00:00:00Z",
+        granularity: "3600",
+      });
+
+      expect(mocks.runQuery).toHaveBeenCalledWith({
+        sql: CHART.definition.sql,
+        parameters: CHART.definition.parameters,
+        timeWindow: {
+          start: "2026-08-01T00:00:00Z",
+          end: "2026-08-08T00:00:00Z",
+        },
+        granularitySeconds: 3600,
+      });
+    });
+  });
+
+  describe("when only one of --start/--end is given", () => {
+    it("refuses locally without calling the API", async () => {
+      await expect(
+        runChartCommand("chart-1", { start: "2026-08-01T00:00:00Z" }),
+      ).rejects.toThrow(ProcessExitError);
+      expect(mocks.get).not.toHaveBeenCalled();
+      expect(mocks.runQuery).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("placeChartCommand()", () => {
+  describe("when given a dashboard and no grid position", () => {
+    it("sends only the dashboard id, leaving allocation to the platform", async () => {
+      mocks.place.mockResolvedValue({
+        ...CHART,
+        dashboardId: "dashboard-1",
+        gridRow: 2,
+      });
+
+      await placeChartCommand("chart-1", { dashboardId: "dashboard-1" });
+
+      expect(mocks.place).toHaveBeenCalledWith("chart-1", {
+        dashboardId: "dashboard-1",
+      });
+    });
+  });
+
+  describe("when no dashboard id is given", () => {
+    it("refuses locally without calling the API", async () => {
+      await expect(placeChartCommand("chart-1", {})).rejects.toThrow(
+        ProcessExitError,
+      );
+      expect(mocks.place).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("the chart family's machine output", () => {
+  describe("when each verb's result is requested as JSON", () => {
+    /** @scenario "Every new CLI verb is machine-readable, not just human-formatted" */
+    it("returns data that JSON round-trips with no human-only formatting in it", async () => {
+      mocks.list.mockResolvedValue({ data: [CHART] });
+      mocks.get.mockResolvedValue(CHART);
+      mocks.create.mockResolvedValue(CHART);
+      mocks.update.mockResolvedValue(CHART);
+      mocks.delete.mockResolvedValue({ id: CHART.id, name: CHART.name });
+      mocks.place.mockResolvedValue({ ...CHART, dashboardId: "dashboard-1" });
+      mocks.unplace.mockResolvedValue(undefined);
+      mocks.runQuery.mockResolvedValue({
+        columns: [],
+        rows: [],
+        statistics: { elapsedMs: 1, rowsRead: 0, bytesRead: 0, rowsReturned: 0 },
+        truncated: false,
+        followsTimeWindow: false,
+        followsGranularity: false,
+        diagnostics: [],
+      });
+
+      const results = [
+        await listChartsCommand(),
+        await getChartCommand(CHART.id),
+        await createChartCommand({
+          name: CHART.name,
+          sql: CHART.definition.sql,
+        }),
+        await updateChartCommand(CHART.id, { name: "Renamed" }),
+        await deleteChartCommand(CHART.id),
+        await runChartCommand(CHART.id, {}),
+        await placeChartCommand(CHART.id, { dashboardId: "dashboard-1" }),
+        await unplaceChartCommand(CHART.id),
+      ];
+
+      for (const result of results) {
+        expect(result, "every verb returns a CommandResult").toBeTruthy();
+        const serialized = JSON.stringify(result!.data);
+        // Parseable, lossless, and free of terminal escape codes: an agent
+        // reads this without ever seeing the human table.
+        expect(JSON.parse(serialized)).toEqual(result!.data);
+        expect(serialized).not.toContain("\u001b");
+      }
+    });
+  });
+});
+
+describe("the chart family while the workbench switch is off", () => {
+  describe("when the platform answers every verb with lwql_not_enabled", () => {
+    /** @scenario "Every CLI verb this slice adds refuses while the workbench switch is off, and writes nothing" */
+    it("every verb exits non-zero, surfacing the refusal instead of swallowing it", async () => {
+      const flagOff = new ChartsApiError(
+        "Failed: lwql_not_enabled",
+        "workbench switch off",
+      );
+      mocks.list.mockRejectedValue(flagOff);
+      mocks.get.mockRejectedValue(flagOff);
+      mocks.create.mockRejectedValue(flagOff);
+      mocks.update.mockRejectedValue(flagOff);
+      mocks.delete.mockRejectedValue(flagOff);
+      mocks.place.mockRejectedValue(flagOff);
+      mocks.unplace.mockRejectedValue(flagOff);
+      mocks.runQuery.mockRejectedValue(flagOff);
+
+      const attempts: [string, () => Promise<unknown>][] = [
+        ["create", () => createChartCommand({ name: "x", sql: "SELECT 1" })],
+        ["update", () => updateChartCommand("chart-1", { name: "y" })],
+        ["delete", () => deleteChartCommand("chart-1")],
+        ["run", () => runChartCommand("chart-1", {})],
+        [
+          "place",
+          () => placeChartCommand("chart-1", { dashboardId: "dashboard-1" }),
+        ],
+        ["unplace", () => unplaceChartCommand("chart-1")],
+      ];
+
+      for (const [verb, attempt] of attempts) {
+        await expect(attempt(), verb).rejects.toThrow(ProcessExitError);
+      }
+      // The refusal came from the platform's switch, before any row was
+      // written — nothing here retried or fell back to another write path.
+      expect(mocks.create).toHaveBeenCalledTimes(1);
+      expect(mocks.update).toHaveBeenCalledTimes(1);
+      expect(mocks.delete).toHaveBeenCalledTimes(1);
+      expect(mocks.place).toHaveBeenCalledTimes(1);
+      expect(mocks.unplace).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/sdks/typescript/src/cli/commands/charts/__tests__/chart-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/charts/__tests__/chart-commands.unit.test.ts
@@ -230,6 +230,60 @@ describe("runChartCommand()", () => {
       expect(mocks.runQuery).not.toHaveBeenCalled();
     });
   });
+
+  describe("when --granularity is not one of the offered steps", () => {
+    it("refuses locally, naming the offered steps, without calling the API", async () => {
+      const errorSpy = vi.mocked(console.error);
+
+      await expect(
+        runChartCommand("chart-1", { granularity: "86400" }),
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(mocks.get).not.toHaveBeenCalled();
+      expect(mocks.runQuery).not.toHaveBeenCalled();
+      const message = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      // The refusal names every offered step, so the caller does not have to
+      // guess which values the API accepts.
+      expect(message).toContain("1 (1 second)");
+      expect(message).toContain("60 (1 minute)");
+      expect(message).toContain("3600 (1 hour)");
+    });
+  });
+
+  describe("when --granularity is an offered step", () => {
+    it("passes it through to the query", async () => {
+      mocks.get.mockResolvedValue(CHART);
+      mocks.runQuery.mockResolvedValue({
+        columns: [],
+        rows: [],
+        statistics: { elapsedMs: 1, rowsRead: 0, bytesRead: 0, rowsReturned: 0 },
+        truncated: false,
+        followsTimeWindow: false,
+        followsGranularity: true,
+        diagnostics: [],
+      });
+
+      await runChartCommand("chart-1", { granularity: "60" });
+
+      expect(mocks.runQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ granularitySeconds: 60 }),
+      );
+    });
+  });
+});
+
+describe("deleteChartCommand()", () => {
+  describe("when the platform answers 204 with no body", () => {
+    it("confirms via the id the caller passed instead of reading a body", async () => {
+      mocks.delete.mockResolvedValue(undefined);
+
+      const result = await deleteChartCommand("chart-1");
+
+      expect(mocks.delete).toHaveBeenCalledWith("chart-1");
+      expect(result).toBeTruthy();
+      expect(result!.data).toEqual({ id: "chart-1", deleted: true });
+    });
+  });
 });
 
 describe("placeChartCommand()", () => {
@@ -267,7 +321,7 @@ describe("the chart family's machine output", () => {
       mocks.get.mockResolvedValue(CHART);
       mocks.create.mockResolvedValue(CHART);
       mocks.update.mockResolvedValue(CHART);
-      mocks.delete.mockResolvedValue({ id: CHART.id, name: CHART.name });
+      mocks.delete.mockResolvedValue(undefined);
       mocks.place.mockResolvedValue({ ...CHART, dashboardId: "dashboard-1" });
       mocks.unplace.mockResolvedValue(undefined);
       mocks.runQuery.mockResolvedValue({

--- a/sdks/typescript/src/cli/commands/charts/create.ts
+++ b/sdks/typescript/src/cli/commands/charts/create.ts
@@ -1,0 +1,68 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+import {
+  ChartInputError,
+  type DefinitionFlags,
+  resolveDefinitionInput,
+} from "./definitionInput";
+
+/**
+ * Returns the created chart rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
+export const createChartCommand = async (
+  options: DefinitionFlags & { name?: string; project?: string },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options.project });
+
+  if (!options.name) {
+    console.error(chalk.red("Error: --name is required"));
+    process.exit(1);
+  }
+
+  let definition;
+  try {
+    definition = resolveDefinitionInput(options);
+  } catch (error) {
+    if (error instanceof ChartInputError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+      process.exit(1);
+    }
+    throw error;
+  }
+  if (!definition) {
+    console.error(
+      chalk.red("Error: a chart needs its statement — pass --sql or --sql-file"),
+    );
+    process.exit(1);
+  }
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(`Creating chart "${options.name}"...`).start();
+
+  try {
+    const chart = await service.create({ name: options.name, definition });
+
+    spinner.succeed(
+      `Created chart "${chalk.cyan(chart.name)}" ${chalk.gray(`(id: ${chart.id})`)}`,
+    );
+
+    return {
+      data: chart,
+      table: () => {
+        if (chart.platformUrl) {
+          console.log(
+            `  ${chalk.bold("View:")}  ${chalk.underline(chart.platformUrl)}`,
+          );
+        }
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "create chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/definitionInput.ts
+++ b/sdks/typescript/src/cli/commands/charts/definitionInput.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "fs";
+import type {
+  ChartParameterValue,
+  SavedChartDefinitionInput,
+} from "@/client-sdk/services/charts/charts-api.service";
+
+/** The flags `chart create` and `chart update` share for the definition. */
+export interface DefinitionFlags {
+  sql?: string;
+  sqlFile?: string;
+  param?: string[];
+  specFile?: string;
+}
+
+/** Thrown for input the CLI can refuse before any request is made. */
+export class ChartInputError extends Error {}
+
+/**
+ * Parses one repeatable `--param key=value` flag. Values that read as JSON
+ * scalars are sent as those scalars (`--param since=7` binds a number,
+ * `--param active=true` a boolean) so a saved parameter keeps the type the
+ * statement's placeholder declares; anything else is sent as the string.
+ */
+export const parseParameterFlags = (
+  flags: string[],
+): Record<string, ChartParameterValue> => {
+  const parameters: Record<string, ChartParameterValue> = {};
+  for (const flag of flags) {
+    const separator = flag.indexOf("=");
+    if (separator <= 0) {
+      throw new ChartInputError(
+        `Invalid --param "${flag}": expected key=value`,
+      );
+    }
+    const key = flag.slice(0, separator);
+    const raw = flag.slice(separator + 1);
+    parameters[key] = coerceScalar(raw);
+  }
+  return parameters;
+};
+
+const coerceScalar = (raw: string): ChartParameterValue => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "string" ||
+      typeof parsed === "number" ||
+      typeof parsed === "boolean" ||
+      parsed === null
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Not JSON — a plain string value.
+  }
+  return raw;
+};
+
+/**
+ * Resolves the definition flags into the request's definition, or undefined
+ * when no definition flag was supplied at all (an update touching only the
+ * name). `--sql` and `--sql-file` are mutually exclusive; a definition needs
+ * one of them, because parameters and a specification mean nothing without
+ * the statement they belong to.
+ */
+export const resolveDefinitionInput = (
+  flags: DefinitionFlags,
+): SavedChartDefinitionInput | undefined => {
+  const hasDefinitionFlag =
+    flags.sql !== undefined ||
+    flags.sqlFile !== undefined ||
+    (flags.param?.length ?? 0) > 0 ||
+    flags.specFile !== undefined;
+  if (!hasDefinitionFlag) return undefined;
+
+  if (flags.sql !== undefined && flags.sqlFile !== undefined) {
+    throw new ChartInputError(
+      "Pass either --sql or --sql-file, not both",
+    );
+  }
+  const sql = flags.sql ?? (flags.sqlFile ? readSqlFile(flags.sqlFile) : undefined);
+  if (sql === undefined || sql.trim().length === 0) {
+    throw new ChartInputError(
+      "A definition needs its statement: pass --sql or --sql-file",
+    );
+  }
+
+  const definition: SavedChartDefinitionInput = {
+    version: 1,
+    sql,
+    parameters: parseParameterFlags(flags.param ?? []),
+  };
+  if (flags.specFile !== undefined) {
+    definition.vegaLiteSpec = readSpecFile(flags.specFile);
+  }
+  return definition;
+};
+
+const readSqlFile = (path: string): string => {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    throw new ChartInputError(`Could not read SQL file: ${path}`);
+  }
+};
+
+const readSpecFile = (path: string): Record<string, unknown> => {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    throw new ChartInputError(`Could not read specification file: ${path}`);
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new ChartInputError(
+        `Specification file is not a JSON object: ${path}`,
+      );
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof ChartInputError) throw error;
+    throw new ChartInputError(
+      `Specification file is not valid JSON: ${path}`,
+    );
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/delete.ts
+++ b/sdks/typescript/src/cli/commands/charts/delete.ts
@@ -1,0 +1,38 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the deleted chart's identity rather than printing it: the output
+ * port renders it in whatever format the caller asked for (utils/output.ts).
+ */
+export const deleteChartCommand = async (
+  id: string,
+  options?: { project?: string },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options?.project });
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(`Deleting chart "${id}"...`).start();
+
+  try {
+    const deleted = await service.delete(id);
+
+    spinner.succeed(
+      `Deleted chart "${chalk.cyan(deleted.name)}" ${chalk.gray(`(id: ${deleted.id})`)}`,
+    );
+
+    return {
+      data: deleted,
+      table: () => {
+        // The spinner line already says everything the human form carries.
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "delete chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/delete.ts
+++ b/sdks/typescript/src/cli/commands/charts/delete.ts
@@ -8,6 +8,8 @@ import type { CommandResult } from "../../utils/output";
 /**
  * Returns the deleted chart's identity rather than printing it: the output
  * port renders it in whatever format the caller asked for (utils/output.ts).
+ * The route answers `204` with no body, so the confirmation carries the id
+ * the caller passed — there is no response body to read a name from.
  */
 export const deleteChartCommand = async (
   id: string,
@@ -19,14 +21,12 @@ export const deleteChartCommand = async (
   const spinner = createSpinner(`Deleting chart "${id}"...`).start();
 
   try {
-    const deleted = await service.delete(id);
+    await service.delete(id);
 
-    spinner.succeed(
-      `Deleted chart "${chalk.cyan(deleted.name)}" ${chalk.gray(`(id: ${deleted.id})`)}`,
-    );
+    spinner.succeed(`Deleted chart "${chalk.cyan(id)}"`);
 
     return {
-      data: deleted,
+      data: { id: id, deleted: true },
       table: () => {
         // The spinner line already says everything the human form carries.
       },

--- a/sdks/typescript/src/cli/commands/charts/get.ts
+++ b/sdks/typescript/src/cli/commands/charts/get.ts
@@ -1,0 +1,68 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the chart rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
+export const getChartCommand = async (
+  id: string,
+  options?: { project?: string },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options?.project });
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(`Fetching chart "${id}"...`).start();
+
+  try {
+    const chart = await service.get(id);
+
+    spinner.succeed(`Found chart "${chart.name}"`);
+
+    return {
+      data: chart,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}        ${chalk.green(chart.id)}`);
+        console.log(`  ${chalk.gray("Name:")}      ${chalk.cyan(chart.name)}`);
+        console.log(
+          `  ${chalk.gray("Dashboard:")} ${chart.dashboardId ? chalk.cyan(chart.dashboardId) : chalk.gray("not placed")}`,
+        );
+        if (chart.dashboardId) {
+          console.log(
+            `  ${chalk.gray("Grid:")}      column ${chart.gridColumn}, row ${chart.gridRow}, spans ${chart.colSpan}x${chart.rowSpan}`,
+          );
+        }
+        console.log();
+        console.log(`  ${chalk.gray("SQL:")}`);
+        for (const line of chart.definition.sql.split("\n")) {
+          console.log(`    ${line}`);
+        }
+        const parameterNames = Object.keys(chart.definition.parameters);
+        if (parameterNames.length > 0) {
+          console.log();
+          console.log(`  ${chalk.gray("Parameters:")}`);
+          for (const name of parameterNames) {
+            console.log(
+              `    ${chalk.cyan(name)} = ${JSON.stringify(chart.definition.parameters[name])}`,
+            );
+          }
+        }
+        if (chart.platformUrl) {
+          console.log();
+          console.log(
+            `  ${chalk.bold("View:")}  ${chalk.underline(chart.platformUrl)}`,
+          );
+        }
+        console.log();
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "fetch chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/list.ts
+++ b/sdks/typescript/src/cli/commands/charts/list.ts
@@ -1,0 +1,74 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { formatTable, formatRelativeTime } from "../../utils/formatting";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
+export const listChartsCommand = async (options?: {
+  project?: string;
+}): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options?.project });
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner("Fetching charts...").start();
+
+  try {
+    const result = await service.list();
+    const charts = result.data;
+
+    spinner.succeed(
+      `Found ${charts.length} chart${charts.length !== 1 ? "s" : ""}`,
+    );
+
+    return {
+      data: result,
+      table: () => {
+        if (charts.length === 0) {
+          console.log();
+          console.log(chalk.gray("No saved charts found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(
+            chalk.cyan(
+              '  langwatch chart create --name "My Chart" --sql-file query.sql',
+            ),
+          );
+          return;
+        }
+
+        console.log();
+
+        const tableData = charts.map((c) => ({
+          Name: c.name,
+          ID: c.id,
+          Dashboard: c.dashboardId ?? "-",
+          Updated: formatRelativeTime(c.updatedAt),
+        }));
+
+        formatTable({
+          data: tableData,
+          headers: ["Name", "ID", "Dashboard", "Updated"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.green,
+          },
+        });
+
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch chart get <id>")} to view chart details`,
+          ),
+        );
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "fetch charts" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/place.ts
+++ b/sdks/typescript/src/cli/commands/charts/place.ts
@@ -1,0 +1,86 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+const parseGridFlag = (name: string, raw: string | undefined): number | undefined => {
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    console.error(
+      chalk.red(`Error: ${name} must be a whole number`),
+    );
+    process.exit(1);
+  }
+  return value;
+};
+
+/**
+ * Returns the placed chart rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts). With no grid
+ * row given, the platform allocates the next free row on that dashboard,
+ * counting charts of every kind.
+ */
+export const placeChartCommand = async (
+  id: string,
+  options: {
+    dashboardId?: string;
+    gridColumn?: string;
+    gridRow?: string;
+    colSpan?: string;
+    rowSpan?: string;
+    project?: string;
+  },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options.project });
+
+  if (!options.dashboardId) {
+    console.error(chalk.red("Error: --dashboard-id is required"));
+    process.exit(1);
+  }
+
+  const gridColumn = parseGridFlag("--grid-column", options.gridColumn);
+  const gridRow = parseGridFlag("--grid-row", options.gridRow);
+  const colSpan = parseGridFlag("--col-span", options.colSpan);
+  const rowSpan = parseGridFlag("--row-span", options.rowSpan);
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(
+    `Placing chart "${id}" on dashboard "${options.dashboardId}"...`,
+  ).start();
+
+  try {
+    const chart = await service.place(id, {
+      dashboardId: options.dashboardId,
+      ...(gridColumn === undefined ? {} : { gridColumn }),
+      ...(gridRow === undefined ? {} : { gridRow }),
+      ...(colSpan === undefined ? {} : { colSpan }),
+      ...(rowSpan === undefined ? {} : { rowSpan }),
+    });
+
+    spinner.succeed(
+      `Placed chart "${chalk.cyan(chart.name)}" on dashboard ${chalk.green(chart.dashboardId ?? options.dashboardId)}`,
+    );
+
+    return {
+      data: chart,
+      table: () => {
+        console.log();
+        console.log(
+          `  ${chalk.gray("Grid:")} column ${chart.gridColumn}, row ${chart.gridRow}, spans ${chart.colSpan}x${chart.rowSpan}`,
+        );
+        if (chart.platformUrl) {
+          console.log(
+            `  ${chalk.bold("View:")} ${chalk.underline(chart.platformUrl)}`,
+          );
+        }
+        console.log();
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "place chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/run.ts
+++ b/sdks/typescript/src/cli/commands/charts/run.ts
@@ -17,6 +17,16 @@ import type { CommandResult } from "../../utils/output";
  * `period_start`/`period_end` parameters for statements that declare them,
  * and `--granularity` the reserved datapoint step, in seconds.
  */
+/**
+ * The datapoint steps the platform offers, in seconds. The API is the source
+ * of truth (`LWQL_GRANULARITY_STEPS`, restricted in the route schema); this
+ * local copy only exists to refuse an off-list value before a request is made,
+ * with a message that names the steps instead of a schema rejection.
+ */
+const OFFERED_GRANULARITY_STEPS = [1, 60, 3600] as const;
+
+const OFFERED_GRANULARITY_STEP_NAMES = "1 (1 second), 60 (1 minute), 3600 (1 hour)";
+
 export const runChartCommand = async (
   id: string,
   options: {
@@ -37,9 +47,15 @@ export const runChartCommand = async (
   let granularitySeconds: number | undefined;
   if (options.granularity !== undefined) {
     granularitySeconds = Number(options.granularity);
-    if (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0) {
+    if (
+      !(OFFERED_GRANULARITY_STEPS as readonly number[]).includes(
+        granularitySeconds,
+      )
+    ) {
       console.error(
-        chalk.red("Error: --granularity must be a positive whole number of seconds"),
+        chalk.red(
+          `Error: --granularity must be one of the offered steps: ${OFFERED_GRANULARITY_STEP_NAMES}`,
+        ),
       );
       process.exit(1);
     }

--- a/sdks/typescript/src/cli/commands/charts/run.ts
+++ b/sdks/typescript/src/cli/commands/charts/run.ts
@@ -1,0 +1,111 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import {
+  type ChartParameterValue,
+  ChartsApiService,
+} from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { formatTable } from "../../utils/formatting";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Runs a saved chart by id: reads the chart, then executes its own statement
+ * and stored parameter values through the LangWatchQL query door — the same
+ * governed execution path every other surface uses, so what this prints is
+ * what the workbench would show. `--start`/`--end` fill the reserved
+ * `period_start`/`period_end` parameters for statements that declare them,
+ * and `--granularity` the reserved datapoint step, in seconds.
+ */
+export const runChartCommand = async (
+  id: string,
+  options: {
+    start?: string;
+    end?: string;
+    granularity?: string;
+    project?: string;
+  },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options.project });
+
+  if ((options.start === undefined) !== (options.end === undefined)) {
+    console.error(
+      chalk.red("Error: --start and --end must be given together"),
+    );
+    process.exit(1);
+  }
+  let granularitySeconds: number | undefined;
+  if (options.granularity !== undefined) {
+    granularitySeconds = Number(options.granularity);
+    if (!Number.isInteger(granularitySeconds) || granularitySeconds <= 0) {
+      console.error(
+        chalk.red("Error: --granularity must be a positive whole number of seconds"),
+      );
+      process.exit(1);
+    }
+  }
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(`Running chart "${id}"...`).start();
+
+  try {
+    const chart = await service.get(id);
+    const result = await service.runQuery({
+      sql: chart.definition.sql,
+      parameters: chart.definition.parameters as Record<
+        string,
+        ChartParameterValue
+      >,
+      ...(options.start !== undefined && options.end !== undefined
+        ? { timeWindow: { start: options.start, end: options.end } }
+        : {}),
+      ...(granularitySeconds === undefined ? {} : { granularitySeconds }),
+    });
+
+    spinner.succeed(
+      `Ran chart "${chart.name}": ${result.rows.length} row${result.rows.length !== 1 ? "s" : ""} in ${result.statistics.elapsedMs}ms`,
+    );
+
+    return {
+      data: { chart: { id: chart.id, name: chart.name }, result },
+      table: () => {
+        console.log();
+        if (result.rows.length === 0) {
+          console.log(chalk.gray("The query returned no rows."));
+        } else {
+          const headers = result.columns.map((column) => column.name);
+          formatTable({
+            data: result.rows.map((row) =>
+              Object.fromEntries(
+                headers.map((name) => {
+                  const value = row[name];
+                  return [
+                    name,
+                    value === null || value === undefined
+                      ? ""
+                      : typeof value === "object"
+                        ? JSON.stringify(value)
+                        : String(value as string | number | boolean),
+                  ];
+                }),
+              ),
+            ),
+            headers,
+          });
+        }
+        if (result.truncated) {
+          console.log();
+          console.log(chalk.yellow("The result was truncated."));
+        }
+        for (const diagnostic of result.diagnostics) {
+          console.log();
+          console.log(chalk.yellow(`${diagnostic.code}: ${diagnostic.message}`));
+        }
+        console.log();
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "run chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/schema.ts
+++ b/sdks/typescript/src/cli/commands/charts/schema.ts
@@ -1,0 +1,62 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { formatTable } from "../../utils/formatting";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the LangWatchQL analytics schema rather than printing it: the
+ * output port renders it in whatever format the caller asked for
+ * (utils/output.ts). This is the discovery step an agent runs before writing
+ * chart SQL — dataset and column names come from here, never from guessing.
+ */
+export const chartSchemaCommand = async (options?: {
+  project?: string;
+}): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options?.project });
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner("Fetching analytics schema...").start();
+
+  try {
+    const schema = await service.schema();
+
+    spinner.succeed(
+      `Found ${schema.datasets.length} dataset${schema.datasets.length !== 1 ? "s" : ""} in ${schema.database}`,
+    );
+
+    return {
+      data: schema,
+      table: () => {
+        for (const dataset of schema.datasets) {
+          console.log();
+          console.log(
+            `  ${chalk.cyan.bold(dataset.name)} ${chalk.gray(`— ${dataset.description}`)}`,
+          );
+          console.log(
+            `  ${chalk.gray("Grain:")} ${dataset.grain}  ${chalk.gray("Time column:")} ${dataset.timeColumn}`,
+          );
+          formatTable({
+            data: dataset.columns.map((column) => ({
+              Column: column.name,
+              Type: column.type,
+              Available: column.available ? "yes" : "no",
+            })),
+            headers: ["Column", "Type", "Available"],
+          });
+        }
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch chart schema -o json")} for descriptions and example queries`,
+          ),
+        );
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "fetch analytics schema" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/unplace.ts
+++ b/sdks/typescript/src/cli/commands/charts/unplace.ts
@@ -1,0 +1,38 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the unplaced chart's identity rather than printing it: the output
+ * port renders it in whatever format the caller asked for (utils/output.ts).
+ * Idempotent, like the endpoint: unplacing a chart that is not placed
+ * succeeds all the same.
+ */
+export const unplaceChartCommand = async (
+  id: string,
+  options?: { project?: string },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options?.project });
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(`Removing chart "${id}" from its dashboard...`).start();
+
+  try {
+    await service.unplace(id);
+
+    spinner.succeed(`Chart "${chalk.cyan(id)}" is no longer on a dashboard`);
+
+    return {
+      data: { id: id, unplaced: true },
+      table: () => {
+        // The spinner line already says everything the human form carries.
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "unplace chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/commands/charts/update.ts
+++ b/sdks/typescript/src/cli/commands/charts/update.ts
@@ -1,0 +1,69 @@
+import chalk from "chalk";
+import { createSpinner } from "../../utils/spinner";
+import { ChartsApiService } from "@/client-sdk/services/charts/charts-api.service";
+import { resolveCredentials } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
+import {
+  ChartInputError,
+  type DefinitionFlags,
+  resolveDefinitionInput,
+} from "./definitionInput";
+
+/**
+ * Returns the updated chart rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts). A call
+ * touching nothing is refused locally, matching the API's own refusal of an
+ * empty update.
+ */
+export const updateChartCommand = async (
+  id: string,
+  options: DefinitionFlags & { name?: string; project?: string },
+): Promise<CommandResult | void> => {
+  await resolveCredentials({ project: options.project });
+
+  let definition;
+  try {
+    definition = resolveDefinitionInput(options);
+  } catch (error) {
+    if (error instanceof ChartInputError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  if (options.name === undefined && definition === undefined) {
+    console.error(
+      chalk.red(
+        "Error: nothing to update — pass --name, or a definition via --sql / --sql-file",
+      ),
+    );
+    process.exit(1);
+  }
+
+  const service = new ChartsApiService();
+  const spinner = createSpinner(`Updating chart "${id}"...`).start();
+
+  try {
+    const chart = await service.update(id, {
+      ...(options.name === undefined ? {} : { name: options.name }),
+      ...(definition === undefined ? {} : { definition }),
+    });
+
+    spinner.succeed(`Updated chart "${chart.name}"`);
+
+    return {
+      data: chart,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}   ${chalk.green(chart.id)}`);
+        console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(chart.name)}`);
+        console.log();
+      },
+    };
+  } catch (error) {
+    failSpinner({ spinner, error, action: "update chart" });
+    process.exit(1);
+  }
+};

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -2812,6 +2812,167 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     },
   );
 
+  // Add chart command group — saved LangWatchQL workbench charts
+  const chartCmd = program
+    .command("chart")
+    .description("Manage saved LangWatchQL charts and place them on dashboards");
+
+  emitsResult(
+    chartCmd
+      .command("schema")
+      .description("Discover the LangWatchQL analytics datasets and columns to write chart SQL against")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: { project?: string }) => {
+      const { chartSchemaCommand: impl } = await import("./commands/charts/schema.js");
+      return impl(options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("list")
+      .description("List the project's saved charts")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: { project?: string }) => {
+      const { listChartsCommand: impl } = await import("./commands/charts/list.js");
+      return impl(options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("get <id>")
+      .description("Get a saved chart by ID — its SQL, parameters, specification and placement")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { project?: string }) => {
+      const { getChartCommand: impl } = await import("./commands/charts/get.js");
+      return impl(id, options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("create")
+      .description("Save a LangWatchQL chart from a statement, parameters and an optional Vega-Lite specification")
+      .requiredOption("--name <name>", "Chart name")
+      .option("--sql <sql>", "The LangWatchQL statement")
+      .option("--sql-file <path>", "Read the statement from a file")
+      .option("--param <key=value>", "Bound parameter value (repeatable)", collectParam)
+      .option("--spec-file <path>", "Vega-Lite specification JSON file")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: {
+      name?: string;
+      sql?: string;
+      sqlFile?: string;
+      param?: string[];
+      specFile?: string;
+      project?: string;
+    }) => {
+      const { createChartCommand: impl } = await import("./commands/charts/create.js");
+      return impl(options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("update <id>")
+      .description("Update a saved chart's name or definition")
+      .option("--name <name>", "New chart name")
+      .option("--sql <sql>", "New LangWatchQL statement")
+      .option("--sql-file <path>", "Read the new statement from a file")
+      .option("--param <key=value>", "Bound parameter value (repeatable)", collectParam)
+      .option("--spec-file <path>", "New Vega-Lite specification JSON file")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (
+      id: string,
+      options: {
+        name?: string;
+        sql?: string;
+        sqlFile?: string;
+        param?: string[];
+        specFile?: string;
+        project?: string;
+      },
+    ) => {
+      const { updateChartCommand: impl } = await import("./commands/charts/update.js");
+      return impl(id, options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("delete <id>")
+      .description("Delete a saved chart")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { project?: string }) => {
+      const { deleteChartCommand: impl } = await import("./commands/charts/delete.js");
+      return impl(id, options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("run <id>")
+      .description("Run a saved chart's statement and print the result")
+      .option("--start <datetime>", "Period start for statements declaring {period_start:DateTime}")
+      .option("--end <datetime>", "Period end for statements declaring {period_end:DateTime}")
+      .option("--granularity <seconds>", "Datapoint step for statements declaring {period_granularity_seconds:UInt32}")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (
+      id: string,
+      options: { start?: string; end?: string; granularity?: string; project?: string },
+    ) => {
+      const { runChartCommand: impl } = await import("./commands/charts/run.js");
+      return impl(id, options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("place <id>")
+      .description("Place a saved chart on a dashboard")
+      .requiredOption("--dashboard-id <id>", "Dashboard to place the chart on")
+      .option("--grid-column <n>", "Grid column")
+      .option("--grid-row <n>", "Grid row (allocated automatically when omitted)")
+      .option("--col-span <n>", "Column span")
+      .option("--row-span <n>", "Row span")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (
+      id: string,
+      options: {
+        dashboardId?: string;
+        gridColumn?: string;
+        gridRow?: string;
+        colSpan?: string;
+        rowSpan?: string;
+        project?: string;
+      },
+    ) => {
+      const { placeChartCommand: impl } = await import("./commands/charts/place.js");
+      return impl(id, options);
+    },
+  );
+
+  emitsResult(
+    chartCmd
+      .command("unplace <id>")
+      .description("Remove a saved chart from its dashboard")
+      .option("--project <slug-or-id>", "Project to run against")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { project?: string }) => {
+      const { unplaceChartCommand: impl } = await import("./commands/charts/unplace.js");
+      return impl(id, options);
+    },
+  );
+
   // Add trigger (automation) command group
   const triggerCmd = program
     .command("trigger")

--- a/sdks/typescript/src/client-sdk/services/charts/__tests__/charts-api.service.unit.test.ts
+++ b/sdks/typescript/src/client-sdk/services/charts/__tests__/charts-api.service.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ChartsApiError,
+  ChartsApiService,
+} from "../charts-api.service";
+import { isLangWatchHandledError } from "@/internal/api/errors";
+import type { LangwatchApiClient } from "@/internal/api/client";
+
+/**
+ * The canonical REST envelope the analytics-sql chart family answers refusals
+ * with (`app/api/shared/schemas.ts`): the whole failure nested under `error`.
+ */
+const notFoundBody = {
+  error: {
+    type: "not_found",
+    code: "saved_workbench_chart_not_found",
+    message: "Saved chart not found.",
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+  },
+};
+
+const clientWith = (result: {
+  data?: unknown;
+  error?: unknown;
+  response?: Response;
+}): LangwatchApiClient =>
+  ({
+    GET: vi.fn(async () => result),
+    POST: vi.fn(async () => result),
+    PATCH: vi.fn(async () => result),
+    PUT: vi.fn(async () => result),
+    DELETE: vi.fn(async () => result),
+  }) as unknown as LangwatchApiClient;
+
+const serviceWith = (result: {
+  data?: unknown;
+  error?: unknown;
+  response?: Response;
+}): ChartsApiService =>
+  new ChartsApiService({
+    langwatchApiClient: clientWith(result),
+    projectId: "project-1",
+  });
+
+describe("ChartsApiService", () => {
+  describe("when the platform names the failure in the canonical envelope", () => {
+    it("raises the typed handled error with the platform's own code, status and message", async () => {
+      const service = serviceWith({
+        error: notFoundBody,
+        response: new Response(null, { status: 404 }),
+      });
+
+      const thrown = await service.get("chart-1").then(
+        () => {
+          throw new Error("expected get to reject");
+        },
+        (error: unknown) => error,
+      );
+
+      expect(isLangWatchHandledError(thrown)).toBe(true);
+      expect(thrown).toMatchObject({
+        code: "saved_workbench_chart_not_found",
+        httpStatus: 404,
+        traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      });
+      expect((thrown as Error).message).toContain("Saved chart not found.");
+    });
+  });
+
+  describe("when the failure body is not the platform's shape", () => {
+    it("throws the family's own error, status attached, exactly as before", async () => {
+      const service = serviceWith({
+        error: "<html>bad gateway</html>",
+        response: new Response(null, { status: 502 }),
+      });
+
+      const thrown = await service.get("chart-1").then(
+        () => {
+          throw new Error("expected get to reject");
+        },
+        (error: unknown) => error,
+      );
+
+      expect(isLangWatchHandledError(thrown)).toBe(false);
+      expect(thrown).toBeInstanceOf(ChartsApiError);
+      expect((thrown as ChartsApiError).status).toBe(502);
+    });
+  });
+
+  describe("when delete answers 204 with no body", () => {
+    it("resolves without reading a body", async () => {
+      const service = serviceWith({
+        data: undefined,
+        error: undefined,
+        response: new Response(null, { status: 204 }),
+      });
+
+      await expect(service.delete("chart-1")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/sdks/typescript/src/client-sdk/services/charts/charts-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/charts/charts-api.service.ts
@@ -9,6 +9,7 @@ import {
   extractStatusFromResponse,
   formatApiErrorForOperation,
 } from "@/client-sdk/services/_shared/format-api-error";
+import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 
 /** A saved workbench chart, exactly as the REST surface answers it. */
 export type SavedChart =
@@ -38,6 +39,12 @@ export class ChartsApiError extends Error {
     message: string,
     public readonly operation: string,
     public readonly originalError?: unknown,
+    /**
+     * The HTTP status the platform answered with, when the response was kept.
+     * Without it the CLI's error reader can only guess `network_error` for a
+     * failure the platform named precisely — same rationale as `TracesApiError`.
+     */
+    public readonly status?: number,
   ) {
     super(message);
     this.name = "ChartsApiError";
@@ -66,13 +73,22 @@ export class ChartsApiService {
     this.configuredProjectId = config?.projectId;
   }
 
-  private handleApiError(operation: string, error: unknown): never {
+  private handleApiError(
+    operation: string,
+    error: unknown,
+    response?: Response,
+  ): never {
+    const status = response?.status ?? extractStatusFromResponse(error);
     const message = formatApiErrorForOperation({
       operation: operation,
       error: error,
-      options: { status: extractStatusFromResponse(error) },
+      options: { status },
     });
-    throw new ChartsApiError(message, operation, error);
+    // A failure the platform NAMED (a code, a status, a meta bag) is raised as
+    // the typed `LangWatchHandledError`, so the CLI's error output carries the
+    // real code instead of degrading everything to `network_error`.
+    throwIfHandledError({ operation, error, response, message });
+    throw new ChartsApiError(message, operation, error, status);
   }
 
   private projectId(operation: string): string {
@@ -91,21 +107,21 @@ export class ChartsApiService {
 
   async list(): Promise<{ data: SavedChart[] }> {
     const projectId = this.projectId("list charts");
-    const { data, error } = await this.apiClient.GET(
+    const { data, error, response } = await this.apiClient.GET(
       "/api/v1/projects/{projectId}/analytics/charts",
       { params: { path: { projectId } } },
     );
-    if (error) this.handleApiError("list charts", error);
+    if (error) this.handleApiError("list charts", error, response);
     return data as unknown as { data: SavedChart[] };
   }
 
   async get(id: string): Promise<SavedChart> {
     const projectId = this.projectId(`get chart "${id}"`);
-    const { data, error } = await this.apiClient.GET(
+    const { data, error, response } = await this.apiClient.GET(
       "/api/v1/projects/{projectId}/analytics/charts/{chartId}",
       { params: { path: { projectId, chartId: id } } },
     );
-    if (error) this.handleApiError(`get chart "${id}"`, error);
+    if (error) this.handleApiError(`get chart "${id}"`, error, response);
     return data as unknown as SavedChart;
   }
 
@@ -114,11 +130,11 @@ export class ChartsApiService {
     definition: SavedChartDefinitionInput;
   }): Promise<SavedChart> {
     const projectId = this.projectId("create chart");
-    const { data, error } = await this.apiClient.POST(
+    const { data, error, response } = await this.apiClient.POST(
       "/api/v1/projects/{projectId}/analytics/charts",
       { params: { path: { projectId } }, body: params },
     );
-    if (error) this.handleApiError("create chart", error);
+    if (error) this.handleApiError("create chart", error, response);
     return data as unknown as SavedChart;
   }
 
@@ -127,22 +143,22 @@ export class ChartsApiService {
     params: { name?: string; definition?: SavedChartDefinitionInput },
   ): Promise<SavedChart> {
     const projectId = this.projectId(`update chart "${id}"`);
-    const { data, error } = await this.apiClient.PATCH(
+    const { data, error, response } = await this.apiClient.PATCH(
       "/api/v1/projects/{projectId}/analytics/charts/{chartId}",
       { params: { path: { projectId, chartId: id } }, body: params },
     );
-    if (error) this.handleApiError(`update chart "${id}"`, error);
+    if (error) this.handleApiError(`update chart "${id}"`, error, response);
     return data as unknown as SavedChart;
   }
 
-  async delete(id: string): Promise<{ id: string; name: string }> {
+  /** Deletes a chart. The route answers `204` with no body, like `unplace`. */
+  async delete(id: string): Promise<void> {
     const projectId = this.projectId(`delete chart "${id}"`);
-    const { data, error } = await this.apiClient.DELETE(
+    const { error, response } = await this.apiClient.DELETE(
       "/api/v1/projects/{projectId}/analytics/charts/{chartId}",
       { params: { path: { projectId, chartId: id } } },
     );
-    if (error) this.handleApiError(`delete chart "${id}"`, error);
-    return data as unknown as { id: string; name: string };
+    if (error) this.handleApiError(`delete chart "${id}"`, error, response);
   }
 
   async place(
@@ -156,31 +172,31 @@ export class ChartsApiService {
     },
   ): Promise<SavedChart> {
     const projectId = this.projectId(`place chart "${id}"`);
-    const { data, error } = await this.apiClient.PUT(
+    const { data, error, response } = await this.apiClient.PUT(
       "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement",
       { params: { path: { projectId, chartId: id } }, body: params },
     );
-    if (error) this.handleApiError(`place chart "${id}"`, error);
+    if (error) this.handleApiError(`place chart "${id}"`, error, response);
     return data as unknown as SavedChart;
   }
 
   async unplace(id: string): Promise<void> {
     const projectId = this.projectId(`unplace chart "${id}"`);
-    const { error } = await this.apiClient.DELETE(
+    const { error, response } = await this.apiClient.DELETE(
       "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement",
       { params: { path: { projectId, chartId: id } } },
     );
-    if (error) this.handleApiError(`unplace chart "${id}"`, error);
+    if (error) this.handleApiError(`unplace chart "${id}"`, error, response);
   }
 
   /** The datasets and columns this key may write chart SQL against. */
   async schema(): Promise<AnalyticsSchema> {
     const projectId = this.projectId("discover analytics schema");
-    const { data, error } = await this.apiClient.GET(
+    const { data, error, response } = await this.apiClient.GET(
       "/api/v1/projects/{projectId}/analytics/schema",
       { params: { path: { projectId } } },
     );
-    if (error) this.handleApiError("discover analytics schema", error);
+    if (error) this.handleApiError("discover analytics schema", error, response);
     return data as unknown as AnalyticsSchema;
   }
 
@@ -198,7 +214,7 @@ export class ChartsApiService {
     granularitySeconds?: number;
   }): Promise<ChartRunResult> {
     const projectId = this.projectId("run chart");
-    const { data, error } = await this.apiClient.POST(
+    const { data, error, response } = await this.apiClient.POST(
       "/api/v1/projects/{projectId}/analytics/query/clickhouse",
       {
         params: { path: { projectId } },
@@ -212,7 +228,7 @@ export class ChartsApiService {
         },
       },
     );
-    if (error) this.handleApiError("run chart", error);
+    if (error) this.handleApiError("run chart", error, response);
     return data as unknown as ChartRunResult;
   }
 }

--- a/sdks/typescript/src/client-sdk/services/charts/charts-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/charts/charts-api.service.ts
@@ -1,0 +1,218 @@
+import type { paths } from "@/internal/generated/openapi/api-client";
+import {
+  createLangWatchApiClient,
+  type LangwatchApiClient,
+} from "@/internal/api/client";
+import { scopedProjectId } from "@/internal/credentialContext";
+import { type InternalConfig } from "@/client-sdk/types";
+import {
+  extractStatusFromResponse,
+  formatApiErrorForOperation,
+} from "@/client-sdk/services/_shared/format-api-error";
+
+/** A saved workbench chart, exactly as the REST surface answers it. */
+export type SavedChart =
+  paths["/api/v1/projects/{projectId}/analytics/charts/{chartId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+/** A scalar value a chart parameter may carry — the platform's own contract. */
+export type ChartParameterValue = string | number | boolean | null;
+
+/** The definition a create or update submits. */
+export interface SavedChartDefinitionInput {
+  version: 1;
+  sql: string;
+  parameters: Record<string, ChartParameterValue>;
+  vegaLiteSpec?: Record<string, unknown>;
+}
+
+/** The LangWatchQL analytics schema, as the discovery endpoint answers it. */
+export type AnalyticsSchema =
+  paths["/api/v1/projects/{projectId}/analytics/schema"]["get"]["responses"]["200"]["content"]["application/json"];
+
+/** The result of running a chart's statement through the LangWatchQL query door. */
+export type ChartRunResult =
+  paths["/api/v1/projects/{projectId}/analytics/query/clickhouse"]["post"]["responses"]["200"]["content"]["application/json"];
+
+export class ChartsApiError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly originalError?: unknown,
+  ) {
+    super(message);
+    this.name = "ChartsApiError";
+  }
+}
+
+/**
+ * Typed client for the saved workbench chart family
+ * (`/api/v1/projects/{projectId}/analytics/charts`).
+ *
+ * The chart routes carry the project id in the path, unlike the older
+ * project-implicit families, so the service resolves one once — the CLI's
+ * request-scoped project first, then `LANGWATCH_PROJECT_ID` — and refuses
+ * loudly when none is known rather than guessing.
+ */
+export class ChartsApiService {
+  private readonly apiClient: LangwatchApiClient;
+  private readonly configuredProjectId: string | undefined;
+
+  constructor(
+    config?: Pick<InternalConfig, "langwatchApiClient"> & {
+      projectId?: string;
+    },
+  ) {
+    this.apiClient = config?.langwatchApiClient ?? createLangWatchApiClient();
+    this.configuredProjectId = config?.projectId;
+  }
+
+  private handleApiError(operation: string, error: unknown): never {
+    const message = formatApiErrorForOperation({
+      operation: operation,
+      error: error,
+      options: { status: extractStatusFromResponse(error) },
+    });
+    throw new ChartsApiError(message, operation, error);
+  }
+
+  private projectId(operation: string): string {
+    const projectId =
+      this.configuredProjectId ??
+      scopedProjectId() ??
+      process.env.LANGWATCH_PROJECT_ID;
+    if (!projectId) {
+      throw new ChartsApiError(
+        "No project is in scope. Pass --project <slug-or-id>, or set LANGWATCH_PROJECT_ID.",
+        operation,
+      );
+    }
+    return projectId;
+  }
+
+  async list(): Promise<{ data: SavedChart[] }> {
+    const projectId = this.projectId("list charts");
+    const { data, error } = await this.apiClient.GET(
+      "/api/v1/projects/{projectId}/analytics/charts",
+      { params: { path: { projectId } } },
+    );
+    if (error) this.handleApiError("list charts", error);
+    return data as unknown as { data: SavedChart[] };
+  }
+
+  async get(id: string): Promise<SavedChart> {
+    const projectId = this.projectId(`get chart "${id}"`);
+    const { data, error } = await this.apiClient.GET(
+      "/api/v1/projects/{projectId}/analytics/charts/{chartId}",
+      { params: { path: { projectId, chartId: id } } },
+    );
+    if (error) this.handleApiError(`get chart "${id}"`, error);
+    return data as unknown as SavedChart;
+  }
+
+  async create(params: {
+    name: string;
+    definition: SavedChartDefinitionInput;
+  }): Promise<SavedChart> {
+    const projectId = this.projectId("create chart");
+    const { data, error } = await this.apiClient.POST(
+      "/api/v1/projects/{projectId}/analytics/charts",
+      { params: { path: { projectId } }, body: params },
+    );
+    if (error) this.handleApiError("create chart", error);
+    return data as unknown as SavedChart;
+  }
+
+  async update(
+    id: string,
+    params: { name?: string; definition?: SavedChartDefinitionInput },
+  ): Promise<SavedChart> {
+    const projectId = this.projectId(`update chart "${id}"`);
+    const { data, error } = await this.apiClient.PATCH(
+      "/api/v1/projects/{projectId}/analytics/charts/{chartId}",
+      { params: { path: { projectId, chartId: id } }, body: params },
+    );
+    if (error) this.handleApiError(`update chart "${id}"`, error);
+    return data as unknown as SavedChart;
+  }
+
+  async delete(id: string): Promise<{ id: string; name: string }> {
+    const projectId = this.projectId(`delete chart "${id}"`);
+    const { data, error } = await this.apiClient.DELETE(
+      "/api/v1/projects/{projectId}/analytics/charts/{chartId}",
+      { params: { path: { projectId, chartId: id } } },
+    );
+    if (error) this.handleApiError(`delete chart "${id}"`, error);
+    return data as unknown as { id: string; name: string };
+  }
+
+  async place(
+    id: string,
+    params: {
+      dashboardId: string;
+      gridColumn?: number;
+      gridRow?: number;
+      colSpan?: number;
+      rowSpan?: number;
+    },
+  ): Promise<SavedChart> {
+    const projectId = this.projectId(`place chart "${id}"`);
+    const { data, error } = await this.apiClient.PUT(
+      "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement",
+      { params: { path: { projectId, chartId: id } }, body: params },
+    );
+    if (error) this.handleApiError(`place chart "${id}"`, error);
+    return data as unknown as SavedChart;
+  }
+
+  async unplace(id: string): Promise<void> {
+    const projectId = this.projectId(`unplace chart "${id}"`);
+    const { error } = await this.apiClient.DELETE(
+      "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement",
+      { params: { path: { projectId, chartId: id } } },
+    );
+    if (error) this.handleApiError(`unplace chart "${id}"`, error);
+  }
+
+  /** The datasets and columns this key may write chart SQL against. */
+  async schema(): Promise<AnalyticsSchema> {
+    const projectId = this.projectId("discover analytics schema");
+    const { data, error } = await this.apiClient.GET(
+      "/api/v1/projects/{projectId}/analytics/schema",
+      { params: { path: { projectId } } },
+    );
+    if (error) this.handleApiError("discover analytics schema", error);
+    return data as unknown as AnalyticsSchema;
+  }
+
+  /**
+   * Runs a saved chart's statement through the LangWatchQL query door — the
+   * same governed execution path the workbench uses. The caller supplies the
+   * chart's own SQL and stored parameter values (from `get`), plus the
+   * surface's time window and granularity for statements that declare the
+   * reserved `period_*` parameters.
+   */
+  async runQuery(params: {
+    sql: string;
+    parameters?: Record<string, ChartParameterValue>;
+    timeWindow?: { start: string; end: string };
+    granularitySeconds?: number;
+  }): Promise<ChartRunResult> {
+    const projectId = this.projectId("run chart");
+    const { data, error } = await this.apiClient.POST(
+      "/api/v1/projects/{projectId}/analytics/query/clickhouse",
+      {
+        params: { path: { projectId } },
+        body: {
+          sql: params.sql,
+          ...(params.parameters ? { parameters: params.parameters } : {}),
+          ...(params.timeWindow ? { timeWindow: params.timeWindow } : {}),
+          ...(params.granularitySeconds === undefined
+            ? {}
+            : { granularitySeconds: params.granularitySeconds }),
+        },
+      },
+    );
+    if (error) this.handleApiError("run chart", error);
+    return data as unknown as ChartRunResult;
+  }
+}

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -848,6 +848,30 @@ export interface paths {
         patch: operations["patchApiV1ProjectsByProjectIdAnalyticsChartsByChartId"];
         trace?: never;
     };
+    "/api/v1/projects/{projectId}/analytics/charts/{chartId}/placement": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Place a saved workbench chart on a dashboard
+         * @description Places one saved LangWatchQL chart on a dashboard in the same project, at the grid position supplied — or, when no grid row is given, at the next row free on that dashboard, counting charts of every kind. A dashboard that is not in this project is reported as not found, exactly like a chart that is not, and nothing is written.
+         */
+        put: operations["putApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement"];
+        post?: never;
+        /**
+         * Remove a saved workbench chart from its dashboard
+         * @description Removes one saved LangWatchQL chart from whatever dashboard it is on, clearing its grid position along with the dashboard id. Idempotent: unplacing a chart that is not placed answers 204 all the same. The chart itself — its statement, parameter values and specification — is untouched.
+         */
+        delete: operations["deleteApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/coding-agent/sessions/{sessionId}/events": {
         parameters: {
             query?: never;
@@ -5117,6 +5141,7 @@ export interface operations {
                         start: string | number;
                         end: string | number;
                     };
+                    granularitySeconds?: number;
                 };
             };
         };
@@ -5143,6 +5168,9 @@ export interface operations {
                         };
                         truncated: boolean;
                         followsTimeWindow: boolean;
+                        followsGranularity: boolean;
+                        granularitySeconds?: number;
+                        coarsenedFromSeconds?: number;
                         diagnostics: {
                             /** @enum {string} */
                             code: "RESULT_TRUNCATED" | "POSSIBLE_FANOUT" | "UNBOUNDED_TIME_RANGE" | "MISSING_TIME_BUCKETS" | "INCOMPLETE_COMPARISON_PERIOD";
@@ -5412,6 +5440,11 @@ export interface operations {
                             createdAt: string;
                             updatedAt: string;
                             platformUrl: string;
+                            dashboardId: string | null;
+                            gridColumn: number;
+                            gridRow: number;
+                            colSpan: number;
+                            rowSpan: number;
                         }[];
                     };
                 };
@@ -5538,6 +5571,11 @@ export interface operations {
                         createdAt: string;
                         updatedAt: string;
                         platformUrl: string;
+                        dashboardId: string | null;
+                        gridColumn: number;
+                        gridRow: number;
+                        colSpan: number;
+                        rowSpan: number;
                     };
                 };
             };
@@ -5657,6 +5695,11 @@ export interface operations {
                         createdAt: string;
                         updatedAt: string;
                         platformUrl: string;
+                        dashboardId: string | null;
+                        gridColumn: number;
+                        gridRow: number;
+                        colSpan: number;
+                        rowSpan: number;
                     };
                 };
             };
@@ -5924,8 +5967,288 @@ export interface operations {
                         createdAt: string;
                         updatedAt: string;
                         platformUrl: string;
+                        dashboardId: string | null;
+                        gridColumn: number;
+                        gridRow: number;
+                        colSpan: number;
+                        rowSpan: number;
                     };
                 };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description No chart with this id in this project */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    putApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                projectId: string;
+                chartId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    dashboardId: string;
+                    gridColumn?: number;
+                    gridRow?: number;
+                    colSpan?: number;
+                    rowSpan?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description The chart, now placed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        definition: {
+                            version: number;
+                            sql: string;
+                            parameters: {
+                                [key: string]: unknown;
+                            };
+                            vegaLiteSpec?: {
+                                [key: string]: unknown;
+                            };
+                        };
+                        createdAt: string;
+                        updatedAt: string;
+                        platformUrl: string;
+                        dashboardId: string | null;
+                        gridColumn: number;
+                        gridRow: number;
+                        colSpan: number;
+                        rowSpan: number;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description No chart with this id in this project */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    deleteApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                projectId: string;
+                chartId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The chart is no longer on any dashboard */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Bad Request */
             400: {

--- a/services/langyagent/internal/assets/AGENTS.md
+++ b/services/langyagent/internal/assets/AGENTS.md
@@ -77,6 +77,7 @@ No framing changes this: hypothetical phrasing, "just an example", "for the audi
 | "open a PR", "fix and submit", "send a patch" | `github` | `gh api /installation/repositories` (finds "my repo"), `gh repo clone`, `gh pr create` |
 | "configured agents", "create agent" | direct CLI | `langwatch agent list`, `langwatch agent create`, `langwatch agent run <id>` |
 | "dashboards" | direct CLI | `langwatch dashboard list`, `langwatch dashboard create` |
+| "build a chart", "save this as a chart", "put it on my dashboard" | `lwql-charts` | `langwatch chart schema`, `langwatch chart create --sql-file <file>`, `langwatch chart run <id>`, `langwatch chart place <id> --dashboard-id <id>` |
 | "alerts", "triggers" | direct CLI | `langwatch trigger list`, `langwatch trigger create` |
 | "workflows" | direct CLI | `langwatch workflow list`, `langwatch workflow run <id>` |
 | "annotations", "thumbs up/down a trace" | direct CLI | `langwatch annotation list`, `langwatch annotation create <traceId> --thumbs-up\|--thumbs-down --comment "…"` (no update command) |

--- a/services/langyagent/internal/assets/AGENTS.md
+++ b/services/langyagent/internal/assets/AGENTS.md
@@ -76,8 +76,7 @@ No framing changes this: hypothetical phrasing, "just an example", "for the audi
 | "test my CLI's usability" | `test-cli-usability` | scenario tests |
 | "open a PR", "fix and submit", "send a patch" | `github` | `gh api /installation/repositories` (finds "my repo"), `gh repo clone`, `gh pr create` |
 | "configured agents", "create agent" | direct CLI | `langwatch agent list`, `langwatch agent create`, `langwatch agent run <id>` |
-| "dashboards" | direct CLI | `langwatch dashboard list`, `langwatch dashboard create` |
-| "build a chart", "save this as a chart", "put it on my dashboard" | `lwql-charts` | `langwatch chart schema`, `langwatch chart create --sql-file <file>`, `langwatch chart run <id>`, `langwatch chart place <id> --dashboard-id <id>` |
+| "dashboards", "build a chart" | `lwql-charts` | `langwatch chart schema` first |
 | "alerts", "triggers" | direct CLI | `langwatch trigger list`, `langwatch trigger create` |
 | "workflows" | direct CLI | `langwatch workflow list`, `langwatch workflow run <id>` |
 | "annotations", "thumbs up/down a trace" | direct CLI | `langwatch annotation list`, `langwatch annotation create <traceId> --thumbs-up\|--thumbs-down --comment "…"` (no update command) |

--- a/services/langyagent/internal/assets/skills/lwql-charts/SKILL.md
+++ b/services/langyagent/internal/assets/skills/lwql-charts/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: lwql-charts
+user-prompt: "Build a chart from a question and put it on my dashboard"
+description: Author a saved analytics chart from a plain question and place it on a dashboard. Discovers the LangWatchQL analytics schema, writes and test-runs the SQL, saves it as a chart with a Vega-Lite specification, and places it where the team already looks. Use when asked to build, save, run, or dashboard a metric or chart.
+license: MIT
+compatibility: Requires the `langwatch` CLI with a valid `LANGWATCH_API_KEY`, and a project with LangWatchQL analytics enabled. Works with Claude Code and similar coding agents.
+metadata:
+  category: recipe
+---
+
+# Author a Chart and Place It on a Dashboard
+
+Turn a question ("how many traces per day?", "cost by model this week") into a saved chart that keeps updating on a dashboard. The loop is: **discover the schema → write and test-run the SQL → save the chart → place it**.
+
+## Prerequisites
+
+LangWatchQL analytics is switched per project. If any chart command answers with error code `lwql_not_enabled`, the feature is off for this project — tell the user, do not retry.
+
+## Step 1: Discover the schema before writing any SQL
+
+Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
+
+```bash
+langwatch chart schema --format json
+```
+
+Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+
+## Step 2: Write the SQL, using the reserved period parameters
+
+A chart that should follow the dashboard's period selector declares the reserved bound parameters instead of hardcoding dates:
+
+- `{period_start:DateTime}` / `{period_end:DateTime}` — the surface's period, half-open `[start, end)`
+- `{period_granularity_seconds:UInt32}` — the surface's datapoint step, in seconds
+
+```sql
+SELECT
+  toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket,
+  count() AS traces
+FROM analytics.traces
+WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}
+GROUP BY bucket
+ORDER BY bucket
+```
+
+Your own parameters (`{since:DateTime}`, `{model:String}`, …) get their values from `--param`; never pass a value for the reserved `period_*` names.
+
+## Step 3: Save the chart, then prove it runs
+
+```bash
+langwatch chart create \
+  --name "Traces per day" \
+  --sql-file query.sql \
+  --spec-file spec.json \
+  --format json
+```
+
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+
+See the numbers before placing it:
+
+```bash
+langwatch chart run <chart-id> \
+  --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
+  --granularity 86400 --format json
+```
+
+`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+
+## Step 4: Place it on a dashboard
+
+```bash
+langwatch dashboard list --format json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+```
+
+With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
+
+## Managing saved charts
+
+```bash
+langwatch chart list --format json
+langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart update <chart-id> --sql-file query.sql
+langwatch chart delete <chart-id>
+```
+
+## Failure modes worth knowing
+
+- `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
+- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
+- `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.

--- a/services/langyagent/internal/assets/skills/lwql-charts/SKILL.md
+++ b/services/langyagent/internal/assets/skills/lwql-charts/SKILL.md
@@ -21,10 +21,10 @@ LangWatchQL analytics is switched per project. If any chart command answers with
 Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
 
 ```bash
-langwatch chart schema --format json
+langwatch chart schema -o json
 ```
 
-Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+Read the datasets, their grain, their time column, and which columns are `available` to you. Saving validates the SQL against the analytics policy and the specification against the chart policy — it does not check that every column exists, so SQL naming a wrong column saves fine and only fails when the chart runs. Writing SQL against the schema you just read, then test-running the chart right after saving it (Step 3), is what catches a bad column before anyone sees it on a dashboard.
 
 ## Step 2: Write the SQL, using the reserved period parameters
 
@@ -52,26 +52,26 @@ langwatch chart create \
   --name "Traces per day" \
   --sql-file query.sql \
   --spec-file spec.json \
-  --format json
+  -o json
 ```
 
-`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates the SQL against the analytics policy and the specification against the chart policy before writing anything — a refusal means fix the input, not retry. It does not check column names against the schema, which is why the very next command is always a run: a chart that saves but names a wrong column fails only at run time.
 
 See the numbers before placing it:
 
 ```bash
 langwatch chart run <chart-id> \
   --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
-  --granularity 86400 --format json
+  --granularity 3600 -o json
 ```
 
-`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+`--start`/`--end` fill the reserved period parameters and `--granularity` the datapoint step, which only accepts the offered steps: `1` (second), `60` (minute), `3600` (hour). A chart whose SQL declares the reserved period parameters **requires** `--start` and `--end` on every run — there is no default window, and running without them is refused. Only a chart that declares none of them runs without the flags.
 
 ## Step 4: Place it on a dashboard
 
 ```bash
-langwatch dashboard list --format json          # find or create the target
-langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+langwatch dashboard list -o json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> -o json
 ```
 
 With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
@@ -79,8 +79,8 @@ With no `--grid-row`, the platform allocates the next free row, so it never land
 ## Managing saved charts
 
 ```bash
-langwatch chart list --format json
-langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart list -o json
+langwatch chart get <chart-id> -o json    # SQL, parameters, spec, placement
 langwatch chart update <chart-id> --sql-file query.sql
 langwatch chart delete <chart-id>
 ```
@@ -88,6 +88,6 @@ langwatch chart delete <chart-id>
 ## Failure modes worth knowing
 
 - `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
-- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- A save that succeeds but a run that fails with an unknown error — the SQL almost certainly names a column that does not exist; re-read the schema (Step 1) and fix the column, then update the chart.
 - `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
 - `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.

--- a/skills/_compiled/generate.sh
+++ b/skills/_compiled/generate.sh
@@ -30,7 +30,7 @@ for skill in $SKILLS; do
   $COMPILER --skills "$skill" --mode docs > "$OUT_DIR/$skill.docs.txt"
 done
 
-RECIPES="debug-instrumentation agent-best-practices debug-with-langwatch eval-triage setup-lw evaluate-multimodal generate-rag-dataset test-compliance test-cli-usability"
+RECIPES="debug-instrumentation agent-best-practices debug-with-langwatch eval-triage setup-lw evaluate-multimodal generate-rag-dataset test-compliance test-cli-usability lwql-charts"
 
 for recipe in $RECIPES; do
   echo "Compiling recipe $recipe..."

--- a/skills/_compiled/native/lwql-charts/SKILL.md
+++ b/skills/_compiled/native/lwql-charts/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: lwql-charts
+user-prompt: "Build a chart from a question and put it on my dashboard"
+description: Author a saved analytics chart from a plain question and place it on a dashboard. Discovers the LangWatchQL analytics schema, writes and test-runs the SQL, saves it as a chart with a Vega-Lite specification, and places it where the team already looks. Use when asked to build, save, run, or dashboard a metric or chart.
+license: MIT
+compatibility: Requires the `langwatch` CLI with a valid `LANGWATCH_API_KEY`, and a project with LangWatchQL analytics enabled. Works with Claude Code and similar coding agents.
+metadata:
+  category: recipe
+---
+
+# Author a Chart and Place It on a Dashboard
+
+Turn a question ("how many traces per day?", "cost by model this week") into a saved chart that keeps updating on a dashboard. The loop is: **discover the schema → write and test-run the SQL → save the chart → place it**.
+
+## Prerequisites
+
+LangWatchQL analytics is switched per project. If any chart command answers with error code `lwql_not_enabled`, the feature is off for this project — tell the user, do not retry.
+
+## Step 1: Discover the schema before writing any SQL
+
+Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
+
+```bash
+langwatch chart schema --format json
+```
+
+Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+
+## Step 2: Write the SQL, using the reserved period parameters
+
+A chart that should follow the dashboard's period selector declares the reserved bound parameters instead of hardcoding dates:
+
+- `{period_start:DateTime}` / `{period_end:DateTime}` — the surface's period, half-open `[start, end)`
+- `{period_granularity_seconds:UInt32}` — the surface's datapoint step, in seconds
+
+```sql
+SELECT
+  toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket,
+  count() AS traces
+FROM analytics.traces
+WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}
+GROUP BY bucket
+ORDER BY bucket
+```
+
+Your own parameters (`{since:DateTime}`, `{model:String}`, …) get their values from `--param`; never pass a value for the reserved `period_*` names.
+
+## Step 3: Save the chart, then prove it runs
+
+```bash
+langwatch chart create \
+  --name "Traces per day" \
+  --sql-file query.sql \
+  --spec-file spec.json \
+  --format json
+```
+
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+
+See the numbers before placing it:
+
+```bash
+langwatch chart run <chart-id> \
+  --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
+  --granularity 86400 --format json
+```
+
+`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+
+## Step 4: Place it on a dashboard
+
+```bash
+langwatch dashboard list --format json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+```
+
+With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
+
+## Managing saved charts
+
+```bash
+langwatch chart list --format json
+langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart update <chart-id> --sql-file query.sql
+langwatch chart delete <chart-id>
+```
+
+## Failure modes worth knowing
+
+- `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
+- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
+- `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.

--- a/skills/_compiled/native/lwql-charts/SKILL.md
+++ b/skills/_compiled/native/lwql-charts/SKILL.md
@@ -21,10 +21,10 @@ LangWatchQL analytics is switched per project. If any chart command answers with
 Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
 
 ```bash
-langwatch chart schema --format json
+langwatch chart schema -o json
 ```
 
-Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+Read the datasets, their grain, their time column, and which columns are `available` to you. Saving validates the SQL against the analytics policy and the specification against the chart policy — it does not check that every column exists, so SQL naming a wrong column saves fine and only fails when the chart runs. Writing SQL against the schema you just read, then test-running the chart right after saving it (Step 3), is what catches a bad column before anyone sees it on a dashboard.
 
 ## Step 2: Write the SQL, using the reserved period parameters
 
@@ -52,26 +52,26 @@ langwatch chart create \
   --name "Traces per day" \
   --sql-file query.sql \
   --spec-file spec.json \
-  --format json
+  -o json
 ```
 
-`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates the SQL against the analytics policy and the specification against the chart policy before writing anything — a refusal means fix the input, not retry. It does not check column names against the schema, which is why the very next command is always a run: a chart that saves but names a wrong column fails only at run time.
 
 See the numbers before placing it:
 
 ```bash
 langwatch chart run <chart-id> \
   --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
-  --granularity 86400 --format json
+  --granularity 3600 -o json
 ```
 
-`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+`--start`/`--end` fill the reserved period parameters and `--granularity` the datapoint step, which only accepts the offered steps: `1` (second), `60` (minute), `3600` (hour). A chart whose SQL declares the reserved period parameters **requires** `--start` and `--end` on every run — there is no default window, and running without them is refused. Only a chart that declares none of them runs without the flags.
 
 ## Step 4: Place it on a dashboard
 
 ```bash
-langwatch dashboard list --format json          # find or create the target
-langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+langwatch dashboard list -o json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> -o json
 ```
 
 With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
@@ -79,8 +79,8 @@ With no `--grid-row`, the platform allocates the next free row, so it never land
 ## Managing saved charts
 
 ```bash
-langwatch chart list --format json
-langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart list -o json
+langwatch chart get <chart-id> -o json    # SQL, parameters, spec, placement
 langwatch chart update <chart-id> --sql-file query.sql
 langwatch chart delete <chart-id>
 ```
@@ -88,6 +88,6 @@ langwatch chart delete <chart-id>
 ## Failure modes worth knowing
 
 - `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
-- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- A save that succeeds but a run that fails with an unknown error — the SQL almost certainly names a column that does not exist; re-read the schema (Step 1) and fix the column, then update the chart.
 - `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
 - `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.

--- a/skills/_tests/lwql-charts-routing.test.ts
+++ b/skills/_tests/lwql-charts-routing.test.ts
@@ -1,0 +1,79 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+import { listNativeSkills, renderSkill } from "../_compiler/native.js";
+
+// Backs specs/analytics/lwql-langy-authoring.feature: the chart family's
+// discoverability for Langy — the CLI command listing (built from
+// feature-map.json), the lwql-charts skill's schema-first instruction, and
+// the committed compiled render staying true to its source.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const skillsRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(skillsRoot, "..");
+
+describe("the lwql-charts skill and the chart command family", () => {
+  describe("given the CLI's command listing source and the compiled skill tree", () => {
+    /** @scenario "The chart family is discoverable by name, and its skill teaches Langy to check the schema first" */
+    it("lists the chart group, teaches schema discovery before SQL, and the committed render matches a fresh one", () => {
+      // The chart group appears in the command listing: `langwatch commands`
+      // reads feature-map.json (embedded at codegen time), so the map is the
+      // listing's source of truth.
+      const featureMap = JSON.parse(
+        fs.readFileSync(path.join(repoRoot, "feature-map.json"), "utf8"),
+      ) as {
+        features: {
+          surfaces?: { code?: { cli?: string[] | null } | null } | null;
+        }[];
+      };
+      const cliCommands = featureMap.features.flatMap(
+        (feature) => feature.surfaces?.code?.cli ?? [],
+      );
+      const chartCommands = cliCommands.filter((command) =>
+        command.startsWith("chart "),
+      );
+      expect(chartCommands).toContain("chart create");
+      expect(chartCommands).toContain("chart place");
+      expect(chartCommands).toContain("chart schema");
+
+      // The skill instructs discovering the analytics schema before writing
+      // SQL: the schema step must come before the SQL-authoring step, and
+      // must forbid guessing names.
+      const skill = listNativeSkills(skillsRoot).find(
+        (s) => s.slug === "lwql-charts",
+      );
+      expect(skill, "lwql-charts is a shipped native skill").toBeTruthy();
+      const rendered = renderSkill(skill!);
+      const schemaStep = rendered.indexOf("langwatch chart schema");
+      const sqlStep = rendered.indexOf("Write the SQL");
+      expect(schemaStep, "the skill names the schema command").toBeGreaterThan(0);
+      expect(sqlStep, "the skill has a SQL-writing step").toBeGreaterThan(0);
+      expect(schemaStep, "schema discovery comes before SQL").toBeLessThan(sqlStep);
+      expect(rendered).toContain("Never guess dataset or column names");
+
+      // The compiled skill committed in the repository matches a fresh
+      // render from its source, and the langyagent mirror carries the same
+      // bytes.
+      const committed = fs.readFileSync(
+        path.join(skillsRoot, "_compiled", "native", "lwql-charts", "SKILL.md"),
+        "utf8",
+      );
+      const mirrored = fs.readFileSync(
+        path.join(
+          repoRoot,
+          "services",
+          "langyagent",
+          "internal",
+          "assets",
+          "skills",
+          "lwql-charts",
+          "SKILL.md",
+        ),
+        "utf8",
+      );
+      expect(committed).toBe(rendered);
+      expect(mirrored).toBe(committed);
+    });
+  });
+});

--- a/skills/recipes/lwql-charts/SKILL.mdx
+++ b/skills/recipes/lwql-charts/SKILL.mdx
@@ -1,0 +1,97 @@
+---
+name: lwql-charts
+user-prompt: "Build a chart from a question and put it on my dashboard"
+description: Author a saved analytics chart from a plain question and place it on a dashboard. Discovers the LangWatchQL analytics schema, writes and test-runs the SQL, saves it as a chart with a Vega-Lite specification, and places it where the team already looks. Use when asked to build, save, run, or dashboard a metric or chart.
+license: MIT
+compatibility: Requires the `langwatch` CLI with a valid `LANGWATCH_API_KEY`, and a project with LangWatchQL analytics enabled. Works with Claude Code and similar coding agents.
+metadata:
+  category: recipe
+---
+
+import CliSetup from '../../_shared/cli-setup.mdx'
+
+# Author a Chart and Place It on a Dashboard
+
+Turn a question ("how many traces per day?", "cost by model this week") into a saved chart that keeps updating on a dashboard. The loop is: **discover the schema → write and test-run the SQL → save the chart → place it**.
+
+## Prerequisites
+
+<CliSetup />
+
+LangWatchQL analytics is switched per project. If any chart command answers with error code `lwql_not_enabled`, the feature is off for this project — tell the user, do not retry.
+
+## Step 1: Discover the schema before writing any SQL
+
+Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
+
+```bash
+langwatch chart schema --format json
+```
+
+Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+
+## Step 2: Write the SQL, using the reserved period parameters
+
+A chart that should follow the dashboard's period selector declares the reserved bound parameters instead of hardcoding dates:
+
+- `{period_start:DateTime}` / `{period_end:DateTime}` — the surface's period, half-open `[start, end)`
+- `{period_granularity_seconds:UInt32}` — the surface's datapoint step, in seconds
+
+```sql
+SELECT
+  toStartOfInterval(OccurredAt, INTERVAL {period_granularity_seconds:UInt32} SECOND) AS bucket,
+  count() AS traces
+FROM analytics.traces
+WHERE OccurredAt >= {period_start:DateTime} AND OccurredAt < {period_end:DateTime}
+GROUP BY bucket
+ORDER BY bucket
+```
+
+Your own parameters (`{since:DateTime}`, `{model:String}`, …) get their values from `--param`; never pass a value for the reserved `period_*` names.
+
+## Step 3: Save the chart, then prove it runs
+
+```bash
+langwatch chart create \
+  --name "Traces per day" \
+  --sql-file query.sql \
+  --spec-file spec.json \
+  --format json
+```
+
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+
+See the numbers before placing it:
+
+```bash
+langwatch chart run <chart-id> \
+  --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
+  --granularity 86400 --format json
+```
+
+`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+
+## Step 4: Place it on a dashboard
+
+```bash
+langwatch dashboard list --format json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+```
+
+With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
+
+## Managing saved charts
+
+```bash
+langwatch chart list --format json
+langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart update <chart-id> --sql-file query.sql
+langwatch chart delete <chart-id>
+```
+
+## Failure modes worth knowing
+
+- `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
+- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
+- `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.

--- a/skills/recipes/lwql-charts/SKILL.mdx
+++ b/skills/recipes/lwql-charts/SKILL.mdx
@@ -25,10 +25,10 @@ LangWatchQL analytics is switched per project. If any chart command answers with
 Never guess dataset or column names. The schema command lists every dataset your credentials may query, each column's type and description, and a runnable example query per dataset:
 
 ```bash
-langwatch chart schema --format json
+langwatch chart schema -o json
 ```
 
-Read the datasets, their grain, their time column, and which columns are `available` to you. A column your permissions withhold is refused by the validator at save time — writing SQL against the schema you just read is what keeps saves from bouncing.
+Read the datasets, their grain, their time column, and which columns are `available` to you. Saving validates the SQL against the analytics policy and the specification against the chart policy — it does not check that every column exists, so SQL naming a wrong column saves fine and only fails when the chart runs. Writing SQL against the schema you just read, then test-running the chart right after saving it (Step 3), is what catches a bad column before anyone sees it on a dashboard.
 
 ## Step 2: Write the SQL, using the reserved period parameters
 
@@ -56,26 +56,26 @@ langwatch chart create \
   --name "Traces per day" \
   --sql-file query.sql \
   --spec-file spec.json \
-  --format json
+  -o json
 ```
 
-`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates both the SQL (against your permissions) and the specification before writing anything — a refusal means fix the input, not retry.
+`spec.json` is a Vega-Lite specification reading from `{"data": {"name": "query_result"}}`, with fields named exactly after the SQL's output columns. The save validates the SQL against the analytics policy and the specification against the chart policy before writing anything — a refusal means fix the input, not retry. It does not check column names against the schema, which is why the very next command is always a run: a chart that saves but names a wrong column fails only at run time.
 
 See the numbers before placing it:
 
 ```bash
 langwatch chart run <chart-id> \
   --start 2026-08-01T00:00:00Z --end 2026-08-08T00:00:00Z \
-  --granularity 86400 --format json
+  --granularity 3600 -o json
 ```
 
-`--start`/`--end` fill the reserved period parameters; `--granularity` the datapoint step. A chart whose SQL declares none of them runs without the flags.
+`--start`/`--end` fill the reserved period parameters and `--granularity` the datapoint step, which only accepts the offered steps: `1` (second), `60` (minute), `3600` (hour). A chart whose SQL declares the reserved period parameters **requires** `--start` and `--end` on every run — there is no default window, and running without them is refused. Only a chart that declares none of them runs without the flags.
 
 ## Step 4: Place it on a dashboard
 
 ```bash
-langwatch dashboard list --format json          # find or create the target
-langwatch chart place <chart-id> --dashboard-id <dashboard-id> --format json
+langwatch dashboard list -o json          # find or create the target
+langwatch chart place <chart-id> --dashboard-id <dashboard-id> -o json
 ```
 
 With no `--grid-row`, the platform allocates the next free row, so it never lands on top of an existing chart. `langwatch chart unplace <chart-id>` takes it off again without deleting it.
@@ -83,8 +83,8 @@ With no `--grid-row`, the platform allocates the next free row, so it never land
 ## Managing saved charts
 
 ```bash
-langwatch chart list --format json
-langwatch chart get <chart-id> --format json    # SQL, parameters, spec, placement
+langwatch chart list -o json
+langwatch chart get <chart-id> -o json    # SQL, parameters, spec, placement
 langwatch chart update <chart-id> --sql-file query.sql
 langwatch chart delete <chart-id>
 ```
@@ -92,6 +92,6 @@ langwatch chart delete <chart-id>
 ## Failure modes worth knowing
 
 - `lwql_not_enabled` — the project's LangWatchQL switch is off; stop and say so.
-- A validator refusal naming a column — re-read the schema (Step 1); the column is misspelled or your permissions withhold it.
+- A save that succeeds but a run that fails with an unknown error — the SQL almost certainly names a column that does not exist; re-read the schema (Step 1) and fix the column, then update the chart.
 - `saved_workbench_chart_specification_refused` — the Vega-Lite specification breaks the chart policy; simplify it (one `query_result` data source, fields matching the SQL columns).
 - `saved_workbench_chart_dashboard_not_found` — the dashboard id is not in this project; list dashboards again.

--- a/specs/analytics/lwql-langy-authoring.feature
+++ b/specs/analytics/lwql-langy-authoring.feature
@@ -190,10 +190,8 @@ Feature: Langy authors saved workbench charts and places them on dashboards
   # ---------------------------------------------------------------------------
   # Langy's CLI — author, then place (bound in later commits of this slice)
   # ---------------------------------------------------------------------------
-  # The CLI-lane scenarios below are delivered by the next slice of #6712
-  # (SDK client, CLI chart family, skill routing); @unimplemented until it lands.
 
-  @integration @unimplemented
+  @integration
   Scenario: Langy creates a chart with the CLI and reads it back with the same query, parameters and specification
     Given Langy holding CLI credentials for a project
     When it creates a chart from a SQL file, named parameters and a
@@ -201,7 +199,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then the SQL, the parameter values and the specification it reads back are
       the ones it submitted
 
-  @integration @unimplemented
+  @integration
   Scenario: A chart Langy creates is indistinguishable from one a member saves by hand
     Given a chart created through the CLI and a chart saved through the
       application by a member
@@ -210,21 +208,21 @@ Feature: Langy authors saved workbench charts and places them on dashboards
       project scoping
     And they differ only in id, name and timestamps
 
-  @integration @unimplemented
+  @integration
   Scenario: SQL naming a column Langy's credentials cannot read is refused identically everywhere
     Given SQL naming a column that Langy's protections withhold
     When the chart is saved through the CLI, through REST directly and through
       the application's own save path
     Then every path refuses with the same LangWatchQL validator error code
 
-  @integration @unimplemented
+  @integration
   Scenario: A specification the chart policy refuses cannot be written through the CLI
     Given a specification the workbench's Vega-Lite policy refuses
     When Langy tries to create a chart carrying it
     Then the CLI reports error code saved_workbench_chart_specification_refused
     And no chart is created
 
-  @integration @unimplemented
+  @integration
   Scenario: Langy places a saved chart on a dashboard with the CLI
     Given Langy holding CLI credentials and the id of a dashboard in the
       project
@@ -232,7 +230,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then the chart's dashboard id and grid position are set
     And the chart is listed among that dashboard's charts
 
-  @unit @unimplemented
+  @unit
   Scenario: Every new CLI verb is machine-readable, not just human-formatted
     Given a chart created, placed, listed, updated, unplaced or deleted through
       the CLI
@@ -240,7 +238,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then the data returned carries no human-only formatting
     And it can be parsed by an agent without inspecting the human table output
 
-  @unit @unimplemented
+  @unit
   Scenario: Every CLI verb this slice adds refuses while the workbench switch is off, and writes nothing
     Given the LangWatchQL feature switch is off for the project
     When Langy invokes create, update, delete, run, place or unplace through
@@ -248,7 +246,7 @@ Feature: Langy authors saved workbench charts and places them on dashboards
     Then every one of them refuses with error code lwql_not_enabled
     And no row is created or mutated by any of them
 
-  @unit @unimplemented
+  @unit
   Scenario: The chart family is discoverable by name, and its skill teaches Langy to check the schema first
     Given the CLI's own command listing and the compiled skill tree
     When the chart command group and the LWQL charts skill are looked up


### PR DESCRIPTION
# Related Issue

- Resolves #6712

Part of #6582, completes #6712 (with #7439, its base).

**Stacked on #7439** (`issue6712/lwql-chart-cli`) — review only the top 3 commits.

## What this slice ships

1. **Typed SDK client regeneration** — the two `/placement` paths from #7439 land in `api-client.ts` (mechanical).
2. **The `langwatch chart` CLI family** — `ChartsApiService` with schema/list/get/create/update/delete/place/unplace/runQuery; a new `chart schema` verb so Langy discovers columns before writing SQL; all verbs machine-readable; feature-map + capability-catalog drift guards green. `chart run` composes GET chart + the governed query door (no REST run endpoint exists; same execution path and semantics).
3. **The `lwql-charts` skill + Langy routing** — schema-first recipe, both generated skill trees committed, `AGENTS.md` routing row in the same commit (bidirectional pin), discoverability pinned by test.

With this slice, all **23/23 scenarios** in `specs/analytics/lwql-langy-authoring.feature` are bound (the 8 CLI-lane scenarios drop their `@unimplemented` from #7439).

## Test evidence

- Feature parity: 23/23 bound, overall exit 0
- App typecheck + typecheck:tests clean; SDK typecheck clean
- SDK unit (chart commands, feature-map drift, command catalog): 35 passed
- Platform unit (service, capability catalog/registry): 66 passed
- REST integration incl. CLI-driven scenarios: 29 passed
- Skills routing tests: 14 passed


## Deployment Impact

No env vars or helm values added or changed. The new surface is application code plus repo assets: the `langwatch chart` CLI verbs live in the TypeScript SDK, the `lwql-charts` skill ships as committed generated assets inside `services/langyagent` (baked into the existing image build — no new service, port, or config), and everything is gated behind the existing `release_lwql_workbench` feature flag. A vanilla `helm install` with no overrides behaves exactly as before: the flag is off, all chart endpoints stay dark, and Langy's routing row points at a skill whose verbs refuse. No BYOC dataplane impact — no new data paths; queries still flow through the existing governed LWQL query endpoint.


## Live CLI QA (real dev server + ClickHouse harness)

Every verb driven end-to-end with the compiled CLI against a live dev server ([full transcript](https://github.com/langwatch/pr-screenshots/blob/main/pr-7443/transcript.md)):

- `schema` / `create`→`get`/`list` (byte-identical round-trip) / `run` (rows at explicit window+granularity) / `update` / `place` / `unplace`: **PASS**
- The money shot — a chart authored entirely through the CLI, placed via `chart place`, rendering live with real data on the dashboard:

![CLI-created chart placed on dashboard](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7443/11-dashboard-placed.png)

After `chart unplace`:

![dashboard after unplace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7443/13-dashboard-unplaced.png)

QA found 6 bugs (delete-after-204 crash, unvalidated `--granularity`, skill examples teaching broken flags, skill/period-flags contract drift, handled error codes swallowed as `network_error`, skill over-promising save-time validation) — **all fixed in a follow-up commit on this branch**. Run-time naming of ClickHouse UNKNOWN_IDENTIFIER is tracked as #7447.


## How I can prove I was successful

- **[proven] CI fully green at head `68c50ad848`** (60 checks).
- **[proven] Fan-out READY at `c2cae594d8`** (security / design / tests) + **clerk READY at `68c50ad848`** verifying the six-bug QA-fix delta — verdict comment on this PR.
- **[proven] Live CLI QA**: every verb driven end-to-end against a real dev server (transcript + screenshots linked above); a CLI-authored chart placed via `chart place` renders live on the dashboard (money shot above). All six bugs QA found are fixed on this branch with sabotage-verified tests.
- **[proven] 23/23 scenarios bound** in `specs/analytics/lwql-langy-authoring.feature`; the skill's committed generated trees are byte-equal to a fresh render (pinned by test).

## Human verification

- `langwatch chart schema && langwatch chart create --sql-file q.sql ... && langwatch chart run <id> --start ... --end ... --granularity 3600 -o json | jq .` — expect rows and a parseable envelope; then `chart place` and see it on the dashboard.
- Feed it an off-list `--granularity 300`: expect a local refusal naming the three offered steps.
