### PR TITLE
ci: point npm_config_node_gyp at the published node-gyp in four workflows

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -179,13 +179,34 @@ jobs:
         with:
           cache-dependency-path: pnpm-lock.yaml
 
-      # skills/ pulls node-pty, whose postinstall falls back to `node-gyp
-      # rebuild` on linux. The composite action above installs node-gyp only
-      # when it does the install itself, and here it does not, so it has to be
-      # installed explicitly before the install below reaches that lifecycle
-      # script — otherwise it ELIFECYCLEs with "node-gyp: not found".
+      # node-pty ships prebuilds only for darwin and win32, so on Linux its
+      # postinstall always falls back to `node-gyp rebuild`. pnpm runs that
+      # rebuild with its OWN vendored node-gyp, whose `gyp/gyp_main.py` ships
+      # mode 644. That is harmless while make only compiles, but the moment
+      # make decides the generated Makefile is stale it re-runs gyp_main.py as
+      # a command and the build dies with "Permission denied" / error 126.
+      # Whether it decides that depends on file mtimes, so the failure comes
+      # and goes with how the concurrent native builds happen to interleave
+      # over the shared ~/.cache/node-gyp headers.
+      #
+      # Installing node-gyp globally is not enough on its own: pnpm exports
+      # `npm_config_node_gyp` pointing at its vendored copy, and that variable
+      # wins over PATH for every lifecycle script, so the global install sits
+      # unused. Point the variable at the published node-gyp, which ships
+      # gyp_main.py mode 755, and the landmine is gone for every later install
+      # in the job. npx-server-smoke.yml and sdk-javascript-ci.yml do the same.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp@12.3.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g node-gyp@12.3.0
+          gyp="$(npm root -g)/node-gyp/bin/node-gyp.js"
+          # Assert rather than trust: a wrong path here would not fail this
+          # step, it would fail whichever native build ran next, which reads
+          # as an unrelated compiler error.
+          test -f "$gyp"
+          test -x "$(dirname "$gyp")/../gyp/gyp_main.py"
+          echo "npm_config_node_gyp=$gyp" >> "$GITHUB_ENV"
 
       # One install for the app and the skills compiler. skills/ used to need
       # `--ignore-workspace` to escape the root workspace it sat inside without

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -228,13 +228,34 @@ jobs:
       - name: Pre-build Go services
         run: go build -o /dev/null ./cmd/service
 
-      # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
-      # its postinstall always falls back to `node-gyp rebuild`. With
-      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
-      # by default — install it globally before any install that hits
-      # mcp-server's onlyBuiltDependencies allowlist.
+      # node-pty ships prebuilds only for darwin and win32, so on Linux its
+      # postinstall always falls back to `node-gyp rebuild`. pnpm runs that
+      # rebuild with its OWN vendored node-gyp, whose `gyp/gyp_main.py` ships
+      # mode 644. That is harmless while make only compiles, but the moment
+      # make decides the generated Makefile is stale it re-runs gyp_main.py as
+      # a command and the build dies with "Permission denied" / error 126.
+      # Whether it decides that depends on file mtimes, so the failure comes
+      # and goes with how the concurrent native builds happen to interleave
+      # over the shared ~/.cache/node-gyp headers.
+      #
+      # Installing node-gyp globally is not enough on its own: pnpm exports
+      # `npm_config_node_gyp` pointing at its vendored copy, and that variable
+      # wins over PATH for every lifecycle script, so the global install sits
+      # unused. Point the variable at the published node-gyp, which ships
+      # gyp_main.py mode 755, and the landmine is gone for every later install
+      # in the job. npx-server-smoke.yml and sdk-javascript-ci.yml do the same.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp@12.3.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g node-gyp@12.3.0
+          gyp="$(npm root -g)/node-gyp/bin/node-gyp.js"
+          # Assert rather than trust: a wrong path here would not fail this
+          # step, it would fail whichever native build ran next, which reads
+          # as an unrelated compiler error.
+          test -f "$gyp"
+          test -x "$(dirname "$gyp")/../gyp/gyp_main.py"
+          echo "npm_config_node_gyp=$gyp" >> "$GITHUB_ENV"
 
       # One install for the app, the MCP server (a workspace dependency of the
       # app, so `...` pulls it in) and the Playwright suite. This used to be

--- a/.github/workflows/gateway-matrix.yaml
+++ b/.github/workflows/gateway-matrix.yaml
@@ -208,8 +208,26 @@ jobs:
         # node-pty (in the app's closure via mcp-server) falls back to
         # `node-gyp rebuild` on linux, and this job bypasses the shared setup
         # action that puts node-gyp on PATH.
+        #
+        # Installing it globally is not enough on its own: pnpm exports
+        # `npm_config_node_gyp` pointing at its own vendored copy, whose
+        # `gyp/gyp_main.py` ships mode 644, and that variable wins over PATH
+        # for every lifecycle script. When make decides the generated Makefile
+        # is stale it re-runs gyp_main.py as a command, and the build dies with
+        # "Permission denied" / error 126. Export the variable at the published
+        # node-gyp, which ships gyp_main.py mode 755. npx-server-smoke.yml and
+        # sdk-javascript-ci.yml do the same.
+        shell: bash
         run: |
