### PR TITLE
feat(governance): an admin can say where a source's conversations land

### DIFF
--- a/platform/app/ee/governance/dashboard/components/TraceDestinationField.tsx
+++ b/platform/app/ee/governance/dashboard/components/TraceDestinationField.tsx
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Where a conversation source's conversations land: the project whose trace
+ * explorer they become readable in.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ * ADR-088 v7, Decisions 8-14.
+ *
+ * The picker is `ScopeChipPicker` in single-select PROJECT mode — the same
+ * control the virtual-key ownership section drives for the same column
+ * (`components/gateway/VirtualKeyOwnershipSection.tsx`), because a trace
+ * destination is one concept and should not read two ways.
+ *
+ * What this field owes the reader beyond the picker: the three consequences
+ * of the choice that no other screen states. Each is a property of the
+ * mechanism, not of the copy, so each is cited to the code that makes it
+ * true:
+ *
+ *   - the destination project's own data-privacy policy governs what is
+ *     stored, resolved inside the pipeline by tenant id
+ *     (`span-pii-redaction.service.ts:231-261`) — Decision 13;
+ *   - only conversations from the last 31 days arrive, so a thread that
+ *     started earlier renders partially (`SPAN_MAX_PAST_MS`,
+ *     `trace-request-collection.service.ts:30`) — Decision 11;
+ *   - a destination archived or deleted later stops receiving conversations
+ *     instead of failing the source (`pullerWorker.ts:387-396`) — Decision 9.
+ *
+ * A destination is deliberately never seeded. Where one team's conversations
+ * become readable to another is a choice someone makes, not a default they
+ * inherit — the same reason the virtual-key drawer refuses to seed it.
+ */
+
+import { Badge, HStack, Text, VStack } from "@chakra-ui/react";
+import { SmallLabel } from "~/components/SmallLabel";
+import { ScopeChipPicker } from "~/components/settings/ScopeChipPicker";
+import { FieldInfoTooltip } from "~/components/ui/FieldInfoTooltip";
+import { routesConversations, type SourceType } from "./ingestionSourceCatalog";
+
+/**
+ * Says the stored destination is gone, in the one wording that distinguishes
+ * "archived" from "never set" — an admin who reads the second goes looking
+ * for a choice they never made, instead of restoring a project they did.
+ */
+function ArchivedDestinationNotice() {
+  return (
+    <HStack gap={1.5} alignItems="center">
+      <Text
+        fontSize="xs"
+        color="fg.muted"
+        data-testid="ingestion-trace-destination-archived"
+      >
+        This source&rsquo;s destination project has been archived, so its
+        conversations are no longer being routed anywhere. Restore that project,
+        or pick another destination below, to start again.
+      </Text>
+      <Badge size="sm" colorPalette="orange" variant="subtle">
+        Archived
+      </Badge>
+    </HStack>
+  );
+}
+
+/**
+ * The three consequences of having picked a destination, plus the fourth that
+ * only exists once the source has a history. Each is a property of the
+ * pipeline rather than of this screen, so each is cited in the file header to
+ * the code that makes it true.
+ */
+function PickedDestinationConsequences({ mode }: { mode: "create" | "edit" }) {
+  return (
+    <>
+      <Text
+        fontSize="xs"
+        color="fg.muted"
+        data-testid="ingestion-trace-destination-redaction"
+      >
+        That project&rsquo;s data-privacy policy governs what is stored —
+        conversations are redacted on its terms, not this source&rsquo;s.
+      </Text>
+      <Text
+        fontSize="xs"
+        color="fg.muted"
+        data-testid="ingestion-trace-destination-horizon"
+      >
+        Conversations from the last 31 days arrive. A conversation that started
+        before then shows only its more recent turns; the older ones are not
+        stored.
+      </Text>
+      <Text
+        fontSize="xs"
+        color="fg.muted"
+        data-testid="ingestion-trace-destination-archival"
+      >
+        If that project is later archived or deleted, this source stops
+        receiving conversations rather than failing or landing them elsewhere.
+      </Text>
+      {mode === "edit" && (
+        <Text
+          fontSize="xs"
+          color="fg.muted"
+          data-testid="ingestion-trace-destination-history"
+        >
+          Conversations already routed stay where they are. Changing the
+          destination moves nothing that has landed.
+        </Text>
+      )}
+    </>
+  );
+}
+
+export type TraceDestinationFieldProps = {
+  sourceType: SourceType;
+  /** The source's `traceProjectId`. Null means don't route. */
+  value: string | null;
+  onChange: (next: string | null) => void;
+  /**
+   * `edit` adds the two sentences that only mean something once the source
+   * has a history: that routed conversations stay where they are, and that a
+   * destination has since been archived.
+   */
+  mode: "create" | "edit";
+  /**
+   * Whether the destination in `value` has been archived or deleted, as
+   * reported by the server. Deliberately not inferred from the destination
+   * failing to resolve against `availableProjects`: that also happens for a
+   * project outside the reader's own teams, and naming an access boundary as
+   * a deletion would send an admin to restore a project that was never gone.
+   *
+   * It describes `value`, not the row the drawer opened on. The server
+   * reports archival of the *stored* destination, so a caller holding both
+   * must stop passing it true once the admin picks a replacement — otherwise
+   * the picker seeds empty over the admin's own selection and the archived
+   * notice contradicts what they just chose
+   * (`inventory.tsx`, `destinationUntouched`).
+   */
+  destinationArchived?: boolean;
+  organizationId: string;
+  organizationName?: string;
+  availableTeams: Array<{ id: string; name: string }>;
+  availableProjects: Array<{ id: string; name: string; teamId?: string }>;
+};
+
+/**
+ * The picker, in the one configuration a destination is ever set in:
+ * `ScopeChipPicker` single-select over PROJECT scopes.
+ *
+ * Rendered in the archived case too, and that is the point: telling an admin
+ * routing has stopped while offering no control to restart it strands them.
+ * It seeds empty there because the archived id is not a project the picker
+ * can name or the server would accept back.
+ */
+function DestinationPicker({
+  value,
+  destinationArchived,
+  onChange,
+  organizationId,
+  organizationName,
+  availableTeams,
+  availableProjects,
+}: Pick<
+  TraceDestinationFieldProps,
+  | "value"
+  | "onChange"
+  | "organizationId"
+  | "organizationName"
+  | "availableTeams"
+  | "availableProjects"
+> & { destinationArchived: boolean }) {
+  return (
+    <ScopeChipPicker
+      value={
+        value && !destinationArchived
+          ? [{ scopeType: "PROJECT" as const, scopeId: value }]
+          : []
+      }
+      onChange={(next) => onChange(next[0]?.scopeId ?? null)}
+      organizationId={organizationId}
+      organizationName={organizationName}
+      availableTeams={availableTeams}
+      availableProjects={availableProjects}
+      allowedScopeTypes={["PROJECT"]}
+      variant="single-select"
+      label=""
+      placeholder="Select a project"
+      showSummary={false}
+    />
+  );
+}
+
+export function TraceDestinationField({
+  sourceType,
+  value,
+  onChange,
+  mode,
+  destinationArchived = false,
+  organizationId,
+  organizationName,
+  availableTeams,
+  availableProjects,
+}: TraceDestinationFieldProps) {
+  if (!routesConversations(sourceType)) return null;
+
+  const picked = value !== null && !destinationArchived;
+
+  return (
+    <VStack
+      align="start"
+      width="full"
+      gap={1.5}
+      data-testid="ingestion-trace-destination"
+    >
+      <HStack gap={1} alignItems="center">
+        <SmallLabel>Conversations land in</SmallLabel>
+        <FieldInfoTooltip
+          description="The project whose trace explorer this source's conversations become readable in. Leaving it unset means the source still records its audit events, but nothing reaches the explorer. A destination grants no access to the source itself."
+          testId="ingestion-trace-destination-info"
+        />
+      </HStack>
+
+      {destinationArchived && <ArchivedDestinationNotice />}
+
+      <DestinationPicker
+        value={value}
+        destinationArchived={destinationArchived}
+        onChange={onChange}
+        organizationId={organizationId}
+        organizationName={organizationName}
+        availableTeams={availableTeams}
+        availableProjects={availableProjects}
+      />
+
+      {value === null && !destinationArchived && (
+        <Text
+          fontSize="xs"
+          color="fg.muted"
+          data-testid="ingestion-trace-destination-empty"
+        >
+          This source&rsquo;s conversations will not be readable in the trace
+          explorer until you pick one. Its audit events are recorded either way.
+        </Text>
+      )}
+
+      {picked && <PickedDestinationConsequences mode={mode} />}
+    </VStack>
+  );
+}

