### PR TITLE
fix(dashboards): dashboard list count matches what the grid renders

### DIFF
--- a/platform/app/src/server/analytics/placeableKindFilter.ts
+++ b/platform/app/src/server/analytics/placeableKindFilter.ts
@@ -1,0 +1,51 @@
+import type { PrismaClient } from "~/generated/prisma/client";
+import {
+  BUILDER_CHART_KIND,
+  WORKBENCH_SQL_CHART_KIND,
+} from "~/server/analytics/chartKinds";
+import { lwqlEnabled } from "~/server/analytics/lwql/access";
+
+/**
+ * The kinds that can sit on a dashboard grid *when the workbench is on*.
+ *
+ * Used only by the procedures that move, resize, remove or count a *card*.
+ * Anything that reads or writes a row's `graph` payload stays scoped to the
+ * single kind whose shape it understands.
+ */
+export const PLACEABLE_CHART_KINDS = [
+  BUILDER_CHART_KIND,
+  WORKBENCH_SQL_CHART_KIND,
+] as const;
+
+/** The `kind` clause a card-level query sends to Prisma. */
+export type PlaceableKindWhere = { kind: string | { in: string[] } };
+
+/**
+ * The kinds a card-level query may touch for this project.
+ *
+ * Asked by every card-level procedure — the graph-card read, all three
+ * placement writes, and the dashboard list's card count — so that a
+ * deployment with the workbench off sees exactly the grid it saw before, and
+ * cannot move, resize, delete or *count* a `workbench_sql` row left behind by
+ * a trial. Gating only the read would leave the rows invisible but still
+ * mutable: a member's reflow of the charts they *can* see would silently
+ * rewrite the placement of ones they cannot, a delete by id would remove a
+ * row the surface never admitted existed, and a list count that skipped the
+ * gate would advertise cards the detail read will not return.
+ */
+export async function placeableKindFilter({
+  prisma,
+  projectId,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+}): Promise<PlaceableKindWhere> {
+  // The filter itself rather than the kind list, so every caller emits the
+  // identical clause. With the workbench off that clause is the bare
+  // `kind: "builder"` the grid used before this feature existed — which is
+  // what makes "exactly the old grid" a statement about the query and not
+  // just about the rows it happens to return.
+  return (await lwqlEnabled({ prisma, projectId }))
+    ? { kind: { in: [...PLACEABLE_CHART_KINDS] } }
+    : { kind: BUILDER_CHART_KIND };
+}

--- a/platform/app/src/server/api/routers/graphs.ts
+++ b/platform/app/src/server/api/routers/graphs.ts
@@ -1,57 +1,16 @@
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import type { PrismaClient } from "~/generated/prisma/client";
 import { allocateNextGridRow } from "~/server/analytics/allocateNextGridRow";
 import {
   BUILDER_CHART_KIND,
   WORKBENCH_SQL_CHART_KIND,
 } from "~/server/analytics/chartKinds";
 import { dashboardBelongsToProject } from "~/server/analytics/dashboardBelongsToProject";
-import { lwqlEnabled } from "~/server/analytics/lwql/access";
+import { placeableKindFilter } from "~/server/analytics/placeableKindFilter";
 import { redactActionParamsFor } from "~/server/app-layer/automations/providers/registry";
 import { type FilterField, filterFieldsEnum } from "../../filters/types";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
