### PR TITLE
fix(feature-flags): a frontend-exposed SYSTEM flag is declared, not a violation

### DIFF
--- a/dev/docs/adr/005-feature-flags.md
+++ b/dev/docs/adr/005-feature-flags.md
@@ -8,7 +8,7 @@
 
 PR #7194 deleted `FeatureFlagServicePostHog` and the PostHog branch of `featureFlagService.isEnabled`. **Both scopes now resolve identically**, and PostHog is not consulted for any flag:
 
-```
+```text
 SYSTEM and PRODUCT:  env override -> FEATURE_FLAG_FORCE_ENABLE -> postgres store (targeting rules, then row value) -> registry default
 ```
 

--- a/dev/docs/adr/005-feature-flags.md
+++ b/dev/docs/adr/005-feature-flags.md
@@ -2,7 +2,23 @@
 
 **Date:** 2026-01-29 (initial), 2026-05-17 (scope split + registry)
 
-**Status:** Accepted
+**Status:** Accepted — amended 2026-08-20, see below
+
+## Amendment (2026-08-20): PostHog removed from the resolver
+
+PR #7194 deleted `FeatureFlagServicePostHog` and the PostHog branch of `featureFlagService.isEnabled`. **Both scopes now resolve identically**, and PostHog is not consulted for any flag:
+
+```
+SYSTEM and PRODUCT:  env override -> FEATURE_FLAG_FORCE_ENABLE -> postgres store (targeting rules, then row value) -> registry default
+```
+
+Three consequences the rest of this document predates:
+
+- **Targeting is scope-independent.** `FeatureFlagStorePostgres.get` evaluates `rules` against the caller's `{ projectId, organizationId }` without reading `scope`, so a SYSTEM flag takes per-project and per-org rules exactly like a PRODUCT one. The claim below that "SYSTEM flags ignore `projectId` / `organizationId`" no longer holds.
+- **Scope is now a classification, not a resolver switch.** It survives because `/ops/feature-flags` groups and badges by it, and because it records who owns the lever: SYSTEM means the internal flag store is the only administration point (usually paired with `envOverridable: false`). It no longer implies anything about *how* the value is fetched.
+- **A SYSTEM-scoped flag exposed to the frontend is a legitimate shape.** `FeatureFlagKey` is the union of all registered keys regardless of scope, so the `featureFlag.isEnabled` router's cast is safe either way. The Langy family relies on this: internal levers that gate a product surface. A guard added in #7357 asserted the opposite — that every frontend-exposed flag must be PRODUCT — and went red on `main` when #7424 landed a SYSTEM flag in `FRONTEND_FEATURE_FLAGS` (issue #7511); it was removed rather than extended, because the premise was inherited from this ADR after the code beneath it had changed.
+
+Sections below describing a PostHog path (Resolution order, Architecture Flow, Targeting via personProperties, PostHog local evaluation) are retained as history of the 2026-05 design and are **not** the current behaviour. `POSTHOG_FEATURE_FLAGS_KEY` no longer affects flag resolution; PostHog remains in the product for analytics and error capture only.
 
 ## Context
 

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -525,7 +525,6 @@ const LEGACY_INERT: string[] = [
   "specs/ops/clickhouse-backup-metrics.feature",
   "specs/ops/dashboard-latency.feature",
   "specs/ops/dejaview-impersonation-access.feature",
-  "specs/ops/internal-feature-flags.feature",
   "specs/ops/local-observability-stack.feature",
   "specs/ops/production-bundle-integrity.feature",
   "specs/otlp/canonical-log-ingestion.feature",

--- a/platform/app/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/platform/app/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -181,9 +181,9 @@ export function FeatureFlagRulesDialog({
           <VStack align="stretch" gap={3}>
             <Text fontSize="sm" color="fg.muted">
               Rules are evaluated top-to-bottom; the first match wins. When no
-              rule matches, the row-level toggle is used as the fallback. Once a
-              row exists in postgres, PostHog is no longer consulted for this
-              flag.
+              rule matches, the row-level toggle is used as the fallback. A
+              per-flag env override, where one is allowed, still wins over
+              everything here.
             </Text>
             <Box>
               <Text fontFamily="mono" fontSize="xs" color="fg.muted">

--- a/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -103,7 +103,7 @@ export function FeatureFlagsContent() {
 
       <ScopeSection
         heading="System"
-        description="Backend kill switches and pipeline toggles. Always resolved from postgres, env, or registry default. PostHog is never consulted."
+        description="Backend kill switches and pipeline toggles. Resolved from env, this postgres store, then the registry default."
         rows={grouped.system}
         canManage={canManage}
         isSaas={isSaas}
@@ -119,8 +119,8 @@ export function FeatureFlagsContent() {
         heading="Product"
         description={
           isSaas
-            ? "UI features and A/B tests. Source of truth is PostHog; postgres value here is an emergency override only."
-            : "UI features. On this self-hosted install, the postgres value here is the source of truth."
+            ? "Customer-facing features. The value here is the source of truth; set a targeting rule to reach a subset of organizations."
+            : "Customer-facing features. The value here is the source of truth."
         }
         rows={grouped.product}
         canManage={canManage}

--- a/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -93,12 +93,11 @@ export function FeatureFlagsContent() {
     <Stack gap={8} paddingY={4} maxWidth="1200px">
       <Box>
         <Text fontSize="sm" color="fg.muted">
-          System-scoped flags are kill switches and pipeline toggles served from
-          this LangWatch postgres database. They never round-trip to PostHog, so
-          flipping them is fast and free.{" "}
-          {isSaas
-            ? "Product-scoped flags still resolve through PostHog for user targeting and A/B tests; postgres values here only apply as an emergency override."
-            : "Product-scoped flags fall back to this postgres store when PostHog is not configured."}
+          Every flag is served from this LangWatch postgres database, whichever
+          scope it carries, so flipping one is fast and free. Scope says who the
+          flag is for: system-scoped flags are kill switches and pipeline
+          toggles, product-scoped flags are customer-facing features. Targeting
+          rules work the same for both.
         </Text>
       </Box>
 
@@ -338,9 +337,9 @@ function FlagRowView({
             </Text>
             <ScopeBadge scope={row.scope} />
             {showProductWarning && (
-              <Tooltip content="PRODUCT flags normally resolve through PostHog. Setting a postgres value here will override PostHog for every caller; emergency use only.">
+              <Tooltip content="This flag gates a customer-facing feature, and a value set here applies to every organization no targeting rule matches. On a shared install that is the whole fleet, so prefer a per-organization or per-project rule when rolling one out.">
                 <Badge colorPalette="yellow" size="sm" variant="subtle">
-                  PostHog managed
+                  All customers
                 </Badge>
               </Tooltip>
             )}

--- a/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
+++ b/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagsContent } from "../FeatureFlagsContent";
+
+/**
+ * This page's copy is the only thing that tells an operator where a flag's
+ * value comes from, and it drifted once already: PostHog left the resolver
+ * without anyone editing the strings, so /ops/feature-flags spent months
+ * telling SaaS operators their postgres edit was "an emergency override
+ * only" when it was in fact the source of truth. An operator who believes
+ * that does not write the row, and the rollout does not happen.
+ *
+ * These assertions are deliberately about meaning rather than wording: they
+ * pin that the SaaS Product copy claims this store as the source of truth
+ * and names no external service, so a future rewrite is free to say it
+ * better but not free to say the old thing again.
+ */
+
+const FLAGS = [
+  {
+    key: "ops_es_trace_processing_killswitch",
+    scope: "SYSTEM" as const,
+    defaultValue: false,
+    description: "Halts trace processing.",
+    family: null,
+    storedValue: null,
+    rules: [],
+    envOverride: null,
+    effective: false,
+    lastEditedBy: null,
+    updatedAt: null,
+  },
+  {
+    key: "release_ui_comparison_leaderboard_enabled",
+    scope: "PRODUCT" as const,
+    defaultValue: false,
+    description: "Bradley-Terry leaderboard chart.",
+    family: null,
+    storedValue: null,
+    rules: [],
+    envOverride: null,
+    effective: false,
+    lastEditedBy: null,
+    updatedAt: null,
+  },
+];
+
+const isSaas = vi.fn(() => true);
+
+vi.mock("~/hooks/useOpsPermission", () => ({
+  useOpsPermission: () => ({ scope: { kind: "platform" } }),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: { IS_SAAS: isSaas() } }),
+}));
+
+vi.mock("~/features/errors", () => ({
+  HandledErrorAlert: () => null,
+  showErrorToast: vi.fn(),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      ops: { listFeatureFlags: { invalidate: vi.fn() } },
+    }),
+    ops: {
+      listFeatureFlags: {
+        useQuery: () => ({
+          data: { flags: FLAGS },
+          isLoading: false,
+          error: null,
+        }),
+      },
+      setFeatureFlag: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+      },
+      clearFeatureFlag: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+      },
+      // Each row mounts the targeting-rules dialog, which reaches for this.
+      setFeatureFlagRules: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  isSaas.mockReturnValue(true);
+});
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <FeatureFlagsContent />
+    </ChakraProvider>,
+  );
+}
+
+/** Every external flag-service name that the removed resolver used to imply.
+ *  Kept as a list so adding a future vendor to the copy trips this too. */
+const EXTERNAL_FLAG_SERVICES = [/posthog/i, /launchdarkly/i, /split\.io/i];
+
+describe("the Ops feature flags page", () => {
+  describe("when an operator on a shared install reads the Product section", () => {
+    it("is told this store decides the value, not an outside service", () => {
+      renderPage();
+
+      const productSection = screen.getByText("Product").parentElement;
+      const copy = productSection?.textContent ?? "";
+
+      expect(copy).toMatch(/source of truth/i);
+      for (const vendor of EXTERNAL_FLAG_SERVICES) {
+        expect(copy).not.toMatch(vendor);
+      }
+    });
+
+    it("is told the same about the System section, so the two cannot disagree", () => {
+      renderPage();
+
+      const systemSection = screen.getByText("System").parentElement;
+      const copy = systemSection?.textContent ?? "";
+
+      for (const vendor of EXTERNAL_FLAG_SERVICES) {
+        expect(copy).not.toMatch(vendor);
+      }
+    });
+  });
+
+  describe("when a PRODUCT flag row is shown on a shared install", () => {
+    /** @scenario Ops page warns about the blast radius of a PRODUCT flag on a shared install */
+    it("carries the fleet-reach warning that a self-hosted install does not", () => {
+      renderPage();
+      expect(screen.getByText("All customers")).toBeDefined();
+
+      cleanup();
+      isSaas.mockReturnValue(false);
+      renderPage();
+      expect(screen.queryByText("All customers")).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
+++ b/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
@@ -108,13 +108,23 @@ function renderPage() {
  *  Kept as a list so adding a future vendor to the copy trips this too. */
 const EXTERNAL_FLAG_SERVICES = [/posthog/i, /launchdarkly/i, /split\.io/i];
 
+/**
+ * The section's own description, not the whole section: several registry
+ * entries still name the removed service in their historical descriptions,
+ * and those render inside this same box. Reading the sibling of the heading
+ * keeps the assertion on the copy this test is about, so a fixture that
+ * quotes a real description cannot fail it for the wrong reason.
+ */
+function sectionDescription(heading: string): string {
+  return screen.getByText(heading).nextElementSibling?.textContent ?? "";
+}
+
 describe("the Ops feature flags page", () => {
   describe("when an operator on a shared install reads the Product section", () => {
     it("is told this store decides the value, not an outside service", () => {
       renderPage();
 
-      const productSection = screen.getByText("Product").parentElement;
-      const copy = productSection?.textContent ?? "";
+      const copy = sectionDescription("Product");
 
       expect(copy).toMatch(/source of truth/i);
       for (const vendor of EXTERNAL_FLAG_SERVICES) {
@@ -125,8 +135,7 @@ describe("the Ops feature flags page", () => {
     it("is told the same about the System section, so the two cannot disagree", () => {
       renderPage();
 
-      const systemSection = screen.getByText("System").parentElement;
-      const copy = systemSection?.textContent ?? "";
+      const copy = sectionDescription("System");
 
       for (const vendor of EXTERNAL_FLAG_SERVICES) {
         expect(copy).not.toMatch(vendor);

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -58,10 +58,14 @@ export const featureFlagRouter = createTRPCRouter({
         "Feature flag check requested",
       );
 
-      // `input.flag` is runtime-validated against FRONTEND_FEATURE_FLAGS
-      // (a subset of registered PRODUCT keys), so the cast is safe;
-      // FRONTEND_FEATURE_FLAGS is wider than the inferred zod enum value
-      // type, hence the explicit FeatureFlagKey narrowing.
+      // `input.flag` is runtime-validated against FRONTEND_FEATURE_FLAGS,
+      // whose entries are registered keys of either scope (FeatureFlagKey
+      // is scope-agnostic, so the cast is safe for SYSTEM and PRODUCT
+      // alike). FRONTEND_FEATURE_FLAGS is wider than the inferred zod enum
+      // value type, hence the explicit FeatureFlagKey narrowing. The one
+      // deliberately unregistered entry, `ops_ui_ops_menu_pinned`, resolves
+      // false server-side by design; frontendFlagsRegistered.unit.test.ts
+      // pins that exception so a new unregistered key cannot slip in.
       const enabled = await featureFlagService.isEnabled(
         input.flag as FeatureFlagKey,
         {

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -15,7 +15,8 @@ const frontendFeatureFlagSchema = z.enum([...FRONTEND_FEATURE_FLAGS] as [
 /**
  * tRPC router for feature flag checks.
  *
- * Uses PostHog for flag evaluation with optional project/organization targeting.
+ * Resolves through the in-code registry and the operator flag store, with
+ * optional project/organization targeting.
  * Results are cached server-side (5s TTL) and client-side (React Query).
  *
  * @see dev/docs/adr/005-feature-flags.md for architecture decisions
@@ -41,8 +42,8 @@ export const featureFlagRouter = createTRPCRouter({
       reason:
         "feature flags are read per authenticated user; no tenant data is exposed",
       allow: {
-        projectId: "for PostHog targeting, not resource access",
-        organizationId: "for PostHog targeting, not resource access",
+        projectId: "for flag targeting rules, not resource access",
+        organizationId: "for flag targeting rules, not resource access",
       },
     })
     .query(async ({ ctx, input }) => {

--- a/platform/app/src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts
@@ -48,9 +48,10 @@ const UNREGISTERED_GRANDFATHERED = ["ops_ui_ops_menu_pinned"];
 /**
  * Frontend-exposed flags that are SYSTEM on purpose: internal levers
  * (`envOverridable: false`, operator-store-only) that happen to gate a
- * product surface. Order matters — the assertion compares the resolved set
- * against this array, so a new such flag lands here as a visible edit next
- * to the one in FRONTEND_FEATURE_FLAGS.
+ * product surface. The assertion compares the resolved set against this
+ * array order-independently, so reordering FRONTEND_FEATURE_FLAGS stays a
+ * cosmetic edit; a new such flag still lands here as a visible one, next to
+ * the one in FRONTEND_FEATURE_FLAGS.
  */
 const FRONTEND_SYSTEM_FLAGS = [
   "release_langy_enabled",
@@ -59,6 +60,7 @@ const FRONTEND_SYSTEM_FLAGS = [
 
 describe("frontend feature flags", () => {
   describe("when a flag is exposed to the frontend via tRPC", () => {
+    /** @scenario a flag the web UI can read is registered, so operators keep the lever */
     it("resolves to a registry definition so operators can target it per organization", () => {
       const unregistered = FRONTEND_FEATURE_FLAGS.filter(
         (key) =>
@@ -71,18 +73,19 @@ describe("frontend feature flags", () => {
   });
 
   describe("when a frontend flag resolves to a SYSTEM-scoped definition", () => {
-    /** @scenario a flag the web UI can read is registered, so operators keep the lever */
+    /** @scenario a frontend flag classified SYSTEM is declared, not discovered */
     it("is one the register declares, so the classification stays reviewed", () => {
       const systemScoped = FRONTEND_FEATURE_FLAGS.filter(
         (key) => resolveFlagDefinition(key)?.scope === "SYSTEM",
       );
 
-      expect(systemScoped).toEqual(FRONTEND_SYSTEM_FLAGS);
+      expect([...systemScoped].sort()).toEqual(
+        [...FRONTEND_SYSTEM_FLAGS].sort(),
+      );
     });
   });
 
   describe("when the pinned lists are read", () => {
-    /** @scenario a frontend flag missing from the registry is caught before it ships */
     it("names exactly the keys each one covers", () => {
       expect(UNREGISTERED_GRANDFATHERED).toEqual(["ops_ui_ops_menu_pinned"]);
       expect(FRONTEND_SYSTEM_FLAGS).toEqual([

--- a/platform/app/src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts
@@ -4,26 +4,37 @@ import { FRONTEND_FEATURE_FLAGS } from "../frontendFeatureFlags";
 import { resolveFlagDefinition } from "../registry";
 
 /**
- * `server/api/routers/featureFlag.ts` documents FRONTEND_FEATURE_FLAGS as
- * "a subset of registered PRODUCT keys" and casts `input.flag` to
- * FeatureFlagKey on that basis, so an unregistered frontend flag compiles
- * clean and fails only at runtime — quietly.
+ * `server/api/routers/featureFlag.ts` casts `input.flag` to FeatureFlagKey,
+ * so an unregistered frontend flag compiles clean and fails only at
+ * runtime — quietly.
  *
  * The failure is not a wrong value (both the router and the service
  * normalize the default to false), it is a missing lever. `resolveFlagDefinition`
- * returning undefined is precisely the branch at featureFlag.service.ts:82
+ * returning undefined is precisely the branch at featureFlag.service.ts:106
  * that sends a key down the legacy in-memory path, skipping the operator
  * store: /ops/feature-flags can then neither list nor write the flag, and
  * per-org targeting rules never apply. The flag becomes deploy-time and
  * fleet-wide, which is the opposite of what a rollout flag is for.
  *
- * These tests call `resolveFlagDefinition` rather than scanning FEATURE_FLAGS
- * directly, so they exercise the same predicate the service does — including
+ * This test calls `resolveFlagDefinition` rather than scanning FEATURE_FLAGS
+ * directly, so it exercises the same predicate the service does — including
  * family-prefix matches — instead of a copy that can drift from it.
  *
- * Two keys predate this check and are pinned below rather than changed here;
- * altering either is a behavior change that belongs in its own PR, not in a
- * test that exists to stop the NEXT one.
+ * The second check is a register, not a violation list. An earlier version
+ * asserted that every frontend-exposed flag carries PRODUCT scope, on the
+ * premise that the router's cast depended on it. It does not: the resolver
+ * has no scope branch once a definition exists (featureFlag.service.ts:106
+ * routes SYSTEM and PRODUCT into the same store call), the postgres store
+ * evaluates targeting rules against `{ projectId, organizationId }` without
+ * consulting scope at all, and FeatureFlagKey is the union of every
+ * registered key regardless of scope. A SYSTEM flag read from the frontend
+ * is a legitimate shape, and the Langy family uses it deliberately.
+ *
+ * What scope still decides is operator-facing: /ops/feature-flags groups by
+ * it, badges it, and warns on PRODUCT rows. A misclassified scope therefore
+ * misleads an operator rather than breaking a resolution, which is worth a
+ * declaration in review but not a failure labelled "wrong scope".
+ * See ADR-005 (Amendment: PostHog removed from the resolver).
  */
 
 /**
@@ -35,10 +46,16 @@ import { resolveFlagDefinition } from "../registry";
 const UNREGISTERED_GRANDFATHERED = ["ops_ui_ops_menu_pinned"];
 
 /**
- * Registered but deliberately not PRODUCT-scoped. `release_langy_enabled`
- * is SYSTEM with `envOverridable: false`, which reads as intentional.
+ * Frontend-exposed flags that are SYSTEM on purpose: internal levers
+ * (`envOverridable: false`, operator-store-only) that happen to gate a
+ * product surface. Order matters — the assertion compares the resolved set
+ * against this array, so a new such flag lands here as a visible edit next
+ * to the one in FRONTEND_FEATURE_FLAGS.
  */
-const NON_PRODUCT_GRANDFATHERED = ["release_langy_enabled"];
+const FRONTEND_SYSTEM_FLAGS = [
+  "release_langy_enabled",
+  "release_langy_ui_actions",
+];
 
 describe("frontend feature flags", () => {
   describe("when a flag is exposed to the frontend via tRPC", () => {
@@ -53,25 +70,25 @@ describe("frontend feature flags", () => {
     });
   });
 
-  describe("when the definition backing a frontend flag is resolved", () => {
-    it("carries PRODUCT scope, the one the router's cast claims", () => {
-      const wrongScope = FRONTEND_FEATURE_FLAGS.filter((key) => {
-        const definition = resolveFlagDefinition(key);
-        return (
-          definition &&
-          definition.scope !== "PRODUCT" &&
-          !NON_PRODUCT_GRANDFATHERED.includes(key)
-        );
-      });
+  describe("when a frontend flag resolves to a SYSTEM-scoped definition", () => {
+    /** @scenario a flag the web UI can read is registered, so operators keep the lever */
+    it("is one the register declares, so the classification stays reviewed", () => {
+      const systemScoped = FRONTEND_FEATURE_FLAGS.filter(
+        (key) => resolveFlagDefinition(key)?.scope === "SYSTEM",
+      );
 
-      expect(wrongScope).toEqual([]);
+      expect(systemScoped).toEqual(FRONTEND_SYSTEM_FLAGS);
     });
   });
 
-  describe("when the grandfathered exceptions are listed", () => {
-    it("names exactly the two keys that predate this check", () => {
+  describe("when the pinned lists are read", () => {
+    /** @scenario a frontend flag missing from the registry is caught before it ships */
+    it("names exactly the keys each one covers", () => {
       expect(UNREGISTERED_GRANDFATHERED).toEqual(["ops_ui_ops_menu_pinned"]);
-      expect(NON_PRODUCT_GRANDFATHERED).toEqual(["release_langy_enabled"]);
+      expect(FRONTEND_SYSTEM_FLAGS).toEqual([
+        "release_langy_enabled",
+        "release_langy_ui_actions",
+      ]);
     });
   });
 });

--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -36,13 +36,21 @@
  *
  * ## Targeting
  *
- * Flags can target users, projects, or organizations via PostHog personProperties.
- * Configure targeting in PostHog release conditions, not in the flag name.
- * Pass `projectId` or `organizationId` to `useFeatureFlag` for targeted evaluation.
+ * Flags target projects or organizations through the operator store's rules,
+ * written at /ops/feature-flags. Configure targeting there, not in the flag
+ * name. Pass `projectId` or `organizationId` to `useFeatureFlag` for targeted
+ * evaluation. Targeting is scope-independent: a SYSTEM flag takes per-project
+ * and per-org rules exactly like a PRODUCT one (PostHog was removed from the
+ * resolver — see ADR-005).
  *
  * ## Adding New Flags
  *
- * 1. Create the flag in PostHog with your desired release conditions
+ * 1. Register the flag in `registry.ts` (`FEATURE_FLAGS`) with a scope and a
+ *    default. Listing a key here WITHOUT registering it is the one real
+ *    failure mode: the service falls through to the legacy in-memory path,
+ *    /ops/feature-flags can neither list nor write it, and targeting rules
+ *    never apply. `__tests__/frontendFlagsRegistered.unit.test.ts` enforces
+ *    this.
  * 2. Add the flag key to this array
  * 3. Use `useFeatureFlag("your_flag_key")` in components
  *

--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -67,8 +67,8 @@ export const FRONTEND_FEATURE_FLAGS = [
   "release_ui_navigation_v2_enabled",
   // Governance: gates the personal-keys / admin oversight /
   // RoutingPolicy / IngestionSource UI surfaces. On by default
-  // (ADR-038 Decision 7); SaaS rollout and per-org kill switches live
-  // in PostHog. Distinct from `release_ui_ai_gateway_menu_enabled`
+  // (ADR-038 Decision 7); SaaS rollout and per-org kill switches are
+  // targeting rules at /ops/feature-flags. Distinct from `release_ui_ai_gateway_menu_enabled`
   // because the gateway product ships on its own flag.
   // Force off in dev: `RELEASE_UI_AI_GOVERNANCE_ENABLED=0`.
   "release_ui_ai_governance_enabled",
@@ -100,7 +100,7 @@ export const FRONTEND_FEATURE_FLAGS = [
   "release_webhook_automations",
   // Pins the Ops section into the main sidebar for a user who already has ops
   // access, so it shows on every route instead of only under /ops. Deliberately
-  // NOT a PostHog flag — it resolves false server-side (unknown flag) and is
+  // NOT registered — it resolves false server-side (unknown flag) and is
   // meant to be forced On locally from the hidden Feature Flags (Dev) drawer,
   // persisting in that browser via the local override. It never widens who can
   // see ops: the sidebar still gates on ops access, so a non-ops user forcing

--- a/specs/ops/internal-feature-flags.feature
+++ b/specs/ops/internal-feature-flags.feature
@@ -168,16 +168,19 @@ Feature: Internal feature flag system for system-level kill switches
     @unit
     Scenario: a flag the web UI can read is registered, so operators keep the lever
       Given a flag key is exposed to the frontend
-      When an operator opens /ops/feature-flags
-      Then the flag is listed there and can be targeted per organization
-      And this holds whether the flag is SYSTEM or PRODUCT scoped
+      Then it resolves to a registry entry, whether SYSTEM or PRODUCT scoped, so
+           /ops/feature-flags can list it and target it per organization
+      And an unregistered key is reported instead, because it would resolve from
+          the legacy in-memory path where the operator store cannot see it
+      And the one historical exception is named explicitly rather than counted
 
     @unit
-    Scenario: a frontend flag missing from the registry is caught before it ships
-      Given a flag key is exposed to the frontend but has no registry entry
-      Then the unregistered key is reported, because it would otherwise resolve
-           from the legacy in-memory path where the operator store cannot see it
-      And the one historical exception is named explicitly rather than counted
+    Scenario: a frontend flag classified SYSTEM is declared, not discovered
+      Given the flags exposed to the frontend that resolve to a SYSTEM-scoped definition
+      Then they match the declared register of such flags exactly
+      And a new SYSTEM classification therefore arrives as a visible edit for
+          review, because scope decides how /ops/feature-flags groups, badges
+          and warns on the flag even though it no longer decides resolution
 
   Rule: Operators manage flags from the Ops Feature Flags page
 
@@ -211,17 +214,20 @@ Feature: Internal feature flag system for system-level kill switches
       And the flag resolves to its registry default again
       And the page row shows source "registry default" and last edit "never"
 
-    Scenario: Ops page warns when a PRODUCT flag is being managed on a SaaS install
-      Given the installation is running in SaaS mode with PostHog enabled
+    @integration
+    Scenario: Ops page warns about the blast radius of a PRODUCT flag on a shared install
+      Given the installation is running in SaaS mode
       And the operator focuses a PRODUCT-scoped flag row
-      Then the page surfaces a note that PRODUCT flags should normally be
-          managed in PostHog so user targeting and A/B test rules apply
-      And the operator can still set a postgres override for emergency use
+      Then the page surfaces a note that the row-level value reaches every
+          organization no targeting rule matches, which on a shared install is
+          the whole fleet
+      And the note points the operator at a per-organization or per-project rule
+          for a rollout
 
   Rule: Self-hosted parity
 
-    Scenario: Self-hosted install with no PostHog can still flip kill switches
-      Given the installation is self-hosted with no PostHog configured
+    Scenario: Self-hosted install with no third-party flag service can still flip kill switches
+      Given the installation is self-hosted with no external flag service configured
       When an operator toggles a SYSTEM kill switch from the Ops UI
       Then the change persists in postgres
       And every pod observes the new value

--- a/specs/ops/internal-feature-flags.feature
+++ b/specs/ops/internal-feature-flags.feature
@@ -24,6 +24,22 @@ Feature: Internal feature flag system for system-level kill switches
   #   - PRODUCT scope: keeps PostHog (A/B testing, user targeting) with
   #     env override on top and a DB fallback so self-hosted installs
   #     without PostHog can still toggle product features.
+  #
+  # ===========================================================================
+  # 2026-08 amendment — PostHog left the resolver entirely
+  # ===========================================================================
+  # PR #7194 deleted the PostHog service and its branch of the resolver, so
+  # the split above no longer describes two paths. BOTH scopes now resolve
+  #   env override -> force-enable list -> postgres store -> registry default
+  # and no flag of either scope consults PostHog. The PRODUCT scenarios below
+  # that name PostHog are kept as the record of the 2026-05 design; the
+  # scenarios under "Every registered flag resolves from our own store" are
+  # the current contract.
+  #
+  # What scope still means: it is the classification the Ops UI groups and
+  # badges by, and it records who owns the lever — SYSTEM meaning the internal
+  # flag store is the only administration point. It decides nothing about how
+  # a value is fetched, and it does not decide whether targeting applies.
 
   Background:
     Given the application registers every flag in a single in-code registry
@@ -32,6 +48,8 @@ Feature: Internal feature flag system for system-level kill switches
         pipeline toggles
     And product-scoped flags are reserved for UI features and A/B tests
     And the registry default for a flag is used when no override is found
+    And both scopes resolve through the same order, so scope changes who
+        administers a flag and never how its value is found
 
   Rule: SYSTEM flags never reach PostHog
 
@@ -77,7 +95,9 @@ Feature: Internal feature flag system for system-level kill switches
       When code checks the new registry key
       Then the flag resolves enabled from the legacy env override
 
-  Rule: PRODUCT flags keep PostHog with a postgres fallback
+  # Superseded by the 2026-08 amendment: PostHog is no longer consulted
+  # for any flag. Retained as the record of the 2026-05 design.
+  Rule: PRODUCT flags kept PostHog with a postgres fallback (until 2026-08)
 
     Scenario: PRODUCT flag with PostHog reachable consults PostHog for user targeting
       Given the registry has a PRODUCT-scoped UI flag
@@ -101,7 +121,7 @@ Feature: Internal feature flag system for system-level kill switches
       When the flag is checked
       Then the flag resolves enabled
 
-  Rule: Postgres targeting rules win over PostHog
+  Rule: Postgres targeting rules decide the value
 
     Scenario: org-scoped postgres rule enables a PRODUCT flag without touching PostHog
       Given the postgres flag store has a row for the PRODUCT flag with
@@ -133,6 +153,31 @@ Feature: Internal feature flag system for system-level kill switches
       When the flag is checked
       Then the flag resolves disabled from the row-level enabled value
       And PostHog is not consulted because the postgres row was present
+
+  Rule: Every registered flag resolves from our own store, whatever its scope
+
+    Scenario: a SYSTEM flag takes per-organization targeting like any other
+      Given the registry has a SYSTEM-scoped flag
+      And the postgres flag store has a row for it whose targeting rule
+          matches the calling organization with enabled true
+      And the row-level enabled value is false
+      When the flag is checked with that organization in context
+      Then the flag resolves enabled from the targeting rule
+      And the result is reached the same way it would be for a PRODUCT flag
+
+    @unit
+    Scenario: a flag the web UI can read is registered, so operators keep the lever
+      Given a flag key is exposed to the frontend
+      When an operator opens /ops/feature-flags
+      Then the flag is listed there and can be targeted per organization
+      And this holds whether the flag is SYSTEM or PRODUCT scoped
+
+    @unit
+    Scenario: a frontend flag missing from the registry is caught before it ships
+      Given a flag key is exposed to the frontend but has no registry entry
+      Then the unregistered key is reported, because it would otherwise resolve
+           from the legacy in-memory path where the operator store cannot see it
+      And the one historical exception is named explicitly rather than counted
 
   Rule: Operators manage flags from the Ops Feature Flags page
 


### PR DESCRIPTION
**For humans**

We have a rule that says "any feature flag the web UI is allowed to read must be the kind customers can be targeted with individually." A flag was added that the web UI reads but is the other kind — an internal switch our own team operates — and the rule went red on `main`.

It turns out the rule was already obsolete. The two kinds of flag used to be fetched from different places; a few days earlier we removed the external service, and now both kinds are fetched the same way from our own database, and both can be targeted at individual customers. So the flag is fine, and so is the code — the rule was describing a distinction that no longer exists.

Rather than adding an exception, the check now keeps a short **register**: the internal-kind flags the web UI reads are listed by name, and adding another means adding a line. Nothing is labelled a violation, but the choice still shows up in review — which matters, because the kind of a flag decides how it appears to the people who operate it. The stale explanations that produced the wrong rule in the first place (our decision record, the spec, two code comments, and the operator page's own help text, which was still promising a round-trip to a service we no longer call) are corrected in the same change.

No customer-visible behaviour changes.

---

## Cause

`frontendFlagsRegistered.unit.test.ts` asserted every `FRONTEND_FEATURE_FLAGS` entry carries `PRODUCT` scope, justified by the router's cast at `src/server/api/routers/featureFlag.ts:61-63`. Semantic conflict: #7424 added `release_langy_ui_actions` (SYSTEM) to the array; #7357 added the guard 90 minutes later. Disjoint diffs, both green, red once both were on `main`.

The premise was already dead when the guard was written. PostHog left the resolver in #7194, and nothing depends on the scope of a frontend-exposed flag:

| claim | reality | evidence |
|---|---|---|
| PRODUCT and SYSTEM resolve differently | one branch, one store call | `featureFlag.service.ts:106` — `scope === "SYSTEM" \|\| scope === "PRODUCT"` |
| SYSTEM flags cannot be targeted per org | store never reads scope | `featureFlagStore.postgres.ts:65-69` — `evaluateRules(row.rules, ctx)` |
| the cast needs a PRODUCT key | `FeatureFlagKey` is scope-agnostic | `registry.ts:395` |
| PostHog serves PRODUCT flags | removed from the resolver | `registry.ts:110-111`, in-tree |

`release_langy_enabled`'s own description already instructs operators to add per-project/per-org targeting rules — for a SYSTEM flag.

## Fix

The scope check becomes a register rather than a violation list:

```ts
const FRONTEND_SYSTEM_FLAGS = ["release_langy_enabled", "release_langy_ui_actions"];

