### PR TITLE
fix(haven): `up` builds the api bundle it runs, and names the CA-serial trap

### DIFF
--- a/tools/thuishaven/app/bringup_preflight_test.go
+++ b/tools/thuishaven/app/bringup_preflight_test.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/tools/thuishaven/domain"
 )
 
 // The api lane runs the production bundle, so `up` has to guarantee the bundle
@@ -68,6 +72,45 @@ func TestEnsureAPIBundleFailsTheUpWhenTheBuildFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), apiBundleRelPath) {
 		t.Errorf("expected the error to name the missing bundle, got %q", err)
+	}
+}
+
+// A play sandbox supervises the same child plan as `up`, so it needs the same
+// guarantee. This pins the wiring: remove the call and the sandbox goes back to
+// serving nothing.
+func TestPreparePlaySandboxBuildsTheAPIBundle(t *testing.T) {
+	root := t.TempDir()
+	lwDir := filepath.Join(root, "platform", "app")
+	if err := os.MkdirAll(filepath.Join(root, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(lwDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A lockfile older than the install stamp keeps ensureDeps a no-op, so the
+	// test exercises the prep sequence and not pnpm.
+	if err := os.WriteFile(filepath.Join(root, "pnpm-lock.yaml"), []byte("lockfileVersion: '9.0'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "node_modules", ".modules.yaml"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := &fakeSupervisor{}
+	o := &Orchestrator{sup: sup, log: zap.NewNop()}
+
+	if err := o.preparePlaySandbox(context.Background(), PlaySandbox{Checkout: root, LwDir: lwDir}, domain.Stack{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var built bool
+	for _, sh := range sup.shells {
+		if strings.Contains(sh, "run build") {
+			built = true
+		}
+	}
+	if !built {
+		t.Fatalf("expected the sandbox prep to build the api bundle, ran %v", sup.shells)
 	}
 }
 

--- a/tools/thuishaven/app/bringup_preflight_test.go
+++ b/tools/thuishaven/app/bringup_preflight_test.go
@@ -17,23 +17,78 @@ import (
 // exists before the lane starts. These pin both directions: build the missing
 // one, leave the present one alone.
 
+// buildingSupervisor is a fakeSupervisor whose build actually writes the bundle,
+// the way pnpm does. ensureAPIBundle checks for the file after the build, so a
+// fake that reports success and emits nothing is — correctly — a failed build,
+// and every test that wants a SUCCESSFUL build has to emit one.
+type buildingSupervisor struct {
+	*fakeSupervisor
+	bundle string
+}
+
+func (b *buildingSupervisor) RunOnce(ctx context.Context, name, dir, shell string, env []string) error {
+	if err := b.fakeSupervisor.RunOnce(ctx, name, dir, shell, env); err != nil {
+		return err
+	}
+	if !strings.Contains(shell, "run build") {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(b.bundle), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(b.bundle, []byte("// built\n"), 0o644)
+}
+
 func TestEnsureAPIBundleBuildsWhenTheBundleIsMissing(t *testing.T) {
 	lwDir := t.TempDir()
-	sup := &fakeSupervisor{}
+	inner := &fakeSupervisor{}
+	sup := &buildingSupervisor{fakeSupervisor: inner, bundle: filepath.Join(lwDir, apiBundleRelPath)}
 	o := &Orchestrator{sup: sup}
 
 	if err := o.ensureAPIBundle(context.Background(), lwDir, nil); err != nil {
 		t.Fatalf("expected the build to be attempted, got error: %v", err)
 	}
 
-	if len(sup.shells) != 1 {
-		t.Fatalf("expected exactly one command, got %v", sup.shells)
+	if len(inner.shells) != 1 {
+		t.Fatalf("expected exactly one command, got %v", inner.shells)
 	}
-	if !strings.Contains(sup.shells[0], "run build") {
-		t.Errorf("expected the app build, got %q", sup.shells[0])
+	if !strings.Contains(inner.shells[0], "run build") {
+		t.Errorf("expected the app build, got %q", inner.shells[0])
 	}
-	if sup.dirs[0] != lwDir {
-		t.Errorf("expected the build to run in %q, got %q", lwDir, sup.dirs[0])
+	if inner.dirs[0] != lwDir {
+		t.Errorf("expected the build to run in %q, got %q", lwDir, inner.dirs[0])
+	}
+}
+
+// A build that exits 0 without emitting the bundle is the failure mode an exit
+// code cannot see: the lane would start on a file that is not there and
+// crash-loop with no explanation. Returning nil here is the bug.
+func TestEnsureAPIBundleFailsWhenTheBuildEmitsNoBundle(t *testing.T) {
+	lwDir := t.TempDir()
+	sup := &fakeSupervisor{} // reports success, writes nothing
+	o := &Orchestrator{sup: sup}
+
+	err := o.ensureAPIBundle(context.Background(), lwDir, nil)
+	if err == nil {
+		t.Fatal("expected a build that produced no bundle to stop the up")
+	}
+	if !strings.Contains(err.Error(), apiBundleRelPath) {
+		t.Errorf("expected the error to name the bundle it wanted, got %q", err)
+	}
+}
+
+// `node <a directory>` fails exactly like a missing file, so a directory parked
+// at the bundle path must not count as "the bundle is already there".
+func TestEnsureAPIBundleRejectsADirectoryAtTheBundlePath(t *testing.T) {
+	lwDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(lwDir, apiBundleRelPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sup := &fakeSupervisor{}
+	o := &Orchestrator{sup: sup}
+
+	if err := o.ensureAPIBundle(context.Background(), lwDir, nil); err == nil {
+		t.Fatal("expected a directory at the bundle path to stop the up")
 	}
 }
 
@@ -96,21 +151,59 @@ func TestPreparePlaySandboxBuildsTheAPIBundle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sup := &fakeSupervisor{}
+	inner := &fakeSupervisor{}
+	sup := &buildingSupervisor{fakeSupervisor: inner, bundle: filepath.Join(lwDir, apiBundleRelPath)}
 	o := &Orchestrator{sup: sup, log: zap.NewNop()}
 
 	if err := o.preparePlaySandbox(context.Background(), PlaySandbox{Checkout: root, LwDir: lwDir}, domain.Stack{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var built bool
-	for _, sh := range sup.shells {
+	builds := 0
+	for _, sh := range inner.shells {
 		if strings.Contains(sh, "run build") {
-			built = true
+			builds++
 		}
 	}
-	if !built {
-		t.Fatalf("expected the sandbox prep to build the api bundle, ran %v", sup.shells)
+	if builds != 1 {
+		t.Fatalf("expected the sandbox prep to build the api bundle exactly once, ran %v", inner.shells)
+	}
+}
+
+// The build is fatal here, unlike the codegen and seed steps it sits between —
+// a sandbox with stale generated files is still worth looking at, a sandbox
+// whose api never starts is not. Nothing else pins that: flip play.go's
+// ensureAPIBundle call to warn-and-continue, matching the steps around it, and
+// the test above still passes. This is the one that notices — and, because prep
+// must stop before the migrations that follow, it pins the order too.
+func TestPreparePlaySandboxStopsWhenTheAPIBundleFails(t *testing.T) {
+	root := t.TempDir()
+	lwDir := filepath.Join(root, "platform", "app")
+	if err := os.MkdirAll(filepath.Join(root, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(lwDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pnpm-lock.yaml"), []byte("lockfileVersion: '9.0'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "node_modules", ".modules.yaml"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the build fails, so a passing prep would have been free to continue.
+	sup := &fakeSupervisor{err: errors.New("vite exploded"), errOn: "run build"}
+	o := &Orchestrator{sup: sup, log: zap.NewNop()}
+
+	err := o.preparePlaySandbox(context.Background(), PlaySandbox{Checkout: root, LwDir: lwDir}, domain.Stack{})
+	if err == nil {
+		t.Fatal("expected a failed api bundle build to stop the sandbox prep")
+	}
+	for _, sh := range sup.shells {
+		if strings.Contains(sh, "start:prepare:db") {
+			t.Errorf("expected prep to stop before migrations, ran %v", sup.shells)
+		}
 	}
 }
 

--- a/tools/thuishaven/app/bringup_preflight_test.go
+++ b/tools/thuishaven/app/bringup_preflight_test.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The api lane runs the production bundle, so `up` has to guarantee the bundle
+// exists before the lane starts. These pin both directions: build the missing
+// one, leave the present one alone.
+
+func TestEnsureAPIBundleBuildsWhenTheBundleIsMissing(t *testing.T) {
+	lwDir := t.TempDir()
+	sup := &fakeSupervisor{}
+	o := &Orchestrator{sup: sup}
+
+	if err := o.ensureAPIBundle(context.Background(), lwDir, nil); err != nil {
+		t.Fatalf("expected the build to be attempted, got error: %v", err)
+	}
+
+	if len(sup.shells) != 1 {
+		t.Fatalf("expected exactly one command, got %v", sup.shells)
+	}
+	if !strings.Contains(sup.shells[0], "run build") {
+		t.Errorf("expected the app build, got %q", sup.shells[0])
+	}
+	if sup.dirs[0] != lwDir {
+		t.Errorf("expected the build to run in %q, got %q", lwDir, sup.dirs[0])
+	}
+}
+
+func TestEnsureAPIBundleSkipsTheBuildWhenTheBundleIsPresent(t *testing.T) {
+	lwDir := t.TempDir()
+	bundle := filepath.Join(lwDir, apiBundleRelPath)
+	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bundle, []byte("// built"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := &fakeSupervisor{}
+	o := &Orchestrator{sup: sup}
+
+	if err := o.ensureAPIBundle(context.Background(), lwDir, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(sup.shells) != 0 {
+		t.Errorf("expected no rebuild for an existing bundle, ran %v", sup.shells)
+	}
+}
+
+// A failed build must STOP the up. Continuing would start the api lane on a
+// bundle that is not there, which crash-loops behind the app lane's ready
+// probe and serves nothing — the silent failure this whole check exists for.
+func TestEnsureAPIBundleFailsTheUpWhenTheBuildFails(t *testing.T) {
+	lwDir := t.TempDir()
+	sup := &fakeSupervisor{err: errors.New("vite exploded")}
+	o := &Orchestrator{sup: sup}
+
+	err := o.ensureAPIBundle(context.Background(), lwDir, nil)
+	if err == nil {
+		t.Fatal("expected a failed build to stop the up")
+	}
+	if !strings.Contains(err.Error(), apiBundleRelPath) {
+		t.Errorf("expected the error to name the missing bundle, got %q", err)
+	}
+}
+
+// The CA-serial preflight. A root-owned ca.srl makes openssl emit ZERO-BYTE
+// host certs, which presents as #7117's already-fixed SAN gap — so the check
+// has to fire before the proxy starts and say what is actually wrong.
+
+func TestPreflightPortlessCAPassesWhenThereIsNoSerialYet(t *testing.T) {
+	home := t.TempDir() // no ~/.portless at all
+	if err := preflightPortlessCAIn(home); err != nil {
+		t.Fatalf("expected a clean pass before portless has ever run, got %v", err)
+	}
+}
+
+func TestPreflightPortlessCAPassesWhenTheSerialIsWritable(t *testing.T) {
+	home := t.TempDir()
+	writeSerial(t, home, 0o644)
+
+	if err := preflightPortlessCAIn(home); err != nil {
+		t.Fatalf("expected a writable serial to pass, got %v", err)
+	}
+}
+
+func TestPreflightPortlessCAStopsTheUpWhenTheSerialIsNotWritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write any file, so the unwritable case cannot be staged")
+	}
+	home := t.TempDir()
+	srl := writeSerial(t, home, 0o400)
+	if err := os.Chmod(srl, 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	err := preflightPortlessCAIn(home)
+	if err == nil {
+		t.Fatal("expected an unwritable CA serial to stop the up")
+	}
+	// The message is the entire value of this check: it must name the file and
+	// steer away from #7117, or the reader re-debugs a fixed bug.
+	msg := err.Error()
+	if !strings.Contains(msg, srl) {
+		t.Errorf("expected the error to name the serial path, got %q", msg)
+	}
+	if !strings.Contains(msg, "#7117") {
+		t.Errorf("expected the error to rule out the SAN bug, got %q", msg)
+	}
+	if !strings.Contains(msg, "-size 0 -delete") {
+		t.Errorf("expected the error to give the cleanup command, got %q", msg)
+	}
+}
+
+func writeSerial(t *testing.T, home string, mode os.FileMode) string {
+	t.Helper()
+	srl := portlessCASerialPath(home)
+	if err := os.MkdirAll(filepath.Dir(srl), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srl, []byte("00\n"), mode); err != nil {
+		t.Fatal(err)
+	}
+	return srl
+}

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -2,8 +2,11 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -288,10 +291,72 @@ func (o *Orchestrator) ensurePortlessProxy() error {
 			return fmt.Errorf("could not install portless automatically (%w) — install it by hand (npm install -g portless) and re-run `haven up`", err)
 		}
 	}
+	if err := preflightPortlessCA(); err != nil {
+		return err
+	}
 	if err := o.proxy.EnsureReady(); err != nil {
 		return fmt.Errorf("could not start the portless proxy: %w", err)
 	}
 	return nil
+}
+
+// portlessCASerialPath is the CA serial openssl maintains while signing the
+// per-host certificates portless serves.
+func portlessCASerialPath(home string) string {
+	return filepath.Join(home, ".portless", "ca.srl")
+}
+
+// preflightPortlessCA stops the up when portless's CA serial file exists but
+// cannot be written.
+//
+// openssl WRITES the serial as it signs (`-CAserial`), so a ca.srl left
+// root-owned by an earlier sudo run makes every per-host signing fail — and
+// the failure is silent: portless leaves a ZERO-BYTE .pem behind instead of
+// erroring, the proxy then serves that hostname with no certificate at all,
+// and the handshake dies with "no peer certificate available".
+//
+// That symptom is indistinguishable from the SAN gap of #7117, which is
+// already fixed (per-stack SANs ship in the cert request). Without this check
+// the next person reads the dead handshake as that bug returning and goes
+// looking for a fix that is already in the tree. Naming the real cause here is
+// the whole point.
+//
+// Reporting only, never repairing: the file is root-owned because something
+// outside haven ran as root, and deleting another user's files is not a dev
+// tool's call. An unreadable home dir or any non-permission error is left to
+// portless to report — this check answers one question and stays quiet
+// otherwise.
+func preflightPortlessCA() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return preflightPortlessCAIn(home)
+}
+
+// preflightPortlessCAIn is preflightPortlessCA against an explicit home, so the
+// check can be exercised without touching the developer's own ~/.portless.
+func preflightPortlessCAIn(home string) error {
+	srl := portlessCASerialPath(home)
+	if _, err := os.Stat(srl); err != nil {
+		// No serial yet — portless creates one owned by whoever runs it.
+		return nil
+	}
+	f, err := os.OpenFile(srl, os.O_WRONLY, 0)
+	if err == nil {
+		_ = f.Close()
+		return nil
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		return nil
+	}
+	return fmt.Errorf(
+		"portless's CA serial is not writable by you: %s\n"+
+			"openssl writes it while signing, so every per-host certificate comes out EMPTY and the proxy serves no certificate at all — the handshake failure looks exactly like the SAN bug of #7117, which is already fixed.\n"+
+			"Clear the root-owned leftovers and the empty certs they produced, then re-run `haven up` (no sudo needed — the directory is yours):\n"+
+			"  rm -f %s ~/.portless/proxy.tls\n"+
+			"  find ~/.portless/host-certs -name '*.pem' -size 0 -delete",
+		srl, srl)
 }
 
 // serviceEndpoint resolves how one routed service is actually reachable.
@@ -397,6 +462,9 @@ func (o *Orchestrator) prepareWorktree(ctx context.Context, p UpParams, st domai
 	if err := o.sup.RunOnce(ctx, "codegen", p.LwDir, "pnpm -s run start:prepare:files", env); err != nil {
 		o.log.Warn("codegen (start:prepare:files) failed (continuing)", zap.Error(err))
 	}
+	if err := o.ensureAPIBundle(ctx, p.LwDir, env); err != nil {
+		return err
+	}
 	// Migrations failing on an existing database is the one prep step that must
 	// STOP the up: continuing would boot the app onto a half-migrated schema,
 	// and silently dropping the data to get past it is never haven's call.
@@ -404,6 +472,36 @@ func (o *Orchestrator) prepareWorktree(ctx context.Context, p UpParams, st domai
 		return fmt.Errorf("migrations failed — nothing was dropped; fix the migration, or run `haven db reset` for a fresh database: %w", err)
 	}
 	o.runSeed(ctx, p, env)
+	return nil
+}
+
+// apiBundleRelPath is what `start:app` executes: the PRODUCTION server bundle.
+// Kept as one constant because the check below and the error it prints must
+// name the same file the lane will look for.
+var apiBundleRelPath = filepath.Join("dist", "server", "server.cjs")
+
+// ensureAPIBundle builds the app bundle when it is missing.
+//
+// The api lane runs `start:app` -> `node dist/server/server.cjs`, but nothing
+// else in the up produces that file: codegen writes generated SOURCE, the
+// migration step only touches the database, and dist/ is gitignored — so a
+// freshly-created worktree has no bundle at all. Without this the lane
+// crash-loops on MODULE_NOT_FOUND while the app (vite) lane sits behind its
+// /api/health ready-probe and never serves the hostname. The stack reports
+// itself up and then answers nothing, which is a much worse failure than a
+// slow first boot.
+//
+// Only the missing case builds. An existing bundle is left alone: rebuilding
+// on every `up` would add a minute to a bring-up for a file that only
+// server-side edits invalidate, and those already require a manual rebuild.
+func (o *Orchestrator) ensureAPIBundle(ctx context.Context, lwDir string, env []string) error {
+	if _, err := os.Stat(filepath.Join(lwDir, apiBundleRelPath)); err == nil {
+		return nil
+	}
+	fmt.Println("building the app bundle (missing — first `up` in this worktree)…")
+	if err := o.sup.RunOnce(ctx, "build", lwDir, "pnpm -s run build", env); err != nil {
+		return fmt.Errorf("the app bundle failed to build — the api lane runs %s and cannot start without it: %w", apiBundleRelPath, err)
+	}
 	return nil
 }
 

--- a/tools/thuishaven/app/orchestrator.go
+++ b/tools/thuishaven/app/orchestrator.go
@@ -350,13 +350,19 @@ func preflightPortlessCAIn(home string) error {
 	if !errors.Is(err, fs.ErrPermission) {
 		return nil
 	}
+	// The diagnostic line names the absolute path so there is no doubt WHICH
+	// file; the command lines below stay on `~` because they are meant to be
+	// pasted into a shell, and a home directory with a space in it (or any
+	// other shell metacharacter) would splice an interpolated absolute path
+	// into the wrong arguments. `~/.portless/ca.srl` IS this file — the path
+	// is always $HOME/.portless/ca.srl — so nothing is lost by the shorthand.
 	return fmt.Errorf(
 		"portless's CA serial is not writable by you: %s\n"+
 			"openssl writes it while signing, so every per-host certificate comes out EMPTY and the proxy serves no certificate at all — the handshake failure looks exactly like the SAN bug of #7117, which is already fixed.\n"+
 			"Clear the root-owned leftovers and the empty certs they produced, then re-run `haven up` (no sudo needed — the directory is yours):\n"+
-			"  rm -f %s ~/.portless/proxy.tls\n"+
+			"  rm -f ~/.portless/ca.srl ~/.portless/proxy.tls\n"+
 			"  find ~/.portless/host-certs -name '*.pem' -size 0 -delete",
-		srl, srl)
+		srl)
 }
 
 // serviceEndpoint resolves how one routed service is actually reachable.
@@ -494,13 +500,25 @@ var apiBundleRelPath = filepath.Join("dist", "server", "server.cjs")
 // Only the missing case builds. An existing bundle is left alone: rebuilding
 // on every `up` would add a minute to a bring-up for a file that only
 // server-side edits invalidate, and those already require a manual rebuild.
+//
+// The contract is the whole point: when this returns nil, node has a file to
+// execute. So both ends are checked against that, not against a weaker proxy.
+// A REGULAR file, because `node <a directory>` is the same crash by another
+// name; and re-checked AFTER the build, because a build can exit 0 without
+// emitting the server bundle (a changed build script, a partial run) and
+// trusting the exit code would hand the lane the exact MODULE_NOT_FOUND
+// crash-loop this function exists to prevent — only now with no explanation.
 func (o *Orchestrator) ensureAPIBundle(ctx context.Context, lwDir string, env []string) error {
-	if _, err := os.Stat(filepath.Join(lwDir, apiBundleRelPath)); err == nil {
+	bundle := filepath.Join(lwDir, apiBundleRelPath)
+	if info, err := os.Stat(bundle); err == nil && info.Mode().IsRegular() {
 		return nil
 	}
 	fmt.Println("building the app bundle (missing — first `up` in this worktree)…")
 	if err := o.sup.RunOnce(ctx, "build", lwDir, "pnpm -s run build", env); err != nil {
 		return fmt.Errorf("the app bundle failed to build — the api lane runs %s and cannot start without it: %w", apiBundleRelPath, err)
+	}
+	if info, err := os.Stat(bundle); err != nil || !info.Mode().IsRegular() {
+		return fmt.Errorf("the app build reported success but left no %s behind — the api lane runs that file and cannot start without it", apiBundleRelPath)
 	}
 	return nil
 }

--- a/tools/thuishaven/app/play.go
+++ b/tools/thuishaven/app/play.go
@@ -1141,6 +1141,15 @@ func (o *Orchestrator) preparePlaySandbox(ctx context.Context, pl PlaySandbox, s
 	if err := o.sup.RunOnce(ctx, "codegen", pl.LwDir, "pnpm -s run start:prepare:files", env); err != nil {
 		o.log.Warn("play codegen failed (continuing)", zap.Error(err))
 	}
+	// A sandbox supervises the SAME child plan as `up` (planChildren below), so
+	// its api lane runs the production bundle too and the checkout it was cut
+	// from has no dist/. Fatal for the same reason it is fatal there: without
+	// the bundle the api never starts and the app lane never leaves its ready
+	// probe, so the sandbox serves nothing at all — and a sandbox that serves
+	// nothing is not "worth looking at" the way stale codegen is.
+	if err := o.ensureAPIBundle(ctx, pl.LwDir, env); err != nil {
+		return err
+	}
 	if err := o.sup.RunOnce(ctx, "prepare", pl.LwDir, "pnpm -s run start:prepare:db", env); err != nil {
 		return fmt.Errorf("play migrations failed: %w", err)
 	}

--- a/tools/thuishaven/app/play_seed_test.go
+++ b/tools/thuishaven/app/play_seed_test.go
@@ -36,14 +36,22 @@ func (fakeContainer) Ensure(context.Context) (string, error) { return "unix:///f
 func (fakeContainer) Profile() string                        { return "fake" }
 
 // playCheckout is a complete-enough checkout for the launcher: a lockfile (so
-// the dependency install resolves a workspace root) and the app directory.
+// the dependency install resolves a workspace root), the app directory, and an
+// already-built api bundle. The bundle is part of "complete enough" because
+// preparePlaySandbox refuses to continue without one — these are seed tests, so
+// they start from a checkout that has been built and say nothing about the
+// build itself; TestPreparePlaySandbox* covers that.
 func playCheckout(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(dir, "platform", "app"), 0o750); err != nil {
+	bundle := filepath.Join(dir, "platform", "app", apiBundleRelPath)
+	if err := os.MkdirAll(filepath.Dir(bundle), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bundle, []byte("// built\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return dir


### PR DESCRIPTION
## For humans

`make haven up` could finish, print a healthy-looking stack, and then serve nothing at all. Two separate causes, both of which you hit on a clean machine, and both of which fail *quietly* — which is why they cost hours rather than minutes.

**1. Nobody built the thing the app runs.** The API process doesn't run from source, it runs a compiled bundle (`dist/server/server.cjs`). Nothing in the startup sequence ever built that file, and it isn't in git. So on a fresh worktree the API just died on startup, over and over. Meanwhile the web UI is deliberately held back until the API answers a health check — so it waited forever and the address never served anything. Now the startup builds the bundle when it's missing, checks that the build actually produced it, and stops with a clear error otherwise. Only the first `up` in a worktree pays the cost.

**2. A root-owned leftover file broke every HTTPS certificate, silently.** The local proxy signs a certificate per hostname. The signing tool needs to write a small counter file (`~/.portless/ca.srl`). If an earlier `sudo` run left that file owned by root, signing fails — but instead of an error you get an **empty** certificate file. The proxy then serves the address with no certificate, and the browser/curl handshake dies with `no peer certificate available`.

That symptom is identical to issue #7117 (a certificate-naming bug), **which was already fixed and shipped**. So the failure actively points you at the wrong thing. Startup now checks that file up front and, if it can't be written, tells you the real cause and the exact commands to clear it. It only reports — it will not delete files owned by another user.

---

## What changed

`tools/thuishaven/app/orchestrator.go`

- **`ensureAPIBundle`** — runs after codegen, before the services boot, in **both** prep paths (`up` in `orchestrator.go`, and `preparePlaySandbox` in `play.go` — a play sandbox supervises the same child plan, so it had the identical bug). Builds `platform/app` when `dist/server/server.cjs` is absent; a build failure aborts the `up` rather than letting the api lane crash-loop behind the app lane's ready-probe. An existing bundle is never rebuilt (a rebuild on every `up` would add a minute for a file only server-side edits invalidate).

  The contract is *"when this returns nil, node has a file to execute"*, so both ends are checked against exactly that: a **regular** file before reusing one (`node <a directory>` is the same crash by another name), and a re-check **after** the build, because a build can exit 0 without emitting the server bundle — a changed build script, a partial run — and trusting the exit code would hand the lane the same crash-loop with no explanation.
- **`preflightPortlessCA`** — runs inside `ensurePortlessProxy`, before `EnsureReady()`. Fails the `up` when `~/.portless/ca.srl` exists but is not writable, with an error naming the file, ruling out #7117 explicitly, and giving the cleanup commands. No serial yet, a writable serial, an unreadable home, or any non-permission error all pass through silently — the check answers one question.

  The cleanup line it prints is meant to be pasted into a shell, so it names `~/.portless/ca.srl` rather than interpolating the absolute path: a home directory containing a space would splice that across two `rm` arguments. The diagnostic line above it still prints the absolute path, where nothing parses it.

Split as `preflightPortlessCA()` / `preflightPortlessCAIn(home)` so it can be tested without touching the developer's own `~/.portless`.

## Tests

`tools/thuishaven/app/bringup_preflight_test.go` — 10 new tests:

| Behaviour | Pinned |
|---|---|
| Bundle missing | builds, in the app dir |
| Bundle present | no rebuild |
| Build fails | aborts the `up`, error names the bundle |
| Build succeeds but emits no bundle | aborts, error names the bundle it wanted |
| A directory sits at the bundle path | aborts rather than accepting it |
| No serial yet | passes |
| Serial writable | passes |
| Serial unwritable | aborts, error names the path, rules out #7117, gives the cleanup command |
| Play sandbox prep | builds the bundle exactly once (pins the second caller) |
| Play sandbox prep, build fails | returns the error and never reaches the migrations |

The last one is the one that notices if `play.go`'s `ensureAPIBundle` call is ever flipped to warn-and-continue like the codegen and seed steps around it — and, because prep has to stop *before* the migrations that follow, it pins the ordering in the only direction that can break anything.

The unwritable-serial test skips under `euid 0`, since root can write any file and the case cannot be staged.

`tools/thuishaven/app/play_seed_test.go` — the `playCheckout` fixture now ships an already-built bundle. Those are seed tests and say nothing about the build; before the post-build check they were silently relying on a fake supervisor that reported a successful build and wrote nothing, which is precisely the state the new check catches.

## Verification

- `go test ./...` in `tools/thuishaven` — **all packages pass**, no regressions in the existing orchestrator/db/play suites.
- `go test -count=1 -race ./tools/thuishaven/...` (what CI runs) — passes.
- `go build ./...`, `go vet ./tools/thuishaven/...` — clean.
- `golangci-lint v2.11.4 --new-from-merge-base=origin/main --enable-only=funlen,gocognit,revive` over CI's package list — **0 issues**.
- Both fixes were derived from a live bring-up: the empty-certificate diagnosis was confirmed with `openssl s_client` (the served cert had correct per-stack SANs once the root-owned serial was cleared, proving #7117's fix is genuinely in place), and the missing bundle was confirmed by the api lane never binding its port until `pnpm run build` was run by hand.

## Known limits

- **Staleness is not detected.** The check is existence-only, so an out-of-date `dist/` is still used as-is; server-side edits continue to need a manual `pnpm run build`. Rebuilding every `up` to close this would cost a minute per bring-up, which is the worse trade.
- **Only the serial is checked**, not the whole `~/.portless` directory. A writable `ca.srl` inside a directory you cannot write still fails later, in portless's own words.

## Risk

Low, and confined to `haven up`. The bundle build is additive and skipped whenever a real bundle exists. The preflight is read-only, fails open on every ambiguous case, and only turns a silent broken-TLS stack into a loud actionable error. The one behaviour that got *stricter* — erroring when a build reports success and leaves no bundle — replaces a silent crash-loop with a named failure.
