### PR TITLE
fix(langy): a sandboxed pi worker can enter the shared session stash

### DIFF
--- a/services/langyagent/adapters/pi/spawn.go
+++ b/services/langyagent/adapters/pi/spawn.go
@@ -167,6 +167,22 @@ func skillsDir(workspaceRoot string) string {
 // and a session file still owned by the dead worker's UID would be unreadable,
 // silently breaking the resume it exists for.
 func provisionSessionDir(in ProvisionInput) error {
+	// The stash parent (`<sessionsRoot>/.pi-sessions`) is shared by every
+	// conversation and owned by the manager; a sandboxed worker only passes
+	// THROUGH it to its own chowned leaf. Mode 0711 grants exactly that
+	// traversal — without the execute bit a per-conversation UID gets EACCES
+	// opening its own session store and the wrapper dies before its ready
+	// handshake — while the absent read bit keeps sibling conversation ids
+	// unlistable. Chmod unconditionally: a stash an earlier build created
+	// 0700 (MkdirAll on the leaf used to mint the parent with the leaf's own
+	// mode) must be repaired, and deployed volumes still hold that mode.
+	stashParent := filepath.Dir(in.SessionDir)
+	if err := os.MkdirAll(stashParent, 0o711); err != nil {
+		return fmt.Errorf("mkdir session stash: %w", err)
+	}
+	if err := os.Chmod(stashParent, 0o711); err != nil {
+		return fmt.Errorf("chmod session stash: %w", err)
+	}
 	if err := os.MkdirAll(in.SessionDir, 0o700); err != nil {
 		return fmt.Errorf("mkdir sessions: %w", err)
 	}

--- a/services/langyagent/adapters/pi/spawn_test.go
+++ b/services/langyagent/adapters/pi/spawn_test.go
@@ -255,6 +255,67 @@ func TestProvision_ChownsLeftoverSessionFiles(t *testing.T) {
 	}
 }
 
+// The stash parent (`<sessionsRoot>/.pi-sessions`) is shared by every
+// conversation and owned by the manager; a sandboxed worker only passes
+// through it to its own chowned leaf. Mode 0711 grants exactly that: the
+// execute bit is what lets a per-conversation UID traverse (without it the
+// wrapper dies on EACCES before its ready handshake, which took down every
+// prod pi spawn), and the absent read bit keeps sibling conversation ids
+// unlistable. The chmod must also repair a stash an earlier build created
+// 0700 — deployed volumes already hold that mode.
+// @scenario "A sandboxed worker can enter the shared session stash"
+func TestProvision_StashParentIsTraversable(t *testing.T) {
+	t.Run("given no stash exists yet", func(t *testing.T) {
+		stash := filepath.Join(t.TempDir(), ".pi-sessions")
+		provisionIntoStash(t, stash)
+		assertMode(t, stash, 0o711)
+	})
+
+	t.Run("given a stash created 0700 by an earlier build", func(t *testing.T) {
+		stash := filepath.Join(t.TempDir(), ".pi-sessions")
+		if err := os.MkdirAll(stash, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		provisionIntoStash(t, stash)
+		assertMode(t, stash, 0o711)
+	})
+
+	t.Run("the conversation's own store stays private", func(t *testing.T) {
+		stash := filepath.Join(t.TempDir(), ".pi-sessions")
+		sessionDir := provisionIntoStash(t, stash)
+		assertMode(t, sessionDir, 0o700)
+	})
+}
+
+func provisionIntoStash(t *testing.T, stash string) string {
+	t.Helper()
+	sessionDir := filepath.Join(stash, "conv-1")
+	agent := NewAgent(0)
+	if err := agent.Provision(ProvisionInput{
+		Home:           t.TempDir(),
+		WorkspaceRoot:  t.TempDir(),
+		SessionDir:     sessionDir,
+		Creds:          testCreds(),
+		UID:            4242,
+		AgentsTemplate: "contract ${LANGWATCH_ENDPOINT}",
+		Runner:         testRunner{},
+	}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	return sessionDir
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", path, got, want)
+	}
+}
+
 func envMap(t *testing.T, env []string) map[string]string {
 	t.Helper()
 	out := map[string]string{}

--- a/specs/langy/langy-pi-harness.feature
+++ b/specs/langy/langy-pi-harness.feature
@@ -133,6 +133,23 @@ Feature: Langy can run a conversation on the pi harness
     When a fresh worker is provisioned for the conversation
     Then every session file is owned by the fresh worker's identity
 
+  # The stash parent is shared by every conversation and stays owned by the
+  # manager. A sandboxed worker runs under its own per-conversation identity
+  # and must pass through the stash to reach its own store. A stash without
+  # that traversal permission killed every pi worker at boot in production:
+  # the wrapper died on a permission error before its ready handshake, every
+  # first message failed with worker_spawn_failed, and the panel hung on
+  # "Thinking" and then "Reconnecting to the agent". The local runner (one
+  # identity for manager and worker) can never see this, which is why it
+  # shipped: the traversal bit is the sandbox-only contract this pins.
+  @unit
+  Scenario: A sandboxed worker can enter the shared session stash
+    Given workers run under per-conversation identities
+    When a worker's session store is provisioned
+    Then the shared stash directory lets a worker pass through it
+    And the stash stays unlistable, so sibling conversation ids stay hidden
+    And a stash created earlier with a stricter mode is repaired on provision
+
   # Conversation content must not sit on the manager's disk indefinitely
   # after the user moved on; a day covers every cache tier the store serves.
   @unit


### PR DESCRIPTION
## What happened

After #7407 turned the pi harness on by default, Langy in production stopped answering: the panel hung on "Thinking" and then "Reconnecting to the agent". Every `/worker/create` with `harness: pi` returned `worker_spawn_failed` in about 0.4 seconds. The rollback was to disable `release_langy_pi_harness`, which put production back on opencode.

## Root cause

`provisionSessionDir` created the pi session store with one `os.MkdirAll(sessionDir, 0700)`. That call also minted the shared stash parent (`<sessionsRoot>/.pi-sessions`) with the leaf's 0700 mode, owned by the manager (root). The leaf is chowned to the per-conversation worker UID, but the worker cannot pass through a root-only 0700 parent. Under the sandboxed runner the wrapper died at boot on `EACCES: permission denied, mkdir`, before its ready handshake, so `WaitReady` saw the process dead and mapped it to `worker_spawn_failed`.

The worker's stderr is discarded by design, so the crash reason never reached the logs. The failure was reproduced by running the boot by hand inside the production pod and by calling `/worker/create` directly with `harness: pi`.

The local runner runs manager and worker as one identity, so no dev setup or CI lane could see the permission boundary. That is why it shipped.

## The fix

The stash parent is now created with mode 0711 and repaired to 0711 on every provision:

- The execute bit lets a per-conversation UID traverse into its own chowned 0700 leaf.
- The absent read bit keeps sibling conversation ids unlistable.
- The unconditional chmod repairs stashes a deployed volume already holds at 0700.

## Verification

Against the production pod (flag still off, no user traffic on pi):

- With the parent at 0700: the wrapper dies on `EACCES` before ready, `/worker/create` returns `worker_spawn_failed` in 0.42s.
- After `chmod 711` on the parent: the same `/worker/create` reaches `worker ready` with `harness: pi` in 0.43s.
- The same request on `harness: opencode` worked in both states (control).

New scenario "A sandboxed worker can enter the shared session stash" in `specs/langy/langy-pi-harness.feature` (20/20 bound), covered by `TestProvision_StashParentIsTraversable` with the fresh-stash, repair, and leaf-stays-0700 cases.

## Deployment Impact

No new environment variables and no changed ones. No new or changed helm values, and no chart template touched.

A vanilla `helm install` with no overrides behaves the same as before for every operator who keeps `release_langy_pi_harness` off, which is the default. The only runtime difference is inside the langyagent manager: the shared pi session stash directory (`<sessionsRoot>/.pi-sessions`) is now created with mode 0711 instead of inheriting 0700 from its leaf, and an existing stash is repaired to 0711 on each provision. The mode change is execute-only for other users, so a per-conversation worker UID can traverse into its own 0700 leaf but still cannot list sibling conversation ids. Nothing outside that one directory changes.

BYOC dataplane: the same manager binary runs there, so a deployed dataplane picks up the mode repair on its next provision with no operator action. Persistent volumes that already hold the stash at 0700 are corrected in place. No migration, no restart order, and no rollback step. Rolling back to the previous image restores the old mode only for stashes created after the rollback.

## Rollout

After this deploys, `release_langy_pi_harness` can be re-enabled. The live pod's stash was chmod'd by hand during the investigation, so pi already works there, but a pod reschedule would recreate the bad mode without this fix.

https://claude.ai/code/session_01WUfQouXLw4S6hsfK2nKmsA



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared session-stash permissions so sandboxed workers can access required sessions without listing sibling conversations.
  * Automatically repairs overly restrictive stash permissions.
  * Preserved private access for individual conversation directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->