### PR TITLE
docs(setup): one generator command by either name, and the fresh-checkout gotcha on paper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,16 @@ Please note, all contributions should start with an issue first.
   - If builds or hot-reload feel slow and you're on a compose-based preset, ensure Docker has enough memory allocated (Docker Desktop → Settings → Resources)
   - Run `make quickstart` for an interactive picker that starts only the services your task needs; see `make quickstart-help` for the full non-interactive preset reference
 
+### Fresh checkout or new worktree
+
+Generated files (Prisma client, generated types, SDK versions) are not committed, so `pnpm typecheck` reports hundreds of "Cannot find module" errors until you generate them. After `pnpm install`, run:
+
+```bash
+pnpm prepare:files        # or: pnpm start:prepare:files
+```
+
+Both names work from the repository root and reach the same generator chain in `platform/app`. Run it again after pulling schema changes.
+
 ## How Can I Contribute?
 
 ### Reporting Bugs and Suggesting Enhancements

--- a/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
+++ b/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// vitest runs from the app package root, so the repository root is one level up.
+const REPO_ROOT = resolve(process.cwd(), "../..");
+
+type Scripts = Record<string, string | undefined>;
+
+const scriptsOf = (path: string): Scripts =>
+  JSON.parse(readFileSync(resolve(REPO_ROOT, path), "utf8")).scripts ?? {};
+
+const APP_GENERATOR_CHAIN = "start:prepare:files";
+
+describe("given a fresh checkout without generated files", () => {
+  describe("when either documented name is invoked from the repository root", () => {
+    // @scenario "Both documented names reach the same generator chain"
+    it("routes both root script names to the app generator chain", () => {
+      const root = scriptsOf("package.json");
+
+      expect(
+        scriptsOf("platform/app/package.json")[APP_GENERATOR_CHAIN],
+      ).toBeDefined();
+      for (const name of ["prepare:files", "start:prepare:files"]) {
+        expect(root[name]).toBe(
+          `pnpm --filter @langwatch/web ${APP_GENERATOR_CHAIN}`,
+        );
+      }
+    });
+  });
+
+  describe("when the app build and development scripts call their generator chain by name", () => {
+    // @scenario "The app keeps the generator chain its build calls by name"
+    it("keeps the chain under start:prepare:files in the app package", () => {
+      const app = scriptsOf("platform/app/package.json");
+      const callers = ["build", "dev:app", "dev:worker"];
+
+      for (const caller of callers) {
+        expect(app[caller]).toContain(APP_GENERATOR_CHAIN);
+      }
+    });
+  });
+
+  describe("when contributing documentation tells a newcomer how to generate the files", () => {
+    // @scenario "Setup guidance names a script that exists where it says to run it"
+    it("names only commands that exist in the scripts they target", () => {
+      const contributing = readFileSync(
+        resolve(REPO_ROOT, "CONTRIBUTING.md"),
+        "utf8",
+      );
+      const root = scriptsOf("package.json");
+
+      const fenced = [...contributing.matchAll(/```bash\n([\s\S]*?)```/g)].map(
+        (match) => match[1] ?? "",
+      );
+      const setupBlock = fenced.find((block) =>
+        block.includes("prepare:files"),
+      );
+      expect(setupBlock).toBeDefined();
+
+      const named = [...(setupBlock ?? "").matchAll(/pnpm ([a-z:.-]+)/g)].map(
+        (match) => match[1],
+      );
+      expect(named.length).toBeGreaterThan(0);
+      for (const name of named) {
+        expect(root[name]).toBeDefined();
+      }
+    });
+  });
+});