+          set -euo pipefail
           npm install -g node-gyp@12.3.0
+          gyp="$(npm root -g)/node-gyp/bin/node-gyp.js"
+          # Assert rather than trust: a wrong path here would not fail this
+          # line, it would fail the native build below, which reads as an
+          # unrelated compiler error.
+          test -f "$gyp"
+          test -x "$(dirname "$gyp")/../gyp/gyp_main.py"
+          export npm_config_node_gyp="$gyp"
           pnpm install --frozen-lockfile --filter "@langwatch/web..."
 
       - name: Apply DB migrations

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1314,13 +1314,34 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vite-
 
-      # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
-      # its postinstall always falls back to `node-gyp rebuild`. With
-      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
-      # by default — install it globally before any install that hits
-      # mcp-server's onlyBuiltDependencies allowlist.
+      # node-pty ships prebuilds only for darwin and win32, so on Linux its
+      # postinstall always falls back to `node-gyp rebuild`. pnpm runs that
+      # rebuild with its OWN vendored node-gyp, whose `gyp/gyp_main.py` ships
+      # mode 644. That is harmless while make only compiles, but the moment
+      # make decides the generated Makefile is stale it re-runs gyp_main.py as
+      # a command and the build dies with "Permission denied" / error 126.
+      # Whether it decides that depends on file mtimes, so the failure comes
+      # and goes with how the concurrent native builds happen to interleave
+      # over the shared ~/.cache/node-gyp headers.
+      #
+      # Installing node-gyp globally is not enough on its own: pnpm exports
+      # `npm_config_node_gyp` pointing at its vendored copy, and that variable
+      # wins over PATH for every lifecycle script, so the global install sits
+      # unused. Point the variable at the published node-gyp, which ships
+      # gyp_main.py mode 755, and the landmine is gone for every later install
+      # in the job. npx-server-smoke.yml and sdk-javascript-ci.yml do the same.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp@12.3.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g node-gyp@12.3.0
+          gyp="$(npm root -g)/node-gyp/bin/node-gyp.js"
+          # Assert rather than trust: a wrong path here would not fail this
+          # step, it would fail whichever native build ran next, which reads
+          # as an unrelated compiler error.
+          test -f "$gyp"
+          test -x "$(dirname "$gyp")/../gyp/gyp_main.py"
+          echo "npm_config_node_gyp=$gyp" >> "$GITHUB_ENV"
 
       # One install. mcp-server is a workspace dependency of the app, so the
       # trailing `...` pulls it in — it used to be installed separately here


### PR DESCRIPTION
Fixes the recurring `gyp_main.py: Permission denied` / `make: *** Error 126` failure that reds out random CI jobs during `pnpm install`.

## The failure

`node-pty` ships prebuilds only for darwin and win32, so on Linux its postinstall always falls back to `node-gyp rebuild`. pnpm runs that rebuild with its **own vendored** node-gyp, whose `gyp/gyp_main.py` reaches the runner mode 644. That is harmless while make only compiles — but the moment make decides the generated Makefile is stale, it re-runs `gyp_main.py` as a command and `sh` answers "Permission denied":

```
/.../pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py: Permission denied
make: *** [Makefile:358: Makefile] Error 126
```

Whether make decides the Makefile is stale depends on file mtimes, so it lands on a random job each run and reads as a flaky test rather than an install that never got to run.

## Why the existing mitigation did not work

Four workflows installed `node-gyp@12.3.0` globally and stopped there. That is not enough: **pnpm exports `npm_config_node_gyp` pointing at its vendored copy, and that variable wins over PATH for every lifecycle script**, so the global install sat unused. The failing log confirms it — the step installs 12.3.0, then the build reports `gyp info using node-gyp@11.5.0` out of pnpm's dist.

## The fix

Export `npm_config_node_gyp` at the published node-gyp, which ships `gyp_main.py` mode 755. This is not a new idea — `npx-server-smoke.yml` and `sdk-javascript-ci.yml` already do exactly this, comment and all; these four just never got it:

| Workflow | Before | After |
|---|---|---|
| `e2e-ci.yml` | global install only | ✅ env var |
| `langwatch-app-ci.yml` | global install only | ✅ env var |
| `docs-ci.yml` | global install only | ✅ env var |
| `gateway-matrix.yaml` | global install only | ✅ env var (exported inline — its install shares one step) |

Each step also asserts the resolved path exists and is executable before exporting it, so a wrong path fails *here* rather than surfacing later as an unrelated compiler error in whichever native build ran next.

`.github/actions/setup-pnpm-node/action.yml` is untouched — it already handles this a different way (chmod +x over the store), which is why workflows using its install path were never affected.

## Verification

- `actionlint` (with shellcheck) on all four files: **12 findings before, 12 after** — all pre-existing, in unrelated steps. Zero new.
- Observed failure this fixes: [e2e-ci run 32676277872](https://github.com/langwatch/langwatch/actions/runs/32676277872/job/97284960612) on #7477, whose diff is unrelated to CI.

## Deployment Impact

None. CI-only; no runtime, image, or infrastructure change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability for native dependency builds by consistently using the verified global `node-gyp` installation.
  * Added validation for required build executables and permissions across documentation, end-to-end, gateway, and application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->