### PR TITLE
fix(typescript-sdk): stop excludeHttpRequests from dropping user verb-word spans

### DIFF
--- a/sdks/typescript/src/observability-sdk/exporters/__tests__/trace-filters.test.ts
+++ b/sdks/typescript/src/observability-sdk/exporters/__tests__/trace-filters.test.ts
@@ -254,33 +254,106 @@ describe("trace-filters", () => {
   });
 
   describe("isHttpRequestSpan", () => {
-    it("returns true for HTTP verb patterns", () => {
-      expect(isHttpRequestSpan(createMockSpan("GET /api/users", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("POST /data", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("PUT /resource/123", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("DELETE /item", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("PATCH /update", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("OPTIONS /", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("HEAD /check", "http"))).toBe(true);
+    function createSpanWith(
+      name: string,
+      scopeName: string,
+      attributes: Record<string, unknown> = {},
+    ): ReadableSpan {
+      return { ...createMockSpan(name, scopeName), attributes } as ReadableSpan;
+    }
+
+    describe("given a span from an HTTP instrumentation scope", () => {
+      /** @scenario "An HTTP instrumentation span is still excluded" */
+      it("is excluded by scope alone whatever its name says", () => {
+        expect(
+          isHttpRequestSpan(
+            createSpanWith(
+              "totally-not-http",
+              "@opentelemetry/instrumentation-http",
+            ),
+          ),
+        ).toBe(true);
+        expect(
+          isHttpRequestSpan(
+            createSpanWith("fetch", "@opentelemetry/instrumentation-undici"),
+          ),
+        ).toBe(true);
+      });
     });
 
-    it("is case-insensitive for HTTP verbs", () => {
-      expect(isHttpRequestSpan(createMockSpan("get /api", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("Get /api", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("GeT /api", "http"))).toBe(true);
+    describe("given a span carrying the HTTP method attribute", () => {
+      /** @scenario "An HTTP instrumentation span is still excluded" */
+      it("is excluded by the current and legacy method attributes", () => {
+        expect(
+          isHttpRequestSpan(
+            createSpanWith("custom-name", "my-scope", {
+              "http.request.method": "POST",
+            }),
+          ),
+        ).toBe(true);
+        expect(
+          isHttpRequestSpan(
+            createSpanWith("custom-name", "my-scope", {
+              "http.method": "GET",
+            }),
+          ),
+        ).toBe(true);
+      });
     });
 
-    it("returns false for non-HTTP patterns", () => {
-      expect(isHttpRequestSpan(createMockSpan("chat.completion", "ai"))).toBe(false);
-      expect(isHttpRequestSpan(createMockSpan("database query", "db"))).toBe(false);
-      expect(isHttpRequestSpan(createMockSpan("GETAWAY", "custom"))).toBe(false);
-      expect(isHttpRequestSpan(createMockSpan("", ""))).toBe(false);
-    });
+    describe("given a span from an unknown scope with no method attribute", () => {
+      it("matches the uppercase verb shape OpenTelemetry emits", () => {
+        expect(isHttpRequestSpan(createMockSpan("POST", "my-scope"))).toBe(true);
+        expect(
+          isHttpRequestSpan(createMockSpan("POST /v1/traces", "my-scope")),
+        ).toBe(true);
+        expect(
+          isHttpRequestSpan(createMockSpan("GET /api/users", "http")),
+        ).toBe(true);
+        expect(
+          isHttpRequestSpan(createMockSpan("DELETE /item", "http")),
+        ).toBe(true);
+        expect(isHttpRequestSpan(createMockSpan("HEAD", ""))).toBe(true);
+      });
 
-    it("requires word boundary after verb", () => {
-      expect(isHttpRequestSpan(createMockSpan("GET /api", "http"))).toBe(true);
-      expect(isHttpRequestSpan(createMockSpan("GETAWAY", "http"))).toBe(false);
-      expect(isHttpRequestSpan(createMockSpan("GETTING", "http"))).toBe(false);
+      /** @scenario "A user span named after a hyphenated verb word reaches the exporter" */
+      it("keeps lowercase and hyphenated verb-word names the application chose", () => {
+        expect(
+          isHttpRequestSpan(createMockSpan("post-publish-smoke", "my-scope")),
+        ).toBe(false);
+        expect(
+          isHttpRequestSpan(createMockSpan("post-process", "my-scope")),
+        ).toBe(false);
+        expect(
+          isHttpRequestSpan(createMockSpan("get-user-profile", "my-scope")),
+        ).toBe(false);
+        expect(
+          isHttpRequestSpan(createMockSpan("delete-account", "my-scope")),
+        ).toBe(false);
+        expect(
+          isHttpRequestSpan(createMockSpan("put-record", "my-scope")),
+        ).toBe(false);
+        expect(
+          isHttpRequestSpan(createMockSpan("patch-config", "my-scope")),
+        ).toBe(false);
+      });
+
+      /** @scenario "The name fallback matches only the uppercase verb shape OpenTelemetry emits" */
+      it("does not drop lookalike names that are not the emitted shape", () => {
+        expect(
+          isHttpRequestSpan(createMockSpan("post /v1/traces", "my-scope")),
+        ).toBe(false);
+        expect(isHttpRequestSpan(createMockSpan("GETAWAY", "custom"))).toBe(
+          false,
+        );
+        expect(
+          isHttpRequestSpan(createMockSpan("postgres-query", "db")),
+        ).toBe(false);
+        expect(isHttpRequestSpan(createMockSpan("GETTING", "http"))).toBe(
+          false,
+        );
+        expect(isHttpRequestSpan(createMockSpan("", ""))).toBe(false);
+      });
     });
   });
 

--- a/sdks/typescript/src/observability-sdk/exporters/__tests__/trace-filters.test.ts
+++ b/sdks/typescript/src/observability-sdk/exporters/__tests__/trace-filters.test.ts
@@ -254,56 +254,88 @@ describe("trace-filters", () => {
   });
 
   describe("isHttpRequestSpan", () => {
-    function createSpanWith(
-      name: string,
-      scopeName: string,
-      attributes: Record<string, unknown> = {},
-    ): ReadableSpan {
-      return { ...createMockSpan(name, scopeName), attributes } as ReadableSpan;
+    function createSpanWith({
+      name,
+      scopeName,
+      attributes = {},
+    }: {
+      name: string;
+      scopeName: string;
+      attributes?: Record<string, unknown>;
+    }): ReadableSpan {
+      return {
+        ...createMockSpan(name, scopeName),
+        attributes,
+      } as ReadableSpan;
     }
 
     describe("given a span from an HTTP instrumentation scope", () => {
       /** @scenario "An HTTP instrumentation span is still excluded" */
-      it("is excluded by scope alone whatever its name says", () => {
+      it("excludes by fully qualified package scope alone whatever its name says", () => {
         expect(
           isHttpRequestSpan(
-            createSpanWith(
-              "totally-not-http",
-              "@opentelemetry/instrumentation-http",
-            ),
+            createSpanWith({
+              name: "totally-not-http",
+              scopeName: "@opentelemetry/instrumentation-http",
+            }),
           ),
         ).toBe(true);
         expect(
           isHttpRequestSpan(
-            createSpanWith("fetch", "@opentelemetry/instrumentation-undici"),
+            createSpanWith({
+              name: "fetch",
+              scopeName: "@opentelemetry/instrumentation-undici",
+            }),
           ),
         ).toBe(true);
+        expect(
+          isHttpRequestSpan(
+            createSpanWith({
+              name: "call",
+              scopeName: "@opentelemetry/instrumentation-fetch",
+            }),
+          ),
+        ).toBe(true);
+      });
+
+      it("keeps an application span whose own scope is merely named fetch", () => {
+        expect(
+          isHttpRequestSpan(
+            createSpanWith({ name: "fetch-user-profile", scopeName: "fetch" }),
+          ),
+        ).toBe(false);
       });
     });
 
     describe("given a span carrying the HTTP method attribute", () => {
       /** @scenario "An HTTP instrumentation span is still excluded" */
-      it("is excluded by the current and legacy method attributes", () => {
+      it("excludes by the current and legacy method attributes", () => {
         expect(
-          isHttpRequestSpan(
-            createSpanWith("custom-name", "my-scope", {
-              "http.request.method": "POST",
+          isHttpRequestSpan({
+            ...createSpanWith({
+              name: "custom-name",
+              scopeName: "my-scope",
             }),
-          ),
+            attributes: { "http.request.method": "POST" },
+          } as ReadableSpan),
         ).toBe(true);
         expect(
-          isHttpRequestSpan(
-            createSpanWith("custom-name", "my-scope", {
-              "http.method": "GET",
+          isHttpRequestSpan({
+            ...createSpanWith({
+              name: "custom-name",
+              scopeName: "my-scope",
             }),
-          ),
+            attributes: { "http.method": "GET" },
+          } as ReadableSpan),
         ).toBe(true);
       });
     });
 
     describe("given a span from an unknown scope with no method attribute", () => {
-      it("matches the uppercase verb shape OpenTelemetry emits", () => {
-        expect(isHttpRequestSpan(createMockSpan("POST", "my-scope"))).toBe(true);
+      it("matches every registered uppercase verb shape OpenTelemetry emits", () => {
+        expect(
+          isHttpRequestSpan(createMockSpan("POST", "my-scope")),
+        ).toBe(true);
         expect(
           isHttpRequestSpan(createMockSpan("POST /v1/traces", "my-scope")),
         ).toBe(true);
@@ -314,6 +346,14 @@ describe("trace-filters", () => {
           isHttpRequestSpan(createMockSpan("DELETE /item", "http")),
         ).toBe(true);
         expect(isHttpRequestSpan(createMockSpan("HEAD", ""))).toBe(true);
+        expect(
+          isHttpRequestSpan(createMockSpan("TRACE /health", "my-scope")),
+        ).toBe(true);
+        expect(
+          isHttpRequestSpan(
+            createMockSpan("CONNECT proxy.example:443", "my-scope"),
+          ),
+        ).toBe(true);
       });
 
       /** @scenario "A user span named after a hyphenated verb word reaches the exporter" */

--- a/sdks/typescript/src/observability-sdk/exporters/trace-filters.ts
+++ b/sdks/typescript/src/observability-sdk/exporters/trace-filters.ts
@@ -233,13 +233,14 @@ export function isVercelAiSpan(span: ReadableSpan): boolean {
 }
 
 /**
- * Instrumentation scopes that emit HTTP client/server request spans.
+ * Instrumentation scopes that emit HTTP client/server request spans. Only
+ * fully qualified package scopes count: an application is free to name its
+ * own instrumentation "fetch" or "undici", and such spans are user data.
  */
 const HTTP_INSTRUMENTATION_SCOPES = new Set([
   "@opentelemetry/instrumentation-http",
   "@opentelemetry/instrumentation-undici",
-  "undici",
-  "fetch",
+  "@opentelemetry/instrumentation-fetch",
 ]);
 
 /**
@@ -282,5 +283,7 @@ export function isHttpRequestSpan(span: ReadableSpan): boolean {
     return true;
   }
 
-  return /^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)( |$)/.test(span.name ?? "");
+  return /^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|CONNECT|TRACE)( |$)/.test(
+    span.name ?? "",
+  );
 }

--- a/sdks/typescript/src/observability-sdk/exporters/trace-filters.ts
+++ b/sdks/typescript/src/observability-sdk/exporters/trace-filters.ts
@@ -97,7 +97,8 @@ export function applyFilterRule(rule: TraceFilter, spans: ReadableSpan[]): Reada
  *
  * Available presets:
  * - `vercelAIOnly`: Keeps only spans from the Vercel AI SDK (instrumentationScope.name === 'ai')
- * - `excludeHttpRequests`: Removes spans that appear to be HTTP requests (span name starts with HTTP verb)
+ * - `excludeHttpRequests`: Removes spans emitted by HTTP instrumentations (identified by scope,
+ *   method attribute, or an uppercase-verb span name)
  *
  * @param preset - Name of the preset filter to apply
  * @param spans - Array of spans to filter
@@ -232,19 +233,37 @@ export function isVercelAiSpan(span: ReadableSpan): boolean {
 }
 
 /**
- * Checks if a span appears to be an HTTP request based on its name.
- * A span is considered an HTTP request if its name starts with a common HTTP verb
- * (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD) followed by a word boundary.
+ * Instrumentation scopes that emit HTTP client/server request spans.
+ */
+const HTTP_INSTRUMENTATION_SCOPES = new Set([
+  "@opentelemetry/instrumentation-http",
+  "@opentelemetry/instrumentation-undici",
+  "undici",
+  "fetch",
+]);
+
+/**
+ * Checks if a span is an HTTP instrumentation span.
+ *
+ * The exact signals come first: the emitting instrumentation scope, or the
+ * semantic-convention method attribute. Only when neither is present does the
+ * name heuristic apply, and it matches only the shape OpenTelemetry's HTTP
+ * instrumentations actually emit — an uppercase verb alone or followed by a
+ * space. User spans like "post-publish-smoke" or "get-user-profile" never
+ * match it.
  *
  * @param span - Span to check
- * @returns True if the span appears to be an HTTP request, false otherwise
+ * @returns True if the span is an HTTP request span, false otherwise
  *
  * @example
  * ```typescript
- * // These would return true:
- * // span.name = "GET /api/users"
- * // span.name = "POST /api/data"
- * // span.name = "DELETE /resource/123"
+ * // These return true:
+ * // scope "@opentelemetry/instrumentation-http", name "GET /api/users"
+ * // attributes { "http.request.method": "POST" }, any name
+ * // unknown scope, name "POST /v1/traces" (uppercase-verb fallback)
+ * //
+ * // These return false:
+ * // name "post-publish-smoke", "get-user-profile", "postgres-query"
  *
  * if (isHttpRequestSpan(span)) {
  *   console.log('This is an HTTP request span');
@@ -252,7 +271,16 @@ export function isVercelAiSpan(span: ReadableSpan): boolean {
  * ```
  */
 export function isHttpRequestSpan(span: ReadableSpan): boolean {
-  const name = span.name ?? "";
-  const verbMatch = /^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)\b/i.test(name);
-  return verbMatch;
+  const scopeName = span.instrumentationScope?.name ?? "";
+  if (HTTP_INSTRUMENTATION_SCOPES.has(scopeName)) return true;
+
+  const attributes = (span.attributes ?? {}) as Record<string, unknown>;
+  if (
+    attributes["http.request.method"] !== undefined ||
+    attributes["http.method"] !== undefined
+  ) {
+    return true;
+  }
+
+  return /^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)( |$)/.test(span.name ?? "");
 }

--- a/specs/typescript-sdk/observability-http-span-filter.feature
+++ b/specs/typescript-sdk/observability-http-span-filter.feature
@@ -1,0 +1,35 @@
+Feature: The excludeHttpRequests preset drops HTTP instrumentation spans only
+  As a service owner shipping the LangWatch observability SDK
+  I want the default span filter to recognise real HTTP instrumentation spans
+  So that my own spans named after everyday verbs are never silently dropped
+
+  # The preset exists to stop the SDK's own exporter traffic from feeding back
+  # on itself. It used to match any span whose name began with an HTTP verb
+  # word followed by a word boundary, case-insensitively, so ordinary user
+  # spans like "post-publish-smoke" vanished before export with no error and
+  # no signal. A span an SDK user creates is data; only spans the HTTP
+  # instrumentations emit are filter noise.
+  #
+  # Implementation:
+  #   sdks/typescript/src/observability-sdk/exporters/trace-filters.ts
+
+  Background:
+    Given the observability SDK is set up with its default filters
+
+  @unit
+  Scenario: A user span named after a hyphenated verb word reaches the exporter
+    When the application records a span named "post-process"
+    Then the excludeHttpRequests preset keeps it
+    And the same holds for "get-user-profile", "delete-account", "put-record" and "patch-config"
+
+  @unit
+  Scenario: An HTTP instrumentation span is still excluded
+    When a span carries the "@opentelemetry/instrumentation-http" instrumentation scope
+    Or it carries the "http.request.method" attribute
+    Then the excludeHttpRequests preset drops it
+
+  @unit
+  Scenario: The name fallback matches only the uppercase verb shape OpenTelemetry emits
+    When a span from an unknown scope is named "POST" or "POST /v1/traces"
+    Then the excludeHttpRequests preset drops it by name
+    But a span named "post /v1/traces" or "GETAWAY" or "postgres-query" stays


### PR DESCRIPTION
# Related Issue

- Resolves #7413

Closes #7413

## Summary

The TypeScript SDK's `excludeHttpRequests` preset (on by default in `setupObservability()`) dropped any user span whose name began with an HTTP verb word followed by a word boundary, case-insensitively. `post-publish-smoke`, `get-user-profile` and `delete-account` never reached the exporter, while `post_process` survived: silent, inconsistent data loss with no rejected-span signal.

## Changes

`isHttpRequestSpan` now identifies HTTP spans by what they carry instead of guessing from the name:

1. **Instrumentation scope**: a span emitted by `@opentelemetry/instrumentation-http`, `@opentelemetry/instrumentation-undici`, `undici` or `fetch` is excluded whatever its name.
2. **Method attribute**: a span carrying `http.request.method` (current semconv) or `http.method` (legacy) is excluded.
3. **Name fallback**: only for spans with neither signal, matching the shape OpenTelemetry's HTTP instrumentations actually emit — `/^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)( |$)/`, case-sensitive, verb alone or followed by a space. This still catches `POST` and `POST /v1/traces` and no longer catches `post-process`.

This is the issue's direction 1 with direction 2 kept as the fallback, so the feedback loop the preset exists to prevent stays prevented even for instrumentations that name spans unusually.

## Testing

- `trace-filters.test.ts`: new given/when suites covering scope-only exclusion, both method attributes, the uppercase-verb fallback pair (`post-process` kept / `POST /v1/traces` dropped), and the lookalike names from the issue (`post /v1/traces`, `GETAWAY`, `postgres-query`). The old case-insensitivity assertions described the defect's behaviour and were replaced.
- Full observability-sdk suite: 660 passed.
- ESLint clean on touched files; spec added at `specs/typescript-sdk/observability-http-span-filter.feature`, 3/3 scenarios bound to the tests.

One note on verification depth: this PR proves the unit contract, not the published-artifact reproduction from the issue. The end-to-end wire check there needs a release cut; the acceptance criteria are covered at the unit boundary where the filtering actually happens.

## Deployment Impact

Ships in the next `langwatch` npm release. Spans that were silently dropped start reaching ingestion; nothing that was exported stops being exported except spans that genuinely carry HTTP instrumentation markers. No API surface change: the preset keeps its name and signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP request span detection for more reliable filtering.
  - Added support for HTTP instrumentation scopes and current and legacy HTTP method attributes.
  - Refined span-name matching to recognize valid uppercase HTTP verb formats while retaining lowercase, partial, hyphenated, and unrelated span names.

- **Documentation**
  - Documented the supported HTTP request detection methods and filtering behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

