### PR TITLE
feat(lwql): name the columns a statement selects that no dataset defines

### DIFF
--- a/platform/app/src/features/analytics-query/__tests__/LangWatchQLResultPane.integration.test.tsx
+++ b/platform/app/src/features/analytics-query/__tests__/LangWatchQLResultPane.integration.test.tsx
@@ -583,6 +583,47 @@ describe("the LangWatchQL result pane", () => {
         );
         expect(chip()).toBe("Timed out");
       });
+
+      /** @scenario "An unhandled failure is never dressed as a refusal" */
+      it("labels an unnamed failure as Failed, never Refused", () => {
+        renderPane(
+          stateWith({
+            answer: { kind: "error", error: new Error("boom") },
+          }),
+        );
+
+        const chip = screen.getByTestId("lwql-result-chip");
+        expect(chip).toHaveTextContent("Failed");
+        // The pane beside the chip says "we've been notified"; a chip claiming
+        // the server refused the statement would contradict it.
+        expect(chip.textContent).not.toContain("Refused");
+        expect(chip.getAttribute("title")).not.toContain("before reading");
+      });
+
+      /** @scenario "An unknown column is presented as the member's own refusal, naming the column" */
+      it("refuses an unknown column by name without claiming it happened before reading", () => {
+        renderPane(
+          stateWith({
+            answer: {
+              kind: "error",
+              error: handledErrorEnvelope({
+                code: "lwql_unknown_identifier",
+                meta: { identifiers: ["NoSuchColumn"] },
+              }),
+            },
+          }),
+        );
+
+        const chip = screen.getByTestId("lwql-result-chip");
+        expect(chip).toHaveTextContent("Refused");
+        // The refusal happens while the server resolves the statement's
+        // names — after the query has started — so the chip must not claim it
+        // happened before reading any data.
+        expect(chip.getAttribute("title")).not.toContain("before reading");
+        expect(screen.getByTestId("lwql-result-pane").textContent).toContain(
+          "NoSuchColumn",
+        );
+      });
     });
   });
 

--- a/platform/app/src/features/analytics-query/components/LangWatchQLResultPane.tsx
+++ b/platform/app/src/features/analytics-query/components/LangWatchQLResultPane.tsx
@@ -50,6 +50,7 @@ import { formatNumber } from "~/utils/formatNumber";
 import {
   type LangWatchQLFailure,
   LWQL_TIMEOUT_CODE,
+  LWQL_UNKNOWN_IDENTIFIER_CODE,
   LWQL_UNPARSEABLE_CODE,
   readLangWatchQLFailure,
 } from "../logic/lwqlFailure";
@@ -94,6 +95,43 @@ interface ResultChip {
   readonly title: string;
 }
 
