### PR TITLE
fix(ui): unbreakable strings wrap inside their message containers

### DIFF
--- a/platform/app/src/components/scenarios/ScenarioTable.tsx
+++ b/platform/app/src/components/scenarios/ScenarioTable.tsx
@@ -83,7 +83,11 @@ export function ScenarioTable({
       }),
       columnHelper.accessor("name", {
         header: "Name",
-        cell: (info) => <Text fontWeight="medium">{info.getValue()}</Text>,
+        cell: (info) => (
+          <Text fontWeight="medium" wordBreak="break-word">
+            {info.getValue()}
+          </Text>
+        ),
       }),
       columnHelper.accessor("labels", {
         header: "Labels",

--- a/platform/app/src/components/scenarios/ui/CriteriaInput.tsx
+++ b/platform/app/src/components/scenarios/ui/CriteriaInput.tsx
@@ -170,6 +170,7 @@ export function CriteriaInput({
               fontSize="sm"
               whiteSpace="pre-wrap"
               wordBreak="break-word"
+              minWidth={0}
             >
               {criterion}
             </Text>

--- a/platform/app/src/components/scenarios/ui/CriteriaInput.tsx
+++ b/platform/app/src/components/scenarios/ui/CriteriaInput.tsx
@@ -165,7 +165,12 @@ export function CriteriaInput({
             <Text fontSize="sm" color="fg.muted" flexShrink={0} mt="1px">
               {index + 1}.
             </Text>
-            <Text flex={1} fontSize="sm" whiteSpace="pre-wrap">
+            <Text
+              flex={1}
+              fontSize="sm"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+            >
               {criterion}
             </Text>
             <Pencil

--- a/platform/app/src/components/simulations/RunCriteriaChip.tsx
+++ b/platform/app/src/components/simulations/RunCriteriaChip.tsx
@@ -42,7 +42,7 @@ function CriteriaList({
             marginTop="2px"
             flexShrink={0}
           />
-          <Text textStyle="xs" color="fg">
+          <Text textStyle="xs" color="fg" wordBreak="break-word">
             {criterion}
           </Text>
         </HStack>

--- a/platform/app/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/platform/app/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -197,7 +197,7 @@ export function ScenarioMessageRenderer({
       case "tool_call":
         return (
           <VStack key={item.id} align="flex-start" gap={1.5} width="100%">
-            <HStack gap={1.5} color="orange.fg">
+            <HStack gap={1.5} color="orange.fg" w="full">
               <Settings size={12} />
               <Text
                 textStyle="2xs"
@@ -205,6 +205,8 @@ export function ScenarioMessageRenderer({
                 textTransform="uppercase"
                 letterSpacing="0.06em"
                 wordBreak="break-word"
+                flex={1}
+                minWidth={0}
               >
                 {item.name}
               </Text>

--- a/platform/app/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/platform/app/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -184,6 +184,7 @@ export function ScenarioMessageRenderer({
                   fontStyle="italic"
                   paddingX={2}
                   textAlign={textAlignForRole(item.role)}
+                  wordBreak="break-word"
                 >
                   {item.transcript}
                 </Text>
@@ -203,6 +204,7 @@ export function ScenarioMessageRenderer({
                 fontWeight="600"
                 textTransform="uppercase"
                 letterSpacing="0.06em"
+                wordBreak="break-word"
               >
                 {item.name}
               </Text>
@@ -264,6 +266,9 @@ export function ScenarioMessageRenderer({
       width="100%"
       height="100%"
       overflowY="auto"
+      // Explicit, so an overflowing unbreakable token clips here instead of
+      // computing overflow-x to auto and growing a horizontal scrollbar.
+      overflowX="hidden"
     >
       {smallerView
         ? items.map(renderItem)

--- a/platform/app/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/platform/app/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -344,6 +344,9 @@ export function ScenarioRunDetailDrawer({
               paddingY={0}
               paddingX={0}
               overflowY="auto"
+              // Explicit, so a stray overflow clips instead of computing
+              // overflow-x to auto and growing a horizontal scrollbar.
+              overflowX="hidden"
               display="flex"
               flexDirection="column"
               width="full"
@@ -633,6 +636,7 @@ function ParameterRow({
         color="fg.muted"
         width="180px"
         flexShrink={0}
+        wordBreak="break-word"
       >
         {name}
       </Text>

--- a/platform/app/src/components/simulations/ScenarioRunHeader.tsx
+++ b/platform/app/src/components/simulations/ScenarioRunHeader.tsx
@@ -34,7 +34,12 @@ export function ScenarioRunHeader({
             <VStack align="start" gap={0} ml={0}>
               {copyableIds.map((id) => (
                 <HStack key={id.label} gap={1}>
-                  <Text fontSize="xs" color="fg.muted" lineHeight="0">
+                  <Text
+                    fontSize="xs"
+                    color="fg.muted"
+                    lineHeight="0"
+                    wordBreak="break-word"
+                  >
                     {id.label}: {id.value}
                   </Text>
                   <CopyButton

--- a/platform/app/src/components/simulations/ScenarioRunHeader.tsx
+++ b/platform/app/src/components/simulations/ScenarioRunHeader.tsx
@@ -33,12 +33,15 @@ export function ScenarioRunHeader({
             </HStack>
             <VStack align="start" gap={0} ml={0}>
               {copyableIds.map((id) => (
-                <HStack key={id.label} gap={1}>
+                <HStack key={id.label} gap={1} w="full">
+                  {/* lineHeight 0 would collide wrapped lines now that long
+                      ids break, so the text uses the normal leading. */}
                   <Text
                     fontSize="xs"
                     color="fg.muted"
-                    lineHeight="0"
                     wordBreak="break-word"
+                    flex={1}
+                    minWidth={0}
                   >
                     {id.label}: {id.value}
                   </Text>
@@ -47,6 +50,7 @@ export function ScenarioRunHeader({
                     label={id.label}
                     height="auto"
                     display="inline-block"
+                    flexShrink={0}
                   />
                 </HStack>
               ))}

--- a/platform/app/src/components/simulations/SetCard.tsx
+++ b/platform/app/src/components/simulations/SetCard.tsx
@@ -55,7 +55,7 @@ export function SetCard({
             {"\uD83C\uDFAD"}
           </Text>
         )}
-        <Text fontWeight="500" color="fg">
+        <Text fontWeight="500" color="fg" wordBreak="break-word">
           {displayName}
         </Text>
 

--- a/platform/app/src/components/simulations/SimulationResults.tsx
+++ b/platform/app/src/components/simulations/SimulationResults.tsx
@@ -57,7 +57,7 @@ function CriteriaSection({
       {criteria.length > 0 ? (
         <VStack alignItems="flex-start" gap={2} pl={2}>
           {criteria.map((criterion: string, idx: number) => (
-            <HStack key={idx} align="flex-start" gap={3}>
+            <HStack key={idx} align="flex-start" gap={3} w="full">
               <Box
                 w={2}
                 h={2}
@@ -71,6 +71,8 @@ function CriteriaSection({
                 fontSize="sm"
                 lineHeight="tall"
                 wordBreak="break-word"
+                flex={1}
+                minWidth={0}
               >
                 {criterion}
               </Text>

--- a/platform/app/src/components/simulations/SimulationResults.tsx
+++ b/platform/app/src/components/simulations/SimulationResults.tsx
@@ -29,7 +29,7 @@ function ReasoningSection({ reasoning }: { reasoning?: string }) {
       <Text fontWeight="semibold" color="fg" fontSize="md" mb={2}>
         Reasoning:
       </Text>
-      <Text color="fg" fontSize="sm" lineHeight="tall">
+      <Text color="fg" fontSize="sm" lineHeight="tall" wordBreak="break-word">
         {reasoning}
       </Text>
     </Box>
@@ -66,7 +66,12 @@ function CriteriaSection({
                 mt={2}
                 flexShrink={0}
               />
-              <Text color={textColor} fontSize="sm" lineHeight="tall">
+              <Text
+                color={textColor}
+                fontSize="sm"
+                lineHeight="tall"
+                wordBreak="break-word"
+              >
                 {criterion}
               </Text>
             </HStack>

--- a/platform/app/src/components/simulations/simulation-console/CriteriaDetails.tsx
+++ b/platform/app/src/components/simulations/simulation-console/CriteriaDetails.tsx
@@ -25,7 +25,7 @@ export function CriteriaDetails({ results }: CriteriaDetailsProps) {
           >
             ✓ Met Criteria ({results.metCriteria.length}):
           </Text>
-          <VStack align="start" gap={1} pl={2}>
+          <VStack align="start" gap={1} pl={2} w="full">
             {results.metCriteria.map((criterion, idx) => (
               <Text
                 key={idx}
@@ -50,7 +50,7 @@ export function CriteriaDetails({ results }: CriteriaDetailsProps) {
           >
             ✗ Unmet Criteria ({results.unmetCriteria.length}):
           </Text>
-          <VStack align="start" gap={1} pl={2}>
+          <VStack align="start" gap={1} pl={2} w="full">
             {results.unmetCriteria.map((criterion, idx) => (
               <Text
                 key={idx}

--- a/platform/app/src/components/simulations/simulation-console/CriteriaDetails.tsx
+++ b/platform/app/src/components/simulations/simulation-console/CriteriaDetails.tsx
@@ -27,7 +27,12 @@ export function CriteriaDetails({ results }: CriteriaDetailsProps) {
           </Text>
           <VStack align="start" gap={1} pl={2}>
             {results.metCriteria.map((criterion, idx) => (
-              <Text key={idx} color={CONSOLE_COLORS.successColor} fontSize="sm">
+              <Text
+                key={idx}
+                color={CONSOLE_COLORS.successColor}
+                fontSize="sm"
+                wordBreak="break-word"
+              >
                 • {criterion}
               </Text>
             ))}
@@ -47,7 +52,12 @@ export function CriteriaDetails({ results }: CriteriaDetailsProps) {
           </Text>
           <VStack align="start" gap={1} pl={2}>
             {results.unmetCriteria.map((criterion, idx) => (
-              <Text key={idx} color={CONSOLE_COLORS.failureColor} fontSize="sm">
+              <Text
+                key={idx}
+                color={CONSOLE_COLORS.failureColor}
+                fontSize="sm"
+                wordBreak="break-word"
+              >
                 • {criterion}
               </Text>
             ))}
@@ -66,6 +76,7 @@ export function CriteriaDetails({ results }: CriteriaDetailsProps) {
             fontSize="sm"
             pl={2}
             whiteSpace="pre-wrap"
+            wordBreak="break-word"
             fontWeight="bold"
           >
             {results.reasoning}

--- a/platform/app/src/components/suites/ExternalSetDetailPanel.tsx
+++ b/platform/app/src/components/suites/ExternalSetDetailPanel.tsx
@@ -229,7 +229,7 @@ export function ExternalSetDetailPanel({
           >
             EXTERNAL SET
           </Text>
-          <Text fontSize="lg" fontWeight="semibold">
+          <Text fontSize="lg" fontWeight="semibold" wordBreak="break-word">
             {scenarioSetId}
           </Text>
         </VStack>

--- a/platform/app/src/components/suites/ScenarioInputMappingSection.tsx
+++ b/platform/app/src/components/suites/ScenarioInputMappingSection.tsx
@@ -284,7 +284,7 @@ export function ScenarioInputMappingSection({
         {valueMappings.length > 0 && (
           <VStack align="stretch" gap={1} marginTop={2}>
             {valueMappings.map(([identifier, mapping]) => (
-              <Box key={identifier}>
+              <Box key={identifier} wordBreak="break-word">
                 <Text
                   as="span"
                   fontSize="xs"

--- a/platform/app/src/components/suites/ScenarioTargetRow.tsx
+++ b/platform/app/src/components/suites/ScenarioTargetRow.tsx
@@ -233,7 +233,9 @@ export function ScenarioTargetRow({
               })}
             </Text>
           </HStack>
-          <Text fontSize="sm" textAlign="left" truncate>
+          {/* minWidth 0 lets the flex child shrink below its text width, so
+              `truncate` ellipses instead of pushing the row wide. */}
+          <Text fontSize="sm" textAlign="left" truncate minWidth={0}>
             {displayName}
           </Text>
           {hasCancelButton && (

--- a/platform/app/src/components/suites/SuiteDetailPanel.tsx
+++ b/platform/app/src/components/suites/SuiteDetailPanel.tsx
@@ -77,7 +77,7 @@ export function SuiteDetailPanel({
       <Box paddingX={6} paddingY={4}>
         <HStack justify="space-between" align="start">
           <VStack align="start" gap={1}>
-            <Text fontSize="xl" fontWeight="bold">
+            <Text fontSize="xl" fontWeight="bold" wordBreak="break-word">
               {suite.name}
             </Text>
             {suite.description && (

--- a/platform/app/src/components/traces/RenderInputOutput.tsx
+++ b/platform/app/src/components/traces/RenderInputOutput.tsx
@@ -142,7 +142,7 @@ export const RenderInputOutput = React.memo(function RenderInputOutput(
           </HStack>
         )}
         {raw || forceRaw ? (
-          <Text fontFamily="mono" fontSize="13px">
+          <Text fontFamily="mono" fontSize="13px" wordBreak="break-word">
             {JSON.stringify(json, null, 2)}
           </Text>
         ) : (
@@ -186,7 +186,7 @@ export const RenderInputOutput = React.memo(function RenderInputOutput(
               {renderCopyButton()}
             </HStack>
           )}
-          <Text fontFamily="mono" fontSize="14px">
+          <Text fontFamily="mono" fontSize="14px" wordBreak="break-word">
             {value
               ? typeof value === "string"
                 ? value

--- a/platform/app/src/components/ui/__tests__/prose.unbreakable-wrap.integration.test.tsx
+++ b/platform/app/src/components/ui/__tests__/prose.unbreakable-wrap.integration.test.tsx
@@ -31,14 +31,14 @@ afterEach(cleanup);
 describe("given a markdown message body", () => {
   describe("when it holds one unbreakable token", () => {
     /** @scenario "A message body carries the wrap rule to every prose element" */
-    it("the Prose root carries overflow-wrap anywhere so every prose element inherits it", () => {
+    it("applies overflow-wrap anywhere on the Prose root so every prose element inherits it", () => {
       expect(PROSE_BASE.overflowWrap).toBe("anywhere");
     });
   });
 
   describe("when it contains a fenced code block", () => {
     /** @scenario "Fenced code blocks scroll instead of breaking mid-token" */
-    it("the pre rule keeps horizontal scrolling and resets the inherited wrap", () => {
+    it("keeps the pre rule scrolling horizontally and resets the inherited wrap", () => {
       const preKey = Object.keys(PROSE_BASE).find((key) =>
         key.includes(":where(pre)"),
       );
@@ -51,7 +51,7 @@ describe("given a markdown message body", () => {
       expect(preStyle.overflowWrap).toBe("normal");
     });
 
-    it("renders markdown with a fenced block without crashing", () => {
+    it("renders a fenced code block without crashing", () => {
       const fenced = `\`\`\`\n${UNBREAKABLE}\n\`\`\``;
       withProviders(<Markdown>{fenced}</Markdown>);
       expect(
@@ -63,7 +63,7 @@ describe("given a markdown message body", () => {
 
 describe("given a raw tool input or output string outside the JSON viewer", () => {
   /** @scenario "Raw tool input and output strings wrap instead of painting wide" */
-  it("the mono fallback carries word-break break-word", () => {
+  it("applies word-break break-word to the raw mono fallback", () => {
     withProviders(
       <RenderInputOutput value={`https://host.example/${UNBREAKABLE}`} />,
     );

--- a/platform/app/src/components/ui/__tests__/prose.unbreakable-wrap.integration.test.tsx
+++ b/platform/app/src/components/ui/__tests__/prose.unbreakable-wrap.integration.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unbreakable strings (URLs, JSON blobs, base64) must wrap inside the
+ * containers that render them instead of painting past their box. The wrap
+ * rule lives on the shared roots: Prose for Markdown output and the raw mono
+ * fallbacks in RenderInputOutput.
+ *
+ * jsdom cannot read Chakra's layered atomic CSS through getComputedStyle, so
+ * the Prose assertions run against PROSE_BASE, the object the recipe ships,
+ * while the RenderInputOutput assertion renders for real.
+ *
+ * Feature: specs/traces-v2/unbreakable-text-wrap.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { Markdown } from "~/components/Markdown";
+import { RenderInputOutput } from "~/components/traces/RenderInputOutput";
+import { PROSE_BASE } from "~/components/ui/prose";
+
+const UNBREAKABLE = "x".repeat(500);
+
+function withProviders(ui: React.ReactElement) {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+afterEach(cleanup);
+
+describe("given a markdown message body", () => {
+  describe("when it holds one unbreakable token", () => {
+    /** @scenario "A message body carries the wrap rule to every prose element" */
+    it("the Prose root carries overflow-wrap anywhere so every prose element inherits it", () => {
+      expect(PROSE_BASE.overflowWrap).toBe("anywhere");
+    });
+  });
+
+  describe("when it contains a fenced code block", () => {
+    /** @scenario "Fenced code blocks scroll instead of breaking mid-token" */
+    it("the pre rule keeps horizontal scrolling and resets the inherited wrap", () => {
+      const preKey = Object.keys(PROSE_BASE).find((key) =>
+        key.includes(":where(pre)"),
+      );
+      expect(preKey).toBeDefined();
+      const preStyle = PROSE_BASE[preKey as keyof typeof PROSE_BASE] as Record<
+        string,
+        string
+      >;
+      expect(preStyle.overflowX).toBe("auto");
+      expect(preStyle.overflowWrap).toBe("normal");
+    });
+
+    it("renders markdown with a fenced block without crashing", () => {
+      const fenced = `\`\`\`\n${UNBREAKABLE}\n\`\`\``;
+      withProviders(<Markdown>{fenced}</Markdown>);
+      expect(
+        screen.getByText(new RegExp(UNBREAKABLE.slice(0, 40))),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("given a raw tool input or output string outside the JSON viewer", () => {
+  /** @scenario "Raw tool input and output strings wrap instead of painting wide" */
+  it("the mono fallback carries word-break break-word", () => {
+    withProviders(
+      <RenderInputOutput value={`https://host.example/${UNBREAKABLE}`} />,
+    );
+
+    const raw = screen.getByText(new RegExp(UNBREAKABLE.slice(0, 40)));
+    expect(raw).toHaveStyle({ wordBreak: "break-word" });
+  });
+});

--- a/platform/app/src/components/ui/prose.tsx
+++ b/platform/app/src/components/ui/prose.tsx
@@ -14,171 +14,180 @@ function inWhere<T extends string>(selector: T): T {
   return `& :where(${base}):not(${EXCLUDE_CLASSNAME}, ${EXCLUDE_CLASSNAME} *)${pseudo}` as T;
 }
 
-export const Prose = chakra("div", {
-  base: {
+// Agent output is full of long unbreakable tokens (URLs, JSON blobs, ids).
+// The default overflow-wrap only breaks at whitespace, so such a token paints
+// past the box holding it. The root carries `anywhere`, which inherits into
+// every prose element; `pre` resets it so fenced code keeps scrolling instead
+// of wrapping mid-token.
+export const PROSE_BASE = {
+  color: "fg",
+  lineHeight: "1.7em",
+  overflowWrap: "anywhere",
+  [inWhere("& p")]: {
+    marginTop: "0.75em",
+    marginBottom: "0.75em",
+  },
+  [inWhere("& blockquote")]: {
+    marginTop: "1.285em",
+    marginBottom: "1.285em",
+    paddingInline: "1.285em",
+    borderInlineStartWidth: "0.25em",
     color: "fg",
-    lineHeight: "1.7em",
-    [inWhere("& p")]: {
-      marginTop: "0.75em",
-      marginBottom: "0.75em",
-    },
-    [inWhere("& blockquote")]: {
-      marginTop: "1.285em",
-      marginBottom: "1.285em",
-      paddingInline: "1.285em",
-      borderInlineStartWidth: "0.25em",
-      color: "fg",
-    },
-    [inWhere("& a")]: {
-      color: "fg",
-      textDecoration: "underline",
-      textUnderlineOffset: "3px",
-      textDecorationThickness: "2px",
-      textDecorationColor: "border.muted",
-      fontWeight: "500",
-    },
-    [inWhere("& strong")]: {
-      fontWeight: "600",
-    },
-    [inWhere("& em")]: {
-      fontStyle: "italic",
-    },
-    [inWhere("& h1")]: {
-      fontSize: "2em",
-      letterSpacing: "-0.02em",
-      marginTop: "0",
-      marginBottom: "0.8em",
-      lineHeight: "1.2em",
-      fontWeight: "bold",
-    },
-    [inWhere("& h2")]: {
-      fontSize: "1.5em",
-      letterSpacing: "-0.02em",
-      marginTop: "1.6em",
-      marginBottom: "0.8em",
-      lineHeight: "1.3em",
-      fontWeight: "bold",
-    },
-    [inWhere("& h3")]: {
-      fontSize: "1.2em",
-      letterSpacing: "-0.01em",
-      marginTop: "1.5em",
-      marginBottom: "0.4em",
-      lineHeight: "1.4em",
-      fontWeight: "bold",
-    },
-    [inWhere("& h4")]: {
-      marginTop: "1.4em",
-      marginBottom: "0.5em",
-      letterSpacing: "-0.01em",
-      lineHeight: "1.5em",
-      fontWeight: "bold",
-    },
-    [inWhere("& :is(h1,h2,h3,h4,h5,hr) + *")]: {
-      marginTop: "0",
-    },
-    [inWhere("& h1, h2, h3, h4, h5, h6")]: {
-      color: "fg",
-      fontWeight: "600",
-    },
-    [inWhere("& code")]: {
-      fontSize: "0.925em",
-      bg: "bg.muted",
-      letterSpacing: "-0.01em",
-      lineHeight: "1",
-      borderRadius: "md",
-      borderWidth: "1px",
-      paddingInline: "0.25em",
-    },
-    [inWhere("& pre code")]: {
-      fontSize: "inherit",
-      letterSpacing: "inherit",
-      borderWidth: "inherit",
-      padding: "0",
-      bg: "transparent",
-    },
-    [inWhere("& pre")]: {
-      backgroundColor: "bg.muted",
-      marginTop: "1.6em",
-      marginBottom: "1.6em",
-      borderRadius: "md",
-      fontSize: "0.9em",
-      paddingTop: "0.65em",
-      paddingBottom: "0.65em",
-      paddingInlineEnd: "1em",
-      paddingInlineStart: "1em",
-      overflowX: "auto",
-      fontWeight: "400",
-    },
-    [inWhere("& ol")]: {
-      marginTop: "1em",
-      marginBottom: "1em",
-      paddingInlineStart: "1.5em",
-    },
-    [inWhere("& ul")]: {
-      marginTop: "1em",
-      marginBottom: "1em",
-      paddingInlineStart: "1.5em",
-    },
-    [inWhere("& li")]: {
-      marginTop: "0.285em",
-      marginBottom: "0.285em",
-    },
-    [inWhere("& ol > li")]: {
-      paddingInlineStart: "0.4em",
-      listStyleType: "decimal",
-      "&::marker": {
-        color: "fg.muted",
-      },
-    },
-    [inWhere("& ul > li")]: {
-      paddingInlineStart: "0.4em",
-      listStyleType: "disc",
-      "&::marker": {
-        color: "fg.muted",
-      },
-    },
-    [inWhere("& ul ul, ul ol, ol ul, ol ol")]: {
-      marginTop: "0.5em",
-      marginBottom: "0.5em",
-    },
-    [inWhere("& hr")]: {
-      marginTop: "2.25em",
-      marginBottom: "2.25em",
-    },
-    [inWhere("& table")]: {
-      width: "100%",
-      tableLayout: "auto",
-      textAlign: "start",
-      lineHeight: "1.5em",
-      marginTop: "2em",
-      marginBottom: "2em",
-    },
-    [inWhere("& thead")]: {
-      borderBottomWidth: "1px",
-      color: "fg",
-    },
-    [inWhere("& tbody tr")]: {
-      borderBottomWidth: "1px",
-      borderBottomColor: "border",
-    },
-    [inWhere("& thead th")]: {
-      paddingInlineEnd: "1em",
-      paddingBottom: "0.65em",
-      paddingInlineStart: "1em",
-      fontWeight: "medium",
-      textAlign: "start",
-    },
-    [inWhere("& tbody td, tfoot td")]: {
-      paddingTop: "0.65em",
-      paddingInlineEnd: "1em",
-      paddingBottom: "0.65em",
-      paddingInlineStart: "1em",
-    },
-    [inWhere("& img")]: {
-      marginTop: "1.7em",
-      marginBottom: "1.7em",
-      borderRadius: "lg",
+  },
+  [inWhere("& a")]: {
+    color: "fg",
+    textDecoration: "underline",
+    textUnderlineOffset: "3px",
+    textDecorationThickness: "2px",
+    textDecorationColor: "border.muted",
+    fontWeight: "500",
+  },
+  [inWhere("& strong")]: {
+    fontWeight: "600",
+  },
+  [inWhere("& em")]: {
+    fontStyle: "italic",
+  },
+  [inWhere("& h1")]: {
+    fontSize: "2em",
+    letterSpacing: "-0.02em",
+    marginTop: "0",
+    marginBottom: "0.8em",
+    lineHeight: "1.2em",
+    fontWeight: "bold",
+  },
+  [inWhere("& h2")]: {
+    fontSize: "1.5em",
+    letterSpacing: "-0.02em",
+    marginTop: "1.6em",
+    marginBottom: "0.8em",
+    lineHeight: "1.3em",
+    fontWeight: "bold",
+  },
+  [inWhere("& h3")]: {
+    fontSize: "1.2em",
+    letterSpacing: "-0.01em",
+    marginTop: "1.5em",
+    marginBottom: "0.4em",
+    lineHeight: "1.4em",
+    fontWeight: "bold",
+  },
+  [inWhere("& h4")]: {
+    marginTop: "1.4em",
+    marginBottom: "0.5em",
+    letterSpacing: "-0.01em",
+    lineHeight: "1.5em",
+    fontWeight: "bold",
+  },
+  [inWhere("& :is(h1,h2,h3,h4,h5,hr) + *")]: {
+    marginTop: "0",
+  },
+  [inWhere("& h1, h2, h3, h4, h5, h6")]: {
+    color: "fg",
+    fontWeight: "600",
+  },
+  [inWhere("& code")]: {
+    fontSize: "0.925em",
+    bg: "bg.muted",
+    letterSpacing: "-0.01em",
+    lineHeight: "1",
+    borderRadius: "md",
+    borderWidth: "1px",
+    paddingInline: "0.25em",
+  },
+  [inWhere("& pre code")]: {
+    fontSize: "inherit",
+    letterSpacing: "inherit",
+    borderWidth: "inherit",
+    padding: "0",
+    bg: "transparent",
+  },
+  [inWhere("& pre")]: {
+    backgroundColor: "bg.muted",
+    marginTop: "1.6em",
+    marginBottom: "1.6em",
+    borderRadius: "md",
+    fontSize: "0.9em",
+    paddingTop: "0.65em",
+    paddingBottom: "0.65em",
+    paddingInlineEnd: "1em",
+    paddingInlineStart: "1em",
+    overflowX: "auto",
+    overflowWrap: "normal",
+    fontWeight: "400",
+  },
+  [inWhere("& ol")]: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    paddingInlineStart: "1.5em",
+  },
+  [inWhere("& ul")]: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    paddingInlineStart: "1.5em",
+  },
+  [inWhere("& li")]: {
+    marginTop: "0.285em",
+    marginBottom: "0.285em",
+  },
+  [inWhere("& ol > li")]: {
+    paddingInlineStart: "0.4em",
+    listStyleType: "decimal",
+    "&::marker": {
+      color: "fg.muted",
     },
   },
+  [inWhere("& ul > li")]: {
+    paddingInlineStart: "0.4em",
+    listStyleType: "disc",
+    "&::marker": {
+      color: "fg.muted",
+    },
+  },
+  [inWhere("& ul ul, ul ol, ol ul, ol ol")]: {
+    marginTop: "0.5em",
+    marginBottom: "0.5em",
+  },
+  [inWhere("& hr")]: {
+    marginTop: "2.25em",
+    marginBottom: "2.25em",
+  },
+  [inWhere("& table")]: {
+    width: "100%",
+    tableLayout: "auto",
+    textAlign: "start",
+    lineHeight: "1.5em",
+    marginTop: "2em",
+    marginBottom: "2em",
+  },
+  [inWhere("& thead")]: {
+    borderBottomWidth: "1px",
+    color: "fg",
+  },
+  [inWhere("& tbody tr")]: {
+    borderBottomWidth: "1px",
+    borderBottomColor: "border",
+  },
+  [inWhere("& thead th")]: {
+    paddingInlineEnd: "1em",
+    paddingBottom: "0.65em",
+    paddingInlineStart: "1em",
+    fontWeight: "medium",
+    textAlign: "start",
+  },
+  [inWhere("& tbody td, tfoot td")]: {
+    paddingTop: "0.65em",
+    paddingInlineEnd: "1em",
+    paddingBottom: "0.65em",
+    paddingInlineStart: "1em",
+  },
+  [inWhere("& img")]: {
+    marginTop: "1.7em",
+    marginBottom: "1.7em",
+    borderRadius: "lg",
+  },
+};
+
+export const Prose = chakra("div", {
+  base: PROSE_BASE,
 });

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationCard.tsx
@@ -345,6 +345,9 @@ function SuggestedCorrection({
         whiteSpace="pre-wrap"
         maxHeight="160px"
         overflowY="auto"
+        // Explicit, so an overflowing unbreakable token clips here instead of
+        // computing overflow-x to auto and growing a horizontal scrollbar.
+        overflowX="hidden"
       >
         {expectedOutput}
       </Box>

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationCard.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationCard.tsx
@@ -343,10 +343,13 @@ function SuggestedCorrection({
         paddingY={1.5}
         fontSize="xs"
         whiteSpace="pre-wrap"
+        wordBreak="break-word"
         maxHeight="160px"
         overflowY="auto"
         // Explicit, so an overflowing unbreakable token clips here instead of
         // computing overflow-x to auto and growing a horizontal scrollbar.
+        // The wrap rule above keeps that clip from ever cutting content away:
+        // pre-wrap alone does not break whitespace-free tokens.
         overflowX="hidden"
       >
         {expectedOutput}

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/TurnSteps.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/TurnSteps.tsx
@@ -169,12 +169,7 @@ function StepRow({ step }: { step: Step }) {
       {/* Shrinkable + minWidth 0 so a whitespace-free label wraps inside its
           box instead of pushing the row wide; flexShrink 0 would make the
           word-break rule inert. */}
-      <Text
-        {...CELL}
-        color="fg"
-        wordBreak="break-word"
-        minWidth={0}
-      >
+      <Text {...CELL} color="fg" wordBreak="break-word" minWidth={0}>
         {step.label}
       </Text>
       {step.arg && (

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/TurnSteps.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/TurnSteps.tsx
@@ -166,7 +166,15 @@ function StepRow({ step }: { step: Step }) {
       >
         {isTool ? "⏺" : "◆"}
       </Text>
-      <Text {...CELL} color="fg" flexShrink={0} wordBreak="break-word">
+      {/* Shrinkable + minWidth 0 so a whitespace-free label wraps inside its
+          box instead of pushing the row wide; flexShrink 0 would make the
+          word-break rule inert. */}
+      <Text
+        {...CELL}
+        color="fg"
+        wordBreak="break-word"
+        minWidth={0}
+      >
         {step.label}
       </Text>
       {step.arg && (

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/TurnSteps.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/conversationView/TurnSteps.tsx
@@ -166,7 +166,7 @@ function StepRow({ step }: { step: Step }) {
       >
         {isTool ? "⏺" : "◆"}
       </Text>
-      <Text {...CELL} color="fg" flexShrink={0}>
+      <Text {...CELL} color="fg" flexShrink={0} wordBreak="break-word">
         {step.label}
       </Text>
       {step.arg && (

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/RenderedMarkdown.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/RenderedMarkdown.tsx
@@ -27,7 +27,16 @@ export function RenderedMarkdown({
   );
 
   return (
-    <Box paddingX={paddingX} paddingY={paddingY} color="fg">
+    // overflowWrap inherits into every prose element below, so unbreakable
+    // tokens (URLs, JSON blobs) wrap instead of painting past the box. It is
+    // inert inside `white-space: pre` code blocks, which keep their own
+    // horizontal scroll.
+    <Box
+      paddingX={paddingX}
+      paddingY={paddingY}
+      color="fg"
+      overflowWrap="anywhere"
+    >
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {markdown}
       </ReactMarkdown>

--- a/specs/traces-v2/unbreakable-text-wrap.feature
+++ b/specs/traces-v2/unbreakable-text-wrap.feature
@@ -1,0 +1,44 @@
+Feature: Unbreakable strings wrap inside their message containers
+  As a reader of agent output
+  I want long tokens without break opportunities to stay inside their bubble
+  So that the end of a URL or id is never painted off-screen
+
+  # Agent transcripts are full of whitespace-free payloads (JSON argument
+  # blobs, signed URLs, base64). The default overflow-wrap only breaks at
+  # whitespace, so such a token painted past its box and grew horizontal
+  # scrollbars on every surface that renders messages. The fix lives at the
+  # shared roots, not per call site:
+  #   platform/app/src/components/ui/prose.tsx            (Markdown -> Prose root)
+  #   platform/app/src/features/traces-v2/components/TraceDrawer/markdownView/RenderedMarkdown.tsx
+  #   platform/app/src/components/traces/RenderInputOutput.tsx (raw mono fallbacks)
+  #
+  # Two further rules applied in the same change, verified by review rather
+  # than a bound test because jsdom cannot resolve Chakra's compiled styles:
+  #   - Message scroll regions pair overflowY="auto" with an explicit
+  #     overflowX="hidden" (ScenarioMessageRenderer, ScenarioRunDetailDrawer,
+  #     AnnotationCard) so stray overflow clips instead of computing
+  #     overflow-x to auto and growing a scrollbar.
+  #   - ScenarioTargetRow's truncating name cell carries minWidth={0}, so the
+  #     flex child shrinks below its text width and ellipses.
+  # House pattern for bare Text surfaces: wordBreak="break-word", matching
+  # AnnotationOutputDiff.tsx.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+
+  @integration
+  Scenario: A message body carries the wrap rule to every prose element
+    When a message renders through Markdown whose text is one unbreakable token
+    Then the prose root resolves overflow-wrap "anywhere"
+    And list items, table cells and links inherit the same rule
+
+  @integration
+  Scenario: Fenced code blocks scroll instead of breaking mid-token
+    Given a message containing a fenced code block with a long token
+    Then the block keeps overflow-x auto
+    And the code does not gain soft wrap opportunities from the wrap rule
+
+  @integration
+  Scenario: Raw tool input and output strings wrap instead of painting wide
+    Given a raw string rendered by RenderInputOutput outside the JSON viewer
+    Then the mono Text carries word-break "break-word"


### PR DESCRIPTION
# Related Issue

- Resolves #7433

Closes #7433

## Summary

Long whitespace-free tokens (URLs, JSON argument blobs, base64 payloads) painted past their bubble on every surface that renders agent output. No element in the Markdown -> Prose chain set `overflow-wrap`, so a token with no break opportunities drew its line box wider than the box holding it, and scroll regions that only set `overflowY` computed `overflow-x` to `auto` and grew horizontal scrollbars.

The fix lands at the shared roots named in the issue plan rather than per call site.

## Changes

Roots:

- `components/ui/prose.tsx`: the style object is now an exported `PROSE_BASE` and carries `overflowWrap: "anywhere"` on the root. The property inherits into every prose element (paragraphs, list items, table cells, links, inline code). The `pre` rule resets it to `normal`, so fenced code blocks keep scrolling horizontally instead of breaking mid-token.
- `features/traces-v2/.../markdownView/RenderedMarkdown.tsx`: same root rule on the wrapper of the second markdown renderer (trace drawer markdown mode, reasoning blocks).
- `components/traces/RenderInputOutput.tsx`: both raw mono fallbacks carry `wordBreak="break-word"`, matching the `AnnotationOutputDiff` house pattern.

Scroll containers:

- `ScenarioMessageRenderer`, `ScenarioRunDetailDrawer`, `AnnotationCard`: explicit `overflowX="hidden"` next to `overflowY="auto"`, so stray overflow clips instead of becoming a scrollbar.

Bare Text surfaces that never reach a renderer:

- Judge reasoning (`SimulationResults`), criteria bullets (`CriteriaDetails`, `CriteriaInput`, `RunCriteriaChip`), media transcript + tool call name (`ScenarioMessageRenderer`), parameter names (`ScenarioRunDetailDrawer`), set/suite/scenario names and raw ids (`ExternalSetDetailPanel`, `ScenarioTable`, `ScenarioRunHeader`, `SuiteDetailPanel`, `SetCard`, `TurnSteps`, input mapping rows).
- `ScenarioTargetRow`: the truncating name cell gains `minWidth={0}` so the flex child ellipses instead of widening its row.

Kept deliberately: the copilotkit code-block patch in `simulations.css` and the parameter value's existing `word-break`. Both guard renderers outside the fixed roots, so removing them would regress those surfaces (this is the part of step 7 in the issue plan I did not apply).

## Testing

- New component suite `prose.unbreakable-wrap.integration.test.tsx`: asserts `PROSE_BASE` ships the wrap rule with the `pre` reset intact, renders a fenced code block end to end, and renders the raw mono fallback carrying `word-break: break-word`. jsdom cannot resolve Chakra's layered CSS through `getComputedStyle`, which is why the Prose assertions run against the exported source object; the repo's own components use the same data-attribute workaround for this limitation.
- Spec added at `specs/traces-v2/unbreakable-text-wrap.feature`, 3/3 scenarios bound.
- `pnpm typecheck:all` clean (the variant that includes test files), biome errors-only clean over every touched file, feature-parity gate green.

## Deployment Impact

CSS-only, no schema or API changes. Text that previously painted off-container now wraps inside it, and three drawers clip horizontally instead of growing scrollbars. Code blocks keep their horizontal scroll. Safe to roll out and revert independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Long scenario names, criteria, IDs, labels, transcripts, and trace content now wrap within available space.
  * Prevented unnecessary horizontal scrolling and layout expansion across scenario, simulation, suite, and trace views.
  * Improved handling of long unbroken Markdown and raw tool input/output values.
  * Preserved horizontal scrolling for fenced code blocks where appropriate.

* **Tests**
  * Added coverage verifying wrapping behavior for unbreakable prose, code, and raw content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->