### PR TITLE
fix(test): follow the docs rename in the update-metadata endpoint test

### DIFF
--- a/platform/app/src/app/api/traces/[[...route]]/__tests__/update-metadata.unit.test.ts
+++ b/platform/app/src/app/api/traces/[[...route]]/__tests__/update-metadata.unit.test.ts
@@ -257,7 +257,7 @@ describe("PATCH /:traceId/metadata", () => {
       const docsPath = path.resolve(
         __dirname,
         "../../../../../../../..",
-        "docs/api-reference/traces/update-metadata.mdx",
+        "docs/api-reference/traces/update-trace-metadata.mdx",
       );
       expect(fs.existsSync(docsPath)).toBe(true);
 


### PR DESCRIPTION
Unblocks every currently open pull request whose merge run hits unit shard 4.

The docs sweep in 41f5002b31 renamed `docs/api-reference/traces/update-metadata.mdx` to `update-trace-metadata.mdx`; the endpoint documentation test kept resolving the old path, so `has the update-metadata docs file` fails wherever main is merged in. The test now points at the renamed file (its assertions on title, PATCH and metadata hold as written).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API documentation reference for trace metadata updates to use the correct documentation page path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->