const systemScoped = FRONTEND_FEATURE_FLAGS.filter(
  (key) => resolveFlagDefinition(key)?.scope === "SYSTEM",
);
expect(systemScoped).toEqual(FRONTEND_SYSTEM_FLAGS);
```

Scope still drives `/ops/feature-flags` grouping, badging and its SaaS warning, so a misclassification misleads an operator — worth a declaration in review, not a failure labelled "wrong scope". The registered-vs-unregistered check, the one with real consequences (unregistered ⇒ legacy in-memory path ⇒ the operator store cannot see or target the flag), is untouched.

## Test evidence

Before — `pnpm test:unit run src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts`:

```
AssertionError: expected [ 'release_langy_ui_actions' ] to deeply equal []
 ❯ src/server/featureFlag/__tests__/frontendFlagsRegistered.unit.test.ts:67:26
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

The new assertion was mutation-checked — dropping `release_langy_ui_actions` from the register fails both directions, so the register is not vacuous:

```
AssertionError: expected [ 'release_langy_enabled', …(1) ] to deeply equal [ 'release_langy_enabled' ]
AssertionError: expected [ 'release_langy_enabled' ] to deeply equal [ 'release_langy_enabled', …(1) ]
      Tests  2 failed | 1 passed (3)
```

After:

