### PR TITLE
fix(dx): root alias for start:prepare:files

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "lint:fix": "pnpm --filter @langwatch/web lint:fix",
     "format": "pnpm --filter @langwatch/web format",
     "prepare:files": "pnpm --filter @langwatch/web start:prepare:files",
+    "start:prepare:files": "pnpm --filter @langwatch/web start:prepare:files",
     "prisma:migrate": "pnpm --filter @langwatch/web prisma:migrate",
     "prisma:seed": "pnpm --filter @langwatch/web prisma:seed",
     "pack:npm": "bash dev/scripts/pack-npm.sh",


### PR DESCRIPTION
# Related Issue

- Resolves #7432

## What

`pnpm run start:prepare:files` only exists inside `platform/app`; at the repo root the working script is `prepare:files`. Docs and habit point at the former, so fresh-worktree priming fails with a missing-script error and the user then sees hundreds of missing-generated-type errors that look like real breakage. This adds a root alias so both names work from the root.

Closes #7432

## How I can prove I was successful

- `node -e "JSON.parse(...)"` on package.json → valid.
- One-line change; `pnpm run start:prepare:files` at root now resolves to the same delegation as `prepare:files`.

## Human verification

From the repo root run `pnpm run start:prepare:files` — expect it to run @langwatch/web's generator chain rather than ERR_PNPM_NO_SCRIPT.

## Deployment Impact

None — root package.json script alias only; no runtime, no packages published from the root manifest.

<!-- no-ui-surface -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a root-level command to prepare files for starting the web application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
