### PR TITLE
feat(governance): Inventory unifies sources and catalog, Departments becomes People, Costs/Billed arrive flag-gated

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -47,7 +47,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { PermissionRequiredNotice } from "~/components/PermissionRequiredNotice";
 import {
   DialogBody,
@@ -61,8 +60,6 @@ import {
 import { Drawer } from "~/components/ui/drawer";
 import { Link } from "~/components/ui/link";
 import { toaster } from "~/components/ui/toaster";
-import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
-import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { HandledErrorAlert, showErrorToast } from "~/features/errors";
 import { useActivePlan } from "~/hooks/useActivePlan";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -565,7 +562,7 @@ function useIngestionSourcesPage() {
   };
 }
 
-function IngestionSourcesPage() {
+export function IngestionSourcesPanel() {
   const {
     orgId,
     isEnterprise,
@@ -586,7 +583,7 @@ function IngestionSourcesPage() {
   } = useIngestionSourcesPage();
 
   return (
-    <GovernanceLayout pageTitle="Catalog · Governance · LangWatch">
+    <>
       <VStack align="stretch" gap={6} width="full" maxW="container.xl">
         <IngestionSourcesHeader
           isEnterprise={isEnterprise}
@@ -645,7 +642,7 @@ function IngestionSourcesPage() {
         onSubmit={(input) => mutations.update.mutate(input)}
         isPending={mutations.update.isPending}
       />
-    </GovernanceLayout>
+    </>
   );
 }
 
@@ -2264,10 +2261,3 @@ function SecretModal({
   );
 }
 
-export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
-  bypassOnboardingRedirect: true,
-})(
-  withPermissionGuard("governance:view", {
-    bypassOnboardingRedirect: true,
-  })(IngestionSourcesPage),
-);

--- a/platform/app/src/__tests__/governanceNavigationRedirects.integration.test.tsx
+++ b/platform/app/src/__tests__/governanceNavigationRedirects.integration.test.tsx
@@ -8,7 +8,7 @@
  * Spec: specs/governance/governance-navigation.feature
  */
 
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import {
   createMemoryRouter,
   type RouteObject,
@@ -40,6 +40,28 @@ function renderRouterAt(initialEntries: string[]) {
       ),
     },
     { path: "/governance/people", element: <div>people page</div> },
+    // The same objects routes.tsx mounts for the inventory unification.
+    {
+      path: "/governance/tool-catalog",
+      element: (
+        <LegacyPrefixRedirect
+          from="/governance/tool-catalog"
+          to="/governance/inventory"
+          search="?tab=catalog"
+        />
+      ),
+    },
+    {
+      path: "/governance/ingestion-sources",
+      element: (
+        <LegacyPrefixRedirect
+          from="/governance/ingestion-sources"
+          to="/governance/inventory"
+          search="?tab=sources"
+        />
+      ),
+    },
+    { path: "/governance/inventory", element: <div>inventory page</div> },
   ];
   const router = createMemoryRouter(routes, {
     initialEntries,
@@ -52,16 +74,42 @@ function renderRouterAt(initialEntries: string[]) {
 describe("given governance pages that were renamed", () => {
   describe("when a reader opens the old departments address from a bookmark", () => {
     // @scenario "Old departments bookmarks land on the people page"
-    it("lands on the people page", () => {
+    it("lands on the people page", async () => {
       const router = renderRouterAt(["/start", "/governance/departments"]);
-      expect(router.state.location.pathname).toBe("/governance/people");
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe("/governance/people");
+      });
     });
   });
 
   describe("when a reader opens the older cost-centers address", () => {
-    it("chains onto the people page", () => {
+    it("chains onto the people page", async () => {
       const router = renderRouterAt(["/start", "/governance/cost-centers"]);
-      expect(router.state.location.pathname).toBe("/governance/people");
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe("/governance/people");
+      });
+    });
+  });
+
+  describe("when a reader opens a retired inventory-family address", () => {
+    // @scenario "Old catalog addresses land on the matching inventory tab"
+    it("lands tool-catalog on the catalog tab of inventory", async () => {
+      const router = renderRouterAt(["/start", "/governance/tool-catalog"]);
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe("/governance/inventory");
+      });
+      expect(router.state.location.search).toBe("?tab=catalog");
+    });
+
+    it("lands ingestion-sources on the sources tab of inventory", async () => {
+      const router = renderRouterAt([
+        "/start",
+        "/governance/ingestion-sources",
+      ]);
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe("/governance/inventory");
+      });
+      expect(router.state.location.search).toBe("?tab=sources");
     });
   });
 });