-
-/**
- * The kinds that can sit on a dashboard grid *when the workbench is on*.
- *
- * Used only by the procedures that move, resize or remove a *card*. Anything
- * that reads or writes a row's `graph` payload stays scoped to the single kind
- * whose shape it understands.
- */
-const PLACEABLE_CHART_KINDS = [
-  BUILDER_CHART_KIND,
-  WORKBENCH_SQL_CHART_KIND,
-] as const;
-
-/**
- * The kinds a placement procedure may touch for this project.
- *
- * Asked by every card-level procedure — the read and all three writes — so
- * that a deployment with the workbench off sees exactly the grid it saw
- * before, and cannot move, resize or delete a `workbench_sql` row left behind
- * by a trial. Gating only the read would leave the rows invisible but still
- * mutable: a member's reflow of the charts they *can* see would silently
- * rewrite the placement of ones they cannot, and a delete by id would remove a
- * row the surface never admitted existed.
- */
-async function placeableKindFilter({
-  prisma,
-  projectId,
-}: {
-  prisma: PrismaClient;
-  projectId: string;
-}): Promise<{ kind: string | { in: string[] } }> {
-  // The filter itself rather than the kind list, so all four procedures emit
-  // the identical clause. With the workbench off that clause is the bare
-  // `kind: "builder"` the grid used before this feature existed — which is
-  // what makes "exactly the old grid" a statement about the query and not
-  // just about the rows it happens to return.
-  return (await lwqlEnabled({ prisma, projectId }))
-    ? { kind: { in: [...PLACEABLE_CHART_KINDS] } }
-    : { kind: BUILDER_CHART_KIND };
-}
 
 /**
  * Read-side hydration shape for the `Add / Edit alert` bell icon on the

--- a/platform/app/src/server/dashboards/__tests__/dashboard.getAll.chartCount.unit.test.ts
+++ b/platform/app/src/server/dashboards/__tests__/dashboard.getAll.chartCount.unit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The dashboard list's card count and the grid read must agree.
+ *
+ * `DashboardRepository.findAll` used to count `graphs` with no `kind`
+ * predicate while every graph-card procedure gates on `placeableKindFilter`,
+ * so the list advertised `workbench_sql` rows the dashboard read would never
+ * return (issue #7437). Asserted on the `kind` clause the count sends to
+ * Prisma, in both flag states, because that clause IS the agreement: it is
+ * derived from the same filter the card procedures call.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PrismaClient } from "~/generated/prisma/client";
+import {
+  BUILDER_CHART_KIND,
+  WORKBENCH_SQL_CHART_KIND,
+} from "~/server/analytics/chartKinds";
+import { placeableKindFilter } from "~/server/analytics/placeableKindFilter";
+import { DashboardService } from "../dashboard.service";
+
+// The gate itself, stubbed per test: this suite is about the clause the count
+// emits with each answer, not about how the flag resolves (which `access.ts`
+// and its own tests own).
+const lwqlEnabledMock = vi.fn();
+vi.mock("~/server/analytics/lwql/access", () => ({
+  lwqlEnabled: (args: unknown) => lwqlEnabledMock(args),
+  LWQL_FLAG: "release_lwql_workbench",
+}));
+
+const findMany = vi.fn();
+
+const createService = () => {
+  const prisma = {
+    dashboard: { findMany },
+  } as unknown as PrismaClient;
+  return { service: DashboardService.create(prisma), prisma };
+};
+
+/** The `kind` clause the graph count of the first recorded call is scoped by. */
+const countKindClauseOf = (spy: ReturnType<typeof vi.fn>): unknown =>
+  spy.mock.calls[0]?.[0]?.include?._count?.select?.graphs?.where?.kind;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findMany.mockResolvedValue([]);
+});
+
+describe("the dashboard list's card count", () => {
+  describe("given the workbench is on for the project", () => {
+    beforeEach(() => {
+      lwqlEnabledMock.mockResolvedValue(true);
+    });
+
+    /** @scenario "The dashboard list counts exactly the cards the grid will render" */
+    it("counts both placeable kinds, matching the grid read", async () => {
+      const { service, prisma } = createService();
+
+      await service.getAll("project_1");
+
+      const gridClause = await placeableKindFilter({
+        prisma,
+        projectId: "project_1",
+      });
+      expect(countKindClauseOf(findMany)).toEqual({
+        in: [BUILDER_CHART_KIND, WORKBENCH_SQL_CHART_KIND],
+      });
+      expect(countKindClauseOf(findMany)).toEqual(gridClause.kind);
+    });
+  });
+
+  describe("given the workbench is off for the project", () => {
+    beforeEach(() => {
+      lwqlEnabledMock.mockResolvedValue(false);
+    });
+
+    /** @scenario "The dashboard list counts exactly the cards the grid will render" */
+    it("counts only builder graphs, as it did before the feature existed", async () => {
+      const { service, prisma } = createService();
+
+      await service.getAll("project_1");
+
+      const gridClause = await placeableKindFilter({
+        prisma,
+        projectId: "project_1",
+      });
+      expect(countKindClauseOf(findMany)).toEqual(BUILDER_CHART_KIND);
+      expect(countKindClauseOf(findMany)).toEqual(gridClause.kind);
+    });
+  });
+});

--- a/platform/app/src/server/dashboards/dashboard.repository.ts
+++ b/platform/app/src/server/dashboards/dashboard.repository.ts
@@ -5,6 +5,7 @@ import type {
 } from "~/generated/prisma/client";
 
 import { BUILDER_CHART_KIND } from "~/server/analytics/chartKinds";
+import type { PlaceableKindWhere } from "~/server/analytics/placeableKindFilter";
 
 /**
  * Input types for dashboard operations
@@ -31,8 +32,16 @@ export class DashboardRepository {
 
   /**
    * Finds all dashboards for a project, ordered by order field.
+   *
+   * The card count is scoped by the caller-supplied `kind` clause so the list
+   * advertises exactly the cards the dashboard's grid will render — the
+   * service derives the clause from the same gate the graph-card procedures
+   * apply, which is what keeps the two endpoints of one resource agreeing.
    */