--- a/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
+++ b/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
@@ -56,10 +56,12 @@ describe("given a fresh checkout without generated files", () => {
       const setupBlock = fenced.find((block) =>
         block.includes("prepare:files"),
       );
-      expect(setupBlock).toBeDefined();
+      if (!setupBlock) {
+        expect.fail("CONTRIBUTING.md lost its bash block naming the command");
+      }
 
       const named = [
-        ...(setupBlock ?? "").matchAll(/pnpm ([a-z:.-]+)/g),
+        ...setupBlock.matchAll(/pnpm ([a-z:.-]+)/g),
       ].flatMap((match) => (match[1] ? [match[1]] : []));
       expect(named.length).toBeGreaterThan(0);
       for (const name of named) {

--- a/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
+++ b/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
@@ -60,9 +60,9 @@ describe("given a fresh checkout without generated files", () => {
         expect.fail("CONTRIBUTING.md lost its bash block naming the command");
       }
 
-      const named = [
-        ...setupBlock.matchAll(/pnpm ([a-z:.-]+)/g),
-      ].flatMap((match) => (match[1] ? [match[1]] : []));
+      const named = [...setupBlock.matchAll(/pnpm ([a-z:.-]+)/g)].flatMap(
+        (match) => (match[1] ? [match[1]] : []),
+      );
       expect(named.length).toBeGreaterThan(0);
       for (const name of named) {
         expect(root[name]).toBeDefined();

--- a/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
+++ b/platform/app/src/server/__tests__/prepare-scripts.unit.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-// vitest runs from the app package root, so the repository root is one level up.
+// vitest runs from the app package root, so the repository root is two levels up.
 const REPO_ROOT = resolve(process.cwd(), "../..");
 
 type Scripts = Record<string, string | undefined>;
@@ -58,9 +58,9 @@ describe("given a fresh checkout without generated files", () => {
       );
       expect(setupBlock).toBeDefined();
 
-      const named = [...(setupBlock ?? "").matchAll(/pnpm ([a-z:.-]+)/g)].map(
-        (match) => match[1],
-      );
+      const named = [
+        ...(setupBlock ?? "").matchAll(/pnpm ([a-z:.-]+)/g),
+      ].flatMap((match) => (match[1] ? [match[1]] : []));
       expect(named.length).toBeGreaterThan(0);
       for (const name of named) {
         expect(root[name]).toBeDefined();

--- a/specs/setup/generated-files-regeneration.feature
+++ b/specs/setup/generated-files-regeneration.feature
@@ -1,0 +1,29 @@
+Feature: Regenerating generated files on a fresh checkout
+  As a contributor opening a fresh clone or worktree
+  I want one obvious command that generates the missing files
+  So that my first typecheck does not read as broken code
+
+  # Generated clients are not committed, so a checkout without them fails
+  # typecheck with hundreds of "Cannot find module" errors. The generator
+  # chain lives in the app package under `start:prepare:files`, while setup
+  # guidance has used both that name and the root's `prepare:files`; both
+  # names resolve from the repository root so no reference points at a
+  # script that is missing where it runs.
+
+  @unit
+  Scenario: Both documented names reach the same generator chain
+    Given the repository root and the app package each expose a prepare script
+    When either documented name is invoked from the repository root
+    Then both names route to the app package's generator chain
+
+  @unit
+  Scenario: The app keeps the generator chain its build calls by name
+    Given the app build and development scripts call their generator chain by name
+    When the app package scripts are read
+    Then the chain still sits under the name those scripts invoke
+
+  @unit
+  Scenario: Setup guidance names a script that exists where it says to run it
+    Given contributing documentation tells a newcomer how to generate the files
+    When every command that guidance names is looked up in the scripts it targets
+    Then each command resolves without a missing-script error


### PR DESCRIPTION
# Related Issue

- Resolves #7432

## What the issue found, after checking the premise

The names were inverted in the report but the trap is real: `start:prepare:files` exists in `platform/app`, and the root proxy is `prepare:files`. Running `pnpm start:prepare:files` from the repository root (where most setup guidance tells you to work) fails with "missing script", and nothing in `CONTRIBUTING.md` mentioned generation at all.

The root alias half of this is now handled by #7470, which landed first; this PR no longer touches `package.json`.

## Changes

- **CONTRIBUTING.md** gains a "Fresh checkout or new worktree" section: install + generate are both required, the command, and when to re-run it.
- **Spec + guard test:** `specs/setup/generated-files-regeneration.feature` (three `@unit` scenarios, 3/3 bound) pins that both names route to the app chain, that the app keeps the name its build/dev scripts call, and that CONTRIBUTING only names commands that exist. The binding lives in a unit test beside the other package.json-shape tests.

No behavior change; CI workflows keep calling `start:prepare:files` inside their own contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added setup guidance for generating required files after a fresh checkout or schema update.
  - Documented both preparation commands and when to rerun them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->