### PR TITLE
fix(flags): point operators at the internal flag store instead of PostHog rules

### DIFF
--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -36,13 +36,14 @@
  *
  * ## Targeting
  *
- * Flags can target users, projects, or organizations via PostHog personProperties.
- * Configure targeting in PostHog release conditions, not in the flag name.
+ * Flags can target users, projects, or organizations via targeting rules in
+ * the internal flag store (/ops/feature-flags). Configure targeting there,
+ * not in the flag name.
  * Pass `projectId` or `organizationId` to `useFeatureFlag` for targeted evaluation.
  *
  * ## Adding New Flags
  *
- * 1. Create the flag in PostHog with your desired release conditions
+ * 1. Create the flag in the registry with its description and default
  * 2. Add the flag key to this array
  * 3. Use `useFeatureFlag("your_flag_key")` in components
  *

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -166,7 +166,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: false,
     description:
-      "Records cost pulled from a provider's own usage/cost report as a priced record on the customer's usage screens (ADR-088). Off by default; enable per organization via the operator store or a PostHog rule. With it off the puller writes audit rows only. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_pulled_usage_cost_enabled.",
+      "Records cost pulled from a provider's own usage/cost report as a priced record on the customer's usage screens (ADR-088). Off by default; enable per organization via the operator store (/ops/feature-flags), including its targeting rules. With it off the puller writes audit rows only. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_pulled_usage_cost_enabled.",
     family: "Governance",
   },
 
@@ -183,7 +183,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: true,
     description:
-      "Surfaces the AI Gateway menu in the project sidebar. Default flipped to on: operators can hide the surface per project via a PostHog rule or operator-store row.",
+      "Surfaces the AI Gateway menu in the project sidebar. Default flipped to on: operators can hide the surface per project via an operator-store row or targeting rule (/ops/feature-flags).",
   },
   {
     key: "release_ui_navigation_v2_enabled",
@@ -311,7 +311,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: false,
     description:
-      "Shows the Langy teaser banner on the home page to users who do NOT have Langy yet (spec: specs/home/langy-home-banner.feature). Purely promotional — it never grants access; users who already have Langy (staff or release_langy_enabled) see the activation banner instead, regardless of this flag. Target the promo audience via a PostHog rule.",
+      "Shows the Langy teaser banner on the home page to users who do NOT have Langy yet (spec: specs/home/langy-home-banner.feature). Purely promotional — it never grants access; users who already have Langy (staff or release_langy_enabled) see the activation banner instead, regardless of this flag. Target the promo audience with targeting rules in the internal flag store (/ops/feature-flags).",
   },
   {
     key: "release_ui_home_signal_focused_enabled",


### PR DESCRIPTION
# Related Issue

- Resolves #7348

Closes #7348

## Summary

Three flag descriptions in the registry and the frontend flags docblock still instructed operators to enable or target a flag "via a PostHog rule". PostHog was removed from the resolver chain in #7194, so an operator who follows those instructions configures a rule nothing reads, sees no change, and concludes the flag is broken.

## Changes

Rewritten to name the mechanism that resolves flags today:

- `release_pulled_usage_cost_enabled`: enable per organization via the operator store (/ops/feature-flags), including its targeting rules.
- `release_ui_ai_gateway_menu_enabled`: hide per project via an operator-store row or targeting rule.
- The Langy home teaser banner: target the promo audience with targeting rules in the internal flag store.
- `frontendFeatureFlags.ts`: the targeting section and the "create the flag in PostHog" walkthrough now describe the registry plus /ops/feature-flags.

## What stayed

The six historical and deliberate mentions are untouched: the old resolver-chain rationale and the 2026-05 billing-incident comment (accurate history explaining the cache design), and the two Langy descriptions that state PostHog is deliberately not consulted. Verified by re-running the issue's grep: only the intended mentions changed.

## Testing

Feature-flag unit suites: 9 files, 67 tests passed. Biome clean on both files. Copy-only change; no behaviour touched.

## Deployment Impact

Comments and operator-facing descriptions only. No runtime behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature-flag guidance to direct configuration and targeting through the internal feature-flag registry.
  * Replaced outdated instructions referencing PostHog targeting rules.
  * Clarified that organization and project targeting is managed from the feature-flag operations page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->