### PR TITLE
docs(sso): correct the Azure AD redirect URI to the microsoft callback path

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -58763,7 +58763,7 @@ When configuring your identity provider, set the redirect/callback URL to:
 https://your-langwatch-domain.com/api/auth/callback/{provider}
 ```
 
-Replace `{provider}` with: `auth0`, `azure-ad`, `cognito`, `github`, `gitlab`, `google`, `okta`, `onelogin`, or `oidc`. This is the same value you set as `NEXTAUTH_PROVIDER`.
+Replace `{provider}` with: `auth0`, `cognito`, `github`, `gitlab`, `google`, `okta`, `onelogin`, or `oidc`. This is the same value you set as `NEXTAUTH_PROVIDER`. Azure AD is the one exception: its callback path uses `microsoft` (the provider id Better Auth mounts it under), so register `https://your-langwatch-domain.com/api/auth/callback/microsoft`.
 
 <Note>
 A `NEXTAUTH_PROVIDER` value LangWatch does not recognise, or one whose client credentials are missing, starts the deployment in email mode and logs which provider it could not mount. That keeps a licensed deployment signable-in while you correct the value, rather than pointing the sign-in page at an identity provider that was never wired up.
@@ -58851,7 +58851,7 @@ curl https://cognito-idp.<region>.amazonaws.com/<userPoolId>/.well-known/openid-
 ### Azure AD
 
 1. Register an application in [Azure Portal > App registrations](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
-2. Add a **Redirect URI**: `https://your-domain.com/api/auth/callback/azure-ad`
+2. Add a **Redirect URI**: `https://your-domain.com/api/auth/callback/microsoft`
 3. Create a client secret under **Certificates & secrets**
 4. Configure in Helm:
 
@@ -62919,6 +62919,8 @@ The callback URL configured in your identity provider must exactly match:
 ```
 https://your-langwatch-domain.com/api/auth/callback/{provider}
 ```
+
+Azure AD is the exception: its callback path uses `microsoft`, so register `https://your-langwatch-domain.com/api/auth/callback/microsoft`.
 
 Check that `app.http.publicUrl` matches your actual domain (including `https://`).
 

--- a/docs/self-hosting/configuration/sso.mdx
+++ b/docs/self-hosting/configuration/sso.mdx
@@ -36,7 +36,7 @@ When configuring your identity provider, set the redirect/callback URL to:
 https://your-langwatch-domain.com/api/auth/callback/{provider}
 ```
 
-Replace `{provider}` with: `auth0`, `azure-ad`, `cognito`, `github`, `gitlab`, `google`, `okta`, `onelogin`, or `oidc`. This is the same value you set as `NEXTAUTH_PROVIDER`.
+Replace `{provider}` with: `auth0`, `cognito`, `github`, `gitlab`, `google`, `okta`, `onelogin`, or `oidc`. This is the same value you set as `NEXTAUTH_PROVIDER`. Azure AD is the one exception: its callback path uses `microsoft` (the provider id Better Auth mounts it under), so register `https://your-langwatch-domain.com/api/auth/callback/microsoft`.
 
 <Note>
 A `NEXTAUTH_PROVIDER` value LangWatch does not recognise, or one whose client credentials are missing, starts the deployment in email mode and logs which provider it could not mount. That keeps a licensed deployment signable-in while you correct the value, rather than pointing the sign-in page at an identity provider that was never wired up.
@@ -124,7 +124,7 @@ curl https://cognito-idp.<region>.amazonaws.com/<userPoolId>/.well-known/openid-
 ### Azure AD
 
 1. Register an application in [Azure Portal > App registrations](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
-2. Add a **Redirect URI**: `https://your-domain.com/api/auth/callback/azure-ad`
+2. Add a **Redirect URI**: `https://your-domain.com/api/auth/callback/microsoft`
 3. Create a client secret under **Certificates & secrets**
 4. Configure in Helm:
 

--- a/docs/self-hosting/troubleshooting.mdx
+++ b/docs/self-hosting/troubleshooting.mdx
@@ -247,6 +247,8 @@ The callback URL configured in your identity provider must exactly match:
 https://your-langwatch-domain.com/api/auth/callback/{provider}
 ```
 
+Azure AD is the exception: its callback path uses `microsoft`, so register `https://your-langwatch-domain.com/api/auth/callback/microsoft`.
+
 Check that `app.http.publicUrl` matches your actual domain (including `https://`).
 
 ### "Email already exists" during SSO migration


### PR DESCRIPTION
# Related Issue

- Resolves #7344

Closes #7344

## Summary

The self-hosting SSO docs told operators to register the Entra redirect URI as `/api/auth/callback/azure-ad`. Azure AD mounts as Better Auth's core `microsoft` social provider with no `redirectURI` override, so the authorization request carries `redirect_uri=<base>/api/auth/callback/microsoft`. Entra compares redirect URIs by exact string and rejects the documented shape with AADSTS50011, so anyone following the docs verbatim could not complete setup.

## Changes

- `docs/self-hosting/configuration/sso.mdx`: the Azure AD setup step now registers `/api/auth/callback/microsoft`, and the `{provider}` list carves Azure AD out with a note that its callback id is `microsoft`.
- `docs/self-hosting/troubleshooting.mdx`: the callback-mismatch section carries the same exception note.
- `docs/llms-full.txt`: regenerated by the pre-commit hook.

## Verification

Code path confirmed against `ee/sso/providers.ts`: the `azure-ad` branch assigns `socialProviders.microsoft` and never pins `redirectURI`; the legacy-callback pinning covers only the generic-OAuth providers.

## Deployment Impact

Docs only. No code or configuration change; deployments that already registered `/callback/microsoft` keep working unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Azure AD SSO callback guidance to use the `microsoft` provider path.
  - Revised supported provider lists and Azure Portal redirect URI instructions.
  - Added deployment and troubleshooting examples for Azure AD callback URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->