--- a/platform/app/src/__tests__/governanceNavigationRedirects.integration.test.tsx
+++ b/platform/app/src/__tests__/governanceNavigationRedirects.integration.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Governance pages rename over time; their addresses must not. These tests
+ * run the REAL redirect route objects routes.tsx mounts inside a memory
+ * router, so what is asserted is the address the reader ends on.
+ *
+ * Spec: specs/governance/governance-navigation.feature
+ */
+
+import { render } from "@testing-library/react";
+import {
+  createMemoryRouter,
+  type RouteObject,
+  RouterProvider,
+} from "react-router";
+import { describe, expect, it } from "vitest";
+import { LegacyPrefixRedirect } from "~/components/LegacyPrefixRedirect";
+
+function renderRouterAt(initialEntries: string[]) {
+  const routes: RouteObject[] = [
+    { path: "/start", element: <div>start</div> },
+    // The same objects routes.tsx mounts for the renamed governance pages.
+    {
+      path: "/governance/departments",
+      element: (
+        <LegacyPrefixRedirect
+          from="/governance/departments"
+          to="/governance/people"
+        />
+      ),
+    },
+    {
+      path: "/governance/cost-centers",
+      element: (
+        <LegacyPrefixRedirect
+          from="/governance/cost-centers"
+          to="/governance/people"
+        />
+      ),
+    },
+    { path: "/governance/people", element: <div>people page</div> },
+  ];
+  const router = createMemoryRouter(routes, {
+    initialEntries,
+    initialIndex: initialEntries.length - 1,
+  });
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("given governance pages that were renamed", () => {
+  describe("when a reader opens the old departments address from a bookmark", () => {
+    // @scenario "Old departments bookmarks land on the people page"
+    it("lands on the people page", () => {
+      const router = renderRouterAt(["/start", "/governance/departments"]);
+      expect(router.state.location.pathname).toBe("/governance/people");
+    });
+  });
+
+  describe("when a reader opens the older cost-centers address", () => {
+    it("chains onto the people page", () => {
+      const router = renderRouterAt(["/start", "/governance/cost-centers"]);
+      expect(router.state.location.pathname).toBe("/governance/people");
+    });
+  });
+});

--- a/platform/app/src/__tests__/legacyRedirects.integration.test.tsx
+++ b/platform/app/src/__tests__/legacyRedirects.integration.test.tsx
@@ -59,11 +59,11 @@ function renderRouterAt(initialEntries: string[]) {
       element: (
         <LegacyPrefixRedirect
           from="/governance/cost-centers"
-          to="/governance/departments"
+          to="/governance/people"
         />
       ),
     },
-    { path: "/governance/departments", element: <div>departments</div> },
+    { path: "/governance/people", element: <div>people</div> },
   ];
   const router = createMemoryRouter(routes, {
     initialEntries,
@@ -192,12 +192,12 @@ describe("legacy governance redirects", () => {
   });
 
   describe("when the retired cost centers address is cold-loaded", () => {
-    /** @scenario The retired cost centers address lands on departments */
-    it("chains through to the departments page", async () => {
+    /** @scenario The retired cost centers address lands on people */
+    it("chains through to the people page", async () => {
       const router = renderRouterAt(["/settings/governance/cost-centers"]);
 
       await waitFor(() => {
-        expect(router.state.location.pathname).toBe("/governance/departments");
+        expect(router.state.location.pathname).toBe("/governance/people");
       });
     });
   });

--- a/platform/app/src/components/LegacyPrefixRedirect.tsx
+++ b/platform/app/src/components/LegacyPrefixRedirect.tsx
@@ -6,23 +6,44 @@ import { Navigate, useLocation } from "react-router";
  * cold load of the SPA, which is exactly how a stale bookmark or emailed
  * link arrives. Keeps the sub-path, query string and hash, and replaces the
  * history entry so the back button never returns to the retired address.
+ *
+ * `search` adds default parameters to the target address (`"?tab=sources"`)
+ * without ever clobbering what the old link already carried: an arriving
+ * parameter wins, a missing one is filled from here.
  */
 export function LegacyPrefixRedirect({
   from,
   to,
+  search,
 }: {
   from: string;
   to: string;
+  search?: string;
 }) {
   const location = useLocation();
   const suffix = location.pathname.startsWith(from)
     ? location.pathname.slice(from.length)
     : "";
+
+  let target = to + suffix;
+  let incoming = location.search;
+  if (search) {
+    const merged = new URLSearchParams(location.search);
+    for (const [key, value] of new URLSearchParams(search)) {
+      if (!merged.has(key)) merged.set(key, value);
+    }
+    const mergedString = merged.toString();
+    incoming = mergedString ? `?${mergedString}` : "";
+    // The defaults live in the query now; leaving them in the path would
+    // make the router read `?tab=...` as path segments.
+    target = target.split("?")[0] ?? target;
+  }
+
   return (
     <Navigate
       to={{
-        pathname: to + suffix,
-        search: location.search,
+        pathname: target,
+        search: incoming,
         hash: location.hash,
       }}
       replace

--- a/platform/app/src/components/governance/GovernanceLayout.tsx
+++ b/platform/app/src/components/governance/GovernanceLayout.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 import { SectionNavigationLayout } from "~/components/ui/layouts/SectionNavigationLayout";
-import { governanceNavItems } from "~/features/navigation/sectionNavItems";
+import { useGovernanceNavItems } from "~/features/navigation/useGovernanceNavItems";
 
 /**
  * Layout for `/governance/*` - wraps DashboardLayout in `orgScope` mode
@@ -8,7 +8,7 @@ import { governanceNavItems } from "~/features/navigation/sectionNavItems";
  * + "Organization-scoped" indicator) and renders a thin org-level
  * sub-navigation in the left column. The item list itself lives in
  * `~/features/navigation/sectionNavItems` so every shell renders the
- * same navigation.
+ * same navigation; the flag gating comes from useGovernanceNavItems.
  *
  * Spec: specs/ai-gateway/governance/governance-home-routing.feature
  */
@@ -16,6 +16,8 @@ export default function GovernanceLayout({
   children,
   pageTitle,
 }: PropsWithChildren<{ pageTitle?: string }>) {
+  const governanceNavItems = useGovernanceNavItems();
+
   return (
     <SectionNavigationLayout
       sectionLabel="AI Governance"

--- a/platform/app/src/components/governance/QuarantineFillAlert.tsx
+++ b/platform/app/src/components/governance/QuarantineFillAlert.tsx
@@ -72,7 +72,7 @@ export function QuarantineFillAlert({
               </Box>
             )}
             <Link
-              href="/governance/ingestion-sources"
+              href="/governance/inventory?tab=sources"
               fontSize="sm"
               color="orange.600"
             >

--- a/platform/app/src/components/me/GovernanceGettingStartedBanner.tsx
+++ b/platform/app/src/components/me/GovernanceGettingStartedBanner.tsx
@@ -127,7 +127,7 @@ export function GovernanceGettingStartedBanner() {
               _active={{ bg: "white/80", transform: "translateY(0)" }}
               transition="background-color 0.12s ease, transform 0.12s ease"
             >
-              <Link href="/governance/tool-catalog">
+              <Link href="/governance/inventory?tab=catalog">
                 Add your first tools
                 <Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
               </Link>

--- a/platform/app/src/components/settings/__tests__/departmentAssignment.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/departmentAssignment.integration.test.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Imported at the top: vitest hoists the vi.mock / vi.hoisted calls below above
 // these statements, so the modules under test still resolve the mocks.
-import DepartmentsPage from "~/pages/governance/departments";
+import DepartmentsPage from "~/pages/governance/people";
 import { DepartmentPicker } from "../DepartmentPicker";
 import { useDepartmentColumn } from "../useDepartmentColumn";
 

--- a/platform/app/src/components/settings/governance/AiToolEntryDrawer.tsx
+++ b/platform/app/src/components/settings/governance/AiToolEntryDrawer.tsx
@@ -471,7 +471,7 @@ export function AiToolEntryDrawer({ organizationId, state, onClose }: Props) {
                 <Text fontSize="xs" color="fg.muted">
                   No departments yet. The tile stays visible to every member.
                   Create departments under{" "}
-                  <Link href="/governance/departments" color="blue.600">
+                  <Link href="/governance/people" color="blue.600">
                     Governance → Departments
                   </Link>{" "}
                   to scope tiles to a group of people.

--- a/platform/app/src/components/settings/governance/IngestionTemplatesEditor.tsx
+++ b/platform/app/src/components/settings/governance/IngestionTemplatesEditor.tsx
@@ -22,7 +22,7 @@ import { api } from "~/utils/api";
 
 /**
  * Admin Ingestion Templates editor — second tab on
- * /governance/tool-catalog. Per
+ * /governance/inventory?tab=catalog. Per
  * `specs/ai-governance/admin-ottl-authoring.feature`:
  *
  *   - Platform-published rows render read-only with a 'View OTTL'

--- a/platform/app/src/features/navigation/__tests__/governanceNavRename.unit.test.ts
+++ b/platform/app/src/features/navigation/__tests__/governanceNavRename.unit.test.ts
@@ -1,0 +1,99 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { noOrgBouncerRoutes } from "~/hooks/useRequiredSession";
+
+import { governanceNavItems } from "../sectionNavItems";
+
+// vitest runs from the app package root.
+const SRC = resolve(process.cwd(), "src");
+
+/**
+ * Files that must keep naming retired addresses on purpose: the redirect
+ * routes themselves, and the compatibility map that recognises old addresses
+ * coming in from stored pins.
+ */
+const ALLOWED = [
+  resolve(SRC, "routes.tsx"),
+  // Recognises retired addresses arriving from stored pins.
+  resolve(SRC, "utils/compat/next-router.ts"),
+  resolve(SRC, "hooks/useRequiredSession.ts"),
+];
+
+/** Retired addresses no live link may carry any more. */
+const RETIRED = ["/governance/departments", "/governance/tool-catalog"];
+
+const tsFiles = (dir: string): string[] => {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "generated" || entry === "__tests__") continue;
+      found.push(...tsFiles(full));
+    } else if (/\.tsx?$/.test(entry)) {
+      found.push(full);
+    }
+  }
+  return found;
+};
+
+describe("given the governance sidebar renames", () => {
+  describe("when the governance navigation items are captured", () => {
+    // @scenario "The sidebar names People where it named Departments"
+    it("names People at /governance/people and keeps no departments item", () => {
+      const people = governanceNavItems.find(
+        (item) => item.href === "/governance/people",
+      );
+      expect(people?.label).toBe("People");
+      expect(
+        governanceNavItems.some((item) =>
+          item.href.startsWith("/governance/departments"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("when every navigation link to a renamed page is inspected", () => {
+    // @scenario "Every internal link follows the rename"
+    it("carries no link to a retired address outside compatibility maps", () => {
+      const offenders = tsFiles(SRC)
+        .filter((file) => !ALLOWED.includes(file))
+        .filter((file) =>
+          RETIRED.some((retired) =>
+            readFileSync(file, "utf8").includes(retired),
+          ),
+        );
+
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  describe("when the allowlist of pages reachable without a project is read", () => {
+    // @scenario "An admin in an empty organization still reaches the renamed page"
+    it("lists the people page under its new address", () => {
+      expect(noOrgBouncerRoutes).toContain("/governance/people");
+    });
+  });
+
+  describe("when the item lists are captured for the inventory unification", () => {
+    // @scenario "The sidebar offers Inventory as one door instead of two"
+    it("offers one Inventory item and keeps no retired list items", () => {
+      const inventory = governanceNavItems.filter(
+        (item) => item.label === "Inventory",
+      );
+      expect(inventory).toHaveLength(1);
+      expect(inventory[0]?.href).toBe("/governance/inventory");
+
+      const retiredListAddresses = [
+        "/governance/tool-catalog",
+        "/governance/ingestion-sources",
+      ];
+      for (const href of retiredListAddresses) {
+        expect(
+          governanceNavItems.some((item) => item.href === href),
+        ).toBe(false);
+      }
+    });
+  });
+});

--- a/platform/app/src/features/navigation/__tests__/governanceSpendViews.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/governanceSpendViews.integration.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Binds the spend-view scenarios from specs/governance/governance-navigation.feature:
+ * with `release_ui_governance_billed_cost_enabled` off, no sidebar item and
+ * a deep link reads as a missing page; with it on, the items appear and
+ * each address renders its placeholder.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import BilledPage from "~/pages/governance/billed";
+// Imported at the top: vitest hoists the vi.mock / vi.hoisted calls below
+// above these statements, so the modules under test still resolve the mocks.
+import CostsPage from "~/pages/governance/costs";
+
+import { useGovernanceNavItems } from "../useGovernanceNavItems";
+
+const { spendEnabled } = vi.hoisted(() => ({
+  spendEnabled: { current: false },
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({
+    enabled: spendEnabled.current,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org_test" },
+    isLoading: false,
+    hasAnyPermission: () => true,
+  }),
+}));
+
+// The layout pulls in the whole section-navigation chrome; the placeholder
+// body is what these scenarios are about.
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+const MISSING_PAGE_TEXT = "This page doesn't exist or has been moved.";
+
+function renderWithChakra(node: ReactNode) {
+  return render(<ChakraProvider value={defaultSystem}>{node}</ChakraProvider>);
+}
+
+describe("given the governance spend views sit behind their switch", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spendEnabled.current = false;
+  });
+
+  describe("when the switch is off", () => {
+    // @scenario "The spend views stay hidden until their switch is on"
+    it("keeps no Costs or Billed item in the navigation list", () => {
+      const { result } = renderHookResult();
+
+      const labels = result.map((item) => item.label);
+      expect(labels).not.toContain("Costs");
+      expect(labels).not.toContain("Billed");
+    });
+
+    // @scenario "The spend views stay hidden until their switch is on"
+    it("reads each spend address as a missing page", () => {
+      renderWithChakra(<CostsPage />);
+      expect(screen.getByText(MISSING_PAGE_TEXT)).toBeDefined();
+
+      cleanup();
+      renderWithChakra(<BilledPage />);
+      expect(screen.getByText(MISSING_PAGE_TEXT)).toBeDefined();
+    });
+  });
+
+  describe("when the switch is on", () => {
+    // @scenario "A switched-on organization sees and reaches the spend pages"
+    it("lists Costs and Billed between Overview and Inventory", () => {
+      spendEnabled.current = true;
+      const { result } = renderHookResult();
+
+      const labels = result.map((item) => item.label);
+      expect(labels.indexOf("Costs")).toBeGreaterThan(
+        labels.indexOf("Overview"),
+      );
+      expect(labels.indexOf("Costs")).toBeLessThan(labels.indexOf("Inventory"));
+      expect(labels).toContain("Billed");
+    });
+
+    // @scenario "A switched-on organization sees and reaches the spend pages"
+    it("renders each address as its placeholder page instead of a missing page", () => {
+      spendEnabled.current = true;
+
+      renderWithChakra(<CostsPage />);
+      expect(screen.getByText(/Cost data for this organization/)).toBeDefined();
+      expect(screen.queryByText(MISSING_PAGE_TEXT)).toBeNull();
+
+      cleanup();
+      renderWithChakra(<BilledPage />);
+      expect(
+        screen.getByText(/Billing records for this organization/),
+      ).toBeDefined();
+      expect(screen.queryByText(MISSING_PAGE_TEXT)).toBeNull();
+    });
+  });
+});
+
+/** Runs the navigation hook and returns its current item list. */
+function renderHookResult() {
+  let result: ReturnType<typeof useGovernanceNavItems>;
+  function Probe() {
+    result = useGovernanceNavItems();
+    return null;
+  }
+  renderWithChakra(<Probe />);
+  return { result: result! };
+}

--- a/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
@@ -75,9 +75,8 @@ describe("given the governance section navigation data", () => {
         capturedItems.map((item) => ({ label: item.label, href: item.href })),
       ).toEqual([
         { label: "Overview", href: "/governance" },
-        { label: "Catalog", href: "/governance/ingestion-sources" },
+        { label: "Inventory", href: "/governance/inventory" },
         { label: "Anomaly Rules", href: "/governance/anomaly-rules" },
-        { label: "Tool Tiles", href: "/governance/tool-catalog" },
         { label: "People", href: "/governance/people" },
       ]);
     });

--- a/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
@@ -78,7 +78,7 @@ describe("given the governance section navigation data", () => {
         { label: "Catalog", href: "/governance/ingestion-sources" },
         { label: "Anomaly Rules", href: "/governance/anomaly-rules" },
         { label: "Tool Tiles", href: "/governance/tool-catalog" },
-        { label: "Departments", href: "/governance/departments" },
+        { label: "People", href: "/governance/people" },
       ]);
     });
   });

--- a/platform/app/src/features/navigation/sectionNavItems.ts
+++ b/platform/app/src/features/navigation/sectionNavItems.ts
@@ -93,22 +93,16 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     icon: Eye,
   },
   {
-    label: "Catalog",
-    href: "/governance/ingestion-sources",
-    includePath: "/governance/ingestion-sources",
-    icon: PlugZap,
+    label: "Inventory",
+    href: "/governance/inventory",
+    includePath: "/governance/inventory",
+    icon: PackageOpen,
   },
   {
     label: "Anomaly Rules",
     href: "/governance/anomaly-rules",
     includePath: "/governance/anomaly-rules",
     icon: AlertTriangle,
-  },
-  {
-    label: "Tool Tiles",
-    href: "/governance/tool-catalog",
-    includePath: "/governance/tool-catalog",
-    icon: PackageOpen,
   },
   {
     label: "People",

--- a/platform/app/src/features/navigation/sectionNavItems.ts
+++ b/platform/app/src/features/navigation/sectionNavItems.ts
@@ -111,9 +111,9 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     icon: PackageOpen,
   },
   {
-    label: "Departments",
-    href: "/governance/departments",
-    includePath: "/governance/departments",
+    label: "People",
+    href: "/governance/people",
+    includePath: "/governance/people",
     icon: Wallet,
   },
 ];

--- a/platform/app/src/features/navigation/sectionNavItems.ts
+++ b/platform/app/src/features/navigation/sectionNavItems.ts
@@ -1,13 +1,13 @@
 import {
   AlertTriangle,
   Brain,
+  CircleDollarSign,
   Eye,
   Gauge,
   KeyRound,
   LineChart,
   type LucideIcon,
   PackageOpen,
-  PlugZap,
   ReceiptText,
   Route,
   Shield,
@@ -15,6 +15,8 @@ import {
   Webhook,
   Zap,
 } from "lucide-react";
+
+import type { FrontendFeatureFlag } from "~/server/featureFlag/frontendFeatureFlags";
 
 /**
  * The Gateway and Governance section navigations as data. The legacy
@@ -27,6 +29,11 @@ export interface SectionNavItemData {
   href: string;
   includePath?: string;
   icon: LucideIcon;
+  /**
+   * When set, the item renders only while that frontend feature flag is
+   * on for the reader (see useGovernanceNavItems).
+   */
+  featureFlag?: FrontendFeatureFlag;
 }
 
 export const gatewayNavItems: readonly SectionNavItemData[] = [
@@ -91,6 +98,21 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     label: "Overview",
     href: "/governance",
     icon: Eye,
+  },
+  {
+    label: "Costs",
+    href: "/governance/costs",
+    includePath: "/governance/costs",
+    icon: CircleDollarSign,
+    // Placeholder pages; both items share one switch.
+    featureFlag: "release_ui_governance_billed_cost_enabled",
+  },
+  {
+    label: "Billed",
+    href: "/governance/billed",
+    includePath: "/governance/billed",
+    icon: ReceiptText,
+    featureFlag: "release_ui_governance_billed_cost_enabled",
   },
   {
     label: "Inventory",

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -19,11 +19,8 @@ import { featureIcons } from "~/utils/featureIcons";
 import { readLastVisitedProduct } from "../logic/productMemory";
 import { resolveSettingsBackTarget } from "../logic/resolveSettingsBackTarget";
 import { isPathUnder, type ProductId } from "../products";
-import {
-  gatewayNavItems,
-  governanceNavItems,
-  type SectionNavItemData,
-} from "../sectionNavItems";
+import { gatewayNavItems, type SectionNavItemData } from "../sectionNavItems";
+import { useGovernanceNavItems } from "../useGovernanceNavItems";
 import { useLlmOpsProjectSlug } from "../useLlmOpsProjectSlug";
 import { useReachableProducts } from "../useReachableProducts";
 import { isSettingsMenuItemActive, useSettingsMenu } from "../useSettingsMenu";
@@ -268,9 +265,7 @@ function ProductSidebarBody({
     );
   }
   if (surface === "governance") {
-    return (
-      <SectionItemsNav items={governanceNavItems} showExpanded={showExpanded} />
-    );
+    return <GovernanceSurfaceItems showExpanded={showExpanded} />;
   }
   return (
     <MainMenuSections
@@ -278,6 +273,19 @@ function ProductSidebarBody({
       shouldIncludeGovernSection={false}
       shouldIncludeOpsSection={false}
     />
+  );
+}
+
+/**
+ * The governance surface's items, filtered through the same flag gate the
+ * legacy governance layout uses, so both shells show Costs / Billed under
+ * one switch.
+ */
+function GovernanceSurfaceItems({ showExpanded }: { showExpanded: boolean }) {
+  const governanceNavItems = useGovernanceNavItems();
+
+  return (
+    <SectionItemsNav items={governanceNavItems} showExpanded={showExpanded} />
   );
 }
 

--- a/platform/app/src/features/navigation/useGovernanceNavItems.ts
+++ b/platform/app/src/features/navigation/useGovernanceNavItems.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+
+import type { SectionNavItemData } from "./sectionNavItems";
+import { governanceNavItems } from "./sectionNavItems";
+
+/**
+ * Drops the navigation items whose feature flag is off, keeping the
+ * declared order. Both governance shells (the legacy layout rails and the
+ * product sidebar) filter through this one function so they cannot drift.
+ */
+export function filterFlaggedNavItems(
+  items: readonly SectionNavItemData[],
+  flagEnabled: (flag: string) => boolean,
+): SectionNavItemData[] {
+  return items.filter(
+    (item) => !item.featureFlag || flagEnabled(item.featureFlag),
+  );
+}
+
+/**
+ * The governance sidebar items visible to the current reader: every
+ * ungated item, plus Costs / Billed only while
+ * `release_ui_governance_billed_cost_enabled` is on for their org.
+ *
+ * While the flag query is still resolving the gated items stay hidden; a
+ * flag that is on adds them a moment later instead of flashing them and
+ * pulling them back.
+ */
+export function useGovernanceNavItems(): readonly SectionNavItemData[] {
+  const { enabled: spendEnabled } = useFeatureFlag(
+    "release_ui_governance_billed_cost_enabled",
+  );
+
+  return useMemo(
+    () => filterFlaggedNavItems(governanceNavItems, () => spendEnabled),
+    [spendEnabled],
+  );
+}

--- a/platform/app/src/hooks/useRequiredSession.ts
+++ b/platform/app/src/hooks/useRequiredSession.ts
@@ -43,6 +43,7 @@ export const noOrgBouncerRoutes = [
   // just haven't created a project yet (and may never need to; governance
   // is org-scoped).
   "/governance",
+  "/governance/inventory",
   "/governance/ingestion-sources",
   "/governance/ingestion-sources/[id]",
   "/governance/anomaly-rules",

--- a/platform/app/src/hooks/useRequiredSession.ts
+++ b/platform/app/src/hooks/useRequiredSession.ts
@@ -44,6 +44,8 @@ export const noOrgBouncerRoutes = [
   // is org-scoped).
   "/governance",
   "/governance/inventory",
+  "/governance/costs",
+  "/governance/billed",
   "/governance/ingestion-sources",
   "/governance/ingestion-sources/[id]",
   "/governance/anomaly-rules",

--- a/platform/app/src/hooks/useRequiredSession.ts
+++ b/platform/app/src/hooks/useRequiredSession.ts
@@ -47,7 +47,7 @@ export const noOrgBouncerRoutes = [
   "/governance/ingestion-sources/[id]",
   "/governance/anomaly-rules",
   "/governance/tool-catalog",
-  "/governance/departments",
+  "/governance/people",
   "/governance/cost-centers",
   "/governance/teams",
   "/governance/teams/[id]",

--- a/platform/app/src/pages/governance/billed.tsx
+++ b/platform/app/src/pages/governance/billed.tsx
@@ -1,0 +1,39 @@
+import { Box, Text } from "@chakra-ui/react";
+
+import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+
+/**
+ * Billed - the organization's invoices and billing history. Placeholder
+ * until the billing view ships; reachable only while
+ * `release_ui_governance_billed_cost_enabled` is on.
+ *
+ * Spec: specs/governance/governance-navigation.feature
+ */
+function BilledPage() {
+  return (
+    <GovernanceLayout pageTitle="Billed">
+      <Box paddingTop={16} textAlign="center">
+        <Text color="fg.muted">
+          Billing records for this organization are not available yet.
+        </Text>
+      </Box>
+    </GovernanceLayout>
+  );
+}
+
+export default withFeatureFlagGuard(
+  "release_ui_governance_billed_cost_enabled",
+  {
+    bypassOnboardingRedirect: true,
+  },
+)(
+  withFeatureFlagGuard("release_ui_ai_governance_enabled", {
+    bypassOnboardingRedirect: true,
+  })(
+    withPermissionGuard("governance:view", {
+      bypassOnboardingRedirect: true,
+    })(BilledPage),
+  ),
+);

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -1,0 +1,39 @@
+import { Box, Text } from "@chakra-ui/react";
+
+import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+
+/**
+ * Costs - the per-tool and per-team spend view for the organization.
+ * Placeholder until the cost rollup ships; reachable only while
+ * `release_ui_governance_billed_cost_enabled` is on.
+ *
+ * Spec: specs/governance/governance-navigation.feature
+ */
+function CostsPage() {
+  return (
+    <GovernanceLayout pageTitle="Costs">
+      <Box paddingTop={16} textAlign="center">
+        <Text color="fg.muted">
+          Cost data for this organization is not available yet.
+        </Text>
+      </Box>
+    </GovernanceLayout>
+  );
+}
+
+export default withFeatureFlagGuard(
+  "release_ui_governance_billed_cost_enabled",
+  {
+    bypassOnboardingRedirect: true,
+  },
+)(
+  withFeatureFlagGuard("release_ui_ai_governance_enabled", {
+    bypassOnboardingRedirect: true,
+  })(
+    withPermissionGuard("governance:view", {
+      bypassOnboardingRedirect: true,
+    })(CostsPage),
+  ),
+);

--- a/platform/app/src/pages/governance/index.tsx
+++ b/platform/app/src/pages/governance/index.tsx
@@ -455,7 +455,7 @@ function GovernanceOverviewPage() {
               subline="Spend grouped by department across every project in the org, including personal AI use (last 30 days)."
               actions={
                 <Link
-                  href="/governance/departments"
+                  href="/governance/people"
                   color="blue.600"
                   fontSize="sm"
                 >

--- a/platform/app/src/pages/governance/index.tsx
+++ b/platform/app/src/pages/governance/index.tsx
@@ -245,7 +245,7 @@ function GovernanceOverviewPage() {
                 }
                 title="Add tools to the catalog"
                 description="Publish the coding assistants, model providers, and internal tools your team installs from their /me portal."
-                href="/governance/tool-catalog"
+                href="/governance/inventory?tab=catalog"
                 ctaLabel={
                   hasCatalogTiles
                     ? `${catalogTiles.length} tile${catalogTiles.length === 1 ? "" : "s"} in the catalog`

--- a/platform/app/src/pages/governance/inventory.tsx
+++ b/platform/app/src/pages/governance/inventory.tsx
@@ -1,0 +1,71 @@
+import { Tabs } from "@chakra-ui/react";
+import { useSearchParams } from "react-router";
+
+import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { IngestionSourcesPanel } from "@ee/governance/dashboard/pages/ingestion-sources";
+import { ToolCatalogPanel } from "./tool-catalog";
+
+/**
+ * Inventory — one roof for "what AI tools does this organization run".
+ *
+ * Two tabs, addressed by `?tab=` so either view is linkable:
+ *   - Sources: the ingestion sources the org streams governance data from
+ *     (the page that used to own the whole "Catalog" nav item).
+ *   - Catalog: the AI tool tile publisher (the former Tool Tiles page).
+ *
+ * The panels are the previous pages' bodies, unchanged; this shell owns the
+ * layout, the section navigation highlight and the single permission gate.
+ * Deep links to the old addresses redirect here with the matching tab.
+ */
+function InventoryPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Default to Sources: that is what the sidebar's old Catalog item showed,
+  // so readers who follow muscle memory land where they expect.
+  const tab = searchParams.get("tab") === "catalog" ? "catalog" : "sources";
+
+  return (
+    <GovernanceLayout pageTitle="Inventory · Governance · LangWatch">
+      <Tabs.Root
+        variant="line"
+        value={tab}
+        onValueChange={(event) => setSearchParams({ tab: event.value })}
+        lazyMount
+      >
+        <Tabs.List>
+          <Tabs.Trigger
+            value="sources"
+            color="fg.muted"
+            _selected={{ color: "fg", fontWeight: "semibold" }}
+          >
+            Sources
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="catalog"
+            color="fg.muted"
+            _selected={{ color: "fg", fontWeight: "semibold" }}
+          >
+            Catalog
+          </Tabs.Trigger>
+        </Tabs.List>
+        {/* lazyMount only (no unmountOnExit): both tabs hold drawers and
+            editors with local draft state that must survive tab hops. */}
+        <Tabs.Content value="sources" paddingTop={4}>
+          <IngestionSourcesPanel />
+        </Tabs.Content>
+        <Tabs.Content value="catalog" paddingTop={4}>
+          <ToolCatalogPanel />
+        </Tabs.Content>
+      </Tabs.Root>
+    </GovernanceLayout>
+  );
+}
+
+export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
+  bypassOnboardingRedirect: true,
+})(
+  withPermissionGuard("governance:view", {
+    bypassOnboardingRedirect: true,
+  })(InventoryPage),
+);

--- a/platform/app/src/pages/governance/people.tsx
+++ b/platform/app/src/pages/governance/people.tsx
@@ -32,7 +32,7 @@ type Department = RouterOutputs["departments"]["list"][number];
  *
  * Spec: specs/ai-governance/rbac/delegated-governance-viewer.feature
  */
-function DepartmentsPage() {
+function PeoplePage() {
   const { organization, hasAnyPermission } = useOrganizationTeamProject({
     redirectToOnboarding: false,
   });
@@ -53,16 +53,16 @@ function DepartmentsPage() {
   const hasDepartments = departments.length > 0;
 
   return (
-    <GovernanceLayout pageTitle="Departments · AI Governance · LangWatch">
+    <GovernanceLayout pageTitle="People · AI Governance · LangWatch">
       <VStack align="stretch" gap={6} width="full" maxW="container.xl">
         <VStack align="start" gap={1}>
           <Text fontSize="xs" color="fg.muted">
             <Link href="/governance" color="blue.600">
               ← AI Governance
             </Link>{" "}
-            · Departments
+            · People
           </Text>
-          <Heading size="md">Departments</Heading>
+          <Heading size="md">People</Heading>
           <Text color="fg.muted" fontSize="sm" maxW="2xl">
             A department is an accounting label for spend. Assign people, teams,
             and projects to one, and spend rolls up by department across the
@@ -394,5 +394,5 @@ export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
 })(
   withPermissionGuard("governance:view", {
     bypassOnboardingRedirect: true,
-  })(DepartmentsPage),
+  })(PeoplePage),
 );

--- a/platform/app/src/pages/governance/tool-catalog.tsx
+++ b/platform/app/src/pages/governance/tool-catalog.tsx
@@ -1,15 +1,12 @@
 import { Heading, HStack, Spacer, Tabs, Text, VStack } from "@chakra-ui/react";
 import { useState } from "react";
 
-import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import type { AiToolEntry } from "~/components/me/tiles/types";
 import { PermissionRequiredNotice } from "~/components/PermissionRequiredNotice";
 import { AiToolEntryDrawer } from "~/components/settings/governance/AiToolEntryDrawer";
 import { IngestionTemplatesEditor } from "~/components/settings/governance/IngestionTemplatesEditor";
 import { ToolCatalogEditor } from "~/components/settings/governance/ToolCatalogEditor";
-import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
-import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 
 /**
@@ -29,7 +26,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
  * delegated viewer arrives here from the section navigation and is told which
  * grant the catalog needs rather than being refused the whole page.
  */
-function ToolCatalogPage() {
+export function ToolCatalogPanel() {
   const { organization, hasAnyPermission } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
@@ -48,20 +45,18 @@ function ToolCatalogPage() {
 
   if (!canManageCatalog) {
     return (
-      <GovernanceLayout pageTitle="Tool Tiles · Governance · LangWatch">
-        <VStack align="stretch" gap={6} width="full">
-          <ToolCatalogHeading />
-          <PermissionRequiredNotice
-            permission="aiTools:manage"
-            detail="The tiles and the ingestion templates stay hidden until then."
-          />
-        </VStack>
-      </GovernanceLayout>
+      <VStack align="stretch" gap={6} width="full">
+        <ToolCatalogHeading />
+        <PermissionRequiredNotice
+          permission="aiTools:manage"
+          detail="The tiles and the ingestion templates stay hidden until then."
+        />
+      </VStack>
     );
   }
 
   return (
-    <GovernanceLayout pageTitle="Tool Tiles · Governance · LangWatch">
+    <>
       <VStack align="stretch" gap={6} width="full">
         <ToolCatalogHeading />
 
@@ -110,7 +105,7 @@ function ToolCatalogPage() {
         state={drawerState}
         onClose={() => setDrawerState(null)}
       />
-    </GovernanceLayout>
+    </>
   );
 }
 
@@ -129,11 +124,3 @@ function ToolCatalogHeading() {
     </HStack>
   );
 }
-
-export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
-  bypassOnboardingRedirect: true,
-})(
-  withPermissionGuard("governance:view", {
-    bypassOnboardingRedirect: true,
-  })(ToolCatalogPage),
-);

--- a/platform/app/src/routes.tsx
+++ b/platform/app/src/routes.tsx
@@ -233,18 +233,26 @@ const routes: RouteObject[] = [
         ...page(() => import("./pages/governance/tool-catalog")),
       },
       {
-        path: "/governance/departments",
-        ...page(() => import("./pages/governance/departments")),
+        path: "/governance/people",
+        ...page(() => import("./pages/governance/people")),
       },
       {
-        // The departments page was once named cost centers; old bookmarks
-        // land on the new name (the legacy /settings/governance/cost-centers
-        // address chains through here).
+        // The people page was named departments, and before that cost
+        // centers; both old addresses chain onto the current one.
+        path: "/governance/departments",
+        element: (
+          <LegacyPrefixRedirect
+            from="/governance/departments"
+            to="/governance/people"
+          />
+        ),
+      },
+      {
         path: "/governance/cost-centers",
         element: (
           <LegacyPrefixRedirect
             from="/governance/cost-centers"
-            to="/governance/departments"
+            to="/governance/people"
           />
         ),
       },

--- a/platform/app/src/routes.tsx
+++ b/platform/app/src/routes.tsx
@@ -254,6 +254,17 @@ const routes: RouteObject[] = [
         ...page(() => import("./pages/governance/people")),
       },
       {
+        // Spend views behind release_ui_governance_billed_cost_enabled;
+        // the pages carry their own flag guard, so a deep link with the
+        // switch off reads as a missing page.
+        path: "/governance/costs",
+        ...page(() => import("./pages/governance/costs")),
+      },
+      {
+        path: "/governance/billed",
+        ...page(() => import("./pages/governance/billed")),
+      },
+      {
         // The people page was named departments, and before that cost
         // centers; both old addresses chain onto the current one.
         path: "/governance/departments",

--- a/platform/app/src/routes.tsx
+++ b/platform/app/src/routes.tsx
@@ -212,9 +212,20 @@ const routes: RouteObject[] = [
         ...page(() => import("./pages/governance/index")),
       },
       {
+        // Inventory unifies the ingestion sources and the tool catalog
+        // behind one address; `?tab=` picks the view and keeps both
+        // linkable.
+        path: "/governance/inventory",
+        ...page(() => import("./pages/governance/inventory")),
+      },
+      {
         path: "/governance/ingestion-sources",
-        ...page(
-          () => import("@ee/governance/dashboard/pages/ingestion-sources"),
+        element: (
+          <LegacyPrefixRedirect
+            from="/governance/ingestion-sources"
+            to="/governance/inventory"
+            search="?tab=sources"
+          />
         ),
       },
       {
@@ -230,7 +241,13 @@ const routes: RouteObject[] = [
       },
       {
         path: "/governance/tool-catalog",
-        ...page(() => import("./pages/governance/tool-catalog")),
+        element: (
+          <LegacyPrefixRedirect
+            from="/governance/tool-catalog"
+            to="/governance/inventory"
+            search="?tab=catalog"
+          />
+        ),
       },
       {
         path: "/governance/people",

--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -94,6 +94,12 @@ export const FRONTEND_FEATURE_FLAGS = [
   // (issue #5103, specs/experiments/comparison-leaderboard.feature). Off by
   // default — power-user surface, additive to the existing win-rate chart.
   "release_ui_comparison_leaderboard_enabled",
+  // The governance spend views (Costs and Billed placeholder pages under
+  // /governance). Off by default: the pages are placeholders, so only
+  // orgs opted in through PostHog targeting see their navigation items.
+  // Sits ON TOP of `release_ui_ai_governance_enabled`, which gates the
+  // whole governance section.
+  "release_ui_governance_billed_cost_enabled",
 ] as const;
 
 /**

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -248,6 +248,15 @@ export const FEATURE_FLAGS = [
     description:
       "Gates the personal keys, admin oversight, RoutingPolicy, IngestionSource UI surfaces, the onboarding intent fork, and the org Primary use setting (ADR-038). On by default; switch off per org via the operator store (or deployment-wide via RELEASE_UI_AI_GOVERNANCE_ENABLED=0) to hide governance and refuse AI-tools device login. Distinct from release_ui_ai_gateway_menu_enabled: the gateway product ships on its own flag.",
   },
+  {
+    key: "release_ui_governance_billed_cost_enabled",
+    scope: "PRODUCT",
+    // The Costs / Billed pages are placeholders; the flag stays off until
+    // the views carry data, then PostHog targeting rolls them out per org.
+    defaultValue: false,
+    description:
+      "Gates the governance spend views (the Costs and Billed pages under /governance) and their navigation items. Off by default while the pages are placeholders. Sits on top of release_ui_ai_governance_enabled, which gates the whole governance section.",
+  },
   // ADR-034 Phase 3 — routes analytics getTimeseries reads to the slim
   // `trace_analytics` / rollup `trace_analytics_rollup` tables (Phases 1+2)
   // when the query shape allows. OFF (default) = legacy trace_summaries reads

--- a/platform/app/src/utils/rbacVocabulary.ts
+++ b/platform/app/src/utils/rbacVocabulary.ts
@@ -98,7 +98,7 @@ export const Resources = {
   //   - aiTools:view → ALL org roles. Portal must work for every member
   //     so they can discover what's available + click through to setup.
   //   - aiTools:manage → org ADMIN only. Catalog editor surface at
-  //     /governance/tool-catalog (CRUD + reorder + enable).
+  //     /governance/inventory?tab=catalog (CRUD + reorder + enable).
   AI_TOOLS: "aiTools",
   // Outbound webhook endpoints (the webhook platform). Org-tier only:
   // endpoints are org-anchored, carry signing secrets, and stream every

--- a/specs/governance/governance-navigation.feature
+++ b/specs/governance/governance-navigation.feature
@@ -53,3 +53,16 @@ Feature: Governance navigation names what the pages show
     Given a reader opens /governance/tool-catalog or /governance/ingestion-sources from a bookmark
     When both addresses are resolved by the mounted routes
     Then each lands on /governance/inventory with its view's tab selected
+
+  @unit
+  Scenario: The spend views stay hidden until their switch is on
+    Given the governance sidebar renders for an organization without the spend views
+    When the item lists are captured
+    Then no item names Costs or Billed
+
+  @unit
+  Scenario: A switched-on organization sees and reaches the spend pages
+    Given the governance sidebar renders for an organization with the spend views on
+    When the item lists are captured and the two spend addresses are opened
+    Then items name Costs and Billed between Overview and Inventory
+    And each address renders its placeholder page instead of a missing page

--- a/specs/governance/governance-navigation.feature
+++ b/specs/governance/governance-navigation.feature
@@ -1,0 +1,55 @@
+Feature: Governance navigation names what the pages show
+  As an administrator reading the governance sidebar
+  I want one name per concept and addresses that outlive renames
+  So that I find things once and old links never die
+
+  # The governance sidebar grows around the analytics it fronts: Inventory
+  # unifies the tool catalog and the ingestion sources under one roof,
+  # Departments becomes People because the page is about the people in the
+  # organization rather than its billing dimension, and two spend views
+  # arrive behind their own switch so unfinished UI never reaches an org
+  # that did not ask for it. Every rename keeps the old address alive as a
+  # redirect, because bookmarks and stored pins do not read changelogs.
+
+  Background:
+    Given the governance sidebar and its routes
+
+  @unit
+  Scenario: The sidebar names People where it named Departments
+    Given the governance layout renders its navigation items
+    When the item lists are captured
+    Then the item naming the organization's people points at /governance/people
+    And no item points at /governance/departments any more
+
+  @unit
+  Scenario: Old departments bookmarks land on the people page
+    Given a reader opens /governance/departments from a bookmark
+    And the chained /governance/cost-centers address from an older bookmark
+    When both addresses are resolved by the mounted routes
+    Then both land on /governance/people
+
+  @unit
+  Scenario: Every internal link follows the rename
+    Given the application source tree
+    When every navigation link to a renamed governance page is inspected
+    Then links name the current address
+    And only the compatibility maps and the redirect itself still carry the old one
+
+  @unit
+  Scenario: An admin in an empty organization still reaches the renamed page
+    Given the org-scoped pages an administrator may open without a project
+    When the allowlist is read
+    Then the people page is on it under its new address
+
+  @unit
+  Scenario: The sidebar offers Inventory as one door instead of two
+    Given the governance layout renders its navigation items
+    When the item lists are captured
+    Then exactly one item names Inventory and points at /governance/inventory
+    And no item points at the retired tool-catalog or ingestion-sources list addresses
+
+  @unit
+  Scenario: Old catalog addresses land on the matching inventory tab
+    Given a reader opens /governance/tool-catalog or /governance/ingestion-sources from a bookmark
+    When both addresses are resolved by the mounted routes
+    Then each lands on /governance/inventory with its view's tab selected

--- a/specs/navigation/gateway-url-move.feature
+++ b/specs/navigation/gateway-url-move.feature
@@ -50,9 +50,9 @@ Feature: Gateway and Governance URLs move to the top level
     And a query string and a hash on the old address survive the move
 
   @integration
-  Scenario: The retired cost centers address lands on departments
+  Scenario: The retired cost centers address lands on people
     When I cold-load "/settings/governance/cost-centers"
-    Then I land on "/governance/departments"
+    Then I land on "/governance/people"
 
   @unit
   Scenario: The CLI prints the new gateway address for a virtual key


### PR DESCRIPTION
# Related Issue

- Resolves #7391

Closes #7391

## What

Three connected governance navigation changes, one PR:

1. **Inventory** at `/governance/inventory` unifies the two doors to "what AI tools does this organization run": **Sources** (the ingestion sources table plus its detail flow) and **Catalog** (the AI tool tile publisher) become tabs of one page. Tab state lives in `?tab=`, replace not push, Sources is the default.
2. **People** at `/governance/people`: the Departments page keeps its content and loses the billing dimension from its name. Nav label, route, page title.
3. **Costs** and **Billed** placeholder pages at `/governance/costs` and `/governance/billed`, visible only behind the new frontend flag `release_ui_governance_billed_cost_enabled`. Off (default): no sidebar items anywhere, and a deep link reads as a missing page through the same guard the other governance pages use. On: both items sit between Overview and Inventory and the pages render their placeholders.

Old addresses stay alive as client-side redirects that preserve sub-paths and query where meaningful, and replace history so back never returns to the retired address:

| Old | Lands on |
| --- | --- |
| `/governance/tool-catalog` | `/governance/inventory?tab=catalog` |
| `/governance/ingestion-sources` (+ `/:id`) | `/governance/inventory?tab=sources` |
| `/governance/departments`, `/governance/cost-centers` | `/governance/people` |

No data-model changes, no new queries, no behavior changes inside the moved panels.

## Relationship to #7357

#7357 builds a tabbed shell at `/governance/catalog`. This branch implements the same unification against current main under the permanent name `/governance/inventory` (issue decision: no URL that renames again later), carrying the tab mechanics across. Whichever lands second rebases; if this one lands first, #7357 closes in favor of it. Flagging @drewdrewthis for coordination.

## How to see the gated pages locally

The spend views ship dark. Force them on with `FEATURE_FLAG_FORCE_ENABLE=release_ui_governance_billed_cost_enabled` in front of the dev server.

## Spec and tests

`specs/governance/governance-navigation.feature` carries 8 scenarios, all tagged and bound:

- rename and link scan (no live link to a retired address outside compatibility maps)
- empty-organization allowlist covers the renamed and new pages
- one Inventory door, bookmark chains land on the matching tab
- spend switch off: no Costs/Billed items, deep links read as missing pages
- spend switch on: items ordered Overview, Costs, Billed, Inventory, Anomaly Rules, People, and each address renders its placeholder

New integration test mounts the real redirect route objects and the real guarded spend pages (flag mocked, guards live); the unit suite pins the item lists and scans the source tree for retired addresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consolidated governance catalog and ingestion sources into a single Inventory area with dedicated tabs.
  * Renamed Departments to People across navigation, pages, links, and redirects.
  * Added gated Costs and Billed governance views with placeholder messaging.
  * Added feature-controlled navigation for the new governance sections.

* **Bug Fixes**
  * Updated legacy governance links and redirects to preserve destinations and tab selections.

* **Tests**
  * Added integration and navigation coverage for renamed pages, redirects, Inventory tabs, and feature-gated views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->