### PR TITLE
fix(gateway): a forwarded provider rejection is logged with the provider's own reason

### DIFF
--- a/services/aigateway/adapters/httpapi/faults.go
+++ b/services/aigateway/adapters/httpapi/faults.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -89,17 +91,31 @@ func faultForCode(code herr.Code) Fault {
 	}
 }
 
+// requestError is one failure, as the log line states it.
+type requestError struct {
+	fault   Fault
+	code    string
+	status  int
+	message string
+	// reason is the provider's own words for a forwarded rejection, when its
+	// body states something our message does not.
+	reason string
+}
+
 // logRequestError emits the single stable failure log line CloudWatch metric
 // filters key on: msg="gateway_request_failed" with fault/code/status fields,
 // plus the calling identity when the request was authenticated.
-func logRequestError(logger *zap.Logger, ctx context.Context, fault Fault, code string, status int, message string) {
+func logRequestError(logger *zap.Logger, ctx context.Context, failure requestError) {
 	fields := []zap.Field{
-		zap.String("fault", string(fault)),
-		zap.String("code", code),
-		zap.String("message", message),
+		zap.String("fault", string(failure.fault)),
+		zap.String("code", failure.code),
+		zap.String("message", failure.message),
 	}
-	if status > 0 {
-		fields = append(fields, zap.Int("status", status))
+	if failure.status > 0 {
+		fields = append(fields, zap.Int("status", failure.status))
+	}
+	if failure.reason != "" {
+		fields = append(fields, zap.String("upstream_reason", failure.reason))
 	}
 	if bundle := BundleFromContext(ctx); bundle != nil {
 		fields = append(fields,
@@ -108,7 +124,53 @@ func logRequestError(logger *zap.Logger, ctx context.Context, fault Fault, code 
 			zap.String("virtual_key_id", bundle.VirtualKeyID),
 		)
 	}
-	logger.Log(fault.level(), "gateway_request_failed", fields...)
+	logger.Log(failure.fault.level(), "gateway_request_failed", fields...)
+}
+
+// upstreamReasonLimit caps the reason field: long enough for any provider's
+// rejection sentence, short enough that a body in a shape we do not know
+// cannot put a request payload on the line.
+const upstreamReasonLimit = 256
+
+// upstreamReason reads the provider's own explanation out of a forwarded error
+// body. Providers state it in different places: OpenAI and Anthropic use
+// error.message, the codex backend answers "detail", several others use a bare
+// message or a plain error string. A body in none of those shapes (an HTML
+// edge page, a text response) is reported by its first line, so the operator
+// still learns who answered and roughly what they said.
+func upstreamReason(body []byte) string {
+	for _, path := range []string{"error.message", "detail", "message", "error"} {
+		if value := gjson.GetBytes(body, path); value.Type == gjson.String && value.Str != "" {
+			return cappedReason(value.Str)
+		}
+	}
+	return cappedReason(firstLine(body))
+}
+
+// unstatedReason is upstreamReason minus what the message already says, so a
+// provider whose words we forwarded as the message is not quoted twice.
+func unstatedReason(message string, body []byte) string {
+	reason := upstreamReason(body)
+	if reason == "" || strings.Contains(message, reason) {
+		return ""
+	}
+	return reason
+}
+
+func cappedReason(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= upstreamReasonLimit {
+		return text
+	}
+	return strings.ToValidUTF8(text[:upstreamReasonLimit], "") + "..."
+}
+
+func firstLine(body []byte) string {
+	text := strings.TrimSpace(string(body))
+	if end := strings.IndexByte(text, '\n'); end >= 0 {
+		text = text[:end]
+	}
+	return text
 }
 
 // recordClientReject counts a rejection the GATEWAY issued against the caller.
@@ -146,7 +208,13 @@ func logWriteError(logger *zap.Logger, ctx context.Context, err error) {
 		if status <= 0 {
 			status = http.StatusBadGateway
 		}
-		logRequestError(logger, ctx, faultForUpstreamStatus(ue.StatusCode), "upstream_error", status, ue.Message)
+		logRequestError(logger, ctx, requestError{
+			fault:   faultForUpstreamStatus(ue.StatusCode),
+			code:    "upstream_error",
+			status:  status,
+			message: ue.Message,
+			reason:  unstatedReason(ue.Message, ue.Body),
+		})
 		return
 	}
 	var e herr.E
@@ -155,9 +223,17 @@ func logWriteError(logger *zap.Logger, ctx context.Context, err error) {
 		if m, ok := e.Meta["message"].(string); ok {
 			msg = m
 		}
-		logRequestError(logger, ctx, faultForCode(e.Code), e.Code.String(), 0, msg)
+		logRequestError(logger, ctx, requestError{
+			fault:   faultForCode(e.Code),
+			code:    e.Code.String(),
+			message: msg,
+		})
 		recordClientReject(ctx, e.Code)
 		return
 	}
-	logRequestError(logger, ctx, FaultPlatform, "unhandled", 0, err.Error())
+	logRequestError(logger, ctx, requestError{
+		fault:   FaultPlatform,
+		code:    "unhandled",
+		message: err.Error(),
+	})
 }

--- a/services/aigateway/adapters/httpapi/faults.go
+++ b/services/aigateway/adapters/httpapi/faults.go
@@ -162,7 +162,8 @@ func cappedReason(text string) string {
 	if len(text) <= upstreamReasonLimit {
 		return text
 	}
-	return strings.ToValidUTF8(text[:upstreamReasonLimit], "") + "..."
+	const ellipsis = "..."
+	return strings.ToValidUTF8(text[:upstreamReasonLimit-len(ellipsis)], "") + ellipsis
 }
 
 func firstLine(body []byte) string {

--- a/services/aigateway/adapters/httpapi/faults_test.go
+++ b/services/aigateway/adapters/httpapi/faults_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -114,8 +115,17 @@ func TestUpstreamReasonIsBoundedAndNotRepeated(t *testing.T) {
 	t.Run("when the body is longer than the cap", func(t *testing.T) {
 		long := strings.Repeat("x", upstreamReasonLimit*4)
 		reason := upstreamReason([]byte(`{"detail":"` + long + `"}`))
-		assert.Len(t, reason, upstreamReasonLimit+len("..."),
+		assert.Len(t, reason, upstreamReasonLimit,
 			"an unknown body must not put a request payload on the log line")
+		assert.True(t, strings.HasSuffix(reason, "..."), "a cut reason says it was cut")
+	})
+
+	t.Run("when the cut lands inside a multi-byte character", func(t *testing.T) {
+		long := strings.Repeat("é", upstreamReasonLimit*4)
+		reason := upstreamReason([]byte(`{"detail":"` + long + `"}`))
+		assert.LessOrEqual(t, len(reason), upstreamReasonLimit,
+			"the cap counts bytes, so a half-written character cannot push past it")
+		assert.True(t, utf8.ValidString(reason), "a cut reason stays valid UTF-8")
 	})
 
 	t.Run("when our message already states the reason", func(t *testing.T) {

--- a/services/aigateway/adapters/httpapi/faults_test.go
+++ b/services/aigateway/adapters/httpapi/faults_test.go
@@ -72,6 +72,59 @@ func TestWriteErrorLogsUpstreamRejectionAsCustomerFault(t *testing.T) {
 	assert.Equal(t, "customer", entry.ContextMap()["fault"])
 }
 
+// @scenario "A forwarded provider rejection names the provider's own reason"
+func TestWriteErrorLogsTheProviderReasonFromTheForwardedBody(t *testing.T) {
+	// The line that named nothing: the codex backend answered 400 with the
+	// parameter it refused, the client got that body verbatim, and the log said
+	// only "codex backend HTTP 400". Every codex turn in production failed for
+	// a week's worth of debugging over a sentence we already held.
+	logs := observedWriteError(t, context.Background(), &domain.UpstreamError{
+		StatusCode: 400,
+		Message:    "codex backend HTTP 400",
+		Body:       []byte(`{"detail":"Unsupported parameter: prompt_cache_retention"}`),
+	})
+	fields := requireSingleFailureLog(t, logs).ContextMap()
+	assert.Equal(t, "Unsupported parameter: prompt_cache_retention", fields["upstream_reason"])
+	assert.Equal(t, int64(400), fields["status"])
+}
+
+// @scenario "A forwarded provider rejection names the provider's own reason"
+func TestUpstreamReasonReadsEveryShapeProvidersUse(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"openai and anthropic", `{"error":{"type":"invalid_request_error","message":"credit balance too low"}}`, "credit balance too low"},
+		{"the codex backend", `{"detail":"Unsupported parameter: prompt_cache_retention"}`, "Unsupported parameter: prompt_cache_retention"},
+		{"a bare message", `{"message":"model not found"}`, "model not found"},
+		{"a plain error string", `{"error":"invalid virtual key"}`, "invalid virtual key"},
+		{"an edge page in front of the provider", "<html>\n<body>error 1010</body>\n</html>", "<html>"},
+		{"a body with nothing in it", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, upstreamReason([]byte(tc.body)))
+		})
+	}
+}
+
+// @scenario "A forwarded provider rejection names the provider's own reason"
+func TestUpstreamReasonIsBoundedAndNotRepeated(t *testing.T) {
+	t.Run("when the body is longer than the cap", func(t *testing.T) {
+		long := strings.Repeat("x", upstreamReasonLimit*4)
+		reason := upstreamReason([]byte(`{"detail":"` + long + `"}`))
+		assert.Len(t, reason, upstreamReasonLimit+len("..."),
+			"an unknown body must not put a request payload on the log line")
+	})
+
+	t.Run("when our message already states the reason", func(t *testing.T) {
+		body := []byte(`{"error":{"message":"credit balance too low"}}`)
+		assert.Empty(t, unstatedReason("credit balance too low", body))
+		assert.Equal(t, "credit balance too low", unstatedReason("provider HTTP 402", body))
+	})
+}
+
 // @scenario "A gateway-classified error is logged by its error code"
 func TestWriteErrorLogsHerrCodesWithTheirFault(t *testing.T) {
 	cases := []struct {

--- a/specs/ai-gateway/error-observability.feature
+++ b/specs/ai-gateway/error-observability.feature
@@ -31,6 +31,22 @@ Feature: Gateway errors are logged with fault attribution
     When the gateway forwards the rejection to the client
     Then an info log records the failure with customer fault, status and message
 
+  # The forwarded response holds the provider's own sentence, and the log line
+  # held only our summary of it ("codex backend HTTP 400"). A production outage
+  # on codex models took a live probe of the backend to name, because the one
+  # place an operator looks never carried the reply that said "Unsupported
+  # parameter: prompt_cache_retention". The reason is read from the shapes
+  # providers use, so a body with none of them still gives the operator its
+  # first line rather than nothing.
+  @unit
+  Scenario: A forwarded provider rejection names the provider's own reason
+    Given the upstream provider rejects the request with a reason in its body
+    When the gateway forwards the rejection to the client
+    Then the log carries that reason next to the status
+    And a body in any of the shapes providers use is read the same way
+    And an unrecognized body is reported by its first line, capped
+    And a reason our own message already states is not repeated
+
   @unit
   Scenario: A gateway-classified error is logged by its error code
     Given the gateway rejects or fails a request with one of its own error codes


### PR DESCRIPTION
## What happened

The codex outage fixed in #7484 was a 400 with the answer in it. The backend replied `{"detail":"Unsupported parameter: prompt_cache_retention"}`, the gateway forwarded that body to the caller, and the log line an operator reads said only:

```
gateway_request_failed  fault=customer code=upstream_error status=400 message="codex backend HTTP 400"
```

The reason was in memory (`UpstreamError.Body`) and was never written. Naming the parameter took a live probe of the ChatGPT backend with a hand-built body.

## The change

`logWriteError` is the one choke point for every error response the gateway writes. It now adds an `upstream_reason` field when a forwarded provider body states something the message does not. This covers every provider, not only codex.

- The reason is read from the shapes providers use: `error.message` (OpenAI, Anthropic), `detail` (the codex backend), a bare `message`, a plain `error` string.
- A body in none of those shapes (an HTML edge page, a text response) is reported by its first line, so the operator still learns who answered.
- The field is capped at 256 characters, so an unknown body cannot put a request payload on the log line.
- A reason the message already states is not repeated.

`logRequestError` now takes a `requestError` struct instead of six positional arguments, which is what makes room for the field.

No change to the response any client receives, and no change to `msg`, `fault`, `code` or `status`, so the CloudWatch metric filters keep working.

## Not this PR

The other half of that debugging session: a provider error that happens before the stream opens reaches the panel as a blank "reply failed" card. For Anthropic the pre-stream 400 becomes a short 200 SSE, which pi reports as "stream ended without a stop reason". That one is a change to the streaming error path and gets its own PR.

## Deployment Impact

No new or changed environment variables, no helm values, no chart templates. A vanilla `helm install` behaves the same for every operator. The only runtime difference is one more field on an existing log line. BYOC dataplanes pick it up with the image, no operator action, no migration, no rollback step.

https://claude.ai/code/session_01WUfQouXLw4S6hsfK2nKmsA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway error logs now include relevant provider rejection reasons when available.
  * Supports common response formats with UTF-8-safe limits of 256 characters.
  * Prevents duplicate provider reasons from appearing in gateway messages.

* **Bug Fixes**
  * Improved handling of empty, HTML, and unrecognized provider error responses.
  * Preserves the original upstream error status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->