### PR TITLE
fix(authz): a pass finishes, and stops holding organizations it cannot clear

### DIFF
--- a/packages/authz-server/src/authz-migration.repository.ts
+++ b/packages/authz-server/src/authz-migration.repository.ts
@@ -83,6 +83,11 @@ export type RoleHeadRow = {
   description: string | null;
   permissions: unknown;
   kind: string;
+  /** Whether the fold has marked this head deleted. A tombstone is still a
+   *  row - the name it took stays taken - so the read that serves the proof
+   *  returns it and says so, rather than dropping it and leaving the check to
+   *  read an absence as "not folded yet". */
+  deleted: boolean;
 };
 
 /**

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -54,7 +54,8 @@ type Data = {
   credentials?: ProjectCredentialFact[];
   groupMemberships?: Array<{ userId: string; groupId: string }>;
   grantHeads?: GrantHeadRow[];
-  roleHeads?: RoleHeadRow[];
+  /** `deleted` defaults to false: a head is live unless a test buries it. */
+  roleHeads?: Array<Omit<RoleHeadRow, "deleted"> & { deleted?: boolean }>;
   resourceRows?: ResourceGrantRow[];
   /** Wraps the recording ledger, for tests that need to observe or fail a
    *  send rather than only read what was sent. */
@@ -86,7 +87,10 @@ function harness(data: Data = {}) {
     },
     findRoleHeads: async () => {
       reads.roleHeads += 1;
-      return data.roleHeads ?? [];
+      return (data.roleHeads ?? []).map((head) => ({
+        ...head,
+        deleted: head.deleted ?? false,
+      }));
     },
     findResourceGrantRows: async () => {
       reads.resourceRows += 1;
@@ -927,6 +931,74 @@ describe("given an organization with legacy access rows", () => {
         "role_gone",
         "role_system",
       ]);
+    });
+
+    /** @scenario "A role head the fold has buried is a deletion applied, not work outstanding" */
+    it("finalizes over a buried role head whose legacy row is gone", async () => {
+      // The organization an API key deletion held forever: the delete a
+      // previous pass sent has landed, the tombstone is permanent — a role's
+      // name stays taken — and nothing about it is still outstanding.
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        roleHeads: [
+          {
+            id: "role_buried",
+            name: "apikey:gone",
+            description: null,
+            permissions: [],
+            kind: "system_api_key",
+            deleted: true,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("finalized");
+      expect(sent.filter((entry) => entry.kind === "deleteRole")).toEqual([]);
+    });
+
+    /** @scenario "A role head the fold has buried is a deletion applied, not work outstanding" */
+    it("names a buried head whose legacy row is back, and states nothing for it", async () => {
+      const { migration, sent } = harness({
+        organizationCreatedAtMs: null,
+        roles: [
+          {
+            id: "role_1",
+            name: "Auditor",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+            createdAtMs: CREATED,
+          },
+        ],
+        roleHeads: [
+          {
+            id: "role_1",
+            name: "Auditor",
+            description: null,
+            permissions: ["traces:view"],
+            kind: "custom",
+            deleted: true,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("migrated");
+      const report = outcome.report as {
+        outstanding: number;
+        diffs: Array<{ kind: string; id: string }>;
+      };
+      // Named, not repaired: `role.upsert` leaves `deletedAt` alone, so no
+      // restatement could raise the row.
+      expect(report.diffs).toContainEqual({
+        kind: "role_deleted",
+        id: "role_1",
+      });
+      expect(report.outstanding).toBe(0);
+      expect(sent.filter((entry) => entry.kind === "defineRole")).toEqual([]);
     });
   });
 

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -57,6 +57,10 @@ type Data = {
   /** `deleted` defaults to false: a head is live unless a test buries it. */
   roleHeads?: Array<Omit<RoleHeadRow, "deleted"> & { deleted?: boolean }>;
   resourceRows?: ResourceGrantRow[];
+  /** Grant ids whose budget handover the seed's guard refuses — a usage row
+   *  that disagrees about which project it belongs to. Their heads keep the
+   *  count the test gave them, however high the seed goes. */
+  unseededGrantIds?: string[];
   /** Wraps the recording ledger, for tests that need to observe or fail a
    *  send rather than only read what was sent. */
   wrapLedger?: (ledger: Ledger) => Ledger;
@@ -68,6 +72,8 @@ function harness(data: Data = {}) {
   const sent: Sent[] = [];
   const seeded: ResourceGrantUsageSeed[][] = [];
   const reads = { grantHeads: 0, roleHeads: 0, resourceRows: 0 };
+  /** Call order, for the steps whose ORDER is the behaviour under test. */
+  const order: string[] = [];
   const store: AuthzEngineMigrationStore = {
     findOrganizationCreatedAtMs: async () =>
       data.organizationCreatedAtMs === undefined
@@ -94,9 +100,26 @@ function harness(data: Data = {}) {
     },
     findResourceGrantRows: async () => {
       reads.resourceRows += 1;
-      return data.resourceRows ?? [];
+      order.push("readResourceRows");
+      // The budget table is a plain row the pass writes DIRECTLY, not a fact
+      // it states and waits on, so a read taken after the seed sees it and a
+      // read taken before does not. Modelling that raise is the only way a
+      // test can tell those two orders apart.
+      const refused = new Set(data.unseededGrantIds ?? []);
+      const budgets = new Map(
+        seeded.flat().map((seed) => [seed.grantId, seed.viewCount]),
+      );
+      return (data.resourceRows ?? []).map((row) =>
+        refused.has(row.grantId)
+          ? row
+          : {
+              ...row,
+              viewCount: Math.max(row.viewCount, budgets.get(row.grantId) ?? 0),
+            },
+      );
     },
     seedResourceGrantUsage: async ({ seeds }) => {
+      order.push("seedBudgets");
       seeded.push([...seeds]);
     },
   };
@@ -120,7 +143,7 @@ function harness(data: Data = {}) {
     ledger: data.wrapLedger ? data.wrapLedger(recording) : recording,
     now: () => NOW,
   });
-  return { migration, sent, seeded, reads };
+  return { migration, sent, seeded, reads, order };
 }
 
 function attachedFacts(sent: Sent[]): GrantFact[] {
@@ -687,14 +710,61 @@ describe("given an organization with legacy access rows", () => {
       );
     });
 
-    it("treats a head behind the legacy view count as lag, not disagreement", async () => {
-      // Views land legacy-side between passes and the monotonic seed raises
-      // the usage row next pass — outstanding, so the organization heals
-      // instead of re-holding forever on an actively-viewed link.
+    /** @scenario "A link viewed between passes does not hold the organization" */
+    it("hands the budget over before it reads what it will check against", async () => {
+      const { migration, order } = harness({
+        shareLinks: [shareLink({ maxViews: 10, viewCount: 3 })],
+      });
+
+      await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(order).toEqual(["seedBudgets", "readResourceRows"]);
+    });
+
+    /** @scenario "A link viewed between passes does not hold the organization" */
+    it("does not hold an organization for a link viewed since the last pass", async () => {
+      // The race this closes: seeding AFTER the read compared a count the
+      // seed had already superseded, so a link viewed at any point between
+      // one pass's seed and the next pass's read counted outstanding all over
+      // again — and an organization whose links are viewed at all could never
+      // finalize, however many passes it was given.
       const row = shareLink({ maxViews: 10, viewCount: 3 });
       const { migration } = harness({
         shareLinks: [row],
         organizationCreatedAtMs: null,
+        resourceRows: [
+          {
+            grantId: row.id,
+            source: "migration",
+            token: row.token,
+            resourceKind: "TRACE",
+            resourceId: row.resourceId,
+            projectId: row.projectId,
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAtMs: null,
+            maxViews: 10,
+            // Two views landed legacy-side since the last pass.
+            viewCount: 1,
+          },
+        ],
+      });
+
+      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
+
+      expect(outcome.status).toBe("finalized");
+    });
+
+    /** @scenario "A view budget is raised on a re-run, never lowered" */
+    it("treats a budget the handover could not raise as lag, not disagreement", async () => {
+      // The one case the seed's guard refuses: a usage row that disagrees
+      // about which project it belongs to. Outstanding rather than a diff, so
+      // it heals the moment the row is corrected instead of latching.
+      const row = shareLink({ maxViews: 10, viewCount: 3 });
+      const { migration } = harness({
+        shareLinks: [row],
+        organizationCreatedAtMs: null,
+        unseededGrantIds: [row.id],
         resourceRows: [
           {
             grantId: row.id,
@@ -933,7 +1003,7 @@ describe("given an organization with legacy access rows", () => {
       ]);
     });
 
-    /** @scenario "A role head the fold has buried is a deletion applied, not work outstanding" */
+    /** @scenario "A custom role deleted before the migration finished stays deleted" */
     it("finalizes over a buried role head whose legacy row is gone", async () => {
       // The organization an API key deletion held forever: the delete a
       // previous pass sent has landed, the tombstone is permanent — a role's
@@ -958,7 +1028,7 @@ describe("given an organization with legacy access rows", () => {
       expect(sent.filter((entry) => entry.kind === "deleteRole")).toEqual([]);
     });
 
-    /** @scenario "A role head the fold has buried is a deletion applied, not work outstanding" */
+    /** @scenario "A deleted custom role that exists again is reported, not quietly restored" */
     it("names a buried head whose legacy row is back, and states nothing for it", async () => {
       const { migration, sent } = harness({
         organizationCreatedAtMs: null,

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -757,11 +757,18 @@ describe("given an organization with legacy access rows", () => {
 
     /** @scenario "A view budget is raised on a re-run, never lowered" */
     it("treats a budget the handover could not raise as lag, not disagreement", async () => {
-      // The one case the seed's guard refuses: a usage row that disagrees
-      // about which project it belongs to. Outstanding rather than a diff, so
-      // it heals the moment the row is corrected instead of latching.
+      // The one case the seed's guard refuses: a GRANTUSAGE row that
+      // disagrees about which project it belongs to. Outstanding rather than
+      // a diff, so it heals the moment the row is corrected instead of
+      // latching.
       //
-      // Only while the COUNTS also disagree, which is what this pins. Such a
+      // The grant below sits on the RIGHT project — `projectId: row.projectId`
+      // — so nothing here is a `resource_changed` diff. That comparison is
+      // over the grant's project, which is checked; the budget row's project
+      // is a different column that `findResourceGrantRows` does not select.
+      // What differs is the count alone, which is why this is lag.
+      //
+      // And only while the COUNTS disagree, which is what this pins. A budget
       // row already at the right count reads as agreement and the
       // organization finalizes over it — deliberately: the row is not the
       // seed's to move, the mismatch fails toward fewer views (the consume

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -760,6 +760,13 @@ describe("given an organization with legacy access rows", () => {
       // The one case the seed's guard refuses: a usage row that disagrees
       // about which project it belongs to. Outstanding rather than a diff, so
       // it heals the moment the row is corrected instead of latching.
+      //
+      // Only while the COUNTS also disagree, which is what this pins. Such a
+      // row already at the right count reads as agreement and the
+      // organization finalizes over it — deliberately: the row is not the
+      // seed's to move, the mismatch fails toward fewer views (the consume
+      // fences on the same columns and simply misses), and holding on it
+      // would be a hold no later pass could clear.
       const row = shareLink({ maxViews: 10, viewCount: 3 });
       const { migration } = harness({
         shareLinks: [row],

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -297,12 +297,17 @@ function roleDiffs({
  * said, mapped to that spelling.
  *
  * The view budget cuts both ways and the two directions mean different
- * things. A head BEHIND the legacy count is convergence lag — views land
- * legacy-side between passes and the monotonic seed raises the usage row
- * next pass — so it is `outstanding`, not a disagreement; reporting it as
- * one made an actively-viewed link re-hold the organization forever. A
- * head AHEAD of the legacy count is a budget that grew back, which nothing
- * legitimate produces, so that is the named diff.
+ * things. A head BEHIND the legacy count is convergence lag and never a
+ * disagreement: reporting it as one made an actively-viewed link re-hold the
+ * organization forever. The pass now hands the budget over BEFORE it takes
+ * the read this walks (see `migrateTenant`), so the lag is already repaired
+ * by the time the comparison runs and this should find nothing. It stays
+ * `outstanding` rather than becoming a diff for the one case the handover
+ * cannot cover — a usage row that disagrees about which project it belongs
+ * to, which the seed's guard deliberately will not move — because that heals
+ * the moment the row is corrected and must not latch. A head AHEAD of the
+ * legacy count is a budget that grew back, which nothing legitimate
+ * produces, so that is the named diff.
  *
  * Tokens are bearer credentials and the report is persisted and rendered
  * on the ops page, so a token disagreement reports fingerprints, never the

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -31,7 +31,12 @@ import {
  *  Missing and extra rows are not diffs: they are `outstanding` — the fold
  *  has not caught up with what this pass stated or revoked. */
 export type AuthzEngineDiff = {
-  kind: "grant_revoked" | "grant_changed" | "role_changed" | "resource_changed";
+  kind:
+    | "grant_revoked"
+    | "grant_changed"
+    | "role_changed"
+    | "role_deleted"
+    | "resource_changed";
   id: string;
   field?: string;
   expected?: string | null;
@@ -104,10 +109,24 @@ export function checkRoleHeads({
       outstanding.push(role.roleId);
       continue;
     }
+    // A buried head is not agreement, and it is not lag either: the fold has
+    // no un-delete — `role.upsert` never touches `deletedAt`, and the delete
+    // moved the row's business time past anything a restatement could carry —
+    // so the disagreement is named for an operator rather than waited on. The
+    // `grant_revoked` treatment, one tier over.
+    if (head.deleted) {
+      diffs.push({ kind: "role_deleted", id: role.roleId });
+      continue;
+    }
     diffs.push(...roleDiffs({ role, head }));
   }
   for (const head of heads.roleHeads) {
-    if (!expectedRoleIds.has(head.id)) {
+    // An extra is a head whose legacy row is gone, waiting on the deletion
+    // this pass sent. A head ALREADY deleted is that deletion applied, and it
+    // never leaves this read — the name a role took stays taken, so the
+    // tombstone is permanent — which makes counting it outstanding a hold no
+    // later pass can clear.
+    if (!head.deleted && !expectedRoleIds.has(head.id)) {
       outstanding.push(head.id);
     }
   }

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -309,14 +309,25 @@ function roleDiffs({
  * legacy count is a budget that grew back, which nothing legitimate
  * produces, so that is the named diff.
  *
- * That last case is only VISIBLE while the counts also disagree. A usage row
- * on the wrong project but already at the right count reads as agreement here
- * and the organization finalizes over it, which is deliberate: the row is not
- * the seed's to move, the mismatch fails toward fewer views rather than more
- * (the consume fences on the same three columns, so it simply does not
- * match), and holding on it would be a hold no pass could ever clear — the
- * exact disease the rest of this file exists to cure. The budget VALUE, which
- * is what the proof is actually about, is correct either way.
+ * That last case is only VISIBLE while the counts also disagree, and it is a
+ * different column from the `projectId` compared below. Two projects are in
+ * play and only one of them is checked:
+ *
+ * - `head.projectId` is the GRANT row's, and the table below compares it, so
+ *   a share whose grant sits on the wrong project is a `resource_changed`
+ *   diff whatever its view count says.
+ * - `GrantUsage.projectId` is the BUDGET row's. `findResourceGrantRows`
+ *   selects only `grantId` and `viewCount` from that table, so it never
+ *   reaches this comparison at all.
+ *
+ * A budget row on the wrong project but already at the right count therefore
+ * reads as agreement here and the organization finalizes over it. That is
+ * deliberate: the row is not the seed's to move, the mismatch fails toward
+ * fewer views rather than more (the consume fences on the same three columns,
+ * so it simply does not match), and holding on it would be a hold no pass
+ * could ever clear — the exact disease the rest of this file exists to cure.
+ * The budget VALUE, which is what the proof is actually about, is correct
+ * either way.
  *
  * Tokens are bearer credentials and the report is persisted and rendered
  * on the ops page, so a token disagreement reports fingerprints, never the

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -309,6 +309,15 @@ function roleDiffs({
  * legacy count is a budget that grew back, which nothing legitimate
  * produces, so that is the named diff.
  *
+ * That last case is only VISIBLE while the counts also disagree. A usage row
+ * on the wrong project but already at the right count reads as agreement here
+ * and the organization finalizes over it, which is deliberate: the row is not
+ * the seed's to move, the mismatch fails toward fewer views rather than more
+ * (the consume fences on the same three columns, so it simply does not
+ * match), and holding on it would be a hold no pass could ever clear — the
+ * exact disease the rest of this file exists to cure. The budget VALUE, which
+ * is what the proof is actually about, is correct either way.
+ *
  * Tokens are bearer credentials and the report is persisted and rendered
  * on the ops page, so a token disagreement reports fingerprints, never the
  * values.

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -256,8 +256,31 @@ export class AuthzEngineMigration implements SystemMigration {
     const inventory = await this.readInventory(organizationId);
     const expected = assembleFacts({ organizationId, inventory });
 
+    // The budget handover, and it runs BEFORE the read below on purpose. It
+    // rides every pass, monotonically upward: legacy keeps counting views
+    // while the organization is held, and the proof compares the two counts
+    // exactly, so re-seeding is what lets the count heal.
+    //
+    // This is not a fact and not an event — it is a direct write to the
+    // budget table, which the pass can therefore observe in the very read it
+    // is about to take. Seeding AFTER that read meant the check compared a
+    // PRE-seed count against legacy, so a link viewed at any point between
+    // one pass's seed and the next pass's read counted `outstanding` all over
+    // again — and an organization whose links are viewed at least once per
+    // pass interval could never finalize, however many passes it was given.
+    // Reading after the write costs nothing and leaves no window: the pass
+    // sees the budget it just handed over instead of waiting a pass for it.
+    await this.deps.store.seedResourceGrantUsage({
+      organizationId,
+      seeds: expected.shareLinks.map((link) => ({
+        grantId: link.row.id,
+        projectId: link.row.projectId,
+        viewCount: link.row.viewCount,
+      })),
+    });
+
     // The projection, read ONCE per pass (the spec's own words) — before
-    // anything is stated, so nothing here waits on a fold. Reconcile and the
+    // anything is STATED, so nothing here waits on a fold. Reconcile and the
     // check both walk this read: what this pass states is invisible to it by
     // construction, lands as `outstanding`, and the NEXT pass sees it folded
     // and finalizes. Holding a first pass to finalize a later one is the
@@ -267,17 +290,6 @@ export class AuthzEngineMigration implements SystemMigration {
     await this.state({ organizationId, expected, heads, signal });
     await this.reconcileStale({ organizationId, expected, heads, signal });
     await this.repairDrift({ organizationId, expected, heads, signal });
-    // The budget handover rides every pass, monotonically upward: legacy
-    // keeps counting views while the organization is held, and the proof
-    // compares counts exactly, so re-seeding is what lets it heal.
-    await this.deps.store.seedResourceGrantUsage({
-      organizationId,
-      seeds: expected.shareLinks.map((link) => ({
-        grantId: link.row.id,
-        projectId: link.row.projectId,
-        viewCount: link.row.viewCount,
-      })),
-    });
 
     const { outstanding, diffs } = this.check({
       organizationId,

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -35,8 +35,8 @@
  * itself and a derived fact — whose legacy representation is the membership
  * or credential row it came from — creates no binding row at all.
  *
- * Two disagreements are named rather than repaired, deliberately — each
- * holds the organization with a diff an operator reads, and both fail
+ * Three disagreements are named rather than repaired, deliberately — each
+ * holds the organization with a diff an operator reads, and all of them fail
  * toward LESS access, never more:
  *
  * - A DERIVED fact whose head was revoked and whose legacy source came back
@@ -49,6 +49,19 @@
  *   `changeGrantRole`, because that event clears `legacyRole` (the
  *   escalation rule in the projection) while the expected fact still
  *   carries it; the check names the `legacyRole` disagreement instead.
+ * - A role head the fold has BURIED, whose legacy CustomRole row came back
+ *   under the same id, reports `role_deleted` each pass: the projection has
+ *   no un-delete, so nothing a restatement could carry would raise it.
+ *
+ * Deletion is also why the role head read returns tombstones and says so
+ * (`RoleHeadRow.deleted`) rather than fencing them out. A role's name stays
+ * taken after a delete, so its row stays for good; a read that dropped it
+ * would make a buried head indistinguishable from one the fold has not
+ * written yet, and the check would count a permanent tombstone as
+ * `outstanding` on every pass — holding the organization on a condition no
+ * later pass can clear, while the sweep re-sent that role's delete for as
+ * long as the migration ran. One API key deleted between two passes was
+ * enough to do it.
  *
  * @see specs/migration/authz-grants-rollout.feature
  * @see dev/docs/adr/110-grant-aggregates-are-grants.md
@@ -382,7 +395,15 @@ export class AuthzEngineMigration implements SystemMigration {
     await this.each({
       items: expected.roles.filter((role) => {
         const head = roleHeadById.get(role.roleId);
-        return head === undefined || roleDrifted({ role, head });
+        if (head === undefined) return true;
+        // A buried head is the one place this filter is not the check's
+        // predicate: the check names `role_deleted` and this states nothing,
+        // because nothing it could state would land. `role.upsert` leaves
+        // `deletedAt` alone by design, so the row would stay buried however
+        // many times the fact were restated — and the delete already moved
+        // the row's business time past the fact's own.
+        if (head.deleted) return false;
+        return roleDrifted({ role, head });
       }),
       signal,
       send: (role) =>
@@ -510,7 +531,13 @@ export class AuthzEngineMigration implements SystemMigration {
       // finalizes, and until then every role head — `system_api_key`
       // included — mirrors a legacy CustomRole row, so a head with no such
       // row is stale whatever its kind.
-      .filter((head) => !expectedRoleIds.has(head.id))
+      //
+      // A head already deleted is not a candidate, for the reason a revoked
+      // grant is not one: the deny has landed. Its tombstone stays in the
+      // head read forever, so re-sending the delete would append one event
+      // per pass, for every pass there will ever be, to bury a row that is
+      // already buried.
+      .filter((head) => !head.deleted && !expectedRoleIds.has(head.id))
       .map((head) => head.id)
       .sort();
     await this.each({
@@ -599,7 +626,7 @@ export class AuthzEngineMigration implements SystemMigration {
     );
     const redefines = expected.roles.flatMap((role) => {
       const head = roleHeadById.get(role.roleId);
-      if (!head || !roleDrifted({ role, head })) return [];
+      if (!head || head.deleted || !roleDrifted({ role, head })) return [];
       return [{ ...role, occurredAtMs }];
     });
     await this.each({

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
@@ -77,6 +77,8 @@ describe("PrismaAuthzMigrationRepository budget seeding", () => {
         });
 
         expect(executeRaw).toHaveBeenCalledTimes(2);
+        // Both chunks, or a statement could drop rows and still count right.
+        expect(boundValues(executeRaw, 0)).toHaveLength(5_000 * 4);
         expect(boundValues(executeRaw, 1)).toHaveLength(1 * 4);
       });
 
@@ -89,6 +91,42 @@ describe("PrismaAuthzMigrationRepository budget seeding", () => {
         });
 
         expect(executeRaw).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the seeded budgets are read back", () => {
+      /** @scenario "A pass is not limited by how many share links an organization has" */
+      it("reads them for the organization, never one parameter per link", async () => {
+        // Postgres binds at most 65535 parameters in a statement, so naming
+        // every grant fails outright at exactly the size where this migration
+        // is hardest - and only once the organization has heads to compare,
+        // never on the empty first pass that would have shown it.
+        const grantFindMany = vi.fn().mockResolvedValue(
+          Array.from({ length: 70_000 }, (_, index) => ({
+            id: `share_${index}`,
+            source: "migration",
+            token: null,
+            resourceKind: "trace",
+            scopeId: "trace_1",
+            projectId: "project_1",
+            principalType: "ANYONE",
+            principalId: null,
+            expiresAt: null,
+            maxViews: null,
+          })),
+        );
+        const usageFindMany = vi.fn().mockResolvedValue([]);
+        const repository = new PrismaAuthzMigrationRepository({
+          grant: { findMany: grantFindMany },
+          grantUsage: { findMany: usageFindMany },
+        } as never);
+
+        await repository.findResourceGrantRows({ organizationId: ORG });
+
+        expect(usageFindMany).toHaveBeenCalledWith({
+          where: { organizationId: ORG },
+          select: { grantId: true, viewCount: true },
+        });
       });
     });
 

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
@@ -123,6 +123,10 @@ describe("PrismaAuthzMigrationRepository budget seeding", () => {
 
         await repository.findResourceGrantRows({ organizationId: ORG });
 
+        // Both halves: the shape of the read, and that there is only one of
+        // it. `toHaveBeenCalledWith` alone passes just as happily on an
+        // implementation that adds a second, per-link read beside it.
+        expect(usageFindMany).toHaveBeenCalledTimes(1);
         expect(usageFindMany).toHaveBeenCalledWith({
           where: { organizationId: ORG },
           select: { grantId: true, viewCount: true },

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
@@ -1,0 +1,134 @@
+/** @vitest-environment node */
+
+/**
+ * The view-budget handover the authz-engine migration runs on every pass.
+ *
+ * It is the one step no head filter covers — while an organization is held,
+ * views keep landing on `ShareLink.viewCount`, so the seed has to ride each
+ * pass to let the count heal. That makes its COST per pass a correctness
+ * concern of its own: an organization with 428k share links spent a round
+ * trip per link here, matched nothing on almost all of them, and never
+ * finished a single pass — so it never recorded a status at all.
+ *
+ * A unit test, and named one: Prisma is a stub, so nothing here opens a
+ * socket. The guard is asserted as SQL because that is what it is; whether
+ * Postgres honours it is the integration lane's question.
+ */
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import type { Prisma } from "~/generated/prisma/client";
+import { PrismaAuthzMigrationRepository } from "../authz-migration.prisma.repository";
+
+const ORG = "org_acme";
+
+function build() {
+  const executeRaw = vi.fn().mockResolvedValue(1);
+  const prisma = { $executeRaw: executeRaw } as never;
+  return {
+    executeRaw,
+    repository: new PrismaAuthzMigrationRepository(prisma),
+  };
+}
+
+/** The statement itself, flattened to one comparable string. */
+function statement(executeRaw: Mock, call = 0): string {
+  const strings = executeRaw.mock.calls[call]?.[0] as unknown as string[];
+  return strings.join("?").replace(/\s+/g, " ");
+}
+
+/** The seed rows the statement carries, as their bound values. */
+function boundValues(executeRaw: Mock, call = 0): unknown[] {
+  const rows = executeRaw.mock.calls[call]?.[1] as Prisma.Sql;
+  return rows.values;
+}
+
+function seeds(count: number, viewCount = 1) {
+  return Array.from({ length: count }, (_, index) => ({
+    grantId: `share_${index}`,
+    projectId: "project_1",
+    viewCount,
+  }));
+}
+
+describe("PrismaAuthzMigrationRepository budget seeding", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given an organization's share links", () => {
+    describe("when the budgets are seeded", () => {
+      /** @scenario "The view budget handover costs statements, not round trips" */
+      it("states every seed in one statement, not one statement per seed", async () => {
+        const { repository, executeRaw } = build();
+
+        await repository.seedResourceGrantUsage({
+          organizationId: ORG,
+          seeds: seeds(400),
+        });
+
+        expect(executeRaw).toHaveBeenCalledTimes(1);
+        expect(boundValues(executeRaw)).toHaveLength(400 * 4);
+      });
+
+      /** @scenario "The view budget handover costs statements, not round trips" */
+      it("chunks past the parameter ceiling instead of growing one statement", async () => {
+        const { repository, executeRaw } = build();
+
+        await repository.seedResourceGrantUsage({
+          organizationId: ORG,
+          seeds: seeds(5_001),
+        });
+
+        expect(executeRaw).toHaveBeenCalledTimes(2);
+        expect(boundValues(executeRaw, 1)).toHaveLength(1 * 4);
+      });
+
+      it("says nothing at all for an organization with no share links", async () => {
+        const { repository, executeRaw } = build();
+
+        await repository.seedResourceGrantUsage({
+          organizationId: ORG,
+          seeds: [],
+        });
+
+        expect(executeRaw).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a seed would lower a budget", () => {
+      // Views are never refunded (decision 22). The guard lives in the UPDATE
+      // itself rather than a filter resolved by an earlier SELECT, so a
+      // consume landing mid-flight cannot be walked back.
+      /** @scenario "A view budget is raised on a re-run, never lowered" */
+      it("raises only where the seed is strictly higher", async () => {
+        const { repository, executeRaw } = build();
+
+        await repository.seedResourceGrantUsage({
+          organizationId: ORG,
+          seeds: seeds(1),
+        });
+
+        const sql = statement(executeRaw);
+        expect(sql).toContain('ON CONFLICT ("grantId") DO UPDATE');
+        expect(sql).toContain(
+          'WHERE "GrantUsage"."viewCount" < EXCLUDED."viewCount"',
+        );
+      });
+
+      /** @scenario "A view budget is raised on a re-run, never lowered" */
+      it("leaves a usage row that disagrees about where it lives alone", async () => {
+        const { repository, executeRaw } = build();
+
+        await repository.seedResourceGrantUsage({
+          organizationId: ORG,
+          seeds: seeds(1),
+        });
+
+        const sql = statement(executeRaw);
+        expect(sql).toContain(
+          'AND "GrantUsage"."organizationId" = EXCLUDED."organizationId"',
+        );
+        expect(sql).toContain(
+          'AND "GrantUsage"."projectId" = EXCLUDED."projectId"',
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -520,8 +520,18 @@ export class PrismaAuthzMigrationRepository
     // The view budget lives on its own table (decision 22), so the proof's
     // "field for field" needs a second read to see it. No usage row means no
     // view has been counted, which is exactly zero.
+    //
+    // Read BY ORGANIZATION rather than by naming every grant. `GrantUsage` is
+    // organization-indexed and scoped to one organization, so both spellings
+    // select the same budgets - but naming them binds a parameter per grant,
+    // and Postgres accepts at most 65535 of those in a statement. An
+    // organization with 428k share links has that many resource grants, so
+    // the named spelling failed outright at exactly the size where this
+    // migration is hardest, and only once the organization had heads to
+    // compare - never on the empty first pass that would have shown it. Any
+    // budget the rows do not claim is free: the lookup below is by id.
     const usages = await this.prisma.grantUsage.findMany({
-      where: { organizationId, grantId: { in: rows.map((row) => row.id) } },
+      where: { organizationId },
       select: { grantId: true, viewCount: true },
     });
     const viewCounts = new Map(

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -23,11 +23,13 @@ import { Prisma, type PrismaClient } from "~/generated/prisma/client";
 import { queryOrganizationOnAuthzEngine } from "../engine-gate";
 
 /**
- * How many guarded budget raises are in flight at once while seeding an
- * organization's view budgets. Bounded so an organization with thousands of
- * share links cannot open thousands of concurrent connections.
+ * Seeds per budget statement. Four binds a row, so this sits well under
+ * Postgres' 65535-parameter ceiling and keeps one statement's memory modest.
+ * The seed rides EVERY pass, so what matters is that its cost scales with
+ * statements, not with rows: an organization with 428k share links was
+ * spending 17k sequential round trips per pass here and never finishing one.
  */
-const BUDGET_RAISE_CONCURRENCY = 25;
+const BUDGET_SEED_CHUNK = 5_000;
 
 /**
  * ADR-092 stage B - storage for the in-place TeamUser backfill, the genesis
@@ -393,24 +395,29 @@ export class PrismaAuthzMigrationRepository
    * The view budgets, handed over rather than restarted - and RAISED on a
    * re-run, never lowered (the port's own contract; decision 22).
    *
-   * Two writes, each safe on its own terms. The `createMany` with
-   * `skipDuplicates` lands missing rows without touching existing ones. The
-   * per-row guarded update then raises a row the legacy path has outgrown:
-   * while an organization is held, views keep landing on
-   * `ShareLink.viewCount`, and a usage row seeded on an earlier pass would
-   * otherwise sit permanently below it - wedging the import proof, which
-   * compares the two counts exactly. The `viewCount: { lt: ... }` predicate
-   * is the refund guard: a row already at or above the seeded count (a view
-   * consumed since the seed) is left exactly as it is.
+   * ONE guarded upsert per chunk, which is create-or-raise stated once: a
+   * missing row is inserted at the seeded count, and an existing row is
+   * updated only where the seeded count is strictly higher. That guard is
+   * the refund guard - a row already at or above the seed (a view consumed
+   * since) is left exactly as it is - and it lives in the UPDATE statement
+   * itself, so a consume landing mid-flight cannot be walked back by a
+   * filter resolved in an earlier SELECT.
    *
-   * The raise is `update` on the filtered unique, not `updateMany`, for the
-   * same reason the share consume paths are: the query compiler keeps a
-   * filtered-unique `update`'s full WHERE on the UPDATE statement itself,
-   * while `updateMany` resolves the filter in a prior SELECT - a consume
-   * landing between the two would be silently walked back. A raise the guard
-   * refuses surfaces as P2025 and is swallowed as the no-op it means. Raises
-   * run concurrently in bounded batches; each targets a distinct row, so
-   * they cannot contend with each other.
+   * It is one statement per chunk rather than one per row because this seed
+   * rides every pass, unfiltered, for as long as an organization is held:
+   * while it is, views keep landing on `ShareLink.viewCount`, and a usage
+   * row seeded on an earlier pass would otherwise sit permanently below it,
+   * wedging the proof, which compares the two counts exactly. The previous
+   * shape paid a round trip per share link - and on a converged organization
+   * every one of them matched nothing, so the pass spent hundreds of
+   * thousands of round trips, and the exceptions they raised, to change
+   * nothing. The organization that found it never finished a pass at all,
+   * and so never recorded a status of any kind.
+   *
+   * `organizationId` and `projectId` are matched in the guard rather than
+   * overwritten: a usage row that disagrees with the seed about where it
+   * lives is not this seed's to move, exactly as the per-row update's
+   * three-column WHERE had it.
    */
   async seedResourceGrantUsage({
     organizationId,
@@ -420,54 +427,37 @@ export class PrismaAuthzMigrationRepository
     seeds: readonly ResourceGrantUsageSeed[];
   }): Promise<void> {
     if (seeds.length === 0) return;
-    await this.prisma.grantUsage.createMany({
-      data: seeds.map((seed) => ({
-        grantId: seed.grantId,
+    for (let offset = 0; offset < seeds.length; offset += BUDGET_SEED_CHUNK) {
+      await this.raiseGrantUsageBudgets({
         organizationId,
-        projectId: seed.projectId,
-        viewCount: seed.viewCount,
-      })),
-      skipDuplicates: true,
-    });
-    for (
-      let offset = 0;
-      offset < seeds.length;
-      offset += BUDGET_RAISE_CONCURRENCY
-    ) {
-      await Promise.all(
-        seeds
-          .slice(offset, offset + BUDGET_RAISE_CONCURRENCY)
-          .map((seed) => this.raiseGrantUsageBudget({ organizationId, seed })),
-      );
+        seeds: seeds.slice(offset, offset + BUDGET_SEED_CHUNK),
+      });
     }
   }
 
-  private async raiseGrantUsageBudget({
+  private raiseGrantUsageBudgets({
     organizationId,
-    seed,
+    seeds,
   }: {
     organizationId: string;
-    seed: ResourceGrantUsageSeed;
-  }): Promise<void> {
-    try {
-      await this.prisma.grantUsage.update({
-        where: {
-          grantId: seed.grantId,
-          organizationId,
-          projectId: seed.projectId,
-          viewCount: { lt: seed.viewCount },
-        },
-        data: { viewCount: seed.viewCount },
-      });
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === "P2025"
-      ) {
-        return;
-      }
-      throw error;
-    }
+    seeds: readonly ResourceGrantUsageSeed[];
+  }): Prisma.PrismaPromise<number> {
+    return this.prisma.$executeRaw`
+      INSERT INTO "GrantUsage" (
+        "grantId", "organizationId", "projectId", "viewCount", "updatedAt"
+      ) VALUES ${Prisma.join(
+        seeds.map(
+          (seed) =>
+            Prisma.sql`(${seed.grantId}, ${organizationId}, ${seed.projectId}, ${seed.viewCount}, NOW())`,
+        ),
+      )}
+      ON CONFLICT ("grantId") DO UPDATE SET
+        "viewCount" = EXCLUDED."viewCount",
+        "updatedAt" = NOW()
+      WHERE "GrantUsage"."viewCount" < EXCLUDED."viewCount"
+        AND "GrantUsage"."organizationId" = EXCLUDED."organizationId"
+        AND "GrantUsage"."projectId" = EXCLUDED."projectId"
+    `;
   }
 
   async findExternalMemberFacts({

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -194,6 +194,12 @@ export class PrismaAuthzMigrationRepository
   }: {
     organizationId: string;
   }): Promise<RoleHeadRow[]> {
+    // Deleted heads included, and flagged: this read serves the proof, which
+    // has to tell a role the fold has never seen from one it has already
+    // buried. `liveRoles` is the fence for every read that DECIDES access;
+    // dropping the tombstones here would make each one read as a role still
+    // waiting to fold, and hold the organization on a condition no later pass
+    // can clear.
     const rows = await this.prisma.role.findMany({
       where: { organizationId },
       select: {
@@ -202,9 +208,13 @@ export class PrismaAuthzMigrationRepository
         description: true,
         permissions: true,
         kind: true,
+        deletedAt: true,
       },
     });
-    return rows;
+    return rows.map(({ deletedAt, ...row }) => ({
+      ...row,
+      deleted: deletedAt !== null,
+    }));
   }
 
   async findLegacyTeamRows({

--- a/specs/migration/authz-grants-rollout.feature
+++ b/specs/migration/authz-grants-rollout.feature
@@ -125,14 +125,21 @@ Feature: Moving an organization onto the grants projection
     Then that grant is revoked
 
   @unit
-  Scenario: A role head the fold has buried is a deletion applied, not work outstanding
-    Given a role head the migration has already deleted
-    And no legacy custom role row behind it
+  Scenario: A custom role deleted before the migration finished stays deleted
+    Given a custom role the migration has already deleted
+    And the organization no longer has that role
     When the migration runs again
     Then the organization finalizes
-    And that role's deletion is not sent a second time
-    But a buried head whose legacy row is back is named as a disagreement
-    And nothing is stated for it, because the projection has no un-delete
+    And that role's deletion is not repeated
+
+  @unit
+  Scenario: A deleted custom role that exists again is reported, not quietly restored
+    Given a custom role the migration has already deleted
+    And the organization has that role again under the same id
+    When the migration runs again
+    Then the organization is held
+    And the report names that role as a disagreement
+    And the role is not restored automatically
 
   @unit
   Scenario: A view budget is raised on a re-run, never lowered
@@ -148,6 +155,24 @@ Feature: Moving an organization onto the grants projection
     When the migration seeds the budgets
     Then the seeds are stated in whole chunks, not one round trip per link
     And an organization with no share links states nothing at all
+
+  # A pass that handed the budget over AFTER checking compared a count it had
+  # already superseded, so any link viewed between two passes was reported as
+  # unfinished work again, and an organization whose links are viewed at all
+  # could never finish.
+  @unit
+  Scenario: A link viewed between passes does not hold the organization
+    Given a share link that has been viewed since the last pass
+    When the migration runs
+    Then the new view count is handed over before the organization is checked
+    And the organization is not held for that link
+
+  @unit
+  Scenario: A pass is not limited by how many share links an organization has
+    Given an organization with hundreds of thousands of share links
+    When the migration reads their view budgets
+    Then the budgets are read for the organization as a whole
+    And the pass is not asked to name every link at once
 
   @integration @unimplemented
   Scenario: The migration is unavailable while the queue is

--- a/specs/migration/authz-grants-rollout.feature
+++ b/specs/migration/authz-grants-rollout.feature
@@ -134,6 +134,21 @@ Feature: Moving an organization onto the grants projection
     But a buried head whose legacy row is back is named as a disagreement
     And nothing is stated for it, because the projection has no un-delete
 
+  @unit
+  Scenario: A view budget is raised on a re-run, never lowered
+    Given a share link whose usage row was seeded on an earlier pass
+    When the migration seeds the budgets again
+    Then a usage row below the legacy count is raised to it
+    And a usage row already at or above it is left exactly as it is
+    And a usage row that disagrees about which project it belongs to is untouched
+
+  @unit
+  Scenario: The view budget handover costs statements, not round trips
+    Given an organization with more share links than one statement can carry
+    When the migration seeds the budgets
+    Then the seeds are stated in whole chunks, not one round trip per link
+    And an organization with no share links states nothing at all
+
   @integration @unimplemented
   Scenario: The migration is unavailable while the queue is
     Given the queue is unavailable

--- a/specs/migration/authz-grants-rollout.feature
+++ b/specs/migration/authz-grants-rollout.feature
@@ -124,6 +124,16 @@ Feature: Moving an organization onto the grants projection
     When the migration runs again
     Then that grant is revoked
 
+  @unit
+  Scenario: A role head the fold has buried is a deletion applied, not work outstanding
+    Given a role head the migration has already deleted
+    And no legacy custom role row behind it
+    When the migration runs again
+    Then the organization finalizes
+    And that role's deletion is not sent a second time
+    But a buried head whose legacy row is back is named as a disagreement
+    And nothing is stated for it, because the projection has no un-delete
+
   @integration @unimplemented
   Scenario: The migration is unavailable while the queue is
     Given the queue is unavailable


### PR DESCRIPTION
Four faults found while driving the authz-engine rollout. Each is a way a pass
either holds an organization on a condition no later pass can clear, or cannot
finish at all — and none of them had an operator lever, so all four needed the
code change.

## 1. A buried role head is a deletion applied, not work outstanding

The migration's role head read took every `Role` row for the organization —
tombstones included — without the `deletedAt IS NULL` fence that `liveRoles()`
exists to make unforgettable:

```ts
// repositories/authz-migration.prisma.repository.ts
const rows = await this.prisma.role.findMany({ where: { organizationId }, … })
```

So a head the fold had already buried read back as a live head with no legacy
`CustomRole` behind it. `checkRoleHeads` counted it `outstanding`, and
`reconcileStale` answered with another `deleteRole` — every pass, appending a
fresh event each time, since that command id carries the pass's `occurredAtMs`.

Neither converged, and neither ever could: a role's name stays taken after a
delete, by design, so the row never leaves that read.

An organization in the rollout sat held with `outstanding: 1` against 33 facts
and no diffs. The id was a `system_api_key` role head, soft-deleted, with no
legacy row:

```
 id                     | kind            | deletedAt            | legacy_row_exists
 KyDZxiQEoM_4s9ZaURIFS  | system_api_key  | 2026-08-23 15:57:13  | false
```

One API key deleted between two passes was enough, so this is not specific to
the organization that found it.

**The change.** The read now reports whether a head is buried instead of hiding
it, which is what lets the proof tell a role the fold has never seen from one it
has already deleted. `RoleHeadRow` gains `deleted`, and the check reads it the
way the grant tier already reads `revoked`:

- an **extra** head already deleted is that deletion applied — neither
  outstanding nor a diff, and never swept again;
- an **expected** head that is buried is a named `role_deleted` diff, the
  `grant_revoked` treatment one tier over. It is not restated: `role.upsert`
  leaves `deletedAt` alone, and the delete moved the row's business time past
  anything a restatement could carry, so a restatement is cost with no possible
  effect.

Dropping the tombstones from the read instead would have been the same bug in a
different disguise — a buried head would become indistinguishable from one the
fold has not written yet.

## 2. The view budget handover costs statements, not round trips

The budget seed is the one step of a pass no head filter covers, and it is right
that it rides every pass: while an organization is held, views keep landing on
`ShareLink.viewCount`, and the proof compares the two counts exactly, so
re-seeding is what lets the count heal.

Its shape was the problem. A `createMany` landed the missing rows, then a
guarded `update` per seed raised the ones legacy had outgrown, 25 at a time,
awaited in sequence:

```ts
for (let offset = 0; offset < seeds.length; offset += BUDGET_RAISE_CONCURRENCY)
  await Promise.all(seeds.slice(…).map((seed) => this.raiseGrantUsageBudget(…)))
```

On a converged organization every one of those updates matches nothing, raises
`P2025`, and is swallowed as the no-op it means. An organization with **428,720
share links** therefore spent **17,149 sequential round trips per pass**, and the
exceptions they raised, to change nothing at all.

It never finished a pass — and a tenant that never returns records nothing and
is not retried, it is *skipped*. `driveTenant` returns early for a tenant whose
claim is already held, and the heartbeat holds that claim for as long as
`migrateTenant` runs. So that organization recorded **no status of any kind** —
not finalized, not held, not parked — and was invisible in every rollout counter
while its 429,187 heads sat complete in the projection, waiting for a check that
never ran. Re-enrolling it did nothing, because enrolment was never what was
missing.

**The change.** Create-or-raise is stated once per chunk: an insert whose
conflict clause updates only where the seeded count is strictly higher. Every
property the two writes had is kept, and kept in the statement rather than
around it — the refund guard, and the organization and project match that the
per-row WHERE carried — so a consume landing mid-flight still cannot be walked
back by a filter resolved in an earlier SELECT.

## 3. A link viewed between passes no longer holds the organization

The handover ran *after* the pass took its projection read, so the check
compared a count the seed had already superseded. A share link viewed at any
point between one pass's seed and the next pass's read was `outstanding` all
over again:

```
pass N:    read heads (usage=U) ──> seed usage:=L_N ──> check: U < L_N?  → outstanding
pass N+1:  read heads (usage=L_N) ──────────────────> check: L_N < L_N+1?
                                    ↑
                        one view landing anywhere in this gap re-arms it
```

An organization whose links are viewed at least once per pass interval could
therefore never finalize, however many passes it was given. With 428,720 share
links that is not a remote risk.

The comparison's own comment shows the harsher version of this was already
found and fixed — reporting the lag as a *diff* "made an actively-viewed link
re-hold the organization forever" — but `outstanding` has the same shape, only
softer.

**The change.** The seed moves ahead of the read. It is a direct write to the
budget table, not a fact the pass states and waits on, so the read that follows
simply sees it — no window, no extra query, and nothing assumed about a write
we could instead observe. `GrantUsage.grantId` carries no foreign key precisely
so a budget row is addressable before its grant exists, which is what makes the
earlier position safe.

A lag can now only mean the seed's guard refused the row — a usage row that
disagrees about which project it belongs to. That stays `outstanding` rather
than becoming a diff, so it heals when the row is corrected instead of latching.

## 4. Budgets are read for the organization, not link by link

`findResourceGrantRows` read the view budgets by naming every grant it had just
read:

```ts
where: { organizationId, grantId: { in: rows.map((row) => row.id) } }
```

Postgres binds at most **65,535** parameters in a statement. An organization
with 428,720 share links has that many resource grants, so this read fails
outright at exactly the size where the migration is hardest.

It has not fired yet only because of the order things happened in: the stuck
pass was that organization's **first**, its heads were empty, and
`if (rows.length === 0) return []` short-circuited before the usage read. The
fold has since written 429,187 heads, so the next pass is the first one to reach
this query with a full head set.

**The change.** Read by `organizationId`, which is indexed on `GrantUsage` and
selects the same budgets — the rows are scoped to the organization either way.
Any budget the grants do not claim is free, because the lookup is by id.

## Rollout effect

Organizations held on the role tombstone clear on their next pass, with no data
change and no operator action, and the per-pass `deleteRole` for an
already-buried role stops. The organization that could never finish a pass
should complete one and finalize — nothing about it is outstanding; it was only
ever unable to reach its own check, and then unable to survive the read that
follows.

For context on what was *not* a fault: most held organizations in the rollout
were ordinary one-pass projection lag. A pass takes its projection read before
it states anything, so the facts it just stated read as `outstanding` and the
next pass finalizes. That is ADR-110 working as designed and is untouched here.

## Known and deliberately not addressed

- **Named permanent holds.** `grant_revoked`, the `custom:<id>` `legacyRole`
  disagreement, and the `role_deleted` this PR adds each hold an organization
  until an operator acts. All three are deliberate and all fail toward less
  access; none self-heals. No organization in the rollout is sitting on one
  today — the held set reports zero diffs.
- **A usage row on the wrong project, already at the right count.** The seed
  guard refuses to move such a row and the budget read does not carry
  `projectId`, so it reads as agreement and the organization finalizes over it.
  Raised in review; left deliberately. Making it a diff would be a hold no pass
  could ever clear — the seed will never move that row — which is the disease
  the rest of this PR cures, and `outstanding` would be a silent version of the
  same. It fails toward *fewer* views, since the consume fences on the same
  `(grant, organization, project)` triple and simply misses, and the **grant**
  row's `projectId` is already compared. Not introduced here: the previous read
  selected the same two columns behind the `IN`. What *was* wrong is that the
  comparison's doc claimed this case stays outstanding when that holds only
  while the counts also disagree; that is corrected.
- **The resource tier's revoked-head asymmetry.** `findResourceGrantRows` fences
  `revokedAt: null`, so an *expected* share link whose head is revoked reads as
  absent, counts `outstanding` forever, and is re-attached each pass while
  `upsertGrant` deliberately never un-revokes. It is the same shape as fault 1,
  one tier over. Left out because I could not find a trigger reachable before
  finalization — the revocation enforcer fires on offboarding and explicit
  revoke, not on view exhaustion — so closing it is a change without a
  demonstrated fault behind it.

## Testing

- `pnpm test:unit src/server/app-layer/authz` — **280 passed / 25 files**.
  Bound regression tests: finalizing over a buried head whose legacy row is
  gone; naming `role_deleted` and stating nothing for a buried head whose legacy
  row is back; the handover ordering, and that a link viewed since the last pass
  no longer holds the organization; a budget the guard could not raise still
  reading as lag rather than disagreement; the organization-scoped budget read;
  and the seed's chunking, empty case, refund guard and tenancy match.
- `check:feature-parity` — `specs/migration/authz-grants-rollout.feature`
  **22/22 scenarios bound**.
- `pnpm lint` — no new diagnostics in the touched files.

The budget seed's guard is asserted as SQL, following the house pattern in
`authz-grants-write.repository.unit.test.ts`: Prisma is a stub, nothing opens a
socket, and whether Postgres honours the guard is the integration lane's
question.

Refs ADR-110.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Authorization migrations now recognize deleted custom roles without repeatedly attempting restoration.
  - Share-link usage counts are seeded and reconciled across projects, preserving higher counts and preventing invalid updates.
  - Large usage datasets are processed in batches for more reliable migrations.

- **Bug Fixes**
  - Prevented deleted roles and completed deletions from reappearing as outstanding migration issues.
  - Improved view-count handovers and delayed resource-usage updates.
  - Added safeguards for mismatched project ownership during usage reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->