### PR TITLE
fix(authz): a disabled membership is not a membership

### DIFF
--- a/dev/docs/adr/092-unified-authorization-engine.md
+++ b/dev/docs/adr/092-unified-authorization-engine.md
@@ -1163,6 +1163,56 @@ deliberately out of scope.
   deliberate: this is the last rewrite of this flow, and correct beats
   expedient everywhere the two diverge.
 
+## Amendment 2026-08-24: a disabled membership is not a membership
+
+The membership gate reads `OrganizationUser`, and that row has carried a
+`disabledAt` column since seat reconciliation shipped: an admin over their
+licensed seats disables people to get back within them, and the row survives
+with its role, department and history so re-enabling restores everything
+(`specs/licensing/seat-reconciliation.feature`).
+
+Nothing on the authorization path read that column. The organization switcher
+filtered it, `getOrganizationWithMembers` filtered it, and the member list
+filtered it, so the organization vanished from a disabled person's UI — while
+`findOrganizationRole`, every binding fence, the API-key ceiling and the
+virtual-key membership set all read the row as if it were live. A disabled
+member kept every permission they had, reachable by direct URL, tRPC call or
+REST call. The legacy resolver had the same hole, so this is not a regression
+the engine introduced; it is one it inherited and now closes.
+
+**Decided.** Membership means ACTIVE membership, everywhere authorization asks:
+
+- The read port returns the row as a fact — `{ role, disabled }` — and the
+  collector applies the policy, setting `isOrgMember` false and
+  `organizationRole` null for a disabled row. Filtering in SQL would have made
+  a disabled membership indistinguishable from an absent one, and the denial
+  could then only have claimed the person was never here.
+- Binding reads keep filtering in SQL (`disabledAt: null` on the membership
+  fence), because those queries return grants and have no fact to hand back.
+- Denials say `membership-disabled`, not `no-membership`. We know the cause
+  and the person can act on it — an admin can return their seat — which is the
+  ADR-045 test for a named error rather than a generic one.
+- Disabling and re-enabling bump the organization's authz epoch. Disabling is
+  a plain column write, so nothing else retires the snapshots §12 caches, and
+  an admin's revocation must not wait out a cache.
+
+**Inventory reads are deliberately untouched.** The legacy-import migration
+still imports a disabled member's grants (they are preserved for re-enable),
+and the listing repositories still list them (an admin has to see somebody to
+re-enable them). Only reads that answer "may this principal act?" changed.
+
+**Consequence worth stating plainly:** the §9 owner ceiling means a disabled
+member's personal API keys stop working, because `effective(key) =
+grants(key) ∩ grants(owner)`. That is the point — a person cut off from an
+organization must not keep a live credential to it — but it reaches past their
+own session, so any automation running on their key stops with them. Service
+keys, which have no owner, are unaffected.
+
+**Write-side membership reads were left alone on purpose.**
+`assertUsersInOrganization` and `group.isUserInOrganization` still let a
+disabled user be *granted* access. That is inert: the grant confers nothing
+while the seat is off, and it is waiting for them when it comes back on.
+
 ## References
 
 - Supersedes: [ADR-001](./001-rbac.md) (its hierarchy + `resource:action` format live on).

--- a/packages/authz-server/src/__tests__/cache.unit.test.ts
+++ b/packages/authz-server/src/__tests__/cache.unit.test.ts
@@ -18,7 +18,7 @@ const otherOrgScope = { type: "organization", id: OTHER_ORG } as const;
  *  are read through a getter so a test can revoke mid-run. */
 function makeMemberReader(bindings: () => CollectedBinding[] = () => []) {
   const reader = makeReader({
-    findOrganizationRole: vi.fn().mockResolvedValue("MEMBER"),
+    findOrganizationMembership: vi.fn().mockResolvedValue({ role: "MEMBER", disabled: false }),
     findUserBindings: vi.fn(() => Promise.resolve(bindings())),
   });
   return {
@@ -261,7 +261,7 @@ describe("AuthzService epoch cache", () => {
       });
 
       expect(epoch).not.toHaveBeenCalled();
-      expect(reader.findOrganizationRole).not.toHaveBeenCalled();
+      expect(reader.findOrganizationMembership).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/authz-server/src/__tests__/owner-ceiling.unit.test.ts
+++ b/packages/authz-server/src/__tests__/owner-ceiling.unit.test.ts
@@ -38,7 +38,7 @@ describe("AuthzService and the api-key owner ceiling (ADR-092 §9)", () => {
       makeReader({
         findApiKeyOwner: vi.fn().mockResolvedValue({ userId: "dave" }),
         findApiKeyBindings: vi.fn().mockResolvedValue(projectBinding("ADMIN")),
-        findOrganizationRole: vi.fn().mockResolvedValue("MEMBER"),
+        findOrganizationMembership: vi.fn().mockResolvedValue({ role: "MEMBER", disabled: false }),
         findUserBindings: vi.fn().mockResolvedValue(projectBinding("VIEWER")),
       });
 
@@ -124,7 +124,7 @@ describe("AuthzService and the api-key owner ceiling (ADR-092 §9)", () => {
   describe("given a user principal", () => {
     it("never looks for an owner", async () => {
       const reader = makeReader({
-        findOrganizationRole: vi.fn().mockResolvedValue("MEMBER"),
+        findOrganizationMembership: vi.fn().mockResolvedValue({ role: "MEMBER", disabled: false }),
         findUserBindings: vi.fn().mockResolvedValue(projectBinding("ADMIN")),
       });
 

--- a/packages/authz-server/src/__tests__/resource-grants-collector.unit.test.ts
+++ b/packages/authz-server/src/__tests__/resource-grants-collector.unit.test.ts
@@ -30,7 +30,7 @@ describe("collector at the resource tier", () => {
       expect(grants.bindings).toEqual([]);
       expect(grants.isOrgMember).toBe(false);
       expect(grants.legacyTeamMemberships).toEqual([]);
-      expect(reader.findOrganizationRole).not.toHaveBeenCalled();
+      expect(reader.findOrganizationMembership).not.toHaveBeenCalled();
       expect(reader.findUserBindings).not.toHaveBeenCalled();
     });
   });
@@ -52,7 +52,7 @@ describe("collector at the resource tier", () => {
       expect(grants.organizationRole).toBeNull();
       expect(grants.isOrgMember).toBe(false);
       expect(grants.legacyTeamMemberships).toEqual([]);
-      expect(reader.findOrganizationRole).not.toHaveBeenCalled();
+      expect(reader.findOrganizationMembership).not.toHaveBeenCalled();
       expect(reader.findLegacyTeamMemberships).not.toHaveBeenCalled();
       expect(reader.findCustomRolePermissions).toHaveBeenCalledWith({
         organizationId: ORG,
@@ -65,7 +65,7 @@ describe("collector at the resource tier", () => {
   describe("when a custom role's stored payload is malformed", () => {
     const collectWith = async (permissions: unknown) => {
       const reader = makeReader({
-        findOrganizationRole: vi.fn().mockResolvedValue("MEMBER"),
+        findOrganizationMembership: vi.fn().mockResolvedValue({ role: "MEMBER", disabled: false }),
         findUserBindings: vi.fn().mockResolvedValue(customRoleBinding),
         findCustomRolePermissions: vi
           .fn()

--- a/packages/authz-server/src/__tests__/support/authz-read.stub.ts
+++ b/packages/authz-server/src/__tests__/support/authz-read.stub.ts
@@ -19,7 +19,7 @@ export function makeReader(
   overrides: Partial<AuthzReadRepository> = {},
 ): Mocked<AuthzReadRepository> {
   const base: ReaderStub = {
-    findOrganizationRole: vi.fn().mockResolvedValue(null),
+    findOrganizationMembership: vi.fn().mockResolvedValue(null),
     findUserBindings: vi.fn().mockResolvedValue([]),
     findGroupBindings: vi.fn().mockResolvedValue([]),
     findApiKeyBindings: vi.fn().mockResolvedValue([]),

--- a/packages/authz-server/src/authz-collector.service.ts
+++ b/packages/authz-server/src/authz-collector.service.ts
@@ -153,6 +153,7 @@ export class AuthzCollectorService {
           organizationId,
           organizationRole: null,
           isOrgMember: false,
+          membershipDisabled: false,
           bindings: [],
           legacyTeamMemberships: [],
           customRolePermissions: new Map(),
@@ -271,6 +272,10 @@ export class AuthzCollectorService {
       // as the §9 ceiling, never as an addition.
       organizationRole: null,
       isOrgMember: false,
+      // A key holds no membership of its own, so it is never "disabled" -
+      // a disabled OWNER bites through the §9 ceiling instead, where the
+      // owner's own snapshot reports it.
+      membershipDisabled: false,
       bindings,
       legacyTeamMemberships: [],
       customRolePermissions: await this.prefetchCustomRolePermissions({
@@ -291,9 +296,9 @@ export class AuthzCollectorService {
     organizationId: string;
     reader: AuthzReadRepository;
   }): Promise<CollectedGrants> {
-    const [organizationRole, directBindings, groupBindings, legacyRows] =
+    const [membership, directBindings, groupBindings, legacyRows] =
       await Promise.all([
-        reader.findOrganizationRole({
+        reader.findOrganizationMembership({
           userId: principal.id,
           organizationId,
         }),
@@ -314,11 +319,24 @@ export class AuthzCollectorService {
       ]);
 
     const bindings = [...directBindings, ...groupBindings];
+    // A seat-disabled membership is NOT a membership: the person keeps their
+    // row, their role and everything they did, and holds no access until an
+    // admin re-enables them (seat-reconciliation.feature). Reporting it as a
+    // membership is what let a disabled member keep every permission - only
+    // the org switcher hid the organization, and a direct call still worked.
+    //
+    // `organizationRole` follows `isOrgMember` rather than the stored role:
+    // the engine reads it to apply the EXTERNAL cap, and a role that outlived
+    // its membership would be answering for a principal who has none.
+    // `membershipDisabled` is carried separately so the denial can say WHICH
+    // gate closed instead of claiming they were never here.
+    const isOrgMember = membership != null && !membership.disabled;
     return {
       principal,
       organizationId,
-      organizationRole,
-      isOrgMember: organizationRole != null,
+      organizationRole: isOrgMember ? membership.role : null,
+      isOrgMember,
+      membershipDisabled: membership?.disabled ?? false,
       bindings,
       legacyTeamMemberships: legacyRows,
       customRolePermissions: await this.prefetchCustomRolePermissions({

--- a/packages/authz-server/src/authz-read.repository.ts
+++ b/packages/authz-server/src/authz-read.repository.ts
@@ -16,6 +16,21 @@ import type {
 /** OrganizationUser.role, or null when no membership row exists. */
 export type OrganizationRole = "ADMIN" | "MEMBER" | "EXTERNAL";
 
+/**
+ * The membership row as stored: its role, and whether an admin has disabled
+ * it to stay within the licensed seat count.
+ *
+ * Both halves are FACTS, not policy - a disabled row keeps its role, and it
+ * is the collector that decides a disabled membership is not a membership
+ * (so `isOrgMember` goes false and the engine's gate denies). The role is
+ * still reported because the denial wants to say WHICH gate closed, and
+ * because re-enabling has to restore exactly what was there.
+ */
+export type OrganizationMembership = {
+  role: OrganizationRole;
+  disabled: boolean;
+};
+
 /** A CustomRole row's permission payload, unparsed - the collector applies
  *  the documented lenient parse (malformed JSON degrades to no grants). */
 export type CustomRolePermissionsRow = {
@@ -58,11 +73,19 @@ export interface ScopeLineageRepository {
 }
 
 export interface AuthzReadRepository extends ScopeLineageRepository {
-  findOrganizationRole(args: {
+  /**
+   * The membership row, disabled or not, or null when there is none.
+   *
+   * Named for what it returns: the previous `findOrganizationRole` reported
+   * only the role, which gave the collector no way to tell a seat-disabled
+   * membership from an absent one - so a disabled member passed the engine's
+   * membership gate and kept every permission.
+   */
+  findOrganizationMembership(args: {
     userId: string;
     organizationId: string;
-  }): Promise<OrganizationRole | null>;
-  /** Direct user bindings - viaGroupId null. */
+  }): Promise<OrganizationMembership | null>;
+  /** Direct user bindings - viaGroupId null. Fenced on an ACTIVE membership. */
   findUserBindings(args: {
     userId: string;
     organizationId: string;

--- a/packages/authz-server/src/authz.service.ts
+++ b/packages/authz-server/src/authz.service.ts
@@ -28,6 +28,7 @@ import {
   ALL_PERMISSIONS,
   AuthzEngine,
   type AuthzDecision,
+  type AuthzDenialReason,
   type AuthzPermission,
   type AuthzPrincipalRef,
   type AuthzScopeRef,
@@ -183,7 +184,11 @@ export class AuthzService {
     principal: AuthzPrincipalRef;
     permission: AuthzPermission;
     ceiling?: boolean;
-  }): Promise<{ allowed: boolean; organizationRole: OrganizationRoleOrNull }> {
+  }): Promise<{
+    allowed: boolean;
+    organizationRole: OrganizationRoleOrNull;
+    denialReason?: AuthzDenialReason;
+  }> {
     const scope = await this.resolveScope({ projectId, teamId, organizationId });
     if (!scope) return { allowed: false, organizationRole: null };
 
@@ -207,7 +212,11 @@ export class AuthzService {
       demoProjectId: this.demoProjectId(),
     });
     recordDenial(decision);
-    return { allowed: decision.allowed, organizationRole: grants.organizationRole };
+    return {
+      allowed: decision.allowed,
+      organizationRole: grants.organizationRole,
+      denialReason: decision.denialReason,
+    };
   }
 
   /**
@@ -227,6 +236,7 @@ export class AuthzService {
     allowed: boolean;
     matchedPermission?: AuthzPermission;
     organizationRole: OrganizationRoleOrNull;
+    denialReason?: AuthzDenialReason;
   }> {
     const scope = await this.collector.resolveScopeRef({ projectId });
     if (!scope) return { allowed: false, organizationRole: null };
@@ -262,6 +272,12 @@ export class AuthzService {
       allowed: matched !== undefined,
       ...(matched ? { matchedPermission: matched } : {}),
       organizationRole: grants.organizationRole,
+      // No single decision to read a reason off - every candidate permission
+      // was refused. The one reason worth naming is the one that refused them
+      // all for the same cause, and the snapshot already carries it.
+      ...(matched === undefined && grants.membershipDisabled
+        ? { denialReason: "membership-disabled" as const }
+        : {}),
     };
   }
 

--- a/packages/authz-server/src/grants.service.ts
+++ b/packages/authz-server/src/grants.service.ts
@@ -77,6 +77,25 @@ export class GrantsService {
     private readonly deps: GrantsServiceDeps,
   ) {}
 
+  /**
+   * Retire every cached snapshot for the organization, without writing a
+   * grant.
+   *
+   * Grant writes bump the epoch themselves, so this exists for the facts that
+   * change who may act WITHOUT touching a grant — today that is exactly one:
+   * enabling or disabling a membership's seat. Those are plain column writes
+   * on `OrganizationUser`, so without this a disabled member keeps answering
+   * from a cached snapshot until it ages out, and the revocation an admin
+   * just performed appears not to have happened.
+   */
+  async invalidateOrganization({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<void> {
+    await this.deps.bumpEpoch({ organizationId });
+  }
+
   /** INSERT (who, role, where) — visible on the next check. */
   async attach({
     actor,

--- a/packages/authz-server/src/index.ts
+++ b/packages/authz-server/src/index.ts
@@ -31,6 +31,7 @@ export {
 export type {
   AuthzReadRepository,
   CustomRolePermissionsRow,
+  OrganizationMembership,
   OrganizationRole,
   ScopeLineageRepository,
   ShareLinkRow,

--- a/packages/authz/src/__tests__/engine.unit.test.ts
+++ b/packages/authz/src/__tests__/engine.unit.test.ts
@@ -57,12 +57,14 @@ function makeGrants({
   legacyTeamMemberships = [] as LegacyTeamMembership[],
   customRolePermissions = new Map<string, readonly string[]>(),
   principal = { type: "user", id: "user-1" } as CollectedGrants["principal"],
+  membershipDisabled = false,
 }: Partial<CollectedGrants> = {}): CollectedGrants {
   return {
     principal,
     organizationId: ORG,
     organizationRole,
     isOrgMember,
+    membershipDisabled,
     bindings,
     legacyTeamMemberships,
     customRolePermissions,
@@ -817,5 +819,173 @@ describe("authz engine explain()", () => {
     expect(lines[0]).toContain("DENIED datasets:delete");
     expect(lines.join("\n")).toContain("via group group-9");
     expect(lines.join("\n")).toContain("denial reason: no-binding");
+  });
+  describe("given a membership an admin disabled to free its seat", () => {
+    /**
+     * The collector is what turns a disabled row into `isOrgMember: false`
+     * (its bindings do not even come back from the reader, which fences on an
+     * active membership). These cases pin what the ENGINE then does with that
+     * snapshot: deny everywhere a member could act, and say which gate closed.
+     */
+    const disabled = (
+      overrides: Partial<CollectedGrants> = {},
+    ): CollectedGrants =>
+      makeGrants({
+        organizationRole: null,
+        isOrgMember: false,
+        membershipDisabled: true,
+        ...overrides,
+      });
+
+    it("denies at organization scope, where a plain member holds the floor", () => {
+      const decision = engine.decide({
+        grants: disabled(),
+        permission: "organization:view",
+        scope: orgScope,
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.denialReason).toBe("membership-disabled");
+    });
+
+    it("denies at team and project scope", () => {
+      for (const scope of [teamScope, projectScope]) {
+        const decision = engine.decide({
+          grants: disabled(),
+          permission: "traces:view",
+          scope,
+        });
+        expect(decision.allowed).toBe(false);
+        expect(decision.denialReason).toBe("membership-disabled");
+      }
+    });
+
+    it("names the disabled seat rather than the absence it causes", () => {
+      // Reported as "no-membership" this would tell somebody who IS a member
+      // that they are not, and point them at nothing they can do.
+      const decision = engine.decide({
+        grants: disabled(),
+        permission: "traces:view",
+        scope: projectScope,
+      });
+      expect(decision.denialReason).not.toBe("no-membership");
+      expect(decision.denialReason).toBe("membership-disabled");
+    });
+
+    it("denies even where a stale binding survived on the scope chain", () => {
+      // Belt and braces: the reader already withholds these rows. If one ever
+      // reaches the engine, membership still decides before bindings do.
+      const decision = engine.decide({
+        grants: disabled({
+          bindings: [binding({ role: "ADMIN", scopeType: "TEAM", scopeId: TEAM })],
+        }),
+        permission: "project:delete",
+        scope: projectScope,
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.denialReason).toBe("membership-disabled");
+    });
+
+    /** @scenario A link that was public to anyone still opens for a disabled member */
+    it("still resolves a public share link, which never depended on membership", () => {
+      // ADR-057: a link anyone can open is not an organization privilege, so
+      // disabling a seat does not close it. It drops to the public audience.
+      const decision = engine.decide({
+        grants: disabled(),
+        permission: "traces:view",
+        scope: traceScope,
+        resourceGrants: [publicTraceGrant],
+      });
+      expect(decision.allowed).toBe(true);
+      expect(decision.audience).toBe("public");
+    });
+
+    /** @scenario A link that was public to anyone still opens for a disabled member */
+    it("loses the member-audience share link, which did depend on membership", () => {
+      const decision = engine.decide({
+        grants: disabled(),
+        permission: "traces:view",
+        scope: traceScope,
+        resourceGrants: [
+          {
+            kind: "trace",
+            id: TRACE,
+            projectId: PROJECT,
+            permission: "traces:view",
+            audience: { kind: "organization", id: ORG },
+          },
+        ],
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.denialReason).toBe("membership-disabled");
+    });
+
+    it("still sees the demo project, which every signed-in user sees", () => {
+      // Not an oversight: the demo project is a product tour, granted to any
+      // signed-in user before membership is consulted at all. Pinned so the
+      // next reader does not "close" it and break the tour for everyone.
+      const decision = engine.decide({
+        grants: disabled(),
+        permission: "traces:view",
+        scope: projectScope,
+        demoProjectId: PROJECT,
+      });
+      expect(decision.allowed).toBe(true);
+      expect(decision.via).toBe("demo-project");
+    });
+
+    /** @scenario A disabled member's API keys stop working */
+    it("stops the API keys they own, through the owner ceiling", () => {
+      // ADR-092 §9: effective(key) = grants(key) ∩ grants(owner). A disabled
+      // owner grants nothing, so their personal keys stop too — which is the
+      // point (a revoked person must not keep a live credential), and is the
+      // one consequence of disabling that reaches beyond their own session.
+      const decision = engine.decideWithCeiling({
+        keyGrants: makeGrants({
+          principal: { type: "apiKey", id: "key-1" },
+          organizationRole: null,
+          isOrgMember: false,
+          bindings: [
+            binding({ role: "ADMIN", scopeType: "TEAM", scopeId: TEAM }),
+          ],
+        }),
+        ownerGrants: disabled(),
+        permission: "traces:view",
+        scope: projectScope,
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.denialReason).toBe("owner-ceiling");
+    });
+
+    /** @scenario A disabled member's API keys stop working */
+    it("leaves a service key alone, because it has no owner to disable", () => {
+      const decision = engine.decideWithCeiling({
+        keyGrants: makeGrants({
+          principal: { type: "apiKey", id: "key-2" },
+          organizationRole: null,
+          isOrgMember: false,
+          bindings: [
+            binding({ role: "ADMIN", scopeType: "TEAM", scopeId: TEAM }),
+          ],
+        }),
+        ownerGrants: null,
+        permission: "traces:view",
+        scope: projectScope,
+      });
+      expect(decision.allowed).toBe(true);
+    });
+
+    it("re-enabling restores access, because nothing else was taken away", () => {
+      const decision = engine.decide({
+        grants: makeGrants({
+          organizationRole: "MEMBER",
+          isOrgMember: true,
+          membershipDisabled: false,
+          bindings: [binding({ role: "ADMIN", scopeType: "TEAM", scopeId: TEAM })],
+        }),
+        permission: "project:delete",
+        scope: projectScope,
+      });
+      expect(decision.allowed).toBe(true);
+    });
   });
 });

--- a/packages/authz/src/errors.ts
+++ b/packages/authz/src/errors.ts
@@ -29,7 +29,9 @@ export class PermissionDeniedError extends HandledError {
       "permission_denied",
       denialReason === "lite-member-restricted"
         ? "This feature is not available for your account"
-        : `You do not have permission to access this ${scope.type}`,
+        : denialReason === "membership-disabled"
+          ? "Your access to this organization has been disabled"
+          : `You do not have permission to access this ${scope.type}`,
       {
         httpStatus: 403,
         meta: {

--- a/packages/authz/src/types.ts
+++ b/packages/authz/src/types.ts
@@ -103,8 +103,19 @@ export type CollectedGrants = {
   organizationId: string;
   /** Null for api-key principals and for users with no OrganizationUser row. */
   organizationRole: "ADMIN" | "MEMBER" | "EXTERNAL" | null;
-  /** True when an OrganizationUser row exists for a user principal. */
+  /**
+   * True when a user principal holds an ACTIVE OrganizationUser row. A row
+   * an admin disabled to free its seat is not one: see `membershipDisabled`.
+   */
   isOrgMember: boolean;
+  /**
+   * The membership row exists but an admin disabled it to stay within the
+   * licensed seat count, so it confers nothing (`isOrgMember` is false).
+   * Carried apart from `isOrgMember` for one reason: the denial can then
+   * tell the person their access was disabled - which they can act on -
+   * instead of telling a member they are not a member.
+   */
+  membershipDisabled: boolean;
   bindings: CollectedBinding[];
   /**
    * LEGACY-QUIRK(B): TeamUser rows, consulted only when `bindings` is empty
@@ -117,6 +128,7 @@ export type CollectedGrants = {
 
 export type AuthzDenialReason =
   | "no-membership"
+  | "membership-disabled"
   | "no-binding"
   | "lite-member-restricted"
   | "owner-ceiling";

--- a/packages/authz/src/walk.ts
+++ b/packages/authz/src/walk.ts
@@ -88,7 +88,17 @@ export function organizationMembershipGateStep({
 }: DecideContext): AuthzDecision | undefined {
   if (scope.type === "resource") return;
   if (grants.principal.type !== "user" || grants.isOrgMember) return;
-  return { ...base, allowed: false, denialReason: "no-membership" };
+  return {
+    ...base,
+    allowed: false,
+    // A disabled membership fails the SAME gate as an absent one - the
+    // difference is only what the person is told, and it is a difference
+    // they can act on: an admin can re-enable a seat, nobody can re-enable
+    // a membership that was never there.
+    denialReason: grants.membershipDisabled
+      ? "membership-disabled"
+      : "no-membership",
+  };
 }
 
 /**
@@ -193,6 +203,15 @@ export function denyStep({
   chainBindings,
   base,
 }: DecideContext): AuthzDecision {
+  // Checked before everything else: a disabled seat is the reason NO path
+  // exists, so reporting the absence it causes ("no membership", "no
+  // binding") would name the symptom. On a resource scope this is the only
+  // step that runs, because the membership gate defers there to keep share
+  // links reachable.
+  if (grants.membershipDisabled) {
+    return { ...base, allowed: false, denialReason: "membership-disabled" };
+  }
+
   const hadAnyPath =
     grants.isOrgMember ||
     chainBindings.length > 0 ||

--- a/platform/app/src/components/AddMembersForm.tsx
+++ b/platform/app/src/components/AddMembersForm.tsx
@@ -28,6 +28,7 @@ import { getDefaultTeamRoleForOrganizationRole } from "~/utils/memberRoleConstra
 import { InfoWithoutSelecting } from "./settings/InfoWithoutSelecting";
 import {
   LITE_MEMBER_EXPLANATION,
+  LITE_MEMBER_NEEDS_TEAM_WARNING,
   LITE_MEMBER_SHORT_DESCRIPTION,
   SEAT_TYPES_DOC_PATH,
 } from "./settings/seatTypeCopy";
@@ -79,6 +80,28 @@ interface AddMembersFormProps {
    * retyped.
    */
   initialEmails?: string;
+}
+
+/**
+ * Shown when a lite invite names no team. A lite seat grants nothing on its
+ * own, so without a team the person can sign in and see nothing — and the
+ * admin only finds out when they say so.
+ */
+function LiteMemberNeedsTeamWarning() {
+  return (
+    <Box
+      paddingX={4}
+      paddingY={3}
+      backgroundColor="orange.subtle"
+      borderRadius="xl"
+      width="100%"
+      data-testid="lite-member-needs-team-warning"
+    >
+      <Text fontSize="sm" color="fg">
+        {LITE_MEMBER_NEEDS_TEAM_WARNING}
+      </Text>
+    </Box>
+  );
 }
 
 export function AddMembersForm({
@@ -356,17 +379,22 @@ export function AddMembersForm({
         )}
 
         {teamFields.length === 0 && (
-          <HStack gap={2}>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={handleAddTeam}
-              disabled={getAvailableTeamOptions().length === 0}
-            >
-              <Plus size={14} /> Add team
-            </Button>
-          </HStack>
+          <VStack align="start" gap={2} width="100%">
+            {orgRole === OrganizationUserRole.EXTERNAL && (
+              <LiteMemberNeedsTeamWarning />
+            )}
+            <HStack gap={2}>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={handleAddTeam}
+                disabled={getAvailableTeamOptions().length === 0}
+              >
+                <Plus size={14} /> Add team
+              </Button>
+            </HStack>
+          </VStack>
         )}
 
         <HStack justify="end" width="100%" marginTop={4}>

--- a/platform/app/src/components/settings/__tests__/AddMembersForm.liteMemberNeedsTeam.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/AddMembersForm.liteMemberNeedsTeam.integration.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Warning an admin about a lite invite that names no team.
+ *
+ * A lite seat carries no organization-wide access of its own: the invite
+ * grants what its teams grant and nothing else. So a lite invite with no team
+ * produces somebody who can sign in, see nothing, and still consume a seat —
+ * and the admin finds out when the person tells them. The form says so before
+ * they send it.
+ *
+ * A warning, not a refusal: assigning the team afterwards is a legitimate way
+ * to work, and the admin is the one who knows whether they mean to.
+ *
+ * Spec: specs/members/member-role-team-restrictions.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    role: { getAll: { useQuery: () => ({ data: [] }) } },
+  },
+}));
+
+import { AddMembersForm } from "../../AddMembersForm";
+
+const WARNING = "lite-member-needs-team-warning";
+
+/**
+ * Rendered with no teams to choose from, which is the state that leaves the
+ * team list empty and reachable — the same state an admin lands in by
+ * removing the row the form starts with.
+ */
+const renderForm = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <AddMembersForm
+        teamOptions={[]}
+        organizationId="org-1"
+        onSubmit={vi.fn()}
+        isLoading={false}
+        hasEmailProvider={true}
+        onClose={vi.fn()}
+        isInviterAdmin={true}
+        initialEmails=""
+      />
+    </ChakraProvider>,
+  );
+
+const markAsLiteMember = () => {
+  fireEvent.click(screen.getByText("Lite Member"));
+};
+
+describe("AddMembersForm", () => {
+  afterEach(cleanup);
+
+  describe("given no team is assigned", () => {
+    describe("when the invite is for a full member", () => {
+      /** @scenario Inviting a full member with no team is not warned about */
+      it("says nothing, because a full member holds access without a team", () => {
+        renderForm();
+
+        expect(screen.queryByTestId(WARNING)).toBeNull();
+      });
+    });
+
+    describe("when the invite is for a lite member", () => {
+      /** @scenario Inviting a Lite Member with no team warns that they will see nothing */
+      it("warns that the person will not be able to see anything", () => {
+        renderForm();
+
+        markAsLiteMember();
+
+        expect(screen.getByTestId(WARNING)).toBeTruthy();
+      });
+
+      /** @scenario Inviting a Lite Member with no team warns that they will see nothing */
+      it("names adding a team as the way out, and says it can wait", () => {
+        renderForm();
+
+        markAsLiteMember();
+
+        const warning = screen.getByTestId(WARNING).textContent ?? "";
+        expect(warning).toContain("Add a team");
+        expect(warning).toContain("later");
+      });
+
+      /** @scenario The warning does not block the invitation */
+      it("still lets the invite be sent, because assigning the team later is allowed", () => {
+        renderForm();
+
+        markAsLiteMember();
+
+        const submit = screen.getByRole("button", { name: /Send invites/i });
+        expect(submit.hasAttribute("disabled")).toBe(false);
+      });
+    });
+  });
+});

--- a/platform/app/src/components/settings/__tests__/AddMembersForm.liteMemberNeedsTeam.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/AddMembersForm.liteMemberNeedsTeam.integration.test.tsx
@@ -15,7 +15,13 @@
  * Spec: specs/members/member-role-team-restrictions.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("~/utils/api", () => ({
@@ -27,19 +33,23 @@ vi.mock("~/utils/api", () => ({
 import { AddMembersForm } from "../../AddMembersForm";
 
 const WARNING = "lite-member-needs-team-warning";
+const TEAM = { label: "Research", value: "team-research" };
+const EMAIL = "dana@example.com";
 
 /**
- * Rendered with no teams to choose from, which is the state that leaves the
- * team list empty and reachable — the same state an admin lands in by
- * removing the row the form starts with.
+ * Rendered with one team to choose from, which the form assigns up front —
+ * the state the feature's Background describes. Each case that needs an empty
+ * team list gets there the way an admin does, by removing that row, so the
+ * warning is exercised on the path that leads to it.
  */
-const renderForm = () =>
+const renderForm = () => {
+  const onSubmit = vi.fn();
   render(
     <ChakraProvider value={defaultSystem}>
       <AddMembersForm
-        teamOptions={[]}
+        teamOptions={[TEAM]}
         organizationId="org-1"
-        onSubmit={vi.fn()}
+        onSubmit={onSubmit}
         isLoading={false}
         hasEmailProvider={true}
         onClose={vi.fn()}
@@ -48,30 +58,50 @@ const renderForm = () =>
       />
     </ChakraProvider>,
   );
+  return { onSubmit };
+};
 
 const markAsLiteMember = () => {
   fireEvent.click(screen.getByText("Lite Member"));
 };
 
+const removeTheAssignedTeam = () => {
+  fireEvent.click(screen.getByLabelText("Remove team assignment"));
+};
+
+const enterEmail = (email: string) => {
+  fireEvent.change(
+    screen.getByPlaceholderText("alice@example.com, bob@example.com"),
+    { target: { value: email } },
+  );
+};
+
+const sendInvites = () => {
+  fireEvent.click(screen.getByRole("button", { name: /Send invites/i }));
+};
+
 describe("AddMembersForm", () => {
   afterEach(cleanup);
 
-  describe("given no team is assigned", () => {
-    describe("when the invite is for a full member", () => {
-      /** @scenario Inviting a full member with no team is not warned about */
-      it("says nothing, because a full member holds access without a team", () => {
+  describe("given the invite is for a lite member", () => {
+    describe("when a team is still assigned", () => {
+      /** @scenario Inviting a Lite Member with no team warns that they will see nothing */
+      it("says nothing, because the team is what they will see", () => {
         renderForm();
+
+        markAsLiteMember();
 
         expect(screen.queryByTestId(WARNING)).toBeNull();
       });
     });
 
-    describe("when the invite is for a lite member", () => {
+    describe("when the assigned team is removed", () => {
       /** @scenario Inviting a Lite Member with no team warns that they will see nothing */
       it("warns that the person will not be able to see anything", () => {
         renderForm();
 
         markAsLiteMember();
+        removeTheAssignedTeam();
 
         expect(screen.getByTestId(WARNING)).toBeTruthy();
       });
@@ -81,6 +111,7 @@ describe("AddMembersForm", () => {
         renderForm();
 
         markAsLiteMember();
+        removeTheAssignedTeam();
 
         const warning = screen.getByTestId(WARNING).textContent ?? "";
         expect(warning).toContain("Add a team");
@@ -88,13 +119,32 @@ describe("AddMembersForm", () => {
       });
 
       /** @scenario The warning does not block the invitation */
-      it("still lets the invite be sent, because assigning the team later is allowed", () => {
-        renderForm();
+      it("still sends the lite invitation with no team, because assigning one later is allowed", async () => {
+        const { onSubmit } = renderForm();
 
         markAsLiteMember();
+        removeTheAssignedTeam();
+        enterEmail(EMAIL);
+        sendInvites();
 
-        const submit = screen.getByRole("button", { name: /Send invites/i });
-        expect(submit.hasAttribute("disabled")).toBe(false);
+        await waitFor(() => {
+          expect(onSubmit).toHaveBeenCalledWith({
+            invites: [{ email: EMAIL, orgRole: "EXTERNAL", teams: [] }],
+          });
+        });
+      });
+    });
+  });
+
+  describe("given the invite is for a full member", () => {
+    describe("when the assigned team is removed", () => {
+      /** @scenario Inviting a full member with no team is not warned about */
+      it("says nothing, because a full member holds access without a team", () => {
+        renderForm();
+
+        removeTheAssignedTeam();
+
+        expect(screen.queryByTestId(WARNING)).toBeNull();
       });
     });
   });

--- a/platform/app/src/components/settings/seatTypeCopy.ts
+++ b/platform/app/src/components/settings/seatTypeCopy.ts
@@ -26,4 +26,22 @@ export const LITE_MEMBER_EXPLANATION =
   "reach the data, including the API and the MCP server. Give someone " +
   "permission to change something and they hold a full seat instead.";
 
+/**
+ * Shown when someone is about to invite a lite member and has named no team.
+ *
+ * A lite seat carries no organization-wide access of its own — the invite
+ * grants only what its teams grant (`applyInviteGrants` skips the
+ * organization-scoped grant for a lite member on purpose). So a lite invite
+ * with no team produces someone who can sign in, see nothing, and still hold
+ * a seat.
+ *
+ * A warning rather than a refusal: assigning the team later is a legitimate
+ * way to work, and the admin is the one who knows. It says what will happen
+ * and how to undo it, and does not explain how grants are put together.
+ */
+export const LITE_MEMBER_NEEDS_TEAM_WARNING =
+  "Add a team, or this person will not see anything. A lite member reaches " +
+  "only the projects their teams give them, so one with no team can sign in " +
+  "and do no more. You can add a team later from the members list.";
+
 export const SEAT_TYPES_DOC_PATH = "/ai-governance/roles-and-permissions#seats";

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -172,6 +172,7 @@ export const APP_ERROR_CODES = [
   "malformed_request",
   "member_not_found",
   "member_seat_limit_reached",
+  "membership_disabled",
   "migration_enrollment_already_exists",
   "migration_enrollment_cloud_only",
   "migration_enrollment_not_found",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1072,6 +1072,14 @@ const presentations = {
     describe: () =>
       "Free a seat by disabling a membership, or upgrade the plan to add more.",
   },
+  membership_disabled: {
+    // The person IS a member, so nothing here may suggest they are not, and
+    // nothing may suggest a role they could ask for instead — the seat is the
+    // whole problem. Names the one action that works: ask an admin.
+    title: "Your access to this organization is turned off",
+    describe: () =>
+      "Your membership is still here with everything you did. An organization admin can turn your access back on when a seat is free.",
+  },
   migration_enrollment_already_exists: {
     title: "This organization is already enrolled",
     describe: (error) => {

--- a/platform/app/src/server/api/__tests__/custom-roles.test.ts
+++ b/platform/app/src/server/api/__tests__/custom-roles.test.ts
@@ -86,6 +86,7 @@ describe("Custom Role Functionality Tests", () => {
     mockPrisma.project.findUnique.mockResolvedValue(mockProjectResult);
     mockPrisma.organizationUser.findFirst.mockResolvedValue({
       role: OrganizationUserRole.MEMBER,
+      disabledAt: null,
     });
     mockPrisma.groupMembership.findMany.mockResolvedValue([]);
   });

--- a/platform/app/src/server/api/__tests__/rbac-integration.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac-integration.test.ts
@@ -73,6 +73,7 @@ describe("RBAC Integration Tests", () => {
     // (falls through to denied).
     mockPrisma.organizationUser.findFirst.mockResolvedValue({
       role: OrganizationUserRole.MEMBER,
+      disabledAt: null,
     });
     mockPrisma.groupMembership.findMany.mockResolvedValue([]);
     mockPrisma.roleBinding.findMany.mockResolvedValue([]);
@@ -214,6 +215,7 @@ describe("RBAC Integration Tests", () => {
 
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.ADMIN,
+        disabledAt: null,
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -236,6 +238,7 @@ describe("RBAC Integration Tests", () => {
 
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
       });
 
       mockPrisma.teamUser.findFirst.mockResolvedValue(null);
@@ -256,6 +259,7 @@ describe("RBAC Integration Tests", () => {
 
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
       });
 
       mockPrisma.teamUser.findFirst.mockResolvedValue({
@@ -298,6 +302,7 @@ describe("RBAC Integration Tests", () => {
     it("returns true for organization admin with org-scoped binding", async () => {
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.ADMIN,
+        disabledAt: null,
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -315,6 +320,7 @@ describe("RBAC Integration Tests", () => {
     it("returns true for organization member with org-scoped binding and view permission", async () => {
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -343,6 +349,7 @@ describe("RBAC Integration Tests", () => {
       // the floor, with bindings + team memberships layered on top.
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
       });
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
       mockPrisma.teamUser.findMany.mockResolvedValue([]);
@@ -379,6 +386,7 @@ describe("RBAC Integration Tests", () => {
       // the MEMBER base bag floor (granting aiTools:view).
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.EXTERNAL,
+        disabledAt: null,
       });
       // A stray ORGANIZATION-scoped ADMIN binding must NOT promote a lite
       // member: the binding-level guard in checkPermissionFromBindings still
@@ -416,6 +424,7 @@ describe("RBAC Integration Tests", () => {
     it("returns false for organization member with manage permission", async () => {
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
       });
 
       const result = await hasOrganizationPermission(
@@ -430,6 +439,7 @@ describe("RBAC Integration Tests", () => {
       // User is organization MEMBER (not admin)
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
       });
 
       // User is team ADMIN in one team
@@ -452,6 +462,7 @@ describe("RBAC Integration Tests", () => {
     it("only allows organization admins to manage organization", async () => {
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.ADMIN,
+        disabledAt: null,
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -474,6 +485,7 @@ describe("RBAC Integration Tests", () => {
       beforeEach(() => {
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.ADMIN,
+          disabledAt: null,
         });
         mockPrisma.roleBinding.findMany.mockResolvedValue([]);
         mockPrisma.teamUser.findMany.mockResolvedValue([
@@ -536,6 +548,7 @@ describe("RBAC Integration Tests", () => {
       beforeEach(() => {
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
         });
         mockPrisma.roleBinding.findMany.mockResolvedValue([]);
         mockPrisma.teamUser.findMany.mockResolvedValue([
@@ -575,6 +588,7 @@ describe("RBAC Integration Tests", () => {
       beforeEach(() => {
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
         });
         mockPrisma.roleBinding.findMany.mockResolvedValue([]);
         mockPrisma.teamUser.findMany.mockResolvedValue([
@@ -671,6 +685,7 @@ describe("RBAC Integration Tests", () => {
 
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
         });
 
         mockPrisma.teamUser.findFirst.mockResolvedValue(null);
@@ -696,6 +711,7 @@ describe("RBAC Integration Tests", () => {
 
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.ADMIN,
+          disabledAt: null,
         });
 
         mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -719,6 +735,7 @@ describe("RBAC Integration Tests", () => {
       it("throws UNAUTHORIZED when user lacks permission", async () => {
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
         });
 
         const middleware = checkOrganizationPermission(
@@ -737,6 +754,7 @@ describe("RBAC Integration Tests", () => {
       it("calls next when user has permission", async () => {
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.ADMIN,
+          disabledAt: null,
         });
 
         mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -803,7 +821,7 @@ describe("RBAC Integration Tests", () => {
       });
       // No orgRole => no OrganizationUser row => not a current member.
       mockPrisma.organizationUser.findFirst.mockResolvedValue(
-        orgRole ? { role: orgRole } : null,
+        orgRole ? { role: orgRole, disabledAt: null } : null,
       );
       if (hasTeamMember && teamRole) {
         mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -1084,7 +1102,7 @@ describe("RBAC Integration Tests", () => {
       });
 
       mockPrisma.organizationUser.findFirst.mockResolvedValue(
-        orgRole ? { role: orgRole } : null,
+        orgRole ? { role: orgRole, disabledAt: null } : null,
       );
 
       mockPrisma.teamUser.findFirst.mockResolvedValue(
@@ -1248,6 +1266,7 @@ describe("RBAC Integration Tests", () => {
 
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
         });
 
         mockPrisma.teamUser.findFirst.mockResolvedValue({
@@ -1274,6 +1293,7 @@ describe("RBAC Integration Tests", () => {
 
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
         });
 
         mockPrisma.teamUser.findFirst.mockResolvedValue({
@@ -1361,6 +1381,7 @@ describe("RBAC Integration Tests", () => {
 
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.ADMIN,
+          disabledAt: null,
         });
 
         mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -1461,6 +1482,7 @@ describe("RBAC Integration Tests", () => {
     } = {}) {
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.EXTERNAL,
+        disabledAt: null,
       });
       mockPrisma.project.findUnique.mockResolvedValue({
         team: {
@@ -1487,6 +1509,7 @@ describe("RBAC Integration Tests", () => {
 
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.EXTERNAL,
+        disabledAt: null,
       });
 
       mockPrisma.teamUser.findFirst.mockResolvedValue({
@@ -1684,6 +1707,7 @@ describe("RBAC Integration Tests", () => {
       it("grants full team-role-based access", async () => {
         mockPrisma.organizationUser.findFirst.mockResolvedValue({
           role: OrganizationUserRole.ADMIN,
+          disabledAt: null,
         });
         mockPrisma.project.findUnique.mockResolvedValue({
           team: { id: "team-1", organizationId: "org-1" },

--- a/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
@@ -46,7 +46,14 @@ const session = { user: { id: USER_ID } } as unknown as Session;
  * An organization whose only record of this user's access is a Grant head:
  * PROJECT-scoped `admin`, no compat binding row behind it.
  */
-function buildPrisma({ onEngine }: { onEngine: boolean | undefined }) {
+function buildPrisma({
+  onEngine,
+  membershipDisabled = false,
+}: {
+  onEngine: boolean | undefined;
+  /** The row stays, with its role; an admin has switched the seat off. */
+  membershipDisabled?: boolean;
+}) {
   const grantFindMany = vi.fn(async (args: any) => {
     if (args?.where?.principalType !== "USER") return [];
     return [
@@ -71,9 +78,12 @@ function buildPrisma({ onEngine }: { onEngine: boolean | undefined }) {
         .mockResolvedValue({ id: TEAM_ID, organizationId: ORGANIZATION_ID }),
     },
     organizationUser: {
-      findFirst: vi
-        .fn()
-        .mockResolvedValue({ role: "MEMBER", disabledAt: null }),
+      findFirst: vi.fn().mockResolvedValue({
+        role: "MEMBER",
+        disabledAt: membershipDisabled
+          ? new Date("2026-08-01T00:00:00Z")
+          : null,
+      }),
     },
     groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
     roleBinding: { findMany: roleBindingFindMany },
@@ -250,6 +260,94 @@ describe("the fork at the permission seams", () => {
         expect([...result.projects]).toEqual([[PROJECT_ID, false]]);
       });
     });
+  });
+
+  describe("given a member whose seat an admin disabled", () => {
+    /**
+     * The membership gate runs before either head reads a binding, so the
+     * answer is the same on both — and it is named: the boundary raises
+     * "your access was disabled", not "you are not a member" or "no
+     * permission", for someone who is a member and holds the role they
+     * always did.
+     */
+    for (const onEngine of [true, false]) {
+      const head = onEngine ? "the engine" : "legacy";
+
+      describe(`when a project permission is resolved on ${head}`, () => {
+        /** @scenario A disabled member cannot act through any permission path */
+        it("refuses by name, before any binding is read", async () => {
+          const { ctx, grantFindMany, roleBindingFindMany } = buildPrisma({
+            onEngine,
+            membershipDisabled: true,
+          });
+
+          const result = await resolveProjectPermission(
+            ctx,
+            PROJECT_ID,
+            "traces:view",
+          );
+
+          expect(result).toEqual({
+            permitted: false,
+            organizationRole: null,
+            denialReason: "membership-disabled",
+          });
+          expect(grantFindMany).not.toHaveBeenCalled();
+          expect(roleBindingFindMany).not.toHaveBeenCalled();
+        });
+      });
+
+      describe(`when a team permission is resolved on ${head}`, () => {
+        /** @scenario A disabled member cannot act through any permission path */
+        it("refuses by name, before any binding is read", async () => {
+          const { ctx, grantFindMany, roleBindingFindMany } = buildPrisma({
+            onEngine,
+            membershipDisabled: true,
+          });
+
+          const result = await resolveTeamPermission(
+            ctx,
+            TEAM_ID,
+            "traces:view",
+          );
+
+          expect(result).toEqual({
+            permitted: false,
+            organizationRole: null,
+            denialReason: "membership-disabled",
+          });
+          expect(grantFindMany).not.toHaveBeenCalled();
+          expect(roleBindingFindMany).not.toHaveBeenCalled();
+        });
+      });
+
+      describe(`when any of several permissions would do, on ${head}`, () => {
+        /** @scenario A disabled member cannot act through any permission path */
+        it("raises the disabled-membership error at the boundary", async () => {
+          const { ctx } = buildPrisma({ onEngine, membershipDisabled: true });
+          const next = vi.fn();
+
+          await expect(
+            checkDeclaredPermissionAny(["annotations:update", "traces:view"])({
+              ctx: {
+                ...(ctx as Record<string, unknown>),
+                permissionChecked: false,
+                app: {
+                  permissions: permissionsServiceFor(
+                    (ctx as { prisma: never }).prisma,
+                  ),
+                },
+              },
+              input: { projectId: PROJECT_ID },
+              next,
+            } as never),
+          ).rejects.toMatchObject({
+            cause: { code: "membership_disabled" },
+          });
+          expect(next).not.toHaveBeenCalled();
+        });
+      });
+    }
   });
 
   describe("given the demo project", () => {

--- a/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.fork.unit.test.ts
@@ -71,7 +71,9 @@ function buildPrisma({ onEngine }: { onEngine: boolean | undefined }) {
         .mockResolvedValue({ id: TEAM_ID, organizationId: ORGANIZATION_ID }),
     },
     organizationUser: {
-      findFirst: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+      findFirst: vi
+        .fn()
+        .mockResolvedValue({ role: "MEMBER", disabledAt: null }),
     },
     groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
     roleBinding: { findMany: roleBindingFindMany },

--- a/platform/app/src/server/api/__tests__/rbac.legacy-fallback.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.legacy-fallback.unit.test.ts
@@ -47,6 +47,7 @@ describe("legacy TeamUser fallback at the resolver seam", () => {
     });
     mockPrisma.organizationUser.findFirst.mockResolvedValue({
       role: OrganizationUserRole.MEMBER,
+      disabledAt: null,
     });
     mockPrisma.groupMembership.findMany.mockResolvedValue([]);
     // No bindings anywhere: the only source of access is the legacy row.

--- a/platform/app/src/server/api/__tests__/rbac.poisoned-binding.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.poisoned-binding.unit.test.ts
@@ -96,9 +96,10 @@ function makePrisma({
       findUnique: vi.fn().mockResolvedValue({ organizationId: ORG_ID }),
     },
     organizationUser: {
-      findFirst: vi
-        .fn()
-        .mockResolvedValue({ role: OrganizationUserRole.MEMBER }),
+      findFirst: vi.fn().mockResolvedValue({
+        role: OrganizationUserRole.MEMBER,
+        disabledAt: null,
+      }),
     },
     groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
     roleBinding: { findMany: vi.fn().mockResolvedValue(bindings) },

--- a/platform/app/src/server/api/__tests__/rbac.project-permission-any.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.project-permission-any.unit.test.ts
@@ -35,7 +35,7 @@ const buildPrisma = (teamRole: TeamUserRole) => {
   });
   const organizationUserFindFirst = vi
     .fn()
-    .mockResolvedValue({ role: OrganizationUserRole.MEMBER });
+    .mockResolvedValue({ role: OrganizationUserRole.MEMBER, disabledAt: null });
   const prisma = {
     project: { findUnique: projectFindUnique },
     organizationUser: { findFirst: organizationUserFindFirst },

--- a/platform/app/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
@@ -108,9 +108,10 @@ describe("read-path tenant isolation", () => {
           }),
         },
         organizationUser: {
-          findFirst: vi
-            .fn()
-            .mockResolvedValue({ role: OrganizationUserRole.MEMBER }),
+          findFirst: vi.fn().mockResolvedValue({
+            role: OrganizationUserRole.MEMBER,
+            disabledAt: null,
+          }),
         },
         groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
         roleBinding: {
@@ -173,9 +174,10 @@ describe("read-path tenant isolation", () => {
     it("still grants a genuine member", async () => {
       const prisma = {
         organizationUser: {
-          findFirst: vi
-            .fn()
-            .mockResolvedValue({ role: OrganizationUserRole.MEMBER }),
+          findFirst: vi.fn().mockResolvedValue({
+            role: OrganizationUserRole.MEMBER,
+            disabledAt: null,
+          }),
         },
         groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
         roleBinding: {

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -1,3 +1,31 @@
+/**
+ * The legacy authorization surface, kept alive as the ADR-110 fork seam.
+ *
+ * Almost everything exported here is `@deprecated`, and the tags are the point
+ * — this module answered every permission question before ADR-092, so it is
+ * still what autocomplete offers and what a nearby file imports from out of
+ * habit. Three kinds of thing live here now:
+ *
+ *   - **Role bags and permission maths** (`teamRoleHasPermission`,
+ *     `getTeamRolePermissions`, `hasPermissionWithHierarchy`,
+ *     `EXTERNAL_MEMBER_PERMISSIONS`, `canView` and friends). These are second
+ *     copies of what `@langwatch/authz` owns. They agree today because
+ *     `roles-parity.unit.test.ts` holds them cell-for-cell against the
+ *     engine's, which is a guard, not a reason to read them.
+ *   - **The `.use()`d tRPC middlewares**, replaced by declaring
+ *     `.permission("…")` on the procedure (ADR-092 decision 25).
+ *   - **The fork resolvers** (`resolveProjectPermission`,
+ *     `hasOrganizationPermission`, the `batch*` helpers). These still RUN:
+ *     they ask the engine for a migrated organization and walk the legacy
+ *     tables for one that is not. They are not dead code, they are the thing
+ *     the contract PR deletes.
+ *
+ * What is NOT deprecated: `authorizeInResolver`, the ops-scope surface, the
+ * demo-project predicates and `organizationDenialReason` — those are current.
+ *
+ * New code decides through `getApp().permissions`, or the `probe*Permission` /
+ * `require*Permission` helpers in `~/server/app-layer/permissions/imperative`.
+ */
 import type {
   AuthzDenialReason,
   AuthzPermission,
@@ -32,6 +60,11 @@ import { CUSTOM_ROLE_KIND } from "../role/role-kind";
  * ADR-092 decision 25: the legacy cross-product type is retired — Permission
  * IS the registry vocabulary now. Sites that legitimately handle unregistered
  * legacy custom-role strings do so as plain strings, never as Permission.
+ *
+ * @deprecated Import `AuthzPermission` from `@langwatch/authz` instead. This
+ * is a bare alias of it kept so the legacy call sites still read, and it puts
+ * the permission vocabulary behind an rbac import that nothing else about a
+ * new call site needs.
  */
 export type Permission = AuthzPermission;
 
@@ -61,7 +94,13 @@ const ORG_EXCLUSIVE_RESOURCES: ReadonlySet<Resource> = new Set<Resource>([
   Resources.GATEWAY_SPEND,
 ]);
 
-/** True when the permission targets an organization-tier-only resource. */
+/**
+ * True when the permission targets an organization-tier-only resource.
+ *
+ * @deprecated Use `permissionGrantTiers` from `@langwatch/authz` instead —
+ * the registry records which tiers each permission is grantable at, so it
+ * cannot fall behind a new resource the way this hand-kept set can.
+ */
 export function isOrgExclusivePermission(permission: Permission): boolean {
   const resource = permission.split(":")[0] as Resource;
   return ORG_EXCLUSIVE_RESOURCES.has(resource);
@@ -73,6 +112,10 @@ export function isOrgExclusivePermission(permission: Permission): boolean {
  * grantable at any scope. Both the tRPC resolver (`checkPermissionFromBindings`)
  * and the gateway resolver (`checkRoleBindingPermission`) gate on this so the
  * rule holds no matter which path evaluates the binding.
+ *
+ * @deprecated Use `bindingScopeCanGrantPermission` from `@langwatch/authz`
+ * instead — the ADR-021 fence is the engine's, and this is a second copy of
+ * it standing in front of the legacy walk.
  */
 export function bindingScopeCanGrant(
   scopeType: RoleBindingScopeType,
@@ -394,6 +437,12 @@ const ORGANIZATION_ROLE_PERMISSIONS: Record<
  *
  * Custom roles, when assigned to EXTERNAL users, override these defaults
  * (see resolveProjectPermission).
+ *
+ * @deprecated Use `builtinRolePermissions("lite-member")` from
+ * `@langwatch/authz` instead — the engine owns the role bags now, and these
+ * two are kept cell-for-cell identical by `roles-parity.unit.test.ts`. Reading
+ * the bag from here is how a caller ends up disagreeing with the engine that
+ * decides the request.
  */
 export const EXTERNAL_MEMBER_PERMISSIONS: Permission[] = [
   "project:view",
@@ -419,6 +468,10 @@ export const EXTERNAL_MEMBER_PERMISSIONS: Permission[] = [
 /**
  * Check if a permission list includes a requested permission, with hierarchy rules
  * manage permissions automatically include view, create, update, and delete permissions
+ *
+ * @deprecated Use `permissionSatisfiedBy` from `@langwatch/authz` instead —
+ * the hierarchy rule belongs to the permission registry, and a second copy of
+ * it can only drift from the one the engine applies.
  */
 export function hasPermissionWithHierarchy(
   permissions: string[],
@@ -454,6 +507,10 @@ export function hasPermissionWithHierarchy(
 
 /**
  * Check if a team role has a specific permission
+ *
+ * @deprecated Use `builtinRoleGrants({ role: roleKeyForTeamRole(role),
+ * permission })` from `@langwatch/authz` instead — the engine owns the role
+ * bags, and this reads a second copy of them.
  */
 export function teamRoleHasPermission(
   role: TeamUserRole,
@@ -464,6 +521,12 @@ export function teamRoleHasPermission(
 
 /**
  * Check if an organization role has a specific permission
+ *
+ * @deprecated Use `builtinRoleGrants` from `@langwatch/authz` with the
+ * `org-admin` or `org-member` role key instead. Note that an answer from here
+ * is NOT an access decision: at organization scope the engine also applies the
+ * membership gate and the org-member floor, so a caller wanting "may they do
+ * this" wants `getApp().permissions`, not a role bag.
  */
 export function organizationRoleHasPermission(
   role: OrganizationUserRole,
@@ -475,6 +538,9 @@ export function organizationRoleHasPermission(
 
 /**
  * Get all permissions for a team role
+ *
+ * @deprecated Use `builtinRolePermissions(roleKeyForTeamRole(role))` from
+ * `@langwatch/authz` instead.
  */
 export function getTeamRolePermissions(role: TeamUserRole): Permission[] {
   return TEAM_ROLE_PERMISSIONS[role];
@@ -482,6 +548,9 @@ export function getTeamRolePermissions(role: TeamUserRole): Permission[] {
 
 /**
  * Get all permissions for an organization role
+ *
+ * @deprecated Use `builtinRolePermissions` from `@langwatch/authz` with the
+ * `org-admin`, `org-member` or `lite-member` role key instead.
  */
 export function getOrganizationRolePermissions(
   role: OrganizationUserRole,
@@ -494,35 +563,60 @@ export function getOrganizationRolePermissions(
 // ============================================================================
 
 /**
- * Check if user can view a resource
+ * Check if user can view a resource *
+ * @deprecated Use `builtinRoleGrants` from `@langwatch/authz` instead, or
+ * `getApp().permissions` when the question is really "may this caller do
+ * this". A team role alone has never been the whole answer — bindings, custom
+ * roles and the lite-member cap all sit on top of it — so these read as an
+ * access check and are not one.
  */
 export function canView(role: TeamUserRole, resource: Resource): boolean {
   return teamRoleHasPermission(role, `${resource}:view` as Permission);
 }
 
 /**
- * Check if user can manage a resource (full CRUD)
+ * Check if user can manage a resource (full CRUD) *
+ * @deprecated Use `builtinRoleGrants` from `@langwatch/authz` instead, or
+ * `getApp().permissions` when the question is really "may this caller do
+ * this". A team role alone has never been the whole answer — bindings, custom
+ * roles and the lite-member cap all sit on top of it — so these read as an
+ * access check and are not one.
  */
 export function canManage(role: TeamUserRole, resource: Resource): boolean {
   return teamRoleHasPermission(role, `${resource}:manage` as Permission);
 }
 
 /**
- * Check if user can create a resource
+ * Check if user can create a resource *
+ * @deprecated Use `builtinRoleGrants` from `@langwatch/authz` instead, or
+ * `getApp().permissions` when the question is really "may this caller do
+ * this". A team role alone has never been the whole answer — bindings, custom
+ * roles and the lite-member cap all sit on top of it — so these read as an
+ * access check and are not one.
  */
 export function canCreate(role: TeamUserRole, resource: Resource): boolean {
   return teamRoleHasPermission(role, `${resource}:create` as Permission);
 }
 
 /**
- * Check if user can update a resource
+ * Check if user can update a resource *
+ * @deprecated Use `builtinRoleGrants` from `@langwatch/authz` instead, or
+ * `getApp().permissions` when the question is really "may this caller do
+ * this". A team role alone has never been the whole answer — bindings, custom
+ * roles and the lite-member cap all sit on top of it — so these read as an
+ * access check and are not one.
  */
 export function canUpdate(role: TeamUserRole, resource: Resource): boolean {
   return teamRoleHasPermission(role, `${resource}:update` as Permission);
 }
 
 /**
- * Check if user can delete a resource
+ * Check if user can delete a resource *
+ * @deprecated Use `builtinRoleGrants` from `@langwatch/authz` instead, or
+ * `getApp().permissions` when the question is really "may this caller do
+ * this". A team role alone has never been the whole answer — bindings, custom
+ * roles and the lite-member cap all sit on top of it — so these read as an
+ * access check and are not one.
  */
 export function canDelete(role: TeamUserRole, resource: Resource): boolean {
   return teamRoleHasPermission(role, `${resource}:delete` as Permission);
@@ -535,6 +629,11 @@ export function canDelete(role: TeamUserRole, resource: Resource): boolean {
 /**
  * Result of resolving a permission check, including the user's organization role.
  * Used by resolve* functions to provide richer context than a simple boolean.
+ */
+/**
+ * @deprecated The answer shape of the fork-seam resolvers below, deprecated
+ * with them. A caller that wants a decision wants `PermissionDecision` from
+ * `~/server/app-layer/permissions/permission-decision.repository`.
  */
 export type PermissionResult = {
   permitted: boolean;
@@ -555,6 +654,10 @@ export type PermissionResult = {
 // MIDDLEWARE & CONTEXT HELPERS
 // ============================================================================
 
+/**
+ * @deprecated The parameter shape of the hand-`.use()`d middlewares below,
+ * deprecated with them — see `checkProjectPermission`.
+ */
 export type PermissionMiddlewareParams<InputType> = {
   ctx: {
     prisma: PrismaClient;
@@ -568,6 +671,10 @@ export type PermissionMiddlewareParams<InputType> = {
   next: () => any;
 };
 
+/**
+ * @deprecated The shape of the hand-`.use()`d middlewares, deprecated with
+ * them — see `checkProjectPermission`.
+ */
 export type PermissionMiddleware<InputType> = (
   params: PermissionMiddlewareParams<InputType>,
 ) => Promise<any>;
@@ -594,6 +701,11 @@ function membershipDisabledDenial(): TRPCError {
  * middleware survives only as a building block for the declared-custom
  * compositions that branch on their input (modelProviders' tenant anchor,
  * project creation). Do not `.use()` it on a new procedure.
+ *
+ * @deprecated Declare `.permission("…")` on the procedure instead
+ * (ADR-092 decision 25). The declared surface is checked at compile time
+ * against the input's scope ids and is what the router sweep audits; a
+ * hand-`.use()`d middleware is invisible to both.
  */
 export const checkProjectPermission =
   (permission: Permission) =>
@@ -643,6 +755,11 @@ export const checkProjectPermission =
 
 /**
  * Check if user has permission for a team
+ *
+ * @deprecated Declare `.permission("…")` on the procedure instead
+ * (ADR-092 decision 25). The declared surface is checked at compile time
+ * against the input's scope ids and is what the router sweep audits; a
+ * hand-`.use()`d middleware is invisible to both.
  */
 export const checkTeamPermission =
   (permission: Permission) =>
@@ -680,6 +797,11 @@ export const checkTeamPermission =
 
 /**
  * Check if user has permission for an organization
+ *
+ * @deprecated Declare `.permission("…")` on the procedure instead
+ * (ADR-092 decision 25). The declared surface is checked at compile time
+ * against the input's scope ids and is what the router sweep audits; a
+ * hand-`.use()`d middleware is invisible to both.
  */
 export const checkOrganizationPermission =
   (permission: Permission) =>
@@ -1064,6 +1186,14 @@ function projectPermissionScopes({
  * Resolve a project permission check, returning the permission decision
  * along with the user's organization role.
  */
+/**
+ * @deprecated Not for new callers. This is the ADR-110 fork seam: it asks
+ * the engine for a migrated organization and runs the legacy walk for one
+ * that is not, and it goes away with the walk. New code decides through
+ * `getApp().permissions` (or `probe*Permission` /
+ * `require*Permission` in `~/server/app-layer/permissions/imperative`),
+ * which reaches the same engine without depending on the fork surviving.
+ */
 export async function resolveProjectPermission(
   ctx: { prisma: PrismaClient; session: Session | null },
   projectId: string,
@@ -1133,6 +1263,14 @@ export async function resolveProjectPermission(
  * The project, the team, the organization and the caller's role in it are the
  * same for every permission, so they are read once and only the binding check
  * repeats.
+ */
+/**
+ * @deprecated Not for new callers. This is the ADR-110 fork seam: it asks
+ * the engine for a migrated organization and runs the legacy walk for one
+ * that is not, and it goes away with the walk. New code decides through
+ * `getApp().permissions` (or `probe*Permission` /
+ * `require*Permission` in `~/server/app-layer/permissions/imperative`),
+ * which reaches the same engine without depending on the fork surviving.
  */
 export async function resolveProjectPermissionAny(
   ctx: { prisma: PrismaClient; session: Session | null },
@@ -1218,6 +1356,14 @@ export async function hasProjectPermission(
 /**
  * Resolve a team permission check, returning the permission decision
  * along with the user's organization role.
+ */
+/**
+ * @deprecated Not for new callers. This is the ADR-110 fork seam: it asks
+ * the engine for a migrated organization and runs the legacy walk for one
+ * that is not, and it goes away with the walk. New code decides through
+ * `getApp().permissions` (or `probe*Permission` /
+ * `require*Permission` in `~/server/app-layer/permissions/imperative`),
+ * which reaches the same engine without depending on the fork surviving.
  */
 export async function resolveTeamPermission(
   ctx: { prisma: PrismaClient; session: Session | null },
@@ -1314,6 +1460,14 @@ export async function hasTeamPermission(
 
 /**
  * Check if user has a specific permission for an organization
+ */
+/**
+ * @deprecated Not for new callers. This is the ADR-110 fork seam: it asks
+ * the engine for a migrated organization and runs the legacy walk for one
+ * that is not, and it goes away with the walk. New code decides through
+ * `getApp().permissions` (or `probe*Permission` /
+ * `require*Permission` in `~/server/app-layer/permissions/imperative`),
+ * which reaches the same engine without depending on the fork surviving.
  */
 export async function hasOrganizationPermission(
   ctx: { prisma: PrismaClient; session: Session },
@@ -1787,6 +1941,12 @@ function teamGrants(
  * Returns the held subset, in the order given, so callers can use it directly as
  * a least-privilege grant list.
  */
+/**
+ * @deprecated Not for new callers. Same ADR-110 fork seam as the single
+ * checks above, and it goes away with the legacy walk. New code batches
+ * through `getApp().permissions` , which reaches
+ * the engine's `canBatchByIds` directly.
+ */
 export async function batchProjectPermissions(
   ctx: { prisma: PrismaClient; session: Session | null },
   args: {
@@ -1831,6 +1991,12 @@ export async function batchProjectPermissions(
  * widen it.
  *
  * Returns the held subset per team, in the order given.
+ */
+/**
+ * @deprecated Not for new callers. Same ADR-110 fork seam as the single
+ * checks above, and it goes away with the legacy walk. New code batches
+ * through `getApp().permissions` , which reaches
+ * the engine's `canBatchByIds` directly.
  */
 export async function batchTeamsPermissions(
   ctx: { prisma: PrismaClient; session: Session | null },
@@ -1953,6 +2119,12 @@ async function legacyBatchScopePermissions(
  * Project resolution still needs to know the project's team so a
  * team-scoped binding inherits to its projects. Callers pass the
  * project→teamId map alongside the project ids.
+ */
+/**
+ * @deprecated Not for new callers. Same ADR-110 fork seam as the single
+ * checks above, and it goes away with the legacy walk. New code batches
+ * through `getApp().permissions` , which reaches
+ * the engine's `canBatchByIds` directly.
  */
 export async function batchScopePermissions(
   ctx: { prisma: PrismaClient; session: Session | null },

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -1,4 +1,8 @@
-import type { AuthzPermission, EnforcedScopeFields } from "@langwatch/authz";
+import type {
+  AuthzDenialReason,
+  AuthzPermission,
+  EnforcedScopeFields,
+} from "@langwatch/authz";
 import { declareAuthzMiddleware } from "@langwatch/authz";
 import { TRPCError } from "@trpc/server";
 import { env } from "~/env.mjs";
@@ -534,6 +538,17 @@ export function canDelete(role: TeamUserRole, resource: Resource): boolean {
 export type PermissionResult = {
   permitted: boolean;
   organizationRole: OrganizationUserRole | null;
+  /**
+   * Why the check failed, when the answer came from the engine — the boundary
+   * needs it to raise the error a caller can act on rather than a generic
+   * refusal.
+   *
+   * Absent on the legacy walk, which never produced one and is being deleted
+   * (ADR-110). A legacy-head organization therefore still DENIES a disabled
+   * member — the security answer is the same on both heads — it just falls
+   * back to the generic copy instead of naming the seat.
+   */
+  denialReason?: AuthzDenialReason;
 };
 
 // ============================================================================
@@ -721,7 +736,12 @@ async function checkPermissionFromBindings({
       organizationId,
       scopeId: { in: scopeIds },
       OR: [
-        { userId, user: { orgMemberships: { some: { organizationId } } } },
+        {
+          userId,
+          user: {
+            orgMemberships: { some: { organizationId, disabledAt: null } },
+          },
+        },
         ...(groupIds.length > 0 ? [{ groupId: { in: groupIds } }] : []),
       ],
     },
@@ -879,7 +899,11 @@ async function getCurrentOrganizationRole({
   organizationId: string;
 }): Promise<OrganizationUserRole | null> {
   const member = await prisma.organizationUser?.findFirst({
-    where: { userId, organizationId },
+    // A membership an admin disabled to reclaim its seat is not a current
+    // one: it keeps its role and its history and confers no access until it
+    // is re-enabled (seat-reconciliation.feature). Matches the predicate the
+    // AuthZ collector applies to the same row.
+    where: { userId, organizationId, disabledAt: null },
     select: { role: true },
   });
   return member?.role ?? null;
@@ -1007,6 +1031,7 @@ export async function resolveProjectPermission(
       // above did, so these agree; the context's is the fallback for the
       // unresolved-scope answer, which carries no snapshot at all.
       organizationRole: decision.organizationRole ?? context.organizationRole,
+      denialReason: decision.denialReason,
     };
   }
 
@@ -1221,6 +1246,19 @@ export async function hasOrganizationPermission(
   return hasOrganizationPermissionLegacy(ctx, organizationId, permission);
 }
 
+export async function organizationDenialReason(
+  ctx: { prisma: PrismaClient; session: Session },
+  organizationId: string,
+): Promise<AuthzDenialReason | undefined> {
+  const userId = ctx.session?.user?.id;
+  if (!userId) return undefined;
+  const membership = await ctx.prisma.organizationUser?.findFirst({
+    where: { userId, organizationId },
+    select: { disabledAt: true },
+  });
+  return membership?.disabledAt ? "membership-disabled" : undefined;
+}
+
 async function hasOrganizationPermissionLegacy(
   ctx: { prisma: PrismaClient; session: Session },
   organizationId: string,
@@ -1233,7 +1271,9 @@ async function hasOrganizationPermissionLegacy(
   const userId = ctx.session.user.id;
 
   const orgMember = await ctx.prisma.organizationUser?.findFirst({
-    where: { userId, organizationId },
+    // A seat-disabled membership confers nothing, exactly as an absent one
+    // does — see getCurrentOrganizationRole above.
+    where: { userId, organizationId, disabledAt: null },
     select: { role: true },
   });
 
@@ -1435,7 +1475,10 @@ async function loadScopeResolution(
                 userId,
                 user: {
                   orgMemberships: {
-                    some: { organizationId: args.organizationId },
+                    some: {
+                      organizationId: args.organizationId,
+                      disabledAt: null,
+                    },
                   },
                 },
               },

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -539,14 +539,13 @@ export type PermissionResult = {
   permitted: boolean;
   organizationRole: OrganizationUserRole | null;
   /**
-   * Why the check failed, when the answer came from the engine — the boundary
-   * needs it to raise the error a caller can act on rather than a generic
-   * refusal.
+   * Why the check failed, when there is something a caller can act on — the
+   * boundary needs it to raise that error rather than a generic refusal.
    *
-   * Absent on the legacy walk, which never produced one and is being deleted
-   * (ADR-110). A legacy-head organization therefore still DENIES a disabled
-   * member — the security answer is the same on both heads — it just falls
-   * back to the generic copy instead of naming the seat.
+   * Set by the engine, and by the membership gate both heads share, which
+   * names a disabled seat before either walk reads a binding. Absent from the
+   * legacy binding walk itself, which never produced one and is being deleted
+   * (ADR-110).
    */
   denialReason?: AuthzDenialReason;
 };
@@ -763,11 +762,14 @@ async function checkPermissionFromBindings({
 
     const teamUser = await prisma.teamUser.findFirst({
       // Gate the legacy fallback on org membership too: a stale cross-org
-      // TeamUser row must not confer access any more than a stale RoleBinding.
+      // TeamUser row must not confer access any more than a stale RoleBinding,
+      // and neither does a seat an admin disabled.
       where: {
         userId,
         teamId: teamScope.scopeId,
-        team: { organization: { members: { some: { userId } } } },
+        team: {
+          organization: { members: { some: { userId, disabledAt: null } } },
+        },
       },
       select: { role: true, assignedRoleId: true },
     });
@@ -881,15 +883,17 @@ async function resolveBindingPermission({
 }
 
 /**
- * The single source of truth for "is this user a CURRENT member of this org,
- * and with what role". `null` means no `OrganizationUser` row — the caller must
- * fail closed rather than fall through to bindings, because a stale cross-org
- * RoleBinding can still name a non-member at a project/team scope.
- *
- * Every scoped permission path derives membership through here so a future
- * tenancy fix lands once instead of in each resolver.
+ * The membership row as stored: the role, and whether an admin disabled the
+ * seat. Both are facts. The policy that a disabled membership is not a
+ * current one lives in `currentRoleOf`, the same split the AuthZ read port
+ * makes, so a refusal can still say WHICH gate closed.
  */
-async function getCurrentOrganizationRole({
+type CurrentMembership = {
+  role: OrganizationUserRole;
+  disabled: boolean;
+};
+
+async function getCurrentMembership({
   prisma,
   userId,
   organizationId,
@@ -897,23 +901,90 @@ async function getCurrentOrganizationRole({
   prisma: PrismaClient;
   userId: string;
   organizationId: string;
-}): Promise<OrganizationUserRole | null> {
+}): Promise<CurrentMembership | null> {
   const member = await prisma.organizationUser?.findFirst({
-    // A membership an admin disabled to reclaim its seat is not a current
-    // one: it keeps its role and its history and confers no access until it
-    // is re-enabled (seat-reconciliation.feature). Matches the predicate the
-    // AuthZ collector applies to the same row.
-    where: { userId, organizationId, disabledAt: null },
-    select: { role: true },
+    where: { userId, organizationId },
+    select: { role: true, disabledAt: true },
   });
-  return member?.role ?? null;
+  if (!member) return null;
+  // `!== null`, not `!= null`: a row arriving without the column reads as
+  // DISABLED, the same loud-lockout choice the read repository makes.
+  return { role: member.role, disabled: member.disabledAt !== null };
 }
 
 /**
+ * A membership an admin disabled to reclaim its seat is not a current one: it
+ * keeps its role and its history and confers no access until it is re-enabled
+ * (seat-reconciliation.feature). Matches the policy the AuthZ collector
+ * applies to the same row.
+ */
+function currentRoleOf(
+  membership: CurrentMembership | null,
+): OrganizationUserRole | null {
+  return membership && !membership.disabled ? membership.role : null;
+}
+
+/**
+ * Why a membership read refused, when there is something to say. A disabled
+ * seat is named so the boundary can tell the person their access was turned
+ * off rather than that they are not a member. An absent row says nothing
+ * here: the generic denial is already the right answer for it.
+ */
+function membershipDenialReason(
+  membership: CurrentMembership | null,
+): AuthzDenialReason | undefined {
+  return membership?.disabled ? "membership-disabled" : undefined;
+}
+
+/**
+ * The single source of truth for "is this user a CURRENT member of this org,
+ * and with what role". `null` means no active `OrganizationUser` row — the
+ * caller must fail closed rather than fall through to bindings, because a
+ * stale cross-org RoleBinding can still name a non-member at a project/team
+ * scope.
+ *
+ * Every scoped permission path derives membership through here so a future
+ * tenancy fix lands once instead of in each resolver.
+ */
+async function getCurrentOrganizationRole(args: {
+  prisma: PrismaClient;
+  userId: string;
+  organizationId: string;
+}): Promise<OrganizationUserRole | null> {
+  return currentRoleOf(await getCurrentMembership(args));
+}
+
+/** A denial reached before any binding was read. */
+function refused(denialReason?: AuthzDenialReason): PermissionResult {
+  return {
+    permitted: false,
+    organizationRole: null,
+    ...(denialReason ? { denialReason } : {}),
+  };
+}
+
+type ProjectPermissionContext = {
+  userId: string;
+  teamId: string;
+  organizationId: string;
+  organizationRole: OrganizationUserRole;
+};
+
+/**
+ * The context resolved to a denial before any binding was read, carrying
+ * the reason when there is one a caller can act on.
+ */
+type ProjectPermissionRefusal = {
+  refused: true;
+  denialReason?: AuthzDenialReason;
+};
+
+/**
  * Where a project sits and where the caller stands in it: everything a
- * permission check needs before it looks at a single binding. Null when the
- * answer is already a denial, either because the project has no team or
- * organization or because the caller is not a member of that organization.
+ * permission check needs before it looks at a single binding. A refusal when
+ * the answer is already a denial, either because the project has no team or
+ * organization or because the caller is not an active member of that
+ * organization.
  *
  * Resolved on its own so a gate that tests several permissions pays for it
  * once: only the binding check below differs from permission to permission.
@@ -921,14 +992,9 @@ async function getCurrentOrganizationRole({
 async function resolveProjectPermissionContext(
   ctx: { prisma: PrismaClient; session: Session | null },
   projectId: string,
-): Promise<{
-  userId: string;
-  teamId: string;
-  organizationId: string;
-  organizationRole: OrganizationUserRole;
-} | null> {
+): Promise<ProjectPermissionContext | ProjectPermissionRefusal> {
   const userId = ctx.session?.user?.id;
-  if (!userId) return null;
+  if (!userId) return { refused: true };
 
   const projectTeam = await ctx.prisma.project.findUnique?.({
     where: { id: projectId },
@@ -938,21 +1004,26 @@ async function resolveProjectPermissionContext(
   const teamId = projectTeam?.team.id;
   const organizationId = projectTeam?.team.organizationId;
 
-  if (!teamId || !organizationId) return null;
+  if (!teamId || !organizationId) return { refused: true };
 
-  const organizationRole = await getCurrentOrganizationRole({
+  const membership = await getCurrentMembership({
     prisma: ctx.prisma,
     userId,
     organizationId,
   });
+  const organizationRole = currentRoleOf(membership);
 
   // Fail closed on current organization membership. A user who is not an
-  // OrganizationUser of the owning org is denied outright, even if a stale
-  // RoleBinding (created through a since-closed cross-org path) still names them
-  // at this project/team scope. The membership check — not the binding row — is
-  // the authoritative tenancy boundary. See the same gate in resolveTeamPermission
-  // and batchScopePermissions, and the direct-binding predicate below.
-  if (organizationRole === null) return null;
+  // active OrganizationUser of the owning org is denied outright, even if a
+  // stale RoleBinding (created through a since-closed cross-org path) still
+  // names them at this project/team scope. The membership check — not the
+  // binding row — is the authoritative tenancy boundary. See the same gate in
+  // resolveTeamPermission and batchScopePermissions, and the direct-binding
+  // predicate below. A disabled seat is refused here too, before either head
+  // runs, and named so the boundary can say so.
+  if (organizationRole === null) {
+    return { refused: true, denialReason: membershipDenialReason(membership) };
+  }
 
   return { userId, teamId, organizationId, organizationRole };
 }
@@ -993,7 +1064,7 @@ export async function resolveProjectPermission(
   }
 
   const context = await resolveProjectPermissionContext(ctx, projectId);
-  if (!context) return { permitted: false, organizationRole: null };
+  if ("refused" in context) return refused(context.denialReason);
 
   /** The legacy binding walk, run only while this organization is still
    *  waiting for its migration. */
@@ -1063,7 +1134,7 @@ export async function resolveProjectPermissionAny(
   }
 
   const context = await resolveProjectPermissionContext(ctx, projectId);
-  if (!context) return { permitted: false, organizationRole: null };
+  if ("refused" in context) return refused(context.denialReason);
 
   const scopes = projectPermissionScopes({
     projectId,
@@ -1088,6 +1159,7 @@ export async function resolveProjectPermissionAny(
     return {
       permitted: decision.allowed,
       organizationRole: decision.organizationRole ?? context.organizationRole,
+      denialReason: decision.denialReason,
     };
   }
 
@@ -1149,17 +1221,19 @@ export async function resolveTeamPermission(
     return { permitted: false, organizationRole: null };
   }
 
-  const organizationRole = await getCurrentOrganizationRole({
+  const membership = await getCurrentMembership({
     prisma: ctx.prisma,
     userId: ctx.session.user.id,
     organizationId: team.organizationId,
   });
+  const organizationRole = currentRoleOf(membership);
 
-  // Fail closed on current organization membership — a non-member is denied even
-  // if a stale cross-org binding names them at this team scope. See the matching
-  // gate in resolveProjectPermission.
+  // Fail closed on current organization membership — a non-member is denied
+  // even if a stale cross-org binding names them at this team scope, and a
+  // disabled seat is refused by name. See the matching gate in
+  // resolveProjectPermission.
   if (organizationRole === null) {
-    return { permitted: false, organizationRole: null };
+    return refused(membershipDenialReason(membership));
   }
 
   const userId = ctx.session.user.id;
@@ -1196,6 +1270,7 @@ export async function resolveTeamPermission(
     return {
       permitted: decision.allowed,
       organizationRole: decision.organizationRole ?? organizationRole,
+      denialReason: decision.denialReason,
     };
   }
 
@@ -1246,17 +1321,24 @@ export async function hasOrganizationPermission(
   return hasOrganizationPermissionLegacy(ctx, organizationId, permission);
 }
 
-export async function organizationDenialReason(
-  ctx: { prisma: PrismaClient; session: Session },
-  organizationId: string,
-): Promise<AuthzDenialReason | undefined> {
+/**
+ * Why an organization-scope check refused, asked only after it did: one
+ * indexed read on the refusal path rather than a second walk, so the
+ * permitted path pays nothing. Undefined when there is nothing more useful
+ * to say than the generic denial.
+ */
+export async function organizationDenialReason({
+  ctx,
+  organizationId,
+}: {
+  ctx: { prisma: PrismaClient; session: Session };
+  organizationId: string;
+}): Promise<AuthzDenialReason | undefined> {
   const userId = ctx.session?.user?.id;
   if (!userId) return undefined;
-  const membership = await ctx.prisma.organizationUser?.findFirst({
-    where: { userId, organizationId },
-    select: { disabledAt: true },
-  });
-  return membership?.disabledAt ? "membership-disabled" : undefined;
+  return membershipDenialReason(
+    await getCurrentMembership({ prisma: ctx.prisma, userId, organizationId }),
+  );
 }
 
 async function hasOrganizationPermissionLegacy(

--- a/platform/app/src/server/api/rbac.ts
+++ b/platform/app/src/server/api/rbac.ts
@@ -16,6 +16,7 @@ import { authzChecksFor } from "~/server/app-layer/authz/checks";
 import { organizationOnAuthzEngine } from "~/server/app-layer/authz/engine-gate";
 import {
   LiteMemberRestrictedError,
+  MembershipDisabledError,
   ProjectPermissionDeniedError,
 } from "~/server/app-layer/permissions/errors";
 import type { Session } from "~/server/auth";
@@ -572,6 +573,21 @@ export type PermissionMiddleware<InputType> = (
 ) => Promise<any>;
 
 /**
+ * A disabled seat outranks the role-shaped denials that follow it: the person
+ * HAS a role, so the lite-member modal and the "ask an admin for this
+ * permission" copy would both point them at something nobody can grant while
+ * the seat is off.
+ */
+function membershipDisabledDenial(): TRPCError {
+  const disabled = new MembershipDisabledError();
+  return new TRPCError({
+    code: "UNAUTHORIZED",
+    message: disabled.message,
+    cause: disabled,
+  });
+}
+
+/**
  * Check if user has permission for a project.
  *
  * ADR-092 decision 25: procedures declare `.permission("…")` now — this
@@ -586,13 +602,13 @@ export const checkProjectPermission =
     input,
     next,
   }: PermissionMiddlewareParams<{ projectId: string }>) => {
-    const { permitted, organizationRole } = await resolveProjectPermission(
-      ctx,
-      input.projectId,
-      permission,
-    );
+    const { permitted, organizationRole, denialReason } =
+      await resolveProjectPermission(ctx, input.projectId, permission);
 
     if (!permitted) {
+      if (denialReason === "membership-disabled") {
+        throw membershipDisabledDenial();
+      }
       if (organizationRole === OrganizationUserRole.EXTERNAL) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
@@ -635,13 +651,13 @@ export const checkTeamPermission =
     input,
     next,
   }: PermissionMiddlewareParams<{ teamId: string }>) => {
-    const { permitted, organizationRole } = await resolveTeamPermission(
-      ctx,
-      input.teamId,
-      permission,
-    );
+    const { permitted, organizationRole, denialReason } =
+      await resolveTeamPermission(ctx, input.teamId, permission);
 
     if (!permitted) {
+      if (denialReason === "membership-disabled") {
+        throw membershipDisabledDenial();
+      }
       if (organizationRole === OrganizationUserRole.EXTERNAL) {
         throw new TRPCError({
           code: "UNAUTHORIZED",

--- a/platform/app/src/server/api/routers/__tests__/evaluators.tenant-workflow.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/evaluators.tenant-workflow.unit.test.ts
@@ -43,7 +43,10 @@ const prisma = {
     }),
   },
   organizationUser: {
-    findFirst: vi.fn().mockResolvedValue({ role: OrganizationUserRole.ADMIN }),
+    findFirst: vi.fn().mockResolvedValue({
+      role: OrganizationUserRole.ADMIN,
+      disabledAt: null,
+    }),
   },
   groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
   roleBinding: {

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
@@ -44,11 +44,13 @@ const organizationUsers = [
     userId: "user_member_of_project_a",
     organizationId: "org_a",
     role: "MEMBER",
+    disabledAt: null,
   },
   {
     userId: "user_other_project_admin",
     organizationId: "org_a",
     role: "MEMBER",
+    disabledAt: null,
   },
   { userId: "user_other_org_admin", organizationId: "org_b", role: "ADMIN" },
 ];

--- a/platform/app/src/server/api/routers/__tests__/organization.setMemberDisabled.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/organization.setMemberDisabled.integration.test.ts
@@ -19,7 +19,7 @@ import {
 } from "~/generated/prisma/client";
 import { UNLIMITED_PLAN } from "../../../../../ee/licensing/constants";
 import { cleanupTestRows } from "../../../../test-utils/cleanupTestRows";
-import { globalForApp, resetApp } from "../../../app-layer/app";
+import { getApp, globalForApp, resetApp } from "../../../app-layer/app";
 import { OrganizationService } from "../../../app-layer/organizations/organization.service";
 import { PrismaOrganizationRepository } from "../../../app-layer/organizations/repositories/organization.prisma.repository";
 import { createTestApp } from "../../../app-layer/presets";
@@ -152,6 +152,29 @@ describe("organization.setMemberDisabled", () => {
     ]);
   });
 
+  /**
+   * Whether the person can actually ACT in the organization, asked the way a
+   * request asks it: through the authorization engine.
+   *
+   * Deliberately NOT `repo.getUserOrgRole`, which is what this file used to
+   * assert on. That reader filtered `disabledAt` for as long as disabling has
+   * existed - but nothing on the permission path did, so a disabled member
+   * kept every permission while this scenario went on passing. An access
+   * assertion has to go through the thing that grants access.
+   *
+   * `organization:view` is the right probe because this member holds no
+   * binding at all: it is the floor every org member gets, so it is exactly
+   * the access that disabling has to take away.
+   */
+  const canActInOrganization = async (userId: string): Promise<boolean> =>
+    (
+      await getApp().permissions.getDecision({
+        userId,
+        permission: "organization:view",
+        scope: { tier: "organization", id: organizationId },
+      })
+    ).permitted;
+
   // Placed first, while every member is still active: these describe the state
   // an organization lands in the moment it activates a license for fewer seats
   // than it already uses.
@@ -161,9 +184,7 @@ describe("organization.setMemberDisabled", () => {
       licensedSeats = 1;
 
       for (const userId of [adminUserId, secondAdminUserId, memberUserId]) {
-        expect(
-          await repo.getUserOrgRole({ userId, organizationId }),
-        ).not.toBeNull();
+        expect(await canActInOrganization(userId)).toBe(true);
       }
 
       licensedSeats = 50;
@@ -198,13 +219,24 @@ describe("organization.setMemberDisabled", () => {
     });
 
     /** @scenario A disabled member loses access but keeps their record */
+    /** @scenario A disabled member cannot act through any permission path */
     it("revokes their access to the organization", async () => {
-      const role = await repo.getUserOrgRole({
+      expect(await canActInOrganization(memberUserId)).toBe(false);
+    });
+
+    /** @scenario A disabled member cannot act through any permission path */
+    it("tells them their access was disabled, not that they are a stranger here", async () => {
+      // They ARE still a member. A denial reading "no membership" would be
+      // both wrong and unactionable; naming the seat points them at the admin
+      // who can return it.
+      const decision = await getApp().permissions.getDecision({
         userId: memberUserId,
-        organizationId,
+        permission: "organization:view",
+        scope: { tier: "organization", id: organizationId },
       });
 
-      expect(role).toBeNull();
+      expect(decision.permitted).toBe(false);
+      expect(decision.denialReason).toBe("membership-disabled");
     });
 
     /** @scenario A disabled member loses access but keeps their record */
@@ -231,12 +263,10 @@ describe("organization.setMemberDisabled", () => {
         disabled: false,
       });
 
-      const role = await repo.getUserOrgRole({
-        userId: memberUserId,
-        organizationId,
-      });
-
-      expect(role).toBe(OrganizationUserRole.MEMBER);
+      expect(await canActInOrganization(memberUserId)).toBe(true);
+      expect(
+        await repo.getUserOrgRole({ userId: memberUserId, organizationId }),
+      ).toBe(OrganizationUserRole.MEMBER);
     });
   });
 

--- a/platform/app/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
@@ -99,9 +99,10 @@ describe("team.update", () => {
         count: organizationUserCount,
         // Current-org membership for the caller: the rbac resolver fails
         // closed without it.
-        findFirst: vi
-          .fn()
-          .mockResolvedValue({ role: OrganizationUserRole.ADMIN }),
+        findFirst: vi.fn().mockResolvedValue({
+          role: OrganizationUserRole.ADMIN,
+          disabledAt: null,
+        }),
       },
       groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
       roleBinding: {

--- a/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/trpc-middleware.unit.test.ts
@@ -30,6 +30,10 @@ vi.mock("~/server/api/rbac", () => ({
   resolveTeamPermission: (...args: unknown[]) => resolveTeamPermission(...args),
   hasOrganizationPermission: (...args: unknown[]) =>
     hasOrganizationPermission(...args),
+  // Only consulted on a refusal, to say WHY. Nothing in this suite is about a
+  // disabled seat, so it answers "nothing more useful to say" and the generic
+  // denial the assertions below expect is what comes out.
+  organizationDenialReason: async () => undefined,
   resolveProjectPermissionAny: (...args: unknown[]) =>
     resolveProjectPermissionAny(...args),
 }));

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.cutover.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.cutover.repository.unit.test.ts
@@ -13,7 +13,7 @@ import { CutoverAwareAuthzReadRepository } from "../authz-read.cutover.repositor
  */
 const spyRepository = (name: string): AuthzReadRepository =>
   ({
-    findOrganizationRole: vi.fn().mockResolvedValue(name),
+    findOrganizationMembership: vi.fn().mockResolvedValue(name),
     findUserBindings: vi.fn().mockResolvedValue([]),
     findGroupBindings: vi.fn().mockResolvedValue([]),
     findApiKeyBindings: vi.fn().mockResolvedValue([]),
@@ -167,7 +167,7 @@ describe("CutoverAwareAuthzReadRepository", () => {
       // both implementations run the same query against the same table, so
       // forking them would cost a gate read and change nothing.
       expect(
-        await repository.findOrganizationRole({
+        await repository.findOrganizationMembership({
           userId: "alice",
           organizationId: "org-1",
         }),
@@ -178,7 +178,7 @@ describe("CutoverAwareAuthzReadRepository", () => {
       await repository.findProjectLineage({ projectId: "proj-1" });
       await repository.findTeamOrganization({ teamId: "team-1" });
 
-      expect(grants.findOrganizationRole).not.toHaveBeenCalled();
+      expect(grants.findOrganizationMembership).not.toHaveBeenCalled();
       expect(grants.findApiKeyOwner).not.toHaveBeenCalled();
       expect(grants.findProjectLineage).not.toHaveBeenCalled();
       expect(grants.findTeamOrganization).not.toHaveBeenCalled();

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.grants.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.grants.repository.unit.test.ts
@@ -19,23 +19,44 @@ const member = () =>
   vi.fn().mockResolvedValue({ userId: "alice" }) as ReturnType<typeof vi.fn>;
 
 describe("GrantsAuthzReadRepository", () => {
-  describe("when findOrganizationRole reads the membership row", () => {
+  describe("when findOrganizationMembership reads the membership row", () => {
     it("reads the membership row, which the ledger never projected", async () => {
-      const findFirst = vi.fn().mockResolvedValue({ role: "ADMIN" });
+      const findFirst = vi
+        .fn()
+        .mockResolvedValue({ role: "ADMIN", disabledAt: null });
       const repository = new GrantsAuthzReadRepository(
         clientFor({ organizationUser: { findFirst } }),
       );
 
       expect(
-        await repository.findOrganizationRole({
+        await repository.findOrganizationMembership({
           userId: "alice",
           organizationId: "org-1",
         }),
-      ).toBe("ADMIN");
+      ).toEqual({ role: "ADMIN", disabled: false });
       expect(findFirst).toHaveBeenCalledWith({
         where: { userId: "alice", organizationId: "org-1" },
-        select: { role: true },
+        select: { role: true, disabledAt: true },
       });
+    });
+
+    it("reports a seat-disabled row as disabled, so the denial can name the seat", async () => {
+      const repository = new GrantsAuthzReadRepository(
+        clientFor({
+          organizationUser: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValue({ role: "MEMBER", disabledAt: new Date() }),
+          },
+        }),
+      );
+
+      expect(
+        await repository.findOrganizationMembership({
+          userId: "alice",
+          organizationId: "org-1",
+        }),
+      ).toEqual({ role: "MEMBER", disabled: true });
     });
   });
 
@@ -340,7 +361,9 @@ describe("GrantsAuthzReadRepository", () => {
           userId: "alice",
           team: {
             organizationId: "org-1",
-            organization: { members: { some: { userId: "alice" } } },
+            organization: {
+              members: { some: { userId: "alice", disabledAt: null } },
+            },
           },
         },
         select: {

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.prisma.repository.unit.test.ts
@@ -12,23 +12,54 @@ import { PrismaAuthzReadRepository } from "../authz-read.prisma.repository";
  * key it was minted for.
  */
 describe("PrismaAuthzReadRepository", () => {
-  describe("findOrganizationRole", () => {
-    describe("when the user is a member of the organization", () => {
+  describe("findOrganizationMembership", () => {
+    describe("when the user is an active member of the organization", () => {
       it("reads the membership row for this user in this organization", async () => {
-        const findFirst = vi.fn().mockResolvedValue({ role: "ADMIN" });
+        const findFirst = vi
+          .fn()
+          .mockResolvedValue({ role: "ADMIN", disabledAt: null });
         const prisma = {
           organizationUser: { findFirst },
         } as unknown as Prisma.TransactionClient;
 
-        const role = await new PrismaAuthzReadRepository(
+        const membership = await new PrismaAuthzReadRepository(
           prisma,
-        ).findOrganizationRole({ userId: "alice", organizationId: "org-1" });
+        ).findOrganizationMembership({
+          userId: "alice",
+          organizationId: "org-1",
+        });
 
+        // `disabledAt` is SELECTED and not filtered on purpose: the row is a
+        // fact and the collector applies the policy. This assertion is the
+        // one that used to pin the opposite - a select without `disabledAt` -
+        // which is how a disabled member kept every permission.
         expect(findFirst).toHaveBeenCalledWith({
           where: { userId: "alice", organizationId: "org-1" },
-          select: { role: true },
+          select: { role: true, disabledAt: true },
         });
-        expect(role).toBe("ADMIN");
+        expect(membership).toEqual({ role: "ADMIN", disabled: false });
+      });
+    });
+
+    describe("when the membership has been disabled to free its seat", () => {
+      it("reports the row as disabled rather than hiding it, so the denial can say so", async () => {
+        const prisma = {
+          organizationUser: {
+            findFirst: vi.fn().mockResolvedValue({
+              role: "ADMIN",
+              disabledAt: new Date("2026-01-01"),
+            }),
+          },
+        } as unknown as Prisma.TransactionClient;
+
+        expect(
+          await new PrismaAuthzReadRepository(
+            prisma,
+          ).findOrganizationMembership({
+            userId: "alice",
+            organizationId: "org-1",
+          }),
+        ).toEqual({ role: "ADMIN", disabled: true });
       });
     });
 
@@ -39,7 +70,9 @@ describe("PrismaAuthzReadRepository", () => {
         } as unknown as Prisma.TransactionClient;
 
         expect(
-          await new PrismaAuthzReadRepository(prisma).findOrganizationRole({
+          await new PrismaAuthzReadRepository(
+            prisma,
+          ).findOrganizationMembership({
             userId: "alice",
             organizationId: "org-1",
           }),
@@ -73,7 +106,11 @@ describe("PrismaAuthzReadRepository", () => {
         where: {
           organizationId: "org-1",
           userId: "alice",
-          user: { orgMemberships: { some: { organizationId: "org-1" } } },
+          user: {
+            orgMemberships: {
+              some: { organizationId: "org-1", disabledAt: null },
+            },
+          },
         },
         select: {
           role: true,
@@ -123,7 +160,11 @@ describe("PrismaAuthzReadRepository", () => {
             members: {
               some: {
                 userId: "alice",
-                user: { orgMemberships: { some: { organizationId: "org-1" } } },
+                user: {
+                  orgMemberships: {
+                    some: { organizationId: "org-1", disabledAt: null },
+                  },
+                },
               },
             },
           },
@@ -374,7 +415,9 @@ describe("PrismaAuthzReadRepository", () => {
           userId: "alice",
           team: {
             organizationId: "org-1",
-            organization: { members: { some: { userId: "alice" } } },
+            organization: {
+              members: { some: { userId: "alice", disabledAt: null } },
+            },
           },
         },
         select: {

--- a/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/__tests__/authz-read.prisma.repository.unit.test.ts
@@ -12,7 +12,7 @@ import { PrismaAuthzReadRepository } from "../authz-read.prisma.repository";
  * key it was minted for.
  */
 describe("PrismaAuthzReadRepository", () => {
-  describe("findOrganizationMembership", () => {
+  describe("when reading organization membership", () => {
     describe("when the user is an active member of the organization", () => {
       it("reads the membership row for this user in this organization", async () => {
         const findFirst = vi

--- a/platform/app/src/server/app-layer/authz/repositories/authz-read.cutover.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-read.cutover.repository.ts
@@ -6,7 +6,7 @@
  * about, asks the cutover gate whether that organization is served by the
  * engine, and delegates.
  *
- * `findOrganizationRole`, `findApiKeyOwner`, `findProjectLineage` and
+ * `findOrganizationMembership`, `findApiKeyOwner`, `findProjectLineage` and
  * `findTeamOrganization` go to legacy always, unconditionally - not an
  * exception to the fork: membership and lineage are not grants and were
  * never projected onto the ledger's head, so both implementations run the
@@ -49,7 +49,7 @@ import type {
 import type {
   AuthzReadRepository,
   CustomRolePermissionsRow,
-  OrganizationRole,
+  OrganizationMembership,
   ShareLinkRow,
 } from "@langwatch/authz-server";
 import type { Prisma } from "~/generated/prisma/client";
@@ -85,11 +85,11 @@ export class CutoverAwareAuthzReadRepository implements AuthzReadRepository {
     return new CutoverAwareAuthzReadRepository(this.prisma, this.repositories);
   }
 
-  async findOrganizationRole(args: {
+  async findOrganizationMembership(args: {
     userId: string;
     organizationId: string;
-  }): Promise<OrganizationRole | null> {
-    return this.repositories.legacy.findOrganizationRole(args);
+  }): Promise<OrganizationMembership | null> {
+    return this.repositories.legacy.findOrganizationMembership(args);
   }
 
   async findUserBindings(args: {

--- a/platform/app/src/server/app-layer/authz/repositories/authz-read.grants.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-read.grants.repository.ts
@@ -26,7 +26,7 @@ import type {
 import type {
   AuthzReadRepository,
   CustomRolePermissionsRow,
-  OrganizationRole,
+  OrganizationMembership,
   ShareLinkRow,
 } from "@langwatch/authz-server";
 import {
@@ -50,18 +50,19 @@ export class GrantsAuthzReadRepository implements AuthzReadRepository {
   constructor(private readonly prisma: Prisma.TransactionClient) {}
 
   /** Membership is not a grant: the same query the legacy repository runs. */
-  async findOrganizationRole({
+  async findOrganizationMembership({
     userId,
     organizationId,
   }: {
     userId: string;
     organizationId: string;
-  }): Promise<OrganizationRole | null> {
+  }): Promise<OrganizationMembership | null> {
     const row = await this.prisma.organizationUser.findFirst({
       where: { userId, organizationId },
-      select: { role: true },
+      select: { role: true, disabledAt: true },
     });
-    return row?.role ?? null;
+    if (!row) return null;
+    return { role: row.role, disabled: row.disabledAt !== null };
   }
 
   async findUserBindings({
@@ -176,7 +177,7 @@ export class GrantsAuthzReadRepository implements AuthzReadRepository {
         userId,
         team: {
           organizationId,
-          organization: { members: { some: { userId } } },
+          organization: { members: { some: { userId, disabledAt: null } } },
         },
       },
       select: {
@@ -407,8 +408,12 @@ export class GrantsAuthzReadRepository implements AuthzReadRepository {
     userId: string;
     organizationId: string;
   }): Promise<boolean> {
+    // `disabledAt: null` is part of the predicate, not a refinement of it: a
+    // seat-disabled membership confers no grants, exactly as a removed one
+    // does. This is the ledger-head twin of the relation fence the legacy
+    // repository puts on each binding query.
     const membership = await this.prisma.organizationUser.findFirst({
-      where: { userId, organizationId },
+      where: { userId, organizationId, disabledAt: null },
       select: { userId: true },
     });
     return membership !== null;

--- a/platform/app/src/server/app-layer/authz/repositories/authz-read.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-read.prisma.repository.ts
@@ -17,7 +17,7 @@ import type {
 import type {
   AuthzReadRepository,
   CustomRolePermissionsRow,
-  OrganizationRole,
+  OrganizationMembership,
   ShareLinkRow,
 } from "@langwatch/authz-server";
 import type { Prisma } from "~/generated/prisma/client";
@@ -26,18 +26,27 @@ import { CUSTOM_ROLE_KIND } from "../../../role/role-kind";
 export class PrismaAuthzReadRepository implements AuthzReadRepository {
   constructor(private readonly prisma: Prisma.TransactionClient) {}
 
-  async findOrganizationRole({
+  async findOrganizationMembership({
     userId,
     organizationId,
   }: {
     userId: string;
     organizationId: string;
-  }): Promise<OrganizationRole | null> {
+  }): Promise<OrganizationMembership | null> {
+    // `disabledAt` is SELECTED, not filtered: the row is a stored fact and the
+    // collector applies the policy. Filtering here would report a disabled
+    // membership as absent, and the denial could then only say "not a member"
+    // of someone who is one.
     const row = await this.prisma.organizationUser.findFirst({
       where: { userId, organizationId },
-      select: { role: true },
+      select: { role: true, disabledAt: true },
     });
-    return row?.role ?? null;
+    if (!row) return null;
+    // `!== null`, not `!= null`: a row that arrives without the column at all
+    // reads as DISABLED. That can only happen if someone drops `disabledAt`
+    // from the select above, and between a loud lockout and a silent return
+    // of everyone's access, the lockout is the one that gets noticed.
+    return { role: row.role, disabled: row.disabledAt !== null };
   }
 
   async findUserBindings({
@@ -48,15 +57,18 @@ export class PrismaAuthzReadRepository implements AuthzReadRepository {
     organizationId: string;
   }): Promise<CollectedBinding[]> {
     const rows = await this.prisma.roleBinding.findMany({
-      // Current organization membership - not the binding row - is the
+      // Current ACTIVE organization membership - not the binding row - is the
       // tenancy boundary: a binding naming a user who has left the
-      // organization confers nothing. Same predicate the legacy resolvers
-      // carry (rbac.ts checkPermissionFromBindings, role-binding-resolver.ts
+      // organization, or whose seat an admin disabled, confers nothing. Same
+      // predicate the legacy resolvers carry (rbac.ts
+      // checkPermissionFromBindings, role-binding-resolver.ts
       // collectBindingsForUser).
       where: {
         organizationId,
         userId,
-        user: { orgMemberships: { some: { organizationId } } },
+        user: {
+          orgMemberships: { some: { organizationId, disabledAt: null } },
+        },
       },
       select: {
         role: true,
@@ -86,7 +98,9 @@ export class PrismaAuthzReadRepository implements AuthzReadRepository {
           members: {
             some: {
               userId,
-              user: { orgMemberships: { some: { organizationId } } },
+              user: {
+                orgMemberships: { some: { organizationId, disabledAt: null } },
+              },
             },
           },
         },
@@ -143,7 +157,7 @@ export class PrismaAuthzReadRepository implements AuthzReadRepository {
         userId,
         team: {
           organizationId,
-          organization: { members: { some: { userId } } },
+          organization: { members: { some: { userId, disabledAt: null } } },
         },
       },
       select: {

--- a/platform/app/src/server/app-layer/authz/trpc-middleware.ts
+++ b/platform/app/src/server/app-layer/authz/trpc-middleware.ts
@@ -283,7 +283,7 @@ function deniedError({
   // offers an upgrade they cannot buy, and the generic denial names a
   // permission nobody can grant them while the seat is off.
   if (denialReason === "membership-disabled") {
-    const disabled = new MembershipDisabledError(scope.id);
+    const disabled = new MembershipDisabledError();
     return new TRPCError({
       code: "UNAUTHORIZED",
       message: disabled.message,

--- a/platform/app/src/server/app-layer/authz/trpc-middleware.ts
+++ b/platform/app/src/server/app-layer/authz/trpc-middleware.ts
@@ -28,6 +28,7 @@
  * and refuses any procedure whose chain carries none.
  */
 import {
+  type AuthzDenialReason,
   type AuthzPermission,
   type DeclaredAuthzMiddleware,
   type DeclaredScopeId,
@@ -42,7 +43,10 @@ import { TRPCError } from "@trpc/server";
 import type { OrganizationUserRole } from "~/generated/prisma/client";
 import type { Session } from "../../auth";
 import { type App, getApp } from "../app";
-import { LiteMemberRestrictedError } from "../permissions/errors";
+import {
+  LiteMemberRestrictedError,
+  MembershipDisabledError,
+} from "../permissions/errors";
 
 const logger = createLogger("langwatch:authz");
 
@@ -96,7 +100,7 @@ export const checkDeclaredPermission = ({
       }
 
       const scope = requireDeclaredScope({ permission, input, via });
-      const { permitted, organizationRole } = await appOf(
+      const { permitted, organizationRole, denialReason } = await appOf(
         ctx,
       ).permissions.getDecision({
         userId: ctx.session.user.id,
@@ -104,7 +108,12 @@ export const checkDeclaredPermission = ({
         scope,
       });
       if (!permitted) {
-        throw deniedError({ permission, scope, organizationRole });
+        throw deniedError({
+          permission,
+          scope,
+          organizationRole,
+          denialReason,
+        });
       }
       // Legacy parity: the organization tier never carried a role onto the
       // context, so only the project/team resolutions (non-null role) do.
@@ -137,7 +146,7 @@ export const checkDeclaredPermissionAny = (
       if (typeof projectId !== "string" || projectId.length === 0) {
         throw wiringBug({ permission: permissions[0] });
       }
-      const { permitted, organizationRole } = await appOf(
+      const { permitted, organizationRole, denialReason } = await appOf(
         ctx,
       ).permissions.getProjectAnyDecision({
         userId: ctx.session.user.id,
@@ -149,6 +158,7 @@ export const checkDeclaredPermissionAny = (
           permission: permissions[0],
           scope: { tier: "project", id: projectId },
           organizationRole,
+          denialReason,
         });
       }
       ctx.organizationRole = organizationRole;
@@ -261,11 +271,25 @@ function deniedError({
   permission,
   scope,
   organizationRole,
+  denialReason,
 }: {
   permission: AuthzPermission;
   scope: DeclaredScopeId;
   organizationRole: OrganizationUserRole | null;
+  denialReason?: AuthzDenialReason;
 }): TRPCError {
+  // Checked before the role, because a disabled member HAS a role and the
+  // role-shaped answers would all be wrong for them: the lite-member modal
+  // offers an upgrade they cannot buy, and the generic denial names a
+  // permission nobody can grant them while the seat is off.
+  if (denialReason === "membership-disabled") {
+    const disabled = new MembershipDisabledError(scope.id);
+    return new TRPCError({
+      code: "UNAUTHORIZED",
+      message: disabled.message,
+      cause: disabled,
+    });
+  }
   // String comparison on purpose: a VALUE import of the Prisma enum would put
   // the generated client on this module's graph for one constant.
   if (organizationRole === "EXTERNAL") {
@@ -280,7 +304,7 @@ function deniedError({
   const denied = new PermissionDeniedError({
     permission,
     scope: { type: scope.tier, id: scope.id },
-    denialReason: "no-binding",
+    denialReason: denialReason ?? "no-binding",
   });
   // The wire code that results is FORBIDDEN, not the UNAUTHORIZED spelled
   // here: `handledErrorMiddleware` re-derives it from the handled cause's

--- a/platform/app/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
@@ -14,9 +14,19 @@ vi.mock("../../tracing", () => ({
   traced: <T>(instance: T) => instance,
 }));
 
-const { mockRevokeAllTraceShares, mockCheckLimit } = vi.hoisted(() => ({
-  mockRevokeAllTraceShares: vi.fn(),
-  mockCheckLimit: vi.fn(),
+const { mockRevokeAllTraceShares, mockCheckLimit, mockInvalidateOrganization } =
+  vi.hoisted(() => ({
+    mockInvalidateOrganization: vi.fn(),
+    mockRevokeAllTraceShares: vi.fn(),
+    mockCheckLimit: vi.fn(),
+  }));
+
+// Disabling a seat is not a grant write, so the service retires the
+// organization's cached authorization snapshots itself.
+vi.mock("../../authz/runtime", () => ({
+  grantsService: () => ({
+    invalidateOrganization: mockInvalidateOrganization,
+  }),
 }));
 
 // The seat check on re-enabling a membership; the service builds it from the
@@ -323,6 +333,33 @@ describe("OrganizationService", () => {
     });
 
     describe("when disabling another member", () => {
+      /** @scenario Disabling takes effect at once, not when a cache expires */
+      it("retires the organization's cached authorization answers", async () => {
+        // Disabling writes a column, not a grant, so nothing else bumps the
+        // authz epoch. Without this the revocation an admin just performed
+        // stays invisible to any cached snapshot until it ages out.
+        vi.mocked(mockRepo.findMembership).mockResolvedValue({
+          userId: "user-456",
+          organizationId: "org-123",
+          role: OrganizationUserRole.MEMBER,
+          disabledAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          user: { id: "user-456", name: null, email: null },
+        });
+
+        await service.setMemberDisabled({
+          organizationId: "org-123",
+          userId: "user-456",
+          disabled: true,
+          actingUser: { id: "admin-789" },
+        });
+
+        expect(mockInvalidateOrganization).toHaveBeenCalledWith({
+          organizationId: "org-123",
+        });
+      });
+
       it("delegates to the repository without a seat check", async () => {
         vi.mocked(mockRepo.findMembership).mockResolvedValue({
           userId: "user-456",

--- a/platform/app/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
@@ -333,7 +333,7 @@ describe("OrganizationService", () => {
     });
 
     describe("when disabling another member", () => {
-      /** @scenario Disabling takes effect at once, not when a cache expires */
+      /** @scenario Disabling or re-enabling a membership takes effect on the next request */
       it("retires the organization's cached authorization answers", async () => {
         // Disabling writes a column, not a grant, so nothing else bumps the
         // authz epoch. Without this the revocation an admin just performed

--- a/platform/app/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
@@ -360,6 +360,36 @@ describe("OrganizationService", () => {
         });
       });
 
+      /** @scenario Disabling or re-enabling a membership takes effect on the next request */
+      it("retires them again on re-enable, so nobody waits out a cache to get back in", async () => {
+        vi.mocked(mockRepo.findMembership).mockResolvedValue({
+          userId: "user-456",
+          organizationId: "org-123",
+          role: OrganizationUserRole.MEMBER,
+          disabledAt: new Date("2026-08-01T00:00:00Z"),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          user: { id: "user-456", name: null, email: null },
+        });
+        mockCheckLimit.mockResolvedValue({
+          allowed: true,
+          limitType: "members",
+          current: 1,
+          max: 5,
+        });
+
+        await service.setMemberDisabled({
+          organizationId: "org-123",
+          userId: "user-456",
+          disabled: false,
+          actingUser: { id: "admin-789" },
+        });
+
+        expect(mockInvalidateOrganization).toHaveBeenCalledWith({
+          organizationId: "org-123",
+        });
+      });
+
       it("delegates to the repository without a seat check", async () => {
         vi.mocked(mockRepo.findMembership).mockResolvedValue({
           userId: "user-456",

--- a/platform/app/src/server/app-layer/organizations/organization.service.ts
+++ b/platform/app/src/server/app-layer/organizations/organization.service.ts
@@ -30,6 +30,7 @@ import {
   isCustomRole,
 } from "../../api/enterprise";
 import { getApp } from "../app";
+import { grantsService } from "../authz/runtime";
 import type { PlanProviderUser } from "../subscription/plan-provider";
 import { computeEffectiveTeamRoleUpdates } from "./compute-effective-team-role-updates";
 import {
@@ -685,7 +686,14 @@ export class OrganizationService {
       }
     }
 
-    return this.repo.setMemberDisabled({ organizationId, userId, disabled });
+    await this.repo.setMemberDisabled({ organizationId, userId, disabled });
+
+    // Disabling is a plain column write, not a grant write, so nothing else
+    // retires the authorization snapshots cached for this organization. An
+    // admin who has just revoked someone's access must not have to wait for a
+    // cache to age out before it is true, and re-enabling must not leave the
+    // person locked out for the same window.
+    await grantsService().invalidateOrganization({ organizationId });
   }
 
   /**

--- a/platform/app/src/server/app-layer/permissions/errors.ts
+++ b/platform/app/src/server/app-layer/permissions/errors.ts
@@ -32,6 +32,37 @@ export class LiteMemberRestrictedError extends HandledError {
  * `permission` goes in `meta` because a client renders it: it is the difference
  * between "you can't do that" and "ask an admin for `datasets:manage`".
  */
+/**
+ * The caller still holds a membership in this organization, but an admin
+ * disabled it to stay within the licensed seat count, so it grants nothing.
+ *
+ * Handled, and deliberately NOT folded into the generic denial: we know
+ * exactly why the check failed, and the person can act on it — an admin can
+ * return a seat to them. Reported as "you do not have permission" it would
+ * read as a role problem they could fix by asking for a role; reported as "no
+ * membership" it would tell someone who IS a member that they are not.
+ *
+ * Nothing here names who disabled them or how many seats the license covers:
+ * that is the organization's business, and the person asking has an admin to
+ * ask.
+ */
+export class MembershipDisabledError extends HandledError {
+  declare readonly code: "membership_disabled";
+
+  constructor(organizationId: string) {
+    super(
+      "membership_disabled",
+      "Your access to this organization has been disabled",
+      {
+        meta: { organizationId },
+        httpStatus: 403,
+        fault: "customer",
+      },
+    );
+    this.name = "MembershipDisabledError";
+  }
+}
+
 export class ProjectPermissionDeniedError extends HandledError {
   declare readonly code: "project_permission_denied";
 

--- a/platform/app/src/server/app-layer/permissions/errors.ts
+++ b/platform/app/src/server/app-layer/permissions/errors.ts
@@ -44,20 +44,17 @@ export class LiteMemberRestrictedError extends HandledError {
  *
  * Nothing here names who disabled them or how many seats the license covers:
  * that is the organization's business, and the person asking has an admin to
- * ask.
+ * ask. No `meta` either: nothing renders one, and the scope a check was made
+ * on is a project or team as often as an organization.
  */
 export class MembershipDisabledError extends HandledError {
   declare readonly code: "membership_disabled";
 
-  constructor(organizationId: string) {
+  constructor() {
     super(
       "membership_disabled",
       "Your access to this organization has been disabled",
-      {
-        meta: { organizationId },
-        httpStatus: 403,
-        fault: "customer",
-      },
+      { httpStatus: 403, fault: "customer" },
     );
     this.name = "MembershipDisabledError";
   }

--- a/platform/app/src/server/app-layer/permissions/permission-decision.repository.ts
+++ b/platform/app/src/server/app-layer/permissions/permission-decision.repository.ts
@@ -10,13 +10,14 @@
  * alone — no shadow or reverse-shadow comparison at request time. The contract
  * PR rewires ONLY this class onto the engine — nothing above it learns.
  */
-import type { AuthzPermission } from "@langwatch/authz";
+import type { AuthzDenialReason, AuthzPermission } from "@langwatch/authz";
 import type {
   OrganizationUserRole,
   PrismaClient,
 } from "~/generated/prisma/client";
 import {
   hasOrganizationPermission,
+  organizationDenialReason,
   resolveProjectPermission,
   resolveProjectPermissionAny,
   resolveTeamPermission,
@@ -26,6 +27,12 @@ import type { Session } from "~/server/auth";
 export type PermissionDecision = {
   permitted: boolean;
   organizationRole: OrganizationUserRole | null;
+  /**
+   * Why the check failed, when it did — the boundary needs it to pick the
+   * error a caller can act on. Absent on a permitted decision, and on the
+   * legacy walk, which never produced one.
+   */
+  denialReason?: AuthzDenialReason;
 };
 
 export interface PermissionDecisionRepository {
@@ -113,15 +120,23 @@ export class ForkAwarePermissionDecisionRepository
     organizationId: string;
     permission: AuthzPermission;
   }): Promise<PermissionDecision> {
+    const ctx = this.resolverContextFor(userId);
+    const permitted = await hasOrganizationPermission(
+      ctx,
+      organizationId,
+      permission,
+    );
     return {
-      permitted: await hasOrganizationPermission(
-        this.resolverContextFor(userId),
-        organizationId,
-        permission,
-      ),
+      permitted,
       // The organization walk carries no membership role in its answer, and
       // legacy never put one on the context either.
       organizationRole: null,
+      // Asked for only on a refusal, so the permitted path pays nothing.
+      ...(permitted
+        ? {}
+        : {
+            denialReason: await organizationDenialReason(ctx, organizationId),
+          }),
     };
   }
 

--- a/platform/app/src/server/app-layer/permissions/permission-decision.repository.ts
+++ b/platform/app/src/server/app-layer/permissions/permission-decision.repository.ts
@@ -135,7 +135,10 @@ export class ForkAwarePermissionDecisionRepository
       ...(permitted
         ? {}
         : {
-            denialReason: await organizationDenialReason(ctx, organizationId),
+            denialReason: await organizationDenialReason({
+              ctx,
+              organizationId,
+            }),
           }),
     };
   }

--- a/platform/app/src/server/gateway/virtualKey.authz.ts
+++ b/platform/app/src/server/gateway/virtualKey.authz.ts
@@ -266,8 +266,12 @@ export async function loadMembershipSet(
   userId: string,
 ): Promise<MembershipSet> {
   const [orgMembership, teamMemberships] = await Promise.all([
-    prisma.organizationUser.findUnique({
-      where: { userId_organizationId: { userId, organizationId } },
+    // `disabledAt` is part of the lookup, not a detail of it: `isOrgAdmin`
+    // below short-circuits visibility to every virtual key in the
+    // organization, so a membership an admin disabled to reclaim its seat
+    // must not answer here at all. A disabled row reads as no membership.
+    prisma.organizationUser.findFirst({
+      where: { userId, organizationId, disabledAt: null },
       select: { role: true },
     }),
     prisma.teamUser.findMany({

--- a/platform/app/src/server/rbac/__tests__/role-binding-resolver.fork.unit.test.ts
+++ b/platform/app/src/server/rbac/__tests__/role-binding-resolver.fork.unit.test.ts
@@ -66,7 +66,9 @@ function buildPrisma({
     },
     team: { findUnique: vi.fn().mockResolvedValue(null) },
     organizationUser: {
-      findFirst: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+      findFirst: vi
+        .fn()
+        .mockResolvedValue({ role: "MEMBER", disabledAt: null }),
     },
     groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
     roleBinding: {

--- a/platform/app/src/server/rbac/role-binding-resolver.ts
+++ b/platform/app/src/server/rbac/role-binding-resolver.ts
@@ -1,3 +1,15 @@
+/**
+ * The legacy api-key authorization surface, kept alive as the ADR-110 fork
+ * seam for the gateway and virtual-key paths.
+ *
+ * Every export here is `@deprecated`. They still RUN — each one asks the
+ * engine for a migrated organization and walks the legacy binding tables for
+ * one that is not — so this is the code the contract PR deletes, not dead
+ * code. New callers decide through `getApp().permissions` /
+ * `AuthzService.checkByIds` with an `apiKey` principal, which applies the same
+ * ADR-092 §9 owner ceiling (`effective(key) = grants(key) ∩ grants(owner)`)
+ * without depending on this fork surviving.
+ */
 import { createLogger } from "@langwatch/observability";
 import {
   OrganizationUserRole,
@@ -26,6 +38,10 @@ const logger = createLogger("langwatch:rbac:role-binding-resolver");
 // Types
 // ============================================================================
 
+/**
+ * @deprecated Use `AuthzScopeRef` from `@langwatch/authz` instead — the
+ * engine's scope reference, which the resolvers here convert to anyway.
+ */
 export type ScopeRef =
   | { type: "org"; id: string }
   | { type: "team"; id: string }
@@ -35,6 +51,9 @@ export type ScopeRef =
  * A principal is the entity whose permissions are being checked.
  * - "user": a human user (supports group memberships)
  * - "apiKey": an API key (no groups)
+ */
+/**
+ * @deprecated Use `AuthzPrincipalRef` from `@langwatch/authz` instead.
  */
 export type Principal =
   | { type: "user"; id: string }
@@ -272,6 +291,13 @@ function systemRoleGuard(principal: Principal) {
  * the requested permission.
  *
  * Accepts either a userId string (backwards-compatible) or a Principal object.
+ *
+ * @deprecated Not for new callers. The ADR-110 fork seam for the api-key
+ * paths: the engine answers for a migrated organization, the legacy union
+ * for one that is not, and this goes away with the legacy half. New code
+ * decides through `getApp().permissions` / `AuthzService.checkByIds` with
+ * an `apiKey` principal, which applies the same ADR-092 §9 owner ceiling
+ * without depending on the fork surviving.
  */
 export async function checkRoleBindingPermission({
   prisma,
@@ -463,6 +489,9 @@ async function checkRoleBindingPermissionInner({
  * version that returned a bare role had already lost two of them at one call
  * site apiece.
  */
+/**
+ * @deprecated The legacy ceiling's answer shape — see `resolveLegacyCeiling`.
+ */
 export type LegacyCeiling = {
   /** Whether the legacy role confers this permission, all floors applied. */
   grants: (permission: Permission) => boolean;
@@ -470,6 +499,11 @@ export type LegacyCeiling = {
 
 const LEGACY_CEILING_DENIES_ALL: LegacyCeiling = { grants: () => false };
 
+/**
+ * @deprecated The legacy half of the api-key ceiling, deprecated with the fork
+ * that calls it — see `resolveApiKeyPermission`. The engine expresses the same
+ * ceiling as `decideWithCeiling`.
+ */
 export async function resolveLegacyCeiling({
   prisma,
   userId,
@@ -573,6 +607,13 @@ export async function resolveLegacyCeiling({
  * Returns true only if BOTH the API key's own bindings AND the owning user's
  * current bindings grant the requested permission. If the user's role has been
  * downgraded, the API key auto-degrades immediately.
+ *
+ * @deprecated Not for new callers. The ADR-110 fork seam for the api-key
+ * paths: the engine answers for a migrated organization, the legacy union
+ * for one that is not, and this goes away with the legacy half. New code
+ * decides through `getApp().permissions` / `AuthzService.checkByIds` with
+ * an `apiKey` principal, which applies the same ADR-092 §9 owner ceiling
+ * without depending on the fork surviving.
  */
 export async function resolveApiKeyPermission({
   prisma,

--- a/platform/app/src/server/rbac/role-binding-resolver.ts
+++ b/platform/app/src/server/rbac/role-binding-resolver.ts
@@ -133,7 +133,9 @@ async function collectBindingsForUser({
       where: {
         organizationId,
         userId,
-        user: { orgMemberships: { some: { organizationId } } },
+        user: {
+          orgMemberships: { some: { organizationId, disabledAt: null } },
+        },
       },
       select: {
         role: true,
@@ -153,7 +155,9 @@ async function collectBindingsForUser({
           members: {
             some: {
               userId,
-              user: { orgMemberships: { some: { organizationId } } },
+              user: {
+                orgMemberships: { some: { organizationId, disabledAt: null } },
+              },
             },
           },
         },
@@ -485,10 +489,13 @@ export async function resolveLegacyCeiling({
   // and the group ids, in one round trip. The org role is needed because
   // EXTERNAL members are capped before any team role is consulted.
   const user = await prisma.user.findFirst({
-    where: { id: userId, orgMemberships: { some: { organizationId } } },
+    where: {
+      id: userId,
+      orgMemberships: { some: { organizationId, disabledAt: null } },
+    },
     select: {
       orgMemberships: {
-        where: { organizationId },
+        where: { organizationId, disabledAt: null },
         select: { role: true },
       },
       groupMemberships: {

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -526,6 +526,56 @@ describe("CLI login personal-project guards", () => {
       });
     });
 
+    describe("when the seat is disabled between approval and exchange", () => {
+      /** @scenario project-login exchange denies a member whose seat was disabled after approval */
+      it("returns forbidden, never the project's API key, and consumes the code", async () => {
+        // Approval is not the last word: the code is exchanged later, and an
+        // admin can switch the seat off in between. The handout is what must
+        // re-derive membership.
+        const dcRes = await app.request("/api/auth/cli/device-code", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ credential_type: "project_api_key" }),
+        });
+        const dc = (await dcRes.json()) as {
+          device_code: string;
+          user_code: string;
+        };
+        const approved = await approve({
+          user_code: dc.user_code,
+          project_id: SHARED_PROJECT_ID,
+        });
+        expect(approved.status).toBe(200);
+
+        await prisma.organizationUser.updateMany({
+          where: { userId: USER_ID, organizationId: ORG_ID },
+          data: { disabledAt: new Date() },
+        });
+        try {
+          const exchange = () =>
+            app.request("/api/auth/cli/exchange", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ device_code: dc.device_code }),
+            });
+
+          const first = await exchange();
+          expect(first.status).toBe(403);
+          expect(await first.text()).not.toContain(SHARED_API_KEY);
+
+          // Consumed: a CLI still polling is told the code is gone, not
+          // left waiting on an approval that will never be honoured.
+          const second = await exchange();
+          expect(second.status).toBe(408);
+        } finally {
+          await prisma.organizationUser.updateMany({
+            where: { userId: USER_ID, organizationId: ORG_ID },
+            data: { disabledAt: null },
+          });
+        }
+      });
+    });
+
     describe("when the caller lacks write access to the picked project", () => {
       /** @scenario project-login approval denies a project the caller cannot write */
       it("returns forbidden and never the project's API key", async () => {

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -565,13 +565,14 @@ describe("CLI login personal-project guards", () => {
           expect(first.status).toBe(410);
           expect(await first.text()).not.toContain(SHARED_API_KEY);
 
-          // Consumed: the record is gone from Redis, so a CLI still polling
-          // is told the code expired rather than left waiting on an approval
-          // that will never be honoured. Asserted on the store, because an
-          // immediate second poll meets the exchange throttle (429) first.
+          // Consumed: the record is gone from Redis, and a CLI still polling
+          // is told the code expired rather than that it polled too soon or
+          // left waiting on an approval that will never be honoured.
           expect(
             await redisConnection!.get(`lwcli:device:${dc.device_code}`),
           ).toBeNull();
+          const second = await exchange();
+          expect(second.status).toBe(408);
         } finally {
           await prisma.organizationUser.updateMany({
             where: { userId: USER_ID, organizationId: ORG_ID },

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -528,7 +528,7 @@ describe("CLI login personal-project guards", () => {
 
     describe("when the seat is disabled between approval and exchange", () => {
       /** @scenario project-login exchange denies a member whose seat was disabled after approval */
-      it("returns forbidden, never the project's API key, and consumes the code", async () => {
+      it("answers the fatal access_denied, never the project's API key, and consumes the code", async () => {
         // Approval is not the last word: the code is exchanged later, and an
         // admin can switch the seat off in between. The handout is what must
         // re-derive membership.
@@ -560,13 +560,18 @@ describe("CLI login personal-project guards", () => {
             });
 
           const first = await exchange();
-          expect(first.status).toBe(403);
+          // 410 access_denied: the one answer the CLI already treats as
+          // fatal, and the same one a removed member gets from the mint.
+          expect(first.status).toBe(410);
           expect(await first.text()).not.toContain(SHARED_API_KEY);
 
-          // Consumed: a CLI still polling is told the code is gone, not
-          // left waiting on an approval that will never be honoured.
-          const second = await exchange();
-          expect(second.status).toBe(408);
+          // Consumed: the record is gone from Redis, so a CLI still polling
+          // is told the code expired rather than left waiting on an approval
+          // that will never be honoured. Asserted on the store, because an
+          // immediate second poll meets the exchange throttle (429) first.
+          expect(
+            await redisConnection!.get(`lwcli:device:${dc.device_code}`),
+          ).toBeNull();
         } finally {
           await prisma.organizationUser.updateMany({
             where: { userId: USER_ID, organizationId: ORG_ID },

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -496,6 +496,36 @@ describe("CLI login personal-project guards", () => {
       });
     });
 
+    describe("when the caller's own seat has been disabled", () => {
+      /** @scenario project-login approval denies a member whose seat has been disabled */
+      it("returns forbidden and never the project's API key", async () => {
+        // The row stays, with its ADMIN role — only the access is gone. A
+        // project key has no owner, so nothing downstream would have caught
+        // this: the membership gate on approve is the whole defence.
+        await prisma.organizationUser.updateMany({
+          where: { userId: USER_ID, organizationId: ORG_ID },
+          data: { disabledAt: new Date() },
+        });
+        try {
+          const userCode = await mintDeviceCode("project_api_key");
+
+          const { status, json } = await approve({
+            user_code: userCode,
+            project_id: SHARED_PROJECT_ID,
+          });
+
+          expect(status).toBe(403);
+          expect(json.error).toBe("forbidden");
+          expect(JSON.stringify(json)).not.toContain(SHARED_API_KEY);
+        } finally {
+          await prisma.organizationUser.updateMany({
+            where: { userId: USER_ID, organizationId: ORG_ID },
+            data: { disabledAt: null },
+          });
+        }
+      });
+    });
+
     describe("when the caller lacks write access to the picked project", () => {
       /** @scenario project-login approval denies a project the caller cannot write */
       it("returns forbidden and never the project's API key", async () => {

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
@@ -451,6 +451,39 @@ describe("/me credentials delivery, given a token whose user is no longer an act
     await prisma.user.deleteMany({ where: { id: offboardId } }).catch(() => {});
   });
 
+  /** @scenario a disabled member's pre-disable token cannot mint or return a personal key */
+  it("refuses a member whose seat was disabled, revokes the token, and creates no workspace", async () => {
+    const disabledId = `usr-disabled-${suffix}`;
+    const token = `lw_at_disabled${suffix.replace(/[^a-z0-9]/gi, "")}`;
+    // An active member when the token was issued; an admin then disabled the
+    // seat. The row stays, with its role — only the access is gone.
+    await seedUserWithCliToken({
+      id: disabledId,
+      email: `disabled-${suffix}@example.com`,
+      name: `Disabled ${suffix}`,
+      token,
+      member: true,
+    });
+    await prisma.organizationUser.updateMany({
+      where: { userId: disabledId, organizationId: ORG_ID },
+      data: { disabledAt: new Date() },
+    });
+
+    const before = await personalTeamCount(disabledId);
+    const res = await app.request("/api/auth/cli/personal-project", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await personalTeamCount(disabledId)).toBe(before);
+    expect(await redisConnection!.get(`lwcli:access:${token}`)).toBeNull();
+
+    await prisma.organizationUser
+      .deleteMany({ where: { userId: disabledId, organizationId: ORG_ID } })
+      .catch(() => {});
+    await prisma.user.deleteMany({ where: { id: disabledId } }).catch(() => {});
+  });
+
   /** @scenario a deactivated user's token cannot mint or return a personal key */
   it("refuses a deactivated user even while org membership lingers", async () => {
     const deactId = `usr-deact-${suffix}`;

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
@@ -502,6 +502,42 @@ describe("/me credentials delivery, given a token whose user is no longer an act
     }
   });
 
+  /** @scenario a disabled member's session cannot be renewed */
+  it("refuses to rotate a disabled member's refresh token, and revokes it", async () => {
+    // A session started while active; the seat is disabled afterwards.
+    // Rotation mints a new pair, so it re-derives membership like every
+    // other minting endpoint — otherwise the hour-long access token would
+    // roll forward for ninety days.
+    const flow = await runDeviceFlow();
+    expect(flow.exchangeStatus).toBe(200);
+    const refreshToken = flow.exchange.refresh_token;
+
+    await prisma.organizationUser.updateMany({
+      where: { userId: USER_ID, organizationId: ORG_ID },
+      data: { disabledAt: new Date() },
+    });
+    try {
+      const res = await app.request("/api/auth/cli/refresh", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_grant");
+      expect(body.access_token).toBeUndefined();
+      expect(
+        await redisConnection!.get(`lwcli:refresh:${refreshToken}`),
+      ).toBeNull();
+    } finally {
+      await prisma.organizationUser.updateMany({
+        where: { userId: USER_ID, organizationId: ORG_ID },
+        data: { disabledAt: null },
+      });
+    }
+  });
+
   /** @scenario a deactivated user's token cannot mint or return a personal key */
   it("refuses a deactivated user even while org membership lingers", async () => {
     const deactId = `usr-deact-${suffix}`;

--- a/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-personal-project.integration.test.ts
@@ -452,36 +452,54 @@ describe("/me credentials delivery, given a token whose user is no longer an act
   });
 
   /** @scenario a disabled member's pre-disable token cannot mint or return a personal key */
-  it("refuses a member whose seat was disabled, revokes the token, and creates no workspace", async () => {
+  it("refuses a member whose seat was disabled, revokes the token, and creates nothing", async () => {
     const disabledId = `usr-disabled-${suffix}`;
     const token = `lw_at_disabled${suffix.replace(/[^a-z0-9]/gi, "")}`;
-    // An active member when the token was issued; an admin then disabled the
-    // seat. The row stays, with its role — only the access is gone.
-    await seedUserWithCliToken({
-      id: disabledId,
-      email: `disabled-${suffix}@example.com`,
-      name: `Disabled ${suffix}`,
-      token,
-      member: true,
-    });
-    await prisma.organizationUser.updateMany({
-      where: { userId: disabledId, organizationId: ORG_ID },
-      data: { disabledAt: new Date() },
-    });
-
-    const before = await personalTeamCount(disabledId);
-    const res = await app.request("/api/auth/cli/personal-project", {
-      headers: { authorization: `Bearer ${token}` },
+    // Everything the scenario says must not appear: the personal team, its
+    // project, and any role binding in the tenant.
+    const provisioned = async () => ({
+      teams: await personalTeamCount(disabledId),
+      projects: await prisma.project.count({
+        where: {
+          team: { organizationId: ORG_ID },
+          ownerUserId: disabledId,
+          isPersonal: true,
+        },
+      }),
+      bindings: await prisma.roleBinding.count({
+        where: { organizationId: ORG_ID, userId: disabledId },
+      }),
     });
 
-    expect(res.status).toBe(403);
-    expect(await personalTeamCount(disabledId)).toBe(before);
-    expect(await redisConnection!.get(`lwcli:access:${token}`)).toBeNull();
+    try {
+      // An active member when the token was issued; an admin then disabled
+      // the seat. The row stays, with its role — only the access is gone.
+      await seedUserWithCliToken({
+        id: disabledId,
+        email: `disabled-${suffix}@example.com`,
+        name: `Disabled ${suffix}`,
+        token,
+        member: true,
+      });
+      await prisma.organizationUser.updateMany({
+        where: { userId: disabledId, organizationId: ORG_ID },
+        data: { disabledAt: new Date() },
+      });
+      const before = await provisioned();
 
-    await prisma.organizationUser
-      .deleteMany({ where: { userId: disabledId, organizationId: ORG_ID } })
-      .catch(() => {});
-    await prisma.user.deleteMany({ where: { id: disabledId } }).catch(() => {});
+      const res = await app.request("/api/auth/cli/personal-project", {
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.status).toBe(403);
+      expect(await provisioned()).toEqual(before);
+      expect(await redisConnection!.get(`lwcli:access:${token}`)).toBeNull();
+    } finally {
+      await prisma.organizationUser.deleteMany({
+        where: { userId: disabledId, organizationId: ORG_ID },
+      });
+      await prisma.user.deleteMany({ where: { id: disabledId } });
+    }
   });
 
   /** @scenario a deactivated user's token cannot mint or return a personal key */

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
@@ -34,7 +34,9 @@ const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
     },
     mockPrisma: {
       organizationUser: {
-        findFirst: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+        findFirst: vi
+          .fn()
+          .mockResolvedValue({ role: "MEMBER", disabledAt: null }),
       },
       groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
       roleBinding: {
@@ -130,7 +132,7 @@ function resetMocks() {
     ]);
   mockPrisma.organizationUser.findFirst
     .mockReset()
-    .mockResolvedValue({ role: "MEMBER" });
+    .mockResolvedValue({ role: "MEMBER", disabledAt: null });
 }
 
 describe("POST /api/mcp/authorize — redirect_uri binding", () => {

--- a/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -49,7 +49,9 @@ const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
       // org-level MEMBER role. The MEMBER org role alone grants no project-level
       // permission, so authorization still hinges on the TEAM binding below.
       organizationUser: {
-        findFirst: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+        findFirst: vi
+          .fn()
+          .mockResolvedValue({ role: "MEMBER", disabledAt: null }),
       },
       // checkPermissionFromBindings: user belongs to no groups …
       groupMembership: { findMany: vi.fn().mockResolvedValue([]) },

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -770,6 +770,32 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
       );
     }
 
+    // Membership is re-derived HERE, not trusted from approval time: an admin
+    // can disable the seat between approve and exchange, and both branches
+    // below hand out credentials the owner ceiling never reaches (a project
+    // key has no owner; a device session mints keys of its own). Refused,
+    // the device code is consumed so the CLI stops polling for a session it
+    // will never get.
+    const activeMembership = await prisma.organizationUser.findFirst({
+      where: {
+        userId: user.id,
+        organizationId: organization.id,
+        disabledAt: null,
+      },
+      select: { userId: true },
+    });
+    if (!activeMembership) {
+      await redis.del(deviceCodeKey(device_code));
+      await redis.del(userCodeKey(record.user_code));
+      return c.json(
+        {
+          error: "access_denied",
+          error_description: "Not an active member of the organization",
+        },
+        403,
+      );
+    }
+
     const responseEndpoint = controlPlaneBaseUrl();
 
     // No-paste API-key flow: the user picked a project on /cli/auth and the

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -788,6 +788,9 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
     if (!activeMembership) {
       await redis.del(deviceCodeKey(device_code));
       await redis.del(userCodeKey(record.user_code));
+      // The poll-rate key too: consumed means the next poll learns the code
+      // is gone (408), not that it polled too soon (429).
+      await redis.del(pollRateKey(device_code));
       return c.json(
         {
           error: "access_denied",
@@ -1142,6 +1145,36 @@ secured.access(CLI_POLICY).post("/refresh", async (c: Context) => {
         401,
       );
     }
+  }
+
+  // Rotation mints a new credential pair, so it re-derives membership the way
+  // the other minting endpoints do: a member whose seat an admin disabled
+  // (or who was removed) after the session started must not be able to
+  // renew it. Bearer-only routes still honour the access token already in
+  // hand until it expires (one hour), the same window a removed member has;
+  // this is what stops that window from rolling forward for ninety days.
+  const activeMembership = await prisma.organizationUser.findFirst({
+    where: {
+      userId: record.user_id,
+      organizationId: record.organization_id,
+      disabledAt: null,
+    },
+    select: { userId: true },
+  });
+  if (!activeMembership) {
+    await redis.del(refreshTokenKey(refresh_token));
+    logger.info(
+      { userId: record.user_id, organizationId: record.organization_id },
+      "rejecting refresh: caller is not an active member of the organization",
+    );
+    return c.json(
+      {
+        error: "invalid_grant",
+        error_description:
+          "Your access to this organization is no longer active. Please run `langwatch login` to start a new session.",
+      },
+      401,
+    );
   }
 
   // Rotate: mint new pair, invalidate old. (Sliding-window rotation —

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -774,8 +774,9 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
     // can disable the seat between approve and exchange, and both branches
     // below hand out credentials the owner ceiling never reaches (a project
     // key has no owner; a device session mints keys of its own). Refused,
-    // the device code is consumed so the CLI stops polling for a session it
-    // will never get.
+    // the device code is consumed and the answer is the same fatal
+    // access_denied/410 the mint below already gives a removed member, so the
+    // CLI stops polling for a session it will never get.
     const activeMembership = await prisma.organizationUser.findFirst({
       where: {
         userId: user.id,
@@ -792,7 +793,7 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
           error: "access_denied",
           error_description: "Not an active member of the organization",
         },
-        403,
+        410,
       );
     }
 

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -473,12 +473,16 @@ async function ensureActiveOrgMemberOr403(
       where: { id: tokenRecord.user_id },
       select: { deactivatedAt: true },
     }),
-    prisma.organizationUser.findUnique({
+    // `disabledAt` is part of the predicate: a seat an admin disabled to
+    // reclaim it is not an active membership, and the keys minted here are
+    // the ones the owner ceiling never reaches — a project key has no owner,
+    // and the gateway honours a personal virtual key on its own status. A
+    // disabled row reads as no membership, and the session is severed below.
+    prisma.organizationUser.findFirst({
       where: {
-        userId_organizationId: {
-          userId: tokenRecord.user_id,
-          organizationId: tokenRecord.organization_id,
-        },
+        userId: tokenRecord.user_id,
+        organizationId: tokenRecord.organization_id,
+        disabledAt: null,
       },
       select: { userId: true },
     }),
@@ -2549,14 +2553,16 @@ secured.access(cliApproveAuth).post("/approve", async (c: Context) => {
   }
   const { user_code, organization_id, project_id } = parsed.data;
 
-  // Verify caller is a member of the org they're issuing a key for.
-  const membership = await prisma.organizationUser.findUnique({
+  // Verify the caller is an ACTIVE member of the org they're issuing a key
+  // for: a membership an admin disabled to reclaim its seat must not approve
+  // a device and hand out a key it could not use itself.
+  const membership = await prisma.organizationUser.findFirst({
     where: {
-      userId_organizationId: {
-        userId: session.user.id,
-        organizationId: organization_id,
-      },
+      userId: session.user.id,
+      organizationId: organization_id,
+      disabledAt: null,
     },
+    select: { userId: true },
   });
   if (!membership) {
     return c.json(

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -110,8 +110,8 @@ Feature: CLI login never lands a user on a personal project
       Given a device code approved while the caller was an active member
       And an admin has since disabled the caller's membership
       When the CLI exchanges that device code
-      Then the response is 403 and the project's API key is NOT returned
-      And the device code is consumed, so a further exchange reports it expired
+      Then the response is the fatal 410 "access_denied" and the project's API key is NOT returned
+      And the device code is consumed, so the CLI stops polling
 
     @unit @project-picker
     Scenario: the project picker lists the caller's personal project explicitly and omits internal-governance projects

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -97,6 +97,14 @@ Feature: CLI login never lands a user on a personal project
       Then the response is 403 with error "forbidden"
       And the project's API key is NOT returned
 
+    @integration @project-picker @rbac
+    Scenario: project-login approval denies a member whose seat has been disabled
+      Given a pending device code with credential_type "project_api_key"
+      And an admin has disabled the caller's membership to free its seat
+      When the caller approves with a shared project's id
+      Then the response is 403 with error "forbidden"
+      And the project's API key is NOT returned
+
     @unit @project-picker
     Scenario: the project picker lists the caller's personal project explicitly and omits internal-governance projects
       Given an org team with a personal project, an internal-governance project, and a shared project

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -105,6 +105,14 @@ Feature: CLI login never lands a user on a personal project
       Then the response is 403 with error "forbidden"
       And the project's API key is NOT returned
 
+    @integration @project-picker @rbac
+    Scenario: project-login exchange denies a member whose seat was disabled after approval
+      Given a device code approved while the caller was an active member
+      And an admin has since disabled the caller's membership
+      When the CLI exchanges that device code
+      Then the response is 403 and the project's API key is NOT returned
+      And the device code is consumed, so a further exchange reports it expired
+
     @unit @project-picker
     Scenario: the project picker lists the caller's personal project explicitly and omits internal-governance projects
       Given an org team with a personal project, an internal-governance project, and a shared project

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -111,7 +111,7 @@ Feature: CLI login never lands a user on a personal project
       And an admin has since disabled the caller's membership
       When the CLI exchanges that device code
       Then the response is the fatal 410 "access_denied" and the project's API key is NOT returned
-      And the device code is consumed, so the CLI stops polling
+      And the device code is consumed, so a further exchange reports it expired
 
     @unit @project-picker
     Scenario: the project picker lists the caller's personal project explicitly and omits internal-governance projects

--- a/specs/ai-governance/cli-onboarding/me-credentials.feature
+++ b/specs/ai-governance/cli-onboarding/me-credentials.feature
@@ -149,6 +149,15 @@ Feature: /me credentials just work - CLI credential resolution after device logi
     And a follow-up call with the same token is 401
 
   @bdd @cli-onboarding @credentials @tenancy @integration
+  Scenario: a disabled member's pre-disable token cannot mint or return a personal key
+    Given a device-session token issued while the user was an active member of an organization
+    And an admin then disables that membership to free its seat
+    When the CLI calls GET /api/auth/cli/personal-project with that token
+    Then the response is 403
+    And no personal team, project, or role binding is created
+    And the presented access token is revoked
+
+  @bdd @cli-onboarding @credentials @tenancy @integration
   Scenario: a deactivated user's token cannot mint or return a personal key
     Given a device-session token for a user whose account is deactivated
     When the CLI calls GET /api/auth/cli/personal-project with that token

--- a/specs/ai-governance/cli-onboarding/me-credentials.feature
+++ b/specs/ai-governance/cli-onboarding/me-credentials.feature
@@ -158,6 +158,14 @@ Feature: /me credentials just work - CLI credential resolution after device logi
     And the presented access token is revoked
 
   @bdd @cli-onboarding @credentials @tenancy @integration
+  Scenario: a disabled member's session cannot be renewed
+    Given a device session started while the user was an active member of an organization
+    And an admin then disables that membership to free its seat
+    When the CLI presents the refresh token to POST /api/auth/cli/refresh
+    Then the response is 401 and no new token pair is issued
+    And the presented refresh token is revoked
+
+  @bdd @cli-onboarding @credentials @tenancy @integration
   Scenario: a deactivated user's token cannot mint or return a personal key
     Given a device-session token for a user whose account is deactivated
     When the CLI calls GET /api/auth/cli/personal-project with that token

--- a/specs/licensing/seat-reconciliation.feature
+++ b/specs/licensing/seat-reconciliation.feature
@@ -59,6 +59,32 @@ Feature: Reconciling an organization down to its licensed seats
     And the work they did is still attributed to them
 
   @integration
+  Scenario: A disabled member cannot act through any permission path
+    Given a member of the organization has been disabled
+    When they try to act in that organization
+    Then the request is refused
+    And they are told their access was disabled, not that they are not a member
+
+  @unit
+  Scenario: A disabled member's API keys stop working
+    Given a member of the organization has been disabled
+    When a request arrives on an API key they own
+    Then the request is refused
+    But a service key that belongs to nobody keeps working
+
+  @unit
+  Scenario: A link that was public to anyone still opens for a disabled member
+    Given a member of the organization has been disabled
+    When they open a link that was shared with anyone
+    Then the link still opens
+    But a link shared only with the organization does not
+
+  @unit
+  Scenario: Disabling takes effect at once, not when a cache expires
+    When an admin disables or re-enables a membership
+    Then every authorization answer held for that organization is retired immediately
+
+  @integration
   Scenario: A disabled member can be re-enabled when a seat is free
     Given the organization is within its seat count
     And a member of the organization has been disabled

--- a/specs/licensing/seat-reconciliation.feature
+++ b/specs/licensing/seat-reconciliation.feature
@@ -80,9 +80,11 @@ Feature: Reconciling an organization down to its licensed seats
     But a link shared only with the organization does not
 
   @unit
-  Scenario: Disabling takes effect at once, not when a cache expires
-    When an admin disables or re-enables a membership
-    Then every authorization answer held for that organization is retired immediately
+  Scenario: Disabling or re-enabling a membership takes effect on the next request
+    When an admin disables a membership
+    Then the member is refused on their very next request
+    When the admin re-enables it
+    Then the member is allowed again on their very next request
 
   @integration
   Scenario: A disabled member can be re-enabled when a seat is free

--- a/specs/members/member-role-team-restrictions.feature
+++ b/specs/members/member-role-team-restrictions.feature
@@ -336,3 +336,33 @@ Feature: Member Role Team Restrictions
     Given a member with a personal workspace
     When an organization admin moves them to a Lite Member seat
     Then their personal workspace access rows are untouched
+
+  # ============================================================================
+  # Inviting a Lite Member with no team
+  # ============================================================================
+  #
+  # A lite seat carries no organization-wide access of its own: the invite
+  # grants what its teams grant and nothing else. So a lite invite naming no
+  # team produces somebody who can sign in, see nothing, and hold a seat while
+  # they do it, and the admin only finds out when that person tells them.
+  #
+  # Warned rather than refused: assigning the team afterwards is a legitimate
+  # way to work, and the admin is the one who knows whether they mean to.
+
+  @integration
+  Scenario: Inviting a Lite Member with no team warns that they will see nothing
+    Given I am inviting someone as a Lite Member
+    When no team is assigned to them
+    Then I am told they will not be able to see anything
+    And I am told I can add a team later
+
+  @integration
+  Scenario: The warning does not block the invitation
+    Given I am inviting someone as a Lite Member with no team
+    Then I can still send the invitation
+
+  @integration
+  Scenario: Inviting a full member with no team is not warned about
+    Given I am inviting someone as a full member
+    When no team is assigned to them
+    Then no warning about team access is shown


### PR DESCRIPTION
## What this fixes

`OrganizationUser.disabledAt` was read by visibility code and by nothing on the authorization path.

```
setMemberDisabled  ──▶ OrganizationUser.disabledAt = now()
                          │
      ┌───────────────────┴────────────────────┐
      │                                        │
  VISIBILITY (filtered it)                 AUTHORIZATION (did not)
  · org switcher                           · findOrganizationRole  ──▶ role
  · getOrganizationWithMembers             · binding fences        ──▶ bindings
  · getMemberById                          · virtualKey.authz      ──▶ isOrgMember
      │                                    · auth-cli key minting  ──▶ project keys, personal VKs
      ▼                                        │
  org vanished from their UI                   ▼
                                        every permission still ALLOWed