-  async findAll(input: { projectId: string }): Promise<
+  async findAll(input: {
+    projectId: string;
+    graphKindWhere: PlaceableKindWhere;
+  }): Promise<
     Array<
       Dashboard & {
         _count: { graphs: number };
@@ -44,7 +53,7 @@ export class DashboardRepository {
       orderBy: { order: "asc" },
       include: {
         _count: {
-          select: { graphs: true },
+          select: { graphs: { where: input.graphKindWhere } },
         },
       },
     });

--- a/platform/app/src/server/dashboards/dashboard.service.ts
+++ b/platform/app/src/server/dashboards/dashboard.service.ts
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import type { PrismaClient } from "~/generated/prisma/client";
+import { placeableKindFilter } from "~/server/analytics/placeableKindFilter";
 import { DashboardRepository } from "./dashboard.repository";
 import { DashboardNotFoundError, DashboardReorderError } from "./errors";
 
@@ -25,10 +26,17 @@ export class DashboardService {
   }
 
   /**
-   * Gets all dashboards for a project.
+   * Gets all dashboards for a project, each with its placeable-card count.
+   *
+   * The count applies the same flag-aware kind gate the graph-card procedures
+   * apply, so the list never advertises a card the dashboard read excludes.
    */
   async getAll(projectId: string) {
-    return await this.repository.findAll({ projectId });
+    const graphKindWhere = await placeableKindFilter({
+      prisma: this.prisma,
+      projectId,
+    });
+    return await this.repository.findAll({ projectId, graphKindWhere });
   }
 
   /**

--- a/specs/analytics/lwql-saved-charts.feature
+++ b/specs/analytics/lwql-saved-charts.feature
@@ -376,6 +376,13 @@ Feature: Saved LangWatchQL workbench charts — the persistence model and its wr
     When the card is rendered
     Then the builder renderer draws it and the add-alert control is offered
 
+  @unit
+  Scenario: The dashboard list counts exactly the cards the grid will render
+    Given a dashboard holding a builder graph and a saved workbench chart
+    When the dashboards are listed with the workbench on and again with it off
+    Then in each state the list's card count admits the same kinds the dashboard's grid read admits
+    And with the workbench off the count sees only builder graphs, as it did before the feature existed
+
   @integration
   Scenario: A workbench card is not offered an alert it cannot evaluate
     Given a dashboard grid holding a saved workbench chart


### PR DESCRIPTION
# Related Issue

- Resolves #7437

Stacked on #7443 (PR5). Fixes #7437.

## What

`DashboardRepository.findAll` counted all graphs unfiltered while the dashboard grid read gates cards through `placeableKindFilter()` — so with the LWQL flag off, a dashboard holding workbench charts showed a count larger than the cards rendered. The filter is now a shared module (`server/analytics/placeableKindFilter.ts`) applied identically to the count and the read.

## How I can prove I was successful

- New unit test `dashboard.getAll.chartCount.unit.test.ts` (2/2) asserts the count's kind clause equals `placeableKindFilter`'s output in both flag states; sabotage (unfiltered count) fails it.
- `graphs.workbenchGate.unit.test.ts` 7/7 — extraction changed no card-procedure behavior.
- typecheck + typecheck:all exit 0, biome 0 errors, parity 50/50 bound.
- Live-browser QA (below): count == rendered cards in both flag states, builder-only regression clean.

## Browser QA evidence

Dashboard "Reports" holds 2 builder charts + 1 `workbench_sql` chart; "QA Builder Only" holds 1 builder chart. The list count surface is `dashboards.getAll` `_count.graphs` (rendered as tRPC JSON in-browser — no UI page shows the count directly).

**Flag ON — list counts Reports=3, QA Builder Only=1:**

![flag on list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7472/01-flag-on-list.png)

**Flag ON — detail grid renders exactly 3 cards (incl. workbench):**

![flag on detail](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7472/02-flag-on-detail.png)

**Flag OFF — list count drops to 2 (workbench excluded):**

![flag off list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7472/03-flag-off-list.png)

**Flag OFF — grid renders only the 2 builder cards:**

![flag off detail](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7472/04-flag-off-detail.png)

**Regression — builder-only dashboard counts 1 and renders 1 in both flag states:**

![regression](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7472/05-regression-builder-only-detail.png)

## Human verification

Place a workbench chart on a dashboard, turn the LWQL flag off: dashboard list count should equal the cards shown on the dashboard (previously off by the hidden workbench cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
