### PR TITLE
feat(governance): the anthropic composer's closed domains become pickers

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The Anthropic composer's three closed-domain fields, and the one place their
+ * domains are allowed to be written down.
+ *
+ * `report` and `bucketWidth` are enums the puller already declares; `startingAt`
+ * is an instant. Rendering them as free text meant the domain lived in a hint,
+ * and the admin found out they had mistyped it from a rejected save. Rendering
+ * them as pickers moves the domain into the form — which is only an improvement
+ * while the form's list and the adapter's schema still say the same thing, so
+ * the option lists are asserted against `anthropicAdminPullConfigSchema` rather
+ * than against a second hand-written copy of themselves.
+ *
+ * The startingAt field carries the subtler risk. Every value that reaches
+ * storage has been through `normalizeStartingAt`, which returns an ISO instant
+ * — so the edit form always seeds an instant, never a calendar date, and a
+ * plain `<input type="date">` handed one renders blank. Blank on an edit form
+ * reads as "no backfill start configured", and saving from there would drop a
+ * setting the admin never touched. The date control therefore shows the
+ * instant's calendar date and leaves the underlying value alone until the
+ * admin actually picks a new one.
+ */
+
+import { describe, expect, it } from "vitest";
+import { anthropicAdminPullConfigSchema } from "../../../services/pullers/anthropicAdmin.puller";
+import {
+  buildAnthropicAdminPullConfig,
+  type ComposerState,
+  dateInputValue,
+  fieldControl,
+  PARSER_FIELDS,
+  reconcileParserValues,
+  seedComposerParserConfig,
+} from "../inventory";
+
+const fieldFor = (key: string) => {
+  const field = PARSER_FIELDS.anthropic_admin.find((f) => f.key === key);
+  if (!field) throw new Error(`no anthropic_admin field named ${key}`);
+  return field;
+};
+
+const selectOptionsFor = (key: string, values: Record<string, string>) => {
+  const control = fieldControl({ field: fieldFor(key), values });
+  if (control.kind !== "select") {
+    throw new Error(`${key} is rendered as ${control.kind}, not a select`);
+  }
+  return control.options;
+};
+
+const composerWith = (parserConfig: Record<string, string>): ComposerState => ({
+  sourceType: "anthropic_admin",
+  name: "Anthropic org",
+  description: "",
+  parserConfig: { credentialsToken: "sk-ant-admin-test", ...parserConfig },
+  pullSchedule: "0 * * * *",
+  ottlStatements: [],
+});
+
+describe("Anthropic composer controls", () => {
+  describe("the report field", () => {
+    // @scenario "The report offers the two reports that exist and nothing else"
+    it("offers exactly the reports the adapter schema declares", () => {
+      const offered = selectOptionsFor("report", {})
+        .map((o) => o.value)
+        .filter((v) => v !== "");
+
+      expect(offered).toEqual([
+        ...anthropicAdminPullConfigSchema.shape.report.options,
+      ]);
+    });
+
+    // @scenario "A required choice does not answer itself"
+    it("offers an unselected entry so a native select cannot preselect for the admin", () => {
+      const options = selectOptionsFor("report", {});
+
+      // A controlled <select> whose value is "" and whose option list has no
+      // "" entry displays its first option while the state stays empty: the
+      // admin is shown "cost" without ever having chosen it.
+      expect(options[0]?.value).toBe("");
+      expect(fieldFor("report").required).toBe(true);
+    });
+  });
+
+  describe("the bucket width field", () => {
+    // @scenario "The bucket widths offered are the ones the adapter declares"
+    it("offers the widths the adapter schema accepts, and no others", () => {
+      const offered = selectOptionsFor("bucketWidth", { report: "usage" })
+        .map((o) => o.value)
+        .filter((v) => v !== "");
+
+      expect(offered).toEqual([
+        ...anthropicAdminPullConfigSchema.shape.bucketWidth.removeDefault()
+          .options,
+      ]);
+    });
+
+    // @scenario "The cost report offers no width to choose between"
+    it("collapses to the default entry on a cost source", () => {
+      const options = selectOptionsFor("bucketWidth", { report: "cost" });
+
+      expect(options.map((o) => o.value)).toEqual([""]);
+      expect(
+        fieldControl({
+          field: fieldFor("bucketWidth"),
+          values: { report: "cost" },
+        }),
+      ).toMatchObject({ hint: expect.stringContaining("always daily") });
+    });
+
+    // @scenario "Switching to the cost report drops a width already chosen"
+    it("clears a width the cost report would refuse", () => {
+      const reconciled = reconcileParserValues({
+        sourceType: "anthropic_admin",
+        values: { report: "cost", bucketWidth: "1h" },
+      });
+
+      expect(reconciled.bucketWidth).toBe("");
+      expect(
+        buildAnthropicAdminPullConfig(composerWith(reconciled)),
+      ).not.toBeNull();
+    });
+
+    // @scenario "Leaving the bucket width alone still means the adapter default"
+    it("submits no bucket width when the default entry is left in place", () => {
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: "usage", bucketWidth: "" }),
+      );
+
+      expect(built).not.toBeNull();
+      expect(built).not.toHaveProperty("bucketWidth");
+    });
+  });
+
+  describe("the backfill start field", () => {
+    // @scenario "The backfill start is a date control"
+    it("is a date control rather than free text", () => {
+      expect(
+        fieldControl({ field: fieldFor("startingAt"), values: {} }).kind,
+      ).toBe("date");
+    });
+
+    // @scenario "A stored instant is shown as its calendar date"
+    it("shows a seeded instant as the date a date input can display", () => {
+      const seeded = seedComposerParserConfig({
+        sourceType: "anthropic_admin",
+        storedParserConfig: {
+          report: "usage",
+          startingAt: "2026-08-01T00:00:00.000Z",
+        },
+      });
+
+      expect(dateInputValue(seeded.startingAt ?? "")).toBe("2026-08-01");
+    });
+
+    // @scenario "Showing an instant on a date control does not rewrite it"
+    it("keeps an untouched instant intact through a save", () => {
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({
+          report: "usage",
+          startingAt: "2026-08-01T13:45:00.000Z",
+        }),
+      );
+
+      // The display truncates to the calendar date; the value must not.
+      expect(dateInputValue("2026-08-01T13:45:00.000Z")).toBe("2026-08-01");
+      expect(built).toMatchObject({ startingAt: "2026-08-01T13:45:00.000Z" });
+    });
+
+    // @scenario "A picked date is still normalized to an instant before saving"
+    it("normalizes a freshly picked date to an instant", () => {
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: "usage", startingAt: "2026-08-01" }),
+      );
+
+      expect(built).toMatchObject({ startingAt: "2026-08-01T00:00:00.000Z" });
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -9,6 +9,7 @@ import {
   Heading,
   HStack,
   Input,
+  NativeSelect,
   Spacer,
   Spinner,
   Tabs,
@@ -1455,6 +1456,119 @@ interface FieldDef {
    * every advanced field untouched must always produce a working source.
    */
   advanced?: boolean;
+  /**
+   * How the field is rendered. Absent means a text input.
+   *
+   * A field only earns a `select` when its domain is closed and small enough
+   * that showing it beats describing it — the point is to move the domain out
+   * of the hint and into the control, so a wrong value is unreachable rather
+   * than merely rejected. `date` is for values the admin thinks of as a day.
+   */
+  control?: "select" | "date";
+  /**
+   * The choices, for `control: "select"`.
+   *
+   * Takes the sibling field values because a domain can depend on them: the
+   * Anthropic cost report accepts no bucket width at all, and offering one
+   * there would offer a value the builder refuses.
+   */
+  options?: (values: Record<string, string>) => readonly FieldOption[];
+  /**
+   * A hint that replaces `hint` for some sibling-field states. Same reason as
+   * `options` — "cost is always daily" is only true on a cost source.
+   */
+  contextHint?: (values: Record<string, string>) => string | undefined;
+}
+
+/** One entry in a `control: "select"` field's list. */
+export interface FieldOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * What to render for a field, once its sibling values are known.
+ *
+ * Kept separate from `parserFieldPresentation`, which answers the create-vs-edit
+ * question and needs no sibling context. This one answers "what control, with
+ * what choices", and is the only place a select's option list comes from — the
+ * render, the staleness check in `reconcileParserValues` and the tests all read
+ * the same list, so a domain cannot drift between what is offered and what is
+ * accepted.
+ */
+export type FieldControl =
+  | { kind: "text"; hint?: string }
+  | { kind: "date"; hint?: string }
+  | { kind: "select"; options: readonly FieldOption[]; hint?: string };
+
+export function fieldControl({
+  field,
+  values,
+}: {
+  field: FieldDef;
+  values: Record<string, string>;
+}): FieldControl {
+  const hint = field.contextHint?.(values);
+  if (field.control === "date") return { kind: "date", hint };
+  if (field.control === "select") {
+    return { kind: "select", options: field.options?.(values) ?? [], hint };
+  }
+  return { kind: "text", hint };
+}
+
+/**
+ * The composer values with any select field cleared whose held value is not
+ * among the choices its own control offers.
+ *
+ * The case this exists for: an admin picks a bucket width of `1h`, then
+ * switches the report to `cost`. The width is now a value `validBucketWidth`
+ * refuses outright — not ignores — so leaving it in place would reject the
+ * whole save for a field the form no longer even offers. Clearing it is the
+ * only outcome that matches what the admin is being shown.
+ *
+ * Deliberately narrow: text and date fields are never touched, because their
+ * domains are not enumerable and "not in the list" means nothing there.
+ */
+export function reconcileParserValues({
+  sourceType,
+  values,
+}: {
+  sourceType: SourceType;
+  values: Record<string, string>;
+}): Record<string, string> {
+  let next = values;
+  for (const field of PARSER_FIELDS[sourceType] ?? []) {
+    const held = values[field.key];
+    if (!held) continue;
+    const control = fieldControl({ field, values });
+    if (control.kind !== "select") continue;
+    if (control.options.some((option) => option.value === held)) continue;
+    if (next === values) next = { ...values };
+    next[field.key] = "";
+  }
+  return next;
+}
+
+/**
+ * The `YYYY-MM-DD` an `<input type="date">` can display for a stored value.
+ *
+ * Every backfill start that reaches storage has been through
+ * `normalizeStartingAt`, which returns an ISO instant — so the edit form always
+ * seeds an instant, never a bare date, and a date input handed one renders
+ * blank. Blank reads as "no backfill start configured", and saving from there
+ * would drop a setting the admin never touched.
+ *
+ * Truncating to the UTC calendar date is display-only: the held value is left
+ * alone until the admin picks a different day, so an instant that carries a
+ * time of day survives an edit to any other field.
+ */
+export function dateInputValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) return "";
+  return new Date(parsed).toISOString().slice(0, 10);
 }
 
 /**
@@ -1464,6 +1578,49 @@ interface FieldDef {
  * one". Everything else — validation, masking, storage routing — is shared.
  */
 export type ParserConfigMode = "create" | "edit";
