### PR TITLE
feat(release): keep one release-note entry per commit on release branches

### DIFF
--- a/.github/scripts/dedupe-release-notes.sh
+++ b/.github/scripts/dedupe-release-notes.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Deduplicates the release-note entries on every open release branch.
+#
+# Runs in release-please-sdks.yml AFTER the release-please action. Squash merges
+# with COMMIT_MESSAGES parse one commit as two entries when the commit body
+# opens with its own conventional-commit line (#7206), and Release Please
+# rewrites each release branch from git history on every run, so the duplicates
+# would come back with any one-time fix. This pass removes them after every
+# regeneration instead: what a release PR merges is what this leaves behind.
+#
+# Environment:
+#   GITHUB_TOKEN     credentials for ls-remote/fetch/push and for asking
+#                    GitHub which pull request a duplicated sha merged, so the
+#                    entry naming the merged pull request is the one kept.
+#
+# Usage: dedupe-release-notes.sh
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+cd "$repo_root"
+
+branches="$(git ls-remote --heads origin 'release-please--branches--*' | awk '{print $2}' | sed 's|refs/heads/||')"
+
+if [ -z "$branches" ]; then
+  echo "no release branches to deduplicate"
+  exit 0
+fi
+
+git config user.name "langwatch-ci"
+git config user.email "ci@langwatch.langwatch.ai"
+
+worktree_root="$(mktemp -d)"
+trap 'git worktree list --porcelain | sed -n "s/^worktree //p" | grep "^$worktree_root" | xargs -r git worktree remove --force; rm -rf "$worktree_root"' EXIT
+
+while IFS= read -r branch; do
+  [ -n "$branch" ] || continue
+  echo "checking $branch"
+  git fetch --force --depth=1 origin "$branch"
+
+  worktree="$worktree_root/${branch//\//-}"
+  git worktree add --detach "$worktree" FETCH_HEAD
+
+  # Every package the manifest releases carries a changelog at its root; only
+  # the ones present on this branch can hold entries.
+  paths=()
+  while IFS= read -r package_path; do
+    changelog="$package_path/CHANGELOG.md"
+    if [ -f "$worktree/$changelog" ]; then
+      paths+=("$changelog")
+    fi
+  done < <(jq -r '.packages | keys[]' "$worktree/.github/release-please-config.json")
+
+  if [ "${#paths[@]}" -eq 0 ]; then
+    echo "  no changelogs on $branch"
+    continue
+  fi
+
+  (cd "$worktree" && node --experimental-strip-types \
+    "$script_dir/dedupe-release-notes.ts" "${paths[@]}")
+
+  if git -C "$worktree" diff --quiet; then
+    echo "  clean"
+    continue
+  fi
+
+  git -C "$worktree" add -u
+  git -C "$worktree" commit -m "chore: keep one release-note entry per commit"
+  git -C "$worktree" push origin "HEAD:refs/heads/$branch"
+  echo "  pushed deduplicated entries"
+done <<< "$branches"