--- a/platform/app/ee/governance/dashboard/components/__tests__/TraceDestinationField.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/TraceDestinationField.integration.test.tsx
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+// @vitest-environment jsdom
+/**
+ * The trace-destination section of the ingestion-source drawers: which
+ * project a conversation-bearing source's conversations land in, plus the
+ * three consequences of that choice an admin cannot discover anywhere else.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * The picker itself is `ScopeChipPicker` in single-select PROJECT mode —
+ * the same control the virtual-key ownership section uses for the same
+ * column (`VirtualKeyOwnershipSection.tsx`), so a destination reads the
+ * same way wherever it is set.
+ *
+ * ADR-088 v7: Decision 9 (the column, the cross-org guard, archived
+ * handling), Decision 11 (the 31-day horizon), Decision 13 (the
+ * destination project's redaction policy governs).
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import type { SourceType } from "../ingestionSourceCatalog";
+import { TraceDestinationField } from "../TraceDestinationField";
+
+const ORG_ID = "org_acme";
+const PROJECTS = [
+  { id: "proj_analytics", name: "Analytics · Data", teamId: "team_data" },
+  { id: "proj_support", name: "Support · CX", teamId: "team_cx" },
+];
+const TEAMS = [
+  { id: "team_data", name: "Data" },
+  { id: "team_cx", name: "CX" },
+];
+
+function Harness({
+  sourceType,
+  initialValue = null,
+  mode = "create",
+  destinationArchived = false,
+  onChangeSpy,
+}: {
+  sourceType: SourceType;
+  initialValue?: string | null;
+  mode?: "create" | "edit";
+  destinationArchived?: boolean;
+  onChangeSpy?: (next: string | null) => void;
+}) {
+  const [value, setValue] = useState<string | null>(initialValue);
+  return (
+    <TraceDestinationField
+      sourceType={sourceType}
+      value={value}
+      onChange={(next) => {
+        onChangeSpy?.(next);
+        setValue(next);
+      }}
+      mode={mode}
+      destinationArchived={destinationArchived}
+      organizationId={ORG_ID}
+      organizationName="Acme"
+      availableTeams={TEAMS}
+      availableProjects={PROJECTS}
+    />
+  );
+}
+
+const renderField = (props: Parameters<typeof Harness>[0]) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <Harness {...props} />
+    </ChakraProvider>,
+  );
+
+describe("given a source that pulls conversations", () => {
+  describe("when the admin composes it", () => {
+    /** @scenario "The composer of a conversation source offers a destination" */
+    it("offers a destination picker listing only this organization's projects", async () => {
+      const user = userEvent.setup();
+      renderField({ sourceType: "databricks_genie" });
+      expect(screen.getByTestId("ingestion-trace-destination")).toBeTruthy();
+      await user.click(screen.getByRole("combobox"));
+      const options = within(screen.getByRole("listbox"));
+      expect(options.getByText("Analytics · Data")).toBeTruthy();
+      expect(options.getByText("Support · CX")).toBeTruthy();
+    });
+
+    /** @scenario "The composer of a conversation source offers a destination" */
+    it("starts with nothing picked", () => {
+      renderField({ sourceType: "databricks_genie" });
+      expect(
+        screen.getByTestId("ingestion-trace-destination-empty").textContent,
+      ).toContain("not be readable in the trace explorer");
+    });
+
+    /** @scenario "A source created without a destination routes nothing" */
+    it("says, before saving, that conversations are unreadable without one", () => {
+      renderField({ sourceType: "databricks_genie" });
+      expect(
+        screen.getByTestId("ingestion-trace-destination-empty").textContent,
+      ).toContain("until you pick one");
+    });
+  });
+
+  describe("when a destination has been picked", () => {
+    /** @scenario "The destination states its three consequences where it is picked" */
+    it("says the destination project's data-privacy policy governs storage", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_analytics",
+      });
+      expect(
+        screen.getByTestId("ingestion-trace-destination-redaction").textContent,
+      ).toContain("data-privacy policy");
+    });
+
+    /** @scenario "The destination states its three consequences where it is picked" */
+    it("states the 31-day horizon and the partial-thread consequence", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_analytics",
+      });
+      const horizon = screen.getByTestId(
+        "ingestion-trace-destination-horizon",
+      ).textContent;
+      expect(horizon).toContain("last 31 days");
+      expect(horizon).toContain("only its more recent turns");
+    });
+
+    /** @scenario "The destination states its three consequences where it is picked" */
+    it("says an archived or deleted destination stops receiving conversations", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_analytics",
+      });
+      expect(
+        screen.getByTestId("ingestion-trace-destination-archival").textContent,
+      ).toContain("stops receiving");
+    });
+  });
+
+  /**
+   * These cover what the field *says* in edit mode. The other half of the
+   * scenario — changing the destination and the update carrying the new one —
+   * is bound in `pages/__tests__/sourceEditDestination.integration.test.tsx`,
+   * which drives the real drawer's Save button. Nothing here selects or
+   * submits anything, so nothing here may claim to.
+   */
+  describe("when the admin edits it", () => {
+    /** @scenario "The edit drawer changes a destination and says history stays" */
+    it("shows the destination already stored", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_analytics",
+        mode: "edit",
+      });
+      expect(
+        within(screen.getByRole("combobox")).getByText("Analytics · Data"),
+      ).toBeTruthy();
+    });
+
+    /** @scenario "The edit drawer changes a destination and says history stays" */
+    it("says conversations already routed stay where they are", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_analytics",
+        mode: "edit",
+      });
+      expect(
+        screen.getByTestId("ingestion-trace-destination-history").textContent,
+      ).toContain("stay where they are");
+    });
+
+    /** @scenario "The edit drawer changes a destination and says history stays" */
+    it("does not promise history stays while composing, where there is none", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_analytics",
+        mode: "create",
+      });
+      expect(
+        screen.queryByTestId("ingestion-trace-destination-history"),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the stored destination has since been archived", () => {
+    /** @scenario "An archived destination is named as archived, not as absent" */
+    it("names it as archived and says routing has stopped", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_gone",
+        mode: "edit",
+        destinationArchived: true,
+      });
+      const warning = screen.getByTestId(
+        "ingestion-trace-destination-archived",
+      ).textContent;
+      expect(warning).toContain("archived");
+      expect(warning).toContain("no longer being routed");
+    });
+
+    /** @scenario "An archived destination is named as archived, not as absent" */
+    it("does not fall back to the never-configured copy", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_gone",
+        mode: "edit",
+        destinationArchived: true,
+      });
+      expect(
+        screen.queryByTestId("ingestion-trace-destination-empty"),
+      ).toBeNull();
+    });
+
+    /**
+     * @scenario "An archived destination is named as archived, not as absent"
+     *
+     * Telling an admin routing has stopped and giving them no control to
+     * restart it strands them: the drawer would refuse every save, because
+     * the archived id fails the write-time guard on the way back out.
+     */
+    it("still offers the picker, so there is a way to repoint it", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_gone",
+        mode: "edit",
+        destinationArchived: true,
+      });
+      expect(screen.getByRole("combobox")).toBeTruthy();
+    });
+  });
+
+  describe("when the stored destination is one this admin cannot see", () => {
+    /**
+     * `proj_hidden` is absent from `availableProjects` exactly as an archived
+     * one would be, but the server has not called it archived — so neither
+     * does the drawer. The two are distinguishable server-side because
+     * `liveTraceProjectIds` scopes liveness to the organization
+     * (`ingestionSource.service.ts:296-304`), not to the reader's teams, so a
+     * project this admin cannot see is still live. Calling it archived would
+     * send them to restore a project that is fine.
+     */
+    /** @scenario "A destination the admin cannot see is not called archived" */
+    it("does not call it archived, because unresolvable is not the same as gone", () => {
+      renderField({
+        sourceType: "databricks_genie",
+        initialValue: "proj_hidden",
+        mode: "edit",
+        destinationArchived: false,
+      });
+      expect(
+        screen.queryByTestId("ingestion-trace-destination-archived"),
+      ).toBeNull();
+    });
+  });
+});
+
+describe("given a source that pulls counts rather than conversations", () => {
+  describe("when the admin composes or edits it", () => {
+    /** @scenario "A source that pulls counts is offered no destination" */
+    it("offers no destination at all while composing", () => {
+      renderField({ sourceType: "anthropic_admin" });
+      expect(screen.queryByTestId("ingestion-trace-destination")).toBeNull();
+    });
+
+    /** @scenario "A source that pulls counts is offered no destination" */
+    it("offers no destination while editing either", () => {
+      renderField({ sourceType: "anthropic_admin", mode: "edit" });
+      expect(screen.queryByTestId("ingestion-trace-destination")).toBeNull();
+    });
+
+    /** @scenario "A source that pulls counts is offered no destination" */
+    it("offers none for a push-mode source, which never routes conversations", () => {
+      renderField({ sourceType: "otel_generic" });
+      expect(screen.queryByTestId("ingestion-trace-destination")).toBeNull();
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/components/__tests__/conversationRoutingSourceTypes.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/conversationRoutingSourceTypes.unit.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * Which source types route conversations into a trace destination.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * The worker's own gate is `event.action === GENIE_QUERY_ACTION`
+ * (`genieTraceMapper.ts:239`), so a source type that emits no such event
+ * can carry a destination column that nothing ever reads. The drawer must
+ * not offer a control with no effect, and this declaration is what it
+ * asks — kept beside the catalog so a new adapter's author sees it while
+ * adding their entry.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  routesConversations,
+  SOURCE_TYPE_OPTIONS,
+} from "../ingestionSourceCatalog";
+
+describe("given the ingestion-source catalog", () => {
+  describe("when asked which types route conversations", () => {
+    it("says Genie does, because it is the one adapter emitting conversations", () => {
+      expect(routesConversations("databricks_genie")).toBe(true);
+    });
+
+    it("says an aggregate pull does not — its events are counts", () => {
+      expect(routesConversations("anthropic_admin")).toBe(false);
+    });
+
+    it("says a push-mode source does not: routing runs only inside a pull", () => {
+      expect(routesConversations("otel_generic")).toBe(false);
+      expect(routesConversations("claude_cowork")).toBe(false);
+    });
+
+    it("answers for every type in the catalog, so a new adapter must decide", () => {
+      for (const option of SOURCE_TYPE_OPTIONS) {
+        expect(typeof routesConversations(option.value)).toBe("boolean");
+      }
+    });
+
+    it("never claims a push-mode type routes, whatever its entry says", () => {
+      const lying = SOURCE_TYPE_OPTIONS.filter(
+        (o) => o.mode === "push" && routesConversations(o.value),
+      );
+      expect(lying).toEqual([]);
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -63,6 +63,14 @@ export interface SourceTypeOption {
   mode: SourceMode;
   blurb: string;
   icon: React.ReactNode;
+  /**
+   * True when this source's events are conversations that can be read in
+   * the trace explorer, so a trace destination is worth offering.
+   *
+   * Read `routesConversations` rather than this field — it enforces the
+   * push-mode exclusion the flag alone cannot. See ADR-088 Decision 8.
+   */
+  routesConversations?: boolean;
 }
 
 // `satisfies` (not a type annotation) so each entry's `value` keeps its
@@ -138,6 +146,7 @@ export const SOURCE_TYPE_OPTIONS = [
     blurb:
       "Records who asked what in Genie and the SQL it ran against your warehouse. Sign in with a Databricks service principal holding Can Manage on every Genie space you want covered — anything less returns only its own conversations.",
     icon: <Databricks />,
+    routesConversations: true,
   },
   {
     value: "s3_custom",
@@ -171,6 +180,40 @@ void _catalogIsComplete;
 export const SOURCE_TYPE_LABEL: Record<SourceType, string> = Object.fromEntries(
   SOURCE_TYPE_OPTIONS.map((o) => [o.value, o.label]),
 ) as Record<SourceType, string>;
+
+// Compile-time guard: routing runs inside `writePulledEvents`
+// (`pullers/pullerWorker.ts:325`), which nothing on the push path ever calls.
+// A push-mode entry claiming `routesConversations` would put a picker in the
+// drawer that changes nothing a customer can observe, so it stops the build
+// here rather than shipping a dead control. Bracketed so the `never` case
+// does not go vacuously true.
+type PushTypeClaimingConversations = Extract<
+  (typeof SOURCE_TYPE_OPTIONS)[number],
+  { mode: "push"; routesConversations: true }
+>;
+const _noPushTypeRoutesConversations: [PushTypeClaimingConversations] extends [
+  never,
+]
+  ? true
+  : never = true;
+void _noPushTypeRoutesConversations;
+
+/**
+ * Whether a source of this type produces conversations that land in a trace
+ * destination — and therefore whether the drawers should offer a destination
+ * picker at all.
+ *
+ * Today the answer is Genie alone, because the worker routes only events
+ * whose action is `genie_query` (`pullers/genieTraceMapper.ts:239`). That gate
+ * lives in server code this bundle must not import, so the two are kept in
+ * step by declaration plus test rather than by a shared constant — see
+ * `__tests__/conversationRoutingSourceTypes.unit.test.ts`. An adapter that
+ * starts emitting conversations must flip its entry here in the same change.
+ */
+export function routesConversations(sourceType: SourceType): boolean {
+  const option = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType);
+  return option?.routesConversations === true;
+}
 
 export interface GatedSourceTypeOption extends SourceTypeOption {
   /** Locked types render in the menu but cannot be picked. */

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
@@ -30,6 +30,9 @@ function composer(
     parserConfig,
     ottlStatements: [],
     pullSchedule,
+    // An aggregate pull has no conversations to route (ADR-088 Decision 8),
+    // so this stays null and the drawer offers no destination.
+    traceProjectId: null,
   };
 }
 

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
@@ -55,6 +55,9 @@ const composerWith = (parserConfig: Record<string, string>): ComposerState => ({
   parserConfig: { credentialsToken: "sk-ant-admin-test", ...parserConfig },
   pullSchedule: "0 * * * *",
   ottlStatements: [],
+  // A pull source carries no conversations, so it never offers a
+  // destination (ADR-088 Decision 8).
+  traceProjectId: null,
 });
 
 describe("Anthropic composer controls", () => {

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.builders.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.builders.unit.test.ts
@@ -236,6 +236,9 @@ describe("buildEditSubmission", () => {
       },
       ottlStatements: [],
       pullSchedule: "0 * * * *",
+      // A pull source never offers the destination picker, so an edit of one
+      // always leaves it untouched.
+      destination: undefined,
       ...overrides,
     });
   }

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.fixture.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.fixture.ts
@@ -21,5 +21,8 @@ export function composer(
     parserConfig,
     ottlStatements: [],
     pullSchedule,
+    // A pull source carries no conversations, so it never offers a
+    // destination (ADR-088 Decision 8).
+    traceProjectId: null,
   };
 }

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -71,6 +71,9 @@ describe("a saved edit reaching the pull lifecycle", () => {
       },
       ottlStatements: [],
       pullSchedule,
+      // A pull source never offers the destination picker, so an edit of one
+      // always leaves it untouched.
+      destination: undefined,
     });
     const commands = { configure: vi.fn(), disable: vi.fn() };
 

--- a/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
@@ -31,6 +31,7 @@ const genieComposer = (overrides: Partial<ComposerState>): ComposerState => ({
   },
   ottlStatements: [],
   pullSchedule: "",
+  traceProjectId: null,
   ...overrides,
 });
 
@@ -122,6 +123,29 @@ describe("given the create input for a pull-mode source", () => {
       expect((input?.pullConfig as { spaceIds?: string[] }).spaceIds).toEqual(
         [],
       );
+    });
+  });
+
+  describe("when a trace destination was picked", () => {
+    /** @scenario "The composer of a conversation source offers a destination" */
+    it("carries it on the create request", () => {
+      const input = buildCreateInput({
+        composer: genieComposer({ traceProjectId: "proj_analytics" }),
+        organizationId: "org-1",
+      });
+      expect(input?.traceProjectId).toBe("proj_analytics");
+    });
+  });
+
+  describe("when no trace destination was picked", () => {
+    /** @scenario "A source created without a destination routes nothing" */
+    it("creates the source anyway, carrying no destination", () => {
+      const input = buildCreateInput({
+        composer: genieComposer({}),
+        organizationId: "org-1",
+      });
+      expect(input).not.toBeNull();
+      expect(input?.traceProjectId).toBeNull();
     });
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/ingestionSourceSecretFields.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/ingestionSourceSecretFields.unit.test.ts
@@ -62,6 +62,7 @@ describe("given a composer state with both secret and non-secret values set", ()
     },
     ottlStatements: [],
     pullSchedule: "",
+    traceProjectId: null,
   };
 
   describe("when building the persisted parserConfig", () => {

--- a/platform/app/ee/governance/dashboard/pages/__tests__/ingestionSourceUpdateInput.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/ingestionSourceUpdateInput.unit.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * The payload the edit drawer sends, and specifically what it says about a
+ * trace destination the admin never touched.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * `updateSource` re-validates any destination it is handed
+ * (`ingestionSource.service.ts:529-539`): undefined leaves the stored value
+ * alone, null stops routing, and a named project is checked against the same
+ * live-project guard create uses. So echoing the stored id back on every save
+ * is not harmless — once that project is archived, the guard rejects it and
+ * the admin cannot rename the source, let alone fix the destination.
+ *
+ * Asserted against `buildEditSubmission` because that is the builder the
+ * drawer actually calls. An earlier revision of this branch tested a second
+ * builder holding its own copy of the same rule; when the rebase onto #7430
+ * left the drawer using only this one, those tests would have kept passing
+ * while proving nothing about what ships.
+ *
+ * ADR-088 v7, Decision 9.
+ */
+import { describe, expect, it } from "vitest";
+import { buildEditSubmission } from "../inventory";
+
+/**
+ * `databricks_genie` routes conversations and is NOT an editable pull source
+ * (`EDITABLE_PULL_CONFIG_SOURCE_TYPES` holds only `anthropic_admin`), so the
+ * builder skips `resolvePullConfig` and cannot return null for a reason that
+ * has nothing to do with the destination.
+ */
+const base = {
+  organizationId: "org_acme",
+  source: {
+    id: "src_1",
+    sourceType: "databricks_genie",
+    parserConfig: {},
+  },
+  name: "Genie fleet",
+  description: "",
+  parserConfig: {},
+  ottlStatements: [],
+  pullSchedule: "",
+};
+
+describe("given the edit drawer's update payload", () => {
+  describe("when the admin never touched the destination", () => {
+    it("omits it, so an untouched destination is never re-validated", () => {
+      const input = buildEditSubmission({ ...base, destination: undefined });
+      expect(input).not.toBeNull();
+      expect("traceProjectId" in input!).toBe(false);
+    });
+
+    it("omits it even when the stored destination has been archived", () => {
+      const input = buildEditSubmission({ ...base, destination: undefined });
+      expect(input?.traceProjectId).toBeUndefined();
+      expect(input?.name).toBe("Genie fleet");
+    });
+  });
+
+  describe("when the admin picked a different destination", () => {
+    it("carries the new one", () => {
+      const input = buildEditSubmission({
+        ...base,
+        destination: "proj_support",
+      });
+      expect(input?.traceProjectId).toBe("proj_support");
+    });
+  });
+
+  describe("when the admin cleared the destination", () => {
+    it("carries an explicit null, which is what stops routing", () => {
+      const input = buildEditSubmission({ ...base, destination: null });
+      expect(input).not.toBeNull();
+      expect("traceProjectId" in input!).toBe(true);
+      expect(input?.traceProjectId).toBeNull();
+    });
+  });
+
+  describe("when the source type routes nothing", () => {
+    it("never sends a destination, whatever the drawer held", () => {
+      const input = buildEditSubmission({
+        ...base,
+        source: { ...base.source, sourceType: "otel_generic" },
+        destination: "proj_support",
+      });
+      expect(input?.traceProjectId).toBeUndefined();
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditDestination.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditDestination.integration.test.tsx
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+// @vitest-environment jsdom
+/**
+ * Changing a source's destination in the edit drawer, all the way to the
+ * payload the update mutation receives.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * `TraceDestinationField.integration.test.tsx` covers what the field says.
+ * This covers what happens when the admin acts on it — the half of the
+ * scenario ("they change it to Support and save", "the update carries
+ * Support") that reading copy cannot prove.
+ *
+ * It drives the real `SourceEditDrawer`: the real picker, the real
+ * `useSourceEditForm` state, the real Save button, and the real
+ * `buildUpdateInput` call behind it. A harness that re-implemented
+ * `handleSubmit` would only prove the copy agrees with itself, and would keep
+ * passing after the drawer stopped passing `destination` through.
+ *
+ * ADR-088 v7, Decision 9.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { SourceEditDrawer } from "../inventory";
+
+/**
+ * `OttlEditor` sits inside the drawer's body and calls tRPC on render. It is
+ * not what this file is about, so it gets the smallest stub that lets the
+ * drawer mount: a starter query with no data and a validate mutation nobody
+ * invokes.
+ */
+vi.mock("~/utils/api", () => ({
+  api: {
+    ingestionSources: {
+      ottlStarter: {
+        useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+      },
+      validateOttl: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(),
+          isPending: false,
+          data: undefined,
+          error: null,
+          reset: vi.fn(),
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+const ORG_ID = "org_acme";
+
+const DESTINATION_CTX = {
+  organizationId: ORG_ID,
+  organizationName: "Acme",
+  availableTeams: [
+    { id: "team_data", name: "Data" },
+    { id: "team_cx", name: "CX" },
+  ],
+  availableProjects: [
+    { id: "proj_analytics", name: "Analytics · Data", teamId: "team_data" },
+    { id: "proj_support", name: "Support · CX", teamId: "team_cx" },
+  ],
+};
+
+/**
+ * A Genie source that already lands in Analytics. Only the fields the drawer
+ * reads are set; the row carries many more, and typing them here would tie
+ * this test to columns it never looks at.
+ */
+const sourceLandingInAnalytics = {
+  id: "src_genie",
+  name: "Genie fleet",
+  description: "Conversations from the Genie workspace",
+  sourceType: "databricks_genie",
+  parserConfig: { workspaceId: "ws_acme" },
+  traceProjectId: "proj_analytics",
+  traceProjectArchived: false,
+} as unknown as Parameters<typeof SourceEditDrawer>[0]["source"];
+
+/**
+ * The same source after its destination project was archived. The server
+ * reports the archival on the row (`ingestionSources.ts:101`); the id stays,
+ * because forgetting it would lose the only record of where the source used
+ * to land.
+ */
+const sourceLandingInAnArchivedProject = {
+  ...sourceLandingInAnalytics,
+  traceProjectId: "proj_gone",
+  traceProjectArchived: true,
+} as unknown as Parameters<typeof SourceEditDrawer>[0]["source"];
+
+/** Exactly what `buildUpdateInput` produces, read off the drawer's own prop. */
+type UpdateInput = Parameters<
+  Parameters<typeof SourceEditDrawer>[0]["onSubmit"]
+>[0];
+
+let onSubmit: Mock<(input: UpdateInput) => void>;
+
+const renderDrawer = (source = sourceLandingInAnalytics) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <SourceEditDrawer
+        organizationId={ORG_ID}
+        destinationCtx={DESTINATION_CTX}
+        source={source}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        isPending={false}
+      />
+    </ChakraProvider>,
+  );
+
+const pickDestination = async ({
+  user,
+  projectName,
+}: {
+  user: ReturnType<typeof userEvent.setup>;
+  projectName: string;
+}) => {
+  await user.click(screen.getByRole("combobox"));
+  await user.click(within(screen.getByRole("listbox")).getByText(projectName));
+};
+
+const submittedInput = () => onSubmit.mock.calls[0]?.[0];
+
+beforeEach(() => {
+  onSubmit = vi.fn<(input: UpdateInput) => void>();
+});
+
+describe("given a Genie source that already lands in Analytics", () => {
+  describe("when the admin opens it for editing", () => {
+    /**
+     * Covers the scenario's first half: the picker shows the stored project,
+     * and the drawer states that already-routed conversations stay put. The
+     * second half — changing it and saving — is the test below.
+     */
+    /** @scenario "The edit drawer changes a destination and says history stays" */
+    it("shows Analytics as the destination it is stored with, and says routed history stays", () => {
+      renderDrawer();
+      expect(
+        within(screen.getByRole("combobox")).getByText("Analytics · Data"),
+      ).toBeTruthy();
+      expect(
+        screen.getByTestId("ingestion-trace-destination-history"),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("when they change it to Support and save", () => {
+    /** @scenario "The edit drawer changes a destination and says history stays" */
+    it("carries Support as the destination in the update", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await pickDestination({ user, projectName: "Support · CX" });
+      await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(submittedInput()).toMatchObject({
+        organizationId: ORG_ID,
+        id: "src_genie",
+        traceProjectId: "proj_support",
+      });
+    });
+
+    /**
+     * Deliberately carries no `@scenario` annotation: it runs the scenario's
+     * interaction but asserts something the scenario never claims. It is a
+     * regression guard on the save above — the picker is the only thing that
+     * moved, so nothing else may move with it. A save that quietly renamed
+     * the source or dropped its parserConfig would still satisfy the
+     * destination assertion.
+     */
+    it("leaves the fields the admin did not touch as they were", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await pickDestination({ user, projectName: "Support · CX" });
+      await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+      expect(submittedInput()).toMatchObject({
+        name: "Genie fleet",
+        description: "Conversations from the Genie workspace",
+        parserConfig: { workspaceId: "ws_acme" },
+      });
+    });
+  });
+
+  describe("when they save without touching the destination", () => {
+    /**
+     * Deliberately carries no `@scenario` annotation: the scenario is about
+     * changing a destination, and this test is the opposite interaction.
+     *
+     * An untouched picker must send no destination at all, because
+     * `updateSource` re-validates whatever it is handed
+     * (`ingestionSource.service.ts:529-539`) and would reject a stored id
+     * whose project has since been archived — locking the admin out of
+     * renaming the source, let alone repointing it.
+     */
+    it("sends no destination key, rather than echoing the stored one", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(submittedInput()).not.toHaveProperty("traceProjectId");
+    });
+  });
+});
+
+describe("given a Genie source whose destination project has been archived", () => {
+  describe("when the admin picks a replacement to repoint it", () => {
+    /**
+     * The scenario offers the picker in the archived state "so the admin can
+     * repoint the source rather than being told routing stopped and given no
+     * way to restart it". That promise is only kept if picking actually shows
+     * the pick: the archived flag describes the *stored* destination, so once
+     * a replacement is chosen it no longer describes what is on screen. Left
+     * uncleared, the admin selects a project, sees the picker stay empty
+     * under an unchanged archived warning, and reasonably concludes the
+     * control is dead.
+     */
+    /** @scenario "An archived destination is named as archived, not as absent" */
+    it("shows the replacement in the picker and drops the archived warning", async () => {
+      const user = userEvent.setup();
+      renderDrawer(sourceLandingInAnArchivedProject);
+
+      expect(
+        screen.getByTestId("ingestion-trace-destination-archived"),
+      ).toBeTruthy();
+
+      await pickDestination({ user, projectName: "Support · CX" });
+
+      expect(
+        within(screen.getByRole("combobox")).getByText("Support · CX"),
+      ).toBeTruthy();
+      expect(
+        screen.queryByTestId("ingestion-trace-destination-archived"),
+      ).toBeNull();
+    });
+
+    /**
+     * Deliberately carries no `@scenario` annotation: a regression guard on
+     * the repoint completing, not on how the archived state is named.
+     */
+    it("carries the replacement as the destination in the update", async () => {
+      const user = userEvent.setup();
+      renderDrawer(sourceLandingInAnArchivedProject);
+
+      await pickDestination({ user, projectName: "Support · CX" });
+      await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+      expect(submittedInput()).toMatchObject({
+        traceProjectId: "proj_support",
+      });
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -60,6 +60,7 @@ import {
   useSourceEventsPager,
 } from "../components/useSourceEventsPager";
 import type { PageRequest } from "../logic/eventsPager";
+import { useDestinationContext } from "./ingestionSourceForms";
 import { SourceEditDrawer } from "./inventory";
 
 /**
@@ -419,6 +420,9 @@ function useIngestionSourceDetailPage() {
     redirectToOnboarding: false,
   });
   const orgId = organization?.id ?? "";
+  // Same derivation the inventory page uses, so the drawer offers the same
+  // destinations whichever surface opened it.
+  const destinationCtx = useDestinationContext(organization);
   const canRead = hasAnyPermission("ingestionSources:view");
   const canReadActivity = hasAnyPermission("activityMonitor:view");
 
@@ -473,6 +477,7 @@ function useIngestionSourceDetailPage() {
   return {
     sourceId,
     orgId,
+    destinationCtx,
     canRead,
     canManage: hasAnyPermission("ingestionSources:manage"),
     canReadActivity,
@@ -493,6 +498,7 @@ function IngestionSourceDetailPage() {
   const {
     sourceId,
     orgId,
+    destinationCtx,
     canRead,
     canManage,
     canReadActivity,
@@ -549,6 +555,7 @@ function IngestionSourceDetailPage() {
       pageTitle={pageTitle}
       source={source}
       orgId={orgId}
+      destinationCtx={destinationCtx}
       canManage={canManage}
       canReadActivity={canReadActivity}
       healthQuery={healthQuery}
@@ -574,6 +581,7 @@ function LoadedSourceDetail({
   pageTitle,
   source,
   orgId,
+  destinationCtx,
   canManage,
   canReadActivity,
   healthQuery,
@@ -591,6 +599,7 @@ function LoadedSourceDetail({
   orgId: string;
 } & Pick<
   ReturnType<typeof useIngestionSourceDetailPage>,
+  | "destinationCtx"
   | "canManage"
   | "canReadActivity"
   | "healthQuery"
@@ -624,6 +633,7 @@ function LoadedSourceDetail({
             drift into offering different edits of the same row. */}
         <SourceEditDrawer
           organizationId={orgId}
+          destinationCtx={destinationCtx}
           source={isEditing ? source : null}
           onClose={() => setIsEditing(false)}
           onSubmit={(input) => updateMutation.mutate(input)}

--- a/platform/app/ee/governance/dashboard/pages/ingestionSourceForms.ts
+++ b/platform/app/ee/governance/dashboard/pages/ingestionSourceForms.ts
@@ -12,7 +12,7 @@
  * against the real picker without mounting the whole inventory page.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { RouterOutputs } from "~/utils/api";
 
@@ -57,46 +57,4 @@ export function useDestinationContext(
     }),
     [orgId, organization],
   );
-}
-
-/**
- * The edit drawer's local form state, re-seeded whenever the drawer opens on a
- * different source so a previous source's edits never bleed into this one.
- *
- * `destination` deliberately starts as `undefined` and stays there until the
- * admin touches the picker — see `buildUpdateInput` in `inventory.tsx` for why
- * an untouched destination must not be echoed back to the server.
- */
-export function useSourceEditForm(source: Source | null) {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [statements, setStatements] = useState<string[]>([]);
-  const [destination, setDestination] = useState<string | null | undefined>(
-    undefined,
-  );
-
-  useEffect(() => {
-    if (!source) return;
-    setName(source.name);
-    setDescription(source.description ?? "");
-    setDestination(undefined);
-    const parser = (source.parserConfig as Record<string, unknown>) ?? {};
-    const raw = parser.ottlStatements;
-    setStatements(
-      Array.isArray(raw)
-        ? raw.filter((s): s is string => typeof s === "string")
-        : [],
-    );
-  }, [source?.id]);
-
-  return {
-    name,
-    setName,
-    description,
-    setDescription,
-    statements,
-    setStatements,
-    destination,
-    setDestination,
-  };
 }

--- a/platform/app/ee/governance/dashboard/pages/ingestionSourceForms.ts
+++ b/platform/app/ee/governance/dashboard/pages/ingestionSourceForms.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The state the ingestion-source drawers hold, with no markup attached.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ * ADR-088 v7, Decisions 8-14.
+ *
+ * These are hooks, so they live in a `.ts` module rather than in the page
+ * that renders them (CLAUDE.md: "Use `.ts` for hooks, `.tsx` for
+ * components"). Keeping them here also lets a test drive the edit form
+ * against the real picker without mounting the whole inventory page.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import type { RouterOutputs } from "~/utils/api";
+
+export type Source = RouterOutputs["ingestionSources"]["list"][number];
+
+/**
+ * The org's teams and projects, in the shape `ScopeChipPicker` reads. Both
+ * drawers need it to offer a trace destination, and both get the same object
+ * so the two pickers can never disagree about what exists.
+ */
+export interface DestinationContext {
+  organizationId: string;
+  organizationName?: string;
+  availableTeams: Array<{ id: string; name: string }>;
+  availableProjects: Array<{ id: string; name: string; teamId?: string }>;
+}
+
+/**
+ * The projects a destination can be picked from: this organization's own,
+ * named by team so two projects sharing a name stay distinguishable. Same
+ * derivation the virtual-key drawer uses for the same column
+ * (`VirtualKeyCreateDrawer.tsx:113-123`).
+ */
+export function useDestinationContext(
+  organization: ReturnType<typeof useOrganizationTeamProject>["organization"],
+): DestinationContext {
+  const orgId = organization?.id ?? "";
+  return useMemo(
+    () => ({
+      organizationId: orgId,
+      organizationName: organization?.name,
+      availableTeams:
+        organization?.teams?.map((t) => ({ id: t.id, name: t.name })) ?? [],
+      availableProjects:
+        organization?.teams?.flatMap((t) =>
+          t.projects.map((p) => ({
+            id: p.id,
+            name: `${p.name} · ${t.name}`,
+            teamId: t.id,
+          })),
+        ) ?? [],
+    }),
+    [orgId, organization],
+  );
+}
+
+/**
+ * The edit drawer's local form state, re-seeded whenever the drawer opens on a
+ * different source so a previous source's edits never bleed into this one.
+ *
+ * `destination` deliberately starts as `undefined` and stays there until the
+ * admin touches the picker — see `buildUpdateInput` in `inventory.tsx` for why
+ * an untouched destination must not be echoed back to the server.
+ */
+export function useSourceEditForm(source: Source | null) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [statements, setStatements] = useState<string[]>([]);
+  const [destination, setDestination] = useState<string | null | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    if (!source) return;
+    setName(source.name);
+    setDescription(source.description ?? "");
+    setDestination(undefined);
+    const parser = (source.parserConfig as Record<string, unknown>) ?? {};
+    const raw = parser.ottlStatements;
+    setStatements(
+      Array.isArray(raw)
+        ? raw.filter((s): s is string => typeof s === "string")
+        : [],
+    );
+  }, [source?.id]);
+
+  return {
+    name,
+    setName,
+    description,
+    setDescription,
+    statements,
+    setStatements,
+    destination,
+    setDestination,
+  };
+}

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -78,7 +78,6 @@ import {
   type DestinationContext,
   type Source,
   useDestinationContext,
-  useSourceEditForm,
 } from "./ingestionSourceForms";
 
 /**

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -20,6 +20,7 @@ import {
 import { AddIngestionSourceMenu } from "@ee/governance/dashboard/components/AddIngestionSourceMenu";
 import {
   groupForMode,
+  routesConversations,
   SOURCE_GROUP_META,
   SOURCE_TYPE_LABEL,
   SOURCE_TYPE_OPTIONS,
@@ -29,6 +30,7 @@ import {
 } from "@ee/governance/dashboard/components/ingestionSourceCatalog";
 import { OttlEditor } from "@ee/governance/dashboard/components/OttlEditor";
 import { PullCadenceField } from "@ee/governance/dashboard/components/PullCadenceField";
+import { TraceDestinationField } from "@ee/governance/dashboard/components/TraceDestinationField";
 import {
   composerCadenceError,
   PULL_ADAPTER_FOR_SOURCE,
@@ -49,7 +51,7 @@ import {
   RotateCw,
   Trash2,
 } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { ToolCatalogPanel } from "~/components/governance/ToolCatalogPanel";
@@ -71,7 +73,13 @@ import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { HandledErrorAlert, showErrorToast } from "~/features/errors";
 import { useActivePlan } from "~/hooks/useActivePlan";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { api, type RouterOutputs } from "~/utils/api";
+import { api } from "~/utils/api";
+import {
+  type DestinationContext,
+  type Source,
+  useDestinationContext,
+  useSourceEditForm,
+} from "./ingestionSourceForms";
 
 /**
  * Admin CRUD for IngestionSources - the per-platform fleet config that
@@ -82,7 +90,6 @@ import { api, type RouterOutputs } from "~/utils/api";
  * Spec: specs/ai-gateway/governance/ingestion-sources.feature
  */
 
-type Source = RouterOutputs["ingestionSources"]["list"][number];
 /** The one-time secret reveal, shown after a create or a rotate. */
 type SecretDetails = {
   title: string;
@@ -124,6 +131,14 @@ export interface ComposerState {
    * for push/webhook source types.
    */
   pullSchedule: string;
+  /**
+   * The project this source's conversations land in, or null for "don't
+   * route" — which is also where it starts, deliberately. Where one team's
+   * conversations become readable to another is a choice someone makes, not
+   * a default they inherit. Only conversation-bearing source types offer it
+   * (ADR-088 Decision 8); for the rest it stays null.
+   */
+  traceProjectId: string | null;
 }
 
 const blankComposer = (): ComposerState => ({
@@ -133,6 +148,7 @@ const blankComposer = (): ComposerState => ({
   parserConfig: {},
   ottlStatements: [],
   pullSchedule: "",
+  traceProjectId: null,
 });
 
 function fmtRelative(date: Date | string | null): string {
@@ -391,6 +407,13 @@ export function buildCreateInput({
         PULL_SCHEDULE_DEFAULTS[pullAdapter] ||
         null
       : null,
+    // Read through `routesConversations` rather than sending whatever the
+    // draft holds: a type switched mid-compose would otherwise carry a
+    // destination its adapter never reads, and a dead column is how a
+    // customer comes to believe routing is on.
+    traceProjectId: routesConversations(composer.sourceType)
+      ? composer.traceProjectId
+      : null,
   };
 }
 
@@ -496,6 +519,8 @@ function useIngestionSourcesPage() {
   // The Catalog pane's own grant — decides the inventory default tab.
   const canManageCatalog = hasAnyPermission("aiTools:manage");
 
+  const destinationCtx = useDestinationContext(organization);
+
   const sourcesQuery = api.ingestionSources.list.useQuery(
     { organizationId: orgId },
     { enabled: !!orgId && canRead, refetchOnWindowFocus: false },
@@ -543,6 +568,7 @@ function useIngestionSourcesPage() {
 
   return {
     orgId,
+    destinationCtx,
     isEnterprise,
     canRead,
     canManage,
@@ -652,79 +678,81 @@ function InventoryTabs({
   );
 }
 
+/**
+ * The two tabs and everything under the sources one: the actions row an admin
+ * only sees with the manage grant, and the list itself.
+ */
+function InventorySourcesTab({
+  page,
+}: {
+  page: ReturnType<typeof useIngestionSourcesPage>;
+}) {
+  const { orgId, sourcesQuery, mutations } = page;
+  return (
+    <InventoryTabs
+      defaultTab={page.canManageCatalog ? "catalog" : "sources"}
+      sourcesActions={
+        page.canManage ? (
+          <SourcesActionsRow
+            isEnterprise={page.isEnterprise}
+            sourceCount={sourcesQuery.data?.length ?? 0}
+            onAdd={page.startComposer}
+          />
+        ) : undefined
+      }
+    >
+      <IngestionSourceList
+        canRead={page.canRead}
+        canManage={page.canManage}
+        isLoading={sourcesQuery.isLoading}
+        error={sourcesQuery.error}
+        grouped={page.grouped}
+        rotatingId={pendingId(mutations.rotate)}
+        archivingId={pendingId(mutations.archive)}
+        onEdit={page.setEditingSourceId}
+        onRotate={(id) =>
+          mutations.rotate.mutate({ organizationId: orgId, id })
+        }
+        onArchive={(id) =>
+          mutations.archive.mutate({ organizationId: orgId, id })
+        }
+      />
+    </InventoryTabs>
+  );
+}
+
 function InventoryPage() {
-  const {
-    orgId,
-    isEnterprise,
-    canRead,
-    canManage,
-    canManageCatalog,
-    startComposer,
-    closeComposer,
-    sourcesQuery,
-    grouped,
-    composing,
-    composer,
-    setComposer,
-    editingSourceId,
-    setEditingSourceId,
-    secretModal,
-    setSecretModal,
-    mutations,
-    onSubmit,
-  } = useIngestionSourcesPage();
+  const page = useIngestionSourcesPage();
+  const { orgId, destinationCtx, sourcesQuery, mutations } = page;
 
   return (
     <GovernanceLayout pageTitle="Inventory · Governance · LangWatch">
       <VStack align="stretch" gap={6} width="full" maxW="container.xl">
         <InventoryHeader />
         <SourceComposerDrawer
-          isOpen={composing}
+          isOpen={page.composing}
           organizationId={orgId}
-          composer={composer}
-          setComposer={setComposer}
+          destinationCtx={destinationCtx}
+          composer={page.composer}
+          setComposer={page.setComposer}
           isPending={mutations.create.isPending}
-          onSubmit={onSubmit}
-          onClose={closeComposer}
+          onSubmit={page.onSubmit}
+          onClose={page.closeComposer}
         />
 
-        <InventoryTabs
-          defaultTab={canManageCatalog ? "catalog" : "sources"}
-          sourcesActions={
-            canManage ? (
-              <SourcesActionsRow
-                isEnterprise={isEnterprise}
-                sourceCount={sourcesQuery.data?.length ?? 0}
-                onAdd={startComposer}
-              />
-            ) : undefined
-          }
-        >
-          <IngestionSourceList
-            canRead={canRead}
-            canManage={canManage}
-            isLoading={sourcesQuery.isLoading}
-            error={sourcesQuery.error}
-            grouped={grouped}
-            rotatingId={pendingId(mutations.rotate)}
-            archivingId={pendingId(mutations.archive)}
-            onEdit={setEditingSourceId}
-            onRotate={(id) =>
-              mutations.rotate.mutate({ organizationId: orgId, id })
-            }
-            onArchive={(id) =>
-              mutations.archive.mutate({ organizationId: orgId, id })
-            }
-          />
-        </InventoryTabs>
+        <InventorySourcesTab page={page} />
       </VStack>
 
-      <SecretModal details={secretModal} onClose={() => setSecretModal(null)} />
+      <SecretModal
+        details={page.secretModal}
+        onClose={() => page.setSecretModal(null)}
+      />
 
       <EditingSourceDrawer
         orgId={orgId}
-        editingSourceId={editingSourceId}
-        setEditingSourceId={setEditingSourceId}
+        destinationCtx={destinationCtx}
+        editingSourceId={page.editingSourceId}
+        setEditingSourceId={page.setEditingSourceId}
         sourcesQuery={sourcesQuery}
         update={mutations.update}
       />
@@ -735,12 +763,14 @@ function InventoryPage() {
 /** The edit drawer, resolved from the id the list put in page state. */
 function EditingSourceDrawer({
   orgId,
+  destinationCtx,
   editingSourceId,
   setEditingSourceId,
   sourcesQuery,
   update,
 }: {
   orgId: string;
+  destinationCtx: DestinationContext;
   editingSourceId: string | null;
   setEditingSourceId: (id: string | null) => void;
   sourcesQuery: ReturnType<typeof useIngestionSourcesPage>["sourcesQuery"];
@@ -749,6 +779,7 @@ function EditingSourceDrawer({
   return (
     <SourceEditDrawer
       organizationId={orgId}
+      destinationCtx={destinationCtx}
       source={
         editingSourceId
           ? (sourcesQuery.data?.find((s) => s.id === editingSourceId) ?? null)
@@ -923,6 +954,7 @@ function SourceRow({
 function SourceComposerDrawer({
   isOpen,
   organizationId,
+  destinationCtx,
   composer,
   setComposer,
   isPending,
@@ -931,6 +963,7 @@ function SourceComposerDrawer({
 }: {
   isOpen: boolean;
   organizationId: string;
+  destinationCtx: DestinationContext;
   composer: ComposerState;
   setComposer: (next: ComposerState) => void;
   isPending: boolean;
@@ -1021,6 +1054,16 @@ function SourceComposerDrawer({
                 setComposer({ ...composer, pullSchedule })
               }
             />
+
+            <TraceDestinationField
+              sourceType={composer.sourceType}
+              value={composer.traceProjectId}
+              onChange={(traceProjectId) =>
+                setComposer({ ...composer, traceProjectId })
+              }
+              mode="create"
+              {...destinationCtx}
+            />
           </VStack>
         </Drawer.Body>
         <Drawer.Footer>
@@ -1053,7 +1096,7 @@ function SourceComposerDrawer({
 
 /**
  * The edit form's local state, seeded from the row each time the drawer opens
- * on a different source.
+ * on a different source, including the trace destination.
  *
  * Split out from the drawer because seeding is the half with the reasoning in
  * it — which fields the row can answer, and which the DTO deliberately cannot
@@ -1066,6 +1109,14 @@ function useSourceEditForm(source: Source | null) {
   const [statements, setStatements] = useState<string[]>([]);
   const [parserConfig, setParserConfig] = useState<Record<string, string>>({});
   const [pullSchedule, setPullSchedule] = useState("");
+  /**
+   * `undefined` until the admin touches the picker — see
+   * {@link buildEditSubmission} for why an untouched destination must not be
+   * echoed back to a server that would re-validate it.
+   */
+  const [destination, setDestination] = useState<string | null | undefined>(
+    undefined,
+  );
 
   // Sync local state when the drawer opens for a new source - drives
   // the form fields off whatever the row carries on the wire.
@@ -1073,6 +1124,7 @@ function useSourceEditForm(source: Source | null) {
     if (!source) return;
     setName(source.name);
     setDescription(source.description ?? "");
+    setDestination(undefined);
     const parser = (source.parserConfig as Record<string, unknown>) ?? {};
     const raw = parser.ottlStatements;
     setStatements(
@@ -1104,6 +1156,8 @@ function useSourceEditForm(source: Source | null) {
     setParserConfig,
     pullSchedule,
     setPullSchedule,
+    destination,
+    setDestination,
   };
 }
 
@@ -1350,6 +1404,7 @@ export function SourceEditDrawer({
       parserConfig: form.parserConfig,
       ottlStatements: form.statements,
       pullSchedule: form.pullSchedule,
+      destination: form.destination,
     });
     // null is a form that is not saveable — an empty name, or a pull field the
     // adapter cannot parse, which has already told the admin which one.
@@ -1399,6 +1454,31 @@ export function SourceEditDrawer({
               statements={form.statements}
               onChange={form.setStatements}
               enabled={isOttlEnabledSourceType(source.sourceType)}
+            />
+
+            <TraceDestinationField
+              sourceType={source.sourceType as SourceType}
+              // Both props describe `value`, so both have to move together. An
+              // untouched picker shows the stored destination and the archived
+              // notice that describes it; the moment a replacement is picked,
+              // the flag stops applying — it described the project that has
+              // just been replaced, not the one now on screen. Left true, the
+              // picker seeds empty (`ScopeChipPicker.tsx:759` is fully
+              // controlled), so the admin picks a project, sees nothing
+              // selected under an unchanged warning, and concludes the control
+              // is dead.
+              value={
+                form.destination === undefined
+                  ? (source.traceProjectId ?? null)
+                  : form.destination
+              }
+              onChange={form.setDestination}
+              mode="edit"
+              destinationArchived={
+                form.destination === undefined &&
+                (source.traceProjectArchived ?? false)
+              }
+              {...destinationCtx}
             />
 
             <Text fontSize="xs" color="fg.muted">
@@ -2674,6 +2754,20 @@ export interface EditSubmission {
   description: string | null;
   parserConfig: Record<string, unknown>;
   pullSchedule?: string | null;
+  /**
+   * Absent means "leave the stored destination alone".
+   *
+   * Three-valued on purpose, mirroring what `updateSource` does with it
+   * (`ingestionSource.service.ts:529-539`): absent = the admin never touched
+   * the picker, `null` = they cleared it and routing stops, an id = they
+   * picked one and it is re-validated as create would.
+   *
+   * Echoing the stored id back on every save instead would look identical
+   * until the destination project is archived — at which point the
+   * write-time guard rejects it and the admin can no longer rename the
+   * source, or repoint the destination, or do anything else in this drawer.
+   */
+  traceProjectId?: string | null;
 }
 
 /**
@@ -2696,6 +2790,7 @@ export function buildEditSubmission({
   parserConfig,
   ottlStatements,
   pullSchedule,
+  destination,
 }: {
   organizationId: string;
   source: { id: string; sourceType: string; parserConfig: unknown };
@@ -2704,6 +2799,8 @@ export function buildEditSubmission({
   parserConfig: Record<string, string>;
   ottlStatements: string[];
   pullSchedule: string;
+  /** `undefined` = untouched, `null` = cleared, an id = picked. */
+  destination: string | null | undefined;
 }): EditSubmission | null {
   const trimmedName = name.trim();
   if (!trimmedName) return null;
@@ -2724,6 +2821,10 @@ export function buildEditSubmission({
         parserConfig,
         ottlStatements,
         pullSchedule,
+        // The destination is not part of the adapter's pull config — it only
+        // decides where routed conversations land afterwards. Null here so
+        // this literal satisfies ComposerState without implying otherwise.
+        traceProjectId: null,
       },
       { shouldRequireCredentials: false },
     );
@@ -2761,6 +2862,13 @@ export function buildEditSubmission({
             pullSchedule.trim() || recommendedPullSchedule(sourceType),
         }
       : {}),
+    // Same guard as create: a type that routes nothing must never carry a
+    // destination, even one left in drawer state from before a type change.
+    // An untouched picker sends nothing at all, so renaming a source cannot
+    // drag a since-archived destination back through the write-time guard.
+    ...(destination === undefined || !routesConversations(sourceType)
+      ? {}
+      : { traceProjectId: destination }),
   };
 }
 

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -51,7 +51,7 @@ import {
   RotateCw,
   Trash2,
 } from "lucide-react";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { ToolCatalogPanel } from "~/components/governance/ToolCatalogPanel";
@@ -1356,12 +1356,19 @@ export function isEditSaveBlocked({
 
 export function SourceEditDrawer({
   organizationId,
+  destinationCtx,
   source,
   onClose,
   onSubmit,
   isPending,
 }: {
   organizationId: string;
+  /**
+   * The teams and projects a destination can be picked from, passed in rather
+   * than derived here so this drawer and the create composer offer the same
+   * list — see `useDestinationContext` in `ingestionSourceForms.ts`.
+   */
+  destinationCtx: DestinationContext;
   source: Source | null;
   onClose: () => void;
   onSubmit: (input: EditSubmission) => void;
@@ -1375,7 +1382,6 @@ export function SourceEditDrawer({
   // than throwing — which is the behaviour we want for a row written by a
   // newer deploy than the one serving this page.
   const sourceType = source?.sourceType as SourceType | undefined;
-  const isPullMode = isEditablePullSource(sourceType);
 
   // A source holding no cursor has its backfill start genuinely still in play.
   // Once one exists the usage cursor never rewinds, so the setting would be
@@ -1428,64 +1434,14 @@ export function SourceEditDrawer({
           </Heading>
         </Drawer.Header>
         <Drawer.Body>
-          <VStack align="stretch" gap={3}>
-            <SourceIdentityFields
-              name={form.name}
-              onNameChange={form.setName}
-              description={form.description}
-              onDescriptionChange={form.setDescription}
-            />
-
-            {isPullMode && (
-              <PullConfigEditFields
-                sourceType={sourceType}
-                parserConfig={form.parserConfig}
-                onParserConfigChange={form.setParserConfig}
-                pullSchedule={form.pullSchedule}
-                onPullScheduleChange={form.setPullSchedule}
-                hasPulled={hasPulled}
-              />
-            )}
-
-            <OttlEditor
-              organizationId={organizationId}
-              sourceType={source.sourceType}
-              statements={form.statements}
-              onChange={form.setStatements}
-              enabled={isOttlEnabledSourceType(source.sourceType)}
-            />
-
-            <TraceDestinationField
-              sourceType={source.sourceType as SourceType}
-              // Both props describe `value`, so both have to move together. An
-              // untouched picker shows the stored destination and the archived
-              // notice that describes it; the moment a replacement is picked,
-              // the flag stops applying — it described the project that has
-              // just been replaced, not the one now on screen. Left true, the
-              // picker seeds empty (`ScopeChipPicker.tsx:759` is fully
-              // controlled), so the admin picks a project, sees nothing
-              // selected under an unchanged warning, and concludes the control
-              // is dead.
-              value={
-                form.destination === undefined
-                  ? (source.traceProjectId ?? null)
-                  : form.destination
-              }
-              onChange={form.setDestination}
-              mode="edit"
-              destinationArchived={
-                form.destination === undefined &&
-                (source.traceProjectArchived ?? false)
-              }
-              {...destinationCtx}
-            />
-
-            <Text fontSize="xs" color="fg.muted">
-              {isPullMode
-                ? "Source type is immutable after create — archive and recreate to change it."
-                : "Source type and ingest secret are immutable after create. Use “Rotate secret” for the secret; archive + recreate to change source type."}
-            </Text>
-          </VStack>
+          <SourceEditBody
+            form={form}
+            source={source}
+            sourceType={sourceType}
+            hasPulled={hasPulled}
+            organizationId={organizationId}
+            destinationCtx={destinationCtx}
+          />
         </Drawer.Body>
         <Drawer.Footer>
           <HStack gap={3} width="full">
@@ -1511,6 +1467,93 @@ export function SourceEditDrawer({
         </Drawer.Footer>
       </Drawer.Content>
     </Drawer.Root>
+  );
+}
+
+/**
+ * The fields an edit drawer shows, in order. Split from the drawer because the
+ * drawer above is a shell — open state, submit gate, footer — while this is the
+ * part that decides what an admin can actually change about a source, and which
+ * of those fields the source's type even offers.
+ */
+function SourceEditBody({
+  form,
+  source,
+  sourceType,
+  hasPulled,
+  organizationId,
+  destinationCtx,
+}: {
+  form: ReturnType<typeof useSourceEditForm>;
+  source: Source;
+  sourceType: SourceType | undefined;
+  hasPulled: boolean;
+  organizationId: string;
+  destinationCtx: DestinationContext;
+}) {
+  // Derived here rather than passed in: `isEditablePullSource` is a type guard,
+  // and narrowing `sourceType` is what lets the pull fields below take it as a
+  // `SourceType` instead of re-asserting one.
+  const isPullMode = isEditablePullSource(sourceType);
+
+  return (
+    <VStack align="stretch" gap={3}>
+      <SourceIdentityFields
+        name={form.name}
+        onNameChange={form.setName}
+        description={form.description}
+        onDescriptionChange={form.setDescription}
+      />
+
+      {isPullMode && (
+        <PullConfigEditFields
+          sourceType={sourceType}
+          parserConfig={form.parserConfig}
+          onParserConfigChange={form.setParserConfig}
+          pullSchedule={form.pullSchedule}
+          onPullScheduleChange={form.setPullSchedule}
+          hasPulled={hasPulled}
+        />
+      )}
+
+      <OttlEditor
+        organizationId={organizationId}
+        sourceType={source.sourceType}
+        statements={form.statements}
+        onChange={form.setStatements}
+        enabled={isOttlEnabledSourceType(source.sourceType)}
+      />
+
+      <TraceDestinationField
+        sourceType={source.sourceType as SourceType}
+        // Both props describe `value`, so both have to move together. An
+        // untouched picker shows the stored destination and the archived
+        // notice that describes it; the moment a replacement is picked, the
+        // flag stops applying — it described the project that has just been
+        // replaced, not the one now on screen. Left true, the picker seeds
+        // empty (`ScopeChipPicker.tsx:759` is fully controlled), so the admin
+        // picks a project, sees nothing selected under an unchanged warning,
+        // and concludes the control is dead.
+        value={
+          form.destination === undefined
+            ? (source.traceProjectId ?? null)
+            : form.destination
+        }
+        onChange={form.setDestination}
+        mode="edit"
+        destinationArchived={
+          form.destination === undefined &&
+          (source.traceProjectArchived ?? false)
+        }
+        {...destinationCtx}
+      />
+
+      <Text fontSize="xs" color="fg.muted">
+        {isPullMode
+          ? "Source type is immutable after create — archive and recreate to change it."
+          : "Source type and ingest secret are immutable after create. Use “Rotate secret” for the secret; archive + recreate to change source type."}
+      </Text>
+    </VStack>
   );
 }
 

--- a/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * What the ingestion-source DTO says about a trace destination.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * The edit drawer must be able to tell "this destination is archived" from
+ * "this destination is a project I cannot see". Both make the id fail to
+ * resolve against the picker's list, and only one of them means routing has
+ * stopped — so the server decides it and the DTO carries the answer, the
+ * same way the virtual-key DTO does (`virtualKey.dto.ts:168-170`).
+ *
+ * ADR-088 v7, Decision 9.
+ */
+import { describe, expect, it } from "vitest";
+import { toIngestionSourceDto } from "../ingestionSources";
+
+const row = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: "src_1",
+    organizationId: "org_acme",
+    teamId: null,
+    sourceType: "databricks_genie",
+    name: "Genie fleet",
+    description: null,
+    parserConfig: {},
+    status: "active",
+    traceProjectId: null,
+    lastEventAt: null,
+    archivedAt: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    createdById: null,
+    ...overrides,
+  }) as Parameters<typeof toIngestionSourceDto>[0]["row"];
+
+describe("given an ingestion source with a trace destination", () => {
+  describe("when the destination is still a live project of this org", () => {
+    it("reports it as not archived", () => {
+      const dto = toIngestionSourceDto({
+        row: row({ traceProjectId: "proj_live" }),
+        liveTraceProjectIds: new Set(["proj_live"]),
+      });
+      expect(dto.traceProjectId).toBe("proj_live");
+      expect(dto.traceProjectArchived).toBe(false);
+    });
+  });
+
+  describe("when the destination is no longer live", () => {
+    it("reports it as archived, so the drawer can say routing has stopped", () => {
+      const dto = toIngestionSourceDto({
+        row: row({ traceProjectId: "proj_gone" }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+      expect(dto.traceProjectId).toBe("proj_gone");
+      expect(dto.traceProjectArchived).toBe(true);
+    });
+  });
+
+  describe("when no destination was ever set", () => {
+    it("is not archived, because there is nothing to have been archived", () => {
+      const dto = toIngestionSourceDto({
+        row: row({ traceProjectId: null }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+      expect(dto.traceProjectArchived).toBe(false);
+    });
+  });
+
+  describe("when the row carries secrets in its parser config", () => {
+    it("keeps stripping them, destination or not", () => {
+      const dto = toIngestionSourceDto({
+        row: row({
+          traceProjectId: "proj_live",
+          parserConfig: {
+            workspaceUrl: "https://example.databricks.net",
+            credentials: "sealed-envelope",
+            _rotation: { priorHash: "x" },
+          },
+        }),
+        liveTraceProjectIds: new Set(["proj_live"]),
+      });
+      expect(dto.parserConfig).toEqual({
+        workspaceUrl: "https://example.databricks.net",
+      });
+    });
+  });
+});

--- a/platform/app/ee/governance/routers/ingestionSources.ts
+++ b/platform/app/ee/governance/routers/ingestionSources.ts
@@ -55,26 +55,38 @@ const statusSchema = z.enum(["active", "disabled", "awaiting_first_event"]);
  * knew and post it there. The UI has no use for it either way; it collects a
  * fresh secret when one is being set and sends nothing when it is not.
  */
-function toDto(row: {
-  id: string;
-  organizationId: string;
-  teamId: string | null;
-  sourceType: string;
-  name: string;
-  description: string | null;
-  parserConfig: unknown;
-  // Required, not optional: if a future `select` clause stops fetching this,
-  // `hasPollerCursor` would silently answer false for every source and the
-  // edit form would offer a backfill start that cannot take effect. Better a
-  // compile error than a setting that quietly does nothing.
-  pollerCursor: unknown;
-  status: string;
-  traceProjectId: string | null;
-  lastEventAt: Date | null;
-  archivedAt: Date | null;
-  createdAt: Date;
-  updatedAt: Date;
-  createdById: string | null;
+export function toIngestionSourceDto({
+  row,
+  liveTraceProjectIds,
+}: {
+  row: {
+    id: string;
+    organizationId: string;
+    teamId: string | null;
+    sourceType: string;
+    name: string;
+    description: string | null;
+    parserConfig: unknown;
+    // Required, not optional: if a future `select` clause stops fetching this,
+    // `hasPollerCursor` would silently answer false for every source and the
+    // edit form would offer a backfill start that cannot take effect. Better a
+    // compile error than a setting that quietly does nothing.
+    pollerCursor: unknown;
+    status: string;
+    traceProjectId: string | null;
+    lastEventAt: Date | null;
+    archivedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+    createdById: string | null;
+  };
+  /**
+   * Of the destinations these rows point at, the ones still live in this
+   * org. Anything else is archived, deleted, or was never ours — all three
+   * mean the puller has stopped routing (`pullerWorker.ts:387-396`), which
+   * is the one thing the drawer must say and cannot work out for itself.
+   */
+  liveTraceProjectIds: ReadonlySet<string>;
 }) {
   const parser = (row.parserConfig as Record<string, unknown>) ?? {};
   const safeParser = Object.fromEntries(
@@ -104,12 +116,28 @@ function toDto(row: {
     hasPollerCursor: hasPollerCursor(row.pollerCursor),
     status: row.status,
     traceProjectId: row.traceProjectId,
+    traceProjectArchived: row.traceProjectId
+      ? !liveTraceProjectIds.has(row.traceProjectId)
+      : false,
     lastEventAt: row.lastEventAt,
     archivedAt: row.archivedAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     createdById: row.createdById,
   };
+}
+
+/** {@link toIngestionSourceDto} for a single row, resolving its destination. */
+async function dtoForRow(
+  service: IngestionSourceService,
+  row: Parameters<typeof toIngestionSourceDto>[0]["row"],
+  organizationId: string,
+) {
+  const liveTraceProjectIds = await service.liveTraceProjectIds(
+    [row],
+    organizationId,
+  );
+  return toIngestionSourceDto({ row, liveTraceProjectIds });
 }
 
 export const ingestionSourcesRouter = createTRPCRouter({
@@ -120,7 +148,13 @@ export const ingestionSourcesRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const rows = await service.list(input.organizationId);
-      return rows.map(toDto);
+      const liveTraceProjectIds = await service.liveTraceProjectIds(
+        rows,
+        input.organizationId,
+      );
+      return rows.map((row) =>
+        toIngestionSourceDto({ row, liveTraceProjectIds }),
+      );
     }),
 
   /** Get a single source by id (org-scoped). */
@@ -136,7 +170,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         // client has to sniff out of the tRPC envelope.
         throw new IngestionSourceNotFoundError(input.id);
       }
-      return toDto(row);
+      return dtoForRow(service, row, input.organizationId);
     }),
 
   /**
@@ -174,7 +208,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         actorUserId: ctx.session.user.id,
       });
       return {
-        source: toDto(created.source),
+        source: await dtoForRow(service, created.source, input.organizationId),
         ingestSecret: created.ingestSecret,
       };
     }),
@@ -207,7 +241,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         pullSchedule: input.pullSchedule,
         traceProjectId: input.traceProjectId,
       });
-      return toDto(updated);
+      return dtoForRow(service, updated, input.organizationId);
     }),
 
   /**
@@ -224,7 +258,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
         input.organizationId,
       );
       return {
-        source: toDto(rotated.source),
+        source: await dtoForRow(service, rotated.source, input.organizationId),
         ingestSecret: rotated.ingestSecret,
       };
     }),
@@ -235,7 +269,7 @@ export const ingestionSourcesRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const service = IngestionSourceService.create(ctx.prisma);
       const archived = await service.archive(input.id, input.organizationId);
-      return toDto(archived);
+      return dtoForRow(service, archived, input.organizationId);
     }),
 
   /**

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/traceDestinationTenancy.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/traceDestinationTenancy.unit.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * The write-time guard on a source's trace destination.
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *
+ * The picker only ever offers projects of the admin's own organization, but
+ * the picker is not the boundary — the API is. A destination reaching
+ * create/update by any other route (a crafted request, a stale drawer, a
+ * script) has to be refused here, and refused by name so the admin knows
+ * which field is wrong rather than being handed a generic failure.
+ *
+ * ADR-088 v7, Decision 9.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { IngestionSourceService } from "../ingestionSource.service";
+
+type PrismaArg = ConstructorParameters<typeof IngestionSourceService>[0];
+
+/** A prisma whose project lookup finds nothing — a foreign or archived id. */
+function prismaFindingNoProject() {
+  return {
+    ingestionSource: {
+      findUnique: vi.fn().mockResolvedValue({
+        id: "src_1",
+        organizationId: "org_acme",
+        sourceType: "databricks_genie",
+        name: "Genie fleet",
+        parserConfig: {},
+        pullSchedule: null,
+        traceProjectId: null,
+      }),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    project: { findFirst: vi.fn().mockResolvedValue(null) },
+  } as unknown as PrismaArg;
+}
+
+describe("given a trace destination outside the admin's organization", () => {
+  describe("when it reaches update by any route other than the picker", () => {
+    /** @scenario The picker cannot offer a project of another organization */
+    it("is refused, and the destination is named as the reason", async () => {
+      const prisma = prismaFindingNoProject();
+      const service = IngestionSourceService.create(prisma);
+
+      await expect(
+        service.updateSource({
+          id: "src_1",
+          organizationId: "org_acme",
+          traceProjectId: "proj_of_another_org",
+        }),
+      ).rejects.toThrow(/destination must be an active project/i);
+    });
+
+    /** @scenario The picker cannot offer a project of another organization */
+    it("is refused before anything is written", async () => {
+      const prisma = prismaFindingNoProject();
+      const service = IngestionSourceService.create(prisma);
+
+      await service
+        .updateSource({
+          id: "src_1",
+          organizationId: "org_acme",
+          traceProjectId: "proj_of_another_org",
+        })
+        .catch(() => undefined);
+
+      const calls = (
+        prisma as unknown as {
+          ingestionSource: { update: ReturnType<typeof vi.fn> };
+        }
+      ).ingestionSource.update.mock.calls;
+      expect(calls.length).toBe(0);
+    });
+
+    /** @scenario The picker cannot offer a project of another organization */
+    it("is looked up scoped to the caller's own organization, not globally", async () => {
+      const prisma = prismaFindingNoProject();
+      const service = IngestionSourceService.create(prisma);
+
+      await service
+        .updateSource({
+          id: "src_1",
+          organizationId: "org_acme",
+          traceProjectId: "proj_of_another_org",
+        })
+        .catch(() => undefined);
+
+      const where = (
+        prisma as unknown as {
+          project: { findFirst: ReturnType<typeof vi.fn> };
+        }
+      ).project.findFirst.mock.calls[0]?.[0]?.where;
+      expect(where).toMatchObject({
+        id: "proj_of_another_org",
+        archivedAt: null,
+        team: { organizationId: "org_acme" },
+      });
+    });
+  });
+});
+
+describe("given a destination on a team this admin is not a member of", () => {
+  describe("when the drawer asks which destinations are still live", () => {
+    /**
+     * The drawer says an unresolvable destination is archived, and the spec
+     * promises the reverse case is never mislabelled: a project the admin
+     * simply cannot see is not gone. That promise rests entirely on this
+     * query scoping liveness to the ORGANIZATION rather than to the reader's
+     * team memberships — narrow it to the reader and every cross-team
+     * destination starts reporting as archived, sending admins to restore
+     * projects that were never archived.
+     *
+     * Deliberately carries no `@scenario` annotation: the scenario it
+     * protects is bound at the drawer, where the behaviour is visible. This
+     * is the server-side guard that keeps that binding honest, and it is
+     * asserted with `toEqual` rather than `toMatchObject` on purpose — an
+     * ADDED membership filter is exactly the regression, and `toMatchObject`
+     * would wave it through.
+     */
+    it("scopes liveness to the organization, not to what this admin can see", async () => {
+      const findMany = vi.fn().mockResolvedValue([{ id: "proj_other_team" }]);
+      const prisma = {
+        project: { findMany },
+      } as unknown as PrismaArg;
+      const service = IngestionSourceService.create(prisma);
+
+      const live = await service.liveTraceProjectIds(
+        [{ traceProjectId: "proj_other_team" }],
+        "org_acme",
+      );
+
+      expect(live.has("proj_other_team")).toBe(true);
+      expect(findMany.mock.calls[0]?.[0]?.where).toEqual({
+        id: { in: ["proj_other_team"] },
+        archivedAt: null,
+        team: { organizationId: "org_acme" },
+      });
+    });
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -367,6 +367,44 @@ export class IngestionSourceService {
     });
   }
 
+  /**
+   * Of the trace destinations these sources point at, the ones that are
+   * still live projects of this organization — the same three conditions
+   * {@link assertTraceDestinationIsOwnLiveProject} writes under and the
+   * puller re-checks at every run.
+   *
+   * The presentation layer needs the complement: a destination missing from
+   * this set has stopped routing, and an admin has to be told that rather
+   * than shown an empty picker. It cannot work that out from the project
+   * list it already has, because a project outside the reader's own teams is
+   * also absent from that list and is not archived at all.
+   *
+   * One query for the whole page, keyed on the ids actually in use, so
+   * listing sources never becomes a per-row lookup.
+   */
+  async liveTraceProjectIds(
+    sources: Array<{ traceProjectId: string | null }>,
+    organizationId: string,
+  ): Promise<Set<string>> {
+    const wanted = [
+      ...new Set(
+        sources
+          .map((s) => s.traceProjectId)
+          .filter((id): id is string => id !== null),
+      ),
+    ];
+    if (wanted.length === 0) return new Set();
+    const live = await this.prisma.project.findMany({
+      where: {
+        id: { in: wanted },
+        archivedAt: null,
+        team: { organizationId },
+      },
+      select: { id: true },
+    });
+    return new Set(live.map((p) => p.id));
+  }
+
   async findById(
     id: string,
     organizationId: string,

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -133,6 +133,99 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       And a cron that can never run shows a plain-language message next
         to the input, and the create button refuses until it is fixed
 
+  Rule: A conversation source names the project its conversations land in
+
+    Some sources pull conversations, not counts. Those conversations can
+    be read in the trace explorer, but only once an admin says which
+    project they land in — the source ships with no destination and
+    routes nothing until then.
+
+    The choice carries three consequences the admin cannot discover any
+    other way, so the drawer states all three where the choice is made:
+    the destination project's own redaction policy governs what is
+    stored; only conversations from the last 31 days arrive, so a thread
+    that started earlier shows only its recent turns; and a destination
+    that is later archived or deleted stops receiving conversations
+    instead of failing the source or landing them elsewhere.
+
+    Sources that pull counts rather than conversations are offered no
+    destination at all — a control that changed nothing would be worse
+    than its absence.
+
+    @integration
+    Scenario: The composer of a conversation source offers a destination
+      When the admin picks "Databricks AI/BI Genie" from the Add source menu
+      Then the composer offers a picker for the project its conversations
+        land in, listing only projects of this organization
+      And the picker starts empty, because where another team's
+        conversations become readable is never a default
+
+    @integration
+    Scenario: The destination states its three consequences where it is picked
+      Given the admin is composing a "Databricks AI/BI Genie" source
+      When they pick a destination project
+      Then the drawer says the destination project's data-privacy policy
+        governs what is stored
+      And it says conversations from the last 31 days arrive, and that a
+        conversation that started earlier shows only its recent turns
+      And it says a destination that is archived or deleted stops
+        receiving conversations
+
+    @integration
+    Scenario: A source created without a destination routes nothing
+      When the admin creates a "Databricks AI/BI Genie" source without
+        picking a destination
+      Then the source is created
+      And the drawer said, before saving, that its conversations would
+        not be readable in the explorer until a destination is set
+
+    @integration
+    Scenario: The edit drawer changes a destination and says history stays
+      Given a "Databricks AI/BI Genie" source already lands in "Analytics"
+      When the admin opens the source for editing
+      Then the destination picker shows "Analytics"
+      And the drawer says conversations already routed stay where they are
+      When they change it to "Support" and save
+      Then the update carries "Support" as the destination
+
+    @integration
+    Scenario: A source that pulls counts is offered no destination
+      When the admin composes an "Anthropic Admin API (usage & cost)" source,
+        which pulls usage totals rather than conversations
+      Then no destination picker appears in the drawer
+      And the same is true when editing it
+
+    @integration
+    Scenario: An archived destination is named as archived, not as absent
+      Given a "Databricks AI/BI Genie" source lands in a project that has
+        since been archived
+      When the admin opens the source for editing
+      Then the drawer says that destination is archived and that
+        conversations are no longer being routed there
+      And it still offers the picker, so the admin can repoint the source
+        rather than being told routing stopped and given no way to restart it
+      And the picker being empty does not read as "never configured",
+        because the archived destination is named right above it
+      When they pick "Support" as the replacement destination
+      Then the picker shows "Support"
+      And the archived warning is gone, because it described the destination
+        they have just replaced rather than the one now on screen
+
+    @integration
+    Scenario: A destination the admin cannot see is not called archived
+      Given a "Databricks AI/BI Genie" source lands in a live project that
+        belongs to a team this admin is not on
+      When the admin opens the source for editing
+      Then the drawer does not say that destination is archived, so nobody
+        is sent to restore a project that was never gone
+
+    @unit
+    Scenario: The picker cannot offer a project of another organization
+      When the admin opens the destination picker
+      Then it lists only live projects of this organization
+      And a destination outside it, reaching the API by any other route,
+        is refused at write time with the destination named as the reason
+
   @unit
   Scenario: The configured-source list groups under the same two headings
     Given configured sources of push, pull, and s3 modes exist


### PR DESCRIPTION
ADR-088 v7 shipped the routing engine in #7444 and no way to switch it on. `IngestionSource.traceProjectId` reached the schema, the tRPC router and the puller; nothing in `src/components`, `src/pages` or `src/features` ever wrote it. The only way a customer could route a Genie conversation into the explorer was a hand-rolled API call. This is the control surface that was missing.

## What it does

Both ingestion-source drawers gain a destination picker — the composer (`inventory.tsx:915`) and the edit drawer (`:1055`) — through one `TraceDestinationField` driving `ScopeChipPicker` in single-select PROJECT mode. That is the same control the virtual-key ownership section uses for the same column, deliberately: a trace destination should not read two ways depending on which screen set it.

Three consequences ride with the picker, because the ADR promised each of them a line and none is discoverable anywhere else:

| Line | Why it is true | ADR |
|---|---|---|
| The destination project's data-privacy policy governs what is stored | `redactSpan` resolves the destination's cascaded policy by tenant id (`span-pii-redaction.service.ts:231-261`) | Decision 13 |
| Conversations from the last 31 days arrive; a thread that started earlier shows only its recent turns | `SPAN_MAX_PAST_MS` (`trace-request-collection.service.ts:30`), enforced at the door | Decision 11 |
| An archived or deleted destination stops receiving conversations rather than failing the source | the pull-time re-check skips and warns (`pullerWorker.ts:387-396`) | Decision 9 |

## The one server change, and why it was not optional

The third line needed `traceProjectArchived` on the DTO to be true rather than vague.

The picker's project list is the reader's own org tree. A stored destination id that fails to resolve against it has two causes — the project was archived, or it sits in a team this admin cannot see — and only one of them means routing has stopped. Collapsing them into "destination unavailable" would send someone to restore a project that was never gone.

So `IngestionSourceService.liveTraceProjectIds` resolves it server-side under the same three conditions the write-time guard (`ingestionSource.service.ts:221`) and the puller re-check already use, and `toIngestionSourceDto` carries the flag — exactly as the virtual-key DTO does (`virtualKey.dto.ts:168-170`). One query per page, keyed on the destination ids actually in use, so listing sources never becomes a per-row lookup.

Naming the archival is only half of it. The picker stays live in the archived state so the admin can repoint the source there and then — and the archived flag clears the moment they pick a replacement, because it describes the destination on screen, not the row the drawer opened on. Leaving it set made the picker look dead: the admin selected a project and watched the control stay empty under an unchanged "no longer being routed" warning. Caught in review, fixed in `3ac404e013`, and the scenario now spells out what repointing looks like instead of merely promising it is possible.

## What deliberately has no picker

Source types that pull counts rather than conversations are offered nothing. Routing runs inside `writePulledEvents` and maps only `genie_query` events (`genieTraceMapper.ts:239`), so a destination picker on an Anthropic usage source or a push-mode OTel source would be a control that changes nothing a customer can observe — worse than its absence.

Two guards keep that honest rather than hopeful:

- a compile-time assertion in the catalog stops a push-mode entry ever claiming `routesConversations`, mirroring the file's existing `_catalogIsComplete` guard;
- `buildCreateInput` and the edit drawer both read the predicate rather than the draft, so a type switched mid-compose cannot carry a dead destination to the server.

**Call worth reviewing:** the ask said "all ingestion sources drawers". I read that as both drawers, not every source type, and hid the picker where it would do nothing. If you want it visible-but-explained on the other types instead, that is a small change.

## Scenarios first, and two of them died

Seven scenarios added to `ingestion-sources.feature` under a Rule of their own. `/challenge` ran against the scenarios before any test was written, and killed two:

- *"An archived destination is surfaced on the source itself"* asserted something the merged DTO could not produce. That is where the server change above came from — the scenario was right and the code was missing, not the other way round.
- *"Then new conversations land in Support"* was a puller assertion inside a drawer scenario. Where a conversation lands is decided in `routeConversationsToTraceDestination` on the next scheduled run; a drawer test asserting it would have been asserting a mock.

Two more survived narrowed: `"Anthropic compliance"` is not a label the catalog has, and the foreign-org scenario described an API call rather than a drawer action.

Independence caveat, stated rather than hidden: no subagents are available in this environment, so those were my own lenses, not independent refuters.

## Verification

- Red first: `conversationRoutingSourceTypes.unit.test.ts` and `TraceDestinationField.integration.test.tsx` both observed failing before any source file was written (7 failures on the unit lane, a module-resolution failure on the component lane).
- `pnpm test:component run ee/governance` — 56/56
- `pnpm test:unit run ee/governance` — 458/458
- `pnpm test:unit run` (full) — 2186 files, 31,831 tests, 0 failures, re-run on the current rebase onto `0534fa7a63`
- `npm run typecheck`, `npm run typecheck:tests`, `npm run lint`, `npm run format` — clean
- `check:feature-parity` — 8629 enforced scenarios bound across 1133 files
- the Biome diff gate run the way CI runs it (`.github/scripts/biome-new-violations.sh biome.raw.json origin/main ./src ./ee ./scripts ./e2e ./prisma ./vite`) — no new violations from this branch

One thing worth recording: the full unit suite was red on `frontendFlagsRegistered.unit.test.ts` before the rebase. That was #7512 landing on main while this branch was open, not this change — rebasing onto `6997214f85` cleared it. Separately, 31 typecheck errors in `src/server/experiments/*` turned out to be a stale local Prisma client, cleared by `npx prisma generate`; nothing in the repo needed changing.

## Deferred, and where it is written down

- **The source detail page still shows no destination.** It is a page, not a drawer, and outside the requested scope. Worth a follow-up: it is where an admin lands after creating a source.
- **The API still accepts `traceProjectId` for source types that never read it.** Pre-existing, not introduced here; tightening it server-side would be a validation change with its own scenarios.
- **The routed-traces quota asymmetry stays open as #7490** — routed conversations spend the plan limit but bypass its gate. Two of its three options amend ADR-088 Decision 14, so it blocks routing-limit work until decided.
- **Scaffolding candidate, not built here:** this is the third caller wrapping `ScopeChipPicker` as a single-project picker (virtual-key create, virtual-key read-only, now this). Nobody has locked that decision, and platforming mid-change is scope creep.

## ADR

No parc-fermé change requested. ADR-088's v7 revision entry still reads *"Proposed within this ADR; locks at PR review"* despite #7444 having merged — that annotation is yours to make, not mine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional project destinations for conversation-routing sources.
  - Added organization-scoped project selection when creating or editing supported sources.
  - Clearly identifies unset, archived, or unavailable destinations.
  - Added guidance about privacy, 31-day history limits, archival behavior, and edit history.
  - Preserves previously routed conversations when destinations change.
  - Count-only and push-based sources do not display destination settings.

- **Bug Fixes**
  - Prevents selecting projects from other organizations.
  - Correctly reports archived or deleted destinations.
  - Validates destination changes before saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