+/** The pill for a failed submission, honest about where the failure happened. */
+function errorChip(failure: LangWatchQLFailure): ResultChip {
+  if (failure.code === LWQL_TIMEOUT_CODE) {
+    return {
+      label: "Timed out",
+      palette: "orange",
+      title: "The database stopped the read at its time ceiling",
+    };
+  }
+  // An unhandled failure named nothing, so the chip must not dress it as a
+  // refusal — the pane beside it is saying "we've been notified", and the
+  // two surfaces have to agree about whose failure this is.
+  if (failure.code === undefined) {
+    return {
+      label: "Failed",
+      palette: "red",
+      title: "The query failed for a reason the server did not name",
+    };
+  }
+  // The unknown-column refusal happens while the server resolves the
+  // statement's names — after the query has started — so its chip must not
+  // claim it happened before reading.
+  if (failure.code === LWQL_UNKNOWN_IDENTIFIER_CODE) {
+    return {
+      label: "Refused",
+      palette: "red",
+      title:
+        "The server refused this statement while resolving its column names",
+    };
+  }
+  return {
+    label: "Refused",
+    palette: "red",
+    title: "The server refused this statement before reading any data",
+  };
+}
+
 function resultChip({
   state,
   failure,
@@ -104,17 +142,7 @@ function resultChip({
   isStale: boolean;
 }): ResultChip | undefined {
   if (state.outcome?.kind === "error" && failure) {
-    return failure.code === LWQL_TIMEOUT_CODE
-      ? {
-          label: "Timed out",
-          palette: "orange",
-          title: "The database stopped the read at its time ceiling",
-        }
-      : {
-          label: "Refused",
-          palette: "red",
-          title: "The server refused this statement before reading any data",
-        };
+    return errorChip(failure);
   }
   if (state.outcome?.kind !== "result") return undefined;
   if (isStale) {

--- a/platform/app/src/features/analytics-query/logic/lwqlFailure.ts
+++ b/platform/app/src/features/analytics-query/logic/lwqlFailure.ts
@@ -28,6 +28,7 @@ export const LWQL_RESERVED_PARAMETER_SUPPLIED_CODE =
 export const LWQL_UNAVAILABLE_CODE = "lwql_unavailable";
 export const LWQL_NOT_ENABLED_CODE = "lwql_not_enabled";
 export const LWQL_TIMEOUT_CODE = "query_timeout";
+export const LWQL_UNKNOWN_IDENTIFIER_CODE = "lwql_unknown_identifier";
 
 /** Where in the submitted statement a refusal points. */
 export interface LangWatchQLSourcePosition {

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -195,6 +195,7 @@ export const APP_ERROR_CODES = [
   "lwql_reserved_parameter_supplied",
   "lwql_reserved_parameter_type",
   "lwql_unavailable",
+  "lwql_unknown_identifier",
   "lwql_unparseable",
   "malformed_custom_role_permissions",
   "malformed_request",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -422,6 +422,16 @@ const presentations = {
     describe: () =>
       "This feature isn't switched on for this workspace yet. Ask your workspace administrator to enable it, or contact support.",
   },
+  lwql_unknown_identifier: {
+    title: "This query names a column that doesn't exist",
+    describe: (error) => {
+      const identifiers = error.meta.identifiers;
+      if (Array.isArray(identifiers) && identifiers.length > 0) {
+        return `No dataset defines ${identifiers.map((name) => `"${String(name)}"`).join(", ")}. Check the spelling against the columns the schema lists and run again.`;
+      }
+      return "Check every column name against the columns the schema lists and run again.";
+    },
+  },
   cli_key_selection_invalid: {
     title: "Check the access selection",
     describe: (error) => {

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.integration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * A saved statement that names a column no dataset defines, as the caller
+ * experiences it.
+ *
+ * Save-time validation proves tables and syntax but not column existence —
+ * only the database knows that — so this failure can only be named at run
+ * time (#7447). What this file proves against a real server: UNKNOWN_IDENTIFIER
+ * arrives as the coded `lwql_unknown_identifier`, a caller fault, with the
+ * missing names in `meta.identifiers`, while the same-shaped query naming only
+ * real columns still runs. The classification and extraction are unit-tested
+ * against synthesised driver errors
+ * (`app-layer/clients/clickhouse/__tests__/translate-query-error.unit.test.ts`
+ * and {@link lwqlUnknownIdentifier.unit.test.ts}); only a real server can say
+ * the synthesised shape is what ClickHouse actually raises.
+ *
+ * Habit carried over from the sibling suite: every refusal is paired with a
+ * succeeding query, so a broken executor cannot read as a working mapping.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createLangWatchQLExecutor,
+  DEFAULT_LWQL_RESULT_LIMITS,
+  type LangWatchQLExecutor,
+} from "../executor";
+import {
+  type LangWatchQLClickHouseHarness,
+  recordSeedControl,
+  startLangWatchQLClickHouse,
+} from "./lwqlClickHouseHarness";
+
+describe("given a statement naming a column no dataset defines", () => {
+  let harness: LangWatchQLClickHouseHarness;
+  let executor: LangWatchQLExecutor;
+  let database: string;
+
+  /** The thrown error itself, or why there is none. */
+  const failureOf = async (
+    sql: string,
+  ): Promise<{ code?: unknown; meta?: unknown } | "<succeeded>"> => {
+    try {
+      await executor.execute({
+        sql,
+        tenantCapability: harness.tenantA.keyHash,
+        limits: DEFAULT_LWQL_RESULT_LIMITS,
+      });
+    } catch (error) {
+      return error as { code?: unknown; meta?: unknown };
+    }
+    return "<succeeded>";
+  };
+
+  beforeAll(async () => {
+    harness = await startLangWatchQLClickHouse({ suite: "unknown-identifier" });
+    database = harness.names.database;
+    executor = createLangWatchQLExecutor({
+      ...harness.restrictedConnection(),
+      database,
+      tenantSetting: harness.names.tenantSetting,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (!harness) return;
+    await harness.stop();
+  });
+
+  describe("when the query selects a column that does not exist", () => {
+    // @scenario "A query naming a column no dataset has fails with a coded, member-actionable error"
+    it("fails with lwql_unknown_identifier carrying the missing names", async () => {
+      const failure = await failureOf(
+        `SELECT TraceId, no_such_column_anywhere FROM ${database}.traces LIMIT 1`,
+      );
+
+      expect(failure).not.toBe("<succeeded>");
+      const { code, meta } = failure as { code?: unknown; meta?: unknown };
+      expect(code).toBe("lwql_unknown_identifier");
+      expect(meta).toEqual({ identifiers: ["no_such_column_anywhere"] });
+    });
+
+    it("answers the same-shaped query that names only real columns", async () => {
+      const control = await recordSeedControl({
+        harness,
+        table: "traces",
+        tenantColumn: "TenantId",
+      });
+
+      const result = await executor.execute({
+        sql: `SELECT TraceId FROM ${database}.traces ORDER BY TraceId`,
+        tenantCapability: harness.tenantA.keyHash,
+        limits: DEFAULT_LWQL_RESULT_LIMITS,
+      });
+
+      expect(result.rows.length).toBe(control.tenantA);
+    });
+  });
+
+  describe("when several named columns are missing", () => {
+    // The server reports one identifier per refusal — the first it cannot
+    // resolve — so the member fixes one and meets the next on the next run.
+    it("names the first unresolvable column", async () => {
+      const failure = await failureOf(
+        `SELECT missing_b, missing_a FROM ${database}.traces LIMIT 1`,
+      );
+
+      expect(failure).not.toBe("<succeeded>");
+      const { code, meta } = failure as { code?: unknown; meta?: unknown };
+      expect(code).toBe("lwql_unknown_identifier");
+      expect(meta).toEqual({ identifiers: ["missing_b"] });
+    });
+  });
+});

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.integration.test.ts
@@ -65,7 +65,7 @@ describe("given a statement naming a column no dataset defines", () => {
     if (!harness) return;
     // The executor owns a connection pool against this server; release it
     // before the container stops, or the sockets outlive the suite.
-    await executor.close();
+    await executor.close?.();
     await harness.stop();
   });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.integration.test.ts
@@ -63,6 +63,9 @@ describe("given a statement naming a column no dataset defines", () => {
 
   afterAll(async () => {
     if (!harness) return;
+    // The executor owns a connection pool against this server; release it
+    // before the container stops, or the sockets outlive the suite.
+    await executor.close();
     await harness.stop();
   });
 

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clickHouseMissingIdentifiers,
+  isClickHouseUnknownIdentifierError,
+} from "~/server/app-layer/clients/clickhouse/translate-query-error";
+
+/**
+ * A synthesised ClickHouse refusal, in the two forms the driver delivers:
+ * typed properties on its own error objects, and the `Code: <n>.` prefix on a
+ * raw HTTP body. The wordings are the engine's own, verbatim from a 25.8
+ * server (`Unknown expression identifier` for analysis failures) plus the
+ * `Missing columns:` listing shape other paths raise.
+ */
+const driverError = (message: string): Error =>
+  Object.assign(new Error(message), {
+    code: "47",
+    type: "UNKNOWN_IDENTIFIER",
+  });
+
+// Verbatim from the server, including the echoed statement after "in scope".
+const SCOPED_REFUSAL =
+  "Code: 47. DB::Exception: Unknown expression identifier `no_such_column_anywhere` in scope SELECT no_such_column_anywhere FROM system.one. (UNKNOWN_IDENTIFIER) (version 25.8.1.5101 (official build))";
+
+describe("given a ClickHouse refusal for unknown identifiers", () => {
+  describe("when the refusal arrives by code or type or body prefix", () => {
+    it("is recognised in all three delivery forms", () => {
+      expect(isClickHouseUnknownIdentifierError(driverError("x"))).toBe(true);
+      expect(
+        isClickHouseUnknownIdentifierError(
+          Object.assign(
+            new Error(
+              "Code: 47. DB::Exception: Unknown expression identifier `c` in scope SELECT c.",
+            ),
+            { type: "UNKNOWN_IDENTIFIER" },
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        isClickHouseUnknownIdentifierError(new Error("some other failure")),
+      ).toBe(false);
+    });
+  });
+
+  describe("when the statement that produced it also contains quoted text", () => {
+    const echoed = driverError(SCOPED_REFUSAL);
+
+    // @scenario "Only the missing column names travel in the error meta"
+    it("extracts exactly the backquoted name, and nothing from the echoed scope", () => {
+      expect(clickHouseMissingIdentifiers(echoed)).toEqual([
+        "no_such_column_anywhere",
+      ]);
+    });
+
+    it("reads every name out of the listing wording too", () => {
+      const listed = driverError(
+        "Code: 47. DB::Exception: Missing columns: 'missing_b', 'missing_a' while processing query: SELECT \\'don\\'t leak this part\\'' FROM t",
+      );
+      expect(clickHouseMissingIdentifiers(listed)).toEqual([
+        "missing_a",
+        "missing_b",
+      ]);
+    });
+  });
+
+  describe("when the refusal carries no parseable clause", () => {
+    it("answers no identifiers rather than guessing", () => {
+      expect(
+        clickHouseMissingIdentifiers(driverError("Code: 47. DB::Exception.")),
+      ).toEqual([]);
+      expect(clickHouseMissingIdentifiers(new Error("unrelated"))).toEqual([]);
+    });
+  });
+});

--- a/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/lwqlUnknownIdentifier.unit.test.ts
@@ -23,19 +23,70 @@ const SCOPED_REFUSAL =
   "Code: 47. DB::Exception: Unknown expression identifier `no_such_column_anywhere` in scope SELECT no_such_column_anywhere FROM system.one. (UNKNOWN_IDENTIFIER) (version 25.8.1.5101 (official build))";
 
 describe("given a ClickHouse refusal for unknown identifiers", () => {
-  describe("when the refusal arrives by code or type or body prefix", () => {
-    it("is recognised in all three delivery forms", () => {
-      expect(isClickHouseUnknownIdentifierError(driverError("x"))).toBe(true);
+  describe("when the refusal arrives through one delivery form at a time", () => {
+    // Three separate errors, each carrying exactly one of the three forms the
+    // matcher reads — so a suite pass proves every form matches alone, not
+    // merely that one of them did.
+    it.each([
+      [
+        "the driver's numeric code property",
+        Object.assign(new Error("x"), { code: "47" }),
+      ],
+      [
+        "the driver's symbolic type property",
+        Object.assign(new Error("x"), { type: "UNKNOWN_IDENTIFIER" }),
+      ],
+      [
+        "the raw body's Code: prefix",
+        new Error(
+          "Code: 47. DB::Exception: Unknown expression identifier `c` in scope SELECT c.",
+        ),
+      ],
+    ])("recognises %s", (_label, error) => {
+      expect(isClickHouseUnknownIdentifierError(error)).toBe(true);
+    });
+
+    it("does not let a message token select the error class", () => {
+      // The symbolic name never matches out of the message: a member could
+      // alias a column UNKNOWN_IDENTIFIER and choose its own error otherwise.
+      const spoofed = new Error(
+        "SELECT UNKNOWN_IDENTIFIER AS x FROM MEMORY_LIMIT_EXCEEDED",
+      );
+      expect(isClickHouseUnknownIdentifierError(spoofed)).toBe(false);
+    });
+  });
+
+  describe("when the interpreter path refuses instead of the analyzer", () => {
+    it("recognises NO_SUCH_COLUMN_IN_TABLE as the same refusal", () => {
+      const interpreter = Object.assign(new Error("x"), { code: "16" });
+      expect(isClickHouseUnknownIdentifierError(interpreter)).toBe(true);
       expect(
-        isClickHouseUnknownIdentifierError(
+        clickHouseMissingIdentifiers(
           Object.assign(
             new Error(
-              "Code: 47. DB::Exception: Unknown expression identifier `c` in scope SELECT c.",
+              "Code: 16. DB::Exception: There is no column with name missing_col in table t",
             ),
-            { type: "UNKNOWN_IDENTIFIER" },
+            { code: "16" },
           ),
         ),
-      ).toBe(true);
+      ).toEqual(["missing_col"]);
+    });
+  });
+
+  describe("when the refused name is qualified with dots", () => {
+    it("keeps the whole dotted name intact", () => {
+      const dotted = driverError(
+        "Code: 47. DB::Exception: Unknown expression identifier `analytics.traces.user_id` in scope SELECT analytics.traces.user_id.",
+      );
+      expect(clickHouseMissingIdentifiers(dotted)).toEqual([
+        "analytics.traces.user_id",
+      ]);
+    });
+  });
+
+  describe("when the refusal arrives by code or type or body prefix", () => {
+    it("is recognised across the combined fixture too", () => {
+      expect(isClickHouseUnknownIdentifierError(driverError("x"))).toBe(true);
       expect(
         isClickHouseUnknownIdentifierError(new Error("some other failure")),
       ).toBe(false);

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -366,8 +366,12 @@ export class LangWatchQLUnknownIdentifierError extends HandledError {
   declare readonly code: "lwql_unknown_identifier";
 
   constructor(
-    /** The column names the server reported as missing. Sorted, deduplicated. */
-    identifiers: readonly string[],
+    options: {
+      /** The column names the server reported as missing. Sorted, deduplicated. */
+      readonly identifiers?: readonly string[];
+      /** The raw driver error, for the operator's logs. Never the response. */
+      readonly reasons?: readonly Error[];
+    } = {},
   ) {
     super(
       "lwql_unknown_identifier",
@@ -377,8 +381,9 @@ export class LangWatchQLUnknownIdentifierError extends HandledError {
         fault: "customer",
         // Named consumers: the workbench's error card, the dashboard widget,
         // and `langwatch chart run` output, which print code plus these names.
-        meta: { identifiers },
+        meta: options.identifiers ? { identifiers: options.identifiers } : {},
         ...remediation("lwql_unknown_identifier"),
+        ...(options.reasons ? { reasons: options.reasons } : {}),
       },
     );
     this.name = "LangWatchQLUnknownIdentifierError";

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -351,3 +351,36 @@ export class LangWatchQLGranularityRequiresTimeWindowError extends HandledError 
     this.name = "LangWatchQLGranularityRequiresTimeWindowError";
   }
 }
+
+/**
+ * The statement selects or filters on a column no dataset defines.
+ *
+ * The validator can refuse unknown tables and syntax at save time, but column
+ * existence only the database knows, so this surfaces at run time instead —
+ * and before it was mapped, it reached the workbench, dashboard widgets and
+ * CLI as an unknown 500 for something one edit fixes. The missing names ride
+ * in `meta.identifiers`, read out of ClickHouse's own refusal; nothing else
+ * from that refusal (which echoes the submitted SQL) travels.
+ */
+export class LangWatchQLUnknownIdentifierError extends HandledError {
+  declare readonly code: "lwql_unknown_identifier";
+
+  constructor(
+    /** The column names the server reported as missing. Sorted, deduplicated. */
+    identifiers: readonly string[],
+  ) {
+    super(
+      "lwql_unknown_identifier",
+      "The query names columns no dataset defines.",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        // Named consumers: the workbench's error card, the dashboard widget,
+        // and `langwatch chart run` output, which print code plus these names.
+        meta: { identifiers },
+        ...remediation("lwql_unknown_identifier"),
+      },
+    );
+    this.name = "LangWatchQLUnknownIdentifierError";
+  }
+}

--- a/platform/app/src/server/analytics/lwql/executor.ts
+++ b/platform/app/src/server/analytics/lwql/executor.ts
@@ -213,6 +213,46 @@ const LWQL_REQUEST_TIMEOUT_MS =
 const LWQL_MAX_OPEN_CONNECTIONS = 10;
 
 /**
+ * What a failed governed run throws, from whatever the driver raised.
+ *
+ * Three translations, in order of how specific the invariant behind them is:
+ *
+ * 1. An unknown column (UNKNOWN_IDENTIFIER / NO_SUCH_COLUMN_IN_TABLE) IS the
+ *    caller's SQL — column existence is the one thing save-time validation
+ *    deliberately does not check — so it becomes the handled
+ *    `lwql_unknown_identifier`, carrying only the names the member wrote.
+ *    The raw database text rides in `reasons` for the operator's logs and
+ *    never in the response: the message echoes the submitted query.
+ * 2. An unknown table/database or an access refusal CANNOT be the caller's
+ *    SQL: the validator only lets catalog-approved names reach this point. It
+ *    is a deployment whose LangWatchQL objects or grants are missing — the
+ *    same "not provisioned here" condition as a null executor, and it gets
+ *    the same answer.
+ * 3. Everything else reuses the read path's translation, so the resource
+ *    ceilings a caller can act on arrive as the platform's existing codes.
+ *    Anything it does not recognise stays unhandled and degrades to
+ *    "unknown" (ADR-045).
+ *
+ * Exported so the translation is testable without a live server; the executor
+ * is its only production caller.
+ */
+export function translateLangWatchQLExecutionError(
+  error: unknown,
+  durationMs: number,
+): unknown {
+  if (isClickHouseUnknownIdentifierError(error)) {
+    return new LangWatchQLUnknownIdentifierError({
+      identifiers: clickHouseMissingIdentifiers(error),
+      reasons: [toError(error)],
+    });
+  }
+  if (isClickHouseObjectUnavailableError(error)) {
+    return new LangWatchQLUnavailableError({ reasons: [toError(error)] });
+  }
+  return translateClickHouseQueryError(error, durationMs);
+}
+
+/**
  * An executor that runs LangWatchQL as the restricted identity.
  *
  * The client is built here rather than taken as an argument so that the two
@@ -261,32 +301,10 @@ export function createLangWatchQLExecutor(
           },
         };
       } catch (error) {
-        // An unknown table/database or an access refusal cannot be the
-        // caller's SQL: the validator only lets catalog-approved names reach
-        // this point. It is a deployment whose LangWatchQL objects or grants
-        // are missing — the same "not provisioned here" condition as a null
-        // executor, and it gets the same answer. The raw error rides in
-        // `reasons` for the operator's logs and never in the response.
-        if (isClickHouseObjectUnavailableError(error)) {
-          throw new LangWatchQLUnavailableError({ reasons: [toError(error)] });
-        }
-        // Unlike the objects above, a missing column CAN be the caller's SQL:
-        // save-time validation proves tables and syntax, but nothing proves
-        // every selected column exists. The member-authored statement gets a
-        // coded refusal naming what to fix; only the missing names travel,
-        // never the database's message, which echoes the submitted query.
-        if (isClickHouseUnknownIdentifierError(error)) {
-          throw new LangWatchQLUnknownIdentifierError(
-            clickHouseMissingIdentifiers(error),
-          );
-        }
-        // Reuses the read path's translation, so the two resource ceilings a
-        // caller can act on arrive as the platform's existing codes rather than
-        // as a second vocabulary for the same two failures. Anything it does
-        // not recognise stays unhandled and degrades to "unknown" — correct,
-        // because a driver diagnostic is not something a caller can act on and
-        // is exactly the kind of text this API must not relay.
-        throw translateClickHouseQueryError(error, Date.now() - startedAt);
+        throw translateLangWatchQLExecutionError(
+          error,
+          Date.now() - startedAt,
+        );
       }
     },
 

--- a/platform/app/src/server/analytics/lwql/executor.ts
+++ b/platform/app/src/server/analytics/lwql/executor.ts
@@ -236,10 +236,13 @@ const LWQL_MAX_OPEN_CONNECTIONS = 10;
  * Exported so the translation is testable without a live server; the executor
  * is its only production caller.
  */
-export function translateLangWatchQLExecutionError(
-  error: unknown,
-  durationMs: number,
-): unknown {
+export function translateLangWatchQLExecutionError({
+  error,
+  durationMs,
+}: {
+  error: unknown;
+  durationMs: number;
+}): unknown {
   if (isClickHouseUnknownIdentifierError(error)) {
     return new LangWatchQLUnknownIdentifierError({
       identifiers: clickHouseMissingIdentifiers(error),
@@ -301,10 +304,10 @@ export function createLangWatchQLExecutor(
           },
         };
       } catch (error) {
-        throw translateLangWatchQLExecutionError(
+        throw translateLangWatchQLExecutionError({
           error,
-          Date.now() - startedAt,
-        );
+          durationMs: Date.now() - startedAt,
+        });
       }
     },
 

--- a/platform/app/src/server/analytics/lwql/executor.ts
+++ b/platform/app/src/server/analytics/lwql/executor.ts
@@ -34,12 +34,17 @@ import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import { createLogger } from "@langwatch/observability";
 
 import {
+  clickHouseMissingIdentifiers,
   isClickHouseObjectUnavailableError,
+  isClickHouseUnknownIdentifierError,
   translateClickHouseQueryError,
 } from "~/server/app-layer/clients/clickhouse/translate-query-error";
 import { toError } from "~/utils/posthogErrorCapture";
 
-import { LangWatchQLUnavailableError } from "./errors";
+import {
+  LangWatchQLUnavailableError,
+  LangWatchQLUnknownIdentifierError,
+} from "./errors";
 import { DEFAULT_LWQL_RESOURCE_LIMITS } from "./provisioning";
 
 const logger = createLogger("langwatch:analytics:lwql:executor");
@@ -264,6 +269,16 @@ export function createLangWatchQLExecutor(
         // `reasons` for the operator's logs and never in the response.
         if (isClickHouseObjectUnavailableError(error)) {
           throw new LangWatchQLUnavailableError({ reasons: [toError(error)] });
+        }
+        // Unlike the objects above, a missing column CAN be the caller's SQL:
+        // save-time validation proves tables and syntax, but nothing proves
+        // every selected column exists. The member-authored statement gets a
+        // coded refusal naming what to fix; only the missing names travel,
+        // never the database's message, which echoes the submitted query.
+        if (isClickHouseUnknownIdentifierError(error)) {
+          throw new LangWatchQLUnknownIdentifierError(
+            clickHouseMissingIdentifiers(error),
+          );
         }
         // Reuses the read path's translation, so the two resource ceilings a
         // caller can act on arrive as the platform's existing codes rather than

--- a/platform/app/src/server/app-layer/clients/clickhouse/translate-query-error.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/translate-query-error.ts
@@ -68,9 +68,18 @@ const ACCESS_DENIED: ServerError = { code: "497", name: "ACCESS_DENIED" };
 // this one CAN be the caller's SQL — member-authored LangWatchQL statements
 // are checked against the catalog at save time, but nothing there proves the
 // columns they select exist.
+// The two shapes of "the statement names a column that is not there": the
+// analyzer's UNKNOWN_IDENTIFIER (47) and the older interpreter path's
+// NO_SUCH_COLUMN_IN_TABLE (16). Grouped because they are the same fact to a
+// caller — a column name the datasets do not expose — differing only in which
+// stage of the server noticed.
 const UNKNOWN_IDENTIFIER: ServerError = {
   code: "47",
   name: "UNKNOWN_IDENTIFIER",
+};
+const NO_SUCH_COLUMN_IN_TABLE: ServerError = {
+  code: "16",
+  name: "NO_SUCH_COLUMN_IN_TABLE",
 };
 
 /**
@@ -132,7 +141,10 @@ export function isClickHouseObjectUnavailableError(error: unknown): boolean {
  */
 export function isClickHouseUnknownIdentifierError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  return raisedServerError({ error, variants: [UNKNOWN_IDENTIFIER] });
+  return raisedServerError({
+    error,
+    variants: [UNKNOWN_IDENTIFIER, NO_SUCH_COLUMN_IN_TABLE],
+  });
 }
 
 /**
@@ -152,19 +164,25 @@ export function isClickHouseUnknownIdentifierError(error: unknown): boolean {
 export function clickHouseMissingIdentifiers(error: unknown): string[] {
   if (!(error instanceof Error)) return [];
 
+  const shapes: readonly RegExp[] = [
+    // Analyzer: Unknown expression identifier `x` in scope SELECT ...
+    /Unknown expression(?: or function)? identifier [`'"]([^`'"\s]{1,128})[`'"]/,
+    // Legacy analyzer: Missing columns: 'a', 'b' while processing query: ...
+    /Missing columns:\s*(.+?)(?:\s+while processing|\.|$)/s,
+    // Interpreter paths over a table's own columns.
+    /There is no column with name [`']?([\w.]{1,128})/,
+    /No such column ([\w.]{1,128}) in table/,
+  ];
+
   const names: string[] = [];
-
-  const scoped =
-    /Unknown expression(?: or function)? identifier `([^`]+)`/.exec(
-      error.message,
-    )?.[1];
-  if (scoped) names.push(scoped);
-
-  const listed = /Missing columns:\s*(.+?)(?:\s+while processing|\.|$)/s.exec(
-    error.message,
-  )?.[1];
-  if (listed) {
-    names.push(...[...listed.matchAll(/'([^']*)'/g)].map((match) => match[1] ?? ""));
+  for (const shape of shapes) {
+    const clause = shape.exec(error.message)?.[1];
+    if (!clause) continue;
+    if (shape.source.startsWith("Missing columns")) {
+      names.push(...[...clause.matchAll(/'([^']*)'/g)].map((m) => m[1] ?? ""));
+    } else {
+      names.push(clause);
+    }
   }
 
   return [...new Set(names)].sort();

--- a/platform/app/src/server/app-layer/clients/clickhouse/translate-query-error.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/translate-query-error.ts
@@ -64,6 +64,15 @@ const UNKNOWN_TABLE: ServerError = { code: "60", name: "UNKNOWN_TABLE" };
 const UNKNOWN_DATABASE: ServerError = { code: "81", name: "UNKNOWN_DATABASE" };
 const ACCESS_DENIED: ServerError = { code: "497", name: "ACCESS_DENIED" };
 
+// The query names a column no table involved defines. Unlike the three above,
+// this one CAN be the caller's SQL — member-authored LangWatchQL statements
+// are checked against the catalog at save time, but nothing there proves the
+// columns they select exist.
+const UNKNOWN_IDENTIFIER: ServerError = {
+  code: "47",
+  name: "UNKNOWN_IDENTIFIER",
+};
+
 /**
  * Whether `error` is one of `variants`, by any of the three forms a server
  * error arrives in: the driver's `code` property, its `type` property, or the
@@ -109,6 +118,56 @@ export function isClickHouseObjectUnavailableError(error: unknown): boolean {
     error,
     variants: [UNKNOWN_TABLE, UNKNOWN_DATABASE, ACCESS_DENIED],
   });
+}
+
+/**
+ * True when the server refused because the query names a column that does not
+ * exist (UNKNOWN_IDENTIFIER, 47).
+ *
+ * Not mapped inside {@link translateClickHouseQueryError} for the same reason
+ * its neighbours are not: on the application's own connection a missing column
+ * is a shipped bug and must degrade to "unknown" (ADR-045). Exported for the
+ * LangWatchQL executor, where the SQL is member-authored and the missing name
+ * is exactly what the caller needs to fix their statement.
+ */
+export function isClickHouseUnknownIdentifierError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return raisedServerError({ error, variants: [UNKNOWN_IDENTIFIER] });
+}
+
+/**
+ * The column names ClickHouse reported as missing, read out of the refusal by
+ * the two wordings the engine uses:
+ *
+ * - modern analysis failures name one identifier per error, backquoted, ahead
+ *   of the echoed statement: ``Unknown expression identifier `x` in scope
+ *   SELECT …``
+ * - some paths instead list them: `Missing columns: 'a', 'b' while processing …`
+ *
+ * The rest of the message echoes the submitted query, so only the names inside
+ * those markers travel — never the message body itself, which must not reach a
+ * response. Answers an empty list when the wording does not parse; the caller
+ * still gets the coded error either way.
+ */
+export function clickHouseMissingIdentifiers(error: unknown): string[] {
+  if (!(error instanceof Error)) return [];
+
+  const names: string[] = [];
+
+  const scoped =
+    /Unknown expression(?: or function)? identifier `([^`]+)`/.exec(
+      error.message,
+    )?.[1];
+  if (scoped) names.push(scoped);
+
+  const listed = /Missing columns:\s*(.+?)(?:\s+while processing|\.|$)/s.exec(
+    error.message,
+  )?.[1];
+  if (listed) {
+    names.push(...[...listed.matchAll(/'([^']*)'/g)].map((match) => match[1] ?? ""));
+  }
+
+  return [...new Set(names)].sort();
 }
 
 /**

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -177,6 +177,12 @@ const registry = {
       "Contact support to have it enabled for this workspace",
     ],
   },
+  lwql_unknown_identifier: {
+    tips: [
+      "Read `meta.identifiers` — it lists every column the query names that no dataset defines",
+      "Check the spelling against the columns the schema endpoint lists for the dataset, then edit and run again",
+    ],
+  },
   page_too_deep: {
     tips: [
       "Narrow the time range or filters so the page falls inside the window",

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -180,7 +180,8 @@ const registry = {
   lwql_unknown_identifier: {
     tips: [
       "Read `meta.identifiers` — it lists every column the query names that no dataset defines",
-      "Check the spelling against the columns the schema endpoint lists for the dataset, then edit and run again",
+      "List the available columns with `langwatch chart schema`, or open the workbench schema sidebar",
+      "Saving cannot check column existence, so a misspelled or renamed column is only refused when the query runs",
     ],
   },
   page_too_deep: {

--- a/specs/analytics/lwql-api.feature
+++ b/specs/analytics/lwql-api.feature
@@ -793,6 +793,26 @@ Feature: LangWatchQL analytics SQL API — read-only native ClickHouse SQL over 
     When the table-function and SSRF policy is looked up
     Then a dedicated ADR documents why user-supplied table functions remain blocked via AST and grants
 
+  # ---------------------------------------------------------------------------
+  # Member-authored SQL naming something the schema does not have (#7447).
+  # Column existence cannot be checked at save time, so run time is the only
+  # place this failure can be named.
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A query naming a column no dataset has fails with a coded, member-actionable error
+    Given an authenticated API client whose statement names a column no dataset defines
+    When the client runs the query
+    Then the failure carries error code lwql_unknown_identifier at HTTP 400, a caller fault
+    And a query naming only columns that exist runs normally
+
+  @unit
+  Scenario: Only the missing column names travel in the error meta
+    Given a ClickHouse refusal for unknown identifiers over a statement that also contains quoted text
+    When the identifiers are read out of the refusal for the error's meta
+    Then exactly the missing column names come back
+    And no other part of the echoed statement, and none of the database's own wording, does
+
 # --- AC Coverage Map ---
 # Issue #6480 ACs → scenarios (grouped as in the issue body).
 #

--- a/specs/analytics/lwql-workbench.feature
+++ b/specs/analytics/lwql-workbench.feature
@@ -240,6 +240,19 @@ Feature: LangWatchQL query workbench — native tables and LangWatchQL Vega-Lite
     Then the member reads a timeout presentation distinct from the generic error
     And it suggests narrowing the query rather than blaming the platform
 
+  @integration
+  Scenario: An unknown column is presented as the member's own refusal, naming the column
+    Given the submitted statement names a column that does not exist
+    When the run is refused with the unknown-identifier code
+    Then the member reads registry copy naming the column
+    And the state chip does not claim the statement was refused before reading any data
+
+  @integration
+  Scenario: An unhandled failure is never dressed as a refusal
+    Given the submitted statement fails for a reason the server did not name
+    When the result pane renders the failure
+    Then the state chip reads Failed rather than Refused
+
   # ---------------------------------------------------------------------------
   # Native result table
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Related Issue

- Resolves #7447

Closes #7447

## What changed

A LangWatchQL statement that names a column no dataset defines used to reach the workbench, dashboard widgets and `langwatch chart run` as an unknown 500. Save-time validation can prove tables and syntax but not column existence, so run time is the only place this can be named.

Now the executor recognizes ClickHouse `UNKNOWN_IDENTIFIER` (code 47) and throws a handled `lwql_unknown_identifier`, HTTP 400, customer fault, with the missing column names in `meta.identifiers`.

## How the identifier is read

Verified against a real server rather than assumed: current ClickHouse wording is one backquoted name per refusal (`Unknown expression identifier \`x\` in scope SELECT ...`), while some paths raise the older `Missing columns: 'a', 'b' while processing ...`. The extractor reads both markers and nothing else: the rest of the message echoes the submitted SQL, so it never travels. Unparseable wording yields an empty list and the same coded error.

The application's own read path keeps degrading this to "unknown" on purpose (ADR-045): there a missing column is a shipped bug, not something a caller can fix. Only the member-SQL executor maps it.

## Surfaces covered by one code

- Workbench and dashboard widgets render from the client presentation registry: new `lwql_unknown_identifier` entry names the columns when present.
- CLI JSON output carries the real code plus `meta.identifiers` through the standard handled-error serialization.
- Remediation tips point at `meta.identifiers` and the schema endpoint.

## Tests

- Unit: recognition across all three delivery forms (driver `code`, `type`, raw-body prefix) plus extraction from both wordings, including a quoted-text echo that must not leak.
- Integration (Testcontainers lane, runs in CI): against a real provisioned server, the coded error with exact meta, the paired control query still succeeding, and the first-unresolvable-column behavior.
- Spec: two scenarios appended to `specs/analytics/lwql-api.feature`, both bound; parity gate 97/97 on that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of analytics queries that reference unavailable columns.
  * These errors now return a clear HTTP 400 response identifying the missing column names.
  * Added guidance to verify column names against the available schema.
  * Queries using valid columns continue to run normally.
  * Updated query result statuses to distinguish refused queries from other failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->