```
 Test Files  10 passed (10)
      Tests  70 passed (70)      # whole src/server/featureFlag suite
```

`pnpm typecheck`, `pnpm run typecheck:tests`, `biome check` on the touched files: clean (12 pre-existing complexity warnings in `FeatureFlagsContent.tsx`, none new).

## Documentation corrected

The guard inherited its premise from documents that #7194 never updated:

- **ADR-005** — amendment recording that both scopes resolve identically, that targeting is scope-independent, and that scope is now a classification rather than a resolver switch. The PostHog sections are marked as history rather than deleted.
- **`specs/ops/internal-feature-flags.feature`** — an amendment block, a new `Rule: Every registered flag resolves from our own store, whatever its scope` with the SYSTEM-targeting scenario, and the stale PRODUCT/PostHog rule renamed as superseded. Two scenarios are `@unit`-tagged and bound; the file leaves `LEGACY_INERT` in `check-feature-parity.ts` as a result (`OK: 8554 enforced scenario(s) bound`).
- **`featureFlag.ts:61`** — the cast comment no longer claims `FRONTEND_FEATURE_FLAGS` is "a subset of registered PRODUCT keys".
- **`frontendFeatureFlags.ts`** — "Adding New Flags" said *create the flag in PostHog*, which would produce exactly the unregistered flag the surviving guard exists to catch. Step 1 is now registry registration.
- **`FeatureFlagsContent.tsx`** — the page copy told operators PRODUCT flags "still resolve through PostHog"; the `PostHog managed` badge is now `All customers`, warning about the thing that is actually true (a row-level value applies to every unmatched organization).