+
+/**
+ * The bucket widths Anthropic's usage report accepts, newest-grained first.
+ *
+ * One list, read by both the picker and `validBucketWidth`, so the form cannot
+ * offer a width the builder then refuses. The adapter's own
+ * `anthropicAdminPullConfigSchema` declares the same domain server-side and the
+ * unit test asserts the two still agree — that cross-check is what keeps this
+ * from becoming a second source of truth rather than a projection of the first.
+ */
+const ANTHROPIC_BUCKET_WIDTHS = ["1m", "1h", "1d"] as const;
+
+const ANTHROPIC_BUCKET_WIDTH_LABELS: Record<string, string> = {
+  "1m": "1m — per minute",
+  "1h": "1h — hourly",
+  "1d": "1d — daily",
+};
+
+/**
+ * The bucket widths offered for the report currently selected.
+ *
+ * The cost report gets the default entry alone. Not politeness: the puller
+ * pins `COST_REPORT_BUCKET_WIDTH` and ignores `config.bucketWidth`, so
+ * `validBucketWidth` rejects any width on a cost source — offering one would
+ * offer a value whose only effect is to fail the save.
+ */
+function anthropicBucketWidthOptions(
+  values: Record<string, string>,
+): readonly FieldOption[] {
+  const isUsage = (values.report ?? "").trim().toLowerCase() === "usage";
+  const fallback: FieldOption = {
+    value: "",
+    label: isUsage ? "Default (1d — daily)" : "1d — daily",
+  };
+  if (!isUsage) return [fallback];
+  return [
+    fallback,
+    ...ANTHROPIC_BUCKET_WIDTHS.map((width) => ({
+      value: width,
+      label: ANTHROPIC_BUCKET_WIDTH_LABELS[width] ?? width,
+    })),
+  ];
+}
 
 export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
   // No parser-config fields for generic OTel sources today - the
