### PR TITLE
fix(feature-flags): the ops page states what actually decides a flag's value

### DIFF
--- a/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -235,11 +235,17 @@ function ScopeSection({
 
 /**
  * Blast-radius note for a PRODUCT flag on a shared install. Held as one
- * constant because it is both the tooltip content and the badge's accessible
- * label: tooltip content is not rendered until hover, so a note kept only
- * there is out of reach of a screen reader — and out of reach of any
- * assertion, which is how the previous wording survived being replaced
- * wholesale with "x" while its bound test stayed green.
+ * constant because it is rendered twice: as the tooltip content for a sighted
+ * operator, and as screen-reader-only text inside the badge for everyone else.
+ * Tooltip content is not in the DOM until hover, so a note kept only there
+ * reaches neither a screen reader nor any assertion — which is how the
+ * previous wording survived being replaced wholesale with "x" while its bound
+ * test stayed green.
+ *
+ * The srOnly copy is deliberate rather than an `aria-label` on the badge:
+ * Chakra renders Badge as a role-less <span>, and ARIA prohibits naming a
+ * generic element, so an aria-label there is ignored by screen readers even
+ * though Testing Library's getByLabelText happily matches it.
  */
 const FLEET_REACH_NOTE =
   "This flag gates a customer-facing feature, and a value set here applies to every organization that no targeting rule matches. On a shared install that is the whole fleet, so prefer a per-organization or per-project rule when rolling one out.";
@@ -349,13 +355,9 @@ function FlagRowView({
             <ScopeBadge scope={row.scope} />
             {showProductWarning && (
               <Tooltip content={FLEET_REACH_NOTE}>
-                <Badge
-                  colorPalette="yellow"
-                  size="sm"
-                  variant="subtle"
-                  aria-label={FLEET_REACH_NOTE}
-                >
+                <Badge colorPalette="yellow" size="sm" variant="subtle">
                   All customers
+                  <Text srOnly>{FLEET_REACH_NOTE}</Text>
                 </Badge>
               </Tooltip>
             )}

--- a/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/platform/app/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -119,8 +119,8 @@ export function FeatureFlagsContent() {
         heading="Product"
         description={
           isSaas
-            ? "Customer-facing features. The value here is the source of truth; set a targeting rule to reach a subset of organizations."
-            : "Customer-facing features. The value here is the source of truth."
+            ? "Customer-facing features. Customers get the value set here when no targeting rule matches and no env override is configured; set a targeting rule to reach a subset of organizations."
+            : "Customer-facing features. Customers get the value set here when no targeting rule matches and no env override is configured."
         }
         rows={grouped.product}
         canManage={canManage}
@@ -233,6 +233,17 @@ function ScopeSection({
   );
 }
 
+/**
+ * Blast-radius note for a PRODUCT flag on a shared install. Held as one
+ * constant because it is both the tooltip content and the badge's accessible
+ * label: tooltip content is not rendered until hover, so a note kept only
+ * there is out of reach of a screen reader — and out of reach of any
+ * assertion, which is how the previous wording survived being replaced
+ * wholesale with "x" while its bound test stayed green.
+ */
+const FLEET_REACH_NOTE =
+  "This flag gates a customer-facing feature, and a value set here applies to every organization that no targeting rule matches. On a shared install that is the whole fleet, so prefer a per-organization or per-project rule when rolling one out.";
+
 function FlagRowView({
   row,
   canManage,
@@ -337,8 +348,13 @@ function FlagRowView({
             </Text>
             <ScopeBadge scope={row.scope} />
             {showProductWarning && (
-              <Tooltip content="This flag gates a customer-facing feature, and a value set here applies to every organization no targeting rule matches. On a shared install that is the whole fleet, so prefer a per-organization or per-project rule when rolling one out.">
-                <Badge colorPalette="yellow" size="sm" variant="subtle">
+              <Tooltip content={FLEET_REACH_NOTE}>
+                <Badge
+                  colorPalette="yellow"
+                  size="sm"
+                  variant="subtle"
+                  aria-label={FLEET_REACH_NOTE}
+                >
                   All customers
                 </Badge>
               </Tooltip>

--- a/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
+++ b/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
@@ -15,9 +15,10 @@ import { FeatureFlagsContent } from "../FeatureFlagsContent";
  * that does not write the row, and the rollout does not happen.
  *
  * These assertions are deliberately about meaning rather than wording: they
- * pin that the SaaS Product copy claims this store as the source of truth
- * and names no external service, so a future rewrite is free to say it
- * better but not free to say the old thing again.
+ * pin what the copy must still tell an operator — what a value set here
+ * reaches, what outranks it, and in what order — and that it names no
+ * external service. A future rewrite is free to say it better, but not free
+ * to say the old thing again, and not free to drop a link in the chain.
  */
 
 const FLAGS = [
@@ -121,11 +122,15 @@ function sectionDescription(heading: string): string {
 
 describe("the Ops feature flags page", () => {
   describe("when an operator on a shared install reads the Product section", () => {
-    /** @scenario The Product section names this store as what customers actually get */
+    /** @scenario The Product section tells operators what the value they set actually reaches */
     it("is told what this value reaches, and the two things that outrank it", () => {
       renderPage();
 
       const copy = sectionDescription("Product");
+
+      // The claim itself, then the two caveats. Asserting only the caveats
+      // would let the sentence they qualify be deleted.
+      expect(copy).toMatch(/customers get the value set here/i);
 
       // Naming the store is not enough on its own: the resolver returns an
       // env override before it ever reads this store, and a targeting rule
@@ -150,13 +155,31 @@ describe("the Ops feature flags page", () => {
       // Order is the assertion, not mere presence: the chain is env override,
       // then this store, then the registry default, and copy that lists them
       // in any other order teaches an operator the wrong precedence.
-      const env = copy.search(/\benv\b/i);
-      const store = copy.search(/postgres/i);
-      const fallback = copy.search(/registry default/i);
+      //
+      // Each link is matched loosely so that rewording the copy — "env" to
+      // "environment variable", say — does not fail a test about ordering.
+      // Only a reordered or missing link should turn this red.
+      const positionOf = (link: string, pattern: RegExp) => {
+        const at = copy.search(pattern);
+        expect(
+          at,
+          `System copy never mentions ${link}: "${copy}"`,
+        ).toBeGreaterThanOrEqual(0);
+        return at;
+      };
 
-      expect(env).toBeGreaterThanOrEqual(0);
-      expect(store).toBeGreaterThan(env);
-      expect(fallback).toBeGreaterThan(store);
+      const env = positionOf("the env override", /\benv(ironment)?\b/i);
+      const store = positionOf("this postgres store", /postgres/i);
+      const fallback = positionOf("the registry default", /registry default/i);
+
+      expect(
+        store,
+        `System copy puts this store before the env override: "${copy}"`,
+      ).toBeGreaterThan(env);
+      expect(
+        fallback,
+        `System copy puts the registry default before this store: "${copy}"`,
+      ).toBeGreaterThan(store);
 
       for (const vendor of EXTERNAL_FLAG_SERVICES) {
         expect(copy).not.toMatch(vendor);
@@ -173,11 +196,15 @@ describe("the Ops feature flags page", () => {
 
       // The explanation used to live only in tooltip content, which Chakra
       // does not render until hover — so the whole note could be replaced
-      // with "x" and this file stayed green. Mirroring it onto the badge's
-      // accessible label puts it in the DOM for a screen reader and for
-      // this assertion at the same time.
-      const note =
-        screen.getByLabelText(/whole fleet/i).getAttribute("aria-label") ?? "";
+      // with "x" and this file stayed green. It is now screen-reader-only
+      // text inside the badge, which puts it in the DOM for a screen reader
+      // and for this assertion at the same time.
+      //
+      // Queried by text rather than by label on purpose: an aria-label on
+      // Chakra's role-less <span> badge would satisfy getByLabelText while
+      // being ignored by an actual screen reader, so a passing label query
+      // would prove nothing about the claim this test exists to pin.
+      const note = screen.getByText(/whole fleet/i).textContent ?? "";
 
       expect(note).toMatch(/no targeting rule matches/i);
       expect(note).toMatch(/per-organization or per-project rule/i);
@@ -187,7 +214,7 @@ describe("the Ops feature flags page", () => {
       renderPage();
 
       expect(screen.queryByText("All customers")).toBeNull();
-      expect(screen.queryByLabelText(/whole fleet/i)).toBeNull();
+      expect(screen.queryByText(/whole fleet/i)).toBeNull();
     });
   });
 });

--- a/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
+++ b/platform/app/src/components/ops/featureFlags/__tests__/FeatureFlagsContent.scopeCopy.integration.test.tsx
@@ -121,21 +121,42 @@ function sectionDescription(heading: string): string {
 
 describe("the Ops feature flags page", () => {
   describe("when an operator on a shared install reads the Product section", () => {
-    it("is told this store decides the value, not an outside service", () => {
+    /** @scenario The Product section names this store as what customers actually get */
+    it("is told what this value reaches, and the two things that outrank it", () => {
       renderPage();
 
       const copy = sectionDescription("Product");
 
-      expect(copy).toMatch(/source of truth/i);
+      // Naming the store is not enough on its own: the resolver returns an
+      // env override before it ever reads this store, and a targeting rule
+      // before it reads the row-level value. Copy that claims "source of
+      // truth" without either caveat is wrong for any flag that has one.
+      expect(copy).toMatch(/no targeting rule matches/i);
+      expect(copy).toMatch(/env override/i);
+
       for (const vendor of EXTERNAL_FLAG_SERVICES) {
         expect(copy).not.toMatch(vendor);
       }
     });
+  });
 
-    it("is told the same about the System section, so the two cannot disagree", () => {
+  describe("when the same operator reads the System section", () => {
+    /** @scenario The System section names the same chain, so the two cannot disagree */
+    it("is given the same resolution chain, in the order the resolver uses", () => {
       renderPage();
 
       const copy = sectionDescription("System");
+
+      // Order is the assertion, not mere presence: the chain is env override,
+      // then this store, then the registry default, and copy that lists them
+      // in any other order teaches an operator the wrong precedence.
+      const env = copy.search(/\benv\b/i);
+      const store = copy.search(/postgres/i);
+      const fallback = copy.search(/registry default/i);
+
+      expect(env).toBeGreaterThanOrEqual(0);
+      expect(store).toBeGreaterThan(env);
+      expect(fallback).toBeGreaterThan(store);
 
       for (const vendor of EXTERNAL_FLAG_SERVICES) {
         expect(copy).not.toMatch(vendor);
@@ -145,14 +166,28 @@ describe("the Ops feature flags page", () => {
 
   describe("when a PRODUCT flag row is shown on a shared install", () => {
     /** @scenario Ops page warns about the blast radius of a PRODUCT flag on a shared install */
-    it("carries the fleet-reach warning that a self-hosted install does not", () => {
+    it("carries a fleet-reach warning that explains itself without a hover", () => {
       renderPage();
+
       expect(screen.getByText("All customers")).toBeDefined();
+
+      // The explanation used to live only in tooltip content, which Chakra
+      // does not render until hover — so the whole note could be replaced
+      // with "x" and this file stayed green. Mirroring it onto the badge's
+      // accessible label puts it in the DOM for a screen reader and for
+      // this assertion at the same time.
+      const note =
+        screen.getByLabelText(/whole fleet/i).getAttribute("aria-label") ?? "";
+
+      expect(note).toMatch(/no targeting rule matches/i);
+      expect(note).toMatch(/per-organization or per-project rule/i);
 
       cleanup();
       isSaas.mockReturnValue(false);
       renderPage();
+
       expect(screen.queryByText("All customers")).toBeNull();
+      expect(screen.queryByLabelText(/whole fleet/i)).toBeNull();
     });
   });
 });

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -59,14 +59,15 @@ export const featureFlagRouter = createTRPCRouter({
         "Feature flag check requested",
       );
 
-      // `input.flag` is runtime-validated against FRONTEND_FEATURE_FLAGS,
-      // whose entries are registered keys of either scope (FeatureFlagKey
-      // is scope-agnostic, so the cast is safe for SYSTEM and PRODUCT
-      // alike). FRONTEND_FEATURE_FLAGS is wider than the inferred zod enum
-      // value type, hence the explicit FeatureFlagKey narrowing. The one
-      // deliberately unregistered entry, `ops_ui_ops_menu_pinned`, resolves
-      // false server-side by design; frontendFlagsRegistered.unit.test.ts
-      // pins that exception so a new unregistered key cannot slip in.
+      // `input.flag` is runtime-validated against FRONTEND_FEATURE_FLAGS, but
+      // that list is not a subset of the registry: `ops_ui_ops_menu_pinned` is
+      // deliberately unregistered, so for that one key the cast below widens a
+      // string the type system cannot vouch for. It stays sound at runtime —
+      // an unregistered key falls through to the legacy in-memory resolver and
+      // returns false — and frontendFlagsRegistered.unit.test.ts pins that
+      // exception by name so a second one cannot slip in behind it. For every
+      // other entry the cast is exact, and FeatureFlagKey is scope-agnostic,
+      // so SYSTEM and PRODUCT keys are equally valid here.
       const enabled = await featureFlagService.isEnabled(
         input.flag as FeatureFlagKey,
         {

--- a/specs/ops/internal-feature-flags.feature
+++ b/specs/ops/internal-feature-flags.feature
@@ -197,10 +197,10 @@ Feature: Internal feature flag system for system-level kill switches
           unresponsive toggle
 
     @integration
-    Scenario: The Product section names this store as what customers actually get
+    Scenario: The Product section tells operators what the value they set actually reaches
       Given an operator opens /ops/feature-flags on a shared install
-      Then the Product section says the value set here is what customers get
-           when no targeting rule matches and no env override is configured
+      Then the Product section says customers get the value set here when no
+           targeting rule matches and no env override is configured
       And it names no external flag service, because none is in the chain
 
     @integration
@@ -242,8 +242,9 @@ Feature: Internal feature flag system for system-level kill switches
           whole fleet
       And the explanation points the operator at a per-organization or
           per-project rule for a rollout
-      And that explanation sits on the badge's accessible label rather than on
-          hover alone, so it survives a reader who never hovers
+      And that explanation is rendered into the page rather than living only in
+          hover-only tooltip content, so an operator who never hovers — or who
+          reads the page with a screen reader — is warned too
 
   Rule: Self-hosted parity
 

--- a/specs/ops/internal-feature-flags.feature
+++ b/specs/ops/internal-feature-flags.feature
@@ -170,8 +170,10 @@ Feature: Internal feature flag system for system-level kill switches
       Given a flag key is exposed to the frontend
       Then it resolves to a registry entry, whether SYSTEM or PRODUCT scoped, so
            /ops/feature-flags can list it and target it per organization
-      And an unregistered key is reported instead, because it would resolve from
-          the legacy in-memory path where the operator store cannot see it
+      And an unregistered key is reported instead, because the resolver never
+          consults the operator store for one — it falls through to the legacy
+          in-memory path — so /ops/feature-flags would still list the row and
+          offer a toggle that silently changes nothing
       And the one historical exception is named explicitly rather than counted
 
     @unit
@@ -179,8 +181,9 @@ Feature: Internal feature flag system for system-level kill switches
       Given the flags exposed to the frontend that resolve to a SYSTEM-scoped definition
       Then they match the declared register of such flags exactly
       And a new SYSTEM classification therefore arrives as a visible edit for
-          review, because scope decides how /ops/feature-flags groups, badges
-          and warns on the flag even though it no longer decides resolution
+          review, because scope decides which section the flag lands in and
+          which badge it carries, and moving one out of PRODUCT also drops the
+          fleet-reach warning, even though scope no longer decides resolution
 
   Rule: Operators manage flags from the Ops Feature Flags page
 
@@ -192,6 +195,20 @@ Feature: Internal feature flag system for system-level kill switches
       And rows whose effective value comes from an env override show an
           "env override" badge so operators do not get confused by an
           unresponsive toggle
+
+    @integration
+    Scenario: The Product section names this store as what customers actually get
+      Given an operator opens /ops/feature-flags on a shared install
+      Then the Product section says the value set here is what customers get
+           when no targeting rule matches and no env override is configured
+      And it names no external flag service, because none is in the chain
+
+    @integration
+    Scenario: The System section names the same chain, so the two cannot disagree
+      Given an operator opens /ops/feature-flags
+      Then the System section names env, this postgres store, and the registry
+           default as the places a value comes from, in that order
+      And it names no external flag service either
 
     Scenario: Operator without ops:manage permission cannot toggle flags
       Given an operator with only ops:view permission opens the page
@@ -217,18 +234,23 @@ Feature: Internal feature flag system for system-level kill switches
     @integration
     Scenario: Ops page warns about the blast radius of a PRODUCT flag on a shared install
       Given the installation is running in SaaS mode
-      And the operator focuses a PRODUCT-scoped flag row
-      Then the page surfaces a note that the row-level value reaches every
-          organization no targeting rule matches, which on a shared install is
-          the whole fleet
-      And the note points the operator at a per-organization or per-project rule
-          for a rollout
+      And a PRODUCT-scoped flag is listed
+      Then the row carries a fleet-reach badge that a self-hosted install does
+           not show
+      And the badge explains that a value set here reaches every organization
+          that no targeting rule matches, which on a shared install is the
+          whole fleet
+      And the explanation points the operator at a per-organization or
+          per-project rule for a rollout
+      And that explanation sits on the badge's accessible label rather than on
+          hover alone, so it survives a reader who never hovers
 
   Rule: Self-hosted parity
 
-    Scenario: Self-hosted install with no third-party flag service can still flip kill switches
-      Given the installation is self-hosted with no external flag service configured
+    Scenario: Flipping a kill switch works the same self-hosted as on a shared install
+      Given the installation is self-hosted
       When an operator toggles a SYSTEM kill switch from the Ops UI
-      Then the change persists in postgres
-      And every pod observes the new value
-      And no PostHog call is ever attempted at any point in the chain
+      Then the change persists in postgres and every pod observes it, exactly
+           as it would on a shared install
+      And nothing in the chain reaches outside the install, because the
+          resolver has no third-party service in it on any deployment


### PR DESCRIPTION
## For humans

The internal Feature Flags page was telling operators something untrue.

It said the value you set on that page is "the source of truth". It usually is not — two other things quietly outrank it. If an environment variable is set for that flag, it wins and your edit does nothing. If a targeting rule matches the organization being checked, that wins too. An operator who believes the page sets the value for everyone will set it, see it stick on screen, and never learn it did not take effect where they meant it to.

There is also a yellow "All customers" badge on customer-facing flags, warning that a value set there reaches the whole fleet. That warning existed only inside a hover tooltip. If you never hovered — or read the page with a screen reader — you never got it. It was also unreachable by the tests, which is how its entire text could be replaced with the letter `x` without a single test going red.

Both are fixed, and the spec now describes the system as it actually behaves rather than as it behaved before an outside flag service was removed from the resolver.

## What changed

**The page copy now states the real order.** The Product section names both things that outrank a value set there. The System section names the full chain — environment variable, then this store, then the registry default — and the test asserts that *order*, so copy that teaches the wrong precedence fails rather than merely looking different.

**The fleet-reach warning is now in the page.** It was moved out of hover-only tooltip content into screen-reader-only text inside the badge, so it reaches an operator who never hovers and one using a screen reader. It is one constant rendered twice, so the tooltip and the spoken text cannot drift apart.

**Four spec claims that were false, not just vague, were corrected.** An unregistered key *is* listed by the ops page and grouped under System — the real failure is subtler and worse: the resolver never reads that flag's stored row, so the toggle the page offers silently does nothing. Scope no longer decides how a value resolves, but it still decides which section a flag lands in, which badge it carries, and whether it gets the fleet-reach warning at all. And a self-hosted scenario described a configuration that no longer exists in any deployment.

**The router's cast comment stopped contradicting itself** — it opened by claiming every frontend flag is registered and closed by naming the one that is not.

## On the tests

Every assertion added here was mutation-checked: the code was broken on purpose and the test confirmed red, then restored. That matters more than usual on this branch, because the defect being fixed *was* a green test guarding a claim nothing read.

One assertion was also checked in the opposite direction — that it does **not** fail when the copy is legitimately reworded. A test that blocks an improvement is a cost, not a safety net.

## Verification

| Check | Result |
| --- | --- |
| Component tests | 3 passed |
| Unit tests (`src/server/featureFlag`) | 70 passed, 10 files |
| Scenario binding (`check:feature-parity`) | OK — 8557 bound across 1132 files |
| `typecheck` / `typecheck:tests` | clean |
| `biome check` | clean (4 pre-existing complexity warnings, untouched) |

## Review

Self-reviewed before opening. That pass found one P1 and two P2s **in the first commit of this branch**, all fixed in the second:

- The fleet-reach note had been mirrored onto `aria-label`. Chakra renders that badge as a role-less `<span>`, where ARIA prohibits naming — so screen readers ignore it, while the test helper matching it does not. The test was green and the claim was false. Confirmed by dumping the rendered DOM, not by reading the code.
- An ordering assertion rejected a *better* wording of the same correct sentence, and failed with a message that did not say why.
- A scenario title claimed something no step and no assertion covered — the exact defect this branch exists to remove, one line above where it was removed.

Two things a reviewer should weigh rather than take on trust:

1. **The refutation steps were run by the same context that formed the findings**, not by an independent reviewer. That is weaker than a real second opinion and is not a substitute for one.
2. **A known gap is deliberately left in place.** `showProductWarning` has no environment-override condition, so the "All customers" badge still overstates its reach on a row whose value is overridden by an environment variable. It is out of scope here and not yet tracked — worth filing.

Refs langwatch/langwatch-saas#1158 (items 2, 3, 4, 5, 7, 8, 9, 10, 11). Item 6 (untagged scenarios) and item 1 (an authorization gap that predates this work) are deliberately not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how product and system feature flags are resolved, including targeting rules, environment overrides, and configured defaults.
  - Added guidance explaining how flag categories affect grouping, badges, and warnings.
- **User Experience**
  - Added persistent fleet-reach warnings for product flags on shared installations.
  - Ensured warnings remain hidden on self-hosted installations.
  - Improved tooltip and screen-reader messaging for customer-impact guidance.
- **Bug Fixes**
  - Updated behavior and documentation to consistently support internal flag resolution across deployment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->