--- a/.github/scripts/dedupe-release-notes.test.ts
+++ b/.github/scripts/dedupe-release-notes.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
+
+import { dedupeChangelog, extractPrNumbers, extractSha } from "./dedupe-release-notes.ts";
+
+const scriptPath = resolve(import.meta.dirname, "dedupe-release-notes.ts");
+
+after(() => {
+  rmSync(join(tmpdir(), "dedupe-release-notes-tests"), {
+    recursive: true,
+    force: true,
+  });
+});
+
+const tempDir = (): string => {
+  const root = join(tmpdir(), "dedupe-release-notes-tests");
+  mkdirSync(root, { recursive: true });
+  return mkdtempSync(join(root, "case-"));
+};
+
+// The pairs below mirror the shapes #7206 diagnosed in the released 3.16.0
+// section: a body-derived entry without a pull-request link beside its
+// subject-derived twin, and one commit whose body names a different pull
+// request than the subject that merged it.
+const bodyEntry = (text: string, sha: string): string =>
+  `* ${text} ([${sha.slice(0, 7)}](https://github.com/langwatch/langwatch/commit/${sha}))\n`;
+
+const subjectEntry = (
+  text: string,
+  pr: number,
+  sha: string,
+): string =>
+  `* ${text} ([#${pr}](https://github.com/langwatch/langwatch/issues/${pr})) ([${sha.slice(0, 7)}](https://github.com/langwatch/langwatch/commit/${sha}))\n`;
+
+describe("dedupe-release-notes", () => {
+  describe("when extracting identifiers from an entry", () => {
+    it("reads the full sha out of the trailing commit link", () => {
+      const line = subjectEntry("a fix", 7186, "fadc6321ddc9846a1208048b2c05994020b65a7c");
+      assert.equal(extractSha(line), "fadc6321ddc9846a1208048b2c05994020b65a7c");
+    });
+
+    it("reads every pull-request link in the entry", () => {
+      const line = subjectEntry("a fix", 7186, "fadc6321ddc9846a1208048b2c05994020b65a7c");
+      assert.deepEqual(extractPrNumbers(line), [7186]);
+    });
+
+    it("answers nothing for an entry without links", () => {
+      assert.equal(extractSha("* a note without links\n"), null);
+      assert.deepEqual(extractPrNumbers("* a note without links\n"), []);
+    });
+  });
+
+  describe("when two entries carry one sha and only one links a pull request", () => {
+    const content = [
+      "# Changelog\n",
+      "## [3.16.0](https://github.com/langwatch/langwatch/compare/langwatch@v3.15.0...langwatch@v3.16.0) (2026-08-21)\n",
+      "\n",
+      "### Bug Fixes\n",
+      "\n",
+      bodyEntry(
+        "**clickhouse:** size the statement bound from the cluster, not one node",
+        "fadc6321ddc9846a1208048b2c05994020b65a7c",
+      ),
+      subjectEntry(
+        "**clickhouse:** size the statement bound from the whole cluster, not one node",
+        7186,
+        "fadc6321ddc9846a1208048b2c05994020b65a7c",
+      ),
+    ].join("");
+
+    // @scenario "Two entries naming one sha keep the one carrying a pull-request link"
+    it("keeps the pull-request-linked entry and drops the other", async () => {
+      const deduped = await dedupeChangelog(content);
+      assert.match(deduped, /whole cluster.*#7186/);
+      assert.doesNotMatch(
+        deduped,
+        /size the statement bound from the cluster, not one node \(\[fadc632/,
+      );
+      assert.equal(deduped.split("\n").length, content.split("\n").length - 1);
+    });
+  });
+
+  describe("when two entries carry one sha and name two different pull requests", () => {
+    const sha = "2afcf8a7f94486dcae55f6b26883139f6c586582";
+    const content = [
+      "## [3.16.0](https://github.com/langwatch/langwatch/compare/langwatch@v3.15.0...langwatch@v3.16.0) (2026-08-21)\n",
+      "\n",
+      "### Bug Fixes\n",
+      "\n",
+      subjectEntry("**governance:** a walk id keeps the pager latest", 7346, sha),
+      subjectEntry("**governance:** a walk id keeps the events pager latest", 7347, sha),
+    ].join("");
+
+    // @scenario "Two entries naming one sha and two pull requests keep the merged one"
+    it("keeps the entry GitHub says the commit merged", async () => {
+      const deduped = await dedupeChangelog(content, {
+        resolveMergedPrs: async (asked) =>
+          asked === sha ? [7347] : [],
+      });
+      assert.match(deduped, /#7347/);
+      assert.doesNotMatch(deduped, /#7346/);
+    });
+
+    it("keeps a pull-request-linked entry when GitHub answers nothing", async () => {
+      const deduped = await dedupeChangelog(content, {
+        resolveMergedPrs: async () => [],
+      });
+      assert.equal(extractSha(deduped.split("\n").find((l) => /^\* /.test(l) && l.includes(sha.slice(0, 7))) ?? ""), sha);
+      assert.equal(deduped.split("\n").filter((l) => l.includes(sha.slice(0, 7))).length, 1);
+    });
+  });
+
+  describe("when every entry names a distinct sha", () => {
+    const content = [
+      "### Features\n",
+      "\n",
+      subjectEntry("**authz:** one entry", 7151, "4f791c7dc6ed88214b0e083f44f2f6ee21973b09"),
+      subjectEntry("**gateway:** another entry", 6420, "7dcd14d9389824c6a114d333ecdec1ad364ff873"),
+    ].join("");
+
+    // @scenario "Entries without a duplicate are left untouched"
+    it("returns the content unchanged", async () => {
+      assert.equal(await dedupeChangelog(content), content);
+    });
+  });
+
+  describe("when the same sha appears in two different sections", () => {
+    it("keeps one entry per section rather than collapsing across versions", async () => {
+      const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const section = (version: string) => [
+        `## [${version}] compare-link\n`,
+        "\n",
+        subjectEntry("**governance:** the same change", 7000, sha),
+        bodyEntry("**governance:** the same change again", sha),
+      ].join("");
+      const content = `${section("3.16.0")}\n${section("3.15.0")}`;
+
+      const deduped = await dedupeChangelog(content);
+      assert.equal(
+        [...deduped.matchAll(new RegExp(`/commit/${sha.slice(0, 7)}`, "g"))]
+          .length,
+        2,
+      );
+      assert.ok(!deduped.includes("the same change again"));
+    });
+  });
+
+  describe("when run over a changelog file through the CLI", () => {
+    const unduplicated =
+      "* **ops:** per-migration enrollment on the migrations page ([#7304](https://github.com/langwatch/langwatch/issues/7304)) ([bc515e5](https://github.com/langwatch/langwatch/commit/bc515e528c3bb61cbc188f9accf9629d5ab194))\n";
+    const heading =
+      "## [3.16.0](https://github.com/langwatch/langwatch/compare/langwatch@v3.15.0...langwatch@v3.16.0) (2026-08-21)\n";
+    const duplicatedPair = [
+      bodyEntry(
+        "**clickhouse:** size the statement bound from the cluster, not one node",
+        "fadc6321ddc9846a1208048b2c05994020b65a7c",
+      ),
+      subjectEntry(
+        "**clickhouse:** size the statement bound from the whole cluster, not one node",
+        7186,
+        "fadc6321ddc9846a1208048b2c05994020b65a7c",
+      ),
+    ];
+
+    // @scenario "A whole changelog is rewritten only where it duplicates"
+    it("removes exactly the duplicate lines and preserves every other byte", async () => {
+      const dir = tempDir();
+      const file = join(dir, "CHANGELOG.md");
+      writeFileSync(file, heading + "\n" + unduplicated + "\n" + duplicatedPair.join("") + "### Bug Fixes\n");
+
+      const result = spawnSync(process.execPath, [
+        "--experimental-strip-types",
+        scriptPath,
+        file,
+      ]);
+      assert.equal(result.status, 0, result.stderr.toString());
+
+      const after = readFileSync(file, "utf8");
+      assert.ok(!after.includes("from the cluster, not one node"));
+      assert.ok(after.includes("from the whole cluster"));
+      assert.ok(after.includes(unduplicated));
+      assert.ok(after.includes(heading));
+    });
+
+    it("reports a clean changelog without rewriting the file", async () => {
+      const dir = tempDir();
+      const file = join(dir, "CHANGELOG.md");
+      const original = heading + unduplicated;
+      writeFileSync(file, original);
+
+      const result = spawnSync(process.execPath, [
+        "--experimental-strip-types",
+        scriptPath,
+        file,
+      ]);
+      assert.equal(result.status, 0, result.stderr.toString());
+      assert.match(result.stdout.toString(), /no duplicate entries/);
+      assert.equal(readFileSync(file, "utf8"), original);
+    });
+  });
+});

--- a/.github/scripts/dedupe-release-notes.ts
+++ b/.github/scripts/dedupe-release-notes.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+// Squash merges here carry COMMIT_MESSAGES, so a pull request whose commit
+// body opens with its own conventional-commit line parses as TWO release-note
+// entries against ONE sha: the subject entry carries the pull-request link,
+// the body entry does not. Release Please writes both, and #7206 shows the
+// pairs landing in every released section. This pass removes them again.
+//
+// It runs AFTER Release Please in release-please-sdks.yml over each release
+// branch's changelogs, so what a release PR merges is already deduplicated.
+// The keeper is deterministic: an entry naming the pull request GitHub says
+// merged the commit, else any pull-request-linked entry, else the first.
+
+/** A trailing commit link, as Release Please renders it: `([abc1234](…/commit/<sha>))`. */
+const shaPattern = /\]\((https:\/\/[^)\s]*\/commit\/([0-9a-f]{7,40}))\)/;
+
+/** A linked pull request number, as Release Please renders issue redirects: `([#123](…/issues/123))`. */
+const prLinkPattern = /https:\/\/[^)\s]*\/issues\/(\d+)/;
+
+export const extractSha = (line: string): string | null =>
+  shaPattern.exec(line)?.[2] ?? null;
+
+export const extractPrNumbers = (line: string): number[] =>
+  [...line.matchAll(new RegExp(prLinkPattern.source, "g"))].map(
+    (match) => Number(match[1]),
+  );
+
+export type DedupeOptions = {
+  /**
+   * Asks GitHub which pull requests one commit merged. Omitted in tests and
+   * offline runs; the keeper falls back to any pull-request-linked entry.
+   */
+  resolveMergedPrs?: (sha: string) => Promise<number[]>;
+};
+
+/**
+ * Removes duplicated release-note entries: within one version section, at
+ * most one bullet per commit sha survives. Every non-bullet line, and bullets
+ * without a duplicate, survive byte for byte.
+ */
+export const dedupeChangelog = async (
+  content: string,
+  options: DedupeOptions = {},
+): Promise<string> => {
+  const lines = content.split("\n");
+  // Section boundaries are the `## [` version headings; a bullet belongs to
+  // the section open where it sits, so the same sha can never be deduped
+  // across versions. Every section's surplus indices are collected before any
+  // removal, because removing as we go would shift the later sections'
+  // positions under our feet.
+  const drop = new Set<number>();
+
+  let sectionStart = 0;
+  while (sectionStart < lines.length) {
+    if (!/^## /.test(lines[sectionStart] ?? "")) {
+      sectionStart += 1;
+      continue;
+    }
+
+    let cursor = sectionStart + 1;
+    while (cursor < lines.length && !/^## /.test(lines[cursor] ?? "")) {
+      cursor += 1;
+    }
+    await markSurplus(lines, sectionStart + 1, cursor, options, drop);
+    sectionStart = cursor;
+  }
+
+  if (drop.size === 0) return content;
+
+  // Descending: each removal would shift every later index.
+  for (const index of [...drop].sort((a, b) => b - a)) {
+    lines.splice(index, 1);
+  }
+  return lines.join("\n");
+};
+
+/**
+ * Adds to `drop` every bullet index inside `[begin, end)` beyond the one
+ * keeper per duplicated sha.
+ */
+const markSurplus = async (
+  lines: string[],
+  begin: number,
+  end: number,
+  options: DedupeOptions,
+  drop: Set<number>,
+): Promise<void> => {
+  const bullets = new Map<string, number[]>();
+  for (let i = begin; i < end; i += 1) {
+    const sha = extractSha(lines[i] ?? "");
+    if (!sha) continue;
+    const seen = bullets.get(sha) ?? [];
+    seen.push(i);
+    bullets.set(sha, seen);
+  }
+
+  for (const [sha, at] of [...bullets.entries()].filter(
+    ([, seen]) => seen.length > 1,
+  )) {
+    const entries = at.map((i) => ({
+      index: i,
+      prNumbers: extractPrNumbers(lines[i] ?? ""),
+    }));
+
+    const merged = (await options.resolveMergedPrs?.(sha)) ?? [];
+    const mergedHere = entries.filter((entry) =>
+      entry.prNumbers.some((number) => merged.includes(number)),
+    );
+    const linked = entries.filter((entry) => entry.prNumbers.length > 0);
+
+    const keeper = mergedHere[0] ?? linked[0] ?? entries[0];
+    for (const entry of entries) {
+      if (entry !== keeper) drop.add(entry.index);
+    }
+  }
+};
+
+/**
+ * Which pull request a commit merged, through the association API: a squash
+ * merge associates exactly the pull request that was merged, which is how two
+ * entries naming two different numbers (#7346/#7347 in 3.16.0) get told apart.
+ * Unavailable without credentials; the caller degrades to link-preference.
+ */
+export const githubMergedPrs = (): ((sha: string) => Promise<number[]>) | undefined => {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) return undefined;
+
+  return async (sha: string): Promise<number[]> => {
+    const response = await fetch(
+      `https://api.github.com/repos/${repository}/commits/${sha}/pulls`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+      },
+    );
+    if (!response.ok) return [];
+    const pulls = (await response.json()) as { number?: number }[];
+    return pulls.flatMap((pull) =>
+      typeof pull.number === "number" ? [pull.number] : [],
+    );
+  };
+};
+
+const main = async (): Promise<number> => {
+  const paths = process.argv.slice(2);
+  if (paths.length === 0) {
+    console.error("usage: dedupe-release-notes.ts <changelog-path> [...]");
+    return 2;
+  }
+
+  const resolveMergedPrs = githubMergedPrs();
+  for (const path of paths) {
+    const before = readFileSync(resolve(path), "utf8");
+    const after = await dedupeChangelog(before, { resolveMergedPrs });
+    if (before === after) {
+      console.log(`${path}: no duplicate entries`);
+      continue;
+    }
+    writeFileSync(resolve(path), after);
+    console.log(`${path}: removed duplicate entries`);
+  }
+  return 0;
+};
+
+const isEntrypoint = (): boolean =>
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isEntrypoint()) {
+  await main().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/.github/workflows/release-please-sdks.yml
+++ b/.github/workflows/release-please-sdks.yml
@@ -61,3 +61,18 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      # Release Please parses each squash commit's body as well as its subject,
+      # so a body that opens with its own conventional-commit line yields TWO
+      # entries for ONE sha (#7206), and every run rewrites the release
+      # branches from history, which would bring a one-time fix back. The pass
+      # below runs after every regeneration instead, so what a release PR
+      # merges is already one-entry-per-commit.
+      #
+      # Runs unconditionally rather than gated on the action's outputs: an
+      # update to an existing release PR reports no output, and it is exactly
+      # those branches that carry duplicates.
+      - name: Deduplicate release-note entries
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: bash .github/scripts/dedupe-release-notes.sh

--- a/.github/workflows/release-scope-guard.yml
+++ b/.github/workflows/release-scope-guard.yml
@@ -8,7 +8,9 @@ on:
       - main
     paths:
       - ".github/scripts/guard-breaking-change-scope*.ts"
+      - ".github/scripts/dedupe-release-notes*.ts"
       - ".github/release-please-config.json"
+      - ".github/workflows/release-please-sdks.yml"
   workflow_dispatch:
 
 # The heaviest superseder in the repo: 29 of its last 100 runs were still
@@ -42,7 +44,10 @@ jobs:
           node-version: 24
 
       - name: Check guard tests
-        run: node --test --experimental-strip-types .github/scripts/guard-breaking-change-scope.test.ts
+        run: |
+          node --test --experimental-strip-types .github/scripts/guard-breaking-change-scope.test.ts
+          node --test --experimental-strip-types .github/scripts/dedupe-release-notes.test.ts
+          bash -n .github/scripts/dedupe-release-notes.sh
 
       # A squash merge puts the pull request title in the subject and the branch
       # commit messages in the body, so those are the two places a breaking

--- a/specs/ci/release-notes-dedupe.feature
+++ b/specs/ci/release-notes-dedupe.feature
@@ -1,0 +1,41 @@
+Feature: One release-note entry per commit
+  As someone reading a LangWatch changelog or an SDK changelog
+  I want every released change listed once
+  So that the notes name real work instead of parsing artifacts
+
+  # Squash merges here carry COMMIT_MESSAGES, so a pull request whose commit
+  # body opens with its own conventional-commit line parses as two entries
+  # against one sha: the subject entry carries the pull-request link, the body
+  # entry does not. Release Please writes both. The dedupe pass runs after
+  # Release Please in the release workflow and keeps one entry per commit,
+  # preferring the entry that names the pull request that merged the commit.
+
+  Background:
+    Given a generated changelog holding release-note entries
+
+  @unit
+  Scenario: Two entries naming one sha keep the one carrying a pull-request link
+    Given two entries in one section carry the same commit sha
+    And only one of them links a pull request number
+    When the dedupe pass runs
+    Then the section keeps only the entry carrying the pull-request link
+
+  @unit
+  Scenario: Two entries naming one sha and two pull requests keep the merged one
+    Given two entries in one section carry the same commit sha
+    And each names a different pull request number
+    When GitHub answers which pull request the commit merged
+    Then the section keeps only the entry naming that pull request
+
+  @unit
+  Scenario: Entries without a duplicate are left untouched
+    Given every entry in the section names a distinct commit sha
+    When the dedupe pass runs
+    Then no line changes
+
+  @unit
+  Scenario: A whole changelog is rewritten only where it duplicates
+    Given a changelog file with duplicated entries across several sections and unduplicated entries beside them
+    When the dedupe pass runs over the file
+    Then every duplicated sha appears once per section afterwards
+    And every other line survives byte for byte


### PR DESCRIPTION
# Related Issue

- Resolves #7392

Closes #7392

## The cause, restated

The repo squash merges with `COMMIT_MESSAGES`, so a squash message is the PR title plus every branch commit's message. When a branch commit opens with its own conventional-commit line, Release Please parses that line as a second entry against the same sha: the subject entry carries the pull-request link, the body entry does not. Six such pairs shipped in 3.16.0.

## The fix

A dedupe pass in `release-please-sdks.yml` runs after the release-please action on every push to main:

1. Lists open branches matching `release-please--branches--*`.
2. For each, derives the changelog paths from `.github/release-please-config.json` and runs `dedupe-release-notes.ts` on them.
3. Pushes only when something changed.

Within one version section at most one bullet per sha survives. Keeper order: an entry naming a pull request GitHub's association API says the commit merged (this is how the 3.16.0 pair naming both #7346 and #7347 resolves), then any pull-request-linked entry, then the first entry. Without credentials it degrades to link-preference.

Because Release Please rewrites each release branch from history on every run, this pass re-runs after every regeneration instead of being a one-time cleanup.

## Validation

- `specs/ci/release-notes-dedupe.feature`: four `@unit` scenarios, 4/4 bound into `dedupe-release-notes.test.ts`, which runs through `node --test --experimental-strip-types` in `release-scope-guard.yml` alongside the existing guard tests.
- Ran the script against main's real `CHANGELOG.md` with live GitHub resolution: all six duplicate shas collapsed, keeping #7316, #7186 and #7347.
- Workflow YAML validated; wrapper passes `bash -n`.

## Deliberate scope

Existing merged sections keep their duplicates: editing generated changelogs by hand was ruled out on #7206, and the next release PR for each component regenerates from an already-clean pipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate release-note entries for the same commit from appearing in generated changelogs.
  * Preserved unique entries and other changelog content while removing only redundant entries.
  * Prioritized entries associated with the merged pull request when resolving duplicates.

* **Automation**
  * Release-note cleanup now runs automatically after release regeneration across applicable release branches.

* **Tests**
  * Added coverage for duplicate detection, pull-request selection, clean changelogs, and command-line behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->