@@ -1576,22 +1733,39 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
     },
     {
       key: "report",
-      label: "Report (usage or cost)",
-      placeholder: "cost",
+      label: "Report",
+      placeholder: "",
       hint: "Exactly one per source. `cost` carries Anthropic's own reported spend (Priority Tier usage is excluded, so it is close to but not the invoice); `usage` pulls token counts that we price ourselves. Never create both reports for the same organization — the same spend would be counted twice.",
       required: true,
+      control: "select",
+      // The empty first entry is load-bearing, not decorative: a controlled
+      // <select> holding "" with no "" option displays its first real option,
+      // so the admin would be shown a report they never chose on a field the
+      // form marks required.
+      options: () => [
+        { value: "", label: "Select a report…" },
+        { value: "usage", label: "Usage — token counts, priced by us" },
+        { value: "cost", label: "Cost — Anthropic's reported spend" },
+      ],
     },
     {
       key: "bucketWidth",
-      label: "Bucket width (optional, usage report only)",
-      placeholder: "1d",
-      hint: "1m, 1h or 1d. Only affects the usage report; cost is always daily. Default 1d.",
+      label: "Bucket width",
+      placeholder: "",
+      hint: "How finely the usage report is bucketed. Only the usage report reads this; cost is always daily.",
+      control: "select",
+      options: anthropicBucketWidthOptions,
+      contextHint: (values) =>
+        (values.report ?? "").trim().toLowerCase() === "cost"
+          ? "The cost report is always daily — Anthropic buckets it that way and the puller pins it, so there is nothing to choose here."
+          : undefined,
     },
     {
       key: "startingAt",
       label: "Backfill start (optional)",
-      placeholder: "2026-08-01",
-      hint: "The date the first run reads from: `2026-08-01`, or an instant carrying a timezone (`2026-08-01T00:00:00Z`). A time without a timezone is rejected rather than read as yours. Empty = 3 calendar days back at midnight UTC for cost, 1 calendar day back at midnight UTC for usage.",
+      placeholder: "",
+      hint: "The day the first run reads from. Later runs follow the cursor instead. Empty = 3 calendar days back at midnight UTC for cost, 1 calendar day back at midnight UTC for usage.",
+      control: "date",
     },
   ],
   databricks_genie: [
@@ -1902,7 +2076,9 @@ function validBucketWidth(
 ): string | null | undefined {
   if (!raw) return undefined;
   if (report !== "usage") return null;
-  return ["1m", "1h", "1d"].includes(raw) ? raw : null;
+  return (ANTHROPIC_BUCKET_WIDTHS as readonly string[]).includes(raw)
+    ? raw
+    : null;
 }
 
 /** Whether y-m-d is a date that exists, rather than one Date would roll forward. */
@@ -2060,6 +2236,102 @@ export function parserFieldPresentation({
   };
 }
 
+/**
+ * The input itself, chosen by control kind.
+ *
+ * Split from `ParserConfigField` so the label, the required marker and the hint
+ * are decided in one place and the control in another — the two were growing a
+ * shared ternary chain, which is how a field ends up rendering one control and
+ * labelling another.
+ */
+function ParserFieldInput({
+  control,
+  isMultiline,
+  isSecret,
+  placeholder,
+  readOnly,
+  value,
+  onChange,
+}: {
+  control: FieldControl;
+  isMultiline: boolean;
+  isSecret: boolean;
+  placeholder: string;
+  readOnly: boolean;
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  if (isMultiline) {
+    return (
+      <Textarea
+        size="sm"
+        rows={6}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        fontFamily="mono"
+        readOnly={readOnly}
+      />
+    );
+  }
+
+  if (control.kind === "select") {
+    // A native select has no readOnly — HTML ignores the attribute there, and
+    // `disabled` is the only thing that would stop the change, at the cost of
+    // dropping the field out of the tab order. So a locked choice is shown as
+    // its own label in a readOnly input instead: genuinely unchangeable, and
+    // still reachable and readable, which is the rule the branches below keep.
+    if (readOnly) {
+      const chosen = control.options.find((option) => option.value === value);
+      return <Input size="sm" value={chosen?.label ?? value} readOnly />;
+    }
+    return (
+      <NativeSelect.Root size="sm">
+        <NativeSelect.Field
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {control.options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </NativeSelect.Field>
+        <NativeSelect.Indicator />
+      </NativeSelect.Root>
+    );
+  }
+
+  if (control.kind === "date") {
+    return (
+      <Input
+        size="sm"
+        type="date"
+        // Display-only truncation — see `dateInputValue`. The held value stays
+        // whatever was stored until the admin picks a different day.
+        value={dateInputValue(value)}
+        onChange={(e) => onChange(e.target.value)}
+        readOnly={readOnly}
+      />
+    );
+  }
+
+  return (
+    <Input
+      size="sm"
+      type={isSecret ? "password" : "text"}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      // readOnly, never disabled: a locked field is shown precisely so the
+      // admin can read what it holds, and `disabled` drops it out of the tab
+      // order where a keyboard or screen-reader user cannot reach it. The
+      // Textarea branch above says the same thing.
+      readOnly={readOnly}
+    />
+  );
+}
+
 function ParserConfigField({
   field,
   values,
@@ -2075,9 +2347,8 @@ function ParserConfigField({
 }) {
   const { isSecret, isMultiline, isRequired, hint, placeholder } =
     parserFieldPresentation({ field, mode });
-  const value = values[field.key] ?? "";
-  const handleChange = (next: string) =>
-    onChange({ ...values, [field.key]: next });
+  const control = fieldControl({ field, values });
+  const shownHint = control.hint ?? hint;
 
   return (
     <VStack align="stretch" gap={1}>
@@ -2089,33 +2360,18 @@ function ParserConfigField({
           </Text>
         )}
       </Text>
-      {isMultiline ? (
-        <Textarea
-          size="sm"
-          rows={6}
-          value={value}
-          onChange={(e) => handleChange(e.target.value)}
-          placeholder={placeholder}
-          fontFamily="mono"
-          readOnly={readOnly}
-        />
-      ) : (
-        <Input
-          size="sm"
-          type={isSecret ? "password" : "text"}
-          value={value}
-          onChange={(e) => handleChange(e.target.value)}
-          placeholder={placeholder}
-          // readOnly, never disabled: a locked field is shown precisely so the
-          // admin can read what it holds, and `disabled` drops it out of the
-          // tab order where a keyboard or screen-reader user cannot reach it.
-          // The Textarea branch above says the same thing.
-          readOnly={readOnly}
-        />
-      )}
-      {hint && (
+      <ParserFieldInput
+        control={control}
+        isMultiline={isMultiline}
+        isSecret={isSecret}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        value={values[field.key] ?? ""}
+        onChange={(next) => onChange({ ...values, [field.key]: next })}
+      />
+      {shownHint && (
         <Text fontSize="xs" color="fg.muted">
-          {hint}
+          {shownHint}
         </Text>
       )}
     </VStack>
@@ -2141,6 +2397,16 @@ export function ParserConfigFields({
    */
   readOnlyKeys?: readonly string[];
 }) {
+  // A held value can stop being offered without the admin touching its field —
+  // switching the Anthropic report to `cost` retires every bucket width. Left
+  // in place it would reject the save for a field the form no longer shows a
+  // choice for, so the correction is pushed back up rather than rendered
+  // around.
+  useEffect(() => {
+    const reconciled = reconcileParserValues({ sourceType, values });
+    if (reconciled !== values) onChange(reconciled);
+  }, [sourceType, values, onChange]);
+
   const fields = PARSER_FIELDS[sourceType];
   const primaryFields = fields.filter((f) => !f.advanced);
   const advancedFields = fields.filter((f) => f.advanced);

--- a/specs/governance/anthropic-source-form-controls.feature
+++ b/specs/governance/anthropic-source-form-controls.feature
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+Feature: Choose Anthropic adapter settings instead of typing them
+  As an organization admin adding or editing an Anthropic Admin API source
+  I want the fields whose answers come from a fixed list to be pickers
+  So that I choose from what the adapter accepts rather than recalling it from
+  a hint and learning I was wrong from a rejected save
+
+  Background:
+    Given an organization with the ingestionSources:manage permission
+    And the source composer is open on the anthropic_admin adapter
+
+  Rule: A field with a closed set of answers is chosen, not typed
+
+    @unit
+    Scenario: The report offers the two reports that exist and nothing else
+      When the admin looks at the report field
+      Then the choices are exactly the usage report and the cost report
+
+    @unit
+    Scenario: The bucket widths offered are the ones the adapter declares
+      Given the report is set to usage
+      When the admin looks at the bucket width field
+      Then the widths offered are the ones the adapter's own schema accepts
+      And no width is offered that the adapter would reject
+
+    @unit
+    Scenario: A required choice does not answer itself
+      When the admin opens the form without touching the report field
+      Then the report field offers an unselected entry carrying no value
+      And the form still marks the report as required
+
+  Rule: A setting the cost report would reject is not offered on a cost source
+
+    @unit
+    Scenario: The cost report offers no width to choose between
+      Given the report is set to cost
+      When the admin looks at the bucket width field
+      Then the only entry offered carries no value
+      And the field explains that the cost report is always daily
+
+    @unit
+    Scenario: Switching to the cost report drops a width already chosen
+      Given the report is set to usage
+      And the admin has chosen a bucket width of 1h
+      When the admin changes the report to cost
+      Then the bucket width is cleared
+      And the configuration builds instead of refusing the unusable width
+
+  Rule: A date is picked on a calendar, and an instant survives being shown on one
+
+    @unit
+    Scenario: The backfill start is a date control
+      When the admin looks at the backfill start field
+      Then it is rendered as a date control rather than a free-text field
+
+    @unit
+    Scenario: A stored instant is shown as its calendar date
+      Given the source was saved with a backfill start of "2026-08-01T00:00:00.000Z"
+      When the admin opens the edit form
+      Then the backfill start shows the 1st of August 2026
+
+    @unit
+    Scenario: Showing an instant on a date control does not rewrite it
+      Given the source was saved with a backfill start of "2026-08-01T13:45:00.000Z"
+      When the admin edits another field and saves
+      Then the submitted backfill start is still that same instant
+
+  Rule: Replacing the control does not change what is stored
+
+    @unit
+    Scenario: Leaving the bucket width alone still means the adapter default
+      Given the report is set to usage
+      When the admin saves without choosing a bucket width
+      Then the submitted configuration carries no bucket width at all
+
+    @unit
+    Scenario: A picked date is still normalized to an instant before saving
+      When the admin picks a backfill start of "2026-08-01"
+      And saves the form
+      Then the submitted backfill start is a timezone-carrying instant


### PR DESCRIPTION
Closes langwatch/langwatch-saas#1157.

**Stacked on #7430** — base is `feat/governance-edit-pull-source-config`, not `main`. Review that one first; this diff is only the three controls.

## What changed

The Anthropic composer asked for three values with closed domains and rendered all three as free text. The domain lived in a hint, and a wrong value came back as a toast after the save.

| Field | Was | Is |
|---|---|---|
| Report | text, placeholder `cost` | select — Usage / Cost |
| Bucket width | text, placeholder `1d` | select — default / `1m` / `1h` / `1d` |
| Backfill start | text, placeholder `YYYY-MM-DD` | `<input type="date">` |

Controls are the ones already in this drawer: `NativeSelect` as used by `PullCadenceField`, and `<Input type="date">` as used across the backoffice and API-key forms.

## Two things that are not cosmetic

**The empty first option is load-bearing.** A controlled `<select>` holding `""` with no `""` entry in its list displays its *first real option* while state stays empty. On a required field that means the admin is shown a report they never chose. Both selects lead with an unselected entry.

**The cost report no longer offers a width.** `validBucketWidth` *refuses* — not ignores — any bucket width on a cost source, because the puller pins `COST_REPORT_BUCKET_WIDTH` and drops `config.bucketWidth`. The old form invited the admin to fill an "optional" field that rejected the entire save. The list now collapses to the default entry on cost, and `reconcileParserValues` clears a width already chosen when the report switches to cost.

## The date-control trap this had to avoid

Every `startingAt` that reaches storage has been through `normalizeStartingAt`, which returns `new Date(parsed).toISOString()`. So the edit form **always** seeds an ISO instant, never a bare date — and `<input type="date">` handed an instant renders **blank**.

Blank on an edit form reads as "no backfill start configured". Saving from there would drop a setting the admin never touched, on every previously-saved Anthropic source.

`dateInputValue` therefore truncates to the UTC calendar date **for display only**; the held value is untouched until the admin picks a different day. An instant carrying a time of day displays as its calendar day and submits unchanged.

I filed the issue believing this was an edge case. It is the only case — found by `/challenge` before any code was written.

## Verification

- **Spec:** `specs/governance/anthropic-source-form-controls.feature` — 10 scenarios, 4 Rules, all `@unit`-tagged and bound.
- **Tests:** `anthropicFormControls.unit.test.ts`, 10 tests, red first (8 failed / 2 passed — the 2 were regression guards on existing builder behaviour).
- **Option lists are asserted against `anthropicAdminPullConfigSchema`**, not against a second hand-written copy, so the form and the adapter cannot drift. `validBucketWidth` and the picker now read one `ANTHROPIC_BUCKET_WIDTHS` constant.
- `pnpm check:feature-parity` — OK, 8562 enforced scenarios bound across 1133 files.
- `pnpm run typecheck:all` — clean.
- `biome-new-violations.sh` against the stack base — 3422 base / 3422 head, **no new violations**. `ParserConfigField` was heading past the cognitive-complexity cap, so the control rendering is extracted into `ParserFieldInput`.
- `vitest run ee/governance` — 56 files, 506 passed.
- Full CI suite ran: all four unit shards, three component shards, four integration shards, `e2e`, `lint`, `typecheck`, `build`, `feature-parity` — green, with the one exception below.

## The one red check is inherited from `main`

`test-unit (3)` fails on `src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts` — *"carries PRODUCT scope, the one the router's cast claims"*, asserting `['release_langy_ui_actions']` equals `[]`.

Not this PR. `registry.ts:319` declares that flag `scope: "SYSTEM"` while `frontendFeatureFlags.ts:77` exposes it to the frontend, where the tRPC router casts every entry as `PRODUCT`. It arrived with #7424 and **`main` is red on the identical assertion** (run 32724011982, shard 2). This branch's only commit touches three governance files and cannot reach the flag registry.

Fix belongs on `main`, one of: flip `registry.ts:319` to `PRODUCT`, or add the key to the test's `NON_PRODUCT_GRANDFATHERED` list.

## Noticed, not fixed

`platform/app/specs/` is a **stray spec tree that `check-feature-parity` never scans** — `SPECS_ROOTS` is `<repo>/specs` and `<repo>/sdks/typescript/specs`. It holds 30 feature files against the canonical tree's 1130, including #7430's `edit-pull-source-config.feature`.

This is the real reason that file enforces nothing — sharper than the "no binding tags" diagnosis from the earlier review. Tagging it in place would have changed nothing. This PR's spec is in the canonical tree; moving and binding #7430's belongs to #7430.

## Scope

Form controls only. No change to the stored `pullConfig` shape, the puller, or the validation rules — the same builder still validates, and a value valid before is valid now.

## Not covered

No browser verification of the rendered controls. The local haven stack has one `databricks_genie` source and no `anthropic_admin` row to demo against.

**CodeRabbit never reviewed this PR.** Its check reports *"Review skipped: reviews are disabled for this base branch"* — it does not run on a PR whose base is a feature branch. This diff has had no bot review at all; the `github-actions` approvals are reviewdog's no-findings pass, not a review.