```

A member an admin disabled to reclaim their seat lost the organization from their switcher
and kept every permission they had — reachable by direct URL, tRPC call or REST call,
including `project:delete`. A disabled org admin could still see and manage **every virtual
key in the organization**, because `isOrgAdmin` short-circuits visibility to all of them. And
through the CLI, a disabled member could still pull a **project API key** — which has no owner,
so nothing downstream would ever have caught it — and mint a **personal virtual key** the
gateway honours on the key's own status.

Both heads had it — legacy walk and engine alike — so this is inherited rather than
introduced. `specs/licensing/seat-reconciliation.feature` has said "a disabled member … cannot
act in that organization" the whole time.

**Why it stayed hidden.** The scenario that covers it asserted through `repo.getUserOrgRole` —
the one reader that already filtered `disabledAt`, and which is not on the permission path —
so it passed throughout. And the read-repository tests pinned the exact query shape *without*
`disabledAt`, freezing the gap in place. Both now assert the opposite.

## How

Membership means **active** membership everywhere authorization asks:

- The read port returns the row as a fact (`{ role, disabled }`) and the collector applies
  the policy, so `isOrgMember` goes false and the existing gate denies. No new step in the
  walk, no reordering. Filtering in SQL instead would make a disabled membership
  indistinguishable from an absent one, and the denial could then only claim the person was
  never here. The legacy `rbac.ts` makes the same split (`getCurrentMembership` →
  `currentRoleOf`), so the membership gate both heads share refuses a disabled seat by name
  before either walk reads a binding.
- Binding reads keep filtering in SQL (`disabledAt: null` on the membership fence) — those
  queries return grants and have no fact to hand back.
- Denials say `membership-disabled`, not `no-membership`, on every tier. We know the cause
  and an admin can act on it, which is the ADR-045 test for a named error over a generic one.
  At organization scope the reason comes from **one indexed read on the refusal path**, not a
  second walk — so the permitted path pays nothing; at project and team scope it comes off
  the membership gate that already ran, and both engine branches forward the engine's own
  reason.
- Disabling and re-enabling bump the organization's authz epoch. Disabling is a plain column
  write, so nothing else retired the snapshots §12 caches.
- The CLI credential endpoints (`ensureActiveOrgMemberOr403`, `/approve`, `/exchange` and
  `/refresh` in `routes/auth-cli.ts`) read `disabledAt`. These never went through the engine — membership
  was their only gate — and they hand out exactly the credentials the §9 owner ceiling cannot
  reach. `/exchange` re-derives membership at handout time rather than trusting the approval,
  because an admin can disable the seat between the two, and it consumes the device code on
  refusal so a polling CLI is told the code is gone. Refusing at the token-guarded endpoints
  also severs the presented CLI token, the way it already did for a removed member.
- The two legacy tRPC middlewares that survive as building blocks (`checkProjectPermission`,
  `checkTeamPermission`) raise the same named error ahead of their role-shaped denials.

Covered at every live path, not just the engine: the prisma, grants and cutover read
repositories, `virtualKey.authz.ts`, `role-binding-resolver.ts`, the legacy `rbac.ts` reader
(including its `TeamUser` fallback), and `auth-cli.ts`.

**Deliberately untouched.** The migration repository still sees a disabled member's grants
(preserved for re-enable) and the listing repositories still list them (an admin has to see
somebody to re-enable them). Write-side reads — `assertUsersInOrganization`,
`group.isUserInOrganization` — still let a disabled user be *granted* access, which is inert:
the grant confers nothing while the seat is off and is waiting when it comes back on.

## Also here

**A lite invite that goes nowhere.** A lite seat grants only what its teams grant
(`applyInviteGrants` skips the organization-scoped grant for a lite member on purpose), and
teams are optional on the invite — so a lite invite naming no team produced somebody who
could sign in, see nothing, and hold a seat while they did it. The form now warns before the
invite is sent. A warning rather than a refusal, because assigning the team afterwards is a
legitimate way to work and the admin is the one who knows.

## Deployment Impact

**A disabled member's personal API keys stop working.** The ADR-092 §9 owner ceiling is
`effective(key) = grants(key) ∩ grants(owner)`; a disabled owner grants nothing, so their keys
deny with `owner-ceiling`. That is the intent — a person cut off from an organization must not
keep a live credential to it — but it reaches past their own session, so **an automation
running on a disabled person's key stops with them**. Service keys, which have no owner, are
unaffected. Proven by test, not asserted.

**A disabled member's CLI stops minting, and cannot renew.** The next call their CLI makes to
a key-minting endpoint (`/personal-project`, `/project-key`, `/virtual-key`) is refused and the
presented device token is severed; they can no longer approve a device login for the
organization, exchange a code approved before the disable, or rotate their session at
`/refresh`. The access token already in hand keeps working on bearer-only routes (budget
status, bootstrap, lookup) until it expires — one hour, the same window a removed member has
today — instead of rolling forward for the refresh token's ninety days. Keys already handed
out are not recalled by this change: a project key has no owner, and a personal virtual key
issued before the disable keeps its own status.

Two smaller behaviour changes, both intended: a disabled member loses their personal
workspace in that organization until re-enabled, and drops to the public audience on share
links (they keep links shared with anyone, lose links shared with the organization).

No migration. No config change. Web sessions are deliberately not revoked — they are not
org-scoped and the gate is per-request, so someone disabled in one organization keeps working
in another.

## Verification

- `@langwatch/authz` 63/63, `@langwatch/authz-server` 95/95
- `pnpm test:unit` over `src/server`, `src/features/errors`, `src/components/settings`:
  **21,231 passed, 0 failed** on the first revision; after the review follow-ups, every
  suite that shapes a membership row (`rbac*`, `custom-roles`, the router authz suites, tRPC
  middleware, read repositories, organization service, permissions, error codes) re-runs at
  **369 passed across 20 files**, including 15/15 on `rbac.fork.unit.test.ts` with the
  disabled-seat cases on both heads
- Component lane `src/components/settings`: 174/174; the lite-invite form test now walks the
  Background's path (one team assigned, removed, invite sent) at 5/5
- The four new `auth-cli` integration cases (disabled seat on `/personal-project`, on
  `/approve`, between `/approve` and `/exchange`, and at `/refresh`) run in CI's datastore
  lane
- Both typecheck configs (`tsgo`, `tsgo.tests`) clean on the first revision; file-scoped
  diagnostics clean on every file the follow-ups touched
- No new lint diagnostics on the changed files; formatter run last, and it touched nothing
  outside this change

## Notes for review

- `disabledAt !== null` rather than `!= null` is deliberate: a row arriving without the column
  reads as *disabled*. That can only happen if someone drops it from the select, and a loud
  lockout beats silently returning everyone's access. Commented at the site — and it earned
  its keep during this change, catching two test fixtures that returned partial membership
  rows on the first revision and forty-odd more in the legacy `rbac` suites once the same
  strictness reached `rbac.ts`.
- `hasOrganizationPermission` keeps its signature and stays the seam every caller and test
  already drives; the denial reason is a separate small export the decision repository calls
  only on a refusal. That was a deliberate second pass: routing the verdict through a new
  wrapper instead would have broken the mocks in five unrelated suites for no gain.
- `MembershipDisabledError` carries no `meta`. Nothing renders one, and the scope id a check
  runs on is a project or team as often as an organization.
- ADR-092 carries an amendment describing the decision; scenarios added to
  `specs/licensing/seat-reconciliation.feature`,
  `specs/members/member-role-team-restrictions.feature`,
  `specs/ai-governance/cli-onboarding/me-credentials.feature` and
  `specs/ai-gateway/governance/cli-login-personal-guard.feature`, each bound with a
  `@scenario` annotation on the test that covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authorization**
  * Disabled organization members can no longer access organization, team, or project resources.
  * Personal API keys belonging to disabled members are denied, while service keys and public links remain available.
  * Re-enabling membership restores access immediately.

* **Error Handling**
  * Added a clear “Your access to this organization has been disabled” message.

* **Member Invitations**
  * Lite-member invitations without a team now display a warning while remaining sendable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
