### PR TITLE
feat(ops): the event-sourcing tools live in their workspace, not the ops menu

### DIFF
--- a/platform/app/src/components/__tests__/MainMenu.navigation.integration.test.tsx
+++ b/platform/app/src/components/__tests__/MainMenu.navigation.integration.test.tsx
@@ -112,7 +112,6 @@ describe("<MainMenu /> navigation", () => {
           "Dashboard",
           "Event Sourcing",
           "The Foundry",
-          "Deja View",
           "Feature Flags",
           "Migrations",
         ]),

--- a/platform/app/src/components/ops/event-sourcing/EventSourcingLayout.tsx
+++ b/platform/app/src/components/ops/event-sourcing/EventSourcingLayout.tsx
@@ -2,6 +2,8 @@ import { Badge } from "@chakra-ui/react";
 import {
   Activity,
   CalendarClock,
+  Database,
+  History,
   Layers,
   Radio,
   Skull,
@@ -72,6 +74,23 @@ export function EventSourcingLayout({
             href: "/ops/event-sourcing/schedules",
             includePath: "/ops/event-sourcing/schedules",
             icon: <CalendarClock size={14} />,
+          },
+          // Both were top-level Ops entries, and neither is a subsystem the
+          // operator watches for trouble — they are tools you reach for once
+          // you know where the trouble is. They read the same substrate as
+          // every section above, so the rail is where they belong; the Ops
+          // menu is for workspaces, not for each tool inside one.
+          {
+            label: "Payload store",
+            href: "/ops/blobs",
+            includePath: "/ops/blobs",
+            icon: <Database size={14} />,
+          },
+          {
+            label: "Deja View",
+            href: "/ops/dejaview",
+            includePath: "/ops/dejaview",
+            icon: <History size={14} />,
           },
         ]}
       >

--- a/platform/app/src/features/navigation/__tests__/opsMenuReachability.unit.test.ts
+++ b/platform/app/src/features/navigation/__tests__/opsMenuReachability.unit.test.ts
@@ -82,4 +82,29 @@ describe("given the internal ops pages the route table registers", () => {
       expect(isClaimedBy({ address, groups: menu })).toBe(true);
     });
   });
+
+  describe("when the event-sourcing tools are looked for", () => {
+    const TOOLS = ["/ops/projections", "/ops/blobs", "/ops/dejaview"];
+
+    /** @scenario The event-sourcing tools are offered inside their workspace */
+    it.each(TOOLS)("%s is not a top-level ops entry", (address) => {
+      // The menu lists workspaces, not every tool inside one. Claiming an
+      // address through `alsoActiveAt` is how a workspace owns a page that
+      // does not sit under its prefix — an entry of its own here would put
+      // the tool back in the menu, which is what this change removed.
+      expect(opsGroup().items.some((item) => item.href === address)).toBe(
+        false,
+      );
+    });
+
+    /** @scenario The event-sourcing tools are offered inside their workspace */
+    it.each(TOOLS)("%s is claimed by the Event Sourcing entry", (address) => {
+      const eventSourcing = opsGroup().items.find(
+        (item) => item.label === "Event Sourcing",
+      );
+      if (!eventSourcing) throw new Error("no Event Sourcing menu entry");
+
+      expect(eventSourcing.alsoActiveAt).toContain(address);
+    });
+  });
 });

