### PR TITLE
fix(dashboards): graph counts and detail reads answer for the same charts

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -347,7 +347,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-governance/sessions/admin-max-ttl.feature",
   "specs/ai-governance/sessions/personal-sessions.feature",
   "specs/ai-governance/sessions/sessions-inventory.feature",
-  "specs/analytics/dashboard-rest-api.feature",
   "specs/analytics/posthog-cost-control.feature",
   "specs/audit-log/audit-log.feature",
   "specs/auth/auth-signin-flows.feature",

--- a/platform/app/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
@@ -154,6 +154,25 @@ describe("Feature: Dashboard REST API", () => {
     });
   }
 
+  /**
+   * A chart saved from the custom-query workbench, planted directly onto a
+   * dashboard. No product write path attaches one yet, so this is the row a
+   * bug or a future placement slice would produce; the reads must not count
+   * it as a card either way.
+   */
+  async function createWorkbenchGraph(dashboardId: string) {
+    return await prisma.customGraph.create({
+      data: {
+        id: nanoid(),
+        projectId: testProjectId,
+        dashboardId,
+        name: `Saved query ${nanoid(6)}`,
+        graph: { sql: "SELECT 1", v: 1 },
+        kind: "workbench_sql",
+      },
+    });
+  }
+
   // ── Authentication ─────────────────────────────────────────────
 
   describe("Authentication", () => {
@@ -207,6 +226,20 @@ describe("Feature: Dashboard REST API", () => {
           expect(dashboard).toHaveProperty("updatedAt");
         }
       });
+
+      // @scenario "The graph count agrees with the charts inside the dashboard"
+      it("reports a count per dashboard that matches its detail read", async () => {
+        const listRes = await helpers.api.get("/api/dashboards");
+        const listBody = await listRes.json();
+
+        for (const listed of listBody.data) {
+          const detailRes = await helpers.api.get(`/api/dashboards/${listed.id}`);
+          expect(detailRes.status).toBe(200);
+
+          const detailBody = await detailRes.json();
+          expect(listed.graphCount).toBe(detailBody.graphs.length);
+        }
+      });
     });
 
     describe("when the project has no dashboards", () => {
@@ -216,6 +249,32 @@ describe("Feature: Dashboard REST API", () => {
 
         const body = await res.json();
         expect(body.data).toHaveLength(0);
+      });
+    });
+
+    describe("when a dashboard also holds a chart saved from the custom-query workbench", () => {
+      let dashboard: Awaited<ReturnType<typeof createDashboard>>;
+
+      beforeEach(async () => {
+        dashboard = await createDashboard({ name: "Mixed Dashboard" });
+        await createGraph(dashboard.id);
+        await createWorkbenchGraph(dashboard.id);
+      });
+
+      // @scenario "A saved custom-query chart on a dashboard is not counted as a card"
+      it("excludes the saved query from the graph count and from the charts list", async () => {
+        const listRes = await helpers.api.get("/api/dashboards");
+        expect(listRes.status).toBe(200);
+
+        const listBody = await listRes.json();
+        expect(listBody.data[0].graphCount).toBe(1);
+
+        const detailRes = await helpers.api.get(`/api/dashboards/${dashboard.id}`);
+        expect(detailRes.status).toBe(200);
+
+        const detailBody = await detailRes.json();
+        expect(detailBody.graphs).toHaveLength(1);
+        expect(detailBody.graphs[0].kind).toBe("builder");
       });
     });
   });

