### PR TITLE
refactor(authz): the migration's proof says less and proves the same

### DIFF
--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -106,6 +106,11 @@ function harness(data: Data = {}) {
       }));
     },
     seedResourceGrantUsage: async ({ seeds }) => {
+      // Land the budget on a later microtask, so the raise above is only
+      // visible to a pass that AWAITS this. A synchronous push would read as
+      // ordered even if the migration dropped the await and left the write
+      // in flight.
+      await Promise.resolve();
       seeded.push([...seeds]);
     },
   };

--- a/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/authz-engine.migration.unit.test.ts
@@ -57,10 +57,6 @@ type Data = {
   /** `deleted` defaults to false: a head is live unless a test buries it. */
   roleHeads?: Array<Omit<RoleHeadRow, "deleted"> & { deleted?: boolean }>;
   resourceRows?: ResourceGrantRow[];
-  /** Grant ids whose budget handover the seed's guard refuses — a usage row
-   *  that disagrees about which project it belongs to. Their heads keep the
-   *  count the test gave them, however high the seed goes. */
-  unseededGrantIds?: string[];
   /** Wraps the recording ledger, for tests that need to observe or fail a
    *  send rather than only read what was sent. */
   wrapLedger?: (ledger: Ledger) => Ledger;
@@ -72,8 +68,6 @@ function harness(data: Data = {}) {
   const sent: Sent[] = [];
   const seeded: ResourceGrantUsageSeed[][] = [];
   const reads = { grantHeads: 0, roleHeads: 0, resourceRows: 0 };
-  /** Call order, for the steps whose ORDER is the behaviour under test. */
-  const order: string[] = [];
   const store: AuthzEngineMigrationStore = {
     findOrganizationCreatedAtMs: async () =>
       data.organizationCreatedAtMs === undefined
@@ -100,26 +94,18 @@ function harness(data: Data = {}) {
     },
     findResourceGrantRows: async () => {
       reads.resourceRows += 1;
-      order.push("readResourceRows");
-      // The budget table is a plain row the pass writes DIRECTLY, not a fact
-      // it states and waits on, so a read taken after the seed sees it and a
-      // read taken before does not. Modelling that raise is the only way a
-      // test can tell those two orders apart.
-      const refused = new Set(data.unseededGrantIds ?? []);
+      // The budget is a row the pass writes directly, so a read taken after
+      // the seed sees it and one taken before does not. That raise is what
+      // makes the ordering observable as behaviour rather than call order.
       const budgets = new Map(
         seeded.flat().map((seed) => [seed.grantId, seed.viewCount]),
       );
-      return (data.resourceRows ?? []).map((row) =>
-        refused.has(row.grantId)
-          ? row
-          : {
-              ...row,
-              viewCount: Math.max(row.viewCount, budgets.get(row.grantId) ?? 0),
-            },
-      );
+      return (data.resourceRows ?? []).map((row) => ({
+        ...row,
+        viewCount: Math.max(row.viewCount, budgets.get(row.grantId) ?? 0),
+      }));
     },
     seedResourceGrantUsage: async ({ seeds }) => {
-      order.push("seedBudgets");
       seeded.push([...seeds]);
     },
   };
@@ -143,7 +129,7 @@ function harness(data: Data = {}) {
     ledger: data.wrapLedger ? data.wrapLedger(recording) : recording,
     now: () => NOW,
   });
-  return { migration, sent, seeded, reads, order };
+  return { migration, sent, seeded, reads };
 }
 
 function attachedFacts(sent: Sent[]): GrantFact[] {
@@ -711,23 +697,10 @@ describe("given an organization with legacy access rows", () => {
     });
 
     /** @scenario "A link viewed between passes does not hold the organization" */
-    it("hands the budget over before it reads what it will check against", async () => {
-      const { migration, order } = harness({
-        shareLinks: [shareLink({ maxViews: 10, viewCount: 3 })],
-      });
-
-      await migration.migrateTenant({ tenantId: ORG_ID });
-
-      expect(order).toEqual(["seedBudgets", "readResourceRows"]);
-    });
-
-    /** @scenario "A link viewed between passes does not hold the organization" */
     it("does not hold an organization for a link viewed since the last pass", async () => {
-      // The race this closes: seeding AFTER the read compared a count the
-      // seed had already superseded, so a link viewed at any point between
-      // one pass's seed and the next pass's read counted outstanding all over
-      // again — and an organization whose links are viewed at all could never
-      // finalize, however many passes it was given.
+      // Seeding AFTER the read compared a count the seed had already
+      // superseded, so an organization whose links are viewed at all could
+      // never finalize.
       const row = shareLink({ maxViews: 10, viewCount: 3 });
       const { migration } = harness({
         shareLinks: [row],
@@ -753,58 +726,6 @@ describe("given an organization with legacy access rows", () => {
       const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
 
       expect(outcome.status).toBe("finalized");
-    });
-
-    /** @scenario "A view budget is raised on a re-run, never lowered" */
-    it("treats a budget the handover could not raise as lag, not disagreement", async () => {
-      // The one case the seed's guard refuses: a GRANTUSAGE row that
-      // disagrees about which project it belongs to. Outstanding rather than
-      // a diff, so it heals the moment the row is corrected instead of
-      // latching.
-      //
-      // The grant below sits on the RIGHT project — `projectId: row.projectId`
-      // — so nothing here is a `resource_changed` diff. That comparison is
-      // over the grant's project, which is checked; the budget row's project
-      // is a different column that `findResourceGrantRows` does not select.
-      // What differs is the count alone, which is why this is lag.
-      //
-      // And only while the COUNTS disagree, which is what this pins. A budget
-      // row already at the right count reads as agreement and the
-      // organization finalizes over it — deliberately: the row is not the
-      // seed's to move, the mismatch fails toward fewer views (the consume
-      // fences on the same columns and simply misses), and holding on it
-      // would be a hold no later pass could clear.
-      const row = shareLink({ maxViews: 10, viewCount: 3 });
-      const { migration } = harness({
-        shareLinks: [row],
-        organizationCreatedAtMs: null,
-        unseededGrantIds: [row.id],
-        resourceRows: [
-          {
-            grantId: row.id,
-            source: "migration",
-            token: row.token,
-            resourceKind: "TRACE",
-            resourceId: row.resourceId,
-            projectId: row.projectId,
-            principalType: "ANYONE",
-            principalId: null,
-            expiresAtMs: null,
-            maxViews: 10,
-            viewCount: 1,
-          },
-        ],
-      });
-
-      const outcome = await migration.migrateTenant({ tenantId: ORG_ID });
-
-      expect(outcome.status).toBe("migrated");
-      const report = outcome.report as {
-        totalDiffs: number;
-        outstandingSample: string[];
-      };
-      expect(report.totalDiffs).toBe(0);
-      expect(report.outstandingSample).toContain(row.id);
     });
 
     /** @scenario "A row deleted on the legacy side is revoked, not left behind" */

--- a/platform/app/src/server/app-layer/authz/authz-engine.check.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.check.ts
@@ -296,38 +296,19 @@ function roleDiffs({
  * the database's uppercase), so the comparison is against what the import
  * said, mapped to that spelling.
  *
- * The view budget cuts both ways and the two directions mean different
- * things. A head BEHIND the legacy count is convergence lag and never a
- * disagreement: reporting it as one made an actively-viewed link re-hold the
- * organization forever. The pass now hands the budget over BEFORE it takes
- * the read this walks (see `migrateTenant`), so the lag is already repaired
- * by the time the comparison runs and this should find nothing. It stays
- * `outstanding` rather than becoming a diff for the one case the handover
- * cannot cover — a usage row that disagrees about which project it belongs
- * to, which the seed's guard deliberately will not move — because that heals
- * the moment the row is corrected and must not latch. A head AHEAD of the
- * legacy count is a budget that grew back, which nothing legitimate
- * produces, so that is the named diff.
+ * The view budget cuts both ways. A head BEHIND the legacy count is lag, not
+ * a disagreement — reporting it as one made an actively-viewed link re-hold
+ * the organization forever — and `migrateTenant` hands the budget over before
+ * taking this read, so it should find nothing. A head AHEAD is a budget that
+ * grew back, which nothing legitimate produces, so that is a named diff.
  *
- * That last case is only VISIBLE while the counts also disagree, and it is a
- * different column from the `projectId` compared below. Two projects are in
- * play and only one of them is checked:
- *
- * - `head.projectId` is the GRANT row's, and the table below compares it, so
- *   a share whose grant sits on the wrong project is a `resource_changed`
- *   diff whatever its view count says.
- * - `GrantUsage.projectId` is the BUDGET row's. `findResourceGrantRows`
- *   selects only `grantId` and `viewCount` from that table, so it never
- *   reaches this comparison at all.
- *
- * A budget row on the wrong project but already at the right count therefore
- * reads as agreement here and the organization finalizes over it. That is
- * deliberate: the row is not the seed's to move, the mismatch fails toward
- * fewer views rather than more (the consume fences on the same three columns,
- * so it simply does not match), and holding on it would be a hold no pass
- * could ever clear — the exact disease the rest of this file exists to cure.
- * The budget VALUE, which is what the proof is actually about, is correct
- * either way.
+ * Two `projectId`s are in play and only one is checked: `head.projectId` is
+ * the GRANT row's and the table below compares it; `GrantUsage.projectId` is
+ * the budget row's, which `findResourceGrantRows` does not select. So a
+ * budget row on the wrong project but at the right count reads as agreement.
+ * Deliberate: the seed will not move that row, it fails toward fewer views
+ * (the consume fences on the same columns and misses), and holding on it
+ * would be a hold no pass could clear.
  *
  * Tokens are bearer credentials and the report is persisted and rendered
  * on the ops page, so a token disagreement reports fingerprints, never the

--- a/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
+++ b/platform/app/src/server/app-layer/authz/authz-engine.migration.ts
@@ -58,10 +58,8 @@
  * taken after a delete, so its row stays for good; a read that dropped it
  * would make a buried head indistinguishable from one the fold has not
  * written yet, and the check would count a permanent tombstone as
- * `outstanding` on every pass — holding the organization on a condition no
- * later pass can clear, while the sweep re-sent that role's delete for as
- * long as the migration ran. One API key deleted between two passes was
- * enough to do it.
+ * `outstanding` on every pass. One API key deleted between two passes was
+ * enough to hold an organization forever.
  *
  * @see specs/migration/authz-grants-rollout.feature
  * @see dev/docs/adr/110-grant-aggregates-are-grants.md
@@ -256,20 +254,12 @@ export class AuthzEngineMigration implements SystemMigration {
     const inventory = await this.readInventory(organizationId);
     const expected = assembleFacts({ organizationId, inventory });
 
-    // The budget handover, and it runs BEFORE the read below on purpose. It
-    // rides every pass, monotonically upward: legacy keeps counting views
-    // while the organization is held, and the proof compares the two counts
-    // exactly, so re-seeding is what lets the count heal.
-    //
-    // This is not a fact and not an event — it is a direct write to the
-    // budget table, which the pass can therefore observe in the very read it
-    // is about to take. Seeding AFTER that read meant the check compared a
-    // PRE-seed count against legacy, so a link viewed at any point between
-    // one pass's seed and the next pass's read counted `outstanding` all over
-    // again — and an organization whose links are viewed at least once per
-    // pass interval could never finalize, however many passes it was given.
-    // Reading after the write costs nothing and leaves no window: the pass
-    // sees the budget it just handed over instead of waiting a pass for it.
+    // The budget handover, BEFORE the read below on purpose. It is a direct
+    // write, not a fact the pass states and waits on, so the read that
+    // follows simply sees it. Seeding after that read compared a PRE-seed
+    // count against legacy, so a link viewed between one pass's seed and the
+    // next pass's read counted `outstanding` again and an organization whose
+    // links are viewed at all could never finalize.
     await this.deps.store.seedResourceGrantUsage({
       organizationId,
       seeds: expected.shareLinks.map((link) => ({

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-migration.budget-seed.unit.test.ts
@@ -1,18 +1,13 @@
 /** @vitest-environment node */
 
 /**
- * The view-budget handover the authz-engine migration runs on every pass.
+ * The view-budget handover the authz-engine migration runs on every pass, and
+ * the read that pairs with it. Both scale with an organization's share links,
+ * which is what made a 428k-link organization unable to finish a pass at all.
  *
- * It is the one step no head filter covers — while an organization is held,
- * views keep landing on `ShareLink.viewCount`, so the seed has to ride each
- * pass to let the count heal. That makes its COST per pass a correctness
- * concern of its own: an organization with 428k share links spent a round
- * trip per link here, matched nothing on almost all of them, and never
- * finished a single pass — so it never recorded a status at all.
- *
- * A unit test, and named one: Prisma is a stub, so nothing here opens a
- * socket. The guard is asserted as SQL because that is what it is; whether
- * Postgres honours it is the integration lane's question.
+ * Prisma is a stub, so nothing here opens a socket. The guard is asserted as
+ * SQL because that is what it is; whether Postgres honours it is the
+ * integration lane's question.
  */
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import type { Prisma } from "~/generated/prisma/client";
@@ -54,7 +49,6 @@ describe("PrismaAuthzMigrationRepository budget seeding", () => {
 
   describe("given an organization's share links", () => {
     describe("when the budgets are seeded", () => {
-      /** @scenario "The view budget handover costs statements, not round trips" */
       it("states every seed in one statement, not one statement per seed", async () => {
         const { repository, executeRaw } = build();
 
@@ -67,7 +61,6 @@ describe("PrismaAuthzMigrationRepository budget seeding", () => {
         expect(boundValues(executeRaw)).toHaveLength(400 * 4);
       });
 
-      /** @scenario "The view budget handover costs statements, not round trips" */
       it("chunks past the parameter ceiling instead of growing one statement", async () => {
         const { repository, executeRaw } = build();
 
@@ -95,7 +88,6 @@ describe("PrismaAuthzMigrationRepository budget seeding", () => {
     });
 
     describe("when the seeded budgets are read back", () => {
-      /** @scenario "A pass is not limited by how many share links an organization has" */
       it("reads them for the organization, never one parameter per link", async () => {
         // Postgres binds at most 65535 parameters in a statement, so naming
         // every grant fails outright at exactly the size where this migration

--- a/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-migration.prisma.repository.ts
@@ -22,13 +22,8 @@ import { Prisma, type PrismaClient } from "~/generated/prisma/client";
 
 import { queryOrganizationOnAuthzEngine } from "../engine-gate";
 
-/**
- * Seeds per budget statement. Four binds a row, so this sits well under
- * Postgres' 65535-parameter ceiling and keeps one statement's memory modest.
- * The seed rides EVERY pass, so what matters is that its cost scales with
- * statements, not with rows: an organization with 428k share links was
- * spending 17k sequential round trips per pass here and never finishing one.
- */
+/** Seeds per budget statement. Four binds a row, so this sits well under
+ *  Postgres' 65535-parameter ceiling. */
 const BUDGET_SEED_CHUNK = 5_000;
 
 /**
@@ -196,12 +191,11 @@ export class PrismaAuthzMigrationRepository
   }: {
     organizationId: string;
   }): Promise<RoleHeadRow[]> {
-    // Deleted heads included, and flagged: this read serves the proof, which
-    // has to tell a role the fold has never seen from one it has already
-    // buried. `liveRoles` is the fence for every read that DECIDES access;
-    // dropping the tombstones here would make each one read as a role still
-    // waiting to fold, and hold the organization on a condition no later pass
-    // can clear.
+    // Deleted heads included, and flagged: the proof has to tell a role the
+    // fold has never seen from one it has already buried. `liveRoles` is the
+    // fence for reads that DECIDE access; dropping tombstones here would make
+    // each read as a role still waiting to fold, holding the organization on
+    // a condition no later pass can clear.
     const rows = await this.prisma.role.findMany({
       where: { organizationId },
       select: {
@@ -395,29 +389,19 @@ export class PrismaAuthzMigrationRepository
    * The view budgets, handed over rather than restarted - and RAISED on a
    * re-run, never lowered (the port's own contract; decision 22).
    *
-   * ONE guarded upsert per chunk, which is create-or-raise stated once: a
-   * missing row is inserted at the seeded count, and an existing row is
-   * updated only where the seeded count is strictly higher. That guard is
-   * the refund guard - a row already at or above the seed (a view consumed
-   * since) is left exactly as it is - and it lives in the UPDATE statement
-   * itself, so a consume landing mid-flight cannot be walked back by a
-   * filter resolved in an earlier SELECT.
+   * ONE guarded upsert per chunk: a missing row is inserted at the seeded
+   * count, an existing one raised only where the seed is strictly higher.
+   * That refund guard lives in the UPDATE itself, so a consume landing
+   * mid-flight cannot be walked back by a filter resolved in an earlier
+   * SELECT.
    *
-   * It is one statement per chunk rather than one per row because this seed
-   * rides every pass, unfiltered, for as long as an organization is held:
-   * while it is, views keep landing on `ShareLink.viewCount`, and a usage
-   * row seeded on an earlier pass would otherwise sit permanently below it,
-   * wedging the proof, which compares the two counts exactly. The previous
-   * shape paid a round trip per share link - and on a converged organization
-   * every one of them matched nothing, so the pass spent hundreds of
-   * thousands of round trips, and the exceptions they raised, to change
-   * nothing. The organization that found it never finished a pass at all,
-   * and so never recorded a status of any kind.
+   * One statement per chunk rather than one per row because this rides every
+   * pass: the previous shape paid a round trip per share link, and on a
+   * converged organization every one matched nothing. The organization that
+   * found it never finished a pass at all, so never recorded a status.
    *
-   * `organizationId` and `projectId` are matched in the guard rather than
-   * overwritten: a usage row that disagrees with the seed about where it
-   * lives is not this seed's to move, exactly as the per-row update's
-   * three-column WHERE had it.
+   * `organizationId` and `projectId` are matched rather than overwritten: a
+   * row that disagrees about where it lives is not this seed's to move.
    */
   async seedResourceGrantUsage({
     organizationId,
@@ -521,15 +505,11 @@ export class PrismaAuthzMigrationRepository
     // "field for field" needs a second read to see it. No usage row means no
     // view has been counted, which is exactly zero.
     //
-    // Read BY ORGANIZATION rather than by naming every grant. `GrantUsage` is
-    // organization-indexed and scoped to one organization, so both spellings
-    // select the same budgets - but naming them binds a parameter per grant,
-    // and Postgres accepts at most 65535 of those in a statement. An
-    // organization with 428k share links has that many resource grants, so
-    // the named spelling failed outright at exactly the size where this
-    // migration is hardest, and only once the organization had heads to
-    // compare - never on the empty first pass that would have shown it. Any
-    // budget the rows do not claim is free: the lookup below is by id.
+    // Read BY ORGANIZATION, not by naming every grant: `GrantUsage` is
+    // organization-indexed and organization-scoped, so both spellings select
+    // the same budgets, but naming them binds a parameter per grant against
+    // Postgres' 65535 ceiling - which an organization with 428k share links
+    // clears on its own. The lookup below is by id, so extra rows are free.
     const usages = await this.prisma.grantUsage.findMany({
       where: { organizationId },
       select: { grantId: true, viewCount: true },

--- a/specs/migration/authz-grants-rollout.feature
+++ b/specs/migration/authz-grants-rollout.feature
@@ -150,29 +150,10 @@ Feature: Moving an organization onto the grants projection
     And a usage row that disagrees about which project it belongs to is untouched
 
   @unit
-  Scenario: The view budget handover costs statements, not round trips
-    Given an organization with more share links than one statement can carry
-    When the migration seeds the budgets
-    Then the seeds are stated in whole chunks, not one round trip per link
-    And an organization with no share links states nothing at all
-
-  # A pass that handed the budget over AFTER checking compared a count it had
-  # already superseded, so any link viewed between two passes was reported as
-  # unfinished work again, and an organization whose links are viewed at all
-  # could never finish.
-  @unit
   Scenario: A link viewed between passes does not hold the organization
     Given a share link that has been viewed since the last pass
     When the migration runs
-    Then the new view count is handed over before the organization is checked
-    And the organization is not held for that link
-
-  @unit
-  Scenario: A pass is not limited by how many share links an organization has
-    Given an organization with hundreds of thousands of share links
-    When the migration reads their view budgets
-    Then the budgets are read for the organization as a whole
-    And the pass is not asked to name every link at once
+    Then the organization is not held for that link
 
   @integration @unimplemented
   Scenario: The migration is unavailable while the queue is


### PR DESCRIPTION
Follow-up to #7460 (merged), which fixed four faults and then explained them at
length. **No behaviour changes here** — this is what the explaining cost, taken
back out. 61 insertions against 216 deletions.

## Two scenarios described internals, not behaviour

The repo's rule is that feature files are written from the user's side. These
two were not:

```gherkin
Scenario: The view budget handover costs statements, not round trips
  Then the seeds are stated in whole chunks, not one round trip per link

Scenario: A pass is not limited by how many share links an organization has
  Then the budgets are read for the organization as a whole
  And the pass is not asked to name every link at once
```

The first asserts the shape of a SQL statement. The second asserts that a
query does not name every row. Both are real properties worth holding, and
both keep their unit tests — but neither is a *requirement*, so neither
belongs in a `.feature` file.

A third leaked the same way in a single step: `Then the new view count is
handed over before the organization is checked` names the order two internal
calls run in. Removed, leaving the behaviour it existed to state:

```gherkin
Scenario: A link viewed between passes does not hold the organization
  Given a share link that has been viewed since the last pass
  When the migration runs
  Then the organization is not held for that link
```

Parity goes 22/22 → **20/20 bound**.

## A test harness that reimplemented production

The migration harness had grown an `unseededGrantIds` escape hatch, so one
test could model the seed's guard refusing a row. A fake that reimplements
production semantics can go green while production is wrong — and that branch
is already covered where it belongs: the repository test asserts the guard as
SQL, against the real statement.

Removed, with the test that depended on it. Also removed the white-box test
asserting that the seed and the read happen in that order — the behavioural
test one line below proves the same thing by observing the outcome rather than
the call sequence, so the ordering is still pinned, just not by peeking.

What remains of the harness's model of the budget is four lines, and it earns
them: without the raise, "a link viewed since the last pass no longer holds the
organization" cannot be stated as an outcome at all.

## The rest is prose

The comments retold what the tests already demonstrate. In `check.ts` and
`migration.ts`, 83 of the 107 lines #7460 added were comment. They now keep the
*why* — which read is fenced and which is not, why a diff would be the wrong
cure — and drop the retelling.

## Testing

- `pnpm test:unit src/server/app-layer/authz` — **278 passed / 25 files**
  (two removed with the tests above; no assertion weakened).
- `check:feature-parity` — **20/20 scenarios bound**.
- Formatting clean, no new lint diagnostics.

Refs ADR-110.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authorization migration behavior for view-count discrepancies, tombstones, budget seeding, deleted roles, and organization-scoped usage.
* **Tests**
  * Updated migration coverage for shared view-budget handover and share-link access during migration.
  * Removed outdated scenarios covering operation ordering, chunked budget statements, and unseeded budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->