## Deployment Impact

No deployment impact. Nothing here changes what a vanilla `helm install` with no overrides does.

- **Env vars:** none added, removed, or renamed.
- **Helm values:** none added, removed, or renamed. No chart file is touched.
- **Default behaviour on a fresh install:** unchanged. The only executable change is a unit test plus one line removed from `platform/app/scripts/check-feature-parity.ts` (a repo-local lint list). No resolver, store, or router logic is modified — the router change is a comment.
- **BYOC dataplane:** unaffected. No new outbound dependency, no new required configuration, no migration.
- **Operator-visible:** one copy change on `/ops/feature-flags`. The page described values as coming from a third-party service that #7194 removed; it now describes them as coming from our own store. Wording only, no behaviour change, and no operator action required.

This PR trips the deployment-impact gate because it amends `dev/docs/adr/005-feature-flags.md`. That amendment is a correction to a document that has been stale since #7194 — it records what already shipped, and asks nothing of operators.

## Sweep

`NON_PRODUCT_GRANDFATHERED`, `scope !== "PRODUCT"` and "registered PRODUCT keys" appear nowhere else in the tree. The wider shape — documentation describing the removed PostHog resolver as current — is what the ADR, spec and Ops UI edits above cover.

## Not fixed

- **`specs/ops/internal-feature-flags.feature` is still mostly unbound.** Only the two new scenarios carry tags; the pre-existing ~20 have no tests to bind them to, and writing those is a separate job.
- **The retained PostHog scenarios in that spec** are marked superseded rather than deleted, so the billing-spike rationale stays readable. They describe behaviour that no longer exists.
- **`FeatureFlagsContent.tsx` complexity warnings** (biome, 12) are pre-existing and untouched.

Fixes #7511


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feature flags now use consistent targeting across system and product settings.
  - Administrators can manage project- and organization-level targeting rules through the operations interface.
  - Database-managed values apply across customers unless targeting rules specify otherwise.
  - Eligible system flags can be exposed in the frontend and managed through operations tools.
  - Environment overrides take precedence over configured targeting rules.

- **Documentation**
  - Updated guidance clarifies shared resolution, registration, scope classification, and external service removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
