### PR TITLE
docs(identity): the identity platform program — epic, delivery plan, and D01–D13

### DIFF
--- a/dev/docs/identity-platform-redesign.md
+++ b/dev/docs/identity-platform-redesign.md
@@ -1,0 +1,348 @@
+# Identity Platform Redesign — EPIC
+
+Self-hosted auth, per-org SSO, MFA, passkeys, SCIM, join-requests — built on the unified authz engine.
+
+**Status:** epic spec. Deliverable specs live in `dev/docs/identity-platform/D*.md`; sequencing and gates in `dev/docs/identity-platform/delivery-plan.md`.
+**Working branch/worktree:** `feat/sso-thinking` (`.claude/worktrees/sso-thinking`)
+**Precondition:** the unified authorization program (**ADR-092**, as reshaped by **ADR-110** — a grant is its own aggregate, one migration per organization, and finishing it IS the switch; #7358, #7404) has **landed on `main`** (checked 2026-08-23): `GrantsService.attach/offboard` is the membership writer, checks go through `.permission()` / `getApp().permissions`, and the engine gate reads the migration's `finalized` status and nothing else. This epic consumes that API; it does not build it. The authz program hands this one two ready-made pieces: the `@langwatch/system-migrations` package (landed, #7079, #7337; carries D01's backfill and D04's grandfathering; cloud pacing is per-organization enrollment and nothing else), and the ADR-110 in-place rollout shape (new head born clean, adoption by ids stable across retries, a migration that states facts and checks once, `finalized` as the only switch for reads and writes, held tenants with outstanding facts named, rollback as a status change) this epic transplants wholesale, re-tenanted to users.
+**Review history:** Notion round 1 (identifiers storage, Redis resilience, self-hosted single-SSO priority, join-requests + invitation resilience); corpus audit round 2 (`review-spec` against `specs/` + `dev/docs/adr/` — findings folded in below); restructure round 3 (RBAC assumed done; epic → deliverables → delivery plan).
+
+# Overview
+
+LangWatch's auth already migrated from NextAuth/Auth0-as-library to better-auth (done on `main`), but enterprise identity still runs through Auth0 as a broker: one auth method per deployment, enterprise SSO reduced to two strings on `Organization` set by hand, no SAML, no MFA, no passkeys, and SCIM writing membership tables directly. Support pain is structural — identity states exist that the product can't see and support can't fix without DB surgery.
+
+This program makes identity first-class and self-service:
+
+- An **identifiers** model: one user, many attach/detach-able verified identifiers (email, password, OAuth, OIDC/SAML, passkey), tombstoned forever. Storage = a **new pure event-truth Postgres `Identifier` projection**, born clean and backfilled grants-style; `Account` stays a 100% row-truth protocol table (see D01, ADR-101 rev. 2026-08-20).
+- A first-class, event-sourced **SsoConnection** per organization with a guarded lifecycle, domain verification, and org-admin self-service onboarding. Self-hosted priority: single-SSO deployments auto-redirect straight to the IdP.
+- **Domain join-requests** (ask-to-join with org-admin approval, or domain auto-join where the org opts in) and **resilient invitations** (identifier-aware acceptance, inviter one-click resend) — the fixes for the invitation dead-end support load and for the orphaned organizations sign-up keeps minting.
+- A **first-party sign-in & sign-up UI** (D13): Auth0 owned the front-door screens; every unauthenticated screen is rebuilt in-product, and sign-up offers join-your-team **before** create-a-workspace.
+- **MFA (TOTP + backup codes, never SMS)** and **passkeys**, using better-auth plugins for protocol while our domain model remains the record.
+- SCIM scoped per connection, producing commands/events, writing membership exclusively through `grants.*`.
+- **Two separate identity surfaces**: a platform-ops identity lookup (cross-org support tooling) and an org-admin surface inside org settings.
+- **Sign-in never touches the event pipeline**: sessions and OAuth tokens are repository-written rows, never events (R12), so the hot path reads and writes Postgres only. Ceremony commands ride the standard pipeline on the one shared ClickHouse event log (R13), staged through the per-user group queue like every other pipeline (ADR-110).
+- Auth0 dies slowly: enterprise customers migrate one at a time onto direct OIDC; then Auth0 code, config, and spend are deleted.
+
+Everything runs on the existing event-sourcing framework — commands → events → applies/projections, process managers — appending to the same ClickHouse `event_log` as every other pipeline (R13: one log, no identity-private event store). Postgres holds the projections and the row-truth values (emails, credentials, sessions); the sign-in hot path touches only Postgres because sessions and tokens never become events (R12). Authorization is expressed entirely in the unified authz API (`registry`, `authz.require`, `grants.*`, `useCan`) — no seams, no interim verbs.
+
+# Requirements
+
+Requirements are stated here at domain level; the normative, implementable version of each lives in the linked deliverable spec.
+
+## Domain: Identifiers → D01
+
+- A user has many identifiers; exactly one PRIMARY email identifier. Types: `email`, `password`, `oauth` (google/github/gitlab/azure-ad), `oidc`, `saml`, `passkey`.
+- Storage: a new Postgres `Identifier` projection, pure event-truth, fold-written, replay-rebuilt whole-row — while `Account` stays a 100% row-truth protocol table (password hash, OAuth tokens; repository-written, never a projection, never in replay). No table mixes truths, so ADR-022/015 stand unamended. **One writer (R10, our adapter):** better-auth supplies protocol logic only — its database adapter reads from PG and routes every domain-significant write through an identity command behind a per-user write gate (grants-style, ships closed; opens as each user's backfill lands), so the pipeline is the only thing that writes identity state. Ships with D01's ADR (ADR-101 rev. 2026-08-20).
+- Multiple verified email identifiers per user (aliases). Login works with any active credential; **login is never gated on email verification** — verification gates routing, linking, and join-matching. Notifications always to PRIMARY; `User.email` polyfilled from PRIMARY.
+- Attach requires ceremony evidence, never bare input. Detach is guarded (≥1 remaining verified identifier + ≥1 recovery path). Tombstones forever.
+
+## Domain: Sign-in routing & screens → D03, D13
+
+- Identifier-first sign-in: email → route by verified ACTIVE connection domain → IdP redirect; otherwise a uniform method picker (no account-existence oracle).
+- Self-hosted priority: exactly one ACTIVE connection ⇒ auto-redirect to the IdP; break-glass local login at `/auth/signin?local=1`.
+- Cloud: multiple methods simultaneously (ends the `NEXTAUTH_PROVIDER` one-method invariant). Amends ADR-027's mechanism (hook → router policy); license-gate semantics preserved.
+- The complete unauthenticated screen set is first-party (D13): sign-in, sign-up, method picker, password reset, email verification, deny/guidance states. D03 owns the routing contract; D13 renders it; both flip on one flag. Sign-up is verification-first and offers join-your-team before workspace creation.
+
+## Domain: Join requests & invitations → D11, D12
+
+- Resilient invitations (D11, needs only identifiers — pulled ahead of the router): identifier-aware acceptance (any verified method), inviter one-click resend, 14-day expiry, explicit states PENDING → ACCEPTED | EXPIRED | REVOKED.
+- Join requests (D12, needs the router, the D13 interstitial hook + org-admin surface): verified email → see colleagues' org → request → org-admin approval (default role, no picker) — or immediate auto-join where the org sets `domainJoin = auto`. Modes `off | request | auto`; default `request` for cloud self-serve orgs; forced `off` for SSO-connected orgs and self-hosted; public email domains never match in any mode.
+- Orphaned-organization prevention (D12 + D13): the join decision comes **before** workspace creation; an org is only created on explicit choice or no-match. Metric: orphaned-org creation rate.
+
+
+## Domain: Enterprise SSO connections → D04, D05
+
+- `SsoConnection` aggregate per (org, IdP): OIDC + SAML, IdP metadata, verified domains, guarded lifecycle (DRAFT → CLAIMED → APPROVED → VERIFICATION_PENDING → VERIFIED → ACTIVE ⇄ SUSPENDED → TEARDOWN_PENDING → TORN_DOWN).
+- Domain claim requires LangWatch ops manual approval (no blocklist); DNS TXT verification; license-bound ops token on self-hosted. First-verifier-owns, global on SaaS.
+- Self-service onboarding in org Settings, gated by `sso:manage`; break-glass bindings with expiry and warning wakes.
+
+## Domain: MFA → D06
+
+- TOTP + hashed one-time backup codes; never SMS. Org policy `mfaRequired`; enforced at session mint and step-up. Sessions carry `identifierId`, `amr`, `mfaVerifiedAt`; per-identifier revocation; impersonation rides the authz `Principal {actor, subject}` — actor must be MFA-verified when policy demands.
+
+## Domain: Passkeys → D07
+
+- `@better-auth/passkey` for ceremonies; passkeys mirrored as `provider="passkey"` identifier rows; discoverable-credential sign-in.
+
+## Domain: SCIM → D08
+
+- Tokens scoped per connection; `User.externalId`; SCIM = command/event producer; membership writes only via `grants.attach`/`grants.offboard`; de-enroll is a replayable event with a proven postcondition.
+
+## Domain: Authorization consumption (not construction)
+
+- New permissions `sso:view`, `sso:manage`, `scim:view`, `scim:manage` are registered directly in `server/authz/registry.ts` (org-scope only). IT-admin custom role = `CustomRole` row holding only those permissions.
+- All identity writes with authorization consequences go through `grants.*`. All UI gating uses `useCan`/`RequireCan`; all tRPC gating uses `.permission()`/`authz.require`.
+- PATs need nothing from this program: they are already edge-resolved principals with owner-ceiling intersection.
+
+## Domain: Identity surfaces (two, deliberately separate) → D05
+
+1. **Platform-ops identity lookup** — cross-org, support tooling, platform-ops-gated; every action a guarded command. The designated replacement for DB surgery.
+2. **Org-admin surface** — inside org Settings, org-scoped at the data layer; link confirmations, join-request approvals, invitation management, member-identifier view.
+
+Shared command handlers; separate pages, routes, and queries. The ops tool must never become customer-reachable by accident of a shared surface.
+
+## Domain: Auth0 retirement → D09, D10
+
+- Per-customer migration to direct OIDC, driven by a **migration wizard** in org settings (assumed design — pending validation against the Notion frontend-flow comment; Open Q7), with both-connections-active grace; then detach and teardown. Customer-paced, per tenant: D10 (deletion) is a program exit criterion, not a scheduled milestone.
+- A temporary **legacy callback shim** keeps customer-pinned `/api/auth/callback/auth0` redirect URIs working through grace (R9); deleted at D10.
+- Final deletion of provider config, Management API password service, federated logout, SCIM webhook, env wiring, the shim, and the agents-box Playwright Auth0 login.
+
+## Cross-cutting
+
+- Event-sourced on the existing framework. Event payloads carry what the fact needs: opaque ids (`userId`, `accountId`, `connectionId`), enums, timestamps, email **domains**, `identifierHash = HMAC-SHA256(per-user key, normalized value)` for uniqueness and correlation (the key is a deletable PG row) — and the normalized **email itself where the fact is about one** (attach, verification, invite targeting). Secrets never appear in any event. Erasure (R11) wipes the email fields out of the affected events — a ClickHouse mutation, routine practice for PII in append-only logs — and deletes the HMAC key, so replay reproduces the erased state. The grants ledger stays fully pseudonymized (ADR-092 §13); identity carries emails because its facts *are* emails, and the difference is pinned in ADR-101.
+- Type safety end-to-end: zod-derived command payloads, event unions with compile-enforced handlers, registry-derived `Permission` type, `Authorized<scope>` witnesses, discriminated identifier types.
+- Every deliverable flag-gated, shadow-compared where it replaces routing, independently revertible (one deliberate exception: the session-shape cutover's forced re-login, D06).
+
+# Out of Scope
+
+- The unified authorization engine itself — ADR-092 as reshaped by ADR-110 (see Precondition; landed). This program only consumes it.
+- Personal-workspace lifecycle (deletion, nav confusion) — owned by the navigation revamp. The authz blocker (lite-member as a role) was resolved by the authz program.
+- Authorization for resources (resource tier / share grants) — authz ADR.
+- Fleet-wide Redis decoupling — only the auth path joins ADR-007's Redis-loss doctrine.
+- Magic-link sign-in — the identifier model accommodates it later as one more type.
+- SMS as any factor — explicitly rejected.
+- Automated domain-claim blocklists — replaced by ops approval.
+- Rate-limiting infrastructure beyond better-auth's existing limiter (see Security Concerns).
+- Cross-org relation graphs / external policy engines (OpenFGA etc.).
+- SAML protocol engine choice (`@better-auth/sso` vs genericOAuth-with-SAML) — decided at D04/D05 design time; the domain model doesn't depend on it.
+
+# Research
+
+Investigation on `origin/main` (full detail carried in the deliverable specs):
+
+- **Auth architecture:** better-auth v1.6.23 is the only auth library; zero next-auth imports; one provider per deployment via `NEXTAUTH_PROVIDER`; hooks port the old signIn logic (domain auto-join, `pendingSsoSetup`, invites). ADR-027 license gating.
+- **Enterprise SSO today** (`platform/app/ee/sso/`): social + auth0/okta via genericOAuth; domain/provider string matching; no SAML; no per-org connection table; self-serve plugin PR #4416 closed unmerged.
+- **SCIM today** (`platform/app/ee/scim/`): full SCIM v2 at `/api/scim/v2`, per-org `ScimToken`, direct writes to `OrganizationUser`/`RoleBinding` with unconditional MEMBER role, Auth0 log-stream webhook.
+- **Data model:** `User` (email unique, `pendingSsoSetup`, no password), `Account`, `Session` (PG + Redis dual-write, `impersonating` JSON), `Organization.ssoDomain/ssoProvider`, `OrganizationInvite` (2-day expiry).
+- **Event-sourcing framework** (`platform/app/src/server/event-sourcing/`): GroupQueue per-aggregate FIFO, CH `event_log` with idempotency dedup, PG state projections, process managers (inbox/outbox, revision-CAS, wakes, idempotent retry), in-memory stores for the test harness (no production no-Redis processor exists — ADR-007's Redis-loss amendment is doctrine, not machinery). Doctrine ADRs: 007 (pipeline model + process roles), 015 (replay coordination), 022 (event log source of truth), 049 (PG operational projections), 052 (PM substrate + content boundary), 066 (fold contract).
+- **better-auth plugin reality:** `passkey` and `sso` are separate packages; `twoFactor` in core; `databaseHooks` don't fire for plugin tables — but the **database adapter sees every write from every plugin uniformly**, which is the structural argument for R10's own-adapter model over endpoint hooks; plugin migrations Kysely-only → hand-written Prisma models.
+- **SaaS infra:** Auth0 is dashboard-only (not Terraform); `AUTH0_*` arrives via the opaque `langwatch_secrets` blob; agents-box Playwright QA logs in via Auth0 and breaks at cutover.
+- **Support pain (production threads):** invited user with Google-linked account failing SSO (fixed by archiving the user); `unable_to_link_account` loop (fixed by DB reset; invite expired mid-debug); personal-workspace admins blocking lite-member conversion (resolved by the authz program). Root cause: invisible identity states + no guarded support actions.
+- **Corpus audit (review-spec round 2):** existing specs that assert what this program changes are mapped per-deliverable in the delivery plan's spec-amendment table; ADR conflicts (007 process roles, 015/022 replay contract, 027 interception mechanism) are carried as explicit amendments in D01–D03.
+
+Decisions settled in design discussion:
+
+| # | Decision | Outcome |
+|---|----------|---------|
+| Q1 | Event-store mechanics | Existing framework as-is; no new outbox infrastructure |
+| Q2 | Plugin vs domain state | better-auth handles protocol only; all reads and writes go through our adapter (R10) |
+| Q3 | Domain-claim safety | No blocklist; LangWatch ops manual approval |
+| Q4 | Ownership scope | Global first-verifier-owns on SaaS; per-instance self-hosted |
+| Q5 | Identifier linking | Auto-link when unambiguous; org-admin confirmation when ambiguous |
+| Q6 | Self-hosted verification | Ops-assisted, bound to the license system |
+| Q8 | PII in events | Events carry the normalized email where the fact is about one; never secrets, never names beyond the value itself. Hashes are HMAC-keyed per user; erasure wipes emails out of the events and shreds the key (R11) |
+| Q9 | Auth0 migration ownership | Engineering/CS-run playbook (wizard shape pending — Open Questions) |
+| Q10 | Legacy sessions | One forced re-login at D06 (precedent: better-auth cutover) |
+| R1 | Identifiers storage | A new pure event-truth Postgres `Identifier` projection, born clean, backfilled + rolled out grants-style (per-user latch, org-paced); `Account` stays 100% row-truth protocol. ADR-022/015 stand unamended (ADR-101, revised 2026-08-20) |
+| R3 | Multi-method sign-in | Cloud priority; self-hosted = single SSO + auto-redirect + break-glass local path |
+| R4 | Rate limiting | Nothing beyond better-auth's existing limiter |
+| R5 | Join requests & invites | `domainJoin` modes `off \| request \| auto` (default `request` for cloud self-serve; forced `off` for SSO orgs/self-hosted; public domains never match); fixed default role; identifier-aware invites + one-click resend + 14-day expiry |
+| R6 | RBAC relationship | **Hard precondition.** The unified authz engine is landed before this program starts; no seam, no parallel track. Registry entries and `grants.*` from day one |
+| R7 | Identity surfaces | Two separate UIs; shared command handlers; separate pages/routes/queries |
+| R8 | Aliases & verification | Multiple verified emails; login never gated on verification; ceremony = verification for OAuth/SSO; notifications to PRIMARY; `User.email` polyfilled |
+| R9 | Legacy Auth0 callback URIs | Temporary redirect shim through the grace period with a per-org usage metric, deleted at D10 — customers are never forced to reconfigure their IdP mid-migration |
+| R10 | better-auth integration | **Our own adapter**: better-auth is the protocol engine for *everything* (core, twoFactor, passkey, sso plugins), but it never writes the database — we implement its first-class `database` contract as a routing facade whose row engine is the stock prismaAdapter (the guarantees live in the facade — routing, gating, veto — not the engine). Reads query the pipeline-maintained PG tables through repositories; domain-significant writes become identity commands dispatched waited through the pipeline: guards → events appended to the shared ClickHouse log → applies feed the projections on the calling path — command → event → projection, never a projection write from a handler; the protocol values ride only on the command and land through the credentials repository (row-truth). Guards therefore veto *before* the write exists, plugin tables are covered uniformly (the `databaseHooks`-don't-fire gap disappears), and there is no enrich-after-write drift window for replay to disagree with. Endpoint `hooks.before` shrink to stamping ceremony context (which flow this write belongs to) onto request-scoped storage for the adapter to read. High-churn protocol writes (session rows, OAuth token refreshes) stay row-truth repository writes with no events (R12) — declared per (model, operation) in a routing table in D01 |
+| R11 | Erasure vs the immutable log | Erasure is itself an event — and the one sanctioned mutation of the log. The erase command wipes the email fields out of the user's prior events (a ClickHouse mutation; ids, enums and hashes stay), deletes the PG value rows and protocol tables, shreds the per-user HMAC key (remaining hashes become unlinkable noise), and emits `user_erased`. Replay *reproduces the erased state* because the log itself no longer carries the value. Encrypting event PII under an org key was rejected: a key inside an immutable log cannot rotate |
+| R12 | Sessions and tokens | Never events — session rows and OAuth token refreshes are better-auth protocol churn, written row-truth through repositories (`SessionRepository`, token columns via the credentials repository). No session lifecycle events either; the session inventory reads the table |
+| R13 | Event-log storage | **One log.** Identity events append to the same ClickHouse `event_log` as every other pipeline — no Postgres event store, no outbox, no per-pipeline store split. Postgres holds projections and row-truth values (emails, credentials, sessions). Sign-in tolerates ClickHouse being down because the hot path emits no events (R12); a CH outage degrades ceremonies (sign-up, attach, connection admin) to a clear retryable error for the window |
+
+# Architecture Overview
+
+## Current state — data shapes and locations
+
+```mermaid
+erDiagram
+    User ||--o{ Account : "1..*"
+    User ||--o{ Session : "1..*"
+    Organization ||--o{ OrganizationUser : "members"
+    Organization ||--o{ ScimToken : "1..* (per-ORG)"
+    Organization ||--o{ OrganizationInvite : "invites"
+
+    User {
+        string email UK "THE identity key"
+        boolean pendingSsoSetup
+        datetime deactivatedAt
+    }
+    Account {
+        string provider "credential|google|github|gitlab|azure-ad|auth0|okta"
+        string providerAccountId
+        string password "bcrypt, credential only"
+    }
+    Session {
+        string sessionToken UK
+        json impersonating "admin impersonation"
+    }
+    Organization {
+        string ssoDomain "UNIQUE, hand-set by ops"
+        string ssoProvider "string pin"
+    }
+    OrganizationInvite {
+        string inviteCode UK
+        string status "2-day expiry, dead-ends"
+    }
+```
+
+The deployment env (`NEXTAUTH_PROVIDER`) is the hidden eighth table: it selects exactly one sign-in method per deployment. (Post-authz-program, the five RBAC resolvers and `TeamUser` are gone; one engine resolves `RoleBinding` + `CustomRole` + group grants.)
+
+## Mapping — current to future
+
+| Current | Future | Deliverable |
+|---|---|---|
+| `User.email` UNIQUE = identity key | `provider="email"` identifier row (PRIMARY); `User.email` = display default | D01 |
+| `Account` rows | Stay pure protocol storage; the new `Identifier` projection carries lifecycle + widened provider vocabulary | D01 |
+| (no passkey/MFA) | `Passkey` + `TwoFactor` plugin tables; passkey mirror rows | D06, D07 |
+| `Organization.ssoDomain/ssoProvider` | `SsoConnection` aggregate + projection; grandfathered VERIFIED | D04 |
+| `NEXTAUTH_PROVIDER` one-method | Identifier-first router; env = self-hosted default method set | D03 |
+| `pendingSsoSetup` flag | Mismatch visible as data (events + states); column dropped | D03 |
+| `Session.impersonating` JSON | authz `Principal {actor, subject}`; session + `identifierId`, `amr`, `mfaVerifiedAt` | D06 |
+| `ScimToken` per-org, direct writes | Per-connection tokens; SCIM = command producer; `grants.*` only writer | D08 |
+| Invites: 2-day, method-sensitive, ops-only resend | Identifier-aware, 14-day, one-click resend, explicit states | D11 |
+| (no join path without invite) | Domain join-requests: admin approval or opt-in auto-join | D12 |
+| Auth0-hosted front-door screens | Complete first-party sign-in/sign-up/reset/verification UI | D13 |
+| Sign-up always mints a fresh org (orphans) | Join-before-create interstitial; org creation is an explicit choice | D12, D13 |
+| (no support visibility) | Platform-ops lookup + org-admin surface | D05 |
+| super-admin hand-sets `ssoDomain` | Org-admin self-service + ops approval; `sso:manage`/`scim:manage` in registry | D05 |
+| Auth0 broker + password service + webhook | Direct OIDC per customer; then deletion | D09, D10 |
+
+## Final state — system overview
+
+```mermaid
+flowchart TB
+    subgraph Edge["Edge (login hot path — reads PG only)"]
+        R[Identifier-first router] --> MW["authz edge middleware<br/>(any credential → Principal)"]
+        MW --> SE["Session {identifierId, amr, mfaVerifiedAt}<br/>Principal {actor, subject}"]
+        SE --> EN["authz engine (one resolver)"]
+    end
+
+    subgraph BA["better-auth (protocol engine — R10 identity adapter)"]
+        CORE[core: email/pwd, OAuth]
+        TF[twoFactor plugin]
+        PK["@better-auth/passkey"]
+        IE["identity adapter (ours, routing facade)<br/>reads ← PG tables · writes → commands<br/>(session/token churn: direct row-truth)"]
+        CORE --> IE
+        TF --> IE
+        PK --> IE
+    end
+
+    subgraph ES["Event-sourced identity domain"]
+        CMD[defineCommand handlers] --> CH[("ClickHouse event_log — shared<br/>append WAITED on the calling path<br/>emails wiped on erasure, R11")]
+        CMD --> APPLY["fold apply (calling path)"]
+        CMD -.->|"best-effort staging<br/>(convergence re-apply;<br/>dropped metric when Redis down)"| GQ["GroupQueue (per-aggregate FIFO)"]
+        GQ --> PRJ
+        APPLY --> PRJ["Identifier projection (PG, event-truth)<br/>+ projections: sso_connections ·<br/>mfa_enrollments · scim_sync_state · join_requests"]
+        CH --> PM["Process managers<br/>inbox/outbox · wakes · idempotent retry"]
+        PM --> GR["grants.* (the only membership writer)"]
+        PM --> EXT[email/notifications/session revocation]
+    end
+
+    IE --> CMD
+    UI[org-admin SSO UI + org-admin surface] --> CMD
+    SCIM["/api/scim/v2"] --> CMD
+    OPS[platform-ops identity lookup] --> CMD
+    PRJ -.->|read| Edge
+```
+
+## Final state — identifier-first sign-in
+
+```mermaid
+flowchart TD
+    A[enter email — or nothing, if instance auto-redirects] --> B["self-hosted, exactly one ACTIVE connection?<br/>→ redirect straight to IdP (break-glass: /auth/signin?local=1)"]
+    B --> C[normalize: lowercase, plus-strip, fold]
+    C --> D{"domain in ACTIVE<br/>sso_connections.domains?<br/>(PG read)"}
+    D -->|yes| E["redirect to IdP (direct OIDC/SAML — no broker)"]
+    D -->|no| F["uniform method picker<br/>passkey | password | social<br/>(same page/timing whether account exists)"]
+    E --> G["callback: match (connectionId, subject)"]
+    G -->|found| H
+    G -->|"not found; verified email matches existing user"| L{"ambiguous?"}
+    L -->|no| LA["auto-link + audit event"] --> H
+    L -->|yes| LP["LinkProposed → org admin confirms<br/>(org-admin surface)"] --> H
+    G -->|no match| J{"connection allows JIT?"}
+    J -->|yes| H
+    J -->|no| X[deny with guidance]
+    F --> H{"MFA enrolled or org requires?"}
+    H -->|yes| I["TOTP / backup-code step-up"]
+    H -->|no| K
+    I --> K["Session {identifierId, amr, mfaVerifiedAt}<br/>Principal {actor, subject} via authz edge middleware"]
+    K --> JR{"new verified email +<br/>colleagues' org exists<br/>on this domain?"}
+    JR -->|yes| JRO["'Acme Corp — 12 colleagues here.'<br/>join (auto if org allows) / request to join<br/>/ create own workspace (explicit choice)"]
+    JR -->|no| DONE[workspace home]
+    JRO --> DONE
+```
+
+Aggregate lifecycles (SsoConnection, identifier, MFA enrollment, SCIM sync, join request) live in their deliverable specs.
+
+# Technical Plan
+
+Thirteen deliverables, each independently shippable and flag-gated. Normative detail per deliverable; sequencing in the delivery plan.
+
+| # | Deliverable spec | One-liner |
+|---|---|---|
+| D01 | `identity-platform/D01-identity-pipeline-and-identifiers.md` | ES pipeline skeleton + `Identifier` projection (`Account` stays row-truth) + backfill + lifecycle events |
+| D03 | `identity-platform/D03-identifier-first-signin-router.md` | Router, uniform picker, self-hosted auto-redirect, cutover |
+| D04 | `identity-platform/D04-sso-connection-aggregate.md` | SsoConnection aggregate + grandfathering + routing parity |
+| D05 | `identity-platform/D05-self-service-onboarding-and-surfaces.md` | Org-admin SSO UI, domain verification, both identity surfaces, registry permissions |
+| D06 | `identity-platform/D06-mfa-and-session-shape.md` | TOTP MFA, session columns, Principal-aligned impersonation, forced re-login |
+| D07 | `identity-platform/D07-passkeys.md` | WebAuthn via plugin + mirror rows |
+| D08 | `identity-platform/D08-scim-per-connection.md` | Per-connection tokens, command-producer SCIM, grants offboard |
+| D09 | `identity-platform/D09-auth0-customer-migrations.md` | Per-customer playbook with grace |
+| D10 | `identity-platform/D10-auth0-deletion.md` | Code, config, infra, and QA-login deletion |
+| D11 | `identity-platform/D11-resilient-invitations.md` | Identifier-aware acceptance, one-click resend, 14-day expiry |
+| D12 | `identity-platform/D12-join-requests.md` | Domain join-requests: admin approval or opt-in auto-join; orphan-org prevention |
+| D13 | `identity-platform/D13-signin-signup-screens.md` | The first-party sign-in & sign-up screens (flips with D03) |
+
+Cross-deliverable conventions:
+
+- Pipeline layout `platform/app/src/server/event-sourcing/pipelines/identity/` per the langy/automations doctrine (ADR-049/052); type identifiers in `schemas/typeIdentifiers.ts`.
+- The **identity adapter** (R10): the `database` contract as a routing facade over the stock prismaAdapter row engine; reads pass through, domain-significant writes become commands dispatched waited — better-auth reads its own write back immediately because command → event → apply completes before the adapter returns. A small endpoint-hook plugin stamps ceremony context (flow, request metadata, actor) onto request-scoped storage so the adapter knows *why* a row is being written; protocol failures/`APIError`s still emit events (they feed the ops "why?" view).
+- Testing: in-memory `EventSourcing` harness + `InMemoryProcessStore`; replay-parity tests for the `Identifier` projection.
+
+# Milestones
+
+See `identity-platform/delivery-plan.md` — dependency graph, flags, exit gates, rollbacks, spec-amendment table, ADRs to write, metrics pack.
+
+# Security Concerns
+
+- **Identifier-first enumeration**: uniform page/timing; domain-level SSO routing discoverable by design, user-level existence never.
+- **Join-request privacy**: org existence/name revealed only after email verification, only on domain match, never for personal orgs; coarse member counts; admin gates every join — except deliberate org opt-in to `domainJoin = auto`, which still requires a verified non-public domain and notifies admins on every join.
+- **Domain auto-join abuse**: public email domains structurally excluded from all domain features; auto mode is admin-set opt-in; every auto-join is an audited event.
+- **Surface separation (R7)**: org-admin queries org-scoped at the data layer; ops lookup platform-ops-gated; no shared pages/routes.
+- **Attach-without-proof**: every identifier attach requires ceremony evidence.
+- **Wrong-human linking**: auto-link only when unambiguous; org-admin confirmation otherwise; before/after audit events on every link.
+- **Domain claim abuse**: ops manual approval; DNS proof before routing; disputes resolved from event history.
+- **Break-glass local path**: bound to break-glass bindings only, audited, rate-limited.
+- **Teardown lockout**: invariant guard (no user left with only the torn-down connection's identifiers) + live break-glass binding with expiry warnings.
+- **MFA bypass paths**: disable requires password+TOTP or audited org-admin action; impersonation requires an MFA-verified actor when policy demands; legacy sessions destroyed at D06 precisely because they can't prove `amr`.
+- **PII in the log**: emails appear in events only where the fact needs them; erasure wipes those fields via ClickHouse mutation, deletes PG rows and protocol tables, and shreds the per-user HMAC key; secrets never appear in any event.
+- **SCIM token scope**: per-connection; cross-org writes impossible; de-enroll failures are visible dead-letters.
+- **Plugin protocol secrets**: TOTP secrets and backup codes live in plugin tables (encrypted/hashed), never in events.
+- **Rate limiting**: better-auth's existing limiter only; one acceptance check that the router endpoint is covered. When the Redis breaker is open, rate limiting fails open (logged) — accepted for outage windows.
+- **Forced re-login (D06)**: one-time, communicated; precedent set by the better-auth cutover.
+
+# Open Questions
+
+1. SAML protocol engine: `@better-auth/sso` (its `ssoProvider` table as protocol state only) vs genericOAuth-based SAML — decide at D04/D05 design time.
+2. Who staffs the domain-approval queue day-to-day, and its SLA.
+3. Env renames (`NEXTAUTH_SECRET` → better-auth-native names) during D10 cleanup, or keep for compatibility?
+4. Passkey `amr` semantics: confirm `["phw"]` satisfies org MFA policy — product/security decision to record in the D06/D07 ADR.
+5. IdP-initiated SSO (launch from Okta/Entra portal): in scope for enterprise? SAML-specific; affects the D04/D05 protocol decision.
+6. Auto-redirect configuration: instance env only, or per-connection override as well? (Lean: env default true when exactly one ACTIVE connection, per-connection override for edge cases.)
+7. Auth0 migration frontend flow: the Notion comment is still unpasted, so D09 now carries an **assumed design** — a migration wizard in org Settings (detect legacy connection → guided OIDC setup → test login → grace with %-linked progress → SCIM repoint → guarded teardown) plus nudges and an ops exception queue. Validate against the comment when it surfaces; adjust D09 scope if it contradicts.
+8. Join-request matching threshold: ≥1 verified member on the domain, or ≥2 to avoid exposing solo orgs? (Lean: ≥1 — behind verification and admin approval anyway.)
+9. **Password reset in cloud/SSO mode**: `specs/auth/password-reset.feature:144-148` currently rejects reset under SSO mode; the uniform picker presumably makes reset available to any user holding a password identifier. Confirm and amend.
+10. ~~Legacy `/api/auth/callback/auth0` redirect URIs~~ — **resolved (R9)**: temporary translation shim with per-org usage metric through the grace period; removed at D10 once traffic is zero.
+11. **License-gate timing**: `specs/licensing/sso-license-gating.feature:16-17` asserts startup-decided gating ("never mid-flight"). Per-method router policy naturally evaluates per-request. Keep restart semantics for self-hosted license changes, or accept mid-flight evaluation? (Lean: keep startup semantics for the license gate specifically.)
+12. **Sign-up enumeration tension**: `signup-does-not-strand-an-account.feature:58-61` returns `email_already_registered`, in tension with the no-oracle stance on sign-up. Deliberate decision needed (sign-up enumeration is conventionally accepted; the no-oracle invariant is scoped to sign-in).
+13. ~~Member-initiated invites (`WAITING_APPROVAL`)~~ — **resolved: retired**. The invite state model is PENDING → ACCEPTED | EXPIRED | REVOKED; D12's join requests carry the member-wants-a-colleague-in motivation from the joiner's side. D11's `update-pending-invitation.feature` amendment drops the WAITING_APPROVAL scenarios.
+14. **Existing orphaned organizations**: D12/D13 stop new ones being minted, but production already carries a long tail of abandoned single-user orgs. Sweep them (delete empty orgs whose owner is active elsewhere on the same domain), build a merge tool, or leave them? Needs a product decision and a data pass to size the pool.
+15. ~~Sessions in or out of the event flow~~ — **resolved (R12): out**. Session rows and OAuth token refreshes are row-truth repository writes; no coarse lifecycle events either — the session inventory reads the table.
+16. **Ceremony-context stamping**: the identity adapter learns *why* a write happens from request-scoped context set by `hooks.before`. Better-auth internals that write outside a request (background token refresh, cron-ish cleanup) need a declared default context — enumerate those paths during D01 and decide whether any of them is domain-significant.
+17. ~~Creating an organization while your domain matches one~~ — **resolved: soft notice**. Org creation stays available everywhere; on a matching domain the create screen shows the join affordance inline ("Acme Corp is already here — join instead?"), never a block.
+
+# Still left to think about
+
+- Email-change flow in the identifiers world (attach new + verify + markPrimary + detach old — needs a guided UI).
+- A "manage emails / sign-in methods" self-serve screen (add/remove alias, switch PRIMARY) — R8 semantics support it; UI undesigned.
+- Org-level `mfaRequired` rollout vs existing sessions (grace window vs immediate step-up).
+- Join-request → invite interplay (convert a pending request into a formal invite with team assignments) — nice-to-have, not v1.
+- How the org-admin surface and the authz Access surface read as one settings area — IA decision when both exist.
+- Metrics/observability pack per deliverable (routing decisions, link proposals, ceremony success, SCIM dead-letters, breaker state, join funnel) — dashboards before flags flip.

--- a/dev/docs/identity-platform/D01-identity-pipeline-and-identifiers.md
+++ b/dev/docs/identity-platform/D01-identity-pipeline-and-identifiers.md
@@ -1,0 +1,255 @@
+# D01 — Identity pipeline skeleton + identifiers
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 1 · Depends on: the landed authz program — ADR-110's migration state, `@langwatch/system-migrations`, and the shared `_shared/per-subject-cached-gate.ts` are all reused here (the authz *engine* itself is never consulted on an identity write)
+
+# Overview
+
+Two sealed pieces shipped together: (a) the event-sourced **identity pipeline** skeleton (commands → GroupQueue → CH `event_log` → applies/projections → process managers), and (b) the **identifiers model** — a new **Postgres `Identifier` table**, a pure event-truth projection born clean, backfilled from current `Account`/`User` state through `@langwatch/system-migrations` and rolled out grants-style: migration first, then reads, then writes, every release production-safe. `Account` keeps its job as the 100% row-truth protocol table (secrets, tokens) and is never a projection. No product behavior changes.
+
+> Storage in one line: **events in ClickHouse `event_log`, the `Identifier` projection and every row-truth value in Postgres.** The sign-in hot path touches Postgres only.
+
+# Requirements
+
+- Pipeline `platform/app/src/server/event-sourcing/pipelines/identity/` following the langy/automations doctrine:
+  - Type identifiers in `schemas/typeIdentifiers.ts`: aggregates `user_identity` (more register in later deliverables), command/event type constants per module.
+  - Events: zod schemas extending `EventSchema`, unioned as `IdentityEvent`; payloads carry ids, enums, timestamps, domains, HMAC hashes — and the normalized email where the fact is about one (erasure wipes it, R11); never secrets. `version` date strings; upcasters when schemas evolve.
+  - Commands via `defineCommand` / class-based `CommandHandler`; dispatched through `mapCommands(pipeline.commands)`; per-aggregate FIFO via GroupQueue group key.
+  - **Dispatch order pinned (ADR-101 §2):** durable CH append (waited) → fold apply on the calling path → GroupQueue staging last, best-effort (staging is convergence, not the primary apply; a failed staging is a metric, never a failed ceremony).
+  - Process managers for durable/scheduled work (intents via typed `ctx.intents.<name>(key, payload)`; outbox handlers zod-parse, idempotent retry, `retryable: false` retires visibly).
+  - Subscribers for best-effort notifications.
+  - No-op command round-trip proving command → queue → event → apply → PM wake.
+- **New Prisma model `Identifier`** (Postgres — additive migration, no change to `Account`):
+
+```prisma
+model Identifier {
+  id             String    @id // deterministic KSUID — every bit derived (ADR-092 grant-id discipline):
+                               // timestamp = occurredAt, entropy = SHA-256(userId, provider,
+                               // providerAccountId | valueHash) — backfill and live emission converge
+  userId         String
+  provider       String    // credential | email | passkey | google | github | gitlab
+                           // | azure-ad | oidc | saml | auth0-legacy | okta-legacy
+  value          String?   // normalized identifier value; erasure wipes it
+  domain         String?   // org-level fact; survives erasure
+  identifierHash String?   // HMAC-SHA256(userHashKey, normalized value); erasure wipes it
+  accountId      String?   // link to the better-auth protocol row, when one exists
+  state          String    // ATTACHED | VERIFIED | PRIMARY | DETACHED | DEAD_END
+  connectionId   String?   // FK-shaped → sso_connections (null until D04)
+  verifiedAt     DateTime?
+  attachedAt     DateTime
+  detachedAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@index([userId])
+  @@index([identifierHash])
+  @@index([value])   // the D03 router's lookup
+  @@index([domain])
+}
+```
+
+  No DB unique constraint on the natural key — tombstones and replay make constraints lie; uniqueness of verified values is a command-time guard re-checked inside the verify command (concurrent verifies → second fails to DEAD_END). The table is an ordinary whole-row projection: replay rebuilds it entirely, ADR-022/015 stand unamended, identity is in replay discovery from the first release.
+
+- **Our own adapter (R10) — better-auth never writes the database.** better-auth's `database` option is a first-class contract (the stock Prisma adapter is just one implementation); we implement the **identity adapter** as a routing facade whose row engine is the stock prismaAdapter — the sanctioned "you handle reading and writing" plug point, uniform across core and every plugin, with the guarantees (routing, gating, veto-before-write) in the facade rather than a reimplemented query layer:
+  - **Reads** pass straight through to PG (protocol reads hit `Account`/`Session` as always; domain reads hit `Identifier` from D03 on; the hot path never touches CH or the queue).
+  - **Domain-significant writes** (account create/delete, verification consumed, passkey add/remove, MFA enroll/disable, user create) check the **per-user write gate**: for a **latched** user (backfill `finalized`; `migrated` is held, ADR-110) they become identity **commands** — guards veto *before* any row exists, deterministic ids, events appended to CH (**waited**), the fold applies them to `Identifier` on the calling path, the protocol values ride only on the command and land through the **credentials repository** on `Account` (row-truth), the row is returned to better-auth. For an **unlatched** user, the protocol write happens identically and no events are emitted (yet) — the gate governs whether events *also* flow, never whether better-auth works. Read-your-writes holds; the queue fold re-applies the same events later and converges because applies are idempotent (ADR-092 §13).
+  - **High-churn protocol writes** (session rows, OAuth token refresh) stay row-truth repository writes with no events (R12) — `SessionRepository` for session rows, the credentials repository for token columns — declared in a per-(model, operation) **routing table** in this module. Nothing is implicitly captured or implicitly passed through — an unrouted write is refused, loudly, naming itself, and the routing coverage test pins the full mounted surface in CI.
+  - **The write gate** is the authz engine gate re-tenanted (ADR-110: finishing the migration IS the switch): reads the user's `identity-d01-identifier-backfill` row in `SystemMigrationTenantState` (tenant = the user), answers true for **`finalized` only** (`migrated` is held — the proof found the projection behind or disagreeing, and the next pass heals it), cached per subject via the shared `_shared/per-subject-cached-gate.ts` the engine gate also uses, fail-safe to the protocol-only path with a warn + metric. Both directions take effect within the cache TTL. Ships closed for everyone — deploying the adapter changes nothing on its own.
+  - A thin endpoint-hook plugin stamps ceremony context (flow, actor, request metadata) onto request-scoped storage so the adapter knows why a row is written (epic Open Q16 for non-request writes).
+- **Truth split (ADR-101 §3):** `Identifier` is pure event-truth (fold-written, replay-rebuilt, whole-row). `Account` is pure row-truth protocol storage (secrets/tokens, repository-written, not a projection, never in replay, deleted on erasure). No table mixes truths; no doctrine amendment exists.
+- **Rollout rides `@langwatch/system-migrations`** (landed with the grants ledger program, #7079), re-tenanted for identity (ADR-101 §6):
+  - A **user-rooted `TenantSource`** registers alongside the organization source — migration state, latch, and gates are per-user. (The generic engine is tenant-agnostic; this is app-composition surface only.)
+  - **Enrollment is a switch (ADR-110)**: on cloud the ops page enrolls organizations — the one pacing lever — and a user is in the cohort when any organization they belong to is enrolled; there is no everyone-else cohort, no sampling, no ladder. A user outside every organization stays on the legacy path until they join one. Self-hosted runs what the release declares (`runsAutomaticallyOnSelfHosted`) for every user, silently.
+  - `identity-d01-identifier-backfill` **does not wait**: each pass re-reads the user's rows, restates every fact (deterministic command ids `backfill:<accountId>`, backdated `occurredAt` from the source row's `createdAt` — restated facts dedupe at the store), detaches identifiers whose `Account` row is gone (`backfill:detach:<identifierId>:<accountId>`), and proves the fold-built `Identifier` rows against what the live `Account`/`User` rows imply. No `previous` record is consulted. Agreement ⇒ `finalized`; a missing or disagreeing row ⇒ held at `migrated` with the outstanding identifiers named on the ops migrations page; a thrown pass parks. Content: `provider="email"` rows minted from `User.email`; VERIFIED state for rows with established ceremonies; existing OAuth/credential rows get lifecycle state from their history.
+  - Writes flip per user via the adapter's gate the moment their backfill finalizes; reads flip in D03 on the *same* status row (one source of truth for both forks). Rollback is a status change, effective within the gate's TTL.
+- From this deliverable on, every latched user's identity write produces its event — structurally, via the adapter, not by hook coverage.
+- Identifier state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> ATTACHED : ceremony started
+    ATTACHED --> VERIFIED : ceremony completed
+    ATTACHED --> DEAD_END : verify failed / race lost
+    VERIFIED --> PRIMARY : markPrimary (exactly one per user)
+    PRIMARY --> VERIFIED : another takes primary
+    VERIFIED --> DETACHED : detach (guards)
+    PRIMARY --> DETACHED : never — must demote first
+    DETACHED --> [*] : tombstone, forever resolvable
+```
+
+- Verification semantics (R8): OAuth/SSO ceremonies arrive VERIFIED; `provider="email"` verifies via the magic-link ceremony below; password/passkey verified at creation (account control, not mailbox). **Login is never gated on email verification** — verification gates routing/linking/join-matching only.
+- `User.email` polyfilled from the PRIMARY identifier for latched users; switching PRIMARY updates it. No UI changes.
+- Normalization at attach: lowercase, plus-tag stripping, unicode-fold.
+
+# Verification ceremony — email (magic link + proof binding)
+
+Verifying an email identifier must prove two distinct things: (a) the person controls the mailbox, and (b) the completion belongs to the ceremony that started it — a forwarded link, a mail-scanner prefetch, or a token minted for one identifier must never verify another.
+
+```text
+  initiating client                    server                        mailbox
+        │  attach / request-verify        │                             │
+        │────────────────────────────────►│                             │
+        │  mints code_verifier (PKCE);    │ mints Verification record:  │
+        │  keeps it local                 │  verificationId (verif_…)   │
+        │  sends code_challenge =         │  identifierId + userId      │
+        │  S256(code_verifier)            │  token — single-use,        │
+        │                                 │  HASHED at rest, TTL 15m    │
+        │                                 │  code_challenge (bound)     │
+        │                                 │──── magic link ────────────►│
+        │                                 │  …/verify?vid=verif_…&token │
+        │                                 │                             │
+        │   link opened (GET) — RENDERS ONLY, never verifies            │
+        │   (scanner/prefetch-safe: completion is a POST)               │
+        │                                 │                             │
+        │  same device: POST with token + code_verifier                 │
+        │────────────────────────────────►│ checks: hash(token) matches,│
+        │                                 │  unexpired, unconsumed,     │
+        │                                 │  S256(verifier)==challenge, │
+        │                                 │  verificationId → EXACTLY   │
+        │                                 │  this identifierId+userId   │
+        │                                 │ ⇒ verify_identifier command │
+        │                                 │                             │
+        │  cross-device: link shows a short one-time code to type       │
+        │  into the initiating context (which holds the verifier) —     │
+        │  completion still happens where the ceremony started          │
+```
+
+- **PKCE binding**: the initiating context mints `code_verifier` and sends only its S256 challenge; completion requires the verifier. Possession of the emailed link alone is insufficient — it cannot complete the ceremony from a context that didn't start it. Cross-device is served by the short-code echo back into the initiating context, not by weakening the binding.
+- **Identity binding ("verify some kind of id")**: the `Verification` record pins `verificationId → (identifierId, userId)` at mint time; the completion path verifies the consumed record targets exactly the identifier being verified. A token can never be replayed against a different identifier, user, or a re-attached successor (the identifier id is deterministic but the verification record is single-use and id-pinned).
+- **Token hygiene**: single-use (consumed transactionally before the verify command dispatches), hashed at rest (row-truth on the better-auth `Verification` protocol table, routed like every protocol model through the adapter's routing table), 15-minute TTL, invalidated by any newer verification mint for the same identifier.
+- **Events**: `identifier_verified` carries `verificationId` and `method: "magic-link" | "oauth" | "saml" | "creation"` in the payload — the proof trail is queryable history; the token and verifier never appear in any event (payload rule).
+- better-auth's own magic-link/verification plumbing supplies the protocol flow; the PKCE binding and id-pinning are ceremony guards in our command handlers — better-auth still never writes the database.
+
+# Data structures
+
+Conventions mirror the grants ledger (ADR-092 §13, as reshaped by ADR-110): calendar-versioned zod schemas extending the framework `EventSchema`, `occurredAt` = business time vs `createdAt` = ledger time, caller-minted `commandId` with per-event `idempotencyKey = <commandId>:<index>` (migrations derive commandIds from source rows: `backfill:<accountId>`). One deliberate divergence: the ledger's payloads are fully pseudonymized, while identity payloads carry the normalized email where the fact is about one — erasure owns the consequences (R11). `identifierHash = HMAC-SHA256(userHashKey, normalized value)`; `userHashKey` is a row-truth PG value minted at user creation and deleted on erasure, after which every remaining hash for that user is unlinkable noise.
+
+**Tenancy of the aggregates** (every CH query filters TenantId first): `user_identity` uses `tenantId = userId` — the user is the tenant of their own identity history, which makes erasure/support lookup a single tenant scan (ADR-029 purge tractability). The event store treats tenant ids as opaque (the ledger already appends under the reserved `"platform"` tenant). Org-rooted aggregates in later deliverables (`sso_connection`, `join_request`) use `tenantId = organizationId`.
+
+Type identifiers (`schemas/typeIdentifiers.ts` / `schemas/constants.ts`):
+
+```ts
+export const IDENTITY_PIPELINE_NAME = "identity" as const;
+export const USER_IDENTITY_AGGREGATE_TYPE = "user_identity" as const;
+
+export const ATTACH_IDENTIFIER_COMMAND_TYPE = "lw.identity.attach_identifier" as const;
+export const VERIFY_IDENTIFIER_COMMAND_TYPE = "lw.identity.verify_identifier" as const;
+export const MARK_PRIMARY_COMMAND_TYPE      = "lw.identity.mark_primary" as const;
+export const DETACH_IDENTIFIER_COMMAND_TYPE = "lw.identity.detach_identifier" as const;
+export const ERASE_USER_COMMAND_TYPE        = "lw.identity.erase_user" as const;
+
+export const IDENTIFIER_ATTACHED_EVENT_TYPE  = "lw.identity.identifier_attached" as const;
+export const IDENTIFIER_VERIFIED_EVENT_TYPE  = "lw.identity.identifier_verified" as const;
+export const IDENTIFIER_DEAD_ENDED_EVENT_TYPE = "lw.identity.identifier_dead_ended" as const;
+export const PRIMARY_CHANGED_EVENT_TYPE      = "lw.identity.primary_changed" as const;
+export const IDENTIFIER_DETACHED_EVENT_TYPE  = "lw.identity.identifier_detached" as const;
+export const USER_ERASED_EVENT_TYPE          = "lw.identity.user_erased" as const;
+
+export const IDENTITY_EVENT_VERSION_LATEST = "2026-08-20" as const;
+```
+
+A command — PII rides here, transiently (commands are dispatched and processed, never durably stored):
+
+```jsonc
+// lw.identity.attach_identifier — emitted by the identity adapter when
+// better-auth creates an Account row inside a sign-up/link ceremony
+{
+  "tenantId": "user_2c9x…",
+  "userId": "user_2c9x…",
+  "commandId": "idcmd_2f8a…",            // caller-minted; retries reuse it
+  "accountId": "acc_9k2p…",
+  "provider": "google",                   // widened provider enum (D01)
+  "value": "Alex.Doe+x@Acme.com",        // RAW — normalized by the handler, never stored in an event
+  "ceremony": { "flow": "oauth-callback", "requestId": "req_…" },
+  "actor": { "type": "user", "id": "user_2c9x…" }
+}
+```
+
+The events it produces — the email is the fact and rides in the payload (erasure wipes it, R11); secrets never appear; the hash serves uniqueness guards, the domain serves routing/join-matching:
+
+```jsonc
+// envelope fields come from the framework EventSchema; data is the payload
+{
+  "id": "evt_…",                          // pure KSUID
+  "aggregateId": "user_2c9x…",
+  "aggregateType": "user_identity",
+  "tenantId": "user_2c9x…",
+  "type": "lw.identity.identifier_attached",
+  "version": "2026-08-20",
+  "occurredAt": 1755446400000,            // business time (backfill: legacy row's createdAt)
+  "createdAt": 1755446400123,             // ledger-accepted time
+  "idempotencyKey": "idcmd_2f8a…:0",
+  "data": {
+    "identifierId": "idf_9k2p…",          // deterministic — the Identifier row's id
+    "accountId": "acc_9k2p…",
+    "userId": "user_2c9x…",
+    "provider": "google",
+    "email": "alex.doe@acme.com",         // normalized; the erase command wipes this field (R11)
+    "identifierHash": "hmac:b1e4…",       // HMAC-SHA256(userHashKey, normalized value) — noise once the key is shredded
+    "domain": "acme.com",                 // org-level fact; survives erasure
+    "connectionId": null,                  // FK → sso_connections from D04 on
+    "state": "VERIFIED",                   // OAuth ceremonies arrive verified (R8)
+    "actor": { "type": "user", "id": "user_2c9x…" }
+  }
+}
+```
+
+```jsonc
+// lw.identity.user_erased — erasure is itself an event (R11): the handler
+// wipes the email fields out of the user's prior events (ClickHouse mutation),
+// wipes Identifier value columns, deletes protocol rows and the userHashKey,
+// and this event records that it happened. Replay reproduces the tombstone.
+{ "type": "lw.identity.user_erased", "data": {
+    "userId": "user_2c9x…",
+    "erasedIdentifierIds": ["idf_9k2p…", "idf_1m3q…"],
+    "actor": { "type": "system", "id": "ops:erasure-request" }
+} }
+```
+
+The truth split, by table (both Postgres):
+
+```text
+Identifier — pure event-truth projection (fold-written; replay rebuilds whole-row)
+  id · userId · provider · value · domain · identifierHash · accountId
+  · state · connectionId · verifiedAt · attachedAt · detachedAt
+Account — pure row-truth protocol table (repository-written; NOT a projection;
+  never in replay; deleted on erasure)
+  password · access_token · refresh_token · id_token · providerAccountId · …
+```
+
+# Out of Scope
+
+- Any routing/sign-in behavior change (D03).
+- Passkey mirror rows (D07), MFA aggregates (D06), connection linkage (D04).
+- The "manage emails" self-serve UI.
+
+# Research
+
+- Framework: `platform/app/src/server/event-sourcing/` — doctrine ADRs 007 (pipeline model), 015 (replay coordination), 022 (event log source of truth), 049 (PG projections), 052 (PM substrate + content boundary), 066 (fold contract). `specs/event-sourcing/pipeline-model.feature` is the doctrine anchor.
+- Rollout precedent this deliverable transplants: ADR-110's shape as shipped — new native head born clean (`Grant`/`Role`), adoption by ids stable across retries (`authz-engine.migration.ts`), one migration whose `finalized` status is the switch for reads and writes alike (`engine-gate.ts` over `_shared/per-subject-cached-gate.ts`), held tenants with their outstanding facts named, `specs/migration/authz-grants-rollout.feature`.
+- Payload-content precedent: ADR-052:74,212 (content boundary — identity deviates deliberately for emails; R11/ADR-101 pin it); ADR-029 §4 (purge tractability).
+- `specs/auth/signup-does-not-strand-an-account.feature` — anti-dead-end anchor this model generalizes.
+
+# Technical Plan
+
+1. Scaffold pipeline module with a no-op command round-trip.
+2. Prisma additive migration: the new `Identifier` table (+ `userHashKey` on `User`) — zero-downtime, nothing reads it yet.
+3. Fold projection: identity events upsert `Identifier` rows under per-key queue locks (`.withProjection`, cursor-guarded); in replay discovery from day one.
+4. The identity adapter (routing facade over prismaAdapter): read pass-through, the (model, operation) write routing table, the per-user write gate (ships closed), ceremony-context read from request-scoped storage; better-auth wired to it for core and plugin models alike.
+5. Verification ceremony guards: PKCE challenge storage on the Verification protocol row, verifier check + id-pinning in the verify command handler, GET-renders/POST-completes route shape.
+6. User-rooted `TenantSource` + `identity-d01-identifier-backfill` rider + org-driven enrollment pacing (PR 2).
+7. Tests: in-memory `EventSourcing` harness + `InMemoryProcessStore`; replay-parity (rebuild `Identifier` from CH, diff vs live table); backfill parity (fold-built rows vs what `Account`/`User` imply); adapter routing-table coverage test (every better-auth model+operation is explicitly routed; an unrouted write fails); verification ceremony tests (scanner GET does not verify; wrong-identifier token refused; verifier mismatch refused).
+
+# Exit gate / rollback
+
+- **Exit:** replay-parity test green; backfill parity self-proving per user; adapter routing-table coverage green; no-op round-trip demonstrated; verification ceremony guards green.
+- **Rollback:** the write gate is data — un-enroll / roll back the migration state and the adapter stops emitting for those users while protocol writes continue untouched; the `Identifier` table is additive and nothing reads it until D03. No deploy needed.
+
+# Security Concerns
+
+- Erasure (R11) from day one: wipes email fields out of the user's events, wipes `Identifier` value columns, deletes protocol rows, shreds the userHashKey. Secrets never appear in any event.
+- Attach-without-proof is impossible: every lifecycle event derives from a better-auth ceremony arriving through the adapter with stamped context.
+- Magic-link verification is scanner-proof (GET renders, POST completes), replay-proof (single-use hashed token), context-bound (PKCE verifier), and identifier-pinned (verificationId → identifierId binding checked at completion).
+
+# Open Questions
+
+- None specific to D01.

--- a/dev/docs/identity-platform/D03-identifier-first-signin-router.md
+++ b/dev/docs/identity-platform/D03-identifier-first-signin-router.md
@@ -1,0 +1,59 @@
+# D03 — Identifier-first sign-in router + cutover
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 2 · Depends on: D01 · Flag: `IDENTITY_ROUTER_V2` (shadow → enforce) · **Highest-risk deliverable**
+
+# Overview
+
+Replace the `NEXTAUTH_PROVIDER` one-method front door with identifier-first routing: enter email → normalize → route by verified ACTIVE connection domain → IdP redirect; otherwise a uniform method picker. Self-hosted keeps the single-login case as the priority: one ACTIVE connection ⇒ auto-redirect, with a break-glass local path. Ends account-linking dead ends via auto-link / org-admin-confirm.
+
+# Requirements
+
+- Router reads the `Identifier` projection + domain routing tables (strings until D04; `SSOCONN_ROUTING` takes over after). PG reads only on the hot path. Per-user read fork: resolve the identifier in `Identifier` first and fall back to legacy routing for users whose D01 backfill is not `finalized` — the ledger's cutover-gate discipline, per user.
+- Normalization identical to D01 attach-time: lowercase, plus-strip, fold.
+- Uniform method picker (passkey placeholder until D07 | password | social): same page, same timing, whether or not the account exists — no user-level existence oracle. Domain-level SSO routing is discoverable by design and accepted. D03 owns this contract and the decision engine; the screens that render it are D13, on the same flag.
+- Self-hosted: exactly one ACTIVE connection ⇒ auto-redirect straight to the IdP; deliberate escape hatch `/auth/signin?local=1` (the break-glass binding made real). Env becomes the default method set, not a global gate.
+- Cloud: multiple methods simultaneously — ends the `NEXTAUTH_PROVIDER` one-method invariant there.
+- SSO callback linking:
+  - `(connectionId, subject)` match → sign in.
+  - No match, verified email matches existing user, unambiguous (no non-corporate identifiers on the target) → auto-link + audit event.
+  - Ambiguous → `LinkProposed`; org admin confirms on the org-admin surface (lands with D05; until then, ops).
+  - No match at all → JIT if the connection allows, else deny with guidance.
+- `pendingSsoSetup`: reconciled once against identifier data, column dropped.
+- ADR-027 amendment: the global `before` hook's path blocking becomes per-method policy on the router. License-gate semantics preserved (SSO requires license; credential paths stay open). Carry over ADR-027's constants table and the `ssoRouteTableCanary.test.ts` discipline — every auth route keeps a reviewed classification.
+- Shadow mode: `IDENTITY_ROUTER_V2` shadow-compares every login against the legacy path before the flip.
+
+# Out of Scope
+
+- The screen set itself (D13 — sign-in, sign-up, reset, verification, deny/guidance states; flips with this deliverable on the same flag). Connection management UI (D05), MFA step-up UI (D06 — the router leaves the hook point), passkeys as a picker method (D07), join-request interstitial (D12 — hook point left).
+
+# Research
+
+- Current gate: `src/server/better-auth/index.ts` + `hooks.ts` (domain auto-join, `pendingSsoSetup`, invites); ADR-027:137 explicitly rejected router-level interception ("the `before` hook remains the only correct interception point") because of the legacy `/callback/auth0|okta` rewrite — ADR-3 must show the router covers every gate site ADR-027 enumerated, including that rewrite.
+- Corpus-audit spec impacts (see delivery-plan amendment table): `phase-1-better-auth-config.feature` (NEXTAUTH_PROVIDER matrix, ssoProvider matching, pendingSsoSetup — retire), `password-reset.feature:144-148` (cloud-mode rejection — Open Q9), `sso-orphan-user-linking.feature` (generalize into the auto-link rule; reconcile its "unverified orphan cannot be hijacked" with R8's login-never-gated), `signup-does-not-strand-an-account.feature` (anchor; enumeration tension = Open Q12), `sso-license-gating.feature` (mechanism amend; restart semantics = Open Q11), `sso-oidc-providers.feature` (Cognito/OneLogin `NEXTAUTH_PROVIDER` mounting, :24/:32 — port to the self-hosted default method set; discovery-document configuration survives), `user-deactivation.feature:134-143` (stale NextAuth wording sweep; behavior anchor survives).
+
+# Technical Plan
+
+1. Router module: email → routing decision (pure function over PG reads; unit-testable; decision logged with reason codes for the ops surface).
+2. Routing-decision contract consumed by D13's screens (decision + reason codes); timing-normalization requirements pinned by contract tests.
+3. Auto-link / LinkProposed commands (identity pipeline); audit events with before/after.
+4. Break-glass local path bound to break-glass bindings (bindings land fully in D05; interim: platform-ops-granted).
+5. `pendingSsoSetup` reconciliation job + column drop.
+6. Shadow comparison + bake; flip; legacy path deletion.
+7. ADR-3 (router + self-service, spans D03–D05).
+
+# Exit gate / rollback
+
+- **Exit:** zero unexplained shadow mismatches over the bake window; sign-in success ≥ baseline (dashboard live before flip).
+- **Rollback:** flag off — legacy path intact until deletion at bake end.
+
+# Security Concerns
+
+- Enumeration: uniform page/timing; the only new probe surface is the router endpoint — verify it's covered by better-auth's existing rate limiter (acceptance check).
+- Wrong-human linking: auto-link only when unambiguous; every link emits before/after audit events.
+- Break-glass path: bound to break-glass bindings, audited, rate-limited — it is the obvious target when a customer IdP is up.
+
+# Open Questions
+
+- (Epic 9) password reset availability in cloud/SSO mode under the uniform picker.
+- (Epic 11) license-gate timing: startup-decided vs per-request evaluation.
+- (Epic 12) sign-up enumeration vs no-oracle scoping.

--- a/dev/docs/identity-platform/D04-sso-connection-aggregate.md
+++ b/dev/docs/identity-platform/D04-sso-connection-aggregate.md
@@ -1,0 +1,108 @@
+# D04 — SsoConnection aggregate + routing parity
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 2 · Depends on: D03 · Flag: `SSOCONN_ROUTING` (shadow → enforce)
+
+# Overview
+
+Enterprise SSO stops being two hand-set strings on `Organization` and becomes a first-class event-sourced aggregate: `SsoConnection` per (org, IdP), with domains, IdP metadata, and a guarded lifecycle. Existing orgs are grandfathered in; the router's domain lookup flips from strings to the projection behind a shadow flag. Super-admin/backoffice parity only — self-service UI is D05.
+
+# Requirements
+
+- Projection table (Prisma model `SsoConnection`):
+
+```text
+id              string PK
+organizationId  string FK → Organization
+type            enum   oidc | saml
+domains         string[]           (verified ones; claims tracked by events)
+idpMetadata     jsonb              (endpoints, clientId, secretRef, certRefs)
+state           enum               (lifecycle states below)
+createdBy       string
+createdAt       datetime
+```
+
+- Lifecycle (aggregate `sso_connection` in the identity pipeline):
+
+```mermaid
+stateDiagram-v2
+    [*] --> DRAFT : registerConnection
+    DRAFT --> CLAIMED : claimDomain
+    CLAIMED --> APPROVED : ops approves (manual)
+    CLAIMED --> REJECTED : ops rejects (note, re-claimable)
+    APPROVED --> VERIFICATION_PENDING : requestVerification (DNS TXT / license token)
+    VERIFICATION_PENDING --> VERIFIED : TXT found
+    VERIFIED --> ACTIVE : test login recorded
+    ACTIVE --> SUSPENDED : suspend (always allowed)
+    SUSPENDED --> ACTIVE : resume
+    ACTIVE --> TEARDOWN_PENDING : requestTeardown
+    SUSPENDED --> TEARDOWN_PENDING : requestTeardown
+    TEARDOWN_PENDING --> TORN_DOWN : grace elapsed
+    DRAFT --> DISCARDED : discard
+    TORN_DOWN --> [*]
+```
+
+- Guards evaluated against folded state in the command handler: `activate` needs ≥1 verified domain + ≥1 live break-glass binding (interim ops-granted until D05); `verifyDomain` refuses domains owned by another ACTIVE connection (global on SaaS, per-instance self-hosted); `requestTeardown` refuses while any user holds only this connection's identifiers.
+- Domain claims need LangWatch ops manual approval — no automated blocklist. Disputes resolved from event history.
+- Grandfathering rides `@langwatch/system-migrations` as a `SystemMigration` named `identity-d04-connection-grandfather`: existing `Organization.ssoDomain/ssoProvider` orgs get backfill events producing VERIFIED/ACTIVE connections (event payloads note `legacy-grandfathered` source); legacy `auth0`/`okta` Account rows re-pointed (`connectionId`) to the grandfathered connections. Proof for `finalized`: the connection-based routing decision matches the string-based one for every domain the org carries — the same comparison `SSOCONN_ROUTING` shadow mode runs, evaluated per tenant.
+- Router integration: `SSOCONN_ROUTING` shadow-compares connection-based routing vs string-based routing on every login; then enforce; then `ssoDomain` writes stop and the columns become derived/legacy.
+- Backoffice edits connections (parity with today's super-admin string-setting).
+
+# Data structures
+
+Aggregate `sso_connection`; `tenantId = organizationId`, `aggregateId = connectionId`. Payload rules per D01: ids, domains, enums, hashes — IdP client secrets and DNS tokens never appear (secrets live in the projection's `idpMetadata.secretRef`, events carry the reference; the DNS ceremony stores the token's hash):
+
+```jsonc
+// lw.identity.connection_registered
+{ "data": {
+    "connectionId": "ssoc_…",
+    "organizationId": "org_…",
+    "type": "oidc",
+    "idp": { "issuer": "https://login.acme.okta.com", "clientIdRef": "cred_…" },
+    "actor": { "type": "user", "id": "user_…" }
+} }
+
+// lw.identity.domain_claimed        { connectionId, domain: "acme.com", actor }
+// lw.identity.domain_claim_approved { connectionId, domain, actor: { type: "user", id: <ops user> } }
+// lw.identity.verification_requested{ connectionId, domain, method: "dns-txt" | "license-token", tokenHash: "sha256:…" }
+// lw.identity.domain_verified       { connectionId, domain, method }
+// lw.identity.connection_activated  { connectionId, testLoginAccountId, actor }
+// lw.identity.connection_suspended / _resumed / teardown_requested / connection_torn_down
+//   — all { connectionId, actor, reason? }; grandfathered orgs' events carry "source": "legacy-grandfathered"
+```
+
+Projection `SsoConnection` (Prisma model above) is fold-written; the router reads it and nothing else on the hot path.
+
+# Out of Scope
+
+- Org-admin self-service UI, DNS TXT ceremony UX, break-glass binding management, connection-scoped SCIM tokens (all D05).
+- SAML protocol engine adoption (the decision is recorded here but implemented in D05's onboarding; see Open Questions).
+
+# Research
+
+- Today: `platform/app/ee/sso/` — `providers.ts` (social + auth0/okta via genericOAuth), `matching.ts` (domain/provider string matching). No SAML, no per-org table. Self-serve plugin PR #4416 closed unmerged — worth re-reading for pitfalls before designing D05.
+- Corpus-audit spec impact: `sso-wrong-provider-recovery.feature` ports from string-matching to connection-based (Background assumptions change; scenarios mostly survive).
+
+# Technical Plan
+
+1. Aggregate + events (`ConnectionRegistered`, `DomainClaimed`, `DomainClaimApproved/Rejected`, `VerificationRequested`, `DomainVerified`, `ConnectionActivated/Suspended/Resumed`, `TeardownRequested`, `ConnectionTornDown`, …) + projection.
+2. Grandfather backfill (idempotency keys `grandfather:<orgId>`).
+3. Process managers: teardown grace timer; break-glass expiry warnings (14/7/1-day wakes) once bindings exist.
+4. Router domain lookup switches to projection behind `SSOCONN_ROUTING`; shadow bake; flip.
+5. Backoffice connection CRUD via commands (never raw table edits).
+6. SAML engine evaluation: `@better-auth/sso@1.6.23` (its `ssoProvider` table treated as protocol state only) vs genericOAuth-with-SAML; record the decision in ADR-3.
+
+# Exit gate / rollback
+
+- **Exit:** routing parity silent over bake; `ssoDomain` writes stopped, columns derived/legacy; grandfathered orgs sign in unchanged.
+- **Rollback:** flag off — strings still dual-written until the flip.
+
+# Security Concerns
+
+- First-verifier-owns with global scope makes the ops approval step the abuse boundary — every claim decision is an audited event.
+- Grandfathered connections must not weaken guards: they get VERIFIED state from history, but activation guards (break-glass binding) still apply to any *state change*.
+
+# Open Questions
+
+- (Epic 1) SAML engine choice — decided here, implemented in D05.
+- (Epic 5) IdP-initiated SSO scope — input to the engine choice.
+- (Epic 2) domain-approval queue staffing/SLA.

--- a/dev/docs/identity-platform/D05-self-service-onboarding-and-surfaces.md
+++ b/dev/docs/identity-platform/D05-self-service-onboarding-and-surfaces.md
@@ -1,0 +1,75 @@
+# D05 — Self-service SSO onboarding + identity surfaces
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 3 · Depends on: D04 + **authz precondition checklist (hard)** · Flag: `SELF_SERVE_SSO` (per-org)
+
+# Overview
+
+Enterprise SSO onboarding stops being a support ticket. Org admins register and verify their own connections in Settings; LangWatch ops approves domain claims; and both support surfaces ship — the platform-ops identity lookup (the designated replacement for DB surgery) and the org-admin surface (link confirmations, member-identifier view). Permissions are real registry entries from day one — no seam.
+
+# Requirements
+
+**Self-service onboarding** (Settings → SSO, gated by `sso:manage`):
+
+- Full lifecycle self-service: register connection (OIDC; SAML per the D04 engine decision) → claim domain → ops approval → DNS TXT ceremony → test login → activate. Self-hosted: license-bound ops token path instead of DNS.
+- DNS TXT: `VerificationToken`-style token; hash stored in the event, never the raw token.
+- Break-glass bindings: expiring `sso:manage` grants via `grants.attach` with expiry; process-manager warning wakes at 14/7/1 days; renewal via platform-ops. Activation guard (≥1 live binding) now fully self-serve.
+- Connection-scoped SCIM token issuance (tokens consumed by D08's reroute).
+- Auto-redirect behavior for self-hosted sole-connection deployments (env default; per-connection override per Open Q6).
+
+**Registry permissions (authz API, no seam):**
+
+- `sso:view`, `sso:manage`, `scim:view`, `scim:manage` registered in `server/authz/registry.ts` (org-scope only, org-exclusive like governance).
+- IT-admin custom role = `CustomRole` row holding only those permissions, bound at org scope.
+- All tRPC gating via `.permission()`/`authz.require`; all UI gating via `useCan`/`RequireCan`.
+
+**Surface 1 — platform-ops identity lookup** (route tree under `ee/admin/`, platform-ops-gated):
+
+- Cross-org: input any email → routing decision (with reason codes from D03), identifiers per user (all states, all users owning fragments), last N identity events, pending `LinkProposed`s, outstanding invites with expiry, pending join-requests.
+- The lookup **read** is itself guarded: every query passes the platform-ops authorization check and writes an audit-log entry (who resolved which email, when) — a cross-org read is never unaudited, command or not.
+- Every action a guarded command: `confirmLink`/`rejectLink`, `detachIdentifier` (guarded), `resendInvite`/`extendInvite`, `revokeSessions(userId | identifierId)`, `approveDomainClaim`/`rejectDomainClaim`.
+- Ships here as the safety net for self-serve onboarding — this is what kills DB surgery.
+
+**Surface 2 — org-admin surface** (org Settings, separate routes/queries):
+
+- Pending link confirmations for the org's members; member-identifier view ("how does each person sign in"). (Join-request approvals arrive with D12; the invitation management shipped at D11 into the existing members UI is absorbed onto this surface.)
+- Org-scoped at the data layer — a bug here cannot expose cross-org data.
+- Gated: `sso:manage` for connection/link actions; member-management permission for the rest.
+
+# Out of Scope
+
+- Join-request approvals (D12 adds them to surface 2) and the invitation panels absorbed from D11.
+- Auth0 migration wizard (D09 reuses this machinery).
+- The IA merge with the authz Access surface (design pass later — "still left to think about").
+
+# Research
+
+- Closed-unmerged self-serve plugin PR #4416 — read for pitfalls before building the UI.
+- ADR-027 license gating must remain enforced on every new route (route-table canary discipline carried over per D03).
+- Corpus-audit: no existing specs cover these surfaces — new `.feature` files to write (org-admin panels, ops actions, connection self-service lifecycle).
+
+# Technical Plan
+
+1. Registry entries + IT-admin role seed; permission checks on all new routes.
+2. Onboarding wizard UI (org Settings → SSO) driving the D04 commands; DNS TXT polling via process-manager wakes; test-login step records the activation event.
+3. Break-glass binding issuance/expiry via `grants.attach` + PM wakes.
+4. Ops lookup: read models over the identity projections + event log queries (last-N events per user/identifier); action buttons dispatch the guarded commands.
+5. Org-admin surface: org-scoped queries only; shared command handlers with the ops surface, nothing else shared.
+6. SCIM token issuance scoped to `connectionId` (new column; newly issued tokens are connection-scoped, legacy tokens keep their organization scope until rotated or reissued — no backfill assigns them a connection — consumed in D08).
+7. New Gherkin specs for both surfaces + onboarding lifecycle.
+
+# Exit gate / rollback
+
+- **Exit:** a new enterprise customer onboards with exactly one LangWatch action (the approval click); the ops surface resolves a real support case end-to-end without DB access.
+- **Rollback:** `SELF_SERVE_SSO` per-org flag; surfaces are additive.
+
+# Security Concerns
+
+- Domain claim abuse: ops approval on every claim; DNS proof before routing; disputes from event history.
+- Surface separation is structural (routes, queries, scopes), not cosmetic.
+- Break-glass bindings expire by default; renewal is deliberate and audited.
+- Ops actions are commands with guards and audit events — no raw mutations.
+
+# Open Questions
+
+- (Epic 6) per-connection auto-redirect override.
+- (Epic 2) approval-queue staffing/SLA — measure queue latency from day one.

--- a/dev/docs/identity-platform/D06-mfa-and-session-shape.md
+++ b/dev/docs/identity-platform/D06-mfa-and-session-shape.md
@@ -1,0 +1,87 @@
+# D06 — MFA (TOTP) + session shape + Principal-aligned impersonation
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 3 · Depends on: D03 · Flags: `MFA_ENROLLMENT_OPEN` + deploy-time session revoke (**one-way door**)
+
+# Overview
+
+Adds MFA (TOTP + backup codes, never SMS) with an event-sourced enrollment aggregate, extends sessions with identifier/MFA claims, and moves impersonation off the legacy `Session.impersonating` JSON onto the authz `Principal {actor, subject}`. All existing sessions are revoked at deploy — they can't prove `amr`, so they can't be trusted under MFA policy.
+
+# Requirements
+
+- `twoFactor` plugin (in better-auth core) for protocol; hand-written Prisma model matching the plugin schema: `TwoFactor` (secret, backupCodes, userId, verified, failedVerificationCount, lockedUntil) + `User.twoFactorEnabled boolean @default(false)`.
+- `MfaEnrollment` aggregate in the identity pipeline. The `twoFactor` plugin's table writes arrive through the identity adapter (R10) like every other model, with ceremony context stamped by the two-factor endpoints (`/two-factor/enable`, `/verify-totp`, `/disable`, `/generate-backup-codes`, `/verify-backup-code`); protocol failures emit events too:
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : enroll (TOTP secret issued)
+    PENDING --> ENABLED : first code confirms
+    PENDING --> EXPIRED : 24h wake, never confirmed
+    ENABLED --> DISABLED : password+TOTP, or org-admin (audited)
+```
+
+- Backup codes hashed, one-time-use (consumption is an event).
+- `Organization.mfaRequired boolean`; policy evaluated at session mint and at step-up. Step-up screen.
+- Session additive columns: `identifierId`, `amr string[]`, `mfaVerifiedAt datetime`. Per-identifier session revocation (ops surface action from D05 consumes this).
+- Impersonation: sessions carry `{actor, subject}` into the authz Principal; actor must hold `mfaVerifiedAt` when the subject's org policy demands; both recorded on every decision (engine behavior — this deliverable supplies the claims). Legacy `Session.impersonating` JSON path deleted.
+- Plugin protocol secrets (TOTP secrets, backup codes) live in plugin tables, encrypted/hashed, never in events.
+
+# Data structures
+
+Session, additive columns (row-truth — sessions never enter the event flow, R12):
+
+```text
+Session
+  + identifierId   string    which Account row minted this session
+  + amr            string[]  authentication method references, e.g. ["pwd","otp"] · ["saml"] · ["phw"]
+  + mfaVerifiedAt  datetime? set by TOTP/backup-code step-up; policy checks read it
+  impersonating (JSON)       deleted — {actor, subject} ride the authz Principal
+```
+
+`MfaEnrollment` events (`tenantId = userId`; TOTP secrets and backup codes never appear — they live hashed/encrypted in the `TwoFactor` plugin table, row-truth):
+
+```jsonc
+// lw.identity.mfa_enrolled        { userId, enrollmentId, method: "totp" }         → PENDING
+// lw.identity.mfa_confirmed       { userId, enrollmentId }                          → ENABLED
+// lw.identity.mfa_enrollment_expired { userId, enrollmentId }                       → 24h PM wake
+// lw.identity.mfa_disabled        { userId, enrollmentId, actor, via: "password+totp" | "org-admin" }
+// lw.identity.backup_code_consumed { userId, enrollmentId, codeIndex }              → one-time-use proof
+// lw.identity.mfa_verification_failed { userId, enrollmentId, failedCount }         → lockout evidence
+```
+
+# Out of Scope
+
+- Passkeys (D07) — though the `amr: ["phw"]` policy question is shared (Open Q4).
+- SMS anything. WebAuthn as an MFA second factor (passkeys are first-factor here).
+- `mfaRequired` rollout UX niceties (grace window vs immediate step-up — "still left to think about").
+
+# Research
+
+- better-auth 1.6.23: `twoFactor` is built in; plugin migrations are Kysely-only ⇒ hand-written Prisma models; `databaseHooks` don't fire for plugin tables — moot under R10: the identity adapter sees plugin-table writes uniformly.
+- Session today: PG + Redis dual-write, 30-day TTL, `impersonating` JSON.
+- Corpus-audit spec impacts: `phase-1-better-auth-config.feature:119-137` (locks in legacy impersonating — retire, replace with `{actor, subject}` scenarios); `sessions-and-devices.feature` (inventory gains `identifierId`/`amr`; `maxSessionDurationDays` × forced re-login interplay); anchors that survive: `impersonation-banner.feature`, `dejaview-impersonation-access.feature` (already conceptually actor/subject), `backoffice-user-impersonation-reason.feature` (reason requirement inherited), `password-reset.feature:90-93` (revoke-all on reset — consistent with per-identifier revocation).
+
+# Technical Plan
+
+1. Prisma models + plugin registration; adapter routing entries for the twoFactor models + ceremony-context stamps on the two-factor endpoints.
+2. MfaEnrollment aggregate + `mfa_enrollments` projection; 24h expiry wake via process manager.
+3. Step-up screen + policy check at session mint.
+4. Session migration (additive columns) + **all sessions revoked at deploy** (one forced re-login; comms precedent = better-auth cutover).
+5. Impersonation rewrite: mint sessions with `{actor, subject}` claims; delete the `impersonating` JSON path; banner/stop endpoints repointed.
+6. ADR-4: `amr` semantics (incl. Open Q4 on `["phw"]`), the forced re-login decision.
+7. New Gherkin specs: enrollment, step-up, backup codes, lockout, org policy, impersonation-under-MFA.
+
+# Exit gate / rollback
+
+- **Exit:** enroll → challenge → backup-code → disable round-trips; org policy enforced at mint and step-up; lockout verified; every authz decision records actor+subject.
+- **Rollback:** `MFA_ENROLLMENT_OPEN` off. The session kill is irreversible — hence comms and a low-traffic deploy window.
+
+# Security Concerns
+
+- Disable requires password+TOTP, or org-admin action with audit event.
+- Impersonation cannot bypass MFA policy — the actor's `mfaVerifiedAt` is checked when policy demands.
+- Legacy sessions are destroyed precisely because they can't prove `amr`.
+- Lockout parameters (`failedVerificationCount`, `lockedUntil`) tuned and tested.
+
+# Open Questions
+
+- (Epic 4) does passkey `amr: ["phw"]` satisfy org MFA policy? Product/security decision, recorded in ADR-4.

--- a/dev/docs/identity-platform/D07-passkeys.md
+++ b/dev/docs/identity-platform/D07-passkeys.md
@@ -1,0 +1,49 @@
+# D07 — Passkeys
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 3 · Depends on: D03 (picker hook point) · Flag: `PASSKEYS_ENABLED`
+
+# Overview
+
+Passkeys become first-class identifiers: WebAuthn ceremonies via the official plugin, protocol state in the plugin's table, and mirror rows in `Account` so the identifiers model stays conceptually uniform ("how does this person sign in" shows passkeys alongside everything else).
+
+# Requirements
+
+- New dependency `@better-auth/passkey@1.6.23` (pins to core; pulls `@simplewebauthn/*`).
+- Hand-written Prisma model matching the plugin schema: `Passkey` (name, publicKey, userId, credentialID, counter, deviceType, backedUp, transports, aaguid).
+- Mirror rows: `Identifier` rows with `provider="passkey"` keyed on the credentialID, maintained by the fold from passkey-ceremony events (pure event-truth, per the D01 truth split).
+- Passkey table writes arrive through the identity adapter (R10) like every other model; ceremony context is stamped by `/passkey/verify-registration`, `/passkey/verify-authentication`, `/passkey/delete-passkey`. The plugin's `registration.afterVerification`/`authentication.afterVerification` callbacks are pre-write — used for gating/enrichment only, never as the event source.
+- Platform and cross-platform authenticators; discoverable-credential (username-less) sign-in where supported.
+- Router integration: passkey appears in the uniform method picker (hook point left by D03).
+- Sessions minted via passkey carry `amr` including `phw` (phishing-resistant) — whether that satisfies org MFA policy is Open Q4 (ADR-4).
+
+# Out of Scope
+
+- Passkeys as an MFA *second* factor (they're a first factor here). Conditional UI / autofill polish beyond plugin defaults.
+
+# Research
+
+- better-auth 1.6.23: passkey is a **separate package**, not in core; plugin migrations Kysely-only ⇒ hand-written Prisma model; plugin tables bypass `databaseHooks` — moot under R10: the identity adapter sees plugin-table writes uniformly.
+- Greenfield — no existing spec coverage; new `.feature` files.
+
+# Technical Plan
+
+1. Dependency + Prisma model + plugin registration.
+2. Pipeline mirror-row maintenance (events → lifecycle apply).
+3. Picker + settings UI (register, name, delete).
+4. Discoverable-credential sign-in path on the router.
+5. Round-trip tests on platform + cross-platform authenticators; new Gherkin specs.
+
+# Exit gate / rollback
+
+- **Exit:** register / sign-in / no-email sign-in / delete round-trips green on platform + cross-platform authenticators; mirror rows consistent with plugin table (replay-parity test covers the `Identifier` projection).
+- **Rollback:** `PASSKEYS_ENABLED` off.
+
+# Security Concerns
+
+- Counter/backedUp semantics come from the plugin — don't reimplement ceremony verification.
+- Passkey deletion obeys the identifier detach guards (≥1 remaining verified identifier + recovery path).
+- A passkey attach is a ceremony by construction — fits the attach-requires-proof invariant.
+
+# Open Questions
+
+- (Epic 4) `amr: ["phw"]` vs org MFA policy — shared with D06, decided in ADR-4.

--- a/dev/docs/identity-platform/D08-scim-per-connection.md
+++ b/dev/docs/identity-platform/D08-scim-per-connection.md
@@ -1,0 +1,85 @@
+# D08 — SCIM per-connection + grants integration
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 3 · Depends on: D05 (connection-scoped tokens) + **authz precondition checklist (hard)** · Flag: `SCIM_V2_GRANTS`
+
+# Overview
+
+SCIM stops writing membership tables directly. Tokens become scoped per SSO connection, a `(connectionId, externalId) → userId` mapping gives IdP-stable identity per connection, and every membership consequence flows through `grants.*` — SCIM becomes a command/event producer in the identity pipeline. De-enroll is a replayable event with a proven postcondition: no effective permissions remain.
+
+# Requirements
+
+- `ScimToken.connectionId` (issued in D05); tokens are per-connection — a token for connection A cannot write org B.
+- IdP-stable identity is **per connection**: a `(connectionId, externalId) → userId` mapping with a composite uniqueness constraint on `(connectionId, externalId)` (survives email changes; one user may carry different `externalId`s across connections). Every SCIM lookup and write keys on both — never on `externalId` alone.
+- `ScimSync` aggregate + `scim_sync_state` projection:
+
+```mermaid
+stateDiagram-v2
+    [*] --> TOKEN_ISSUED : token minted (connection-scoped)
+    TOKEN_ISSUED --> SYNCING : first push
+    SYNCING --> ERROR : push/apply failed
+    ERROR --> SYNCING : retry (backoff)
+    SYNCING --> REVOKED : revoke / connection torn down
+    ERROR --> REVOKED : revoke
+```
+
+- All membership writes via `grants.attach` / `grants.offboard` — no direct `OrganizationUser`/`RoleBinding` writes. De-enroll calls `grants.offboard`; the empty-proof postcondition is asserted in an integration test.
+- Failed applies are visible dead-letters via the pipeline's existing process-manager mechanism (handlers zod-parse, retry idempotently, `retryable: false` retires visibly — nothing new is introduced; the pipeline itself has no outbox, ADR-101/R13), never silent drift.
+- Group → role-binding mapping UI stays; its writes also go through `grants.attach`. SCIM-managed group provenance guards (no rename/member edits outside SCIM) survive.
+- Connection teardown revokes its SCIM tokens (lifecycle event → PM intent).
+
+# Data structures
+
+```text
+ScimToken
+  + connectionId  string  FK → sso_connections; the token's entire write authority
+ScimExternalId           new mapping table: (connectionId, externalId) → userId
+  connectionId    string  FK → sso_connections
+  externalId      string  the IdP's stable identifier (survives email changes)
+  userId          string  FK → User
+  @@unique([connectionId, externalId])
+```
+
+`ScimSync` events (`tenantId = organizationId`, `aggregateId = scimSyncId`; SCIM payload PII stays out per the D01 rule — user references are `userId`/`externalId`):
+
+```jsonc
+// lw.identity.scim_user_pushed    { scimSyncId, connectionId, userId, externalId, op: "create" | "update" | "deactivate" }
+// lw.identity.scim_group_mapped   { scimSyncId, connectionId, groupId, roleKey }
+// lw.identity.scim_apply_failed   { scimSyncId, connectionId, op, errorCode }       → dead-letter evidence
+// lw.identity.scim_token_revoked  { scimSyncId, connectionId, cause: "revoke" | "teardown" }
+```
+
+Membership consequences are grants-ledger events, not SCIM events: the reconciler dispatches `grants.attach`/`grants.offboard`, whose `grant_attached`/`grant_revoked` facts carry `source: "scim"` and `actor: { "type": "system", "id": "<connectionId>" }` — the shape the ledger already accommodates.
+
+# Out of Scope
+
+- SCIM protocol surface changes (v2 Users+Groups already complete). Seat/billing classification (license system owns it; lite-member-as-role was the authz program).
+
+# Research
+
+- Today: `platform/app/ee/scim/` — full SCIM v2 at `/api/scim/v2`, per-org bearer tokens, direct writes with unconditional MEMBER role, Auth0 log-stream webhook (dies at D10; customers repoint at D09).
+- Doctrine anchor: `specs/event-sourcing/pipeline-model.feature` (pipelines own their commands/events/projections); content-boundary precedent ADR-052.
+- Corpus-audit spec impacts: `scim-group-mapping.feature` — 20/24 scenarios `@unimplemented`; amend deprovisioning (:170-178) from "direct RoleBinding records removed" to the grants-offboard framing now, while it's cheap. `groups-rest-api.feature` — provenance guards (:83-86, :101-104, :129-132, :149-152) are anchors that survive. `specs/organizations/scim-tokens-rest-api.feature` — the REST mint/revoke contract gains connection scoping (create names a connection); the secret-shown-once and no-secrets-in-list anchors survive.
+
+# Technical Plan
+
+1. `ScimToken.connectionId` migration + backfill (org's first connection; D05 issues new tokens scoped).
+2. `ScimExternalId` mapping migration (composite-unique on `(connectionId, externalId)`) + SCIM payload mapping keyed on both.
+3. ScimSync aggregate, events, projection; SCIM endpoints become command producers (same external API).
+4. Process manager: de-enroll → `grants.offboard` with postcondition check; retry with backoff; dead-letter visibility in the ops surface.
+5. Group mapping UI write path repointed to `grants.attach`.
+6. Amend `scim-group-mapping.feature` and `scim-tokens-rest-api.feature`; integration test asserting the offboard postcondition.
+
+# Exit gate / rollback
+
+- **Exit:** push/group/deactivate round-trip; token scoping enforced (cross-connection write rejected); offboard postcondition asserted in integration test; dead-letters visible.
+- **Rollback:** legacy direct-write path behind `SCIM_V2_GRANTS` flag until bake completes.
+
+# Security Concerns
+
+- Token scope: per-connection; cross-org writes impossible by construction.
+- De-enroll is the highest-stakes SCIM operation — replayable event + proven postcondition + visible failure, never silent.
+- SCIM events carry ids/externalIds and the email where the fact is about one, never tokens or secrets (D01 payload rules).
+
+# Open Questions
+
+- None specific. (Role-mapping semantics for the unified engine — e.g. unconditional-MEMBER replacement — were settled by the authz program's roleKey model; SCIM maps seat → roleKey per that program.)

--- a/dev/docs/identity-platform/D09-auth0-customer-migrations.md
+++ b/dev/docs/identity-platform/D09-auth0-customer-migrations.md
@@ -1,0 +1,105 @@
+# D09 — Auth0 customer migrations
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 4 · Depends on: D05, D08 · Rollback is structural: both-connections-active grace · **customer-paced, per tenant — slow by design**
+
+# Overview
+
+Enterprise customers move off the Auth0 broker onto direct OIDC connections, one tenant at a time, driven by a **migration wizard** in org settings (assumed frontend shape — Open Q7 — pending validation against the Notion comment). Grace with both connections active is the rollback. A temporary **legacy callback shim** (R9) keeps customer-pinned Auth0 redirect URIs working through grace, so no customer is ever forced to reconfigure their IdP mid-migration.
+
+# What Auth0 is today, and what removes each piece
+
+| Auth0 dependency today | What retires it | When |
+|---|---|---|
+| OIDC broker for enterprise SSO (genericOAuth `auth0`/`okta` providers) | Direct per-org `SsoConnection` (OIDC/SAML), one customer at a time | this deliverable, per tenant |
+| Front-door screens (Universal Login owned the unauthenticated visuals) | First-party screen set | D13, at the `IDENTITY_ROUTER_V2` flip |
+| `Organization.ssoDomain`/`ssoProvider` string routing | Connection-based routing | D04 (`SSOCONN_ROUTING`) |
+| `src/server/auth0/passwordService.ts` (Management API password ops) | Identifier-model password change (`change-password-auth0.feature` rewrite) | D10 |
+| Federated logout | Direct-connection logout semantics | this deliverable per tenant; code deleted D10 |
+| SCIM log-stream webhook | Per-connection SCIM tokens; customers repoint during Step 6 | D08 machinery; per tenant here; webhook deleted D10 |
+| Customer-pinned `/api/auth/callback/auth0\|okta` redirect URIs | The legacy callback shim (R9) through grace; zero-hit metric | shim deleted D10 |
+| `AUTH0_*` secrets via the `langwatch_secrets` blob | Nothing to replace — removed from the blob | D10 |
+| agents-box Playwright QA login via Auth0 | QA login against the first-party screens | D10 |
+
+# Requirements
+
+**Migration wizard** (org Settings → SSO; reuses D05 machinery):
+
+- **Step 0 — detect:** the org has a grandfathered legacy (Auth0-broker) connection → "Migrate your SSO" banner. Ops can also enroll an org from the ops surface.
+- **Step 1 — create direct OIDC connection:** pick IdP vendor (Okta / Entra / Google Workspace cheat sheets), enter issuer/clientId/secret; we display the redirect URIs to register — with the explicit note that the legacy URI keeps working via the shim, so there's no IdP-side cutoff moment.
+- **Step 2 — domains:** already verified (grandfathered at D04) — no re-verification.
+- **Step 3 — test login** as the org admin.
+- **Step 4 — activate alongside legacy** → grace begins.
+- **Step 5 — progress view:** % of active users linked (link-on-login: unambiguous → auto-link; ambiguous → org-admin confirm), straggler list, one-click nudge emails.
+- **Step 6 — SCIM repoint** if the customer uses SCIM (D08 connection-scoped tokens; the Auth0 log-stream webhook is retired for this customer).
+- **Step 7 — teardown:** enabled at 100% of active users linked (admin override possible, standard guards apply): detach legacy identifiers → teardown legacy connection.
+
+**Nudges + exception queue:**
+
+- In-app banner during grace ("18 of 42 users migrated"), periodic email to org admins, CS escalation after N days without progress.
+- Ops-surface exception queue: stuck customers, ambiguous links, dormant users (contractors, service users who never log in) — guarded ops actions: extend grace, force-detach with override + audit event.
+
+**Legacy callback shim (R9):**
+
+- `/api/auth/callback/auth0` (and `/okta`) stay mounted as thin shims translating to the matching legacy connection's handler while any legacy connection is ACTIVE. The shim never accepts credentials itself — translation only, no new auth surface.
+- Per-org shim-hit metric; a customer with zero shim hits and a direct connection is provably clean.
+- Deleted at D10, when no ACTIVE legacy connections remain.
+
+**Pacing:** per tenant, no fleet deadline. D10 starts only at zero ACTIVE legacy connections — treat D10 as a program exit criterion, not a scheduled milestone; Auth0 spend continues until then and that's fine.
+
+# Data structures
+
+Per-tenant migration state is a `@langwatch/system-migrations` record (migration name `identity-d09-auth0-cutover`) — the runner's pass re-computes the proof each boot, the ops migrations page shows the fleet, and the operator rollback maps to "extend grace". The rider is **proof-only**: a pass re-verifies and holds (`migrated`), never drives a tenant forward — only the customer moves the work:
+
+```jsonc
+{
+  "migrationName": "identity-d09-auth0-cutover",
+  "tenantId": "org_…",
+  "status": "migrated",              // work done, held: proof below not yet clean
+  "report": {
+    "directConnectionId": "ssoc_…",
+    "activeUsers": 42,
+    "linkedUsers": 18,               // link-on-login progress (identifier data)
+    "stragglers": ["user_…"],        // dormant/contractor accounts for the exception queue
+    "legacyLoginsLast14d": 3,
+    "shimHitsLast14d": 7             // per-org shim metric (R9)
+  }
+}
+// finalized ⇔ linkedUsers == activeUsers ∧ legacyLogins quiet ∧ shimHits == 0
+// finalized is what enables Step 7 teardown; rolled_back pins the org on grace
+```
+
+Progress reads are queries over identifier data (`Identifier` rows with `connectionId = <direct>` vs legacy — ADR-116 retires `Account`, so nothing here may read it), not stored counters; the wizard and the report render the same query.
+
+# Out of Scope
+
+- Auth0 code/config deletion (D10). Non-SSO Auth0 remnants (already migrated off with better-auth).
+
+# Research
+
+- Auth0 today: OIDC provider via genericOAuth; `src/server/auth0/passwordService.ts`; federated logout; SCIM log-stream webhook. SaaS infra: `AUTH0_*` via the opaque `langwatch_secrets` blob (passthrough — no Terraform diff).
+- Customer IdP apps pin `/api/auth/callback/auth0` (`specs/auth/auth-signin-flows.feature:46-48`) — the shim exists precisely so this is not a day-one outage.
+- The support threads in the epic are the failure modes this wizard must surface instead: every stuck state is visible on the ops surface with a guarded action.
+
+# Technical Plan
+
+1. Wizard UI driving D05's connection commands + progress reads (% linked from identifier data).
+2. Comms pack: email templates + per-IdP cheat sheets.
+3. Shim + per-org hit metric — must exist **before the pilot activates** (pilot checklist item).
+4. Playbook doc (engineering/CS) + exception-queue views on the ops surface.
+5. Pilot customer → batches at whatever pace customers move.
+
+# Exit gate / rollback
+
+- **Exit per customer:** all active users linked; quiet grace (no legacy logins for N days, shim hits at zero); teardown event.
+- **Program exit:** zero ACTIVE legacy connections.
+- **Rollback:** grace *is* the rollback — legacy stays ACTIVE until teardown.
+
+# Security Concerns
+
+- Both-active windows widen attack surface slightly — mitigated by link-on-login audit events and the linking ambiguity guards.
+- Legacy identifier detach obeys the standard guards (≥1 remaining verified identifier + recovery path); ops force-detach override is audited.
+- Shim is translation-only and logged; it must never become a credential endpoint.
+
+# Open Questions
+
+- (Epic 7) validate the wizard shape against the Notion frontend-flow comment when it surfaces; adjust scope if it contradicts.

--- a/dev/docs/identity-platform/D10-auth0-deletion.md
+++ b/dev/docs/identity-platform/D10-auth0-deletion.md
@@ -1,0 +1,48 @@
+# D10 — Auth0 code + config deletion
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 4 · Depends on: D09 program exit (zero ACTIVE legacy connections) · **Program exit criterion — customer-paced, not a scheduled milestone**
+
+# Overview
+
+Auth0 actually dies: provider config, Management API password service, federated logout, SCIM webhook, env wiring, SaaS secrets, the legacy callback shim, and the agents-box Playwright login. Customer migration is deliberately slow and per-tenant (D09); this deliverable starts only when the last legacy connection tears down. This is the program's DONE signal.
+
+# Requirements
+
+- Delete from `platform/app`: Auth0 provider config in `ee/sso/providers.ts`, `src/server/auth0/passwordService.ts`, federated logout, the SCIM Auth0 log-stream webhook, related env wiring.
+- Delete the temporary legacy callback shim (`/api/auth/callback/auth0`, `/okta` — R9) once shim metrics show zero traffic and no ACTIVE legacy connections remain.
+- Rewrite `specs/settings/change-password-auth0.feature`: the Auth0 Management API scenarios retire; password change becomes an identifier-model operation (which identifier's password, current-password proof) against better-auth native behavior.
+- Retire the Auth0 sign-in flow scenarios in `specs/auth/auth-signin-flows.feature` (the pinned legacy callback URI's raison d'être ended with the shim's removal).
+- SaaS infra: swap `langwatch_secrets` keys (passthrough blob — no Terraform diff); remove `AUTH0_*` keys.
+- agents-box post-deploy Playwright QA: rewrite login to an email/password test user (currently authenticates via Auth0 — breaks the moment the provider goes).
+- Env naming: decide Open Q3 (`NEXTAUTH_*` → better-auth-native names) as part of this cleanup.
+- Cancel Auth0 spend — only now, not before.
+
+# Out of Scope
+
+- Customer migrations (D09 must be complete first). Any remaining `auth0-legacy`/`okta-legacy` identifier rows — they're tombstoned history, they stay.
+
+# Research
+
+- SaaS infra: Auth0 is dashboard-only (not Terraform-managed); prod/staging receive `AUTH0_*` via the `langwatch_secrets` blob auto-injected as env vars; dev wires `NEXTAUTH_SECRET` explicitly; `modules/agents-box/main.tf` Playwright QA logs in via Auth0.
+
+# Technical Plan
+
+1. Deletion PR(s) with the grep gate below.
+2. agents-box QA rewrite + verification deploy.
+3. Secrets blob swap (coordinate with deploy).
+4. Spec amendments (change-password rewrite, signin-flows retirement).
+5. Billing cancellation.
+
+# Exit gate / rollback
+
+- **Exit:** repository-wide `grep -ri auth0` (not just `platform/app` — the deletion scope spans agents-box, specifications, and env wiring too) → hits only in the allowlist: changelog, tombstoned history, and the retained planning documents under `dev/docs/` (this file and the delivery plan deliberately keep the word); the `langwatch_secrets` blob verified to carry no `AUTH0_*` keys; deployment configuration (env wiring, `modules/agents-box/main.tf`) verified Auth0-free; deploy pipeline green; agents-box QA green. **This is the DONE signal.**
+- **Rollback:** a tested restore artifact, not "nothing left". Before the deletion PR merges: tag the last Auth0-capable commit (`pre-auth0-deletion`), escrow the `AUTH0_*` secrets outside the blob (ops vault, dated), and prove the tag deploys green in staging. The last fallback (the shim, then the secrets) is deleted only after an observation window — zero shim hits for a sustained window (the shim's own metric, per Security), zero Auth0-attributed sign-in failures, no open customer thread naming a legacy connection. The escrow and tag are retired only once the exit grep has stayed green through a full release cycle after that window; billing cancellation comes last.
+
+# Security Concerns
+
+- Federated logout deletion: confirm session-revocation coverage (D06 per-identifier revocation + ops `revokeSessions`) replaces any logout semantics customers relied on.
+- Shim removal is gated on its own usage metric — zero hits for a sustained window, not just "all connections torn down."
+
+# Open Questions
+
+- (Epic 3) env renames during this cleanup or kept for compatibility.

--- a/dev/docs/identity-platform/D11-resilient-invitations.md
+++ b/dev/docs/identity-platform/D11-resilient-invitations.md
@@ -1,0 +1,60 @@
+# D11 — Resilient invitations
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 2 · Depends on: D01 (identifiers) only · Invite changes additive
+
+# Overview
+
+The direct fix for the invitation dead-end support load — pulled ahead of the router because it needs only identifiers, not routing. Acceptance works via any verified method, the inviter can resend in one click, and expiry becomes a visible, recoverable state instead of a silent dead end.
+
+# Requirements
+
+- **Identifier-aware acceptance:** an invite targets an email; acceptance succeeds via any VERIFIED identifier matching that email after normalization — password, Google, or the org's SSO. Account exists with a different method → they sign in with what they have and the invite applies. No account → guided signup that attaches whatever method they choose. No more "invited by email, has a Google account, can't get in."
+- **One-click resend** by the inviter (and any org admin): new `inviteCode`, fresh 14-day expiry, new email; old code revoked. Lands in the existing members/invitations UI now; the org-admin surface absorbs the panel at D05.
+- **Expiry 2 days → 14 days** — resend is painless, so the window can be generous; EXPIRED is a visible, resendable state.
+- **Explicit states:** PENDING → ACCEPTED | EXPIRED | REVOKED; resend = EXPIRED → PENDING (new token). Outstanding invites with state and expiry visible in the members UI now, in both identity surfaces when they exist.
+
+# Data structures
+
+`OrganizationInvite` stays a plain Prisma model (no aggregate — invites are org-admin CRUD with an expiry, not a lifecycle worth a fold). Plain row, guarded transitions: resend and acceptance each **claim** the row with a conditional update on the expected `(status, inviteCode)` pair, so two racers on the same PENDING invite cannot both win — the loser sees a stale-code refusal. The columns that matter:
+
+```text
+OrganizationInvite
+  id · organizationId · email (normalized at write) · inviteCode UK
+  role · teamIds                       what acceptance passes to grants.attach
+  status      PENDING | ACCEPTED | EXPIRED | REVOKED
+  expiresAt   createdAt + 14 days      resend: new inviteCode, fresh expiresAt, old code → REVOKED
+  invitedById · acceptedByUserId? · acceptedViaAccountId?   which VERIFIED identifier matched
+```
+
+Acceptance lookup: invite.email → normalize → all VERIFIED identifiers matching that value across providers → the holder signs in with any of them → the acceptance claims the row (conditional update on PENDING + the presented `inviteCode`) → `grants.attach` (ledger event `grant_attached` with `source: "invite"`, idempotency-keyed by the invitation id — a retry after a landed attach re-applies nothing) → status ACCEPTED. The authorization fact lives in the grants ledger; the invite row records only its own outcome.
+
+# Out of Scope
+
+- Join requests (D12 — but note the interplay rules there: answering a request with an invite, and invite acceptance auto-withdrawing a pending request). The acceptance *screen* set (D13's invitation-acceptance screen; this deliverable ships the logic inside today's members UI). Team-assignment UX changes.
+
+# Research
+
+- Today: `OrganizationInvite` (inviteCode, status, 2-day expiry); acceptance assumes the inviter's chosen method; expiry is silent; resend is an ops action. Support threads: Google-linked invitee failing SSO sign-in; invite expiring mid-debug of an `unable_to_link_account` loop.
+- Corpus-audit spec impacts: `specs/members/update-pending-invitation.feature` — 48h → 14 days (:94-99); state model PENDING/WAITING_APPROVAL → new states (:121-126, :190-196); add resend scenarios (none exist today). `specs/licensing/enforcement-members.feature:110-123` — expired-invite counting aligns to the new states.
+
+# Technical Plan
+
+1. Acceptance lookup rewrite: invite email → VERIFIED identifiers (normalized) across all methods → sign-in-with-what-you-have → apply invite.
+2. `resendInvite` tRPC mutation (permission-checked; inviter + org admins): new code, fresh expiry, new email, old code revoked.
+3. Expiry constant + explicit states on `OrganizationInvite`; members-UI affordances (resend, state + expiry display).
+4. Spec amendments (`update-pending-invitation`, `enforcement-members`).
+5. **Support-pain replay tests:** the Google-linked invitee case and the invite-expired-mid-debug case encoded as tests — green is part of the exit gate.
+
+# Exit gate / rollback
+
+- **Exit:** round-trips — invite → wrong-method account → accepted; expiry → resend → accepted; support-pain replay tests green.
+- **Rollback:** additive changes (new states/columns); old acceptance flow flag-restorable during bake.
+
+# Security Concerns
+
+- Acceptance must not weaken targeting: the accepting identifier must be VERIFIED and match the invite email after normalization.
+- Resend invalidates the old code — a leaked stale invite link dies on resend.
+
+# Open Questions
+
+- None. Member-initiated `WAITING_APPROVAL` invites are retired (epic Q13): the state model above is complete, and D12's join requests carry the member-wants-a-colleague-in motivation from the joiner's side. The `update-pending-invitation.feature` amendment drops the WAITING_APPROVAL scenarios (`:94-99`, duplicate detection `:121-126`).

--- a/dev/docs/identity-platform/D12-join-requests.md
+++ b/dev/docs/identity-platform/D12-join-requests.md
@@ -1,0 +1,107 @@
+# D12 — Join requests + domain auto-join (Anthropic-Teams-style)
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 3 · Depends on: D03 (router) + D13 (sign-up interstitial hook) + D05 (org-admin surface hosts approvals) · Flag: `JOIN_REQUESTS`
+
+# Overview
+
+Sign up with a work email, see that your colleagues already have an org, and get in — either by requesting (an admin approves in-app) or, where the org has opted in, by walking straight in on a verified domain match. No invitation needed. The request path is admin-gated, which is what makes it safe without any SSO machinery: worst case is a stranger's request sitting in an admin's inbox. The auto-join path is org opt-in, verified-email-only, and never available on public email domains.
+
+Because this decision now happens **before** workspace creation (D13's interstitial), it is also the fix for orphaned organizations: today every sign-up mints a fresh org, including the thousands of solo workspaces people abandon the moment they join their real one.
+
+# The journey (the case this must cover, end to end)
+
+1. I sign up for LangWatch with `me@acme.com` and verify the email.
+2. Before any workspace is created, I see that Acme Corp already exists here ("12 of your colleagues"), with **Join Acme Corp** as the primary action and "create a new organization" as the secondary one.
+3. Depending on Acme's `domainJoin` setting:
+   - **`request`** — I ask to join; my manager (any org admin) gets an email + in-app notification and approves or rejects; I get notified and land in the org with the default role.
+   - **`auto`** — I'm in immediately with the default role; admins are notified it happened.
+   - **`off`** — I see nothing about Acme at all; sign-up proceeds to workspace creation as today.
+4. At no point has a throwaway organization been created for me unless I explicitly chose "create a new organization" (or no match existed).
+
+# Requirements
+
+Aggregate `join_request` in the identity pipeline; projection `join_requests` (`id, userId, organizationId, domain, state, createdAt, resolvedAt, resolvedByType, resolvedById`):
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : requestJoin (verified email, domain match)
+    PENDING --> APPROVED : org admin approves (org-admin surface)
+    PENDING --> APPROVED : policy auto-approval (domainJoin = auto)
+    PENDING --> REJECTED : org admin rejects
+    PENDING --> EXPIRED : 14 days (admin reminder wake at day 7)
+    PENDING --> WITHDRAWN : requester cancels
+```
+
+Auto-join reuses the same lifecycle: the request is created and immediately approved by policy (`resolvedBy = policy:domain-auto`), so the audit trail and metrics are identical to the admin path.
+
+- **Org setting `domainJoin`: `off` | `request` | `auto`.** Default `request` for cloud self-serve orgs; forced `off` for SSO-connected orgs (their connection's JIT handles it) and for self-hosted (per-org override available). `auto` is opt-in only, admin-set. On self-hosted, domain auto-join is part of the licensed SSO surface (`specs/licensing/sso-license-gating.feature:10-11` counts it as SSO; `:182` keeps it off unlicensed) — the per-org override requires a genuine license; unlicensed deployments stay `off`.
+- **Matching** (post-verification only): orgs with ≥1 member holding a VERIFIED identifier on the requester's domain (threshold Open Q8), excluding personal orgs, excluding orgs with ACTIVE SSO connections, excluding orgs with `domainJoin = off`. **Public email domains (gmail.com, outlook.com, …) never match** — maintained deny-list; no domain feature exists for them in any mode.
+- **Privacy:** org existence/name revealed only after the requester's email is verified, only on domain match, never for personal orgs; member counts coarse ("12 of your colleagues").
+- **No role picker:** approval — admin or policy — always grants the org's default role (MEMBER); admins upgrade later. Least privilege by construction.
+- **Orphan-org prevention:** the interstitial runs **before** workspace creation (D13's sign-up flow); "join" is the primary action on a match and org creation is the explicit secondary choice. A user with a pending request lands on a "request pending" screen and may still create a workspace deliberately — but never gets one minted silently. Metric: orphaned-organization creation rate (orgs created by users who join another org on the same domain within 30 days).
+- **Anti-abuse:** one pending request per (user, org); requests rate-limited like auth endpoints; rejection is silent-ish ("not approved", no reason required); auto-join notifies all org admins after the fact (email + in-app) so a surprising join is visible immediately.
+- **Process manager per request:** `JoinRequested` → notify org admins (email + in-app); day-7 reminder wake; day-14 `JoinExpired`. Approval intent (admin or policy) → `grants.attach` → notify requester (email + in-app).
+- **Interplay with invitations (D11):** one panel, two directions. An admin looking at a pending join request approves it as-is (default role); they may instead answer it with a formal invite sent through the existing D11 flow, which owns the role/team picker — the invite supersedes: sending it resolves the request as APPROVED with `resolvedBy` the invite. D12 wires only that resolution; a dedicated convert-to-invite flow inside the panel stays out of scope (below). In the other direction, accepting any org invite auto-withdraws the same user's pending join request for that org — a user never holds both. Duplicate suppression: a pending request blocks a second request (one per user+org), never blocks an invite.
+- **Existing users can always create another organization** (org switcher → create), whether or not their domain matches one; the interstitial only orders the choices. On a matching domain the create screen shows a soft notice with the join affordance inline ("Acme Corp is already here — join instead?"), never a block (epic Q17).
+- **UI:** the sign-up interstitial ("Acme Corp — 12 of your colleagues are here. Join / Request to join" alongside "create a new organization"), also shown post-login for existing users, once per domain per user, dismissible (hook point left by D13/D03); approvals live on the org-admin surface (badge + approvals row); the `domainJoin` setting lives in org Settings next to the SSO configuration.
+
+# Data structures
+
+Aggregate `join_request` in the identity pipeline; `tenantId = organizationId` (admins query by org), `aggregateId = joinRequestId`. Events carry ids, the domain, and enums — the requester's email never needs to appear; the domain is the fact (D01 payload rules):
+
+```jsonc
+// lw.identity.join_requested
+{ "data": {
+    "joinRequestId": "jreq_…",
+    "userId": "user_…",
+    "organizationId": "org_…",
+    "domain": "acme.com",
+    "matchedVia": "verified-identifier-domain"
+} }
+
+// lw.identity.join_approved — same shape for the policy path
+{ "data": {
+    "joinRequestId": "jreq_…",
+    "resolvedBy": { "type": "user", "id": "user_admin…" }   // or { "type": "policy", "id": "domain-auto" }
+                                                             // or { "type": "invite", "id": "inv_…" } (D11 interplay)
+} }
+
+// lw.identity.join_rejected { joinRequestId, resolvedBy }         — no reason field; rejection is silent-ish
+// lw.identity.join_expired  { joinRequestId }                      — day-14 PM wake
+// lw.identity.join_withdrawn { joinRequestId, cause: "user" | "invite-accepted" }
+```
+
+Projection `join_requests` (PG, fold-written): `id · userId · organizationId · domain · state · createdAt · resolvedAt · resolvedByType · resolvedById`. Membership itself is never written here — approval dispatches `grants.attach` (the ledger's `grant_attached` with `source: "invite"`-class provenance carries the authorization fact).
+
+# Out of Scope
+
+- Converting a pending request into a formal invite with team assignments (nice-to-have later). SSO JIT provisioning (belongs to the connection, D04). Cleanup of the orphaned organizations that already exist (Open Q14 — this deliverable stops the bleeding, it doesn't drain the pool).
+
+# Research
+
+- Greenfield for the lifecycle — no existing spec coverage; new `.feature` files to write (lifecycle, matching, privacy, anti-abuse, auto-join, join-before-create). One corpus touchpoint: `specs/licensing/sso-license-gating.feature` (:10-11, :182) counts domain auto-join as licensed SSO — its `domainJoin` amendment rides this deliverable (see the delivery plan's amendment table).
+- Motivation: the invitation dead-end support threads — users who should have found their org instead landed in "create personal workspace" flows they couldn't escape. The same flow is why production carries a long tail of orphaned single-user organizations: sign-up creates one unconditionally, and joining your real org later doesn't remove it.
+
+# Technical Plan
+
+1. Projection + events (`JoinRequested`, `JoinApproved`, `JoinRejected`, `JoinExpired`, `JoinWithdrawn`) + matching query over VERIFIED identifiers; policy auto-approval path with `resolvedBy = policy:domain-auto`.
+2. Process manager: notifications (incl. after-the-fact admin notification on auto-join), day-7 reminder, day-14 expiry; approval intent → `grants.attach`.
+3. Interstitial content into D13's sign-up hook (join-before-create) + post-login variant; org-admin surface approvals panel + `domainJoin` setting.
+4. Orphaned-organization metric (creation rate + the 30-day join-elsewhere signal), on the dashboard before the flag flips.
+5. New Gherkin specs for the lifecycle, matching rules, privacy, anti-abuse, auto-join, and join-before-create.
+
+# Exit gate / rollback
+
+- **Exit:** request → approve → member round-trip; auto-join round-trip on an opted-in org (and refused on a public email domain); reminder/expiry wakes verified; matching/privacy specs green; orphaned-organization creation rate visibly down.
+- **Rollback:** `JOIN_REQUESTS` off.
+
+# Security Concerns
+
+- Request ≠ access — an admin gates every join, except where the org has deliberately opted into `auto`; that path still requires a verified email on a matching non-public domain and notifies admins immediately.
+- Public email domains are excluded from every mode — a gmail.com "domain match" must be structurally impossible, not just unlikely.
+- Reveal discipline: post-verification only, domain match only, never personal orgs, coarse counts.
+
+# Open Questions
+
+- (Epic 8) matching threshold ≥1 vs ≥2 verified members on the domain. (Lean: ≥1 — behind verification and admin approval anyway; for `auto` mode the lean flips to ≥2 or admin-verified domain, to be settled in the spec.)
+- (Epic 14) the orphaned organizations that already exist: sweep, merge tool, or leave them?

--- a/dev/docs/identity-platform/D13-signin-signup-screens.md
+++ b/dev/docs/identity-platform/D13-signin-signup-screens.md
@@ -1,0 +1,77 @@
+# D13 — Sign-in & sign-up screens (the first-party auth UI)
+
+Epic: `../identity-platform-redesign.md` · Plan: `delivery-plan.md` · Wave 2 · Depends on: D01 (identifier model); flips with D03 (same flag: `IDENTITY_ROUTER_V2`)
+
+# Overview
+
+Auth0 owned the front-door visuals; retiring it means every screen an unauthenticated person can touch must be rebuilt first-party. This deliverable is that screen set: sign-in, sign-up, method picker, password reset, email verification, and every deny/guidance state — designed as one experience, shipped behind the router flag, with the hook points D06/D07/D12 later fill. It also moves the join-your-team decision to **before** workspace creation, which is where orphaned organizations stop being minted.
+
+# Requirements
+
+**Screen inventory** (each with golden path + failure states in its spec):
+
+- **Sign-in — identifier-first**: email step → routed outcome (IdP redirect, or the uniform method picker: password | social | passkey placeholder until D07). Same page, same timing whether or not the account exists (D03 owns the contract; this UI implements it). Self-hosted sole-connection auto-redirect and the `?local=1` break-glass variant.
+- **Sign-up**: email step → verification → method choice (password or social, reusing the picker components). After verification, the **join-before-create interstitial** (hook filled by D12): if the domain matches an org, "join Acme Corp" / auto-join leads and "create a new organization" is the secondary action. An organization is created only when the user explicitly chooses it or no match exists — sign-up stops defaulting into a fresh org nobody will ever use.
+- **Password reset**: request + reset screens; availability under SSO/cloud mode per Open Q9; uniform response whether or not the email exists.
+- **Email verification states**: sent, verified, expired-link, resend.
+- **Invitation acceptance**: the invite-link landing — org name, inviter, and the same method picker (accept via any verified method matching the invite email, D11's rule). Signed-in variant: confirm-and-join. Signed-out variant: sign in or sign up first, the invite riding through the ceremony untouched. EXPIRED offers "ask for a new invitation" (pings the inviter, whose side is one-click resend); REVOKED ends without detail. D11 ships the acceptance logic inside today's members screens; this deliverable renders it as part of the first-party set.
+- **Deny/guidance states**: JIT-off denial with guidance, wrong-method guidance (points at the method the account actually has), deactivated account, license-gated SSO, suspended connection.
+- **Hook points left, not built**: MFA challenge (D06), passkey button + no-email sign-in (D07), interstitial content and matching (D12).
+- Consistent with the product design system; no Auth0-hosted pages, assets, or redirects anywhere on the unauthenticated surface.
+
+**Cutover:** the screens ship dark behind `IDENTITY_ROUTER_V2` and appear at the enforce flip together with D03's routing. Shadow mode never renders them (it compares routing decisions only).
+
+**Where the UI lives** (all first-party app routes; zero Auth0-hosted pages):
+
+```text
+unauthenticated (this deliverable)
+  /auth/signin              identifier-first email step → routed outcome (picker | IdP redirect)
+  /auth/signin?local=1      self-hosted break-glass local login
+  /auth/signup              email → verification → method choice → join-before-create interstitial
+  /auth/reset · /auth/reset/<token>       password reset request + completion
+  /auth/verify/<token>      email verification states (sent · verified · expired · resend)
+  /invite/<code>            invitation acceptance (logic from D11)
+  /auth/join                join-before-create interstitial (content and matching from D12)
+
+authenticated identity surfaces (later deliverables — listed for orientation)
+  Settings → SSO            connection onboarding wizard (D05) · Auth0 migration wizard (D09) · domainJoin setting (D12)
+  Settings → Members        invitations with states + one-click resend (D11); absorbed by the org-admin surface at D05
+  Settings → Identity       the org-admin surface (D05): link confirmations, member identifiers, join-request approvals (D12)
+  ee/admin → Identity       platform-ops identity lookup (D05), cross-org, ops-gated
+```
+
+# Out of Scope
+
+- Routing logic and auto-link rules (D03). MFA/passkey ceremonies (D06/D07). Join-request matching, privacy and approvals (D12). Org-admin and ops surfaces (D05). The "manage sign-in methods" self-serve settings screen (epic: still left to think about).
+
+# Research
+
+- Today's screens are thin because Auth0's Universal Login carried the weight; there is no first-party UI for method choice, verification states, or recovery guidance.
+- Sign-up today always lands in workspace creation — the direct source of the orphaned-organization problem (users create a solo org, later get invited to the real one, the solo org lingers forever).
+- Spec impacts: `specs/auth/auth-signin-flows.feature` ports to router + screens (with D03); `signup-does-not-strand-an-account.feature` anchors survive; `sign-in-failure-messages.feature` is an anchor — the new screens keep saying *why* a sign-in failed (wrong password, rate-limit wait, origin mismatch); new `.feature` files for the full screen set.
+
+# Technical Plan
+
+1. Screen components over D03's routing contract (the router returns a decision + reason; the UI renders it — no routing logic in components).
+2. Page-level timing normalization for the enumeration guarantee.
+3. Sign-up flow with verification-first ordering and the interstitial hook API (D12 plugs matching + content in; until then the hook renders nothing and sign-up proceeds to create-org).
+4. Deny/guidance states wired to router reason codes — the same codes the D05 ops surface displays.
+5. New Gherkin specs per screen (golden + failure paths), tagged and bound.
+6. Flip with D03; legacy screens deleted at bake end.
+
+# Exit gate / rollback
+
+- **Exit:** every unauthenticated journey round-trips in the new UI (sign-in per live method, sign-up per method, reset, verification, deny states); zero Auth0-hosted pages or assets; sign-up completion ≥ baseline on the funnel dashboard.
+- **Rollback:** flag off — legacy screens intact until bake end.
+
+# Security Concerns
+
+- Enumeration: uniform page/timing on sign-in (D03's contract); reset/verification responses identical whether the account exists; sign-up enumeration stance per Open Q12.
+- Reset and verification links single-use and expiring.
+- Guidance copy must never confirm account existence to an unauthenticated caller beyond what the no-oracle stance allows.
+
+# Open Questions
+
+- (Epic 9) password reset availability in cloud/SSO mode.
+- (Epic 12) sign-up enumeration vs the no-oracle scoping.
+- (Epic 14) what to do about the orphaned organizations that already exist.

--- a/dev/docs/identity-platform/delivery-plan.md
+++ b/dev/docs/identity-platform/delivery-plan.md
@@ -1,0 +1,202 @@
+# Identity Platform — Delivery Plan
+
+The final spec: how the thirteen deliverables (`D01`–`D13`, see `../identity-platform-redesign.md` for the epic) sequence, gate, and roll back. Each deliverable is a sealed goal: independently shippable, flag-gated, measurable exit, stated rollback.
+
+# Precondition — authz program landed
+
+**Landed (2026-08-23 check against `main`).** The unified authorization engine is ADR-092 (engine, registry, fork) as reshaped by **ADR-110** (`dev/docs/adr/110-grant-aggregates-are-grants.md`; #7358, #7404): a grant is its own aggregate, there is one migration per organization, and finishing it IS the switch — no cutover step, no cutover table, no cached cutover gate, no cohorts. The engine gate (`server/app-layer/authz/engine-gate.ts`) reads the migration's `finalized` status and nothing else. Ready-to-start checklist, as it stands on `main`:
+
+- [x] `packages/authz/src/registry.ts` is the permission registry (org-scope entries exist; registry-derived `Permission` type exported).
+- [x] `GrantsService.attach` / `.offboard` (`packages/authz-server/src/grants.service.ts`) emit ledger commands with actor context; offboard takes a principal filter and carries the empty-proof postcondition (`offboard.ts`).
+- [x] `.permission()` on tRPC procedures (`server/app-layer/authz/trpc-middleware.ts`, resolved through `getApp().permissions`); `useCan` / `RequireCan` for UI.
+- [ ] Edge middleware: any credential → `Principal {actor, subject}` with session claims — the vocabulary exists (`packages/authz/src/vocabulary.ts`), the impersonation-aware principal is D06's to finish.
+- [x] The `Role` projection supports org-scope permission keys (for the IT-admin role).
+- [x] Every membership write in identity code goes through `grants.*`, every check through `.permission()` / `getApp().permissions` — identity code never calls `rbac.ts`/`TeamUser`.
+
+D05 and D08 consume the checked items. **Any authz API change is a breaking change to this program** (risk register).
+
+## What the authz program hands this program
+
+- **There is no Redis-loss deliverable.** D02 proposed exactly that and was **withdrawn on 2026-08-24**: bounded fail-open on better-auth's secondary storage, a best-effort staging leg, and a calling-path fold, all to keep ceremonies working through a Redis outage. It bought resilience the product had not asked for at a complexity nobody wanted to carry. Identity takes ADR-110's position unchanged — every write through the group queue, Redis down ⇒ identity writes stop landing in the projection — and the facts stay durable in ClickHouse regardless.
+- **The ADR-110 rollout shape** — new native head born clean, adoption by ids that are stable across retries, one migration that states facts and checks once, `finalized` as the only switch, held tenants with their outstanding facts named, rollback as a status change — is what Wave 1 transplants, re-tenanted to users. The earlier three-stage arc (witnessed migrations → write gate → parity-proved cutover) is gone from `main` and from this plan.
+- **`@langwatch/system-migrations` (on `main`, #7079, #7337)** drives every in-place backfill: leased runner in the worker process with per-tenant claims, state machine `pending → migrated (held) → finalized → rolled_back`, parked failures, ops migrations dashboard + operator rollback included. Cloud pacing is per-(organization, migration) enrollment and nothing else. D01's identifier backfill and D04's grandfathering are riders; D09's per-customer progress record is a candidate (open question there).
+- **SCIM converges on `grants.*`** (D08): when connections exist, the reconciler's actor is the connection — `actor: { type: "system", id: <connectionId> }` — which the ledger event shape accommodates with no schema change.
+- **Offboarding is a service seam**: identity deprovision paths call `GrantsService` (revoke/offboard, empty-proof postcondition); no identity imports inside authz packages, no cross-pipeline event subscriptions.
+- **Doctrine mirrored, never shared tables**: identity copies the ledger's dispatch discipline (waited CH append, idempotent applies, deterministic ids, caller-minted commandIds) and its projection-cursor pattern — but no table has two pipeline owners, and identity events may carry emails where the ledger's stay pseudonymized (epic R11).
+
+# Sequencing
+
+Critical path: **D01 → D03+D13 → D04 → D05 → D08 → D09 → D10**. D11 forks off after D01; D06/D07/D12 fork off after D03/D05; Wave 4 has no dates by design.
+
+The chart shows the wave structure; the exact per-deliverable dependencies live in the **Needs** column of the tables below (drawing every edge made the graph unreadable).
+
+```text
+ WAVE 1                      WAVE 2                         WAVE 3                           WAVE 4
+ foundations —               the new front door             self-service + factors           Auth0 dies —
+ nothing a user can see      + the invite fix               (parallel tracks)                customer-paced
+
+ D01 identifiers             D03 router  ═╗                 D05 self-serve SSO +             D09 per-customer
+      │                      D13 screens ═╝ one flag         │  identity surfaces                migration
+      └──────────────────►   └─► D04 SsoConnection    ──►   └─► D08 SCIM per          ──►    └─► D10 delete
+                                  aggregate                      connection                       Auth0
+                             D11 resilient invitations      D06 MFA  ·  D07 passkeys
+                             (needs only D01)               D12 join requests + auto-join
+                                                             ▲
+                             authz precondition ═════════════╝  hard — gates D05 and D08
+```
+
+# What each wave actually delivers
+
+## Wave 1 — foundations
+
+Nothing a customer can see. Both deliverables exist to make Wave 2 safe.
+
+| # | Needs | What ships | Impact when it lands |
+|---|---|---|---|
+| D01 | — | The identifier model: one user, many verified sign-in methods, a new pure event-truth Postgres `Identifier` projection (born clean; `Account` stays 100% row-truth protocol), full backfill via system-migrations with per-user write gating | No product change yet — but identity state becomes *visible data* for the first time, and every other deliverable builds on it |
+
+## Wave 2 — the new front door + the invite fix
+
+The customer-visible core: a completely new unauthenticated experience, and the end of the invitation dead ends.
+
+| # | Needs | What ships | Impact when it lands |
+|---|---|---|---|
+| D03 | D01 | The identifier-first routing engine: email → route to the right IdP or method set, auto-link rules, shadow-compared cutover | One front door for every method at once — ends the one-method-per-deployment limit; account-linking dead ends stop being support tickets |
+| D13 | D01; flips with D03 | The complete first-party sign-in & sign-up screens (Auth0 owned these visuals until now): sign-in, sign-up, method picker, password reset, email verification, every deny/guidance state | The first thing every user ever sees is ours; sign-up gains the join-your-team step **before** workspace creation, which is where orphaned organizations stop being minted |
+| D04 | D03 | `SsoConnection` as a real aggregate with a guarded lifecycle; existing `ssoDomain` strings grandfathered in silently | Enterprise SSO becomes data with history instead of two hand-set strings; no customer notices, which is the point |
+| D11 | D01 only | Resilient invitations: accept via any verified method, one-click resend, 14-day expiry, visible states | The loudest support pain (invited with email, has a Google account, can't get in) is fixed — before the router cutover makes noise |
+
+## Wave 3 — self-service + factors
+
+Parallel tracks; staff in any order capacity allows.
+
+| # | Needs | What ships | Impact when it lands |
+|---|---|---|---|
+| D05 | D04 + authz checklist (hard) | Self-serve SSO onboarding (register → verify domain → activate) plus both identity surfaces: platform-ops lookup and the org-admin panel | Enterprise onboarding drops to one LangWatch action (an approval click); DB surgery as a support tool ends |
+| D06 | D03 | TOTP MFA + backup codes, org-level `mfaRequired`, sessions that carry `amr` (one forced re-login) | Orgs can finally require MFA; impersonation and step-up become provable |
+| D07 | D03 | Passkeys via WebAuthn, including no-email discoverable sign-in | The fastest sign-in method, and the phishing-resistant one |
+| D08 | D05 + authz checklist (hard) | SCIM tokens scoped per connection; SCIM writes membership only through `grants.*` | Cross-org SCIM writes become impossible; deprovisioning gets a provable postcondition |
+| D12 | D03/D13 + D05 | Join requests + domain auto-join: sign up with a work email → see your company's org → request (admin approves) or walk straight in where the org allows it | "I signed up and my company was invisible" is over; the join-before-create flow is what starves orphaned organizations |
+
+## Wave 4 — Auth0 dies
+
+| # | Needs | What ships | Impact when it lands |
+|---|---|---|---|
+| D09 | D05, D08 | The per-customer migration wizard with both-connections grace and the legacy callback shim (R9) | Each enterprise moves at its own pace with rollback built in; nobody reconfigures their IdP under pressure |
+| D10 | D09 program exit: zero ACTIVE legacy connections | Deletion: provider config, password service, webhook, shim, secrets, QA login | Auth0 spend and code hit zero. This is the program's DONE signal — customer-paced, not a scheduled milestone |
+
+# Sequencing rationale
+
+- **D03 and D13 flip together** — one flag (`IDENTITY_ROUTER_V2`): the router is the logic, the screens are the experience, and shipping either alone would mean building throwaway UI or an invisible engine. Shadow mode exercises the router only; the screens appear at the enforce flip.
+- **D03 is the highest-risk deliverable** — every human's front door. It lands only after D01's replay parity is green.
+- **D11 was pulled out of the old combined deliverable into Wave 2**: identifier-aware acceptance and one-click resend need only D01's identifiers — they fix the loudest support pain and shouldn't wait for the router. Resend UI lands in the existing members/invitations area; the org-admin surface absorbs it at D05.
+- **D06/D07/D08/D12 are mutually independent** after D03/D05. Suggested order: D06 → D07 → D08; D12 needs D13's interstitial hook (rides D03's flag) and D05's org-admin surface.
+- **D09 is customer-paced, per tenant, slow by design** — no fleet deadline. **D10 is a program exit criterion, not a schedulable milestone**: it starts when the last legacy connection tears down; Auth0 spend and the agents-box login survive until then, and that's fine.
+
+# Deliverable gates
+
+| # | Flag(s) | Exit gate | Rollback | Risk |
+|---|---|---|---|---|
+| D01 | — (write gate is data, ships closed) | Replay rebuilds `Identifier` from CH and matches live table; backfill parity self-proving per user; adapter routing-table coverage: every better-auth model+operation explicitly routed, unrouted writes fail | Un-enroll / roll back migration state — adapter stops emitting, protocol writes untouched; table additive, nothing reads it until D03 | Low |
+| D03 | `IDENTITY_ROUTER_V2` (shadow → enforce) | Zero unexplained shadow mismatches over bake; sign-in success ≥ baseline | Flag off | **Highest** |
+| D04 | `SSOCONN_ROUTING` (shadow → enforce) | Routing parity silent vs `ssoDomain` strings; string writes stopped | Flag off, strings still dual-written | Medium |
+| D05 | `SELF_SERVE_SSO` (per-org) | New enterprise customer onboards with exactly one LangWatch action (approval click); ops surface resolves a real support case | Per-org flag off | Medium |
+| D06 | `MFA_ENROLLMENT_OPEN` + deploy-time session revoke | Enroll → challenge → backup-code → disable round-trips; org policy enforced; lockout verified | Flag off; session kill is irreversible (comms!) | **One-way door** |
+| D07 | `PASSKEYS_ENABLED` | Register / sign-in / no-email sign-in / delete round-trips, platform + cross-platform authenticators | Flag off | Low |
+| D08 | `SCIM_V2_GRANTS` | Push/group/deactivate round-trip; token scoping enforced; offboard postcondition asserted in integration test | Legacy write path behind flag | Medium |
+| D09 | per-customer | Per customer: all active users linked, quiet grace, shim hits at zero, teardown event. Program: zero ACTIVE legacy connections | Both-connections-active grace IS the rollback | Customer-facing |
+| D10 (program exit criterion — customer-paced) | — | Repository-wide `grep -ri auth0` → allowlist only (changelog, tombstoned history, retained `dev/docs/` planning documents); secrets blob + deployment config verified Auth0-free; deploy pipeline green; agents-box QA green | Tagged restore point + secret escrow, retired only after the observation window (see D10) | Low |
+| D11 | invite changes additive | Round-trips: invite → wrong-method → accepted; expiry → resend → accepted; Slack invite cases replay green | Additive; old flow flag-restorable during bake | Low |
+| D12 | `JOIN_REQUESTS` | request → approve → member round-trip; domain auto-join round-trip (org opt-in, never public email domains); reminder/expiry wakes verified; matching/privacy specs green; orphaned-org creation rate visibly down | `JOIN_REQUESTS` off | Low |
+| D13 | `IDENTITY_ROUTER_V2` (with D03) | Every unauthenticated journey round-trips in the new UI: sign-in per method, sign-up per method, reset, verification, deny/guidance states; zero Auth0-hosted pages or assets; sign-up completion ≥ baseline | Flag off — legacy screens intact until bake end | Medium (rides the D03 flip) |
+
+# Wave 1 — PR breakdown
+
+The program starts here. Same shape as the authz program's plan (`dev/docs/plans/adr-092-authz-delivery-plan.md`): few PRs, gates and data protect the rollout, not PR boundaries — every PR ships gated closed and is production-safe on its own. D01 is two PRs because live path and history are separately provable: PR 1 lands everything dark (the write gate answers false for every user until a backfill exists), PR 2 brings the runner plumbing that opens it per user.
+
+```text
+ PR 1  D01a — the live path                PR 2  D01b — history + rollout
+ pipeline skeleton + no-op round-trip      user-rooted TenantSource for the runner
+ additive migration: NEW Identifier        backfill rider (adoption events,
+ table (PG) + User.userHashKey             deterministic ids, backdated occurredAt)
+ identity write seam + ceremonies          org-driven enrollment pacing +
+ queue-staged fold (ADR-110)          ──►  (no everyone-else cohort: ADR-110)
+ per-user write gate (ships CLOSED —       backfill parity self-proving per user
+ no migration rows exist yet)              (the D01 exit gate) — latch opens the
+ verification ceremony guards              write gate user by user
+ replay discovery from day one
+```
+
+- **PR 1 gate:** no-op command round-trip green; adapter routing-table coverage green (every better-auth model+operation explicitly routed, an unrouted write fails at startup); replay-parity green (rebuild `Identifier` from CH, diff vs live — trivially empty until users latch, structurally proven by test); write gate demonstrably closed by default. Rollback: revert — the table is additive, nothing reads it, no user is latched.
+- **PR 2 gate:** the D01 exit gate — backfill parity: the fold-built `Identifier` rows match what live `Account`/`User` rows imply, per user (the migration states its facts and checks once; disagreement holds the user at `migrated` with the outstanding identifiers named on the ops migrations page, and the gate stays closed for a held user — `finalized` is the only switch, ADR-110). Rollback: withdraw the organization's enrollment / move the user's status to `rolled_back` — the write gate closes again within its TTL, protocol writes never depended on it.
+D11 (invitations) forks off after PR 2 for a second engineer; D03/D13 start only when the Wave 1 gates are green.
+
+> **Landed 2026-08-20:** PR 1 and PR 2 shipped together in a single PR alongside the program docs (Alex's call). The per-PR gates above still hold slice by slice and remain the review map.
+>
+> **D02 withdrawn 2026-08-24:** the Redis-loss deliverable and everything it added — the fail-open secondary storage seam, the bounded best-effort staging leg, `AUTH_REDIS_FAIL_OPEN`, and the calling-path fold — are deleted. The exit gate it carried (the dev-compose Redis-kill run) goes with it.
+>
+> **Re-based 2026-08-23 on ADR-110:** the authz cutover gate the write gate was transplanted from no longer exists on `main`; the gate now opens on `finalized` only through the shared per-subject cache the engine gate uses; the everyone-else cohort and the org-paced enrollment expansion's synthetic ids are deleted (enrollment is a switch); the backfill restates every pass and detaches identifiers whose account row is gone. ADR-101 carries the revision note.
+
+# ADRs to write (before or with the gated deliverable)
+
+Plain design docs, written before the code they cover:
+
+1. **Identity platform + identifiers** (D01) — **written: [ADR-101](../adr/101-identity-pipeline-and-identifiers.md)** (revised 2026-08-20; re-based on ADR-110 2026-08-23). The identity adapter (R10) with its per-user write gate; the truth split — a new pure event-truth Postgres `Identifier` projection, `Account` stays 100% row-truth protocol — which leaves **ADR-022 and ADR-015 unamended** (the earlier column-truth carve-out and replay column scoping are deleted from the program); the ADR-110-shaped rollout re-tenanted to users (org enrollment expanding to members, per-user `finalized` latch, calling-path apply as the one recorded divergence). Carries the payload rule (the email rides in the event where the fact is about one; HMAC-keyed hashes; secrets never) and erasure-as-event-plus-log-wipe (R11).
+3. **Sign-in router, screens + SSO self-service** (D03/D13–D05) — identifier-first routing, auto-link rules, the first-party screen set; **explicitly amends ADR-027 (`027-license-gated-sso.md`; the number is collided)** (hook → per-method router policy; carries over the constants table and the route-table canary; answers the license-timing question, Open Q11).
+4. **MFA + session shape** (D06) — `amr` semantics incl. the passkey/`phw` decision (Open Q4); the forced re-login.
+
+Gherkin specs to write fresh (no existing coverage): join-request lifecycle including domain auto-join and the join-before-create sign-up path (D12/D13), the full sign-in & sign-up screen set with its deny/guidance states (D13), org-admin surface panels (D05), ops lookup actions (D05), MFA enrollment/step-up (D06), connection self-service lifecycle (D05). Use `/write-spec` per deliverable.
+
+# Spec-amendment table (existing corpus)
+
+| Existing spec | Action | Deliverable |
+|---|---|---|
+| `specs/auth/phase-1-better-auth-config.feature` | Retire `NEXTAUTH_PROVIDER` matrix (:19-45), `ssoProvider` matching (:51-73), `pendingSsoSetup` (:112-117); keep better-auth/bcrypt anchors | D03 |
+| 〃 `:119-137` (legacy `Session.impersonating`) | Retire; replace with `{actor, subject}` scenarios | D06 |
+| `specs/auth/auth-signin-flows.feature` | Port credentials/Google flows to the router + the new screens; Auth0 flow retired at D10 (legacy callback kept working by the shim, R9, until then) | D03/D13, D09/D10 |
+| `specs/auth/sso-oidc-providers.feature` | Port Cognito/OneLogin from `NEXTAUTH_PROVIDER` mounting (:24, :32) to the self-hosted default method set; discovery-document configuration survives | D03 |
+| `specs/auth/sign-in-failure-messages.feature` | Anchor — failure copy (wrong password, rate-limit wait, origin mismatch) survives on the new screens | D13 |
+| `specs/auth/password-reset.feature` | Flip cloud/SSO-mode rejection per Open Q9; keep no-oracle + revoke-all anchors | D03 |
+| `specs/auth/sso-wrong-provider-recovery.feature` | Port from `ssoDomain` strings to `SsoConnection`; most scenarios survive | D04 |
+| `specs/auth/sso-orphan-user-linking.feature` | Generalize into the auto-link/admin-confirm rule; reconcile "unverified orphan" with R8 | D03 |
+| `specs/auth/signup-does-not-strand-an-account.feature` | Anchor (keep); resolve enumeration tension (Open Q12) | D03 |
+| `specs/settings/change-password-auth0.feature` | Retire Auth0 Management API scenarios; rewrite as identifier-model password change | D10 |
+| `specs/members/update-pending-invitation.feature` | 48h → 14 days; states → PENDING/ACCEPTED/EXPIRED/REVOKED (WAITING_APPROVAL retired, epic Q13); add resend scenarios | D11 |
+| `specs/licensing/enforcement-members.feature` (expired-invite counting only) | Align to new invite states | D11 |
+| `specs/licensing/sso-license-gating.feature` | Amend mechanism (hook → router policy); settle restart semantics (Open Q11); behavioral invariants survive — including domain auto-join as licensed SSO (:10-11, :182), which D12's `domainJoin` honors | D03, D12 |
+| `specs/features/scim-group-mapping.feature` | Amend deprovisioning to grants-offboard framing (20/24 scenarios `@unimplemented` — cheap now) | D08 |
+| `specs/groups/groups-rest-api.feature` | Keep provenance anchors (SCIM-managed guards survive) | D08 |
+| `specs/organizations/scim-tokens-rest-api.feature` | REST mint/revoke gains connection scoping (create names a connection); secret-shown-once and no-secrets-in-list anchors survive | D08 |
+| `specs/ai-gateway/governance/sessions-and-devices.feature` | Session inventory gains `identifierId`/`amr`; `maxSessionDurationDays` × forced re-login interplay | D06 |
+| `specs/auth/impersonation-banner.feature`, `specs/ops/dejaview-impersonation-access.feature`, `specs/features/backoffice-user-impersonation-reason.feature` | Anchors — survive; mechanism swaps underneath | D06 |
+| `specs/features/user-deactivation.feature:134-143` | Stale "NextAuth signIn callback" wording sweep; behavior anchor survives | D03 |
+| `specs/event-sourcing/pipeline-model.feature` | Doctrine anchor for D01 — no change | D01 |
+| `specs/rbac/*`, `specs/api-keys/*`, `specs/members/member-role-team-restrictions.feature` | Owned by the authz program, not this one — listed for visibility | — |
+
+# Flag inventory
+
+`IDENTITY_ROUTER_V2` (D03 + D13 — router and screens flip together) · `SSOCONN_ROUTING` (D04) · `SELF_SERVE_SSO` per-org (D05) · `MFA_ENROLLMENT_OPEN` (D06) · `PASSKEYS_ENABLED` (D07) · `SCIM_V2_GRANTS` (D08) · invite changes additive (D11) · `JOIN_REQUESTS` (D12) · deploy-time session revoke (D06, one-way).
+
+House discipline: dashboards before flags flip. Metrics pack per deliverable: routing decisions by outcome, link proposals auto vs confirmed, ceremony success rates, SCIM dead-letters, Redis-loss seam drops/fail-opens, join-request funnel (incl. auto-joins), invite resend/expiry rates, sign-up funnel + orphaned-organization creation rate, per-customer migration progress + shim hits, sign-in success vs baseline.
+
+# Risk register
+
+| Risk | Where | Mitigation |
+|---|---|---|
+| Cutover breaks sign-in fleet-wide | D03 | Shadow bake with zero-mismatch gate; flag off = instant revert |
+| New front door tanks sign-up conversion | D13 | Sign-up funnel dashboard live before the flip; completion ≥ baseline in the exit gate; flag off restores legacy screens |
+| Domain auto-join admits the wrong person | D12 | Org opt-in only; verified email required; public email domains excluded outright; every auto-join is an audited event admins are notified of |
+| Replay touches protocol secrets | D01 | Structurally impossible: `Account` is not a projection and never enters replay; `Identifier` carries no secrets and replays whole-row (ADR-101 §3); replay-parity test in exit gate |
+| Session revoke-all strands users mid-work | D06 | Comms + precedent (better-auth cutover); schedule low-traffic window |
+| Customer IdP apps pin legacy Auth0 callback URI | D09 | Resolved (R9): temporary shim with per-org usage metric through grace; removed at D10 |
+| Auth0 retirement stalls on stragglers | D09/D10 | By design: per-tenant, no deadline; D10 is an exit criterion, not a milestone; nudge/escalation ladder in the wizard |
+| Authz API drift while we build against it | D05/D08 | Precondition checklist is a contract; any authz API change is a breaking change to this program |
+| Domain-approval queue becomes the new bottleneck | D05 | Staffing/SLA is Open Q2; measure queue latency from day one |
+
+# Staffing notes
+
+- D01–D03 are strictly sequential, same owner ideally (they share the pipeline + dispatch path).
+- D13 pairs with D03: one engineer on the router, one on the screens, one flag between them.
+- D06/D07 pair naturally (both touch session shape + better-auth plugins).
+- D09 is engineering + CS per customer; the wizard and playbook are engineering's deliverable, execution is shared and deliberately slow.
+- D11 (invitations) is the best parallelization candidate for a second engineer; it needs only D01 and can start immediately after it.


### PR DESCRIPTION
## Why

The identity platform redesign is a twelve-deliverable program, and until now its documentation was riding inside the wave 1 code PR (#7333). That is the wrong place for it: eleven of the twelve deliverables ship no code in that PR, so the documents gate nothing there, review as noise alongside 9,000 lines of implementation, and delay a merge they have no stake in.

This PR is the program documentation on its own, so it can merge on its own.

## What changed

Documentation only — no code, no tests, no configuration. Fourteen files:

- `dev/docs/identity-platform-redesign.md` — the epic: what the redesign is for, the decisions taken (R8, R10–R13), and the shape the program converges on.
- `dev/docs/identity-platform/delivery-plan.md` — sequencing across the waves, and what each deliverable can start after.
- `dev/docs/identity-platform/D01`–`D13` — one document per deliverable: the pipeline and identifiers, the identifier-first sign-in router, the SSO connection aggregate, self-service onboarding, MFA and session shape, passkeys, per-connection SCIM, the Auth0 customer migrations and deletion, resilient invitations, join requests, and the sign-in/sign-up screens.

D02 is absent by design: it was folded into ADR-110's queue-only rule rather than shipping as its own deliverable.

## How it works

Nothing executes. These are planning documents that describe intended behaviour per deliverable; the requirements that bind code are the `.feature` specs, and the decisions that bind architecture are the ADRs — both of which live with the code that implements them.

## Test plan

No behaviour to test. `docs-ci` and `readme-links` cover the mechanical checks (front matter, link resolution).

## Anything surprising?

- **Merge this before #7333.** ADR-101 in that PR carries relative links to `dev/docs/identity-platform/delivery-plan.md` and `D01-identity-pipeline-and-identifiers.md`. Nothing in CI validates those links — `readme-links` only resolves the README — but merging this first keeps them live from the moment the ADR lands.
- **These documents describe intent, not what shipped.** D01 is the only deliverable with code on main after #7333, and even there the ADRs are the authority on what was actually built. Read the D-docs for direction, the ADRs for decisions, and the specs for behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive identity platform redesign specification.
  * Documented plans for SSO, MFA, passkeys, SCIM, invitations, join requests, and first-party sign-in screens.
  * Added guidance for customer-paced migration from legacy authentication and its eventual retirement.
  * Defined delivery milestones, rollout and rollback criteria, security controls, and operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->