--- a/platform/app/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
+++ b/platform/app/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
@@ -233,7 +233,9 @@ describe("Feature: Dashboard REST API", () => {
         const listBody = await listRes.json();
 
         for (const listed of listBody.data) {
-          const detailRes = await helpers.api.get(`/api/dashboards/${listed.id}`);
+          const detailRes = await helpers.api.get(
+            `/api/dashboards/${listed.id}`,
+          );
           expect(detailRes.status).toBe(200);
 
           const detailBody = await detailRes.json();
@@ -269,7 +271,9 @@ describe("Feature: Dashboard REST API", () => {
         const listBody = await listRes.json();
         expect(listBody.data[0].graphCount).toBe(1);
 
-        const detailRes = await helpers.api.get(`/api/dashboards/${dashboard.id}`);
+        const detailRes = await helpers.api.get(
+          `/api/dashboards/${dashboard.id}`,
+        );
         expect(detailRes.status).toBe(200);
 
         const detailBody = await detailRes.json();

--- a/platform/app/src/server/dashboards/dashboard.repository.ts
+++ b/platform/app/src/server/dashboards/dashboard.repository.ts
@@ -3,6 +3,7 @@ import type {
   Prisma,
   PrismaClient,
 } from "~/generated/prisma/client";
+import { BUILDER_CHART_KIND } from "~/server/analytics/chartKinds";
 
 /**
  * Input types for dashboard operations
@@ -29,6 +30,10 @@ export class DashboardRepository {
 
   /**
    * Finds all dashboards for a project, ordered by order field.
+   *
+   * The graph count answers for the charts a dashboard shows, which is the
+   * same set the reports grid renders ({@link BUILDER_CHART_KIND}); a chart
+   * saved from another surface sharing the table must not inflate it.
    */
   async findAll(input: { projectId: string }): Promise<
     Array<
@@ -42,7 +47,9 @@ export class DashboardRepository {
       orderBy: { order: "asc" },
       include: {
         _count: {
-          select: { graphs: true },
+          select: {
+            graphs: { where: { kind: BUILDER_CHART_KIND } },
+          },
         },
       },
     });
@@ -50,6 +57,9 @@ export class DashboardRepository {
 
   /**
    * Finds a dashboard by id within a project, including its graphs.
+   *
+   * Reads the same kind the list's graph count counts and the grid renders,
+   * so no endpoint of this resource can promise a chart another one omits.
    */
   async findById(input: { id: string; projectId: string }) {
     return await this.prisma.dashboard.findFirst({
@@ -59,6 +69,7 @@ export class DashboardRepository {
       },
       include: {
         graphs: {
+          where: { kind: BUILDER_CHART_KIND },
           orderBy: [{ gridRow: "asc" }, { gridColumn: "asc" }],
         },
       },

--- a/specs/analytics/dashboard-rest-api.feature
+++ b/specs/analytics/dashboard-rest-api.feature
@@ -48,3 +48,23 @@ Feature: Dashboard REST API
   Scenario: Unauthenticated request
     When I call GET /api/dashboards without an API key
     Then I receive 401 Unauthorized
+
+  @integration
+  Rule: A dashboard's graph count names what the dashboard shows
+
+    The list reports one number per dashboard and the detail returns the
+    charts themselves. Both answer for the same set: the charts the
+    reports grid renders. A chart saved from another surface, which no
+    dashboard shows yet, is nobody's card.
+
+    @integration
+    Scenario: The graph count agrees with the charts inside the dashboard
+      Given the project has a dashboard with charts
+      When I call GET /api/dashboards and GET /api/dashboards/:id
+      Then each graph count matches how many charts the detail read returns
+
+    @integration
+    Scenario: A saved custom-query chart on a dashboard is not counted as a card
+      Given a project dashboard also holds a chart saved from the custom-query workbench
+      When I call GET /api/dashboards and GET /api/dashboards/:id
+      Then neither the graph count nor the charts list includes it


### PR DESCRIPTION
# Related Issue

- Resolves #7437

Closes #7437

## The problem

The dashboard list reported a graph count over every `CustomGraph` row attached to the dashboard. The reports grid renders builder charts only (`graphs.getAll` filters by kind), so any row saved from another surface sharing that table would raise a card count for a chart no endpoint of the dashboard displays.

## The fix

`DashboardRepository.findAll` counts and `findById` reads now scope to the same kind the grid renders:

```ts
_count: { select: { graphs: { where: { kind: BUILDER_CHART_KIND } } } }
graphs: { where: { kind: BUILDER_CHART_KIND }, orderBy: ... }
```

List count, detail read and grid render now answer for one set by construction.

Two notes on scope:

- **No flag gating yet.** Saved workbench charts cannot be attached to a dashboard today (no write path sets their `dashboardId`), so there is nothing flag-aware to count. When the placement slice lands behind `release_lwql_workbench`, both predicates extend together.
- **Issue path correction:** the issue names `src/server/analytics/repositories/dashboard.repository.ts`, which does not exist in git history; the repository lives at `src/server/dashboards/dashboard.repository.ts`, and neither read carried a kind predicate before this change.

## Spec + tests

`specs/analytics/dashboard-rest-api.feature` gains a Rule with two `@integration` scenarios (2/2 bound, parity gate green):

- The graph count agrees with the charts inside the dashboard
- A saved custom-query chart on a dashboard is not counted as a card

Both bind into `dashboard-rest-api.integration.test.ts`. The exclusion test was verified against the unfixed repository code first (fails with count 2 vs 1), then green after the fix. Full suite: 21 passed. `pnpm typecheck` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dashboard graph counts now accurately match the charts displayed in dashboard details.
  - Custom-query and workbench-saved charts are excluded from dashboard counts and chart lists when they aren’t rendered in the reports grid.

- **Tests**
  - Added integration coverage to verify consistent dashboard counts and chart results across dashboard list and detail views.
  - Added scenarios covering dashboards with custom-query charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->