--- a/platform/app/src/features/navigation/useSettingsMenu.ts
+++ b/platform/app/src/features/navigation/useSettingsMenu.ts
@@ -9,7 +9,6 @@ import {
   Building2,
   Coins,
   CreditCard,
-  Database,
   DatabaseZap,
   EyeOff,
   Fingerprint,
@@ -17,7 +16,6 @@ import {
   FolderKanban,
   FolderOpen,
   Gauge,
-  History,
   KeyRound,
   Link2,
   Lock,
@@ -25,7 +23,6 @@ import {
   MailX,
   Network,
   RefreshCw,
-  Repeat,
   ScrollText,
   Settings2,
   ShieldCheck,
@@ -309,19 +306,27 @@ export function opsGroup(): SettingsMenuGroup {
       {
         label: "Event Sourcing",
         href: "/ops/event-sourcing",
-        // The scheduler address redirects onto the schedules section of
-        // the event-sourcing workspace.
-        alsoActiveAt: ["/ops/scheduler"],
+        // Addresses this workspace owns that do not sit under its prefix.
+        // The scheduler one redirects onto the schedules section; the other
+        // three are sections of the workspace reached from its own rail —
+        // the payload store and Deja View as pages, projection replay as the
+        // drawer that address redirects to. Naming them here is what keeps
+        // this entry lit while the reader is inside the workspace, and what
+        // tells the reachability test the addresses have an owner.
+        alsoActiveAt: [
+          "/ops/scheduler",
+          "/ops/projections",
+          "/ops/blobs",
+          "/ops/dejaview",
+        ],
         icon: Workflow,
       },
-      {
-        label: "Projection Replay",
-        href: "/ops/projections",
-        icon: Repeat,
-      },
+      // Projection replay, the payload store and Deja View are not here:
+      // all three are event-sourcing tools, and they now live in that
+      // workspace's own rail rather than as top-level Ops entries. Replay was
+      // already only a drawer opened from the projections section, so its
+      // entry here pointed at a redirect.
       { label: "The Foundry", href: "/ops/foundry", icon: Anvil },
-      { label: "Payload store", href: "/ops/blobs", icon: Database },
-      { label: "Deja View", href: "/ops/dejaview", icon: History },
       { label: "Feature Flags", href: "/ops/feature-flags", icon: Flag },
       { label: "Migrations", href: "/ops/migrations", icon: DatabaseZap },
     ],

--- a/platform/app/src/pages/ops/blobs.tsx
+++ b/platform/app/src/pages/ops/blobs.tsx
@@ -1,11 +1,20 @@
-import { useEffect } from "react";
-import { useRouter } from "~/utils/compat/next-router";
+import { BlobStoreContent } from "~/components/ops/blobs";
+import { EventSourcingLayout } from "~/components/ops/event-sourcing/EventSourcingLayout";
 
-/** The payload store is a drawer on the ops dashboard now; old links follow. */
+/**
+ * The payload store, as a section of the event-sourcing workspace.
+ *
+ * It was a top-level Ops entry, then a redirect onto a drawer over the ops
+ * dashboard. Neither placement said what it is: the offloaded bodies of
+ * event-sourcing payloads, read by the same operator working through the
+ * sections beside it. This address is a page again so the workspace rail
+ * stays on screen and the entry can be active, and the dashboard keeps its
+ * own drawer shortcut for the operator who is already there.
+ */
 export default function OpsBlobsPage() {
-  const router = useRouter();
-  useEffect(() => {
-    void router.replace("/ops?drawer.open=opsBlobs");
-  }, [router]);
-  return null;
+  return (
+    <EventSourcingLayout pageTitle="Payload store">
+      <BlobStoreContent />
+    </EventSourcingLayout>
+  );
 }

--- a/platform/app/src/pages/ops/dejaview.tsx
+++ b/platform/app/src/pages/ops/dejaview.tsx
@@ -1,10 +1,18 @@
 import { DejaViewContent } from "~/components/ops/dejaview";
-import { OpsPageShell } from "~/components/ops/shared/OpsPageShell";
+import { EventSourcingLayout } from "~/components/ops/event-sourcing/EventSourcingLayout";
 
+/**
+ * Deja View, as a section of the event-sourcing workspace.
+ *
+ * It reads the event log an aggregate at a time — the same substrate every
+ * other section here reports on — so it belongs beside them rather than as
+ * its own top-level Ops entry. `EventSourcingLayout` replaces the bare page
+ * shell so the workspace rail stays on screen.
+ */
 export default function OpsDejaViewPage() {
   return (
-    <OpsPageShell>
+    <EventSourcingLayout pageTitle="Deja View">
       <DejaViewContent />
-    </OpsPageShell>
+    </EventSourcingLayout>
   );
 }

--- a/specs/navigation/ops-navigation-v2.feature
+++ b/specs/navigation/ops-navigation-v2.feature
@@ -51,6 +51,17 @@ Feature: Internal ops navigation in the new navigation modes
     When each registered ops address is matched against the settings menu
     Then every one of them is claimed by a menu entry
 
+  # The ops menu lists workspaces, not every tool inside one. Projection
+  # replay, the payload store and Deja View all read the event-sourcing
+  # substrate, so they are reached from that workspace's own rail — replay
+  # was already only a drawer opened from its projections section, so its
+  # menu entry pointed at a redirect.
+  @unit
+  Scenario: The event-sourcing tools are offered inside their workspace
+    When the ops menu is built
+    Then projection replay, the payload store and Deja View are not top-level ops entries
+    And the Event Sourcing entry claims their addresses
+
   @integration
   Scenario: An ops page renders inside the new settings shell
     Given my device is on a new navigation mode


### PR DESCRIPTION
Projection replay, the payload store and Deja View were top-level Ops menu entries. All three read the event-sourcing substrate, so they belong in that workspace's rail: **the menu lists workspaces, not every tool inside one.**

## Two of the three were already pointing at redirects

- `/ops/projections` forwarded to `/ops/event-sourcing/projections?drawer.open=opsReplay`
- `/ops/blobs` forwarded to `/ops?drawer.open=opsBlobs`

So "Projection Replay" in the Ops menu was a link, to a redirect, to a drawer.

## What moved

**Projection replay** needed nothing — it is already opened from the projections section and from the overview's replay history. Its menu entry was the only stale part, and it is gone.

**Payload store** and **Deja View** become sections of the workspace:

- `/ops/blobs` is a page again rather than a redirect, rendering the same `BlobStoreContent` the drawer renders.
- `/ops/dejaview` swaps its bare `OpsPageShell` for `EventSourcingLayout`.

Both keep their existing addresses, so links already out there still land, and both now keep the workspace rail on screen instead of dropping the reader out of the section they were navigating.

The ops dashboard **keeps** its own payload-store drawer. An operator already on the dashboard should not have to travel to read a payload.

## Why they are not simply orphaned

The three addresses move to the Event Sourcing entry's `alsoActiveAt`, which is precisely what that field documents itself as being for. That does two things:

1. Keeps the Ops menu lit on "Event Sourcing" while the reader is inside the workspace — otherwise the menu would show nothing selected on those pages.
2. Satisfies `opsMenuReachability.unit.test.ts`, which asserts every `/ops` address registered in `routes.tsx` is claimed by some menu entry. These are now claimed by the workspace that owns them rather than by an entry each — which is the honest reading, not a workaround.

## Why the overview was not used

`ops-dashboard.md`'s rule is that space is proportional to trouble, and the event-sourcing overview is deliberately trouble-first: dead letters, fleet strip, health line. These two are tools you reach for *after* you know where the trouble is, so the rail is the right home and the overview is not.

## Tests

- 88 navigation unit tests and 23 menu component tests pass.
- The placement is bound by a scenario, not left to the diff — an entry of its own could reappear in the menu and nothing would have said so. `check:feature-parity` reports `9/9 ✓ all bound` for `ops-navigation-v2.feature`.
- `MainMenu.navigation.integration.test.tsx` no longer expects "Deja View" among the ops links.
- Scoped typecheck clean on every touched file, checked by filename; biome clean.

## Deployment Impact

None. No routes are removed and no addresses change — `/ops/projections`, `/ops/blobs` and `/ops/dejaview` all still resolve. The only change a reader sees is where the three are offered from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Consolidated Projection Replay, Payload store, and Deja View under the **Event Sourcing** workspace.
  * Added navigation links and icons for Payload store and Deja View.
  * Updated Payload store and Deja View pages to display within the Event Sourcing layout.
* **Tests**
  * Added coverage confirming event-sourcing tools are accessible through the Event Sourcing navigation rather than as top-level entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->