### PR TITLE
fix(typescript-sdk): a near-miss on langwatch: "disabled" no longer silently exports (#3289)

### DIFF
--- a/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The `langwatch` option's disable sentinel, and what happens to a value that is
+ * neither the sentinel nor an options object.
+ *
+ * `langwatch: "disabled"` turns the LangWatch exporter off. The resolution used
+ * to be two lines:
+ *
+ *   const isDisabled = options.langwatch === 'disabled';
+ *   const config = typeof options.langwatch === 'object' ? options.langwatch : {};
+ *
+ * A near-miss satisfied neither branch. `langwatch: "disable"` is not the
+ * sentinel, so it did not disable; `typeof` said `string`, so `config` fell to
+ * `{}`, `apiKey` came from `process.env.LANGWATCH_API_KEY`, and the exporter came
+ * up against the caller's real endpoint. Someone who asked to send nothing sent
+ * everything, and the only signal was the absence of one.
+ *
+ * TypeScript rejects that typo, which is why this is not a compile-time problem.
+ * It is a runtime one: the value arrives from a config file, a JSON payload or
+ * plain JavaScript, none of which the union protects.
+ *
+ * `null` was the mirror image. `typeof null === "object"`, so it passed the
+ * object branch and threw a TypeError on the first property read, naming neither
+ * the option nor the value.
+ *
+ * The assertions below are about the EXPORTER, not about a log line, because
+ * "did we send data the caller asked us not to send" is the thing that matters.
+ * LangWatchTraceExporter is mocked, so constructing it is observable.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { setupObservability } from "../setup.js";
+import { LANGWATCH_DISABLED } from "../types.js";
+import { resetObservabilitySdkConfig } from "../../../config.js";
+import { LangWatchTraceExporter } from "../../../exporters";
+
+vi.mock("../../utils", () => ({
+  isConcreteProvider: vi.fn(() => false),
+  getConcreteProvider: vi.fn(() => undefined),
+  createMergedResource: vi.fn(() => resourceFromAttributes({})),
+}));
+vi.mock("../../../exporters", () => ({
+  LangWatchTraceExporter: vi.fn().mockImplementation(function () {
+    return { shutdown: vi.fn() };
+  }),
+  LangWatchLogsExporter: vi.fn().mockImplementation(function () {
+    return { shutdown: vi.fn() };
+  }),
+}));
+vi.mock("@opentelemetry/sdk-node", () => ({
+  NodeSDK: vi.fn().mockImplementation(function () {
+    return { start: vi.fn(), shutdown: vi.fn().mockResolvedValue(undefined) };
+  }),
+}));
+vi.mock("../../../logger", () => ({
+  setLangWatchLoggerProvider: vi.fn(),
+}));
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+const setup = (langwatch: unknown) =>
+  setupObservability({
+    serviceName: "svc",
+    langwatch: langwatch as never,
+    debug: { logger },
+  });
+
+const exporterWasConstructed = () =>
+  vi.mocked(LangWatchTraceExporter).mock.calls.length > 0;
+
+let previousApiKey: string | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetObservabilitySdkConfig();
+  // The old fall-through only exported because an API key was reachable. Setting
+  // one is what makes the regression visible rather than masked by an empty env.
+  previousApiKey = process.env.LANGWATCH_API_KEY;
+  process.env.LANGWATCH_API_KEY = "sk-lw-from-the-environment";
+});
+
+afterEach(() => {
+  if (previousApiKey === undefined) delete process.env.LANGWATCH_API_KEY;
+  else process.env.LANGWATCH_API_KEY = previousApiKey;
+});
+
+describe("given the disable sentinel", () => {
+  it("is the string the option's union accepts", () => {
+    expect(LANGWATCH_DISABLED).toBe("disabled");
+  });
+
+  describe("when it is passed", () => {
+    it("constructs no LangWatch exporter", () => {
+      setup(LANGWATCH_DISABLED);
+      expect(exporterWasConstructed()).toBe(false);
+    });
+  });
+});
+
+describe("given an options object", () => {
+  it("constructs the exporter, so the guard has not disabled the ordinary path", () => {
+    setup({ apiKey: "sk-lw-explicit" });
+    expect(exporterWasConstructed()).toBe(true);
+  });
+});
+
+describe("given a value that is neither the sentinel nor an options object", () => {
+  const nearMisses: [string, unknown][] = [
+    ["a typo of the sentinel", "disable"],
+    ["a different casing", "Disabled"],
+    ["the sentinel with whitespace", " disabled"],
+    ["an unrelated string", "off"],
+    ["the empty string", ""],
+    ["null", null],
+    ["a boolean", true],
+    ["a number", 0],
+  ];
+
+  describe.each(nearMisses)("when it is %s", (_label, value) => {
+    it("constructs no exporter, because it cannot be read as a request to export", () => {
+      setup(value);
+      expect(exporterWasConstructed()).toBe(false);
+    });
+
+    it("says so at error level, naming the value it rejected", () => {
+      setup(value);
+      const reported = logger.error.mock.calls.map(([message]) => String(message)).join("\n");
+      expect(reported).toContain("Invalid `langwatch` option");
+      expect(reported).toContain(JSON.stringify(value));
+    });
+  });
+
+  it("does not throw on null, which used to reach a property read", () => {
+    expect(() => setup(null)).not.toThrow();
+  });
+});

