### PR TITLE
fix(governance): panel takes semantic orange, so dark mode stops printing white on cream

### DIFF
--- a/platform/app/src/components/settings/governance/ToolCatalogEditor.tsx
+++ b/platform/app/src/components/settings/governance/ToolCatalogEditor.tsx
@@ -240,12 +240,12 @@ export function ToolCatalogEditor({
       {(isCatalogEmpty || showImport) && (
         // Semantic orange, not the raw palette: `orange.50/300/600` are fixed
         // light-mode values, so in dark mode this panel kept a cream
-        // background while its text stayed on the semantic `fg`/`fg.muted`
-        // tokens that do flip — white-on-cream at 1.01:1. The semantic triple
-        // (_app.tsx) flips instead: subtle/emphasized/fg resolve to
-        // orange.900/700/200 in dark. Light mode shifts one step darker
-        // (50→100 bg, 300→400 border, 600→800 icon), which is the cost of
-        // dropping the hardcoded pair.
+        // background while its text stayed on the `fg`/`fg.muted` tokens that
+        // do flip — white on cream, 1.01:1. The semantic triple (_app.tsx)
+        // flips instead, taking the heading to 10.49:1 and the body to 7.39:1.
+        // Light mode is untouched to the eye: the fill moves orange.50 ->
+        // orange.100, which is 1.05:1 of difference, and the icon gets better
+        // (3.26:1 -> 8.16:1) because orange.fg is darker than orange.600.
         <Box
           borderWidth="1px"
           borderColor="orange.emphasized"

--- a/platform/app/src/components/settings/governance/ToolCatalogEditor.tsx
+++ b/platform/app/src/components/settings/governance/ToolCatalogEditor.tsx
@@ -238,15 +238,23 @@ export function ToolCatalogEditor({
         </HStack>
       )}
       {(isCatalogEmpty || showImport) && (
+        // Semantic orange, not the raw palette: `orange.50/300/600` are fixed
+        // light-mode values, so in dark mode this panel kept a cream
+        // background while its text stayed on the semantic `fg`/`fg.muted`
+        // tokens that do flip — white-on-cream at 1.01:1. The semantic triple
+        // (_app.tsx) flips instead: subtle/emphasized/fg resolve to
+        // orange.900/700/200 in dark. Light mode shifts one step darker
+        // (50→100 bg, 300→400 border, 600→800 icon), which is the cost of
+        // dropping the hardcoded pair.
         <Box
           borderWidth="1px"
-          borderColor="orange.300"
+          borderColor="orange.emphasized"
           borderRadius="md"
-          backgroundColor="orange.50"
+          backgroundColor="orange.subtle"
           padding={4}
         >
           <HStack alignItems="start" gap={3}>
-            <Box color="orange.600" paddingTop="2px">
+            <Box color="orange.fg" paddingTop="2px">
               <PackageOpen size={20} />
             </Box>
             <VStack align="start" gap={2} flex={1} minWidth={0}>


### PR DESCRIPTION
## What

The starter-pack import panel in the Inventory → Catalog tab is unreadable in dark mode. Three raw palette tokens become three semantic ones.

## The bug

`ToolCatalogEditor.tsx` styled the panel with `backgroundColor="orange.50"`, `borderColor="orange.300"` and `color="orange.600"`. Those are fixed palette values — they do not flip with the theme. The text inside sits on `fg` and `fg.muted`, which do. In dark mode the result is near-white text on a cream background.

Measured in the browser with dark mode active, against the panel background `rgb(255, 250, 240)`:

| element | color | contrast |
|---|---|---|
| "Publish a starter pack to get going" | `rgb(248, 250, 252)` | **1.01:1** |
| body copy, "Coding assistants" / "Model providers" | `rgb(203, 213, 225)` | **1.43:1** |
| tile labels (Claude Code, Codex, …) | `rgb(248, 250, 252)` | **1.01:1** |

WCAG AA wants 4.5:1. Only the checkboxes and the Import button were visible; every label was not.

## The fix

The semantic orange scale is already defined per theme in `_app.tsx:152-183`, over a palette in `color-mode.tsx:49-60`:

| token | `_light` | `_dark` |
|---|---|---|
| `orange.subtle` | orange.100 `#FFF3E4` | orange.900 `#652B19` |
| `orange.emphasized` | orange.400 `#ED8926` | orange.700 `#c05621` |
| `orange.fg` | orange.800 `#7B341E` | orange.200 `#FFD19B` |

Swapping to those three is the pattern `OnboardAgentPill` already uses, and the codebase's clear majority: **105 files** use semantic orange, **5** hand-roll an inline `_dark` override.

Computed from those hex values:

| | before | after |
|---|---|---|
| dark, heading on fill | 1.01:1 ❌ | **10.49:1** ✅ |
| dark, body on fill | 1.43:1 ❌ | **7.39:1** ✅ |
| dark, border vs surface | — | 4.36:1 (3:1 needed for UI boundaries) |
| light, heading | 18.13:1 | 17.24:1 |
| light, body | 10.23:1 | 9.73:1 |
| light, icon | 3.26:1 | **8.16:1** |

**Light mode is untouched to the eye.** The fill moves `orange.50` → `orange.100`, a difference of 1.05:1. Text loses half a point off an 18-point base. The icon gets materially better, because `orange.fg` resolves darker than the `orange.600` it replaces. There is no tradeoff to weigh here — an earlier revision of this description claimed one, and the numbers say it was wrong.

## Scope

The bug predates the Inventory work — the file is byte-identical to what it was before, and the panel had the same problem at the old `/governance/tool-catalog` address. Folding Tool Tiles into the Catalog tab is only what made it easy to hit.

One file, three tokens, one explanatory comment.

## Same bug, other panels — not fixed here

Found while establishing the convention, left alone to keep this PR one file:

- `ProviderCredentialPicker.tsx:178-180` — identical `orange.300`/`orange.50` panel, no dark handling at all.
- `RoutingPoliciesTable.tsx:135` — `borderColor="orange.300"`.
- `EnterpriseCapabilitiesSection.tsx:169` — *has* a dark override, but it sets `backgroundColor: "orange.950"`, and **`orange.950` is not defined** in `color-mode.tsx` (the orange scale stops at 900). That override resolves to nothing. It is the best argument for the semantic route this PR takes.

Worth its own issue.

## Verification

- Contrast numbers above measured in a browser on the running stack, then re-derived from the theme hex — the two agree on 1.01 and 1.43.
- `pnpm typecheck` — clean. `pnpm typecheck:all` — clean.
- Biome on the changed file — 0 errors.
- `check:feature-parity` — `OK: 8030 enforced scenario(s) bound across 1096 file(s)`.
- `ToolCatalogEditorStarterPack.integration.test.tsx` — 1 passed.

**Not verified:** the fixed panel has not been seen rendered. The local stack went down before the change could reload, so the after-numbers are computed from the theme, not sampled from pixels. Worth a glance in dark mode before merge.

No test added: the token swap has no behavioural surface, matching `fefb72e17c`, the previous governance token fix, which shipped seven source files and zero tests.

## Base

Stacked on `issue7353/catalog-tab-shell` (#7357, still open), which now carries the squash-merged #7394. `main` has none of this yet.
