### PR TITLE
fix(navigation): highlight the top result while the project search runs

### DIFF
--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -593,7 +593,7 @@ describe("the product-switcher top bar", () => {
     /** @scenario Typing highlights the top result */
     it("highlights the first result as I type, with no arrow key", async () => {
       renderShell();
-      await openProjectPicker();
+      const user = await openProjectPicker();
       const field = screen.getByPlaceholderText("Search projects");
 
       searchFor("billing");
@@ -606,9 +606,13 @@ describe("the product-switcher top bar", () => {
         expect(field).toHaveAttribute("aria-activedescendant", first?.id);
       });
 
-      // Enter opening the highlighted project is the sibling scenario
-      // above; what this one pins is that typing alone does the
-      // highlighting, so no arrow key is needed to get there.
+      // Enter alone opens it, which is the point of the highlight.
+      await user.keyboard("{Enter}");
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith(
+          expect.stringContaining("billing-sync"),
+        );
+      });
     });
 
     /** @scenario Creating a project stays available while the list is unfiltered */

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -590,6 +590,27 @@ describe("the product-switcher top bar", () => {
       });
     });
 
+    /** @scenario Typing highlights the top result */
+    it("highlights the first result as I type, with no arrow key", async () => {
+      renderShell();
+      await openProjectPicker();
+      const field = screen.getByPlaceholderText("Search projects");
+
+      searchFor("billing");
+      // Highlighted by the typing itself, before any arrow key. The field
+      // names the highlighted option, which is the machine's own state
+      // rather than a class the list happens to carry.
+      await waitFor(() => {
+        const [first] = screen.getAllByRole("option");
+        expect(first).toHaveAttribute("data-highlighted");
+        expect(field).toHaveAttribute("aria-activedescendant", first?.id);
+      });
+
+      // Enter opening the highlighted project is the sibling scenario
+      // above; what this one pins is that typing alone does the
+      // highlighting, so no arrow key is needed to get there.
+    });
+
     /** @scenario Creating a project stays available while the list is unfiltered */
     it("keeps the per-team create entries while nothing is typed and drops them while searching", async () => {
       renderShell();

--- a/platform/app/src/features/navigation/shell/ProjectSwitcherCombobox.tsx
+++ b/platform/app/src/features/navigation/shell/ProjectSwitcherCombobox.tsx
@@ -58,6 +58,11 @@ export function ProjectSwitcherCombobox({
       value={[currentProjectId]}
       openOnClick
       selectionBehavior="clear"
+      // Typing highlights the top result, so a reader can search and press
+      // Enter without reaching for the arrow keys or the mouse. A running
+      // search offers projects only, so Enter can never land on a create
+      // entry (see `useProjectPickItems`).
+      inputBehavior="autohighlight"
       onValueChange={(details) => {
         const next = details.value?.[0];
         if (next) pick(next);

--- a/specs/navigation/product-switcher-navigation.feature
+++ b/specs/navigation/product-switcher-navigation.feature
@@ -138,6 +138,14 @@ Feature: Product switcher navigation
     Then the highlighted project opens
 
   @integration
+  Scenario: Typing highlights the top result
+    Given my organization holds more than eight projects
+    And the project menu is open
+    When I type enough of a project's name to narrow the list
+    Then the first result is already highlighted, with no arrow key pressed
+    And Enter opens it, by the scenario above
+
+  @integration
   Scenario: Creating a project stays available while the list is unfiltered
     Given my organization holds more than eight projects
     When I open the project menu without typing

--- a/specs/navigation/product-switcher-navigation.feature
+++ b/specs/navigation/product-switcher-navigation.feature
@@ -143,7 +143,8 @@ Feature: Product switcher navigation
     And the project menu is open
     When I type enough of a project's name to narrow the list
     Then the first result is already highlighted, with no arrow key pressed
-    And Enter opens it, by the scenario above
+    When I press Enter
+    Then that project opens
 
   @integration
   Scenario: Creating a project stays available while the list is unfiltered


### PR DESCRIPTION
## What

The project search now highlights the top result as you type, so you can search for a project and press Enter without touching the arrow keys or the mouse.

Before, the popup opened with nothing highlighted. Typing narrowed the list, but Enter did nothing until you pressed the down arrow first.

![Project search with the first result highlighted](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/project-search-autohighlight.png)

The search reads "a", the list narrows, and the first result carries the highlight. The current project keeps its check mark and does not take the highlight.

## How

`ProjectSwitcherCombobox` asks the combobox for `inputBehavior="autohighlight"`. In zag, the transitions that flag guards run in the typing state on every list change, so the highlight follows the narrowing list and is not only set when the popup opens.

Enter is safe here: `useProjectPickItems` drops the per-team "New Project" entries whenever a query is running, so a highlighted first result is always a project.

## Verification

- Browser QA on a project list of 18: typed "edge", the single result took the highlight with no arrow key, Enter opened `/edge-router-qa7`.
- New integration test `highlights the first result as I type, with no arrow key` asserts the first option carries `data-highlighted` and the search field's `aria-activedescendant` names it.
- New spec scenario `Typing highlights the top result` in `specs/navigation/product-switcher-navigation.feature`. The file reports 20/20 bound.
- `pnpm test:component run src/features/navigation`: 9 files, 97 tests, all pass.

Enter opening the highlighted project stays pinned by the sibling test that walks the list with the arrow keys, so this test covers only what changed.

https://claude.ai/code/session_01BDTbQR75RWmN54kKyUgWDP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project search now automatically highlights the first matching result as you type.
  * Pressing Enter selects and opens the highlighted project without requiring arrow-key navigation.

* **Tests**
  * Added coverage for automatic highlighting and selection in project menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->