### PR TITLE
docs(adr): record the LWQL granularity reserved-parameter design

### DIFF
--- a/dev/docs/adr/101-lwql-granularity-reserved-parameter.md
+++ b/dev/docs/adr/101-lwql-granularity-reserved-parameter.md
@@ -1,0 +1,164 @@
+# ADR-101: Datapoint granularity is a fourth reserved LangWatchQL parameter, bound and budgeted server-side
+
+**Date:** 2026-08-24
+
+**Status:** Accepted
+
+**Relates to:** [ADR-081](./081-lwql-table-function-and-ssrf-policy.md) (submitted SQL is never rewritten — the same rule this decision extends to granularity), [ADR-084](./084-lwql-postgres-mapping-tenant-predicate.md) (the same reserved-parameter shape applied to `period_start`/`period_end`).
+
+Behavioural contract: [specs/analytics/lwql-workbench.feature](../../../specs/analytics/lwql-workbench.feature).
+
+## Context
+
+A saved LangWatchQL chart placed on a dashboard needs to bucket its datapoints
+at a size the member controls — per-second, per-minute, per-hour — windowed by
+the dashboard's own date range. The statement's SQL text is fixed at save
+time; the bucket size is a per-render choice made by whatever surface renders
+the chart next.
+
+Two things collide when a caller controls both the window and the granularity of
+the same query. First, bucket count is the actual cost driver of a chart query,
+independent of the window's span: `INTERVAL 1 SECOND` over a seven-day range is
+10,080 buckets from a completely ordinary pairing, already past a workable
+ceiling. Second, ClickHouse compiles the unit half of an `INTERVAL` expression
+to a function name — `INTERVAL 1 HOUR` becomes `toIntervalHour(1)` — so the unit
+cannot itself be a bound value; only the multiplier can. A caller who could set
+that multiplier without the server capping it at a fixed unit could ask for
+whatever bucket count they wanted, self-serve, in every request.
+
+The `period_start`/`period_end` reserved-parameter contract (predates this
+decision) already solved the adjacent problem of a surface varying a value
+inside an otherwise-fixed statement text without rewriting the statement.
+Granularity extends the same shape rather than inventing a second one.
+
+## Decision
+
+**`period_granularity_seconds` joins `period_start` and `period_end` as a
+reserved LangWatchQL parameter name**, declared in a statement as
+`{period_granularity_seconds:UInt32}` and used as the seconds multiplier of a
+fixed-unit interval: `INTERVAL {period_granularity_seconds:UInt32} SECOND`.
+Fixing the unit at seconds and making only the multiplier bindable is what
+lets ClickHouse's compile-time unit requirement and a caller-set bucket size
+coexist at all — the surface has exactly one value left to inject, and it is a
+value, not a function name.
+
+The three reserved names share one refusal: **a request carrying a value for
+any of them is refused**, whether or not the statement declares it. Each name is
+set by whatever is showing the chart; a caller who supplies one is pinning
+something that will then ignore its own surface. Declaration-time and run-time
+are policed by the same validator (`resolveTimeWindow.ts`) so tRPC, REST and
+anything added later cannot drift from each other.
+
+Granularity carries a second contract the window pair does not: **a server-side
+bucket-count budget**, `LWQL_GRANULARITY_MAX_BUCKETS = 10_000`, enforced as
+`ceil(window_seconds / step_seconds) <= budget`. The offered steps are fixed at
+`[1, 60, 3_600]` seconds — one second, one minute, one hour — and only a step
+from that list is ever accepted; day-scale is out of scope for now (a fixed
+86,400-second interval has no notion of a local day and drifts off midnight on
+a DST-transition date, measured against ClickHouse 25.10 over the
+Europe/Amsterdam fallback night). Overflow has two designed outcomes, chosen by
+the caller of the resolver rather than by the request:
+
+- **Refuse** — the workbench and the REST route, where the caller chose the
+  step, get `LangWatchQLGranularityTooFineError` and must pick a coarser one
+  themselves.
+- **Coarsen** — the dashboard, which owns the range but not the caller's
+  original step choice, gets silently bumped to the finest offered step that
+  fits the budget, with `coarsenedFromSeconds` set so the widget can name
+  requested and effective side by side rather than changing a shared control's
+  meaning without saying so.
+
+A window that overflows even the coarsest offered step (one hour) refuses in
+both modes — the budget is a hard cap, not a preference coarsening may trade
+away.
+
+**Declaring granularity without both period bounds is refused at save time**,
+not run time: without a window there is nothing to compute the budget against,
+and refusing at save means an author learns their statement is unrunnable
+before it is anywhere a caller can hit it.
+
+## Rationale / Trade-offs
+
+**Granularity is a cost dial, and the budget is what keeps a caller from moving
+it past a workable size.** Nothing about the statement's SQL text changes
+between a fine and a coarse render — same submitted string, same
+`system.query_log` entry pattern the "never rewritten" guard already protects.
+Only the bound multiplier changes, which is the mechanism the reserved-parameter
+contract exists for.
+
+**Server must vary the value against an immutable query text.** A saved chart's
+identity is its SQL text; a dashboard that coarsens on overflow, a cache keyed
+on the statement, and an audit trail reading `system.query_log` all depend on
+that text staying byte-identical across every render at every granularity. If
+granularity were expressed by rewriting the statement — splicing in a different
+literal `INTERVAL` — the saved chart would carry as many effective identities as
+it has been rendered at, and the "never rewritten" guard from ADR-081/084 would
+have to carve out an exception for exactly the case those ADRs exist to close.
+Binding a parameter, the same mechanism the window pair already uses, keeps one
+statement and N bound values instead of N statements.
+
+**Trust boundary: the server is the final author of the value, never the
+caller.** The three refusals — reserved-name type check, caller-supplied
+check, off-list step check — exist because the granularity multiplier is the
+one part of the query the caller does not get to choose freely, even though it
+looks, syntactically, like an ordinary bound parameter. Membership in
+`LWQL_GRANULARITY_STEPS` is checked by list membership rather than "is a
+positive integer", because coarsening picks its answer from that same list: an
+off-list step admitted at the boundary (7,200 seconds, say) could be
+"coarsened" to the one-hour step — finer than what was asked for — and reported
+as a coarsening, which inverts the guarantee.
+
+**Known deviation, tracked separately.** The tRPC run path currently forwards
+the caller's `onBudgetOverflow` choice rather than fixing it server-side per
+surface (workbench/REST refuse, dashboard coarsens, decided by which door the
+request came through — not by a client-supplied flag). This is tracked as
+[#7502](https://github.com/langwatch/langwatch/issues/7502) and is not resolved
+by this ADR; it is recorded here so the gap is not silently normalized as the
+design.
+
+## Alternatives considered
+
+**A per-request `LIMIT`-style clamp on returned rows, applied after the query
+runs.** Rejected: it would not touch the actual query cost — ClickHouse still
+computes every bucket the fine-grained `INTERVAL` produces — and it hides
+exactly the overflow the budget exists to name. A member would get a
+silently-truncated chart with no signal that the range they asked for was too
+fine for the step they asked for.
+
+**Let the caller pass any positive step, unbounded, and cap only the resulting
+bucket count with a hard row limit at the client.** Rejected for the same
+reason ADR-084 rejected `additional_table_filters` and statement rewriting for
+the window pair: it moves the enforcement point to a place that does not
+prevent the expensive read from happening, only from being displayed in full.
+The budget has to sit where the query is bound, before ClickHouse executes it.
+
+## Consequences
+
+- `period_granularity_seconds` is reserved wherever `period_start`/`period_end`
+  are: schema browser listings, the caller-supplied-parameter refusal, and the
+  save-time validator. A statement can decline the contract entirely — an
+  all-time, ungranulated total is a legitimate chart — but cannot declare it
+  halfway (granularity without both period bounds refuses at save).
+- Day-scale granularity remains unavailable until a reserved `period_timezone`
+  parameter exists; the namespace (`period_` prefix) already anticipates it.
+  Tracked as a follow-up, not part of this decision.
+- `timeWindow.ts` keeps zero imports, including for granularity: the workbench
+  reads the same module the database is bound with, and the policy — the
+  handled errors, the budget arithmetic — stays in `resolveTimeWindow.ts`,
+  which the browser never loads.
+- The tRPC-forwarded-`onBudgetOverflow` deviation ([#7502](https://github.com/langwatch/langwatch/issues/7502))
+  is open. Until it closes, a workbench-style caller reaching the run path
+  through tRPC can, in principle, ask for `coarsen` instead of being refused —
+  narrower than the REST/workbench contract this ADR describes, and worth
+  re-reading this ADR against once it lands.
+
+## References
+
+- Issue [#6713](https://github.com/langwatch/langwatch/issues/6713) — saved-chart granularity, slice 3 of the saved-charts epic ([#6582](https://github.com/langwatch/langwatch/issues/6582))
+- Issue [#7502](https://github.com/langwatch/langwatch/issues/7502) — tRPC run forwards client `onBudgetOverflow` instead of fixing it per surface
+- PR [#7426](https://github.com/langwatch/langwatch/pull/7426) — ships the contract this ADR describes
+- `platform/app/src/server/analytics/lwql/timeWindow.ts` — the reserved-parameter vocabulary, `LWQL_GRANULARITY_STEPS`
+- `platform/app/src/server/analytics/lwql/resolveTimeWindow.ts` — `resolveLangWatchQLGranularity`, `assertLangWatchQLGranularityDeclaration`, the budget
+- `specs/analytics/lwql-workbench.feature` — the behavioural contract
+- [ADR-081](./081-lwql-table-function-and-ssrf-policy.md) — submitted SQL is never rewritten
+- [ADR-084](./084-lwql-postgres-mapping-tenant-predicate.md) — the reserved-parameter shape this decision extends

--- a/dev/docs/adr/101-lwql-granularity-reserved-parameter.md
+++ b/dev/docs/adr/101-lwql-granularity-reserved-parameter.md
@@ -19,7 +19,7 @@ the chart next.
 Two things collide when a caller controls both the window and the granularity of
 the same query. First, bucket count is the actual cost driver of a chart query,
 independent of the window's span: `INTERVAL 1 SECOND` over a seven-day range is
-10,080 buckets from a completely ordinary pairing, already past a workable
+604,800 buckets from a completely ordinary pairing, already past a workable
 ceiling. Second, ClickHouse compiles the unit half of an `INTERVAL` expression
 to a function name — `INTERVAL 1 HOUR` becomes `toIntervalHour(1)` — so the unit
 cannot itself be a bound value; only the multiplier can. A caller who could set

--- a/dev/docs/adr/101-lwql-granularity-reserved-parameter.md
+++ b/dev/docs/adr/101-lwql-granularity-reserved-parameter.md
@@ -156,7 +156,7 @@ The budget has to sit where the query is bound, before ClickHouse executes it.
 
 - Issue [#6713](https://github.com/langwatch/langwatch/issues/6713) — saved-chart granularity, slice 3 of the saved-charts epic ([#6582](https://github.com/langwatch/langwatch/issues/6582))
 - Issue [#7502](https://github.com/langwatch/langwatch/issues/7502) — tRPC run forwards client `onBudgetOverflow` instead of fixing it per surface
-- PR [#7426](https://github.com/langwatch/langwatch/pull/7426) — ships the contract this ADR describes
+- PR [#7474](https://github.com/langwatch/langwatch/pull/7474) — workbench epic that ships the contract this ADR describes
 - `platform/app/src/server/analytics/lwql/timeWindow.ts` — the reserved-parameter vocabulary, `LWQL_GRANULARITY_STEPS`
 - `platform/app/src/server/analytics/lwql/resolveTimeWindow.ts` — `resolveLangWatchQLGranularity`, `assertLangWatchQLGranularityDeclaration`, the budget
 - `specs/analytics/lwql-workbench.feature` — the behavioural contract


### PR DESCRIPTION
**Low risk** — docs-only, one new file, zero code/runtime changes. Start here: [`dev/docs/adr/101-lwql-granularity-reserved-parameter.md`](https://github.com/langwatch/langwatch/blob/docs/adr-101-lwql-granularity/dev/docs/adr/101-lwql-granularity-reserved-parameter.md) is the entire diff.

## Why

No issue to close: #6713 (saved-chart granularity, epic #6582 slice 3) was already closed by [#7474](https://github.com/langwatch/langwatch/pull/7474), the merged workbench-epic PR that shipped the design this ADR documents. This PR records that design after the fact — a saved LangWatchQL chart needs its bucket size to vary per-render while its SQL text stays fixed at save time, and ClickHouse's compile-time `INTERVAL` unit collides with letting a caller set that size freely. #7474 solved it; this ADR is the durable record of *why* it was solved that way, including the rejected alternatives. It also documents a known, tracked gap ([#7502](https://github.com/langwatch/langwatch/issues/7502), open) rather than letting the gap go unrecorded.

**Correction (post-review):** an earlier version of this body and the ADR's References section cited PR #7426 as the shipping PR. #7426 is closed and unmerged — the review-clerk on this PR caught the error; the actual merged PR is #7474. Fixed in both places.

## What changed

- **One new file, `dev/docs/adr/101-lwql-granularity-reserved-parameter.md`** → the alternative (folding this into ADR-084, which already covers the sibling `period_start`/`period_end` reserved-parameter contract) was rejected because granularity carries a contract the window pair doesn't (the server-side bucket-count budget and its two overflow modes) — conflating them would bury that distinction in an ADR that isn't about budgets.
- **No code changes.** The design was already shipped in #7474; this PR ships no diff to `platform/app/src/server/analytics/lwql/*`.

## How it works

Not applicable in the usual "trace the code" sense — this PR *is* the explanation. The ADR documents:
- `period_granularity_seconds` as a fourth reserved LangWatchQL parameter, bound as `INTERVAL {period_granularity_seconds:UInt32} SECOND` (fixed-unit, bindable multiplier — the only way around ClickHouse compiling the `INTERVAL` unit to a function name at compile time).
- The `LWQL_GRANULARITY_MAX_BUCKETS = 10_000` server-side budget and its two overflow outcomes (refuse for workbench/REST, coarsen for dashboards).
- The known deviation (#7502): the tRPC run path currently forwards the caller's `onBudgetOverflow` choice instead of fixing it per-surface.

## Deployment Impact

No deployment impact — docs-only. This PR adds a single Architecture Decision Record (`dev/docs/adr/101-lwql-granularity-reserved-parameter.md`) and changes no other file. No env vars, no Helm values, no default `helm install` behavior, and no BYOC dataplane surface are touched. The design it documents already shipped in #7474; this PR records it after the fact and carries no runtime change of its own.

## Human verification

For if you really don't trust me — independently re-verify this ADR yourself:

1. Open [`dev/docs/adr/101-lwql-granularity-reserved-parameter.md`](https://github.com/langwatch/langwatch/blob/docs/adr-101-lwql-granularity/dev/docs/adr/101-lwql-granularity-reserved-parameter.md) and read it end to end.
2. Cross-check the claimed constants/functions against the shipped code: `platform/app/src/server/analytics/lwql/timeWindow.ts` and `resolveTimeWindow.ts` — confirm `LWQL_GRANULARITY_STEPS = [1, 60, 3600]`, `LWQL_GRANULARITY_MAX_BUCKETS = 10_000`, `resolveLangWatchQLGranularity`, `assertLangWatchQLGranularityDeclaration`, and `LangWatchQLBudgetOverflowMode = "refuse" | "coarsen"` all exist as described.
3. Recompute the worked example yourself: `INTERVAL 1 SECOND` over a 7-day range = 7 × 86,400 = 604,800 buckets. Confirm the ADR states this number, not a stale draft value.
4. Open #6713, #7502, #7474 and confirm their live state matches what the ADR claims (#6713 closed-by-#7474, #7502 open/tracked, #7474 merged).
5. Judge the decision on the merits: does folding `period_granularity_seconds` into ADR-084 instead of a new ADR look wrong to you? Does the rejected-alternatives section hold up?

## How I can prove I was successful

This is a docs-only ADR with no running-system surface (no UI, no API response, no CLI output) — the applicable evidence shape is cross-reading the shipped source and independently recomputing the claims, not a test run. Every claim below was exercised this session, not assumed:

| Claim | Status | Evidence |
|---|---|---|
| ADR's named constants/functions exist exactly as described | **Proven** | Read `platform/app/src/server/analytics/lwql/timeWindow.ts` and `resolveTimeWindow.ts` directly and confirmed `LWQL_GRANULARITY_STEPS = [1, 60, 3600]`, `LWQL_GRANULARITY_MAX_BUCKETS = 10_000`, `resolveLangWatchQLGranularity`, `assertLangWatchQLGranularityDeclaration`, `LangWatchQLBudgetOverflowMode = "refuse" \| "coarsen"`, `coarsenedFromSeconds` all present |
| Worked-example arithmetic is correct | **Proven** | Recomputed independently: `INTERVAL 1 SECOND` over 7 days = 7 × 86,400 = 604,800 buckets (an earlier draft had 10,080 — wrong; caught and fixed in commit `9374ab4cbf` during this same PR's review) |
| Format matches sibling ADRs | **Proven** | Diffed section structure against ADR-081 and ADR-084; grepped `dev/docs/adr/**` for the heading convention — `Behavioural contract:` used 20×, `Behavioral contract:` used 0× — confirmed this ADR matches the corpus, not the outlier |
| Linked issues/PRs are in the state the ADR claims | **Corrected, now proven** | An earlier version of the ADR and this body cited PR #7426 as the shipping PR — this was wrong (#7426 is closed, unmerged). The review-clerk assigned to this PR caught it; verified live via `gh pr view 7426/7474 --json state,mergedAt`: #7426 CLOSED/unmerged, #7474 MERGED (2026-08-24, closed #6713). Both the ADR's References section and this body are now fixed to cite #7474. |
| The rendered document itself is legible and renders as intended | **Proven** | Screenshot of the ADR rendered by GitHub's own markdown viewer, below |

![ADR-101 rendered](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7506/adr-rendered.png)

## Anything surprising?

The initial draft of this ADR had the seven-day-range bucket-count example wrong (10,080 instead of the correct 604,800) — caught by CodeRabbit review on this same PR and fixed in a follow-up commit before merge. A second CodeRabbit comment suggesting "Behavioural" → "Behavioral" (US spelling) was investigated and declined: the repo's own ADR corpus uses "Behavioural contract:" as a fixed heading 20 times and "Behavioral contract:" zero times, so the suggested change would have made this ADR the outlier rather than more consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for controlling query time-period granularity using fixed-second intervals.
  - Documented supported intervals of 1 second, 1 minute, and 1 hour.
  - Clarified validation rules, including required time bounds and a limit of 10,000 result buckets.
  - Explained how dashboards automatically select the finest suitable interval, while unsupported or excessive ranges are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
