### PR TITLE
fix(langy): codex models run again on pi, the backend refuses prompt_cache_retention

### DIFF
--- a/services/aigateway/adapters/providers/codex.go
+++ b/services/aigateway/adapters/providers/codex.go
@@ -270,14 +270,16 @@ func codexRequestBody(raw []byte, model string) ([]byte, error) {
 			return nil, fmt.Errorf("rewrite %s on codex body: %w", set.path, err)
 		}
 	}
-	// The codex backend refuses the sampling params the wider Responses API
-	// accepts: a body carrying temperature or top_p comes back 400 Bad Request.
-	// Clients that set them for other providers (the title generator and the
-	// tiny assists both send temperature) would break every codex call, so
-	// strip them here where the gateway already owns the backend's invariants.
-	// DeleteBytes is a no-op when the key is absent, so this is safe for the
-	// opencode turns that never set them.
-	for _, path := range []string{"temperature", "top_p"} {
+	// The codex backend refuses params the wider Responses API accepts: a body
+	// carrying temperature, top_p, or prompt_cache_retention comes back
+	// 400 Bad Request ("Unsupported parameter", verified against the live
+	// backend; prompt_cache_key passes). Clients that set them for other
+	// providers would break every codex call — the title generator and the
+	// tiny assists send temperature, and pi's long-cache-retention mode sends
+	// prompt_cache_retention — so strip them here where the gateway already
+	// owns the backend's invariants. DeleteBytes is a no-op when the key is
+	// absent, so this is safe for the opencode turns that never set them.
+	for _, path := range []string{"temperature", "top_p", "prompt_cache_retention"} {
 		body, err = sjson.DeleteBytes(body, path)
 		if err != nil {
 			return nil, fmt.Errorf("strip %s from codex body: %w", path, err)

--- a/services/aigateway/adapters/providers/codex_test.go
+++ b/services/aigateway/adapters/providers/codex_test.go
@@ -296,6 +296,7 @@ func TestCodexRequestBody_PinsInvariantsAndStripsSampling(t *testing.T) {
 	// (the codex backend answers 400 on them), and leave the client's include
 	// and input untouched.
 	raw := []byte(`{"model":"openai_codex/gpt-5.6-terra","temperature":0.2,"top_p":0.9,` +
+		`"prompt_cache_retention":"24h","prompt_cache_key":"session-1",` +
 		`"input":[{"role":"user"}],"include":["reasoning.encrypted_content"]}`)
 	body, err := codexRequestBody(raw, "openai_codex/gpt-5.6-terra")
 	if err != nil {
@@ -315,6 +316,14 @@ func TestCodexRequestBody_PinsInvariantsAndStripsSampling(t *testing.T) {
 	}
 	if gjson.GetBytes(body, "top_p").Exists() {
 		t.Errorf("top_p must be stripped: %s", body)
+	}
+	if gjson.GetBytes(body, "prompt_cache_retention").Exists() {
+		t.Errorf("prompt_cache_retention must be stripped (codex 400s on it): %s", body)
+	}
+	// prompt_cache_key the backend accepts — it must survive so the session's
+	// cache routing keeps working.
+	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != "session-1" {
+		t.Errorf("prompt_cache_key must pass through, got %q in %s", got, body)
 	}
 	// The client's include (reasoning round-trip) and input pass through.
 	if got := gjson.GetBytes(body, "include.0").String(); got != "reasoning.encrypted_content" {

--- a/services/langyagent/adapters/pi/spawn.go
+++ b/services/langyagent/adapters/pi/spawn.go
@@ -135,12 +135,13 @@ func modelLane(model string) workerModelConfig {
 	case strings.HasPrefix(model, "openai_codex/"):
 		lane.API = "openai-responses"
 		lane.Reasoning = true
-		lane.Compat = map[string]any{
-			"supportsStore": false,
-			// With retention long, pi sets prompt_cache_retention "24h" on
-			// the Responses lane; OpenAI charges no write premium for it.
-			"supportsLongCacheRetention": true,
-		}
+		// NO supportsLongCacheRetention here: the ChatGPT codex backend
+		// answers 400 "Unsupported parameter: prompt_cache_retention" on the
+		// field the flag makes pi send (the API-key Responses endpoint
+		// accepts it, which is how it slipped past the spike). The gateway
+		// also strips the field on the codex route, so this is belt and
+		// braces on the same invariant.
+		lane.Compat = map[string]any{"supportsStore": false}
 	case strings.HasPrefix(model, "openai/"):
 		lane.API = "openai-responses"
 		lane.Reasoning = true

--- a/services/langyagent/adapters/pi/spawn_test.go
+++ b/services/langyagent/adapters/pi/spawn_test.go
@@ -173,8 +173,11 @@ func TestProvision_ModelLanes(t *testing.T) {
 		if compatOf(model)["supportsStore"] != false {
 			t.Errorf("codex must pin supportsStore false, got %v", compatOf(model))
 		}
-		if compatOf(model)["supportsLongCacheRetention"] != true {
-			t.Errorf("codex lane must allow long cache retention, got %v", compatOf(model))
+		// The ChatGPT codex backend rejects prompt_cache_retention with 400
+		// "Unsupported parameter" — the flag that makes pi send it must stay
+		// off on this lane, or every codex turn dies on its first LLM call.
+		if _, present := compatOf(model)["supportsLongCacheRetention"]; present {
+			t.Errorf("codex lane must not ask for long cache retention, got %v", compatOf(model))
 		}
 		if model["id"] != "openai_codex/gpt-5-codex" {
 			t.Errorf("codex id must ride verbatim, got %v", model["id"])

--- a/specs/langy/langy-pi-harness.feature
+++ b/specs/langy/langy-pi-harness.feature
@@ -162,12 +162,16 @@ Feature: Langy can run a conversation on the pi harness
   # Provider prompt caching is what makes a long conversation affordable, and
   # the default cache tier expires faster than the pauses between a user's
   # messages. The worker asks for the long tier: anthropic's hour-long
-  # cache_control, the Responses lane's day-long retention.
+  # cache_control, the Responses lane's day-long retention. The codex lane is
+  # the exception: the ChatGPT backend rejects the retention parameter with a
+  # 400 (the API-key endpoint accepts it), and in production that 400 killed
+  # every codex turn on its first LLM call. So the codex lane never asks.
   @unit
   Scenario: The worker asks the provider for long cache retention
     Given a pi worker provisioned for an anthropic or openai model
     When its config and environment are assembled
     Then the model allows long cache retention and the environment selects it
+    But a codex model never asks for it, because its backend refuses the request
 
   @unit
   Scenario: A corrupt persisted session degrades to a fresh one instead of failing the spawn


### PR DESCRIPTION
## What happened

With the pi harness re-enabled in production, turns on `openai_codex` models (for example gpt-5.6-terra) failed on their first LLM call. The worker reported "OpenAI API error (400)", the gateway logged `upstream_error: codex backend HTTP 400`, and the panel showed a dead "Langy's reply failed" card. Gemini and other chat-completions models worked.

## Root cause

The pi codex lane set `supportsLongCacheRetention`, which makes pi put `prompt_cache_retention: "24h"` on its Responses requests. The ChatGPT codex backend refuses that parameter. Probed live against `chatgpt.com/backend-api/codex/responses` with a pi-shaped body:

- without the parameter: HTTP 200, stream starts
- with the parameter: HTTP 400 `{"detail":"Unsupported parameter: prompt_cache_retention"}`
- `prompt_cache_key` is accepted in both cases

The API-key `/v1/responses` endpoint accepts the parameter, which is how the flag got onto the codex lane unnoticed: the harness spike validated codex before the retention flag existed, and retention was then validated on the API-key lane.

## The fix

Two layers on the same invariant:

- The gateway strips `prompt_cache_retention` in `codexRequestBody`, next to the existing `temperature` and `top_p` strips, so no client can break the codex route with it. `prompt_cache_key` passes through, pinned by test.
- The pi codex lane no longer sets `supportsLongCacheRetention`, so the worker stops asking for a retention the backend cannot give. The `openai/` and `anthropic/` lanes keep it.

Spec: "The worker asks the provider for long cache retention" in `specs/langy/langy-pi-harness.feature` now names the codex exception (20/20 bound).

## Not this PR

The same production check also found `anthropic/claude-opus-5` failing, with a different cause: the "Central LangWatch Anthropic" provider account reached its monthly usage limit (access returns 2026-09-01). That is an account/billing action, not a code change.

## Deployment Impact

No new or changed environment variables, no helm values, no chart templates. A vanilla `helm install` behaves the same for every operator. The only runtime difference: the gateway drops `prompt_cache_retention` from codex-route bodies (the backend rejected the whole request before, so no working request changes), and pi workers on codex models stop sending it. BYOC dataplanes pick both up with the image, no operator action, no migration, no rollback step.

https://claude.ai/code/session_01WUfQouXLw4S6hsfK2nKmsA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Codex by preventing unsupported cache-retention settings from being sent.
  * Preserved supported prompt-cache settings where applicable.
  * Improved session setup by repairing shared storage permissions automatically.
  * Kept individual conversation session directories private while allowing required traversal.

* **Reliability**
  * Added validation for cache behavior across supported model providers and for session storage permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->