### PR TITLE
fix(aigateway): distinguish 401/403/499 in classifyUpstream

### DIFF
--- a/services/aigateway/app/pipeline/trace.go
+++ b/services/aigateway/app/pipeline/trace.go
@@ -37,6 +37,12 @@ func classifyUpstream(err error) (status int, errType string) {
 			return status, "provider_error"
 		case status == 404:
 			return status, "not_found"
+		case status == 401:
+			return status, "unauthorized"
+		case status == 403:
+			return status, "forbidden"
+		case status == 499:
+			return status, "client_closed_request"
 		case status >= 400:
 			return status, "bad_request"
 		default:

--- a/services/aigateway/app/pipeline/trace_classify_test.go
+++ b/services/aigateway/app/pipeline/trace_classify_test.go
@@ -92,6 +92,10 @@ func TestClassifyUpstream_ForwardedProviderResponseStillWins(t *testing.T) {
 		{"a provider rate limit", &domain.UpstreamError{StatusCode: 429}, 429, "rate_limited"},
 		{"a provider outage", &domain.UpstreamError{StatusCode: 503}, 503, "provider_error"},
 		{"a provider rejecting the caller", &domain.UpstreamError{StatusCode: 402}, 402, "bad_request"},
+		{"a malformed body", &domain.UpstreamError{StatusCode: 400}, 400, "bad_request"},
+		{"an expired credential", &domain.UpstreamError{StatusCode: 401}, 401, "unauthorized"},
+		{"a permission failure", &domain.UpstreamError{StatusCode: 403}, 403, "forbidden"},
+		{"a client disconnect", &domain.UpstreamError{StatusCode: 499}, 499, "client_closed_request"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/services/aigateway/app/pipeline/trace_error_test.go
+++ b/services/aigateway/app/pipeline/trace_error_test.go
@@ -27,6 +27,9 @@ func TestClassifyUpstream(t *testing.T) {
 		{"upstream 429", &domain.UpstreamError{StatusCode: 429}, 429, "rate_limited"},
 		{"upstream 500", &domain.UpstreamError{StatusCode: 500}, 500, "provider_error"},
 		{"upstream 400", &domain.UpstreamError{StatusCode: 400}, 400, "bad_request"},
+		{"upstream 401", &domain.UpstreamError{StatusCode: 401}, 401, "unauthorized"},
+		{"upstream 403", &domain.UpstreamError{StatusCode: 403}, 403, "forbidden"},
+		{"upstream 499", &domain.UpstreamError{StatusCode: 499}, 499, "client_closed_request"},
 		{"upstream 404", &domain.UpstreamError{StatusCode: 404}, 404, "not_found"},
 		{"non-upstream error", assert.AnError, 502, "provider_error"},
 	}


### PR DESCRIPTION
## Why

Closes #6809

`classifyUpstream` collapsed every 4xx that isn't 429, 404, 408, or 504 into a single `error.type` of `bad_request`. An expired credential (401), a permission failure (403), a client disconnect (499), and a malformed body (400) were indistinguishable when grouping on `error.type`.

## What changed

Map those user-visible statuses to distinct types and leave 400 as `bad_request`:

- 401 → `unauthorized`
- 403 → `forbidden`
- 499 → `client_closed_request`
- 400 → `bad_request` (unchanged)

LangWatch-internal untyped failures still land on `502` / `provider_error`. Existing 429 / 404 / 408 / 504 / 5xx mappings are unchanged.

## Test plan

- Added table cases for 400/401/403/499 in `trace_error_test.go` and `trace_classify_test.go`.
- `go test ./services/aigateway/app/pipeline/ -count=1` passes.
- 402 stays `bad_request` (existing case, not one of the named modes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upstream error reporting for unauthorized, forbidden, and client-closed requests.
  - HTTP statuses 401, 403, and 499 now receive accurate classifications instead of a generic bad-request label.
  - Preserved provider-specific response classifications when available.

- **Tests**
  - Added coverage for the updated status classifications and provider response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->