### PR TITLE
fix(traces-v2): conversation pill filter matches the value the pill shows

### DIFF
--- a/platform/app/src/server/api/routers/tracesV2.ts
+++ b/platform/app/src/server/api/routers/tracesV2.ts
@@ -44,6 +44,7 @@ import type {
   SpanSummaryRow,
   TraceEventRollup,
 } from "~/server/app-layer/traces/repositories/span-storage.repository";
+import { resolveConversationId } from "~/server/app-layer/traces/resolve-conversation-id";
 import type { TraceListItem } from "~/server/app-layer/traces/trace-list.service";
 import {
   traceMetadataUpdateSchema,
@@ -193,10 +194,7 @@ export function mapTraceSummaryToHeader(
       summary.attributes["langwatch.span.name"] ?? summary.traceId.slice(0, 8),
     serviceName: summary.attributes["service.name"] ?? "",
     origin: summary.attributes["langwatch.origin"] ?? "application",
-    conversationId:
-      summary.attributes["gen_ai.conversation.id"] ??
-      summary.attributes["langgraph.thread_id"] ??
-      null,
+    conversationId: resolveConversationId(summary.attributes) || null,
     userId: summary.attributes["langwatch.user_id"] ?? null,
     durationMs: summary.totalDurationMs,
     spanCount: summary.spanCount,

--- a/platform/app/src/server/app-layer/traces/__tests__/resolve-conversation-id.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/resolve-conversation-id.unit.test.ts
@@ -1,0 +1,163 @@
+/**
+ * One resolved source for a trace's conversation id: the drawer header
+ * pill, the facet expression, the has/none predicate and the trace-header
+ * mapper all read through resolve-conversation-id, so a value the pill
+ * displays is always a value the filter can match.
+ *
+ * Feature: specs/traces-v2/data-layer.feature
+ * Rule: A pill's filter queries the same value the pill displays
+ */
+import { describe, expect, it } from "vitest";
+
+import { mapTraceSummaryToHeader } from "~/server/api/routers/tracesV2";
+import {
+  type ExpressionCategoricalDef,
+  FACET_REGISTRY,
+} from "../facet-registry";
+import { translateFilterToClickHouse } from "../filter-to-clickhouse";
+import { evaluateQueryInMemory } from "../filter-to-clickhouse/evaluate";
+import type { InMemoryTrace } from "../filter-to-clickhouse/field-def";
+import {
+  CONVERSATION_ID_CLICKHOUSE_EXPRESSION,
+  resolveConversationId,
+} from "../resolve-conversation-id";
+import type { TraceSummaryData } from "../types";
+
+function summary(attributes: Record<string, string>): TraceSummaryData {
+  return {
+    traceId: "trace_1",
+    spanCount: 0,
+    totalDurationMs: 0,
+    containsErrorStatus: false,
+    containsOKStatus: true,
+    errorMessage: null,
+    models: [],
+    attributes,
+    annotationIds: [],
+    occurredAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    LastEventOccurredAt: 0,
+  } as TraceSummaryData;
+}
+
+function traceWith(attributes: Record<string, string>): InMemoryTrace {
+  return { summary: summary(attributes) };
+}
+
+describe("resolveConversationId", () => {
+  it("prefers the canonical key over the legacy keys", () => {
+    expect(
+      resolveConversationId({
+        "gen_ai.conversation.id": "canonical",
+        "langgraph.thread_id": "legacy",
+      }),
+    ).toBe("canonical");
+  });
+
+  it("falls through to langgraph.thread_id on rows that never carried the canonical key", () => {
+    expect(resolveConversationId({ "langgraph.thread_id": "lg-1" })).toBe(
+      "lg-1",
+    );
+  });
+
+  it("falls through to langwatch.thread_id last", () => {
+    expect(resolveConversationId({ "langwatch.thread_id": "lw-1" })).toBe(
+      "lw-1",
+    );
+  });
+
+  it("treats an empty earlier key as absent", () => {
+    expect(
+      resolveConversationId({
+        "gen_ai.conversation.id": "",
+        "langgraph.thread_id": "lg-2",
+      }),
+    ).toBe("lg-2");
+  });
+
+  it("returns an empty string when no supported key carries a value", () => {
+    expect(resolveConversationId({})).toBe("");
+  });
+});
+
+describe("the conversation facet resolves the whole key chain", () => {
+  const def = FACET_REGISTRY.find(
+    (facet): facet is ExpressionCategoricalDef =>
+      facet.key === "conversation" && facet.kind === "categorical",
+  );
+
+  /** @scenario "Facet read and display resolution never disagree on precedence" */
+  it("the facet's in-memory read and the drawer header resolution agree on every key layout", () => {
+    expect(def).toBeDefined();
+    for (const attributes of [
+      { "gen_ai.conversation.id": "c-1" },
+      { "langgraph.thread_id": "lg-3" },
+      { "langwatch.thread_id": "lw-3" },
+      { "gen_ai.conversation.id": "", "langgraph.thread_id": "lg-4" },
+      {},
+    ]) {
+      const facetValue = def!.read!({ summary: summary(attributes) });
+      const header = mapTraceSummaryToHeader(summary(attributes));
+      expect(facetValue).toBe(resolveConversationId(attributes));
+      expect(header.conversationId ?? "").toBe(
+        resolveConversationId(attributes),
+      );
+    }
+  });
+
+  /** @scenario "Facet read and display resolution never disagree on precedence" */
+  it("the ClickHouse expression spells out every supported key", () => {
+    for (const key of [
+      "gen_ai.conversation.id",
+      "langgraph.thread_id",
+      "langwatch.thread_id",
+    ]) {
+      expect(CONVERSATION_ID_CLICKHOUSE_EXPRESSION).toContain(`'${key}'`);
+    }
+  });
+
+  /** @scenario "Facet read and display resolution never disagree on precedence" */
+  it("compiles equality against the registry expression", () => {
+    const compiled = translateFilterToClickHouse(
+      'conversation:"lg-5"',
+      "tenant-1",
+      { from: 0, to: 1 },
+    );
+    expect(compiled?.sql).toContain(CONVERSATION_ID_CLICKHOUSE_EXPRESSION);
+  });
+});
+
+describe("filtering by a legacy-key conversation id", () => {
+  /** @scenario "Conversation pill on a legacy-key trace filters to that conversation" */
+  it("matches in memory where only langgraph.thread_id carries the id", () => {
+    const legacyOnly = traceWith({ "langgraph.thread_id": "lg-6" });
+    const canonicalOther = traceWith({ "gen_ai.conversation.id": "other" });
+    const bare = traceWith({});
+
+    expect(evaluateQueryInMemory('conversation:"lg-6"', legacyOnly)).toBe(true);
+    expect(evaluateQueryInMemory('conversation:"lg-6"', canonicalOther)).toBe(
+      false,
+    );
+    expect(evaluateQueryInMemory('conversation:"lg-6"', bare)).toBe(false);
+  });
+
+  /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
+  it("has:conversation and none:conversation evaluate legacy-key traces in memory like their SQL predicate", () => {
+    const legacyOnly = traceWith({ "langgraph.thread_id": "lg-7" });
+    const canonical = traceWith({ "gen_ai.conversation.id": "c-7" });
+    const bare = traceWith({});
+
+    const compiled = translateFilterToClickHouse(
+      "has:conversation",
+      "tenant-1",
+      { from: 0, to: 1 },
+    );
+    expect(compiled?.sql).toContain(CONVERSATION_ID_CLICKHOUSE_EXPRESSION);
+
+    expect(evaluateQueryInMemory("has:conversation", legacyOnly)).toBe(true);
+    expect(evaluateQueryInMemory("has:conversation", canonical)).toBe(true);
+    expect(evaluateQueryInMemory("has:conversation", bare)).toBe(false);
+    expect(evaluateQueryInMemory("none:conversation", bare)).toBe(true);
+  });
+});

--- a/platform/app/src/server/app-layer/traces/__tests__/resolve-conversation-id.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/resolve-conversation-id.unit.test.ts
@@ -201,7 +201,7 @@ describe("given a trace whose conversation id rides langgraph.thread_id only", (
 
   describe("when the query asks whether a conversation exists", () => {
     /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
-    it("has:conversation and none:conversation agree with their SQL predicate", () => {
+    it("has:conversation and none:conversation agree with their SQL predicate on every key layout", () => {
       const compiled = translateFilterToClickHouse(
         "has:conversation",
         "tenant-1",
@@ -214,7 +214,11 @@ describe("given a trace whose conversation id rides langgraph.thread_id only", (
       const bare = traceWith({});
 
       expect(evaluateQueryInMemory("has:conversation", legacyOnly)).toBe(true);
+      expect(evaluateQueryInMemory("none:conversation", legacyOnly)).toBe(
+        false,
+      );
       expect(evaluateQueryInMemory("has:conversation", canonical)).toBe(true);
+      expect(evaluateQueryInMemory("none:conversation", canonical)).toBe(false);
       expect(evaluateQueryInMemory("has:conversation", bare)).toBe(false);
       expect(evaluateQueryInMemory("none:conversation", bare)).toBe(true);
     });

--- a/platform/app/src/server/app-layer/traces/__tests__/resolve-conversation-id.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/resolve-conversation-id.unit.test.ts
@@ -23,141 +23,200 @@ import {
 } from "../resolve-conversation-id";
 import type { TraceSummaryData } from "../types";
 
-function summary(attributes: Record<string, string>): TraceSummaryData {
-  return {
-    traceId: "trace_1",
-    spanCount: 0,
-    totalDurationMs: 0,
-    containsErrorStatus: false,
-    containsOKStatus: true,
-    errorMessage: null,
-    models: [],
-    attributes,
-    annotationIds: [],
-    occurredAt: 0,
-    createdAt: 0,
-    updatedAt: 0,
-    LastEventOccurredAt: 0,
-  } as TraceSummaryData;
+const baseSummary: TraceSummaryData = {
+  traceId: "trace_1",
+  spanCount: 0,
+  totalDurationMs: 0,
+  computedIOSchemaVersion: "1",
+  computedInput: null,
+  computedOutput: null,
+  timeToFirstTokenMs: null,
+  timeToLastTokenMs: null,
+  tokensPerSecond: null,
+  containsErrorStatus: false,
+  containsOKStatus: true,
+  errorMessage: null,
+  models: [],
+  totalCost: null,
+  nonBilledCost: null,
+  tokensEstimated: false,
+  totalPromptTokenCount: null,
+  totalCompletionTokenCount: null,
+  outputFromRootSpan: false,
+  outputSpanEndTimeMs: 0,
+  blockedByGuardrail: false,
+  rootSpanType: null,
+  containsAi: false,
+  containsPrompt: false,
+  selectedPromptId: null,
+  selectedPromptSpanId: null,
+  selectedPromptStartTimeMs: null,
+  lastUsedPromptId: null,
+  lastUsedPromptVersionNumber: null,
+  lastUsedPromptVersionId: null,
+  lastUsedPromptSpanId: null,
+  lastUsedPromptStartTimeMs: null,
+  topicId: null,
+  subTopicId: null,
+  annotationIds: [],
+  attributes: {},
+  traceName: "",
+  occurredAt: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  LastEventOccurredAt: 0,
+};
+
+function summaryWith(attributes: Record<string, string>): TraceSummaryData {
+  return { ...baseSummary, attributes };
 }
 
 function traceWith(attributes: Record<string, string>): InMemoryTrace {
-  return { summary: summary(attributes) };
+  return { summary: summaryWith(attributes) };
 }
 
-describe("resolveConversationId", () => {
-  it("prefers the canonical key over the legacy keys", () => {
-    expect(
-      resolveConversationId({
-        "gen_ai.conversation.id": "canonical",
-        "langgraph.thread_id": "legacy",
-      }),
-    ).toBe("canonical");
+function categoricalFacet(key: string): ExpressionCategoricalDef {
+  const def = FACET_REGISTRY.find(
+    (facet): facet is ExpressionCategoricalDef =>
+      facet.key === key && facet.kind === "categorical",
+  );
+  if (!def) throw new Error(`facet "${key}" is not an expression categorical`);
+  return def;
+}
+
+describe("given the shared conversation id resolver", () => {
+  describe("when summaries carry the id under different keys", () => {
+    it("prefers the canonical key over the legacy keys", () => {
+      expect(
+        resolveConversationId({
+          "gen_ai.conversation.id": "canonical",
+          "langgraph.thread_id": "legacy",
+        }),
+      ).toBe("canonical");
+    });
+
+    it("falls through to langgraph.thread_id on rows that never carried the canonical key", () => {
+      expect(resolveConversationId({ "langgraph.thread_id": "lg-1" })).toBe(
+        "lg-1",
+      );
+    });
+
+    it("falls through to langwatch.thread_id last", () => {
+      expect(resolveConversationId({ "langwatch.thread_id": "lw-1" })).toBe(
+        "lw-1",
+      );
+    });
   });
 
-  it("falls through to langgraph.thread_id on rows that never carried the canonical key", () => {
-    expect(resolveConversationId({ "langgraph.thread_id": "lg-1" })).toBe(
-      "lg-1",
-    );
+  describe("when an earlier key holds an empty string", () => {
+    it("falls through to the next key instead of returning the empty value", () => {
+      expect(
+        resolveConversationId({
+          "gen_ai.conversation.id": "",
+          "langgraph.thread_id": "lg-2",
+        }),
+      ).toBe("lg-2");
+    });
   });
 
-  it("falls through to langwatch.thread_id last", () => {
-    expect(resolveConversationId({ "langwatch.thread_id": "lw-1" })).toBe(
-      "lw-1",
-    );
-  });
-
-  it("treats an empty earlier key as absent", () => {
-    expect(
-      resolveConversationId({
-        "gen_ai.conversation.id": "",
-        "langgraph.thread_id": "lg-2",
-      }),
-    ).toBe("lg-2");
-  });
-
-  it("returns an empty string when no supported key carries a value", () => {
-    expect(resolveConversationId({})).toBe("");
+  describe("when no supported key carries a value", () => {
+    it("resolves to an empty string", () => {
+      expect(resolveConversationId({})).toBe("");
+    });
   });
 });
 
-describe("the conversation facet resolves the whole key chain", () => {
-  const def = FACET_REGISTRY.find(
-    (facet): facet is ExpressionCategoricalDef =>
-      facet.key === "conversation" && facet.kind === "categorical",
-  );
-
-  /** @scenario "Facet read and display resolution never disagree on precedence" */
-  it("the facet's in-memory read and the drawer header resolution agree on every key layout", () => {
-    expect(def).toBeDefined();
-    for (const attributes of [
-      { "gen_ai.conversation.id": "c-1" },
-      { "langgraph.thread_id": "lg-3" },
-      { "langwatch.thread_id": "lw-3" },
-      { "gen_ai.conversation.id": "", "langgraph.thread_id": "lg-4" },
-      {},
-    ]) {
-      const facetValue = def!.read!({ summary: summary(attributes) });
-      const header = mapTraceSummaryToHeader(summary(attributes));
+describe("given the conversation facet and the drawer header resolution", () => {
+  describe("when the same attributes flow through both", () => {
+    /** @scenario "Facet read and display resolution never disagree on precedence" */
+    it.each([
+      [{ "gen_ai.conversation.id": "c-1" }],
+      [{ "langgraph.thread_id": "lg-3" }],
+      [{ "langwatch.thread_id": "lw-3" }],
+      [{ "gen_ai.conversation.id": "", "langgraph.thread_id": "lg-4" }],
+      [{}],
+    ])("facet read and header conversationId agree for %j", (attributes) => {
+      const facetValue = categoricalFacet("conversation").read!({
+        summary: summaryWith(attributes),
+      });
+      const header = mapTraceSummaryToHeader(summaryWith(attributes));
       expect(facetValue).toBe(resolveConversationId(attributes));
       expect(header.conversationId ?? "").toBe(
         resolveConversationId(attributes),
       );
-    }
-  });
+    });
 
-  /** @scenario "Facet read and display resolution never disagree on precedence" */
-  it("the ClickHouse expression spells out every supported key", () => {
-    for (const key of [
-      "gen_ai.conversation.id",
-      "langgraph.thread_id",
-      "langwatch.thread_id",
-    ]) {
-      expect(CONVERSATION_ID_CLICKHOUSE_EXPRESSION).toContain(`'${key}'`);
-    }
-  });
-
-  /** @scenario "Facet read and display resolution never disagree on precedence" */
-  it("compiles equality against the registry expression", () => {
-    const compiled = translateFilterToClickHouse(
-      'conversation:"lg-5"',
-      "tenant-1",
-      { from: 0, to: 1 },
-    );
-    expect(compiled?.sql).toContain(CONVERSATION_ID_CLICKHOUSE_EXPRESSION);
+    /** @scenario "Facet read and display resolution never disagree on precedence" */
+    it("compiles equality against the registry expression spelling out every key", () => {
+      const compiled = translateFilterToClickHouse(
+        'conversation:"lg-5"',
+        "tenant-1",
+        { from: 0, to: 1 },
+      );
+      for (const key of [
+        "gen_ai.conversation.id",
+        "langgraph.thread_id",
+        "langwatch.thread_id",
+      ]) {
+        expect(CONVERSATION_ID_CLICKHOUSE_EXPRESSION).toContain(`'${key}'`);
+      }
+      expect(compiled?.sql).toContain(CONVERSATION_ID_CLICKHOUSE_EXPRESSION);
+    });
   });
 });
 
-describe("filtering by a legacy-key conversation id", () => {
-  /** @scenario "Conversation pill on a legacy-key trace filters to that conversation" */
-  it("matches in memory where only langgraph.thread_id carries the id", () => {
-    const legacyOnly = traceWith({ "langgraph.thread_id": "lg-6" });
-    const canonicalOther = traceWith({ "gen_ai.conversation.id": "other" });
-    const bare = traceWith({});
+describe("given the user facet and the drawer header resolution", () => {
+  describe("when the same attributes flow through both", () => {
+    /** @scenario "User pill display and filter agree on one source" */
+    it.each([
+      [{ "langwatch.user_id": "u-1" }],
+      [{}],
+    ])("facet read and header userId agree for %j", (attributes) => {
+      const facetValue = categoricalFacet("user").read!({
+        summary: summaryWith(attributes),
+      });
+      const header = mapTraceSummaryToHeader(summaryWith(attributes));
+      expect(facetValue).toBe(header.userId ?? "");
+    });
+  });
+});
 
-    expect(evaluateQueryInMemory('conversation:"lg-6"', legacyOnly)).toBe(true);
-    expect(evaluateQueryInMemory('conversation:"lg-6"', canonicalOther)).toBe(
-      false,
-    );
-    expect(evaluateQueryInMemory('conversation:"lg-6"', bare)).toBe(false);
+describe("given a trace whose conversation id rides langgraph.thread_id only", () => {
+  describe("when the pill's filter token is evaluated", () => {
+    /** @scenario "Conversation pill on a legacy-key trace filters to that conversation" */
+    it("matches the legacy-key trace in memory and nothing else", () => {
+      const legacyOnly = traceWith({ "langgraph.thread_id": "lg-6" });
+      const canonicalOther = traceWith({ "gen_ai.conversation.id": "other" });
+      const bare = traceWith({});
+
+      expect(evaluateQueryInMemory('conversation:"lg-6"', legacyOnly)).toBe(
+        true,
+      );
+      expect(evaluateQueryInMemory('conversation:"lg-6"', canonicalOther)).toBe(
+        false,
+      );
+      expect(evaluateQueryInMemory('conversation:"lg-6"', bare)).toBe(false);
+    });
   });
 
-  /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
-  it("has:conversation and none:conversation evaluate legacy-key traces in memory like their SQL predicate", () => {
-    const legacyOnly = traceWith({ "langgraph.thread_id": "lg-7" });
-    const canonical = traceWith({ "gen_ai.conversation.id": "c-7" });
-    const bare = traceWith({});
+  describe("when the query asks whether a conversation exists", () => {
+    /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
+    it("has:conversation and none:conversation agree with their SQL predicate", () => {
+      const compiled = translateFilterToClickHouse(
+        "has:conversation",
+        "tenant-1",
+        { from: 0, to: 1 },
+      );
+      expect(compiled?.sql).toContain(CONVERSATION_ID_CLICKHOUSE_EXPRESSION);
 
-    const compiled = translateFilterToClickHouse(
-      "has:conversation",
-      "tenant-1",
-      { from: 0, to: 1 },
-    );
-    expect(compiled?.sql).toContain(CONVERSATION_ID_CLICKHOUSE_EXPRESSION);
+      const legacyOnly = traceWith({ "langgraph.thread_id": "lg-7" });
+      const canonical = traceWith({ "gen_ai.conversation.id": "c-7" });
+      const bare = traceWith({});
 
-    expect(evaluateQueryInMemory("has:conversation", legacyOnly)).toBe(true);
-    expect(evaluateQueryInMemory("has:conversation", canonical)).toBe(true);
-    expect(evaluateQueryInMemory("has:conversation", bare)).toBe(false);
-    expect(evaluateQueryInMemory("none:conversation", bare)).toBe(true);
+      expect(evaluateQueryInMemory("has:conversation", legacyOnly)).toBe(true);
+      expect(evaluateQueryInMemory("has:conversation", canonical)).toBe(true);
+      expect(evaluateQueryInMemory("has:conversation", bare)).toBe(false);
+      expect(evaluateQueryInMemory("none:conversation", bare)).toBe(true);
+    });
   });
 });

--- a/platform/app/src/server/app-layer/traces/facet-registry.ts
+++ b/platform/app/src/server/app-layer/traces/facet-registry.ts
@@ -22,6 +22,10 @@ import type {
   RangeRead,
 } from "./filter-to-clickhouse/field-def";
 import { UNSUPPORTED } from "./filter-to-clickhouse/field-def";
+import {
+  CONVERSATION_ID_CLICKHOUSE_EXPRESSION,
+  resolveConversationId,
+} from "./resolve-conversation-id";
 
 export type FacetTable = "trace_summaries" | "evaluation_runs" | "stored_spans";
 export type FacetGroup =
@@ -163,8 +167,8 @@ export const FACET_REGISTRY: readonly FacetDefinition[] = [
     label: "Conversation",
     group: "trace",
     table: "trace_summaries",
-    expression: "Attributes['gen_ai.conversation.id']",
-    read: (t) => t.summary.attributes["gen_ai.conversation.id"] ?? "",
+    expression: CONVERSATION_ID_CLICKHOUSE_EXPRESSION,
+    read: (t) => resolveConversationId(t.summary.attributes),
   },
   {
     // The same key the analytics layer aliases as `metadata.customer_id`.

--- a/platform/app/src/server/app-layer/traces/filter-to-clickhouse/meta-handlers.ts
+++ b/platform/app/src/server/app-layer/traces/filter-to-clickhouse/meta-handlers.ts
@@ -1,6 +1,10 @@
 import type { TagToken } from "liqe";
 import { FilterParseError } from "../errors";
 import {
+  CONVERSATION_ID_CLICKHOUSE_EXPRESSION,
+  resolveConversationId,
+} from "../resolve-conversation-id";
+import {
   type FieldDef,
   type InMemoryTrace,
   UNSUPPORTED,
@@ -158,7 +162,7 @@ function translateExistence(
       return wrap("length(AnnotationIds) > 0", negated);
 
     case "conversation":
-      return wrap("Attributes['gen_ai.conversation.id'] != ''", negated);
+      return wrap(`${CONVERSATION_ID_CLICKHOUSE_EXPRESSION} != ''`, negated);
 
     case "user":
       return wrap("Attributes['langwatch.user_id'] != ''", negated);
@@ -240,7 +244,7 @@ function evaluateExistence(
     case "annotation":
       return polarise(trace.summary.annotationIds.length > 0);
     case "conversation":
-      return polarise((attrs["gen_ai.conversation.id"] ?? "") !== "");
+      return polarise(resolveConversationId(attrs) !== "");
     case "user":
       return polarise((attrs["langwatch.user_id"] ?? "") !== "");
     case "customer":

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -609,4 +609,87 @@ describe("TraceListClickHouseRepository filtering across row versions", () => {
       expect(counts.values).toEqual({});
     });
   });
+
+  describe("given a trace whose conversation id rides a legacy attribute key", () => {
+    const legacyTenant = `test-legacy-conversation-${nanoid()}`;
+    const legacyTraceId = "legacy-conversation-trace";
+    const legacyTimeRange = { from: base - 60_000, to: base + 60_000 };
+
+    const conversationFacetExpression = (() => {
+      const def = FACET_REGISTRY.find((facet) => facet.key === "conversation");
+      if (!def || !("expression" in def)) {
+        throw new Error(
+          "the conversation facet no longer carries an expression",
+        );
+      }
+      return def.expression;
+    })();
+
+    /** The filter the sidebar compiles, so the test reads the production SQL. */
+    const filterForLegacy = (queryText: string) => {
+      const compiled = translateFilterToClickHouse(
+        queryText,
+        legacyTenant,
+        legacyTimeRange,
+      );
+      if (!compiled) throw new Error(`"${queryText}" compiled to no filter`);
+      return compiled;
+    };
+
+    const listWith = (queryText: string) =>
+      repo.findAll({
+        tenantId: legacyTenant,
+        timeRange: legacyTimeRange,
+        sort: { column: "OccurredAt", direction: "desc" },
+        limit: 50,
+        offset: 0,
+        filterWhere: filterForLegacy(queryText),
+      });
+
+    beforeAll(async () => {
+      // Rows written before the canonicaliser folded thread ids onto
+      // gen_ai.conversation.id keep the raw langgraph key only.
+      await insertRows([
+        makeTraceSummaryRow(0, {
+          TenantId: legacyTenant,
+          TraceId: legacyTraceId,
+          OccurredAt: new Date(base),
+          CreatedAt: new Date(base),
+          UpdatedAt: new Date(base),
+          LastEventOccurredAt: new Date(base),
+          Attributes: { "langgraph.thread_id": "thread-legacy-1" },
+        }),
+      ]);
+    }, 120_000);
+
+    afterAll(async () => {
+      if (!ch) return;
+      await ch.exec({
+        query:
+          "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: legacyTenant },
+      });
+    });
+
+    /** @scenario "Filtering by a legacy-key conversation id returns the trace from ClickHouse" */
+    it("finds the trace when filtering by its conversation id", async () => {
+      const page = await listWith('conversation:"thread-legacy-1"');
+
+      expect(page.rows.map((row) => row.traceId)).toEqual([legacyTraceId]);
+      expect(page.totalHits).toBe(1);
+    });
+
+    /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
+    it("counts the trace under has:conversation and lists its id in the facet values", async () => {
+      const withConversation = await listWith("has:conversation");
+      expect(withConversation.totalHits).toBe(1);
+
+      const counts = await repo.findFacetCounts({
+        tenantId: legacyTenant,
+        timeRange: legacyTimeRange,
+        facetExpression: conversationFacetExpression,
+      });
+      expect(counts.values).toEqual({ "thread-legacy-1": 1 });
+    });
+  });
 });

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -671,25 +671,27 @@ describe("TraceListClickHouseRepository filtering across row versions", () => {
       });
     });
 
-    /** @scenario "Filtering by a legacy-key conversation id returns the trace from ClickHouse" */
-    it("finds the trace when filtering by its conversation id", async () => {
-      const page = await listWith('conversation:"thread-legacy-1"');
+    describe("when the list is filtered by that trace's conversation id", () => {
+      /** @scenario "Filtering by a legacy-key conversation id returns the trace from ClickHouse" */
+      it("finds the trace when filtering by its conversation id", async () => {
+        const page = await listWith('conversation:"thread-legacy-1"');
 
-      expect(page.rows.map((row) => row.traceId)).toEqual([legacyTraceId]);
-      expect(page.totalHits).toBe(1);
-    });
-
-    /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
-    it("counts the trace under has:conversation and lists its id in the facet values", async () => {
-      const withConversation = await listWith("has:conversation");
-      expect(withConversation.totalHits).toBe(1);
-
-      const counts = await repo.findFacetCounts({
-        tenantId: legacyTenant,
-        timeRange: legacyTimeRange,
-        facetExpression: conversationFacetExpression,
+        expect(page.rows.map((row) => row.traceId)).toEqual([legacyTraceId]);
+        expect(page.totalHits).toBe(1);
       });
-      expect(counts.values).toEqual({ "thread-legacy-1": 1 });
+
+      /** @scenario "has:conversation counts a legacy-key trace as having a conversation" */
+      it("counts the trace under has:conversation and lists its id in the facet values", async () => {
+        const withConversation = await listWith("has:conversation");
+        expect(withConversation.totalHits).toBe(1);
+
+        const counts = await repo.findFacetCounts({
+          tenantId: legacyTenant,
+          timeRange: legacyTimeRange,
+          facetExpression: conversationFacetExpression,
+        });
+        expect(counts.values).toEqual({ "thread-legacy-1": 1 });
+      });
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/resolve-conversation-id.ts
+++ b/platform/app/src/server/app-layer/traces/resolve-conversation-id.ts
@@ -1,0 +1,42 @@
+/**
+ * One resolved source for a trace's conversation id.
+ *
+ * A summary row can carry its conversation id under more than one
+ * attribute key: the canonical `gen_ai.conversation.id`, plus the legacy
+ * keys the canonicaliser folds into it at ingest (`langgraph.thread_id`,
+ * `langwatch.thread_id`). Rows written before that fold existed keep the
+ * legacy key only. Every surface that reads or filters by conversation —
+ * the drawer header pill, the facet expression, the has/none predicate,
+ * the trace-header mapper — resolves through this module so display and
+ * query can never disagree.
+ */
+
+/** Precedence: canonical first, then the legacy keys in fold order. */
+const CONVERSATION_ID_KEYS = [
+  "gen_ai.conversation.id",
+  "langgraph.thread_id",
+  "langwatch.thread_id",
+] as const;
+
+/**
+ * ClickHouse expression resolving to the conversation id for the row, or ''
+ * when no supported key carries one. Map lookups yield '' for missing keys,
+ * so each candidate is wrapped in nullIf to let coalesce fall through.
+ */
+export const CONVERSATION_ID_CLICKHOUSE_EXPRESSION = `coalesce(${CONVERSATION_ID_KEYS.map(
+  (key) => `nullIf(Attributes['${key}'], '')`,
+).join(", ")}, '')`;
+
+/**
+ * In-memory mirror of {@link CONVERSATION_ID_CLICKHOUSE_EXPRESSION}: the
+ * first non-empty value across the same keys in the same order, else ''.
+ */
+export function resolveConversationId(
+  attributes: Record<string, string | undefined>,
+): string {
+  for (const key of CONVERSATION_ID_KEYS) {
+    const value = attributes[key];
+    if (value) return value;
+  }
+  return "";
+}

--- a/specs/traces-v2/data-layer.feature
+++ b/specs/traces-v2/data-layer.feature
@@ -230,6 +230,11 @@ Rule: A pill's filter queries the same value the pill displays
     And an empty string under an earlier key falls through to the next key
 
   @unit
+  Scenario: User pill display and filter agree on one source
+    Given summaries carrying a user id under "langwatch.user_id", or none at all
+    Then the user facet's in-memory read and the drawer header resolution return the same value
+
+  @unit
   Scenario: has:conversation counts a legacy-key trace as having a conversation
     Given a trace summary whose conversation id is set under "langgraph.thread_id" only
     When the query "has:conversation" is evaluated

--- a/specs/traces-v2/data-layer.feature
+++ b/specs/traces-v2/data-layer.feature
@@ -205,6 +205,42 @@ Rule: Strongly typed filter field registry
     Then the parser produces a Tag with a wildcard expression
     And the ClickHouse translation uses arrayExists with LIKE
 
+Rule: A pill's filter queries the same value the pill displays
+  The drawer header renders a Conversation (or User) identity pill from one
+  resolved source, and its filter affordance compiles that same value against
+  the facet expression. Trace summaries exist where the conversation id was
+  stamped under a legacy key (`langgraph.thread_id`, `langwatch.thread_id`)
+  instead of `gen_ai.conversation.id`, so the facet resolves the whole key
+  chain, not just the canonical attribute.
+
+  Implementation:
+    platform/app/src/server/app-layer/traces/resolve-conversation-id.ts
+
+  @unit
+  Scenario: Conversation pill on a legacy-key trace filters to that conversation
+    Given a trace summary whose conversation id is set under "langgraph.thread_id" only
+    When the drawer header renders the Conversation pill and the reader clicks its filter
+    Then the compiled ClickHouse predicate matches that trace's conversation id
+    And the in-memory evaluation agrees with the SQL result
+
+  @unit
+  Scenario: Facet read and display resolution never disagree on precedence
+    Given summaries carrying the conversation id under any of the supported keys, or several at once
+    Then the facet's in-memory read and the drawer header resolution follow the same precedence chain
+    And an empty string under an earlier key falls through to the next key
+
+  @unit
+  Scenario: has:conversation counts a legacy-key trace as having a conversation
+    Given a trace summary whose conversation id is set under "langgraph.thread_id" only
+    When the query "has:conversation" is evaluated
+    Then both the SQL predicate and the in-memory evaluation report the conversation as present
+
+  @integration
+  Scenario: Filtering by a legacy-key conversation id returns the trace from ClickHouse
+    Given an ingested trace whose conversation id is stored under "langgraph.thread_id" only
+    When the trace list is filtered by `conversation:"<that id>"`
+    Then the trace appears in the results
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # FILTER STATE MACHINE


### PR DESCRIPTION
# Related Issue

- Resolves #7318

Closes #7318

## Summary

Clicking the filter icon on the Conversation pill scoped to nothing on traces whose conversation id is stored under a legacy attribute key. The pill's value and the filter's query read different sources:

- The pill renders `trace.conversationId`, which the header mapper fills from `gen_ai.conversation.id` with a fallback to `langgraph.thread_id`.
- The emitted `conversation:"<value>"` token compiles against the facet expression, which only ever read `Attributes['gen_ai.conversation.id']`.

So for any trace where the canonical key is absent (rows written before the canonicaliser folded thread ids onto it), the pill showed an id the filter could never match.

One note on the issue write-up: it suspected a top-level `ConversationId` column vs attribute split. That column exists on the analytics tables, not on `trace_summaries`, which carries no such column. The real divergence class is the legacy-key fallback described above, and this fix closes it.

## Changes

- New `resolve-conversation-id.ts`: one resolver with the chain `gen_ai.conversation.id` -> `langgraph.thread_id` -> `langwatch.thread_id`, empty values falling through, plus its exact ClickHouse mirror (`coalesce(nullIf(...), ...)`).
- `facet-registry.ts`: the conversation facet's expression and in-memory read go through the resolver.
- `meta-handlers.ts`: `has:conversation` / `none:conversation` use the same expression and read, so existence checks agree with equality.
- `tracesV2.ts` mapper: `conversationId` resolves through the same function instead of an inline two-key fallback.

The User pill needed no change: its display source (`langwatch.user_id`) already equals the user facet's single key; a unit test now locks that agreement.

## Testing

- New unit suite `resolve-conversation-id.unit.test.ts`: precedence, empty-string fallthrough, facet-read vs display parity across every key layout, `has:`/`none:` in-memory evaluation, compiled SQL containment. Bound to the new spec scenarios.
- Integration tests against ClickHouse: a summary row carrying only `langgraph.thread_id` is found by `conversation:"<id>"`, counted by `has:conversation`, and listed under its id in facet counts.
- Full trace-list integration file: 14 passed, 1 skipped (pre-existing skip).
- Filter-to-clickhouse + facets unit suites: 475 passed.
- `pnpm typecheck` clean; biome errors-only check clean on all touched files.
- `check-feature-parity.ts`: data-layer.feature reports 5/5 bound.

## Deployment Impact

Read-path only, no migrations or config. Filters by conversation id start matching traces they previously missed; nothing that matched before stops matching. Safe to roll out and revert independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation IDs are now consistently recognized across canonical and legacy trace attributes.
  * Conversation facets, filters, headers, and identity displays now show the same resolved conversation ID.
  * Empty canonical values automatically fall back to supported legacy values.

* **Bug Fixes**
  * Improved conversation filtering and existence checks for traces using legacy conversation identifiers.

* **Tests**
  * Added comprehensive unit, integration, and end-to-end coverage for conversation ID resolution and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->