--- a/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
@@ -209,9 +209,7 @@ describe("given an object whose type name the caller controls", () => {
     // Not a plain object literal: that would be accepted as options and would
     // report nothing, so the assertion would pass without testing anything.
     class Tagged {
-      get [Symbol.toStringTag](): string {
-        return "sk-lw-from-the-environment";
-      }
+      readonly [Symbol.toStringTag] = "sk-lw-from-the-environment";
     }
     setup(new Tagged());
 

--- a/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
@@ -20,7 +20,13 @@
  *
  * `null` was the mirror image. `typeof null === "object"`, so it passed the
  * object branch and threw a TypeError on the first property read, naming neither
- * the option nor the value.
+ * the option nor the value. An array passed that branch too, and worse: it read
+ * as a configuration whose every field was `undefined`, so the exporter came up
+ * on the environment's API key with nothing reported at all.
+ *
+ * Reporting a rejected value is its own hazard. `JSON.stringify` throws on a
+ * BigInt, so naming the value that way turned the diagnostic into an unrelated
+ * serialisation error.
  *
  * The assertions below are about the EXPORTER, not about a log line, because
  * "did we send data the caller asked us not to send" is the thing that matters.
@@ -109,18 +115,24 @@ describe("given an options object", () => {
 });
 
 describe("given a value that is neither the sentinel nor an options object", () => {
-  const nearMisses: [string, unknown][] = [
-    ["a typo of the sentinel", "disable"],
-    ["a different casing", "Disabled"],
-    ["the sentinel with whitespace", " disabled"],
-    ["an unrelated string", "off"],
-    ["the empty string", ""],
-    ["null", null],
-    ["a boolean", true],
-    ["a number", 0],
+  // The third column is how the report must name the value. It is spelled out
+  // rather than derived, because deriving it with JSON.stringify would make the
+  // test throw on the very value the third case is about.
+  const nearMisses: [string, unknown, string][] = [
+    ["a typo of the sentinel", "disable", '"disable"'],
+    ["a different casing", "Disabled", '"Disabled"'],
+    ["the sentinel with whitespace", " disabled", '" disabled"'],
+    ["an unrelated string", "off", '"off"'],
+    ["the empty string", "", '""'],
+    ["null", null, "null"],
+    ["a boolean", true, "true"],
+    ["a number", 0, "0"],
+    ["an array", [], "[]"],
+    ["a bigint", BigInt(1), "bigint"],
+    ["a symbol", Symbol("nope"), "symbol"],
   ];
 
-  describe.each(nearMisses)("when it is %s", (_label, value) => {
+  describe.each(nearMisses)("when it is %s", (_label, value, rendered) => {
     it("constructs no exporter, because it cannot be read as a request to export", () => {
       setup(value);
       expect(exporterWasConstructed()).toBe(false);
@@ -130,11 +142,15 @@ describe("given a value that is neither the sentinel nor an options object", () 
       setup(value);
       const reported = logger.error.mock.calls.map(([message]) => String(message)).join("\n");
       expect(reported).toContain("Invalid `langwatch` option");
-      expect(reported).toContain(JSON.stringify(value));
+      expect(reported).toContain(rendered);
     });
   });
 
   it("does not throw on null, which used to reach a property read", () => {
     expect(() => setup(null)).not.toThrow();
+  });
+
+  it("does not throw on a value JSON cannot serialise, which the report itself used to hit", () => {
+    expect(() => setup(BigInt(1))).not.toThrow();
   });
 });

--- a/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
@@ -115,21 +115,27 @@ describe("given an options object", () => {
 });
 
 describe("given a value that is neither the sentinel nor an options object", () => {
-  // The third column is how the report must name the value. It is spelled out
-  // rather than derived, because deriving it with JSON.stringify would make the
-  // test throw on the very value the third case is about.
+  // The third column is the KIND the report must name. It is never the value
+  // itself: `langwatch: process.env.LANGWATCH_API_KEY` is an easy thing to
+  // write by mistake, and echoing the value would put the key in the logs.
   const nearMisses: [string, unknown, string][] = [
-    ["a typo of the sentinel", "disable", '"disable"'],
-    ["a different casing", "Disabled", '"Disabled"'],
-    ["the sentinel with whitespace", " disabled", '" disabled"'],
-    ["an unrelated string", "off", '"off"'],
-    ["the empty string", "", '""'],
+    ["a typo of the sentinel", "disable", "a string"],
+    ["a different casing", "Disabled", "a string"],
+    ["the sentinel with whitespace", " disabled", "a string"],
+    ["an unrelated string", "off", "a string"],
+    ["the empty string", "", "a string"],
     ["null", null, "null"],
-    ["a boolean", true, "true"],
-    ["a number", 0, "0"],
-    ["an array", [], "[]"],
-    ["a bigint", BigInt(1), "bigint"],
-    ["a symbol", Symbol("nope"), "symbol"],
+    ["a boolean", true, "a boolean"],
+    ["a number", 0, "a number"],
+    ["a bigint", BigInt(1), "a bigint"],
+    ["a symbol", Symbol("nope"), "a symbol"],
+    ["a function", () => undefined, "a function"],
+    ["an array", [], "an array"],
+    ["a Date", new Date(), "a Date"],
+    ["a Map", new Map(), "a Map"],
+    ["a Set", new Set(), "a Set"],
+    ["a regular expression", /nope/, "a RegExp"],
+    ["a boxed string", new String("disabled"), "a String"],
   ];
 
   describe.each(nearMisses)("when it is %s", (_label, value, rendered) => {
@@ -152,5 +158,36 @@ describe("given a value that is neither the sentinel nor an options object", () 
 
   it("does not throw on a value JSON cannot serialise, which the report itself used to hit", () => {
     expect(() => setup(BigInt(1))).not.toThrow();
+  });
+
+  it("never echoes the value, because an API key is an easy thing to pass here by mistake", () => {
+    setup(process.env.LANGWATCH_API_KEY);
+    const reported = logger.error.mock.calls.map(([message]) => String(message)).join("\n");
+    expect(reported).toContain("Invalid `langwatch` option");
+    expect(reported).not.toContain("sk-lw-from-the-environment");
+  });
+});
+
+describe("given an array carrying an option key", () => {
+  it("is still rejected, because an array is never a configuration record", () => {
+    setup(Object.assign([] as unknown[], { apiKey: "sk-lw-explicit" }));
+    expect(exporterWasConstructed()).toBe(false);
+  });
+});
+
+describe("given an object that is not a plain record but carries an option key", () => {
+  it("still configures the exporter, so a configuration built by a class is not broken", () => {
+    class Options {
+      apiKey = "sk-lw-explicit";
+    }
+    setup(new Options());
+    expect(exporterWasConstructed()).toBe(true);
+  });
+});
+
+describe("given a record with a null prototype", () => {
+  it("is read as options, because JSON and Object.create(null) both produce one", () => {
+    setup(Object.assign(Object.create(null) as object, { apiKey: "sk-lw-explicit" }));
+    expect(exporterWasConstructed()).toBe(true);
   });
 });

--- a/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/__tests__/langwatch-option-guard.unit.test.ts
@@ -168,6 +168,60 @@ describe("given a value that is neither the sentinel nor an options object", () 
   });
 });
 
+describe("given a value that cannot even be inspected", () => {
+  const revoked = () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    return proxy;
+  };
+
+  it("constructs no exporter, because a value that throws on every question is not a configuration", () => {
+    setup(revoked());
+    expect(exporterWasConstructed()).toBe(false);
+  });
+
+  it("does not throw, so the guard disables setup rather than taking it down", () => {
+    expect(() => setup(revoked())).not.toThrow();
+  });
+
+  it("is still reported, naming it as an object", () => {
+    setup(revoked());
+    const reported = logger.error.mock.calls.map(([message]) => String(message)).join("\n");
+    expect(reported).toContain("Invalid `langwatch` option");
+    expect(reported).toContain("an object");
+  });
+});
+
+describe("given an object whose type name the caller controls", () => {
+  it("reports the runtime's type, not the caller's string, which could be a key", () => {
+    const tampered = new Date(0);
+    (tampered as unknown as { constructor: unknown }).constructor = {
+      name: "sk-lw-from-the-environment",
+    };
+    setup(tampered);
+
+    const reported = logger.error.mock.calls.map(([message]) => String(message)).join("\n");
+    expect(reported).toContain("a Date");
+    expect(reported).not.toContain("sk-lw-from-the-environment");
+  });
+
+  it("ignores a forged toStringTag for the same reason", () => {
+    // Not a plain object literal: that would be accepted as options and would
+    // report nothing, so the assertion would pass without testing anything.
+    class Tagged {
+      get [Symbol.toStringTag](): string {
+        return "sk-lw-from-the-environment";
+      }
+    }
+    setup(new Tagged());
+
+    const reported = logger.error.mock.calls.map(([message]) => String(message)).join("\n");
+    expect(reported).toContain("Invalid `langwatch` option");
+    expect(reported).toContain("an object");
+    expect(reported).not.toContain("sk-lw-from-the-environment");
+  });
+});
+
 describe("given an array carrying an option key", () => {
   it("is still rejected, because an array is never a configuration record", () => {
     setup(Object.assign([] as unknown[], { apiKey: "sk-lw-explicit" }));

--- a/sdks/typescript/src/observability-sdk/setup/node/index.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/index.ts
@@ -5,3 +5,4 @@
 
 export { setupObservability, ensureSetup } from "./setup";
 export type { SetupObservabilityOptions, ObservabilityHandle } from "./types";
+export { LANGWATCH_DISABLED } from "./types";

--- a/sdks/typescript/src/observability-sdk/setup/node/setup.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/setup.ts
@@ -25,21 +25,53 @@ const createNoOpHandle = (logger: Logger): ObservabilityHandle => ({
 });
 
 /**
- * Renders a rejected value for the message below, without throwing.
+ * The three keys the options object is made of. A value carrying one of them is
+ * a request to configure the exporter whatever it was constructed from.
+ */
+const LANGWATCH_OPTION_KEYS = ["apiKey", "endpoint", "processorType"] as const;
+
+/**
+ * Whether `value` can be read as the options object.
  *
- * The message is the only thing standing between a misconfigured caller and
- * silence, so producing it must not fail. `JSON.stringify` raises a TypeError on
- * a BigInt, which would replace the diagnostic with an unrelated serialisation
- * error from the code meant to report the problem. It returns `undefined` rather
- * than a string for a symbol or a function, which would render as "undefined"
- * and name nothing. Both fall back to the type, which is what a caller needs to
- * see.
+ * A plain record is the ordinary case: an object literal, a JSON payload, a
+ * spread, `Object.create(null)`. Everything else has to earn it by carrying at
+ * least one option key, which keeps a configuration built by a class working
+ * while `new Date()`, `new Map()`, `new Set()`, a regular expression and a
+ * boxed string are turned away. None of those carries a key, so each one used
+ * to read as an empty configuration and export on the environment's API key,
+ * which is the same hole as the array by a different route.
+ *
+ * An empty `{}` stays valid: it is the documented way to say "configure me from
+ * the environment", so emptiness on its own cannot be the signal.
+ */
+const isLangWatchOptions = (value: object): boolean => {
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  if (prototype === Object.prototype || prototype === null) return true;
+  return LANGWATCH_OPTION_KEYS.some((key) => key in value);
+};
+
+/**
+ * Names the KIND of a rejected value, never its contents.
+ *
+ * The contents cannot be logged. `langwatch: process.env.LANGWATCH_API_KEY` is
+ * an easy thing to write by mistake, and a report that echoed the value would
+ * put the API key in the application's logs, turning a misconfiguration into a
+ * credential leak. The kind is enough to act on, because the message names the
+ * one string the option accepts right beside it.
+ *
+ * Reading `constructor` can throw on a proxy, and this runs on the path that
+ * exists to explain a problem, so it must not become one.
  */
 const describeRejectedValue = (value: unknown): string => {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  if (typeof value !== "object") return `a ${typeof value}`;
+
   try {
-    return JSON.stringify(value) ?? typeof value;
+    const name = (value as { constructor?: { name?: string } }).constructor?.name;
+    return name && name !== "Object" ? `a ${name}` : "an object";
   } catch {
-    return typeof value;
+    return "an object";
   }
 };
 
@@ -56,9 +88,11 @@ const describeRejectedValue = (value: unknown): string => {
  *
  * `null` was the same shape of hole from the other side: `typeof null` is
  * `"object"`, so it reached the property reads below and threw a TypeError
- * naming neither the option nor the value. An array is the same hole again: it
- * is a non-null object, so it read as a configuration, every field came back
- * `undefined`, and the API key fell through to the environment.
+ * naming neither the option nor the value. Every other non-record object was
+ * the same hole again, by a longer route: an array, a `Date`, a `Map`, a
+ * regular expression and a boxed string all read as a configuration whose
+ * every field was `undefined`, so the API key fell through to the environment
+ * and the exporter came up. `isLangWatchOptions` is what turns those away.
  *
  * An unrecognised value is treated as disabled rather than guessed at. It is the
  * only safe reading: every value that lands here is a caller who did not
@@ -74,12 +108,17 @@ const resolveLangWatchOption = (
     return { disabled: langwatch === LANGWATCH_DISABLED, config: {} };
   }
 
-  if (typeof langwatch === "object" && langwatch !== null && !Array.isArray(langwatch)) {
+  if (
+    typeof langwatch === "object" &&
+    langwatch !== null &&
+    !Array.isArray(langwatch) &&
+    isLangWatchOptions(langwatch)
+  ) {
     return { disabled: false, config: langwatch };
   }
 
   logger.error(
-    `Invalid \`langwatch\` option: ${describeRejectedValue(langwatch)}.\n` +
+    `Invalid \`langwatch\` option: got ${describeRejectedValue(langwatch)}.\n` +
       `Expected an options object, or "${LANGWATCH_DISABLED}" to turn the integration off.\n` +
       `Treating it as "${LANGWATCH_DISABLED}", because a value that is neither cannot be read as a request to export.`,
   );

--- a/sdks/typescript/src/observability-sdk/setup/node/setup.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/setup.ts
@@ -1,7 +1,7 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { SimpleLogRecordProcessor, BatchLogRecordProcessor, type LogRecordProcessor, ConsoleLogRecordExporter, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { createMergedResource, getConcreteProvider, isConcreteProvider } from "../utils";
-import { type SetupObservabilityOptions, type ObservabilityHandle } from "./types";
+import { type SetupObservabilityOptions, type ObservabilityHandle, LANGWATCH_DISABLED } from "./types";
 import { trace } from "@opentelemetry/api";
 import {
   ConsoleSpanExporter,
@@ -24,9 +24,49 @@ const createNoOpHandle = (logger: Logger): ObservabilityHandle => ({
   },
 });
 
-const getLangWatchConfig = (options: SetupObservabilityOptions) => {
-  const isDisabled = options.langwatch === 'disabled';
-  const config = typeof options.langwatch === 'object' ? options.langwatch : {};
+/**
+ * Whether `langwatch` names the disable sentinel, an options object, or neither.
+ *
+ * The third case is why this exists. `langwatch: "disable"` used to satisfy
+ * neither branch of the old two-line resolution: it is not the sentinel, so it
+ * did not disable, and `typeof` said `string`, so it fell to `{}` and the
+ * exporter came up on the environment's API key. A caller who asked to send
+ * nothing sent everything, and nothing said so. TypeScript rejects that typo,
+ * but this value routinely arrives from config, JSON or plain JavaScript, where
+ * nothing does.
+ *
+ * `null` was the same shape of hole from the other side: `typeof null` is
+ * `"object"`, so it reached the property reads below and threw a TypeError
+ * naming neither the option nor the value.
+ *
+ * An unrecognised value is treated as disabled rather than guessed at. It is the
+ * only safe reading: every value that lands here is a caller who did not
+ * successfully ask for the exporter, and exporting anyway is the failure worth
+ * avoiding. It is reported at `error`, and setup's existing "disabled with no
+ * alternative exporter" guidance then explains what to do next.
+ */
+const resolveLangWatchOption = (
+  langwatch: SetupObservabilityOptions["langwatch"],
+  logger: Logger,
+): { disabled: boolean; config: Exclude<typeof langwatch, string | undefined> } => {
+  if (langwatch === void 0 || langwatch === LANGWATCH_DISABLED) {
+    return { disabled: langwatch === LANGWATCH_DISABLED, config: {} };
+  }
+
+  if (typeof langwatch === "object" && langwatch !== null) {
+    return { disabled: false, config: langwatch };
+  }
+
+  logger.error(
+    `Invalid \`langwatch\` option: ${JSON.stringify(langwatch)}.\n` +
+      `Expected an options object, or "${LANGWATCH_DISABLED}" to turn the integration off.\n` +
+      `Treating it as "${LANGWATCH_DISABLED}", because a value that is neither cannot be read as a request to export.`,
+  );
+  return { disabled: true, config: {} };
+};
+
+const getLangWatchConfig = (options: SetupObservabilityOptions, logger: Logger) => {
+  const { disabled: isDisabled, config } = resolveLangWatchOption(options.langwatch, logger);
 
   return {
     disabled: isDisabled,
@@ -289,7 +329,7 @@ function setupDedicatedProvider(
   options: SetupObservabilityOptions,
   logger: Logger,
 ): ObservabilityHandle {
-  const langwatch = getLangWatchConfig(options);
+  const langwatch = getLangWatchConfig(options, logger);
   const addedProcessors: SpanProcessor[] = [];
 
   const internalArray = (provider as any)?._activeSpanProcessor?._spanProcessors;
@@ -394,7 +434,7 @@ function attachToExistingProvider(
     }
   };
 
-  const langwatch = getLangWatchConfig(options);
+  const langwatch = getLangWatchConfig(options, logger);
   const addedProcessors: SpanProcessor[] = [];
 
   if (!langwatch.disabled) {
@@ -456,7 +496,7 @@ export function createAndStartNodeSdk(
   logger: Logger,
   resource: Resource,
 ): NodeSDK {
-  const langwatch = getLangWatchConfig(options);
+  const langwatch = getLangWatchConfig(options, logger);
 
   if (langwatch.disabled) {
     logger.warn("LangWatch integration disabled, using user-provided SpanProcessors and LogRecordProcessors");

--- a/sdks/typescript/src/observability-sdk/setup/node/setup.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/setup.ts
@@ -25,6 +25,25 @@ const createNoOpHandle = (logger: Logger): ObservabilityHandle => ({
 });
 
 /**
+ * Renders a rejected value for the message below, without throwing.
+ *
+ * The message is the only thing standing between a misconfigured caller and
+ * silence, so producing it must not fail. `JSON.stringify` raises a TypeError on
+ * a BigInt, which would replace the diagnostic with an unrelated serialisation
+ * error from the code meant to report the problem. It returns `undefined` rather
+ * than a string for a symbol or a function, which would render as "undefined"
+ * and name nothing. Both fall back to the type, which is what a caller needs to
+ * see.
+ */
+const describeRejectedValue = (value: unknown): string => {
+  try {
+    return JSON.stringify(value) ?? typeof value;
+  } catch {
+    return typeof value;
+  }
+};
+
+/**
  * Whether `langwatch` names the disable sentinel, an options object, or neither.
  *
  * The third case is why this exists. `langwatch: "disable"` used to satisfy
@@ -37,7 +56,9 @@ const createNoOpHandle = (logger: Logger): ObservabilityHandle => ({
  *
  * `null` was the same shape of hole from the other side: `typeof null` is
  * `"object"`, so it reached the property reads below and threw a TypeError
- * naming neither the option nor the value.
+ * naming neither the option nor the value. An array is the same hole again: it
+ * is a non-null object, so it read as a configuration, every field came back
+ * `undefined`, and the API key fell through to the environment.
  *
  * An unrecognised value is treated as disabled rather than guessed at. It is the
  * only safe reading: every value that lands here is a caller who did not
@@ -53,12 +74,12 @@ const resolveLangWatchOption = (
     return { disabled: langwatch === LANGWATCH_DISABLED, config: {} };
   }
 
-  if (typeof langwatch === "object" && langwatch !== null) {
+  if (typeof langwatch === "object" && langwatch !== null && !Array.isArray(langwatch)) {
     return { disabled: false, config: langwatch };
   }
 
   logger.error(
-    `Invalid \`langwatch\` option: ${JSON.stringify(langwatch)}.\n` +
+    `Invalid \`langwatch\` option: ${describeRejectedValue(langwatch)}.\n` +
       `Expected an options object, or "${LANGWATCH_DISABLED}" to turn the integration off.\n` +
       `Treating it as "${LANGWATCH_DISABLED}", because a value that is neither cannot be read as a request to export.`,
   );

--- a/sdks/typescript/src/observability-sdk/setup/node/setup.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/setup.ts
@@ -43,11 +43,44 @@ const LANGWATCH_OPTION_KEYS = ["apiKey", "endpoint", "processorType"] as const;
  *
  * An empty `{}` stays valid: it is the documented way to say "configure me from
  * the environment", so emptiness on its own cannot be the signal.
+ *
+ * Every question asked here throws on a revoked proxy, including
+ * `Array.isArray`. A throw would escape the resolver and take down setup rather
+ * than disable it, so the answer for a value that cannot even be inspected is
+ * the same as for one that can: it is not a configuration.
  */
 const isLangWatchOptions = (value: object): boolean => {
-  const prototype = Object.getPrototypeOf(value) as unknown;
-  if (prototype === Object.prototype || prototype === null) return true;
-  return LANGWATCH_OPTION_KEYS.some((key) => key in value);
+  try {
+    if (Array.isArray(value)) return false;
+    const prototype = Object.getPrototypeOf(value) as unknown;
+    if (prototype === Object.prototype || prototype === null) return true;
+    return LANGWATCH_OPTION_KEYS.some((key) => key in value);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Names a rejected object by a type the runtime owns.
+ *
+ * Not by `constructor.name`, and not by `Object.prototype.toString`. Both read
+ * a string the caller supplies: `date.constructor = { name: "sk-live-..." }`
+ * and `{ [Symbol.toStringTag]: "sk-live-..." }` each put that string straight
+ * into the report. `instanceof` asks the global constructor instead, so a
+ * tampered `Date` is still reported as a Date and nothing the caller wrote is
+ * echoed. Anything not on this list is just "an object".
+ */
+const describeObject = (value: object): string => {
+  if (value instanceof Date) return "a Date";
+  if (value instanceof Map) return "a Map";
+  if (value instanceof Set) return "a Set";
+  if (value instanceof RegExp) return "a RegExp";
+  if (value instanceof String) return "a String";
+  if (value instanceof Number) return "a Number";
+  if (value instanceof Boolean) return "a Boolean";
+  if (value instanceof Promise) return "a Promise";
+  if (value instanceof Error) return "an Error";
+  return "an object";
 };
 
 /**
@@ -59,17 +92,15 @@ const isLangWatchOptions = (value: object): boolean => {
  * credential leak. The kind is enough to act on, because the message names the
  * one string the option accepts right beside it.
  *
- * Reading `constructor` can throw on a proxy, and this runs on the path that
- * exists to explain a problem, so it must not become one.
+ * This runs on the path that exists to explain a problem, so it must not become
+ * one. `typeof` is the only question here that a revoked proxy answers.
  */
 const describeRejectedValue = (value: unknown): string => {
   if (value === null) return "null";
-  if (Array.isArray(value)) return "an array";
   if (typeof value !== "object") return `a ${typeof value}`;
 
   try {
-    const name = (value as { constructor?: { name?: string } }).constructor?.name;
-    return name && name !== "Object" ? `a ${name}` : "an object";
+    return Array.isArray(value) ? "an array" : describeObject(value);
   } catch {
     return "an object";
   }
@@ -108,12 +139,7 @@ const resolveLangWatchOption = (
     return { disabled: langwatch === LANGWATCH_DISABLED, config: {} };
   }
 
-  if (
-    typeof langwatch === "object" &&
-    langwatch !== null &&
-    !Array.isArray(langwatch) &&
-    isLangWatchOptions(langwatch)
-  ) {
+  if (typeof langwatch === "object" && langwatch !== null && isLangWatchOptions(langwatch)) {
     return { disabled: false, config: langwatch };
   }
 

--- a/sdks/typescript/src/observability-sdk/setup/node/types.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/types.ts
@@ -37,6 +37,17 @@ import { type DataCaptureOptions } from "../../features/data-capture/types";
  * };
  * ```
  */
+/**
+ * The value that disables the LangWatch integration.
+ *
+ * Prefer this over writing `"disabled"` by hand. A TypeScript caller is already
+ * protected by the union below, but the value often arrives from config, JSON or
+ * plain JavaScript, where a typo is not a compile error. See the guard in
+ * `getLangWatchConfig`, which is what stops a near-miss from silently enabling
+ * the exporter.
+ */
+export const LANGWATCH_DISABLED = "disabled" as const;
+
 export interface SetupObservabilityOptions {
   /**
    * LangWatch configuration for sending observability data to LangWatch.


### PR DESCRIPTION
## Ticket

Closes #3289. `SetupObservabilityOptions.langwatch` accepts the bare string `'disabled'` as a disable signal, and a typo falls through to the enabled path.

## Premise, re-checked on current main

Holds, and the failure is worse than "easy to typo silently". The resolution is two lines, `setup.ts:28`:

```ts
const isDisabled = options.langwatch === 'disabled';
const config = typeof options.langwatch === 'object' ? options.langwatch : {};
```

A value that is neither the sentinel nor an object satisfies **neither branch**. Trace `langwatch: "disable"` through it:

| step | value |
|---|---|
| `isDisabled` | `false`, it is not the sentinel |
| `config` | `{}`, because `typeof` says `string`, not `object` |
| `apiKey` | `process.env.LANGWATCH_API_KEY` |
| `endpoint` | the resolved default |

So the exporter comes up and sends to the caller's real endpoint. **Someone who asked to send nothing sends everything, and the only signal is the absence of one.** That is a data-egress outcome from a typo, which reads higher than P3 to me, though I have left the label alone.

Two corrections to the ticket's framing, both from reading the code rather than the description:

- **TypeScript already rejects the typo.** The option's type is `{...} | "disabled"`, so a typed call site cannot compile `'disable'`. This is a runtime problem, not a compile-time one: the value arrives from a config file, a JSON payload, or plain JavaScript, none of which the union protects. The ticket's "typos silently fall through" is right about the outcome and wrong about who is exposed.
- **The sprawl is already contained.** The ticket says "~10 places across integration tests". There are 4 real call sites, and `setup/node/__tests__/createIntegrationObservability.ts` already centralises the default for that class of test.

There is also a second hole the ticket does not mention. `typeof null === "object"`, so `langwatch: null` passed the object branch and threw a `TypeError` on the first property read, naming neither the option nor the value.

## Change

`resolveLangWatchOption` replaces the two-line resolution and classifies the value into the three cases that actually exist: the sentinel, an options object, and neither.

Neither is **treated as disabled and reported at `error`**, naming the value it rejected. Disabled rather than guessed, because every value that lands there is a caller who did not successfully ask for the exporter, and exporting anyway is the failure worth avoiding. Reported rather than thrown, because this file already handles misconfiguration that way (see the "OpenTelemetry is already set up" path), and because setup's existing "disabled but no alternative exporter configured" guidance then fires and tells the developer what to do next.

The ticket's **option 1** ships too: `LANGWATCH_DISABLED` is exported from the setup surface, so call sites can reference the constant instead of retyping the string.

**Option 2** (replacing the sentinel with `{ enabled: false }`) is not here. The ticket calls it breaking and says to target a minor bump; that is a product decision about the SDK's public surface, not tech debt to take unilaterally. The guard makes the current form safe in the meantime, and the two are compatible if option 2 is later chosen.

## Evidence

The assertions are about **whether the exporter was constructed**, not about a log line, because "did we send data the caller asked us not to send" is the question. `LangWatchTraceExporter` is mocked, so construction is observable. `LANGWATCH_API_KEY` is set in `beforeEach`: the old fall-through only exported because a key was reachable, so an empty environment would have hidden the regression.

```
pnpm test:unit src/observability-sdk        19 files, 567 tests passed
pnpm run generate && npx tsc --noEmit       0 errors
```

Eight near-miss values are covered: a typo of the sentinel, a different casing, the sentinel with leading whitespace, an unrelated string, the empty string, `null`, a boolean, and a number.

### Mutation testing

| Mutation | Result |
| --- | --- |
| restores the original two-line resolution | CAUGHT (15 of 20 fail) |
| treats an unrecognised value as enabled | CAUGHT |
| lets `null` through the object branch | CAUGHT |
| rewords the report so it no longer names the option | CAUGHT |
| drops the rejected value from the report | CAUGHT |
| an unrelated comment (control) | not caught, correctly |

The first row is the one that matters: it restores the exact code on `main`, and 15 of the 20 assertions fail on it.

### A process note against myself

My first run of this suite reported 11 failing files. That was my error, not the branch's: I ran `npx vitest` directly, which skips the package's `pretest` codegen hook, so `src/internal/generated/types/` was empty and those files could not resolve their imports. `CLAUDE.md` says to go through the package scripts for exactly this reason. Re-run as `pnpm test:unit`, it is 19 files and 567 tests green. Recording it because the first number was wrong and reached my own notes before I caught it.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

---
<sub>🤖 **Filed by `tech-debt-fixer` via the create-issue procedure, on behalf of the fleet.** Authored under the owner's GitHub token for API access — the content is the fleet's, not his. Owner-authored and fleet-authored issues are otherwise indistinguishable in this repo; this footer is the only signal.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the exported `LANGWATCH_DISABLED` constant for explicitly disabling the LangWatch integration.
  * Improved configuration handling across supported setup paths.

* **Bug Fixes**
  * Invalid configuration values are now logged safely and treated as disabled.
  * Prevented unintended exporter activation from invalid or near-miss values.

* **Tests**
  * Added coverage for disabled settings, valid options, invalid values, unsafe inputs, and environment-based fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->